### PR TITLE
assorted: plumb cancellation to sandbox executions, handle ctrl-c for `minimal package`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,6 +2430,7 @@ dependencies = [
  "stdlib",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml",
  "toml_edit",
  "tracing",
@@ -2529,6 +2530,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tokio",
+ "tokio-util",
  "toml",
  "toml_edit",
  "tracing",
@@ -2739,6 +2741,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
  "walkdir",
@@ -2781,6 +2784,7 @@ dependencies = [
  "rcache",
  "sandbox2",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -3679,6 +3683,7 @@ dependencies = [
  "hakoniwa",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "walkdir",
 ]

--- a/crates/mctx/Cargo.toml
+++ b/crates/mctx/Cargo.toml
@@ -20,6 +20,7 @@ tempfile.workspace = true
 futures.workspace = true
 tracing.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 
 hakoniwa.workspace = true
 sandbox2.workspace = true

--- a/crates/mctx/src/error.rs
+++ b/crates/mctx/src/error.rs
@@ -221,6 +221,9 @@ impl From<sandbox2::Error> for Error {
                 sandbox2::error::ExecutionError::SpawnFailed(e) => {
                     Self::Other(anyhow::anyhow!("spawn failed: {}", e))
                 }
+                sandbox2::error::ExecutionError::Cancelled => {
+                    Self::Other(anyhow::anyhow!("execution cancelled"))
+                }
             },
             sandbox2::Error::Output(e) => Self::Other(e.into()),
         }

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -423,6 +423,16 @@ impl Context {
         graph: &Graph,
         log_sink: Option<futures::channel::mpsc::UnboundedSender<orchestrator::BuildEvent>>,
     ) -> Result<(), Error> {
+        self.build_graph_with_cancel(graph, log_sink, tokio_util::sync::CancellationToken::new())
+            .await
+    }
+
+    pub async fn build_graph_with_cancel(
+        &mut self,
+        graph: &Graph,
+        log_sink: Option<futures::channel::mpsc::UnboundedSender<orchestrator::BuildEvent>>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<(), Error> {
         let cache = self.local_cache();
         let rc = if self.config.use_remote_cache() {
             Some(self.remote_cache(false, false).await.unwrap())
@@ -441,6 +451,7 @@ impl Context {
             cache.clone(),
             log_sink,
             self.config.ot.clone(),
+            cancel,
         )?;
 
         let (built, result) = match (

--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -35,6 +35,7 @@ serde_json.workspace = true
 
 rayon.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 futures.workspace = true
 
 anyhow.workspace = true

--- a/crates/minimal/src/cmd_pkg.rs
+++ b/crates/minimal/src/cmd_pkg.rs
@@ -70,7 +70,17 @@ pub async fn pkg_build_impl(
 ) -> Result<(), Error> {
     trace!("build_impl");
 
-    ctx.build_graph(graph, log_sink).await?;
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let cancel2 = cancel.clone();
+    tokio::select! {
+        result = ctx.build_graph_with_cancel(graph, log_sink, cancel) => {
+            result?;
+        }
+        _ = tokio::signal::ctrl_c() => {
+            cancel2.cancel();
+            return Err(Error::Other(anyhow::anyhow!("build cancelled")));
+        }
+    }
 
     // Display build summary
     if !quiet {

--- a/crates/op/Cargo.toml
+++ b/crates/op/Cargo.toml
@@ -25,6 +25,7 @@ size.workspace = true
 tar.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/op/src/patched.rs
+++ b/crates/op/src/patched.rs
@@ -62,6 +62,7 @@ impl<'a, SF: crate::SourceFetcher> Runnable for PatchedBuild<'a, SF> {
             remote_fetcher: self.remote_fetcher,
             stdout_writer: self.stdout_writer.take(),
             stderr_writer: self.stderr_writer.take(),
+            cancel: tokio_util::sync::CancellationToken::new(),
         }
         .run(opts)
         .await?;

--- a/crates/op/src/specs.rs
+++ b/crates/op/src/specs.rs
@@ -34,6 +34,9 @@ pub struct SpecBuild<'a, SF: crate::SourceFetcher> {
     pub stdout_writer: Option<Box<dyn tokio::io::AsyncWrite + Unpin + Send + Sync>>,
     /// Optional async writer that receives a copy of the sandbox's stderr stream.
     pub stderr_writer: Option<Box<dyn tokio::io::AsyncWrite + Unpin + Send + Sync>>,
+
+    /// Cancellation token to stop the build.
+    pub cancel: tokio_util::sync::CancellationToken,
 }
 
 impl<'a, SF: crate::SourceFetcher> SpecBuild<'a, SF> {
@@ -273,7 +276,7 @@ impl<'a, SF: crate::SourceFetcher> Runnable for SpecBuild<'a, SF> {
         info!("Building package: {}", build.name);
         let start = Instant::now();
         sandbox
-            .run(
+            .run_with_cancel(
                 self.invocations(build)?
                     .into_iter()
                     .map(|(program, args)| sandbox2::config::Invocation {
@@ -284,6 +287,7 @@ impl<'a, SF: crate::SourceFetcher> Runnable for SpecBuild<'a, SF> {
                     .collect(),
                 self.stdout_writer.take(),
                 self.stderr_writer.take(),
+                self.cancel.clone(),
             )
             .await?;
         let build_ms = Instant::now().duration_since(start).as_millis() as usize;

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -16,6 +16,7 @@ futures.workspace = true
 generational-arena.workspace = true
 google-cloud-storage.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 
 lcache.workspace = true

--- a/crates/orchestrator/src/local_backend.rs
+++ b/crates/orchestrator/src/local_backend.rs
@@ -137,6 +137,7 @@ pub struct LocalBackend<SF: SourceFetcher + 'static> {
     pub(crate) num_concurrent_builds: usize,
     pub(crate) log_sink: Option<mpsc::UnboundedSender<BuildEvent>>,
     pub(crate) ot: Option<OpTracker>,
+    pub(crate) cancel: tokio_util::sync::CancellationToken,
 }
 
 impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
@@ -215,6 +216,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
                         Box::new(SinkWriter::new(s.clone(), dr.inner_idx(), true))
                     },
                 ),
+                cancel: shared.backend.cancel.clone(),
             };
 
             let res = b
@@ -395,6 +397,7 @@ impl<SF: SourceFetcher> LocalBackend<SF> {
         cache: Cache<LocalDir>,
         log_sink: Option<mpsc::UnboundedSender<BuildEvent>>,
         ot: Option<OpTracker>,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<Orchestrator<Self>, Error> {
         Ok(Orchestrator {
             top_levels,
@@ -406,6 +409,7 @@ impl<SF: SourceFetcher> LocalBackend<SF> {
                 build_semaphore: Semaphore::new(num_concurrent_builds),
                 num_concurrent_builds,
                 ot,
+                cancel,
             },
             graph,
             cache,

--- a/crates/sandbox2/Cargo.toml
+++ b/crates/sandbox2/Cargo.toml
@@ -11,6 +11,7 @@ globset.workspace = true
 tracing.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 walkdir.workspace = true
 
 common.workspace = true

--- a/crates/sandbox2/src/error.rs
+++ b/crates/sandbox2/src/error.rs
@@ -52,6 +52,7 @@ pub enum ExecutionError {
         stderr: String,
     },
     SpawnFailed(hakoniwa::Error),
+    Cancelled,
 }
 
 impl fmt::Display for ExecutionError {
@@ -76,6 +77,9 @@ impl fmt::Display for ExecutionError {
             Self::SpawnFailed(e) => {
                 write!(f, "Invocation spawn failed: {}", e)
             }
+            Self::Cancelled => {
+                write!(f, "Execution cancelled")
+            }
         }
     }
 }
@@ -85,6 +89,7 @@ impl std::error::Error for ExecutionError {
         match self {
             Self::InvocationFailed { .. } => None,
             Self::SpawnFailed(e) => Some(e),
+            Self::Cancelled => None,
         }
     }
 }

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -439,8 +439,28 @@ impl<C: Channel> Sandbox<C> {
     pub async fn run<W1, W2>(
         &mut self,
         invocations: Vec<Invocation>,
+        stdout_writer: Option<W1>,
+        stderr_writer: Option<W2>,
+    ) -> Result<(), Error>
+    where
+        W1: tokio::io::AsyncWrite + Unpin + Send,
+        W2: tokio::io::AsyncWrite + Unpin + Send,
+    {
+        self.run_with_cancel(
+            invocations,
+            stdout_writer,
+            stderr_writer,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+    }
+
+    pub async fn run_with_cancel<W1, W2>(
+        &mut self,
+        invocations: Vec<Invocation>,
         mut stdout_writer: Option<W1>,
         mut stderr_writer: Option<W2>,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<(), Error>
     where
         W1: tokio::io::AsyncWrite + Unpin + Send,
@@ -448,6 +468,10 @@ impl<C: Channel> Sandbox<C> {
     {
         let container = self.new_container()?;
         for (i, exec) in invocations.iter().enumerate() {
+            if cancel.is_cancelled() {
+                return Err(Error::Execution(ExecutionError::Cancelled));
+            }
+
             let mut cmd = self.command(&container, &exec.executable, &exec.args, &exec.envs)?;
             cmd.stderr(hakoniwa::Stdio::MakePipe);
             cmd.stdout(hakoniwa::Stdio::MakePipe);
@@ -563,36 +587,58 @@ impl<C: Channel> Sandbox<C> {
                 Ok::<(), Error>(())
             };
 
-            let (stdout_fwd_res, stderr_fwd_res) = tokio::join!(stdout_fwd, stderr_fwd);
+            // Race the forwarding against cancellation. When cancelled, kill the
+            // child process — this closes its pipes, which unblocks the reader
+            // threads, which drop the senders, which completes the fwd futures.
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    let _ = child.kill();
 
-            // Collect results from the reader threads.
-            let stdout_file = stdout_thread
-                .join()
-                .expect("stdout reader thread panicked")?;
-            let (stderr_file, stderr_tail) = stderr_thread
-                .join()
-                .expect("stderr reader thread panicked")?;
+                    // Recover stdout/stderr files from the reader threads.
+                    // The threads will finish promptly now that pipes are closed.
+                    if let Ok(Ok(f)) = stdout_thread.join() {
+                        self.stdout = f;
+                    }
+                    if let Ok(Ok((f, _tail))) = stderr_thread.join() {
+                        self.stderr = f;
+                    }
 
-            self.stdout = stdout_file;
-            self.stderr = stderr_file;
+                    // Reap the child process.
+                    let _ = child.wait();
+                    return Err(Error::Execution(ExecutionError::Cancelled));
+                }
+                (stdout_fwd_res, stderr_fwd_res) = async { tokio::join!(stdout_fwd, stderr_fwd) } => {
+                    // Collect results from the reader threads.
+                    let stdout_file = stdout_thread
+                        .join()
+                        .expect("stdout reader thread panicked")?;
+                    let (stderr_file, stderr_tail) = stderr_thread
+                        .join()
+                        .expect("stderr reader thread panicked")?;
 
-            // Propagate any async writer errors.
-            stdout_fwd_res?;
-            stderr_fwd_res?;
+                    self.stdout = stdout_file;
+                    self.stderr = stderr_file;
 
-            // The pipes are drained, so the child should have exited.
-            let status = child
-                .wait()
-                .map_err(|e| Error::Execution(ExecutionError::SpawnFailed(e)))?;
+                    // Propagate any async writer errors.
+                    stdout_fwd_res?;
+                    stderr_fwd_res?;
 
-            if !status.success() {
-                let stderr_str = String::from_utf8_lossy(&stderr_tail).into_owned();
-                return Err(Error::Execution(ExecutionError::InvocationFailed {
-                    idx: i,
-                    code: status.code,
-                    reason: status.reason.clone(),
-                    stderr: stderr_str,
-                }));
+                    // The pipes are drained, so the child should have exited.
+                    let status = child
+                        .wait()
+                        .map_err(|e| Error::Execution(ExecutionError::SpawnFailed(e)))?;
+
+                    if !status.success() {
+                        let stderr_str = String::from_utf8_lossy(&stderr_tail).into_owned();
+                        return Err(Error::Execution(ExecutionError::InvocationFailed {
+                            idx: i,
+                            code: status.code,
+                            reason: status.reason.clone(),
+                            stderr: stderr_str,
+                        }));
+                    }
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
This will gracefully shutdown a package build, cleaning up resources as well as committing successful builds when interrupted.

Will also allow us to abort sandbox tasks in res-server.