### PR TITLE
crates/sandbox2: fix overflowing small stack for min commands

### DIFF
--- a/crates/sandbox2/src/listener.rs
+++ b/crates/sandbox2/src/listener.rs
@@ -39,10 +39,12 @@ impl<C: Channel + Send> Listener<C> {
         let channel_addr = &mut *channel as *mut C as usize;
 
         let rootfs = rootfs.into();
-        let thread = thread::spawn(move || {
-            let channel: &mut C = unsafe { &mut *(channel_addr as *mut C) };
-            Self::run(listener, channel, shutdown_clone, rootfs);
-        });
+        let thread = thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(move || {
+                let channel: &mut C = unsafe { &mut *(channel_addr as *mut C) };
+                Self::run(listener, channel, shutdown_clone, rootfs);
+            })?;
 
         Ok(Self {
             shutdown,


### PR DESCRIPTION
Fixes:

```sh
xxx@lptp:~/minimal$ cargo run -- -C ~/pkgs shell

bash-5.3$ min check bash

thread '<unknown>' (1568181) has overflowed its stack
fatal runtime error: stack overflow, aborting
bash-5.3$ Aborted
```