### PR TITLE
crates/mctx (mostly): Refactored mfile search in mctx into an enum with multiple search strategies for different scenarios and fixed a related bug in `minimal init`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,6 +2721,7 @@ dependencies = [
  "ot",
  "rcache",
  "sandbox2",
+ "serial_test",
  "stdlib",
  "tempfile",
  "tokio",
@@ -4293,6 +4294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4330,6 +4340,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -4473,6 +4489,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ prost-build = "0.14"
 prost-types = "0.14"
 resolv-conf = "0.7"
 serde_json = { version = "1.0" }
+serial_test = "3"
 sha2 = "0.11"
 shlex = "1.3"
 size = "0.5"

--- a/crates/mctx/Cargo.toml
+++ b/crates/mctx/Cargo.toml
@@ -39,3 +39,4 @@ stdlib.workspace = true
 
 [dev-dependencies]
 indoc.workspace = true
+serial_test.workspace = true

--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -1,4 +1,7 @@
-use std::{fmt, path::PathBuf};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 
 use checkouts::ManagerHandle;
 use ot::OpTracker;
@@ -74,18 +77,18 @@ impl ConfigBuilder {
         self
     }
     /// Overrides the base directory for system state.
-    pub fn with_state_dir(mut self, dir: PathBuf) -> Self {
-        self.minimal_dir = Some(dir);
+    pub fn with_state_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.minimal_dir = Some(dir.into());
         self
     }
     /// Overrides loading of the standard library, getting it from the given path instead.
-    pub fn with_stdlib_dir(mut self, dir: PathBuf) -> Self {
-        self.stdlib_dir = Some(dir);
+    pub fn with_stdlib_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.stdlib_dir = Some(dir.into());
         self
     }
     /// Use the repository rooted at the given directory, instead of inferring it from the cwd.
-    pub fn with_repo_dir(mut self, dir: PathBuf) -> Self {
-        self.repo_dir = Some(dir);
+    pub fn with_repo_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.repo_dir = Some(dir.into());
         self
     }
     /// Use the specified vcs manager instead of initializing one from disk.
@@ -182,16 +185,16 @@ pub struct Config {
 }
 
 impl Config {
-    pub(crate) fn stdlib_dir_override(&self) -> &Option<PathBuf> {
-        &self.stdlib_dir
+    pub(crate) fn stdlib_dir_override(&self) -> Option<&Path> {
+        self.stdlib_dir.as_deref()
     }
     pub(crate) fn vcs_manager_override(&self) -> Option<ManagerHandle> {
         self.vcs_manager.clone()
     }
 
     /// Returns the path to the repo, if overridden (i.e. via '-C' argument).
-    pub fn repo_dir_override(&self) -> &Option<PathBuf> {
-        &self.repo_dir
+    pub fn repo_dir_override(&self) -> Option<&Path> {
+        self.repo_dir.as_deref()
     }
 
     /// Returns true if objects should be used from the local cache instead of fetched/rebuilt.

--- a/crates/mctx/src/error.rs
+++ b/crates/mctx/src/error.rs
@@ -260,3 +260,9 @@ impl From<common::HardlinkError> for Error {
         }
     }
 }
+
+impl From<mfile::Error> for Error {
+    fn from(value: mfile::Error) -> Self {
+        Self::MFile(value)
+    }
+}

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -25,6 +25,9 @@ use graph::{BinProvider, BuildSpecRef, Graph, MaskingBinProvider, Transitives};
 use mfile::{EnvPatches, EnvVarValue, LinkConfig, Task};
 pub use sandbox2::config::Invocation;
 
+mod mfile_search_strategy;
+pub use mfile_search_strategy::MFileSearchStrategy;
+
 pub use env::Env;
 use tokio::sync::Semaphore;
 use toml_edit::{Array, DocumentMut, Item, TableLike, Value};
@@ -224,7 +227,7 @@ impl Context {
         //  - The version embedded in the binary, stamped to disk
         let stdlib_dir = {
             if let Some(dir) = config.stdlib_dir_override() {
-                dir.clone()
+                dir.to_path_buf()
             } else {
                 stdlib::upsert_stdlib_to_disk(config.stdlib_dir()).map_err(|e| {
                     Error::Other(anyhow!("loading embedded standard library: {}", e))
@@ -237,21 +240,20 @@ impl Context {
 
     /// Initializes a new context using the given configuration.
     pub fn new(config: Config) -> Result<Self, Error> {
-        let (vcs, cache, stdlib_dir) = Self::sub_setup(&config)?;
-
-        // Load the minimal file. All error are terminal.
-        let mfile = match config
-            .repo_dir_override()
-            .as_ref()
-            .map(|d| mfile::File::from_dir(d.clone()))
-            .unwrap_or_else(|| mfile::File::from_dir_recursive(std::env::current_dir().unwrap()))
-        {
-            Ok(mfile) => mfile,
-            Err(e) => {
-                return Err(Error::MFile(e));
+        let strategy = {
+            match config.repo_dir_override() {
+                Some(path) => MFileSearchStrategy::Override(path.to_path_buf()),
+                _ => MFileSearchStrategy::CurrentDirRecursive,
             }
         };
+        Self::new_with_strategy(config, strategy)
+    }
 
+    /// Initializes a new context using the given configuration and `strategy` for finding the mfile
+    /// This is useful when a given command needs to override the behaviour for finding the mfile
+    pub fn new_with_strategy(config: Config, strategy: MFileSearchStrategy) -> Result<Self, Error> {
+        let (vcs, cache, stdlib_dir) = Self::sub_setup(&config)?;
+        let mfile = strategy.find_mfile()?;
         Ok(Self {
             config,
             stdlib_dir,

--- a/crates/mctx/src/mfile_search_strategy.rs
+++ b/crates/mctx/src/mfile_search_strategy.rs
@@ -1,0 +1,126 @@
+use crate::error::Error;
+use std::path::PathBuf;
+
+/// Describes how to find an MFile
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MFileSearchStrategy {
+    // Only look at a specific path, if there is no mfile there,
+    // we do not find one
+    Override(PathBuf),
+    /// Try the current directory first, if there is no mfile there,
+    /// we do not find one
+    CurrentDirOnly,
+    /// Start in the current directory and recurse the ancestor directories until we find an mfile
+    CurrentDirRecursive,
+}
+
+impl MFileSearchStrategy {
+    /// Find the mfile according to the strategy
+    pub fn find_mfile(&self) -> Result<mfile::File, Error> {
+        match self {
+            Self::Override(path) => mfile::File::from_dir(path).map_err(|e| e.into()),
+            Self::CurrentDirOnly => {
+                let current_dir = std::env::current_dir()
+                    .map_err(|e| Error::IO("Getting current directory", PathBuf::new(), e))?;
+                mfile::File::from_dir(current_dir).map_err(Error::MFile)
+            }
+            Self::CurrentDirRecursive => {
+                let current_dir = std::env::current_dir()
+                    .map_err(|e| Error::IO("Getting current directory", PathBuf::new(), e))?;
+                mfile::File::from_dir_recursive(current_dir).map_err(Error::MFile)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::path::Path;
+
+    /// Restore the current working directory automatically when dropped
+    struct DirGuard(std::path::PathBuf);
+
+    impl DirGuard {
+        fn new() -> Self {
+            Self(std::env::current_dir().unwrap())
+        }
+    }
+
+    impl Drop for DirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
+    fn cargo_manifest_dir() -> &'static Path {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+    }
+
+    fn testdata() -> PathBuf {
+        cargo_manifest_dir().join("testdata")
+    }
+
+    fn fakerepo() -> PathBuf {
+        testdata().join("fakerepo")
+    }
+
+    fn uninitialized_repo() -> PathBuf {
+        testdata().join("fake-ancestor").join("uninitialized-repo")
+    }
+
+    #[test]
+    fn mfile_search_strategy_override() {
+        // Case: Override path has an mfile
+        let strategy = MFileSearchStrategy::Override(fakerepo());
+        let mfile = strategy.find_mfile().unwrap();
+        assert_eq!(*mfile.file_path().unwrap(), fakerepo().join("minimal.toml"));
+
+        // Case: Override path doesn't exist
+        let strategy = MFileSearchStrategy::Override(
+            testdata().join("pleasedontcreateadirectorywiththisname"),
+        );
+        assert!(strategy.find_mfile().is_err());
+
+        // Case: Override path exists but has no mfile
+        let strategy = MFileSearchStrategy::Override(uninitialized_repo());
+        assert!(strategy.find_mfile().is_err());
+    }
+
+    #[test]
+    #[serial] // Any test that sets CWD must be serial to avoid race conditions
+    fn mfile_search_strategy_current_dir_only() {
+        let _guard = DirGuard::new();
+        let strategy = MFileSearchStrategy::CurrentDirOnly;
+
+        // Case: Current directory has an mfile
+        std::env::set_current_dir(fakerepo()).unwrap();
+        let mfile = strategy.find_mfile().unwrap();
+        assert_eq!(*mfile.file_path().unwrap(), fakerepo().join("minimal.toml"));
+
+        // Case: Current directory does not have an mfile (and ancestor does)
+        std::env::set_current_dir(uninitialized_repo()).unwrap();
+        assert!(strategy.find_mfile().is_err());
+    }
+
+    #[test]
+    #[serial] // Any test that sets CWD must be serial to avoid race conditions
+    fn mfile_search_strategy_current_dir_recursive() {
+        let _guard = DirGuard::new();
+        let strategy = MFileSearchStrategy::CurrentDirRecursive;
+
+        // Case: Current directory has an mfile
+        std::env::set_current_dir(fakerepo()).unwrap();
+        let mfile = strategy.find_mfile().unwrap();
+        assert_eq!(*mfile.file_path().unwrap(), fakerepo().join("minimal.toml"));
+
+        // Case: Current directory doesn't have an mfile but an ancestor does
+        std::env::set_current_dir(uninitialized_repo()).unwrap();
+        let mfile = strategy.find_mfile().unwrap();
+        assert_eq!(
+            *mfile.file_path().unwrap(),
+            testdata().join("fake-ancestor").join("minimal.toml")
+        );
+    }
+}

--- a/crates/mctx/testdata/fake-ancestor/minimal.toml
+++ b/crates/mctx/testdata/fake-ancestor/minimal.toml
@@ -1,0 +1,15 @@
+[upstream] # Source of software & tooling
+repo = "https://github.com/gominimal/pkgs"
+branch = "main"
+locked_commit = "fc9feab386409702428705543ff0cd3df6c61082"
+
+[harness]
+use = "rust"
+
+[defaults]
+state_key = "dev"
+
+[tasks.shell]
+interactive = true
+packages = ["base"]
+exec = "bash --noprofile -l"

--- a/crates/minimal/src/cmd_init.rs
+++ b/crates/minimal/src/cmd_init.rs
@@ -1,7 +1,9 @@
 //! Command to initialize a minimal file based on matching the source tree to a valid harness.
 
 use std::io::Write;
+use std::path::PathBuf;
 
+use anyhow::anyhow;
 use common::{SpecOrigin, Target, repo_spec::Repo};
 use graph::Graph;
 use mctx::{Config, Context, Error};
@@ -19,63 +21,77 @@ const DEFAULT_PKGS_BRANCH: &str = "main";
 const FALLBACK_HARNESS: &str = "shell";
 
 pub async fn cmd_init(args: InitArgs, config: Config) -> Result<(), Error> {
+    let mfile_strategy = match config.repo_dir_override() {
+        Some(path) => mctx::MFileSearchStrategy::Override(path.to_path_buf()),
+        _ => mctx::MFileSearchStrategy::CurrentDirOnly,
+    };
     // Harnesses have the match rules, so we need a graph, either from the repo
     // minimal file or some default based on the MPPR.
-    let (upstream_origin, repo_dir, toml_path, graph) = match Context::new(config.clone()) {
-        // We are in a repo where theres a minimal file, and the minimal file has an upstream.
-        // Lets use that upstream. Maybe the user is re-initializing?
-        Ok(mut ctx) if ctx.minimal_file().upstream.is_some() => (
-            ctx.minimal_file()
-                .upstream
-                .as_ref()
-                .unwrap()
-                .as_ref()
-                .as_spec_origin()
-                .unwrap(),
-            ctx.repo_dir().to_path_buf(),
-            ctx.minimal_file().file_path().cloned(),
-            ctx.graph_from_all_packages()?,
-        ),
-        // Unsurprisingly, theres no minimal file yet, or theres no upstream so theres no
-        // useful information. We need the harnesses though for auto-detection, so lets
-        // wire up a default graph.
-        Err(Error::MFile(mfile::Error::NotFound)) | Ok(_) => {
-            let (mut vcs, _cache, stdlib_dir) = Context::sub_setup(&config)?;
-            let (_dir, rev) = vcs.checkout_of(
-                DEFAULT_PKGS,
-                checkouts::GitRef::Branch(DEFAULT_PKGS_BRANCH.to_string()),
-            )?;
+    let (upstream_origin, repo_dir, toml_path, graph) =
+        match Context::new_with_strategy(config.clone(), mfile_strategy) {
+            // We are in a repo where theres a minimal file, and the minimal file has an upstream.
+            // Lets use that upstream. Maybe the user is re-initializing?
+            Ok(mut ctx) if ctx.minimal_file().upstream.is_some() => {
+                let upstream = ctx.minimal_file().upstream.clone().unwrap();
+                let origin = upstream.as_ref().as_spec_origin().ok_or_else(|| {
+                    Error::Other(anyhow!(
+                        "Could not use upstream{} as a spec origin",
+                        ctx.minimal_file()
+                            .file_path()
+                            .map(|p| format!(" from minimal file at {}", p.to_string_lossy()))
+                            .unwrap_or("".into())
+                    ))
+                })?;
+                (
+                    origin,
+                    ctx.repo_dir().to_path_buf(),
+                    ctx.minimal_file().file_path().cloned(),
+                    ctx.graph_from_all_packages()?,
+                )
+            }
+            // Unsurprisingly, theres no minimal file yet, or theres no upstream so theres no
+            // useful information. We need the harnesses though for auto-detection, so lets
+            // wire up a default graph.
+            Err(Error::MFile(mfile::Error::NotFound)) | Ok(_) => {
+                let (mut vcs, _cache, stdlib_dir) = Context::sub_setup(&config)?;
+                let (_dir, rev) = vcs.checkout_of(
+                    DEFAULT_PKGS,
+                    checkouts::GitRef::Branch(DEFAULT_PKGS_BRANCH.to_string()),
+                )?;
 
-            (
-                SpecOrigin::Repo(common::repo_spec::Repo::Git {
-                    url: DEFAULT_PKGS.to_string(),
-                    rev: rev.clone(),
-                    tracking: Some(common::repo_spec::GitRef::Branch(
-                        DEFAULT_PKGS_BRANCH.to_string(),
-                    )),
-                }),
-                config
-                    .repo_dir_override()
-                    .clone()
-                    .unwrap_or_else(|| std::env::current_dir().unwrap()),
-                None,
-                Graph::new_from_chain(
-                    vcs,
-                    &mut (),
-                    LinkConfig::Git {
-                        repo: "https://github.com/gominimal/pkgs".to_string(),
-                        branch: Some("main".to_string()),
-                        locked_commit: Some(rev),
-                    },
-                    stdlib_dir,
-                    Target::host(),
-                )?,
-            )
-        }
-        Err(e) => {
-            return Err(e);
-        }
-    };
+                let repo_dir = match config.repo_dir_override() {
+                    Some(path) => path.to_path_buf(),
+                    _ => std::env::current_dir()
+                        .map_err(|e| Error::IO("Getting current directory", PathBuf::new(), e))?,
+                };
+
+                (
+                    SpecOrigin::Repo(common::repo_spec::Repo::Git {
+                        url: DEFAULT_PKGS.to_string(),
+                        rev: rev.clone(),
+                        tracking: Some(common::repo_spec::GitRef::Branch(
+                            DEFAULT_PKGS_BRANCH.to_string(),
+                        )),
+                    }),
+                    repo_dir,
+                    None,
+                    Graph::new_from_chain(
+                        vcs,
+                        &mut (),
+                        LinkConfig::Git {
+                            repo: DEFAULT_PKGS.to_string(),
+                            branch: Some(DEFAULT_PKGS_BRANCH.to_string()),
+                            locked_commit: Some(rev),
+                        },
+                        stdlib_dir,
+                        Target::host(),
+                    )?,
+                )
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        };
     let toml_path = toml_path.unwrap_or_else(|| repo_dir.join(mfile::MFILE_NAME));
 
     // Apply all predicates, collecting the harness name, any additional build packages, and any additional runtime packages.


### PR DESCRIPTION
## Bugfixes
- The `init` command will no longer look in ancestor directories for an mfile and will just search the current working directory or the override if `-C` is specified

## Refactored finding MFiles
The logic for determining the strategy for finding MFiles was previously hard-coded in `Context::new`. Because we needed different behaviour for `init` vs other commands, this needed to change. I refactored the logic out into an enum called `MFileSearchStrategy` which is used to specify how to find the mfile, allowing individual commands to specify this behaviour when they build their `Context` struct.

The options are:
- `OverrideWithFallback` - previous behaviour and now the default behaviour. Checks a given directory first and falls back to recursively searching ancestors of the current directory
- `OverrideOnly` - Only check the specified override directory (not actually used but included because it took a few seconds)
- `CurrentDirOnly` - Only check the current directory. This is the desired behaviour for the `init` command
- `CurrentDirRecursive` - The fallback behaviour for `OverrideWithFallback`

## Misc. Changes
- Added serial_test as a dev dependency. This was required to run tests that need to change the current working directory serially to avoid race conditions. The crate has over 100 million downloads, is MIT licensed, and is actively maintained with the last release being only 2 months ago
- Changed the `mctx` `Config` build pattern methods that take  `impl Into<PathBuf>` instead of just straight `PathBuf`. This improves the ergonomics as it allows you to pass a `&Path` while preserving the old behavior if you pass a `PathBuf`.
- Implemented `From<mfile::Error> for Error` for `mctx` `Error` as it was missing

## Testing

I added tests for the different MFileSearchStrategy behaviours. I also manually tested that the init command follows the new desired behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selectable minimal-file discovery strategies (override, current-dir only, recursive).
  * New context constructor that accepts an explicit search strategy.

* **Improvements**
  * More flexible path inputs and safer override accessors for repo/stdlib paths.
  * Cleaner, more consistent error propagation when locating or loading files and resolving directories.
  * Safer init flow that surfaces failures instead of panicking.

* **Tests**
  * Added isolated tests validating search behaviors and working-directory safety; included test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->