### PR TITLE
chore: remove unused dependency candidates (machete)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,6 @@ dependencies = [
  "google-cloud-auth",
  "google-cloud-storage",
  "hex",
- "indoc",
  "jaq-all",
  "lzma-rs",
  "nickel-lang-core",
@@ -660,7 +659,6 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
  "tracing",
  "url",
  "walkdir",
@@ -2791,7 +2789,6 @@ name = "mfile"
 version = "0.0.1"
 dependencies = [
  "args",
- "clap",
  "common",
  "indoc",
  "serde",
@@ -2876,13 +2873,11 @@ dependencies = [
  "rayon",
  "rcache",
  "remote-client",
- "remote-proto",
  "serde",
  "serde_json",
  "smallvec",
  "tokio",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
  "toml_edit 0.25.11+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
@@ -2963,7 +2958,6 @@ dependencies = [
  "generational-arena",
  "graph",
  "hakoniwa",
- "indoc",
  "libc",
  "mctx",
  "mfile",
@@ -2971,7 +2965,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3263,7 +3256,6 @@ name = "ot"
 version = "0.0.1"
 dependencies = [
  "indicatif",
- "indoc",
 ]
 
 [[package]]
@@ -4075,7 +4067,6 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
- "tracing",
 ]
 
 [[package]]
@@ -4698,9 +4689,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stdlib"
 version = "0.0.15"
-dependencies = [
- "indoc",
-]
 
 [[package]]
 name = "streaming-iterator"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -6,9 +6,6 @@ license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true
 
-[dev-dependencies]
-indoc.workspace = true
-
 [dependencies]
 anyhow.workspace = true
 serde.workspace = true
@@ -34,7 +31,6 @@ zstd.workspace = true
 
 args.workspace = true
 nickel-lang-core.workspace = true
-toml.workspace = true
 
 bytes.workspace = true
 reqwest.workspace = true

--- a/crates/mfile/Cargo.toml
+++ b/crates/mfile/Cargo.toml
@@ -14,7 +14,6 @@ tempfile.workspace = true
 args.workspace = true
 common.workspace = true
 
-clap.workspace = true
 serde.workspace = true
 toml.workspace = true
 shlex.workspace = true

--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -19,7 +19,6 @@ op.workspace = true
 ot.workspace = true
 orchestrator.workspace = true
 remote-client.workspace = true
-remote-proto.workspace = true
 
 nickel-lang-core.workspace = true
 codespan-reporting.workspace = true
@@ -41,7 +40,6 @@ futures.workspace = true
 
 anyhow.workspace = true
 
-toml.workspace = true
 toml_edit.workspace = true
 
 petgraph.workspace = true

--- a/crates/multi/Cargo.toml
+++ b/crates/multi/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 publish.workspace = true
 
 [dev-dependencies]
-indoc.workspace = true
 tracing-subscriber.workspace = true
 
 [dependencies]
@@ -17,7 +16,6 @@ hakoniwa.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-toml.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 

--- a/crates/ot/Cargo.toml
+++ b/crates/ot/Cargo.toml
@@ -6,8 +6,5 @@ license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true
 
-[dev-dependencies]
-indoc.workspace = true
-
 [dependencies]
 indicatif.workspace = true

--- a/crates/remote-proto/Cargo.toml
+++ b/crates/remote-proto/Cargo.toml
@@ -7,8 +7,6 @@ license = "MIT OR Apache-2.0"
 publish.workspace = true
 
 [dependencies]
-tracing.workspace = true
-
 prost.workspace = true
 prost-types.workspace = true
 tonic.workspace = true

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -5,6 +5,3 @@ rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true
-
-[dev-dependencies]
-indoc.workspace = true


### PR DESCRIPTION
**Summary** — Remove 10 unused dependency candidates flagged by cargo-machete in #216.

**Removed**
- `common`: `indoc` (dev-dep), `toml`
- `mfile`: `clap`
- `minimal`: `remote-proto`, `toml`
- `multi`: `indoc` (dev-dep), `toml`
- `ot`: `indoc` (dev-dep)
- `remote-proto`: `tracing`
- `stdlib`: `indoc` (dev-dep)

(Now-empty `[dev-dependencies]` tables in `common`, `ot`, and `stdlib` were removed as well.)

**Verified false positive (kept)**
- None. All 10 candidates were confirmed genuinely unused via grep of each crate's `src/`/`tests/` (including underscore-name, `[features]`, and `cfg`/re-export checks). Known false positives from the issue (`minimal::hakoniwa`, `remote-proto`'s prost/tonic build-codegen deps) were left untouched.

**Verification**
- `cargo test -p common -p stdlib -p ot -p remote-proto -p mfile` — all passed.
- `cargo clippy -p common -p stdlib -p ot -p remote-proto -p mfile --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — no changes.
- `multi` and `minimal` could not be compiled on the macOS dev host (they pull the Linux-only sandbox stack: `caps`/`procfs` fail to build on macOS even on a clean `main`). Their removed deps were verified unused by source grep; CI on Linux will exercise the full build.
- cargo-machete not installed on host; re-run check skipped.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal dependencies to streamline project build configuration across multiple crates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->