### PR TITLE
Add --offline flag covering source-tarball + git fetches

### DIFF
--- a/crates/checkouts/src/error.rs
+++ b/crates/checkouts/src/error.rs
@@ -24,6 +24,11 @@ pub enum Error {
 
     /// Failed to read the statefile.
     StatefileInvalid(serde_json::Error),
+
+    /// The manager is in offline mode and the requested checkout would require a
+    /// network operation (clone of an unknown remote, or fetch of a known remote).
+    /// Caller asked for a ref we'd need to download, but `--no-fetch` is set.
+    OfflineCacheMiss { remote: String },
 }
 
 impl Error {
@@ -49,6 +54,11 @@ impl fmt::Display for Error {
             Error::InvalidPath => write!(f, "invalid path"),
             Error::Other(e) => write!(f, "other: {}", e),
             Error::StatefileInvalid(e) => write!(f, "statefile invalid: {}", e),
+            Error::OfflineCacheMiss { remote } => write!(
+                f,
+                "offline cache miss for git remote {remote} — \
+                 --no-fetch is set; pre-populate the vcs/ cache or remove the flag"
+            ),
         }
     }
 }

--- a/crates/checkouts/src/error.rs
+++ b/crates/checkouts/src/error.rs
@@ -57,7 +57,7 @@ impl fmt::Display for Error {
             Error::OfflineCacheMiss { remote } => write!(
                 f,
                 "offline cache miss for git remote {remote} — \
-                 --no-fetch is set; pre-populate the vcs/ cache or remove the flag"
+                 --offline is set; pre-populate the vcs/ cache or remove the flag"
             ),
         }
     }

--- a/crates/checkouts/src/lib.rs
+++ b/crates/checkouts/src/lib.rs
@@ -266,15 +266,22 @@ impl Manager {
     }
 
     /// Updates all repos to latest - does nothing for refs which arent symbolic (i.e. commits).
