### PR TITLE
decode,graph: defer BuildDecl.target resolution to graph construction

### DIFF
--- a/crates/decode/src/builds.rs
+++ b/crates/decode/src/builds.rs
@@ -746,8 +746,14 @@ impl RuntimeDep {
 pub struct BuildDecl {
     /// The human-readable name declared on the build decl.
     pub name: String,
-    /// The system this build-decl is meant to run on. Defaults to amd64 Linux.
-    pub target: Target,
+    /// The system this build-decl is meant to run on.
+    ///
+    /// `None` means the build-decl did not explicitly declare a target and should
+    /// be hydrated with the target of whatever graph is being constructed from it.
+    /// This happens at the decode→graph seam in `graph::BuildSpec::from_decoded`,
+    /// which consults `Loader::for_target`. See gominimal/infra#18 for the arm64
+    /// res-server dispatch bug that motivated moving this from eager to deferred.
+    pub target: Option<Target>,
     /// Any attributes explicitly set on this build-decl.
     pub attrs: Option<IndexMap<String, AttrValue>>,
     /// Marker that this build-spec is a prebuilt, meaning:
@@ -1225,7 +1231,7 @@ impl BuildDecl {
             attrs,
             prebuilt,
             build_args,
-            target: target.unwrap_or(Target::host()),
+            target,
             build_deps,
             runtime_deps,
             abstract_deps: needs,
@@ -1421,7 +1427,7 @@ mod tests {
                 replace_on_cycle,
                 tests: None,
             } if name == "single buildspec" &&
-                target == Target::host() &&
+                target.is_none() &&
                 cmds == vec![vec!["./build.sh"]] &&
                 replace_on_cycle.is_none() &&
                 build_args == Some([("fish".to_string(), "swiggity swooty".to_string())].into()) &&
@@ -1566,7 +1572,7 @@ mod tests {
 
         let build = BuildDecl::from_term(&term, &mut program, &mut ()).unwrap();
 
-        assert_eq!(build.target, Target::new(Arch::Arm64, OS::MacOS),);
+        assert_eq!(build.target, Some(Target::new(Arch::Arm64, OS::MacOS)),);
     }
 
     #[test]

--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -29,6 +29,10 @@ struct Loader {
     origin: Arc<SpecOrigin>,
     into_graph: RefCell<Graph>,
     resolved: RefCell<HashMap<generational_arena::Index, BuildSpecRef>>,
+    /// The target the containing graph is being constructed for. Used to hydrate
+    /// any [`decode::builds::BuildDecl::target`] that was left `None` by the
+    /// decoder (i.e. no explicit target in the NCL).
+    for_target: Target,
 }
 
 impl Loader {
@@ -163,7 +167,14 @@ impl BuildSpec {
     fn from_decoded(bd: &builds::BuildDecl, loader: &Loader) -> Result<Self, Error> {
         Ok(Self {
             name: bd.name.clone(),
-            target: bd.target.clone(),
+            // If the NCL didn't explicitly set a target, inherit from the
+            // graph's target. This is how a graph constructed on amd64 for
+            // arm64 execution (e.g. buildbot dispatching to res-server-arm64)
+            // produces specs that match the destination host.
+            target: bd
+                .target
+                .clone()
+                .unwrap_or_else(|| loader.for_target.clone()),
             prebuilt: bd.prebuilt,
             cmds: bd.cmds.clone(),
             build_args: bd.build_args.clone(),
@@ -564,11 +575,15 @@ impl Graph {
 
     /// Loads build declarations in from the given layer.
     pub fn ingest(self, layer: Layer) -> Result<Self, Error> {
+        // Capture the target before self moves into the Loader. Set by
+        // `new_from_chain` (`out.target = for_target`) prior to ingesting layers.
+        let for_target = self.target.clone();
         let mut loader = Loader {
             origin: Arc::new(layer.origin.clone()),
             from: layer,
             into_graph: RefCell::new(self),
             resolved: RefCell::new(HashMap::with_capacity(1024)),
+            for_target,
         };
         let new_toplevels = loader.load_toplevels()?;
 


### PR DESCRIPTION
## Summary

Defers target resolution on `BuildDecl` from decode-time to graph-construction-time, so graphs constructed on one arch for execution on a different arch (e.g. `buildbot` on amd64 dispatching to `res-server-arm64`) produce specs whose `target` field matches the destination host.

Tom proposed the approach on Slack; this is the implementation.

## Root cause

`decode::BuildDecl.target` previously had type `Target` and defaulted at decode time via `target.unwrap_or(Target::host())` (`crates/decode/src/builds.rs:1228` on `main`). `Target::host()` is a `const fn` dispatched by `cfg!()` at compile time, so it captured the architecture of the process *running the decoder*, not the target the caller actually requested via `graph_from_all_packages_with_target(target)`.

When the decoder and the executor ran on the same host (every historical invocation until now) the check at `crates/op/src/specs.rs:256` silently passed. The first cross-host graph construction — an amd64 `build-bot` VM generating a graph to dispatch to `res-server-arm64` — hit:

```
cannot build spec with target amd64/linux on arm64/linux
```

See the full trace in the issue / in [this debugging session][session].

[session]: <linked from PR discussion if needed>

## Fix

Change `BuildDecl.target` from `Target` to `Option<Target>`:
- `None` means "the NCL didn't set it; inherit from the graph this spec is being constructed into."
- `Some(_)` preserves the ability for an NCL author to pin a spec to an explicit target (no package currently does this, but the capability is retained).

Hydration happens at the decode→graph seam in `graph::BuildSpec::from_decoded`, which consults a new `Loader::for_target` field. The Loader's `for_target` is populated in `Graph::ingest` by cloning `self.target` before the graph moves into the loader's `RefCell`. This works because `Graph::new_from_chain` (already on `main` from 39d2d52c) sets `out.target = for_target` before calling `ingest`, so by the time the loader runs, `self.target` holds the correct value.

## Scope of changes

Only **two files** touched. Grepping for readers of `BuildDecl.target` across the entire workspace:

| File | Kind | Notes |
|---|---|---|
| `crates/graph/src/graph.rs:166` | **Reader** (only prod one) | Updated to `bd.target.clone().unwrap_or_else(\|\| loader.for_target.clone())` |
| `crates/decode/src/builds.rs:750` | Definition | Type: `Target` → `Option<Target>` |
| `crates/decode/src/builds.rs:1228` | Writer (`from_term`) | `target.unwrap_or(Target::host())` → `target,` (pass-through) |
| `crates/decode/src/builds.rs:1424-1429` | Test (`simple_buildspec`) | `target == Target::host()` → `target.is_none()` |
| `crates/decode/src/builds.rs:1569` | Test (NCL-declared target) | Wrapped in `Some(...)` |
| `crates/decode/src/lib.rs` | Holds `Arena<BuildDecl>` / `BuildDecl::default()` | No changes — `Option::default() = None`, correct. |
| `crates/minimal/src/cmd_dep.rs` | `edge_ref.target()` etc. | Unrelated — petgraph edge accessors, not `BuildDecl.target`. |

No wire-protocol change. No `pkgs` change. No `res-server` change. No changes to `Target` type itself.

## Tests

- `cargo test -p decode` — 42/42 passing. The two test updates at `:1424-1429` (now asserts `target.is_none()`) and `:1569` (now wraps in `Some(...)`) both pass.
- `cargo test -p graph` — the 44 non-`spec_hasher` tests pass. The 5 `spec_hasher::tests::*` failures are **pre-existing on `main`** in my macOS dev environment (`cargo test -p graph spec_hasher` fails identically with my changes stashed). They are not caused by this PR. CI will run on Linux where they should pass.
- `cargo check -p decode -p graph` — clean.
- `cargo check -p mctx` / anything pulling in `sandbox2` — fails on my macOS dev host due to `procfs` / `caps` being Linux-only, not related to this PR. CI covers the full workspace on `ubuntu-latest`.
- `cargo fmt --check -p decode -p graph` — clean.
- `cargo clippy -p decode -p graph -- -D warnings` — clean.

## Operational note for downstream consumers

Existing entries in any `layer_cache_dir` (`~/.cache/minimal/...` on dev hosts, and the one on the `build-bot` prod VM) were written under the old schema where every `BuildDecl` had a concrete `target: Target` baked in — almost always `amd64/linux` if the writer was an amd64 buildbot process. Those JSON payloads will deserialize cleanly under `Option<Target>` as `Some(amd64/linux)` (serde handles this transparently), **but** they will continue to carry the wrong cached target until rewritten, so arm64 res-server dispatch on a cold re-run will still fail against a stale cache.

Recommended post-merge step on any host that caches layers (especially `build-bot` on prod):

```bash
# From a session on build-bot:
sudo rm -rf /var/lib/buildbot/layer_cache   # or wherever `layer_cache_dir` points
```

Then re-trigger a run — the fresh decode will produce `Some(None) → hydrated from graph` targets and dispatch correctly.

## Test plan (for reviewer)

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p decode -p graph -- -D warnings` clean
- [x] `cargo test -p decode` 42/42 pass
- [x] `cargo test -p graph` (non-spec_hasher) pass
- [ ] Full CI on Linux (spec_hasher, mctx, op/specs, sandbox2, cross-arch release builds)
- [ ] After merge + `gominimal/build-servers` rev bump + fresh buildbot binary + `layer_cache` clear: arm64 dispatch through `res-server-arm64` should progress past `op/src/specs.rs:256` and actually run builds

## Related

- `gominimal/infra#18` merged earlier today: deploys the second res-server instance on arm64.
- `gominimal/build-servers` will need a follow-up bump of the `minimal` git dep revs to point at this commit once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
