### PR TITLE
crates/minimal: This is 0.3.0

### DIFF
--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimal"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 


### PR DESCRIPTION
# Bug fixes and changes

 * Fix bug where `minimal run` would not print an error message when mounting of patches/files in the sandbox fails
 * Fix bug where the standard library was erroneously reported as out of date when comparing versions `0.0.9` and `0.0.10`
 * Limit concurrent downloads of packages to 8 (formally no limit)
 * Removed exclusive section which limited sandboxes to being created one at a time
 * `--no-fetch`, `--no-cache`, and `-n` / `--num-parallel-builds` options no longer need to be specified before a subcommand, and may be specified at the end of an invocation of a `minimal` command

# New features

 * Implements experimental support for sideloading
 * Implements support for typing task arguments as an enumeration of permitted values
 * New argument `--rebuild` for `minimal package` command: forces the named packages to be (re)built from source even if they are available in a local or remote cache