### PR TITLE
crates/{check,sandbox2}: set SOURCE_DATE_EPOCH/PYTHONHASHSEED in all build sandboxes

### DIFF
--- a/crates/check/src/lib.rs
+++ b/crates/check/src/lib.rs
@@ -1133,10 +1133,20 @@ impl FileBasedChecker for AdjacentImportCheck {
 
 /// Regexes that build scripts are audited against. If any match, the check fails.
 static BUILD_SCRIPT_AUDIT_REGEXES: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
-    vec![(
-        Regex::new(r"\btar\s+-?xf\b").unwrap(),
-        "use 'tar -xof' instead of 'tar -xf' to extract archives in build scripts",
-    )]
+    vec![
+        (
+            Regex::new(r"\btar\s+-?xf\b").unwrap(),
+            "use 'tar -xof' instead of 'tar -xf' to extract archives in build scripts",
+        ),
+        (
+            Regex::new(r"\bSOURCE_DATE_EPOCH\s*=\s*0").unwrap(),
+            "SOURCE_DATE_EPOCH=0 is already set by the build sandbox",
+        ),
+        (
+            Regex::new(r"\bPYTHONHASHSEED\s*=\s*0").unwrap(),
+            "PYTHONHASHSEED=0 is already set by the build sandbox",
+        ),
+    ]
 });
 
 struct BuildScriptDisallowedPatterns;

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -296,6 +296,8 @@ impl Container {
         if let WdSetup::Isolated { .. } = sandbox.config.wd {
             command.env("OUTPUT_DIR", "/build/output");
             command.env("GIT_TERMINAL_PROMPT", "0");
+            command.env("SOURCE_DATE_EPOCH", "0");
+            command.env("PYTHONHASHSEED", "0");
         }
 
         command.env("LANG", "en_US.utf8");


### PR DESCRIPTION
This also adds a lint for build scripts that set it themselves, which would be annoying if we couldnt just tell a clanker to fix it.

<img width="917" height="593" alt="image" src="https://github.com/user-attachments/assets/70f3b2f9-fbe0-49fa-8457-1eaf84a2ce9b" />
