### PR TITLE
crates/minimal: implement `minimal run --upstream {} --task-spec {}`

### DIFF
--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -137,6 +137,24 @@ impl ConfigBuilder {
     }
 }
 
+impl Config {
+    /// Converts this config back into a builder, preserving all values.
+    /// Useful for layering overrides on top of an existing configuration.
+    pub fn into_builder(self) -> ConfigBuilder {
+        ConfigBuilder {
+            no_cache: Some(self.no_cache),
+            no_fetch: Some(self.no_fetch),
+            num_parallel_builds: Some(self.num_parallel_builds),
+            minimal_dir: Some(self.minimal_dir),
+            stdlib_dir: self.stdlib_dir,
+            repo_dir: self.repo_dir,
+            vcs_manager: self.vcs_manager,
+            ot: self.ot,
+            remote_cache_bucket: Some(self.remote_cache_bucket),
+        }
+    }
+}
+
 /// Configuration for a [super::Context].
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -329,9 +329,16 @@ impl Context {
     pub fn index_dir(&self) -> PathBuf {
         self.config.index_dir()
     }
+    /// Returns the directory where compiled layers are cached.
+    pub fn layer_cache_dir(&self) -> PathBuf {
+        self.config.layer_cache_dir()
+    }
+
     /// Returns the path to the root of the repo.
     pub fn repo_dir(&self) -> &Path {
-        self.mfile.repo_path().unwrap()
+        self.mfile
+            .repo_path()
+            .unwrap_or_else(|| self.config.repo_dir_override().as_ref().unwrap())
     }
     /// Returns a path to the standard library.
     pub fn stdlib_dir(&self) -> &PathBuf {
@@ -618,7 +625,7 @@ impl Context {
         let wd = if let Some(wd) = wd {
             wd
         } else {
-            mfile.repo_path().unwrap().to_path_buf()
+            self.repo_dir().to_path_buf()
         };
         let state_base_dir = match state_key {
             Some(name) if !name.is_empty() => {

--- a/crates/minimal/src/cmd_run.rs
+++ b/crates/minimal/src/cmd_run.rs
@@ -1,42 +1,238 @@
 use anyhow::anyhow;
+use common::Target;
 use graph::Graph;
-use mctx::{Context, Error};
+use mctx::{Config, Context, Error};
 use tracing::trace;
 
-#[derive(Debug, clap::Args)]
-#[command(trailing_var_arg = true)]
+/// Specifies which task to run.
+#[derive(Debug, Clone)]
+pub enum RunVariant {
+    /// Run a task by name from `minimal.toml`.
+    ByName { task_name: String },
+    /// Run a task specified inline via upstream and task-spec strings.
+    BySpec {
+        upstream: mfile::LinkConfig,
+        task_spec: Box<mfile::Task>,
+    },
+}
+
+#[derive(Debug)]
 pub struct RunArgs {
-    pub task_name: String,
+    pub variant: RunVariant,
     /// Additional arguments to pass to the task, parsed according to the task's args schema.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub task_args: Vec<String>,
+}
+
+impl clap::FromArgMatches for RunArgs {
+    fn from_arg_matches(matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        let upstream = matches.get_one::<String>("upstream").cloned();
+        let task_spec = matches.get_one::<String>("task_spec").cloned();
+        let task_name = matches.get_one::<String>("task_name").cloned();
+        let task_args: Vec<String> = matches
+            .get_many::<String>("task_args")
+            .unwrap_or_default()
+            .cloned()
+            .collect();
+
+        let variant = match (task_name, upstream, task_spec) {
+            (Some(name), None, None) => RunVariant::ByName { task_name: name },
+            (None, Some(ups), Some(spec)) => {
+                let upstream: mfile::LinkConfig = serde_json::from_str(&ups).map_err(|e| {
+                    clap::Error::raw(
+                        clap::error::ErrorKind::ValueValidation,
+                        format!("invalid --upstream JSON: {e}\n"),
+                    )
+                })?;
+                let task: mfile::Task = serde_json::from_str(&spec).map_err(|e| {
+                    clap::Error::raw(
+                        clap::error::ErrorKind::ValueValidation,
+                        format!("invalid --task-spec JSON: {e}\n"),
+                    )
+                })?;
+                RunVariant::BySpec {
+                    upstream,
+                    task_spec: Box::new(task),
+                }
+            }
+            (None, Some(_), None) | (None, None, Some(_)) => {
+                return Err(clap::Error::raw(
+                    clap::error::ErrorKind::MissingRequiredArgument,
+                    "--upstream and --task-spec must both be provided\n",
+                ));
+            }
+            (Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
+                return Err(clap::Error::raw(
+                    clap::error::ErrorKind::ArgumentConflict,
+                    "cannot use <task_name> with --upstream/--task-spec\n",
+                ));
+            }
+            (None, None, None) => {
+                return Err(clap::Error::raw(
+                    clap::error::ErrorKind::MissingRequiredArgument,
+                    "either <task_name> or --upstream/--task-spec is required\n",
+                ));
+            }
+        };
+
+        Ok(RunArgs { variant, task_args })
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl clap::Args for RunArgs {
+    fn augment_args(cmd: clap::Command) -> clap::Command {
+        cmd.trailing_var_arg(true)
+            .override_usage(
+                "minimal run [OPTIONS] <task_name> [task_args]...\n       \
+                 minimal run [OPTIONS] --upstream <upstream> --task-spec <task_spec> [task_args]...",
+            )
+            .arg(
+                clap::Arg::new("task_name")
+                    .help("Name of the task to run (from minimal.toml)")
+                    .conflicts_with_all(["upstream", "task_spec"])
+                    .value_parser(clap::builder::NonEmptyStringValueParser::new()),
+            )
+            .arg(
+                clap::Arg::new("upstream")
+                    .long("upstream")
+                    .help("JSON stanza specifying the software supply chain")
+                    .long_help(
+                        "JSON stanza specifying the software supply chain. Must be used with --task-spec.\n\n\
+                         Example:\n  \
+                         '{\"repo\": \"https://github.com/gominimal/pkgs\", \"branch\": \"main\", \"locked_commit\": \"abc\"}'",
+                    )
+                    .requires("task_spec")
+                    .value_parser(clap::builder::NonEmptyStringValueParser::new()),
+            )
+            .arg(
+                clap::Arg::new("task_spec")
+                    .long("task-spec")
+                    .help("JSON stanza specifying a task.")
+                    .long_help(
+                        "JSON stanza specifying a task. Must be used with --upstream.\n\n\
+                         Example:\n  \
+                         '{\"exec\": \"echo hello\", \"packages\": [\"coreutils\"]}'",
+                    )
+                    .requires("upstream")
+                    .value_parser(clap::builder::NonEmptyStringValueParser::new()),
+            )
+            .arg(
+                clap::Arg::new("task_args")
+                    .help("Additional arguments to pass to the task")
+                    .trailing_var_arg(true)
+                    .allow_hyphen_values(true)
+                    .num_args(..),
+            )
+    }
+
+    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
+        Self::augment_args(cmd)
+    }
 }
 
 pub async fn cmd_run(args: RunArgs, ctx: &mut Context) -> Result<(), Error> {
     trace!("cmd_run");
-    let graph = ctx.graph_from_all_packages()?;
-    let (task, graph) = match ctx.task(graph, &args.task_name)? {
-        None => return Err(Error::Other(anyhow!("no such task: {}", args.task_name))),
-        Some((t, g)) => (t, g),
-    };
+
+    match args.variant {
+        RunVariant::ByName { task_name } => {
+            let graph = ctx.graph_from_all_packages()?;
+            let (task, graph) = match ctx.task(graph, &task_name)? {
+                None => return Err(Error::Other(anyhow!("no such task: {}", task_name))),
+                Some((t, g)) => (t, g),
+            };
+
+            let parsed_args = if !task.args.is_empty() {
+                Some(
+                    task.args
+                        .parse_argv_named(&format!("minimal run {}", task_name), &args.task_args)
+                        .map_err(|e| {
+                            e.print().unwrap();
+                            Error::Other(anyhow!(
+                                "task {} called with invalid arguments",
+                                task_name
+                            ))
+                        })?,
+                )
+            } else {
+                None
+            };
+
+            run_task(&task_name, &task, parsed_args, graph, ctx).await
+        }
+        RunVariant::BySpec { .. } => {
+            unreachable!("BySpec variant should be handled before Context::new via cmd_run_by_spec")
+        }
+    }
+}
+
+/// Handles `minimal run --upstream ... --task-spec ...` without requiring a minimal.toml.
+/// Called before Context::new in main, similar to how `cmd_init` is handled.
+pub async fn cmd_run_by_spec(
+    mut upstream: mfile::LinkConfig,
+    task: Box<mfile::Task>,
+    task_args: Vec<String>,
+    config: Config,
+) -> Result<(), Error> {
+    trace!("cmd_run_by_spec");
+    super::enforce_science_mode()?;
+
+    let (mut vcs, cache, stdlib_dir) = Context::sub_setup(&config)?;
+
+    // We let the upstream omit locked_commit, in which case we fetch the latest
+    // and use that.
+    if let mfile::LinkConfig::Git {
+        repo,
+        branch: Some(b),
+        locked_commit,
+    } = &mut upstream
+        && locked_commit.is_none()
+    {
+        vcs.update()?;
+        *locked_commit = Some(
+            vcs.checkout_of(&repo.clone(), checkouts::GitRef::Branch(b.clone()))?
+                .1,
+        );
+    }
+
+    let mut ctx = Context::new_from_parts(
+        config
+            .into_builder()
+            .with_vcs_manager(vcs.clone())
+            .with_repo_dir(std::env::current_dir().unwrap())
+            .build()
+            .unwrap(),
+        mfile::File::synthetic(upstream.clone()),
+        vcs,
+        cache,
+        stdlib_dir.clone(),
+    );
+
+    let graph = Graph::new_from_chain(
+        ctx.vcs_manager(),
+        &mut graph::LayerCacheDir(ctx.layer_cache_dir()),
+        upstream,
+        stdlib_dir,
+        Target::host(),
+    )?;
 
     let parsed_args = if !task.args.is_empty() {
         Some(
             task.args
-                .parse_argv_named(&format!("minimal run {}", args.task_name), &args.task_args)
+                .parse_argv_named("minimal run --task-spec ... ", &task_args)
                 .map_err(|e| {
                     e.print().unwrap();
-                    Error::Other(anyhow!(
-                        "task {} called with invalid arguments",
-                        args.task_name
-                    ))
+                    Error::Other(anyhow!("task called with invalid arguments",))
                 })?,
         )
     } else {
         None
     };
 
-    run_task(&args.task_name, &task, parsed_args, graph, ctx).await
+    run_task("task", &task, parsed_args, graph, &mut ctx).await
 }
 
 pub async fn run_task(

--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -23,7 +23,7 @@ use cmd_patched_build::{PatchedBuildArgs, cmd_patched_build};
 #[cfg(target_os = "linux")]
 mod cmd_run;
 #[cfg(target_os = "linux")]
-use cmd_run::{RunArgs, cmd_run};
+use cmd_run::{RunArgs, cmd_run, cmd_run_by_spec};
 mod cmd_dep;
 use cmd_dep::{DepArgs, cmd_dep};
 mod cmd_update;
@@ -56,7 +56,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Runs a task specified in `minimal.toml`.
+    /// Runs a task, such as one specified in `minimal.toml`.
     #[cfg(target_os = "linux")]
     Run(RunArgs),
     /// Refreshes local checkouts of upstream packages & the standard library.
@@ -186,13 +186,6 @@ async fn main() -> Result<(), Error> {
 
     let cli = Cli::parse();
 
-    if let Command::Completions(CompletionsArgs { shell }) = &cli.command {
-        let mut cmd = Cli::command();
-        let name = cmd.get_name().to_string();
-        clap_complete::generate(*shell, &mut cmd, name, &mut io::stdout());
-        return Ok(());
-    }
-
     let result = run_cli(cli).await;
 
     if let Err(e) = result {
@@ -225,10 +218,25 @@ async fn run_cli(cli: Cli) -> Result<(), Error> {
     }
     let config = config.build()?;
 
-    // `minimal init` is typically run where there exists no `minimal.toml`, so
-    // context setup will fail.
-    if let Command::Init(args) = command {
-        return cmd_init(args, config).await;
+    // Commands that don't need a minimal.toml / full Context.
+    match command {
+        Command::Completions(CompletionsArgs { shell }) => {
+            let mut cmd = Cli::command();
+            let name = cmd.get_name().to_string();
+            clap_complete::generate(shell, &mut cmd, name, &mut io::stdout());
+            return Ok(());
+        }
+        Command::Init(args) => return cmd_init(args, config).await,
+        #[cfg(target_os = "linux")]
+        Command::Run(RunArgs {
+            variant:
+                cmd_run::RunVariant::BySpec {
+                    upstream,
+                    task_spec,
+                },
+            task_args,
+        }) => return cmd_run_by_spec(upstream, task_spec, task_args, config).await,
+        _ => {}
     }
     let mut ctx = Context::new(config)?;
 
@@ -245,7 +253,9 @@ async fn run_cli(cli: Cli) -> Result<(), Error> {
         Command::Shell => {
             cmd_run(
                 RunArgs {
-                    task_name: "shell".to_string(),
+                    variant: cmd_run::RunVariant::ByName {
+                        task_name: "shell".to_string(),
+                    },
                     task_args: vec![],
                 },
                 &mut ctx,
@@ -255,7 +265,9 @@ async fn run_cli(cli: Cli) -> Result<(), Error> {
         Command::Build => {
             cmd_run(
                 RunArgs {
-                    task_name: "build".to_string(),
+                    variant: cmd_run::RunVariant::ByName {
+                        task_name: "build".to_string(),
+                    },
                     task_args: vec![],
                 },
                 &mut ctx,
@@ -265,7 +277,9 @@ async fn run_cli(cli: Cli) -> Result<(), Error> {
         Command::Test => {
             cmd_run(
                 RunArgs {
-                    task_name: "test".to_string(),
+                    variant: cmd_run::RunVariant::ByName {
+                        task_name: "test".to_string(),
+                    },
                     task_args: vec![],
                 },
                 &mut ctx,
@@ -279,8 +293,7 @@ async fn run_cli(cli: Cli) -> Result<(), Error> {
         Command::Rexec(args) => cmd_rexec(args, &mut ctx).await,
         Command::RemoteBuild(args) => cmd_remote_build(args, &mut ctx).await,
         Command::Cache(args) => cmd_cache(args, &mut ctx).await,
-        // Handled earlier
-        Command::Completions(_) => Ok(()),
-        Command::Init(_) => Ok(()),
+        // Handled before Context::new
+        Command::Completions(_) | Command::Init(_) => unreachable!(),
     }
 }


### PR DESCRIPTION
```shell
$> minimal run --help
Runs a task, such as one specified in `minimal.toml`

Usage: minimal run [OPTIONS] <task_name> [task_args]...
       minimal run [OPTIONS] --upstream <upstream> --task-spec <task_spec> [task_args]...

Arguments:
  [task_name]
          Name of the task to run (from minimal.toml)

  [task_args]...
          Additional arguments to pass to the task

Options:
      --upstream <upstream>
          JSON stanza specifying the software supply chain. Must be used with --task-spec.

          Example:
            '{"repo": "https://github.com/gominimal/pkgs", "branch": "main", "locked_commit": "abc"}'

      --task-spec <task_spec>
          JSON stanza specifying a task. Must be used with --upstream.

          Example:
            '{"exec": "echo hello", "packages": ["coreutils"]}'

      --no-cache
          Ignore locally-available binary artifacts (results in rebuilds unless present in a remote cache)

      --no-fetch
          Do not fetch binary artifacts from the internet

  -n, --num-parallel-builds <NUM_PARALLEL_BUILDS>
          Configure the number of parallel builds

  -h, --help
          Print help (see a summary with '-h')
```

#### Testing instructions

```shell
$> cargo build
$> (cd ~ && minimal/target/debug/minimal run --upstream '{"repo": "https://github.com/gominimal/pkgs", "branch": "main"}' --task-spec '{"bash": "echo beep boop"}')
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run tasks directly using inline JSON specifications without requiring config files.
  * Expose layer cache directory setting for improved cache control.

* **Improvements**
  * Better repository path resolution with a configurable fallback.
  * Stronger CLI validation for mutually exclusive/required run-mode options.
  * Early handling of completions/init and direct inline-run dispatch to streamline startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->