### PR TITLE
crates/common: fix error checking in Gcs fetcher impl, check request error in CachingDownloader

### DIFF
--- a/crates/common/src/fetchers.rs
+++ b/crates/common/src/fetchers.rs
@@ -182,7 +182,10 @@ impl FetchResponse for Result<google_cloud_storage::read_object::ReadObjectRespo
         self.is_ok()
     }
     fn error_for_status(self) -> Result<Self, Self::Error> {
-        Ok(self)
+        match self {
+            Ok(_) => Ok(self),
+            Err(e) => Err(e),
+        }
     }
 
     async fn bytes(self) -> Result<Bytes, Self::Error> {

--- a/crates/common/src/file_cache.rs
+++ b/crates/common/src/file_cache.rs
@@ -1,5 +1,5 @@
 use crate::Tee;
-use crate::fetchers::{self, FetchUrl};
+use crate::fetchers::{self, FetchResponse, FetchUrl};
 
 use either::Either;
 use ot::OpTracker;
@@ -227,6 +227,8 @@ impl<B: fetchers::FetchBackend> CachingDownloader<B> for (&B, &FileCache) {
             .0
             .execute(self.0.get(url).map_err(Either::Right)?)
             .await
+            .map_err(Either::Right)?
+            .error_for_status()
             .map_err(Either::Right)?;
 
         self.1.write_through(&filename, sha256, &mut r, op).await


### PR DESCRIPTION
Fixes a panic when trying to populate an entry in `CachingDownloader` (i.e. source fetch) where the `FetchBackend` returns a non-200 code, e.g.

```
called `Result::unwrap()` on an `Err` value: Error { kind: Transport(TransportDetails { status_code: Some(404), headers: Some({"content-type": "text/html; charset=UTF-8", "x-guploader-uploadid": "<redacted>", "date": "Wed, 01 Apr 2026 <redacted>", "vary": "Origin", "vary": "X-Origin", "cache-control": "private, max-age=0", "content-length": "76", "server": "UploadServer", payload: Some(b"No such object: minimal-staging-archives/clang-tools-extra-21.1.8.src.tar.xz") }), source: None }
```