### PR TITLE
crates/decode: fix type error when subsetting an upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4597,7 +4597,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdlib"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "indoc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,4 +113,4 @@ remote-proto = { version = "0.0.1", path = "crates/remote-proto" }
 remote-client = { version = "0.0.1", path = "crates/remote-client" }
 sandbox2 = { version = "0.0.1", path = "crates/sandbox2" }
 
-stdlib = { version = "0.0.12", path = "crates/stdlib" }
+stdlib = { version = "0.0.13", path = "crates/stdlib" }

--- a/crates/decode/src/builds.rs
+++ b/crates/decode/src/builds.rs
@@ -1724,4 +1724,56 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn parse_subset_of_upstream() {
+        let (term, mut program, _origin, _target) = Loader::new(
+            indoc! {
+                "
+                let {subsetOf, upstream, BuildSpec, HostPath, OutputLib, ..} = import \"minimal.ncl\" in
+                {
+        			name = \"single buildspec\",
+        			build_deps = [subsetOf (upstream \"upstream-pkg\") [\"libgcc\"]],
+        			runtime_deps = [subsetOf (upstream \"upstream-pkg\") [\"libgcc\"]],
+        			cmd = \"./build.sh\",
+        		} | BuildSpec"
+            }
+            .to_string(),
+            None,
+            &LoadOptions::for_test(),
+        )
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("load failed");
+        })
+        .finish()
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("finish failed");
+        });
+
+        let build = BuildDecl::from_term(&term, &mut program, &mut ()).unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("from_term failed");
+        });
+
+        assert_eq!(
+            build.build_deps[0],
+            BuildDep::Subset(SubsetInput {
+                from: BuildRef::Upstream {
+                    name: "upstream-pkg".to_string()
+                },
+                outputs: vec!["libgcc".to_string()].into()
+            })
+        );
+        assert_eq!(
+            build.runtime_deps[0],
+            RuntimeDep::Subset(SubsetInput {
+                from: BuildRef::Upstream {
+                    name: "upstream-pkg".to_string()
+                },
+                outputs: vec!["libgcc".to_string()].into()
+            })
+        );
+    }
 }

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stdlib"
-version = "0.0.12"
+version = "0.0.13"
 rust-version = "1.87"
 license = "MIT OR Apache-2.0"
 edition.workspace = true

--- a/crates/stdlib/minimal-ncl/minimal.ncl
+++ b/crates/stdlib/minimal-ncl/minimal.ncl
@@ -128,14 +128,25 @@ let CmdSpec = std.contract.any_of [
           | String,
     },
 
+    Subsettable | doc "Possible types which can be subsetted." = fun Contract =>
+        std.contract.custom (fun label value =>
+            match {
+                {ty = 'Builder, ..} => std.contract.check BuildSpec label value,
+                {ty = 'Upstream, ..} => std.contract.check UpstreamPkg label value,
+                _ => 'Error {
+                    message = "Expected Input type",
+                },
+            }
+            value
+        ),
     Subset | doc "A dependency on a subset of the outputs from another build spec." = {
         ty | Tys = 'Subset,
         from
-          | BuildSpec,
+          | Subsettable,
         outputs
           | Array String,
     },
-    subsetOf | BuildSpec -> Array String -> Subset | doc "Constructs a subset of the outputs of a build, for use as an input or runtime_dep." =
+    subsetOf | Dyn -> Array String -> Subset | doc "Constructs a subset of the outputs of a build, for use as an input or runtime_dep." =
       fun spec outputs =>
         {from = spec, include outputs}  | Subset,
 


### PR DESCRIPTION
Fixes MIN-208

 * Nickel types now permit a subset defined from an upstream declaration
 * Parsing code was already correct, added test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended subset dependency support to allow upstream packages as subset targets, in addition to build specifications.

* **Tests**
  * Added validation test for subset dependency decoding with upstream packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->