### PR TITLE
**/Cargo.{lock,toml}: bump versions, MSRV 1.91

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,12 +893,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -917,11 +917,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -942,11 +941,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1033,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
@@ -1645,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1665,7 +1664,8 @@ dependencies = [
 [[package]]
 name = "hakoniwa"
 version = "1.6.0"
-source = "git+https://github.com/souk4711/hakoniwa?branch=main#4ab967f5134038e88468a7381a9161410038d7cb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6361cf8f90dcee65a22616a3eaf289942b536dca4102310b17b60ec7ff23c82"
 dependencies = [
  "bitflags",
  "caps",
@@ -2105,11 +2105,11 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -2525,7 +2525,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3104,9 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -3664,8 +3664,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3686,7 +3686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3774,7 +3774,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3961,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -4160,7 +4160,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4462,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
  "base64",
  "chrono",
@@ -4481,11 +4481,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4560,7 +4560,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4621,9 +4621,9 @@ checksum = "4bb57743b52ea059937169c0061d70298fe2df1d2c988b44caae79dd979d9b49"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "size"
@@ -4943,9 +4943,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -4958,15 +4958,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5927,6 +5927,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5958,11 +5976,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5978,6 +6013,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5988,6 +6029,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6002,10 +6049,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6020,6 +6079,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6030,6 +6095,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6044,6 +6115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6054,6 +6131,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ lto = true
 codegen-units = 1
 
 [workspace.dependencies]
-anyhow = "1.0.100"
+anyhow = "1.0"
 blake3 = { version = "1", features = ["serde"] }
-bytes = "1.11.0" # keep in sync with reqwest
+bytes = "1.11" # keep in sync with reqwest
 bzip2 = "0.6"
 clap = { version = "4.6", features = ["derive", "env", "string"] }
 clap_complete = { version = "4.6" }
@@ -43,16 +43,16 @@ dirs = "6"
 either = { version = "1.15", default-features = false }
 flate2 = "1.1"
 futures = "0.3"
-generational-arena = {version = "^0.2", features = ["serde"] }
+generational-arena = {version = "0.2", features = ["serde"] }
 google-cloud-gax = "1.4"
 google-cloud-auth = "1.3"
 google-cloud-storage = "1.5"
-hakoniwa = { git = "https://github.com/souk4711/hakoniwa", branch = "main", features = ["cgroups"] }
+hakoniwa = { version = "1.6", features = ["cgroups"] }
 http-body = "1"
 hex = "0.4"
 indicatif = "0.18"
 indoc = "^2.0"
-jaq-all = "0.1.0-beta"
+jaq-all = "0.1.0"
 lzma-rs = "0.3"
 
 # Revert back to crates.io dep once 0.18 is released.
@@ -60,13 +60,13 @@ nickel-lang-core = { git = "https://github.com/nickel-lang/nickel.git", rev = "3
 
 
 object = { version = "0.39", default-features = false, features = ["archive", "elf", "read_core", "std"] }
-oci-spec = "0.9.0"
-path-absolutize = "^3.1"
+oci-spec = "0.9"
+path-absolutize = "3.1"
 rand = "0.10"
-rayon = "1.11"
+rayon = "1.12"
 regex = "1" # keep in sync with nickel-lang-core
 reqwest = { version = "0.13", features = ["stream"], default-features = false } # keep in sync with google-cloud-gax
-rustc-hash = "2.1.1"
+rustc-hash = "2.1.2"
 serde = { version = "1.0", features = ["derive", "rc"] } # Keep within the same minor version as nickel-lang-core
 prost = "0.14"
 prost-build = "0.14"
@@ -79,15 +79,15 @@ shlex = "1.3"
 size = "0.5"
 smallvec = {version = "1.15", features = ["serde"]}
 tar = "0.4"
-tempfile = "3.23"
+tempfile = "3.27"
 tokio = { version = "1.52", features = ["full"] }
 tokio-stream = "0.1"
 tokio-util = "0.7"
 toml = "1.1"
 toml_edit = "0.25"
-tonic = "0.14.2"
-tonic-prost = "0.14.2"
-tonic-prost-build = "0.14.2"
+tonic = "0.14.5"
+tonic-prost = "0.14.5"
+tonic-prost-build = "0.14.5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 url = "2" # keep in sync with reqwest

--- a/crates/args/Cargo.toml
+++ b/crates/args/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "args"
 version = "0.0.1"
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true

--- a/crates/checkouts/Cargo.toml
+++ b/crates/checkouts/Cargo.toml
@@ -2,7 +2,7 @@
 name = "checkouts"
 version = "0.0.1"
 edition.workspace = true
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 publish.workspace = true
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "common"
 version = "0.0.1"
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -553,20 +553,20 @@ fn get_cgroup_limit_gb() -> Option<f64> {
     // cgroup v2
     if let Ok(content) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
         let trimmed = content.trim();
-        if trimmed != "max" {
-            if let Ok(bytes) = trimmed.parse::<u64>() {
-                return Some(bytes as f64 / 1_073_741_824.0);
-            }
+        if trimmed != "max"
+            && let Ok(bytes) = trimmed.parse::<u64>()
+        {
+            return Some(bytes as f64 / 1_073_741_824.0);
         }
     }
 
     // cgroup v1
-    if let Ok(content) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes") {
-        if let Ok(bytes) = content.trim().parse::<u64>() {
-            // v1 reports a huge sentinel value (near u64::MAX) when unlimited
-            if bytes < u64::MAX / 2 {
-                return Some(bytes as f64 / 1_073_741_824.0);
-            }
+    if let Ok(content) = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+        && let Ok(bytes) = content.trim().parse::<u64>()
+    {
+        // v1 reports a huge sentinel value (near u64::MAX) when unlimited
+        if bytes < u64::MAX / 2 {
+            return Some(bytes as f64 / 1_073_741_824.0);
         }
     }
 

--- a/crates/decode/Cargo.toml
+++ b/crates/decode/Cargo.toml
@@ -2,7 +2,7 @@
 name = "decode"
 version = "0.0.1"
 edition.workspace = true
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 publish.workspace = true
 

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -117,14 +117,14 @@ impl Layer {
     pub fn new<P: AsRef<Path>>(layer_dir: P, opts: &LoadOptions) -> Result<Self, Error> {
         let (upstream, params, config_dir) = match mfile::File::from_dir(layer_dir.as_ref()) {
             Ok(mfile) => {
-                if let Some(min_vers) = &mfile.stdlib.minimum_version {
-                    if stdlib::outdated(min_vers) {
-                        return Err(Error::StdlibOutdated {
-                            need_version: min_vers.to_string(),
-                            needed_by: layer_dir.as_ref().to_str().unwrap().to_string(),
-                            current_version: stdlib::VERSION.to_string(),
-                        });
-                    }
+                if let Some(min_vers) = &mfile.stdlib.minimum_version
+                    && stdlib::outdated(min_vers)
+                {
+                    return Err(Error::StdlibOutdated {
+                        need_version: min_vers.to_string(),
+                        needed_by: layer_dir.as_ref().to_str().unwrap().to_string(),
+                        current_version: stdlib::VERSION.to_string(),
+                    });
                 }
 
                 (

--- a/crates/decode/src/load.rs
+++ b/crates/decode/src/load.rs
@@ -333,26 +333,18 @@ impl Loader {
                         }
                     });
 
-                    if is_buildspec {
-                        if let Some(inner_term) = annotation_data.inner.as_term() {
-                            let annotated =
-                                Term::Annotated(nickel_lang_core::term::AnnotatedData {
-                                    annot: annotation_data.annot.clone(),
-                                    inner: annotate_record!(
-                                        inner_term.clone(),
-                                        buildspec_id_ident,
-                                        id,
-                                        val,
-                                        (
-                                            &annotation_data.inner,
-                                            &files,
-                                            &pos_table,
-                                            minimal_lib_path
-                                        ),
-                                    ),
-                                });
-                            return Ok(NickelValue::term(annotated, val.pos_idx()));
-                        }
+                    if is_buildspec && let Some(inner_term) = annotation_data.inner.as_term() {
+                        let annotated = Term::Annotated(nickel_lang_core::term::AnnotatedData {
+                            annot: annotation_data.annot.clone(),
+                            inner: annotate_record!(
+                                inner_term.clone(),
+                                buildspec_id_ident,
+                                id,
+                                val,
+                                (&annotation_data.inner, &files, &pos_table, minimal_lib_path),
+                            ),
+                        });
+                        return Ok(NickelValue::term(annotated, val.pos_idx()));
                     }
                 }
 
@@ -363,20 +355,18 @@ impl Loader {
                         Some(Term::Var(v)) if v.label() == "build"
                     );
 
-                    if is_build_decl {
-                        if let Some(arg_term) = app_data.arg.as_term() {
-                            let app = Term::App(nickel_lang_core::term::AppData {
-                                head: app_data.head.clone(),
-                                arg: annotate_record!(
-                                    arg_term.clone(),
-                                    buildspec_id_ident,
-                                    id,
-                                    val,
-                                    (&app_data.arg, &files, &pos_table, minimal_lib_path),
-                                ),
-                            });
-                            return Ok(NickelValue::term(app, val.pos_idx()));
-                        }
+                    if is_build_decl && let Some(arg_term) = app_data.arg.as_term() {
+                        let app = Term::App(nickel_lang_core::term::AppData {
+                            head: app_data.head.clone(),
+                            arg: annotate_record!(
+                                arg_term.clone(),
+                                buildspec_id_ident,
+                                id,
+                                val,
+                                (&app_data.arg, &files, &pos_table, minimal_lib_path),
+                            ),
+                        });
+                        return Ok(NickelValue::term(app, val.pos_idx()));
                     }
                 }
             }

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graph"
 version = "0.0.1"
 edition.workspace = true
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 publish.workspace = true
 

--- a/crates/graph/src/planner.rs
+++ b/crates/graph/src/planner.rs
@@ -257,13 +257,13 @@ fn make_reachable<BP: BinProvider>(
         );
         if path.contains(bsr) {
             // We've found a cycle! eagerly bring in cycle breaker if there is one.
-            if let Some(cycle_breaker) = build.replace_on_cycle {
-                if !builds.contains_key(&cycle_breaker) {
-                    path.push(*bsr);
-                    let result = make_reachable(&cycle_breaker, graph, bin_provider, builds, path);
-                    path.pop();
-                    result?;
-                }
+            if let Some(cycle_breaker) = build.replace_on_cycle
+                && !builds.contains_key(&cycle_breaker)
+            {
+                path.push(*bsr);
+                let result = make_reachable(&cycle_breaker, graph, bin_provider, builds, path);
+                path.pop();
+                result?;
             }
         }
 
@@ -388,14 +388,11 @@ impl<'a, BP: BinProvider> ExecPlan<'a, BP> {
                     });
                 }
 
-                if cycle_breakers_allowed {
-                    if let Some(cycle_breaker) = info.cycle_breaker.as_ref() {
-                        // NOTE: For a cycle breaker that wasn't reached in make_reachable,
-                        // there may not be an entry in self.builds - so we can't just consult that.
-                        if let Some(res) = self.dep_candidate(cycle_breaker, cycle_breakers_allowed)
-                        {
-                            return Some(res.with_breaker_for(Some(*dependency)));
-                        }
+                if cycle_breakers_allowed && let Some(cycle_breaker) = info.cycle_breaker.as_ref() {
+                    // NOTE: For a cycle breaker that wasn't reached in make_reachable,
+                    // there may not be an entry in self.builds - so we can't just consult that.
+                    if let Some(res) = self.dep_candidate(cycle_breaker, cycle_breakers_allowed) {
+                        return Some(res.with_breaker_for(Some(*dependency)));
                     }
                 }
                 None
@@ -719,24 +716,24 @@ impl<'a, BP: BinProvider> Iterator for ExecPlan<'a, BP> {
             for path in &cycles {
                 let (first, last) = (path.first().unwrap(), path.last().unwrap());
                 for cycle in &[first, last] {
-                    if let Some(cycle_breaker) = self.graph.get(cycle).unwrap().replace_on_cycle {
-                        if !self.builds.contains_key(&cycle_breaker) {
-                            let mut path = Vec::new();
-                            // We found a new cycle breaker we haven't brought into the fray yet.
-                            make_reachable(
-                                &cycle_breaker,
-                                self.graph,
-                                &mut self.bin_provider,
-                                &mut self.builds,
-                                &mut path,
-                            )
-                            .unwrap();
-                            // self.builds
-                            //     .get_mut(&cycle_breaker)
-                            //     .unwrap()
-                            //     .cycle_breaker_of = Some(**cycle);
-                            added_cycle_breaker = true;
-                        }
+                    if let Some(cycle_breaker) = self.graph.get(cycle).unwrap().replace_on_cycle
+                        && !self.builds.contains_key(&cycle_breaker)
+                    {
+                        let mut path = Vec::new();
+                        // We found a new cycle breaker we haven't brought into the fray yet.
+                        make_reachable(
+                            &cycle_breaker,
+                            self.graph,
+                            &mut self.bin_provider,
+                            &mut self.builds,
+                            &mut path,
+                        )
+                        .unwrap();
+                        // self.builds
+                        //     .get_mut(&cycle_breaker)
+                        //     .unwrap()
+                        //     .cycle_breaker_of = Some(**cycle);
+                        added_cycle_breaker = true;
                     }
                 }
             }

--- a/crates/graph/src/spec_hasher.rs
+++ b/crates/graph/src/spec_hasher.rs
@@ -226,15 +226,15 @@ fn build_attrs_hash(spec: &BuildSpec, h: &mut Hasher) {
     for cmd in &spec.cmds {
         cmd.iter().for_each(|e| h.write_all(e.as_bytes()).unwrap());
     }
-    if let Some(build_args) = &spec.build_args {
-        if !build_args.is_empty() {
-            h.write_all(b"-build args").unwrap();
-            for (name, value) in build_args.iter() {
-                h.write_all(b"k").unwrap();
-                h.write_all(name.as_bytes()).unwrap();
-                h.write_all(b"v").unwrap();
-                h.write_all(value.as_bytes()).unwrap();
-            }
+    if let Some(build_args) = &spec.build_args
+        && !build_args.is_empty()
+    {
+        h.write_all(b"-build args").unwrap();
+        for (name, value) in build_args.iter() {
+            h.write_all(b"k").unwrap();
+            h.write_all(name.as_bytes()).unwrap();
+            h.write_all(b"v").unwrap();
+            h.write_all(value.as_bytes()).unwrap();
         }
     }
 

--- a/crates/lcache/Cargo.toml
+++ b/crates/lcache/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lcache"
 version = "0.0.1"
 edition.workspace = true
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 publish.workspace = true
 

--- a/crates/lcache/src/lib.rs
+++ b/crates/lcache/src/lib.rs
@@ -172,10 +172,10 @@ impl<FS: FileSystem> CacheInner<FS> {
         })
     }
     fn record_access(&self, hash: &SpecHash) {
-        if let Some(t) = &self.read_tracker {
-            if let Err(e) = t.as_ref().lock().unwrap().record_read(hash) {
-                tracing::warn!("Error flushing read tracker: {}", e);
-            }
+        if let Some(t) = &self.read_tracker
+            && let Err(e) = t.as_ref().lock().unwrap().record_read(hash)
+        {
+            tracing::warn!("Error flushing read tracker: {}", e);
         }
     }
 }

--- a/crates/mctx/Cargo.toml
+++ b/crates/mctx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mctx"
 version = "0.0.1"
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -99,18 +99,18 @@ impl EnvChannel<'_> {
             }
         }
         for bsr in transitives.keys() {
-            if self.has_packages.insert(*bsr) {
-                if let Err(e) = common::hardlink_dir_contents(
+            if self.has_packages.insert(*bsr)
+                && let Err(e) = common::hardlink_dir_contents(
                     self.ctx
                         .cache
                         .read_dir(&new_graph.spec_hash(bsr))
                         .unwrap()
                         .path(),
                     rootfs,
-                ) {
-                    writeln!(stream, "error: {}", e).ok();
-                    return;
-                }
+                )
+            {
+                writeln!(stream, "error: {}", e).ok();
+                return;
             }
         }
         writeln!(
@@ -462,14 +462,14 @@ impl sandbox2::Channel for EnvChannel<'_> {
             }
         };
 
-        if let Some((add_mode, pkgs)) = add_dep {
-            if let Err(e) = self.ctx.add_deps(
+        if let Some((add_mode, pkgs)) = add_dep
+            && let Err(e) = self.ctx.add_deps(
                 self.graph,
                 pkgs.into_iter().map(|a| a.1).collect::<Vec<_>>(),
                 add_mode,
-            ) {
-                writeln!(stream, "error: {}", e).ok();
-            }
+            )
+        {
+            writeln!(stream, "error: {}", e).ok();
         }
     }
 }

--- a/crates/mfile/Cargo.toml
+++ b/crates/mfile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mfile"
 version = "0.0.1"
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -89,11 +89,11 @@ impl LinkConfig {
     }
 
     fn fixup_relative<P: AsRef<Path>>(&mut self, mfile_path: P) {
-        if let (LinkConfig::Dir { dir }, Some(parent_dir)) = (self, mfile_path.as_ref().parent()) {
-            if !dir.starts_with("/") {
-                let new = parent_dir.join(&dir);
-                *dir = new.to_str().unwrap().to_string();
-            }
+        if let (LinkConfig::Dir { dir }, Some(parent_dir)) = (self, mfile_path.as_ref().parent())
+            && !dir.starts_with("/")
+        {
+            let new = parent_dir.join(&dir);
+            *dir = new.to_str().unwrap().to_string();
         }
     }
 }

--- a/crates/multi/Cargo.toml
+++ b/crates/multi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multi"
 version = "0.0.1"
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true

--- a/crates/op/Cargo.toml
+++ b/crates/op/Cargo.toml
@@ -2,7 +2,7 @@
 name = "op"
 version = "0.0.1"
 edition.workspace = true
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 publish.workspace = true
 

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "orchestrator"
 version = "0.0.1"
 edition.workspace = true
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 publish.workspace = true
 

--- a/crates/ot/Cargo.toml
+++ b/crates/ot/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ot"
 version = "0.0.1"
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true

--- a/crates/rcache/Cargo.toml
+++ b/crates/rcache/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rcache"
 version = "0.0.1"
 edition.workspace = true
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 publish.workspace = true
 

--- a/crates/rcache/src/remote_writer.rs
+++ b/crates/rcache/src/remote_writer.rs
@@ -157,14 +157,13 @@ impl<S: StubStorage + 'static> RemoteCacheWriter<S> {
             )
             .send()
             .await
+            && stat.object().size > 1024 * 1024
         {
-            if stat.object().size > 1024 * 1024 {
-                // Object already exists and is large enough to be real, skip the upload.
-                // We still push to the pending-set because while this tarball may exist,
-                // its likely not wired to this spec hash.
-                self.pending.push((spec_hash.clone(), sha256));
-                return Ok(false);
-            }
+            // Object already exists and is large enough to be real, skip the upload.
+            // We still push to the pending-set because while this tarball may exist,
+            // its likely not wired to this spec hash.
+            self.pending.push((spec_hash.clone(), sha256));
+            return Ok(false);
         }
 
         self.backend

--- a/crates/remote-client/Cargo.toml
+++ b/crates/remote-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "remote-client"
 version = "0.0.1"
 edition.workspace = true
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 publish.workspace = true
 

--- a/crates/remote-proto/Cargo.toml
+++ b/crates/remote-proto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "remote-proto"
 version = "0.0.1"
 edition.workspace = true
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 publish.workspace = true
 

--- a/crates/sandbox2/Cargo.toml
+++ b/crates/sandbox2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sandbox2"
 version = "0.0.1"
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -71,14 +71,14 @@ impl<C: Channel> Drop for Sandbox<C> {
             drop(stderr);
         }
 
-        if !self.keep_dir {
-            if let Err(e) = common::remove_dir_all(&self.base_dir) {
-                tracing::warn!(
-                    "Failed cleanup for sandbox at path {}: {}",
-                    self.base_dir.display(),
-                    e,
-                );
-            }
+        if !self.keep_dir
+            && let Err(e) = common::remove_dir_all(&self.base_dir)
+        {
+            tracing::warn!(
+                "Failed cleanup for sandbox at path {}: {}",
+                self.base_dir.display(),
+                e,
+            );
         }
     }
 }

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stdlib"
 version = "0.0.14"
-rust-version = "1.87"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped many workspace dependencies to newer versions and switched one dependency to its crates.io release.
  * Raised the minimum Rust toolchain across crates to 1.91 for improved compiler compatibility.

* **Refactor**
  * Internal code flow and formatting refined in multiple components with no change to public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->