### PR TITLE
crates/sandbox2: support MINIMAL_INTERNAL_PATCH_STRIP setting

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -538,7 +538,13 @@ impl FsMapping {
     pub fn path_in_sandbox(&self) -> String {
         match &self.sandbox_path {
             Some(p) => p.clone(),
-            None => self.host_path.clone(),
+            None => match std::env::var("MINIMAL_INTERNAL_PATCH_STRIP") {
+                Err(_) => self.host_path.clone(),
+                Ok(prefix) => match self.host_path.strip_prefix(&prefix) {
+                    Some(stripped) => stripped.to_string(),
+                    None => self.host_path.clone(),
+                },
+            },
         }
     }
 }

--- a/crates/sandbox2/src/config.rs
+++ b/crates/sandbox2/src/config.rs
@@ -60,6 +60,30 @@ pub enum WdSetup {
     },
 }
 
+impl WdSetup {
+    /// Returns the path within the sandbox of the cwd. The returned path
+    /// is always relative.
+    ///
+    /// SAFETY:
+    ///  * This function will panic if the variant is not `BoundDir`.
+    pub(crate) fn bound_dir_sandbox_cwd(&self) -> &Path {
+        let p = match self {
+            Self::BoundDir { path, .. } => match std::env::var("MINIMAL_INTERNAL_PATCH_STRIP") {
+                Err(_) => path,
+                Ok(prefix) => match path.strip_prefix(&prefix) {
+                    Err(_) => path,
+                    Ok(stripped) => stripped,
+                },
+            },
+            _ => panic!("sandbox_cwd called for non bound-dir variant {:?}", self),
+        };
+        if p.is_absolute() {
+            return p.strip_prefix("/").unwrap();
+        }
+        p
+    }
+}
+
 /// Describes the setup of a sandbox.
 #[derive(Debug)]
 pub struct Config {

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -161,17 +161,22 @@ impl<C: Channel> Sandbox<C> {
                     .map_err(|e| Error::IO("create output usr/lib64 symlink", out_usr_lib64, e))?;
             }
             WdSetup::BoundDir {
-                path,
+                path: _,
                 fs_mappings,
                 read_only: _,
             } => {
-                let cwd = rootfs.join(path);
-                fs::create_dir_all(&cwd)
-                    .map_err(|e| Error::IO("create shadow cwd tree", cwd.clone(), e))?;
+                let rootfs_cwd = rootfs.join(config.wd.bound_dir_sandbox_cwd());
+                fs::create_dir_all(&rootfs_cwd)
+                    .map_err(|e| Error::IO("create shadow cwd tree", rootfs_cwd, e))?;
 
                 // Create bind-mount targets
                 for m in fs_mappings {
-                    let p = rootfs.join(m.path_in_sandbox());
+                    let sp = m.path_in_sandbox();
+                    let sp = match sp.strip_prefix("/") {
+                        Some(stripped) => stripped,
+                        None => &sp,
+                    };
+                    let p = rootfs.join(sp);
 
                     if m.is_file {
                         fs::create_dir_all(p.parent().unwrap())
@@ -276,7 +281,10 @@ impl Container {
         let mut command = self.container.command(program);
         command.args(args);
         command.current_dir(match &sandbox.config.wd {
-            WdSetup::BoundDir { path, .. } => path.to_str().unwrap().to_string(),
+            WdSetup::BoundDir { .. } => format!(
+                "/{}",
+                sandbox.config.wd.bound_dir_sandbox_cwd().to_str().unwrap()
+            ),
             WdSetup::Isolated { .. } => "/build".to_string(),
         });
 
@@ -357,12 +365,26 @@ impl<C: Channel> Sandbox<C> {
                 path,
                 read_only: false,
                 fs_mappings: _,
-            } => container.bindmount_rw(path.to_str().unwrap(), path.to_str().unwrap()),
+            } => container.bindmount_rw(
+                path.to_str().unwrap(),
+                format!(
+                    "/{}",
+                    self.config.wd.bound_dir_sandbox_cwd().to_str().unwrap()
+                )
+                .as_str(),
+            ),
             WdSetup::BoundDir {
                 path,
                 read_only: true,
                 fs_mappings: _,
-            } => container.bindmount_ro(path.to_str().unwrap(), path.to_str().unwrap()),
+            } => container.bindmount_ro(
+                path.to_str().unwrap(),
+                format!(
+                    "/{}",
+                    self.config.wd.bound_dir_sandbox_cwd().to_str().unwrap()
+                )
+                .as_str(),
+            ),
         };
         // Mount in any file mappings
         if let WdSetup::BoundDir { fs_mappings, .. } = &self.config.wd {


### PR DESCRIPTION
Adds internal env-var `MINIMAL_INTERNAL_PATCH_STRIP`, so `minimal-entry` in the mac orchestration code can set `MINIMAL_INTERNAL_PATCH_STRIP=/host` and end up with identical paths in the minimal sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox path handling with conditional prefix transformations based on environment configuration
  * Enhanced working directory and bind-mount management in sandboxed environments for proper path resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->