### PR TITLE
crates/stdlib: define upstream_purl & peer_purl attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4624,7 +4624,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdlib"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "indoc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,4 +114,4 @@ remote-proto = { version = "0.0.1", path = "crates/remote-proto" }
 remote-client = { version = "0.0.1", path = "crates/remote-client" }
 sandbox2 = { version = "0.0.1", path = "crates/sandbox2" }
 
-stdlib = { version = "0.0.13", path = "crates/stdlib" }
+stdlib = { version = "0.0.14", path = "crates/stdlib" }

--- a/crates/decode/src/attrs.rs
+++ b/crates/decode/src/attrs.rs
@@ -279,4 +279,20 @@ mod tests {
 
         assert!(res.is_ok());
     }
+
+    #[test]
+    fn attr_upstream_purl_ok() {
+        let res = Loader::new(
+            "let {Attrs, ..} = import \"minimal.ncl\" in {upstream_purl = \"pkg:npm/foobar@12.3.1?arch=i386&distro=jessie\"} | Attrs",
+            None,
+            &LoadOptions::for_test(),
+        )
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("load failed");
+        })
+        .finish();
+
+        assert!(res.is_ok());
+    }
 }

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stdlib"
-version = "0.0.13"
+version = "0.0.14"
 rust-version = "1.87"
 license = "MIT OR Apache-2.0"
 edition.workspace = true

--- a/crates/stdlib/minimal-ncl/attr_classes.ncl
+++ b/crates/stdlib/minimal-ncl/attr_classes.ncl
@@ -38,7 +38,7 @@ in
 let PURL = std.contract.custom (fun _label value =>
     if std.typeof value != 'String then
         'Error { message = "PURLs must be a string" }
-    else if std.string.is_match m%%"^pkg:(alpm|apk|bitbucket|cargo|cpan|docker|deb|gem|generic|github|golang|huggingface|npm|oci|pypi|rpm|vscode|yocto)/([^@]*)@(?:[^\s]*)$"%% value then
+    else if std.string.is_match m%%"^pkg:(alpm|apk|bitbucket|cargo|cpan|docker|deb|gem|generic|github|golang|huggingface|npm|oci|pypi|rpm|vscode|yocto)/[^\s/@]+(?:/[^\s/@]+)*(?:@[^\s?#]+)?(?:\?[^\s#]*)?(?:#[^\s]*)?$"%% value then
         'Ok value
     else
         'Error { message = "expected PURL string" }

--- a/crates/stdlib/minimal-ncl/attr_classes.ncl
+++ b/crates/stdlib/minimal-ncl/attr_classes.ncl
@@ -35,6 +35,15 @@ let source_provenance_website = {
     downloads_page | String | optional | doc "The web page linking to the latest release or enumerating releases.",
 }
 in
+let PURL = std.contract.custom (fun _label value =>
+    if std.typeof value != 'String then
+        'Error { message = "PURLs must be a string" }
+    else if std.string.is_match m%%"^pkg:(alpm|apk|bitbucket|cargo|cpan|docker|deb|gem|generic|github|golang|huggingface|npm|oci|pypi|rpm|vscode|yocto)/([^@]*)@(?:[^\s]*)$"%% value then
+        'Ok value
+    else
+        'Error { message = "expected PURL string" }
+)
+in
 {
     upstream_version = {
         name = "upstream version",
@@ -73,6 +82,16 @@ in
         name = "spdx license string",
         desc = "The SPDX name of the license the software is covered by. See: https://spdx.org/licenses",
         validate = std.contract.any_of [String, Array String],
+    },
+    upstream_purl = {
+        name = "PURL(s) of the packaged software",
+        desc = "The Package URL describing upstream.",
+        validate = std.contract.any_of [PURL, Array PURL],
+    },
+    peer_purl = {
+        name = "PURL(s) of the software in other package managers",
+        desc = "Package URL(s) of the software within other package managers.",
+        validate = std.contract.any_of [PURL, Array PURL],
     },
 
     env_dir_mappings = {


### PR DESCRIPTION
Defines new attributes to record PURLs relevant to a package, to assist as connective tissue to vulnerability databases.

 * `upstream_purl` - Specifies the purl(s) of the software being packaged. We expect to set this fairly rarely as we can stamp it in automatically based on `source_provenance`.
 * `peer_purl` - Specifies purl(s) which describe this software, but in a different package manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `upstream_purl` and `peer_purl` attributes with Package URL validation; accept single values or arrays and support query parameters.

* **Tests**
  * Added test coverage validating Package URL attributes that include query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->