### PR TITLE
chore: install agent contract and chore workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report something that is not working in minimal
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+<!-- Provenance: sourced from norrietaylor/minimal-vm-mac (PoC fork, MIT). Parameterized for minimal. -->
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include error output, stack traces, or logs if available.
+
+## Environment
+
+- Repo: minimal
+- OS:
+- Version / commit:
+
+## Additional Context
+
+Add any other context, screenshots, or links that might help diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -33,5 +33,7 @@ If this chore was opened by an agent, it will carry one of:
 - `agent:doc-drift`
 - `agent:coverage`
 - `agent:dep-drift`
+- `agent:api-drift`
+- `agent:not-gating-audit`
 
 See `AGENTS.md` for the full agent contract.

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,37 @@
+---
+name: Chore
+about: Maintenance task, refactor, or internal improvement for minimal
+title: "chore: "
+labels: chore
+assignees: ""
+---
+
+<!-- Provenance: sourced from norrietaylor/minimal-vm-mac (PoC fork, MIT). Parameterized for minimal. -->
+
+## Summary
+
+A concise description of the maintenance task or internal improvement.
+
+## Context
+
+Why does this need to happen now? Is there a deadline, dependency, or risk driving this?
+
+## Scope of Changes
+
+List the files, systems, or areas affected.
+
+## Definition of Done
+
+- [ ]
+- [ ]
+- [ ]
+
+## Agent Label (if applicable)
+
+If this chore was opened by an agent, it will carry one of:
+
+- `agent:doc-drift`
+- `agent:coverage`
+- `agent:dep-drift`
+
+See `AGENTS.md` for the full agent contract.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,35 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement for minimal
+title: "feat: "
+labels: feature
+assignees: ""
+---
+
+<!-- Provenance: sourced from norrietaylor/minimal-vm-mac (PoC fork, MIT). Parameterized for minimal. -->
+
+## Summary
+
+A concise description of the feature or enhancement.
+
+## Motivation
+
+Why is this needed? What problem does it solve? What value does it provide?
+
+## Proposed Solution
+
+Describe the change you would like to see. Include API sketches, workflow diagrams, or examples if helpful.
+
+## Alternatives Considered
+
+List any alternative approaches you considered and why you rejected them.
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Additional Context
+
+Add any other context, references, or links here.

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,0 +1,32 @@
+---
+name: Feedback
+about: General feedback, observations, or suggestions for minimal
+title: "feedback: "
+labels: feedback
+assignees: ""
+---
+
+<!-- Provenance: sourced from norrietaylor/minimal-vm-mac (PoC fork, MIT). Parameterized for minimal. -->
+
+## Feedback
+
+Share your observation, suggestion, or reaction here. No particular format required.
+
+## Source
+
+Where did this feedback originate? (Slack channel, user interview, internal review, etc.)
+
+## Who is Affected
+
+Describe who would benefit from acting on this feedback.
+
+## Priority Suggestion
+
+- [ ] Must have
+- [ ] Should have
+- [ ] Nice to have
+- [ ] Unscored
+
+## Additional Context
+
+Any supporting context, links, or screenshots.

--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,0 +1,19 @@
+# .github/agents/
+
+<!-- Provenance: sourced from norrietaylor/minimal-vm-mac (PoC fork, MIT). -->
+
+This directory holds agent definition files (`.md`) for `gh-aw` chores running in this repo.
+
+## Adding an Agent
+
+1. Create a new `.md` file in this directory (e.g., `doc-drift.md`).
+2. Use `gh aw compile` to compose the prompt from fragments in `gominimal/min-aw/gh-aw-fragments/`.
+3. Reference the agent from the corresponding workflow in `.github/workflows/`.
+
+## Fragment Pattern
+
+Agent definitions import shared fragments by reference. Do not copy fragment content here. Edit fragments upstream in `gominimal/min-aw/gh-aw-fragments/` and let `gh aw compile` resolve them at runtime.
+
+## Active Agents
+
+See `AGENTS.md` at the repo root for the full list of active agents, their triggers, and permitted actions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,39 @@
+# Copilot Instructions: minimal
+
+<!-- Provenance: sourced from norrietaylor/minimal-vm-mac (PoC fork, MIT). Repo-specific bits stripped and parameterized for installation by scripts/quick-setup.sh. -->
+
+## Repository Context
+
+This is **minimal**, a Rust project in the Minimal monorepo ecosystem. Agentic workflows for this repo are orchestrated via `gh-aw` and pull shared context from `gominimal/min-aw/gh-aw-fragments/`.
+
+## Fragment Import Pattern
+
+Agent prompts are composed from shared fragments using `gh aw compile`. Each fragment is stored in `gominimal/min-aw/gh-aw-fragments/`. When writing or reviewing agent prompts for this repo, import fragments by reference:
+
+```yaml
+# In a .github/agents/*.md agent definition:
+# gh aw compile imports these fragments automatically:
+#   - gh-aw-fragments/rigor.md
+#   - gh-aw-fragments/formatting.md
+#   - gh-aw-fragments/safe-output-create-issue.md
+#   - gh-aw-fragments/repo-conventions.md
+#   - gh-aw-fragments/minimal-tools.md
+#   - gh-aw-fragments/runtime-setup.md
+```
+
+Do not copy fragment content into agent definitions. Edit fragments upstream.
+
+## Code Conventions
+
+- Primary language: **Rust**
+- Follow conventions documented in any `CLAUDE.md` at the repo root or in relevant subdirectories. `CLAUDE.md` is the canonical doc surface for agent context.
+- Prefer existing patterns over introducing new ones.
+- Shell scripts use `set -euo pipefail` and `bash`.
+
+## Agent Contract
+
+Active agents, their permitted actions, and the label taxonomy are documented in `AGENTS.md` at the repo root. Agents do not gate merges; branch protection depends only on Minimal CI.
+
+## Not a Merge Gate
+
+`gh-aw` workflows are **not** required CI checks. No agent failure can block a PR merge. See `gominimal/min-aw/decisions/0001-not-gating.md` for the full ADR.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -20,6 +20,14 @@
   color: "0e8a16"
   description: "Marks a PR eligible for agent-assisted auto-merge"
 
