### PR TITLE
crates/minimald: create scaffolding for building up SSH channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
+checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
 dependencies = [
  "aead",
  "aes",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
  "cipher",
 ]
@@ -635,12 +635,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
  "zeroize",
 ]
@@ -881,6 +881,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "constcat"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d3e02915a2cea4d74caa8681e2d44b1c3254bdbf17d11d41d587ff858832c"
+
+[[package]]
 name = "copy_dir"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
@@ -1059,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
@@ -1297,7 +1303,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1406,7 +1412,7 @@ checksum = "cda94f31325c4275e9706adecbb6f0650dee2f904c915a98e3d81adaaaa757aa"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "digest 0.11.3",
  "hkdf",
  "hybrid-array",
@@ -2844,7 +2850,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "rand_core 0.10.1",
 ]
 
@@ -3352,11 +3358,14 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "clap_complete",
+ "constcat",
  "dirs",
  "futures",
  "ot",
  "russh",
  "serde",
+ "serde_json",
+ "stdlib",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4229,7 +4238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b52e6ee42db392378a95622b463c9740631171d1efce43fa445a569c1600cb6"
 dependencies = [
  "crypto-bigint",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
@@ -6517,7 +6526,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ bzip2 = "0.6"
 clap = { version = "4.6", features = ["derive", "env", "string"] }
 clap_complete = { version = "4.6" }
 codespan-reporting = { version = "0.13", features = ["serialization"] } # Keep in sync with nickel-lang-core
+constcat = "0.6"
 copy_dir = "0.1.3"
 dirs = "6"
 either = { version = "1.15", default-features = false }

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -7,14 +7,17 @@ publish.workspace = true
 [dependencies]
 clap.workspace = true
 clap_complete.workspace = true
+constcat.workspace = true
 dirs.workspace = true
 futures.workspace = true
 
 russh.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
 ot.workspace = true
+stdlib.workspace = true

--- a/crates/minimald/src/connection.rs
+++ b/crates/minimald/src/connection.rs
@@ -1,6 +1,29 @@
-use russh::server::{Config as RuConfig, RunningSession};
-pub use std::sync::{Arc, Mutex};
-use tokio::net::UnixStream;
+use russh::{
+    Channel as RuChannel, ChannelId,
+    server::{Config as RuConfig, Msg, RunningSession, Session},
+};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, LazyLock},
+};
+use tokio::{net::UnixStream, spawn, sync::Mutex};
+
+use crate::{
+    ChannelConfig, RequestedPty,
+    rpc::{self, OneshotSshRpc},
+    server::ServerStateHandle,
+};
+
+static PROTOCOL_TRACE_ENABLED: LazyLock<bool> =
+    LazyLock::new(|| std::env::var("PROTOCOL_TRACE").as_deref() == Ok("1"));
+
+macro_rules! protocol_trace {
+    ($($arg:tt)*) => {
+        if *PROTOCOL_TRACE_ENABLED {
+            tracing::info!($($arg)*);
+        }
+    };
+}
 
 /// The auth state of the SSH connection.
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -10,22 +33,93 @@ pub enum Auth {
     Local,
 }
 
