### PR TITLE
assorted: refactor keyword search to common implementation, add version in search output

### DIFF
--- a/crates/common/src/fuzzy_search.rs
+++ b/crates/common/src/fuzzy_search.rs
@@ -1,0 +1,178 @@
+//! Fuzzy string matching for package name search.
+
+use std::cmp::Ordering;
+
+/// Describes the quality of a search match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchMatch {
+    /// The needle matches the haystack exactly (case-insensitive).
+    ExactMatch,
+    /// The haystack starts with the needle.
+    PrefixMatch { haystack_len: u32 },
+    /// The haystack contains the needle as a substring.
+    ContainsMatch { extra_len: u32 },
+    /// The needle matches the haystack fuzzily (characters appear in order).
+    Fuzzy { score: u32 },
+}
+
+impl Ord for SearchMatch {
+    fn cmp(&self, other: &Self) -> Ordering {
+        fn rank(m: &SearchMatch) -> u8 {
+            match m {
+                SearchMatch::ExactMatch => 3,
+                SearchMatch::PrefixMatch { .. } => 2,
+                SearchMatch::ContainsMatch { .. } => 1,
+                SearchMatch::Fuzzy { .. } => 0,
+            }
+        }
+
+        match rank(self).cmp(&rank(other)) {
+            Ordering::Equal => match (self, other) {
+                (
+                    SearchMatch::PrefixMatch { haystack_len: a },
+                    SearchMatch::PrefixMatch { haystack_len: b },
+                ) => b.cmp(a), // shorter haystack = better
+                (
+                    SearchMatch::ContainsMatch { extra_len: a },
+                    SearchMatch::ContainsMatch { extra_len: b },
+                ) => b.cmp(a), // less extra = better
+                (SearchMatch::Fuzzy { score: a }, SearchMatch::Fuzzy { score: b }) => a.cmp(b), // higher score = better
+                _ => Ordering::Equal,
+            },
+            ord => ord,
+        }
+    }
+}
+
+impl PartialOrd for SearchMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Performs a fuzzy match of `needle` against `haystack`, returning a [`SearchMatch`]
+/// describing the quality of the match. Returns `None` if there is no meaningful match.
+pub fn fuzzy_match(needle: &str, haystack: &str) -> Option<SearchMatch> {
+    let n = needle.trim().to_lowercase();
+    let h = haystack.trim().to_lowercase();
+
+    if n == h {
+        return Some(SearchMatch::ExactMatch);
+    }
+    if h.contains(n.as_str()) {
+        if h.starts_with(n.as_str()) {
+            return Some(SearchMatch::PrefixMatch {
+                haystack_len: h.len() as u32,
+            });
+        }
+        return Some(SearchMatch::ContainsMatch {
+            extra_len: (h.len() - n.len()) as u32,
+        });
+    }
+
+    let mut h_rest = h.as_str();
+    let mut score = 0u32;
+    let mut consecutive_bonus = 0u32;
+    let mut matched = 0u32;
+
+    for ch in n.chars() {
+        if let Some(idx) = h_rest.find(ch) {
+            consecutive_bonus = if idx == 0 && matched > 0 {
+                consecutive_bonus + 1
+            } else {
+                0
+            };
+            score += 10 + consecutive_bonus;
+            h_rest = &h_rest[idx + ch.len_utf8()..];
+            matched += 1;
+        }
+    }
+
+    let n_len = n.chars().count() as u32;
+    let h_len = h.chars().count() as u32;
+    let char_score = score * 10 / (n_len * 11); // approx divide by 1.1
+    let length_penalty_num = n_len * 100 / n_len.max(h_len);
+    let final_score = char_score * length_penalty_num / 100;
+
+    if final_score < 3 {
+        return None;
+    }
+    Some(SearchMatch::Fuzzy { score: final_score })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_match() {
+        assert_eq!(
+            fuzzy_match("libffi", "libffi"),
+            Some(SearchMatch::ExactMatch)
+        );
+        assert_eq!(
+            fuzzy_match("LibFFI", "libffi"),
+            Some(SearchMatch::ExactMatch)
+        );
+    }
+
+    #[test]
+    fn prefix_match() {
+        assert!(matches!(
+            fuzzy_match("lib", "libffi"),
+            Some(SearchMatch::PrefixMatch { .. })
+        ));
+    }
+
+    #[test]
+    fn contains_match() {
+        assert!(matches!(
+            fuzzy_match("lib", "zlib"),
+            Some(SearchMatch::ContainsMatch { .. })
+        ));
+    }
+
+    #[test]
+    fn fuzzy() {
+        assert!(
+            matches!(
+                fuzzy_match("lbffi", "libffi"),
+                Some(SearchMatch::Fuzzy { .. })
+            ),
+            "got: {:?}",
+            fuzzy_match("lbffi", "libffi")
+        );
+    }
+
+    #[test]
+    fn no_match() {
+        assert_eq!(fuzzy_match("xyz", "libffi"), None);
+    }
+
+    #[test]
+    fn ordering() {
+        let exact = SearchMatch::ExactMatch;
+        let prefix = SearchMatch::PrefixMatch { haystack_len: 6 };
+        let contains = SearchMatch::ContainsMatch { extra_len: 1 };
+        let fuzzy = SearchMatch::Fuzzy { score: 50 };
+
+        assert!(exact > prefix);
+        assert!(prefix > contains);
+        assert!(contains > fuzzy);
+
+        // Within PrefixMatch: shorter haystack is better
+        let short_prefix = SearchMatch::PrefixMatch { haystack_len: 4 };
+        let long_prefix = SearchMatch::PrefixMatch { haystack_len: 10 };
+        assert!(short_prefix > long_prefix);
+
+        // Within ContainsMatch: less extra is better
+        let small_extra = SearchMatch::ContainsMatch { extra_len: 1 };
+        let large_extra = SearchMatch::ContainsMatch { extra_len: 5 };
+        assert!(small_extra > large_extra);
+
+        // Within Fuzzy: higher score is better
+        let high_score = SearchMatch::Fuzzy { score: 80 };
+        let low_score = SearchMatch::Fuzzy { score: 20 };
+        assert!(high_score > low_score);
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod archive;
 pub mod fetchers;
 pub mod file_cache;
+pub mod fuzzy_search;
 pub mod jq;
 mod remote_storage;
 pub use remote_storage::RemoteStorage;

--- a/crates/graph/src/builds.rs
+++ b/crates/graph/src/builds.rs
@@ -252,4 +252,13 @@ impl BuildSpec {
                 || (self.cmds.len() == 1
                     && (self.cmds[0].is_empty() || self.cmds[0][0].is_empty())))
     }
+
+    /// Returns the upstream version, if set on the package.
+    pub fn upstream_version(&self) -> Option<&String> {
+        if let Some(AttrValue::String(s, _)) = self.attrs.get("upstream_version") {
+            Some(s)
+        } else {
+            None
+        }
+    }
 }

