### PR TITLE
chore(sync): patch in git-author config + bump pin v0.2.5 -> v0.3.1

### DIFF
--- a/.github/workflows/sync-from-source-of-truth.yml
+++ b/.github/workflows/sync-from-source-of-truth.yml
@@ -22,7 +22,7 @@ on:
         # Default is substituted by quick-setup.sh at install time. Operator
         # bumps it via PR or by re-running quick-setup with a newer
         # --source-ref. Manual dispatch can override per-run.
-        default: 'v0.2.8'
+        default: 'v0.3.1'
         type: string
 
 jobs:
@@ -77,7 +77,7 @@ jobs:
           # 1. workflow_dispatch input (operator override per-run)
           # 2. workflow_dispatch input default (substituted by quick-setup
           #    at install time, bumped via PR thereafter)
-          SOURCE_REF="${{ github.event.inputs.source_ref || 'v0.2.8' }}"
+          SOURCE_REF="${{ github.event.inputs.source_ref || 'v0.3.1' }}"
 
           # Immutability + substitution-check in one regex pair. source_ref
           # must be a pinned tag (vN.N.N pattern) or full 40-char SHA. Branch
@@ -138,7 +138,7 @@ jobs:
           # exits 128 with `empty ident name` unless we configure it here.
           # Use the canonical github-actions[bot] noreply form including the
           # numeric user-id prefix so GitHub attributes the commit to the bot
-          # account in UI/API. Patched in from gominimal/min-aw v0.2.7;
+          # account in UI/API. Patched in from gominimal/min-aw v0.3.1;
           # subsequent sync runs (or a re-install via quick-setup at that
           # version or later) will carry the same step in the wrapper template.
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/sync-from-source-of-truth.yml
+++ b/.github/workflows/sync-from-source-of-truth.yml
@@ -22,7 +22,7 @@ on:
         # Default is substituted by quick-setup.sh at install time. Operator
         # bumps it via PR or by re-running quick-setup with a newer
         # --source-ref. Manual dispatch can override per-run.
-        default: 'v0.2.5'
+        default: 'v0.2.7'
         type: string
 
 jobs:
@@ -77,7 +77,7 @@ jobs:
           # 1. workflow_dispatch input (operator override per-run)
           # 2. workflow_call default (v0.2.5, substituted by quick-setup
           #    at install time, bumped via PR thereafter)
-          SOURCE_REF="${{ github.event.inputs.source_ref || 'v0.2.5' }}"
+          SOURCE_REF="${{ github.event.inputs.source_ref || 'v0.2.7' }}"
 
           # Immutability + substitution-check in one regex pair. source_ref
           # must be a pinned tag (vN.N.N pattern) or full 40-char SHA. Branch
@@ -129,6 +129,20 @@ jobs:
           fi
 
           chmod +x sync-workflows.sh
+
+      - name: Configure git author for the sync commit
+        if: steps.app_config.outputs.available == 'true'
+        run: |
+          # sync-workflows.sh creates a chore branch and commits the synced
+          # files. The runner has no default git identity, so the commit step
+          # exits 128 with `empty ident name` unless we configure it here.
+          # Use the canonical github-actions[bot] noreply form including the
+          # numeric user-id prefix so GitHub attributes the commit to the bot
+          # account in UI/API. Patched in from gominimal/min-aw v0.2.7;
+          # subsequent sync runs (or a re-install via quick-setup at v0.2.7+)
+          # will carry the same step in the wrapper template.
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
       - name: Run sync-workflows.sh
         if: steps.app_config.outputs.available == 'true'

--- a/.github/workflows/sync-from-source-of-truth.yml
+++ b/.github/workflows/sync-from-source-of-truth.yml
@@ -75,22 +75,22 @@ jobs:
         run: |
           # Resolution order:
           # 1. workflow_dispatch input (operator override per-run)
-          # 2. workflow_call default (v0.2.5, substituted by quick-setup
+          # 2. workflow_dispatch input default (substituted by quick-setup
           #    at install time, bumped via PR thereafter)
           SOURCE_REF="${{ github.event.inputs.source_ref || 'v0.2.8' }}"
 
           # Immutability + substitution-check in one regex pair. source_ref
           # must be a pinned tag (vN.N.N pattern) or full 40-char SHA. Branch
-          # names (main, master, dev) and the unsubstituted 'v0.2.5'
-          # token both fail this check. A separate unsubstituted-token guard
-          # used to live above, but quick-setup.sh substitutes 'v0.2.5'
+          # names (main, master, dev) and an unsubstituted default token
+          # both fail this check. A separate unsubstituted-token guard
+          # used to live above, but quick-setup.sh substitutes the default
           # globally including inside that guard's literal — which made the
           # guard self-rejecting post-substitution. Dropped; the regex below
           # catches the same condition correctly.
           if [[ ! "${SOURCE_REF}" =~ ^[0-9a-f]{40}$ ]] && \
              [[ ! "${SOURCE_REF}" =~ ^v?[0-9]+(\.[0-9]+){1,2}([.-][0-9A-Za-z._-]+)?$ ]]; then
             echo "ERROR: source_ref must be a pinned tag (e.g. v1.2.3) or full 40-char SHA." >&2
