### PR TITLE
ci(promote): gate on production environment + Slack approval ping

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - name: Notify Slack — approval required
         continue-on-error: true
+        timeout-minutes: 5
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -16,11 +16,12 @@ on:
 jobs:
   notify-pending:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Notify Slack — approval required
         continue-on-error: true
         timeout-minutes: 5
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -14,8 +14,24 @@ on:
         type: string
 
 jobs:
-  promote:
+  notify-pending:
     runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack — approval required
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "*Promotion approval required:* `${{ github.repository }}`\nWorkflow: `${{ github.workflow }}`\nRequested by: ${{ github.actor }}\nApprove: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+
+  promote:
+    needs: notify-pending
+    runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -30,10 +30,32 @@ jobs:
               "text": "*Promotion approval required:* `${{ github.repository }}`\nWorkflow: `${{ github.workflow }}`\nRequested by: ${{ github.actor }}\nApprove: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 
-  promote:
+  approval:
     needs: notify-pending
     runs-on: ubuntu-latest
-    environment: production
+    permissions:
+      issues: write
+    timeout-minutes: 1440
+    steps:
+      - name: Wait for manual approval
+        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1.12.0
+        with:
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          approvers: bryan-minimal,evanspearman,jessie-minimal,jtnkminimal,Max-minimal,mitodrummer,msample,norrietaylor,twitchyliquid64
+          minimum-approvals: 1
+          issue-title: "Promotion approval required: ${{ github.workflow }} run ${{ github.run_number }}"
+          issue-body: |
+            **Repo:** `${{ github.repository }}`
+            **Workflow:** `${{ github.workflow }}`
+            **Requested by:** @${{ github.actor }}
+            **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Comment **`approved`** to proceed or **`denied`** to cancel.
+          exclude-workflow-initiator-as-approver: true
+
+  promote:
+    needs: approval
+    runs-on: ubuntu-latest
     permissions:
       contents: "read"
       id-token: "write"


### PR DESCRIPTION
  Split promote.yml into two jobs:

  - notify-pending: posts a Slack incoming-webhook message announcing the run and linking to the approval URL. continue-on-error so a Slack outage does not block promotion.
  - promote: needs notify-pending; issue-based approval. Existing steps unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Slack notification to alert stakeholders when a promotion requires approval; notification failures do not block the pipeline.
  * Added an explicit approval gate so promotion tasks now pause and await manual approval before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->