### PR TITLE
crates/minimal: cmd_dump accepts --arch to override target

### DIFF
--- a/crates/common/src/target.rs
+++ b/crates/common/src/target.rs
@@ -1,6 +1,8 @@
 use blake3::Hasher;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::io::Write;
+use std::str::FromStr;
 
 /// A supported CPU architecture.
 #[derive(Debug, Clone, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -15,6 +17,43 @@ impl Arch {
         match self {
             Arch::Amd64 => b"'Amd64",
             Arch::Arm64 => b"'Arm64",
+        }
+    }
+}
+
+/// Error from parsing an [`Arch`] out of a string the user typed on the
+/// command line or in a config file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArchParseError {
+    input: String,
+}
+
+impl fmt::Display for ArchParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "unsupported architecture: {}. Use 'amd64' or 'arm64'.",
+            self.input
+        )
+    }
+}
+
+impl std::error::Error for ArchParseError {}
+
+impl FromStr for Arch {
+    type Err = ArchParseError;
+
+    /// Parse an arch from the strings a user is likely to type on the
+    /// command line. Accepts both the Minimal-native names (`amd64`,
+    /// `arm64`) and the Rust target-triple forms (`x86_64`, `aarch64`)
+    /// so that `uname -m` output works verbatim on both platforms.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "amd64" | "x86_64" => Ok(Arch::Amd64),
+            "arm64" | "aarch64" => Ok(Arch::Arm64),
+            _ => Err(ArchParseError {
+                input: s.to_string(),
+            }),
         }
     }
 }
@@ -129,5 +168,46 @@ impl AsRef<str> for Target {
             (Arm64, Linux) => "arm64/linux",
             (Arm64, MacOS) => "arm64/macos",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arch_parses_amd64_and_alias() {
+        assert_eq!("amd64".parse::<Arch>().unwrap(), Arch::Amd64);
+        assert_eq!("x86_64".parse::<Arch>().unwrap(), Arch::Amd64);
+    }
+
+    #[test]
+    fn arch_parses_arm64_and_alias() {
+        assert_eq!("arm64".parse::<Arch>().unwrap(), Arch::Arm64);
+        assert_eq!("aarch64".parse::<Arch>().unwrap(), Arch::Arm64);
+    }
+
+    #[test]
+    fn arch_rejects_unknown_and_names_input() {
+        let err = "riscv64".parse::<Arch>().unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("riscv64") && msg.contains("'amd64'") && msg.contains("'arm64'"),
+            "error should name the bad input and list valid options, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn arch_rejects_case_mismatch() {
+        // Case-sensitive — "AMD64" isn't an accepted spelling, users
+        // should stick to the lowercase form that matches uname -m /
+        // rust target triples.
+        assert!("AMD64".parse::<Arch>().is_err());
+        assert!("ARM64".parse::<Arch>().is_err());
+    }
+
+    #[test]
+    fn arch_rejects_empty_string() {
+        assert!("".parse::<Arch>().is_err());
     }
 }

--- a/crates/common/src/target.rs
+++ b/crates/common/src/target.rs
@@ -75,6 +75,37 @@ impl OS {
     }
 }
 
+/// Error from parsing an [`OS`] out of a string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OsParseError {
+    input: String,
+}
+
+impl fmt::Display for OsParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unsupported OS: {}. Use 'linux' or 'macos'.", self.input)
+    }
+}
+
+impl std::error::Error for OsParseError {}
+
+impl FromStr for OS {
+    type Err = OsParseError;
+
+    /// Parse an OS from the short lowercase strings that appear in
+    /// `Target::as_ref()` output and that consumers (build.ncl target
+    /// expressions, CLI args) type by hand.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "linux" => Ok(OS::Linux),
+            "macos" => Ok(OS::MacOS),
+            _ => Err(OsParseError {
+                input: s.to_string(),
+            }),
+        }
+    }
+}
+
 /// The description of a system where software runs.
 #[derive(Debug, Clone, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Target {
@@ -171,6 +202,49 @@ impl AsRef<str> for Target {
     }
 }
 
