### PR TITLE
sandbox2: hardlink CS mirror contents into rootfs (#228 follow-up)

### DIFF
--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -103,6 +103,30 @@ impl<C: Channel> Sandbox<C> {
             }
         }
         hardlink_dir_contents(&base_dir.join("synth"), &rootfs)?;
+
+        // MINIMAL_INTERNAL_CS_BUILD bundle: when the env var is "1"
+        // AND the convention path exists on host, hardlink that
+        // directory's contents into the sandbox rootfs root. This is
+        // the same mechanism the public `extra_rootfs` field used to
+        // provide; it now happens behind the (undocumented) CS flag
+        // with a hardcoded convention path, so there's no new public
+        // API surface.
+        //
+        // Convention: minimalmertic's hermetic-builder-rs stages its
+        // CS-only cache bundle (cargo-vendor, npm-cache, pnpm-store,
+        // bun-cache, pip-wheels, rust-stage0, goproxy) at
+        // /root/.cache/minimal/cs-mirror/. Inside the sandbox these
+        // appear at /cargo-vendor, /goproxy, etc. — top-level paths
+        // matching the existing pkg-build.sh offline-cache idiom.
+        //
+        // Inert when env var unset or the convention path doesn't
+        // exist (tests, dev environments, non-CS callers).
+        if std::env::var("MINIMAL_INTERNAL_CS_BUILD").as_deref() == Ok("1") {
+            let cs_mirror = Path::new("/root/.cache/minimal/cs-mirror");
+            if cs_mirror.exists() {
+                hardlink_dir_contents(cs_mirror, &rootfs)?;
+            }
+        }
         tracing::trace!("rootfs hardlinking took {:?}", hardlinking_start.elapsed());
 
         // On aarch64, autotools/libtool defaults to installing libraries
