### PR TITLE
crates/minimal: This is 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "minimal"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "args",

--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimal"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 publish.workspace = true
 


### PR DESCRIPTION
Lets get a bunch of bugfixes out there, also so we can test using `MINIMAL_INTERNAL_PATCH_STRIP` in the mac stuff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version update (0.3.3) for the minimal package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->