+- name: "agent:api-drift"
+  color: "fbca04"
+  description: "Opened or updated by the api-surface-drift agent"
+
+- name: "agent:not-gating-audit"
+  color: "c5def5"
+  description: "Opened or updated by the not-gating-audit agent"
+
 - name: "worker-tuning"
   color: "e99695"
   description: "Tuning issue for the chore-issue worker (Phase E1 R4.4 negative-case escalation). Note: not in the agent:* taxonomy because it's a meta-label about worker behavior, not a chore-output category. The agent: prefix is reserved for chore-output labels (agent:doc-drift, agent:coverage, agent:dep-drift, agent:auto-merge, agent:not-gating-audit, agent:api-drift)."

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,58 @@
+# .github/labels.yml
+# Provenance: sourced from norrietaylor/minimal-vm-mac (PoC fork, MIT).
+# Repo-specific bits stripped for installation by scripts/quick-setup.sh.
+# Managed by gominimal/min-aw. Edit upstream; do not modify locally.
+
+# Agent labels - used by chore workflows to tag issues and PRs they own
+- name: "agent:doc-drift"
+  color: "0075ca"
+  description: "Opened or updated by the doc-drift agent"
+
+- name: "agent:coverage"
+  color: "e4e669"
+  description: "Opened or updated by the coverage agent"
+
+- name: "agent:dep-drift"
+  color: "d73a4a"
+  description: "Opened or updated by the dep-drift agent"
+
+- name: "agent:auto-merge"
+  color: "0e8a16"
+  description: "Marks a PR eligible for agent-assisted auto-merge"
+
+- name: "worker-tuning"
+  color: "e99695"
+  description: "Tuning issue for the chore-issue worker (Phase E1 R4.4 negative-case escalation). Note: not in the agent:* taxonomy because it's a meta-label about worker behavior, not a chore-output category. The agent: prefix is reserved for chore-output labels (agent:doc-drift, agent:coverage, agent:dep-drift, agent:auto-merge, agent:not-gating-audit, agent:api-drift)."
+
+# Standard triage labels
+- name: "bug"
+  color: "d73a4a"
+  description: "Something is not working"
+
+- name: "feature"
+  color: "a2eeef"
+  description: "New feature or enhancement request"
+
+- name: "chore"
+  color: "e4e669"
+  description: "Maintenance task or internal improvement"
+
+- name: "feedback"
+  color: "cfd3d7"
+  description: "General feedback from users or stakeholders"
+
+- name: "good first issue"
+  color: "7057ff"
+  description: "Good for newcomers"
+
+- name: "help wanted"
+  color: "008672"
+  description: "Extra attention is needed"
+
+- name: "wontfix"
+  color: "ffffff"
+  description: "This will not be worked on"
+
+- name: "duplicate"
+  color: "cfd3d7"
+  description: "This issue or pull request already exists"

