### PR TITLE
crates/{mctx,orchestrator}: limit max concurrent downloads to 8

### DIFF
--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -4,6 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt,
     path::{Path, PathBuf},
+    sync::Arc,
     time::SystemTime,
 };
 
@@ -25,6 +26,7 @@ use mfile::{EnvPatches, EnvVarValue, LinkConfig, Task};
 pub use sandbox2::config::Invocation;
 
 pub use env::Env;
+use tokio::sync::Semaphore;
 use toml_edit::{Array, DocumentMut, Item, TableLike, Value};
 
 use crate::env::EnvArgs;
@@ -680,6 +682,7 @@ impl Context {
         let rc = self.remote_cache(false, true).await.unwrap();
         let mut task_set = tokio::task::JoinSet::new();
         let fetch_start = SystemTime::now();
+        let semaphore = Arc::new(Semaphore::new(8));
         for (bsr, _depinfo) in Transitives::for_toplevels(graph, pkgs.into_iter().collect(), false)
         {
             let b = graph.get(&bsr).unwrap();
@@ -691,8 +694,10 @@ impl Context {
             {
                 let rc_clone = rc.clone(); // TODO: This is trash
                 let cache_clone = self.cache.clone();
+                let semaphore = semaphore.clone();
                 task_set.spawn(async move {
-                    rc_clone
+                    let sema = semaphore.acquire().await;
+                    let res = rc_clone
                         .materialize(&spec_hash, &cache_clone, &name)
                         .await
                         .map(|(t, d)| {
@@ -706,7 +711,9 @@ impl Context {
                                     ..Default::default()
                                 },
                             )
-                        })
+                        });
+                    drop(sema);
+                    res
                 });
             }
         }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -11,7 +11,7 @@ use common::SpecHash;
 use graph::{BinProvider, BuildSpecRef, ExecPlan, Graph, SubsetInput};
 use lcache::{Cache, LocalDir};
 use tokio::{
-    sync::{RwLock, RwLockReadGuard},
+    sync::{RwLock, RwLockReadGuard, Semaphore},
     task::{JoinSet, yield_now},
 };
 
@@ -38,6 +38,7 @@ pub struct Shared<B: Backend> {
     pub graph: Graph,
     pub cache: Cache<LocalDir>,
     pub backend: B,
+    pub fetch_semaphore: Semaphore,
 }
 
 /// An async / task-friendly wrapper around state used everywhere.
@@ -84,6 +85,7 @@ impl<B: Backend> Orchestrator<B> {
             graph: self.graph.clone(),
             cache: self.cache.clone(),
             backend: self.backend,
+            fetch_semaphore: Semaphore::new(8),
         };
         let state = match State::from_plan(
             &shared.graph,

--- a/crates/orchestrator/src/local_backend.rs
+++ b/crates/orchestrator/src/local_backend.rs
@@ -283,6 +283,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
         let shared_hnd2 = shared_hnd.clone();
         spawn_blocking(async move || {
             let shared = shared_hnd2.inner().read().await;
+            let sema = shared.fetch_semaphore.acquire().await;
             let res = if let Some(remote_cache) = shared.backend.remote_cache.as_ref() {
                 let build = shared.graph.get(&bsr).unwrap();
 
@@ -316,6 +317,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
             } else {
                 Err(Error::Cache(CacheErr::NotFound))
             };
+            drop(sema);
             drop(shared);
             res
         })


### PR DESCRIPTION
Because 200+ concurrent downloads is probably not a good thing for TCP congestion control.