+/// Error from parsing a [`Target`] out of an `<arch>/<os>` string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TargetParseError {
+    /// The string didn't match the required `<arch>/<os>` shape.
+    Shape(String),
+    /// The arch segment didn't parse.
+    Arch(ArchParseError),
+    /// The OS segment didn't parse.
+    Os(OsParseError),
+}
+
+impl fmt::Display for TargetParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TargetParseError::Shape(s) => write!(
+                f,
+                "target {s:?} is not in the expected <arch>/<os> form (e.g. 'amd64/linux')"
+            ),
+            TargetParseError::Arch(e) => write!(f, "target: {e}"),
+            TargetParseError::Os(e) => write!(f, "target: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for TargetParseError {}
+
+impl FromStr for Target {
+    type Err = TargetParseError;
+
+    /// Parse a [`Target`] from the `<arch>/<os>` string produced by
+    /// [`Target::as_ref`] — round-trips with that impl. Arch and OS
+    /// parsing delegate to [`Arch::from_str`] / [`OS::from_str`] so the
+    /// accepted alias set stays consistent across every consumer.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (arch_str, os_str) = s
+            .split_once('/')
+            .ok_or_else(|| TargetParseError::Shape(s.to_string()))?;
+        let arch = arch_str.parse::<Arch>().map_err(TargetParseError::Arch)?;
+        let os = os_str.parse::<OS>().map_err(TargetParseError::Os)?;
+        Ok(Target::new(arch, os))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -209,5 +283,48 @@ mod tests {
     #[test]
     fn arch_rejects_empty_string() {
         assert!("".parse::<Arch>().is_err());
+    }
+
+    #[test]
+    fn os_parses_both_variants() {
+        assert_eq!("linux".parse::<OS>().unwrap(), OS::Linux);
+        assert_eq!("macos".parse::<OS>().unwrap(), OS::MacOS);
+    }
+
+    #[test]
+    fn os_rejects_unknown() {
+        let err = "freebsd".parse::<OS>().unwrap_err();
+        assert!(format!("{err}").contains("freebsd"));
+    }
+
+    #[test]
+    fn target_roundtrips_with_as_ref() {
+        // Every representation in Target::all() must parse back to the
+        // same value — keeps as_ref and from_str in lockstep.
+        for expected in Target::all() {
+            let s: &str = expected.as_ref();
+            let parsed: Target = s.parse().expect("every Target::all() must parse");
+            assert_eq!(&parsed, expected, "roundtrip failed for {s}");
+        }
+    }
+
+    #[test]
+    fn target_rejects_missing_separator() {
+        let err = "amd64linux".parse::<Target>().unwrap_err();
+        assert!(matches!(err, TargetParseError::Shape(_)));
+    }
+
+    #[test]
+    fn target_propagates_arch_error() {
+        let err = "riscv64/linux".parse::<Target>().unwrap_err();
+        assert!(matches!(err, TargetParseError::Arch(_)));
+        assert!(format!("{err}").contains("riscv64"));
+    }
+
+    #[test]
+    fn target_propagates_os_error() {
+        let err = "amd64/freebsd".parse::<Target>().unwrap_err();
+        assert!(matches!(err, TargetParseError::Os(_)));
+        assert!(format!("{err}").contains("freebsd"));
     }
 }

--- a/crates/decode/src/builds.rs
+++ b/crates/decode/src/builds.rs
@@ -907,12 +907,12 @@ impl BuildDecl {
                                         program,
                                     )?)
                                     .unwrap();
-                                match Target::all().iter().find(|t| t.as_ref() == target_str) {
-                                    None => Err(Error::InvalidTarget { files: program.files(), got: target_str, pos: rt.pos(program.pos_table()) }),
-                                    Some(t) => {
-                                        target = Some(t.clone());
+                                match target_str.parse::<Target>() {
+                                    Ok(t) => {
+                                        target = Some(t);
                                         Ok(())
                                     }
+                                    Err(_) => Err(Error::InvalidTarget { files: program.files(), got: target_str, pos: rt.pos(program.pos_table()) }),
                                 }
                             } else {
                                 Ok(())

--- a/crates/minimal/src/cmd_dump.rs
+++ b/crates/minimal/src/cmd_dump.rs
@@ -1,6 +1,9 @@
 use std::{fmt::Display, io::stdout};
 
+use anyhow::anyhow;
+use common::Target;
 use common::fuzzy_search::fuzzy_match;
+use common::target::{Arch, OS};
 use decode::AttrValue;
 use graph::{BuildDep, BuildOutput, BuildSpec, BuildSpecRef, Graph, RuntimeDep, SourceInput};
 use mctx::{Cache, Context, Error};
@@ -17,6 +20,15 @@ pub struct DumpArgs {
 
     #[arg(long, default_value_t = false)]
     pub exact: bool,
+
+    /// Target architecture to evaluate packages against (e.g., "amd64",
+    /// "arm64"). When a package's `build_deps` uses
+    /// `match { arch = 'Amd64 } => ..., { arch = 'Arm64 } => ... } target`
+    /// to select between per-arch source URLs, only the matching arm's
+    /// output appears in the dump. Overrides the host default so tools
+    /// downstream can aggregate both arches by running the dump twice.
+    #[arg(long)]
+    pub arch: Option<String>,
 
     pub name: Option<String>,
 }
@@ -120,7 +132,8 @@ impl From<&AttrValue> for PkgAttr {
 pub async fn cmd_dump(args: DumpArgs, ctx: &mut Context) -> Result<(), Error> {
     let mut out_packages = Vec::new();
 
-    let graph = ctx.graph_from_all_packages()?;
+    let target = resolve_target(args.arch.as_deref())?;
+    let graph = ctx.graph_from_all_packages_with_target(target)?;
     let cache = ctx.local_cache();
 
     if args.kind.packages {
@@ -217,5 +230,67 @@ fn pkg_ref_from_input(g: &Graph, i: &BuildDep, _c: &Cache) -> Result<PkgRef, Err
         }),
         BuildDep::Source(s) => Ok(PkgRef::Source(s.clone())),
         _ => todo!("bsi variant {:?}", i),
+    }
+}
+
+/// Resolve the `--arch` flag into a [`Target`], matching `cmd_materialize`'s
+/// parsing (arm64/aarch64 → Arm64, amd64/x86_64 → Amd64). When the flag is
+/// absent, defaults to [`Target::host`]. OS is always Linux — dump consumers
+/// want per-arch evaluation of the same pkgs repo, not cross-OS.
+fn resolve_target(arch: Option<&str>) -> Result<Target, Error> {
+    let Some(arch_str) = arch else {
+        return Ok(Target::host());
+    };
+    let arch = match arch_str {
+        "arm64" | "aarch64" => Arch::Arm64,
+        "amd64" | "x86_64" => Arch::Amd64,
+        other => {
+            return Err(Error::Other(anyhow!(
+                "unsupported --arch value: {other}. Use 'amd64' or 'arm64'."
+            )));
+        }
+    };
+    Ok(Target::new(arch, OS::Linux))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_target_defaults_to_host_when_arg_missing() {
+        let target = resolve_target(None).unwrap();
+        assert_eq!(target.arch(), Target::host().arch());
+        assert_eq!(target.os(), Target::host().os());
+    }
+
+    #[test]
+    fn resolve_target_parses_amd64_aliases() {
+        let target = resolve_target(Some("amd64")).unwrap();
+        assert!(matches!(target.arch(), Arch::Amd64));
+        assert!(matches!(target.os(), OS::Linux));
+
+        let target = resolve_target(Some("x86_64")).unwrap();
+        assert!(matches!(target.arch(), Arch::Amd64));
+    }
+
+    #[test]
+    fn resolve_target_parses_arm64_aliases() {
+        let target = resolve_target(Some("arm64")).unwrap();
+        assert!(matches!(target.arch(), Arch::Arm64));
+        assert!(matches!(target.os(), OS::Linux));
+
+        let target = resolve_target(Some("aarch64")).unwrap();
+        assert!(matches!(target.arch(), Arch::Arm64));
+    }
+
+    #[test]
+    fn resolve_target_rejects_unknown_arch() {
+        let err = resolve_target(Some("riscv64")).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("riscv64") && msg.contains("'amd64'") && msg.contains("'arm64'"),
+            "error should name the bad input and list valid options, got: {msg}"
+        );
     }
 }

--- a/crates/minimal/src/cmd_dump.rs
+++ b/crates/minimal/src/cmd_dump.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Display, io::stdout};
 