--- a/.github/workflows/sync-from-source-of-truth.yml
+++ b/.github/workflows/sync-from-source-of-truth.yml
@@ -1,0 +1,148 @@
+# .github/workflows/sync-from-source-of-truth.yml
+# Provenance: sourced from gominimal/min-aw.
+# Repo-specific bits stripped for installation by scripts/quick-setup.sh.
+# Managed by gominimal/min-aw. Edit upstream; do not modify locally.
+#
+# Syncs all workflows/ sources from gominimal/min-aw including:
+#   docs-patrol.md, test-coverage-detector.md, dependency-review.md,
+#   trivial-dep-bump.md, not-gating-audit.md, route.md, worker-fix.md
+# New workflow sources are picked up automatically by sync-workflows.sh.
+
+name: Sync workflows from source of truth
+
+on:
+  schedule:
+    # Weekly on Monday at 00:00 UTC
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: 'Source ref to sync workflows from. Must be a pinned tag (e.g. v1.2.3) or full 40-char SHA — branch names like main are explicitly rejected.'
+        required: false
+        # Default is substituted by quick-setup.sh at install time. Operator
+        # bumps it via PR or by re-running quick-setup with a newer
+        # --source-ref. Manual dispatch can override per-run.
+        default: 'v0.2.4'
+        type: string
+
+jobs:
+  sync-workflows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+
+      - name: Preflight App config
+        id: app_config
+        env:
+          APP_ID: ${{ vars.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          # Graceful no-op when the gominimal-aw-bot App is not yet configured.
+          # Same pattern as worker-fix.yml. The source-of-truth repo
+          # (gominimal/min-aw) is private; anonymous raw fetches will 404.
+          # The App-minted token grants read access on the source-of-truth so
+          # the script + lock files can be downloaded.
+          if [[ -z "${APP_ID}" || -z "${APP_PRIVATE_KEY}" ]]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "sync-from-source-of-truth: APP_ID or APP_PRIVATE_KEY not set; no-op."
+            echo "Configure the gominimal-aw-bot App per docs/rollout/01-org-secrets.md."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mint App token (read on source-of-truth)
+        if: steps.app_config.outputs.available == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Owner with no repositories: scopes the token to every repo the App
+          # is installed on under gominimal. The sync needs read on the
+          # source-of-truth (raw fetch) and write on the running repo (commit
+          # synced workflows + open PR). Both fall under the App's installation
+          # set; an unscoped owner token is the minimum that covers both
+          # without coupling the template to the source-of-truth repo's name.
+          owner: gominimal
+
+      - name: Set source ref
+        if: steps.app_config.outputs.available == 'true'
+        id: source
+        run: |
+          # Resolution order:
+          # 1. workflow_dispatch input (operator override per-run)
+          # 2. workflow_call default (v0.2.4, substituted by quick-setup
+          #    at install time, bumped via PR thereafter)
+          SOURCE_REF="${{ github.event.inputs.source_ref || 'v0.2.4' }}"
+
+          # Fail loudly if quick-setup didn't substitute the token (i.e. the
+          # template was committed unsubstituted). Catches install-time
+          # regressions where the operator runs the script with a broken
+          # token-substitution path.
+          if [[ "${SOURCE_REF}" == "v0.2.4" ]]; then
+            echo "ERROR: source_ref default still holds the unsubstituted token." >&2
+            echo "Re-run scripts/quick-setup.sh from the source-of-truth repo to fix." >&2
+            exit 1
+          fi
+
+          # Immutability: source_ref must be a pinned tag (vN.N.N pattern) or
+          # full 40-char SHA. Branch names (main, master, dev) are rejected
+          # because they're mutable and the workflow fetches+executes remote
+          # content using them as a ref.
+          if [[ ! "${SOURCE_REF}" =~ ^[0-9a-f]{40}$ ]] && \
+             [[ ! "${SOURCE_REF}" =~ ^v?[0-9]+(\.[0-9]+){1,2}([.-][0-9A-Za-z._-]+)?$ ]]; then
+            echo "ERROR: source_ref must be a pinned tag (e.g. v1.2.3) or full 40-char SHA." >&2
+            echo "Got: '${SOURCE_REF}'. Branch names are not accepted." >&2
+            exit 1
+          fi
+
+          echo "ref=${SOURCE_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch sync-workflows.sh from source of truth
+        if: steps.app_config.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          SOURCE_REF="${{ steps.source.outputs.ref }}"
+          SYNC_SCRIPT_URL="https://raw.githubusercontent.com/gominimal/min-aw/${SOURCE_REF}/scripts/sync-workflows.sh"
+
+          # Authenticated fetch: source-of-truth is private; raw URLs require
+          # bearer-auth via the App token. Anonymous curl 404s.
+          curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "${SYNC_SCRIPT_URL}" -o sync-workflows.sh
+
+          # Checksum verification (optional but recommended for supply-chain hardening).
+          # Set the SYNC_SCRIPT_SHA256 repository variable to the expected sha256 hash
+          # of sync-workflows.sh at the pinned ref. If the variable is unset the step
+          # logs a warning and proceeds for back-compat; if set and mismatched it exits.
+          EXPECTED_SHA="${{ vars.SYNC_SCRIPT_SHA256 }}"
+          if [[ -n "${EXPECTED_SHA}" ]]; then
+            ACTUAL_SHA="$(sha256sum sync-workflows.sh | awk '{print $1}')"
+            if [[ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]]; then
+              echo "ERROR: sync-workflows.sh checksum mismatch." >&2
+              echo "  expected: ${EXPECTED_SHA}" >&2
+              echo "  actual:   ${ACTUAL_SHA}" >&2
+              exit 1
+            fi
+            echo "Checksum verified: ${ACTUAL_SHA}"
+          else
+            echo "WARN: SYNC_SCRIPT_SHA256 repository variable is not set. Skipping checksum verification." >&2
+            echo "Set the variable to the sha256 of sync-workflows.sh at the pinned ref to enable verification."
+          fi
+
+          chmod +x sync-workflows.sh
+
+      - name: Run sync-workflows.sh
+        if: steps.app_config.outputs.available == 'true'
+        run: |
+          SOURCE_REF="${{ steps.source.outputs.ref }}"
+          ./sync-workflows.sh --source-ref "${SOURCE_REF}"
+        env:
+          # The script fetches additional files from the private source-of-truth
+          # using GH_TOKEN, then commits + pushes synced workflows back to the
+          # running repo. The App token covers both reads and writes.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/sync-from-source-of-truth.yml
+++ b/.github/workflows/sync-from-source-of-truth.yml
@@ -22,7 +22,7 @@ on:
         # Default is substituted by quick-setup.sh at install time. Operator
         # bumps it via PR or by re-running quick-setup with a newer
         # --source-ref. Manual dispatch can override per-run.
-        default: 'v0.2.4'
+        default: 'v0.2.5'
         type: string
 
 jobs:
@@ -75,28 +75,23 @@ jobs:
         run: |
           # Resolution order:
           # 1. workflow_dispatch input (operator override per-run)
-          # 2. workflow_call default (v0.2.4, substituted by quick-setup
+          # 2. workflow_call default (v0.2.5, substituted by quick-setup
           #    at install time, bumped via PR thereafter)
-          SOURCE_REF="${{ github.event.inputs.source_ref || 'v0.2.4' }}"
+          SOURCE_REF="${{ github.event.inputs.source_ref || 'v0.2.5' }}"
 
-          # Fail loudly if quick-setup didn't substitute the token (i.e. the
-          # template was committed unsubstituted). Catches install-time
-          # regressions where the operator runs the script with a broken
-          # token-substitution path.
-          if [[ "${SOURCE_REF}" == "v0.2.4" ]]; then
-            echo "ERROR: source_ref default still holds the unsubstituted token." >&2
-            echo "Re-run scripts/quick-setup.sh from the source-of-truth repo to fix." >&2
-            exit 1
-          fi
-
-          # Immutability: source_ref must be a pinned tag (vN.N.N pattern) or
-          # full 40-char SHA. Branch names (main, master, dev) are rejected
-          # because they're mutable and the workflow fetches+executes remote
-          # content using them as a ref.
+          # Immutability + substitution-check in one regex pair. source_ref
+          # must be a pinned tag (vN.N.N pattern) or full 40-char SHA. Branch
+          # names (main, master, dev) and the unsubstituted 'v0.2.5'
+          # token both fail this check. A separate unsubstituted-token guard
+          # used to live above, but quick-setup.sh substitutes 'v0.2.5'
+          # globally including inside that guard's literal — which made the
+          # guard self-rejecting post-substitution. Dropped; the regex below
+          # catches the same condition correctly.
           if [[ ! "${SOURCE_REF}" =~ ^[0-9a-f]{40}$ ]] && \
              [[ ! "${SOURCE_REF}" =~ ^v?[0-9]+(\.[0-9]+){1,2}([.-][0-9A-Za-z._-]+)?$ ]]; then
             echo "ERROR: source_ref must be a pinned tag (e.g. v1.2.3) or full 40-char SHA." >&2
-            echo "Got: '${SOURCE_REF}'. Branch names are not accepted." >&2
+            echo "Got: '${SOURCE_REF}'. Branch names and the unsubstituted 'v0.2.5' token are not accepted." >&2
+            echo "If you see the literal token, re-run scripts/quick-setup.sh from gominimal/min-aw at a pinned ref." >&2
             exit 1
           fi
 

--- a/.github/workflows/worker-fix.yml
+++ b/.github/workflows/worker-fix.yml
@@ -1,0 +1,130 @@
+# .github/workflows/worker-fix.yml
+# Provenance: sourced from gominimal/min-aw.
+# Thin caller for the worker-fix chore-issue worker. References the canonical
+# worker-fix.md source at a pinned source_ref; do not inline worker logic here.
+# Managed by gominimal/min-aw. Edit upstream; do not modify locally.
+
+name: Worker fix
+
+on:
+  schedule:
+    # Daily 12:00 UTC. Internal trigger only. No comment-triggered path.
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: 'Source ref (full 40-char commit SHA only — tags rejected for immutability) for worker-fix.md. Optional; falls back to vars.WORKER_SOURCE_REF if unset.'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  worker-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Preflight App config
+        id: app_config
+        env:
+          APP_ID: ${{ vars.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          # Graceful no-op when the gominimal-aw-bot App has not been configured yet.
+          # Avoids opaque create-github-app-token errors during initial repo setup
+          # (App registration is documented in docs/rollout/01-org-secrets.md).
+          if [[ -z "${APP_ID}" || -z "${APP_PRIVATE_KEY}" ]]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "worker-fix: APP_ID or APP_PRIVATE_KEY not set; no-op."
+            echo "Configure the gominimal-aw-bot App per docs/rollout/01-org-secrets.md."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mint App token
+        if: steps.app_config.outputs.available == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # owner with no repositories: requests a token scoped to every repo
+          # gominimal-aw-bot is installed on under gominimal. The worker needs
+          # write on the running repo (push branches, open PRs) and read on
+          # the source-of-truth (raw fetch of worker-fix.md). Both fall under
+          # the App's installation set; an unscoped owner token is the
+          # minimum that covers both without hard-coding a repo list that
+          # would couple this template to the source-of-truth repo's name.
+          owner: gominimal
+
+      - name: Set source ref
+        if: steps.app_config.outputs.available == 'true'
+        id: source
+        env:
+          DISPATCH_REF: ${{ github.event.inputs.source_ref }}
+          REPO_VAR_REF: ${{ vars.WORKER_SOURCE_REF }}
+        run: |
+          # Source-ref resolution order:
+          # 1. workflow_dispatch input (operator override for testing)
+          # 2. vars.WORKER_SOURCE_REF repo variable (operator-pinned default for cron)
+          # If neither is set, log a clear noop and exit 0 so cron runs do not
+          # fail loudly while the operator is still configuring the repo variable.
+          SOURCE_REF="${DISPATCH_REF:-${REPO_VAR_REF}}"
+          if [[ -z "${SOURCE_REF}" ]]; then
+            echo "worker-fix: neither workflow_dispatch input nor vars.WORKER_SOURCE_REF set; no-op."
+            echo "Set the WORKER_SOURCE_REF repository variable to a full 40-char commit SHA. Tags are rejected for immutability."
+            echo "ref=" >> "$GITHUB_OUTPUT"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Phase E1 spec R2.1 immutability requirement, hardened per CodeRabbit
+          # finding on min-aw#85: this caller wrapper fetches+executes remote
+          # content (workflows/worker-fix.md) using a write-capable App token,
+          # so source_ref must be a full 40-character commit SHA. Tags are
+          # rejected because they're mutable — a tag could be moved to a
+          # malicious commit between the operator's review and the cron run.
+          # SHA-pinning ensures the bytes executed are exactly the bytes
+          # reviewed at install time.
+          #
+          # Operator workflow: pin a SHA via `vars.WORKER_SOURCE_REF`; bump it
+          # by editing that variable when a new release is reviewed. The
+          # WORKFLOW_TRIGGER_TOKEN-equivalent secret rotation cadence is the
+          # forcing function for re-pinning.
+          if [[ ! "${SOURCE_REF}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ERROR: source_ref must be a full 40-char commit SHA." >&2
+            echo "Got: '${SOURCE_REF}'. Tags and branch names are not accepted because" >&2
+            echo "this caller wrapper fetches+executes remote content using a write-capable" >&2
+            echo "App token. SHA-pinning is the only ref form that guarantees immutability." >&2
+            exit 1
+          fi
+          echo "ref=${SOURCE_REF}" >> "$GITHUB_OUTPUT"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout target repo
+        if: steps.app_config.outputs.available == 'true' && steps.source.outputs.ready == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # The minted App token lets the worker push branches and open PRs.
+          # The default GITHUB_TOKEN is insufficient because workflow files
+          # created with it cannot trigger further workflow runs (GitHub
+          # restriction). The App is installed per docs/rollout/11-worker-tokens.md.
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Fetch worker-fix.md from source of truth
+        if: steps.app_config.outputs.available == 'true' && steps.source.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          SOURCE_REF="${{ steps.source.outputs.ref }}"
+          # Source repo is private; the App token grants read access on it.
+          curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+            "https://raw.githubusercontent.com/gominimal/min-aw/${SOURCE_REF}/workflows/worker-fix.md" \
+            -o worker-fix.md
+
+      - name: Run worker-fix
+        if: steps.app_config.outputs.available == 'true' && steps.source.outputs.ready == 'true'
+        run: gh aw run worker-fix.md
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/worker-iterate.yml
+++ b/.github/workflows/worker-iterate.yml
@@ -1,0 +1,171 @@
+# .github/workflows/worker-iterate.yml
+# Provenance: sourced from gominimal/min-aw.
+# Thin caller for the worker-iterate chore. References the canonical
+# worker-iterate.md source at a pinned source_ref; do not inline
+# worker-iterate logic here. Managed by gominimal/min-aw. Edit upstream;
+# do not modify locally.
+
+name: Worker iterate
+
+on:
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: 'Source ref (full 40-char commit SHA only — tags rejected for immutability) for worker-iterate.md. Optional; falls back to vars.WORKER_ITERATE_SOURCE_REF if unset.'
+        required: false
+        default: ''
+        type: string
+      pr_number:
+        description: 'PR number to iterate on (workflow_dispatch only).'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  worker-iterate:
+    runs-on: ubuntu-latest
+    # Author + title gating. The chore-suite worker-iterate is only ever
+    # valid on bot-authored worker PRs. Skip the entire job otherwise so
+    # human PRs and non-worker bot PRs do not trigger gh aw run.
+    if: |
+      github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.user.login == 'gominimal-aw-bot[bot]' &&
+        startsWith(github.event.pull_request.title, '[worker:')
+      )
+    steps:
+      - name: Preflight App config
+        id: app_config
+        env:
+          APP_ID: ${{ vars.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          # Graceful no-op when the gominimal-aw-bot App has not been
+          # configured yet. Avoids opaque create-github-app-token errors
+          # during initial repo setup (App registration is documented in
+          # docs/rollout/01-org-secrets.md).
+          if [[ -z "${APP_ID}" || -z "${APP_PRIVATE_KEY}" ]]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "worker-iterate: APP_ID or APP_PRIVATE_KEY not set; no-op."
+            echo "Configure the gominimal-aw-bot App per docs/rollout/01-org-secrets.md."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mint App token
+        if: steps.app_config.outputs.available == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # owner with no repositories: requests a token scoped to every
+          # repo gominimal-aw-bot is installed on under gominimal. The
+          # iterator needs write on the running repo (push to PR branch,
+          # reply on inline threads) and read on the source-of-truth (raw
+          # fetch of worker-iterate.md). Both fall under the App's
+          # installation set; an unscoped owner token is the minimum that
+          # covers both without coupling this template to the source-of-
+          # truth repo's name.
+          owner: gominimal
+
+      - name: Set source ref
+        if: steps.app_config.outputs.available == 'true'
+        id: source
+        env:
+          DISPATCH_REF: ${{ github.event.inputs.source_ref }}
+          REPO_VAR_REF: ${{ vars.WORKER_ITERATE_SOURCE_REF }}
+        run: |
+          # Source-ref resolution order:
+          # 1. workflow_dispatch input (operator override for testing)
+          # 2. vars.WORKER_ITERATE_SOURCE_REF repo variable (operator-pinned default)
+          # If neither is set, log a clear noop and exit 0 so review-
+          # triggered runs do not fail loudly while the operator is still
+          # configuring the repo variable.
+          SOURCE_REF="${DISPATCH_REF:-${REPO_VAR_REF}}"
+          if [[ -z "${SOURCE_REF}" ]]; then
+            echo "worker-iterate: neither workflow_dispatch input nor vars.WORKER_ITERATE_SOURCE_REF set; no-op."
+            echo "Set the WORKER_ITERATE_SOURCE_REF repository variable to a full 40-char commit SHA. Tags are rejected for immutability."
+            echo "ref=" >> "$GITHUB_OUTPUT"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Phase 0c immutability requirement: this caller wrapper
+          # fetches+executes remote content (workflows/worker-iterate.md)
+          # using a write-capable App token, so source_ref must be a full
+          # 40-character commit SHA. Tags are rejected because they're
+          # mutable — a tag could be moved to a malicious commit between
+          # the operator's review and the next review-triggered run.
+          # SHA-pinning ensures the bytes executed are exactly the bytes
+          # reviewed at install time. Same security rationale as
+          # worker-fix.yml.
+          if [[ ! "${SOURCE_REF}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ERROR: source_ref must be a full 40-char commit SHA." >&2
+            echo "Got: '${SOURCE_REF}'. Tags and branch names are not accepted because" >&2
+            echo "this caller wrapper fetches+executes remote content using a write-capable" >&2
+            echo "App token. SHA-pinning is the only ref form that guarantees immutability." >&2
+            exit 1
+          fi
+          echo "ref=${SOURCE_REF}" >> "$GITHUB_OUTPUT"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve PR number
+        if: steps.app_config.outputs.available == 'true' && steps.source.outputs.ready == 'true'
+        id: pr
+        env:
+          DISPATCH_PR: ${{ github.event.inputs.pr_number }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+        run: |
+          # On pull_request_review the PR number comes from the event.
+          # On workflow_dispatch the operator passes it via the input.
+          PR_NUMBER="${DISPATCH_PR:-${EVENT_PR}}"
+          if [[ -z "${PR_NUMBER}" ]]; then
+            echo "worker-iterate: no PR number resolvable (event payload empty and no dispatch input); no-op."
+            echo "number=" >> "$GITHUB_OUTPUT"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Sanity-check the value is a positive integer to keep injection
+          # off the gh CLI command line further down.
+          if [[ ! "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "ERROR: pr_number must be a positive integer; got '${PR_NUMBER}'." >&2
+            exit 1
+          fi
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout target repo
+        if: steps.app_config.outputs.available == 'true' && steps.source.outputs.ready == 'true' && steps.pr.outputs.ready == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # The minted App token lets the iterator push to the PR branch
+          # via the push-to-pull-request-branch safe-output. The default
+          # GITHUB_TOKEN is insufficient because workflow files created
+          # with it cannot trigger further workflow runs (GitHub
+          # restriction). The App is installed per docs/rollout/11-worker-tokens.md.
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Fetch worker-iterate.md from source of truth
+        if: steps.app_config.outputs.available == 'true' && steps.source.outputs.ready == 'true' && steps.pr.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          SOURCE_REF="${{ steps.source.outputs.ref }}"
+          # Source repo is private; the App token grants read access on it.
+          curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+            "https://raw.githubusercontent.com/gominimal/min-aw/${SOURCE_REF}/workflows/worker-iterate.md" \
+            -o worker-iterate.md
+
+      - name: Run worker-iterate
+        if: steps.app_config.outputs.available == 'true' && steps.source.outputs.ready == 'true' && steps.pr.outputs.ready == 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_AW_PR_NUMBER: ${{ steps.pr.outputs.number }}
+          GH_AW_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_AW_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: gh aw run worker-iterate.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# Agent Contract: minimal
+
+## Overview
+
+This document defines the agentic workflow contract for **minimal**. It lists which chore workflows are active, what they are permitted to do, what labels they emit, and the constraints all of them honor.
+
+Primary language: **Rust**. Source-of-truth: [`gominimal/min-aw`](https://github.com/gominimal/min-aw).
+
+## Active chore workflows
+
+The bootstrap install adds three workflow files to `.github/workflows/` directly:
+
+- **`sync-from-source-of-truth.yml`** — pulls compiled chore `.lock.yml` files from `gominimal/min-aw` on a weekly schedule. First scheduled run lands the rest of the chore set.
+- **`worker-fix.yml`** — caller wrapper for the chore-issue worker (mints an App token, fetches the worker prompt at the pinned `WORKER_SOURCE_REF`).
+- **`worker-iterate.yml`** — caller wrapper for the worker-iterate chore (mints an App token, fetches the worker-iterate prompt at the pinned `WORKER_ITERATE_SOURCE_REF`). Triggers on `pull_request_review` events for bot-authored `[worker:` PRs.
+
+After the sync workflow's first run, the language-applicable chores below land as `.lock.yml` files alongside the wrappers. The chore matrix is governed by the per-language policy in [ADR 0003](https://github.com/gominimal/min-aw/blob/main/docs/decisions/0003-language-portability.md):
+
+| Workflow | Output | Trigger | Applies to LANGUAGE |
+|---|---|---|---|
+| `docs-patrol` | One issue per drift, label `agent:doc-drift` | Fuzzy weekly Monday + `push` to main on doc paths | all |
+| `worker-fix` | Draft PR fixing one open `agent:*` issue | Fuzzy daily + `workflow_dispatch` | all |
+| `worker-iterate` | Pushes commits to existing worker-fix PR branches addressing CodeRabbit review feedback; replies inline per the saved-memory rule | `pull_request_review: types: [submitted]` on bot-authored `[worker:` PRs | all |
+| `dependency-review` | One issue per advisory or semver concern, label `agent:dep-drift` | `pull_request` on lockfile + fuzzy twice-weekly | rust (today); go / node next |
+| `api-surface-drift` | One issue per surface change, label `agent:api-drift` | Fuzzy weekly Tuesday + `pull_request` on source | rust (today); go / node next |
+| `test-coverage-detector` | Up to 3 issues for untested high-complexity paths, label `agent:coverage` | Fuzzy weekly Tuesday + `pull_request: closed` | rust (today); go / node next |
+| `trivial-dep-bump` | One auto-merge-labeled PR with patch-level lockfile bumps | Fuzzy daily | rust (today); go / node next |
+
+The Cargo-coupled chores at the bottom of the table install on Rust targets only today. Per [ADR 0003](https://github.com/gominimal/min-aw/blob/main/docs/decisions/0003-language-portability.md), a planned per-language refactor generalizes them to Go, Node/TS, and Nickel. Until that refactor lands, non-Rust targets receive only `docs-patrol` + `worker-fix`.
+
+A separate `not-gating-audit` chore runs only on `gominimal/min-aw` (not synced to target repos) and watches branch-protection drift across the install set. If any `gh-aw`-emitted check appears in this repo's `required_status_checks` after install, that chore files an issue against `gominimal/min-aw` (not against this repo) so the operator can remediate without local action here.
+
+## Constraints (every chore)
+
+- **Not-gating.** No chore output appears in `required_status_checks`. Branch protection depends only on the existing CI. Per [ADR 0001](https://github.com/gominimal/min-aw/blob/main/decisions/0001-not-gating.md). The `not-gating-audit` chore on `gominimal/min-aw` actively defends this and files an issue if drift is detected on any target.
+- **Caps.** Audit chores cap at 1 issue per run (3 for `test-coverage-detector`); fix chores cap at 1 PR per run. Older open issues with the same `agent:*` label are closed in-place when a new one is filed (`close-older-issues: true`).
+- **No direct `main` push.** All chore output flows through gh-aw safe outputs (issues, draft PRs). No chore runs `git push` or `gh pr merge` directly.
+- **Issue caps.** Each issue body is capped at 10 `@mentions` and 50 links; only the HTML tags listed in [`gh-aw-fragments/safe-output-create-issue.md`](https://github.com/gominimal/min-aw/blob/main/gh-aw-fragments/safe-output-create-issue.md) are permitted.
+
+## Label taxonomy
+
+Defined in [`.github/labels.yml`](.github/labels.yml). Two prefixes; meanings differ:
+
+**`agent:*` — chore-output labels (issues opened by audit chores).** A chore opens an issue and applies its label. The label identifies which chore filed the issue and what kind of follow-up the worker is allowed to draft (per its switch table).
+
+| Label | Filed by | What it means |
+|---|---|---|
+| `agent:doc-drift` | `docs-patrol` | Documentation has drifted from the implementation |
+| `agent:coverage` | `test-coverage-detector` | A high-complexity function lacks test coverage |
+| `agent:dep-drift` | `dependency-review` | A dependency advisory or semver concern needs review |
+| `agent:api-drift` | `api-surface-drift` | An external API surface this repo depends on has changed |
+| `agent:not-gating-audit` | `not-gating-audit` | Branch-protection drift on a target repo (filed against `gominimal/min-aw`) |
+
+**`agent:auto-merge` is *not* an issue label.** It's a **PR-output label** the worker (and `trivial-dep-bump`) apply to draft PRs that satisfy the trivial-scope criteria (patch-level lockfile only, etc.). Branch-protection rules consume the label to enable auto-merge once CI is green. The label is in `.github/labels.yml` for completeness but is *applied to PRs, not issues*; nothing about its presence implies an "agent" actively approves and merges. The merge happens through GitHub's standard auto-merge flow once required checks pass.
+
+| Label | Applied to | What it means |
+|---|---|---|
+| `agent:auto-merge` | Draft PRs | This PR is eligible for GitHub auto-merge once CI is green. Applied by `worker-fix` on `agent:dep-drift` fixes that pass the trivial-scope check, and by `trivial-dep-bump` on its scheduled patch-bump PRs. |
+| `worker-tuning` | Issues opened against `gominimal/min-aw` | The worker failed to produce a PR within 72h on an `agent:*` issue; meta-feedback for tuning the worker prompt. Not an `agent:*` label because it's a worker self-feedback signal, not a chore output. |
+
+## Fragment imports
+
+Chore prompts in `.github/workflows/<chore>.lock.yml` import shared fragments from `gominimal/min-aw/gh-aw-fragments/` at compile time. Edit fragments in the source-of-truth repo; the next sync run lands the new compiled lock file.
+
+## Updating this document
+
+This file is managed by `scripts/quick-setup.sh` from `gominimal/min-aw`. To change the contract, open a PR against the source-of-truth repo; changes propagate to instrumented repos via the weekly sync workflow.


### PR DESCRIPTION
> This is a hand-off from `gominimal/min-aw`, not a self-merging change. Review the diff at your own pace; mark ready-for-review and merge when satisfied. The min-aw operator job ended at draft creation; they will not enable auto-merge on this PR. See [`docs/rollout/07-target-repo-rollout.md`](https://github.com/gominimal/min-aw/blob/main/docs/rollout/07-target-repo-rollout.md) for the full hand-off contract and [`decisions/0001-not-gating.md`](https://github.com/gominimal/min-aw/blob/main/decisions/0001-not-gating.md) for the no-mutation-of-branch-protection rule.

## TL;DR

- **Markdown only.** No source code, no CI mutation, no branch-protection mutation. Safe to merge as-is.
- **What runs after merge.** A weekly sync workflow pulls chore workflows from `gominimal/min-aw@v0.2.4`. Chores file issues / open draft PRs against this repo on a fuzzy schedule. Caps: max 1 issue per chore per run; max 1 PR per chore per run; auto-merge **opt-in** per chore (only `trivial-dep-bump` enables it, and only for patch-level Cargo.lock changes).
- **You can opt out anytime.** Disable a specific chore by deleting its `.github/workflows/<chore>.lock.yml` after sync, OR halt all chores by removing the sync workflow itself. No retaliatory state on the source-of-truth side.

## What this PR installs (markdown-only)

- `AGENTS.md` — agent context document for human + AI tooling
- `.github/copilot-instructions.md` — Copilot instructions referencing gh-aw-fragments
- `.github/labels.yml` — agent label set (`agent:*`, `kind:*`, `priority:*`)
- `.github/agents/` — agent definition directory
- `.github/ISSUE_TEMPLATE/` — issue templates (bug, feature, chore, feedback)
- `.github/workflows/sync-from-source-of-truth.yml` — weekly sync workflow that pulls compiled `.lock.yml` files from min-aw

Source-of-truth pin: [`gominimal/min-aw@v0.2.4`](https://github.com/gominimal/min-aw/tree/v0.2.4). The pin is either a release tag (`vX.Y.Z`) or a full 40-char commit SHA — both link via `/tree/` so the link works regardless of which form was passed to `quick-setup.sh`.

## What runs after merge

The sync workflow lands compiled chore `.lock.yml` files on a weekly schedule. Each chore is governed by its own caps and triggers; full details in [`workflows/` on min-aw](https://github.com/gominimal/min-aw/tree/main/workflows). For minimal (LANGUAGE=Rust) per [ADR 0003](https://github.com/gominimal/min-aw/blob/main/docs/decisions/0003-language-portability.md), the applicable chores include:

- `docs-patrol` — files an issue when documentation drifts from the source code (1 issue/run, fuzzy weekly Monday).
- `worker-fix` — picks up open `agent:*` issues and drafts a fix PR (1 PR/run, fuzzy daily). Bot-authored PRs auto-trigger CodeRabbit review.
- `worker-iterate` — addresses CodeRabbit (and human) inline review-comment feedback on `gominimal-aw-bot[bot]`-authored `[worker: ...` PRs. Triggered per CodeRabbit review submission; pushes commits to the PR branch and replies inline. Caps: 3 comments/run, 5 runs/PR. ([#83](https://github.com/gominimal/min-aw/issues/83))
- `not-gating-audit` — weekly audit that branch protection on `main` requires only your CI (no `gh-aw` checks added). Files an issue if drift is detected.
- Rust-coupled chores (`dependency-review`, `api-surface-drift`, `test-coverage-detector`, `trivial-dep-bump`) — install only if LANGUAGE=rust today; per-language overlays for Go/Node/Nickel land in [#69](https://github.com/gominimal/min-aw/issues/69) phase 1.

## What this does NOT do

- **Does not modify branch protection.** Per ADR 0001, no `gh-aw` check is ever added to `required_status_checks`. Your CI remains the only gate. The `not-gating-audit` chore actively defends this; it files an issue if any `gh-aw` check appears in branch protection.
- **Does not modify your CI.** No edits to existing workflow files; only adds the sync workflow.
- **Does not push commits to `main`.** All chore output flows through the gh-aw safe-output gate (PRs and issues, never direct pushes).

## Review checklist

- [ ] Diff touches only `AGENTS.md` + `.github/` markdown/yaml files; no source code touched
- [ ] Token substitution looks correct (REPO_NAME=minimal, LANGUAGE=Rust)
- [ ] `AGENTS.md` matches the active agent set for this repo
- [ ] `.github/workflows/sync-from-source-of-truth.yml` pins to a release tag (not `main`)
- [ ] No direct push to `main` was made (this is a PR)
- [ ] Branch protection on `main` is unchanged (verify via `gh api repos/gominimal/minimal/branches/main/protection`)

## Hand-off

This PR is **opened as draft**. The min-aw operator will not toggle ready-for-review or enable auto-merge. When you are satisfied:

1. Click "Ready for review."
2. Optionally request review from CODEOWNERS or your team.
3. Merge when CI is green and you are satisfied.

To push back or roll back, see the rollback procedure in [`docs/rollout/07-target-repo-rollout.md`](https://github.com/gominimal/min-aw/blob/main/docs/rollout/07-target-repo-rollout.md). Or comment on this PR — feedback shapes the next sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added GitHub issue templates for standardized bug reporting, feature requests, chores, and feedback
  * Added agent workflows documentation and guidelines

* **Chores**
  * Introduced standardized GitHub labels for issue triage and workflow organization
  * Added automated workflows for repository synchronization and maintenance tasks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->