### PR TITLE
crates/minimal: add materialize type raw-file

### DIFF
--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -320,28 +320,77 @@ pub struct Stack {
 
 impl Eq for Stack {}
 
-/// Describes the specific type of output being generated.
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+/// Describes the specific type of output being generated, along with any
+/// fields which are only meaningful for that output type.
+///
+/// Serialized with an internal `type` tag (e.g. `type = "oci-image"`), so
+/// fields like `entrypoint`/`cmd`/`vars` can only be set on the `OciImage`
+/// variant — setting them with any other `type` is a deserialization error.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "kebab-case")]
 pub enum OutputKind {
-    #[default]
-    #[serde(alias = "oci-image")]
-    OciImage,
+    /// An output representing a container image.
+    OciImage {
+        #[serde(default)]
+        entrypoint: Option<StrOrList>,
+        #[serde(default)]
+        cmd: Option<StrOrList>,
+        #[serde(default, alias = "env_vars")]
+        vars: HashMap<String, String>,
+    },
+
+    /// An output representing a file extracted from some packages.
+    RawFile { path: String },
+}
+
+impl Default for OutputKind {
+    fn default() -> Self {
+        OutputKind::OciImage {
+            entrypoint: None,
+            cmd: None,
+            vars: HashMap::new(),
+        }
+    }
+}
+
+/// Flat intermediate used to deserialize [Output]. Combining
+/// `#[serde(flatten)]` on a tagged enum with a `#[serde(flatten)]` catch-all
+/// `extra` map causes serde to duplicate variant fields into both
+/// destinations, so we deserialize into a flat struct and then validate &
+/// route fields into the proper [OutputKind] variant in [TryFrom].
+#[derive(serde::Deserialize)]
+struct OutputRaw {
+    #[serde(rename = "type")]
+    ty: Option<String>,
+
+    #[serde(default)]
+    packages: Vec<String>,
+    #[serde(default)]
+    arch: Option<String>,
+
+    #[serde(default)]
+    entrypoint: Option<StrOrList>,
+    #[serde(default)]
+    cmd: Option<StrOrList>,
+    #[serde(default, alias = "env_vars")]
+    vars: HashMap<String, String>,
+
+    #[serde(default)]
+    path: String,
+
+    #[serde(flatten)]
+    extra: HashMap<String, toml::Value>,
 }
 
 /// An output, defined in a `[outputs.<output_name>]` section of [File].
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[serde(try_from = "OutputRaw")]
 pub struct Output {
-    #[serde(alias = "type")]
-    pub ty: OutputKind,
-    #[serde(default)]
-    pub packages: Vec<String>,
+    #[serde(flatten)]
+    pub kind: OutputKind,
 
     #[serde(default)]
-    pub entrypoint: Option<StrOrList>,
-    #[serde(default)]
-    pub cmd: Option<StrOrList>,
-    #[serde(default, alias = "env_vars")]
-    pub vars: HashMap<String, String>,
+    pub packages: Vec<String>,
 
     /// Target architecture for OCI images. Defaults to "amd64".
     /// Common values: "amd64", "arm64"
@@ -351,6 +400,61 @@ pub struct Output {
     /// Any fields which are not understood by this version of minimal.
     #[serde(flatten)]
     extra: HashMap<String, toml::Value>,
+}
+
+impl TryFrom<OutputRaw> for Output {
+    type Error = String;
+
+    fn try_from(raw: OutputRaw) -> Result<Self, Self::Error> {
+        let ty = raw.ty.as_deref().unwrap_or("oci-image");
+        let kind = match ty {
+            "oci-image" => {
+                for (field, set) in [("path", !raw.path.is_empty())] {
+                    if set {
+                        return Err(format!(
+                            "field `{field}` is not valid for outputs with type = \"oci-image\""
+                        ));
+                    }
+                }
+
+                OutputKind::OciImage {
+                    entrypoint: raw.entrypoint,
+                    cmd: raw.cmd,
+                    vars: raw.vars,
+                }
+            }
+            "raw-file" => {
+                for (field, set) in [
+                    ("entrypoint", raw.entrypoint.is_some()),
+                    ("cmd", raw.cmd.is_some()),
+                    ("vars", !raw.vars.is_empty()),
+                ] {
+                    if set {
+                        return Err(format!(
+                            "field `{field}` is not valid for outputs with type = \"raw-file\""
+                        ));
+                    }
+                }
+                let path = if raw.path.is_empty() {
+                    Err("field `path` is required for outputs with type = \"raw-file\"".to_string())
+                } else {
+                    Ok(raw.path)
+                }?;
+                OutputKind::RawFile { path }
+            }
+            other => {
+                return Err(format!(
+                    "unknown output type {other:?}, expected \"oci-image\" or \"raw-file\""
+                ));
+            }
+        };
+        Ok(Output {
+            kind,
+            packages: raw.packages,
+            arch: raw.arch,
+            extra: raw.extra,
+        })
+    }
 }
 
 /// Configuration for the standard library.
@@ -765,11 +869,12 @@ mod tests {
                 outputs: [(
                     "test".to_string(),
                     Output {
-                        ty: OutputKind::OciImage,
+                        kind: OutputKind::OciImage {
+                            entrypoint: Some(StrOrList::Single("/bin/sh".to_string())),
+                            cmd: None,
+                            vars: HashMap::new(),
+                        },
                         packages: vec!["bash".to_string(), "go".to_string()],
-                        cmd: None,
-                        entrypoint: Some(StrOrList::Single("/bin/sh".to_string())),
-                        vars: HashMap::new(),
                         arch: None,
                         extra: HashMap::new(),
                     }
@@ -948,10 +1053,76 @@ mod tests {
         let output = &mf.outputs["app"];
         assert_eq!(output.arch, Some("arm64".to_string()));
         assert_eq!(output.packages, vec!["base", "openssl"]);
+        let OutputKind::OciImage {
+            entrypoint, vars, ..
+        } = &output.kind
+        else {
+            panic!("expected OciImage, got {:?}", output.kind);
+        };
         assert_eq!(
-            output.entrypoint,
-            Some(StrOrList::Single("/app/server".to_string()))
+            entrypoint,
+            &Some(StrOrList::Single("/app/server".to_string()))
         );
-        assert_eq!(output.vars["PORT"], "8080");
+        assert_eq!(vars["PORT"], "8080");
+    }
+
+    #[test]
+    fn output_raw_file() {
+        let mf: File = toml::from_str(indoc! {
+            r#"
+            [outputs.bash-bin]
+            type = "raw-file"
+            arch = "amd64"
+            path = "/usr/bin/bash"
+            "#
+        })
+        .unwrap();
+        assert_eq!(mf.outputs["bash-bin"].arch, Some("amd64".to_string()));
+        assert_eq!(
+            mf.outputs["bash-bin"].kind,
+            OutputKind::RawFile {
+                path: "/usr/bin/bash".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn raw_file_must_configure_path() {
+        let toml_str = "[outputs.f]\ntype = \"raw-file\"\n".to_string();
+        let err = toml::from_str::<File>(&toml_str).expect_err("expected error");
+        assert!(
+            err.to_string()
+                .contains("field `path` is required for outputs with type = \"raw-file\""),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn raw_file_rejects_oci_image_fields() {
+        for field in ["entrypoint = \"/x\"", "cmd = \"/x\"", "vars.X = \"y\""] {
+            let toml_str = format!("[outputs.f]\ntype = \"raw-file\"\n{field}\n",);
+            let err = toml::from_str::<File>(&toml_str)
+                .expect_err(&format!("expected error for `{field}` on raw-file"));
+            assert!(
+                err.to_string()
+                    .contains("not valid for outputs with type = \"raw-file\""),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_output_type_is_rejected() {
+        let err = toml::from_str::<File>(indoc! {
+            r#"
+            [outputs.f]
+            type = "weird"
+            "#
+        })
+        .expect_err("expected error for unknown output type");
+        assert!(
+            err.to_string().contains("unknown output type"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/minimal/src/cmd_materialize.rs
+++ b/crates/minimal/src/cmd_materialize.rs
@@ -3,6 +3,9 @@
 use anyhow::anyhow;
 use common::Target;
 use common::target::{Arch, OS};
+use graph::Transitives;
+use mfile::{OutputKind, StrOrList};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use mctx::{Context, Error};
@@ -13,8 +16,7 @@ pub struct MaterializeArgs {
     #[arg(short, long)]
     output: PathBuf,
 
-    /// Target architecture for OCI images (e.g., "amd64", "arm64").
-    /// Overrides the `arch` field in minimal.toml and the host default.
+    /// Override the architecture used when building the output
     #[arg(long)]
     arch: Option<String>,
 
@@ -37,7 +39,7 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
     // Resolve target architecture: CLI flag > minimal.toml > host default.
     // String-to-arch parsing is delegated to common::target::Arch so the
     // alias set stays consistent across every consumer.
-    let arch: Arch = match args.arch.or(output.arch) {
+    let arch: Arch = match args.arch.clone().or(output.arch) {
         Some(s) => s
             .parse()
             .map_err(|e: common::target::ArchParseError| Error::Other(anyhow!("{e}")))?,
@@ -52,22 +54,38 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
         0 => ctx.graph_from_package_names_with_target(["base"], target)?,
         _ => ctx.graph_from_package_names_with_target(output.packages.clone(), target)?,
     };
-    let cache = ctx.local_cache();
 
-    // Make sure the packages are built for the target
-    crate::cmd_pkg::pkg_build_impl(&graph, ctx, cache.clone(), false, false, None).await?;
+    crate::cmd_pkg::pkg_build_impl(&graph, ctx, ctx.local_cache(), true, false, None).await?;
 
-    // Create the OCI image — arch is queried from graph.target()
+    match output.kind {
+        OutputKind::OciImage {
+            entrypoint,
+            cmd,
+            vars,
+        } => materialize_oci_image(&args, ctx, graph, output.packages, entrypoint, cmd, vars).await,
+        OutputKind::RawFile { path } => materialize_raw_file(&args, ctx, graph, path).await,
+    }
+}
+
+async fn materialize_oci_image(
+    args: &MaterializeArgs,
+    ctx: &mut Context,
+    graph: graph::Graph,
+    packages: Vec<String>,
+    entrypoint: Option<StrOrList>,
+    cmd: Option<StrOrList>,
+    vars: HashMap<String, String>,
+) -> Result<(), Error> {
     let mut op = op::OciImageCreate {
-        packages: output.packages,
-        output_file: args.output,
+        packages,
+        output_file: args.output.clone(),
         name: Some(args.output_name.clone()),
-        entrypoint: output.entrypoint,
-        cmd: output.cmd,
-        vars: output.vars,
+        entrypoint,
+        cmd,
+        vars,
     };
     let opts = op::Options {
-        cache,
+        cache: ctx.local_cache(),
         graph: &graph,
         exec_base: "/invalid".into(),
         ot: ctx.op_tracker(),
@@ -75,4 +93,37 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
 
     use op::Runnable;
     op.run(&opts).await.map_err(|e| Error::Other(anyhow!(e)))
+}
+
+async fn materialize_raw_file(
+    args: &MaterializeArgs,
+    ctx: &mut Context,
+    graph: graph::Graph,
+    path: String,
+) -> Result<(), Error> {
+    let rel_path = if let Some(stripped) = path.strip_prefix("/") {
+        stripped.to_string()
+    } else {
+        path.clone()
+    };
+
+    let cache = ctx.local_cache();
+    let transitives = Transitives::for_toplevels(&graph, graph.top_levels.clone(), false);
+
+    for dir in transitives
+        .keys()
+        .map(|bsr| cache.read_dir(&graph.spec_hash(bsr)))
+    {
+        let dir = dir.map_err(|e| Error::Other(anyhow!(e)))?;
+        let p = dir.path().join(&rel_path);
+        if p.exists() {
+            std::fs::copy(&p, &args.output).map_err(|e| Error::IO("copying output file", p, e))?;
+            return Ok(());
+        }
+    }
+
+    Err(Error::Other(anyhow!(
+        "raw-file output {:?} was not found in the built package set",
+        path
+    )))
 }


### PR DESCRIPTION
This implements a new materialize type `raw-file`, which lets us pull a file out of the minimal universe. This is intended to be used with for instance the [virtio-linux](https://github.com/gominimal/pkgs/pull/154) package, which gives you a linux image for your microVM.

Now that we have more than one output type, I've also refactored the serde deserialize code so that only valid output configurations are representiable, namely by putting output-specific fields in their corresponding enum variant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `raw-file` output type to materialize individual files from built packages.
  * OCI-image outputs now materialize with configured entrypoint, command, and environment variables.
  * CLI `--arch` flag now takes precedence when selecting the target architecture.

* **Improvements**
  * Output configs are validated per output type, rejecting invalid field combinations and returning clearer errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->