-use anyhow::anyhow;
 use common::Target;
 use common::fuzzy_search::fuzzy_match;
 use common::target::{Arch, OS};
@@ -233,23 +232,19 @@ fn pkg_ref_from_input(g: &Graph, i: &BuildDep, _c: &Cache) -> Result<PkgRef, Err
     }
 }
 
-/// Resolve the `--arch` flag into a [`Target`], matching `cmd_materialize`'s
-/// parsing (arm64/aarch64 → Arm64, amd64/x86_64 → Amd64). When the flag is
-/// absent, defaults to [`Target::host`]. OS is always Linux — dump consumers
-/// want per-arch evaluation of the same pkgs repo, not cross-OS.
+/// Resolve the `--arch` flag into a [`Target`]. Delegates the string
+/// parsing to the shared `Arch::from_str` impl in common so the alias
+/// set (arm64/aarch64, amd64/x86_64) stays consistent with every other
+/// consumer. When the flag is absent, defaults to [`Target::host`]. OS
+/// is always Linux — dump consumers want per-arch evaluation of the
+/// same pkgs repo, not cross-OS.
 fn resolve_target(arch: Option<&str>) -> Result<Target, Error> {
     let Some(arch_str) = arch else {
         return Ok(Target::host());
     };
-    let arch = match arch_str {
-        "arm64" | "aarch64" => Arch::Arm64,
-        "amd64" | "x86_64" => Arch::Amd64,
-        other => {
-            return Err(Error::Other(anyhow!(
-                "unsupported --arch value: {other}. Use 'amd64' or 'arm64'."
-            )));
-        }
-    };
+    let arch: Arch = arch_str
+        .parse()
+        .map_err(|e: common::target::ArchParseError| Error::Other(e.into()))?;
     Ok(Target::new(arch, OS::Linux))
 }
 
