### PR TITLE
crates/minimal: This is 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "minimal"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "args",

--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimal"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish.workspace = true
 


### PR DESCRIPTION
Lets merge after https://github.com/gominimal/minimal/pull/148 and https://github.com/gominimal/minimal/pull/149.

 * crates/minimal: cmd_dump accepts --arch to override target
 * crates/mctx: fix min check, now depends on multithreaded executor
 * crates/graph: separate API for manipulating graph from code building it
 * crates/orchestrator: fix divergent top_levels configuration
 * crates/stdlib: add attrs: license_spdx, website variant for source_provenance