### PR TITLE
.github: update minimal-check job to not fetch all packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,4 +194,4 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-minimal
       - name: Check
-        run: minimal check
+        run: minimal --no-fetch check


### PR DESCRIPTION
It seems a refactor removed the logic where we would only fetch packages local to the repo, rather than everything in the graph. Whoops.

Sets `--no-fetch` for now to unblock CI.