### PR TITLE
crates/stdlib: add binary_from attr to mark packages with fetched binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,7 +4595,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdlib"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "indoc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,4 +113,4 @@ remote-proto = { version = "0.0.1", path = "crates/remote-proto" }
 remote-client = { version = "0.0.1", path = "crates/remote-client" }
 sandbox2 = { version = "0.0.1", path = "crates/sandbox2" }
 
-stdlib = { version = "0.0.11", path = "crates/stdlib" }
+stdlib = { version = "0.0.12", path = "crates/stdlib" }

--- a/crates/decode/src/attrs.rs
+++ b/crates/decode/src/attrs.rs
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn attr_wrong_schema_nickel_err() {
         let res = Loader::new(
-            "let {Attrs, ..} = import \"minimal.ncl\" in {env_state_wiring = \"a\"} | Attrs",
+            "let {Attrs, ..} = import \"minimal.ncl\" in {binary_from = \"blueberry://example.com/bersh.exe\"} | Attrs",
             None,
             &LoadOptions::for_test(),
         )
@@ -262,5 +262,21 @@ mod tests {
 
         assert!(res.is_err());
         assert!(matches!(res, Err(Error::Nickel(_))));
+    }
+
+    #[test]
+    fn attr_binary_from_ok() {
+        let res = Loader::new(
+            "let {Attrs, ..} = import \"minimal.ncl\" in {binary_from = \"https://example.com/bersh.exe\"} | Attrs",
+            None,
+            &LoadOptions::for_test(),
+        )
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("load failed");
+        })
+        .finish();
+
+        assert!(res.is_ok());
     }
 }

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stdlib"
-version = "0.0.11"
+version = "0.0.12"
 rust-version = "1.87"
 license = "MIT OR Apache-2.0"
 edition.workspace = true

--- a/crates/stdlib/minimal-ncl/attr_classes.ncl
+++ b/crates/stdlib/minimal-ncl/attr_classes.ncl
@@ -51,6 +51,19 @@ in
         desc = "When set, the source backing this package is not publically available.",
         validate = Bool,
     },
+    binary_from = {
+        name = "binary from",
+        desc = "Indicates binaries in the package were fetched from the given URL instead of built from source.",
+        validate = std.contract.custom (fun _label value =>
+            if std.typeof value != 'String then
+                'Error { message = "URLs must be a string" }
+            else if std.string.is_match m%%"^(?:https?|ftp|git)://[A-Za-z0-9.-]+(?::[0-9]+)?(?:/[^\s]*)?$"%% value then
+                'Ok value
+            else
+                'Error { message = "expected URL string" }
+        ),
+    },
+
     description = {
         name = "description",
         desc = "A short description of the function of the software.",


### PR DESCRIPTION
Intended for stuff like `claude-code`, which is closed-source and downloaded from a URL.

Lets us mark this fact, also we can surface it in the pkgs website.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New `binary_from` attribute in the standard library that accepts and validates URL strings (http/https/ftp/git).

* **Updates**
  * Standard library bumped to version 0.0.12.

* **Tests**
  * Added tests covering valid `binary_from` URLs and invalid/unsupported schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->