@@ -434,32 +458,32 @@ impl<C: Channel> Sandbox<C> {
         //    upstream to see if hakoniwa would accept a per-mount
         //    runctl that would let us scope this to /proc only.
         //
-        // 2. Symlink the hermetic-builder's ecosystem cache paths.
-        //    hermetic-builder-rs stages caches at
-        //    <state>/cs-mirror/{cargo-vendor,npm-cache,...}/. The
-        //    state dir is bind-mounted at /state, so the caches are
-        //    already accessible there. Pkg build.shs in the
-        //    minimalmertic pkg set reference /cargo-vendor,
-        //    /npm-cache, etc. as hardcoded paths (per the
-        //    if-d-cargo-vendor offline-cache idiom); these symlinks
-        //    bridge the two without requiring every build.sh to know
-        //    about /state/cs-mirror/. Dangling symlinks (when a given
-        //    cache wasn't staged for the current pkg) are safe —
-        //    `[ -d /<name> ]` returns false through a dangling
-        //    symlink, so the build.sh's online-fallback branch is
-        //    taken correctly.
+        // 2. (Cache delivery for hermetic-builder's ecosystem caches —
+        //    cargo-vendor, npm-cache, pnpm-store, bun-cache,
+        //    pip-wheels, rust-stage0, goproxy — happens in Sandbox::new
+        //    via hardlink_dir_contents from the convention path
+        //    /root/.cache/minimal/cs-mirror/. Earlier iteration of
+        //    this PR used /state/cs-mirror-pointing symlinks here,
+        //    but /state inside each sandbox is per-build state, not
+        //    shared with the orchestrator's outer state_dir, so the
+        //    symlinks pointed at unreachable paths. The hardlink
+        //    mechanism (matching the old extra_rootfs behavior) does
+        //    the right thing without expanding public API surface.)
         //
         // Inert when the env var is unset; default `minimal package`
         // invocations see no behavior change.
         if std::env::var("MINIMAL_INTERNAL_CS_BUILD").as_deref() == Ok("1") {
             container.bindmount_rw("/proc", "/proc");
             container.runctl(hakoniwa::Runctl::MountFallback);
-            container.symlink("/state/cs-mirror/cargo-vendor", "/cargo-vendor");
-            container.symlink("/state/cs-mirror/npm-cache", "/npm-cache");
-            container.symlink("/state/cs-mirror/pnpm-store", "/pnpm-store");
-            container.symlink("/state/cs-mirror/bun-cache", "/bun-cache");
-            container.symlink("/state/cs-mirror/pip-wheels", "/pip-wheels");
-            container.symlink("/state/cs-mirror/rust-stage0", "/rust-stage0");
+            // Cache delivery (cargo-vendor, npm-cache, ...) is handled
+            // by the hardlink_dir_contents call in Sandbox::new — see
+            // lib.rs near line ~105. Earlier iteration of this PR
+            // used /state/<...>-pointing symlinks here, but /state
+            // inside each sandbox is per-build state (created via
+            // base_dir.join("state") in Sandbox::new), not shared with
+            // the orchestrator's outer state_dir, so the symlinks
+            // pointed at unreachable paths. The hardlink mechanism
+            // replaces them.
         }
 
         if self.needs_bin_symlink()? {


### PR DESCRIPTION
# sandbox2: hardlink CS mirror contents into rootfs (fix #228 follow-up)

Follow-up to #228 (sandbox2 + op: CS-compatible nested-sandbox plumbing). The `MINIMAL_INTERNAL_CS_BUILD=1` bundle landed with the right intent, but the cache-delivery half didn't survive integration: the `container.symlink("/state/cs-mirror/<X>", "/<X>")` calls pointed at `/state/cs-mirror/...` assuming `/state` was shared across all sandboxes — but `/state` inside each per-build sandbox is `base_dir.join("state")`, a per-build location, so every symlink dangled. Pkg build.shs that probe `[ -d /cargo-vendor ]` all took their online-fallback branch, which fails in CS because there's no egress.

## Fix

Replace the six broken symlinks with a single `hardlink_dir_contents` call from a hardcoded convention path. Same mechanism the (since-removed) public `extra_rootfs` field used; now triggered behind the existing CS flag with no new public API.

```rust
// In Sandbox::new, right after the synth-dir hardlink:
if std::env::var("MINIMAL_INTERNAL_CS_BUILD").as_deref() == Ok("1") {
    let cs_mirror = Path::new("/root/.cache/minimal/cs-mirror");
    if cs_mirror.exists() {
        hardlink_dir_contents(cs_mirror, &rootfs)?;
    }
}
```

The convention: minimalmertic's hermetic-builder-rs stages its CS bundle (`cargo-vendor`, `npm-cache`, `pnpm-store`, `bun-cache`, `pip-wheels`, `rust-stage0`, `goproxy`) at `/root/.cache/minimal/cs-mirror/`. The hardlink presents these as `/cargo-vendor`, `/goproxy`, etc. at sandbox rootfs root — the same top-level paths the build.sh offline-cache idiom already references.

The `/proc` bind-mount + `MountFallback` runctl from #228 stay — that half of the bundle was correct.

## Why hardlink + convention path rather than a config field

Per the #228 review thread, the constraint was **no new configurables / boolean-flag-only**. This PR honors that:

- Still one env var: `MINIMAL_INTERNAL_CS_BUILD`
- Still boolean semantics (`== "1"`)
- The path `/root/.cache/minimal/cs-mirror` is a project-internal convention (same category as `/state`, `/run`) — not operator-configurable

If a future use case needs operator configurability, the right move is a separate proposal for that use case, not a `config.extra_rootfs` field that could be repurposed.

## Safety

- **Inert when flag unset**: gated on `MINIMAL_INTERNAL_CS_BUILD == "1"`; `minimal package` invocations see no behavior change
- **Inert when path doesn't exist**: `cs_mirror.exists()` check before the call. Tests, dev environments, and any non-CS caller with the flag accidentally set won't break.
- **Mechanism is already exercised**: `hardlink_dir_contents` runs just above this call for the synth-dir copy. The same code path that's been working in `minimal package` since forever.

## Validation

Validated end-to-end in the minimalmertic deployment over 2026-05-25/26:

- 260+ pkgs signed under the new sandbox bundle (C, Go, Cargo, npm, pnpm, pypi)
- `bash-bootstrap@5.3` reproducibility: built three times — once against gominimal's prebuilt, once as a rebuild, once against its own CS output — all produced sha `1d99e33f…`
- `perl@5.42.0` builds from source CS-side after a separate `-std=gnu17` fix to its `build.sh`

Both formerly-trust-pinned bootstrap_artifacts (bash-bootstrap, perl) graduated out via this mechanism. The bundle is exercised continuously by the production builder.

## Diff size

```
 crates/sandbox2/src/lib.rs | 64 +++++++++++++++++++++++++++++++---------------
 1 file changed, 44 insertions(+), 20 deletions(-)
```

Single file, single commit, applies cleanly to current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sandbox cache delivery mechanism to use hardlink-based installation instead of symlink bridging, improving cache efficiency in containerized build environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->