### PR TITLE
crates/sandbox2: do not error if systemd cgroups setup fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,9 +1663,8 @@ dependencies = [
 
 [[package]]
 name = "hakoniwa"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6361cf8f90dcee65a22616a3eaf289942b536dca4102310b17b60ec7ff23c82"
+version = "1.7.0"
+source = "git+https://github.com/souk4711/hakoniwa.git?rev=8de107ed506b870d0ab4bf3291271d2168003f1b#8de107ed506b870d0ab4bf3291271d2168003f1b"
 dependencies = [
  "bitflags",
  "caps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ generational-arena = {version = "0.2", features = ["serde"] }
 google-cloud-gax = "1.10"
 google-cloud-auth = "1.3"
 google-cloud-storage = "1.5"
-hakoniwa = { version = "1.6", features = ["cgroups"] }
+# Revert back to crates.io dep once new version is released.
+hakoniwa = { git = "https://github.com/souk4711/hakoniwa.git", rev = "8de107ed506b870d0ab4bf3291271d2168003f1b", features = ["cgroups"] }
 http-body = "1"
 hex = "0.4"
 indicatif = "0.18"

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -383,7 +383,8 @@ impl<C: Channel> Sandbox<C> {
             .unwrap()
             .devfsmount("/dev")
             .tmpfsmount("/tmp")
-            .unshare(hakoniwa::Namespace::Cgroup);
+            .unshare(hakoniwa::Namespace::Cgroup)
+            .runctl(hakoniwa::Runctl::IgnoreCgroupSetupFailed);
 
         let rec = BindOpts {
             recursive: true,
@@ -448,20 +449,18 @@ impl<C: Channel> Sandbox<C> {
             container.unshare(hakoniwa::Namespace::Uts);
             container.hostname(hn);
         }
-        if let Some(s) = &self.config.cpu_weight {
-            if systemd_probably_works() || std::env::var("MINIMAL_CGROUPS_ALWAYS").is_ok() {
-                container.cgroups_resources({
-                    let mut resources = hakoniwa::cgroups::Resources::default();
-                    resources.cpu({
-                        let mut cpu = hakoniwa::cgroups::Cpu::default();
-                        cpu.shares(*s);
-                        cpu
-                    });
-                    resources
+        if let Some(s) = &self.config.cpu_weight
+            && booted_with_systemd()
+        {
+            container.cgroups_resources({
+                let mut resources = hakoniwa::cgroups::Resources::default();
+                resources.cpu({
+                    let mut cpu = hakoniwa::cgroups::Cpu::default();
+                    cpu.shares(*s);
+                    cpu
                 });
-            } else {
-                tracing::debug!("Not configuring cgroups: systemd probably not available");
-            }
+                resources
+            });
         }
 
         Ok(Container { container })
@@ -779,18 +778,16 @@ impl Sandbox {
     }
 }
 
-fn hardlink_dir_contents(src_dir: &Path, dst_parent_dir: &Path) -> Result<(), Error> {
-    common::hardlink_dir_contents(src_dir, dst_parent_dir).map_err(Error::HardlinkFailed)
+// Matches the logic in the libcgroups crate. If we do not conditionally
+// set cpu resources, the underlying code in libcgroups will panic :(
+fn booted_with_systemd() -> bool {
+    std::fs::symlink_metadata("/run/systemd/system")
+        .map(|p| p.is_dir())
+        .unwrap_or_default()
 }
 
-fn systemd_probably_works() -> bool {
-    if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok() {
-        return true;
-    }
-    if let Ok(dir) = std::env::var("XDG_RUNTIME_DIR") {
-        return std::fs::metadata(PathBuf::from(dir).join("bus")).is_ok();
-    }
-    false
+fn hardlink_dir_contents(src_dir: &Path, dst_parent_dir: &Path) -> Result<(), Error> {
+    common::hardlink_dir_contents(src_dir, dst_parent_dir).map_err(Error::HardlinkFailed)
 }
 
 /// Returns the kernel-locked mount flags for the mount containing `path`.


### PR DESCRIPTION
Fixes gominimal/inbox#133

This uses an [upstream change](https://github.com/souk4711/hakoniwa/commit/373b6d6780045db3036972042a93225ad255b2af) which allows the sandbox to continue setup even if systemd cgroup setup fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Temporarily pinned an internal dependency to a specific revision (will revert to the registry once a new release is available).
* **Improvements**
  * Made container cgroup setup more resilient to failures.
  * CPU cgroup resource settings now apply only when the system is detected to be booted with systemd.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->