### PR TITLE
assorted: stop using toml for arg values, proper path for computing LoadOptions input hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ name = "common"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "args",
  "blake3",
  "bytes",
  "bzip2",
@@ -943,6 +944,7 @@ name = "decode"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "args",
  "blake3",
  "codespan-reporting",
  "common",
@@ -957,6 +959,7 @@ dependencies = [
  "smallvec",
  "stdlib",
  "tempfile",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2672,6 +2675,7 @@ name = "mctx"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "args",
  "check",
  "checkouts",
  "codespan-reporting",
@@ -2805,6 +2809,7 @@ name = "minimal"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "args",
  "blake3",
  "check",
  "checkouts",
@@ -2866,6 +2871,7 @@ name = "multi"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "args",
  "checkouts",
  "common",
  "generational-arena",

--- a/crates/args/Cargo.toml
+++ b/crates/args/Cargo.toml
@@ -10,7 +10,7 @@ publish.workspace = true
 clap.workspace = true
 serde.workspace = true
 shlex.workspace = true
-toml.workspace = true
 
 [dev-dependencies]
 indoc.workspace = true
+toml.workspace = true

--- a/crates/args/src/lib.rs
+++ b/crates/args/src/lib.rs
@@ -1,53 +1,145 @@
-//! Typed arguments support for tasks & sideloads.
+//! Types for defining the schema of arguments of `mfile::Task` & parameters to sideloads.
+//!
+//!  * [Arg] / [ScalarArg]: A concrete argument value.
+//!  * [ArgSchema]: The type of an argument.
+//!  * [ArgSpec]: The type of an argument, combined with metadata such as help text.
+//!    [ArgSpec::parse] can be used to parse a string representing the invocation of
+//!    these arguments into their concrete values.
+//!  * [ArgsSpec]: Newtype around a map of argument names to [ArgSpec] (schema) descriptions.
+//!
+//!  A concrete set of arguments is represented using `HashMap<String, Arg>`.
 
-use std::collections::{BTreeSet, HashMap};
+use std::{
+    collections::{BTreeSet, HashMap},
+    hash::Hash,
+};
+
+/// Deterministic hash of the value of a set of arguments.
+pub fn hash_args<H: std::hash::Hasher>(args: &HashMap<String, Arg>, state: &mut H) {
+    let keys: BTreeSet<_> = args.keys().cloned().collect();
+    for k in keys.into_iter() {
+        k.hash(state);
+        args.get(&k).unwrap().hash(state);
+    }
+}
+
+/// A scalar argument value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ScalarArg {
+    String(String),
+    Number(f64),
+    Boolean(bool),
+}
+
+impl Hash for ScalarArg {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::String(s) => s.hash(state),
+            Self::Number(n) => n.to_le_bytes().hash(state),
+            Self::Boolean(b) => b.hash(state),
+        }
+    }
+}
+
+impl ScalarArg {
+    /// Append the nickel literal representation of this value to `buf`.
+    pub fn write_nickel(&self, buf: &mut String) {
+        match self {
+            ScalarArg::String(s) => {
+                buf.push('"');
+                buf.push_str(s);
+                buf.push('"');
+            }
+            ScalarArg::Number(f) => buf.push_str(&f.to_string()),
+            ScalarArg::Boolean(b) => buf.push_str(if *b { "true" } else { "false" }),
+        }
+    }
+}
+
+/// An argument value.
+#[derive(Debug, Clone, Hash, PartialEq)]
+pub enum Arg {
+    Scalar(ScalarArg),
+    Array(Vec<ScalarArg>),
+    Enum(String),
+}
+
+impl Arg {
+    /// Append the nickel literal representation of this value to `buf`.
+    pub fn write_nickel(&self, buf: &mut String) {
+        match self {
+            Arg::Scalar(s) => s.write_nickel(buf),
+            Arg::Enum(s) => {
+                buf.push('"');
+                buf.push_str(s);
+                buf.push('"');
+            }
+            Arg::Array(v) => {
+                buf.push('[');
+                for (i, s) in v.iter().enumerate() {
+                    if i > 0 {
+                        buf.push_str(", ");
+                    }
+                    s.write_nickel(buf);
+                }
+                buf.push(']');
+            }
+        }
+    }
+
+    /// Write a `let <ident> = <value> in\n` binding into `buf`.
+    pub fn write_nickel_binding(&self, ident: &str, buf: &mut String) {
+        buf.push_str("let ");
+        buf.push_str(ident);
+        buf.push_str(" = ");
+        self.write_nickel(buf);
+        buf.push_str(" in\n");
+    }
+}
 
 /// The leaf scalar types an argument can have.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ArgPrimitive {
+pub enum PrimitiveSpec {
     String,
     Number,
     Boolean,
 }
 