+/// Represents the state variants of an SSH channel within a connection.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum ChannelInner {
+    /// A channel has been created but not yet minted into a specific variant,
+    /// namely an exec variant, shell, or subsystem variant.
+    Pending(RuChannel<Msg>, ChannelConfig),
+    /// The pending channel was finalized, and the channel handle was taken
+    /// to be used for writing bytes from a different async context.
+    Taken,
+}
+
+/// Represents the state of an SSH channel within a connection.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct Channel {
+    pub id: ChannelId,
+    pub inner: ChannelInner,
+    closed: bool,
+}
+
+impl Channel {
+    /// Mints a new session state object. Expected to be called from the russh
+    /// handler code for a connection.
+    fn new_session(id: ChannelId, c: RuChannel<Msg>) -> Self {
+        Channel {
+            id,
+            inner: ChannelInner::Pending(
+                c,
+                ChannelConfig {
+                    env_vars: BTreeMap::new(),
+                    pty: None,
+                },
+            ),
+            closed: false,
+        }
+    }
+
+    /// Called when the client wants to close this channel.
+    fn handle_channel_close(&mut self) {
+        self.closed = true;
+    }
+
+    /// Consumes a pending session, returning its state and leaving [`ChannelInner::Taken`] in its place.
+    pub fn take(&mut self) -> Option<(RuChannel<Msg>, ChannelConfig)> {
+        match std::mem::replace(&mut self.inner, ChannelInner::Taken) {
+            ChannelInner::Pending(c, p) => Some((c, p)),
+            other => {
+                self.inner = other;
+                None
+            }
+        }
+    }
+
+    /// Returns a mutable reference to the state of the channel under construction, if
+    /// the channel has not already been launched and/or closed.
+    pub fn pending_config_mut(&mut self) -> Option<&mut ChannelConfig> {
+        if let ChannelInner::Pending(_, p) = &mut self.inner {
+            Some(p)
+        } else {
+            None
+        }
+    }
+}
+
 /// Represents the SSH connection. Lives for the
 /// lifetime of the connection.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 #[allow(dead_code)]
 pub struct Connection {
+    /// The current authentication state of this connection.
     pub auth: Auth,
-
     /// The username given via SSH. Not populated till the client
     /// authenticates the connection.
     pub ssh_username: Option<String>,
+
+    /// State specific to an SSH channel.
+    channels: BTreeMap<ChannelId, Channel>,
+
+    serv: ServerStateHandle,
 }
 
 impl Connection {
     pub(crate) async fn from_socket(
         s: UnixStream,
         c: Arc<RuConfig>,
+        serv: ServerStateHandle,
         was_local_uds: bool,
     ) -> (ConnectionHandle, RunningSession<ConnectionHandler>) {
         let h = ConnectionHandle(Arc::new(Mutex::new(Self {
@@ -34,7 +128,9 @@ impl Connection {
             } else {
                 Auth::Pending
             },
-            ..Default::default()
+            ssh_username: None,
+            channels: BTreeMap::new(),
+            serv,
         })));
 
         (
@@ -43,6 +139,34 @@ impl Connection {
                 .await
                 .unwrap(),
         )
+    }
+
+    pub(crate) fn pending_config_mut(&mut self, id: ChannelId) -> Option<&mut ChannelConfig> {
+        let c = self.channels.get_mut(&id)?;
+        if c.closed {
+            tracing::warn!("Client tried to update config on an already-closed channel {id}");
+            return None;
+        }
+        c.pending_config_mut()
+    }
+
+    fn take(&mut self, id: ChannelId) -> Option<(RuChannel<Msg>, ChannelConfig)> {
+        let c = self.channels.get_mut(&id)?;
+        if c.closed {
+            tracing::warn!("Client tried to take an already-closed channel {id}");
+            return None;
+        }
+        c.take()
+    }
+
+    fn handle_channel_close(&mut self, id: ChannelId) -> Result<(), ConnectionError> {
+        match self.channels.remove(&id) {
+            None => tracing::warn!("request to close channel {id} which does not exist"),
+            Some(mut c) => {
+                c.handle_channel_close();
+            }
+        };
+        Ok(())
     }
 }
 
@@ -54,7 +178,16 @@ pub struct ConnectionHandle(Arc<Mutex<Connection>>);
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum ConnectionError {
+    /// A protocol error.
     Protocol(russh::Error),
+
+    /// Failed to (de)serialize a JSON-encoded RPC message.
+    Json(serde_json::Error),
+
+    /// An operation was attempted after the session was launched
+    /// (i.e. setting env vars after exec), which is both non-sensical and
+    /// heavily implied by RFC 4254 to be invalid.
+    SetupAfterInitiation,
 }
 
 impl From<russh::Error> for ConnectionError {
@@ -63,19 +196,169 @@ impl From<russh::Error> for ConnectionError {
     }
 }
 
+impl From<serde_json::Error> for ConnectionError {
+    fn from(value: serde_json::Error) -> Self {
+        ConnectionError::Json(value)
+    }
+}
+
 /// A [`russh::server::Handler`] for a [`Connection`].
+///
+/// IMPORTANT: Handler methods must be fast to avoid blocking the
+/// task which is servicing the socket. Handlers should reconfigure
+/// state, spawn an async task for any potentially long-running task,
+/// and return.
+///
+/// NOTE: channel_eof left at default impl, implementing channel_eof prevents propagation
+/// to channel handle. Similarly, don't implement data().
 pub struct ConnectionHandler(ConnectionHandle);
 
 impl russh::server::Handler for ConnectionHandler {
     type Error = ConnectionError;
 
     async fn auth_none(&mut self, user: &str) -> Result<russh::server::Auth, Self::Error> {
-        let mut s = self.0.0.lock().unwrap();
+        let mut s = self.0.0.lock().await;
         if s.auth == Auth::Local {
             s.ssh_username = Some(user.to_string());
             Ok(russh::server::Auth::Accept)
         } else {
             Ok(russh::server::Auth::reject())
         }
+    }
+
+    async fn channel_open_session(
+        &mut self,
+        c: RuChannel<Msg>,
+        _: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        let mut s = self.0.0.lock().await;
+        if s.auth != Auth::Local {
+            return Ok(false); // indicate failure
+        }
+
+        protocol_trace!("Minting session channel with id {}", c.id());
+        s.channels.insert(c.id(), Channel::new_session(c.id(), c));
+
+        Ok(true) // indicate success
+    }
+
+    async fn env_request(
+        &mut self,
+        id: ChannelId,
+        var_name: &str,
+        var_value: &str,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        protocol_trace!("Got env_request on channel {id}: {var_name}={var_value}");
+
+        match self.0.0.lock().await.pending_config_mut(id) {
+            Some(p) => {
+                session.channel_success(id)?;
+                p.env_vars
+                    .insert(var_name.to_string(), var_value.to_string());
+            }
+            None => session.channel_failure(id)?,
+        }
+        Ok(())
+    }
+
+    async fn pty_request(
+        &mut self,
+        id: ChannelId,
+        term: &str,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        modes: &[(russh::Pty, u32)],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        protocol_trace!(
+            "Got pty_request on channel {id}: term={term} sz=({col_width}, {row_height}) p_sz=({pix_width}, {pix_height}) modes={:?}",
+            modes,
+        );
+
+        match self.0.0.lock().await.pending_config_mut(id) {
+            Some(p) => {
+                session.channel_success(id)?;
+                p.pty = Some(RequestedPty {
+                    char_sizes: (col_width, row_height),
+                    pixel_sizes: (pix_width, pix_height),
+                    term: term.to_string(),
+                    modes: modes.to_vec(),
+                });
+            }
+            None => session.channel_failure(id)?,
+        }
+        Ok(())
+    }
+
+    async fn exec_request(
+        &mut self,
+        id: ChannelId,
+        data: &[u8],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        protocol_trace!(
+            "Got exec_request on channel {id}: {:?}",
+            String::from_utf8(data.to_vec())
+        );
+        session.channel_failure(id)?; // TODO: handle exec request
+        Ok(())
+    }
+
+    async fn shell_request(
+        &mut self,
+        id: ChannelId,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        protocol_trace!("Got shell_request on channel {id}");
+        session.channel_failure(id)?; // TODO: handle shell request
+        Ok(())
+    }
+
+    async fn subsystem_request(
+        &mut self,
+        id: ChannelId,
+        name: &str,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        protocol_trace!("Got subsystem_request on channel {id}: subsystem={name}");
+
+        match name {
+            rpc::GetVersion::NAME => {
+                let c_hnd = match self.0.0.lock().await.take(id) {
+                    None => {
+                        session.channel_failure(id)?;
+                        return Ok(());
+                    }
+                    Some((channel, _p)) => channel,
+                };
+                session.channel_success(id)?;
+
+                spawn(async move {
+                    rpc::GetVersion
+                        .handle(c_hnd, |_req| {
+                            Ok(rpc::GetVersionResponse {
+                                version: env!("CARGO_PKG_VERSION").to_string(),
+                                long_version: env!("LONG_VERSION").to_string(),
+                                stdlib_version: stdlib::VERSION.to_string(),
+                            })
+                        })
+                        .await
+                });
+
+                Ok(())
+            }
+            _ => {
+                session.channel_failure(id)?;
+                Ok(())
+            }
+        }
+    }
+
+    async fn channel_close(&mut self, id: ChannelId, _: &mut Session) -> Result<(), Self::Error> {
+        protocol_trace!("Got channel_close on channel {id}");
+        self.0.0.lock().await.handle_channel_close(id)
     }
 }

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -1,0 +1,23 @@
+use std::collections::BTreeMap;
+
+pub mod connection;
+pub mod rpc;
+pub mod server;
+
+/// Represents the parameters of a requested PTY.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct RequestedPty {
+    char_sizes: (u32, u32),
+    pixel_sizes: (u32, u32),
+    term: String,
+    modes: Vec<(russh::Pty, u32)>,
+}
+
+/// Represents the currently configured parameters for a channel being created.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct ChannelConfig {
+    pub(crate) env_vars: BTreeMap<String, String>,
+    pub(crate) pty: Option<RequestedPty>,
+}

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -7,10 +7,7 @@ use std::path::PathBuf;
 use tokio::net::UnixListener;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
