### PR TITLE
all: nickel-lang-core 0.15.3 → 0.17.0

### DIFF
--- a/.minimal/minimal.toml
+++ b/.minimal/minimal.toml
@@ -1,7 +1,7 @@
 [upstream] # Source of software & tooling
 repo = "https://github.com/gominimal/pkgs"
 branch = "main"
-locked_commit = "f50ffcb0dd274f8cc063d66ea9963819406f10d4"
+locked_commit = "20fb6d2868ed90693be7561f6c9e70a7a76d70ca"
 
 [harness]
 use = "rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,16 +235,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bit-set"
@@ -411,7 +438,7 @@ dependencies = [
  "graph",
  "lcache",
  "nickel-lang-core",
- "object",
+ "object 0.38.1",
  "op",
  "ot",
  "regex",
@@ -545,23 +572,12 @@ checksum = "2205f7f6d3de68ecf4c291c789b3edf07b6569268abd0188819086f71ae42225"
 
 [[package]]
 name = "codespan"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4b418d52c9206820a56fc1aa28db73d67e346ba8ba6aa90987e8d6becef7e4"
+checksum = "583f52b0658b321b25fd6b209b6c76cf058f433071297de64e5980c3d9aad937"
 dependencies = [
- "codespan-reporting 0.12.0",
+ "codespan-reporting",
  "serde",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
-dependencies = [
- "serde",
- "termcolor",
- "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -893,7 +909,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "blake3",
- "codespan-reporting 0.13.1",
+ "codespan-reporting",
  "common",
  "either",
  "generational-arena",
@@ -1292,6 +1308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,7 +1551,7 @@ version = "0.0.1"
 dependencies = [
  "blake3",
  "checkouts",
- "codespan-reporting 0.13.1",
+ "codespan-reporting",
  "common",
  "decode",
  "generational-arena",
@@ -2025,6 +2047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,12 +2270,21 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json_scanner"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0a2dc336065c75719cffd3c6c929e0ec4ed85b92b8248a7bbd999acb0e419c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2433,34 +2470,32 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logos"
-version = "0.15.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-codegen"
-version = "0.15.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
 dependencies = [
- "beef",
  "fnv",
- "lazy_static",
  "proc-macro2",
  "quote",
+ "regex-automata",
  "regex-syntax",
- "rustc_version",
  "syn",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.15.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
 dependencies = [
  "logos-codegen",
 ]
@@ -2501,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "malachite"
-version = "0.6.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec410515e231332b14cd986a475d1c3323bcfa4c7efc038bfa1d5b410b1c57e4"
+checksum = "8de8195e0d0bccfa3e54997e8e7c6c67859b08512067801b5a63dd0b7a174e87"
 dependencies = [
  "malachite-base",
  "malachite-float",
@@ -2513,11 +2548,11 @@ dependencies = [
 
 [[package]]
 name = "malachite-base"
-version = "0.6.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c738d3789301e957a8f7519318fcbb1b92bb95863b28f6938ae5a05be6259f34"
+checksum = "a8b6f86fdbb1eb9955946be91775239dfcb0acdb1a51bb07d5fc9b8c854f5ccd"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "itertools 0.14.0",
  "libm",
  "ryu",
@@ -2525,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-float"
-version = "0.6.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9446a966be7f1708c10badd6690d3094b5ad62d3accdcf2154740656d7650cfa"
+checksum = "47d5021773c1552820b10ce7410817fadc1dfcef907b4f9a29af5346d756fd28"
 dependencies = [
  "itertools 0.14.0",
  "malachite-base",
@@ -2538,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-nz"
-version = "0.6.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1707c9a1fa36ce21749b35972bfad17bbf34cf5a7c96897c0491da321e387d3b"
+checksum = "0197a2f5cfee19d59178e282985c6ca79a9233e26a2adcf40acb693896aa09f6"
 dependencies = [
  "itertools 0.14.0",
  "libm",
@@ -2551,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-q"
-version = "0.6.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d764801aa4e96bbb69b389dcd03b50075345131cd63ca2e380bca71cc37a3675"
+checksum = "be2add95162aede090c48f0ee51bea7d328847ce3180aa44588111f846cc116b"
 dependencies = [
  "itertools 0.14.0",
  "malachite-base",
@@ -2583,7 +2618,7 @@ dependencies = [
  "anyhow",
  "check",
  "checkouts",
- "codespan-reporting 0.13.1",
+ "codespan-reporting",
  "common",
  "dirs",
  "futures",
@@ -2663,6 +2698,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,7 +2753,7 @@ dependencies = [
  "checkouts",
  "clap",
  "clap_complete",
- "codespan-reporting 0.13.1",
+ "codespan-reporting",
  "common",
  "decode",
  "dirs",
@@ -2778,25 +2843,29 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nickel-lang-core"
-version = "0.15.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cdfc3035139574c1c362e19d62c411da194ec5b541c9ebb4716393ce83af1f"
+checksum = "81ec3efee570877109c89bd23e5a44ff7b4a60f1d3c6394945a2520ebda84117"
 dependencies = [
+ "base64",
  "bumpalo",
  "codespan",
- "codespan-reporting 0.12.0",
+ "codespan-reporting",
  "colorchoice",
  "indexmap 2.14.0",
  "indoc",
+ "json_scanner",
  "lalrpop",
  "lalrpop-util",
  "logos",
  "malachite",
  "malachite-q",
  "md-5",
+ "nickel-lang-parser",
  "nickel-lang-vector",
  "once_cell",
  "ouroboros",
+ "paste",
  "pretty",
  "regex",
  "saphyr-parser",
@@ -2810,12 +2879,38 @@ dependencies = [
  "strip-ansi-escapes",
  "strsim",
  "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "topiary-core",
  "topiary-queries",
  "tree-sitter-nickel",
  "typed-arena",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nickel-lang-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f405189a72d136913a3ec470a27def520e93784b611578c2e4f3dd909b3fc75"
+dependencies = [
+ "bumpalo",
+ "codespan",
+ "codespan-reporting",
+ "indexmap 2.14.0",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "malachite",
+ "nickel-lang-vector",
+ "ouroboros",
+ "pretty",
+ "regex",
+ "saphyr-parser",
+ "serde",
+ "serde_json",
+ "simple-counter",
+ "toml_edit 0.24.1+spec-1.1.0",
+ "typed-arena",
 ]
 
 [[package]]
@@ -2882,6 +2977,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3403,8 +3507,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3425,7 +3529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3866,6 +3970,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3996,9 +4106,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
 dependencies = [
  "bytemuck",
 ]
@@ -4445,6 +4555,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4515,6 +4646,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4747,6 +4898,19 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.24.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
@@ -4845,18 +5009,21 @@ dependencies = [
 
 [[package]]
 name = "topiary-core"
-version = "0.6.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257cc8cafa40a9e2938fcbc01e47ea1e979e1534509a73e687aee56f1b0d055e"
+checksum = "89df094e19f103c5b8e120a1ffa30a6309daa10bef8d186e598a3df633e6a221"
 dependencies = [
  "futures",
  "itertools 0.11.0",
  "log",
+ "miette",
  "pretty_assertions",
  "prettydiff",
+ "rayon",
  "serde",
  "serde_json",
  "streaming-iterator",
+ "thiserror 2.0.18",
  "tokio",
  "topiary-tree-sitter-facade",
  "topiary-web-tree-sitter-sys",
@@ -4865,15 +5032,15 @@ dependencies = [
 
 [[package]]
 name = "topiary-queries"
-version = "0.6.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e27ba6aef9100c23287d9d323b54d4232c5403e6ca84b08e495678b18314b5"
+checksum = "13439d04bb7987de5f937071c8131c995f3d18fcc0df6ce4ab33180a88fbc72c"
 
 [[package]]
 name = "topiary-tree-sitter-facade"
-version = "0.6.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e106b96399aba85776eb0d0629cf9b1e671b321dc6fc1cd77d3ce732253a3a"
+checksum = "41b7f801962f0e1d022f78a46c6afa2d2158138a3955dbbd25bb92cc5ef61ddb"
 dependencies = [
  "js-sys",
  "streaming-iterator",
@@ -4886,9 +5053,9 @@ dependencies = [
 
 [[package]]
 name = "topiary-web-tree-sitter-sys"
-version = "0.6.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54422f7b76de3b5b1daf4ac3e307f4b8403b7937cf98c2b3835d18decf7e22d"
+checksum = "c9877bfc1ad20d17e6da579911925768df2edd6e276300d660265940881d7b9d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5008,9 +5175,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.10"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
 dependencies = [
  "cc",
  "regex",
@@ -5076,6 +5243,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5291,22 +5464,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
- "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.103"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -5318,9 +5490,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.53"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5331,9 +5503,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5341,9 +5513,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5354,9 +5526,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
@@ -5410,9 +5582,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5439,9 +5611,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.33"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ indicatif = "0.18"
 indoc = "^2.0"
 jaq-all = "0.1.0-beta"
 lzma-rs = "0.3"
-nickel-lang-core = { version = "0.15.3", default-features = false, features = ["format"] }
+nickel-lang-core = { version = "0.17.0", default-features = false, features = ["format"] }
 object = { version = "0.38", default-features = false, features = ["archive", "elf", "read_core", "std"] }
 oci-spec = "0.8.3"
 path-absolutize = "^3.1"

--- a/crates/check/src/harness.rs
+++ b/crates/check/src/harness.rs
@@ -6,7 +6,6 @@ use lcache::{Cache, LocalDir};
 use nickel_lang_core::eval::cache::CacheImpl;
 use nickel_lang_core::identifier::LocIdent;
 use nickel_lang_core::program::Program;
-use nickel_lang_core::term::Term;
 use ot::{OpTracker, Operation};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -155,10 +154,10 @@ fn check_harness_name(
     };
 
     // If we got this far, the nickel AST compiled fine, so lets try and pull out the harness name.
-    if let Term::Record(rd) = tree.as_ref()
-        && let Ok(Some(Some(s))) = rd
+    if let Some(rd) = tree.as_record().and_then(|c| c.into_opt())
+        && let Ok(Some(s)) = rd
             .get_value_with_ctrs(&LocIdent::new("name"))
-            .map(|rt| rt.map(|t| t.term.to_nickel_string()))
+            .map(|rt| rt.and_then(|t| t.to_nickel_string()))
     {
         if s.as_str() == harness {
             return Ok(CheckResult::harness_name_pass());

--- a/crates/check/src/profile.rs
+++ b/crates/check/src/profile.rs
@@ -7,7 +7,6 @@ use nickel_lang_core::error::report::report_as_str;
 use nickel_lang_core::eval::cache::CacheImpl;
 use nickel_lang_core::identifier::LocIdent;
 use nickel_lang_core::program::Program;
-use nickel_lang_core::term::Term;
 use ot::{OpTracker, Operation};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -188,10 +187,10 @@ fn check_profile_name(
     };
 
     // If we got this far, the nickel AST compiled fine, so lets try and pull out the profile name.
-    if let Term::Record(rd) = tree.as_ref()
-        && let Ok(Some(Some(s))) = rd
+    if let Some(rd) = tree.as_record().and_then(|c| c.into_opt())
+        && let Ok(Some(s)) = rd
             .get_value_with_ctrs(&LocIdent::new("name"))
-            .map(|rt| rt.map(|t| t.term.to_nickel_string()))
+            .map(|rt| rt.and_then(|t| t.to_nickel_string()))
     {
         if s.as_str() == profile {
             return Ok(CheckResult::profile_name_pass());

--- a/crates/common/src/ncl_eval.rs
+++ b/crates/common/src/ncl_eval.rs
@@ -1,6 +1,5 @@
 use nickel_lang_core::error::Error;
 use nickel_lang_core::files::Files;
-use nickel_lang_core::term::Term;
 use nickel_lang_core::{error::NullReporter, eval::cache::CacheImpl, program::Program};
 use std::io;
 
@@ -79,11 +78,10 @@ impl VarCtx {
             .compile()
             .map_err(|e| Box::new((program.files(), e)))?;
 
-        if let Term::Str(s) = program
+        let result = program
             .eval_full()
-            .map_err(|e| Box::new((program.files(), e)))?
-            .as_ref()
-        {
+            .map_err(|e| Box::new((program.files(), e)))?;
+        if let Some(s) = result.as_string() {
             Ok(s.to_string())
         } else {
             Ok("".to_string())

--- a/crates/decode/src/attrs.rs
+++ b/crates/decode/src/attrs.rs
@@ -1,11 +1,11 @@
 use nickel_lang_core::{
-    eval::cache::CacheImpl,
+    eval::{cache::CacheImpl, value::NickelValue},
     program::Program,
-    term::{IndexMap, RichTerm, RuntimeContract, Term},
+    term::{IndexMap, RuntimeContract},
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, StrPos, eval_if_closure};
+use crate::{Error, StrPos, eval_if_closure, record_data_from_val};
 
 /// The value of an attribute.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -26,56 +26,74 @@ impl Default for AttrValue {
 
 impl AttrValue {
     pub(crate) fn from_term(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
     ) -> Result<Option<Self>, Error> {
         let rt = eval_if_closure(rt, program)?;
 
-        Ok(match rt.term.as_ref() {
-            Term::Str(s) => Some(Self::String(s.to_string(), rt.pos.try_into().ok())),
-            Term::Bool(b) => Some(Self::Bool(*b)),
-            Term::Num(v) => Some(Self::Number(v.try_into().unwrap())),
-            Term::Enum(a) => Some(Self::String(a.into_label(), rt.pos.try_into().ok())),
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                let mut map = IndexMap::with_capacity(6);
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        if let Some(rt) = field.value.as_ref() {
-                            let rt = RuntimeContract::apply_all(
-                                rt.clone(),
-                                field.pending_contracts.iter().cloned(),
-                                rt.pos,
-                            );
+        if let Some(s) = rt.as_string() {
+            let pos = rt.pos(program.pos_table()).try_into().ok();
+            return Ok(Some(Self::String(s.to_string(), pos)));
+        }
+        if let Some(b) = rt.as_bool() {
+            return Ok(Some(Self::Bool(b)));
+        }
+        if let Some(v) = rt.as_number() {
+            return Ok(Some(Self::Number(f64::try_from(v).unwrap())));
+        }
+        if let Some(tag) = rt.as_enum_tag() {
+            return Ok(Some(Self::String(
+                tag.into_label(),
+                rt.pos(program.pos_table()).try_into().ok(),
+            )));
+        }
+        if let Some(r) = record_data_from_val(&rt) {
+            let mut map = IndexMap::with_capacity(6);
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    if let Some(val) = field.value.as_ref() {
+                        let val = RuntimeContract::apply_all(
+                            val.clone(),
+                            field.pending_contracts.iter().cloned(),
+                            val.pos_idx(),
+                        );
 
-                            if let Some(value) = AttrValue::from_term(&rt, program)? {
-                                map.insert(ident_and_loc.label().to_string(), value);
-                            }
+                        if let Some(value) = AttrValue::from_term(&val, program)? {
+                            map.insert(ident_and_loc.label().to_string(), value);
                         }
-                        Ok(())
-                    })?;
-                Some(Self::Map(map))
-            }
-            Term::Array(e, _attrs) => Some(Self::List(
-                e.iter()
+                    }
+                    Ok(())
+                })?;
+            return Ok(Some(Self::Map(map)));
+        }
+        if let Some(a) = rt.as_array() {
+            return Ok(Some(Self::List(
+                a.iter()
                     .map(|e| AttrValue::from_term(e, program))
                     .collect::<Result<Vec<_>, Error>>()?
                     .into_iter()
                     .flatten()
                     .collect(),
-            )),
-            // Optional fields which are validated by a custom contract will come
-            // across as this type - so we treat them as unset.
-            Term::CustomContract(_) => None,
-            Term::EnumVariant { tag, arg, attrs: _ } => Some(Self::EnumVariant(
-                tag.into_label(),
-                Box::new(AttrValue::from_term(arg, program)?.unwrap()),
-            )),
-            _ => todo!(
-                "error for unexpected attribute value type: {:?}",
-                rt.term.as_ref()
-            ),
-        })
+            )));
+        }
+        // Optional fields which are validated by a custom contract will come
+        // across as this type - so we treat them as unset.
+        if rt.type_of() == Some("CustomContract") {
+            return Ok(None);
+        }
+        // Empty records (Container::Empty) - treat as empty map
+        if crate::is_record(&rt) {
+            return Ok(Some(Self::Map(IndexMap::default())));
+        }
+        if let Some(ev) = rt.as_enum_variant() {
+            return Ok(Some(Self::EnumVariant(
+                ev.tag.into_label(),
+                Box::new(AttrValue::from_term(&ev.arg.clone().unwrap(), program)?.unwrap()),
+            )));
+        }
+
+        todo!("error for unexpected attribute value type: {:?}", rt)
     }
 
     /// Returns the inner list, if this [AttrValue] is the list variant.

--- a/crates/decode/src/builds.rs
+++ b/crates/decode/src/builds.rs
@@ -3,10 +3,11 @@
 use crate::StrPos;
 use crate::{Error, ObjTy, attrs::AttrValue, eval_if_closure, read_ty};
 use common::Target;
+use nickel_lang_core::eval::value::NickelValue;
 use nickel_lang_core::files::FileId;
 use nickel_lang_core::identifier::LocIdent;
 use nickel_lang_core::position::TermPos;
-use nickel_lang_core::term::{IndexMap, RichTerm, RuntimeContract, Term};
+use nickel_lang_core::term::{IndexMap, RuntimeContract};
 use nickel_lang_core::{eval::cache::CacheImpl, program::Program};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -59,7 +60,7 @@ impl core::hash::Hash for BuildRef {
 
 impl BuildRef {
     pub(crate) fn from_term<A: super::DeclAccumulator>(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
         acc: &mut A,
     ) -> Result<Self, Error> {
@@ -69,11 +70,7 @@ impl BuildRef {
         let ty = read_ty(&rt, program)?;
         match ty {
             ObjTy::Upstream => {
-                let record = match rt.as_ref() {
-                    Term::RecRecord(record_data, _, _, _) => record_data,
-                    Term::Record(record_data) => record_data,
-                    _ => unreachable!(),
-                };
+                let record = crate::record_data_from_val(&rt).unwrap();
 
                 let name =
                     if let Ok(Some(n_rt)) = record.get_value_with_ctrs(&LocIdent::new("name")) {
@@ -82,7 +79,7 @@ impl BuildRef {
                         return Err(Error::MissingField {
                             files: program.files(),
                             obj: ObjTy::Upstream,
-                            pos: rt.pos,
+                            pos: rt.pos(program.pos_table()),
                             field: "name",
                         });
                     };
@@ -91,21 +88,23 @@ impl BuildRef {
             }
 
             ObjTy::Builder => {
-                let record = match rt.as_ref() {
-                    Term::RecRecord(record_data, _, _, _) => record_data,
-                    Term::Record(record_data) => record_data,
-                    _ => unreachable!(),
-                };
+                let record = crate::record_data_from_val(&rt).unwrap();
                 let id = if let Ok(Some(id_rt)) =
                     record.get_value_with_ctrs(&LocIdent::new("__magic_buildspec_id"))
                 {
-                    if let Term::ForeignId(id) = id_rt.as_ref() {
+                    if let Some(id) = id_rt.as_foreign_id() {
                         *id
                     } else {
-                        return Err(Error::MissingID(program.files(), rt.pos));
+                        return Err(Error::MissingID(
+                            program.files(),
+                            rt.pos(program.pos_table()),
+                        ));
                     }
                 } else {
-                    return Err(Error::MissingID(program.files(), rt.pos));
+                    return Err(Error::MissingID(
+                        program.files(),
+                        rt.pos(program.pos_table()),
+                    ));
                 };
 
                 let name =
@@ -115,7 +114,7 @@ impl BuildRef {
                         return Err(Error::MissingField {
                             files: program.files(),
                             obj: ObjTy::Builder,
-                            pos: rt.pos,
+                            pos: rt.pos(program.pos_table()),
                             field: "name",
                         });
                     };
@@ -132,7 +131,7 @@ impl BuildRef {
                 files: program.files(),
                 got: ty,
                 want: ObjTy::Builder,
-                pos: rt.pos,
+                pos: rt.pos(program.pos_table()),
             }),
         }
     }
@@ -163,7 +162,7 @@ pub struct SourceInput {
 }
 
 impl SourceInput {
-    fn from_term(rt: &RichTerm, program: &mut Program<CacheImpl>) -> Result<Self, Error> {
+    fn from_term(rt: &NickelValue, program: &mut Program<CacheImpl>) -> Result<Self, Error> {
         let mut filename: Option<(String, FileId)> = None;
 
         let mut url: Option<(String, Option<TermPos>)> = None;
@@ -171,62 +170,63 @@ impl SourceInput {
 
         let mut extract: Option<bool> = None;
         let mut strip_prefix: Option<String> = None;
-        match rt.term.as_ref() {
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        match ident_and_loc.label() {
-                            "file" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                    filename = Some((
-                                        String::deserialize(eval_if_closure(rt, program)?).unwrap(),
-                                        field.value.as_ref().unwrap().pos.src_id().unwrap(),
-                                    ));
-                                }
-                                Ok(())
+        if let Some(r) = crate::record_data_from_val(rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    match ident_and_loc.label() {
+                        "file" => {
+                            if let Some(rt) = field.value.as_ref() {
+                                filename = Some((
+                                    String::deserialize(eval_if_closure(rt, program)?).unwrap(),
+                                    field
+                                        .value
+                                        .as_ref()
+                                        .unwrap()
+                                        .pos(program.pos_table())
+                                        .src_id()
+                                        .unwrap(),
+                                ));
                             }
-                            "url" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                    url = Some((
-                                        String::deserialize(eval_if_closure(rt, program)?).unwrap(),
-                                        Some(rt.pos),
-                                    ));
-                                }
-                                Ok(())
-                            }
-                            "sha256" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                    sha256 = Some((
-                                        String::deserialize(eval_if_closure(rt, program)?).unwrap(),
-                                        Some(rt.pos),
-                                    ));
-                                }
-                                Ok(())
-                            }
-                            "extract" => {
-                                if let Some(ext_rt) = field.value.as_ref() {
-                                    extract = Some(
-                                        bool::deserialize(eval_if_closure(ext_rt, program)?)
-                                            .unwrap(),
-                                    );
-                                }
-                                Ok(())
-                            }
-                            "strip_prefix" => {
-                                if let Some(st_rt) = field.value.as_ref() {
-                                    strip_prefix = Some(
-                                        String::deserialize(eval_if_closure(st_rt, program)?)
-                                            .unwrap(),
-                                    );
-                                }
-                                Ok(())
-                            }
-                            _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                            Ok(())
                         }
-                    })?;
-            }
-            _ => {}
+                        "url" => {
+                            if let Some(rt) = field.value.as_ref() {
+                                url = Some((
+                                    String::deserialize(eval_if_closure(rt, program)?).unwrap(),
+                                    Some(rt.pos(program.pos_table())),
+                                ));
+                            }
+                            Ok(())
+                        }
+                        "sha256" => {
+                            if let Some(rt) = field.value.as_ref() {
+                                sha256 = Some((
+                                    String::deserialize(eval_if_closure(rt, program)?).unwrap(),
+                                    Some(rt.pos(program.pos_table())),
+                                ));
+                            }
+                            Ok(())
+                        }
+                        "extract" => {
+                            if let Some(ext_rt) = field.value.as_ref() {
+                                extract = Some(
+                                    bool::deserialize(eval_if_closure(ext_rt, program)?).unwrap(),
+                                );
+                            }
+                            Ok(())
+                        }
+                        "strip_prefix" => {
+                            if let Some(st_rt) = field.value.as_ref() {
+                                strip_prefix = Some(
+                                    String::deserialize(eval_if_closure(st_rt, program)?).unwrap(),
+                                );
+                            }
+                            Ok(())
+                        }
+                        _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                    }
+                })?;
         }
 
         let from = if let Some((file, file_id)) = filename {
@@ -262,7 +262,7 @@ impl SourceInput {
                     return Err(Error::MissingField {
                         files: program.files(),
                         obj: ObjTy::Source,
-                        pos: rt.pos,
+                        pos: rt.pos(program.pos_table()),
                         field: "url",
                     });
                 }
@@ -273,7 +273,7 @@ impl SourceInput {
                     return Err(Error::MissingField {
                         files: program.files(),
                         obj: ObjTy::Source,
-                        pos: rt.pos,
+                        pos: rt.pos(program.pos_table()),
                         field: "sha256",
                     });
                 }
@@ -314,57 +314,56 @@ impl SubsetInput {
 
 impl SubsetInput {
     fn from_term<A: super::DeclAccumulator>(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
         acc: &mut A,
     ) -> Result<Self, Error> {
         let mut from: Option<BuildRef> = None;
         let mut outputs: Option<SmallVec<[String; 4]>> = None;
-        match rt.term.as_ref() {
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        match ident_and_loc.label() {
-                            "from" => {
-                                from = Some(BuildRef::from_term(
-                                    field.value.as_ref().unwrap(),
-                                    program,
-                                    acc,
-                                )?);
-                                Ok(())
-                            }
-                            "outputs" => {
-                                let outputs_rt =
-                                    field.value.as_ref().map(|rt| eval_if_closure(rt, program));
-                                match outputs_rt {
-                                    None => {}
-                                    Some(outputs_rt) => match outputs_rt?.term.as_ref() {
-                                        Term::Array(a, _attrs) => {
-                                            outputs = Some(
-                                                a.iter()
-                                                    .map(|input| {
-                                                        Ok(String::deserialize(eval_if_closure(
-                                                            input, program,
-                                                        )?)
-                                                        .unwrap())
-                                                    })
-                                                    .collect::<Result<SmallVec<_>, Error>>()?,
-                                            );
-                                        }
-                                        _ => todo!(
+        if let Some(r) = crate::record_data_from_val(rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    match ident_and_loc.label() {
+                        "from" => {
+                            from = Some(BuildRef::from_term(
+                                field.value.as_ref().unwrap(),
+                                program,
+                                acc,
+                            )?);
+                            Ok(())
+                        }
+                        "outputs" => {
+                            let outputs_rt =
+                                field.value.as_ref().map(|rt| eval_if_closure(rt, program));
+                            match outputs_rt {
+                                None => {}
+                                Some(outputs_rt) => {
+                                    let outputs_val = outputs_rt?;
+                                    if let Some(a) = outputs_val.as_array() {
+                                        outputs = Some(
+                                            a.iter()
+                                                .map(|input| {
+                                                    Ok(String::deserialize(eval_if_closure(
+                                                        input, program,
+                                                    )?)
+                                                    .unwrap())
+                                                })
+                                                .collect::<Result<SmallVec<_>, Error>>()?,
+                                        );
+                                    } else {
+                                        todo!(
                                             "handle outputs value being non-array {:?}",
                                             field.value
-                                        ),
-                                    },
+                                        );
+                                    }
                                 }
-                                Ok(())
                             }
-                            _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                            Ok(())
                         }
-                    })?;
-            }
-            _ => {}
+                        _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                    }
+                })?;
         }
         let from = match from {
             Some(from) => from,
@@ -372,7 +371,7 @@ impl SubsetInput {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ObjTy::Subset,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "from",
                 });
             }
@@ -383,7 +382,7 @@ impl SubsetInput {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ObjTy::Subset,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "outputs",
                 });
             }
@@ -423,7 +422,7 @@ impl BuildDep {
 
 impl BuildDep {
     fn from_term<A: super::DeclAccumulator>(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
         acc: &mut A,
     ) -> Result<Self, Error> {
@@ -458,37 +457,34 @@ impl BuildDep {
                 files: program.files(),
                 got: ty,
                 want: ObjTy::Builder,
-                pos: rt.pos,
+                pos: rt.pos(program.pos_table()),
             }),
         }
     }
 
     fn from_term_hostpath(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
     ) -> Result<String, Error> {
         let mut path: Option<String> = None;
-        match rt.term.as_ref() {
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        match ident_and_loc.label() {
-                            "path" => {
-                                path = Some(
-                                    String::deserialize(eval_if_closure(
-                                        field.value.as_ref().unwrap(),
-                                        program,
-                                    )?)
-                                    .unwrap(),
-                                );
-                                Ok(())
-                            }
-                            _ => Ok(()), // TODO: Should we error if we see an unknown field?
+        if let Some(r) = crate::record_data_from_val(rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    match ident_and_loc.label() {
+                        "path" => {
+                            path = Some(
+                                String::deserialize(eval_if_closure(
+                                    field.value.as_ref().unwrap(),
+                                    program,
+                                )?)
+                                .unwrap(),
+                            );
+                            Ok(())
                         }
-                    })?;
-            }
-            _ => {}
+                        _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                    }
+                })?;
         }
         let path = match path {
             Some(path) => path,
@@ -496,7 +492,7 @@ impl BuildDep {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ObjTy::Path,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "path",
                 });
             }
@@ -506,32 +502,35 @@ impl BuildDep {
     }
 
     fn from_term_local(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
     ) -> Result<(PathBuf, String, blake3::Hash), Error> {
         let mut file: Option<(String, FileId)> = None;
-        match rt.term.as_ref() {
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        match ident_and_loc.label() {
-                            "file" => {
-                                file = Some((
-                                    String::deserialize(eval_if_closure(
-                                        field.value.as_ref().unwrap(),
-                                        program,
-                                    )?)
+        if let Some(r) = crate::record_data_from_val(rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    match ident_and_loc.label() {
+                        "file" => {
+                            file = Some((
+                                String::deserialize(eval_if_closure(
+                                    field.value.as_ref().unwrap(),
+                                    program,
+                                )?)
+                                .unwrap(),
+                                field
+                                    .value
+                                    .as_ref()
+                                    .unwrap()
+                                    .pos(program.pos_table())
+                                    .src_id()
                                     .unwrap(),
-                                    field.value.as_ref().unwrap().pos.src_id().unwrap(),
-                                ));
-                                Ok(())
-                            }
-                            _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                            ));
+                            Ok(())
                         }
-                    })?;
-            }
-            _ => {}
+                        _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                    }
+                })?;
         }
         let (file, src_id) = match file {
             Some(file) => file,
@@ -539,7 +538,7 @@ impl BuildDep {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ObjTy::Local,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "file",
                 });
             }
@@ -601,7 +600,7 @@ impl BuildOutput {
 }
 
 impl BuildOutput {
-    fn from_term(rt: &RichTerm, program: &mut Program<CacheImpl>) -> Result<Self, Error> {
+    fn from_term(rt: &NickelValue, program: &mut Program<CacheImpl>) -> Result<Self, Error> {
         let rt = eval_if_closure(rt, program)?;
 
         // The type hint ty identifies which output variant this term represents
@@ -611,51 +610,45 @@ impl BuildOutput {
         let mut allow_data: Option<bool> = None;
         let mut allow_missing_interpreter: Option<bool> = None;
 
-        match rt.term.as_ref() {
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        match ident_and_loc.label() {
-                            "glob" => {
-                                glob = Some(
-                                    String::deserialize(eval_if_closure(
-                                        field.value.as_ref().unwrap(),
-                                        program,
-                                    )?)
-                                    .unwrap(),
-                                );
-                                Ok(())
-                            }
-                            "allow_executable" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                    allow_executable = Some(
-                                        bool::deserialize(eval_if_closure(rt, program)?).unwrap(),
-                                    );
-                                }
-                                Ok(())
-                            }
-                            "allow_data" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                    allow_data = Some(
-                                        bool::deserialize(eval_if_closure(rt, program)?).unwrap(),
-                                    );
-                                }
-                                Ok(())
-                            }
-                            "allow_missing_interpreter" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                    allow_missing_interpreter = Some(
-                                        bool::deserialize(eval_if_closure(rt, program)?).unwrap(),
-                                    );
-                                }
-                                Ok(())
-                            }
-                            _ => Ok(()), // TODO: Should we error if we see an unknown field?
+        if let Some(r) = crate::record_data_from_val(&rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    match ident_and_loc.label() {
+                        "glob" => {
+                            glob = Some(
+                                String::deserialize(eval_if_closure(
+                                    field.value.as_ref().unwrap(),
+                                    program,
+                                )?)
+                                .unwrap(),
+                            );
+                            Ok(())
                         }
-                    })?;
-            }
-            _ => {}
+                        "allow_executable" => {
+                            if let Some(rt) = field.value.as_ref() {
+                                allow_executable =
+                                    Some(bool::deserialize(eval_if_closure(rt, program)?).unwrap());
+                            }
+                            Ok(())
+                        }
+                        "allow_data" => {
+                            if let Some(rt) = field.value.as_ref() {
+                                allow_data =
+                                    Some(bool::deserialize(eval_if_closure(rt, program)?).unwrap());
+                            }
+                            Ok(())
+                        }
+                        "allow_missing_interpreter" => {
+                            if let Some(rt) = field.value.as_ref() {
+                                allow_missing_interpreter =
+                                    Some(bool::deserialize(eval_if_closure(rt, program)?).unwrap());
+                            }
+                            Ok(())
+                        }
+                        _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                    }
+                })?;
         }
         let glob = match glob {
             Some(glob) => glob,
@@ -663,7 +656,7 @@ impl BuildOutput {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ty,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "glob",
                 });
             }
@@ -686,7 +679,7 @@ impl BuildOutput {
                 files: program.files(),
                 got: ty,
                 want: ObjTy::OutputLib,
-                pos: rt.pos,
+                pos: rt.pos(program.pos_table()),
             }),
         }
     }
@@ -715,7 +708,7 @@ impl RuntimeDep {
 
 impl RuntimeDep {
     fn from_term<A: super::DeclAccumulator>(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
         acc: &mut A,
     ) -> Result<RuntimeDep, Error> {
@@ -734,7 +727,7 @@ impl RuntimeDep {
                 files: program.files(),
                 got: ty,
                 want: ObjTy::Builder,
-                pos: rt.pos,
+                pos: rt.pos(program.pos_table()),
             }),
         }
     }
@@ -793,7 +786,7 @@ impl BuildDecl {
 
 impl BuildDecl {
     pub(crate) fn from_term<A: super::DeclAccumulator>(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
         acc: &mut A,
     ) -> Result<Self, Error> {
@@ -813,354 +806,365 @@ impl BuildDecl {
         let mut attrs: Option<IndexMap<String, AttrValue>> = None;
         let mut prebuilt: Option<bool> = None;
         let mut tests: Option<IndexMap<String, crate::Test>> = None;
-        match rt.term.as_ref() {
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        match ident_and_loc.label() {
-                            "ty" => {
-                                ty = Some(
-                                    ObjTy::deserialize(eval_if_closure(
-                                        field.value.as_ref().unwrap(),
-                                        program,
-                                    )?)
-                                    .unwrap(),
-                                );
-                                Ok(())
+        if let Some(r) = crate::record_data_from_val(&rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    match ident_and_loc.label() {
+                        "ty" => {
+                            ty = Some(
+                                ObjTy::deserialize(eval_if_closure(
+                                    field.value.as_ref().unwrap(),
+                                    program,
+                                )?)
+                                .unwrap(),
+                            );
+                            Ok(())
+                        }
+                        "name" => {
+                            name = Some(
+                                String::deserialize(eval_if_closure(
+                                    field.value.as_ref().unwrap(),
+                                    program,
+                                )?)
+                                .unwrap(),
+                            );
+                            Ok(())
+                        }
+                        "prebuilt" => {
+                            if let Some(rt) = field.value.as_ref() {
+                            prebuilt = Some(
+                                bool::deserialize(eval_if_closure(
+                                    rt,
+                                    program,
+                                )?)
+                                .unwrap(),
+                            );
                             }
-                            "name" => {
-                                name = Some(
-                                    String::deserialize(eval_if_closure(
-                                        field.value.as_ref().unwrap(),
-                                        program,
-                                    )?)
-                                    .unwrap(),
-                                );
-                                Ok(())
-                            }
-                            "prebuilt" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                prebuilt = Some(
-                                    bool::deserialize(eval_if_closure(
-                                        rt,
-                                        program,
-                                    )?)
-                                    .unwrap(),
-                                );
-                                }
-                                Ok(())
-                            }
-                            "cmd" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                    let rt = eval_if_closure(rt, program)?;
-                                    match rt.term.as_ref() {
-                                        Term::Str(s) => {
-                                            cmds = Some(vec![
-                                                shlex::split(s).unwrap(),
-                                            ]);
-                                        }
-                                        Term::Array(a, _attrs) => {
-                                            cmds = Some(vec![
-                                                a.iter()
-                                                    .map(|rt| eval_if_closure(rt, program))
-                                                    .collect::<Result<Vec<_>, _>>()?
-                                                    .into_iter()
-                                                    .map(|rt| String::deserialize(rt).unwrap())
-                                                    .collect(),
-                                            ]);
-                                        }
-                                        _ => todo!("error for 'cmd' field being non-string & non-array, got {:?}", rt.term.as_ref()),
-                                    };
-                                    Ok(())
-                                } else {
-                                    Ok(())
-                                }
-                            }
-                            "cmds" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                    let rt = eval_if_closure(rt,program)?;
-                                    if let Term::Array(cmds_rt, _attrs) = rt.term.as_ref() {
-                                        cmds = Some(
-                                            cmds_rt.iter()
-                                                .map(|rt| {
-                                                    let rt = eval_if_closure(rt, program)?;
-                                                    if let Term::Array(a, _attrs) = rt.term.as_ref() {
-                                                        Ok::<_, Error>(a.iter()
-                                                            .map(|rt| eval_if_closure(rt, program))
-                                                            .collect::<Result<Vec<_>, _>>()?
-                                                            .into_iter()
-                                                            .map(|rt| String::deserialize(rt).unwrap())
-                                                            .collect())
-                                                    } else if let Term::Str(s) = rt.term.as_ref() {
-                                                        Ok::<_, Error>(shlex::split(s).unwrap())
-                                                    } else {
-                                                        todo!("error for 'cmds' field being non-array & non-string, got {:?}", rt.term.as_ref());
-                                                    }
-                                                })
-                                                .collect::<Result<Vec<_>, _>>()?,
-                                        );
-
-                                        Ok(())
-                                    } else {
-                                        todo!("error for 'cmds' field being non-array, got {:?}", rt.term.as_ref());
-                                    }
-                                } else {
-                                    Ok(())
-                                }
-                            }
-                            "target" => {
-                                if let Some(target_rt) = field.value.as_ref() {
-                                    let target_str =
-                                        String::deserialize(eval_if_closure(
-                                            target_rt,
-                                            program,
-                                        )?)
-                                        .unwrap();
-                                    match Target::all().iter().find(|t| t.as_ref() == target_str) {
-                                        None => Err(Error::InvalidTarget { files: program.files(), got: target_str, pos: rt.pos }),
-                                        Some(t) => {
-                                            target = Some(t.clone());
-                                            Ok(())
-                                        }
-                                    }
-                                } else {
-                                    Ok(())
-                                }
-                            }
-                            "build_args" => {
-                                if let Some(build_args_rt) = field.value.as_ref() {
-                                    let build_args_rt =
-                                        eval_if_closure(build_args_rt, program)?;
-
-                                    match build_args_rt.term.as_ref() {
-                                        Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                                            build_args = Some(r.fields.iter().map(
-                                                |(ident_and_loc, field)| -> Result<(String, String), Error> {
-                                                    if field.value.is_none() {
-                                                        // TODO: This should be a more customized error, missing
-                                                        // field with the pretty print will probably get the message
-                                                        // across, but its not super precise.
-                                                        return Err(Error::MissingField{
-                                                            field: "build_args",
-                                                            files: program.files(),
-                                                            obj: ObjTy::Builder,
-                                                            pos: ident_and_loc.pos,
-                                                        });
-                                                    }
-
-                                                    Ok((
-                                                        ident_and_loc.label().to_string(),
-                                                        String::deserialize(eval_if_closure(
-                                                            field.value.as_ref().unwrap(),
-                                                            program,
-                                                        )?)
-                                                        .unwrap(),
-                                                    ))
-                                                },
-                                            ).collect::<Result<IndexMap<_, _>, Error>>()?
-                                            );
-                                        }
-                                        _ => todo!("unexpected term for build_args"),
-                                    };
-                                }
-
-                                Ok(())
-                            }
-                            "build_deps" => {
-                                let build_deps_rt = field
-                                    .value
-                                    .as_ref()
-                                    .map(|rt| eval_if_closure(rt, program))
-                                    .ok_or_else(|| Error::MissingField {
-                                        files: program.files(),
-                                        obj: ObjTy::Builder,
-                                        pos: rt.pos,
-                                        field: "build_deps",
-                                    })??;
-                                if let Term::Array(a, _attrs) = build_deps_rt.as_ref() {
-                                    build_deps = Some(
+                            Ok(())
+                        }
+                        "cmd" => {
+                            if let Some(rt) = field.value.as_ref() {
+                                let rt = eval_if_closure(rt, program)?;
+                                if let Some(s) = rt.as_string() {
+                                    cmds = Some(vec![
+                                        shlex::split(s.as_ref()).unwrap(),
+                                    ]);
+                                } else if let Some(a) = rt.as_array() {
+                                    cmds = Some(vec![
                                         a.iter()
-                                            .map(|input| BuildDep::from_term(input, program, acc))
-                                            .collect::<Result<SmallVec<_>, Error>>()?,
-                                    );
+                                            .map(|rt| eval_if_closure(rt, program))
+                                            .collect::<Result<Vec<_>, _>>()?
+                                            .into_iter()
+                                            .map(|rt| String::deserialize(rt).unwrap())
+                                            .collect(),
+                                    ]);
                                 } else {
-                                    todo!("handle build_deps value being non-array {:?}", field.value);
-                                };
+                                    todo!("error for 'cmd' field being non-string & non-array, got {:?}", rt);
+                                }
+                                Ok(())
+                            } else {
                                 Ok(())
                             }
-                            "runtime_deps" => {
-                                let runtime_deps_rt =
-                                    field.value.as_ref().map(|rt| eval_if_closure(rt, program));
-                                match runtime_deps_rt {
-                                    None => {}
-                                    Some(runtime_deps_rt) => match runtime_deps_rt?.term.as_ref() {
-                                        Term::Array(a, _attrs) => {
-                                            runtime_deps = Some(
-                                                a.iter()
-                                                    .map(|input| {
-                                                        RuntimeDep::from_term(input, program, acc)
-                                                    })
-                                                    .collect::<Result<SmallVec<_>, Error>>()?,
-                                            );
-                                        }
-                                        _ => todo!(
+                        }
+                        "cmds" => {
+                            if let Some(rt) = field.value.as_ref() {
+                                let rt = eval_if_closure(rt,program)?;
+                                if let Some(cmds_rt) = rt.as_array() {
+                                    cmds = Some(
+                                        cmds_rt.iter()
+                                            .map(|rt| {
+                                                let rt = eval_if_closure(rt, program)?;
+                                                if let Some(a) = rt.as_array() {
+                                                    Ok::<_, Error>(a.iter()
+                                                        .map(|rt| eval_if_closure(rt, program))
+                                                        .collect::<Result<Vec<_>, _>>()?
+                                                        .into_iter()
+                                                        .map(|rt| String::deserialize(rt).unwrap())
+                                                        .collect())
+                                                } else if let Some(s) = rt.as_string() {
+                                                    Ok::<_, Error>(shlex::split(s.as_ref()).unwrap())
+                                                } else {
+                                                    todo!("error for 'cmds' field being non-array & non-string, got {:?}", rt);
+                                                }
+                                            })
+                                            .collect::<Result<Vec<_>, _>>()?,
+                                    );
+
+                                    Ok(())
+                                } else {
+                                    todo!("error for 'cmds' field being non-array, got {:?}", rt);
+                                }
+                            } else {
+                                Ok(())
+                            }
+                        }
+                        "target" => {
+                            if let Some(target_rt) = field.value.as_ref() {
+                                let target_str =
+                                    String::deserialize(eval_if_closure(
+                                        target_rt,
+                                        program,
+                                    )?)
+                                    .unwrap();
+                                match Target::all().iter().find(|t| t.as_ref() == target_str) {
+                                    None => Err(Error::InvalidTarget { files: program.files(), got: target_str, pos: rt.pos(program.pos_table()) }),
+                                    Some(t) => {
+                                        target = Some(t.clone());
+                                        Ok(())
+                                    }
+                                }
+                            } else {
+                                Ok(())
+                            }
+                        }
+                        "build_args" => {
+                            if let Some(build_args_rt) = field.value.as_ref() {
+                                let build_args_rt =
+                                    eval_if_closure(build_args_rt, program)?;
+
+                                if let Some(r) = crate::record_data_from_val(&build_args_rt) {
+                                    build_args = Some(r.fields.iter().map(
+                                        |(ident_and_loc, field)| -> Result<(String, String), Error> {
+                                            if field.value.is_none() {
+                                                // TODO: This should be a more customized error, missing
+                                                // field with the pretty print will probably get the message
+                                                // across, but its not super precise.
+                                                return Err(Error::MissingField{
+                                                    field: "build_args",
+                                                    files: program.files(),
+                                                    obj: ObjTy::Builder,
+                                                    pos: ident_and_loc.pos,
+                                                });
+                                            }
+
+                                            Ok((
+                                                ident_and_loc.label().to_string(),
+                                                String::deserialize(eval_if_closure(
+                                                    field.value.as_ref().unwrap(),
+                                                    program,
+                                                )?)
+                                                .unwrap(),
+                                            ))
+                                        },
+                                    ).collect::<Result<IndexMap<_, _>, Error>>()?
+                                    );
+                                } else if crate::is_record(&build_args_rt) {
+                                    build_args = Some(Default::default());
+                                } else {
+                                    todo!("unexpected term for build_args");
+                                }
+                            }
+
+                            Ok(())
+                        }
+                        "build_deps" => {
+                            let build_deps_rt = field
+                                .value
+                                .as_ref()
+                                .map(|rt| eval_if_closure(rt, program))
+                                .ok_or_else(|| Error::MissingField {
+                                    files: program.files(),
+                                    obj: ObjTy::Builder,
+                                    pos: rt.pos(program.pos_table()),
+                                    field: "build_deps",
+                                })??;
+                            if let Some(a) = build_deps_rt.as_array() {
+                                build_deps = Some(
+                                    a.iter()
+                                        .map(|input| BuildDep::from_term(input, program, acc))
+                                        .collect::<Result<SmallVec<_>, Error>>()?,
+                                );
+                            } else {
+                                todo!("handle build_deps value being non-array {:?}", field.value);
+                            };
+                            Ok(())
+                        }
+                        "runtime_deps" => {
+                            let runtime_deps_rt =
+                                field.value.as_ref().map(|rt| eval_if_closure(rt, program));
+                            match runtime_deps_rt {
+                                None => {}
+                                Some(runtime_deps_rt) => {
+                                    let runtime_deps_val = runtime_deps_rt?;
+                                    if let Some(a) = runtime_deps_val.as_array() {
+                                        runtime_deps = Some(
+                                            a.iter()
+                                                .map(|input| {
+                                                    RuntimeDep::from_term(input, program, acc)
+                                                })
+                                                .collect::<Result<SmallVec<_>, Error>>()?,
+                                        );
+                                    } else {
+                                        todo!(
                                             "handle runtime_deps value being non-array {:?}",
                                             field.value
-                                        ),
-                                    },
-                                }
-                                Ok(())
-                            }
-                            "outputs" => {
-                                let outputs_rt = field
-                                    .value
-                                    .as_ref()
-                                    .map(|rt| eval_if_closure(rt, program))
-                                    .ok_or_else(|| Error::MissingField {
-                                        files: program.files(),
-                                        obj: ObjTy::Builder,
-                                        pos: rt.pos,
-                                        field: "outputs",
-                                    })??;
-
-                                if let Term::Record(r) = outputs_rt.as_ref() {
-                                    outputs = Some(
-                                        r.iter_serializable()
-                                            .map(|entry| entry.unwrap())
-                                            .map(|(ident, val)| {
-                                                Ok((
-                                                    ident.label().to_string(),
-                                                    BuildOutput::from_term(val, program)?,
-                                                ))
-                                            })
-                                            .collect::<Result<_, Error>>()?,
-                                    );
-                                } else {
-                                    todo!("handle value being non-dict {:?}", field.value);
-                                };
-                                Ok(())
-                            }
-                            "replace_on_cycle" => {
-                                if let Some(value) = &field.value {
-                                    replace_on_cycle = Some(BuildRef::from_term(value, program, acc)?);
-                                }
-                                Ok(())
-                            }
-                            "attrs" => {
-                                if let Some(attrs_rt) = field.value.as_ref() {
-                                    let attrs_rt =
-                                        eval_if_closure(attrs_rt, program)?;
-
-                                    match attrs_rt.term.as_ref() {
-                                        Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                                            attrs = Some(r.fields.iter().map(
-                                                |(ident_and_loc, field)| -> Result<Option<(String, AttrValue)>, Error> {
-                                                    if let Some(rt) = field.value.as_ref() {
-                                                        let rt = RuntimeContract::apply_all(
-                                                            rt.clone(),
-                                                            field.pending_contracts.iter().cloned(),
-                                                            rt.pos,
-                                                        );
-
-                                                        let value = AttrValue::from_term(
-                                                            &rt,
-                                                            program,
-                                                        )?;
-                                                        match value {
-                                                            Some(v) => Ok(Some((
-                                                                ident_and_loc.label().to_string(),
-                                                                v,
-                                                            ))),
-                                                            None => Ok(None),
-                                                        }
-                                                    } else {
-                                                        Ok(None)
-                                                    }
-                                                },
-                                            ).collect::<Result<Vec<_>, Error>>()?
-                                            .into_iter()
-                                            .flatten()
-                                            .collect());
-                                        }
-                                        _ => todo!("unexpected term for attrs: {:?}", attrs_rt.term.as_ref()),
-                                    };
-                                }
-
-                                Ok(())
-                            }
-                            "needs" => {
-                                if let Some(needs_rt) = field.value.as_ref() {
-                                    let needs_rt =
-                                        eval_if_closure(needs_rt, program)?;
-
-                                    match needs_rt.term.as_ref() {
-                                        Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                                            needs = Some(r.fields.iter().map(
-                                                |(ident_and_loc, field)| -> Result<Option<(String, AttrValue)>, Error> {
-                                                    let value = AttrValue::from_term(
-                                                        field.value.as_ref().unwrap(),
-                                                        program,
-                                                    )?;
-                                                    match value {
-                                                        Some(v) => Ok(Some((
-                                                            ident_and_loc.label().to_string(),
-                                                            v,
-                                                        ))),
-                                                        None => Ok(None),
-                                                    }
-                                                },
-                                            ).collect::<Result<Vec<_>, Error>>()?
-                                            .into_iter()
-                                            .flatten()
-                                            .collect());
-                                        }
-                                        _ => todo!("unexpected term for needs: {:?}", needs_rt.term.as_ref()),
-                                    };
-                                }
-
-                                Ok(())
-                            }
-                            "tests" => {
-                                if let Some(tests_res) = field
-                                    .value
-                                    .as_ref()
-                                    .map(|rt| eval_if_closure(rt, program)) {
-                                        let tests_rt = tests_res?;
-
-                                        if let Term::Record(r) = tests_rt.as_ref() {
-                                            tests = Some(
-                                                r.iter_serializable()
-                                                    .map(|entry| entry.unwrap())
-                                                    .map(|(ident, val)| {
-                                                        Ok((
-                                                            ident.label().to_string(),
-                                                            crate::Test::from_term(val, program, acc)?,
-                                                        ))
-                                                    })
-                                                    .collect::<Result<_, Error>>()?,
-                                            );
-                                        } else {
-                                            todo!("handle value being non-dict {:?}", field.value);
-                                        };
+                                        );
                                     }
-                                Ok(())
+                                }
                             }
-                            _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                            Ok(())
                         }
-                    })?;
-            }
-            _ => {}
+                        "outputs" => {
+                            let outputs_rt = field
+                                .value
+                                .as_ref()
+                                .map(|rt| eval_if_closure(rt, program))
+                                .ok_or_else(|| Error::MissingField {
+                                    files: program.files(),
+                                    obj: ObjTy::Builder,
+                                    pos: rt.pos(program.pos_table()),
+                                    field: "outputs",
+                                })??;
+
+                            if let Some(r) = crate::record_data_from_val(&outputs_rt) {
+                                outputs = Some(
+                                    r.iter_serializable()
+                                        .map(|entry| entry.unwrap())
+                                        .map(|(ident, val)| {
+                                            Ok((
+                                                ident.label().to_string(),
+                                                BuildOutput::from_term(val, program)?,
+                                            ))
+                                        })
+                                        .collect::<Result<_, Error>>()?,
+                                );
+                            } else if crate::is_record(&outputs_rt) {
+                                // Empty record - no outputs
+                                outputs = Some(Default::default());
+                            } else {
+                                todo!("handle value being non-dict {:?}", field.value);
+                            };
+                            Ok(())
+                        }
+                        "replace_on_cycle" => {
+                            if let Some(value) = &field.value {
+                                replace_on_cycle = Some(BuildRef::from_term(value, program, acc)?);
+                            }
+                            Ok(())
+                        }
+                        "attrs" => {
+                            if let Some(attrs_rt) = field.value.as_ref() {
+                                let attrs_rt =
+                                    eval_if_closure(attrs_rt, program)?;
+
+                                if let Some(r) = crate::record_data_from_val(&attrs_rt) {
+                                    attrs = Some(r.fields.iter().map(
+                                        |(ident_and_loc, field)| -> Result<Option<(String, AttrValue)>, Error> {
+                                            if let Some(rt) = field.value.as_ref() {
+                                                let rt = RuntimeContract::apply_all(
+                                                    rt.clone(),
+                                                    field.pending_contracts.iter().cloned(),
+                                                    rt.pos_idx(),
+                                                );
+
+                                                let value = AttrValue::from_term(
+                                                    &rt,
+                                                    program,
+                                                )?;
+                                                match value {
+                                                    Some(v) => Ok(Some((
+                                                        ident_and_loc.label().to_string(),
+                                                        v,
+                                                    ))),
+                                                    None => Ok(None),
+                                                }
+                                            } else {
+                                                Ok(None)
+                                            }
+                                        },
+                                    ).collect::<Result<Vec<_>, Error>>()?
+                                    .into_iter()
+                                    .flatten()
+                                    .collect());
+                                } else if crate::is_record(&attrs_rt) {
+                                    attrs = Some(Default::default());
+                                } else {
+                                    todo!("unexpected term for attrs: {:?}", attrs_rt);
+                                }
+                            }
+
+                            Ok(())
+                        }
+                        "needs" => {
+                            if let Some(needs_rt) = field.value.as_ref() {
+                                let needs_rt =
+                                    eval_if_closure(needs_rt, program)?;
+
+                                if let Some(r) = crate::record_data_from_val(&needs_rt) {
+                                    needs = Some(r.fields.iter().map(
+                                        |(ident_and_loc, field)| -> Result<Option<(String, AttrValue)>, Error> {
+                                            let value = AttrValue::from_term(
+                                                field.value.as_ref().unwrap(),
+                                                program,
+                                            )?;
+                                            match value {
+                                                Some(v) => Ok(Some((
+                                                    ident_and_loc.label().to_string(),
+                                                    v,
+                                                ))),
+                                                None => Ok(None),
+                                            }
+                                        },
+                                    ).collect::<Result<Vec<_>, Error>>()?
+                                    .into_iter()
+                                    .flatten()
+                                    .collect());
+                                } else if crate::is_record(&needs_rt) {
+                                    needs = Some(Default::default());
+                                } else {
+                                    todo!("unexpected term for needs: {:?}", needs_rt);
+                                }
+                            }
+
+                            Ok(())
+                        }
+                        "tests" => {
+                            if let Some(tests_res) = field
+                                .value
+                                .as_ref()
+                                .map(|rt| eval_if_closure(rt, program)) {
+                                    let tests_rt = tests_res?;
+
+                                    if let Some(r) = crate::record_data_from_val(&tests_rt) {
+                                        tests = Some(
+                                            r.iter_serializable()
+                                                .map(|entry| entry.unwrap())
+                                                .map(|(ident, val)| {
+                                                    Ok((
+                                                        ident.label().to_string(),
+                                                        crate::Test::from_term(val, program, acc)?,
+                                                    ))
+                                                })
+                                                .collect::<Result<_, Error>>()?,
+                                        );
+                                    } else if crate::is_record(&tests_rt) {
+                                        // Empty record - no tests
+                                        tests = Some(Default::default());
+                                    } else {
+                                        todo!("handle value being non-dict {:?}", field.value);
+                                    };
+                                }
+                            Ok(())
+                        }
+                        _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                    }
+                })?;
         }
         match ty {
             Some(ObjTy::Builder) => {} // happy path
-            None => return Err(Error::MissingTy(program.files(), rt.pos)),
+            None => {
+                return Err(Error::MissingTy(
+                    program.files(),
+                    rt.pos(program.pos_table()),
+                ));
+            }
             Some(ty) => {
                 return Err(Error::UnexpectedObject {
                     files: program.files(),
                     got: ty,
                     want: ObjTy::Builder,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                 });
             }
         }
@@ -1170,7 +1174,7 @@ impl BuildDecl {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ObjTy::Builder,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "name",
                 });
             }
@@ -1183,7 +1187,7 @@ impl BuildDecl {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ObjTy::Builder,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "build_deps",
                 });
             }
@@ -1198,7 +1202,7 @@ impl BuildDecl {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ObjTy::Builder,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "outputs",
                 });
             }
@@ -1601,11 +1605,11 @@ mod tests {
             panic!("finish failed");
         });
 