-impl std::fmt::Display for ArgPrimitive {
+impl std::fmt::Display for PrimitiveSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ArgPrimitive::String => f.write_str("string"),
-            ArgPrimitive::Number => f.write_str("number"),
-            ArgPrimitive::Boolean => f.write_str("boolean"),
+            PrimitiveSpec::String => f.write_str("string"),
+            PrimitiveSpec::Number => f.write_str("number"),
+            PrimitiveSpec::Boolean => f.write_str("boolean"),
         }
     }
 }
 
-impl TryFrom<&str> for ArgPrimitive {
+impl TryFrom<&str> for PrimitiveSpec {
     type Error = ();
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s.to_ascii_lowercase().as_str() {
-            "string" => Ok(ArgPrimitive::String),
-            "number" => Ok(ArgPrimitive::Number),
-            "boolean" | "bool" => Ok(ArgPrimitive::Boolean),
+            "string" => Ok(PrimitiveSpec::String),
+            "number" => Ok(PrimitiveSpec::Number),
+            "boolean" | "bool" => Ok(PrimitiveSpec::Boolean),
             _ => Err(()),
         }
     }
 }
 
-/// Parse a string value into a [toml::Value] according to the given primitive type.
-fn parse_primitive(s: &str, p: &ArgPrimitive) -> Result<toml::Value, String> {
+/// Parse a string value into a [ScalarArg] according to the given primitive type.
+fn parse_primitive(s: &str, p: &PrimitiveSpec) -> Result<ScalarArg, String> {
     match p {
-        ArgPrimitive::String => Ok(toml::Value::String(s.to_string())),
-        ArgPrimitive::Number => {
-            if let Ok(i) = s.parse::<i64>() {
-                Ok(toml::Value::Integer(i))
-            } else if let Ok(f) = s.parse::<f64>() {
-                Ok(toml::Value::Float(f))
-            } else {
-                Err(format!("expected a number, got `{s}`"))
-            }
+        PrimitiveSpec::String => Ok(ScalarArg::String(s.to_string())),
+        PrimitiveSpec::Number => {
+            let f: f64 = s
+                .parse()
+                .map_err(|_| format!("expected a number, got `{s}`"))?;
+            Ok(ScalarArg::Number(f))
         }
-        ArgPrimitive::Boolean => match s {
-            "true" => Ok(toml::Value::Boolean(true)),
-            "false" => Ok(toml::Value::Boolean(false)),
+        PrimitiveSpec::Boolean => match s {
+            "true" => Ok(ScalarArg::Boolean(true)),
+            "false" => Ok(ScalarArg::Boolean(false)),
             _ => Err(format!("expected `true` or `false`, got `{s}`")),
         },
     }
@@ -57,9 +149,9 @@ fn parse_primitive(s: &str, p: &ArgPrimitive) -> Result<toml::Value, String> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArgSchema {
     /// A single scalar value: "string", "number", or "boolean".
-    Scalar(ArgPrimitive),
+    Scalar(PrimitiveSpec),
     /// An array whose elements are the given primitive type.
-    Array(ArgPrimitive),
+    Array(PrimitiveSpec),
     /// An exhaustive enumeration of mutually-exclusive options.
     Enum(BTreeSet<String>),
 }
@@ -72,11 +164,11 @@ impl TryFrom<&str> for ArgSchema {
             .or_else(|| s.strip_prefix("array "))
         {
             return Ok(ArgSchema::Array(
-                ArgPrimitive::try_from(rest)
+                PrimitiveSpec::try_from(rest)
                     .map_err(|_| format!("invalid array primitive `{rest}`"))?,
             ));
         }
-        if let Ok(primitive) = ArgPrimitive::try_from(s) {
+        if let Ok(primitive) = PrimitiveSpec::try_from(s) {
             return Ok(ArgSchema::Scalar(primitive));
         }
 
@@ -132,7 +224,7 @@ impl<'de> serde::Deserialize<'de> for ArgSchema {
                     if key == "type" {
                         type_str = Some(map.next_value()?);
                     } else {
-                        map.next_value::<toml::Value>()?; // skip unknown
+                        map.next_value::<de::IgnoredAny>()?; // skip unknown
                     }
                 }
                 let s =
@@ -308,7 +400,7 @@ impl<'de> serde::Deserialize<'de> for ArgSpec {
                         "type" => type_str = Some(map.next_value()?),
                         "help" => help = Some(map.next_value()?),
                         _ => {
-                            map.next_value::<toml::Value>()?; // skip unknown
+                            map.next_value::<de::IgnoredAny>()?; // skip unknown
                         }
                     }
                 }
@@ -339,19 +431,20 @@ impl serde::Serialize for ArgSpec {
 
 /// A set of arguments defined together.
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct ArgSet(pub HashMap<String, ArgSpec>);
+pub struct ArgsSpec(pub HashMap<String, ArgSpec>);
 
-impl ArgSet {
+impl ArgsSpec {
     /// Returns true if no arguments are defined.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
     /// Parse a CLI argument string (e.g. `"--count 42 --name foo"`) according
-    /// to this schema, returning the parsed values as a [toml::Value::Table].
+    /// to this schema, returning the parsed values as a map of argument names
+    /// to [Arg] values.
     ///
     /// Shell quoting is handled via `shlex`.
-    pub fn parse(&self, args: &str) -> Result<toml::Value, clap::Error> {
+    pub fn parse(&self, args: &str) -> Result<HashMap<String, Arg>, clap::Error> {
         let argv = shlex::split(args).ok_or_else(|| {
             clap::Command::new("task").no_binary_name(true).error(
                 clap::error::ErrorKind::InvalidValue,
@@ -362,11 +455,11 @@ impl ArgSet {
     }
 
     /// Parse pre-split CLI arguments according to this schema, returning the
-    /// parsed values as a [toml::Value::Table].
+    /// parsed values as a map of argument names to [Arg] values.
     ///
     /// Equivalent to [`parse_argv_named`](Self::parse_argv_named) with a
     /// display name of `"task"`.
-    pub fn parse_argv<I, T>(&self, args: I) -> Result<toml::Value, clap::Error>
+    pub fn parse_argv<I, T>(&self, args: I) -> Result<HashMap<String, Arg>, clap::Error>
     where
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
@@ -375,7 +468,7 @@ impl ArgSet {
     }
 
     /// Parse pre-split CLI arguments according to this schema, returning the
-    /// parsed values as a [toml::Value::Table].
+    /// parsed values as a map of argument names to [Arg] values.
     ///
     /// `display_name` controls the program name shown in clap's usage/error
     /// output (e.g. `"minimal run smoketest"`).
@@ -386,34 +479,33 @@ impl ArgSet {
     ///
     /// | Schema | CLI | Result |
     /// |--------|-----|--------|
-    /// | `arg = "string"` | `--arg foo` | `arg = "foo"` |
-    /// | `arg = "number"` | `--arg 42` | `arg = 42` |
-    /// | `arg = "boolean"` | `--arg true` | `arg = true` |
-    /// | `arg = "Array string"` | `--arg a --arg b` | `arg = ["a", "b"]` |
-    /// | `arg = "Array number"` | `--arg 1 --arg 2` | `arg = [1, 2]` |
-    /// | `arg = "[a, b]"` | `--arg a` | `arg = a` |
+    /// | `arg = "string"` | `--arg foo` | `Arg::Scalar(ScalarArg::String("foo"))` |
+    /// | `arg = "number"` | `--arg 42` | `Arg::Scalar(ScalarArg::Number(42.0))` |
+    /// | `arg = "boolean"` | `--arg true` | `Arg::Scalar(ScalarArg::Boolean(true))` |
+    /// | `arg = "Array string"` | `--arg a --arg b` | `Arg::Array(vec![..])` |
+    /// | `arg = "Array number"` | `--arg 1 --arg 2` | `Arg::Array(vec![..])` |
+    /// | `arg = "[a, b]"` | `--arg a` | `Arg::Enum("a")` |
     pub fn parse_argv_named<I, T>(
         &self,
         display_name: &str,
         args: I,
-    ) -> Result<toml::Value, clap::Error>
+    ) -> Result<HashMap<String, Arg>, clap::Error>
     where
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        use clap::{Arg, ArgAction, Command};
+        use clap::{Arg as ClapArg, ArgAction, Command};
 
         // Build a clap command. One flag per top-level arg name.
         let mut cmd = Command::new(display_name.to_string()).no_binary_name(true);
         for (n, ta) in self.0.iter() {
-            let mut arg =
-                Arg::new(n.clone())
-                    .long(n.clone())
-                    .required(true)
-                    .action(match &ta.spec {
-                        ArgSchema::Array(_) => ArgAction::Append,
-                        _ => ArgAction::Set,
-                    });
+            let mut arg = ClapArg::new(n.clone())
+                .long(n.clone())
+                .required(true)
+                .action(match &ta.spec {
+                    ArgSchema::Array(_) => ArgAction::Append,
+                    _ => ArgAction::Set,
+                });
             if let ArgSchema::Enum(opts) = &ta.spec {
                 arg = arg.value_parser(opts.iter().cloned().collect::<Vec<_>>());
             }
@@ -425,35 +517,34 @@ impl ArgSet {
         // Helper to produce a clap value-validation error.
         let val_err = |msg: String| cmd.clone().error(clap::error::ErrorKind::InvalidValue, msg);
 
-        // Reconstruct a toml table from the matches.
-        let mut root = toml::map::Map::new();
+        let mut result = HashMap::new();
         for (name, ta) in self.0.iter() {
             match &ta.spec {
                 ArgSchema::Scalar(p) => {
                     if let Some(raw) = matches.get_one::<String>(name) {
-                        root.insert(name.clone(), parse_primitive(raw, p).map_err(&val_err)?);
+                        result.insert(
+                            name.clone(),
+                            Arg::Scalar(parse_primitive(raw, p).map_err(&val_err)?),
+                        );
                     }
                 }
                 ArgSchema::Array(p) => {
                     if let Some(values) = matches.get_many::<String>(name) {
-                        let arr: Result<Vec<toml::Value>, clap::Error> = values
+                        let arr: Result<Vec<ScalarArg>, clap::Error> = values
                             .map(|v| parse_primitive(v, p).map_err(&val_err))
                             .collect();
-                        root.insert(name.clone(), toml::Value::Array(arr?));
+                        result.insert(name.clone(), Arg::Array(arr?));
                     }
                 }
                 ArgSchema::Enum(_) => {
                     if let Some(raw) = matches.get_one::<String>(name) {
-                        root.insert(
-                            name.clone(),
-                            parse_primitive(raw, &ArgPrimitive::String).map_err(&val_err)?,
-                        );
+                        result.insert(name.clone(), Arg::Enum(raw.clone()));
                     }
                 }
             }
         }
 
-        Ok(toml::Value::Table(root))
+        Ok(result)
     }
 }
 
@@ -467,7 +558,7 @@ mod tests {
     #[derive(serde::Deserialize)]
     struct ArgsOnly {
         #[serde(default)]
-        args: ArgSet,
+        args: ArgsSpec,
     }
 
     #[test]
@@ -482,16 +573,16 @@ mod tests {
         .unwrap();
         assert_eq!(
             t.args.0.get("name").unwrap().spec,
-            ArgSchema::Scalar(ArgPrimitive::String)
+            ArgSchema::Scalar(PrimitiveSpec::String)
         );
         assert_eq!(
             t.args.0.get("tags").unwrap().spec,
-            ArgSchema::Array(ArgPrimitive::Number)
+            ArgSchema::Array(PrimitiveSpec::Number)
         );
         assert_eq!(
             t.args.0.get("input").unwrap(),
             &ArgSpec {
-                spec: ArgSchema::Scalar(ArgPrimitive::String),
+                spec: ArgSchema::Scalar(PrimitiveSpec::String),
                 help: Some("something".to_string()),
             }
         );
@@ -532,14 +623,26 @@ mod tests {
             .args
             .parse("--name hello --count 42 --verbose true --tags a --tags b --enum a")
             .unwrap();
-        let table = result.as_table().unwrap();
-        assert_eq!(table.get("name").unwrap().as_str().unwrap(), "hello");
-        assert_eq!(table.get("count").unwrap().as_integer().unwrap(), 42);
-        assert_eq!(table.get("enum").unwrap().as_str().unwrap(), "a");
-        assert!(table.get("verbose").unwrap().as_bool().unwrap());
-        let arr = table.get("tags").unwrap().as_array().unwrap();
-        assert_eq!(arr.len(), 2);
-        assert_eq!(arr[0].as_str().unwrap(), "a");
+        assert_eq!(
+            result.get("name").unwrap(),
+            &Arg::Scalar(ScalarArg::String("hello".to_string()))
+        );
+        assert_eq!(
+            result.get("count").unwrap(),
+            &Arg::Scalar(ScalarArg::Number(42.0))
+        );
+        assert_eq!(result.get("enum").unwrap(), &Arg::Enum("a".to_string()));
+        assert_eq!(
+            result.get("verbose").unwrap(),
+            &Arg::Scalar(ScalarArg::Boolean(true))
+        );
+        assert_eq!(
+            result.get("tags").unwrap(),
+            &Arg::Array(vec![
+                ScalarArg::String("a".to_string()),
+                ScalarArg::String("b".to_string()),
+            ])
+        );
     }
 
     #[test]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -32,6 +32,7 @@ lzma-rs.workspace = true
 tempfile.workspace = true
 zstd.workspace = true
 
+args.workspace = true
 nickel-lang-core.workspace = true
 toml.workspace = true
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -19,6 +19,7 @@ pub mod ncl_eval;
 
 use std::{
     env, fmt,
+    hash::Hash,
     io::{self, ErrorKind, Write},
     path::{Path, PathBuf},
     sync::{Mutex, MutexGuard},
@@ -77,14 +78,40 @@ impl SpecOrigin {
             None
         }
     }
+}
 
-    /// Returns a hashed hex representation of the origin + target, suitable as a cache key.
-    pub fn hash_hex(&self, target: &Target) -> impl AsRef<str> {
-        let origin_bytes = serde_json::to_vec(self).unwrap();
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(&origin_bytes);
-        target.hash_to(&mut hasher);
-        hasher.finalize().to_hex()
+impl Hash for SpecOrigin {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Inline => state.write_u8(0), // type marker: 0 == Inline
+            Self::LocalDir { given, absolute } => {
+                state.write_u8(1); // type marker: 1 == LocalDir
+                state.write(given.as_os_str().as_encoded_bytes());
+                state.write_u8(b',');
+                state.write(absolute.as_os_str().as_encoded_bytes());
+            }
+            Self::Repo(r) => {
+                state.write_u8(2); // type marker: 2 == Repo
+                match r {
+                    repo_spec::Repo::Git { url, rev, tracking } => {
+                        state.write(url.as_bytes());
+                        state.write_u8(b',');
+                        state.write(rev.as_bytes());
+                        state.write_u8(b',');
+                        match tracking {
+                            Some(repo_spec::GitRef::Branch(b)) => {
+                                state.write(b.as_bytes());
+                            }
+                            Some(repo_spec::GitRef::Tag(t)) => {
+                                state.write_u8(b't');
+                                state.write(t.as_bytes());
+                            }
+                            None => {}
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/crates/common/src/ncl_eval.rs
+++ b/crates/common/src/ncl_eval.rs
@@ -9,51 +9,11 @@ pub struct VarCtx {
 }
 
 impl VarCtx {
-    pub fn new<S: AsRef<str>, I: IntoIterator<Item = (S, toml::Value)>>(values: I) -> Self {
+    pub fn new<S: AsRef<str>, I: IntoIterator<Item = (S, args::Arg)>>(values: I) -> Self {
         let mut base = String::with_capacity(512);
         for (ident, value) in values.into_iter() {
-            base.push_str("let ");
-            base.push_str(ident.as_ref());
-            base.push_str(" = ");
-            match value {
-                toml::Value::Boolean(b) => {
-                    if b {
-                        base.push_str("true")
-                    } else {
-                        base.push_str("false")
-                    }
-                }
-                toml::Value::Float(f) => base.push_str(&f.to_string()),
-                toml::Value::String(s) => {
-                    base.push('"');
-                    base.push_str(&s);
-                    base.push('"');
-                }
-                toml::Value::Integer(i) => base.push_str(&i.to_string()),
-                // TODO: This is shit and also only works one level. Make a trait
-                // for serializing to nickel which is recursive and use that?
-                toml::Value::Array(v) => v.into_iter().for_each(|e| match e {
-                    toml::Value::String(s) => {
-                        base.push('"');
-                        base.push_str(&s);
-                        base.push('"');
-                    }
-                    toml::Value::Boolean(b) => {
-                        if b {
-                            base.push_str("true")
-                        } else {
-                            base.push_str("false")
-                        }
-                    }
-                    toml::Value::Float(f) => base.push_str(&f.to_string()),
-                    _ => todo!(),
-                }),
-                _ => todo!(),
-            }
-
-            base.push_str(" in\n");
+            value.write_nickel_binding(ident.as_ref(), &mut base);
         }
-
         Self { base }
     }
 
@@ -95,13 +55,13 @@ mod tests {
 
     #[test]
     fn empty_var_ctx() {
-        let ctx = VarCtx::new(std::iter::empty::<(&str, toml::Value)>());
+        let ctx = VarCtx::new(std::iter::empty::<(&str, args::Arg)>());
         assert_eq!(ctx.base, "");
     }
 
     #[test]
     fn passthrough_basic_strings() {
-        let ctx = VarCtx::new(std::iter::empty::<(&str, toml::Value)>());
+        let ctx = VarCtx::new(std::iter::empty::<(&str, args::Arg)>());
         assert_eq!(ctx.eval_string("hello").unwrap(), "hello");
         assert_eq!(ctx.eval_string("world").unwrap(), "world");
         assert_eq!(ctx.eval_string("hello world").unwrap(), "hello world");
@@ -109,11 +69,12 @@ mod tests {
     }
 
     #[test]
-    fn interpolation_with_vars() {
+    fn interpolation_with_vars_scalar() {
+        use args::{Arg, ScalarArg};
         let ctx = VarCtx::new(vec![
-            ("name", toml::Value::String("world".to_string())),
-            ("count", toml::Value::Integer(42)),
-            ("flag", toml::Value::Boolean(true)),
+            ("name", Arg::Scalar(ScalarArg::String("world".to_string()))),
+            ("count", Arg::Scalar(ScalarArg::Number(42.0))),
+            ("flag", Arg::Scalar(ScalarArg::Boolean(true))),
         ]);
         assert_eq!(ctx.eval_string("hello %{name}").unwrap(), "hello world");
         assert_eq!(
@@ -125,6 +86,29 @@ mod tests {
             ctx.eval_string("flag=%{std.string.from_bool flag}")
                 .unwrap(),
             "flag=true"
+        );
+    }
+
+    #[test]
+    fn interpolation_with_vars_array() {
+        use args::{Arg, ScalarArg};
+        let ctx = VarCtx::new(vec![
+            (
+                "a",
+                Arg::Array(vec![
+                    ScalarArg::String("hello".to_string()),
+                    ScalarArg::String("world".to_string()),
+                ]),
+            ),
+            (
+                "b",
+                Arg::Array(vec![ScalarArg::Boolean(true), ScalarArg::Boolean(false)]),
+            ),
+        ]);
+        assert_eq!(
+            ctx.eval_string("%{std.string.from_bool (std.array.at 1 b)}")
+                .unwrap(),
+            "false"
         );
     }
 }

--- a/crates/common/src/target.rs
+++ b/crates/common/src/target.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::io::Write;
 
 /// A supported CPU architecture.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Arch {
     #[default]
     Amd64,
@@ -20,7 +20,7 @@ impl Arch {
 }
 
 /// A supported OS.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OS {
     #[default]
     Linux,
@@ -37,7 +37,7 @@ impl OS {
 }
 
 /// The description of a system where software runs.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Target {
     arch: Arch,
     os: OS,

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -20,9 +20,11 @@ regex.workspace = true
 generational-arena.workspace = true
 smallvec.workspace = true
 
+toml.workspace = true
 serde.workspace = true
-
 shlex.workspace = true
+
+args.workspace = true
 common.workspace = true
 mfile.workspace = true
 stdlib.workspace = true

--- a/crates/decode/src/load.rs
+++ b/crates/decode/src/load.rs
@@ -11,6 +11,8 @@ use nickel_lang_core::identifier::LocIdent;
 use nickel_lang_core::term::Term;
 use nickel_lang_core::typ::TypeF;
 use nickel_lang_core::{error::NullReporter, eval::cache::CacheImpl, program::Program};
+use std::collections::HashMap;
+use std::hash::Hash;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -21,10 +23,12 @@ use std::path::{Path, PathBuf};
 pub struct LoadOptions {
     /// Where on the filesystem the minimal base library (i.e. minimal.ncl) is located.
     pub minimal_lib_path: PathBuf,
-    /// A description of where the top-level layer/repo was sourced from.
+    /// A description of where the layer/repo was sourced from.
     pub from: SpecOrigin,
     /// The target we are loading for.
     pub target: Target,
+    /// The parameters being passed to the layer during evaluation.
+    pub params: Option<HashMap<String, args::Arg>>,
 }
 
 impl LoadOptions {
@@ -34,11 +38,45 @@ impl LoadOptions {
             minimal_lib_path: std::path::Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
                 .join("minimal-ncl"),
             target: Target::default(),
+            params: None,
         }
     }
 
+    /// Returns the [Target] this layer is evaluated for.
     pub fn for_target(&self) -> &Target {
         &self.target
+    }
+
+    /// Computes a hash that describes the inputs to layer evaluation. Layer
+    /// evaluation (i.e. eval nickel => structs) is deterministic, so an
+    /// input hash should correspond 1:1 with the result of [Loader::finish].
+    pub fn input_hash_to<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.from.hash(state);
+        self.target.hash(state);
+        if let Some(params) = &self.params {
+            state.write(b"params");
+            args::hash_args(params, state);
+        }
+    }
+
+    /// Computes a hash that describes the inputs to layer evaluation. Layer
+    /// evaluation (i.e. eval nickel => structs) is deterministic, so an
+    /// input hash should correspond 1:1 with the result of [Loader::finish].
+    pub fn input_hash(&self) -> blake3::Hash {
+        struct Blake3StdHasher(blake3::Hasher);
+
+        impl std::hash::Hasher for Blake3StdHasher {
+            fn write(&mut self, bytes: &[u8]) {
+                self.0.update(bytes);
+            }
+            fn finish(&self) -> u64 {
+                panic!("unreachable")
+            }
+        }
+
+        let mut hasher = Blake3StdHasher(blake3::Hasher::new());
+        self.input_hash_to(&mut hasher);
+        hasher.0.finalize()
     }
 }
 

--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -6,7 +6,7 @@
 use common::repo_spec::Repo;
 use common::{SpecOrigin, Target};
 use decode::builds::BuildRef;
-use decode::{Harness, Layer, Profile, builds};
+use decode::{Harness, Layer, LoadOptions, Profile, builds};
 use mfile::{self, LinkConfig};
 use nickel_lang_core::term::IndexMap;
 
@@ -259,25 +259,17 @@ impl SourceProvider for checkouts::ManagerHandle {
 pub trait LayerCache {
     type Error: std::fmt::Debug;
 
-    fn insert(&mut self, origin: SpecOrigin, layer: &Layer) -> Result<(), Self::Error>;
-    fn get(
-        &mut self,
-        origin: &SpecOrigin,
-        for_target: &Target,
-    ) -> Result<Option<Layer>, Self::Error>;
+    fn insert(&mut self, lo: LoadOptions, layer: &Layer) -> Result<(), Self::Error>;
+    fn get(&mut self, lo: &LoadOptions) -> Result<Option<Layer>, Self::Error>;
 }
 
 impl LayerCache for () {
     type Error = ();
 
-    fn insert(&mut self, _origin: SpecOrigin, _layer: &Layer) -> Result<(), Self::Error> {
+    fn insert(&mut self, _lo: LoadOptions, _layer: &Layer) -> Result<(), Self::Error> {
         Ok(())
     }
-    fn get(
-        &mut self,
-        _origin: &SpecOrigin,
-        _for_target: &Target,
-    ) -> Result<Option<Layer>, Self::Error> {
+    fn get(&mut self, _lo: &LoadOptions) -> Result<Option<Layer>, Self::Error> {
         Ok(None)
     }
 }
@@ -288,13 +280,13 @@ pub struct LayerCacheDir(pub PathBuf);
 impl LayerCache for LayerCacheDir {
     type Error = ();
 
-    fn insert(&mut self, origin: SpecOrigin, layer: &Layer) -> Result<(), Self::Error> {
+    fn insert(&mut self, lo: LoadOptions, layer: &Layer) -> Result<(), Self::Error> {
         // Its only safe to cache stuff that is pinned to a hash
-        if !matches!(origin, SpecOrigin::Repo(_)) {
+        if !matches!(lo.from, SpecOrigin::Repo(_)) {
             return Ok(());
         }
 
-        let p = self.0.join(origin.hash_hex(&layer.for_target).as_ref());
+        let p = self.0.join(lo.input_hash().to_hex().as_ref());
         if std::fs::exists(&p).unwrap_or(false) {
             return Ok(());
         }
@@ -314,8 +306,8 @@ impl LayerCache for LayerCacheDir {
 
         Ok(())
     }
-    fn get(&mut self, origin: &SpecOrigin, target: &Target) -> Result<Option<Layer>, Self::Error> {
-        let p = self.0.join(origin.hash_hex(target).as_ref());
+    fn get(&mut self, lo: &LoadOptions) -> Result<Option<Layer>, Self::Error> {
+        let p = self.0.join(lo.input_hash().to_hex().as_ref());
 
         if let Ok(f) = std::fs::File::open(&p) {
             let layer: Layer = serde_json::from_reader(f).map_err(|e| {
@@ -510,23 +502,21 @@ impl Graph {
             };
 
             // Load the layer, either from the layer cache or by doing a full load via [Layer::new].
+            let load_opts = decode::LoadOptions {
+                minimal_lib_path: minimal_lib_path.clone(),
+                from: upstream.clone(),
+                target: for_target.clone(),
+                params: None,
+            };
             let layer = if let Some(layer) = lc
-                .get(&upstream, &for_target)
+                .get(&load_opts)
                 .map_err(|e| Error::Fetch(format!("layer-cache fetch: {:?}", e)))?
             {
                 layer
             } else {
-                let layer = Layer::new(
-                    src_path,
-                    &decode::LoadOptions {
-                        minimal_lib_path: minimal_lib_path.clone(),
-                        from: upstream.clone(),
-                        target: for_target.clone(),
-                    },
-                )
-                .map_err(Error::Decode)?;
+                let layer = Layer::new(src_path, &load_opts).map_err(Error::Decode)?;
 
-                if let Err(e) = lc.insert(upstream.clone(), &layer) {
+                if let Err(e) = lc.insert(load_opts, &layer) {
                     tracing::warn!("Failed to cache layer for origin {:?}: {:?}", upstream, e);
                 }
                 layer

--- a/crates/mctx/Cargo.toml
+++ b/crates/mctx/Cargo.toml
@@ -25,6 +25,7 @@ tokio-util.workspace = true
 hakoniwa.workspace = true
 sandbox2.workspace = true
 
+args.workspace = true
 lcache.workspace = true
 rcache.workspace = true
 common.workspace = true

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -665,15 +665,21 @@ impl<'a> Env<'a> {
     pub async fn task_invocations(
         &mut self,
         task: &mfile::Task,
-        parsed_args: Option<&toml::Value>,
+        parsed_args: Option<&std::collections::HashMap<String, args::Arg>>,
     ) -> Result<(bool, Vec<Invocation>), Error> {
-        let base = [("task_packages", task.packages.clone().into())].into_iter();
+        let base = [(
+            "task_packages",
+            args::Arg::Array(
+                task.packages
+                    .iter()
+                    .map(|s| args::ScalarArg::String(s.clone()))
+                    .collect(),
+            ),
+        )]
+        .into_iter();
         let var_ctx = if let Some(args) = parsed_args {
-            let table = args
-                .as_table()
-                .ok_or_else(|| Error::Other(anyhow::anyhow!("parsed_args is not a table")))?;
             common::ncl_eval::VarCtx::new(
-                base.chain(table.iter().map(|(k, v)| (k.as_str(), v.clone()))),
+                base.chain(args.iter().map(|(k, v)| (k.as_str(), v.clone()))),
             )
         } else {
             common::ncl_eval::VarCtx::new(base)

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -1174,10 +1174,10 @@ mod tests {
             let (interactive, invocations) = env
                 .task_invocations(
                     &task,
-                    Some(&toml::Value::Table(toml::Table::from_iter([(
+                    Some(&std::collections::HashMap::from([(
                         "input".to_string(),
-                        toml::Value::String("beep".to_string()),
-                    )]))),
+                        args::Arg::Scalar(args::ScalarArg::String("beep".to_string())),
+                    )])),
                 )
                 .await
                 .unwrap();

--- a/crates/mfile/src/tasks.rs
+++ b/crates/mfile/src/tasks.rs
@@ -1,5 +1,5 @@
 use super::{EnvPatches, EnvVarValue, StrOrList};
-use args::ArgSet;
+use args::ArgsSpec;
 use std::collections::HashMap;
 
 /// A task, defined in a `[tasks.<task_name>]` section of [File].
@@ -37,7 +37,7 @@ pub struct Task {
 
     /// Typed schema of named arguments this task accepts.
     #[serde(default)]
-    pub args: ArgSet,
+    pub args: ArgsSpec,
 
     /// Any fields which are not understood by this version of minimal.
     #[serde(flatten)]
@@ -230,9 +230,8 @@ mod tests {
         .unwrap();
 
         let parsed = t.args.parse("--greeting hello --name world").unwrap();
-        let table = parsed.as_table().unwrap();
         let var_ctx =
-            common::ncl_eval::VarCtx::new(table.iter().map(|(k, v)| (k.as_str(), v.clone())));
+            common::ncl_eval::VarCtx::new(parsed.iter().map(|(k, v)| (k.as_str(), v.clone())));
         let t2 = t
             .map_exec_strings(|s| {
                 var_ctx

--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+args.workspace = true
 graph.workspace = true
 lcache.workspace = true
 rcache.workspace = true

--- a/crates/minimal/src/cmd_run.rs
+++ b/crates/minimal/src/cmd_run.rs
@@ -42,7 +42,7 @@ pub async fn cmd_run(args: RunArgs, ctx: &mut Context) -> Result<(), Error> {
 pub async fn run_task(
     task_name: &str,
     task: &mfile::Task,
-    parsed_args: Option<toml::Value>,
+    parsed_args: Option<std::collections::HashMap<String, args::Arg>>,
     mut graph: Graph,
     ctx: &mut Context,
 ) -> Result<(), Error> {

--- a/crates/multi/Cargo.toml
+++ b/crates/multi/Cargo.toml
@@ -24,6 +24,7 @@ uuid.workspace = true
 libc = "0.2"
 vt100-ctt = "0.17"
 
+args.workspace = true
 checkouts.workspace = true
 common.workspace = true
 graph.workspace = true

--- a/crates/multi/src/environment.rs
+++ b/crates/multi/src/environment.rs
@@ -87,7 +87,7 @@ impl EnvironmentHandle {
     pub async fn new_named_task(
         &self,
         name: String,
-        task_args: Option<&toml::Value>,
+        task_args: Option<&std::collections::HashMap<String, args::Arg>>,
     ) -> Result<TaskHandle, mctx::Error> {
         let (graph, ctx) = self.build_new().await?;
         let shared = self.0.lock().await.shared.clone();

--- a/crates/multi/src/tasks.rs
+++ b/crates/multi/src/tasks.rs
@@ -90,7 +90,7 @@ impl TaskRuntime {
         ctx: Context,
         name: &str,
         task: &mfile::Task,
-        task_args: Option<&toml::Value>,
+        task_args: Option<&std::collections::HashMap<String, args::Arg>>,
     ) -> Result<Self, mctx::Error> {
         let mut graph = Box::new(graph);
         let mut ctx = Box::new(ctx);
@@ -164,7 +164,7 @@ impl Task {
     /// Creates a new named task, building a fresh Env from the given Context and Graph.
     pub(crate) async fn new_named(
         name: String,
-        task_args: Option<&toml::Value>,
+        task_args: Option<&std::collections::HashMap<String, args::Arg>>,
         graph: Graph,
         mut ctx: Context,
         environment: EnvironmentHandle,


### PR DESCRIPTION
Prep for sideload stuff.

 - Args cleanup - better testing, stop using `toml::Value`.
 - The inputs to loading/eval'ing a layer have a proper path for computing an input hash.