### PR TITLE
crates/{check,decode}: support running check across packages/ which are partitioned

### DIFF
--- a/crates/check/src/lib.rs
+++ b/crates/check/src/lib.rs
@@ -334,29 +334,18 @@ fn package_check_futures(
     fix: bool,
     ot: Option<OpTracker>,
 ) -> Result<Vec<CheckFuture>, Error> {
-    let package_dirs = match std::fs::read_dir(&packages_dir) {
+    let package_dirs = match decode::build_decls_in_dir(&packages_dir) {
         Ok(i) => i,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(vec![]),
         Err(e) => return Err(Error::IO("reading package dirs", packages_dir.clone(), e)),
     }
-    .filter_map(|e| match e {
-        Err(e) => Some(Err(e)),
-        Ok(e) => {
-            if !e.file_type().unwrap().is_dir() {
-                None
-            } else {
-                Some(Ok(e.file_name()))
-            }
-        }
-    })
-    .collect::<Result<Vec<_>, _>>()
-    .map_err(|e| Error::IO("listing packages", packages_dir.clone(), e))?
     .into_iter()
     // Filter based on any given filter names
-    .filter_map(|pkg| {
-        let pkg = pkg.to_str().unwrap().to_string();
+    .filter_map(|fpath| {
+        let dir = fpath.parent().unwrap();
+        let pkg = dir.file_name().unwrap().to_str().unwrap().to_string();
         if filter_names.is_empty() || filter_names.contains(&pkg) {
-            Some(pkg)
+            Some((pkg, dir.to_path_buf()))
         } else {
             None
         }
@@ -364,20 +353,19 @@ fn package_check_futures(
 
     Ok(package_dirs
         .into_iter()
-        .map::<CheckFuture, _>(move |pkg| {
+        .map::<CheckFuture, _>(move |(pkg, dir)| {
             let graph_hnd = graph_hnd.clone();
             let skip_checkers = skip_checkers.clone();
             let stdlib_dir = stdlib_dir.clone();
             let cache = cache.clone();
-            let packages_dir = packages_dir.clone();
             let ot = ot.clone();
             Box::pin(async move {
                 let result = check_package(
                     pkg.clone(),
+                    dir,
                     graph_hnd,
                     fix,
                     skip_checkers,
-                    packages_dir,
                     stdlib_dir,
                     cache,
                     ot,
@@ -531,10 +519,10 @@ fn harness_check_futures(
 #[allow(clippy::too_many_arguments)]
 async fn check_package(
     pkg: String,
+    package_dir: PathBuf,
     all_graph: Option<Arc<RwLock<Graph>>>,
     fix: bool,
     skip_checkers: Vec<String>,
-    packages_dir: PathBuf,
     stdlib_dir: PathBuf,
     cache: Cache<LocalDir>,
     ot: Option<OpTracker>,
@@ -557,6 +545,7 @@ async fn check_package(
                             &skip_checkers,
                             fix,
                             pkg.clone(),
+                            package_dir.as_ref(),
                             graph.read().await,
                             cache.clone(),
                             Some(check_op.clone()),
@@ -588,7 +577,6 @@ async fn check_package(
     let file_based_results = {
         let skip_checkers = skip_checkers.clone();
         let pkg = pkg.clone();
-        let pkg_dir = packages_dir.join(&pkg);
         let stdlib_dir = stdlib_dir.clone();
 
         tokio::task::spawn_blocking(move || {
@@ -607,7 +595,7 @@ async fn check_package(
                         &skip_checkers,
                         fix,
                         &pkg,
-                        &pkg_dir,
+                        &package_dir,
                         &stdlib_dir,
                         Some(check_op.clone()),
                     )
@@ -642,12 +630,14 @@ pub(crate) trait FileBasedChecker: Send {
 
 /// A checker which checks a package by looking at its representation in the graph.
 /// These checkers are run in parallel.
+#[allow(clippy::too_many_arguments)]
 pub(crate) trait GraphBasedChecker {
     async fn check(
         self,
         skip_checkers: &[String],
         fix: bool,
         pkg: String,
+        package_dir: &Path,
         graph: RwLockReadGuard<'_, Graph>,
         cache: Cache<LocalDir>,
         ot: Option<OpTracker>,
@@ -934,6 +924,7 @@ impl GraphBasedChecker for StandaloneTestCheck {
         skip_checkers: &[String],
         _fix: bool,
         pkg: String,
+        _package_dir: &Path,
         graph: RwLockReadGuard<'_, Graph>,
         cache: Cache<LocalDir>,
         ot: Option<OpTracker>,
@@ -1130,6 +1121,7 @@ impl GraphBasedChecker for BuildScriptDisallowedPatterns {
         skip_checkers: &[String],
         _fix: bool,
         pkg: String,
+        _package_dir: &Path,
         graph: RwLockReadGuard<'_, Graph>,
         _cache: Cache<LocalDir>,
         _ot: Option<OpTracker>,
@@ -1204,6 +1196,7 @@ impl GraphBasedChecker for BuildScriptIsExecutable {
         skip_checkers: &[String],
         _fix: bool,
         pkg: String,
+        _package_dir: &Path,
         graph: RwLockReadGuard<'_, Graph>,
         _cache: Cache<LocalDir>,
         _ot: Option<OpTracker>,

--- a/crates/check/src/naming.rs
+++ b/crates/check/src/naming.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use super::Error;
 use crate::{CheckResult, CheckVerdict};
 use graph::{BuildOutput, Graph};
@@ -13,6 +15,7 @@ impl crate::GraphBasedChecker for SpecNameMatchesDir {
         skip_checkers: &[String],
         _fix: bool,
         pkg: String,
+        _package_dir: &Path,
         graph: RwLockReadGuard<'_, Graph>,
         _cache: Cache<LocalDir>,
         _ot: Option<OpTracker>,
@@ -51,6 +54,7 @@ impl crate::GraphBasedChecker for SpecNameValid {
         skip_checkers: &[String],
         _fix: bool,
         pkg: String,
+        _package_dir: &Path,
         _graph: RwLockReadGuard<'_, Graph>,
         _cache: Cache<LocalDir>,
         _ot: Option<OpTracker>,
@@ -90,6 +94,7 @@ impl crate::GraphBasedChecker for CycleBreakerNaming {
         skip_checkers: &[String],
         _fix: bool,
         pkg: String,
+        _package_dir: &Path,
         graph: RwLockReadGuard<'_, Graph>,
         _cache: Cache<LocalDir>,
         _ot: Option<OpTracker>,
@@ -138,6 +143,7 @@ impl crate::GraphBasedChecker for OutputNaming {
         skip_checkers: &[String],
         _fix: bool,
         pkg: String,
+        _package_dir: &Path,
         graph: RwLockReadGuard<'_, Graph>,
         _cache: Cache<LocalDir>,
         _ot: Option<OpTracker>,
@@ -203,6 +209,7 @@ impl crate::GraphBasedChecker for EnumerateBins {
         skip_checkers: &[String],
         _fix: bool,
         pkg: String,
+        _package_dir: &Path,
         graph: RwLockReadGuard<'_, Graph>,
         cache: Cache<LocalDir>,
         _ot: Option<OpTracker>,

--- a/crates/check/src/outputs.rs
+++ b/crates/check/src/outputs.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use super::Error;
@@ -20,6 +20,7 @@ impl crate::GraphBasedChecker for OutputTypesValid {
         skip_checkers: &[String],
         _fix: bool,
         pkg: String,
+        _package_dir: &Path,
         graph: RwLockReadGuard<'_, Graph>,
         cache: lcache::Cache<LocalDir>,
         _ot: Option<OpTracker>,
@@ -114,6 +115,7 @@ impl crate::GraphBasedChecker for MissingRuntimeDeps {
         skip_checkers: &[String],
         _fix: bool,
         pkg: String,
+        _package_dir: &Path,
         graph: RwLockReadGuard<'_, Graph>,
         cache: lcache::Cache<LocalDir>,
         _ot: Option<OpTracker>,

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 mod load;
-pub use load::LoadOptions;
+pub use load::{LoadOptions, build_decls_in_dir};
 
 mod error;
 pub use error::Error;

--- a/crates/decode/src/load.rs
+++ b/crates/decode/src/load.rs
@@ -130,12 +130,16 @@ macro_rules! annotate_record {
     };
 }
 
-fn build_decls_in_dir<P: AsRef<Path>>(dir: P) -> Result<Vec<PathBuf>, Error> {
+/// Enumerates the list of package `build.ncl` within a `packages/` directory.
+///
+/// Partitioning of the packages list by name (i.e.: `a/abseil/build.ncl`) is handled
+/// automatically.
+pub fn build_decls_in_dir<P: AsRef<Path>>(dir: P) -> Result<Vec<PathBuf>, std::io::Error> {
     fn walk_dir_inner<P: AsRef<Path>>(
         out: &mut Vec<PathBuf>,
         is_toplevel: bool,
         dir: P,
-    ) -> Result<(), Error> {
+    ) -> Result<(), std::io::Error> {
         for entry in std::fs::read_dir(dir)? {
             let entry = entry?;
             let meta = entry.metadata()?;


### PR DESCRIPTION
I.e. can check a layer using the scheme `packages/a/abseil/build.ncl` instead of only `packages/abseil/build.ncl`.