### PR TITLE
Let `--no-{cache,fetch}` be specified after subcommand, support minimal package --rebuild

### DIFF
--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -1,4 +1,6 @@
 //! The in-memory, semantic graph of software which make up a minimal environment.
+use std::collections::HashSet;
+
 use common::{SpecHash, SpecOrigin};
 use serde::{Deserialize, Serialize};
 
@@ -99,7 +101,7 @@ impl From<decode::Error> for Error {
     }
 }
 
-/// A reference to some other [BuildSpec] in a [DepGraph].
+/// A reference to some other [BuildSpec] in a [Graph].
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct BuildSpecRef(pub(crate) generational_arena::Index);
 
@@ -110,6 +112,65 @@ impl BuildSpecRef {
     /// know what youre doing.
     pub fn index(&self) -> usize {
         self.0.into_raw_parts().0
+    }
+}
+
+/// Something which indicates what builds are done + useable from some cache.
+pub trait BinProvider: std::fmt::Debug {
+    fn exists(&self, bsr: &BuildSpecRef) -> bool;
+}
+
+impl BinProvider for () {
+    fn exists(&self, _bsr: &BuildSpecRef) -> bool {
+        false
+    }
+}
+
+impl<BP: BinProvider + ?Sized> BinProvider for Box<BP> {
+    fn exists(&self, bsr: &BuildSpecRef) -> bool {
+        self.as_ref().exists(bsr)
+    }
+}
+
+impl<BP1: BinProvider, BP2: BinProvider> BinProvider for (BP1, BP2) {
+    fn exists(&self, bsr: &BuildSpecRef) -> bool {
+        self.0.exists(bsr) || self.1.exists(bsr)
+    }
+}
+
+impl<BP1: BinProvider, BP2: BinProvider, BP3: BinProvider> BinProvider for (BP1, BP2, BP3) {
+    fn exists(&self, bsr: &BuildSpecRef) -> bool {
+        self.0.exists(bsr) || self.1.exists(bsr) || self.2.exists(bsr)
+    }
+}
+
+/// A wrapper for types implementing [BinProvider] that pretends specific specs are never cached.
+#[derive(Debug)]
+pub struct MaskingBinProvider<BP: BinProvider> {
+    p: BP,
+    masked: HashSet<BuildSpecRef>,
+}
+
+impl<BP: BinProvider> MaskingBinProvider<BP> {
+    pub fn new<I: IntoIterator<Item = R>, R: Into<BuildSpecRef>>(provider: BP, mask: I) -> Self {
+        Self {
+            p: provider,
+            masked: mask.into_iter().map(|e| e.into()).collect(),
+        }
+    }
+
+    pub fn into_inner(self) -> BP {
+        self.p
+    }
+}
+
+impl<BP: BinProvider> BinProvider for MaskingBinProvider<BP> {
+    fn exists(&self, bsr: &BuildSpecRef) -> bool {
+        if self.masked.contains(bsr) {
+            false
+        } else {
+            self.p.exists(bsr)
+        }
     }
 }
 
@@ -131,7 +192,7 @@ pub use spec_hasher::SpecHasher;
 
 mod planner;
 pub use planner::Dep as PlannerDep;
-pub use planner::{BinProvider, ExecPlan, PlanErr};
+pub use planner::{ExecPlan, PlanErr};
 
 mod transitives;
 pub use transitives::Dep as TransitivesDep;

--- a/crates/graph/src/planner.rs
+++ b/crates/graph/src/planner.rs
@@ -1,4 +1,4 @@
-use crate::{BuildDep, BuildSpecRef, Graph, SubsetInput, Transitives, transitives};
+use crate::{BinProvider, BuildDep, BuildSpecRef, Graph, SubsetInput, Transitives, transitives};
 use nickel_lang_core::term::IndexMap;
 use std::{
     collections::{HashMap, HashSet},
@@ -178,29 +178,6 @@ impl Dep {
             }
         }
         self
