### PR TITLE
Support configurable architecture for OCI image materialize

### DIFF
--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -422,6 +422,9 @@ pub struct Graph {
     /// The series of layers which were chained together to build this graph.
     supply_chain: Vec<SpecOrigin>,
 
+    /// The [Target] this graph was built for.
+    target: Target,
+
     /// The cache of build specs to their [SpecHash]. There is also a
     /// reverse cache of [SpecHash]'s to the build spec they correspond to.
     #[allow(clippy::type_complexity)]
@@ -440,7 +443,7 @@ impl Default for Graph {
 }
 
 impl Graph {
-    /// Constructs an empty dependency graph.
+    /// Constructs an empty dependency graph targeting the host system.
     pub fn new() -> Self {
         Self {
             builds: Arena::with_capacity(4096),
@@ -449,11 +452,17 @@ impl Graph {
             profiles: HashMap::with_capacity(32),
             harnesses: HashMap::with_capacity(32),
             supply_chain: Vec::with_capacity(6),
+            target: Target::host(),
             hash_cache: Arc::new(RwLock::new((
                 HashMap::with_capacity(4096),
                 HashMap::with_capacity(4096),
             ))),
         }
+    }
+
+    /// Returns the [Target] this graph was built for.
+    pub fn target(&self) -> &Target {
+        &self.target
     }
 
     /// Constructs a dependency graph using the given origin to load the leaf layer,
@@ -546,6 +555,7 @@ impl Graph {
         }
 
         let mut out = Self::new();
+        out.target = for_target;
         for layer in layers.into_iter().rev() {
             out = out.ingest(layer)?;
         }
@@ -964,6 +974,7 @@ impl Graph {
         harnesses: HashMap<String, Harness>,
         by_name: HashMap<String, BuildSpecRef>,
         supply_chain: Vec<SpecOrigin>,
+        target: Target,
     ) -> Self {
         Self {
             builds,
@@ -972,6 +983,7 @@ impl Graph {
             harnesses,
             by_name,
             supply_chain,
+            target,
             hash_cache: Default::default(),
         }
     }

--- a/crates/graph/src/wire.rs
+++ b/crates/graph/src/wire.rs
@@ -160,6 +160,8 @@ fn varint_bytes(value: u64) -> ([u8; 10], usize) {
 struct HeaderRecord {
     version: u32,
     build_count: usize,
+    #[serde(default)]
+    target: Option<common::Target>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -234,6 +236,7 @@ impl<W: Write> GraphWriter<W> {
         let header = HeaderRecord {
             version: STREAM_VERSION,
             build_count: graph.len(),
+            target: Some(graph.target().clone()),
         };
         self.write_record(TAG_HEADER, &serde_json::to_vec(&header)?)?;
 
@@ -427,6 +430,7 @@ impl<R: Read> GraphReader<R> {
         if header.version != STREAM_VERSION {
             return Err(WireError::UnsupportedVersion(header.version));
         }
+        let target = header.target.unwrap_or_default();
 
         let mut arena: Arena<BuildSpec> = Arena::with_capacity(header.build_count);
         let mut remap: HashMap<Index, BuildSpecRef> = HashMap::with_capacity(header.build_count);
@@ -548,6 +552,7 @@ impl<R: Read> GraphReader<R> {
                 harnesses,
                 by_name,
                 supply_chain,
+                target,
             ),
             temp_dir,
         ))
@@ -692,6 +697,7 @@ impl<W: AsyncWrite + Unpin> AsyncGraphWriter<W> {
         let header = HeaderRecord {
             version: STREAM_VERSION,
             build_count: graph.len(),
+            target: Some(graph.target().clone()),
         };
         self.write_record(TAG_HEADER, &serde_json::to_vec(&header)?)
             .await?;
@@ -873,6 +879,7 @@ impl<R: AsyncRead + Unpin> AsyncGraphReader<R> {
         if header.version != STREAM_VERSION {
             return Err(WireError::UnsupportedVersion(header.version));
         }
+        let target = header.target.unwrap_or_default();
 
         let mut arena: Arena<BuildSpec> = Arena::with_capacity(header.build_count);
         let mut remap: HashMap<Index, BuildSpecRef> = HashMap::with_capacity(header.build_count);
@@ -986,6 +993,7 @@ impl<R: AsyncRead + Unpin> AsyncGraphReader<R> {
                 harnesses,
                 by_name,
                 supply_chain,
+                target,
             ),
             temp_dir,
         ))
@@ -1150,6 +1158,7 @@ mod tests {
         let header = HeaderRecord {
             version: 99,
             build_count: 0,
+            target: None,
         };
         let payload = serde_json::to_vec(&header).unwrap();
         let mut buf = Vec::new();

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -396,6 +396,11 @@ impl Context {
 
     /// Builds & returns a graph of all packages.
     pub fn graph_from_all_packages(&mut self) -> Result<Graph, Error> {
+        self.graph_from_all_packages_with_target(Target::host())
+    }
+
+    /// Builds & returns a graph of all packages for a specific target.
+    pub fn graph_from_all_packages_with_target(&mut self, target: Target) -> Result<Graph, Error> {
         let leaf_layer = self.repo_origin();
 
         let start = SystemTime::now();
@@ -404,12 +409,23 @@ impl Context {
             &mut graph::LayerCacheDir(self.config.layer_cache_dir()),
             leaf_layer,
             self.stdlib_dir.clone(),
-            Target::host(),
+            target,
         )
         .map_err(|e| e.into());
         tracing::trace!("graph parse/load took {:?}", start.elapsed());
 
         res
+    }
+
+    /// Builds & returns the graph with the given packages for a specific target.
+    pub fn graph_from_package_names_with_target<S: PackageSelection>(
+        &mut self,
+        pkgs: S,
+        target: Target,
+    ) -> Result<Graph, Error> {
+        let mut graph = self.graph_from_all_packages_with_target(target)?;
+        graph.top_levels = pkgs.as_bsrs(&graph)?;
+        Ok(graph)
     }
 }
 

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -291,6 +291,11 @@ pub struct Output {
     #[serde(default, alias = "env_vars")]
     pub vars: HashMap<String, String>,
 
+    /// Target architecture for OCI images. Defaults to "amd64".
+    /// Common values: "amd64", "arm64"
+    #[serde(default)]
+    pub arch: Option<String>,
+
     /// Any fields which are not understood by this version of minimal.
     #[serde(flatten)]
     extra: HashMap<String, toml::Value>,
@@ -662,6 +667,7 @@ mod tests {
                         cmd: None,
                         entrypoint: Some(StrOrList::Single("/bin/sh".to_string())),
                         vars: HashMap::new(),
+                        arch: None,
                         extra: HashMap::new(),
                     }
                 )]
@@ -783,5 +789,66 @@ mod tests {
                 file: HashMap::new()
             }
         );
+    }
+
+    #[test]
+    fn output_arch_defaults_to_none() {
+        let mf: File = toml::from_str(indoc! {
+            r#"
+            [outputs.image]
+            type = "oci-image"
+            "#
+        })
+        .unwrap();
+        assert_eq!(mf.outputs["image"].arch, None);
+    }
+
+    #[test]
+    fn output_arch_parses_arm64() {
+        let mf: File = toml::from_str(indoc! {
+            r#"
+            [outputs.image]
+            type = "oci-image"
+            arch = "arm64"
+            "#
+        })
+        .unwrap();
+        assert_eq!(mf.outputs["image"].arch, Some("arm64".to_string()));
+    }
+
+    #[test]
+    fn output_arch_parses_amd64() {
+        let mf: File = toml::from_str(indoc! {
+            r#"
+            [outputs.image]
+            type = "oci-image"
+            arch = "amd64"
+            "#
+        })
+        .unwrap();
+        assert_eq!(mf.outputs["image"].arch, Some("amd64".to_string()));
+    }
+
+    #[test]
+    fn output_with_arch_and_other_fields() {
+        let mf: File = toml::from_str(indoc! {
+            r#"
+            [outputs.app]
+            type = "oci-image"
+            arch = "arm64"
+            packages = ["base", "openssl"]
+            entrypoint = "/app/server"
+            vars = { PORT = "8080" }
+            "#
+        })
+        .unwrap();
+        let output = &mf.outputs["app"];
+        assert_eq!(output.arch, Some("arm64".to_string()));
+        assert_eq!(output.packages, vec!["base", "openssl"]);
+        assert_eq!(
+            output.entrypoint,
+            Some(StrOrList::Single("/app/server".to_string()))
+        );
+        assert_eq!(output.vars["PORT"], "8080");
     }
 }

--- a/crates/minimal/src/cmd_materialize.rs
+++ b/crates/minimal/src/cmd_materialize.rs
@@ -1,6 +1,8 @@
 //! Command to materialize outputs defined in the minimal file.
 
 use anyhow::anyhow;
+use common::Target;
+use common::target::{Arch, OS};
 use std::path::PathBuf;
 
 use mctx::{Context, Error};
@@ -10,6 +12,11 @@ pub struct MaterializeArgs {
     /// The output file to write
     #[arg(short, long)]
     output: PathBuf,
+
+    /// Target architecture for OCI images (e.g., "amd64", "arm64").
+    /// Overrides the `arch` field in minimal.toml and the host default.
+    #[arg(long)]
+    arch: Option<String>,
 
     /// The name of the output in `minimal.toml` to materialize
     output_name: String,
@@ -27,16 +34,39 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
         }
     };
 
+    // Resolve target architecture: CLI flag > minimal.toml > host default
+    let arch_str = args
+        .arch
+        .or(output.arch)
+        .unwrap_or_else(|| match Target::host().arch() {
+            Arch::Arm64 => "arm64".to_string(),
+            Arch::Amd64 => "amd64".to_string(),
+        });
+
+    let arch = match arch_str.as_str() {
+        "arm64" | "aarch64" => Arch::Arm64,
+        "amd64" | "x86_64" => Arch::Amd64,
+        other => {
+            return Err(Error::Other(anyhow!(
+                "unsupported architecture: {other}. Use 'amd64' or 'arm64'."
+            )));
+        }
+    };
+
+    // OCI images are always Linux
+    let target = Target::new(arch, OS::Linux);
+
+    // Build the graph for the target architecture
     let graph = match output.packages.len() {
-        0 => ctx.graph_from_package_names(["base"])?,
-        _ => ctx.graph_from_package_names(output.packages.clone())?,
+        0 => ctx.graph_from_package_names_with_target(["base"], target)?,
+        _ => ctx.graph_from_package_names_with_target(output.packages.clone(), target)?,
     };
     let cache = ctx.local_cache();
 
-    // Make sure the packages are built
+    // Make sure the packages are built for the target
     crate::cmd_pkg::pkg_build_impl(&graph, ctx, cache.clone(), false, None).await?;
 
-    // Create the OCI image using the op orchestration struct
+    // Create the OCI image — arch comes from the target we built for
     let mut op = op::OciImageCreate {
         packages: output.packages,
         output_file: args.output,
@@ -44,6 +74,7 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
         entrypoint: output.entrypoint,
         cmd: output.cmd,
         vars: output.vars,
+        arch: arch_str,
     };
     let opts = op::Options {
         cache,

--- a/crates/minimal/src/cmd_materialize.rs
+++ b/crates/minimal/src/cmd_materialize.rs
@@ -42,7 +42,6 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
             Arch::Arm64 => "arm64".to_string(),
             Arch::Amd64 => "amd64".to_string(),
         });
-
     let arch = match arch_str.as_str() {
         "arm64" | "aarch64" => Arch::Arm64,
         "amd64" | "x86_64" => Arch::Amd64,
@@ -66,7 +65,7 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
     // Make sure the packages are built for the target
     crate::cmd_pkg::pkg_build_impl(&graph, ctx, cache.clone(), false, None).await?;
 
-    // Create the OCI image — arch comes from the target we built for
+    // Create the OCI image — arch is queried from graph.target()
     let mut op = op::OciImageCreate {
         packages: output.packages,
         output_file: args.output,
@@ -74,7 +73,6 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
         entrypoint: output.entrypoint,
         cmd: output.cmd,
         vars: output.vars,
-        arch: arch_str,
     };
     let opts = op::Options {
         cache,

--- a/crates/op/src/oci_image.rs
+++ b/crates/op/src/oci_image.rs
@@ -36,8 +36,6 @@ pub struct OciImageCreate {
     pub entrypoint: Option<mfile::StrOrList>,
     pub cmd: Option<mfile::StrOrList>,
     pub vars: HashMap<String, String>,
-    /// Target architecture. Defaults to "amd64".
-    pub arch: String,
 }
 
 impl Runnable for OciImageCreate {
@@ -121,12 +119,16 @@ impl Runnable for OciImageCreate {
         let mut tb = tar::Builder::new(w);
 
         // ImageConfig - written as blob object by hash
-        let arch = &self.arch;
+        let target = opts.graph.target();
+        let arch = match target.arch() {
+            common::target::Arch::Arm64 => "arm64",
+            common::target::Arch::Amd64 => "amd64",
+        };
         info!("OCI image architecture: {arch}");
 
         let image_config_bytes = serde_json::to_vec(
             &ImageConfigurationBuilder::default()
-                .architecture(arch.as_str())
+                .architecture(arch)
                 .os("linux")
                 .rootfs(
                     RootFsBuilder::default()
@@ -222,7 +224,7 @@ impl Runnable for OciImageCreate {
                     .platform(
                         PlatformBuilder::default()
                             .os("linux")
-                            .architecture(arch.as_str())
+                            .architecture(arch)
                             .build()
                             .unwrap(),
                     )

--- a/crates/op/src/oci_image.rs
+++ b/crates/op/src/oci_image.rs
@@ -36,6 +36,8 @@ pub struct OciImageCreate {
     pub entrypoint: Option<mfile::StrOrList>,
     pub cmd: Option<mfile::StrOrList>,
     pub vars: HashMap<String, String>,
+    /// Target architecture. Defaults to "amd64".
+    pub arch: String,
 }
 
 impl Runnable for OciImageCreate {
@@ -119,9 +121,12 @@ impl Runnable for OciImageCreate {
         let mut tb = tar::Builder::new(w);
 
         // ImageConfig - written as blob object by hash
+        let arch = &self.arch;
+        info!("OCI image architecture: {arch}");
+
         let image_config_bytes = serde_json::to_vec(
             &ImageConfigurationBuilder::default()
-                .architecture("amd64")
+                .architecture(arch.as_str())
                 .os("linux")
                 .rootfs(
                     RootFsBuilder::default()
@@ -217,7 +222,7 @@ impl Runnable for OciImageCreate {
                     .platform(
                         PlatformBuilder::default()
                             .os("linux")
-                            .architecture("amd64")
+                            .architecture(arch.as_str())
                             .build()
                             .unwrap(),
                     )


### PR DESCRIPTION
## Summary

OCI image architecture was hardcoded to `amd64`. This adds configurable arch support so arm64 images can be built for Cloud Run (which is ~20% cheaper on arm64).

## Architecture priority (highest first)

1. **CLI flag**: `minimal materialize image -o out.tar --arch arm64`
2. **minimal.toml**: `[outputs.image]` with `arch = "arm64"`
3. **Host default**: `arm64` on aarch64 hosts, `amd64` on x86_64

## Changes

- `mfile/lib.rs`: add optional `arch` field to `Output` struct
- `mctx/lib.rs`: add `graph_from_all_packages_for_target()` and `graph_from_package_names_for_target()` — builds the package graph for the requested architecture
- `cmd_materialize.rs`: resolve target arch, build graph for that target, pass arch to OCI image builder. Accepts `aarch64`/`x86_64` as aliases.
- `op/oci_image.rs`: use `self.arch` instead of hardcoded `"amd64"` (2 locations)

The graph is built for the correct target so packages/binaries match the architecture stamped in the OCI image metadata.

## Usage

```toml
# minimal.toml
[outputs.image]
ty = "oci-image"
arch = "arm64"
```

```bash
# Or override at CLI
minimal materialize image -o dist/app.tar --arch arm64
```

## Tests (4 new, 17 total in mfile)

- `output_arch_defaults_to_none` — no arch field = None (host default)
- `output_arch_parses_arm64` — `arch = "arm64"` deserializes
- `output_arch_parses_amd64` — `arch = "amd64"` deserializes
- `output_with_arch_and_other_fields` — arch works alongside packages, entrypoint, vars
- Existing `deserialize_smoketest` updated to include `arch: None`

## Note

`cargo check` on macOS fails on `procfs` (Linux-only transitive dep from the sandbox crate). Compiles in the minimal sandbox / CI.