### PR TITLE
chore: move reference docs into repo + promote on version promotion (#195)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -160,6 +160,7 @@ jobs:
           workload_identity_provider: "projects/289724348228/locations/global/workloadIdentityPools/github/providers/gominimal"
 
       - name: Promote CLI version
+        id: promote
         env:
           DRY_RUN: ${{ inputs.dry_run }}
           # Pass dispatch inputs via env (NOT inline ${{ inputs.* }} in `run:`)
@@ -221,4 +222,40 @@ jobs:
             echo "[dry-run] CLI would have been promoted to ${SHA} for platforms: ${PLATFORMS}"
           else
             echo "CLI promoted to ${SHA} for platforms: ${PLATFORMS}"
+          fi
+
+          # Pin reference docs to the promoted SHA so docs.minimal.dev/reference
+          # tracks the promoted CLI version rather than docs-repo main. The docs
+          # build reads this pointer to decide which minimal SHA to fetch
+          # docs/reference/*.md from.
+          echo "{\"version\":\"${SHA}\"}" > docs.json
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[dry-run] would: gcloud storage cp --cache-control=max-age=300 docs.json gs://minimal-shim/config/docs.json"
+          else
+            gcloud storage cp \
+              --cache-control="max-age=300" \
+              docs.json \
+              gs://minimal-shim/config/docs.json
+            echo "Reference docs pinned to ${SHA}"
+          fi
+
+          # Export resolved SHA for the docs-rebuild dispatch step below.
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger docs rebuild
+        env:
+          # minimal-aw-bot PAT with repo-dispatch (contents: write) on
+          # gominimal/docs. The default GITHUB_TOKEN cannot dispatch other repos.
+          GH_TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          SHA: ${{ steps.promote.outputs.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[dry-run] would dispatch reference-docs-promoted to gominimal/docs for ${SHA}"
+          else
+            gh api repos/gominimal/docs/dispatches \
+              -f event_type=reference-docs-promoted \
+              -F "client_payload[sha]=${SHA}"
+            echo "Dispatched reference-docs-promoted to gominimal/docs for ${SHA}"
           fi

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -242,11 +242,24 @@ jobs:
           # Export resolved SHA for the docs-rebuild dispatch step below.
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
+      # Mint a short-lived token scoped to gominimal/docs via the
+      # gominimal-aw-bot GitHub App (org standard — App tokens over PATs, see
+      # gominimal/min-aw ADR-0002). The default GITHUB_TOKEN cannot dispatch
+      # other repos; this token carries the App's contents:write permission
+      # narrowed to the docs repo only.
+      - name: Mint docs-repo token (gominimal-aw-bot)
+        id: docs-token
+        if: ${{ inputs.dry_run != true }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.AW_BOT_APP_ID }}
+          private-key: ${{ secrets.AW_BOT_PRIVATE_KEY }}
+          owner: gominimal
+          repositories: docs
+
       - name: Trigger docs rebuild
         env:
-          # minimal-aw-bot PAT with repo-dispatch (contents: write) on
-          # gominimal/docs. The default GITHUB_TOKEN cannot dispatch other repos.
-          GH_TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.docs-token.outputs.token }}
           DRY_RUN: ${{ inputs.dry_run }}
           SHA: ${{ steps.promote.outputs.sha }}
         run: |

