### PR TITLE
crates/check: add checks for missing interpreter for executable scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4230,7 +4230,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdlib"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "indoc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,4 +112,4 @@ remote-proto = { version = "0.0.1", path = "crates/remote-proto" }
 remote-client = { version = "0.0.1", path = "crates/remote-client" }
 sandbox2 = { version = "0.0.1", path = "crates/sandbox2" }
 
-stdlib = { version = "0.0.8", path = "crates/stdlib" }
+stdlib = { version = "0.0.9", path = "crates/stdlib" }

--- a/crates/check/src/naming.rs
+++ b/crates/check/src/naming.rs
@@ -162,9 +162,10 @@ impl crate::GraphBasedChecker for OutputNaming {
         result.verdict = CheckVerdict::Pass;
         for (name, output) in &build.outputs {
             match output {
-                BuildOutput::Binary { glob }
-                    if glob == "usr/bin/*" || glob == "usr/bin/**" || glob == "usr/bin/**/*" =>
-                {
+                BuildOutput::Binary {
+                    glob,
+                    allow_missing_interpreter: _,
+                } if glob == "usr/bin/*" || glob == "usr/bin/**" || glob == "usr/bin/**/*" => {
                     if name != "bins" {
                         result.err.push(format!(
                                 "{}: binary output {}: catch-all binary outputs should be named 'bins' by convention",
@@ -245,7 +246,7 @@ impl crate::GraphBasedChecker for EnumerateBins {
             .map_err(|e| Error::IO("stat binary", bins_dir, e))?;
 
         let has_bins_wildcard = build.outputs.iter().any(|o| {
-            matches!(o.1, BuildOutput::Binary { glob }
+            matches!(o.1, BuildOutput::Binary { glob, allow_missing_interpreter: _ }
             if glob == "usr/bin/*" || glob == "usr/bin/**" || glob == "usr/bin/**/*")
         });
         if !has_bins_wildcard {

--- a/crates/check/src/outputs.rs
+++ b/crates/check/src/outputs.rs
@@ -161,9 +161,13 @@ impl crate::GraphBasedChecker for MissingRuntimeDeps {
 
         result.verdict = CheckVerdict::Pass;
 
-        // Collect the ELF imports that each file in each bin/lib output wants.
+        // Collect:
+        //  - the ELF imports that each file in each bin/lib output wants.
+        //  - the interpreter of any executable scripts
         let mut all_imports: HashMap<String, HashMap<(&String, PathBuf), HashSet<String>>> =
             HashMap::with_capacity(1024);
+        let mut script_interpreters: HashMap<PathBuf, (String, String)> =
+            HashMap::with_capacity(32);
         for (name, output) in &build.outputs {
             let glob = output.glob();
             for path in common::match_files_for_glob(cached_build.path(), glob)
@@ -207,6 +211,32 @@ impl crate::GraphBasedChecker for MissingRuntimeDeps {
                             }
                         }
                     }
+                }
+
+                if let BuildOutput::Binary {
+                    glob: _,
+                    allow_missing_interpreter: false,
+                } = output
+                    && data.starts_with(b"#!")
+                    && let Some(newline_idx) = data.iter().position(|c| c == &b'\n')
+                {
+                    // NOTE: most Linux kernels (and many Unix systems) treat everything after #!
+                    // up to the first space as the interpreter, and everything after the first space
+                    // as a single argument. So we just collect everything after the shebang up to
+                    // the first space (or, newline).
+                    let interpreter = String::from_utf8(data[2..newline_idx].to_vec())
+                        .map_err(|e| Error::Other(e.into()))?
+                        .trim_start()
+                        .split(" ")
+                        .next()
+                        .unwrap()
+                        .to_string();
+                    script_interpreters.insert(
+                        path.strip_prefix(cached_build.path())
+                            .unwrap()
+                            .to_path_buf(),
+                        (name.clone(), interpreter),
+                    );
                 }
             }
         }
@@ -305,6 +335,35 @@ impl crate::GraphBasedChecker for MissingRuntimeDeps {
                     ));
                     result.verdict = CheckVerdict::Fail;
                 }
+            }
+        }
+
+        // Lets also check that all binary outputs which are scripts (i.e. start with a shebang) declare a runtime
+        // dep providing the interpreter.
+        for (bin_path, (output_name, interpreter)) in script_interpreters.into_iter() {
+            let interpreter = interpreter.trim_start_matches("/");
+
+            let satisfied = deps.iter().any(|(_bsr, cache_dir)| {
+                if cache_dir.path().join(&interpreter).exists() {
+                    return true;
+                }
+                if let Some(rest) = interpreter.strip_prefix("/bin/")
+                    && cache_dir.path().join("usr/bin").join(rest).exists()
+                {
+                    return true;
+                }
+
+                false
+            });
+
+            if !satisfied {
+                result.err.push(format!(
+                    "interpreter '{}' not in runtime deps, needed by script {} (output {})",
+                    interpreter,
+                    bin_path.display(),
+                    output_name,
+                ));
+                result.verdict = CheckVerdict::Fail;
             }
         }
 

--- a/crates/decode/src/builds.rs
+++ b/crates/decode/src/builds.rs
@@ -574,13 +574,19 @@ pub enum BuildOutput {
         allow_executable: bool,
     },
     /// This output describes binaries matched with the given glob.
-    Binary { glob: String },
+    Binary {
+        glob: String,
+        allow_missing_interpreter: bool,
+    },
 }
 
 impl BuildOutput {
     pub fn glob(&self) -> &String {
         match self {
-            BuildOutput::Binary { glob } => glob,
+            BuildOutput::Binary {
+                glob,
+                allow_missing_interpreter: _,
+            } => glob,
             BuildOutput::Data {
                 glob,
                 allow_executable: _,
@@ -602,6 +608,7 @@ impl BuildOutput {
         let mut glob: Option<String> = None;
         let mut allow_executable: Option<bool> = None;
         let mut allow_data: Option<bool> = None;
+        let mut allow_missing_interpreter: Option<bool> = None;
 
         match rt.term.as_ref() {
             Term::Record(r) | Term::RecRecord(r, _, _, _) => {
@@ -635,6 +642,14 @@ impl BuildOutput {
                                 }
                                 Ok(())
                             }
+                            "allow_missing_interpreter" => {
+                                if let Some(rt) = field.value.as_ref() {
+                                    allow_missing_interpreter = Some(
+                                        bool::deserialize(eval_if_closure(rt, program)?).unwrap(),
+                                    );
+                                }
+                                Ok(())
+                            }
                             _ => Ok(()), // TODO: Should we error if we see an unknown field?
                         }
                     })?;
@@ -654,6 +669,7 @@ impl BuildOutput {
         };
         let allow_executable = allow_executable.unwrap_or(false);
         let allow_data = allow_data.unwrap_or(false);
+        let allow_missing_interpreter = allow_missing_interpreter.unwrap_or(false);
 
         match ty {
             ObjTy::OutputLib => Ok(BuildOutput::Library { glob, allow_data }),
@@ -661,7 +677,10 @@ impl BuildOutput {
                 glob,
                 allow_executable,
             }),
-            ObjTy::OutputBin => Ok(BuildOutput::Binary { glob }),
+            ObjTy::OutputBin => Ok(BuildOutput::Binary {
+                glob,
+                allow_missing_interpreter,
+            }),
             _ => Err(Error::UnexpectedObject {
                 files: program.files(),
                 got: ty,
@@ -1597,7 +1616,8 @@ mod tests {
         assert_eq!(
             o_bin,
             BuildOutput::Binary {
-                glob: "/bin/uwu".to_string()
+                glob: "/bin/uwu".to_string(),
+                allow_missing_interpreter: false,
             },
         );
         // We expect that buildspec to have one Data output

--- a/crates/graph/src/builds.rs
+++ b/crates/graph/src/builds.rs
@@ -149,13 +149,19 @@ pub enum BuildOutput {
         allow_executable: bool,
     },
     /// This output describes binaries matched with the given glob.
-    Binary { glob: String },
+    Binary {
+        glob: String,
+        allow_missing_interpreter: bool,
+    },
 }
 
 impl BuildOutput {
     pub fn glob(&self) -> &String {
         match self {
-            BuildOutput::Binary { glob } => glob,
+            BuildOutput::Binary {
+                glob,
+                allow_missing_interpreter: _,
+            } => glob,
             BuildOutput::Data {
                 glob,
                 allow_executable: _,

--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -114,7 +114,13 @@ impl BuildDep {
 impl BuildOutput {
     fn from_decoded(bd: &builds::BuildOutput) -> Self {
         match bd.clone() {
-            builds::BuildOutput::Binary { glob } => Self::Binary { glob },
+            builds::BuildOutput::Binary {
+                glob,
+                allow_missing_interpreter,
+            } => Self::Binary {
+                glob,
+                allow_missing_interpreter,
+            },
             builds::BuildOutput::Data {
                 glob,
                 allow_executable,
@@ -885,7 +891,7 @@ impl Graph {
                         ("libs", BuildOutput::Library { .. }) => None,
                         (_, BuildOutput::Data { .. }) => None,
                         // Match binaries by name or usr/bin/{s}
-                        (_, BuildOutput::Binary { glob }) => {
+                        (_, BuildOutput::Binary { glob, .. }) => {
                             if let Some(m) = fuzzy_match(term, name.as_str())
                                 && m > min_output_match
                             {

--- a/crates/graph/src/spec_hasher.rs
+++ b/crates/graph/src/spec_hasher.rs
@@ -148,9 +148,15 @@ fn build_output_hash(output: &BuildOutput, h: &mut Hasher) {
                 h.write_all(b"-allow_exec").unwrap();
             }
         }
-        Binary { glob } => {
+        Binary {
+            glob,
+            allow_missing_interpreter,
+        } => {
             h.write_all(b"bin").unwrap();
             h.write_all(glob.as_bytes()).unwrap();
+            if *allow_missing_interpreter {
+                h.write_all(b"-allow_missing_interp").unwrap();
+            }
         }
     }
 }

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stdlib"
-version = "0.0.8"
+version = "0.0.9"
 rust-version = "1.87"
 license = "MIT OR Apache-2.0"
 edition.workspace = true

--- a/crates/stdlib/minimal-ncl/minimal.ncl
+++ b/crates/stdlib/minimal-ncl/minimal.ncl
@@ -62,6 +62,7 @@ let CmdSpec = std.contract.any_of [
         ty | Tys = 'OutputBin,
         glob
           | String,
+        allow_missing_interpreter | Bool | optional,
     },
     OutputData | doc "An output of a build spec which represents data files that are used during execution." = {
         ty | Tys = 'OutputData,


### PR DESCRIPTION
This will cause a dozen or so packages to go red but thats okay, I will fix before this gets promoted