### PR TITLE
crates/sandbox2: do not synchronize hakoniwa spawns

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -22,24 +22,8 @@ use std::{
     hash::Hash,
     io::{self, ErrorKind, Write},
     path::{Path, PathBuf},
-    sync::{Mutex, MutexGuard},
 };
 use tracing::warn;
-
-static HAKONIWA_SPAWN_LOCK: Mutex<()> = Mutex::new(());
-
-/// Global lock to synchronize the creation of files with any calls to fork(),
-/// which may in-advertently inherit them.
-pub struct FdSynchronizer;
-
-impl FdSynchronizer {
-    /// Returns a RAII guard that symbolizes that you may fork+exec.
-    pub fn lock_fork() -> MutexGuard<'static, ()> {
-        HAKONIWA_SPAWN_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-}
 
 /// Describes where a build-spec came from.
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -20,7 +20,6 @@ use std::time::SystemTime;
 pub mod error;
 use crate::config::{Invocation, WdSetup};
 use crate::error::ExecutionError;
-use common::FdSynchronizer;
 pub use error::Error;
 
 mod listener;
@@ -494,17 +493,9 @@ impl<C: Channel> Sandbox<C> {
             cmd.stdout(hakoniwa::Stdio::MakePipe);
             tracing::debug!("Executing: {} {}", &exec.executable, exec.args.join(" "));
 
-            // Exclusive section: only one hakoniwa command can be spawned
-            // at a time. This prevents races with a file descriptor being held
-            // by one forked process while being needed closed in another process.
-            //
-            // Waiting for spawn lets us wait till exec, at which point all such
-            // file descriptors (which have O_CLOEXEC) will have been closed.
-            let mut child = {
-                let _guard = FdSynchronizer::lock_fork();
-                cmd.spawn()
-            }
-            .map_err(|e| Error::Execution(ExecutionError::SpawnFailed(e)))?;
+            let mut child = cmd
+                .spawn()
+                .map_err(|e| Error::Execution(ExecutionError::SpawnFailed(e)))?;
 
             // Take pipes from the child so threads can stream them into the stdout/stderr
             // files, as well as to the caller-provided writers if applicable.


### PR DESCRIPTION
Hakoniwa is responsible for closing file descriptors now, so I think we no longer need this.