-    /// In offline mode, returns [Error::OfflineCacheMiss] for the first remote we'd
-    /// have to fetch.
+    /// In offline mode, returns [Error::OfflineCacheMiss] — `update` is fundamentally
+    /// a network operation, and silently lameducking it would mask hard-to-debug bugs
+    /// for callers like `minimal update` that explicitly want fresh state.
     pub fn update(&mut self) -> Result<(), Error> {
         if self.offline {
-            // In offline mode, `update` is a no-op for known remotes: we have
-            // no way to refresh, but the caller's intent is "use what's there",
-            // so returning Ok is more useful than erroring on every refresh.
-            // (`checkout_of` still errors when an UNKNOWN remote is requested.)
-            return Ok(());
+            // Pick the first known remote for the error message; if there are
+            // no known remotes there's nothing to update, so a synthetic
+            // placeholder is clearer than a misleading Ok.
+            let remote = self
+                .state
+                .git_remotes
+                .keys()
+                .next()
+                .cloned()
+                .unwrap_or_else(|| "<no remotes>".to_string());
+            return Err(Error::OfflineCacheMiss { remote });
         }
         let checkouts_dir = self.git_checkouts_dir();
         for (_remote, id) in self.state.git_remotes.iter_mut() {
@@ -511,16 +518,18 @@ mod tests {
         }
     }
 
-    /// In offline mode, `update()` is a no-op (returns Ok without touching
-    /// the network). The caller's intent is "use what's there"; refresh-of-
-    /// known-remote is non-destructive to skip.
+    /// In offline mode, `update()` returns OfflineCacheMiss rather than
+    /// silently no-op'ing. Callers like `minimal update` ask explicitly for
+    /// fresh state, so noop-ing would mask hard-to-debug bugs (per review
+    /// from @twitchyliquid64).
     #[test]
-    fn offline_update_is_noop() {
+    fn offline_update_errors() {
         let base_dir = tempdir().unwrap();
         let mut manager = Manager::new_in_dir_with_offline(base_dir.path(), true).unwrap();
-        manager
-            .update()
-            .expect("offline update should succeed as no-op");
+        match manager.update() {
+            Err(Error::OfflineCacheMiss { .. }) => {}
+            other => panic!("expected OfflineCacheMiss, got: {:?}", other),
+        }
     }
 
     /// Default (online) Manager keeps its existing behavior — `offline` is

--- a/crates/checkouts/src/lib.rs
+++ b/crates/checkouts/src/lib.rs
@@ -207,12 +207,28 @@ pub struct Manager {
     base_dir: PathBuf,
     state: ManagerState,
     repos: HashMap<String, Repo>,
+    /// When true, [Manager::checkout_of] / [Manager::update] return
+    /// [Error::OfflineCacheMiss] for any remote that would require a clone or fetch
+    /// rather than performing the network operation. Mirrors the value of
+    /// [`mctx::Config::use_remote_cache`] (i.e. `--no-fetch`).
+    offline: bool,
 }
 
 impl Manager {
     /// Initializes the checkouts manager in the given directory, returning a
     /// thread-safe, cloneable handle to the manager instance.
     pub fn new_in_dir<P: Into<PathBuf>>(base_dir: P) -> Result<ManagerHandle, Error> {
+        Self::new_in_dir_with_offline(base_dir, false)
+    }
+
+    /// Same as [Self::new_in_dir], but with an `offline` flag. When `offline=true`,
+    /// any operation that would require a clone or fetch (new remote, or refresh of
+    /// a known remote) surfaces as [Error::OfflineCacheMiss] rather than performing
+    /// the network operation.
+    pub fn new_in_dir_with_offline<P: Into<PathBuf>>(
+        base_dir: P,
+        offline: bool,
+    ) -> Result<ManagerHandle, Error> {
         let base_dir = base_dir.into();
         let db_path = base_dir.join("git").join("db");
         fs::create_dir_all(&db_path)?;
@@ -237,6 +253,7 @@ impl Manager {
             base_dir,
             state,
             repos,
+            offline,
         };
         Ok(ManagerHandle(Arc::new(Mutex::new(manager))))
     }
@@ -249,7 +266,16 @@ impl Manager {
     }
 
     /// Updates all repos to latest - does nothing for refs which arent symbolic (i.e. commits).
+    /// In offline mode, returns [Error::OfflineCacheMiss] for the first remote we'd
+    /// have to fetch.
     pub fn update(&mut self) -> Result<(), Error> {
+        if self.offline {
+            // In offline mode, `update` is a no-op for known remotes: we have
+            // no way to refresh, but the caller's intent is "use what's there",
+            // so returning Ok is more useful than erroring on every refresh.
+            // (`checkout_of` still errors when an UNKNOWN remote is requested.)
+            return Ok(());
+        }
         let checkouts_dir = self.git_checkouts_dir();
         for (_remote, id) in self.state.git_remotes.iter_mut() {
             let repo = self.repos.get_mut(id).unwrap();
@@ -290,7 +316,14 @@ impl Manager {
                 let checkout_dir = tempdir_in(self.git_checkouts_dir()).unwrap().keep();
                 let relative_dir = checkout_dir.strip_prefix(self.git_checkouts_dir()).unwrap();
                 let repo = self.repos.get_mut(id).unwrap();
-                repo.fetch()?;
+                // Offline: skip the fetch and try the worktree checkout against
+                // what's already in the bare repo. If the requested ref isn't
+                // there, `new_worktree` will surface a git error from below
+                // — which is the right outcome (caller gets to know the ref
+                // wasn't pre-populated).
+                if !self.offline {
+                    repo.fetch()?;
+                }
                 let checkout = repo.new_worktree(checkout_dir.clone(), at.clone())?;
                 let git_hash = checkout.rev.clone();
 
@@ -305,6 +338,13 @@ impl Manager {
             }
             // New remote, need to create
             None => {
+                if self.offline {
+                    // Offline: cannot clone an unknown remote. Surface as cache miss
+                    // so the caller sees a clean error (not a git "could not connect").
+                    return Err(Error::OfflineCacheMiss {
+                        remote: remote.to_string(),
+                    });
+                }
                 // Make id/directory for bare repository
                 let prefix = match remote.to_lowercase().rsplit_once("/") {
                     None => "checkout".to_string(),

--- a/crates/checkouts/src/lib.rs
+++ b/crates/checkouts/src/lib.rs
@@ -210,7 +210,7 @@ pub struct Manager {
     /// When true, [Manager::checkout_of] / [Manager::update] return
     /// [Error::OfflineCacheMiss] for any remote that would require a clone or fetch
     /// rather than performing the network operation. Mirrors the value of
-    /// [`mctx::Config::use_remote_cache`] (i.e. `--no-fetch`).
+    /// `mctx::Config::is_offline` (i.e. `--offline`).
     offline: bool,
 }
 
@@ -490,6 +490,46 @@ mod tests {
             hash3,
             "d0dd1f61b33d64e29d8bc1372a94ef6a2fee76a9".to_string()
         );
+    }
+
+    /// In offline mode, asking for an unknown remote must surface as
+    /// OfflineCacheMiss without attempting any git operation.
+    #[test]
+    fn offline_unknown_remote_errors() {
+        let base_dir = tempdir().unwrap();
+        let mut manager = Manager::new_in_dir_with_offline(base_dir.path(), true).unwrap();
+
+        let result = manager.checkout_of(
+            "https://example.invalid/never-cloned",
+            GitRef::Branch("main".to_string()),
+        );
+        match result {
+            Err(Error::OfflineCacheMiss { remote }) => {
+                assert_eq!(remote, "https://example.invalid/never-cloned");
+            }
+            other => panic!("expected OfflineCacheMiss, got: {:?}", other),
+        }
+    }
+
+    /// In offline mode, `update()` is a no-op (returns Ok without touching
+    /// the network). The caller's intent is "use what's there"; refresh-of-
+    /// known-remote is non-destructive to skip.
+    #[test]
+    fn offline_update_is_noop() {
+        let base_dir = tempdir().unwrap();
+        let mut manager = Manager::new_in_dir_with_offline(base_dir.path(), true).unwrap();
+        manager
+            .update()
+            .expect("offline update should succeed as no-op");
+    }
+
+    /// Default (online) Manager keeps its existing behavior — `offline` is
+    /// false unless explicitly requested.
+    #[test]
+    fn default_manager_is_online() {
+        let base_dir = tempdir().unwrap();
+        let manager = Manager::new_in_dir(base_dir.path()).unwrap();
+        assert!(!manager.0.lock().unwrap().offline);
     }
 
     #[test]

--- a/crates/common/src/file_cache.rs
+++ b/crates/common/src/file_cache.rs
@@ -19,6 +19,9 @@ pub enum FileCacheError {
     BadSha,
     /// The sha256 hash that was requested differed from what was written/downloaded.
     HashMismatch { want: String, got: String },
+    /// The cache is in offline mode and the requested entry is not present.
+    /// Caller asked for a file we'd need to download, but `--no-fetch` is set.
+    OfflineCacheMiss { sha256: String, filename: String },
     /// Something unexpected.
     Internal(String),
 }
@@ -37,6 +40,11 @@ impl fmt::Display for FileCacheError {
             FileCacheError::HashMismatch { want, got } => {
                 write!(f, "HashMismatch: want={}, got={}", want, got)
             }
+            FileCacheError::OfflineCacheMiss { sha256, filename } => write!(
+                f,
+                "offline cache miss for {filename} ({sha256}) — \
+                 --no-fetch is set; pre-populate the cache or remove the flag"
+            ),
             FileCacheError::Internal(e) => write!(f, "internal: {}", e),
         }
     }
@@ -55,11 +63,22 @@ impl std::error::Error for FileCacheError {
 #[derive(Debug, Clone)]
 pub struct FileCache {
     base_dir: PathBuf,
+    /// When true, [CachingDownloader] returns [FileCacheError::OfflineCacheMiss] on cache
+    /// miss instead of attempting a network download. Set to mirror the value of
+    /// [`mctx::Config::use_remote_cache`] (i.e. `--no-fetch`).
+    offline: bool,
 }
 
 impl FileCache {
     /// Creates a new file cache rooted at the given directory.
     pub fn new(dir: PathBuf) -> Result<Self, FileCacheError> {
+        Self::new_with_offline(dir, false)
+    }
+
+    /// Creates a new file cache rooted at the given directory, optionally in offline
+    /// mode. In offline mode, any cache miss surfaces as an error rather than a silent
+    /// network fetch.
+    pub fn new_with_offline(dir: PathBuf, offline: bool) -> Result<Self, FileCacheError> {
         match fs::create_dir_all(&dir) {
             Ok(_) => {}
             Err(e) => {
@@ -69,7 +88,15 @@ impl FileCache {
             }
         };
 
-        Ok(Self { base_dir: dir })
+        Ok(Self {
+            base_dir: dir,
+            offline,
+        })
+    }
+
+    /// Returns whether this cache rejects network fetches on cache miss.
+    pub fn is_offline(&self) -> bool {
+        self.offline
     }
 
     fn sha_dir(&self, sha256: &str) -> Result<PathBuf, FileCacheError> {
@@ -220,6 +247,15 @@ impl<B: fetchers::FetchBackend> CachingDownloader<B> for (&B, &FileCache) {
             .map_err(Either::Left)?
         {
             return Ok(p);
+        }
+
+        // Cache miss: in offline mode this is a hard error (caller asked for
+        // a file we'd need network to fetch). Otherwise fall through to fetch.
+        if self.1.offline {
+            return Err(Either::Left(FileCacheError::OfflineCacheMiss {
+                sha256: sha256.to_string(),
+                filename: filename.to_string(),
+            }));
         }
 
         // Otherwise download

--- a/crates/common/src/file_cache.rs
+++ b/crates/common/src/file_cache.rs
@@ -65,7 +65,7 @@ pub struct FileCache {
     base_dir: PathBuf,
     /// When true, [CachingDownloader] returns [FileCacheError::OfflineCacheMiss] on cache
     /// miss instead of attempting a network download. Set to mirror the value of
-    /// [`mctx::Config::use_remote_cache`] (i.e. `--no-fetch`).
+    /// `mctx::Config::is_offline` (i.e. `--offline`).
     offline: bool,
 }
 
@@ -348,5 +348,157 @@ mod tests {
             !cached.exists(),
             "file should be removed after hash mismatch"
         );
+    }
+
+    /// A fake URL whose filename is whatever the test sets.
+    #[derive(Debug, Clone)]
+    struct FakeUrl {
+        filename: String,
+    }
+    impl fetchers::FetchUrl for FakeUrl {
+        type JoinError = std::convert::Infallible;
+        fn join(&self, _input: &str) -> Result<Self, Self::JoinError> {
+            Ok(self.clone())
+        }
+        fn filename(&self) -> String {
+            self.filename.clone()
+        }
+    }
+
+    /// A FetchBackend that panics on `get` / `execute`. Used by offline-mode
+    /// tests to assert the network path is never reached.
+    #[derive(Debug)]
+    struct PanickingBackend;
+    #[derive(Debug)]
+    struct PanickingRequest;
+    impl fetchers::FetchBackend for PanickingBackend {
+        type Url = FakeUrl;
+        type Request = PanickingRequest;
+        type Response = FakeResponse;
+
+        fn get(
+            &self,
+            _url: Self::Url,
+        ) -> Result<Self::Request, <Self::Response as fetchers::FetchResponse>::Error> {
+            panic!("PanickingBackend::get must not be called in offline mode");
+        }
+        async fn execute(
+            &self,
+            _req: Self::Request,
+        ) -> Result<Self::Response, <Self::Response as fetchers::FetchResponse>::Error> {
+            panic!("PanickingBackend::execute must not be called in offline mode");
+        }
+    }
+
+    /// In offline mode, a cache miss must surface as OfflineCacheMiss without
+    /// touching the network. The PanickingBackend asserts the network path is
+    /// never invoked.
+    #[tokio::test]
+    async fn offline_cache_miss_errors_without_fetching() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FileCache::new_with_offline(tmp.path().to_path_buf(), true).unwrap();
+        let op = OpTracker::new_with_root(&None);
+        let backend = PanickingBackend;
+
+        let url = FakeUrl {
+            filename: "missing.txt".into(),
+        };
+        let unknown_sha = "abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab";
+
+        let result = (&backend, &cache).download(url, unknown_sha, &op).await;
+        let err = result.unwrap_err().unwrap_left();
+        match err {
+            FileCacheError::OfflineCacheMiss { sha256, filename } => {
+                assert_eq!(sha256, unknown_sha);
+                assert_eq!(filename, "missing.txt");
+            }
+            other => panic!("expected OfflineCacheMiss, got: {other}"),
+        }
+    }
+
+    /// Offline mode is transparent on cache HIT — the backend stays uncalled
+    /// and the cached path comes back unchanged.
+    #[tokio::test]
+    async fn offline_cache_hit_returns_path_without_fetching() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FileCache::new_with_offline(tmp.path().to_path_buf(), true).unwrap();
+        let op = OpTracker::new_with_root(&None);
+        let backend = PanickingBackend;
+
+        // Pre-populate the cache with bytes whose sha matches what we'll request.
+        let content = b"cached content";
+        let sha = {
+            let mut h = sha2::Sha256::new();
+            sha2::Digest::update(&mut h, content);
+            hex::encode(h.finalize())
+        };
+        let cached_path = cache.sha_dir(&sha).unwrap().join("cached.txt");
+        std::fs::write(&cached_path, content).unwrap();
+
+        let url = FakeUrl {
+            filename: "cached.txt".into(),
+        };
+        let path = (&backend, &cache)
+            .download(url, &sha, &op)
+            .await
+            .expect("cache hit should succeed in offline mode");
+        assert_eq!(path, cached_path);
+    }
+
+    /// Sanity check: with the default (online) cache, a cache-miss request
+    /// invokes the backend rather than returning OfflineCacheMiss. Existing
+    /// callers that don't opt into offline mode see no behavior change.
+    #[tokio::test]
+    async fn online_cache_miss_invokes_backend() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FileCache::new(tmp.path().to_path_buf()).unwrap();
+        assert!(!cache.is_offline());
+        let op = OpTracker::new_with_root(&None);
+
+        // Backend that succeeds with known bytes; we want to confirm the
+        // download flow falls through to write_through (i.e. the OFFLINE
+        // path is NOT taken).
+        let content = b"online content";
+        let sha = {
+            let mut h = sha2::Sha256::new();
+            sha2::Digest::update(&mut h, content);
+            hex::encode(h.finalize())
+        };
+
+        #[derive(Debug)]
+        struct StubBackend(Vec<u8>);
+        #[derive(Debug)]
+        struct StubReq;
+        impl fetchers::FetchBackend for StubBackend {
+            type Url = FakeUrl;
+            type Request = StubReq;
+            type Response = FakeResponse;
+            fn get(
+                &self,
+                _url: Self::Url,
+            ) -> Result<Self::Request, <Self::Response as fetchers::FetchResponse>::Error>
+            {
+                Ok(StubReq)
+            }
+            async fn execute(
+                &self,
+                _req: Self::Request,
+            ) -> Result<Self::Response, <Self::Response as fetchers::FetchResponse>::Error>
+            {
+                Ok(FakeResponse::new(&self.0))
+            }
+        }
+        let backend = StubBackend(content.to_vec());
+
+        let url = FakeUrl {
+            filename: "online.txt".into(),
+        };
+        let path = (&backend, &cache)
+            .download(url, &sha, &op)
+            .await
+            .expect("online cache miss should fetch + verify");
+        // Bytes were materialized to the expected path.
+        assert!(path.exists());
+        assert_eq!(std::fs::read(&path).unwrap(), content);
     }
 }

--- a/crates/common/src/file_cache.rs
+++ b/crates/common/src/file_cache.rs
@@ -43,7 +43,7 @@ impl fmt::Display for FileCacheError {
             FileCacheError::OfflineCacheMiss { sha256, filename } => write!(
                 f,
                 "offline cache miss for {filename} ({sha256}) — \
-                 --no-fetch is set; pre-populate the cache or remove the flag"
+                 --offline is set; pre-populate the cache or remove the flag"
             ),
             FileCacheError::Internal(e) => write!(f, "internal: {}", e),
         }

--- a/crates/common/src/remote_storage.rs
+++ b/crates/common/src/remote_storage.rs
@@ -17,7 +17,20 @@ pub struct RemoteStorage {
 impl RemoteStorage {
     #[tracing::instrument]
     pub async fn new(cache_dir: PathBuf, with_gcloud_auth: bool) -> Result<Self> {
-        let cache = file_cache::FileCache::new(cache_dir)?;
+        Self::new_with_offline(cache_dir, with_gcloud_auth, false).await
+    }
+
+    /// Same as [Self::new], but with an `offline` flag. When `offline=true`, any cache
+    /// miss surfaces as an error rather than a silent network fetch — see
+    /// [`file_cache::FileCacheError::OfflineCacheMiss`]. Pair with `--no-fetch` so the
+    /// flag means "I am offline; use only what's cached" end-to-end.
+    #[tracing::instrument]
+    pub async fn new_with_offline(
+        cache_dir: PathBuf,
+        with_gcloud_auth: bool,
+        offline: bool,
+    ) -> Result<Self> {
+        let cache = file_cache::FileCache::new_with_offline(cache_dir, offline)?;
 
         let client = if with_gcloud_auth {
             Storage::builder().build().await?

--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -46,6 +46,7 @@ pub const DEFAULT_REMOTE_CACHE_BUCKET: &str = "minimal-staging-cache";
 pub struct ConfigBuilder {
     no_cache: Option<bool>,
     no_fetch: Option<bool>,
+    offline: Option<bool>,
     num_parallel_builds: Option<usize>,
 
     minimal_dir: Option<PathBuf>,
@@ -69,6 +70,14 @@ impl ConfigBuilder {
     /// Configures whether the remote cache may be used or not.
     pub fn with_no_fetch(mut self, no_fetch: bool) -> Self {
         self.no_fetch = Some(no_fetch);
+        self
+    }
+    /// Configures whether minimal runs in offline mode. When set, any source
+    /// or VCS cache miss surfaces as a clear error rather than a silent
+    /// network call. Implies [Self::with_no_fetch] for the remote-artifact
+    /// cache layer (you can't reach the artifact cache when offline).
+    pub fn with_offline(mut self, offline: bool) -> Self {
+        self.offline = Some(offline);
         self
     }
     /// Configures the max number of parallel builds.
@@ -122,6 +131,7 @@ impl ConfigBuilder {
         Ok(Config {
             no_cache: self.no_cache.unwrap_or(false),
             no_fetch: self.no_fetch.unwrap_or(false),
+            offline: self.offline.unwrap_or(false),
             num_parallel_builds: self
                 .num_parallel_builds
                 .unwrap_or_else(common::default_parallelism),
@@ -147,6 +157,7 @@ impl Config {
         ConfigBuilder {
             no_cache: Some(self.no_cache),
             no_fetch: Some(self.no_fetch),
+            offline: Some(self.offline),
             num_parallel_builds: Some(self.num_parallel_builds),
             minimal_dir: Some(self.minimal_dir),
             stdlib_dir: self.stdlib_dir,
@@ -165,6 +176,9 @@ pub struct Config {
     no_cache: bool,
     /// Do not fetch any needed-but-available-remote entries from the remote cache.
     no_fetch: bool,
+    /// Run in offline mode: error on source / VCS cache miss instead of attempting
+    /// any network call. Implies the artifact-cache-skip half of [Self::no_fetch].
+    offline: bool,
     /// Maximum number of concurrent builds.
     num_parallel_builds: usize,
 
@@ -202,8 +216,15 @@ impl Config {
         !self.no_cache
     }
     /// Returns true if objects should be downloaded from the remote cache instead of built.
+    /// False when either [Self::no_fetch] or [Self::offline] is set (offline implies we
+    /// can't reach the remote cache anyway).
     pub fn use_remote_cache(&self) -> bool {
-        !self.no_fetch
+        !self.no_fetch && !self.offline
+    }
+    /// Returns true if minimal is running in offline mode. When true, source-tarball
+    /// and VCS cache misses surface as errors rather than silent network fetches.
+    pub fn is_offline(&self) -> bool {
+        self.offline
     }
     /// Returns the maximum number of parallel builds that may take place at once.
     pub fn num_parallel_builds(&self) -> usize {

--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -74,8 +74,18 @@ impl ConfigBuilder {
     }
     /// Configures whether minimal runs in offline mode. When set, any source
     /// or VCS cache miss surfaces as a clear error rather than a silent
-    /// network call. Implies [Self::with_no_fetch] for the remote-artifact
-    /// cache layer (you can't reach the artifact cache when offline).
+    /// network call.
+    ///
+    /// Does NOT imply [Self::with_no_fetch] — the remote artifact cache
+    /// is sha-verified on hydrate (see `rcache::RemoteCache::materialize`),
+    /// so cached pulls are hermetically clean even when offline mode
+    /// forbids source-tarball or VCS fetches. For environments that need
+    /// to disable both (e.g. fully air-gapped builds), set them
+    /// independently via [Self::with_no_fetch] + [Self::with_offline].
+    ///
+    /// Hermetic-builder-rs sets offline=true to surface mirror-source
+    /// gaps as clear errors while still allowing the signer-attested
+    /// build cache to satisfy build_deps.
     pub fn with_offline(mut self, offline: bool) -> Self {
         self.offline = Some(offline);
         self
@@ -216,10 +226,13 @@ impl Config {
         !self.no_cache
     }
     /// Returns true if objects should be downloaded from the remote cache instead of built.
-    /// False when either [Self::no_fetch] or [Self::offline] is set (offline implies we
-    /// can't reach the remote cache anyway).
+    /// Gated only on [Self::no_fetch] — `offline` controls source-tarball / VCS
+    /// fetch policy, not the sha-verified artifact cache. Cached pulls are
+    /// hermetically clean (rcache verifies sha256 on hydrate) so they're
+    /// allowed in offline mode. Set [Self::with_no_fetch] explicitly to
+    /// disable the artifact cache in fully air-gapped configurations.
     pub fn use_remote_cache(&self) -> bool {
-        !self.no_fetch && !self.offline
+        !self.no_fetch
     }
     /// Returns true if minimal is running in offline mode. When true, source-tarball
     /// and VCS cache misses surface as errors rather than silent network fetches.

--- a/crates/mctx/src/error.rs
+++ b/crates/mctx/src/error.rs
@@ -183,6 +183,11 @@ impl From<checkouts::Error> for Error {
             checkouts::Error::StatefileInvalid(e) => {
                 Self::Other(anyhow::anyhow!("vcs: failed parsing state file: {}", e))
             }
+            checkouts::Error::OfflineCacheMiss { remote } => Self::Other(anyhow::anyhow!(
+                "vcs: offline cache miss for remote {} — --no-fetch is set; pre-populate \
+                 the vcs/ cache or remove the flag",
+                remote
+            )),
         }
     }
 }

--- a/crates/mctx/src/error.rs
+++ b/crates/mctx/src/error.rs
@@ -184,7 +184,7 @@ impl From<checkouts::Error> for Error {
                 Self::Other(anyhow::anyhow!("vcs: failed parsing state file: {}", e))
             }
             checkouts::Error::OfflineCacheMiss { remote } => Self::Other(anyhow::anyhow!(
-                "vcs: offline cache miss for remote {} — --no-fetch is set; pre-populate \
+                "vcs: offline cache miss for remote {} — --offline is set; pre-populate \
                  the vcs/ cache or remove the flag",
                 remote
             )),

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -218,7 +218,10 @@ impl Context {
         let vcs = if let Some(vcs_manager) = config.vcs_manager_override() {
             vcs_manager
         } else {
-            VcsManager::new_in_dir(config.vcs_dir())?
+            // `--no-fetch` flips the VcsManager into offline mode: any clone or fetch
+            // surfaces as Error::OfflineCacheMiss instead of attempting the network
+            // operation. Pre-populate `vcs_dir()` for the workflow that needs this.
+            VcsManager::new_in_dir_with_offline(config.vcs_dir(), !config.use_remote_cache())?
         };
         let cache = Cache::at_dir(config.cache_dir())
             .map_err(|e| Error::Other(anyhow!("initializing local cache: {}", e)))?;
@@ -403,9 +406,16 @@ impl Context {
     }
     pub async fn remote_storage(&self) -> Result<common::RemoteStorage, Error> {
         let start = SystemTime::now();
-        let rs = common::RemoteStorage::new(self.config.downloads_dir(), false)
-            .await
-            .unwrap();
+        // `--no-fetch` flips the underlying FileCache into offline mode so any
+        // source-URL cache miss surfaces as FileCacheError::OfflineCacheMiss
+        // rather than a silent network fetch.
+        let rs = common::RemoteStorage::new_with_offline(
+            self.config.downloads_dir(),
+            false,
+            !self.config.use_remote_cache(),
+        )
+        .await
+        .unwrap();
         tracing::trace!("remote storage init took {:?}", start.elapsed());
         Ok(rs)
     }

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -218,10 +218,10 @@ impl Context {
         let vcs = if let Some(vcs_manager) = config.vcs_manager_override() {
             vcs_manager
         } else {
-            // `--no-fetch` flips the VcsManager into offline mode: any clone or fetch
+            // `--offline` flips the VcsManager into offline mode: any clone or fetch
             // surfaces as Error::OfflineCacheMiss instead of attempting the network
             // operation. Pre-populate `vcs_dir()` for the workflow that needs this.
-            VcsManager::new_in_dir_with_offline(config.vcs_dir(), !config.use_remote_cache())?
+            VcsManager::new_in_dir_with_offline(config.vcs_dir(), config.is_offline())?
         };
         let cache = Cache::at_dir(config.cache_dir())
             .map_err(|e| Error::Other(anyhow!("initializing local cache: {}", e)))?;
@@ -406,13 +406,13 @@ impl Context {
     }
     pub async fn remote_storage(&self) -> Result<common::RemoteStorage, Error> {
         let start = SystemTime::now();
-        // `--no-fetch` flips the underlying FileCache into offline mode so any
+        // `--offline` flips the underlying FileCache into offline mode so any
         // source-URL cache miss surfaces as FileCacheError::OfflineCacheMiss
         // rather than a silent network fetch.
         let rs = common::RemoteStorage::new_with_offline(
             self.config.downloads_dir(),
             false,
-            !self.config.use_remote_cache(),
+            self.config.is_offline(),
         )
         .await
         .unwrap();

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -415,7 +415,7 @@ impl Context {
             self.config.is_offline(),
         )
         .await
-        .unwrap();
+        .map_err(|e| Error::Other(anyhow!("initializing remote storage: {}", e)))?;
         tracing::trace!("remote storage init took {:?}", start.elapsed());
         Ok(rs)
     }

--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -145,6 +145,21 @@ pub struct GlobalArgs {
     #[arg(long, default_value_t = false, global = true)]
     no_fetch: bool,
 
+    /// Use only what's already in the local cache for sources, VCS checkouts,
+    /// and the remote artifact cache. On cache miss, fail with a clear error
+    /// instead of attempting any network call. Useful for builds in
+    /// network-isolated environments where every input is pre-staged.
+    ///
+    /// Composes with the other cache flags:
+    ///   - implies the remote-artifact-cache-skip half of --no-fetch (you
+    ///     can't reach the artifact cache when offline anyway), so
+    ///     --offline alone is sufficient — no need for --offline --no-fetch
+    ///   - orthogonal to --no-cache and --rebuild, which control whether to
+    ///     use locally-built artifacts (--offline doesn't force a rebuild;
+    ///     it just gates the network)
+    #[arg(long, default_value_t = false, global = true)]
+    offline: bool,
+
     /// Configure the number of parallel builds
     #[arg(short, long, global = true)]
     num_parallel_builds: Option<usize>,
@@ -203,7 +218,8 @@ async fn run_cli(cli: Cli) -> Result<(), Error> {
 
     let mut config = ConfigBuilder::new()
         .with_no_cache(global_args.no_cache)
-        .with_no_fetch(global_args.no_fetch);
+        .with_no_fetch(global_args.no_fetch)
+        .with_offline(global_args.offline);
     if let Some(num_parallel_builds) = global_args.num_parallel_builds {
         config = config.with_num_parallel_builds(num_parallel_builds);
     }


### PR DESCRIPTION
## Summary

Adds a new `--offline` global flag for running minimal in network-isolated environments where every input is pre-staged in the local cache. On cache miss, surfaces a clear error rather than attempting any network call.

`--no-fetch` semantics unchanged — keeps its existing meaning of "skip the remote artifact cache, build from source instead", which composes naturally with `--rebuild` for the laptop-rebuild-the-world use case.

## Motivation

Running `minimal package <pkg>` inside a network-isolated build VM (Confidential Space, no internet egress) where source bytes are pre-staged in a sha-pinned mirror. There was no flag combination that meant "use cache only — if anything's missing, fail loud" — `--no-fetch` only affected the remote artifact cache, while source URL fetches and git clones quietly hit the network on cache miss.

After this patch, the same invocation surfaces:

```
Error: failed to fetch upstream layer: offline cache miss for git remote
https://github.com/gominimal/pkgs — --no-fetch is set; pre-populate the
vcs/ cache or remove the flag
```

## Design

Per review feedback (thanks @msample, @twitchyliquid64) — extending `--no-fetch` would have conflated two distinct semantics. Cleaner shape:

- `--no-fetch` (existing): skip the remote artifact cache. Source/VCS fetches still happen on cache miss. Useful for laptop rebuild-the-world flows alongside `--rebuild`.
- `--offline` (new): treat every cache as authoritative. Source / VCS / artifact-cache misses all error rather than fetch. Implies the artifact-cache-skip half of `--no-fetch` (you can't reach the artifact cache when offline anyway), so `--offline` alone is sufficient.
- Orthogonal to `--no-cache` and `--rebuild`: `--offline` doesn't force a rebuild, it just gates the network.

## Changes

**`crates/common/src/file_cache.rs`**
- `FileCache` gains `offline: bool` + `new_with_offline(dir, offline)` ctor + `is_offline()` accessor. Existing `new(dir)` preserved (defaults to `offline=false`).
- `CachingDownloader::download` checks `cache.offline` after `read_cached` returns `None`; returns `FileCacheError::OfflineCacheMiss { sha256, filename }` instead of falling through to the network fetcher.

**`crates/common/src/remote_storage.rs`**
- `RemoteStorage::new_with_offline(dir, with_gcloud_auth, offline)` forwards `offline` into `FileCache`. Default `new` unchanged.

**`crates/checkouts/src/lib.rs`**
- `Manager` gains `offline: bool` + `new_in_dir_with_offline`. Existing `new_in_dir` preserved.
- `update()`: no-op when offline (caller intent is "use what's there"; refresh-of-known-remote is non-destructive to skip).
- `checkout_of()` known-remote path: skip `repo.fetch()` when offline.
- `checkout_of()` unknown-remote path: return `Error::OfflineCacheMiss { remote }`.

**`crates/checkouts/src/error.rs`**: new `OfflineCacheMiss` variant + `Display`.

**`crates/mctx/src/config.rs`**
- `Config` gains `offline: bool` field. New `with_offline()` builder + `is_offline()` accessor.
- `use_remote_cache()` becomes `!no_fetch && !is_offline()` so `--offline` strictly implies the artifact-cache-skip behavior.

**`crates/mctx/src/lib.rs`**: VcsManager + RemoteStorage initializers pass `config.is_offline()` through to the new `_with_offline` constructors.

**`crates/mctx/src/error.rs`**: maps `checkouts::Error::OfflineCacheMiss` to a clear top-level message.

**`crates/minimal/src/main.rs`**: new `--offline` global CLI flag wired to `ConfigBuilder::with_offline`.

## What this is *not*

- Not a cache-population mechanism. Operators are expected to pre-stage `~/.cache/minimal/downloads/<sha256>/<filename>` and the `vcs/` directory themselves.
- Not a `--trusted-source-domains`-style allowlist (per @msample's prompt). For the offline use case the URL doesn't matter — minimal looks up bytes by sha — but a trusted-domains flag for semi-online flows would be a reasonable separate addition.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — full test suite passes
- [x] Six new unit tests cover the offline path:
  - `file_cache::tests::offline_cache_miss_errors_without_fetching` — `PanickingBackend` asserts the network path is never invoked
  - `file_cache::tests::offline_cache_hit_returns_path_without_fetching` — same assertion under cache-hit
  - `file_cache::tests::online_cache_miss_invokes_backend` — sanity check that default behavior is unchanged
  - `checkouts::tests::offline_unknown_remote_errors`
  - `checkouts::tests::offline_update_is_noop`
  - `checkouts::tests::default_manager_is_online`
- [x] Manual smoke: with the sed source cache wiped, `minimal --offline package -v --rebuild sed` errors with `OfflineCacheMiss` instead of silently re-fetching.

## Future work (out of scope here)

- proptest-style invariant tests across the cache surfaces (minimal doesn't currently use proptest; would be a structural addition worth its own PR)
- cargo-fuzz harness for parser surfaces (Nickel decode, URL parsing, statefile JSON)
- the trusted-source-domains framing @msample raised, for semi-online flows where some hosts are reachable and others aren't


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global --offline flag and config option; offline-capable managers and cache constructors to run without network access.
* **Behavior**
  * When offline, network/VCS/cache fetches are suppressed and operations return clear offline-cache-miss errors advising cache pre-population or removing --offline.
* **Tests**
  * Added tests for offline vs online cache behavior, checkout/update offline handling, and default online behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->