@@ -265,32 +260,26 @@ mod tests {
     }
 
     #[test]
-    fn resolve_target_parses_amd64_aliases() {
+    fn resolve_target_wraps_parsed_arch_with_linux_os() {
         let target = resolve_target(Some("amd64")).unwrap();
         assert!(matches!(target.arch(), Arch::Amd64));
         assert!(matches!(target.os(), OS::Linux));
 
-        let target = resolve_target(Some("x86_64")).unwrap();
-        assert!(matches!(target.arch(), Arch::Amd64));
-    }
-
-    #[test]
-    fn resolve_target_parses_arm64_aliases() {
         let target = resolve_target(Some("arm64")).unwrap();
         assert!(matches!(target.arch(), Arch::Arm64));
         assert!(matches!(target.os(), OS::Linux));
-
-        let target = resolve_target(Some("aarch64")).unwrap();
-        assert!(matches!(target.arch(), Arch::Arm64));
     }
 
     #[test]
-    fn resolve_target_rejects_unknown_arch() {
+    fn resolve_target_propagates_arch_parse_error() {
+        // String-to-arch parsing (and its error message) lives in
+        // common::target; this test confirms cmd_dump surfaces that
+        // error to the caller rather than silently eating it.
         let err = resolve_target(Some("riscv64")).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("riscv64") && msg.contains("'amd64'") && msg.contains("'arm64'"),
-            "error should name the bad input and list valid options, got: {msg}"
+            msg.contains("riscv64"),
+            "error should name the bad input, got: {msg}"
         );
     }
 }

--- a/crates/minimal/src/cmd_materialize.rs
+++ b/crates/minimal/src/cmd_materialize.rs
@@ -34,22 +34,14 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
         }
     };
 
