### PR TITLE
Implement sideloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,7 @@ dependencies = [
 name = "graph"
 version = "0.0.1"
 dependencies = [
+ "args",
  "blake3",
  "checkouts",
  "codespan-reporting",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4526,7 +4526,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdlib"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "indoc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,4 +113,4 @@ remote-proto = { version = "0.0.1", path = "crates/remote-proto" }
 remote-client = { version = "0.0.1", path = "crates/remote-client" }
 sandbox2 = { version = "0.0.1", path = "crates/sandbox2" }
 
-stdlib = { version = "0.0.9", path = "crates/stdlib" }
+stdlib = { version = "0.0.10", path = "crates/stdlib" }

--- a/crates/args/Cargo.toml
+++ b/crates/args/Cargo.toml
@@ -10,7 +10,7 @@ publish.workspace = true
 clap.workspace = true
 serde.workspace = true
 shlex.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 indoc.workspace = true
-toml.workspace = true

--- a/crates/args/src/lib.rs
+++ b/crates/args/src/lib.rs
@@ -6,20 +6,42 @@
 //!    [ArgSpec::parse] can be used to parse a string representing the invocation of
 //!    these arguments into their concrete values.
 //!  * [ArgsSpec]: Newtype around a map of argument names to [ArgSpec] (schema) descriptions.
-//!
-//!  A concrete set of arguments is represented using `HashMap<String, Arg>`.
+//!  * [ArgsSet]: A concrete set of arguments, effectively a Newtype of `HashMap<String, Arg>`.
 
 use std::{
     collections::{BTreeSet, HashMap},
     hash::Hash,
 };
 
-/// Deterministic hash of the value of a set of arguments.
-pub fn hash_args<H: std::hash::Hasher>(args: &HashMap<String, Arg>, state: &mut H) {
-    let keys: BTreeSet<_> = args.keys().cloned().collect();
-    for k in keys.into_iter() {
-        k.hash(state);
-        args.get(&k).unwrap().hash(state);
+/// A set of arguments.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ArgsSet(HashMap<String, Arg>);
+
+impl ArgsSet {
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Arg)> {
+        self.0.iter()
+    }
+}
+
+impl Hash for ArgsSet {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let keys: BTreeSet<_> = self.0.keys().cloned().collect();
+        for k in keys.into_iter() {
+            k.hash(state);
+            self.0.get(&k).unwrap().hash(state);
+        }
+    }
+}
+
+impl From<HashMap<String, Arg>> for ArgsSet {
+    fn from(value: HashMap<String, Arg>) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<HashMap<String, Arg>> for ArgsSet {
+    fn as_ref(&self) -> &HashMap<String, Arg> {
+        &self.0
     }
 }
 
@@ -444,7 +466,7 @@ impl ArgsSpec {
     /// to [Arg] values.
     ///
     /// Shell quoting is handled via `shlex`.
-    pub fn parse(&self, args: &str) -> Result<HashMap<String, Arg>, clap::Error> {
+    pub fn parse(&self, args: &str) -> Result<ArgsSet, clap::Error> {
         let argv = shlex::split(args).ok_or_else(|| {
             clap::Command::new("task").no_binary_name(true).error(
                 clap::error::ErrorKind::InvalidValue,
@@ -459,7 +481,7 @@ impl ArgsSpec {
     ///
     /// Equivalent to [`parse_argv_named`](Self::parse_argv_named) with a
     /// display name of `"task"`.
-    pub fn parse_argv<I, T>(&self, args: I) -> Result<HashMap<String, Arg>, clap::Error>
+    pub fn parse_argv<I, T>(&self, args: I) -> Result<ArgsSet, clap::Error>
     where
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
@@ -489,7 +511,7 @@ impl ArgsSpec {
         &self,
         display_name: &str,
         args: I,
-    ) -> Result<HashMap<String, Arg>, clap::Error>
+    ) -> Result<ArgsSet, clap::Error>
     where
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
@@ -544,7 +566,7 @@ impl ArgsSpec {
             }
         }
 
-        Ok(result)
+        Ok(ArgsSet(result))
     }
 }
 
@@ -624,20 +646,23 @@ mod tests {
             .parse("--name hello --count 42 --verbose true --tags a --tags b --enum a")
             .unwrap();
         assert_eq!(
-            result.get("name").unwrap(),
+            result.as_ref().get("name").unwrap(),
             &Arg::Scalar(ScalarArg::String("hello".to_string()))
         );
         assert_eq!(
-            result.get("count").unwrap(),
+            result.as_ref().get("count").unwrap(),
             &Arg::Scalar(ScalarArg::Number(42.0))
         );
-        assert_eq!(result.get("enum").unwrap(), &Arg::Enum("a".to_string()));
         assert_eq!(
-            result.get("verbose").unwrap(),
+            result.as_ref().get("enum").unwrap(),
+            &Arg::Enum("a".to_string())
+        );
+        assert_eq!(
+            result.as_ref().get("verbose").unwrap(),
             &Arg::Scalar(ScalarArg::Boolean(true))
         );
         assert_eq!(
-            result.get("tags").unwrap(),
+            result.as_ref().get("tags").unwrap(),
             &Arg::Array(vec![
                 ScalarArg::String("a".to_string()),
                 ScalarArg::String("b".to_string()),

--- a/crates/args/src/lib.rs
+++ b/crates/args/src/lib.rs
@@ -127,6 +127,26 @@ pub enum PrimitiveSpec {
     Boolean,
 }
 
+impl PrimitiveSpec {
+    /// Parse a string value into a [ScalarArg] according to the given primitive type.
+    pub fn parse(&self, s: &str) -> Result<ScalarArg, String> {
+        match self {
+            PrimitiveSpec::String => Ok(ScalarArg::String(s.to_string())),
+            PrimitiveSpec::Number => {
+                let f: f64 = s
+                    .parse()
+                    .map_err(|_| format!("expected a number, got `{s}`"))?;
+                Ok(ScalarArg::Number(f))
+            }
+            PrimitiveSpec::Boolean => match s {
+                "true" => Ok(ScalarArg::Boolean(true)),
+                "false" => Ok(ScalarArg::Boolean(false)),
+                _ => Err(format!("expected `true` or `false`, got `{s}`")),
+            },
+        }
+    }
+}
+
 impl std::fmt::Display for PrimitiveSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -146,24 +166,6 @@ impl TryFrom<&str> for PrimitiveSpec {
             "boolean" | "bool" => Ok(PrimitiveSpec::Boolean),
             _ => Err(()),
         }
-    }
-}
-
-/// Parse a string value into a [ScalarArg] according to the given primitive type.
-fn parse_primitive(s: &str, p: &PrimitiveSpec) -> Result<ScalarArg, String> {
-    match p {
-        PrimitiveSpec::String => Ok(ScalarArg::String(s.to_string())),
-        PrimitiveSpec::Number => {
-            let f: f64 = s
-                .parse()
-                .map_err(|_| format!("expected a number, got `{s}`"))?;
-            Ok(ScalarArg::Number(f))
-        }
-        PrimitiveSpec::Boolean => match s {
-            "true" => Ok(ScalarArg::Boolean(true)),
-            "false" => Ok(ScalarArg::Boolean(false)),
-            _ => Err(format!("expected `true` or `false`, got `{s}`")),
-        },
     }
 }
 
@@ -260,6 +262,26 @@ impl<'de> serde::Deserialize<'de> for ArgSchema {
 }
 
 impl ArgSchema {
+    /// Parses the given value string into a concrete argument.
+    pub fn parse(&self, value: &str) -> Result<Arg, String> {
+        match &self {
+            ArgSchema::Scalar(p) => Ok(Arg::Scalar(p.parse(value)?)),
+            ArgSchema::Array(p) => {
+                let items = parse_bracketed_list(value)?;
+                let arr: Result<Vec<ScalarArg>, String> =
+                    items.iter().map(|v| p.parse(v)).collect();
+                Ok(Arg::Array(arr?))
+            }
+            ArgSchema::Enum(permitted) => {
+                if permitted.contains(value) {
+                    Ok(Arg::Enum(value.to_string()))
+                } else {
+                    Err(format!("`{value}` is not a valid value"))
+                }
+            }
+        }
+    }
+
     /// Returns the string form of this spec (e.g. `"Array number"`).
     pub fn as_type_string(&self) -> String {
         match self {
@@ -276,24 +298,24 @@ impl ArgSchema {
     }
 }
 
-/// Parse an enum spec string of the form `[opt1, opt2, "opt 3"]` into its options.
+/// Parse a bracketed, comma-separated list of the form `[val1, val2, "val 3"]`.
 ///
-/// Whitespace around options is trimmed. Options may optionally be quoted with
+/// Whitespace around values is trimmed. Values may optionally be quoted with
 /// double quotes, which allows commas and leading/trailing whitespace within a
 /// value. Returns an error if the input is not wrapped in `[]` or contains
 /// malformed quoting.
-fn parse_enum_schema(s: &str) -> Result<BTreeSet<String>, String> {
+fn parse_bracketed_list(s: &str) -> Result<Vec<String>, String> {
     let s = s.trim();
     let inner = s
         .strip_prefix('[')
         .and_then(|s| s.strip_suffix(']'))
-        .ok_or_else(|| format!("enum spec must be wrapped in `[]`, got `{s}`"))?;
+        .ok_or_else(|| format!("expected value wrapped in `[]`, got `{s}`"))?;
 
-    let mut opts = BTreeSet::new();
+    let mut values = Vec::new();
     let mut chars = inner.chars().peekable();
 
     loop {
-        // Skip leading whitespace before the next option.
+        // Skip leading whitespace before the next value.
         while chars.peek() == Some(&' ') || chars.peek() == Some(&'\t') {
             chars.next();
         }
@@ -304,19 +326,19 @@ fn parse_enum_schema(s: &str) -> Result<BTreeSet<String>, String> {
         }
 
         let value = if chars.peek() == Some(&'"') {
-            // Quoted option: consume until the closing `"`.
+            // Quoted value: consume until the closing `"`.
             chars.next(); // opening quote
             let mut buf = String::new();
             loop {
                 match chars.next() {
                     Some('"') => break,
                     Some(c) => buf.push(c),
-                    None => return Err("unterminated quote in enum spec".to_string()),
+                    None => return Err("unterminated quote in bracketed list".to_string()),
                 }
             }
             buf
         } else {
-            // Unquoted option: consume until `,` or end.
+            // Unquoted value: consume until `,` or end.
             let mut buf = String::new();
             while let Some(&c) = chars.peek() {
                 if c == ',' {
@@ -327,12 +349,12 @@ fn parse_enum_schema(s: &str) -> Result<BTreeSet<String>, String> {
             }
             let trimmed = buf.trim().to_string();
             if trimmed.is_empty() {
-                return Err("empty option in enum spec".to_string());
+                return Err("empty value in bracketed list".to_string());
             }
             trimmed
         };
 
-        opts.insert(value);
+        values.push(value);
 
         // Skip whitespace after the value, then expect `,` or end.
         while chars.peek() == Some(&' ') || chars.peek() == Some(&'\t') {
@@ -342,16 +364,21 @@ fn parse_enum_schema(s: &str) -> Result<BTreeSet<String>, String> {
             Some(&',') => {
                 chars.next();
             }
-            Some(c) => return Err(format!("unexpected character `{c}` in enum spec")),
+            Some(c) => return Err(format!("unexpected character `{c}` in bracketed list")),
             None => break,
         }
     }
 
-    if opts.is_empty() {
+    Ok(values)
+}
+
+/// Parse an enum spec string of the form `[opt1, opt2, "opt 3"]` into its options.
+fn parse_enum_schema(s: &str) -> Result<BTreeSet<String>, String> {
+    let values = parse_bracketed_list(s)?;
+    if values.is_empty() {
         return Err("enum spec must contain at least one option".to_string());
     }
-
-    Ok(opts)
+    Ok(values.into_iter().collect())
 }
 
 impl serde::Serialize for ArgSchema {
@@ -363,12 +390,13 @@ impl serde::Serialize for ArgSchema {
 /// A single argument definition: the type schema plus optional metadata like `help`.
 ///
 /// Deserializes from either:
-/// - A string: `"string"` → `TaskArg { spec: Scalar(String), help: None }`
-/// - A table with `type`: `{type = "string", help = "something"}` → `TaskArg { spec: .., help: Some(..) }`
+/// - A string: `"string"` → `TaskArg { spec: Scalar(String), help: None, default: None }`
+/// - A table with `type`: `{type = "string"[, help = ..][, default = ...]}` → `TaskArg { spec: .., .. }`
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArgSpec {
     pub spec: ArgSchema,
     pub help: Option<String>,
+    pub default: Option<String>,
 }
 
 impl<'de> serde::Deserialize<'de> for ArgSpec {
@@ -391,6 +419,7 @@ impl<'de> serde::Deserialize<'de> for ArgSpec {
                 Ok(ArgSpec {
                     spec: ArgSchema::try_from(v).map_err(de::Error::custom)?,
                     help: None,
+                    default: None,
                 })
             }
 
@@ -411,16 +440,19 @@ impl<'de> serde::Deserialize<'de> for ArgSpec {
                 Ok(ArgSpec {
                     spec: ArgSchema::Enum(opts),
                     help: None,
+                    default: None,
                 })
             }
 
             fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<ArgSpec, A::Error> {
                 let mut type_str: Option<String> = None;
                 let mut help: Option<String> = None;
+                let mut default: Option<String> = None;
                 while let Some(key) = map.next_key::<String>()? {
                     match key.as_str() {
                         "type" => type_str = Some(map.next_value()?),
                         "help" => help = Some(map.next_value()?),
+                        "default" => default = Some(map.next_value()?),
                         _ => {
                             map.next_value::<de::IgnoredAny>()?; // skip unknown
                         }
@@ -429,7 +461,16 @@ impl<'de> serde::Deserialize<'de> for ArgSpec {
                 let s =
                     type_str.ok_or_else(|| de::Error::custom("expected `type` key in table"))?;
                 let spec = ArgSchema::try_from(s.as_str()).map_err(de::Error::custom)?;
-                Ok(ArgSpec { spec, help })
+                if let Some(default) = &default {
+                    // Validate default
+                    spec.parse(default).map_err(de::Error::custom)?;
+                }
+
+                Ok(ArgSpec {
+                    spec,
+                    help,
+                    default,
+                })
             }
         }
 
@@ -459,6 +500,70 @@ impl ArgsSpec {
     /// Returns true if no arguments are defined.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    /// Hydrates the table of toml values against the argument schema, returning an [ArgsSet] if valid.
+    pub fn from_toml(&self, value: &toml::Value) -> Result<ArgsSet, String> {
+        let table = value
+            .as_table()
+            .ok_or_else(|| "expected table of toml arguments".to_string())?;
+
+        let scalar_from_toml = |v: &toml::Value,
+                                p: &PrimitiveSpec,
+                                name: &str|
+         -> Result<ScalarArg, String> {
+            match (v, p) {
+                (toml::Value::String(s), PrimitiveSpec::String) => Ok(ScalarArg::String(s.clone())),
+                (toml::Value::Integer(i), PrimitiveSpec::Number) => {
+                    Ok(ScalarArg::Number(*i as f64))
+                }
+                (toml::Value::Float(f), PrimitiveSpec::Number) => Ok(ScalarArg::Number(*f)),
+                (toml::Value::Boolean(b), PrimitiveSpec::Boolean) => Ok(ScalarArg::Boolean(*b)),
+                (toml::Value::Datetime(dt), PrimitiveSpec::String) => {
+                    Ok(ScalarArg::String(dt.to_string()))
+                }
+                _ => Err(format!("argument `{name}`: expected {p}, got `{v}`")),
+            }
+        };
+
+        let mut out = HashMap::with_capacity(self.0.len());
+        for (name, spec) in self.0.iter() {
+            let v = match (table.get(name), &spec.default) {
+                (None, None) => return Err(format!("missing argument {name}")),
+                (None, Some(default)) => {
+                    out.insert(name.clone(), spec.spec.parse(default)?);
+                    continue;
+                }
+                (Some(v), _) => v,
+            };
+
+            let arg = match &spec.spec {
+                ArgSchema::Scalar(p) => Arg::Scalar(scalar_from_toml(v, p, name)?),
+                ArgSchema::Array(p) => {
+                    let arr = v
+                        .as_array()
+                        .ok_or_else(|| format!("argument `{name}`: expected array, got `{v}`"))?;
+                    let items: Result<Vec<ScalarArg>, String> = arr
+                        .iter()
+                        .map(|elem| scalar_from_toml(elem, p, name))
+                        .collect();
+                    Arg::Array(items?)
+                }
+                ArgSchema::Enum(permitted) => {
+                    let s = v.as_str().ok_or_else(|| {
+                        format!("argument `{name}`: expected string for enum, got `{v}`")
+                    })?;
+                    if !permitted.contains(s) {
+                        return Err(format!(
+                            "argument `{name}`: `{s}` is not a valid enum value"
+                        ));
+                    }
+                    Arg::Enum(s.to_string())
+                }
+            };
+            out.insert(name.clone(), arg);
+        }
+        Ok(ArgsSet(out))
     }
 
     /// Parse a CLI argument string (e.g. `"--count 42 --name foo"`) according
@@ -523,7 +628,7 @@ impl ArgsSpec {
         for (n, ta) in self.0.iter() {
             let mut arg = ClapArg::new(n.clone())
                 .long(n.clone())
-                .required(true)
+                .required(ta.default.is_none())
                 .action(match &ta.spec {
                     ArgSchema::Array(_) => ArgAction::Append,
                     _ => ArgAction::Set,
@@ -541,20 +646,23 @@ impl ArgsSpec {
 
         let mut result = HashMap::new();
         for (name, ta) in self.0.iter() {
+            if !matches.contains_id(name)
+                && let Some(default) = &ta.default
+            {
+                result.insert(name.clone(), ta.spec.parse(default).map_err(&val_err)?);
+                continue;
+            }
+
             match &ta.spec {
                 ArgSchema::Scalar(p) => {
                     if let Some(raw) = matches.get_one::<String>(name) {
-                        result.insert(
-                            name.clone(),
-                            Arg::Scalar(parse_primitive(raw, p).map_err(&val_err)?),
-                        );
+                        result.insert(name.clone(), Arg::Scalar(p.parse(raw).map_err(&val_err)?));
                     }
                 }
                 ArgSchema::Array(p) => {
                     if let Some(values) = matches.get_many::<String>(name) {
-                        let arr: Result<Vec<ScalarArg>, clap::Error> = values
-                            .map(|v| parse_primitive(v, p).map_err(&val_err))
-                            .collect();
+                        let arr: Result<Vec<ScalarArg>, clap::Error> =
+                            values.map(|v| p.parse(v).map_err(&val_err)).collect();
                         result.insert(name.clone(), Arg::Array(arr?));
                     }
                 }
@@ -590,7 +698,7 @@ mod tests {
             args.name = "string"
             args.tags = "Array number"
             args.enum = "[a, b, c-eeee]"
-            args.input = {type = "string", help = "something"}
+            args.input = {type = "string", help = "something", default = "c"}
         "#})
         .unwrap();
         assert_eq!(
@@ -606,6 +714,7 @@ mod tests {
             &ArgSpec {
                 spec: ArgSchema::Scalar(PrimitiveSpec::String),
                 help: Some("something".to_string()),
+                default: Some("c".to_string()),
             }
         );
         assert_eq!(
@@ -638,6 +747,7 @@ mod tests {
             args.verbose = "boolean"
             args.tags = "Array string"
             args.enum = "[a, b]"
+            args.default_str = {type = "string", default = ""}
         "#})
         .unwrap();
 
@@ -667,6 +777,10 @@ mod tests {
                 ScalarArg::String("a".to_string()),
                 ScalarArg::String("b".to_string()),
             ])
+        );
+        assert_eq!(
+            result.as_ref().get("default_str").unwrap(),
+            &Arg::Scalar(ScalarArg::String("".to_string()))
         );
     }
 
@@ -732,6 +846,197 @@ mod tests {
         assert!(parse_enum_schema("[]").is_err());
         assert!(parse_enum_schema("[a, , b]").is_err());
         assert!(parse_enum_schema(r#"["unterminated]"#).is_err());
+    }
+
+    #[test]
+    fn argschema_parse() {
+        assert_eq!(
+            ArgSchema::Array(PrimitiveSpec::String)
+                .parse("[hello, world]")
+                .unwrap(),
+            Arg::Array(vec![
+                ScalarArg::String("hello".to_string()),
+                ScalarArg::String("world".to_string()),
+            ])
+        );
+
+        assert_eq!(
+            ArgSchema::Array(PrimitiveSpec::Number)
+                .parse("[1, 2.5, 3]")
+                .unwrap(),
+            Arg::Array(vec![
+                ScalarArg::Number(1.0),
+                ScalarArg::Number(2.5),
+                ScalarArg::Number(3.0),
+            ])
+        );
+        // Quoted values with commas
+        assert_eq!(
+            ArgSchema::Array(PrimitiveSpec::String)
+                .parse(r#"["hello, world", foo]"#)
+                .unwrap(),
+            Arg::Array(vec![
+                ScalarArg::String("hello, world".to_string()),
+                ScalarArg::String("foo".to_string()),
+            ])
+        );
+
+        // Empty array
+        assert_eq!(
+            ArgSchema::Array(PrimitiveSpec::Number).parse("[]").unwrap(),
+            Arg::Array(vec![])
+        );
+        // Invalid number in array
+        assert!(
+            ArgSchema::Array(PrimitiveSpec::Number)
+                .parse("[1, abc]")
+                .is_err()
+        );
+
+        // booleans
+        assert_eq!(
+            ArgSchema::Scalar(PrimitiveSpec::Boolean)
+                .parse("true")
+                .unwrap(),
+            Arg::Scalar(ScalarArg::Boolean(true)),
+        );
+        assert_eq!(
+            ArgSchema::Scalar(PrimitiveSpec::Boolean)
+                .parse("false")
+                .unwrap(),
+            Arg::Scalar(ScalarArg::Boolean(false)),
+        );
+
+        // strings
+        assert_eq!(
+            ArgSchema::Scalar(PrimitiveSpec::String)
+                .parse("true")
+                .unwrap(),
+            Arg::Scalar(ScalarArg::String("true".to_string())),
+        );
+
+        // enums
+        assert_eq!(
+            ArgSchema::Enum(["a".to_string(), "b".to_string()].into())
+                .parse("a")
+                .unwrap(),
+            Arg::Enum("a".to_string())
+        );
+        assert_eq!(
+            ArgSchema::Enum(["a".to_string(), "b".to_string()].into())
+                .parse("b")
+                .unwrap(),
+            Arg::Enum("b".to_string())
+        );
+        assert!(
+            ArgSchema::Enum(["a".to_string(), "b".to_string()].into())
+                .parse("c")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn argsspec_from_toml() {
+        let spec: ArgsOnly = toml::from_str(indoc! {r#"
+            args.name = "string"
+            args.count = "number"
+            args.verbose = "boolean"
+            args.tags = "Array string"
+            args.mode = "[debug, release]"
+            args.default_enum = {type = "[x, y]", default = "x"}
+            args.default_str = {type = "string", default = "fallback"}
+        "#})
+        .unwrap();
+
+        // All explicit values provided.
+        let values: toml::Value = toml::from_str(indoc! {r#"
+            name = "hello"
+            count = 42
+            verbose = true
+            tags = ["a", "b"]
+            mode = "release"
+        "#})
+        .unwrap();
+        let result = spec.args.from_toml(&values).unwrap();
+
+        assert_eq!(
+            result.as_ref().get("name").unwrap(),
+            &Arg::Scalar(ScalarArg::String("hello".to_string()))
+        );
+        assert_eq!(
+            result.as_ref().get("count").unwrap(),
+            &Arg::Scalar(ScalarArg::Number(42.0))
+        );
+        assert_eq!(
+            result.as_ref().get("verbose").unwrap(),
+            &Arg::Scalar(ScalarArg::Boolean(true))
+        );
+        assert_eq!(
+            result.as_ref().get("tags").unwrap(),
+            &Arg::Array(vec![
+                ScalarArg::String("a".to_string()),
+                ScalarArg::String("b".to_string()),
+            ])
+        );
+        assert_eq!(
+            result.as_ref().get("mode").unwrap(),
+            &Arg::Enum("release".to_string())
+        );
+        // Defaults should be filled in.
+        assert_eq!(
+            result.as_ref().get("default_enum").unwrap(),
+            &Arg::Enum("x".to_string())
+        );
+        assert_eq!(
+            result.as_ref().get("default_str").unwrap(),
+            &Arg::Scalar(ScalarArg::String("fallback".to_string()))
+        );
+
+        // Float number.
+        let values: toml::Value = toml::from_str(indoc! {r#"
+            name = "hi"
+            count = 3.15
+            verbose = false
+            tags = []
+            mode = "debug"
+        "#})
+        .unwrap();
+        let result = spec.args.from_toml(&values).unwrap();
+        assert_eq!(
+            result.as_ref().get("count").unwrap(),
+            &Arg::Scalar(ScalarArg::Number(3.15))
+        );
+        assert_eq!(
+            result.as_ref().get("verbose").unwrap(),
+            &Arg::Scalar(ScalarArg::Boolean(false))
+        );
+        assert_eq!(result.as_ref().get("tags").unwrap(), &Arg::Array(vec![]));
+
+        // Missing required arg is an error.
+        let values: toml::Value = toml::from_str("name = \"hi\"\n").unwrap();
+        assert!(spec.args.from_toml(&values).is_err());
+
+        // Invalid enum value is an error.
+        let values: toml::Value = toml::from_str(indoc! {r#"
+            name = "hi"
+            count = 1
+            verbose = true
+            tags = []
+            mode = "profile"
+        "#})
+        .unwrap();
+        assert!(spec.args.from_toml(&values).is_err());
+
+        // Type mismatch (string where number expected) is an error.
+        let values: toml::Value = toml::from_str(indoc! {r#"
+            name = "hi"
+            count = "not a number"
+            verbose = true
+            tags = []
+            mode = "debug"
+        "#})
+        .unwrap();
+        assert!(spec.args.from_toml(&values).is_err());
     }
 
     #[test]

--- a/crates/args/src/lib.rs
+++ b/crates/args/src/lib.rs
@@ -503,11 +503,7 @@ impl ArgsSpec {
     }
 
     /// Hydrates the table of toml values against the argument schema, returning an [ArgsSet] if valid.
-    pub fn from_toml(&self, value: &toml::Value) -> Result<ArgsSet, String> {
-        let table = value
-            .as_table()
-            .ok_or_else(|| "expected table of toml arguments".to_string())?;
-
+    pub fn from_toml(&self, table: &toml::Table) -> Result<ArgsSet, String> {
         let scalar_from_toml = |v: &toml::Value,
                                 p: &PrimitiveSpec,
                                 name: &str|
@@ -957,7 +953,7 @@ mod tests {
             mode = "release"
         "#})
         .unwrap();
-        let result = spec.args.from_toml(&values).unwrap();
+        let result = spec.args.from_toml(values.as_table().unwrap()).unwrap();
 
         assert_eq!(
             result.as_ref().get("name").unwrap(),
@@ -1001,7 +997,7 @@ mod tests {
             mode = "debug"
         "#})
         .unwrap();
-        let result = spec.args.from_toml(&values).unwrap();
+        let result = spec.args.from_toml(values.as_table().unwrap()).unwrap();
         assert_eq!(
             result.as_ref().get("count").unwrap(),
             &Arg::Scalar(ScalarArg::Number(3.15))
@@ -1014,7 +1010,7 @@ mod tests {
 
         // Missing required arg is an error.
         let values: toml::Value = toml::from_str("name = \"hi\"\n").unwrap();
-        assert!(spec.args.from_toml(&values).is_err());
+        assert!(spec.args.from_toml(values.as_table().unwrap()).is_err());
 
         // Invalid enum value is an error.
         let values: toml::Value = toml::from_str(indoc! {r#"
@@ -1025,7 +1021,7 @@ mod tests {
             mode = "profile"
         "#})
         .unwrap();
-        assert!(spec.args.from_toml(&values).is_err());
+        assert!(spec.args.from_toml(values.as_table().unwrap()).is_err());
 
         // Type mismatch (string where number expected) is an error.
         let values: toml::Value = toml::from_str(indoc! {r#"
@@ -1036,7 +1032,7 @@ mod tests {
             mode = "debug"
         "#})
         .unwrap();
-        assert!(spec.args.from_toml(&values).is_err());
+        assert!(spec.args.from_toml(values.as_table().unwrap()).is_err());
     }
 
     #[test]

--- a/crates/args/src/lib.rs
+++ b/crates/args/src/lib.rs
@@ -7,13 +7,59 @@
 //!    these arguments into their concrete values.
 //!  * [ArgsSpec]: Newtype around a map of argument names to [ArgSpec] (schema) descriptions.
 //!  * [ArgsSet]: A concrete set of arguments, effectively a Newtype of `HashMap<String, Arg>`.
+//!
+//! ## Usage
+//!
+//! ### Loading argument schema
+//!
+//! The argument schema is typically defined in some config file. Represent the schema of
+//! arguments by having a field in your config file of type [ArgsSpec], which implements the
+//! serde traits.
+//!
+//! ```rust
+//! # use args::ArgsSpec;
+//! let schema: ArgsSpec = toml::from_str("name = \"string\"").unwrap();
+//! ```
+//!
+//! ### Hydrating arguments from a config file
+//!
+//! Use the [DiskArg] type to capture arguments specified in a config file:
+//!
+//! ```rust
+//! # use std::collections::HashMap;
+//! # use args::DiskArg;
+//! #[derive(serde::Deserialize)]
+//! struct MyConfig {
+//!   args: HashMap<String, DiskArg>,
+//! }
+//! ```
+//!
+//! You can then hydrate a map of [DiskArg]'s against an [ArgsSpec]:
+//!
+//! ```rust
+//! # use std::collections::HashMap;
+//! # use args::{DiskArg, ArgsSpec};
+//! # let args = HashMap::from_iter([("name".to_string(), DiskArg::String("a".to_string()))]);
+//! let schema: ArgsSpec = toml::from_str("name = \"string\"").unwrap();
+//! schema.from_deserialized(&args);
+//! ```
+//! ### Hydrating arguments from a command-line invocation
+//!
+//! Use [ArgsSet::parse] to parse the arguments section of a command-line invocartion:
+//!
+//! ```rust
+//! # use std::collections::HashMap;
+//! # use args::{DiskArg, ArgsSpec};
+//! let schema: ArgsSpec = toml::from_str("name = \"string\"").unwrap();
+//! schema.parse("--name hello"); // Ok(ArgsSet)
+//! ```
 
 use std::{
     collections::{BTreeSet, HashMap},
     hash::Hash,
 };
 
-/// A set of arguments.
+/// A set of arguments, already validated against a corresponding schema.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ArgsSet(HashMap<String, Arg>);
 
@@ -42,6 +88,50 @@ impl From<HashMap<String, Arg>> for ArgsSet {
 impl AsRef<HashMap<String, Arg>> for ArgsSet {
     fn as_ref(&self) -> &HashMap<String, Arg> {
         &self.0
+    }
+}
+
+/// A deserialized argument value captured without schema knowledge.
+///
+/// When deserializing argument values from a configuration file (TOML, JSON, etc.),
+/// the schema is not yet available, so the concrete type cannot be validated. `DiskArg`
+/// captures the raw value as-is and can later be validated against an [`ArgsSpec`] via
+/// [`ArgsSpec::from_deserialized`].
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum DiskArg {
+    Boolean(bool),
+    Integer(i64),
+    Float(f64),
+    String(String),
+    Array(Vec<DiskArg>),
+}
+
+impl Hash for DiskArg {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            DiskArg::Boolean(b) => {
+                state.write_u8(0); // Type marker
+                b.hash(state);
+            }
+            DiskArg::Integer(i) => {
+                state.write_u8(1); // Type marker
+                i.hash(state);
+            }
+            DiskArg::Float(f) => {
+                state.write_u8(2); // Type marker
+                f.to_le_bytes().hash(state);
+            }
+            DiskArg::String(s) => {
+                state.write_u8(3); // Type marker
+                s.hash(state);
+            }
+            DiskArg::Array(a) => {
+                state.write_u8(4); // Type marker
+                state.write_u64(a.len() as u64);
+                a.iter().for_each(|e| e.hash(state));
+            }
+        }
     }
 }
 
@@ -492,7 +582,7 @@ impl serde::Serialize for ArgSpec {
     }
 }
 
-/// A set of arguments defined together.
+/// A set of argument schemas defined together.
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct ArgsSpec(pub HashMap<String, ArgSpec>);
 
@@ -502,29 +592,29 @@ impl ArgsSpec {
         self.0.is_empty()
     }
 
-    /// Hydrates the table of toml values against the argument schema, returning an [ArgsSet] if valid.
-    pub fn from_toml(&self, table: &toml::Table) -> Result<ArgsSet, String> {
-        let scalar_from_toml = |v: &toml::Value,
+    /// Hydrates a map of deserialized [`DiskArg`] values against the argument schema,
+    /// returning an [`ArgsSet`] if valid.
+    ///
+    /// This is the format-agnostic equivalent of [`from_toml`](Self::from_toml):
+    /// the caller deserializes a `HashMap<String, DiskArg>` from any serde-supported
+    /// format (TOML, JSON, YAML, …) and this method validates and converts the values.
+    pub fn from_deserialized(&self, values: &HashMap<String, DiskArg>) -> Result<ArgsSet, String> {
+        let scalar_from_disk = |v: &DiskArg,
                                 p: &PrimitiveSpec,
                                 name: &str|
          -> Result<ScalarArg, String> {
             match (v, p) {
-                (toml::Value::String(s), PrimitiveSpec::String) => Ok(ScalarArg::String(s.clone())),
-                (toml::Value::Integer(i), PrimitiveSpec::Number) => {
-                    Ok(ScalarArg::Number(*i as f64))
-                }
-                (toml::Value::Float(f), PrimitiveSpec::Number) => Ok(ScalarArg::Number(*f)),
-                (toml::Value::Boolean(b), PrimitiveSpec::Boolean) => Ok(ScalarArg::Boolean(*b)),
-                (toml::Value::Datetime(dt), PrimitiveSpec::String) => {
-                    Ok(ScalarArg::String(dt.to_string()))
-                }
-                _ => Err(format!("argument `{name}`: expected {p}, got `{v}`")),
+                (DiskArg::String(s), PrimitiveSpec::String) => Ok(ScalarArg::String(s.clone())),
+                (DiskArg::Integer(i), PrimitiveSpec::Number) => Ok(ScalarArg::Number(*i as f64)),
+                (DiskArg::Float(f), PrimitiveSpec::Number) => Ok(ScalarArg::Number(*f)),
+                (DiskArg::Boolean(b), PrimitiveSpec::Boolean) => Ok(ScalarArg::Boolean(*b)),
+                _ => Err(format!("argument `{name}`: expected {p}, got {v:?}")),
             }
         };
 
         let mut out = HashMap::with_capacity(self.0.len());
         for (name, spec) in self.0.iter() {
-            let v = match (table.get(name), &spec.default) {
+            let v = match (values.get(name), &spec.default) {
                 (None, None) => return Err(format!("missing argument {name}")),
                 (None, Some(default)) => {
                     out.insert(name.clone(), spec.spec.parse(default)?);
@@ -534,27 +624,33 @@ impl ArgsSpec {
             };
 
             let arg = match &spec.spec {
-                ArgSchema::Scalar(p) => Arg::Scalar(scalar_from_toml(v, p, name)?),
+                ArgSchema::Scalar(p) => Arg::Scalar(scalar_from_disk(v, p, name)?),
                 ArgSchema::Array(p) => {
-                    let arr = v
-                        .as_array()
-                        .ok_or_else(|| format!("argument `{name}`: expected array, got `{v}`"))?;
+                    let arr = match v {
+                        DiskArg::Array(arr) => arr,
+                        _ => return Err(format!("argument `{name}`: expected array, got {v:?}")),
+                    };
                     let items: Result<Vec<ScalarArg>, String> = arr
                         .iter()
-                        .map(|elem| scalar_from_toml(elem, p, name))
+                        .map(|elem| scalar_from_disk(elem, p, name))
                         .collect();
                     Arg::Array(items?)
                 }
                 ArgSchema::Enum(permitted) => {
-                    let s = v.as_str().ok_or_else(|| {
-                        format!("argument `{name}`: expected string for enum, got `{v}`")
-                    })?;
-                    if !permitted.contains(s) {
+                    let s = match v {
+                        DiskArg::String(s) => s,
+                        _ => {
+                            return Err(format!(
+                                "argument `{name}`: expected string for enum, got {v:?}"
+                            ));
+                        }
+                    };
+                    if !permitted.contains(s.as_str()) {
                         return Err(format!(
                             "argument `{name}`: `{s}` is not a valid enum value"
                         ));
                     }
-                    Arg::Enum(s.to_string())
+                    Arg::Enum(s.clone())
                 }
             };
             out.insert(name.clone(), arg);
@@ -932,7 +1028,32 @@ mod tests {
     }
 
     #[test]
-    fn argsspec_from_toml() {
+    fn disk_arg_deserialize() {
+        // DiskArg should capture values from TOML without schema knowledge.
+        let raw: HashMap<String, DiskArg> = toml::from_str(indoc! {r#"
+            name = "hello"
+            count = 42
+            ratio = 2.72
+            verbose = true
+            tags = ["a", "b"]
+        "#})
+        .unwrap();
+
+        assert_eq!(raw.get("name").unwrap(), &DiskArg::String("hello".into()));
+        assert_eq!(raw.get("count").unwrap(), &DiskArg::Integer(42));
+        assert_eq!(raw.get("ratio").unwrap(), &DiskArg::Float(2.72));
+        assert_eq!(raw.get("verbose").unwrap(), &DiskArg::Boolean(true));
+        assert_eq!(
+            raw.get("tags").unwrap(),
+            &DiskArg::Array(vec![
+                DiskArg::String("a".into()),
+                DiskArg::String("b".into()),
+            ])
+        );
+    }
+
+    #[test]
+    fn argsspec_from_deserialized() {
         let spec: ArgsOnly = toml::from_str(indoc! {r#"
             args.name = "string"
             args.count = "number"
@@ -945,7 +1066,7 @@ mod tests {
         .unwrap();
 
         // All explicit values provided.
-        let values: toml::Value = toml::from_str(indoc! {r#"
+        let values: HashMap<String, DiskArg> = toml::from_str(indoc! {r#"
             name = "hello"
             count = 42
             verbose = true
@@ -953,7 +1074,7 @@ mod tests {
             mode = "release"
         "#})
         .unwrap();
-        let result = spec.args.from_toml(values.as_table().unwrap()).unwrap();
+        let result = spec.args.from_deserialized(&values).unwrap();
 
         assert_eq!(
             result.as_ref().get("name").unwrap(),
@@ -978,7 +1099,7 @@ mod tests {
             result.as_ref().get("mode").unwrap(),
             &Arg::Enum("release".to_string())
         );
-        // Defaults should be filled in.
+        // Defaults filled in.
         assert_eq!(
             result.as_ref().get("default_enum").unwrap(),
             &Arg::Enum("x".to_string())
@@ -989,7 +1110,7 @@ mod tests {
         );
 
         // Float number.
-        let values: toml::Value = toml::from_str(indoc! {r#"
+        let values: HashMap<String, DiskArg> = toml::from_str(indoc! {r#"
             name = "hi"
             count = 3.15
             verbose = false
@@ -997,23 +1118,18 @@ mod tests {
             mode = "debug"
         "#})
         .unwrap();
-        let result = spec.args.from_toml(values.as_table().unwrap()).unwrap();
+        let result = spec.args.from_deserialized(&values).unwrap();
         assert_eq!(
             result.as_ref().get("count").unwrap(),
             &Arg::Scalar(ScalarArg::Number(3.15))
         );
-        assert_eq!(
-            result.as_ref().get("verbose").unwrap(),
-            &Arg::Scalar(ScalarArg::Boolean(false))
-        );
-        assert_eq!(result.as_ref().get("tags").unwrap(), &Arg::Array(vec![]));
 
         // Missing required arg is an error.
-        let values: toml::Value = toml::from_str("name = \"hi\"\n").unwrap();
-        assert!(spec.args.from_toml(values.as_table().unwrap()).is_err());
+        let values: HashMap<String, DiskArg> = toml::from_str("name = \"hi\"\n").unwrap();
+        assert!(spec.args.from_deserialized(&values).is_err());
 
         // Invalid enum value is an error.
-        let values: toml::Value = toml::from_str(indoc! {r#"
+        let values: HashMap<String, DiskArg> = toml::from_str(indoc! {r#"
             name = "hi"
             count = 1
             verbose = true
@@ -1021,10 +1137,10 @@ mod tests {
             mode = "profile"
         "#})
         .unwrap();
-        assert!(spec.args.from_toml(values.as_table().unwrap()).is_err());
+        assert!(spec.args.from_deserialized(&values).is_err());
 
         // Type mismatch (string where number expected) is an error.
-        let values: toml::Value = toml::from_str(indoc! {r#"
+        let values: HashMap<String, DiskArg> = toml::from_str(indoc! {r#"
             name = "hi"
             count = "not a number"
             verbose = true
@@ -1032,7 +1148,7 @@ mod tests {
             mode = "debug"
         "#})
         .unwrap();
-        assert!(spec.args.from_toml(values.as_table().unwrap()).is_err());
+        assert!(spec.args.from_deserialized(&values).is_err());
     }
 
     #[test]

--- a/crates/common/src/ncl_eval.rs
+++ b/crates/common/src/ncl_eval.rs
@@ -9,14 +9,6 @@ pub struct VarCtx {
 }
 
 impl VarCtx {
-    pub fn new<S: AsRef<str>, I: IntoIterator<Item = (S, args::Arg)>>(values: I) -> Self {
-        let mut base = String::with_capacity(512);
-        for (ident, value) in values.into_iter() {
-            value.write_nickel_binding(ident.as_ref(), &mut base);
-        }
-        Self { base }
-    }
-
     pub fn eval_string(&self, s: &str) -> Result<String, Box<(Files, Error)>> {
         let mut source = String::with_capacity(self.base.len() + s.len() + 16);
         source.push_str(&self.base);
@@ -49,19 +41,29 @@ impl VarCtx {
     }
 }
 
+impl<S: AsRef<str>> FromIterator<(S, args::Arg)> for VarCtx {
+    fn from_iter<T: IntoIterator<Item = (S, args::Arg)>>(iter: T) -> Self {
+        let mut base = String::with_capacity(512);
+        for (ident, value) in iter.into_iter() {
+            value.write_nickel_binding(ident.as_ref(), &mut base);
+        }
+        Self { base }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn empty_var_ctx() {
-        let ctx = VarCtx::new(std::iter::empty::<(&str, args::Arg)>());
+        let ctx = VarCtx::from_iter(std::iter::empty::<(&str, args::Arg)>());
         assert_eq!(ctx.base, "");
     }
 
     #[test]
     fn passthrough_basic_strings() {
-        let ctx = VarCtx::new(std::iter::empty::<(&str, args::Arg)>());
+        let ctx = VarCtx::from_iter(std::iter::empty::<(&str, args::Arg)>());
         assert_eq!(ctx.eval_string("hello").unwrap(), "hello");
         assert_eq!(ctx.eval_string("world").unwrap(), "world");
         assert_eq!(ctx.eval_string("hello world").unwrap(), "hello world");
@@ -71,7 +73,7 @@ mod tests {
     #[test]
     fn interpolation_with_vars_scalar() {
         use args::{Arg, ScalarArg};
-        let ctx = VarCtx::new(vec![
+        let ctx = VarCtx::from_iter(vec![
             ("name", Arg::Scalar(ScalarArg::String("world".to_string()))),
             ("count", Arg::Scalar(ScalarArg::Number(42.0))),
             ("flag", Arg::Scalar(ScalarArg::Boolean(true))),
@@ -92,7 +94,7 @@ mod tests {
     #[test]
     fn interpolation_with_vars_array() {
         use args::{Arg, ScalarArg};
-        let ctx = VarCtx::new(vec![
+        let ctx = VarCtx::from_iter(vec![
             (
                 "a",
                 Arg::Array(vec![

--- a/crates/decode/src/attrs.rs
+++ b/crates/decode/src/attrs.rs
@@ -133,16 +133,17 @@ mod tests {
 
     #[test]
     fn parse_str() {
-        let (term, mut program, _origin, _target) = Loader::new("\"a\"", &LoadOptions::for_test())
-            .unwrap_or_else(|e| {
-                e.report_to_stderr();
-                panic!("load failed");
-            })
-            .finish()
-            .unwrap_or_else(|e| {
-                e.report_to_stderr();
-                panic!("finish failed");
-            });
+        let (term, mut program, _origin, _target) =
+            Loader::new("\"a\"", None, &LoadOptions::for_test())
+                .unwrap_or_else(|e| {
+                    e.report_to_stderr();
+                    panic!("load failed");
+                })
+                .finish()
+                .unwrap_or_else(|e| {
+                    e.report_to_stderr();
+                    panic!("finish failed");
+                });
 
         assert!(matches!(
         AttrValue::from_term(&term, &mut program).unwrap().unwrap(),
@@ -151,16 +152,17 @@ mod tests {
     }
     #[test]
     fn parse_bool() {
-        let (term, mut program, _origin, _target) = Loader::new("true", &LoadOptions::for_test())
-            .unwrap_or_else(|e| {
-                e.report_to_stderr();
-                panic!("load failed");
-            })
-            .finish()
-            .unwrap_or_else(|e| {
-                e.report_to_stderr();
-                panic!("finish failed");
-            });
+        let (term, mut program, _origin, _target) =
+            Loader::new("true", None, &LoadOptions::for_test())
+                .unwrap_or_else(|e| {
+                    e.report_to_stderr();
+                    panic!("load failed");
+                })
+                .finish()
+                .unwrap_or_else(|e| {
+                    e.report_to_stderr();
+                    panic!("finish failed");
+                });
 
         assert_eq!(
             AttrValue::from_term(&term, &mut program).unwrap().unwrap(),
@@ -169,16 +171,17 @@ mod tests {
     }
     #[test]
     fn parse_enum() {
-        let (term, mut program, _origin, _target) = Loader::new("'Uwu", &LoadOptions::for_test())
-            .unwrap_or_else(|e| {
-                e.report_to_stderr();
-                panic!("load failed");
-            })
-            .finish()
-            .unwrap_or_else(|e| {
-                e.report_to_stderr();
-                panic!("finish failed");
-            });
+        let (term, mut program, _origin, _target) =
+            Loader::new("'Uwu", None, &LoadOptions::for_test())
+                .unwrap_or_else(|e| {
+                    e.report_to_stderr();
+                    panic!("load failed");
+                })
+                .finish()
+                .unwrap_or_else(|e| {
+                    e.report_to_stderr();
+                    panic!("finish failed");
+                });
 
         assert!(matches!(
         AttrValue::from_term(&term, &mut program).unwrap().unwrap(),
@@ -189,7 +192,7 @@ mod tests {
     #[test]
     fn parse_record() {
         let (term, mut program, _origin, _target) =
-            Loader::new("{key = \"a\"}", &LoadOptions::for_test())
+            Loader::new("{key = \"a\"}", None, &LoadOptions::for_test())
                 .unwrap_or_else(|e| {
                     e.report_to_stderr();
                     panic!("load failed");
@@ -209,7 +212,7 @@ mod tests {
     #[test]
     fn parse_list() {
         let (term, mut program, _origin, _target) =
-            Loader::new("[\"a\", \"b\"]", &LoadOptions::for_test())
+            Loader::new("[\"a\", \"b\"]", None, &LoadOptions::for_test())
                 .unwrap_or_else(|e| {
                     e.report_to_stderr();
                     panic!("load failed");
@@ -231,6 +234,7 @@ mod tests {
     fn unknown_attr_nickel_err() {
         let res = Loader::new(
             "let {Attrs, ..} = import \"minimal.ncl\" in {unknown_attr = \"a\"} | Attrs",
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -247,6 +251,7 @@ mod tests {
     fn attr_wrong_schema_nickel_err() {
         let res = Loader::new(
             "let {Attrs, ..} = import \"minimal.ncl\" in {env_state_wiring = \"a\"} | Attrs",
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {

--- a/crates/decode/src/builds.rs
+++ b/crates/decode/src/builds.rs
@@ -1263,6 +1263,7 @@ mod tests {
                 "
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1294,6 +1295,7 @@ mod tests {
 
         let (term, mut program, _origin, _target) = Loader::new(
             format!("import \"{}\"", path.to_str().unwrap()),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1324,6 +1326,7 @@ mod tests {
                 "
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1362,6 +1365,7 @@ mod tests {
                 "
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1401,6 +1405,7 @@ mod tests {
         		} | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1452,6 +1457,7 @@ mod tests {
         		} | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1487,7 +1493,7 @@ mod tests {
                     ],
         		} | BuildSpec"
             }
-            .to_string(),
+            .to_string(),None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1524,6 +1530,7 @@ mod tests {
         		} | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1562,6 +1569,7 @@ mod tests {
         		} | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1593,6 +1601,7 @@ mod tests {
                 "
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1657,6 +1666,7 @@ mod tests {
         		} | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1696,6 +1706,7 @@ mod tests {
         		} | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -1732,6 +1743,7 @@ mod tests {
         		} | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {

--- a/crates/decode/src/decl_tests.rs
+++ b/crates/decode/src/decl_tests.rs
@@ -166,6 +166,7 @@ mod tests {
                 "
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -211,6 +212,7 @@ mod tests {
                 "
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {

--- a/crates/decode/src/harnesses.rs
+++ b/crates/decode/src/harnesses.rs
@@ -649,7 +649,7 @@ mod tests {
                 }
                 "
             }
-            .to_string(),
+            .to_string(),None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -108,13 +108,13 @@ impl Layer {
 
     /// Simple builder of literal nickel for a test.
     pub fn new_for_test(s: String) -> Result<Self, Error> {
-        let l = load::Loader::new(s, &load::LoadOptions::for_test())?;
+        let l = load::Loader::new(s, None, &load::LoadOptions::for_test())?;
         Self::from_loader(l, None)
     }
 
     /// Loads all objects in the given directory following the standard directory layout.
     pub fn new<P: AsRef<Path>>(layer_dir: P, opts: &LoadOptions) -> Result<Self, Error> {
-        let (upstream, config_dir) = match mfile::File::from_dir(layer_dir.as_ref()) {
+        let (upstream, params, config_dir) = match mfile::File::from_dir(layer_dir.as_ref()) {
             Ok(mfile) => {
                 if let Some(min_vers) = &mfile.stdlib.minimum_version {
                     if **min_vers > *stdlib::VERSION {
@@ -128,19 +128,30 @@ impl Layer {
 
                 (
                     mfile.upstream.clone(),
+                    mfile.params.clone(),
                     mfile.dir_path().map(|p| p.to_path_buf()),
                 )
             }
             Err(mfile::Error::IO(_, _, e)) if e.kind() == std::io::ErrorKind::NotFound => {
-                (None, None)
+                (None, None, None)
             }
-            Err(mfile::Error::NotFound) => (None, None),
+            Err(mfile::Error::NotFound) => (None, None, None),
             Err(mfile::Error::IO(_, _, e)) => return Err(Error::IO(e)),
             Err(e) => return Err(Error::Other(e.to_string())),
         };
 
+        let args = match params {
+            Some(schema) => Some(
+                // TODO: Make own error for bad parameters
+                schema
+                    .from_deserialized(&opts.params.clone().unwrap_or_default())
+                    .map_err(|e| Error::Other(format!("bad parameters: {e}")))?,
+            ),
+            None => None,
+        };
         let loader = load::Loader::new_with_all_pkgs(
             config_dir.unwrap_or_else(|| layer_dir.as_ref().to_path_buf()),
+            args.as_ref(),
             opts,
         )?;
         Self::from_loader(loader, upstream)
@@ -511,6 +522,7 @@ mod tests {
         		} | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -580,6 +592,7 @@ mod tests {
         		} | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -621,6 +634,7 @@ mod tests {
         		} | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {
@@ -664,6 +678,7 @@ mod tests {
                 } | BuildSpec"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -143,7 +143,7 @@ impl Layer {
             config_dir.unwrap_or_else(|| layer_dir.as_ref().to_path_buf()),
             opts,
         )?;
-        Self::from_loader(loader, upstream)
+        Self::from_loader(loader, upstream.map(|u| u.link))
     }
 
     fn from_loader(loader: load::Loader, upstream: Option<LinkConfig>) -> Result<Self, Error> {

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -6,7 +6,7 @@
 
 use common::{SpecOrigin, Target};
 use generational_arena::Arena;
-use mfile::{EnvPatches, LinkConfig, PatchSetting};
+use mfile::{EnvPatches, PatchSetting, Upstream};
 use nickel_lang_core::eval::value::NickelValue;
 use nickel_lang_core::identifier::LocIdent;
 use nickel_lang_core::position::TermPos;
@@ -58,7 +58,7 @@ impl TryFrom<TermPos> for StrPos {
 /// A collection of nickel objects, defined together in a single codebase.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Layer {
-    upstream: Option<LinkConfig>,
+    upstream: Option<Upstream>,
     pub origin: SpecOrigin,
     pub for_target: Target,
 
@@ -102,7 +102,7 @@ impl Layer {
     }
 
     /// Returns the upstream layer this layer depends on, if any.
-    pub fn upstream(&self) -> Option<&LinkConfig> {
+    pub fn upstream(&self) -> Option<&Upstream> {
         self.upstream.as_ref()
     }
 
@@ -143,10 +143,10 @@ impl Layer {
             config_dir.unwrap_or_else(|| layer_dir.as_ref().to_path_buf()),
             opts,
         )?;
-        Self::from_loader(loader, upstream.map(|u| u.link))
+        Self::from_loader(loader, upstream)
     }
 
-    fn from_loader(loader: load::Loader, upstream: Option<LinkConfig>) -> Result<Self, Error> {
+    fn from_loader(loader: load::Loader, upstream: Option<Upstream>) -> Result<Self, Error> {
         let (ncl_tree, mut program, origin, for_target) = loader.finish()?;
         let mut layer = Self {
             origin,

--- a/crates/decode/src/load.rs
+++ b/crates/decode/src/load.rs
@@ -11,6 +11,7 @@ use nickel_lang_core::identifier::LocIdent;
 use nickel_lang_core::term::Term;
 use nickel_lang_core::typ::TypeF;
 use nickel_lang_core::{error::NullReporter, eval::cache::CacheImpl, program::Program};
+use std::collections::{BTreeSet, HashMap};
 use std::hash::Hash;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -27,7 +28,7 @@ pub struct LoadOptions {
     /// The target we are loading for.
     pub target: Target,
     /// The parameters being passed to the layer during evaluation.
-    pub params: Option<args::ArgsSet>,
+    pub params: Option<HashMap<String, args::DiskArg>>,
 }
 
 impl LoadOptions {
@@ -54,7 +55,11 @@ impl LoadOptions {
         self.target.hash(state);
         if let Some(params) = &self.params {
             state.write(b"params");
-            params.hash(state);
+            let keys: BTreeSet<_> = params.keys().cloned().collect();
+            for k in keys.into_iter() {
+                k.hash(state);
+                params.get(&k).unwrap().hash(state);
+            }
         }
     }
 
@@ -179,15 +184,37 @@ pub(crate) struct Loader {
 
 impl Loader {
     /// Processes literal source representing a top-level collection of objects.
-    pub(crate) fn new<S: Into<String>>(src: S, opts: &LoadOptions) -> Result<Self, Error> {
+    pub(crate) fn new<S: Into<String>>(
+        src: S,
+        args: Option<&args::ArgsSet>,
+        opts: &LoadOptions,
+    ) -> Result<Self, Error> {
         let generated_lib_dir = tempfile::TempDir::new()?;
         std::fs::write(generated_lib_dir.path().join("__injected_config__.ncl"), {
             let mut out = Vec::with_capacity(128);
-            out.extend(b"{target = {os = ");
+            out.extend(b"{\n\ttarget = {os = ");
             out.extend(opts.for_target().os().as_nickel_literal());
             out.extend(b",arch = ");
             out.extend(opts.for_target().arch().as_nickel_literal());
-            out.extend(b"}}");
+            out.extend(b"},");
+            out.extend(b"\n\targs = ");
+            match args {
+                None => out.extend(b"{}"),
+                Some(set) => {
+                    out.extend(b"{");
+                    let mut buf = String::with_capacity(64);
+                    for (name, v) in set.iter() {
+                        buf.clear();
+                        v.write_nickel(&mut buf);
+
+                        out.extend(b"\n\t\t");
+                        out.extend(format!("\"{name}\" = {buf},").as_bytes());
+                    }
+                    out.extend(b"\n\t}");
+                }
+            }
+
+            out.extend(b",\n}");
             out
         })?;
 
@@ -221,6 +248,7 @@ impl Loader {
     /// Loads all build decls in the given directory following the standard directory layout.
     pub fn new_with_all_pkgs<P: AsRef<Path>>(
         layer_dir: P,
+        args: Option<&args::ArgsSet>,
         opts: &LoadOptions,
     ) -> Result<Self, Error> {
         let mut src = String::with_capacity(2048);
@@ -275,7 +303,7 @@ impl Loader {
 
         src.push('}');
 
-        Self::new(src, opts)
+        Self::new(src, args, opts)
     }
 
     /// Walks the AST to find unique build-spec declarations, annotating them with a unique ID.
@@ -442,13 +470,23 @@ mod tests {
 
     #[test]
     fn loader_empty() {
-        let _sr = Loader::new("{}".to_string(), &LoadOptions::for_test()).unwrap();
+        let _sr = Loader::new("{}".to_string(), None, &LoadOptions::for_test()).unwrap();
     }
 
     #[test]
     fn loader_injects_config() {
+        let args = {
+            let schema: args::ArgsSpec = toml::from_str("a = \"string\"").unwrap();
+            schema
+                .from_deserialized(&HashMap::from_iter([(
+                    "a".to_string(),
+                    args::DiskArg::String("hi".to_string()),
+                )]))
+                .unwrap()
+        };
         let _sr = Loader::new(
             "{c = import \"__injected_config__.ncl\"}".to_string(),
+            Some(&args),
             &LoadOptions::for_test(),
         )
         .unwrap();
@@ -467,6 +505,7 @@ mod tests {
         		}"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         );
 
@@ -496,6 +535,7 @@ mod tests {
                 }"
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         );
 
@@ -567,7 +607,7 @@ mod tests {
         )
         .unwrap();
 
-        let sr = Loader::new_with_all_pkgs(temp_dir.path(), &LoadOptions::for_test());
+        let sr = Loader::new_with_all_pkgs(temp_dir.path(), None, &LoadOptions::for_test());
         // So we can see the actual error when the test fails
         if let Some(e) = sr.as_ref().err().iter().next() {
             e.report_to_stderr();

--- a/crates/decode/src/load.rs
+++ b/crates/decode/src/load.rs
@@ -11,7 +11,6 @@ use nickel_lang_core::identifier::LocIdent;
 use nickel_lang_core::term::Term;
 use nickel_lang_core::typ::TypeF;
 use nickel_lang_core::{error::NullReporter, eval::cache::CacheImpl, program::Program};
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -28,7 +27,7 @@ pub struct LoadOptions {
     /// The target we are loading for.
     pub target: Target,
     /// The parameters being passed to the layer during evaluation.
-    pub params: Option<HashMap<String, args::Arg>>,
+    pub params: Option<args::ArgsSet>,
 }
 
 impl LoadOptions {
@@ -55,7 +54,7 @@ impl LoadOptions {
         self.target.hash(state);
         if let Some(params) = &self.params {
             state.write(b"params");
-            args::hash_args(params, state);
+            params.hash(state);
         }
     }
 

--- a/crates/decode/src/profiles.rs
+++ b/crates/decode/src/profiles.rs
@@ -213,6 +213,7 @@ mod tests {
                 "
             }
             .to_string(),
+            None,
             &LoadOptions::for_test(),
         )
         .unwrap_or_else(|e| {

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -21,6 +21,7 @@ tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
+args.workspace = true
 common.workspace = true
 checkouts.workspace = true
 decode.workspace = true

--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -7,7 +7,7 @@ use common::repo_spec::Repo;
 use common::{SpecOrigin, Target};
 use decode::builds::BuildRef;
 use decode::{Harness, Layer, LoadOptions, Profile, builds};
-use mfile::{self, LinkConfig};
+use mfile::{self, LinkConfig, Upstream};
 use nickel_lang_core::term::IndexMap;
 
 use generational_arena::Arena;
@@ -355,6 +355,145 @@ impl LayerCache for LayerCacheDir {
     }
 }
 
+/// Loads layers from source with caching, and assembles them into a [Graph].
+///
+/// This struct encapsulates the infrastructure needed for chain loading: source resolution
+/// via [SourceProvider] and parsed-layer caching via [LayerCache]. The traversal logic
+/// (following upstream links, loading sideloads) is implemented as methods, making it
+/// easy to reuse `load_layer` for both upstream and sideload loading.
+pub struct ChainLoader<'lc, SP: SourceProvider, LC: LayerCache> {
+    sp: SP,
+    lc: &'lc mut LC,
+    minimal_lib_path: PathBuf,
+    for_target: Target,
+}
+
+impl<'lc, SP: SourceProvider, LC: LayerCache> ChainLoader<'lc, SP, LC> {
+    pub fn new(sp: SP, lc: &'lc mut LC, minimal_lib_path: PathBuf, for_target: Target) -> Self {
+        Self {
+            sp,
+            lc,
+            minimal_lib_path,
+            for_target,
+        }
+    }
+
+    /// Resolves a [SpecOrigin] to a filesystem path using the [SourceProvider].
+    fn resolve_source(&mut self, origin: &SpecOrigin) -> Result<PathBuf, Error> {
+        match origin {
+            SpecOrigin::Inline => {
+                unreachable!()
+            }
+            SpecOrigin::Repo(Repo::Git { url, rev, tracking }) => self
+                .sp
+                .checkout_of(&LinkConfig::Git {
+                    repo: url.clone(),
+                    branch: tracking.as_ref().and_then(|b| match b {
+                        common::repo_spec::GitRef::Branch(b) => Some(b.clone()),
+                        common::repo_spec::GitRef::Tag(_t) => None,
+                    }),
+                    locked_commit: Some(rev.clone()),
+                })
+                .map_err(|e| Error::Fetch(e.to_string())),
+            SpecOrigin::LocalDir { absolute, .. } => Ok(absolute.clone()),
+        }
+    }
+
+    /// Loads a single layer from the given origin, using the cache where possible.
+    fn load_layer(
+        &mut self,
+        upstream: &Upstream,
+        params: Option<args::ArgsSet>,
+    ) -> Result<Layer, Error> {
+        let origin = upstream.link.as_spec_origin().unwrap();
+        let src_path = self.resolve_source(&origin)?;
+        let load_opts = LoadOptions {
+            minimal_lib_path: self.minimal_lib_path.clone(),
+            from: origin.clone(),
+            target: self.for_target.clone(),
+            params,
+        };
+
+        if let Some(layer) = self
+            .lc
+            .get(&load_opts)
+            .map_err(|e| Error::Fetch(format!("layer-cache fetch: {:?}", e)))?
+        {
+            Ok(layer)
+        } else {
+            let layer = Layer::new(src_path, &load_opts).map_err(Error::Decode)?;
+            if let Err(e) = self.lc.insert(load_opts, &layer) {
+                tracing::warn!("Failed to cache layer for origin {:?}: {:?}", origin, e);
+            }
+            Ok(layer)
+        }
+    }
+
+    /// Validates a layer's upstream reference and returns the next [Upstream] to load,
+    /// or `None` if this layer is the root of the chain.
+    fn next_upstream(
+        layer: &Layer,
+        current_origin: &SpecOrigin,
+    ) -> Result<Option<Upstream>, Error> {
+        let Some(next_upstream) = layer.upstream() else {
+            return Ok(None);
+        };
+
+        match &next_upstream.link {
+            LinkConfig::Git {
+                repo,
+                branch: _,
+                locked_commit,
+            } => {
+                if current_origin
+                    .as_repo()
+                    .is_some_and(|r| matches!(r, Repo::Git { url, ..} if url == repo))
+                {
+                    return Err(Error::Fetch(format!(
+                        "layer at {} defines an upstream that points to itself",
+                        repo.clone(),
+                    )));
+                }
+                if locked_commit.is_none() {
+                    return Err(Error::UpstreamNotPinned {
+                        upstream: repo.to_string(),
+                        at_layer: layer.origin.clone(),
+                    });
+                }
+            }
+            LinkConfig::Dir { .. } => {}
+        };
+
+        Ok(Some(next_upstream.clone()))
+    }
+
+    /// Loads the full layer chain starting from a leaf, including any sideloads
+    /// declared by layers in the chain, and assembles them into a [Graph].
+    pub fn load_chain(&mut self, leaf: LinkConfig) -> Result<Graph, Error> {
+        let mut layers = Vec::with_capacity(6);
+        let mut cursor = Some(Upstream::from_link(leaf));
+
+        while let Some(upstream) = cursor.take() {
+            // Load sideloads declared by this layer. They are pushed before
+            // the declaring layer so they can depend on packages from the upstream.
+            for sideload in upstream.sideloads() {
+                layers.push(self.load_layer(&Upstream::from_link(sideload.link().clone()), None)?);
+            }
+
+            let layer = self.load_layer(&upstream, None)?;
+            cursor = Self::next_upstream(&layer, &upstream.link.as_spec_origin().unwrap())?;
+            layers.push(layer);
+        }
+
+        let mut out = Graph::new();
+        out.target = self.for_target.clone();
+        for layer in layers.into_iter().rev() {
+            out = out.ingest(layer)?;
+        }
+        Ok(out)
+    }
+}
+
 /// Describes a match between a search term and a package.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SearchMatch {
@@ -471,97 +610,16 @@ impl Graph {
     /// Constructs a dependency graph using the given origin to load the leaf layer,
     /// and resolving the files for upstream layers using the given implementation of [SourceProvider].
     ///
-    /// SAFETY:
-    ///   The given leaf parameter must not be `SpecOrigin::Inline`, or this function will panic.
+    /// This is a convenience wrapper around [ChainLoader]. For more control over the
+    /// loading process (e.g. loading individual layers), construct a [ChainLoader] directly.
     pub fn new_from_chain<SP: SourceProvider, LC: LayerCache>(
-        mut sp: SP,
+        sp: SP,
         lc: &mut LC,
-        leaf: SpecOrigin,
+        leaf: LinkConfig,
         minimal_lib_path: PathBuf,
         for_target: Target,
     ) -> Result<Self, Error> {
-        let mut layers = Vec::with_capacity(6);
-
-        let mut cursor = Some(leaf);
-
-        while let Some(upstream) = cursor.take() {
-            let src_path = match &upstream {
-                SpecOrigin::Inline => {
-                    panic!("SpecOrigin::Inline given as leaf to new_from_chain()")
-                }
-                SpecOrigin::Repo(Repo::Git { url, rev, tracking }) => sp
-                    .checkout_of(&LinkConfig::Git {
-                        repo: url.clone(),
-                        branch: tracking.as_ref().and_then(|b| match b {
-                            common::repo_spec::GitRef::Branch(b) => Some(b.clone()),
-                            common::repo_spec::GitRef::Tag(_t) => None,
-                        }),
-                        locked_commit: Some(rev.clone()),
-                    })
-                    .map_err(|e| Error::Fetch(e.to_string()))?,
-                SpecOrigin::LocalDir { absolute, .. } => absolute.clone(),
-            };
-
-            // Load the layer, either from the layer cache or by doing a full load via [Layer::new].
-            let load_opts = decode::LoadOptions {
-                minimal_lib_path: minimal_lib_path.clone(),
-                from: upstream.clone(),
-                target: for_target.clone(),
-                params: None,
-            };
-            let layer = if let Some(layer) = lc
-                .get(&load_opts)
-                .map_err(|e| Error::Fetch(format!("layer-cache fetch: {:?}", e)))?
-            {
-                layer
-            } else {
-                let layer = Layer::new(src_path, &load_opts).map_err(Error::Decode)?;
-
-                if let Err(e) = lc.insert(load_opts, &layer) {
-                    tracing::warn!("Failed to cache layer for origin {:?}: {:?}", upstream, e);
-                }
-                layer
-            };
-
-            cursor = if let Some(next_upstream) = layer.upstream() {
-                match next_upstream {
-                    LinkConfig::Git {
-                        repo,
-                        branch: _,
-                        locked_commit,
-                    } => {
-                        if upstream
-                            .as_repo()
-                            .is_some_and(|r| matches!(r, Repo::Git { url, ..} if url == repo))
-                        {
-                            return Err(Error::Fetch(format!(
-                                "layer at {} defines an upstream that points to itself",
-                                repo.clone(),
-                            )));
-                        }
-                        if locked_commit.is_none() {
-                            return Err(Error::UpstreamNotPinned {
-                                upstream: repo.to_string(),
-                                at_layer: layer.origin,
-                            });
-                        }
-                    }
-                    LinkConfig::Dir { .. } => {} // nothing to validate
-                };
-
-                Some(next_upstream.as_spec_origin().unwrap())
-            } else {
-                None
-            };
-            layers.push(layer);
-        }
-
-        let mut out = Self::new();
-        out.target = for_target;
-        for layer in layers.into_iter().rev() {
-            out = out.ingest(layer)?;
-        }
-        Ok(out)
+        ChainLoader::new(sp, lc, minimal_lib_path, for_target).load_chain(leaf)
     }
 
     /// Loads build declarations in from the given layer.
@@ -1366,7 +1424,7 @@ mod tests {
         let graph = Graph::new_from_chain(
             &mut sp,
             &mut (),
-            middle_repo.as_spec_origin().unwrap(),
+            middle_repo.clone(),
             LoadOptions::for_test().minimal_lib_path,
             Target::default(),
         )
@@ -1394,6 +1452,139 @@ mod tests {
             &vec![
                 apex_repo.as_spec_origin().unwrap(),
                 middle_repo.as_spec_origin().unwrap(),
+            ],
+        )
+    }
+
+    #[test]
+    fn sideload_chain() {
+        let apex = TempDir::new().unwrap();
+        std::fs::create_dir_all(apex.path().join("packages").join("top")).unwrap();
+        std::fs::write(
+            apex.path().join("packages").join("top").join("build.ncl"),
+            indoc! {
+            "
+            let {build, ..} = import \"minimal.ncl\" in
+
+            build {
+                name = \"top\",
+                build_deps = [],
+                cmd = \"\",
+            }"
+            },
+        )
+        .unwrap();
+        let apex_repo = LinkConfig::Git {
+            repo: "git@fakehub.com:minimal/apex.git".to_string(),
+            locked_commit: Some("abc123".to_string()),
+            branch: None,
+        };
+
+        let root = TempDir::new().unwrap();
+        std::fs::write(
+            root.path().join(MFILE_NAME),
+            indoc! {
+            "
+            [upstream]
+            repo = \"git@fakehub.com:minimal/apex.git\"
+            locked_commit = \"abc123\"
+
+            [[upstream.sideload]]
+            repo = \"git@fakehub.com:minimal/sideload.git\"
+            locked_commit = \"def\"
+            "
+            },
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.path().join("packages").join("root")).unwrap();
+        std::fs::write(
+            root.path().join("packages").join("root").join("build.ncl"),
+            indoc! {
+            "
+            let {build, upstream, ..} = import \"minimal.ncl\" in
+
+            build {
+                name = \"root\",
+                build_deps = [upstream \"top\"],
+                cmd = \"\",
+            }"
+            },
+        )
+        .unwrap();
+        let root_repo = LinkConfig::Git {
+            repo: "git@fakehub.com:minimal/root.git".to_string(),
+            locked_commit: Some("abc123".to_string()),
+            branch: None,
+        };
+
+        let sideload = TempDir::new().unwrap();
+        std::fs::write(
+            sideload.path().join(MFILE_NAME),
+            indoc! {
+            "
+            [upstream]
+            repo = \"git@fakehub.com:minimal/apex.git\"
+            locked_commit = \"abc123\"
+            "
+            },
+        )
+        .unwrap();
+        std::fs::create_dir_all(sideload.path().join("packages").join("sideload")).unwrap();
+        std::fs::write(
+            sideload
+                .path()
+                .join("packages")
+                .join("sideload")
+                .join("build.ncl"),
+            indoc! {
+            "
+            let {build, upstream, ..} = import \"minimal.ncl\" in
+
+            build {
+                name = \"sideload\",
+                build_deps = [upstream \"top\"],
+                cmd = \"\",
+            }"
+            },
+        )
+        .unwrap();
+        let sideload_repo = LinkConfig::Git {
+            repo: "git@fakehub.com:minimal/sideload.git".to_string(),
+            locked_commit: Some("def".to_string()),
+            branch: None,
+        };
+
+        let mut sp = SourceProviderFake(HashMap::from_iter([
+            (apex_repo.clone(), apex),
+            (root_repo.clone(), root),
+            (sideload_repo.clone(), sideload),
+        ]));
+        let graph = Graph::new_from_chain(
+            &mut sp,
+            &mut (),
+            root_repo.clone(),
+            LoadOptions::for_test().minimal_lib_path,
+            Target::default(),
+        )
+        .unwrap();
+
+        // Make sure the build from both apex, middle, & sideload is present
+        assert_eq!(
+            graph
+                .builds
+                .iter()
+                .map(|(_, b)| &b.name)
+                .collect::<Vec<_>>(),
+            vec!["top", "sideload", "root"]
+        );
+
+        // Make sure the supply chain was tracked in the correct order
+        assert_eq!(
+            graph.software_supply_chain(),
+            &vec![
+                apex_repo.as_spec_origin().unwrap(),
+                sideload_repo.as_spec_origin().unwrap(),
+                root_repo.as_spec_origin().unwrap(),
             ],
         )
     }

--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -471,7 +471,8 @@ impl Graph {
     /// Constructs a dependency graph using the given origin to load the leaf layer,
     /// and resolving the files for upstream layers using the given implementation of [SourceProvider].
     ///
-    /// The given leaf paramater must not be `SpecOrigin::Inline`, or this function will panic.
+    /// SAFETY:
+    ///   The given leaf parameter must not be `SpecOrigin::Inline`, or this function will panic.
     pub fn new_from_chain<SP: SourceProvider, LC: LayerCache>(
         mut sp: SP,
         lc: &mut LC,

--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -403,7 +403,7 @@ impl<'lc, SP: SourceProvider, LC: LayerCache> ChainLoader<'lc, SP, LC> {
     fn load_layer(
         &mut self,
         upstream: &Upstream,
-        params: Option<args::ArgsSet>,
+        params: Option<HashMap<String, args::DiskArg>>,
     ) -> Result<Layer, Error> {
         let origin = upstream.link.as_spec_origin().unwrap();
         let src_path = self.resolve_source(&origin)?;
@@ -476,8 +476,11 @@ impl<'lc, SP: SourceProvider, LC: LayerCache> ChainLoader<'lc, SP, LC> {
         while let Some(upstream) = cursor.take() {
             // Load sideloads declared by this layer. They are pushed before
             // the declaring layer so they can depend on packages from the upstream.
-            for sideload in upstream.sideloads() {
-                layers.push(self.load_layer(&Upstream::from_link(sideload.link().clone()), None)?);
+            for sideload in upstream.sideloads().iter().rev() {
+                layers.push(self.load_layer(
+                    &Upstream::from_link(sideload.link().clone()),
+                    sideload.params().cloned(),
+                )?);
             }
 
             let layer = self.load_layer(&upstream, None)?;
@@ -1490,8 +1493,13 @@ mod tests {
             locked_commit = \"abc123\"
 
             [[upstream.sideload]]
-            repo = \"git@fakehub.com:minimal/sideload.git\"
+            repo = \"git@fakehub.com:minimal/sideload-noparams.git\"
             locked_commit = \"def\"
+
+            [[upstream.sideload]]
+            repo = \"git@fakehub.com:minimal/sideload-params.git\"
+            locked_commit = \"def\"
+            params.enum = \"a\"
             "
             },
         )
@@ -1517,9 +1525,9 @@ mod tests {
             branch: None,
         };
 
-        let sideload = TempDir::new().unwrap();
+        let sideload_noparams = TempDir::new().unwrap();
         std::fs::write(
-            sideload.path().join(MFILE_NAME),
+            sideload_noparams.path().join(MFILE_NAME),
             indoc! {
             "
             [upstream]
@@ -1529,27 +1537,81 @@ mod tests {
             },
         )
         .unwrap();
-        std::fs::create_dir_all(sideload.path().join("packages").join("sideload")).unwrap();
-        std::fs::write(
-            sideload
+        std::fs::create_dir_all(
+            sideload_noparams
                 .path()
                 .join("packages")
-                .join("sideload")
+                .join("sideload-noparams"),
+        )
+        .unwrap();
+        std::fs::write(
+            sideload_noparams
+                .path()
+                .join("packages")
+                .join("sideload-noparams")
                 .join("build.ncl"),
             indoc! {
             "
             let {build, upstream, ..} = import \"minimal.ncl\" in
 
             build {
-                name = \"sideload\",
+                name = \"sideload-noparams\",
                 build_deps = [upstream \"top\"],
                 cmd = \"\",
             }"
             },
         )
         .unwrap();
-        let sideload_repo = LinkConfig::Git {
-            repo: "git@fakehub.com:minimal/sideload.git".to_string(),
+        let sideload_noparams_repo = LinkConfig::Git {
+            repo: "git@fakehub.com:minimal/sideload-noparams.git".to_string(),
+            locked_commit: Some("def".to_string()),
+            branch: None,
+        };
+        let sideload_params = TempDir::new().unwrap();
+        std::fs::write(
+            sideload_params.path().join(MFILE_NAME),
+            indoc! {
+            "
+            [upstream]
+            repo = \"git@fakehub.com:minimal/apex.git\"
+            locked_commit = \"abc123\"
+
+            [params]
+            enum = {type = \"[\\\"a\\\", \\\"b\\\"]\", default =\"b\"}
+            cmd = {type = \"string\", default =\"tar\"}
+            "
+            },
+        )
+        .unwrap();
+        std::fs::create_dir_all(
+            sideload_params
+                .path()
+                .join("packages")
+                .join("sideload-params"),
+        )
+        .unwrap();
+        std::fs::write(
+            sideload_params
+                .path()
+                .join("packages")
+                .join("sideload-params")
+                .join("build.ncl"),
+            indoc! {
+            "
+            let {build, upstream, ..} = import \"minimal.ncl\" in
+            let {param, ..} = import \"config.ncl\" in
+
+            build {
+                name = \"sideload-params\",
+                build_deps = [upstream \"top\"],
+                cmd = param \"cmd\",
+                attrs.upstream_version = param \"enum\",
+            }"
+            },
+        )
+        .unwrap();
+        let sideload_params_repo = LinkConfig::Git {
+            repo: "git@fakehub.com:minimal/sideload-params.git".to_string(),
             locked_commit: Some("def".to_string()),
             branch: None,
         };
@@ -1557,7 +1619,8 @@ mod tests {
         let mut sp = SourceProviderFake(HashMap::from_iter([
             (apex_repo.clone(), apex),
             (root_repo.clone(), root),
-            (sideload_repo.clone(), sideload),
+            (sideload_noparams_repo.clone(), sideload_noparams),
+            (sideload_params_repo.clone(), sideload_params),
         ]));
         let graph = Graph::new_from_chain(
             &mut sp,
@@ -1568,14 +1631,33 @@ mod tests {
         )
         .unwrap();
 
-        // Make sure the build from both apex, middle, & sideload is present
+        // Make sure the build from both apex, middle, & sideloads are present
         assert_eq!(
             graph
                 .builds
                 .iter()
                 .map(|(_, b)| &b.name)
                 .collect::<Vec<_>>(),
-            vec!["top", "sideload", "root"]
+            vec!["top", "sideload-noparams", "sideload-params", "root"]
+        );
+
+        // Check the parameterization that set on sideload-params
+        // Param 'cmd' should have gotten default 'tar'.
+        assert_eq!(
+            graph
+                .get(graph.by_name("sideload-params").unwrap())
+                .unwrap()
+                .cmds,
+            vec![vec!["tar".to_string()]]
+        );
+        // Param 'enum' should have gotten defined value (not default) 'a'.
+        // We stuffed it into upstream_version.
+        assert_eq!(
+            graph
+                .get(graph.by_name("sideload-params").unwrap())
+                .unwrap()
+                .upstream_version(),
+            Some(&"a".to_string()),
         );
 
         // Make sure the supply chain was tracked in the correct order
@@ -1583,7 +1665,8 @@ mod tests {
             graph.software_supply_chain(),
             &vec![
                 apex_repo.as_spec_origin().unwrap(),
-                sideload_repo.as_spec_origin().unwrap(),
+                sideload_noparams_repo.as_spec_origin().unwrap(),
+                sideload_params_repo.as_spec_origin().unwrap(),
                 root_repo.as_spec_origin().unwrap(),
             ],
         )

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -665,7 +665,7 @@ impl<'a> Env<'a> {
     pub async fn task_invocations(
         &mut self,
         task: &mfile::Task,
-        parsed_args: Option<&std::collections::HashMap<String, args::Arg>>,
+        parsed_args: Option<&args::ArgsSet>,
     ) -> Result<(bool, Vec<Invocation>), Error> {
         let base = [(
             "task_packages",
@@ -678,11 +678,11 @@ impl<'a> Env<'a> {
         )]
         .into_iter();
         let var_ctx = if let Some(args) = parsed_args {
-            common::ncl_eval::VarCtx::new(
+            common::ncl_eval::VarCtx::from_iter(
                 base.chain(args.iter().map(|(k, v)| (k.as_str(), v.clone()))),
             )
         } else {
-            common::ncl_eval::VarCtx::new(base)
+            common::ncl_eval::VarCtx::from_iter(base)
         };
 
         Ok((

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -1174,10 +1174,13 @@ mod tests {
             let (interactive, invocations) = env
                 .task_invocations(
                     &task,
-                    Some(&std::collections::HashMap::from([(
-                        "input".to_string(),
-                        args::Arg::Scalar(args::ScalarArg::String("beep".to_string())),
-                    )])),
+                    Some(
+                        &std::collections::HashMap::from([(
+                            "input".to_string(),
+                            args::Arg::Scalar(args::ScalarArg::String("beep".to_string())),
+                        )])
+                        .into(),
+                    ),
                 )
                 .await
                 .unwrap();

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -21,7 +21,7 @@ mod config;
 pub use config::{Config, ConfigBuilder, ConfigError};
 mod env;
 use graph::{BinProvider, BuildSpecRef, Graph, MaskingBinProvider, Transitives};
-use mfile::{EnvPatches, EnvVarValue, Task};
+use mfile::{EnvPatches, EnvVarValue, LinkConfig, Task};
 pub use sandbox2::config::Invocation;
 
 pub use env::Env;
@@ -401,13 +401,13 @@ impl Context {
 
     /// Builds & returns a graph of all packages for a specific target.
     pub fn graph_from_all_packages_with_target(&mut self, target: Target) -> Result<Graph, Error> {
-        let leaf_layer = self.repo_origin();
-
         let start = SystemTime::now();
         let res = Graph::new_from_chain(
             self.vcs_manager(),
             &mut graph::LayerCacheDir(self.config.layer_cache_dir()),
-            leaf_layer,
+            LinkConfig::Dir {
+                dir: self.repo_dir().to_str().unwrap().to_string(),
+            },
             self.stdlib_dir.clone(),
             target,
         )

--- a/crates/mfile/src/error.rs
+++ b/crates/mfile/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     Format(toml::de::Error),
     NotFound,
     ConflictingLayouts(Vec<PathBuf>),
+    MissingParamDefault(String),
 }
 
 impl fmt::Display for Error {
@@ -29,6 +30,9 @@ impl fmt::Display for Error {
                     .collect::<Vec<_>>()
                     .join(",")
             ),
+            Error::MissingParamDefault(e) => {
+                write!(f, "invalid parameter: `{}` does not define a default", e)
+            }
         }
     }
 }
@@ -40,6 +44,7 @@ impl std::error::Error for Error {
             Error::Format(e) => Some(e),
             Error::NotFound => None,
             Error::ConflictingLayouts(_) => None,
+            Error::MissingParamDefault(_) => None,
         }
     }
 }

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -111,8 +111,19 @@ pub struct Upstream {
 }
 
 impl Upstream {
+    pub fn from_link(link: LinkConfig) -> Self {
+        Self {
+            link,
+            sideloads: vec![],
+        }
+    }
+
     fn fixup_relative<P: AsRef<Path>>(&mut self, mfile_path: P) {
         self.link.fixup_relative(mfile_path);
+    }
+
+    pub fn sideloads(&self) -> &[Sideload] {
+        &self.sideloads
     }
 }
 
@@ -129,6 +140,16 @@ pub struct Sideload {
     link: LinkConfig,
     #[serde(default)]
     params: Option<toml::Table>,
+}
+
+impl Sideload {
+    pub fn link(&self) -> &LinkConfig {
+        &self.link
+    }
+
+    pub fn params(&self) -> Option<&toml::Table> {
+        self.params.as_ref()
+    }
 }
 
 /// The value of a declared environment variable. Either a literal value

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -98,6 +98,39 @@ impl LinkConfig {
     }
 }
 
+/// Describes the upstream, the previous link in the software supply chain.
+///
+/// The top-most link will not have an upstream, so this may not be set in all layers.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct Upstream {
+    #[serde(flatten)]
+    pub link: LinkConfig,
+
+    #[serde(default, alias = "sideload")]
+    sideloads: Vec<Sideload>,
+}
+
+impl Upstream {
+    fn fixup_relative<P: AsRef<Path>>(&mut self, mfile_path: P) {
+        self.link.fixup_relative(mfile_path);
+    }
+}
+
+impl AsRef<LinkConfig> for Upstream {
+    fn as_ref(&self) -> &LinkConfig {
+        &self.link
+    }
+}
+
+/// A sideload configured in this repo.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct Sideload {
+    #[serde(flatten)]
+    link: LinkConfig,
+    #[serde(default)]
+    params: Option<toml::Table>,
+}
+
 /// The value of a declared environment variable. Either a literal value
 /// or the symbolic variant `{ inherit = true }`, meaning to read it from the parent process.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -328,7 +361,10 @@ pub enum Layout {
 pub struct File {
     /// The previous link in the software supply chain.
     #[serde(alias = "base")]
-    pub upstream: Option<LinkConfig>,
+    pub upstream: Option<Upstream>,
+    /// The schema for any parameters which configure this layer.
+    pub params: Option<args::ArgsSpec>,
+
     /// Default profile, state_key etc.
     #[serde(default, alias = "default")]
     pub defaults: Defaults,
@@ -382,6 +418,28 @@ impl File {
         }
     }
 
+    /// Helper to finish initialization of the structure after being deserialized.
+    fn init_toml(mut self, path: &PathBuf, layout: Layout) -> Result<Self, Error> {
+        self.mfile_path = Some(path.to_path_buf());
+        self.layout = Some(layout);
+        if let Some(u) = self.upstream.as_mut() {
+            u.fixup_relative(path);
+            for sideload in u.sideloads.iter_mut() {
+                sideload.link.fixup_relative(path);
+            }
+        }
+        // Parameters, if set, must declare defaults.
+        if let Some(params) = &self.params {
+            for (n, s) in params.0.iter() {
+                if s.default.is_none() {
+                    return Err(Error::MissingParamDefault(n.clone()));
+                }
+            }
+        }
+        self.warn_unknown_fields();
+        Ok(self)
+    }
+
     /// Loads the minimal file from the given directory path. The given
     /// directory must be a repository / minimalfile root.
     pub fn from_dir<P: AsRef<Path>>(dir: P) -> Result<Self, Error> {
@@ -396,14 +454,11 @@ impl File {
                     return Err(Error::ConflictingLayouts(vec![path, conflicting_path]));
                 }
 
-                let mut mfile: Self = toml::from_slice(&file_data).map_err(Error::Format)?;
-                mfile.mfile_path = Some(path.to_path_buf());
-                mfile.layout = Some(Layout::Root);
-                if let Some(u) = mfile.upstream.as_mut() {
-                    u.fixup_relative(&path)
-                }
-                mfile.warn_unknown_fields();
-                return Ok(mfile);
+                return Self::init_toml(
+                    toml::from_slice(&file_data).map_err(Error::Format)?,
+                    &path,
+                    Layout::Root,
+                );
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => return Err(Error::IO("minimal file", path, e)),
@@ -412,16 +467,11 @@ impl File {
         // Check for the minimal file at `./.minimal`.
         let path = dir.as_ref().join(".minimal").join(MFILE_NAME);
         match std::fs::read(&path) {
-            Ok(file_data) => {
-                let mut mfile: Self = toml::from_slice(&file_data).map_err(Error::Format)?;
-                mfile.mfile_path = Some(path.to_path_buf());
-                mfile.layout = Some(Layout::DotMinimal);
-                if let Some(u) = mfile.upstream.as_mut() {
-                    u.fixup_relative(&path)
-                }
-                mfile.warn_unknown_fields();
-                Ok(mfile)
-            }
+            Ok(file_data) => Self::init_toml(
+                toml::from_slice(&file_data).map_err(Error::Format)?,
+                &path,
+                Layout::DotMinimal,
+            ),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(Error::NotFound),
             Err(e) => Err(Error::IO("minimal file", path, e)),
         }
@@ -432,7 +482,10 @@ impl File {
     // DO NOT USE unless you know what you are doing.
     pub fn synthetic(upstream: LinkConfig) -> Self {
         Self {
-            upstream: Some(upstream),
+            upstream: Some(Upstream {
+                link: upstream,
+                sideloads: vec![],
+            }),
             ..Default::default()
         }
     }
@@ -614,6 +667,10 @@ mod tests {
             repo = "https://github.com/gominimal/pkgs"
             branch = "main"
 
+            [params]
+            str = "string"
+            some_enum = {type = "[a,b]", default = "b"}
+
             [tasks.test]
             state_key = "test"
             patch.dir."~/.claude" = "read-write"
@@ -631,11 +688,32 @@ mod tests {
         assert_eq!(
             mf,
             File {
-                upstream: Some(LinkConfig::Git {
-                    repo: "https://github.com/gominimal/pkgs".to_string(),
-                    branch: Some("main".to_string()),
-                    locked_commit: None,
+                upstream: Some(Upstream {
+                    link: LinkConfig::Git {
+                        repo: "https://github.com/gominimal/pkgs".to_string(),
+                        branch: Some("main".to_string()),
+                        locked_commit: None,
+                    },
+                    sideloads: vec![]
                 }),
+                params: Some(args::ArgsSpec(HashMap::from([
+                    (
+                        "str".to_string(),
+                        args::ArgSpec {
+                            spec: args::ArgSchema::Scalar(args::PrimitiveSpec::String),
+                            help: None,
+                            default: None,
+                        }
+                    ),
+                    (
+                        "some_enum".to_string(),
+                        args::ArgSpec {
+                            spec: args::ArgSchema::Enum(["a".to_string(), "b".to_string()].into()),
+                            help: None,
+                            default: Some("b".to_string()),
+                        }
+                    ),
+                ]))),
                 defaults: Default::default(),
                 harness: None,
                 tasks: [(

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -139,7 +139,7 @@ pub struct Sideload {
     #[serde(flatten)]
     link: LinkConfig,
     #[serde(default)]
-    params: Option<toml::Table>,
+    params: Option<HashMap<String, args::DiskArg>>,
 }
 
 impl Sideload {
@@ -147,7 +147,7 @@ impl Sideload {
         &self.link
     }
 
-    pub fn params(&self) -> Option<&toml::Table> {
+    pub fn params(&self) -> Option<&HashMap<String, args::DiskArg>> {
         self.params.as_ref()
     }
 }

--- a/crates/mfile/src/tasks.rs
+++ b/crates/mfile/src/tasks.rs
@@ -230,8 +230,9 @@ mod tests {
         .unwrap();
 
         let parsed = t.args.parse("--greeting hello --name world").unwrap();
-        let var_ctx =
-            common::ncl_eval::VarCtx::new(parsed.iter().map(|(k, v)| (k.as_str(), v.clone())));
+        let var_ctx = common::ncl_eval::VarCtx::from_iter(
+            parsed.iter().map(|(k, v)| (k.as_str(), v.clone())),
+        );
         let t2 = t
             .map_exec_strings(|s| {
                 var_ctx

--- a/crates/minimal/src/cmd_init.rs
+++ b/crates/minimal/src/cmd_init.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use common::{SpecOrigin, Target, repo_spec::Repo};
 use graph::Graph;
 use mctx::{Config, Context, Error};
+use mfile::LinkConfig;
 
 #[derive(clap::Args)]
 pub struct InitArgs {
@@ -61,11 +62,11 @@ pub async fn cmd_init(args: InitArgs, config: Config) -> Result<(), Error> {
                 Graph::new_from_chain(
                     vcs,
                     &mut (),
-                    SpecOrigin::Repo(common::repo_spec::Repo::Git {
-                        url: "https://github.com/gominimal/pkgs".to_string(),
-                        rev,
-                        tracking: Some(common::repo_spec::GitRef::Branch("main".to_string())),
-                    }),
+                    LinkConfig::Git {
+                        repo: "https://github.com/gominimal/pkgs".to_string(),
+                        branch: Some("main".to_string()),
+                        locked_commit: Some(rev),
+                    },
                     stdlib_dir,
                     Target::host(),
                 )?,

--- a/crates/minimal/src/cmd_init.rs
+++ b/crates/minimal/src/cmd_init.rs
@@ -28,6 +28,7 @@ pub async fn cmd_init(args: InitArgs, config: Config) -> Result<(), Error> {
                 .upstream
                 .as_ref()
                 .unwrap()
+                .as_ref()
                 .as_spec_origin()
                 .unwrap(),
             ctx.repo_dir().to_path_buf(),

--- a/crates/minimal/src/cmd_run.rs
+++ b/crates/minimal/src/cmd_run.rs
@@ -42,7 +42,7 @@ pub async fn cmd_run(args: RunArgs, ctx: &mut Context) -> Result<(), Error> {
 pub async fn run_task(
     task_name: &str,
     task: &mfile::Task,
-    parsed_args: Option<std::collections::HashMap<String, args::Arg>>,
+    parsed_args: Option<args::ArgsSet>,
     mut graph: Graph,
     ctx: &mut Context,
 ) -> Result<(), Error> {

--- a/crates/minimal/src/cmd_update.rs
+++ b/crates/minimal/src/cmd_update.rs
@@ -7,15 +7,16 @@ pub async fn cmd_update(_args: UpdateArgs, ctx: &mut Context) -> Result<(), Erro
     let mfile = ctx.minimal_file();
     let mfile_path = mfile.file_path().cloned();
 
-    let upstream: Option<(String, Option<String>, Option<String>)> = match mfile.upstream.as_ref() {
-        Some(mfile::LinkConfig::Git {
-            repo,
-            branch,
-            locked_commit,
-        }) => Some((repo.clone(), branch.clone(), locked_commit.clone())),
-        Some(mfile::LinkConfig::Dir { .. }) => None,
-        None => None,
-    };
+    let upstream: Option<(String, Option<String>, Option<String>)> =
+        match mfile.upstream.as_ref().map(|u| &u.link) {
+            Some(mfile::LinkConfig::Git {
+                repo,
+                branch,
+                locked_commit,
+            }) => Some((repo.clone(), branch.clone(), locked_commit.clone())),
+            Some(mfile::LinkConfig::Dir { .. }) => None,
+            None => None,
+        };
 
     // best effort, yeet any cached remote index so a fresh fetch occurs
     std::fs::remove_file(ctx.index_dir().join(rcache::INDEX_FILENAME)).ok();

--- a/crates/multi/src/environment.rs
+++ b/crates/multi/src/environment.rs
@@ -87,7 +87,7 @@ impl EnvironmentHandle {
     pub async fn new_named_task(
         &self,
         name: String,
-        task_args: Option<&std::collections::HashMap<String, args::Arg>>,
+        task_args: Option<&args::ArgsSet>,
     ) -> Result<TaskHandle, mctx::Error> {
         let (graph, ctx) = self.build_new().await?;
         let shared = self.0.lock().await.shared.clone();

--- a/crates/multi/src/tasks.rs
+++ b/crates/multi/src/tasks.rs
@@ -90,7 +90,7 @@ impl TaskRuntime {
         ctx: Context,
         name: &str,
         task: &mfile::Task,
-        task_args: Option<&std::collections::HashMap<String, args::Arg>>,
+        task_args: Option<&args::ArgsSet>,
     ) -> Result<Self, mctx::Error> {
         let mut graph = Box::new(graph);
         let mut ctx = Box::new(ctx);
@@ -164,7 +164,7 @@ impl Task {
     /// Creates a new named task, building a fresh Env from the given Context and Graph.
     pub(crate) async fn new_named(
         name: String,
-        task_args: Option<&std::collections::HashMap<String, args::Arg>>,
+        task_args: Option<&args::ArgsSet>,
         graph: Graph,
         mut ctx: Context,
         environment: EnvironmentHandle,

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stdlib"
-version = "0.0.9"
+version = "0.0.10"
 rust-version = "1.87"
 license = "MIT OR Apache-2.0"
 edition.workspace = true

--- a/crates/stdlib/minimal-ncl/config.ncl
+++ b/crates/stdlib/minimal-ncl/config.ncl
@@ -2,4 +2,7 @@ let ic = import "__injected_config__.ncl" in
 let {Target, ..} = import "minimal.ncl" in
 {
     target | Target | doc "The system that the software is being compiled for." = ic.target,
+
+    param | String -> Dyn | doc "Reads the named parameter passed into the layer." =
+      fun name => ic.args."%{name}",
 }


### PR DESCRIPTION
 - Moved the logic for walking the supply chain out of a `Graph` method and into its own type
 - Refactored the storage types for arguments to use `DiskArg`, plumbed through loader methods
 - Implemented Newtype `DiskArg` for loading arguments from config when schema is not yet known, and method to hydrate/validate based on schema
 - Plumb writing parameters into nickel `__injected_config__.ncl`. We will do this without writing a file to disk when that becomes possible
 - Test for sideloading, including parameters, parameter defaults, load/ingest order