### PR TITLE
crates/orchestrator: make cpu shares more aggressive for critical-path builds

### DIFF
--- a/crates/orchestrator/src/local_backend.rs
+++ b/crates/orchestrator/src/local_backend.rs
@@ -219,7 +219,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
                     },
                 ),
                 cancel: shared.backend.cancel.clone(),
-                cpu_weight: Some(((80 + depended_on_by * 10) as u64).min(10000)),
+                cpu_weight: Some(((60 + depended_on_by * 25) as u64).min(10000)),
             };
 
             let res = b


### PR DESCRIPTION
Shares are linear and relative to every other cgroup in the parent, which is still too even across the concurrent builds. Bump up the multiple to make critical-path builds get an even greater share.