### PR TITLE
chore(sessions): Add Primites for Paths and Patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,15 +225,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -447,6 +447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -491,6 +500,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -528,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1496,13 +1514,12 @@ checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1961,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-type"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcae00eb50388f5127e65cf2d45679fc4ec0e3596975bb6ec41aec6319a51c9"
+checksum = "d3658f2192252ba301a9d0a26e298bd56b55f0edb32de499a2f41ff244c09cf8"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2099,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2176,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2221,9 +2238,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "ctutils",
  "subtle",
@@ -2470,7 +2487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2547,16 +2564,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_ci"
@@ -2688,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -2698,14 +2705,14 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2802,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2813,6 +2820,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signature 2.2.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2930,9 +2938,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -2968,10 +2976,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3012,9 +3017,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "logos"
@@ -3622,9 +3627,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3898,7 +3903,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -4028,18 +4033,18 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4095,12 +4100,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "poly1305"
@@ -4419,9 +4418,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "memchr",
@@ -4490,7 +4489,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4671,15 +4670,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -5023,7 +5013,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5362,11 +5352,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5381,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -5444,6 +5435,8 @@ dependencies = [
 name = "sessions"
 version = "0.0.1"
 dependencies = [
+ "camino",
+ "globset",
  "serde",
  "toml 1.1.2+spec-1.1.0",
 ]
@@ -6109,7 +6102,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6162,7 +6155,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6171,7 +6164,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6327,20 +6320,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6418,9 +6411,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
 dependencies = [
  "cc",
  "regex",
@@ -6864,9 +6857,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
+checksum = "9a7714cd0430a663154667c74da5d09325c2387695bee18b3f7f72825aa3693a"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -7002,6 +6995,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -7033,11 +7044,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -7062,6 +7090,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7072,6 +7106,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7086,10 +7126,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7104,6 +7156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7114,6 +7172,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7128,6 +7192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7140,6 +7210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7150,9 +7226,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -7324,9 +7400,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -7348,6 +7424,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ anyhow = "1.0"
 blake3 = { version = "1", features = ["serde"] }
 bytes = "1.11" # keep in sync with reqwest
 bzip2 = "0.6"
+camino = { version = "1", features = ["serde1"] }
 clap = { version = "4.6", features = ["derive", "env", "string"] }
 clap_complete = { version = "4.6" }
 codespan-reporting = { version = "0.13", features = ["serialization"] } # Keep in sync with nickel-lang-core

--- a/crates/sessions/Cargo.toml
+++ b/crates/sessions/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+globset.workspace = true
+camino.workspace = true
 serde.workspace = true
 
 [dev-dependencies]

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -3,3 +3,6 @@
 
 pub mod lifecyclehook;
 pub mod loadout;
+pub mod patches;
+pub mod paths;
+pub mod vars;

--- a/crates/sessions/src/lifecyclehook.rs
+++ b/crates/sessions/src/lifecyclehook.rs
@@ -6,8 +6,8 @@
 //! [`LifecycleHook::builder`] or deserialize them from configuration; both paths
 //! enforce the same invariant.
 
+use crate::paths::ConfigRelPath;
 use core::fmt;
-use std::path::PathBuf;
 
 /// Errors produced when constructing a [`LifecycleHook`].
 #[non_exhaustive]
@@ -39,6 +39,11 @@ impl std::error::Error for Error {}
 /// Either the script body provided directly ([`Inline`](Self::Inline)) or a
 /// path to a script file on disk ([`External`](Self::External)).
 ///
+/// External scripts are [`ConfigRelPath`]s — anchored to the directory of the
+/// `minimal.toml` they were decoded from. Absolute paths are rejected at
+/// deserialization. To run an arbitrary host path, the executor binds the
+/// `ConfigRelPath` against the known config directory.
+///
 /// Serialized with adjacent tagging — the wire form is a table with `type` and
 /// `value` keys:
 ///
@@ -51,8 +56,8 @@ impl std::error::Error for Error {}
 pub enum HookScript {
     /// Script body stored inline.
     Inline(String),
-    /// Path to a script file on disk.
-    External(PathBuf),
+    /// Path to a script file on disk, relative to the config directory.
+    External(ConfigRelPath),
 }
 
 /// A set of scripts to run at lifecycle transition points of a host resource.
@@ -257,9 +262,10 @@ mod tests {
         "#;
         let hook: LifecycleHook = toml::from_str(src).unwrap();
         assert!(matches!(hook.on_activate(), Some(HookScript::Inline(s)) if s == "echo activated"));
-        assert!(
-            matches!(hook.on_destroy(), Some(HookScript::External(p)) if p == &PathBuf::from("./teardown.sh"))
-        );
+        assert!(matches!(
+            hook.on_destroy(),
+            Some(HookScript::External(p)) if p.as_str() == "./teardown.sh"
+        ));
         assert!(matches!(hook.on_failure(), Some(HookScript::Inline(s)) if s == "echo failed"));
     }
 
@@ -287,7 +293,9 @@ mod tests {
     fn serde_round_trip_through_toml() {
         let original = LifecycleHook::builder()
             .with_on_activate(HookScript::Inline("echo hi".into()))
-            .with_on_failure(HookScript::External(PathBuf::from("./fail.sh")))
+            .with_on_failure(HookScript::External(
+                ConfigRelPath::try_new("./fail.sh").unwrap(),
+            ))
             .build()
             .unwrap();
 
@@ -295,10 +303,23 @@ mod tests {
         let parsed: LifecycleHook = toml::from_str(&serialized).unwrap();
 
         assert!(matches!(parsed.on_activate(), Some(HookScript::Inline(s)) if s == "echo hi"));
-        assert!(
-            matches!(parsed.on_failure(), Some(HookScript::External(p)) if p == &PathBuf::from("./fail.sh"))
-        );
+        assert!(matches!(
+            parsed.on_failure(),
+            Some(HookScript::External(p)) if p.as_str() == "./fail.sh"
+        ));
         assert!(parsed.on_destroy().is_none());
+    }
+
+    #[test]
+    fn external_rejects_absolute_path_at_deserialize() {
+        let src = r#"
+            on_activate = { type = "external", value = "/etc/hook.sh" }
+        "#;
+        let err = toml::from_str::<LifecycleHook>(src).unwrap_err();
+        assert!(
+            err.to_string().contains("relative"),
+            "expected realm error, got: {err}",
+        );
     }
 
     #[test]

--- a/crates/sessions/src/loadout.rs
+++ b/crates/sessions/src/loadout.rs
@@ -1,10 +1,13 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::lifecyclehook::LifecycleHook;
+use crate::vars::Var;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Loadout {
-    env_vars: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    vars: BTreeMap<String, Var>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     lifecycle_hooks: Vec<LifecycleHook>,
+    // #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
 }

--- a/crates/sessions/src/patches.rs
+++ b/crates/sessions/src/patches.rs
@@ -1,0 +1,800 @@
+//! Patches: descriptions of files brought into a session, the provenance of
+//! each patch, and the policy controlling which non-user patches are honored.
+//!
+//! # Sources of patches
+//!
+//! Patches enter the session from three distinct origins (see [`PatchOrigin`]):
+//!
+//! - **User** — the user's personal config. Implicit trust: only [`PatchPolicy::ignore`]
+//!   applies; `allow` and `deny` are bypassed (the user *is* the policy).
+//! - **Project** — the shared `minimal.toml` in the project. Subject to the
+//!   full policy (`allow`, `deny`, `ignore`) — a project config can't
+//!   silently read from your `~/.ssh`.
+//! - **Package** — declared by an installed package's spec. Subject to the
+//!   full policy. Carries the package name so prompts/errors can attribute
+//!   the request.
+//!
+//! # Wire form vs domain form
+//!
+//! TOML files describe patches without origin information — the *loader*
+//! attaches the origin based on which file the declaration came from. The
+//! split is reflected in the types:
+//!
+//! - [`PatchDecl`] / [`PatchDecls`] — wire form. Deserialized from TOML.
+//! - [`Patch`] / [`Patches`] — domain form. Built from a [`PatchDecls`] plus
+//!   a [`PatchOrigin`] via [`PatchDecls::promote`].
+//!
+//! # The `FileSet` primitive
+//!
+//! [`FileSet`] is the description of "which files" — reused for patch
+//! sources, allowlists, denylists, and ignore lists. The wire form accepts
+//! three shapes (bare string, list, table); see its docs.
+//!
+//! Path expansion (`~`, `$VAR`) and canonicalization are **not** performed
+//! by this module — `FileSet` stores patterns as written. Callers must
+//! resolve them at config-load time before using them for policy checks,
+//! since comparing unresolved paths is a path-traversal hazard.
+//! This is necessary because which `$VAR` can be used are subject to
+//! a separate policy.
+//!
+//! # Example user config
+//!
+//! ```toml
+//! # User-origin patches — applied unconditionally outside hermetic builds.
+//! # Only `ignore` from `[patch_policy]` filters these; `allow`/`deny` are
+//! # bypassed.
+//! patches = [
+//!     { dest = "~/.gitconfig",                       source = "~/dotfiles/gitconfig" },
+//!     { dest = "~/.config/alacritty/alacritty.toml", source = "~/dotfiles/alacritty.toml" },
+//!     { dest = "~/.config/nvim/",                    source = { base = "~/dotfiles/nvim", patterns = ["**/*"] } },
+//!
+//!     # Multi-glob to one dest:
+//!     { dest = "~/Pictures/wallpapers/",             source = ["~/dotfiles/wallpapers/*.jpg",
+//!                                                              "~/dotfiles/wallpapers/*.png"] },
+//! ]
+//!
+//! # Policy for non-user patches (project and package origins).
+//! # `ignore` here also applies to user-origin patches above.
+//! [patch_policy]
+//! allow  = ["~/.config/**", "~/.local/share/applications/**", "/etc/xdg/**"]
+//! deny   = ["~/.ssh/**", "~/.aws/**", "**/id_rsa*", "**/*.pem"]
+//! ignore = ["**/.DS_Store", "**/*.bak", "**/*.swp"]
+//! ```
+
+use crate::paths::{HostPath, SandboxPath};
+use camino::{Utf8Component, Utf8PathBuf};
+use core::fmt;
+
+/// Errors produced when constructing patch types.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum Error {
+    /// A pattern string failed to parse as a glob.
+    InvalidGlob {
+        pattern: String,
+        source: globset::Error,
+    },
+    /// A `FileSet` had an empty `base` (e.g. `base = ""`).
+    EmptyBase,
+    /// A patch destination was empty.
+    EmptyDest,
+    /// A patch destination contained a `..` component, which is rejected
+    /// before path canonicalization to avoid traversal attacks.
+    DestTraversal(Utf8PathBuf),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidGlob { pattern, source } => {
+                write!(f, "invalid glob pattern `{pattern}`: {source}")
+            }
+            Self::EmptyBase => f.write_str("`base` must not be the empty string"),
+            Self::EmptyDest => f.write_str("patch destination must not be empty"),
+            Self::DestTraversal(p) => write!(
+                f,
+                "patch destination `{p}` must not contain `..` components",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidGlob { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+// =====================================================================
+// PatchOrigin
+// =====================================================================
+
+/// Where a patch came from. Determines how [`PatchPolicy`] applies:
+///
+/// | Origin    | `allow` / `deny` | `ignore` |
+/// |-----------|------------------|----------|
+/// | `User`    | bypassed         | applies  |
+/// | `Project` | applies          | applies  |
+/// | `Package` | applies          | applies  |
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum PatchOrigin {
+    /// From the user's personal config.
+    User,
+    /// From the shared project config (`minimal.toml`).
+    Project,
+    /// Declared by an installed package's spec.
+    Package {
+        /// Name (or identifier) of the package that declared the patch.
+        /// Used in permission prompts and error messages.
+        package: String,
+    },
+}
+
+// =====================================================================
+// FileSet
+// =====================================================================
+
+/// A description of a set of files on the *host* filesystem: an optional
+/// base directory plus glob patterns interpreted relative to it.
+///
+/// Patterns are parsed as globs at construction time, so malformed patterns
+/// fail at config load with a useful error rather than at apply time. Use
+/// [`FileSet::raw_patterns`] to recover the original pattern strings (e.g.
+/// for re-serialization).
+///
+/// Absolute or `~`-prefixed patterns are valid; the [`base`](Self::base)
+/// field is meaningful only for relative patterns. `~`-prefixed bases
+/// classify as [`HostPath::Rel`] — the apply layer is responsible for
+/// expansion. The apply layer should follow `Utf8PathBuf::join` semantics
+/// when combining a base with a pattern (an absolute right-hand side
+/// replaces the left).
+///
+/// # Wire format
+///
+/// `FileSet` accepts three forms when deserialized — pick whichever is least
+/// noisy at the call site:
+///
+/// ```toml
+/// allow  = "~/.config/**"                                           # bare string
+/// deny   = ["~/.ssh/**", "**/id_rsa*"]                              # list
+/// source = { base = "~/dotfiles/nvim", patterns = ["**/*"] }        # full table
+/// ```
+#[derive(Clone, Debug)]
+pub struct FileSet {
+    base: Option<HostPath>,
+    patterns: Vec<String>,
+    compiled: Vec<globset::Glob>,
+}
+
+impl FileSet {
+    /// Construct a [`FileSet`] from raw patterns and an optional base.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidGlob`] if any pattern fails to parse, or
+    /// [`Error::EmptyBase`] if `base` is `Some` but empty.
+    pub fn try_new<I, S>(base: Option<HostPath>, patterns: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        if let Some(b) = &base
+            && b.as_str().is_empty()
+        {
+            return Err(Error::EmptyBase);
+        }
+        let raw: Vec<String> = patterns.into_iter().map(Into::into).collect();
+        let compiled = raw
+            .iter()
+            .map(|p| {
+                globset::Glob::new(p).map_err(|source| Error::InvalidGlob {
+                    pattern: p.clone(),
+                    source,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            base,
+            patterns: raw,
+            compiled,
+        })
+    }
+
+    /// Construct an empty `FileSet`. Useful as a `Default` for policy fields
+    /// where "matches nothing" is a meaningful default.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            base: None,
+            patterns: Vec::new(),
+            compiled: Vec::new(),
+        }
+    }
+
+    /// The base directory for relative patterns, if set.
+    #[must_use]
+    pub fn base(&self) -> Option<&HostPath> {
+        self.base.as_ref()
+    }
+
+    /// The original pattern strings (suitable for re-serialization).
+    #[must_use]
+    pub fn raw_patterns(&self) -> &[String] {
+        &self.patterns
+    }
+
+    /// The compiled glob patterns.
+    #[must_use]
+    pub fn globs(&self) -> &[globset::Glob] {
+        &self.compiled
+    }
+
+    /// Returns `true` if the set contains no patterns.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+}
+
+impl Default for FileSet {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl PartialEq for FileSet {
+    fn eq(&self, other: &Self) -> bool {
+        // `compiled` is derived from `patterns`, so equality on the raw inputs
+        // implies equality of the compiled forms.
+        self.base == other.base && self.patterns == other.patterns
+    }
+}
+impl Eq for FileSet {}
+
+impl std::hash::Hash for FileSet {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.base.hash(state);
+        self.patterns.hash(state);
+    }
+}
+
+impl serde::Serialize for FileSet {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let len = 1 + usize::from(self.base.is_some());
+        let mut st = ser.serialize_struct("FileSet", len)?;
+        if let Some(b) = &self.base {
+            st.serialize_field("base", b)?;
+        }
+        st.serialize_field("patterns", &self.patterns)?;
+        st.end()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for FileSet {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Full {
+                #[serde(default)]
+                base: Option<HostPath>,
+                patterns: Vec<String>,
+            },
+            Many(Vec<String>),
+            One(String),
+        }
+        let (base, patterns) = match Repr::deserialize(deserializer)? {
+            Repr::Full { base, patterns } => (base, patterns),
+            Repr::Many(p) => (None, p),
+            Repr::One(p) => (None, vec![p]),
+        };
+        Self::try_new(base, patterns).map_err(serde::de::Error::custom)
+    }
+}
+
+// =====================================================================
+// PatchDest
+// =====================================================================
+
+/// A validated patch destination — a path inside the *sandbox*, where the
+/// patch's content will land.
+///
+/// Rejected at construction:
+/// - empty paths,
+/// - paths containing `..` components (path-traversal protection — the
+///   apply layer also canonicalizes, but rejecting at the config layer
+///   gives a config-line-number error and prevents the value from ever
+///   existing in memory).
+///
+/// Wraps a [`SandboxPath`], so the realm tag is preserved through to the
+/// apply layer. No `AsRef<std::path::Path>` is provided on purpose: a
+/// destination path cannot be passed to host I/O without going through a
+/// [`crate::paths::Translator`] first.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PatchDest(SandboxPath);
+
+impl PatchDest {
+    /// Construct a `PatchDest` after validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::EmptyDest`] for empty paths, or
+    /// [`Error::DestTraversal`] for paths containing `..` components.
+    pub fn try_new(path: impl Into<Utf8PathBuf>) -> Result<Self, Error> {
+        let path = path.into();
+        if path.as_str().is_empty() {
+            return Err(Error::EmptyDest);
+        }
+        if path
+            .components()
+            .any(|c| matches!(c, Utf8Component::ParentDir))
+        {
+            return Err(Error::DestTraversal(path));
+        }
+        Ok(Self(SandboxPath::new(path)))
+    }
+
+    /// Borrow the underlying sandbox path.
+    #[must_use]
+    pub fn as_sandbox_path(&self) -> &SandboxPath {
+        &self.0
+    }
+}
+
+impl serde::Serialize for PatchDest {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(ser)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for PatchDest {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let p = Utf8PathBuf::deserialize(deserializer)?;
+        Self::try_new(p).map_err(serde::de::Error::custom)
+    }
+}
+
+// =====================================================================
+// PatchDecl / PatchDecls — wire form
+// =====================================================================
+
+/// A patch as declared in a config file, **before** origin is attached.
+///
+/// This is the form that comes out of deserializing TOML — the file itself
+/// doesn't say where it came from, so origin is supplied by the loader via
+/// [`Self::promote`] (or in bulk via [`PatchDecls::promote`]).
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct PatchDecl {
+    source: FileSet,
+    dest: PatchDest,
+}
+
+impl PatchDecl {
+    /// Construct a declaration without origin.
+    #[must_use]
+    pub fn new(source: FileSet, dest: PatchDest) -> Self {
+        Self { source, dest }
+    }
+
+    /// The source fileset.
+    #[must_use]
+    pub fn source(&self) -> &FileSet {
+        &self.source
+    }
+
+    /// The destination path.
+    #[must_use]
+    pub fn dest(&self) -> &PatchDest {
+        &self.dest
+    }
+
+    /// Attach an origin and produce a fully-typed [`Patch`].
+    #[must_use]
+    pub fn promote(self, origin: PatchOrigin) -> Patch {
+        Patch {
+            source: self.source,
+            dest: self.dest,
+            origin,
+        }
+    }
+}
+
+/// An ordered collection of [`PatchDecl`] entries — the wire form of a
+/// `patches = [...]` array.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct PatchDecls(Vec<PatchDecl>);
+
+impl PatchDecls {
+    /// Construct from a vector of declarations.
+    #[must_use]
+    pub fn new(decls: Vec<PatchDecl>) -> Self {
+        Self(decls)
+    }
+
+    /// Returns `true` if there are no declarations.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Number of declarations.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Iterate over the declarations.
+    pub fn iter(&self) -> std::slice::Iter<'_, PatchDecl> {
+        self.0.iter()
+    }
+
+    /// Promote every declaration to a [`Patch`] with the given origin.
+    #[must_use]
+    pub fn promote(self, origin: &PatchOrigin) -> Patches {
+        Patches(
+            self.0
+                .into_iter()
+                .map(|d| d.promote(origin.clone()))
+                .collect(),
+        )
+    }
+}
+
+impl<'a> IntoIterator for &'a PatchDecls {
+    type Item = &'a PatchDecl;
+    type IntoIter = std::slice::Iter<'a, PatchDecl>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+// =====================================================================
+// Patch / Patches — domain form
+// =====================================================================
+
+/// A single patch entry with its origin attached.
+///
+/// For single-file sources, `dest` is the destination file path. For
+/// multi-file sources (lists, globs, directory copies), `dest` is the
+/// destination *directory*. Enforcing this invariant requires expanded paths
+/// and is the apply layer's responsibility.
+///
+/// Construct via [`Patch::new`] or by promoting a [`PatchDecl`] with
+/// [`PatchDecl::promote`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Patch {
+    source: FileSet,
+    dest: PatchDest,
+    origin: PatchOrigin,
+}
+
+impl Patch {
+    /// Construct a new patch.
+    #[must_use]
+    pub fn new(source: FileSet, dest: PatchDest, origin: PatchOrigin) -> Self {
+        Self {
+            source,
+            dest,
+            origin,
+        }
+    }
+
+    /// The source fileset.
+    #[must_use]
+    pub fn source(&self) -> &FileSet {
+        &self.source
+    }
+
+    /// The destination path.
+    #[must_use]
+    pub fn dest(&self) -> &PatchDest {
+        &self.dest
+    }
+
+    /// Where the patch came from.
+    #[must_use]
+    pub fn origin(&self) -> &PatchOrigin {
+        &self.origin
+    }
+}
+
+/// An ordered collection of [`Patch`] entries.
+///
+/// Not directly deserializable — patches require an origin, which the wire
+/// format doesn't carry. Build from a [`PatchDecls`] via
+/// [`PatchDecls::promote`].
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Patches(Vec<Patch>);
+
+impl Patches {
+    /// Construct from a vector of patches.
+    #[must_use]
+    pub fn new(patches: Vec<Patch>) -> Self {
+        Self(patches)
+    }
+
+    /// Returns `true` if there are no patches.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Number of patches.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Iterate over the patches.
+    pub fn iter(&self) -> std::slice::Iter<'_, Patch> {
+        self.0.iter()
+    }
+
+    /// Append all patches from another collection.
+    pub fn extend(&mut self, other: Patches) {
+        self.0.extend(other.0);
+    }
+}
+
+impl<'a> IntoIterator for &'a Patches {
+    type Item = &'a Patch;
+    type IntoIter = std::slice::Iter<'a, Patch>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+// =====================================================================
+// PatchPolicy
+// =====================================================================
+
+/// Policy gating which patches are honored.
+///
+/// Applied to patches based on their [`PatchOrigin`]:
+///
+/// - **User-origin patches**: only [`ignore`](Self::ignore) applies.
+///   `allow` and `deny` are bypassed — the user is the policy for their own
+///   declarations.
+/// - **Project- and Package-origin patches**: all three fields apply.
+///   A patch is honored iff its destination matches `allow`, does not match
+///   `deny`, and does not match `ignore`. Patches matching only `ignore`
+///   are silently dropped; matching `deny` is an error/prompt; matching
+///   neither `allow` nor `ignore` triggers a permission prompt.
+///
+/// Precedence within the policy: `ignore` first (silent), then `deny`
+/// (reject), then `allow` (permit). Anything else prompts.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PatchPolicy {
+    #[serde(default, skip_serializing_if = "FileSet::is_empty")]
+    allow: FileSet,
+    #[serde(default, skip_serializing_if = "FileSet::is_empty")]
+    deny: FileSet,
+    #[serde(default, skip_serializing_if = "FileSet::is_empty")]
+    ignore: FileSet,
+}
+
+impl PatchPolicy {
+    /// Construct a policy from its three filesets.
+    #[must_use]
+    pub fn new(allow: FileSet, deny: FileSet, ignore: FileSet) -> Self {
+        Self {
+            allow,
+            deny,
+            ignore,
+        }
+    }
+
+    /// Paths non-user patches **may** target. Does not apply to
+    /// [`PatchOrigin::User`].
+    #[must_use]
+    pub fn allow(&self) -> &FileSet {
+        &self.allow
+    }
+
+    /// Paths non-user patches **must not** target. Does not apply to
+    /// [`PatchOrigin::User`].
+    #[must_use]
+    pub fn deny(&self) -> &FileSet {
+        &self.deny
+    }
+
+    /// Paths to silently drop without prompting. **Applies to every origin
+    /// including [`PatchOrigin::User`].**
+    #[must_use]
+    pub fn ignore(&self) -> &FileSet {
+        &self.ignore
+    }
+}
+
+// =====================================================================
+// Tests
+// =====================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, serde::Deserialize, serde::Serialize)]
+    struct Wrap<T> {
+        x: T,
+    }
+
+    fn parse<T: serde::de::DeserializeOwned>(toml_str: &str) -> T {
+        toml::from_str::<Wrap<T>>(toml_str).unwrap().x
+    }
+
+    // ---- FileSet ----
+
+    #[test]
+    fn fileset_from_bare_string() {
+        let fs: FileSet = parse(r#"x = "~/.gitconfig""#);
+        assert_eq!(fs.raw_patterns(), &["~/.gitconfig"]);
+        assert!(fs.base().is_none());
+        assert_eq!(fs.globs().len(), 1);
+    }
+
+    #[test]
+    fn fileset_from_list() {
+        let fs: FileSet = parse(r#"x = ["**/*.jpg", "**/*.png"]"#);
+        assert_eq!(fs.raw_patterns(), &["**/*.jpg", "**/*.png"]);
+        assert_eq!(fs.globs().len(), 2);
+    }
+
+    #[test]
+    fn fileset_from_full_table() {
+        let fs: FileSet = parse(r#"x = { base = "./assets", patterns = ["**/*.jpg"] }"#);
+        assert_eq!(fs.base().map(HostPath::as_str), Some("./assets"));
+        assert_eq!(fs.raw_patterns(), &["**/*.jpg"]);
+    }
+
+    #[test]
+    fn fileset_rejects_invalid_glob() {
+        let err = toml::from_str::<Wrap<FileSet>>(r#"x = "[invalid""#).unwrap_err();
+        assert!(err.to_string().contains("invalid glob"), "got: {err}");
+    }
+
+    #[test]
+    fn fileset_rejects_empty_base() {
+        let err =
+            toml::from_str::<Wrap<FileSet>>(r#"x = { base = "", patterns = ["a"] }"#).unwrap_err();
+        assert!(err.to_string().contains("base"), "got: {err}");
+    }
+
+    #[test]
+    fn fileset_round_trip() {
+        let original =
+            FileSet::try_new(Some(HostPath::new("./themes")), ["**/*", "**/*.toml"]).unwrap();
+        let s = toml::to_string(&Wrap {
+            x: original.clone(),
+        })
+        .unwrap();
+        let parsed: FileSet = parse(&s);
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn fileset_serializes_without_base_when_none() {
+        let fs = FileSet::try_new(None, ["a"]).unwrap();
+        let s = toml::to_string(&Wrap { x: fs }).unwrap();
+        assert!(s.contains("patterns"));
+        assert!(!s.contains("base"));
+    }
+
+    // ---- PatchDest ----
+
+    #[test]
+    fn patchdest_rejects_empty() {
+        assert!(matches!(PatchDest::try_new(""), Err(Error::EmptyDest)));
+    }
+
+    #[test]
+    fn patchdest_rejects_traversal() {
+        assert!(matches!(
+            PatchDest::try_new("foo/../bar"),
+            Err(Error::DestTraversal(_))
+        ));
+    }
+
+    #[test]
+    fn patchdest_accepts_absolute_and_home_paths() {
+        assert!(PatchDest::try_new("/etc/foo").is_ok());
+        assert!(PatchDest::try_new("~/.gitconfig").is_ok());
+    }
+
+    #[test]
+    fn patchdest_classifies_absolute_into_sandbox_abs_variant() {
+        let dest = PatchDest::try_new("/etc/foo").unwrap();
+        assert!(dest.as_sandbox_path().is_absolute());
+        // Tilde-prefixed paths classify as Rel — apply layer expands them.
+        let home = PatchDest::try_new("~/.gitconfig").unwrap();
+        assert!(!home.as_sandbox_path().is_absolute());
+    }
+
+    #[test]
+    fn patchdecl_deserialize_rejects_bad_dest() {
+        let err = toml::from_str::<Wrap<PatchDecl>>(r#"x = { dest = "foo/../bar", source = "a" }"#)
+            .unwrap_err();
+        assert!(err.to_string().contains(".."), "got: {err}");
+    }
+
+    // ---- PatchDecl / PatchDecls / promote ----
+
+    #[test]
+    fn patchdecl_with_string_source() {
+        let d: PatchDecl = parse(r#"x = { dest = "/etc/foo.conf", source = "./foo.conf" }"#);
+        assert_eq!(d.dest().as_sandbox_path().as_str(), "/etc/foo.conf");
+        assert_eq!(d.source().raw_patterns(), &["./foo.conf"]);
+    }
+
+    #[test]
+    fn patchdecls_deserialize_from_array() {
+        let src = r#"
+            x = [
+                { dest = "/a", source = "a" },
+                { dest = "/b", source = ["b1", "b2"] },
+            ]
+        "#;
+        let ds: PatchDecls = parse(src);
+        assert_eq!(ds.len(), 2);
+    }
+
+    #[test]
+    fn promote_attaches_origin_to_every_patch() {
+        let src = r#"
+            x = [
+                { dest = "/a", source = "a" },
+                { dest = "/b", source = "b" },
+            ]
+        "#;
+        let decls: PatchDecls = parse(src);
+        let patches = decls.promote(&PatchOrigin::Project);
+        assert_eq!(patches.len(), 2);
+        for p in &patches {
+            assert_eq!(p.origin(), &PatchOrigin::Project);
+        }
+    }
+
+    #[test]
+    fn promote_with_package_origin_preserves_package_name() {
+        let decl = PatchDecl::new(
+            FileSet::try_new(None, ["a"]).unwrap(),
+            PatchDest::try_new("/a").unwrap(),
+        );
+        let patch = decl.promote(PatchOrigin::Package {
+            package: "git".into(),
+        });
+        match patch.origin() {
+            PatchOrigin::Package { package } => assert_eq!(package, "git"),
+            other => panic!("expected Package origin, got {other:?}"),
+        }
+    }
+
+    // ---- PatchPolicy ----
+
+    #[test]
+    fn patch_policy_full_example() {
+        let src = r#"
+            allow = ["~/.config/**", "/etc/xdg/**"]
+            deny = ["~/.ssh/**", "**/*.pem"]
+            ignore = ["**/.DS_Store"]
+        "#;
+        let policy: PatchPolicy = toml::from_str(src).unwrap();
+        assert_eq!(policy.allow().raw_patterns().len(), 2);
+        assert_eq!(policy.deny().raw_patterns().len(), 2);
+        assert_eq!(policy.ignore().raw_patterns().len(), 1);
+    }
+
+    #[test]
+    fn patch_policy_defaults_when_omitted() {
+        let policy: PatchPolicy = toml::from_str("").unwrap();
+        assert!(policy.allow().is_empty());
+        assert!(policy.deny().is_empty());
+        assert!(policy.ignore().is_empty());
+    }
+}

--- a/crates/sessions/src/paths.rs
+++ b/crates/sessions/src/paths.rs
@@ -1,0 +1,1070 @@
+//! Realm-tagged path types.
+//!
+//! `PathBuf` carries no information about *which* filesystem a path belongs
+//! to. In a system that bridges the user's host, the sandbox rootfs, and
+//! (eventually) the minimald daemon, that ambiguity is a footgun: it is easy
+//! to pass a host path to code that expects a sandbox-internal path, and the
+//! type checker will not stop you.
+//!
+//! This module encodes the filesystem a path belongs to as a *phantom type
+//! parameter*, splits absolute and relative paths into distinct types, and
+//! requires crossing realms to go through an explicit [`Translator`].
+//!
+//! # Quick tour
+//!
+//! - [`Realm`] is a marker trait; [`Host`], [`Sandbox`], [`Daemon`], and
+//!   [`ConfigRelative`] are the zero-sized implementors.
+//! - [`AbsPath<R>`] is an absolute UTF-8 path tagged with realm `R`.
+//! - [`RelPath<R>`] is a relative UTF-8 path tagged with the realm it will
+//!   eventually resolve in.
+//! - [`AbsPath::join`] only accepts a [`RelPath`], which kills the "join an
+//!   absolute onto an absolute and silently drop the base" footgun by
+//!   construction.
+//! - [`RelPath<ConfigRelative>::bind_to_host`] is the one sanctioned way to
+//!   leave the [`ConfigRelative`] realm.
+//!
+//! # Example
+//!
+//! ```
+//! use sessions::paths::{AbsPath, Host, RelPath};
+//!
+//! let base: AbsPath<Host> = AbsPath::try_new("/etc/minimal").unwrap();
+//! let rel: RelPath<Host> = RelPath::try_new("hooks/cleanup.sh").unwrap();
+//!
+//! let joined = base.join(&rel);
+//! assert_eq!(joined.as_utf8_path().as_str(), "/etc/minimal/hooks/cleanup.sh");
+//!
+//! // Passing an absolute string to `RelPath::try_new` is a *compile-time*-shaped
+//! // error: it fails at construction, so `AbsPath::join` cannot silently
+//! // override its base.
+//! assert!(RelPath::<Host>::try_new("/oops/absolute").is_err());
+//! ```
+
+use camino::{Utf8Components, Utf8Path, Utf8PathBuf};
+use core::fmt;
+use core::marker::PhantomData;
+use std::borrow::Borrow;
+use std::cmp::Ordering;
+use std::path::Path;
+use std::str::FromStr;
+
+/// Marker trait for filesystem realms.
+///
+/// Implementors are zero-sized; instances never exist at runtime — the realm
+/// is encoded purely in the type system. `NAME` is used in [`fmt::Debug`]
+/// output so logs and panics are unambiguous about which realm a path belongs
+/// to.
+pub trait Realm: 'static {
+    /// Lowercase identifier used in [`fmt::Debug`] output.
+    const NAME: &'static str;
+}
+
+/// The user's host filesystem.
+#[derive(Debug, Copy, Clone)]
+pub struct Host;
+impl Realm for Host {
+    const NAME: &'static str = "host";
+}
+
+/// A sandbox rootfs constructed by `sandbox2`.
+#[derive(Debug, Copy, Clone)]
+pub struct Sandbox;
+impl Realm for Sandbox {
+    const NAME: &'static str = "sandbox";
+}
+
+/// The minimald daemon's filesystem view (future).
+#[derive(Debug, Copy, Clone)]
+pub struct Daemon;
+impl Realm for Daemon {
+    const NAME: &'static str = "daemon";
+}
+
+/// A path whose anchor is "the directory of the config file it was decoded
+/// from".
+///
+/// [`ConfigRelative`] paths cannot be used directly — they must be bound to a
+/// concrete host directory via
+/// [`RelPath::<ConfigRelative>::bind_to_host`].
+#[derive(Debug, Copy, Clone)]
+pub struct ConfigRelative;
+impl Realm for ConfigRelative {
+    const NAME: &'static str = "config-relative";
+}
+
+/// Absolute path on the user's host filesystem.
+pub type HostAbsPath = AbsPath<Host>;
+/// Relative path resolved against a [`Host`]-realm anchor.
+pub type HostRelPath = RelPath<Host>;
+/// Either an absolute or relative path in the [`Host`] realm.
+pub type HostPath = EitherPath<Host>;
+/// Absolute path inside a sandbox rootfs.
+pub type SandboxAbsPath = AbsPath<Sandbox>;
+/// Relative path resolved against a [`Sandbox`]-realm anchor.
+pub type SandboxRelPath = RelPath<Sandbox>;
+/// Either an absolute or relative path in the [`Sandbox`] realm.
+pub type SandboxPath = EitherPath<Sandbox>;
+/// Absolute path in the minimald daemon's filesystem view.
+pub type DaemonAbsPath = AbsPath<Daemon>;
+/// Relative path resolved against a [`Daemon`]-realm anchor.
+pub type DaemonRelPath = RelPath<Daemon>;
+/// Either an absolute or relative path in the [`Daemon`] realm.
+pub type DaemonPath = EitherPath<Daemon>;
+/// Relative path anchored to the directory of the config file it was decoded
+/// from. There is no absolute variant — config-relative paths only make
+/// sense as relatives waiting to be bound via
+/// [`RelPath::<ConfigRelative>::bind_to_host`].
+pub type ConfigRelPath = RelPath<ConfigRelative>;
+
+/// Errors produced when constructing a path.
+#[non_exhaustive]
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    /// An [`AbsPath`] was constructed from a non-absolute input.
+    NotAbsolute(Utf8PathBuf),
+    /// A [`RelPath`] was constructed from an absolute input.
+    IsAbsolute(Utf8PathBuf),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotAbsolute(p) => write!(f, "expected an absolute path, got: {p}"),
+            Self::IsAbsolute(p) => write!(f, "expected a relative path, got: {p}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// An *absolute* UTF-8 path in realm `R`.
+///
+/// Invariant: `inner.is_absolute()` is always true. Construction goes through
+/// [`AbsPath::try_new`], which validates the input.
+///
+/// The realm parameter is phantom: `AbsPath<Host>` and `AbsPath<Sandbox>` are
+/// distinct types that the compiler will not mix. Crossing realms requires a
+/// [`Translator`].
+#[must_use]
+pub struct AbsPath<R: Realm> {
+    inner: Utf8PathBuf,
+    _realm: PhantomData<fn() -> R>,
+}
+
+impl<R: Realm> AbsPath<R> {
+    /// Constructs an [`AbsPath`] after verifying the input is absolute.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotAbsolute`] if `p` is relative.
+    pub fn try_new(p: impl Into<Utf8PathBuf>) -> Result<Self, Error> {
+        let inner = p.into();
+        if inner.is_absolute() {
+            Ok(Self {
+                inner,
+                _realm: PhantomData,
+            })
+        } else {
+            Err(Error::NotAbsolute(inner))
+        }
+    }
+
+    /// Borrows the underlying UTF-8 path.
+    #[must_use]
+    pub fn as_utf8_path(&self) -> &Utf8Path {
+        &self.inner
+    }
+
+    /// Borrows the underlying path as a `&str`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.inner.as_str()
+    }
+
+    /// Joins a relative path *in the same realm*, producing a new
+    /// [`AbsPath<R>`].
+    ///
+    /// Unlike [`Utf8PathBuf::join`], this cannot be passed an absolute path:
+    /// [`RelPath`] is constructively non-absolute, so the "join overrides
+    /// base" footgun is unreachable.
+    pub fn join(&self, rel: &RelPath<R>) -> AbsPath<R> {
+        AbsPath {
+            inner: self.inner.join(&rel.inner),
+            _realm: PhantomData,
+        }
+    }
+
+    /// Returns the parent directory, if any.
+    #[must_use]
+    pub fn parent(&self) -> Option<AbsPath<R>> {
+        self.inner.parent().map(|p| AbsPath {
+            inner: p.to_owned(),
+            _realm: PhantomData,
+        })
+    }
+
+    /// Strips `base` from the front of this path and returns the suffix as
+    /// a [`RelPath<R>`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`std::path::StripPrefixError`] when `base` is not a prefix.
+    pub fn strip_prefix(
+        &self,
+        base: &AbsPath<R>,
+    ) -> Result<RelPath<R>, std::path::StripPrefixError> {
+        self.inner.strip_prefix(&base.inner).map(|p| RelPath {
+            inner: p.to_owned(),
+            _realm: PhantomData,
+        })
+    }
+
+    /// The final component of the path, if any.
+    #[must_use]
+    pub fn file_name(&self) -> Option<&str> {
+        self.inner.file_name()
+    }
+
+    /// The extension of the final component, if any.
+    #[must_use]
+    pub fn extension(&self) -> Option<&str> {
+        self.inner.extension()
+    }
+
+    /// Iterator over the path's components.
+    pub fn components(&self) -> Utf8Components<'_> {
+        self.inner.components()
+    }
+}
+
+impl<R: Realm> Clone for AbsPath<R> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _realm: PhantomData,
+        }
+    }
+}
+
+impl<R: Realm> PartialEq for AbsPath<R> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<R: Realm> Eq for AbsPath<R> {}
+
+impl<R: Realm> std::hash::Hash for AbsPath<R> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.hash(state);
+    }
+}
+
+impl<R: Realm> PartialOrd for AbsPath<R> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<R: Realm> Ord for AbsPath<R> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.inner.cmp(&other.inner)
+    }
+}
+
+impl<R: Realm> AsRef<Utf8Path> for AbsPath<R> {
+    fn as_ref(&self) -> &Utf8Path {
+        &self.inner
+    }
+}
+
+impl<R: Realm> AsRef<Path> for AbsPath<R> {
+    fn as_ref(&self) -> &Path {
+        self.inner.as_std_path()
+    }
+}
+
+impl<R: Realm> AsRef<str> for AbsPath<R> {
+    fn as_ref(&self) -> &str {
+        self.inner.as_str()
+    }
+}
+
+impl<R: Realm> Borrow<Utf8Path> for AbsPath<R> {
+    fn borrow(&self) -> &Utf8Path {
+        &self.inner
+    }
+}
+
+impl<R: Realm> FromStr for AbsPath<R> {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_new(s)
+    }
+}
+
+impl<R: Realm> fmt::Debug for AbsPath<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AbsPath<{}>({})", R::NAME, self.inner)
+    }
+}
+
+impl<R: Realm> fmt::Display for AbsPath<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl<R: Realm> serde::Serialize for AbsPath<R> {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        self.inner.serialize(ser)
+    }
+}
+
+impl<'de, R: Realm> serde::Deserialize<'de> for AbsPath<R> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let p = Utf8PathBuf::deserialize(deserializer)?;
+        Self::try_new(p).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A *relative* UTF-8 path, tagged with the realm it will resolve in.
+///
+/// Invariant: `inner.is_absolute()` is always false. Construction goes
+/// through [`RelPath::new`], which validates the input.
+#[must_use]
+pub struct RelPath<R: Realm> {
+    inner: Utf8PathBuf,
+    _realm: PhantomData<fn() -> R>,
+}
+
+impl<R: Realm> RelPath<R> {
+    /// Constructs a [`RelPath`] after verifying the input is not absolute.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::IsAbsolute`] if `p` is an absolute path.
+    pub fn try_new(p: impl Into<Utf8PathBuf>) -> Result<Self, Error> {
+        let inner = p.into();
+        if inner.is_absolute() {
+            Err(Error::IsAbsolute(inner))
+        } else {
+            Ok(Self {
+                inner,
+                _realm: PhantomData,
+            })
+        }
+    }
+
+    /// Borrows the underlying UTF-8 path.
+    #[must_use]
+    pub fn as_utf8_path(&self) -> &Utf8Path {
+        &self.inner
+    }
+
+    /// Borrows the underlying path as a `&str`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.inner.as_str()
+    }
+
+    /// Joins another relative path in the same realm.
+    pub fn join(&self, other: &RelPath<R>) -> RelPath<R> {
+        RelPath {
+            inner: self.inner.join(&other.inner),
+            _realm: PhantomData,
+        }
+    }
+
+    /// Resolves this relative path against an absolute base in the *same*
+    /// realm.
+    ///
+    /// To cross realms, see [`Translator`] (or, for [`ConfigRelative`],
+    /// [`RelPath::<ConfigRelative>::bind_to_host`]).
+    pub fn resolve_against(&self, base: &AbsPath<R>) -> AbsPath<R> {
+        base.join(self)
+    }
+
+    /// Returns the parent directory, if any.
+    #[must_use]
+    pub fn parent(&self) -> Option<RelPath<R>> {
+        self.inner.parent().map(|p| RelPath {
+            inner: p.to_owned(),
+            _realm: PhantomData,
+        })
+    }
+
+    /// The final component of the path, if any.
+    #[must_use]
+    pub fn file_name(&self) -> Option<&str> {
+        self.inner.file_name()
+    }
+
+    /// The extension of the final component, if any.
+    #[must_use]
+    pub fn extension(&self) -> Option<&str> {
+        self.inner.extension()
+    }
+
+    /// Iterator over the path's components.
+    pub fn components(&self) -> Utf8Components<'_> {
+        self.inner.components()
+    }
+}
+
+impl RelPath<ConfigRelative> {
+    /// Anchors a config-relative path against a host-side config directory,
+    /// producing a host-realm absolute path.
+    ///
+    /// This is the one sanctioned way to leave the [`ConfigRelative`] realm.
+    /// Lifecycle hooks decoded from a `minimal.toml` start life as
+    /// `RelPath<ConfigRelative>`; once the decoder knows the directory of
+    /// the file they came from, it calls `bind_to_host` to produce something
+    /// the executor can actually run.
+    ///
+    /// The returned path is *not* canonicalized — interior `.` or `..`
+    /// components survive. If a caller needs a canonical path, it must run
+    /// the result through `std::fs::canonicalize` (or similar) itself.
+    pub fn bind_to_host(&self, config_dir: &AbsPath<Host>) -> AbsPath<Host> {
+        AbsPath {
+            inner: config_dir.inner.join(&self.inner),
+            _realm: PhantomData,
+        }
+    }
+}
+
+impl<R: Realm> Clone for RelPath<R> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _realm: PhantomData,
+        }
+    }
+}
+
+impl<R: Realm> PartialEq for RelPath<R> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<R: Realm> Eq for RelPath<R> {}
+
+impl<R: Realm> std::hash::Hash for RelPath<R> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.hash(state);
+    }
+}
+
+impl<R: Realm> PartialOrd for RelPath<R> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<R: Realm> Ord for RelPath<R> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.inner.cmp(&other.inner)
+    }
+}
+
+impl<R: Realm> AsRef<Utf8Path> for RelPath<R> {
+    fn as_ref(&self) -> &Utf8Path {
+        &self.inner
+    }
+}
+
+impl<R: Realm> AsRef<Path> for RelPath<R> {
+    fn as_ref(&self) -> &Path {
+        self.inner.as_std_path()
+    }
+}
+
+impl<R: Realm> AsRef<str> for RelPath<R> {
+    fn as_ref(&self) -> &str {
+        self.inner.as_str()
+    }
+}
+
+impl<R: Realm> Borrow<Utf8Path> for RelPath<R> {
+    fn borrow(&self) -> &Utf8Path {
+        &self.inner
+    }
+}
+
+impl<R: Realm> FromStr for RelPath<R> {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_new(s)
+    }
+}
+
+impl<R: Realm> fmt::Debug for RelPath<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RelPath<{}>({})", R::NAME, self.inner)
+    }
+}
+
+impl<R: Realm> fmt::Display for RelPath<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl<R: Realm> serde::Serialize for RelPath<R> {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        self.inner.serialize(ser)
+    }
+}
+
+impl<'de, R: Realm> serde::Deserialize<'de> for RelPath<R> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let p = Utf8PathBuf::deserialize(deserializer)?;
+        Self::try_new(p).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Either an [`AbsPath<R>`] or a [`RelPath<R>`], for config fields where the
+/// user may legitimately supply either.
+///
+/// Resolving the relative case against some realm-appropriate base is the
+/// caller's responsibility — `EitherPath` only encodes the choice.
+///
+/// # Wire form
+///
+/// Serializes as a bare path string. Deserialization auto-detects: a leading
+/// `/` parses as [`Abs`](Self::Abs), anything else as [`Rel`](Self::Rel). No
+/// tag is needed — every UTF-8 path is unambiguously one or the other.
+///
+/// ```
+/// use sessions::paths::HostPath;
+///
+/// let abs: HostPath = toml::from_str::<Wrap>(r#"x = "/etc/minimal""#).unwrap().x;
+/// let rel: HostPath = toml::from_str::<Wrap>(r#"x = "etc/minimal""#).unwrap().x;
+/// assert!(abs.is_absolute());
+/// assert!(!rel.is_absolute());
+/// # #[derive(serde::Deserialize)] struct Wrap { x: HostPath }
+/// ```
+pub enum EitherPath<R: Realm> {
+    /// Absolute variant.
+    Abs(AbsPath<R>),
+    /// Relative variant.
+    Rel(RelPath<R>),
+}
+
+impl<R: Realm> Clone for EitherPath<R> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Abs(p) => Self::Abs(p.clone()),
+            Self::Rel(p) => Self::Rel(p.clone()),
+        }
+    }
+}
+
+impl<R: Realm> PartialEq for EitherPath<R> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Abs(a), Self::Abs(b)) => a == b,
+            (Self::Rel(a), Self::Rel(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl<R: Realm> Eq for EitherPath<R> {}
+
+impl<R: Realm> std::hash::Hash for EitherPath<R> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Abs(p) => p.hash(state),
+            Self::Rel(p) => p.hash(state),
+        }
+    }
+}
+
+impl<R: Realm> fmt::Debug for EitherPath<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Abs(p) => write!(f, "EitherPath::Abs({p:?})"),
+            Self::Rel(p) => write!(f, "EitherPath::Rel({p:?})"),
+        }
+    }
+}
+
+impl<R: Realm> EitherPath<R> {
+    /// Constructs an `EitherPath` by inspecting whether `p` is absolute.
+    ///
+    /// Infallible: every UTF-8 path is either absolute or relative, so the
+    /// invariants of both [`AbsPath::new`] and [`RelPath::new`] are
+    /// guaranteed to hold for exactly one variant.
+    pub fn new(p: impl Into<Utf8PathBuf>) -> Self {
+        let inner = p.into();
+        if inner.is_absolute() {
+            Self::Abs(AbsPath {
+                inner,
+                _realm: PhantomData,
+            })
+        } else {
+            Self::Rel(RelPath {
+                inner,
+                _realm: PhantomData,
+            })
+        }
+    }
+
+    /// Borrows the underlying UTF-8 path regardless of variant.
+    #[must_use]
+    pub fn as_utf8_path(&self) -> &Utf8Path {
+        match self {
+            Self::Abs(p) => p.as_utf8_path(),
+            Self::Rel(p) => p.as_utf8_path(),
+        }
+    }
+
+    /// Borrows the underlying path as a `&str`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.as_utf8_path().as_str()
+    }
+
+    /// Returns `true` if this is the [`Abs`](Self::Abs) variant.
+    #[must_use]
+    pub fn is_absolute(&self) -> bool {
+        matches!(self, Self::Abs(_))
+    }
+
+    /// Returns the absolute variant, if any.
+    #[must_use]
+    pub fn as_abs(&self) -> Option<&AbsPath<R>> {
+        match self {
+            Self::Abs(p) => Some(p),
+            Self::Rel(_) => None,
+        }
+    }
+
+    /// Returns the relative variant, if any.
+    #[must_use]
+    pub fn as_rel(&self) -> Option<&RelPath<R>> {
+        match self {
+            Self::Abs(_) => None,
+            Self::Rel(p) => Some(p),
+        }
+    }
+
+    /// The final component of the path, if any.
+    #[must_use]
+    pub fn file_name(&self) -> Option<&str> {
+        self.as_utf8_path().file_name()
+    }
+
+    /// The extension of the final component, if any.
+    #[must_use]
+    pub fn extension(&self) -> Option<&str> {
+        self.as_utf8_path().extension()
+    }
+
+    /// Iterator over the path's components.
+    pub fn components(&self) -> Utf8Components<'_> {
+        self.as_utf8_path().components()
+    }
+}
+
+impl<R: Realm> PartialOrd for EitherPath<R> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<R: Realm> Ord for EitherPath<R> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Abs(a), Self::Abs(b)) => a.cmp(b),
+            (Self::Rel(a), Self::Rel(b)) => a.cmp(b),
+            (Self::Abs(_), Self::Rel(_)) => Ordering::Less,
+            (Self::Rel(_), Self::Abs(_)) => Ordering::Greater,
+        }
+    }
+}
+
+impl<R: Realm> AsRef<Utf8Path> for EitherPath<R> {
+    fn as_ref(&self) -> &Utf8Path {
+        self.as_utf8_path()
+    }
+}
+
+impl<R: Realm> AsRef<Path> for EitherPath<R> {
+    fn as_ref(&self) -> &Path {
+        self.as_utf8_path().as_std_path()
+    }
+}
+
+impl<R: Realm> AsRef<str> for EitherPath<R> {
+    fn as_ref(&self) -> &str {
+        self.as_utf8_path().as_str()
+    }
+}
+
+impl<R: Realm> FromStr for EitherPath<R> {
+    type Err = core::convert::Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::new(s))
+    }
+}
+
+impl<R: Realm> From<AbsPath<R>> for EitherPath<R> {
+    fn from(p: AbsPath<R>) -> Self {
+        Self::Abs(p)
+    }
+}
+
+impl<R: Realm> From<RelPath<R>> for EitherPath<R> {
+    fn from(p: RelPath<R>) -> Self {
+        Self::Rel(p)
+    }
+}
+
+impl<R: Realm> fmt::Display for EitherPath<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Abs(p) => fmt::Display::fmt(p, f),
+            Self::Rel(p) => fmt::Display::fmt(p, f),
+        }
+    }
+}
+
+impl<R: Realm> serde::Serialize for EitherPath<R> {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        self.as_utf8_path().serialize(ser)
+    }
+}
+
+impl<'de, R: Realm> serde::Deserialize<'de> for EitherPath<R> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let p = Utf8PathBuf::deserialize(deserializer)?;
+        Ok(Self::new(p))
+    }
+}
+
+/// Translates absolute paths from one realm into another.
+///
+/// Crossing realms is fallible by default: a host path may not have a
+/// sandbox image, an in-sandbox path may not round-trip back to the host,
+/// etc. Implementors expose their mapping rules through this trait.
+pub trait Translator<Src: Realm, Dst: Realm> {
+    /// Reason translation failed.
+    type Error;
+
+    /// Translates `src` from realm `Src` into realm `Dst`.
+    ///
+    /// # Errors
+    ///
+    /// Implementations decide what counts as a failure (no mapping, path
+    /// outside the mapped subtree, etc.).
+    fn translate(&self, src: &AbsPath<Src>) -> Result<AbsPath<Dst>, Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abs_path_rejects_relative_input() {
+        let err = AbsPath::<Host>::try_new("relative/thing").unwrap_err();
+        assert!(matches!(err, Error::NotAbsolute(_)));
+    }
+
+    #[test]
+    fn rel_path_rejects_absolute_input() {
+        let err = RelPath::<Host>::try_new("/absolute/thing").unwrap_err();
+        assert!(matches!(err, Error::IsAbsolute(_)));
+    }
+
+    #[test]
+    fn abs_join_only_accepts_relpath_so_base_is_preserved() {
+        // The original PathBuf footgun: PathBuf::from("/a").join("/b") == "/b".
+        // The compile-time analogue is unreachable here because join takes
+        // &RelPath<R>, and RelPath::new("/b") would have already failed.
+        let base = AbsPath::<Host>::try_new("/etc/minimal").unwrap();
+        let rel = RelPath::<Host>::try_new("hooks/run.sh").unwrap();
+        assert_eq!(
+            base.join(&rel).as_utf8_path().as_str(),
+            "/etc/minimal/hooks/run.sh",
+        );
+    }
+
+    #[test]
+    fn resolve_against_is_join_in_reverse() {
+        let base = AbsPath::<Host>::try_new("/etc/minimal").unwrap();
+        let rel = RelPath::<Host>::try_new("hooks/run.sh").unwrap();
+        assert_eq!(rel.resolve_against(&base), base.join(&rel));
+    }
+
+    #[test]
+    fn parent_of_root_is_none() {
+        let root = AbsPath::<Host>::try_new("/").unwrap();
+        assert!(root.parent().is_none());
+    }
+
+    #[test]
+    fn parent_of_nested_drops_last_component() {
+        let p = AbsPath::<Host>::try_new("/a/b/c").unwrap();
+        assert_eq!(p.parent().unwrap().as_utf8_path().as_str(), "/a/b");
+    }
+
+    #[test]
+    fn config_relative_binds_only_to_host() {
+        let cfg_dir = AbsPath::<Host>::try_new("/home/u/project").unwrap();
+        let hook = RelPath::<ConfigRelative>::try_new("./scripts/cleanup.sh").unwrap();
+        let bound = hook.bind_to_host(&cfg_dir);
+        assert_eq!(
+            bound.as_utf8_path().as_str(),
+            "/home/u/project/./scripts/cleanup.sh",
+        );
+    }
+
+    #[test]
+    fn debug_includes_realm_tag() {
+        let host = AbsPath::<Host>::try_new("/x").unwrap();
+        let sandbox = AbsPath::<Sandbox>::try_new("/x").unwrap();
+        assert_eq!(format!("{host:?}"), "AbsPath<host>(/x)");
+        assert_eq!(format!("{sandbox:?}"), "AbsPath<sandbox>(/x)");
+    }
+
+    #[test]
+    fn display_omits_realm_tag() {
+        let p = AbsPath::<Host>::try_new("/x/y").unwrap();
+        assert_eq!(format!("{p}"), "/x/y");
+    }
+
+    #[test]
+    fn equality_and_hash_ignore_realm_phantom() {
+        // Same realm, same path → equal.
+        let a = AbsPath::<Host>::try_new("/x").unwrap();
+        let b = AbsPath::<Host>::try_new("/x").unwrap();
+        assert_eq!(a, b);
+
+        // Equality across realms does not even typecheck — this is the
+        // whole point. (Uncommenting the next line would be a compile error.)
+        // let sandbox = AbsPath::<Sandbox>::try_new("/x").unwrap();
+        // let _ = a == sandbox;
+    }
+
+    #[derive(Debug, serde::Deserialize, serde::Serialize)]
+    struct Wrap<T> {
+        x: T,
+    }
+
+    #[test]
+    fn abs_path_serializes_as_bare_string() {
+        let p = HostAbsPath::try_new("/etc/minimal").unwrap();
+        let s = toml::to_string(&Wrap { x: p }).unwrap();
+        assert_eq!(s.trim(), r#"x = "/etc/minimal""#);
+    }
+
+    #[test]
+    fn abs_path_round_trips_through_toml() {
+        let original = HostAbsPath::try_new("/etc/minimal").unwrap();
+        let s = toml::to_string(&Wrap {
+            x: original.clone(),
+        })
+        .unwrap();
+        let parsed: Wrap<HostAbsPath> = toml::from_str(&s).unwrap();
+        assert_eq!(parsed.x, original);
+    }
+
+    #[test]
+    fn abs_path_deserialize_rejects_relative_input() {
+        let err = toml::from_str::<Wrap<HostAbsPath>>(r#"x = "etc/minimal""#).unwrap_err();
+        assert!(err.to_string().contains("absolute"), "got: {err}");
+    }
+
+    #[test]
+    fn rel_path_round_trips_through_toml() {
+        let original = ConfigRelPath::try_new("hooks/cleanup.sh").unwrap();
+        let s = toml::to_string(&Wrap {
+            x: original.clone(),
+        })
+        .unwrap();
+        let parsed: Wrap<ConfigRelPath> = toml::from_str(&s).unwrap();
+        assert_eq!(parsed.x, original);
+    }
+
+    #[test]
+    fn rel_path_deserialize_rejects_absolute_input() {
+        let err = toml::from_str::<Wrap<HostRelPath>>(r#"x = "/etc/minimal""#).unwrap_err();
+        assert!(err.to_string().contains("relative"), "got: {err}");
+    }
+
+    #[test]
+    fn realm_aliases_resolve_to_the_underlying_generic_types() {
+        // These assignments would be type errors if the aliases drifted.
+        let _: HostAbsPath = AbsPath::<Host>::try_new("/h").unwrap();
+        let _: HostRelPath = RelPath::<Host>::try_new("h").unwrap();
+        let _: SandboxAbsPath = AbsPath::<Sandbox>::try_new("/s").unwrap();
+        let _: SandboxRelPath = RelPath::<Sandbox>::try_new("s").unwrap();
+        let _: DaemonAbsPath = AbsPath::<Daemon>::try_new("/d").unwrap();
+        let _: DaemonRelPath = RelPath::<Daemon>::try_new("d").unwrap();
+        let _: ConfigRelPath = RelPath::<ConfigRelative>::try_new("c").unwrap();
+        let _: HostPath = EitherPath::<Host>::new("/h");
+        let _: SandboxPath = EitherPath::<Sandbox>::new("s");
+        let _: DaemonPath = EitherPath::<Daemon>::new("/d");
+    }
+
+    #[test]
+    fn either_path_new_routes_by_absoluteness() {
+        let abs: HostPath = EitherPath::new("/etc/minimal");
+        let rel: HostPath = EitherPath::new("etc/minimal");
+        assert!(abs.is_absolute());
+        assert!(!rel.is_absolute());
+        assert!(abs.as_abs().is_some());
+        assert!(abs.as_rel().is_none());
+        assert!(rel.as_rel().is_some());
+        assert!(rel.as_abs().is_none());
+    }
+
+    #[test]
+    fn either_path_deserializes_absolute_into_abs_variant() {
+        let parsed: Wrap<HostPath> = toml::from_str(r#"x = "/etc/minimal""#).unwrap();
+        assert!(matches!(parsed.x, EitherPath::Abs(_)));
+        assert_eq!(parsed.x.as_utf8_path().as_str(), "/etc/minimal");
+    }
+
+    #[test]
+    fn either_path_deserializes_relative_into_rel_variant() {
+        let parsed: Wrap<HostPath> = toml::from_str(r#"x = "etc/minimal""#).unwrap();
+        assert!(matches!(parsed.x, EitherPath::Rel(_)));
+        assert_eq!(parsed.x.as_utf8_path().as_str(), "etc/minimal");
+    }
+
+    #[test]
+    fn either_path_round_trips_through_toml() {
+        let abs: HostPath = EitherPath::new("/etc/minimal");
+        let rel: HostPath = EitherPath::new("hooks/run.sh");
+        for original in [abs, rel] {
+            let s = toml::to_string(&Wrap {
+                x: original.clone(),
+            })
+            .unwrap();
+            let parsed: Wrap<HostPath> = toml::from_str(&s).unwrap();
+            assert_eq!(parsed.x, original);
+        }
+    }
+
+    #[test]
+    fn either_path_serializes_as_bare_string_without_tag() {
+        let abs: HostPath = EitherPath::new("/etc/minimal");
+        let s = toml::to_string(&Wrap { x: abs }).unwrap();
+        assert_eq!(s.trim(), r#"x = "/etc/minimal""#);
+    }
+
+    #[test]
+    fn either_path_from_impls_lift_either_variant() {
+        let abs = HostAbsPath::try_new("/h").unwrap();
+        let rel = HostRelPath::try_new("h").unwrap();
+        let lifted_abs: HostPath = abs.clone().into();
+        let lifted_rel: HostPath = rel.clone().into();
+        assert_eq!(lifted_abs.as_abs(), Some(&abs));
+        assert_eq!(lifted_rel.as_rel(), Some(&rel));
+    }
+
+    // ---- AsRef / Borrow ----
+
+    fn takes_path(p: impl AsRef<Path>) -> std::path::PathBuf {
+        p.as_ref().to_path_buf()
+    }
+
+    #[test]
+    fn as_ref_into_std_path_works_for_owned_types() {
+        let abs = HostAbsPath::try_new("/etc/minimal").unwrap();
+        let rel = HostRelPath::try_new("hooks/run.sh").unwrap();
+        let either: HostPath = EitherPath::new("/etc/minimal");
+        assert_eq!(takes_path(&abs), Path::new("/etc/minimal"));
+        assert_eq!(takes_path(&rel), Path::new("hooks/run.sh"));
+        assert_eq!(takes_path(&either), Path::new("/etc/minimal"));
+    }
+
+    #[test]
+    fn as_ref_str_returns_inner_path_string() {
+        let p = HostAbsPath::try_new("/etc/minimal").unwrap();
+        let s: &str = p.as_ref();
+        assert_eq!(s, "/etc/minimal");
+        assert_eq!(p.as_str(), "/etc/minimal");
+    }
+
+    #[test]
+    fn borrow_supports_map_lookup_by_utf8_path() {
+        use std::collections::HashMap;
+        let mut m: HashMap<HostAbsPath, u8> = HashMap::new();
+        m.insert(HostAbsPath::try_new("/x").unwrap(), 1);
+        let key = Utf8Path::new("/x");
+        assert_eq!(m.get(key).copied(), Some(1));
+    }
+
+    // ---- FromStr ----
+
+    #[test]
+    fn from_str_parses_abs_and_rel() {
+        let abs: HostAbsPath = "/etc/minimal".parse().unwrap();
+        let rel: HostRelPath = "hooks/run.sh".parse().unwrap();
+        let either: HostPath = "/etc/minimal".parse().unwrap();
+        assert_eq!(abs.as_str(), "/etc/minimal");
+        assert_eq!(rel.as_str(), "hooks/run.sh");
+        assert!(either.is_absolute());
+    }
+
+    #[test]
+    fn from_str_rejects_wrong_orientation() {
+        assert!("etc/minimal".parse::<HostAbsPath>().is_err());
+        assert!("/etc/minimal".parse::<HostRelPath>().is_err());
+    }
+
+    // ---- Ord ----
+
+    #[test]
+    fn ord_sorts_lexicographically_within_a_realm() {
+        let mut v = [
+            HostAbsPath::try_new("/b").unwrap(),
+            HostAbsPath::try_new("/a/b").unwrap(),
+            HostAbsPath::try_new("/a").unwrap(),
+        ];
+        v.sort();
+        let strs: Vec<_> = v.iter().map(HostAbsPath::as_str).collect();
+        assert_eq!(strs, ["/a", "/a/b", "/b"]);
+    }
+
+    #[test]
+    fn either_path_ord_puts_abs_before_rel() {
+        let abs: HostPath = EitherPath::new("/zz");
+        let rel: HostPath = EitherPath::new("aa");
+        assert!(abs < rel);
+    }
+
+    // ---- strip_prefix ----
+
+    #[test]
+    fn strip_prefix_yields_a_relpath_in_the_same_realm() {
+        let base = HostAbsPath::try_new("/home/u").unwrap();
+        let full = HostAbsPath::try_new("/home/u/projects/minimal").unwrap();
+        let rel = full.strip_prefix(&base).unwrap();
+        assert_eq!(rel.as_str(), "projects/minimal");
+    }
+
+    #[test]
+    fn strip_prefix_returns_err_when_not_a_prefix() {
+        let base = HostAbsPath::try_new("/var").unwrap();
+        let full = HostAbsPath::try_new("/home/u").unwrap();
+        assert!(full.strip_prefix(&base).is_err());
+    }
+
+    // ---- file_name / extension / components ----
+
+    #[test]
+    fn file_name_extension_and_components() {
+        let p = HostAbsPath::try_new("/a/b/c.txt").unwrap();
+        assert_eq!(p.file_name(), Some("c.txt"));
+        assert_eq!(p.extension(), Some("txt"));
+        let parts: Vec<_> = p.components().map(|c| c.as_str().to_owned()).collect();
+        assert_eq!(parts, ["/", "a", "b", "c.txt"]);
+    }
+}

--- a/crates/sessions/src/vars.rs
+++ b/crates/sessions/src/vars.rs
@@ -1,0 +1,6 @@
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub enum Var {
+    Inherit,
+    InheritWithDefault { default: String },
+    Specified { value: String },
+}


### PR DESCRIPTION
More details can be found in the modules respective doc strings, but at a high level:

## Part 1: Paths

If you're just using `PathBuf` everywhere for paths, you run into a few problems:
    - `PathBuf` can represent paths with non-utf8 characters. We currently only support utf8 paths so converting between paths and rust strings is a pain
    - `PathBuf` contains no context as to what filesystem a path is for, so there is potential for bugs if we mix them up
    - `PathBuf` you can do weird things like joining an absolute path onto the end of another path which will silently succeed even though it is a logical error

The solution to this was:
    - Adopt `camino`'s `Utf8PathBuf` as our core path primitive instead of `std`'s `PathBuf`
    - Create a concept of `Realm` for paths which are encoded into wrapper types using Phantom markers using Rust's type system to prevent paths from different realms from mixing without explicit translation
    - Separate type wrappers for absolute and relative paths so we can use Rust's type system to prevent logically illegal operations (as well as an enum for cases when a path can be either without loosing type safety)

## Part 2: Patches

First pass at a data model for file system patches. This includes the `FileSet` primitive which is re-used both in patches themselves and patch policies (allow, deny, ignore lists). Patch primitive for specifying files to be patched, as well as "promoted" forms with provenance as to where the patch came from for logs, error messages, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added patch management system to include host files in sessions with policy controls (allow/deny/ignore)
  * Introduced realm-typed filesystem paths with construction-time validation for enhanced safety
  * Added environment variable management with inheritance, defaults, and explicit value specification
  * Enhanced external hook script paths to enforce relative-path-only validation

* **Chores**
  * Added `camino` and `globset` dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->