### PR TITLE
crates/mctx: configurable remote_cache_bucket on ConfigBuilder

### DIFF
--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -27,6 +27,10 @@ impl std::error::Error for ConfigError {
     }
 }
 
+/// Default GCS bucket name used when the caller does not configure one
+/// via [ConfigBuilder::with_remote_cache_bucket].
+pub const DEFAULT_REMOTE_CACHE_BUCKET: &str = "minimal-staging-cache";
+
 /// Builder for [Config].
 #[derive(Debug, Default, Clone)]
 pub struct ConfigBuilder {
@@ -39,6 +43,7 @@ pub struct ConfigBuilder {
     repo_dir: Option<PathBuf>,
     vcs_manager: Option<ManagerHandle>,
     ot: Option<OpTracker>,
+    remote_cache_bucket: Option<String>,
 }
 
 impl ConfigBuilder {
@@ -86,6 +91,12 @@ impl ConfigBuilder {
         self.ot = Some(ot);
         self
     }
+    /// Override the GCS bucket name used by the remote cache reader and
+    /// writer. Defaults to [DEFAULT_REMOTE_CACHE_BUCKET] when unset.
+    pub fn with_remote_cache_bucket(mut self, bucket: String) -> Self {
+        self.remote_cache_bucket = Some(bucket);
+        self
+    }
 }
 
 impl ConfigBuilder {
@@ -107,6 +118,9 @@ impl ConfigBuilder {
             repo_dir: self.repo_dir,
             vcs_manager: self.vcs_manager,
             ot: self.ot,
+            remote_cache_bucket: self
+                .remote_cache_bucket
+                .unwrap_or_else(|| DEFAULT_REMOTE_CACHE_BUCKET.to_string()),
         })
     }
 }
