### PR TITLE
ci(promote): add inline DIY issue-based approval gate

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -39,7 +39,9 @@ jobs:
           REPO: ${{ github.repository }}
           WORKFLOW: ${{ github.workflow }}
           RUN_NUMBER: ${{ github.run_number }}
-          ACTOR: ${{ github.actor }}
+          # triggering_actor (NOT actor) — actor is frozen on rerun, so a rerun
+          # by a different user would still let the original initiator self-approve.
+          ACTOR: ${{ github.triggering_actor }}
           SERVER_URL: ${{ github.server_url }}
           RUN_ID: ${{ github.run_id }}
           SHA_INPUT: ${{ inputs.sha }}
@@ -80,7 +82,7 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "text": "*Promotion approval required:* `${{ github.repository }}`\nRequested by: ${{ github.actor }}\nApprove here: ${{ steps.issue.outputs.url }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "*Promotion approval required:* `${{ github.repository }}`\nRequested by: ${{ github.triggering_actor }}\nApprove here: ${{ steps.issue.outputs.url }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 
       - name: Wait for approver decision
@@ -88,7 +90,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
           REPO: ${{ github.repository }}
-          INITIATOR: ${{ github.actor }}
+          # triggering_actor reflects the user who triggered THIS run (incl. reruns),
+          # so rerunning the workflow as a different user correctly excludes them.
+          INITIATOR: ${{ github.triggering_actor }}
           POLL_INTERVAL: "30"
         run: |
           set -euo pipefail
@@ -156,9 +160,14 @@ jobs:
       - name: Promote CLI version
         env:
           DRY_RUN: ${{ inputs.dry_run }}
+          # Pass dispatch inputs via env (NOT inline ${{ inputs.* }} in `run:`)
+          # to avoid shell template injection — see GitHub's hardening guide.
+          INPUT_SHA: ${{ inputs.sha }}
+          INPUT_PLATFORMS: ${{ inputs.platforms }}
         run: |
-          SHA="$(echo "${{ inputs.sha }}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-          PLATFORMS="$(echo "${{ inputs.platforms }}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          # Trim leading/trailing whitespace; users often paste SHAs with stray spaces.
+          SHA="$(printf '%s' "$INPUT_SHA" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+          PLATFORMS="$(printf '%s' "$INPUT_PLATFORMS" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 
           if [ "$PLATFORMS" = "all" ]; then
             PLATFORMS="amd64-linux,arm64-linux"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -12,9 +12,136 @@ on:
         required: false
         default: "amd64-linux,arm64-linux"
         type: string
+      dry_run:
+        description: "Dry run — open issue + wait for approval but skip the GCS write"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  # Single source of truth for the gate's approver allowlist.
+  # Comma-separated, no spaces (the polling step splits on `,`).
+  APPROVERS: bryan-minimal,evanspearman,jessie-minimal,jtnkminimal,Max-minimal,mitodrummer,msample,norrietaylor,twitchyliquid64
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    timeout-minutes: 1440
+    outputs:
+      issue_url: ${{ steps.issue.outputs.url }}
+    steps:
+      - name: Open approval issue
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_NUMBER: ${{ github.run_number }}
+          ACTOR: ${{ github.actor }}
+          SERVER_URL: ${{ github.server_url }}
+          RUN_ID: ${{ github.run_id }}
+          SHA_INPUT: ${{ inputs.sha }}
+          PLATFORMS_INPUT: ${{ inputs.platforms }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          BODY="**Repo:** \`${REPO}\`
+          **Workflow:** \`${WORKFLOW}\`
+          **Requested by:** @${ACTOR}
+          **Run:** ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}
+          **SHA input:** \`${SHA_INPUT:-<latest>}\`
+          **Platforms:** \`${PLATFORMS_INPUT}\`
+          **Dry run:** \`${DRY_RUN}\`
+
+          Comment **\`approved\`** to proceed or **\`denied\`** to cancel.
+          Closing this issue without an approval comment counts as denial.
+
+          Approver list (initiator excluded at runtime):
+          ${APPROVERS//,/, }"
+
+          URL=$(gh issue create \
+            --repo "$REPO" \
+            --title "Promotion approval required: ${WORKFLOW} run ${RUN_NUMBER}" \
+            --label "promotion-approval" \
+            --body "$BODY")
+          NUM="${URL##*/}"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "number=$NUM" >> "$GITHUB_OUTPUT"
+          echo "Opened approval issue: $URL"
+
+      - name: Notify Slack — approval required
+        continue-on-error: true
+        timeout-minutes: 5
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "*Promotion approval required:* `${{ github.repository }}`\nRequested by: ${{ github.actor }}\nApprove here: ${{ steps.issue.outputs.url }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+
+      - name: Wait for approver decision
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          REPO: ${{ github.repository }}
+          INITIATOR: ${{ github.actor }}
+          POLL_INTERVAL: "30"
+        run: |
+          set -euo pipefail
+
+          INITIATOR_LC=$(printf '%s' "$INITIATOR" | tr '[:upper:]' '[:lower:]')
+          ALLOWED_JSON=$(printf '%s' "$APPROVERS" | tr ',' '\n' \
+            | tr '[:upper:]' '[:lower:]' \
+            | grep -vx "$INITIATOR_LC" \
+            | jq -R . | jq -s .)
+
+          echo "Polling issue #${ISSUE_NUMBER}. Allowed approvers (initiator ${INITIATOR} excluded):"
+          echo "$ALLOWED_JSON" | jq -r '.[]'
+
+          while true; do
+            STATE=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.state')
+
+            DECISION=$(gh api --paginate "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" \
+              | jq -s 'add // []' \
+              | jq -c --argjson allowed "$ALLOWED_JSON" '
+                  map(select(.user.login | ascii_downcase as $u | $allowed | index($u)))
+                  | sort_by(.created_at)
+                  | map(
+                      (.body | ascii_downcase | gsub("[[:space:]]"; "")) as $b
+                      | if   ($b | test("^(approved|approve|lgtm)$"))      then {decision: "approved", user: .user.login}
+                        elif ($b | test("^(denied|deny|reject|rejected)$")) then {decision: "denied",   user: .user.login}
+                        else empty end
+                    )
+                  | first // empty')
+
+            if [ -n "$DECISION" ] && [ "$DECISION" != "null" ]; then
+              DEC=$(echo "$DECISION" | jq -r '.decision')
+              USR=$(echo "$DECISION" | jq -r '.user')
+              if [ "$DEC" = "approved" ]; then
+                echo "Approved by @${USR}."
+                gh issue close "$ISSUE_NUMBER" --repo "$REPO" --comment "Approved by @${USR}. Proceeding." || true
+                exit 0
+              else
+                echo "Denied by @${USR}."
+                gh issue close "$ISSUE_NUMBER" --repo "$REPO" --comment "Denied by @${USR}. Cancelling promotion." || true
+                exit 1
+              fi
+            fi
+
+            if [ "$STATE" = "closed" ]; then
+              echo "Issue closed without an approval comment — treating as denial."
+              exit 1
+            fi
+
+            sleep "$POLL_INTERVAL"
+          done
+
   promote:
+    needs: gate
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
@@ -27,6 +154,8 @@ jobs:
           workload_identity_provider: "projects/289724348228/locations/global/workloadIdentityPools/github/providers/gominimal"
 
       - name: Promote CLI version
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           SHA="$(echo "${{ inputs.sha }}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           PLATFORMS="$(echo "${{ inputs.platforms }}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
@@ -65,10 +194,20 @@ jobs:
             plat="$(echo "$plat" | tr -d ' ')"
             echo "Promoting CLI to ${SHA} for ${plat}..."
             echo "{\"version\":\"${SHA}\"}" > "cli-${plat}.json"
-            gcloud storage cp \
-              --cache-control="max-age=300" \
-              "cli-${plat}.json" \
-              "gs://minimal-shim/config/cli-${plat}.json"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] would: gcloud storage cp --cache-control=max-age=300 cli-${plat}.json gs://minimal-shim/config/cli-${plat}.json"
+              echo "[dry-run] config payload:"
+              cat "cli-${plat}.json"
+            else
+              gcloud storage cp \
+                --cache-control="max-age=300" \
+                "cli-${plat}.json" \
+                "gs://minimal-shim/config/cli-${plat}.json"
+            fi
           done
 
-          echo "CLI promoted to ${SHA} for platforms: ${PLATFORMS}"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[dry-run] CLI would have been promoted to ${SHA} for platforms: ${PLATFORMS}"
+          else
+            echo "CLI promoted to ${SHA} for platforms: ${PLATFORMS}"
+          fi

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -28,7 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-    timeout-minutes: 1440
+    # 6h matches the GitHub-hosted runner hard limit. A higher value is
+    # misleading — `ubuntu-latest` jobs are killed at 6h regardless.
+    timeout-minutes: 360
     outputs:
       issue_url: ${{ steps.issue.outputs.url }}
     steps:


### PR DESCRIPTION
## Why

Promote workflow currently runs unguarded on `workflow_dispatch`. Adding a `production` environment with required reviewers does not work on this org/repo:

> If you are on a GitHub Free, GitHub Pro, or **GitHub Team** plan, **required reviewers are only available for public repositories**.
>
> — [GitHub docs: Deployments and environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)

Org plan is Team, repo is private → the env-based approach is inert (PUT on any protection rule returns `Failed to create the environment protection rule. Please ensure the billing plan supports …`).

The same gate is shipping for `minimal-vm-mac` (gominimal/minimal-vm-mac#18, validated end-to-end) and will follow on `shim`. This PR is the `minimal` mirror.

## Approach

Inline `gate` job using ordinary GitHub issues as the approval surface — works on any plan.

```
gate                                      promote
├─ open issue (label: promotion-approval) needs: gate
├─ Slack ping with **issue URL**          (existing GCS upload, with dry-run guard)
└─ poll comments until approved/denied
```

- Approver allowlist hoisted to a workflow-level `env: APPROVERS` (single source of truth — issue body and polling step both reference `${APPROVERS}`).
- Initiator excluded at runtime.
- Strict regex on body — `^(approved|approve|lgtm)$` / `^(denied|deny|reject|rejected)$` after lowercase + whitespace strip. "I approved this earlier" cannot trigger.
- Comments sorted by `created_at`; first matching approver decision wins.
- Manually closing the issue counts as denial.
- `github-actions[bot]` cannot self-approve (bot not in allowlist).
- 30s poll, 24h job timeout.
- Slack step has `continue-on-error` + `timeout-minutes: 5` — Slack outage does not block the gate.
- `permissions: { issues: write }` scoped to the `gate` job only; `promote` keeps `contents: read` + `id-token: write`.

No third-party action — fully self-contained shell.

## What this PR ships in addition

- A `dry_run` workflow_dispatch input (default `false`). When `true`, each `gcloud storage cp` is replaced with an `echo` of what would have been written. Lets the full flow be validated on this branch without publishing.

## Test plan

| # | Action | Expected |
|---|---|---|
| 1 | `gh workflow run promote-cli --ref norrie/promotion-approval-issue-gate -f dry_run=true` | Issue opens (label `promotion-approval`), Slack ping fires with issue URL, polling starts |
| 2 | Comment `approved` from your own account (initiator) | Ignored, polling continues |
| 3 | Have another org admin comment `approved` | Gate exits 0; issue auto-closes; promote runs in dry-run; no GCS write |
| 4 | New trigger; approver comments `denied` | Gate exits 1; issue auto-closes; promote skipped |
| 5 | New trigger; manually close issue | Gate notices closed state on next poll, exits 1 |
| 6 | New trigger; approver comments "I approved this earlier" | Strict regex rejects it; polling continues |

## Cleanup

`SLACK_WEBHOOK_URL` already exists on this repo. Once merged, the previous `norrie/promotion-approval-gate` branch (env-gate prototype) can be deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an approval gate that opens an approval issue, notifies Slack, and polls comments for allow/deny responses; approval closes the issue and proceeds, denial or issue closure halts the promotion.
  * Promotion now requires passing the approval gate before continuing.

* **Chores**
  * Adds a dry-run workflow input that logs intended commands and payloads, skips actual writes, and emits a dry-run final status message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->