-use crate::server::Server;
-
-mod connection;
-mod server;
+use minimald::server::{Config, HostKey, Server};
 
 #[derive(Parser)]
 #[command(name = "minimald", version = env!("CARGO_PKG_VERSION"), long_version = env!("LONG_VERSION"))]
@@ -26,19 +23,36 @@ struct Cli {
 impl Cli {
     /// Returns the path to the minimal-dir (base directory for state)
     /// based on command-line arguments.
-    pub fn minimal_dir(&self) -> PathBuf {
+    pub fn minimal_state_dir(&self) -> PathBuf {
         self.global_args.minimal_dir.clone().unwrap_or_else(|| {
-            dirs::cache_dir()
-                .unwrap_or_else(|| PathBuf::from("~/.cache"))
+            dirs::state_dir()
+                .unwrap_or_else(|| PathBuf::from("~/.local/state"))
                 .join("minimal")
         })
     }
+
+    /// Returns the path to base directory for caching
+    /// based on command-line arguments.
+    pub fn minimal_cache_dir(&self) -> PathBuf {
+        dirs::cache_dir()
+            .unwrap_or_else(|| PathBuf::from("~/.local/cache"))
+            .join("minimal")
+    }
+
+    /// Returns the path to the directory containing sockets/info about this daemon for clients.
+    pub fn client_instance_dir(&self) -> PathBuf {
+        let instance_num = match &self.command {
+            Command::Run(ListenArgs { instance_num }) => *instance_num,
+            _ => 0,
+        };
+        self.minimal_state_dir()
+            .join("providers")
+            .join(format!("local-{instance_num}"))
+    }
+
     /// Returns the path to the UDS socket we should listen on.
     pub fn listen_on(&self) -> PathBuf {
-        match &self.command {
-            Command::Run(ListenArgs { socket: Some(p) }) => p.clone(),
-            _ => self.minimal_dir().join("minimald.sock"),
-        }
+        self.client_instance_dir().join("ssh.sock")
     }
 }
 
@@ -64,7 +78,7 @@ struct CompletionsArgs {
 /// Shared arguments for all subcommands.
 #[derive(Debug, Args)]
 pub struct GlobalArgs {
-    /// Override the base directory used for operations (default: ~/.cache/minimal)
+    /// Override the state directory used for operations (default: $XDG_STATE_DIR/minimal)
     #[arg(long)]
     minimal_dir: Option<PathBuf>,
     /// Load the minimal standard library from the given path instead
@@ -80,9 +94,12 @@ pub struct GlobalArgs {
 /// Arguments describing where minimald should listen for connections.
 #[derive(Debug, Args)]
 pub struct ListenArgs {
-    /// Override the UDS path to listen on.
-    #[arg(long)]
-    socket: Option<PathBuf>,
+    /// Instance number for this minimald; determines client-relevant paths under
+    /// `<minimal_state_dir>/providers/local-<instance-num>`.
+    ///
+    /// The SSH socket is accessible as `ssh.sock`.
+    #[arg(long, default_value_t = 0)]
+    instance_num: u32,
 }
 
 /// An error at the top level of minimald.
@@ -114,7 +131,7 @@ async fn main() -> Result<(), MainError> {
         return Ok(());
     }
 
-    if let Err(e) = std::fs::create_dir_all(cli.minimal_dir())
+    if let Err(e) = std::fs::create_dir_all(cli.minimal_state_dir())
         && e.kind() != std::io::ErrorKind::AlreadyExists
     {
         return Err(MainError::IO(e, "creating minimal dir"));
@@ -122,6 +139,15 @@ async fn main() -> Result<(), MainError> {
 
     // If we got this far we need to launch minimald.
     //
+    // Ensure the socket's parent directory exists.
+    let socket_path = cli.listen_on();
+    if let Some(parent) = socket_path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+        && e.kind() != std::io::ErrorKind::AlreadyExists
+    {
+        return Err(MainError::IO(e, "creating provider dir"));
+    }
+
     // Listen on the UDS socket.
     if let Err(e) = std::fs::remove_file(cli.listen_on())
         && e.kind() != std::io::ErrorKind::NotFound
@@ -131,11 +157,21 @@ async fn main() -> Result<(), MainError> {
     let listener =
         UnixListener::bind(cli.listen_on()).map_err(|e| MainError::IO(e, "listening to socket"))?;
     tracing::info!("Started listening on {}", cli.listen_on().display());
+    tracing::info!(
+        "Run the following to debug the socket:\n\nssh -o ProxyCommand='socat - UNIX-CONNECT:{}' \\\n\t-o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' \\\n\tlocal",
+        cli.listen_on().display()
+    );
+
+    // TODO: When we have a daemonize command, daemonize here.
 
     // Setup the server.
-    let config = server::Config {
-        host_key: server::HostKey::Ephemeral,
-        minimal_dir: cli.minimal_dir(),
+    let config = Config {
+        host_key: HostKey::OnDisk {
+            path: cli.client_instance_dir().join("ssh_host_ed25519_key"),
+            create_if_missing: true,
+        },
+        minimal_state_dir: cli.minimal_state_dir(),
+        minimal_cache_dir: cli.minimal_cache_dir(),
     };
 
     match cli.command {

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -1,0 +1,61 @@
+use russh::{Channel as RuChannel, server::Msg};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::connection::ConnectionError;
+
+pub const RPC_SUBSYSTEM_PREFIX: &str = "minimald-v1-";
+
+/// Describes a minimal-specific RPC method sent over ssh.
+///
+/// Oneshot RPCs are not streaming.
+pub(crate) trait OneshotSshRpc {
+    /// The subsystem name used to call for this RPC.
+    const NAME: &'static str;
+    /// The type schema of the request.
+    type Request<'a>: Deserialize<'a>;
+    /// The type schema of the response.
+    type Response: Serialize;
+
+    async fn handle<F>(&self, c: RuChannel<Msg>, handler: F) -> Result<(), ConnectionError>
+    where
+        F: for<'a> FnOnce(Self::Request<'a>) -> Result<Self::Response, ConnectionError>,
+    {
+        let mut stream = c.into_stream();
+
+        let mut buf = Vec::with_capacity(1024);
+        stream
+            .read_to_end(&mut buf)
+            .await
+            .map_err(russh::Error::from)?;
+
+        let request: Self::Request<'_> = serde_json::from_slice(&buf)?;
+        let response = handler(request)?;
+        let response_bytes = serde_json::to_vec(&response)?;
+
+        stream
+            .write_all(&response_bytes)
+            .await
+            .map_err(russh::Error::from)?;
+        stream.flush().await.map_err(russh::Error::from)?;
+        stream.shutdown().await.map_err(russh::Error::from)?;
+        Ok(())
+    }
+}
+
+/// An RPC to get the version of minimald.
+pub struct GetVersion;
+
+/// The response to the [`GetVersion`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetVersionResponse {
+    pub version: String,
+    pub long_version: String,
+    pub stdlib_version: String,
+}
+
+impl OneshotSshRpc for GetVersion {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "GetVersion");
+    type Request<'a> = ();
+    type Response = GetVersionResponse;
+}

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -4,11 +4,12 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::UnixListener;
+use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 
 use crate::connection::Connection;
 
-/// The host private key for the SSH server.
+/// The ed25519 host private key for the SSH server.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HostKey {
@@ -16,27 +17,90 @@ pub enum HostKey {
     Ephemeral,
     /// An OpenSSH-formatted PEM private key.
     Raw(String),
-    /// A path to an OpenSSH-formatted PEM private key.
-    Path(PathBuf),
+    /// A path where an OpenSSH-formatted PEM private key should be stored,
+    /// optionally created on first use.
+    OnDisk {
+        path: PathBuf,
+        create_if_missing: bool,
+    },
 }
 
 /// Global Configuration for the minimald server.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
     pub host_key: HostKey,
-    pub minimal_dir: PathBuf,
+    pub minimal_state_dir: PathBuf,
+    pub minimal_cache_dir: PathBuf,
 }
 
 impl Config {
     /// Returns the SSH host key to use.
+    ///
+    /// For [`HostKey`] variant `OnDisk{ create_on_missing: true, ..}`,
+    /// a new key will be generated and written if the file does not exist.
     pub fn host_key(&self) -> Result<PrivateKey, KeyError> {
         match &self.host_key {
             HostKey::Ephemeral => {
                 let key = PrivateKey::random(&mut safe_rng(), russh::keys::Algorithm::Ed25519)?;
                 Ok(key)
             }
-            HostKey::Path(path) => Ok(PrivateKey::read_openssh_file(path)?),
+            HostKey::OnDisk {
+                path,
+                create_if_missing,
+            } => match PrivateKey::read_openssh_file(path) {
+                Ok(k) => Ok(k),
+                Err(KeyError::Io(std::io::ErrorKind::NotFound)) => {
+                    if *create_if_missing {
+                        let key =
+                            PrivateKey::random(&mut safe_rng(), russh::keys::Algorithm::Ed25519)?;
+                        key.write_openssh_file(path, russh::keys::ssh_key::LineEnding::LF)?;
+                        Ok(key)
+                    } else {
+                        Err(KeyError::Io(std::io::ErrorKind::NotFound))
+                    }
+                }
+                Err(e) => Err(e),
+            },
             HostKey::Raw(r) => Ok(PrivateKey::from_openssh(r.as_bytes())?),
+        }
+    }
+}
+
+/// A container for the state of the server.
+#[derive(Debug)]
+pub struct ServerState {
+    config: Config,
+
+    /// Memoized SSH host key, after first successful load.
+    host_key: Option<PrivateKey>,
+}
+
+impl ServerState {
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            host_key: None,
+        }
+    }
+}
+
+/// A thread-safe handle to the server state.
+#[derive(Clone, Debug)]
+pub struct ServerStateHandle(Arc<Mutex<ServerState>>);
+
+impl ServerStateHandle {
+    pub async fn host_key(&self) -> Result<PrivateKey, KeyError> {
+        let mut s = self.0.lock().await;
+        if let Some(hk) = &s.host_key {
+            return Ok(hk.clone());
+        }
+
+        match s.config.host_key() {
+            Ok(hk) => {
+                s.host_key = Some(hk.clone());
+                Ok(hk)
+            }
+            Err(e) => Err(e),
         }
     }
 }
@@ -44,20 +108,22 @@ impl Config {
 /// A listening minimald server.
 #[derive(Debug)]
 pub struct Server {
-    config: Config,
+    state: ServerStateHandle,
     listener: UnixListener,
 }
 
 impl Server {
     /// Launches minimald, listening for connections on the given UDS socket.
     pub async fn run_on_uds(config: Config, listener: UnixListener) -> Result<(), std::io::Error> {
-        Server { config, listener }.run().await
+        let state = ServerStateHandle(Arc::new(Mutex::new(ServerState::new(config))));
+        Server { state, listener }.run().await
     }
 
     async fn run(self) -> Result<(), std::io::Error> {
         let russh_config = Arc::new(russh::server::Config {
-            keys: vec![self.config.host_key().unwrap()],
+            keys: vec![self.state.host_key().await.unwrap()],
             auth_rejection_time_initial: Some(std::time::Duration::ZERO),
+            nodelay: true,
             ..Default::default()
         });
 
@@ -65,7 +131,8 @@ impl Server {
         loop {
             let (socket, _) = self.listener.accept().await?;
             let (_conn_hnd, session_fut) =
-                Connection::from_socket(socket, russh_config.clone(), true).await;
+                Connection::from_socket(socket, russh_config.clone(), self.state.clone(), true)
+                    .await;
             session_set.spawn(session_fut);
         }
     }


### PR DESCRIPTION
Basically, the connection handler type wraps the connection handle, and very quickly reaches into it via a lock to tweak state when managing the ssh connection. As requests for pty, env vars etc come in, we mutate this pending state (owned by the Connection) to accumlate the configurables, sorta like the builder pattern.

When its time for the channel to actually be wired to something heavy, we take the `RuChannel<Msg>` out of the connection state, and it lives with the async context which actually does the work. The handler method returns quickly, freeing up the thread which services the connection once again. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-channel SSH session lifecycle and per-channel configuration (env/PTY) handling
  * SSH one-shot RPC subsystem with a GetVersion RPC
  * Per-instance sockets via a CLI instance option for isolated daemon instances
  * Optional protocol tracing controlled via environment

* **Chores**
  * Separate state vs cache dirs and per-instance client directories
  * Persistent on-disk host key generation/usage and memoized server state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->