--- a/docs/reference/build-specs.md
+++ b/docs/reference/build-specs.md
@@ -1,0 +1,85 @@
+---
+description: Build spec schema for defining Minimal packages in Nickel — build_deps, runtime_deps, commands, outputs, tests, and metadata.
+---
+
+# Build specs
+
+Build specs declare everything about a [package](/concepts/packages), the fundamental unit of software
+in Minimal.
+
+This declaration includes:
+
+ * The packages that are needed to build the software, including runtime dependencies (i.e. need to be present wherever this software runs)
+ * The source code, and configuration to build the software
+ * Extensive metadata capture information such as software version, the provenance of source code,
+   directories used at runtime for state, and a number of other data points.
+
+Build specs are defined in a [Nickel](https://nickel-lang.org/) file located at `packages/<package name>/build.ncl`, either in your codebase
+or any layer in your [software supply chain](/concepts/software-supply-chain). The `packages/` directory in a layer is always adjacent to
+the [`minimal.toml`](/reference/minimal-dot-toml) file at its base. The directory can be omitted if the layer does not define any packages.
+
+## Example
+
+Here is a simplified build spec for `jq`, based on the [Minimal Public Package Registry](https://github.com/gominimal/pkgs/tree/main/packages):
+
+```ncl
+let { build_spec, .. } = import "minimal.ncl" in
+build_spec {
+  name = "jq",
+
+  build_deps = [
+    { src = { url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-1.8.1.tar.gz", sha256 = "..." } },
+    { pkg = "make" },
+    { pkg = "gcc" },
+    { pkg = "glibc" },
+  ],
+
+  runtime_deps = [
+    { pkg = "glibc" },
+  ],
+
+  cmd = ["./build.sh"],
+
+  outputs = {
+    bin = { glob = "usr/bin/*" },
+    lib = { glob = "usr/lib/*" },
+    man = { glob = "usr/share/man/**" },
+  },
+
+  tests = {
+    smoketest = { cmd = ["jq", "--version"] },
+    basic = { cmd = [
+      "/bin/bash", "-c",
+      "echo '{\"name\": \"minimal\"}' | jq -r '.name' | grep -q minimal"
+    ]},
+  },
+
+  attrs = {
+    upstream_version = "1.8.1",
+  },
+}
+```
+
+Each package also has a `build.sh` script adjacent to `build.ncl` that performs the actual compilation.
+
+More examples are maintained in the [Minimal Public Package Registry](https://github.com/gominimal/pkgs/tree/main/packages).
+
+## Schema
+
+The canonical typing of a Build-spec is defined using [Nickel](https://nickel-lang.org/) in Minimal's
+embedded standard library, located
+[here](https://github.com/gominimal/minimal/blob/main/crates/stdlib/minimal-ncl/minimal.ncl#L10).
+
+| **Field name** | **Type** | **Usage** |
+|---|---|---|
+| `name` | String | Declares the name of the package.   May only contain alphanumeric characters, dashes, and underscores.  Must match the name of the containing directory. |
+| `build_deps` | Array&lt;BuildDep> | A list of dependencies that are needed at build time. This may be:<br>- Other packages<br>- `Subset`s of other packages<br>- `Source` objects<br>- `Local` objects |
+| `runtime_deps` | Array&lt;RuntimeDep> | A list of dependencies that are needed both at build time, and wherever the package is needed. These may be:<br>- Other packages<br>- Subsets of other packages |
+| `cmd`, `cmds` | Array&lt;String> or Array&lt;Array&lt;String>> | The command that is invoked to build the package.  This is either an array of arguments, or an array of commands, each of which is an array of arguments. |
+| `build_args` | Map&lt;String, String> | A list of arguments to be passed to the build command.  These are made available to the build commands as environment variables.  eg: `build_args.abc = "def"` would be available as the environment variable `MINIMAL_ARG_ABC` with the value `def`. |
+| `outputs` | Map&lt;String, Output> | The named set of output files that are captured from a build. If no files match a named output, it's a build error.   |
+| `attrs` | Attrs | The typed set of metadata attached to a given package. |
+| `needs` | Needs | Any abstract needs declared on a given package. |
+| `tests` | Map&lt;String, Test> | A list of tests that are run by `minimal check`. |
+| `target` | String | The target string this package supports. Defaults to the current target. |
+| `prebuilt` | Bool | Indicates that a package is not built, but just the unpacked files from the first `Source` object in `build_deps`. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,138 @@
+---
+description: Complete CLI reference for all Minimal commands (run, build, test, shell, add, init, update, check, package, dep) and global flags.
+---
+
+# Minimal CLI Reference
+
+## Global Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--repo-dir <PATH>` | `-C` | Use the given directory as the repository root instead of searching from cwd |
+| `--minimal-dir <PATH>` | | Override the base directory used for operations (default: `~/.cache/minimal`) |
+| `--no-cache` | | Ignore locally-available binary artifacts (forces rebuilds unless present in remote cache) |
+| `--no-fetch` | | Do not fetch binary artifacts from the internet |
+| `--num-parallel-builds <N>` | `-j` | Configure the number of parallel builds |
+
+## Commands
+
+### `run <TASK_NAME> [<args>]` {#run}
+
+Runs a task specified in [`minimal.toml`](/reference/tasks). *(Linux only)*
+
+### `shell`
+
+Launches a development shell. Shorthand for `minimal run shell`.
+
+### `build`
+
+Runs the build task. Shorthand for `minimal run build`.
+
+### `test`
+
+Runs the test task. Shorthand for `minimal run test`.
+
+### `update`
+
+Refreshes local checkouts of upstream packages and the standard library.
+
+### `add <PACKAGES...>` {#add}
+
+Add a new tool or dependency. Requires exactly one of:
+
+| Flag | Description |
+|------|-------------|
+| `--runtime` | Add as a runtime dependency |
+| `--build` | Add as a build dependency |
+| `--task <TASK_NAME>` | Add to a task's package list |
+
+### `init`
+
+Automatically initialize Minimal configuration based on your source tree.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--yes` | `-y` | Skip confirmation, write configuration based on auto-detection |
+
+### `status`
+
+Shows the status of Minimal in this codebase.
+
+### `package <PACKAGES...>` (alias: `pkg`)
+
+Builds specified package(s) in a clean room, making them available in the local cache. If no packages are specified, Minimal will build packages from local origin.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--verbose` | `-v` | Log stdout/stderr during the build |
+
+### `materialize <OUTPUT_NAME>` {#materialize}
+
+Materializes an output defined in an [`[outputs.<name>]`](/reference/minimal-dot-toml#outputs) section of `minimal.toml`.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output <PATH>` | `-o` | **(required)** The output file to write |
+| `--arch <ARCH>` | | Target architecture for OCI images (e.g. `amd64`, `arm64`). Overrides the `arch` field in `minimal.toml` and the host default |
+
+Supported output types:
+
+- `oci-image` — a Linux OCI image archive containing the configured packages, suitable for `docker load` or pushing to a registry.
+
+See [`[outputs.*]`](/reference/minimal-dot-toml#outputs) for the full configuration schema.
+
+### `check [FILTER_NAMES...]` {#check}
+
+Validates Minimal's configuration including packages, harnesses, and profiles.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--fix` | `-f` | Attempt to fix any issues |
+| `--skip-checkers <NAMES>` | `-s` | Comma-delimited checker names to skip |
+| `--packages` | | Check packages defined in the codebase |
+| `--harnesses` | | Check harnesses defined in the codebase |
+| `--profiles` | | Check profiles defined in the codebase |
+
+If no type flags are specified, all types are checked by default.
+
+If filter names are specified, any package, harness, or profile matching a specified name is checked.
+
+### `dep [PACKAGES...]`
+
+Generates a dependency graph visualization.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--excludes <PKGS>` | `-e` | | Comma-delimited packages to exclude |
+| `--build-spec-deps` | | `true` | Include build spec "build_deps" |
+| `--source-deps` | | `false` | Include source code "build_deps" |
+| `--local-deps` | | `false` | Include local (build.sh) "input" deps |
+| `--hostpath-deps` | | `false` | Include host path "build_deps" |
+| `--needs` | | `false` | Include "Needs" nodes and edges |
+| `--provides` | | `false` | Include "Provides" edges and "Needs" nodes |
+| `--bootstrap` | | `false` | Include replace-on-cycle/prebuilts/bootstrap |
+| `--subtrees-only` | | `false` | Require non-zero subtree deps for runtime/input deps |
+| `--input-deps-depth <N>` | | `-1` | How deeply input dependencies are followed (-1 = all) |
+| `--runtime-deps-depth <N>` | | `-1` | How deeply runtime dependencies are followed (-1 = all) |
+| `--prune-edgeless` | | `false` | Discard graph nodes with no edges |
+| `--output-format <FMT>` | | `dot` | Output format: `dot` or `mermaid` |
+
+### `cache clean`
+
+Remove cache entries that haven't been used recently.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--older-than <DURATION>` | `14d` | Duration string (e.g. `7d`, `24h`, `30m`) |
+
+### `completions <SHELL>`
+
+Generate shell completion script. Supported shells: `bash`, `zsh`, `elvish`, `fish`.
+
+Usage: `source <(minimal completions bash)`
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `RUST_LOG` | Controls logging level (default: `info`) |

--- a/docs/reference/harness-specs.md
+++ b/docs/reference/harness-specs.md
@@ -1,0 +1,144 @@
+---
+description: Harness spec schema for defining build system harnesses in Nickel — packages, build commands, env vars, and project detection rules.
+---
+
+# Harnesses
+
+Harnesses specify a set of tools and how to use them in a codebase. They encapsulate a common pattern for building software.
+
+Harnesses are defined in a [Nickel](https://nickel-lang.org/) file located at `harnesses/<harness name>/harness.ncl`, either in your codebase
+or any layer in your [software supply chain](/concepts/software-supply-chain). The `harnesses/` directory in a layer is always adjacent to
+the [`minimal.toml`](/reference/minimal-dot-toml) file at the base of the layer. The directory can be omitted if the layer does not define any harnesses.
+
+## Examples
+
+A number of harnesses are defined and maintained in the [Minimal Public Package Registry](https://github.com/gominimal/pkgs/tree/main/harnesses), which serves as the canonical reference for defining harnesses.
+
+Here is a harness for code that uses `pnpm`:
+
+```ncl
+let { harness, .. } = import "minimal.ncl" in
+harness {
+  name = "pnpm",
+
+  runtime_packages = ["node"],
+  build_packages = ["pnpm", "base"],
+
+  # A command that generates the build command, i.e. commands executed by `minimal build`.
+  build_cmds_cmd = [
+    "/bin/bash",
+    "-c",
+    m%"
+    # Run pnpm install if no packages are installed (first start)
+    [ -z "$(pnpm list 2>/dev/null)" ] && echo "/bin/pnpm install"
+    echo '/bin/pnpm build'
+  "%
+  ],
+
+  # Rules to detect when the harness is applicable to a codebase.
+  matches_project_if_any = [
+    {
+      file_regexes = {
+        "pnpm-lock.yaml" = "*",
+        "pnpm-workspace.yaml" = "*",
+      },
+    }
+  ],
+}
+```
+
+## Schema
+
+### `name`
+
+_String_
+
+The name of the harness. Must match the name of the containing directory.
+
+### `runtime_packages`
+
+_Array of String's, optional_
+
+A list of package names that must be present wherever the codebase is run, including in its compiled form. This typically contains system libraries that must be present, and in the case of interpreted
+languages, this usually references the interpreter as well.
+
+### `build_packages`
+
+_Array of String's, optional_
+
+A list of package names that must be present when the build command, `cmd`, is invoked. This usually contains
+build-time tools such as pkg-config or compilers.
+
+### `build_env_vars`
+
+_Dictionary of String's, optional_
+
+Pairs of environment-variable names and their values that should be set for a build. These are inherited
+by all tasks in a codebase that uses the harness, unless the task sets the environment variable itself.
+
+### `build_cmds` or `build_cmds_cmd`
+
+_`build_cmds`: Nested array of all the arguments of all commands_
+
+_`build_cmds_cmd`: Nested array of the arguments for a command, which ultimately generates the build command_
+
+`build_cmds` & `build_cmds_cmd` are mutually-exclusive fields that declare the command for
+building software which uses this harness.
+
+`build_cmds` defines static commands to be used when `minimal build` is invoked.
+
+```toml
+let { harness, .. } = import "minimal.ncl" in
+harness {
+  name = "rust",
+
+  build_packages = ["gcc", "rust", "binutils", "pkgconf"],
+  build_cmd = "cargo build --release", # [!code focus]
+  # ...
+}
+```
+
+`build_cmds_cmd` defines the arguments for a command that generates the build command. This
+command is expected to print the necessary build commands, with each terminating with a newline.
+
+```toml
+let { harness, .. } = import "minimal.ncl" in
+harness {
+  name = "rust",
+
+  build_packages = ["gcc", "rust", "binutils", "pkgconf"],
+  build_cmds_cmd = [ # [!code focus:9]
+    "/bin/bash",
+    "-c",
+    m%"
+        # Run pnpm install if no packages are installed (first start)
+        [ -z "$(pnpm list 2>/dev/null)" ] && echo "/bin/pnpm install"
+        echo '/bin/pnpm build'
+    "%
+  ],
+  # ...
+}
+```
+
+### `matches_project_if_any`
+
+_Array of ProjectMatcher objects, optional_
+
+Defines a list of rules which detect when a harness is applicable to some codebase. This
+is the mechanism underlying `minimal init`.
+
+A harness is considered applicable if any ProjectMatcher in the array matches.
+
+Each matcher has the following fields, all optional:
+
+ * `file_regexes` - A map of file paths to regexes that must match in the codebase for this
+   matcher to be considered matched. The regex syntax is as per the [regex](https://docs.rs/regex/) crate.
+   If the special regex string `*` is used, this predicate automatically matches if the file exists.
+ * `file_predicates` - A map of file paths to [jq](https://jqlang.org/) filters that must match
+   for the matcher to be considered matched.
+ * `build_package_if_any` - A map of package names to a list of `PackageMatcher` objects. The
+   additional package will be wired as a build package if any object in the list matches.
+ * `runtime_package_if_any` - A map of package names to a list of `PackageMatcher` objects. The
+   additional package will be wired as a build package if any object in the list matches.
+ 
+The `PackageMatcher` object has both `file_regexes` and `file_predicates` fields, with identical semantics.

--- a/docs/reference/harness-specs.md
+++ b/docs/reference/harness-specs.md
@@ -93,7 +93,7 @@ harness {
   name = "rust",
 
   build_packages = ["gcc", "rust", "binutils", "pkgconf"],
-  build_cmd = "cargo build --release", # [!code focus]
+  build_cmds = [["cargo", "build", "--release"]], # [!code focus]
   # ...
 }
 ```
@@ -139,6 +139,6 @@ Each matcher has the following fields, all optional:
  * `build_package_if_any` - A map of package names to a list of `PackageMatcher` objects. The
    additional package will be wired as a build package if any object in the list matches.
  * `runtime_package_if_any` - A map of package names to a list of `PackageMatcher` objects. The
-   additional package will be wired as a build package if any object in the list matches.
+   additional package will be wired as a runtime package if any object in the list matches.
  
 The `PackageMatcher` object has both `file_regexes` and `file_predicates` fields, with identical semantics.

--- a/docs/reference/minimal-dot-toml.md
+++ b/docs/reference/minimal-dot-toml.md
@@ -1,0 +1,180 @@
+---
+description: Schema reference for the minimal.toml configuration file — upstream, harness, defaults, tasks, and outputs sections.
+---
+
+# `minimal.toml`
+
+The `minimal.toml` file defines the configuration for Minimal in a codebase.
+
+This file must be present at the base of the repository (i.e. `./minimal.toml`), or
+in a `.minimal` directory at the base of the repository.
+
+Unless [`-C`](/reference/cli#opt-c) is specified, the [Minimal CLI](/reference/cli) searches the directory tree backwards from
+the current directory till a `minimal.toml` file is found. This behavior allows minimal to be invoked in project directories.
+
+## Example
+
+```toml
+[upstream]
+repo = "https://github.com/gominimal/pkgs"
+branch = "main"
+locked_commit = "d39aaaa581f983d6b3ba5eaaf383485a602f37f0"
+
+[harness]
+use = "pnpm"
+build_packages = ["railway"]
+
+[defaults]
+state_key = "dev"
+
+[tasks.dev]
+exec = "pnpm run dev"
+
+[tasks.preview]
+env_vars.PORT = "8080"
+bash = "pnpm run build && pnpm run start"
+
+[tasks.deploy]
+packages = ["railway"]
+exec = "railway up"
+
+[tasks.shell]
+interactive = true
+packages = ["base", "git", "nano"]
+exec = "bash -l"
+```
+
+## Schema
+
+### `[upstream]` - Where software comes from {#upstream}
+
+The `[upstream]` section defines the precise source of packages, harnesses, and profiles. This represents the
+preceding link in the [software supply chain](/concepts/software-supply-chain).
+
+```toml
+[upstream]
+repo = "<git URL>"
+branch = "<branch>"
+locked_commit = "<commit hash>"
+```
+
+`locked_commit` is automatically updated when `minimal update` is run.
+
+#### `[[upstream.sideload]]` - Additional software sideloaded into your supply chain {#sideload}
+
+Sideload entries let you load in additional packages, harnesses, and profiles from a separate repository, but those packages
+are built using the version of packages from your upstream.
+
+Each sideload entry is loaded in order from the specified repository, and follows the same schema as `[upstream]`:
+
+```toml
+[[upstream.sideload]]
+repo = "<git URL>"
+branch = "<branch>"
+locked_commit = "<commit hash>" # Updated via `minimal update`
+```
+
+Sideload repositories have the same layout as an upstream: that is having a `minimal.toml` file, and `packages/` / `harnesses/` / `profiles/`
+directories as needed.
+
+### `[harness]` - How to build code in your repo {#harness}
+
+```toml
+[harness]
+use = "<harness name>"
+build_packages = ["<additional build package>"]     # optional
+runtime_packages = ["<additional runtime package>"] # optional
+```
+
+The `[harness]` section configures the [harness](/concepts/harnesses) to use for building code, if any.
+
+The environment variables and packages configured on a harness are inherited on all tasks in this repository.
+
+`build_packages` and `runtime_packages` are optional fields that allow you to declare
+additional package dependencies for build time or run time respectively.
+
+
+
+### `[defaults]` - Settings for all tasks {#defaults}
+
+```toml
+[defaults]
+profile = "<profile name>" # optional
+state_key = "<state key>"  # optional
+```
+
+When set, `defaults.profile` will set a [profile](/concepts/profiles) on all tasks which do not set a profile.
+
+When set, `defaults.state_key` will set a state key on all tasks which do not set `state_key`.
+
+
+
+### `[tasks.*]` - Run tasks, scripts, & dev tooling {#tasks}
+
+See: [tasks](/reference/tasks).
+
+
+
+### `[outputs.*]` - Artifacts produced by `minimal materialize` {#outputs}
+
+Each `[outputs.<name>]` section defines an artifact that can be produced with
+[`minimal materialize <name> -o <path>`](/reference/cli#materialize).
+
+```toml
+[outputs.<name>]
+type = "<output type>"          # required; alias: `ty`
+packages = ["<package>", ...]   # optional; defaults to ["base"] when empty
+arch = "<arch>"                 # optional; e.g. "amd64", "arm64"
+entrypoint = "<cmd>"            # optional; string or list of strings
+cmd = ["<arg>", ...]            # optional; string or list of strings
+vars = { KEY = "value" }        # optional; alias: `env_vars`
+```
+
+#### Output types
+
+| `type` | Description |
+|--------|-------------|
+| `oci-image` | A Linux OCI image archive built from `packages`. Compatible with `docker load` and OCI-compatible registries. |
+
+#### Fields
+
+- **`type`** (alias: `ty`) — The output kind. Currently only `oci-image` is supported.
+- **`packages`** — Packages to include in the materialized output. When omitted or empty, defaults to `["base"]`.
+- **`arch`** — Target architecture for OCI images. Common values: `amd64`, `arm64`. The CLI flag [`--arch`](/reference/cli#materialize) overrides this; if neither is set, the host architecture is used.
+- **`entrypoint`** — OCI image entrypoint. May be a string (`"/app/server"`) or a list (`["/bin/sh", "-c"]`).
+- **`cmd`** — OCI image default command. Same string-or-list shape as `entrypoint`.
+- **`vars`** (alias: `env_vars`) — Environment variables baked into the image as a `KEY = "value"` table.
+
+#### Examples
+
+A minimal OCI image of just the `base` packages, useful for ad-hoc shells:
+
+```toml
+[outputs.base-image]
+type = "oci-image"
+```
+
+```sh
+minimal materialize base-image -o ./base.tar
+```
+
+A server image with extra packages, an entrypoint, and an env var:
+
+```toml
+[outputs.app]
+type = "oci-image"
+arch = "arm64"
+packages = ["base", "openssl"]
+entrypoint = "/app/server"
+vars = { PORT = "8080" }
+```
+
+```sh
+minimal materialize app -o ./app.tar
+```
+
+Override the architecture at the command line:
+
+```sh
+minimal materialize app --arch amd64 -o ./app-amd64.tar
+```

--- a/docs/reference/minimal-dot-toml.md
+++ b/docs/reference/minimal-dot-toml.md
@@ -9,7 +9,7 @@ The `minimal.toml` file defines the configuration for Minimal in a codebase.
 This file must be present at the base of the repository (i.e. `./minimal.toml`), or
 in a `.minimal` directory at the base of the repository.
 
-Unless [`-C`](/reference/cli#opt-c) is specified, the [Minimal CLI](/reference/cli) searches the directory tree backwards from
+Unless [`-C`](/reference/cli#global-flags) is specified, the [Minimal CLI](/reference/cli) searches the directory tree backwards from
 the current directory till a `minimal.toml` file is found. This behavior allows minimal to be invoked in project directories.
 
 ## Example

--- a/docs/reference/sandbox-operations.md
+++ b/docs/reference/sandbox-operations.md
@@ -1,0 +1,50 @@
+---
+description: In-sandbox min helper commands — add packages, search, check configuration, and run tasks from within a sandbox.
+---
+
+# `min` commands
+
+`min` helper commands are available within all task sandboxes.
+
+## Commands
+
+### `add <PACKAGES...>` {#add}
+
+Installs tools & dependencies into the running sandbox. If flags are provided, the named packages
+are also configured as a build, runtime, or task dependency in `minimal.toml`.
+
+| Flag | Description |
+|------|-------------|
+| `--runtime` | Add packages to `harness.runtime_packages` |
+| `--build` | Add packages to `harness.build_packages` |
+| `--task <TASK_NAME>` | Add packages to `tasks.<TASK_NAME>.packages` |
+
+`min add` is the in-sandbox equivalent of the [`minimal add`](/reference/cli#add) command.
+
+### `search <TERM>`
+
+Searches-for and lists packages related to the search term.
+
+### `check [<OPTIONS>] [FILTER_NAMES...]`
+
+Validates minimal configuration including packages, harnesses, and profiles.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--fix` | `-f` | Attempt to fix any issues |
+| `--skip-checkers <NAMES>` | `-s` | Comma-delimited checker names to skip |
+| `--packages` | | Check packages defined in the codebase |
+| `--harnesses` | | Check harnesses defined in the codebase |
+| `--profiles` | | Check profiles defined in the codebase |
+
+If no type flags are specified, all types are checked by default.
+
+If filter names are specified, any package, harness, or profile matching a specified name is checked.
+
+`min check` is the in-sandbox equivalent of the [`minimal check`](/reference/cli#check) command.
+
+### `run <TASK_NAME> [<ARGS>...]`
+
+Runs the specified task in a new Minimal sandbox. Interactive tasks are not supported.
+
+`min run` is the in-sandbox equivalent of the [`minimal run`](/reference/cli#run) command.

--- a/docs/reference/sandbox-operations.md
+++ b/docs/reference/sandbox-operations.md
@@ -23,7 +23,7 @@ are also configured as a build, runtime, or task dependency in `minimal.toml`.
 
 ### `search <TERM>`
 
-Searches-for and lists packages related to the search term.
+Searches for and lists packages related to the search term.
 
 ### `check [<OPTIONS>] [FILTER_NAMES...]`
 

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -1,0 +1,191 @@
+---
+description: Full task schema reference — packages, exec/bash commands, state_key, env_vars, patches, profiles, args, and interactive mode.
+---
+
+# Tasks
+
+Tasks are defined in a [`minimal.toml`](/reference/minimal-dot-toml) file, and describe
+a runtime environment + command invocations to be executed using [`minimal run <taskname>`](/reference/cli#minimal-run)
+
+## Tasks schema
+
+Tasks are defined in a `[tasks.<task-name>]` block in your minimal file.
+
+### `packages` - Packages to be installed in the runtime environment
+
+_Optional_
+
+`packages` lists additional [packages](/concepts/packages) which will be installed in the tasks'
+runtime environment. Packages listed here are in addition to any installed due to the profile or harness.
+
+```toml
+[tasks.my_task]
+packages = ["python"] # Additionally install python
+```
+
+### `exec` or `bash` - What the task should do
+
+`exec` describes a command or invocation that should run when the task is launched. `exec` can be
+defined either as an argv string:
+
+```toml
+[tasks.my_task]
+exec = "pnpm build"
+```
+
+or as a program and its list of arguments:
+
+```toml
+[tasks.my_task]
+exec = ["pnpm", "build"]
+```
+
+`bash` describes a bash command that should run when the task is launched.
+
+```toml
+[tasks.my_task]
+bash = "echo \"hello\" > hello.txt"
+```
+
+When [args](#args) are set on the task, arguments can be substituted into the invocation using
+Nickel's string interpolation [syntax](https://nickel-lang.org/user-manual/syntax/#strings):
+
+```toml
+[tasks.greet]
+args.name = "string"
+bash = "echo \"Hello %{name}!\""
+```
+
+
+### `state_key` - Persist state between invocations
+
+_Optional_
+
+`state_key` controls caching of build artifacts and files between runs.
+
+```toml
+[tasks.my_task]
+state_key = "dev" # Cache build artifacts under 'dev'
+```
+
+
+### `env_vars` - Environment variables to set
+
+_Optional, Alias `vars`_
+
+`env_vars` sets environment variables in the tasks' runtime environment. Variables
+set here take precedence over any inherited from the profile.
+
+```toml
+[tasks.my_task]
+env_vars = {
+  CC = "gcc",
+  AWS_PROJECT = "zest",
+}
+```
+
+Environment variables can also inherit their value from the parent process. To do this,
+declare the variable with the value `{ inherit = true }`:
+
+```toml
+[tasks.my_task]
+env_vars.TOKEN = { inherit = true }
+```
+
+
+### `interactive` - TUI apps and shells
+
+_Optional, Default `false`_
+
+`interactive` indicates that this task must be run interactively (that is, with standard input and a tty connected).
+
+```toml
+[tasks.my_task]
+interactive = true
+```
+
+
+### `profile` - Inherit customization from a profile
+
+_Optional_
+
+`profile` applies the configuration in the named profile to the tasks' runtime environment.
+
+```toml
+[tasks.my_task]
+profile = "dev" # Initializes package/env_vars based on the 'dev' profile
+```
+
+`profile` can be set to the empty string to avoid applying any default profile.
+
+```toml
+[defaults]
+profile = "dev"
+
+[tasks.my_task]
+profile = "" # No profile applied to `my_task`
+```
+
+### `patches` - Map in files/directories from the system
+
+_Optional, Alias `patch`_
+
+`patches` configures files and directories to be mapped into the tasks' runtime environment.
+
+```toml
+[tasks.my_task]
+patches.dir."~/.claude" = "read-write"
+patches.file."~/.claude.json" = "read-write"
+```
+
+`patches` is a structure with two optional fields, `dir` & `file`, each of which contains a mapping
+of file paths to be mapped in, and the corresponding map mode. The map mode may only be the
+string "read-only" / "ro" for read-only mappings, or the string "read-write" / "rw" for writeable
+mappings.
+
+If a mapped file or directory does not exist on the host, an empty file or directory is created.
+
+Mapped paths must be absolute or start with `~`, in which case the tilda is expanded to the users'
+home directory.
+
+### `inherit_cwd` - Use parent working directory instead of repository root
+
+_Optional, Default `false`_
+
+`inherit_cwd` configures minimal to setup the task in the current working directory, instead
+of the repository root.
+
+```toml
+[tasks.my_task]
+inherit_cwd = true
+```
+
+### `args` - Pass arguments to tasks {#args}
+
+_Optional_
+
+`args` configures named arguments and their datatype, which can be substituted into the command
+being executed by the task.
+
+```toml
+[tasks.greeter]
+args = {
+    name = "string",
+    greeting = "string",
+}
+exec = "echo %{greeting} %{name}"
+```
+
+All arguments become mandatory for invoking the task. In the example above, running the task `greeter`
+without its two arguments will trigger an error:
+
+```shell
+$> minimal run greeter
+error: the following required arguments were not provided:
+  --name <name>
+  --greeting <greeting>
+
+Usage: minimal run greeter --name <name> --greeting <greeting>
+```
+
+Valid datatypes are `string`, `number`, and `boolean`.

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -5,7 +5,7 @@ description: Full task schema reference — packages, exec/bash commands, state_
 # Tasks
 
 Tasks are defined in a [`minimal.toml`](/reference/minimal-dot-toml) file, and describe
-a runtime environment + command invocations to be executed using [`minimal run <taskname>`](/reference/cli#minimal-run)
+a runtime environment + command invocations to be executed using [`minimal run <taskname>`](/reference/cli#run)
 
 ## Tasks schema
 
@@ -145,7 +145,7 @@ mappings.
 
 If a mapped file or directory does not exist on the host, an empty file or directory is created.
 
-Mapped paths must be absolute or start with `~`, in which case the tilda is expanded to the users'
+Mapped paths must be absolute or start with `~`, in which case the tilde is expanded to the user's
 home directory.
 
 ### `inherit_cwd` - Use parent working directory instead of repository root


### PR DESCRIPTION
Part 1 of 2 for #195. Moves the 6 reference docs into `minimal` and ties their publication to CLI version promotion.

## Moved into `docs/reference/`
- `cli.md`
- `minimal-dot-toml.md`
- `tasks.md`
- `build-specs.md`
- `harness-specs.md`
- `sandbox-operations.md`

Content lifted verbatim from `gominimal/docs@main:docs/reference/`. `installation-methods.md` stays in the docs repo (install topic, not a code reference).

## Promotion wiring (`promote.yml`)
- Pins reference docs to the promoted CLI SHA: writes `gs://minimal-shim/config/docs.json = {"version":"<sha>"}` (dry-run aware).
- Dispatches `reference-docs-promoted` to `gominimal/docs` so the site rebuilds against the promoted SHA.
- Reuses the existing approval gate; honors `dry_run`.

## Auth (gominimal-aw-bot App, not a PAT)
Per org standard (min-aw ADR-0002: App tokens over PATs), the dispatch step mints a short-lived `actions/create-github-app-token` token scoped to `repositories: docs`.

Requires, available to this repo:
- `vars.AW_BOT_APP_ID` (gominimal-aw-bot App, id `3600621`)
- `secrets.AW_BOT_PRIVATE_KEY` (App PEM)
- App installation must grant **Contents: write** on `gominimal/docs` (required for `repository_dispatch`).

## Depends on
`gominimal/docs` PR #20 (Part 2) switches the docs build to fetch these files pinned to the promoted SHA and removes the originals. Merge order: this PR first, then the docs PR.

## Naming note
`harness-specs.md` filename/path kept stable to preserve the `/reference/harness-specs.html` URL. harness→stack content reconciliation is deferred to a separate issue.

Refs #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reference guides for CLI commands, build specifications, harness specifications, task definitions, and minimal.toml configuration.
  * Updated sandbox operations documentation with available in-sandbox helper commands.

* **Chores**
  * Improved documentation promotion workflow: pins promoted docs, supports dry-run safety, and triggers remote documentation rebuilds when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->