### PR TITLE
crates/sandbox2: Copy `Local` build_deps to avoid hardlinking errors

### DIFF
--- a/crates/mctx/src/error.rs
+++ b/crates/mctx/src/error.rs
@@ -249,6 +249,10 @@ impl From<sandbox2::Error> for Error {
                 }
             },
             sandbox2::Error::Output(e) => Self::Other(e.into()),
+            sandbox2::Error::MappedFile(p) => Self::Other(anyhow::anyhow!(
+                "internal: file {} mapped to rootfs",
+                p.display()
+            )),
         }
     }
 }

--- a/crates/op/src/specs.rs
+++ b/crates/op/src/specs.rs
@@ -55,7 +55,7 @@ impl<'a, SF: crate::SourceFetcher> SpecBuild<'a, SF> {
         for input in build.build_deps.iter() {
             match input {
                 BuildDep::Local { full_path, .. } => {
-                    build_deps.push(SandboxMapped::File(full_path.to_path_buf()))
+                    build_deps.push(SandboxMapped::FileCopy(full_path.to_path_buf()))
                 }
                 BuildDep::Source(source) => {
                     let resolved_src = crate::SourceLoad {

--- a/crates/sandbox2/src/config.rs
+++ b/crates/sandbox2/src/config.rs
@@ -10,6 +10,9 @@ pub enum SandboxMapped {
     File(PathBuf),
     Dir(PathBuf),
     TempDir(tempfile::TempDir),
+    /// Special case of [`SandboxMapped::File`] where the path is
+    /// copied-in + permissions applied, rather than hardlinked.
+    FileCopy(PathBuf),
 }
 
 impl PartialEq for SandboxMapped {
@@ -18,6 +21,7 @@ impl PartialEq for SandboxMapped {
             (Self::File(f1), Self::File(f2)) => f1.eq(f2),
             (Self::Dir(d1), Self::Dir(d2)) => d1.eq(d2),
             (Self::TempDir(d1), Self::TempDir(d2)) => d1.path().eq(d2.path()),
+            (Self::FileCopy(f1), Self::FileCopy(f2)) => f1.eq(f2),
             _ => false,
         }
     }
@@ -38,6 +42,10 @@ impl Hash for SandboxMapped {
             Self::TempDir(p) => {
                 "t".hash(state);
                 p.path().hash(state);
+            }
+            Self::FileCopy(p) => {
+                "fc".hash(state);
+                p.hash(state);
             }
         }
     }

--- a/crates/sandbox2/src/error.rs
+++ b/crates/sandbox2/src/error.rs
@@ -6,6 +6,7 @@ pub enum Error {
     Output(OutputError),
     IO(&'static str, PathBuf, std::io::Error),
     HardlinkFailed(common::HardlinkError),
+    MappedFile(PathBuf),
 }
 
 impl fmt::Display for Error {
@@ -16,6 +17,13 @@ impl fmt::Display for Error {
             Self::HardlinkFailed(e) => e.fmt(f),
             Self::IO(op, path, err) => {
                 write!(f, "{}: I/O error on path {}: {}", op, path.display(), err)
+            }
+            Self::MappedFile(path) => {
+                write!(
+                    f,
+                    "Mapped files in rootfs are not supported: {}",
+                    path.display()
+                )
             }
         }
     }
@@ -28,6 +36,7 @@ impl std::error::Error for Error {
             Self::Output(e) => e.source(),
             Self::HardlinkFailed(e) => e.source(),
             Self::IO(_, _, err) => Some(err),
+            Self::MappedFile(_) => None,
         }
     }
 }

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -97,7 +97,9 @@ impl<C: Channel> Sandbox<C> {
             match i {
                 config::SandboxMapped::Dir(p) => hardlink_dir_contents(p, &rootfs)?,
                 config::SandboxMapped::TempDir(td) => hardlink_dir_contents(td.path(), &rootfs)?,
-                config::SandboxMapped::File(_p) => todo!(),
+                config::SandboxMapped::File(p) | config::SandboxMapped::FileCopy(p) => {
+                    return Err(Error::MappedFile(p.clone()));
+                }
             }
         }
         hardlink_dir_contents(&base_dir.join("synth"), &rootfs)?;
@@ -141,6 +143,11 @@ impl<C: Channel> Sandbox<C> {
                                 }
                             }
                             .map_err(|e| Error::IO("hardlinking input file", dest.clone(), e))?;
+                        }
+                        config::SandboxMapped::FileCopy(p) => {
+                            let dest = b.join(p.file_name().unwrap());
+                            fs::copy(p, &dest)
+                                .map_err(|e| Error::IO("copying input file", dest, e))?;
                         }
                         config::SandboxMapped::Dir(p) => hardlink_dir_contents(p, &b)?,
                         config::SandboxMapped::TempDir(td) => hardlink_dir_contents(td.path(), &b)?,


### PR DESCRIPTION
Fixes gominimal/inbox#129



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Local build dependencies are now copied into sandboxes (with permissions) instead of being hardlinked, improving isolation and reliability of sandboxed builds.
* **Bug Fixes**
  * Sandboxing now returns a clear error when mapped files in the root filesystem are unsupported, producing more actionable messages for failing builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->