### PR TITLE
crates/sandbox2: catch panics in env channel handler to avoid socket permanently dying

### DIFF
--- a/crates/sandbox2/src/listener.rs
+++ b/crates/sandbox2/src/listener.rs
@@ -70,7 +70,13 @@ impl<C: Channel + Send> Listener<C> {
                         match line {
                             Ok(line) => {
                                 tracing::trace!("listener received: {}", line);
-                                channel.handle(&mut stream2, &line, &rootfs);
+                                if let Err(panic) =
+                                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                        channel.handle(&mut stream2, &line, &rootfs)
+                                    }))
+                                {
+                                    tracing::error!("channel handler panicked: {:?}", panic);
+                                };
                             }
                             Err(e) => {
                                 tracing::warn!("listener read error: {}", e);


### PR DESCRIPTION
Defense-in-depth against the socket channel that powers `min` being permanently borked when something unexpected happens, which seems to be happening a bunch lately.