-        let (o_lib, o_bin, o_data) = if let Term::Array(a, _) = term.as_ref() {
+        let (o_lib, o_bin, o_data) = if let Some(a) = term.as_array() {
             (
-                BuildOutput::from_term(&a[0], &mut program).unwrap(),
-                BuildOutput::from_term(&a[1], &mut program).unwrap(),
-                BuildOutput::from_term(&a[2], &mut program).unwrap(),
+                BuildOutput::from_term(a.get(0).unwrap(), &mut program).unwrap(),
+                BuildOutput::from_term(a.get(1).unwrap(), &mut program).unwrap(),
+                BuildOutput::from_term(a.get(2).unwrap(), &mut program).unwrap(),
             )
         } else {
             unreachable!()

--- a/crates/decode/src/decl_tests.rs
+++ b/crates/decode/src/decl_tests.rs
@@ -1,12 +1,11 @@
 use nickel_lang_core::{
-    eval::cache::CacheImpl,
+    eval::{cache::CacheImpl, value::NickelValue},
     program::Program,
-    term::{RichTerm, Term},
 };
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use crate::{Error, ObjTy, builds::BuildRef, eval_if_closure, read_ty};
+use crate::{Error, ObjTy, builds::BuildRef, eval_if_closure, read_ty, record_data_from_val};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Test {
@@ -21,7 +20,7 @@ pub struct Test {
 
 impl Test {
     pub(crate) fn from_term<A: super::DeclAccumulator>(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
         acc: &mut A,
     ) -> Result<Self, Error> {
@@ -34,108 +33,105 @@ impl Test {
                 let mut cmds: Option<Vec<Vec<String>>> = None;
                 let mut deps: Option<SmallVec<[BuildRef; 6]>> = None;
                 let mut is_build_test: bool = false;
-                match rt.term.as_ref() {
-                    Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                        r.fields.iter().try_for_each(
-                            |(ident_and_loc, field)| -> Result<(), Error> {
-                                match ident_and_loc.label() {
-                                    "class" => {
-                                        let rt = eval_if_closure(field.value.as_ref().unwrap(), program)?;
-                                        if let Term::Enum(e) = rt.term.as_ref() {
-                                            is_build_test = e.as_ref() == "Build";
+                if let Some(r) = record_data_from_val(&rt) {
+                    r.fields.iter().try_for_each(
+                        |(ident_and_loc, field)| -> Result<(), Error> {
+                            match ident_and_loc.label() {
+                                "class" => {
+                                    let rt = eval_if_closure(field.value.as_ref().unwrap(), program)?;
+                                    if let Some(tag) = rt.as_enum_tag() {
+                                        is_build_test = tag.label() == "Build";
+                                    } else {
+                                        todo!("class enum err: {:?}", rt)
+                                    }
+                                    Ok(())
+                                }
+                                "cmd" => {
+                                    if let Some(rt) = field.value.as_ref() {
+                                        let rt = eval_if_closure(rt, program)?;
+                                        if let Some(s) = rt.as_string() {
+                                            cmds = Some(vec![
+                                                shlex::split(s.as_ref()).unwrap(),
+                                            ]);
+                                        } else if let Some(a) = rt.as_array() {
+                                            cmds = Some(vec![
+                                                a.iter()
+                                                    .map(|rt| eval_if_closure(rt, program))
+                                                    .collect::<Result<Vec<_>, _>>()?
+                                                    .into_iter()
+                                                    .map(|rt| String::deserialize(rt).unwrap())
+                                                    .collect(),
+                                            ]);
                                         } else {
-                                            todo!("class enum err: {:?}", rt)
+                                            todo!("error for 'cmd' field being non-string & non-array, got {:?}", rt);
                                         }
                                         Ok(())
+                                    } else {
+                                        Ok(())
                                     }
-                                    "cmd" => {
-                                        if let Some(rt) = field.value.as_ref() {
-                                            let rt = eval_if_closure(rt, program)?;
-                                            match rt.term.as_ref() {
-                                                Term::Str(s) => {
-                                                    cmds = Some(vec![
-                                                        shlex::split(s).unwrap(),
-                                                    ]);
-                                                }
-                                                Term::Array(a, _attrs) => {
-                                                    cmds = Some(vec![
-                                                        a.iter()
-                                                            .map(|rt| eval_if_closure(rt, program))
-                                                            .collect::<Result<Vec<_>, _>>()?
-                                                            .into_iter()
-                                                            .map(|rt| String::deserialize(rt).unwrap())
-                                                            .collect(),
-                                                    ]);
-                                                }
-                                                _ => todo!("error for 'cmd' field being non-string & non-array, got {:?}", rt.term.as_ref()),
-                                            };
-                                            Ok(())
-                                        } else {
-                                            Ok(())
-                                        }
-                                    }
-                                    "cmds" => {
-                                        if let Some(rt) = field.value.as_ref() {
-                                            let rt = eval_if_closure(rt,program)?;
-                                            if let Term::Array(cmds_rt, _attrs) = rt.term.as_ref() {
-                                                cmds = Some(
-                                                    cmds_rt.iter()
-                                                        .map(|rt| {
-                                                            let rt = eval_if_closure(rt, program)?;
-                                                            if let Term::Array(a, _attrs) = rt.term.as_ref() {
-                                                                Ok::<_, Error>(a.iter()
-                                                                    .map(|rt| eval_if_closure(rt, program))
-                                                                    .collect::<Result<Vec<_>, _>>()?
-                                                                    .into_iter()
-                                                                    .map(|rt| String::deserialize(rt).unwrap())
-                                                                    .collect())
-                                                            } else if let Term::Str(s) = rt.term.as_ref() {
-                                                                Ok::<_, Error>(shlex::split(s).unwrap())
-                                                            } else {
-                                                                todo!("error for 'cmds' field being non-array & non-string, got {:?}", rt.term.as_ref());
-                                                            }
-                                                        })
-                                                        .collect::<Result<Vec<_>, _>>()?,
-                                                );
+                                }
+                                "cmds" => {
+                                    if let Some(rt) = field.value.as_ref() {
+                                        let rt = eval_if_closure(rt,program)?;
+                                        if let Some(cmds_a) = rt.as_array() {
+                                            cmds = Some(
+                                                cmds_a.iter()
+                                                    .map(|rt| {
+                                                        let rt = eval_if_closure(rt, program)?;
+                                                        if let Some(a) = rt.as_array() {
+                                                            Ok::<_, Error>(a.iter()
+                                                                .map(|rt| eval_if_closure(rt, program))
+                                                                .collect::<Result<Vec<_>, _>>()?
+                                                                .into_iter()
+                                                                .map(|rt| String::deserialize(rt).unwrap())
+                                                                .collect())
+                                                        } else if let Some(s) = rt.as_string() {
+                                                            Ok::<_, Error>(shlex::split(s.as_ref()).unwrap())
+                                                        } else {
+                                                            todo!("error for 'cmds' field being non-array & non-string, got {:?}", rt);
+                                                        }
+                                                    })
+                                                    .collect::<Result<Vec<_>, _>>()?,
+                                            );
 
-                                                Ok(())
-                                            } else {
-                                                todo!("error for 'cmds' field being non-array, got {:?}", rt.term.as_ref());
-                                            }
-                                        } else {
                                             Ok(())
+                                        } else {
+                                            todo!("error for 'cmds' field being non-array, got {:?}", rt);
                                         }
+                                    } else {
+                                        Ok(())
                                     }
-                                    "test_deps" => {
-                                        let test_deps_rt =
-                                            field.value.as_ref().map(|rt| eval_if_closure(rt, program));
-                                        match test_deps_rt {
-                                            None => {}
-                                            Some(test_deps_rt) => match test_deps_rt?.term.as_ref() {
-                                                Term::Array(a, _attrs) => {
-                                                    deps = Some(
-                                                        a.iter()
-                                                            .map(|input| {
-                                                                BuildRef::from_term(input, program, acc)
-                                                            })
-                                                            .collect::<Result<SmallVec<_>, Error>>()?,
-                                                    );
-                                                }
-                                                _ => todo!(
+                                }
+                                "test_deps" => {
+                                    let test_deps_rt =
+                                        field.value.as_ref().map(|rt| eval_if_closure(rt, program));
+                                    match test_deps_rt {
+                                        None => {}
+                                        Some(test_deps_rt) => {
+                                            let test_deps_val = test_deps_rt?;
+                                            if let Some(a) = test_deps_val.as_array() {
+                                                deps = Some(
+                                                    a.iter()
+                                                        .map(|input| {
+                                                            BuildRef::from_term(input, program, acc)
+                                                        })
+                                                        .collect::<Result<SmallVec<_>, Error>>()?,
+                                                );
+                                            } else {
+                                                todo!(
                                                     "handle test_deps value being non-array {:?}",
                                                     field.value
-                                                ),
-                                            },
+                                                );
+                                            }
                                         }
-                                        Ok(())
                                     }
-                                    _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                                    Ok(())
                                 }
-                            },
-                        )?;
-                    }
-                    _ => {}
-                };
+                                _ => Ok(()), // TODO: Should we error if we see an unknown field?
+                            }
+                        },
+                    )?;
+                }
 
                 let cmds = cmds.unwrap_or_default();
                 Ok(Test {
@@ -148,7 +144,7 @@ impl Test {
                 files: program.files(),
                 got: ty,
                 want: ObjTy::Test,
-                pos: rt.pos,
+                pos: rt.pos(program.pos_table()),
             }),
         }
     }

--- a/crates/decode/src/harnesses.rs
+++ b/crates/decode/src/harnesses.rs
@@ -4,14 +4,14 @@ use common::jq::JqError;
 use either::Either;
 use mfile::{EnvVarValue, TaskAction};
 use nickel_lang_core::{
-    eval::cache::CacheImpl,
+    eval::{cache::CacheImpl, value::NickelValue},
     program::Program,
-    term::{IndexMap, RichTerm, RuntimeContract, Term},
+    term::{IndexMap, RuntimeContract},
 };
 use regex::bytes::Regex;
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, ObjTy, eval_if_closure};
+use crate::{Error, ObjTy, eval_if_closure, record_data_from_val};
 
 /// A predicate that when matched, indicates a package should be added when using a harness.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -35,77 +35,72 @@ impl PackageMatcherPredicate {
 
     /// Deserializes a matcher structure from the given nickel term tree.
     pub(crate) fn from_term(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
     ) -> Result<Self, Error> {
         let rt = eval_if_closure(rt, program)?;
 
         let mut file_regexes: Option<IndexMap<String, String>> = None;
         let mut file_predicates: Option<IndexMap<String, String>> = None;
-        match rt.term.as_ref() {
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        if let Some(rt) = field.value.as_ref() {
-                        let rt = RuntimeContract::apply_all(
-                            rt.clone(),
-                            field.pending_contracts.iter().cloned(),
-                            rt.pos,
-                        );
+        if let Some(r) = record_data_from_val(&rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    if let Some(rt) = field.value.as_ref() {
+                    let rt = RuntimeContract::apply_all(
+                        rt.clone(),
+                        field.pending_contracts.iter().cloned(),
+                        rt.pos_idx(),
+                    );
 
-                        match ident_and_loc.label() {
-                            "file_regexes" => {
-                                    let rt = eval_if_closure(&rt, program)?;
-                                    match rt.term.as_ref() {
-                                        Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                                            file_regexes = Some(r.fields.iter().map(
-                                                |(ident_and_loc, field)| -> Result<(String, String), Error> {
-                                                    Ok((
-                                                        ident_and_loc.label().to_string(),
-                                                        String::deserialize(eval_if_closure(
-                                                            field.value.as_ref().unwrap(),
-                                                            program,
-                                                        )?).unwrap(),
-                                                    ))
-                                                },
-                                            ).collect::<Result<IndexMap<_, _>, Error>>()?);
-                                        }
-                                        _ => todo!("unexpected term for file_regexes: {:?}", rt.term.as_ref()),
-                                    };
+                    match ident_and_loc.label() {
+                        "file_regexes" => {
+                                let rt = eval_if_closure(&rt, program)?;
+                                if let Some(r) = record_data_from_val(&rt) {
+                                    file_regexes = Some(r.fields.iter().map(
+                                        |(ident_and_loc, field)| -> Result<(String, String), Error> {
+                                            Ok((
+                                                ident_and_loc.label().to_string(),
+                                                String::deserialize(eval_if_closure(
+                                                    field.value.as_ref().unwrap(),
+                                                    program,
+                                                )?).unwrap(),
+                                            ))
+                                        },
+                                    ).collect::<Result<IndexMap<_, _>, Error>>()?);
+                                } else {
+                                    todo!("unexpected term for file_regexes: {:?}", rt);
+                                }
 
-                                Ok(())
-                            }
-                            "file_predicates" => {
-                                    let rt = eval_if_closure(&rt, program)?;
-                                    match rt.term.as_ref() {
-                                        Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                                            file_predicates = Some(r.fields.iter().map(
-                                                |(ident_and_loc, field)| -> Result<(String, String), Error> {
-                                                    Ok((
-                                                        ident_and_loc.label().to_string(),
-                                                        String::deserialize(eval_if_closure(
-                                                            field.value.as_ref().unwrap(),
-                                                            program,
-                                                        )?).unwrap(),
-                                                    ))
-                                                },
-                                            ).collect::<Result<IndexMap<_, _>, Error>>()?);
-                                        }
-                                        _ => todo!("unexpected term for file_predicates: {:?}", rt.term.as_ref()),
-                                    };
-
-                                Ok(())
-                            }
-                            _ => Ok(()),
-                        }
-                        } else {
                             Ok(())
                         }
-                    })?;
-            }
-            _ => {}
-        };
+                        "file_predicates" => {
+                                let rt = eval_if_closure(&rt, program)?;
+                                if let Some(r) = record_data_from_val(&rt) {
+                                    file_predicates = Some(r.fields.iter().map(
+                                        |(ident_and_loc, field)| -> Result<(String, String), Error> {
+                                            Ok((
+                                                ident_and_loc.label().to_string(),
+                                                String::deserialize(eval_if_closure(
+                                                    field.value.as_ref().unwrap(),
+                                                    program,
+                                                )?).unwrap(),
+                                            ))
+                                        },
+                                    ).collect::<Result<IndexMap<_, _>, Error>>()?);
+                                } else {
+                                    todo!("unexpected term for file_predicates: {:?}", rt);
+                                }
+
+                            Ok(())
+                        }
+                        _ => Ok(()),
+                    }
+                    } else {
+                        Ok(())
+                    }
+                })?;
+        }
 
         Ok(PackageMatcherPredicate {
             file_regexes: file_regexes.unwrap_or_default(),
@@ -116,36 +111,33 @@ impl PackageMatcherPredicate {
 
 /// Parses a nickel tree representing a map of `String` to `Vec<PackageMatcherPredicate>`.
 fn package_map_from_term(
-    rt: &RichTerm,
+    rt: &NickelValue,
     program: &mut Program<CacheImpl>,
 ) -> Result<IndexMap<String, Vec<PackageMatcherPredicate>>, Error> {
     let rt = eval_if_closure(rt, program)?;
-    match rt.term.as_ref() {
-        Term::Record(r) | Term::RecRecord(r, _, _, _) => r
-            .fields
+    if let Some(r) = record_data_from_val(&rt) {
+        r.fields
             .iter()
             .map(
                 |(ident_and_loc, field)| -> Result<(String, Vec<PackageMatcherPredicate>), Error> {
                     let a_rt = eval_if_closure(field.value.as_ref().unwrap(), program)?;
-                    let pred = match a_rt.term.as_ref() {
-                        Term::Array(a, _attrs) => a
-                            .iter()
+                    let pred = if let Some(a) = a_rt.as_array() {
+                        a.iter()
                             .map(|input| PackageMatcherPredicate::from_term(input, program))
-                            .collect::<Result<Vec<_>, Error>>()?,
-                        _ => todo!(
+                            .collect::<Result<Vec<_>, Error>>()?
+                    } else {
+                        todo!(
                             "handle build_package_if_any value being non-array {:?}",
                             field.value
-                        ),
+                        )
                     };
 
                     Ok((ident_and_loc.label().to_string(), pred))
                 },
             )
-            .collect::<Result<IndexMap<_, _>, Error>>(),
-        _ => todo!(
-            "unexpected term for build_package_if_any: {:?}",
-            rt.term.as_ref()
-        ),
+            .collect::<Result<IndexMap<_, _>, Error>>()
+    } else {
+        todo!("unexpected term for build_package_if_any: {:?}", rt)
     }
 }
 
@@ -219,7 +211,7 @@ impl HarnessMatcher {
 
     /// Deserializes a harness matcher structure from the given nickel term tree.
     pub(crate) fn from_term(
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
     ) -> Result<Self, Error> {
         let rt = eval_if_closure(rt, program)?;
@@ -233,36 +225,33 @@ impl HarnessMatcher {
             Default::default();
         let mut runtime_package_matchers: IndexMap<String, Vec<PackageMatcherPredicate>> =
             Default::default();
-        match rt.term.as_ref() {
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        if let Some(rt) = field.value.as_ref() {
-                            let rt = RuntimeContract::apply_all(
-                                rt.clone(),
-                                field.pending_contracts.iter().cloned(),
-                                rt.pos,
-                            );
+        if let Some(r) = record_data_from_val(&rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    if let Some(rt) = field.value.as_ref() {
+                        let rt = RuntimeContract::apply_all(
+                            rt.clone(),
+                            field.pending_contracts.iter().cloned(),
+                            rt.pos_idx(),
+                        );
 
-                            match ident_and_loc.label() {
-                                "build_package_if_any" => {
-                                    build_package_matchers = package_map_from_term(&rt, program)?;
-                                    Ok(())
-                                }
-                                "runtime_package_if_any" => {
-                                    runtime_package_matchers = package_map_from_term(&rt, program)?;
-                                    Ok(())
-                                }
-                                _ => Ok(()),
+                        match ident_and_loc.label() {
+                            "build_package_if_any" => {
+                                build_package_matchers = package_map_from_term(&rt, program)?;
+                                Ok(())
                             }
-                        } else {
-                            Ok(())
+                            "runtime_package_if_any" => {
+                                runtime_package_matchers = package_map_from_term(&rt, program)?;
+                                Ok(())
+                            }
+                            _ => Ok(()),
                         }
-                    })?;
-            }
-            _ => {}
-        };
+                    } else {
+                        Ok(())
+                    }
+                })?;
+        }
 
         Ok(HarnessMatcher {
             file_regexes,
@@ -307,7 +296,7 @@ pub struct Harness {
 
 impl Harness {
     /// Deserializes a harness structure from the given nickel term tree.
-    pub fn from_term(rt: &RichTerm, program: &mut Program<CacheImpl>) -> Result<Self, Error> {
+    pub fn from_term(rt: &NickelValue, program: &mut Program<CacheImpl>) -> Result<Self, Error> {
         let rt = eval_if_closure(rt, program)?;
 
         let mut ty: Option<ObjTy> = None;
@@ -320,224 +309,217 @@ impl Harness {
         let mut matches_project_if_any: Option<Vec<HarnessMatcher>> = None;
         let mut matches_project_priority: Option<i32> = None;
 
-        match rt.term.as_ref() {
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        match ident_and_loc.label() {
-                            "ty" => {
-                                ty = Some(
-                                    ObjTy::deserialize(eval_if_closure(
-                                        field.value.as_ref().unwrap(),
-                                        program,
-                                    )?)
-                                    .unwrap(),
-                                );
-                                Ok(())
-                            }
-                            "name" => {
-                                name = Some(
-                                    String::deserialize(eval_if_closure(
-                                        field.value.as_ref().unwrap(),
-                                        program,
-                                    )?)
-                                    .unwrap(),
-                                );
-                                Ok(())
-                            }
-
-                            "build_env_vars" => {
-                                if let Some(ev_rt) = field.value.as_ref() {
-                                    let ev_rt =
-                                        eval_if_closure(ev_rt, program)?;
-
-                                    match ev_rt.term.as_ref() {
-                                        Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                                            build_env_vars = Some(r.fields.iter().map(
-                                                |(ident_and_loc, field)| -> Result<(String, EnvVarValue), Error> {
-                                                    Ok((
-                                                        ident_and_loc.label().to_string(),
-                                                        EnvVarValue::Value(String::deserialize(eval_if_closure(
-                                                            field.value.as_ref().unwrap(),
-                                                            program,
-                                                        )?).unwrap()),
-                                                    ))
-                                                },
-                                            ).collect::<Result<IndexMap<_, _>, Error>>()?);
-                                        }
-                                        _ => todo!("unexpected term for build_env_vars: {:?}", ev_rt.term.as_ref()),
-                                    };
-                                }
-
-                                Ok(())
-                            }
-                            "build_packages" => {
-                                if let Some(packages_rt) = field.value.as_ref() {
-                                    let packages_rt =
-                                        eval_if_closure(packages_rt, program)?;
-
-                                    match packages_rt.term.as_ref() {
-                                        Term::Array(a, _attrs) => {
-                                            build_packages = Some(
-                                                a.iter()
-                                                    .map(|input| {
-                                                        Ok(String::deserialize(eval_if_closure(
-                                                            input,
-                                                            program,
-                                                        )?).unwrap())
-                                                    })
-                                                    .collect::<Result<Vec<_>, Error>>()?,
-                                            );
-                                        }
-                                        _ => todo!(
-                                            "handle build_packages value being non-array {:?}",
-                                            field.value
-                                        ),
-                                    }
-                                }
-
-                                Ok(())
-                            }
-                            "runtime_packages" => {
-                                if let Some(packages_rt) = field.value.as_ref() {
-                                    let packages_rt =
-                                        eval_if_closure(packages_rt, program)?;
-
-                                    match packages_rt.term.as_ref() {
-                                        Term::Array(a, _attrs) => {
-                                            runtime_packages = Some(
-                                                a.iter()
-                                                    .map(|input| {
-                                                        Ok(String::deserialize(eval_if_closure(
-                                                            input,
-                                                            program,
-                                                        )?).unwrap())
-                                                    })
-                                                    .collect::<Result<Vec<_>, Error>>()?,
-                                            );
-                                        }
-                                        _ => todo!(
-                                            "handle runtime_packages value being non-array {:?}",
-                                            field.value
-                                        ),
-                                    }
-                                }
-
-                                Ok(())
-                            }
-                            "build_cmd" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                    let rt = eval_if_closure(rt, program)?;
-                                    match rt.term.as_ref() {
-                                        Term::Str(s) => {
-                                            build_cmds = Some(vec![
-                                                shlex::split(s).unwrap(),
-                                            ]);
-                                        }
-                                        Term::Array(a, _attrs) => {
-                                            build_cmds = Some(vec![
-                                                a.iter()
-                                                    .map(|rt| eval_if_closure(rt, program))
-                                                    .collect::<Result<Vec<_>, _>>()?
-                                                    .into_iter()
-                                                    .map(|rt| String::deserialize(rt).unwrap())
-                                                    .collect(),
-                                            ]);
-                                        }
-                                        _ => todo!("error for 'build_cmds' field being non-string & non-array, got {:?}", rt.term.as_ref()),
-                                    };
-                                    Ok(())
-                                } else {
-                                    Ok(())
-                                }
-                            }
-                            "build_cmds_cmd" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                    let rt = eval_if_closure(rt, program)?;
-                                    match rt.term.as_ref() {
-                                        Term::Str(s) => {
-                                            build_cmds_cmd = Some(
-                                                shlex::split(s).unwrap(),
-                                            );
-                                        }
-                                        Term::Array(a, _attrs) => {
-                                            build_cmds_cmd = Some(
-                                                a.iter()
-                                                    .map(|rt| eval_if_closure(rt, program))
-                                                    .collect::<Result<Vec<_>, _>>()?
-                                                    .into_iter()
-                                                    .map(|rt| String::deserialize(rt).unwrap())
-                                                    .collect(),
-                                            );
-                                        }
-                                        _ => todo!("error for 'build_cmds_cmd' field being non-string & non-array, got {:?}", rt.term.as_ref()),
-                                    };
-                                    Ok(())
-                                } else {
-                                    Ok(())
-                                }
-                            }
-                            "matches_project_if_any" => {
-                                if let Some(matchers_rt) = field.value.as_ref() {
-                                    let matchers_rt =
-                                        eval_if_closure(matchers_rt, program)?;
-
-                                    match matchers_rt.term.as_ref() {
-                                        Term::Array(a, attrs) => {
-                                            matches_project_if_any = Some(
-                                                a.iter()
-                                                    .map(|m| {
-                                                        let rt = RuntimeContract::apply_all(
-                                                            m.clone(),
-                                                            attrs.pending_contracts.iter().cloned(),
-                                                            m.pos,
-                                                        );
-
-                                                        HarnessMatcher::from_term(&eval_if_closure(
-                                                            &rt,
-                                                            program,
-                                                        )?, program)
-                                                    })
-                                                    .collect::<Result<Vec<_>, Error>>()?,
-                                            );
-                                        }
-                                        _ => todo!(
-                                            "handle matches_project_if_any value being non-array {:?}",
-                                            field.value
-                                        ),
-                                    }
-                                }
-
-                                Ok(())
-                            }
-                            "matches_project_priority" => {
-                                if let Some(matchers_rt) = field.value.as_ref() {
-                                    let matchers_rt =
-                                        eval_if_closure(matchers_rt, program)?;
-                                    matches_project_priority = Some(i32::deserialize(matchers_rt).unwrap());
-                                }
-
-                                Ok(())
-                            }
-
-                            // TODO: `build_cmds` like `cmds` in build-specs.
-                            _ => Ok(()),
+        if let Some(r) = record_data_from_val(&rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    match ident_and_loc.label() {
+                        "ty" => {
+                            ty = Some(
+                                ObjTy::deserialize(eval_if_closure(
+                                    field.value.as_ref().unwrap(),
+                                    program,
+                                )?)
+                                .unwrap(),
+                            );
+                            Ok(())
                         }
-                    })?;
-            }
-            _ => {}
-        };
+                        "name" => {
+                            name = Some(
+                                String::deserialize(eval_if_closure(
+                                    field.value.as_ref().unwrap(),
+                                    program,
+                                )?)
+                                .unwrap(),
+                            );
+                            Ok(())
+                        }
+
+                        "build_env_vars" => {
+                            if let Some(ev_rt) = field.value.as_ref() {
+                                let ev_rt = eval_if_closure(ev_rt, program)?;
+
+                                if let Some(r) = record_data_from_val(&ev_rt) {
+                                    build_env_vars = Some(r.fields.iter().map(
+                                        |(ident_and_loc, field)| -> Result<(String, EnvVarValue), Error> {
+                                            Ok((
+                                                ident_and_loc.label().to_string(),
+                                                EnvVarValue::Value(String::deserialize(eval_if_closure(
+                                                    field.value.as_ref().unwrap(),
+                                                    program,
+                                                )?).unwrap()),
+                                            ))
+                                        },
+                                    ).collect::<Result<IndexMap<_, _>, Error>>()?);
+                                } else {
+                                    todo!("unexpected term for build_env_vars: {:?}", ev_rt);
+                                }
+                            }
+
+                            Ok(())
+                        }
+                        "build_packages" => {
+                            if let Some(packages_rt) = field.value.as_ref() {
+                                let packages_rt = eval_if_closure(packages_rt, program)?;
+
+                                if let Some(a) = packages_rt.as_array() {
+                                    build_packages = Some(
+                                        a.iter()
+                                            .map(|input| {
+                                                Ok(String::deserialize(eval_if_closure(
+                                                    input,
+                                                    program,
+                                                )?).unwrap())
+                                            })
+                                            .collect::<Result<Vec<_>, Error>>()?,
+                                    );
+                                } else {
+                                    todo!(
+                                        "handle build_packages value being non-array {:?}",
+                                        field.value
+                                    );
+                                }
+                            }
+
+                            Ok(())
+                        }
+                        "runtime_packages" => {
+                            if let Some(packages_rt) = field.value.as_ref() {
+                                let packages_rt = eval_if_closure(packages_rt, program)?;
+
+                                if let Some(a) = packages_rt.as_array() {
+                                    runtime_packages = Some(
+                                        a.iter()
+                                            .map(|input| {
+                                                Ok(String::deserialize(eval_if_closure(
+                                                    input,
+                                                    program,
+                                                )?).unwrap())
+                                            })
+                                            .collect::<Result<Vec<_>, Error>>()?,
+                                    );
+                                } else {
+                                    todo!(
+                                        "handle runtime_packages value being non-array {:?}",
+                                        field.value
+                                    );
+                                }
+                            }
+
+                            Ok(())
+                        }
+                        "build_cmd" => {
+                            if let Some(rt) = field.value.as_ref() {
+                                let rt = eval_if_closure(rt, program)?;
+                                if let Some(s) = rt.as_string() {
+                                    build_cmds = Some(vec![
+                                        shlex::split(s.as_ref()).unwrap(),
+                                    ]);
+                                } else if let Some(a) = rt.as_array() {
+                                    build_cmds = Some(vec![
+                                        a.iter()
+                                            .map(|rt| eval_if_closure(rt, program))
+                                            .collect::<Result<Vec<_>, _>>()?
+                                            .into_iter()
+                                            .map(|rt| String::deserialize(rt).unwrap())
+                                            .collect(),
+                                    ]);
+                                } else {
+                                    todo!("error for 'build_cmds' field being non-string & non-array, got {:?}", rt);
+                                }
+                                Ok(())
+                            } else {
+                                Ok(())
+                            }
+                        }
+                        "build_cmds_cmd" => {
+                            if let Some(rt) = field.value.as_ref() {
+                                let rt = eval_if_closure(rt, program)?;
+                                if let Some(s) = rt.as_string() {
+                                    build_cmds_cmd = Some(
+                                        shlex::split(s.as_ref()).unwrap(),
+                                    );
+                                } else if let Some(a) = rt.as_array() {
+                                    build_cmds_cmd = Some(
+                                        a.iter()
+                                            .map(|rt| eval_if_closure(rt, program))
+                                            .collect::<Result<Vec<_>, _>>()?
+                                            .into_iter()
+                                            .map(|rt| String::deserialize(rt).unwrap())
+                                            .collect(),
+                                    );
+                                } else {
+                                    todo!("error for 'build_cmds_cmd' field being non-string & non-array, got {:?}", rt);
+                                }
+                                Ok(())
+                            } else {
+                                Ok(())
+                            }
+                        }
+                        "matches_project_if_any" => {
+                            if let Some(matchers_rt) = field.value.as_ref() {
+                                let matchers_rt = eval_if_closure(matchers_rt, program)?;
+
+                                if let Some(a) = matchers_rt.as_array() {
+                                    matches_project_if_any = Some(
+                                        a.iter()
+                                            .map(|m| {
+                                                let pending = a.iter_pending_contracts()
+                                                    .cloned()
+                                                    .collect::<Vec<_>>();
+                                                let rt = RuntimeContract::apply_all(
+                                                    m.clone(),
+                                                    pending.into_iter(),
+                                                    m.pos_idx(),
+                                                );
+
+                                                HarnessMatcher::from_term(&eval_if_closure(
+                                                    &rt,
+                                                    program,
+                                                )?, program)
+                                            })
+                                            .collect::<Result<Vec<_>, Error>>()?,
+                                    );
+                                } else {
+                                    todo!(
+                                        "handle matches_project_if_any value being non-array {:?}",
+                                        field.value
+                                    );
+                                }
+                            }
+
+                            Ok(())
+                        }
+                        "matches_project_priority" => {
+                            if let Some(matchers_rt) = field.value.as_ref() {
+                                let matchers_rt =
+                                    eval_if_closure(matchers_rt, program)?;
+                                matches_project_priority = Some(i32::deserialize(matchers_rt).unwrap());
+                            }
+
+                            Ok(())
+                        }
+
+                        // TODO: `build_cmds` like `cmds` in build-specs.
+                        _ => Ok(()),
+                    }
+                })?;
+        }
 
         match ty {
             Some(ObjTy::Harness) => {} // happy path
-            None => return Err(Error::MissingTy(program.files(), rt.pos)),
+            None => {
+                return Err(Error::MissingTy(
+                    program.files(),
+                    rt.pos(program.pos_table()),
+                ));
+            }
             Some(ty) => {
                 return Err(Error::UnexpectedObject {
                     files: program.files(),
                     got: ty,
                     want: ObjTy::Harness,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                 });
             }
         };
@@ -547,7 +529,7 @@ impl Harness {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ObjTy::Builder,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "name",
                 });
             }
@@ -568,7 +550,7 @@ impl Harness {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ObjTy::Harness,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "build_cmd or build_cmds_cmd",
                 });
             }

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -7,9 +7,9 @@
 use common::{SpecOrigin, Target};
 use generational_arena::Arena;
 use mfile::{EnvPatches, LinkConfig, PatchSetting};
+use nickel_lang_core::eval::value::NickelValue;
 use nickel_lang_core::identifier::LocIdent;
 use nickel_lang_core::position::TermPos;
-use nickel_lang_core::term::{RichTerm, Term};
 use nickel_lang_core::{
     eval::{Closure, cache::CacheImpl},
     program::Program,
@@ -46,8 +46,8 @@ impl TryFrom<TermPos> for StrPos {
     type Error = ();
     fn try_from(value: TermPos) -> Result<Self, Self::Error> {
         match value {
-            TermPos::Inherited(_) | TermPos::None => Err(()),
-            TermPos::Original(p) => Ok(Self {
+            TermPos::None => Err(()),
+            TermPos::Original(p) | TermPos::Inherited(p) => Ok(Self {
                 start_offset: p.start.to_usize(),
                 end_offset: p.end.to_usize(),
             }),
@@ -166,73 +166,65 @@ impl Layer {
         //  - A Layer object, containing arrays of all the objects to ingest
 
         let ncl_tree = eval_if_closure(&ncl_tree, &mut program)?;
-        layer.top_levels = match ncl_tree.term.as_ref() {
-            Term::Array(a, _attrs) => a
-                .iter()
+        layer.top_levels = if let Some(a) = ncl_tree.as_array() {
+            a.iter()
                 .map(|bs| layer.ingest_buildspec(bs, &mut program))
-                .collect::<Result<Vec<_>, Error>>()?,
-            _ => {
-                let ty = read_ty(&ncl_tree, &mut program)?;
-                match ty {
-                    ObjTy::Builder => vec![layer.ingest_buildspec(&ncl_tree, &mut program)?],
-                    ObjTy::Layer => {
-                        let record = match ncl_tree.as_ref() {
-                            Term::RecRecord(record_data, _, _, _) => record_data,
-                            Term::Record(record_data) => record_data,
-                            _ => unreachable!(), // read_ty implicitly does the same check
-                        };
+                .collect::<Result<Vec<_>, Error>>()?
+        } else {
+            let ty = read_ty(&ncl_tree, &mut program)?;
+            match ty {
+                ObjTy::Builder => vec![layer.ingest_buildspec(&ncl_tree, &mut program)?],
+                ObjTy::Layer => {
+                    let record = ncl_tree
+                        .as_record()
+                        .expect("Layer must be a record")
+                        .into_opt()
+                        .expect("Layer record must not be empty");
 
-                        if let Ok(Some(rt)) = record.get_value_with_ctrs(&LocIdent::new("profiles"))
-                        {
-                            if let Term::Array(a, _attrs) =
-                                eval_if_closure(&rt, &mut program)?.term.as_ref()
-                            {
-                                layer.profiles = HashMap::from_iter(
-                                    a.iter()
-                                        .map(|p| layer.ingest_profile(p, &mut program))
-                                        .collect::<Result<Vec<_>, Error>>()?
-                                        .into_iter()
-                                        .map(|p| (p.name.clone(), p)),
-                                );
-                            }
-                        };
-                        if let Ok(Some(rt)) =
-                            record.get_value_with_ctrs(&LocIdent::new("harnesses"))
-                        {
-                            if let Term::Array(a, _attrs) =
-                                eval_if_closure(&rt, &mut program)?.term.as_ref()
-                            {
-                                layer.harnesses = HashMap::from_iter(
-                                    a.iter()
-                                        .map(|p| layer.ingest_harness(p, &mut program))
-                                        .collect::<Result<Vec<_>, Error>>()?
-                                        .into_iter()
-                                        .map(|p| (p.name.clone(), p)),
-                                );
-                            }
-                        };
-                        if let Ok(Some(rt)) = record.get_value_with_ctrs(&LocIdent::new("builds")) {
-                            if let Term::Array(a, _attrs) =
-                                eval_if_closure(&rt, &mut program)?.term.as_ref()
-                            {
+                    if let Ok(Some(rt)) = record.get_value_with_ctrs(&LocIdent::new("profiles")) {
+                        let rt = eval_if_closure(&rt, &mut program)?;
+                        if let Some(a) = rt.as_array() {
+                            layer.profiles = HashMap::from_iter(
                                 a.iter()
-                                    .map(|bs| layer.ingest_buildspec(bs, &mut program))
+                                    .map(|p| layer.ingest_profile(p, &mut program))
                                     .collect::<Result<Vec<_>, Error>>()?
-                            } else {
-                                unreachable!(); // validation for Layer should ensure its an array
-                            }
-                        } else {
-                            vec![]
+                                    .into_iter()
+                                    .map(|p| (p.name.clone(), p)),
+                            );
                         }
+                    };
+                    if let Ok(Some(rt)) = record.get_value_with_ctrs(&LocIdent::new("harnesses")) {
+                        let rt = eval_if_closure(&rt, &mut program)?;
+                        if let Some(a) = rt.as_array() {
+                            layer.harnesses = HashMap::from_iter(
+                                a.iter()
+                                    .map(|p| layer.ingest_harness(p, &mut program))
+                                    .collect::<Result<Vec<_>, Error>>()?
+                                    .into_iter()
+                                    .map(|p| (p.name.clone(), p)),
+                            );
+                        }
+                    };
+                    if let Ok(Some(rt)) = record.get_value_with_ctrs(&LocIdent::new("builds")) {
+                        let rt = eval_if_closure(&rt, &mut program)?;
+                        if let Some(a) = rt.as_array() {
+                            a.iter()
+                                .map(|bs| layer.ingest_buildspec(bs, &mut program))
+                                .collect::<Result<Vec<_>, Error>>()?
+                        } else {
+                            unreachable!(); // validation for Layer should ensure its an array
+                        }
+                    } else {
+                        vec![]
                     }
-                    _ => {
-                        return Err(Error::UnexpectedObject {
-                            files: program.files(),
-                            got: ty,
-                            want: ObjTy::Builder,
-                            pos: ncl_tree.pos,
-                        });
-                    }
+                }
+                _ => {
+                    return Err(Error::UnexpectedObject {
+                        files: program.files(),
+                        got: ty,
+                        want: ObjTy::Builder,
+                        pos: ncl_tree.pos(program.pos_table()),
+                    });
                 }
             }
         };
@@ -242,7 +234,7 @@ impl Layer {
 
     fn ingest_buildspec(
         &mut self,
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
     ) -> Result<generational_arena::Index, Error> {
         let id = match builds::BuildRef::from_term(rt, program, self)? {
@@ -264,7 +256,7 @@ impl Layer {
 
     fn ingest_profile(
         &mut self,
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
     ) -> Result<Profile, Error> {
         Profile::from_term(rt, program)
@@ -272,7 +264,7 @@ impl Layer {
 
     fn ingest_harness(
         &mut self,
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
     ) -> Result<Harness, Error> {
         Harness::from_term(rt, program)
@@ -283,7 +275,7 @@ impl DeclAccumulator for Layer {
     fn maybe_decode(
         &mut self,
         spec_id: &u64,
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
     ) -> Result<(), Error> {
         if self.read_ids.contains_key(spec_id) {
@@ -306,7 +298,7 @@ trait DeclAccumulator {
     fn maybe_decode(
         &mut self,
         spec_id: &u64,
-        rt: &RichTerm,
+        rt: &NickelValue,
         program: &mut Program<CacheImpl>,
     ) -> Result<(), Error>;
 }
@@ -316,7 +308,7 @@ impl DeclAccumulator for () {
     fn maybe_decode(
         &mut self,
         _spec_id: &u64,
-        _rt: &RichTerm,
+        _rt: &NickelValue,
         _program: &mut Program<CacheImpl>,
     ) -> Result<(), Error> {
         Ok(())
@@ -342,34 +334,30 @@ pub enum ObjTy {
     Harness,
 }
 
-pub(crate) fn read_ty(rt: &RichTerm, program: &mut Program<CacheImpl>) -> Result<ObjTy, Error> {
-    let record = match rt.as_ref() {
-        Term::RecRecord(record_data, _, _, _) => record_data,
-        Term::Record(record_data) => record_data,
-        _ => todo!("err"),
-    };
+pub(crate) fn read_ty(val: &NickelValue, program: &mut Program<CacheImpl>) -> Result<ObjTy, Error> {
+    let record = val
+        .as_record()
+        .expect("read_ty: expected record")
+        .into_opt()
+        .expect("read_ty: expected non-empty record");
     if let Ok(Some(rt)) = record.get_value_with_ctrs(&LocIdent::new("ty")) {
         let rt = eval_if_closure(&rt, program)?;
         Ok(ObjTy::deserialize(rt).unwrap())
     } else {
-        Err(Error::MissingTy(program.files(), rt.pos))
+        Err(Error::MissingTy(
+            program.files(),
+            val.pos(program.pos_table()),
+        ))
     }
 }
 
 pub(crate) fn eval_if_closure(
-    rt: &RichTerm,
+    val: &NickelValue,
     program: &'_ mut Program<CacheImpl>,
-) -> Result<RichTerm, Error> {
-    if let Term::Closure(c) = rt.term.as_ref() {
-        program.eval_closure(c.clone().into_closure()).map_err(|e| {
-            Error::Nickel(Box::new((
-                program.files(),
-                nickel_lang_core::error::Error::EvalError(e),
-            )))
-        })
-    } else if !rt.term.is_eff_whnf() {
+) -> Result<NickelValue, Error> {
+    if !val.is_whnf() {
         program
-            .eval_closure(Closure::atomic_closure(rt.clone()))
+            .eval_closure(Closure::from(val.clone()))
             .map_err(|e| {
                 Error::Nickel(Box::new((
                     program.files(),
@@ -377,90 +365,112 @@ pub(crate) fn eval_if_closure(
                 )))
             })
     } else {
-        Ok(rt.clone())
+        Ok(val.clone())
     }
 }
 
+pub(crate) fn record_data_from_val(
+    val: &NickelValue,
+) -> Option<&nickel_lang_core::term::record::RecordData> {
+    val.as_record().and_then(|c| c.into_opt())
+}
+
+/// Returns true if the value is a record (including an empty one).
+pub(crate) fn is_record(val: &NickelValue) -> bool {
+    val.as_record().is_some()
+}
+
 pub(crate) fn patches_from_term(
-    rt: &RichTerm,
+    rt: &NickelValue,
     program: &mut Program<CacheImpl>,
 ) -> Result<EnvPatches, Error> {
     let patch_rt = eval_if_closure(rt, program)?;
 
     let mut dirs: Option<HashMap<String, PatchSetting>> = None;
     let mut files: Option<HashMap<String, PatchSetting>> = None;
-    match patch_rt.term.as_ref() {
-        Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-            r.fields
-                .iter()
-                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                    match ident_and_loc.label() {
-                        "dir" | "dirs" => {
-                            let dir_rt =
-                                eval_if_closure(field.value.as_ref().unwrap(), program)?;
 
-                            match dir_rt.term.as_ref() {
-                                Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                                    if dirs.is_some() {
-                                        todo!("error for both 'dirs' and 'dir' set");
-                                    }
-                                    dirs = Some(r.fields.iter().map(
-                                        |(ident_and_loc, field)| -> Result<(String, PatchSetting), Error> {
-                                            let val = String::deserialize(eval_if_closure(
-                                                field.value.as_ref().unwrap(),
-                                                program,
-                                            )?).unwrap();
-                                            Ok((
-                                                ident_and_loc.label().to_string(),
-                                                match val.as_str() {
-                                                    "ReadOnly" | "read-only" | "ro" => PatchSetting::ReadOnly,
-                                                    "ReadWrite" | "read-write" | "rw" => PatchSetting::ReadWrite,
-                                                    _ => todo!("unexpected patch setting: {}", val),
-                                                },
-                                            ))
-                                        },
-                                    ).collect::<Result<HashMap<_, _>, Error>>()?);
-                                    Ok(())
-                                }
-                                _ => todo!("error for unexpected term for dir: {:?}", dir_rt.term.as_ref()),
-                            }
-                        },
-                        "file" | "files" => {
-                            let file_rt =
-                                eval_if_closure(field.value.as_ref().unwrap(), program)?;
+    let r = record_data_from_val(&patch_rt)
+        .unwrap_or_else(|| panic!("unexpected term for patches: {:?}", patch_rt));
 
-                            match file_rt.term.as_ref() {
-                                Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                                    if files.is_some() {
-                                        todo!("error for both 'file' and 'files' set");
-                                    }
-                                    files = Some(r.fields.iter().map(
-                                        |(ident_and_loc, field)| -> Result<(String, PatchSetting), Error> {
-                                            let val = String::deserialize(eval_if_closure(
-                                                field.value.as_ref().unwrap(),
-                                                program,
-                                            )?).unwrap();
-                                            Ok((
-                                                ident_and_loc.label().to_string(),
-                                                match val.as_str() {
-                                                    "ReadOnly" | "read-only" | "ro" => PatchSetting::ReadOnly,
-                                                    "ReadWrite" | "read-write" | "rw" => PatchSetting::ReadWrite,
-                                                    _ => todo!("unexpected patch setting: {}", val),
-                                                },
-                                            ))
-                                        },
-                                    ).collect::<Result<HashMap<_, _>, Error>>()?);
-                                    Ok(())
-                                }
-                                _ => todo!("error for unexpected term for file: {:?}", file_rt.term.as_ref()),
-                            }
-                        },
-                        _ => Ok(()),
+    r.fields
+        .iter()
+        .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+            match ident_and_loc.label() {
+                "dir" | "dirs" => {
+                    let dir_rt = eval_if_closure(field.value.as_ref().unwrap(), program)?;
+
+                    let r = record_data_from_val(&dir_rt)
+                        .unwrap_or_else(|| panic!("unexpected term for dir: {:?}", dir_rt));
+                    if dirs.is_some() {
+                        todo!("error for both 'dirs' and 'dir' set");
                     }
-                })?;
-        }
-        _ => todo!("unexpected term for patches: {:?}", patch_rt.term.as_ref()),
-    };
+                    dirs = Some(
+                        r.fields
+                            .iter()
+                            .map(
+                                |(ident_and_loc, field)| -> Result<(String, PatchSetting), Error> {
+                                    let val = String::deserialize(eval_if_closure(
+                                        field.value.as_ref().unwrap(),
+                                        program,
+                                    )?)
+                                    .unwrap();
+                                    Ok((
+                                        ident_and_loc.label().to_string(),
+                                        match val.as_str() {
+                                            "ReadOnly" | "read-only" | "ro" => {
+                                                PatchSetting::ReadOnly
+                                            }
+                                            "ReadWrite" | "read-write" | "rw" => {
+                                                PatchSetting::ReadWrite
+                                            }
+                                            _ => todo!("unexpected patch setting: {}", val),
+                                        },
+                                    ))
+                                },
+                            )
+                            .collect::<Result<HashMap<_, _>, Error>>()?,
+                    );
+                    Ok(())
+                }
+                "file" | "files" => {
+                    let file_rt = eval_if_closure(field.value.as_ref().unwrap(), program)?;
+
+                    let r = record_data_from_val(&file_rt)
+                        .unwrap_or_else(|| panic!("unexpected term for file: {:?}", file_rt));
+                    if files.is_some() {
+                        todo!("error for both 'file' and 'files' set");
+                    }
+                    files = Some(
+                        r.fields
+                            .iter()
+                            .map(
+                                |(ident_and_loc, field)| -> Result<(String, PatchSetting), Error> {
+                                    let val = String::deserialize(eval_if_closure(
+                                        field.value.as_ref().unwrap(),
+                                        program,
+                                    )?)
+                                    .unwrap();
+                                    Ok((
+                                        ident_and_loc.label().to_string(),
+                                        match val.as_str() {
+                                            "ReadOnly" | "read-only" | "ro" => {
+                                                PatchSetting::ReadOnly
+                                            }
+                                            "ReadWrite" | "read-write" | "rw" => {
+                                                PatchSetting::ReadWrite
+                                            }
+                                            _ => todo!("unexpected patch setting: {}", val),
+                                        },
+                                    ))
+                                },
+                            )
+                            .collect::<Result<HashMap<_, _>, Error>>()?,
+                    );
+                    Ok(())
+                }
+                _ => Ok(()),
+            }
+        })?;
 
     Ok(EnvPatches {
         file: files.unwrap_or_default(),

--- a/crates/decode/src/load.rs
+++ b/crates/decode/src/load.rs
@@ -6,8 +6,9 @@ use crate::Error;
 use common::{SpecOrigin, Target};
 
 use nickel_lang_core::cache::TermCacheError;
+use nickel_lang_core::eval::value::NickelValue;
 use nickel_lang_core::identifier::LocIdent;
-use nickel_lang_core::term::{RichTerm, Term};
+use nickel_lang_core::term::Term;
 use nickel_lang_core::typ::TypeF;
 use nickel_lang_core::{error::NullReporter, eval::cache::CacheImpl, program::Program};
 use std::io;
@@ -42,55 +43,46 @@ impl LoadOptions {
 }
 
 macro_rules! annotate_record {
-    ($record:expr, $buildspec_id_ident:expr, $id:expr, $rt:expr, ($inner:expr, $files:expr, $minimal_lib_path:expr),) => {
+    ($val:expr, $buildspec_id_ident:expr, $id:expr, $orig_val:expr, ($inner:expr, $files:expr, $pos_table:expr, $minimal_lib_path:expr),) => {
         // Skip annotation for any part of the minimal library.
-        if $inner
-            .pos
-            .src_id()
-            .map(|file_id| {
-                let file_path = $files.name(file_id);
-                file_path
-                    .to_str()
-                    .map(|s| {
-                        s.starts_with($minimal_lib_path)
-                            || if let Ok(md) = std::env::var("CARGO_MANIFEST_DIR") {
-                                (s.contains("minimal-ncl/")
-                                    && s.contains("crates")
-                                    && s.starts_with(&md))
-                            } else {
-                                false
-                            }
-                    })
-                    .unwrap_or(false)
-            })
-            .unwrap_or(false)
-        {
-            return Ok($rt);
+        if {
+            let inner_pos = $inner.pos($pos_table);
+            inner_pos
+                .src_id()
+                .map(|file_id| {
+                    let file_path = $files.name(file_id);
+                    file_path
+                        .to_str()
+                        .map(|s| {
+                            s.starts_with($minimal_lib_path)
+                                || if let Ok(md) = std::env::var("CARGO_MANIFEST_DIR") {
+                                    (s.contains("minimal-ncl/")
+                                        && s.contains("crates")
+                                        && s.starts_with(&md))
+                                } else {
+                                    false
+                                }
+                        })
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false)
+        } {
+            return Ok($orig_val);
         } else {
-            match $record {
-                Term::RecRecord(mut record_data, includes, dyn_fields, deps) => {
-                    if record_data.fields.get(&$buildspec_id_ident).is_some() {
-                        return Ok($rt);
+            // In the new API, pre-evaluation records are Term::RecRecord
+            match $val {
+                Term::RecRecord(mut rec_data) => {
+                    if rec_data.record.fields.get(&$buildspec_id_ident).is_some() {
+                        return Ok($orig_val);
                     }
-                    record_data.fields.insert(
+                    rec_data.record.fields.insert(
                         LocIdent::new("__magic_buildspec_id"),
-                        RichTerm::from(Term::ForeignId($id)).into(),
+                        NickelValue::foreign_id_posless($id).into(),
                     );
                     $id += 1;
-                    Term::RecRecord(record_data, includes, dyn_fields, deps).into()
+                    NickelValue::term_posless(Term::RecRecord(rec_data))
                 }
-                Term::Record(mut record_data) => {
-                    if record_data.fields.get(&$buildspec_id_ident).is_some() {
-                        return Ok($rt);
-                    }
-                    record_data.fields.insert(
-                        LocIdent::new("__magic_buildspec_id"),
-                        RichTerm::from(Term::ForeignId($id)).into(),
-                    );
-                    $id += 1;
-                    Term::Record(record_data).into()
-                }
-                _ => unreachable!("record type was {:?}", $record),
+                _ => unreachable!("record type was {:?}", $val),
             }
         }
     };
@@ -254,70 +246,79 @@ impl Loader {
         use nickel_lang_core::traverse::{Traverse as _, TraverseOrder};
 
         let files = self.p.files();
+        let pos_table = self.p.pos_table().clone();
         let minimal_lib_path = self.minimal_lib_path.to_str().unwrap();
 
         let mut id: u64 = self.last_id;
         let buildspec_id_ident = LocIdent::new("__magic_buildspec_id");
-        let mut traversal = |rt: RichTerm| -> Result<RichTerm, TermCacheError<()>> {
-            // Explicit declaration: { ... } | BuildSpec
-            if let Term::Annotated(annotation, inner) = rt.as_ref() {
-                let is_buildspec = annotation.contracts.iter().any(|lt| {
-                    if let TypeF::Contract(c) = &lt.typ.typ {
-                        if let Term::Var(v) = c.as_ref() {
-                            v.label() == "BuildSpec"
+        let mut traversal = |val: NickelValue| -> Result<NickelValue, TermCacheError<()>> {
+            // We need to inspect the Term inside NickelValue for unevaluated AST
+            if let Some(term) = val.as_term() {
+                // Explicit declaration: { ... } | BuildSpec
+                if let Term::Annotated(ref annotation_data) = *term {
+                    let is_buildspec = annotation_data.annot.contracts.iter().any(|lt| {
+                        if let TypeF::Contract(c) = &lt.typ.typ {
+                            matches!(c.as_term(), Some(Term::Var(v)) if v.label() == "BuildSpec")
                         } else {
                             false
                         }
-                    } else {
-                        false
+                    });
+
+                    if is_buildspec {
+                        if let Some(inner_term) = annotation_data.inner.as_term() {
+                            let annotated =
+                                Term::Annotated(nickel_lang_core::term::AnnotatedData {
+                                    annot: annotation_data.annot.clone(),
+                                    inner: annotate_record!(
+                                        inner_term.clone(),
+                                        buildspec_id_ident,
+                                        id,
+                                        val,
+                                        (
+                                            &annotation_data.inner,
+                                            &files,
+                                            &pos_table,
+                                            minimal_lib_path
+                                        ),
+                                    ),
+                                });
+                            return Ok(NickelValue::term(annotated, val.pos_idx()));
+                        }
                     }
-                });
+                }
 
-                if is_buildspec {
-                    return Ok(Term::Annotated(
-                        annotation.clone(),
-                        annotate_record!(
-                            inner.term.as_ref().clone(),
-                            buildspec_id_ident,
-                            id,
-                            rt,
-                            (inner, files, minimal_lib_path),
-                        ),
-                    )
-                    .into());
+                // Function-based declaration: build { ... }
+                if let Term::App(ref app_data) = *term {
+                    let is_build_decl = matches!(
+                        app_data.head.as_term(),
+                        Some(Term::Var(v)) if v.label() == "build"
+                    );
+
+                    if is_build_decl {
+                        if let Some(arg_term) = app_data.arg.as_term() {
+                            let app = Term::App(nickel_lang_core::term::AppData {
+                                head: app_data.head.clone(),
+                                arg: annotate_record!(
+                                    arg_term.clone(),
+                                    buildspec_id_ident,
+                                    id,
+                                    val,
+                                    (&app_data.arg, &files, &pos_table, minimal_lib_path),
+                                ),
+                            });
+                            return Ok(NickelValue::term(app, val.pos_idx()));
+                        }
+                    }
                 }
             }
 
-            // Function-based declaration: build { ... }
-            if let Term::App(func, arg) = rt.as_ref() {
-                let is_build_decl = if let Term::Var(v) = func.as_ref() {
-                    v.label() == "build"
-                } else {
-                    false
-                };
-
-                if is_build_decl {
-                    return Ok(Term::App(
-                        func.clone(),
-                        annotate_record!(
-                            arg.term.as_ref().clone(),
-                            buildspec_id_ident,
-                            id,
-                            rt,
-                            (arg, files, minimal_lib_path),
-                        ),
-                    )
-                    .into());
-                }
-            }
-
-            Ok(rt)
+            Ok(val)
         };
 
         let result = self
             .p
-            .custom_transform(1, |_cache, rt| {
-                rt.traverse(&mut traversal, TraverseOrder::TopDown)
+            .custom_transform(1, |_cache, _pos_table, val| {
+                val.traverse(&mut traversal, TraverseOrder::TopDown)
             })
             .map_err(|e| Error::Other(format!("annotation: {:?}", e)));
         self.last_id = id;
@@ -325,7 +326,7 @@ impl Loader {
     }
 
     /// Destroys the loader, returning the outputs of processing (the nickel tree, where it came from).
-    pub fn finish(self) -> Result<(RichTerm, Program<CacheImpl>, SpecOrigin, Target), Error> {
+    pub fn finish(self) -> Result<(NickelValue, Program<CacheImpl>, SpecOrigin, Target), Error> {
         let Self {
             mut p,
             from,
@@ -539,32 +540,27 @@ mod tests {
         let mut sr = sr.unwrap();
         assert_eq!(sr.last_id, 3); // three build specs
 
-        if let Term::Record(rd) = sr.p.eval().unwrap().as_ref() {
+        let eval_result = sr.p.eval().unwrap();
+        if let Some(rd) = eval_result.as_record().and_then(|c| c.into_opt()) {
             // Check a field 'profiles' was an array with one object
-            assert!(matches!(
-                eval_if_closure(
-                    &rd.get_value_with_ctrs(&LocIdent::new("profiles"))
-                        .unwrap()
-                        .unwrap(),
-                    &mut sr.p,
-                )
-                .unwrap()
-                .as_ref(),
-                Term::Array(a, _attrs) if a.len() == 1,
-            ));
+            let profiles_val = eval_if_closure(
+                &rd.get_value_with_ctrs(&LocIdent::new("profiles"))
+                    .unwrap()
+                    .unwrap(),
+                &mut sr.p,
+            )
+            .unwrap();
+            assert!(profiles_val.as_array().map(|a| a.len()).unwrap_or(0) == 1,);
 
             // Check a field 'harnesses' was an array with one object
-            assert!(matches!(
-                eval_if_closure(
-                    &rd.get_value_with_ctrs(&LocIdent::new("harnesses"))
-                        .unwrap()
-                        .unwrap(),
-                    &mut sr.p,
-                )
-                .unwrap()
-                .as_ref(),
-                Term::Array(a, _attrs) if a.len() == 1,
-            ));
+            let harnesses_val = eval_if_closure(
+                &rd.get_value_with_ctrs(&LocIdent::new("harnesses"))
+                    .unwrap()
+                    .unwrap(),
+                &mut sr.p,
+            )
+            .unwrap();
+            assert!(harnesses_val.as_array().map(|a| a.len()).unwrap_or(0) == 1,);
         }
     }
 }

--- a/crates/decode/src/profiles.rs
+++ b/crates/decode/src/profiles.rs
@@ -1,12 +1,12 @@
 use mfile::{EnvPatches, EnvVarValue};
 use nickel_lang_core::{
-    eval::cache::CacheImpl,
+    eval::{cache::CacheImpl, value::NickelValue},
     program::Program,
-    term::{IndexMap, RichTerm, Term},
+    term::IndexMap,
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, ObjTy, eval_if_closure};
+use crate::{Error, ObjTy, eval_if_closure, record_data_from_val};
 
 /// A profile, the initial configuration for an environment.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -42,7 +42,7 @@ impl Profile {
     }
 
     /// Deserializes a profile structure from the given nickel term tree.
-    pub fn from_term(rt: &RichTerm, program: &mut Program<CacheImpl>) -> Result<Self, Error> {
+    pub fn from_term(rt: &NickelValue, program: &mut Program<CacheImpl>) -> Result<Self, Error> {
         let rt = eval_if_closure(rt, program)?;
 
         let mut ty: Option<ObjTy> = None;
@@ -51,118 +51,119 @@ impl Profile {
         let mut packages: Option<Vec<String>> = None;
         let mut env_vars: Option<IndexMap<String, EnvVarValue>> = None;
         let mut patches: Option<EnvPatches> = None;
-        match rt.term.as_ref() {
-            Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                r.fields
-                    .iter()
-                    .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
-                        match ident_and_loc.label() {
-                            "ty" => {
-                                ty = Some(
-                                    ObjTy::deserialize(eval_if_closure(
-                                        field.value.as_ref().unwrap(),
-                                        program,
-                                    )?)
-                                    .unwrap(),
-                                );
-                                Ok(())
-                            }
-                            "name" => {
-                                name = Some(
-                                    String::deserialize(eval_if_closure(
-                                        field.value.as_ref().unwrap(),
-                                        program,
-                                    )?)
-                                    .unwrap(),
-                                );
-                                Ok(())
-                            }
-                            "from_profile" => {
-                                if let Some(rt) = field.value.as_ref() {
-                                from_profile = Some(
-                                    String::deserialize(eval_if_closure(rt,program,)?).unwrap(),
-                                );
-                                }
-                                Ok(())
-                            }
 
-                            "env_vars" => {
-                                if let Some(ev_rt) = field.value.as_ref() {
-                                    let ev_rt =
-                                        eval_if_closure(ev_rt, program)?;
-
-                                    match ev_rt.term.as_ref() {
-                                        Term::Record(r) | Term::RecRecord(r, _, _, _) => {
-                                            env_vars = Some(r.fields.iter().map(
-                                                |(ident_and_loc, field)| -> Result<(String, EnvVarValue), Error> {
-                                                    Ok((
-                                                        ident_and_loc.label().to_string(),
-                                                        EnvVarValue::Value(String::deserialize(eval_if_closure(
-                                                            field.value.as_ref().unwrap(),
-                                                            program,
-                                                        )?).unwrap()),
-                                                    ))
-                                                },
-                                            ).collect::<Result<IndexMap<_, _>, Error>>()?);
-                                        }
-                                        _ => todo!("unexpected term for env_vars: {:?}", ev_rt.term.as_ref()),
-                                    };
-                                }
-
-                                Ok(())
-                            }
-                            "packages" => {
-                                if let Some(packages_rt) = field.value.as_ref() {
-                                    let packages_rt =
-                                        eval_if_closure(packages_rt, program)?;
-
-                                    match packages_rt.term.as_ref() {
-                                        Term::Array(a, _attrs) => {
-                                            packages = Some(
-                                                a.iter()
-                                                    .map(|input| {
-                                                        Ok(String::deserialize(eval_if_closure(
-                                                            input,
-                                                            program,
-                                                        )?).unwrap())
-                                                    })
-                                                    .collect::<Result<Vec<_>, Error>>()?,
-                                            );
-                                        }
-                                        _ => todo!(
-                                            "handle packages value being non-array {:?}",
-                                            field.value
-                                        ),
-                                    }
-                                }
-
-                                Ok(())
-                            }
-                            "patch" | "patches" => {
-                                if let Some(patch_rt) = field.value.as_ref() {
-                                    if patches.is_some() {
-                                        todo!("error for both 'patch' and 'patches' set");
-                                    }
-                                    patches = Some(crate::patches_from_term(patch_rt, program)?);
-                                }
-                                Ok(())
-                            }
-                            _ => Ok(()),
+        if let Some(r) = record_data_from_val(&rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    match ident_and_loc.label() {
+                        "ty" => {
+                            ty = Some(
+                                ObjTy::deserialize(eval_if_closure(
+                                    field.value.as_ref().unwrap(),
+                                    program,
+                                )?)
+                                .unwrap(),
+                            );
+                            Ok(())
                         }
-                    })?;
-            }
-            _ => {}
-        };
+                        "name" => {
+                            name = Some(
+                                String::deserialize(eval_if_closure(
+                                    field.value.as_ref().unwrap(),
+                                    program,
+                                )?)
+                                .unwrap(),
+                            );
+                            Ok(())
+                        }
+                        "from_profile" => {
+                            if let Some(rt) = field.value.as_ref() {
+                            from_profile = Some(
+                                String::deserialize(eval_if_closure(rt,program,)?).unwrap(),
+                            );
+                            }
+                            Ok(())
+                        }
+
+                        "env_vars" => {
+                            if let Some(ev_rt) = field.value.as_ref() {
+                                let ev_rt =
+                                    eval_if_closure(ev_rt, program)?;
+
+                                if let Some(r) = record_data_from_val(&ev_rt) {
+                                    env_vars = Some(r.fields.iter().map(
+                                        |(ident_and_loc, field)| -> Result<(String, EnvVarValue), Error> {
+                                            Ok((
+                                                ident_and_loc.label().to_string(),
+                                                EnvVarValue::Value(String::deserialize(eval_if_closure(
+                                                    field.value.as_ref().unwrap(),
+                                                    program,
+                                                )?).unwrap()),
+                                            ))
+                                        },
+                                    ).collect::<Result<IndexMap<_, _>, Error>>()?);
+                                } else {
+                                    todo!("unexpected term for env_vars: {:?}", ev_rt);
+                                }
+                            }
+
+                            Ok(())
+                        }
+                        "packages" => {
+                            if let Some(packages_rt) = field.value.as_ref() {
+                                let packages_rt =
+                                    eval_if_closure(packages_rt, program)?;
+
+                                if let Some(a) = packages_rt.as_array() {
+                                    packages = Some(
+                                        a.iter()
+                                            .map(|input| {
+                                                Ok(String::deserialize(eval_if_closure(
+                                                    input,
+                                                    program,
+                                                )?).unwrap())
+                                            })
+                                            .collect::<Result<Vec<_>, Error>>()?,
+                                    );
+                                } else {
+                                    todo!(
+                                        "handle packages value being non-array {:?}",
+                                        field.value
+                                    );
+                                }
+                            }
+
+                            Ok(())
+                        }
+                        "patch" | "patches" => {
+                            if let Some(patch_rt) = field.value.as_ref() {
+                                if patches.is_some() {
+                                    todo!("error for both 'patch' and 'patches' set");
+                                }
+                                patches = Some(crate::patches_from_term(patch_rt, program)?);
+                            }
+                            Ok(())
+                        }
+                        _ => Ok(()),
+                    }
+                })?;
+        }
 
         match ty {
             Some(ObjTy::Profile) => {} // happy path
-            None => return Err(Error::MissingTy(program.files(), rt.pos)),
+            None => {
+                return Err(Error::MissingTy(
+                    program.files(),
+                    rt.pos(program.pos_table()),
+                ));
+            }
             Some(ty) => {
                 return Err(Error::UnexpectedObject {
                     files: program.files(),
                     got: ty,
                     want: ObjTy::Profile,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                 });
             }
         };
@@ -172,7 +173,7 @@ impl Profile {
                 return Err(Error::MissingField {
                     files: program.files(),
                     obj: ObjTy::Builder,
-                    pos: rt.pos,
+                    pos: rt.pos(program.pos_table()),
                     field: "name",
                 });
             }

--- a/crates/minimal/src/cmd_dep.rs
+++ b/crates/minimal/src/cmd_dep.rs
@@ -5,7 +5,6 @@ use graph::{
     Transitives,
 };
 use mctx::{Context, Error};
-use nickel_lang_core::bytecode::ast::Node;
 use nickel_lang_core::traverse::TraverseControl;
 use petgraph::Direction;
 use petgraph::graph::{DiGraph, NodeIndex, NodeWeightsMut};


### PR DESCRIPTION
## Me

This was mostly AI, but i have pretty high confidence in its correctness:

 - Extensive test suite passes
 - Running it on `pkgs` yields exactly the same specs and spec-hashes as before
 - Ran `minimal dump` with both this commit and main, manually verified the diff

## Clanker

All 108 tests pass across all affected crates, clippy is clean, code is formatted.

  Here's a summary of the migration:

  nickel-lang-core 0.15.3 → 0.17.0 Migration Complete

  Core changes applied:

  1. `RichTerm` → `NickelValue` across all files. The fundamental value type changed from a term wrapper to a tagged-pointer value type (`nickel_lang_core::eval::value::NickelValue`).
  2. Term matching replaced with accessor methods: `Term::Str(s)` → `val.as_string()`, `Term::Bool(b)` → `val.as_bool()`, `Term::Record(r)` → `val.as_record()`, `Term::Array(a, _)` → `val.as_array()`, `Term::ForeignId(id)` →
  `val.as_foreign_id()`, etc.
  3. `eval_if_closure()` simplified: No longer checks for Term::Closure (which was removed). Uses val.is_whnf() + `Closure::from(val)` instead of `Closure::atomic_closure()`.
  4. `Container::Empty` handling: New API represents empty records/arrays as inline values. Added `is_record()` helper and empty-record fallbacks throughout.
  5. Position access: `rt.pos` → `val.pos(&program.pos_table())` or `val.pos_idx()`.
  6. custom_transform signature: Now takes `(&mut CacheHub, &mut PosTable, NickelValue)` instead of `(&mut CacheHub, RichTerm)`.
  7. `annotate_record!` macro: Updated for `Term::RecRecord(Box<RecRecordData>)` (single boxed field) and `NickelValue::foreign_id_posless()` instead of `RichTerm::from(Term::ForeignId(...))`.

  Files changed:

  - `Cargo.toml` - version bump
  - `crates/common/src/ncl_eval.rs` - NickelValue return type
  - `crates/decode/src/{lib,load,builds,attrs,profiles,harnesses,decl_tests,error}.rs` - full migration
  - `crates/check/src/{harness,profile}.rs` - record access pattern
  - `crates/minimal/src/cmd_dep.rs` - removed bytecode::ast::Node impor