### PR TITLE
.github: conserve cache in build task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-1-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-1-
       - name: Build
         run: cargo build --verbose
       - name: Run tests
@@ -37,6 +38,10 @@ jobs:
         run: cargo fmt -- --check
       - name: Run Clippy
         run: cargo clippy --all-targets -- -D warnings
+      - name: Trim cargo cache
+        run: |
+          cargo install cargo-cache --no-default-features --features ci-autoclean
+          cargo-cache
 
   build-in-minimal:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 * ~Use `checkout@v5` which actually exists, I guess v6 was just falling back~
 * Change the cache key to invalidate the ones that are already too big
 * Use `cargo-cache` to trim unneeded objects at the end