### PR TITLE
assorted: update nickel dep, set initial-env instead of writing files to disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "indoc",
+ "nickel-lang-core",
  "serde",
  "shlex 2.0.1",
  "toml 1.1.2+spec-1.1.0",
@@ -2993,7 +2994,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 [[package]]
 name = "nickel-lang-core"
 version = "0.17.0"
-source = "git+https://github.com/nickel-lang/nickel.git?rev=3a399233dcb5b5e8610a1245eeb171c29787a903#3a399233dcb5b5e8610a1245eeb171c29787a903"
+source = "git+https://github.com/nickel-lang/nickel.git?rev=5bf193c843bdd5fe87aac288d1b1e32a945c2f29#5bf193c843bdd5fe87aac288d1b1e32a945c2f29"
 dependencies = [
  "base64",
  "bumpalo",
@@ -3038,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "nickel-lang-parser"
 version = "0.2.0"
-source = "git+https://github.com/nickel-lang/nickel.git?rev=3a399233dcb5b5e8610a1245eeb171c29787a903#3a399233dcb5b5e8610a1245eeb171c29787a903"
+source = "git+https://github.com/nickel-lang/nickel.git?rev=5bf193c843bdd5fe87aac288d1b1e32a945c2f29#5bf193c843bdd5fe87aac288d1b1e32a945c2f29"
 dependencies = [
  "bumpalo",
  "codespan",
@@ -3063,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "nickel-lang-vector"
 version = "0.1.0"
-source = "git+https://github.com/nickel-lang/nickel.git?rev=3a399233dcb5b5e8610a1245eeb171c29787a903#3a399233dcb5b5e8610a1245eeb171c29787a903"
+source = "git+https://github.com/nickel-lang/nickel.git?rev=5bf193c843bdd5fe87aac288d1b1e32a945c2f29#5bf193c843bdd5fe87aac288d1b1e32a945c2f29"
 dependencies = [
  "imbl-sized-chunks",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ jaq-all = "0.1.0"
 lzma-rs = "0.3"
 
 # Revert back to crates.io dep once 0.18 is released.
-nickel-lang-core = { git = "https://github.com/nickel-lang/nickel.git", rev = "3a399233dcb5b5e8610a1245eeb171c29787a903", default-features = false, features = ["format"] }
+nickel-lang-core = { git = "https://github.com/nickel-lang/nickel.git", rev = "5bf193c843bdd5fe87aac288d1b1e32a945c2f29", default-features = false, features = ["format"] }
 
 nix = { version = "0.31", features = ["fs"] }
 object = { version = "0.39", default-features = false, features = ["archive", "elf", "read_core", "std"] }

--- a/crates/args/Cargo.toml
+++ b/crates/args/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 
 [dependencies]
 clap.workspace = true
+nickel-lang-core.workspace = true
 serde.workspace = true
 shlex.workspace = true
 toml.workspace = true

--- a/crates/args/src/lib.rs
+++ b/crates/args/src/lib.rs
@@ -156,16 +156,16 @@ impl Hash for ScalarArg {
 }
 
 impl ScalarArg {
-    /// Append the nickel literal representation of this value to `buf`.
-    pub fn write_nickel(&self, buf: &mut String) {
+    /// Returns this value as a Nickel value, suitable for use in an
+    /// initial-env binding.
+    pub fn to_nickel(&self) -> nickel_lang_core::eval::value::NickelValue {
+        use nickel_lang_core::eval::value::NickelValue;
         match self {
-            ScalarArg::String(s) => {
-                buf.push('"');
-                buf.push_str(s);
-                buf.push('"');
+            ScalarArg::String(s) => NickelValue::string_posless(s.as_str()),
+            ScalarArg::Number(f) => {
+                NickelValue::number_posless(nickel_lang_core::term::Number::try_from(*f).unwrap())
             }
-            ScalarArg::Number(f) => buf.push_str(&f.to_string()),
-            ScalarArg::Boolean(b) => buf.push_str(if *b { "true" } else { "false" }),
+            ScalarArg::Boolean(b) => NickelValue::bool_value_posless(*b),
         }
     }
 }
@@ -179,35 +179,18 @@ pub enum Arg {
 }
 
 impl Arg {
-    /// Append the nickel literal representation of this value to `buf`.
-    pub fn write_nickel(&self, buf: &mut String) {
+    /// Returns this value as a Nickel value, suitable for use in an
+    /// initial-env binding.
+    pub fn to_nickel(&self) -> nickel_lang_core::eval::value::NickelValue {
+        use nickel_lang_core::eval::value::{Array, NickelValue};
         match self {
-            Arg::Scalar(s) => s.write_nickel(buf),
-            Arg::Enum(s) => {
-                buf.push('"');
-                buf.push_str(s);
-                buf.push('"');
-            }
-            Arg::Array(v) => {
-                buf.push('[');
-                for (i, s) in v.iter().enumerate() {
-                    if i > 0 {
-                        buf.push_str(", ");
-                    }
-                    s.write_nickel(buf);
-                }
-                buf.push(']');
-            }
+            Arg::Scalar(s) => s.to_nickel(),
+            Arg::Enum(s) => NickelValue::string_posless(s.as_str()),
+            Arg::Array(items) => NickelValue::array_posless(
+                Array::from_iter(items.iter().map(ScalarArg::to_nickel)),
+                Vec::new(),
+            ),
         }
-    }
-
-    /// Write a `let <ident> = <value> in\n` binding into `buf`.
-    pub fn write_nickel_binding(&self, ident: &str, buf: &mut String) {
-        buf.push_str("let ");
-        buf.push_str(ident);
-        buf.push_str(" = ");
-        self.write_nickel(buf);
-        buf.push_str(" in\n");
     }
 }
 

--- a/crates/check/src/lib.rs
+++ b/crates/check/src/lib.rs
@@ -665,36 +665,60 @@ impl FileBasedChecker for ParseCheck {
         }
 
         use nickel_lang_core::error::report::report_as_str;
+        use nickel_lang_core::eval::value::{NickelValue, RecordData};
+        use nickel_lang_core::identifier::{Ident, LocIdent};
+        use nickel_lang_core::program::{BuilderError, ProgramBuilder};
         use nickel_lang_core::{error::NullReporter, eval::cache::CacheImpl, program::Program};
 
-        let program_res = Program::new_from_source(
-            std::io::Cursor::new(format!(
-                "import \"{}\"",
-                pkg_dir.join("build.ncl").as_os_str().to_str().unwrap()
-            )),
-            "toplevel",
-            std::io::stderr(),
-            NullReporter {},
-        );
+        let target_val = NickelValue::record_posless(RecordData::with_field_values([
+            (
+                LocIdent::new("os"),
+                NickelValue::enum_tag_posless(LocIdent::new("Linux")),
+            ),
+            (
+                LocIdent::new("arch"),
+                NickelValue::enum_tag_posless(LocIdent::new("Amd64")),
+            ),
+        ]));
+        let injected = NickelValue::record_posless(RecordData::with_field_values([
+            (LocIdent::new("target"), target_val),
+            (
+                LocIdent::new("args"),
+                NickelValue::record_posless(RecordData::default()),
+            ),
+        ]));
+
+        let program_res: Result<Program<CacheImpl>, _> = ProgramBuilder::new()
+            .add_source(
+                std::io::Cursor::new(format!(
+                    "import \"{}\"",
+                    pkg_dir.join("build.ncl").as_os_str().to_str().unwrap()
+                )),
+                "toplevel",
+            )
+            .add_import_paths([ctx.stdlib_dir.as_path()].iter())
+            .extend_initial_env(vec![(Ident::new("__minimal_injected_config"), injected)])
+            .with_reporter(NullReporter {})
+            .with_trace(std::io::stderr())
+            .build();
 
         let mut program: Program<CacheImpl> = match program_res {
             Ok(p) => p,
             Err(e) => {
+                let msg = match e {
+                    BuilderError::NoInputs => unreachable!(),
+                    BuilderError::Io { path, error } => match path {
+                        Some(p) => format!("{}: {}", p.display(), error),
+                        None => format!("{}", error),
+                    },
+                };
                 return Ok(CheckResult {
                     check: "parse".into(),
                     verdict: CheckVerdict::Fail,
-                    err: vec![format!("{}", e)],
+                    err: vec![msg],
                 });
             }
         };
-
-        let generated_lib_dir = tempfile::TempDir::new().unwrap();
-        std::fs::write(
-            generated_lib_dir.path().join("__injected_config__.ncl"),
-            b"{target = {arch = 'Amd64, os = 'Linux}}",
-        )
-        .unwrap();
-        program.add_import_paths([ctx.stdlib_dir.as_path(), generated_lib_dir.path()].iter());
 
         if let Err(e) = program.typecheck(nickel_lang_core::typecheck::TypecheckMode::Walk) {
             return Ok(CheckResult {
@@ -719,7 +743,6 @@ impl FileBasedChecker for ParseCheck {
             });
         }
 
-        drop(generated_lib_dir);
         Ok(CheckResult {
             check: "parse".into(),
             verdict: CheckVerdict::Pass,

--- a/crates/check/src/profile.rs
+++ b/crates/check/src/profile.rs
@@ -20,33 +20,43 @@ pub(crate) async fn check_profile(
     let mut out = Vec::new();
 
     use nickel_lang_core::error::report::report_as_str;
+    use nickel_lang_core::program::{BuilderError, ProgramBuilder};
     use nickel_lang_core::{error::NullReporter, eval::cache::CacheImpl, program::Program};
 
-    let program_res = Program::new_from_source(
-        std::io::Cursor::new(format!(
-            "import \"{}\"",
-            profiles_dir
-                .join(&profile)
-                .join("profile.ncl")
-                .as_os_str()
-                .to_str()
-                .unwrap()
-        )),
-        "toplevel",
-        std::io::stderr(),
-        NullReporter {},
-    );
+    let program_res: Result<Program<CacheImpl>, _> = ProgramBuilder::new()
+        .add_source(
+            std::io::Cursor::new(format!(
+                "import \"{}\"",
+                profiles_dir
+                    .join(&profile)
+                    .join("profile.ncl")
+                    .as_os_str()
+                    .to_str()
+                    .unwrap()
+            )),
+            "toplevel",
+        )
+        .add_import_paths([ctx.stdlib_dir.clone()].iter())
+        .with_reporter(NullReporter {})
+        .with_trace(std::io::stderr())
+        .build();
 
     let mut program: Program<CacheImpl> = match program_res {
         Ok(p) => p,
         Err(e) => {
+            let msg = match e {
+                BuilderError::NoInputs => unreachable!(),
+                BuilderError::Io { path, error } => match path {
+                    Some(p) => format!("{}: {}", p.display(), error),
+                    None => format!("{}", error),
+                },
+            };
             return Ok(vec![CheckResult::parse_failure(format!(
                 "loading failed: {}",
-                e
+                msg
             ))]);
         }
     };
-    program.add_import_paths([ctx.stdlib_dir.clone()].iter());
 
     if let Err(e) = program.typecheck(nickel_lang_core::typecheck::TypecheckMode::Walk) {
         return Ok(vec![CheckResult::parse_failure(report_as_str(

--- a/crates/check/src/stack.rs
+++ b/crates/check/src/stack.rs
@@ -19,51 +19,45 @@ pub(crate) async fn check_stack(
     let mut out = Vec::new();
 
     use nickel_lang_core::error::report::report_as_str;
+    use nickel_lang_core::program::{BuilderError, ProgramBuilder};
     use nickel_lang_core::{error::NullReporter, eval::cache::CacheImpl, program::Program};
 
     // TODO: Transitioning from 'harness' => 'stack', remove after May 2026
-    let program_res = if stacks_dir.join(&stack).join("harness.ncl").exists() {
-        Program::new_from_source(
-            std::io::Cursor::new(format!(
-                "import \"{}\"",
-                stacks_dir
-                    .join(&stack)
-                    .join("harness.ncl")
-                    .as_os_str()
-                    .to_str()
-                    .unwrap()
-            )),
-            "toplevel",
-            std::io::stderr(),
-            NullReporter {},
-        )
+    let entry_file = if stacks_dir.join(&stack).join("harness.ncl").exists() {
+        stacks_dir.join(&stack).join("harness.ncl")
     } else {
-        Program::new_from_source(
+        stacks_dir.join(&stack).join("stack.ncl")
+    };
+
+    let program_res: Result<Program<CacheImpl>, _> = ProgramBuilder::new()
+        .add_source(
             std::io::Cursor::new(format!(
                 "import \"{}\"",
-                stacks_dir
-                    .join(&stack)
-                    .join("stack.ncl")
-                    .as_os_str()
-                    .to_str()
-                    .unwrap()
+                entry_file.as_os_str().to_str().unwrap()
             )),
             "toplevel",
-            std::io::stderr(),
-            NullReporter {},
         )
-    };
+        .add_import_paths([ctx.stdlib_dir.clone()].iter())
+        .with_reporter(NullReporter {})
+        .with_trace(std::io::stderr())
+        .build();
 
     let mut program: Program<CacheImpl> = match program_res {
         Ok(p) => p,
         Err(e) => {
+            let msg = match e {
+                BuilderError::NoInputs => unreachable!(),
+                BuilderError::Io { path, error } => match path {
+                    Some(p) => format!("{}: {}", p.display(), error),
+                    None => format!("{}", error),
+                },
+            };
             return Ok(vec![CheckResult::parse_failure(format!(
                 "loading failed: {}",
-                e
+                msg
             ))]);
         }
     };
-    program.add_import_paths([ctx.stdlib_dir.clone()].iter());
 
     if let Err(e) = program.typecheck(nickel_lang_core::typecheck::TypecheckMode::Walk) {
         return Ok(vec![CheckResult::parse_failure(report_as_str(

--- a/crates/common/src/ncl_eval.rs
+++ b/crates/common/src/ncl_eval.rs
@@ -1,27 +1,32 @@
 use nickel_lang_core::error::Error;
+use nickel_lang_core::eval::value::NickelValue;
 use nickel_lang_core::files::Files;
-use nickel_lang_core::{error::NullReporter, eval::cache::CacheImpl, program::Program};
-use std::io;
+use nickel_lang_core::identifier::Ident;
+use nickel_lang_core::{
+    error::NullReporter,
+    eval::cache::CacheImpl,
+    program::{Program, ProgramBuilder},
+};
 
 /// Resolves string interpolations to given base values.
 pub struct VarCtx {
-    base: String,
+    vars: Vec<(Ident, NickelValue)>,
 }
 
 impl VarCtx {
     pub fn eval_string(&self, s: &str) -> Result<String, Box<(Files, Error)>> {
-        let mut source = String::with_capacity(self.base.len() + s.len() + 16);
-        source.push_str(&self.base);
-        source.push_str("\nm%\"");
+        let mut source = String::with_capacity(s.len() + 6);
+        source.push_str("m%\"");
         source.push_str(s);
         source.push_str("\"%");
 
-        let mut program: Program<CacheImpl> = Program::new_from_sources(
-            [(io::Cursor::new(source), "toplevel")],
-            std::io::stderr(),
-            NullReporter {},
-        )
-        .unwrap();
+        let mut program: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source_string(source, "toplevel")
+            .extend_initial_env(self.vars.clone())
+            .with_reporter(NullReporter {})
+            .with_trace(std::io::stderr())
+            .build()
+            .unwrap();
 
         program
             .typecheck(nickel_lang_core::typecheck::TypecheckMode::Walk)
@@ -43,11 +48,11 @@ impl VarCtx {
 
 impl<S: AsRef<str>> FromIterator<(S, args::Arg)> for VarCtx {
     fn from_iter<T: IntoIterator<Item = (S, args::Arg)>>(iter: T) -> Self {
-        let mut base = String::with_capacity(512);
-        for (ident, value) in iter.into_iter() {
-            value.write_nickel_binding(ident.as_ref(), &mut base);
-        }
-        Self { base }
+        let vars = iter
+            .into_iter()
+            .map(|(ident, value)| (Ident::new(ident.as_ref()), value.to_nickel()))
+            .collect();
+        Self { vars }
     }
 }
 
@@ -58,7 +63,7 @@ mod tests {
     #[test]
     fn empty_var_ctx() {
         let ctx = VarCtx::from_iter(std::iter::empty::<(&str, args::Arg)>());
-        assert_eq!(ctx.base, "");
+        assert!(ctx.vars.is_empty());
     }
 
     #[test]

--- a/crates/common/src/target.rs
+++ b/crates/common/src/target.rs
@@ -13,10 +13,10 @@ pub enum Arch {
 }
 
 impl Arch {
-    pub fn as_nickel_literal(&self) -> &[u8] {
+    pub fn as_nickel_str(&self) -> &'static str {
         match self {
-            Arch::Amd64 => b"'Amd64",
-            Arch::Arm64 => b"'Arm64",
+            Arch::Amd64 => "Amd64",
+            Arch::Arm64 => "Arm64",
         }
     }
 }
@@ -67,10 +67,10 @@ pub enum OS {
 }
 
 impl OS {
-    pub fn as_nickel_literal(&self) -> &[u8] {
+    pub fn as_nickel_str(&self) -> &'static str {
         match self {
-            OS::Linux => b"'Linux",
-            OS::MacOS => b"'MacOS",
+            OS::Linux => "Linux",
+            OS::MacOS => "MacOS",
         }
     }
 }

--- a/crates/decode/src/load.rs
+++ b/crates/decode/src/load.rs
@@ -6,14 +6,18 @@ use crate::Error;
 use common::{SpecOrigin, Target};
 
 use nickel_lang_core::cache::TermCacheError;
-use nickel_lang_core::eval::value::NickelValue;
-use nickel_lang_core::identifier::LocIdent;
+use nickel_lang_core::eval::value::{NickelValue, RecordData};
+use nickel_lang_core::identifier::{Ident, LocIdent};
+use nickel_lang_core::program::BuilderError;
 use nickel_lang_core::term::Term;
 use nickel_lang_core::typ::TypeF;
-use nickel_lang_core::{error::NullReporter, eval::cache::CacheImpl, program::Program};
+use nickel_lang_core::{
+    error::NullReporter,
+    eval::cache::CacheImpl,
+    program::{Program, ProgramBuilder},
+};
 use std::collections::{BTreeSet, HashMap};
 use std::hash::Hash;
-use std::io;
 use std::path::{Path, PathBuf};
 
 /// Configuration for loading a layer (of Nickel files).
@@ -182,9 +186,34 @@ pub(crate) struct Loader {
     for_target: Target,
     minimal_lib_path: PathBuf,
     last_id: u64,
+}
 
-    #[allow(dead_code)]
-    generated_lib_dir: tempfile::TempDir,
+/// Name of the initial-env variable that exposes the target & layer parameters
+/// to nickel code (see `config.ncl` in the stdlib).
+pub(crate) const INJECTED_CONFIG_VAR: &str = "__minimal_injected_config";
+
+fn build_injected_config(target: &Target, args: Option<&args::ArgsSet>) -> NickelValue {
+    let target_val = NickelValue::record_posless(RecordData::with_field_values([
+        (
+            LocIdent::new("os"),
+            NickelValue::enum_tag_posless(LocIdent::new(target.os().as_nickel_str())),
+        ),
+        (
+            LocIdent::new("arch"),
+            NickelValue::enum_tag_posless(LocIdent::new(target.arch().as_nickel_str())),
+        ),
+    ]));
+    let args_val = match args {
+        None => NickelValue::record_posless(RecordData::default()),
+        Some(set) => NickelValue::record_posless(RecordData::with_field_values(
+            set.iter()
+                .map(|(name, v)| (LocIdent::new(name), v.to_nickel())),
+        )),
+    };
+    NickelValue::record_posless(RecordData::with_field_values([
+        (LocIdent::new("target"), target_val),
+        (LocIdent::new("args"), args_val),
+    ]))
 }
 
 impl Loader {
@@ -194,42 +223,19 @@ impl Loader {
         args: Option<&args::ArgsSet>,
         opts: &LoadOptions,
     ) -> Result<Self, Error> {
-        let generated_lib_dir = tempfile::TempDir::new()?;
-        std::fs::write(generated_lib_dir.path().join("__injected_config__.ncl"), {
-            let mut out = Vec::with_capacity(128);
-            out.extend(b"{\n\ttarget = {os = ");
-            out.extend(opts.for_target().os().as_nickel_literal());
-            out.extend(b",arch = ");
-            out.extend(opts.for_target().arch().as_nickel_literal());
-            out.extend(b"},");
-            out.extend(b"\n\targs = ");
-            match args {
-                None => out.extend(b"{}"),
-                Some(set) => {
-                    out.extend(b"{");
-                    let mut buf = String::with_capacity(64);
-                    for (name, v) in set.iter() {
-                        buf.clear();
-                        v.write_nickel(&mut buf);
+        let injected = build_injected_config(opts.for_target(), args);
 
-                        out.extend(b"\n\t\t");
-                        out.extend(format!("\"{name}\" = {buf},").as_bytes());
-                    }
-                    out.extend(b"\n\t}");
-                }
-            }
-
-            out.extend(b",\n}");
-            out
-        })?;
-
-        let mut program = Program::new_from_sources(
-            [(io::Cursor::new(src.into()), "toplevel")],
-            std::io::stderr(),
-            NullReporter {},
-        )?;
-
-        program.add_import_paths([&opts.minimal_lib_path, generated_lib_dir.path()].iter());
+        let mut program: Program<CacheImpl> = ProgramBuilder::new()
+            .add_source(std::io::Cursor::new(src.into()), "toplevel")
+            .add_import_paths([&opts.minimal_lib_path].iter())
+            .extend_initial_env(vec![(Ident::new(INJECTED_CONFIG_VAR), injected)])
+            .with_reporter(NullReporter {})
+            .with_trace(std::io::stderr())
+            .build()
+            .map_err(|e| match e {
+                BuilderError::NoInputs => unreachable!(),
+                BuilderError::Io { path: _, error } => Error::IO(error),
+            })?;
 
         program
             .typecheck(nickel_lang_core::typecheck::TypecheckMode::Walk)
@@ -244,7 +250,6 @@ impl Loader {
             for_target: opts.for_target().clone(),
             last_id: 0,
             minimal_lib_path: opts.minimal_lib_path.canonicalize()?,
-            generated_lib_dir,
         };
         out.annotate()?;
         Ok(out)
@@ -498,7 +503,7 @@ mod tests {
                 .unwrap()
         };
         let _sr = Loader::new(
-            "{c = import \"__injected_config__.ncl\"}".to_string(),
+            "{c = __minimal_injected_config}".to_string(),
             Some(&args),
             &LoadOptions::for_test(),
         )

--- a/crates/stdlib/minimal-ncl/config.ncl
+++ b/crates/stdlib/minimal-ncl/config.ncl
@@ -1,8 +1,7 @@
-let ic = import "__injected_config__.ncl" in
 let {Target, ..} = import "minimal.ncl" in
 {
-    target | Target | doc "The system that the software is being compiled for." = ic.target,
+    target | Target | doc "The system that the software is being compiled for." = __minimal_injected_config.target,
 
     param | String -> Dyn | doc "Reads the named parameter passed into the layer." =
-      fun name => ic.args."%{name}",
+      fun name => __minimal_injected_config.args."%{name}",
 }


### PR DESCRIPTION
Now that https://github.com/nickel-lang/nickel/pull/2611 is merged, we can remove the hack where we wrote injected config to disk so we could access it in nickel.

Also cleans up the string eval path which was accomplishing the same by accumulating nickel source literals as a string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored argument conversion to use native Nickel values instead of generated literal strings, improving internal handling consistency.
  * Improved program building pipeline with direct environment injection for configuration, eliminating temporary file generation.
  * Streamlined Nickel program construction across multiple modules for better maintainability.

* **Chores**
  * Updated workspace dependency to latest revision.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->