-            echo "Got: '${SOURCE_REF}'. Branch names and the unsubstituted 'v0.2.5' token are not accepted." >&2
+            echo "Got: '${SOURCE_REF}'. Branch names and unsubstituted default tokens are not accepted." >&2
             echo "If you see the literal token, re-run scripts/quick-setup.sh from gominimal/min-aw at a pinned ref." >&2
             exit 1
           fi
@@ -139,8 +139,8 @@ jobs:
           # Use the canonical github-actions[bot] noreply form including the
           # numeric user-id prefix so GitHub attributes the commit to the bot
           # account in UI/API. Patched in from gominimal/min-aw v0.2.7;
-          # subsequent sync runs (or a re-install via quick-setup at v0.2.7+)
-          # will carry the same step in the wrapper template.
+          # subsequent sync runs (or a re-install via quick-setup at that
+          # version or later) will carry the same step in the wrapper template.
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 

--- a/.github/workflows/sync-from-source-of-truth.yml
+++ b/.github/workflows/sync-from-source-of-truth.yml
@@ -22,7 +22,7 @@ on:
         # Default is substituted by quick-setup.sh at install time. Operator
         # bumps it via PR or by re-running quick-setup with a newer
         # --source-ref. Manual dispatch can override per-run.
-        default: 'v0.2.7'
+        default: 'v0.2.8'
         type: string
 
 jobs:
@@ -77,7 +77,7 @@ jobs:
           # 1. workflow_dispatch input (operator override per-run)
           # 2. workflow_call default (v0.2.5, substituted by quick-setup
           #    at install time, bumped via PR thereafter)
-          SOURCE_REF="${{ github.event.inputs.source_ref || 'v0.2.7' }}"
+          SOURCE_REF="${{ github.event.inputs.source_ref || 'v0.2.8' }}"
 
           # Immutability + substitution-check in one regex pair. source_ref
           # must be a pinned tag (vN.N.N pattern) or full 40-char SHA. Branch


### PR DESCRIPTION
Hand-patches the installed sync-wrapper to backport the v0.2.7 fixes from `gominimal/min-aw#121`. Required to unblock Phase 0b acceptance on this repo.

## Why this is needed

The installed `.github/workflows/sync-from-source-of-truth.yml` (from quick-setup at v0.2.5, refreshed at v0.2.6 via #189) ships with two latent bugs that block any `workflow_dispatch` of the sync:

1. **Missing `git config user.name`/`user.email`** — when the wrapper invokes `./sync-workflows.sh`, the runner has no git identity; `git commit` exits 128 with `empty ident name`. Observed on runs [25524419155](https://github.com/gominimal/minimal/actions/runs/25524419155) and [25525573086](https://github.com/gominimal/minimal/actions/runs/25525573086).
2. **Pinned source_ref points at v0.2.5/v0.2.6** — those tags contain a destructive deletion bug in `sync-workflows.sh` that would delete target-owned `*.yml` files (`ci.yml`, `promote.yml`) and the script's own caller wrappers. Both runs failed at `git commit` (bug 1, unintended safety net) before the deletion could push.

Both fixed in [`gominimal/min-aw#121`](https://github.com/gominimal/min-aw/pull/121) and shipped in [v0.2.7](https://github.com/gominimal/min-aw/releases/tag/v0.2.7).

## What this patch does

1. Adds a `Configure git author for the sync commit` step using the canonical `41898282+github-actions[bot]@users.noreply.github.com` email so GitHub attributes the synced-workflows commit to the bot.
2. Bumps the pinned `default` source_ref from `v0.2.5` to `v0.2.7` in both places (workflow_dispatch input + in-script fallback). The next sync run pulls the FIXED `sync-workflows.sh` (`.md`-only deletion scope), preserving `ci.yml`, `promote.yml`, and the caller wrappers.

The historical comments on lines 78/84/86/93 still mention v0.2.5; that's doc-drift, not behavior. Will be cleaned up the next time `quick-setup.sh --source-ref v0.2.7` is re-run against this repo (lays down a freshly-substituted wrapper).

## Verification (after merge)

```
gh workflow run sync-from-source-of-truth.yml --repo gominimal/minimal
```

Expected: pulls `workflows/*.md` from `gominimal/min-aw@v0.2.7`; preserves all `*.yml` files in `.github/workflows/`; `git commit` succeeds with the bot identity; opens a PR with the additive `.md` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI workflow reliability by adding automatic git author configuration so sync commits proceed consistently.

* **Chores**
  * Updated the workflow default reference and fallback value to v0.3.1.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/197)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->