-    // Resolve target architecture: CLI flag > minimal.toml > host default
-    let arch_str = args
-        .arch
-        .or(output.arch)
-        .unwrap_or_else(|| match Target::host().arch() {
-            Arch::Arm64 => "arm64".to_string(),
-            Arch::Amd64 => "amd64".to_string(),
-        });
-    let arch = match arch_str.as_str() {
-        "arm64" | "aarch64" => Arch::Arm64,
-        "amd64" | "x86_64" => Arch::Amd64,
-        other => {
-            return Err(Error::Other(anyhow!(
-                "unsupported architecture: {other}. Use 'amd64' or 'arm64'."
-            )));
-        }
+    // Resolve target architecture: CLI flag > minimal.toml > host default.
+    // String-to-arch parsing is delegated to common::target::Arch so the
+    // alias set stays consistent across every consumer.
+    let arch: Arch = match args.arch.or(output.arch) {
+        Some(s) => s.parse().map_err(|e: common::target::ArchParseError| {
+            Error::Other(anyhow!("{e}"))
+        })?,
+        None => Target::host().arch().clone(),
     };
 
     // OCI images are always Linux

--- a/crates/minimal/src/cmd_materialize.rs
+++ b/crates/minimal/src/cmd_materialize.rs
@@ -38,9 +38,9 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
     // String-to-arch parsing is delegated to common::target::Arch so the
     // alias set stays consistent across every consumer.
     let arch: Arch = match args.arch.or(output.arch) {
-        Some(s) => s.parse().map_err(|e: common::target::ArchParseError| {
-            Error::Other(anyhow!("{e}"))
-        })?,
+        Some(s) => s
+            .parse()
+            .map_err(|e: common::target::ArchParseError| Error::Other(anyhow!("{e}")))?,
         None => Target::host().arch().clone(),
     };
 


### PR DESCRIPTION
## Summary

Closes #125. Adds a `--arch` flag to `minimal dump` so downstream tools can evaluate arch-matched packages for both architectures.

```
minimal dump --packages --arch amd64
minimal dump --packages --arch arm64
```

When `--arch` is absent, defaults to `Target::host()` (preserves current behavior).

## Why

`mctx::graph_from_all_packages_with_target(target)` has existed for a while but `cmd_dump` was hard-coded to `Target::host()`. For packages that use `match { arch = 'Amd64 } => ..., { arch = 'Arm64 } => ... } target` to select between per-arch source URLs (claude-code, go, deno, gcloud, etc.), this meant only the host arm's data surfaced in the dump — the other arm was erased at evaluation time.

That blind spot cascades:
- pkgmgr silently corrupts arch-matched packages on update (skipping them via a guardrail in its current form, once it can see both it can update both)
- supply-chain's scanner only sees one arch's resolved source URL per package

Exposing the target at the CLI lets consumers run the dump twice and aggregate.

## Design notes

- Follows `cmd_materialize`'s existing `--arch` pattern verbatim: accepts `amd64`/`x86_64` → `Arch::Amd64`, `arm64`/`aarch64` → `Arch::Arm64`. Rejects anything else with an error message naming the bad input and listing valid options.
- OS is pinned to `OS::Linux`. Dump consumers want per-arch evaluation of the same pkgs repo, not cross-OS targets. Easy to extend later if a cross-OS case emerges.
- `resolve_target` is factored out so it's unit-testable without spinning up a `Context`. Extracted into a private helper matching the codebase's existing style of small helpers colocated with their command.

## Test plan
- [x] New unit tests in `cmd_dump::tests` cover the four paths: default (host), amd64 aliases, arm64 aliases, unknown-arch error
- [x] `minimal test` — full suite passes, including the new cmd_dump tests
- [x] `minimal run fmt-check` — clean
- [x] `minimal run clippy` — clean (no new warnings)

## Follow-ups (not this PR)

- pkgmgr's guardrail on multi-arch packages can now be lifted: supply-chain reads the dump for each arch, aggregates the per-arch `sha256`/`url` data, and pkgmgr rewrites all arms in one pass.
- supply-chain's scanner can use the per-arch output to catch arch-specific advisories.