@@ -131,6 +145,10 @@ pub struct Config {
     vcs_manager: Option<ManagerHandle>,
     /// The [OpTracker] to use instead of the root.
     pub(crate) ot: Option<OpTracker>,
+    /// GCS bucket name for the remote cache reader/writer. Always set —
+    /// defaults to [DEFAULT_REMOTE_CACHE_BUCKET] when the builder did
+    /// not specify one.
+    remote_cache_bucket: String,
 }
 
 impl Config {
@@ -157,6 +175,10 @@ impl Config {
     /// Returns the maximum number of parallel builds that may take place at once.
     pub fn num_parallel_builds(&self) -> usize {
         self.num_parallel_builds
+    }
+    /// Returns the GCS bucket name for the remote cache.
+    pub fn remote_cache_bucket(&self) -> &str {
+        &self.remote_cache_bucket
     }
 
     pub(crate) fn cache_dir(&self) -> PathBuf {

--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -7,6 +7,9 @@ use ot::OpTracker;
 #[derive(Debug)]
 pub enum ConfigError {
     IO(&'static str, PathBuf, std::io::Error),
+    /// Configured remote cache bucket name is empty or whitespace-only.
+    /// Carries the offending value for diagnostics.
+    InvalidRemoteCacheBucket(String),
 }
 
 impl fmt::Display for ConfigError {
@@ -14,6 +17,9 @@ impl fmt::Display for ConfigError {
         match self {
             ConfigError::IO(ctx, path, e) => {
                 write!(f, "{} I/O error at path {}: {}", ctx, path.display(), e)
+            }
+            ConfigError::InvalidRemoteCacheBucket(bucket) => {
+                write!(f, "invalid remote cache bucket: {:?}", bucket)
             }
         }
     }
@@ -23,6 +29,7 @@ impl std::error::Error for ConfigError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ConfigError::IO(_, _, e) => Some(e),
+            ConfigError::InvalidRemoteCacheBucket(_) => None,
         }
     }
 }
@@ -102,6 +109,13 @@ impl ConfigBuilder {
 impl ConfigBuilder {
     /// Constructs a config object using the given builder.
     pub fn build(self) -> Result<Config, ConfigError> {
+        let remote_cache_bucket = self
+            .remote_cache_bucket
+            .unwrap_or_else(|| DEFAULT_REMOTE_CACHE_BUCKET.to_string());
+        if remote_cache_bucket.trim().is_empty() {
+            return Err(ConfigError::InvalidRemoteCacheBucket(remote_cache_bucket));
+        }
+
         Ok(Config {
             no_cache: self.no_cache.unwrap_or(false),
             no_fetch: self.no_fetch.unwrap_or(false),
@@ -118,9 +132,7 @@ impl ConfigBuilder {
             repo_dir: self.repo_dir,
             vcs_manager: self.vcs_manager,
             ot: self.ot,
-            remote_cache_bucket: self
-                .remote_cache_bucket
-                .unwrap_or_else(|| DEFAULT_REMOTE_CACHE_BUCKET.to_string()),
+            remote_cache_bucket,
         })
     }
 }
@@ -207,5 +219,43 @@ impl Config {
     }
     pub(crate) fn layer_cache_dir(&self) -> PathBuf {
         self.minimal_dir.join("lc")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_cache_bucket_defaults_when_unset() {
+        let cfg = ConfigBuilder::new().build().unwrap();
+        assert_eq!(cfg.remote_cache_bucket(), DEFAULT_REMOTE_CACHE_BUCKET);
+    }
+
+    #[test]
+    fn remote_cache_bucket_honors_override() {
+        let cfg = ConfigBuilder::new()
+            .with_remote_cache_bucket("my-bucket".into())
+            .build()
+            .unwrap();
+        assert_eq!(cfg.remote_cache_bucket(), "my-bucket");
+    }
+
+    #[test]
+    fn remote_cache_bucket_rejects_empty() {
+        let err = ConfigBuilder::new()
+            .with_remote_cache_bucket(String::new())
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidRemoteCacheBucket(_)));
+    }
+
+    #[test]
+    fn remote_cache_bucket_rejects_whitespace_only() {
+        let err = ConfigBuilder::new()
+            .with_remote_cache_bucket("   \t\n".into())
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidRemoteCacheBucket(_)));
     }
 }

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -19,7 +19,7 @@ use rcache::{Error as RemoteError, RemoteBinProvider, RemoteCache, RemoteCacheWr
 mod error;
 pub use error::Error;
 mod config;
-pub use config::{Config, ConfigBuilder, ConfigError};
+pub use config::{Config, ConfigBuilder, ConfigError, DEFAULT_REMOTE_CACHE_BUCKET};
 mod env;
 use graph::{BinProvider, BuildSpecRef, Graph, MaskingBinProvider, Transitives};
 use mfile::{EnvPatches, EnvVarValue, LinkConfig, Task};
@@ -362,7 +362,7 @@ impl Context {
 
         let res = RemoteCache::new_with_gcs_bucket(
             backend,
-            "minimal-staging-cache",
+            self.config.remote_cache_bucket(),
             if force_fresh {
                 None
             } else {
@@ -382,8 +382,12 @@ impl Context {
     pub async fn remote_cache_writer(&self) -> Result<RemoteCacheWriter, RemoteError<GcsError>> {
         let start = SystemTime::now();
         let backend = GcsStorage::builder().build().await.unwrap();
-        let res =
-            RemoteCacheWriter::new(backend, "minimal-staging-cache", self.config.ot.clone()).await;
+        let res = RemoteCacheWriter::new(
+            backend,
+            self.config.remote_cache_bucket(),
+            self.config.ot.clone(),
+        )
+        .await;
         tracing::trace!("remote cache writer init took {:?}", start.elapsed());
         res
     }


### PR DESCRIPTION
## Summary

Makes the GCS bucket name configurable on `ConfigBuilder` instead of hardcoding `"minimal-staging-cache"` inside `Context::remote_cache` and `Context::remote_cache_writer`.

- Adds `ConfigBuilder::with_remote_cache_bucket(String) -> Self`
- Adds `Config::remote_cache_bucket() -> &str` (always set; defaults to `DEFAULT_REMOTE_CACHE_BUCKET = "minimal-staging-cache"` when the builder does not specify one)
- Re-exports `DEFAULT_REMOTE_CACHE_BUCKET` from the crate root so callers can be explicit about the default

Behavior is identical for any caller that does not set `with_remote_cache_bucket` -- the default matches the previous hardcoded value, so existing call sites continue to work unchanged.

## Why

Motivated by gominimal/build-servers#57: the res-server `Check` RPC's proto already exposes a `remote_cache_gcs_bucket` field, but mctx had no way to honor it -- so the field was an unused placeholder in `crates/buildbot/src/orchestrate.rs::run_package_checks` (passed as `None` with a comment noting it's currently ignored).

With this PR landed, the build-servers-side follow-up can:
1. Thread `params.remote_cache_gcs_bucket` from the Check request into the `ConfigBuilder` via the new method
2. Call `ctx.download_if_available(&graph, top_levels)` before `check::run_checks` so any artifacts not already in res-server's local cache get pulled from the configured GCS bucket
3. Buildbot passes `Some(cache_bucket.clone())` so the field actually does what its name says

That fixes the latent silent-Skip risk where `check::run_checks` returns `CheckVerdict::Skip` on cache misses (e.g., when the build phase had cache hits and didn't materialize a transitive dep).

## Test plan

- [x] `minimal run ci` green (all test crates pass, fmt + clippy clean)
- [x] No call site changes needed -- existing callers keep the previous hardcoded default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote caching now supports configurable GCS bucket selection. Users can set a custom Google Cloud Storage bucket for remote cache operations; a sensible default is used when none is provided.
* **Bug Fixes**
  * Configuration now validates the bucket value and rejects empty or whitespace-only entries with a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->