--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -793,18 +793,39 @@ impl Graph {
     }
 
     /// Returns a list of [BuildSpecRef] objects who's names matched the given search term.
-    pub fn fuzzy_name_search(&self, term: &str, num_results: usize) -> Vec<(BuildSpecRef, u32)> {
-        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    pub fn fuzzy_name_search(
+        &self,
+        term: &str,
+        num_results: usize,
+    ) -> Vec<(BuildSpecRef, common::fuzzy_search::SearchMatch)> {
+        use common::fuzzy_search::{SearchMatch, fuzzy_match};
+
+        #[derive(Debug, Clone, PartialEq, Eq)]
         struct SearchEntry {
-            score: u32,
+            score: SearchMatch,
             bsr: BuildSpecRef,
+        }
+
+        impl Ord for SearchEntry {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                self.score
+                    .cmp(&other.score)
+                    .then_with(|| self.bsr.cmp(&other.bsr))
+            }
+        }
+        impl PartialOrd for SearchEntry {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
         }
 
         use std::collections::BinaryHeap;
         let mut results = BinaryHeap::with_capacity(num_results);
 
         for (bsr, build) in self.builds.iter() {
-            let score = fuzzy_match(term, &build.name);
+            let Some(score) = fuzzy_match(term, &build.name) else {
+                continue;
+            };
             results.push(std::cmp::Reverse(SearchEntry {
                 score,
                 bsr: BuildSpecRef(bsr),
@@ -881,42 +902,6 @@ impl Graph {
             crate::wire::GraphReader::new(std::io::Cursor::new(data)).read_graph()?;
         Ok(graph)
     }
-}
-
-fn fuzzy_match(needle: &str, haystack: &str) -> u32 {
-    let n = needle.trim().to_lowercase();
-    let h = haystack.trim().to_lowercase();
-
-    if n == h {
-        return 1000;
-    }
-    if h.contains(n.as_str()) {
-        return 950;
-    }
-
-    let mut h_rest = h.as_str();
-    let mut score = 0u32;
-    let mut consecutive_bonus = 0u32;
-    let mut matched = 0u32;
-
-    for ch in n.chars() {
-        if let Some(idx) = h_rest.find(ch) {
-            consecutive_bonus = if idx == 0 && matched > 0 {
-                consecutive_bonus + 1
-            } else {
-                0
-            };
-            score += 10 + consecutive_bonus;
-            h_rest = &h_rest[idx + ch.len_utf8()..];
-            matched += 1;
-        }
-    }
-
-    let n_len = n.chars().count() as u32;
-    let h_len = h.chars().count() as u32;
-    let char_score = score * 10 / (n_len * 11); // approx divide by 1.1
-    let length_penalty_num = n_len * 100 / n_len.max(h_len);
-    (char_score * length_penalty_num / 100).min(900)
 }
 
 #[cfg(test)]
@@ -1354,6 +1339,8 @@ mod tests {
 
     #[test]
     fn fuzzy_name_search() {
+        use common::fuzzy_search::SearchMatch;
+
         let layer = Layer::new_for_test(
             indoc! {
                 "
@@ -1392,6 +1379,7 @@ mod tests {
         let results = dp.fuzzy_name_search("libffi", 3);
         assert_eq!(results.len(), 3);
         assert_eq!(dp.get(&results[0].0).unwrap().name, "libffi");
+        assert_eq!(results[0].1, SearchMatch::ExactMatch);
 
         // Partial match: "lib" should prefer libffi/libxml2 over zlib
         let results = dp.fuzzy_name_search("lib", 2);
@@ -1400,6 +1388,8 @@ mod tests {
             .map(|r| dp.get(&r.0).unwrap().name.as_str())
             .collect();
         assert!(names.contains(&"libffi") || names.contains(&"libxml2"));
+        // "lib" is a prefix of libffi/libxml2
+        assert!(matches!(results[0].1, SearchMatch::PrefixMatch { .. }));
 
         // Limiting num_results works
         let results = dp.fuzzy_name_search("lib", 1);

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -390,16 +390,18 @@ impl sandbox2::Channel for EnvChannel<'_> {
                 self.graph
                     .fuzzy_name_search(term, 8)
                     .iter()
-                    .for_each(|(bsr, n)| {
-                        if *n < 8 {
-                            return;
-                        }
-                        let name = &self.graph.get(bsr).unwrap().name;
+                    .for_each(|(bsr, _)| {
+                        let b = self.graph.get(bsr).unwrap();
+                        let name = &b.name;
                         if name.ends_with(" (prebuilt)") {
                             return;
                         }
 
-                        writeln!(stream, "msg: * {}", name).ok();
+                        write!(stream, "msg: * {}", name).ok();
+                        if let Some(v) = b.upstream_version() {
+                            write!(stream, " (version {})", v).ok();
+                        }
+                        writeln!(stream).ok();
                     });
                 None
             }

--- a/crates/minimal/src/cmd_dump.rs
+++ b/crates/minimal/src/cmd_dump.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Display, io::stdout};
 
+use common::fuzzy_search::fuzzy_match;
 use decode::AttrValue;
 use graph::{BuildDep, BuildOutput, BuildSpec, BuildSpecRef, Graph, RuntimeDep, SourceInput};
 use mctx::{Cache, Context, Error};
@@ -125,10 +126,13 @@ pub async fn cmd_dump(args: DumpArgs, ctx: &mut Context) -> Result<(), Error> {
     if args.kind.packages {
         for bsr in graph.all() {
             let b = graph.get(&bsr).unwrap();
-            if let Some(name) = &args.name
-                && !fuzzy_match(args.exact, name, &b.name)
-            {
-                continue;
+            if let Some(name) = &args.name {
+                if args.exact && name != &b.name {
+                    continue;
+                }
+                if fuzzy_match(name, &b.name).is_none() {
+                    continue;
+                }
             }
 
             out_packages.push(build_pkg_info(&graph, &bsr, b, &cache)?);
@@ -147,26 +151,6 @@ pub async fn cmd_dump(args: DumpArgs, ctx: &mut Context) -> Result<(), Error> {
     }
 
     Ok(())
-}
-
-/// Simple subsequence fuzzy matcher: all query chars appear in order in target.
-fn fuzzy_match(exact: bool, query: &str, target: &str) -> bool {
-    if exact {
-        return query == target;
-    }
-
-    let mut query_chars = query.chars();
-    let mut current = query_chars.next();
-    for c in target.chars() {
-        if let Some(q) = current {
-            if c == q {
-                current = query_chars.next();
-            }
-        } else {
-            return true;
-        }
-    }
-    current.is_none()
 }
 
 fn build_pkg_info(


### PR DESCRIPTION
 * Move `fuzzy_search` to `common` crate, create real result type
 * Tests
 * Prioritize exact matches over prefix matches over fuzzy matches
 * Use for both dump filter and `min search`
 * Show version in `min search`:

```shell
bash-5.3$ min search ll
 * llvm
 * llama.cpp (version b8041)
 * llvm-bootstrap
 * zellij (version 0.43.1)
 * nushell (version 0.110.0)
 * shellcheck (version 0.10.0)
 ```