### PR TITLE
assorted: synchronize only hakoniwa spawn, not file writes

### DIFF
--- a/crates/common/src/archive.rs
+++ b/crates/common/src/archive.rs
@@ -198,7 +198,6 @@ fn extract_tar_impl<R: Read>(
     dest_dir: &Path,
     strip_prefix: Option<&String>,
 ) -> Result<(), ArchiveError> {
-    let _guard = super::FdSynchronizer::lock_writing_files();
     let mut archive = tar::Archive::new(reader);
 
     if let Some(prefix) = strip_prefix {

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -21,27 +21,21 @@ use std::{
     env, fmt,
     io::{self, ErrorKind, Write},
     path::{Path, PathBuf},
-    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+    sync::{Mutex, MutexGuard},
 };
 use tracing::warn;
 
-static HAKONIWA_SPAWN_LOCK: RwLock<()> = RwLock::new(());
+static HAKONIWA_SPAWN_LOCK: Mutex<()> = Mutex::new(());
 
 /// Global lock to synchronize the creation of files with any calls to fork(),
 /// which may in-advertently inherit them.
 pub struct FdSynchronizer;
 
 impl FdSynchronizer {
-    /// Returns a RAII guard that symbolizes that files may be written.
-    pub fn lock_writing_files() -> RwLockReadGuard<'static, ()> {
-        HAKONIWA_SPAWN_LOCK
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
     /// Returns a RAII guard that symbolizes that you may fork+exec.
-    pub fn lock_fork() -> RwLockWriteGuard<'static, ()> {
+    pub fn lock_fork() -> MutexGuard<'static, ()> {
         HAKONIWA_SPAWN_LOCK
-            .write()
+            .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }

--- a/crates/op/src/subsets.rs
+++ b/crates/op/src/subsets.rs
@@ -46,7 +46,6 @@ impl<'a> Runnable for SubsetBuild<'a> {
 
         // Copy all matched files into the under-construction subset
         let out_base = out.path();
-        let l = common::FdSynchronizer::lock_writing_files();
         for file in files.into_iter() {
             let trimmed = file.strip_prefix(&build_dir).unwrap();
             if let Some(parent) = trimmed.parent() {
@@ -54,7 +53,6 @@ impl<'a> Runnable for SubsetBuild<'a> {
             }
             std::fs::copy(&file, out_base.join(trimmed))?;
         }
-        drop(l);
 
         Ok(out)
     }

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -662,8 +662,6 @@ impl Sandbox {
         let output_dir = self.base_dir.join("build").join("output");
         let dest_dir = dest_dir.as_ref();
 
-        let _l = FdSynchronizer::lock_writing_files();
-
         for entry in walkdir::WalkDir::new(&output_dir) {
             let entry =
                 entry.map_err(|e| Error::IO("walking outputs", output_dir.clone(), e.into()))?;


### PR DESCRIPTION
Hakoniwa has closed unneeded FD's before spawn returns for some time now, which afaict negates the need for us to sequences writing out package files with sandbox spawns.