-    }
-}
-
-/// Types which can tell the planner what build-specs are built & available.
-pub trait BinProvider: std::fmt::Debug {
-    fn exists(&self, bsr: &BuildSpecRef) -> bool;
-}
-
-impl BinProvider for () {
-    fn exists(&self, _bsr: &BuildSpecRef) -> bool {
-        false
-    }
-}
-
-impl<BP1: BinProvider, BP2: BinProvider> BinProvider for (BP1, BP2) {
-    fn exists(&self, bsr: &BuildSpecRef) -> bool {
-        self.0.exists(bsr) || self.1.exists(bsr)
-    }
-}
-
-impl<BP1: BinProvider, BP2: BinProvider, BP3: BinProvider> BinProvider for (BP1, BP2, BP3) {
-    fn exists(&self, bsr: &BuildSpecRef) -> bool {
-        self.0.exists(bsr) || self.1.exists(bsr) || self.2.exists(bsr)
     }
 }
 

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -55,7 +55,7 @@ impl EnvChannel<'_> {
             .enable_all()
             .build()
             .unwrap();
-        if let Err(e) = rt.block_on(self.ctx.build_graph(self.graph, None)) {
+        if let Err(e) = rt.block_on(self.ctx.build_graph(self.graph, false, None)) {
             writeln!(stream, "error: {}", e).ok();
             return;
         };

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -20,7 +20,7 @@ pub use error::Error;
 mod config;
 pub use config::{Config, ConfigBuilder, ConfigError};
 mod env;
-use graph::{BuildSpecRef, Graph, Transitives};
+use graph::{BinProvider, BuildSpecRef, Graph, MaskingBinProvider, Transitives};
 use mfile::{EnvPatches, EnvVarValue, Task};
 pub use sandbox2::config::Invocation;
 
@@ -437,15 +437,22 @@ impl Context {
     pub async fn build_graph(
         &mut self,
         graph: &Graph,
+        rebuild_top_level: bool,
         log_sink: Option<futures::channel::mpsc::UnboundedSender<orchestrator::BuildEvent>>,
     ) -> Result<(), Error> {
-        self.build_graph_with_cancel(graph, log_sink, tokio_util::sync::CancellationToken::new())
-            .await
+        self.build_graph_with_cancel(
+            graph,
+            rebuild_top_level,
+            log_sink,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
     }
 
     pub async fn build_graph_with_cancel(
         &mut self,
         graph: &Graph,
+        rebuild_top_level: bool,
         log_sink: Option<futures::channel::mpsc::UnboundedSender<orchestrator::BuildEvent>>,
         cancel: tokio_util::sync::CancellationToken,
     ) -> Result<(), Error> {
@@ -470,32 +477,33 @@ impl Context {
             cancel,
         )?;
 
-        let (built, result) = match (
+        let mut bin_provider: Box<dyn BinProvider> = match (
             self.config.use_local_cache(),
             self.config.use_remote_cache(),
         ) {
             // No local or remote cache
-            (false, false) => LocalBackend::run_local_build(orchestrator, ()).await,
+            (false, false) => Box::new(()),
             // Both caches
             (true, true) => {
                 let local_adapter = CacheBinProvider::new(graph, cache.clone());
                 let remote_adapter = RemoteBinProvider::new(graph, rc.as_ref().unwrap());
-                LocalBackend::run_local_build(orchestrator, (local_adapter, remote_adapter)).await
+                Box::new((local_adapter, remote_adapter))
             }
             // Only remote cache
-            (false, true) => {
-                let remote_adapter = RemoteBinProvider::new(graph, rc.as_ref().unwrap());
-                LocalBackend::run_local_build(orchestrator, remote_adapter).await
-            }
+            (false, true) => Box::new(RemoteBinProvider::new(graph, rc.as_ref().unwrap())),
             // Only local cache
-            (true, false) => {
-                let local_adapter = CacheBinProvider::new(graph, cache.clone());
-                LocalBackend::run_local_build(orchestrator, local_adapter).await
-            }
+            (true, false) => Box::new(CacheBinProvider::new(graph, cache.clone())),
         };
+        if rebuild_top_level {
+            // Forcing a rebuild of named packages was requested. To do this, we wrap the BinProvider
+            // with one that pretends the named packages are never in any cache, resulting in a build for them.
+            bin_provider = Box::new(MaskingBinProvider::new(
+                bin_provider,
+                graph.top_levels.clone(),
+            ));
+        }
 
-        // let build_succeeded = run_result.is_ok();
-        // let error_message = run_result.as_ref().err().map(|e| e.to_string());
+        let (built, result) = LocalBackend::run_local_build(orchestrator, bin_provider).await;
 
         // commit all built artifacts to the local cache
         for (pending_dir, meta) in built {
@@ -603,7 +611,7 @@ impl Context {
 
         if !all_built {
             tracing::trace!("missing local packages, calling mctx.build_graph()");
-            self.build_graph(graph, None).await?;
+            self.build_graph(graph, false, None).await?;
         } else {
             tracing::trace!("all packages available locally, eluding build");
         }
@@ -870,7 +878,7 @@ mod tests {
 
         rt.block_on(async {
             let graph = ctx.graph_from_package_names(["uroot"]).unwrap();
-            ctx.build_graph(&graph, None).await.unwrap();
+            ctx.build_graph(&graph, false, None).await.unwrap();
 
             let temp_dir = ctx.local_cache().temp_dir().unwrap();
             let mut t = StandaloneTest {

--- a/crates/minimal/src/cmd_materialize.rs
+++ b/crates/minimal/src/cmd_materialize.rs
@@ -63,7 +63,7 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
     let cache = ctx.local_cache();
 
     // Make sure the packages are built for the target
-    crate::cmd_pkg::pkg_build_impl(&graph, ctx, cache.clone(), false, None).await?;
+    crate::cmd_pkg::pkg_build_impl(&graph, ctx, cache.clone(), false, false, None).await?;
 
     // Create the OCI image — arch is queried from graph.target()
     let mut op = op::OciImageCreate {

--- a/crates/minimal/src/cmd_pkg.rs
+++ b/crates/minimal/src/cmd_pkg.rs
@@ -11,6 +11,9 @@ pub struct PkgArgs {
     /// Whether to log stdout/stderr during the build
     #[arg(short, long, default_value_t = false)]
     verbose: bool,
+    /// Always build the specified packages, even if they are already available
+    #[arg(long, default_value_t = false)]
+    rebuild: bool,
 
     /// Packages to build
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args=0..)]
@@ -56,7 +59,7 @@ pub async fn cmd_pkg(args: PkgArgs, ctx: &mut Context) -> Result<(), Error> {
         None
     };
 
-    pkg_build_impl(&graph, ctx, cache, false, log_sink).await?;
+    pkg_build_impl(&graph, ctx, cache, false, args.rebuild, log_sink).await?;
 
     Ok(())
 }
@@ -66,6 +69,7 @@ pub async fn pkg_build_impl(
     ctx: &mut Context,
     cache: Cache,
     quiet: bool,
+    rebuild_top_level: bool,
     log_sink: Option<mpsc::UnboundedSender<BuildEvent>>,
 ) -> Result<(), Error> {
     trace!("build_impl");
@@ -73,7 +77,7 @@ pub async fn pkg_build_impl(
     let cancel = tokio_util::sync::CancellationToken::new();
     let cancel2 = cancel.clone();
     tokio::select! {
-        result = ctx.build_graph_with_cancel(graph, log_sink, cancel) => {
+        result = ctx.build_graph_with_cancel(graph, rebuild_top_level, log_sink, cancel) => {
             result?;
         }
         _ = tokio::signal::ctrl_c() => {

--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -138,21 +138,16 @@ pub struct GlobalArgs {
     stdlib_dir: Option<PathBuf>,
 
     /// Ignore locally-available binary artifacts (results in rebuilds unless present in a remote cache)
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, global = true)]
     no_cache: bool,
 
     /// Do not fetch binary artifacts from the internet
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, global = true)]
     no_fetch: bool,
 
     /// Configure the number of parallel builds
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     num_parallel_builds: Option<usize>,
-
-    /// Write build events to a protobuf text format file
-    #[arg(long)]
-    #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
-    build_events_file: Option<PathBuf>,
 }
 
 pub(crate) fn enforce_science_mode() -> Result<(), Error> {


### PR DESCRIPTION
 * You can now do `minimal <command> --no-cache --no-fetch` instead of always having those options before the subcommand, feels more natural sometimes
 * * NOTE: I havent done this for `-C` as I'm not sure thats natural yet
 * You can now do `minimal package --rebuild <packages>` to force a rebuild of specifically the named packages.