### PR TITLE
chore: add tracing instrumentation to execution-path async fns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "regex",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4063,6 +4064,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/check/Cargo.toml
+++ b/crates/check/Cargo.toml
@@ -14,6 +14,7 @@ regex.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 moka.workspace = true
+tracing.workspace = true
 
 common.workspace = true
 decode.workspace = true

--- a/crates/check/src/lib.rs
+++ b/crates/check/src/lib.rs
@@ -371,6 +371,7 @@ impl CheckCtx {
 ///
 /// If `None` is given for a `packages_dir`, `profiles_dir`, or `stacks_dir`, the corresponding
 /// class of checkers are skipped.
+#[tracing::instrument(skip_all, err)]
 pub fn run_checks(
     packages_dir: Option<PathBuf>,
     profiles_dir: Option<PathBuf>,
@@ -402,6 +403,7 @@ pub fn run_checks(
         .collect::<FuturesUnordered<_>>())
 }
 
+#[tracing::instrument(skip_all, err)]
 fn package_check_futures(packages_dir: PathBuf, ctx: CheckCtx) -> Result<Vec<CheckFuture>, Error> {
     let package_dirs: Vec<_> = match decode::build_decls_in_dir(&packages_dir) {
         Ok(i) => i,
@@ -434,6 +436,7 @@ fn package_check_futures(packages_dir: PathBuf, ctx: CheckCtx) -> Result<Vec<Che
         .collect::<Vec<_>>())
 }
 
+#[tracing::instrument(skip_all, err)]
 fn profile_check_futures(profiles_dir: PathBuf, ctx: CheckCtx) -> Result<Vec<CheckFuture>, Error> {
     let dirs: Vec<std::ffi::OsString> = match std::fs::read_dir(&profiles_dir) {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(vec![]),
@@ -482,6 +485,7 @@ fn profile_check_futures(profiles_dir: PathBuf, ctx: CheckCtx) -> Result<Vec<Che
         .collect())
 }
 
+#[tracing::instrument(skip_all, err)]
 fn stack_check_futures(stacks_dir: PathBuf, ctx: CheckCtx) -> Result<Vec<CheckFuture>, Error> {
     let dirs: Vec<std::ffi::OsString> = match std::fs::read_dir(&stacks_dir) {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(vec![]),
@@ -529,6 +533,7 @@ fn stack_check_futures(stacks_dir: PathBuf, ctx: CheckCtx) -> Result<Vec<CheckFu
         .collect())
 }
 
+#[tracing::instrument(skip_all, fields(pkg = %pkg), err)]
 async fn check_package(
     pkg: String,
     package_dir: PathBuf,
@@ -583,8 +588,10 @@ async fn check_package(
     let file_based_results = {
         let ctx = ctx.clone();
         let pkg = pkg.clone();
+        let span = tracing::Span::current();
 
         tokio::task::spawn_blocking(move || {
+            let _enter = span.enter();
             let file_based: Vec<Box<dyn FileBasedChecker>> = vec![
                 Box::new(ParseCheck),
                 Box::new(ImportLineCheck),

--- a/crates/op/src/oci_image.rs
+++ b/crates/op/src/oci_image.rs
@@ -38,6 +38,7 @@ pub struct OciImageCreate {
 impl Runnable for OciImageCreate {
     type Result = ();
 
+    #[tracing::instrument(skip_all, err)]
     async fn run<'b>(&mut self, opts: &Options<'b>) -> Result<Self::Result, Error> {
         let mut all_deps: Vec<(BuildSpecRef, TransitivesDep)> =
             Transitives::for_toplevels(opts.graph, opts.graph.top_levels.to_vec(), false)
@@ -281,6 +282,7 @@ impl BuiltLayer {
     }
 }
 
+#[tracing::instrument(err)]
 async fn create_base_layer() -> anyhow::Result<BuiltLayer> {
     let enc = GzEncoder::new(tempfile::tempfile()?, Compression::best());
     let mut tar = tar::Builder::new(enc);
@@ -328,6 +330,7 @@ async fn create_base_layer() -> anyhow::Result<BuiltLayer> {
     })
 }
 
+#[tracing::instrument(skip_all, fields(package_name = %package_name), err)]
 async fn create_layer_from_cache(
     cache: &lcache::Cache<lcache::LocalDir>,
     spec_hash: &SpecHash,

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -75,6 +75,7 @@ pub const INDEX_FILENAME: &str = "index.shisha";
 const INDEX_EXPIRY_SECONDS: u64 = 5 * 60; // how long a fetch of the remote index is considered fresh for
 
 impl RemoteCache<Client> {
+    #[tracing::instrument(skip_all, err)]
     pub async fn new_over_https<URL: Into<ReqwestUrl>>(
         url: URL,
         index_dir: Option<PathBuf>,
@@ -91,6 +92,7 @@ impl RemoteCache<Client> {
 
 impl RemoteCache<Storage> {
     /// Instantiates a new remote cache using the given GCS client + bucket.
+    #[tracing::instrument(skip_all, fields(bucket_id = %bucket_id), err)]
     pub async fn new_with_gcs_bucket(
         storage: Storage,
         bucket_id: &str,
@@ -110,6 +112,7 @@ impl RemoteCache<Storage> {
     /// cache fast path (and therefore has no recorded generation), the index
     /// is refetched from GCS so the writer's compare-and-swap commit has an
     /// authoritative generation to match against.
+    #[tracing::instrument(skip_all, err)]
     pub async fn into_writer(
         self,
         ot: Option<OpTracker>,
@@ -218,6 +221,7 @@ impl<B: FetchBackend> RemoteCache<B> {
     }
 
     /// Download the given spec hash into the local cache.
+    #[tracing::instrument(skip_all, fields(span_name = %span_name), err)]
     pub async fn materialize(
         &self,
         spec_hash: &SpecHash,

--- a/crates/rcache/src/remote_writer.rs
+++ b/crates/rcache/src/remote_writer.rs
@@ -136,6 +136,7 @@ impl<S: StubStorage + 'static> RemoteCacheWriter<S> {
     /// The artifact blob upload is content-addressed, so concurrent uploads
     /// of the same blob bytes are safe (last-writer-wins on identical content).
     /// The index update is deferred to [Self::finish_uploads].
+    #[tracing::instrument(skip_all, err)]
     pub async fn upload(
         &mut self,
         spec_hash: &SpecHash,
@@ -195,6 +196,7 @@ impl<S: StubStorage + 'static> RemoteCacheWriter<S> {
     ///
     /// Bounded by [MAX_INDEX_WRITE_RETRIES] attempts with exponential backoff
     /// + jitter; after exhaustion the underlying GCS error is returned.
+    #[tracing::instrument(skip_all, err)]
     pub async fn finish_uploads(self) -> Result<(), Error<GcsError>> {
         let Self {
             backend,

--- a/crates/remote-client/Cargo.toml
+++ b/crates/remote-client/Cargo.toml
@@ -17,6 +17,7 @@ http-body.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true
 tonic.workspace = true
+tracing.workspace = true
 
 check.workspace = true
 common.workspace = true

--- a/crates/remote-client/src/lib.rs
+++ b/crates/remote-client/src/lib.rs
@@ -13,6 +13,7 @@ use remote_proto::{res::*, *};
 use tempfile::NamedTempFile;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tonic::transport::{Channel, Error as TransportError};
+use tracing::Instrument;
 
 type CreateEnvStream = Pin<Box<dyn futures::Stream<Item = CreateEnvMessage> + Send>>;
 type CreateBuildStream = Pin<Box<dyn futures::Stream<Item = OrchestrateBuildMessage> + Send>>;
@@ -75,6 +76,7 @@ where
     <T::ResponseBody as http_body::Body>::Error:
         Into<Box<dyn std::error::Error + Send + Sync>> + Send,
 {
+    #[tracing::instrument(skip_all)]
     pub async fn make_env<'b>(&mut self, cwd: Worktree<'b>) -> Result<Env<'b>, Error> {
         use create_env_message::*;
         let client_id = format!(
@@ -87,12 +89,15 @@ where
         use stream_config::*;
         let (graph_writer, graph_reader) = tokio::io::duplex(8 * 1024);
         let graph_clone = self.g.clone();
-        tokio::spawn(async move {
-            graph::wire::AsyncGraphWriter::new(graph_writer)
-                .write_graph(&graph_clone)
-                .await
-                .expect("graph wire serialization failed");
-        });
+        tokio::spawn(
+            async move {
+                graph::wire::AsyncGraphWriter::new(graph_writer)
+                    .write_graph(&graph_clone)
+                    .await
+                    .expect("graph wire serialization failed");
+            }
+            .instrument(tracing::Span::current()),
+        );
         let graph_stream: (StreamConfig, CreateEnvStream) = (
             StreamConfig {
                 format: Some(Format::Graph(GraphFormat::GfStreamingV1.into())),
@@ -204,6 +209,7 @@ where
         })
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn exec<'b>(
         &mut self,
         env: &Env<'b>,
@@ -275,12 +281,15 @@ where
         use stream_config::*;
         let (graph_writer, graph_reader) = tokio::io::duplex(8 * 1024);
         let graph_clone = self.g.clone();
-        tokio::spawn(async move {
-            graph::wire::AsyncGraphWriter::new(graph_writer)
-                .write_graph(&graph_clone)
-                .await
-                .expect("graph wire serialization failed");
-        });
+        tokio::spawn(
+            async move {
+                graph::wire::AsyncGraphWriter::new(graph_writer)
+                    .write_graph(&graph_clone)
+                    .await
+                    .expect("graph wire serialization failed");
+            }
+            .instrument(tracing::Span::current()),
+        );
         let (graph_config, graph_stream): (StreamConfig, CreateBuildStream) = (
             StreamConfig {
                 format: Some(Format::Graph(GraphFormat::GfStreamingV1.into())),
@@ -490,81 +499,88 @@ where
             .into_inner();
 
         let (tx, rx) = mpsc::unbounded();
-        tokio::spawn(async move {
-            while let Some(msg) = rpc.next().await {
-                let msg = match msg {
-                    Ok(m) => m,
-                    Err(e) => {
-                        let _ = tx.unbounded_send((
-                            check::CheckObj::Package(String::new()),
-                            Err(Error::Other(e.into())),
-                        ));
-                        break;
-                    }
-                };
-                match msg.msg {
-                    Some(check_response::Msg::Error(e)) => {
-                        let _ = tx.unbounded_send((
-                            check::CheckObj::Package(String::new()),
-                            Err(Error::Other(anyhow!("check failed: {}", e.msg).into())),
-                        ));
-                        break;
-                    }
-                    Some(check_response::Msg::Check(c)) => {
-                        let obj = match c.obj.and_then(|o| o.msg) {
-                            Some(check_object::Msg::Package(n)) => check::CheckObj::Package(n),
-                            Some(check_object::Msg::Profile(n)) => check::CheckObj::Profile(n),
-                            Some(check_object::Msg::Harness(n)) => check::CheckObj::Stack(n),
-                            None => {
-                                let _ = tx.unbounded_send((
-                                    check::CheckObj::Package(String::new()),
-                                    Err(Error::Other(
-                                        anyhow!("check response missing object").into(),
-                                    )),
-                                ));
-                                break;
-                            }
-                        };
-                        let check_results: Result<Vec<_>, Error> = c
-                            .results
-                            .into_iter()
-                            .map(|r| -> Result<check::CheckResult, Error> {
-                                let verdict = match check_result::CheckVerdict::try_from(r.verdict)
-                                {
-                                    Ok(check_result::CheckVerdict::CvFail) => {
-                                        check::CheckVerdict::Fail
-                                    }
-                                    Ok(check_result::CheckVerdict::CvFixed) => {
-                                        check::CheckVerdict::Fixed
-                                    }
-                                    Ok(check_result::CheckVerdict::CvSkip) => {
-                                        check::CheckVerdict::Skip
-                                    }
-                                    Ok(check_result::CheckVerdict::CvPass) => {
-                                        check::CheckVerdict::Pass
-                                    }
-                                    Ok(check_result::CheckVerdict::CvUnspecified) | Err(_) => {
-                                        return Err(Error::Other(
-                                            anyhow!("invalid check verdict value {}", r.verdict)
-                                                .into(),
-                                        ));
-                                    }
-                                };
-                                Ok(check::CheckResult {
-                                    check: r.check.into(),
-                                    verdict,
-                                    err: r.errors,
-                                })
-                            })
-                            .collect();
-                        if tx.unbounded_send((obj, check_results)).is_err() {
+        tokio::spawn(
+            async move {
+                while let Some(msg) = rpc.next().await {
+                    let msg = match msg {
+                        Ok(m) => m,
+                        Err(e) => {
+                            let _ = tx.unbounded_send((
+                                check::CheckObj::Package(String::new()),
+                                Err(Error::Other(e.into())),
+                            ));
                             break;
                         }
+                    };
+                    match msg.msg {
+                        Some(check_response::Msg::Error(e)) => {
+                            let _ = tx.unbounded_send((
+                                check::CheckObj::Package(String::new()),
+                                Err(Error::Other(anyhow!("check failed: {}", e.msg).into())),
+                            ));
+                            break;
+                        }
+                        Some(check_response::Msg::Check(c)) => {
+                            let obj = match c.obj.and_then(|o| o.msg) {
+                                Some(check_object::Msg::Package(n)) => check::CheckObj::Package(n),
+                                Some(check_object::Msg::Profile(n)) => check::CheckObj::Profile(n),
+                                Some(check_object::Msg::Harness(n)) => check::CheckObj::Stack(n),
+                                None => {
+                                    let _ = tx.unbounded_send((
+                                        check::CheckObj::Package(String::new()),
+                                        Err(Error::Other(
+                                            anyhow!("check response missing object").into(),
+                                        )),
+                                    ));
+                                    break;
+                                }
+                            };
+                            let check_results: Result<Vec<_>, Error> = c
+                                .results
+                                .into_iter()
+                                .map(|r| -> Result<check::CheckResult, Error> {
+                                    let verdict =
+                                        match check_result::CheckVerdict::try_from(r.verdict) {
+                                            Ok(check_result::CheckVerdict::CvFail) => {
+                                                check::CheckVerdict::Fail
+                                            }
+                                            Ok(check_result::CheckVerdict::CvFixed) => {
+                                                check::CheckVerdict::Fixed
+                                            }
+                                            Ok(check_result::CheckVerdict::CvSkip) => {
+                                                check::CheckVerdict::Skip
+                                            }
+                                            Ok(check_result::CheckVerdict::CvPass) => {
+                                                check::CheckVerdict::Pass
+                                            }
+                                            Ok(check_result::CheckVerdict::CvUnspecified)
+                                            | Err(_) => {
+                                                return Err(Error::Other(
+                                                    anyhow!(
+                                                        "invalid check verdict value {}",
+                                                        r.verdict
+                                                    )
+                                                    .into(),
+                                                ));
+                                            }
+                                        };
+                                    Ok(check::CheckResult {
+                                        check: r.check.into(),
+                                        verdict,
+                                        err: r.errors,
+                                    })
+                                })
+                                .collect();
+                            if tx.unbounded_send((obj, check_results)).is_err() {
+                                break;
+                            }
+                        }
+                        None => {}
                     }
-                    None => {}
                 }
             }
-        });
+            .instrument(tracing::Span::current()),
+        );
 
         Ok(rx)
     }


### PR DESCRIPTION
**Summary** — Adds `#[tracing::instrument]` to high-value async `Result`-returning functions on the execution path and propagates span context into spawned gRPC streaming tasks.

**Instrumented**

- `crates/remote-client/src/lib.rs`
  - `Client::make_env` → `#[tracing::instrument(skip_all)]`
  - `Client::exec` → `#[tracing::instrument(skip_all)]`
  - `tokio::spawn` graph-streaming task in `make_env` → wrapped with `.instrument(tracing::Span::current())`
  - `tokio::spawn` graph-streaming task in `build` → wrapped with `.instrument(tracing::Span::current())`
  - `tokio::spawn` check-response streaming task in `check` → wrapped with `.instrument(tracing::Span::current())`
- `crates/check/src/lib.rs`
  - `run_checks` → `#[tracing::instrument(skip_all, err)]`
  - `package_check_futures` → `#[tracing::instrument(skip_all, err)]`
  - `profile_check_futures` → `#[tracing::instrument(skip_all, err)]`
  - `stack_check_futures` → `#[tracing::instrument(skip_all, err)]`
  - `check_package` → `#[tracing::instrument(skip_all, fields(pkg = %pkg), err)]`
  - `tokio::task::spawn_blocking` in `check_package` → span propagated by capturing `tracing::Span::current()` and `span.enter()` inside the closure (closures can't use `.instrument()`)
- `crates/rcache/src/remote.rs`
  - `RemoteCache::new_over_https` → `#[tracing::instrument(skip_all, err)]`
  - `RemoteCache::new_with_gcs_bucket` → `#[tracing::instrument(skip_all, fields(bucket_id = %bucket_id), err)]`
  - `RemoteCache::into_writer` → `#[tracing::instrument(skip_all, err)]`
  - `RemoteCache::materialize` → `#[tracing::instrument(skip_all, fields(span_name = %span_name), err)]`
- `crates/rcache/src/remote_writer.rs`
  - `RemoteCacheWriter::upload` → `#[tracing::instrument(skip_all, err)]`
  - `RemoteCacheWriter::finish_uploads` → `#[tracing::instrument(skip_all, err)]`
- `crates/op/src/oci_image.rs`
  - `OciImageCreate::run` (the public `Runnable` entry point covering the whole OCI path) → `#[tracing::instrument(skip_all, err)]`
  - `create_base_layer` → `#[tracing::instrument(err)]`
  - `create_layer_from_cache` → `#[tracing::instrument(skip_all, fields(package_name = %package_name), err)]`

Also added `tracing.workspace = true` to `crates/remote-client/Cargo.toml` and `crates/check/Cargo.toml` (the only two target crates that did not already depend on `tracing`).

**Skipped**

- `remote-client` `make_env` / `exec` use `#[instrument(skip_all)]` without `err`: the crate's `remote_client::Error` enum implements `Debug` but not `Display`, and the `err` directive requires `Display` (confirmed by a failing compile). Dropped `err` on these two per the issue's guidance.
- `commit_index` free fn (named in the issue for `remote_writer.rs`): does not exist in the codebase. The index-commit logic lives inline inside `RemoteCacheWriter::finish_uploads`, which is instrumented instead.
- `build_oci_image` public wrapper (named in the issue for `oci_image.rs`): does not exist. The public OCI entry point is `OciImageCreate::run` (impl of `Runnable::run`), which is instrumented and covers the whole OCI path.

**Verification**

All run in a Linux container (`rust:1-bookworm`); the target crates transitively depend on `sandbox2`, which is Linux-only (`hakoniwa`/`nix`), so it cannot build on the macOS dev host.

- `cargo fmt --all --check` — passed
- `cargo build -p remote-client -p check -p rcache -p op` — passed
- `cargo build --workspace` — passed
- `cargo clippy -p remote-client -p check -p rcache -p op --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
