### PR TITLE
feat(minvmd): macOS host broker crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3388,6 +3388,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "minvmd"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "camino",
+ "clap",
+ "dirs",
+ "nix 0.31.3",
+ "serde",
+ "serial_test",
+ "sessions",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/minimal",
     "crates/minimal2",
     "crates/minimald",
+    "crates/minvmd",
     "crates/remote-client",
     "crates/remote-proto",
     "crates/sandbox2",
@@ -35,6 +36,7 @@ codegen-units = 1
 
 [workspace.dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 blake3 = { version = "1", features = ["serde"] }
 bytes = "1.11" # keep in sync with reqwest
 bzip2 = "0.6"

--- a/crates/minvmd/Cargo.toml
+++ b/crates/minvmd/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name              = "minvmd"
+version           = "0.0.1"
+edition.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "minvmd"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace             = true
+async-trait.workspace        = true
+camino.workspace             = true
+clap.workspace               = true
+dirs.workspace               = true
+# Workspace `nix` is `features = ["fs"]`; minvmd's lifecycle SIGTERM/reap path
+# needs `signal` + `process` on top (Cargo unions these with the workspace set).
+nix                          = { workspace = true, features = ["signal", "process"] }
+serde.workspace              = true
+sessions                     = { path = "../sessions" }
+toml.workspace               = true
+tokio.workspace              = true
+tokio-util.workspace         = true
+tracing.workspace            = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+serial_test.workspace = true
+tempfile.workspace    = true

--- a/crates/minvmd/SPEC.md
+++ b/crates/minvmd/SPEC.md
@@ -1,0 +1,54 @@
+# minvmd + pkgs-sourced VM image — landed shape
+
+Scope: how `minvmd` and the VM image fit together once both land in `minimal`,
+with the image produced by the package registry rather than a fetched URL.
+
+## Components
+
+| Piece | Where | Role |
+|---|---|---|
+| `minvmd` | `crates/minvmd` (macOS) | Host broker: `up`/`down`/`status`/`debug-shell`. Drives `krunkit`, bridges host UDS ↔ guest vsock. |
+| `alpine-virtio-linux` | pkgs package | Builds `vm-image.raw` (EFI GPT: ESP + ext4 root) + `manifest.json` from `virtio-linux` (kernel) + Alpine rootfs. |
+| `minimald` | `crates/minimald` (Linux, in-VM) | Session orchestrator; terminates the `minimald-v1-*` SSH RPC. |
+
+## Image provisioning (the change vs today)
+
+- The image is a **`minimal` package output**, not a `MINVMD_IMAGE_URL` download. `minvmd` and `minimal` ship in the same repo, so `minvmd` resolves the `alpine-virtio-linux` package through the package manager.
+- `minvmd up` ensures the `alpine-virtio-linux` output is materialized (built or pulled from the binary cache), then stages into `~/.minimal/vm/`:
+  - `rootfs.raw` ← the package's `vm-image.raw` (read-only boot disk)
+  - `state.qcow2` ← created locally (writable overlay)
+  - `efivars.fd` ← created on first boot
+- The package `manifest.json` carries the kernel/rootfs/image sha256s; `minvmd` verifies against it. A `MINVMD_IMAGE_*` env override stays for dev/CI.
+- This retires minvmd's current "single fetched artifact + env digest" contract (R2.x).
+
+## Boot + lifecycle (validated against krunkit 1.2.1)
+
+`minvmd` spawns `krunkit` with:
+
+```
+--cpus N --memory N
+--bootloader efi,variable-store=<vm>/efivars.fd,create
+--device virtio-blk,path=<vm>/rootfs.raw,format=raw
+--device virtio-blk,path=<vm>/state.qcow2,format=qcow2
+--device virtio-vsock,port=1024,socketURL=<vm>/control.sock,connect
+--device virtio-vsock,port=1025,socketURL=<vm>/root-debug.sock,connect
+--device virtio-serial,logFilePath=<vm>/serial.log
+--restful-uri unix://<vm>/krunkit.sock
+```
+
+- Boot path: OVMF → `vmlinuz-efi` on the ESP → ext4 root (`/dev/vda2`) → init. The kernel cmdline is supplied by `virtio-linux` (baked `CONFIG_CMDLINE_FORCE`) — **open decision**, see below.
+- `status` ← REST `GET /vm/state` (`VirtualMachineStateRunning|Stopped`); `down` ← REST `{"state":"Stop"}` then SIGTERM reap.
+- vsock is `connect` (host→guest): `minimald` / the debug shell *listen* inside the guest; `minvmd` dials in. The broker byte-pumps opaquely on port 1024; `minimald` parses the RPC.
+
+## Integration with existing crates
+
+- Paths use `sessions::paths::HostAbsPath` at the `minvmd` boundary; the guest is the `Daemon` realm (future `Translator` seam).
+- Errors via a local `UserFacing` (no repo-wide equivalent exists yet).
+- macOS-only crate; non-macOS builds a no-op shim so the workspace builds on Linux.
+
+## Deferred / open
+
+- **Kernel cmdline delivery**: bake into `virtio-linux` (validated, recommended) vs a bootloader/UKI package. Blocks a bootable image.
+- **Production `KrunkitRunner`** + CLI wiring: `up`/`down`/`status` are stubbed; no real krunkit subprocess is launched yet.
+- **Rootfs dedupe**: `alpine-virtio-linux` re-assembles the Alpine rootfs because build_deps merge into one root and musl collides with the glibc image tools. Cleaner once `alpine-minirootfs` emits a namespaced `rootfs.tar`.
+- **Real init**: `minimald` replaces the boot-verification `stub-init` as guest pid-1.

--- a/crates/minvmd/src/broker.rs
+++ b/crates/minvmd/src/broker.rs
@@ -1,0 +1,153 @@
+//! Bidirectional UDS bridge: host socket <-> in-VM minimald socket.
+
+use crate::uds;
+use anyhow::{Context as _, Result};
+use std::path::Path;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+/// Byte-pump between the host control socket and the in-VM minimald socket.
+///
+/// Listens on `host_sock` and, for each accepted connection, connects to
+/// `vsock_sock` and copies bytes bidirectionally. Runs until
+/// `token` is cancelled, then drains all in-flight relay tasks before
+/// returning.
+///
+/// The pump is *opaque*: minvmd never parses the minimald SSH RPC frames that
+/// ride over these streams — that is terminated by minimald inside the guest.
+pub async fn serve(host_sock: &Path, vsock_sock: &Path, token: CancellationToken) -> Result<()> {
+    // create parent dir with mode 0700
+    if let Some(parent) = host_sock.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        create_dir_restricted(parent)?;
+    }
+
+    // bind host socket
+    let listener = uds::listen(host_sock).await.context("bind host socket")?;
+
+    // set the host socket to mode 0600 after bind. We use a path-based
+    // chmod rather than fchmod because fchmod on a Unix-domain socket fd
+    // returns EINVAL on macOS (Darwin) — the only platform this broker runs on
+    // in production. The socket lives inside the 0700 parent created above, so
+    // no other user can traverse to it during the brief post-bind window.
+    set_file_mode(host_sock, 0o600)?;
+
+    // Accept loop with cancellation. Spawned relay tasks are
+    // tracked in a JoinSet and carry a clone of the token so cancellation
+    // drops both streams; serve drains them before returning.
+    let mut pumps: JoinSet<()> = JoinSet::new();
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => break,
+            result = listener.accept() => {
+                let (mut client, _) = result.context("accept on host socket")?;
+                let vsock_path = vsock_sock.to_path_buf();
+                let task_token = token.clone();
+                pumps.spawn(async move {
+                    // connect to in-VM minimald
+                    match uds::connect(&vsock_path).await {
+                        Ok(mut server) => {
+                            // opaque bidirectional byte pump. Cancellation
+                            // drops both streams, terminating the pump cleanly.
+                            tokio::select! {
+                                _ = task_token.cancelled() => {}
+                                _ = tokio::io::copy_bidirectional(&mut client, &mut server) => {}
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("broker: vsock connect failed: {e}");
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    // drain in-flight pumps so serve does not return while bytes are
+    // still being relayed.
+    while pumps.join_next().await.is_some() {}
+    Ok(())
+}
+
+fn create_dir_restricted(path: &Path) -> Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    if !path.exists() {
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)
+            .with_context(|| format!("create dir {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn set_file_mode(path: &Path, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .with_context(|| format!("chmod {mode:o} {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{UnixListener, UnixStream};
+
+    #[tokio::test]
+    async fn byte_pump_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let host_path = dir.path().join("host.sock");
+        let vsock_path = dir.path().join("vsock.sock");
+
+        // Bind the "vsock" server (mimics minimald inside the VM).
+        let vsock_server = UnixListener::bind(&vsock_path).unwrap();
+
+        let token = CancellationToken::new();
+        let cancel = token.clone();
+        let hp = host_path.clone();
+        let vp = vsock_path.clone();
+
+        tokio::spawn(async move {
+            serve(&hp, &vp, cancel).await.unwrap();
+        });
+
+        // Connect as the "minimal" client once the broker has bound, retrying
+        // until the host socket is ready rather than sleeping a fixed amount.
+        let mut client = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                match UnixStream::connect(&host_path).await {
+                    Ok(stream) => break stream,
+                    Err(err)
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+                        ) =>
+                    {
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+                    Err(err) => panic!("failed to connect to broker: {err}"),
+                }
+            }
+        })
+        .await
+        .expect("broker did not bind in time");
+
+        // Accept on the vsock side (mimics minimald accepting).
+        let (mut vm_side, _) = vsock_server.accept().await.unwrap();
+
+        // client → VM
+        client.write_all(b"hello from minimal").await.unwrap();
+        let mut buf = vec![0u8; 18];
+        vm_side.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello from minimal");
+
+        // VM → client
+        vm_side.write_all(b"hello from minimald").await.unwrap();
+        let mut buf2 = vec![0u8; 19];
+        client.read_exact(&mut buf2).await.unwrap();
+        assert_eq!(&buf2, b"hello from minimald");
+
+        token.cancel();
+    }
+}

--- a/crates/minvmd/src/cli.rs
+++ b/crates/minvmd/src/cli.rs
@@ -1,0 +1,51 @@
+//! CLI surface and command dispatch (macOS-only).
+
+use clap::{Parser, Subcommand};
+
+use crate::error::UserFacing;
+use crate::{config, debug_shell, image};
+
+#[derive(Parser)]
+#[command(name = "minvmd", about = "macOS VM host broker for minimald")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Boot the Linux VM.
+    Up,
+    /// Stop the Linux VM.
+    Down,
+    /// Print the VM status (Running, Stopped, or NotRunning).
+    Status,
+    /// Open a root shell inside the guest.
+    DebugShell,
+}
+
+/// Parse argv and run the requested subcommand.
+pub async fn run() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    tracing::info!("minvmd starting");
+    match cli.command {
+        Command::Up => {
+            let cfg = config::Config::load_default()?;
+            let vm_dir = image::default_vm_dir()?;
+            image::ensure_image(&cfg, vm_dir.as_utf8_path().as_std_path()).await?;
+            Err(anyhow::Error::from(UserFacing::new(
+                "not yet implemented: minvmd up (lifecycle)",
+            )))
+        }
+        Command::Down => Err(anyhow::Error::from(UserFacing::new(
+            "not yet implemented: minvmd down",
+        ))),
+        Command::Status => Err(anyhow::Error::from(UserFacing::new(
+            "not yet implemented: minvmd status",
+        ))),
+        Command::DebugShell => {
+            let socket_path = debug_shell::debug_shell_socket_path()?;
+            debug_shell::connect_debug_shell(socket_path.as_utf8_path().as_std_path()).await
+        }
+    }
+}

--- a/crates/minvmd/src/config.rs
+++ b/crates/minvmd/src/config.rs
@@ -1,0 +1,108 @@
+//! `Config` — minvmd daemon configuration.
+//!
+//! Reads `~/.minimal/vm/minvmd.toml`; falls back to defaults when the file is
+//! absent. Unknown keys are silently ignored (forward-compatible).
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+// TODO(unit-2): wire into lifecycle::up. `Config` is consumed by
+// image::ensure_image in Sub-task 2.1 and lifecycle in Sub-task 3.1. Until
+// those land, only tests construct it, so the bin target flags dead code.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub cpus: u32,
+    pub memory_mib: u64,
+    pub state_size_gib: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            cpus: 2,
+            memory_mib: 2048,
+            state_size_gib: 10,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl Config {
+    /// Load config from `path`. If the file does not exist, returns defaults.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => Ok(toml::from_str(&contents)?),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Load from the canonical path `$MINIMAL_HOME/vm/minvmd.toml`.
+    /// `$MINIMAL_HOME` defaults to `~/.minimal` when unset.
+    pub fn load_default() -> anyhow::Result<Self> {
+        let home = std::env::var_os("MINIMAL_HOME")
+            .map(std::path::PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|h| h.join(".minimal")))
+            .ok_or_else(|| anyhow::anyhow!("cannot determine MINIMAL_HOME"))?;
+        Self::load(&home.join("vm").join("minvmd.toml"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{serial_test::serial, with_isolated_home};
+
+    #[test]
+    #[serial]
+    fn default_config_when_no_file() {
+        with_isolated_home(|_home| {
+            let cfg = Config::load_default().expect("load");
+            assert_eq!(cfg.cpus, 2);
+            assert_eq!(cfg.memory_mib, 2048);
+            assert_eq!(cfg.state_size_gib, 10);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn load_default_resolves_minimal_home_and_reads_file() {
+        with_isolated_home(|home| {
+            let vm_dir = home.join("vm");
+            std::fs::create_dir_all(&vm_dir).unwrap();
+            std::fs::write(
+                vm_dir.join("minvmd.toml"),
+                "cpus = 8\nmemory_mib = 16384\nstate_size_gib = 40\n",
+            )
+            .unwrap();
+
+            let cfg = Config::load_default().expect("load_default");
+            assert_eq!(cfg.cpus, 8);
+            assert_eq!(cfg.memory_mib, 16384);
+            assert_eq!(cfg.state_size_gib, 40);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn overrides_from_toml_file() {
+        with_isolated_home(|home| {
+            let vm_dir = home.join("vm");
+            std::fs::create_dir_all(&vm_dir).unwrap();
+            let toml_path = vm_dir.join("minvmd.toml");
+            std::fs::write(
+                &toml_path,
+                "cpus = 4\nmemory_mib = 8192\nstate_size_gib = 20\n",
+            )
+            .unwrap();
+
+            let cfg = Config::load(&toml_path).expect("load");
+            assert_eq!(cfg.cpus, 4);
+            assert_eq!(cfg.memory_mib, 8192);
+            assert_eq!(cfg.state_size_gib, 20);
+        });
+    }
+}

--- a/crates/minvmd/src/debug_shell.rs
+++ b/crates/minvmd/src/debug_shell.rs
@@ -1,0 +1,159 @@
+//! Connect to the guest root debug shell via vsock.
+
+use crate::error::UserFacing;
+use crate::uds;
+use anyhow::{Context as _, Result};
+use sessions::paths::HostAbsPath;
+use std::path::Path;
+use tokio::io::{self, AsyncRead, AsyncWrite};
+
+/// Default path to the root debug shell socket on the host.
+///
+/// Anchored at the user's home directory (`~/.minimal/vm/root-debug.sock`),
+/// which is always absolute.
+pub fn debug_shell_socket_path() -> Result<HostAbsPath> {
+    let home = dirs::home_dir().context("cannot determine home directory")?;
+    let path = home.join(".minimal/vm/root-debug.sock");
+    let utf8 = camino::Utf8PathBuf::from_path_buf(path).map_err(|p| {
+        anyhow::anyhow!(
+            "debug shell socket path is not valid UTF-8: {}",
+            p.display()
+        )
+    })?;
+    HostAbsPath::try_new(utf8).context("debug shell socket path must be absolute")
+}
+
+/// Connect to the root debug shell and forward stdin/stdout bidirectionally.
+pub async fn connect_debug_shell(socket_path: &Path) -> Result<()> {
+    // a missing socket is the only user-facing condition. Check existence
+    // up front so the connect call below can propagate every *other* failure
+    // (e.g. permission denied) with `?` rather than masking it as "not found".
+    if !socket_path.exists() {
+        return Err(anyhow::Error::from(UserFacing::new(format!(
+            "debug shell socket not found: {}",
+            socket_path.display()
+        ))));
+    }
+
+    let stream = uds::connect(socket_path).await?;
+
+    // Bridge the host terminal (stdin/stdout) to the socket. join() pairs the
+    // read-only stdin with the write-only stdout into one duplex.
+    let local = io::join(io::stdin(), io::stdout());
+    bridge(local, stream).await
+}
+
+/// Forward bytes both ways between a local duplex and the debug-shell socket.
+///
+/// `local` carries the host terminal (stdin -> socket, socket -> stdout).
+///
+/// Drives the two directions independently and returns as soon as *either*
+/// completes. `copy_bidirectional` is unsuitable here: it returns only after
+/// *both* directions reach EOF, so a guest disconnect (socket -> stdout hits
+/// EOF) while the local stdin stays open would leave the stdin -> socket copy
+/// waiting forever and the subcommand would hang. Returning on the first
+/// direction to finish makes "exit on socket disconnect" hold (-> exit 0).
+async fn bridge<L, S>(local: L, stream: S) -> Result<()>
+where
+    L: AsyncRead + AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let (mut local_rd, mut local_wr) = io::split(local);
+    let (mut sock_rd, mut sock_wr) = io::split(stream);
+
+    tokio::select! {
+        // Guest disconnect: socket -> stdout hits EOF; return so we exit 0.
+        r = io::copy(&mut sock_rd, &mut local_wr) => { r?; }
+        // Local stdin closed (e.g. EOF / Ctrl-D): stdin -> socket finishes.
+        r = io::copy(&mut local_rd, &mut sock_wr) => { r?; }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixListener;
+
+    /// proof artifact: bind an in-process `UnixListener`, invoke the
+    /// debug-shell connect path (`bridge` over a real `uds::connect` stream),
+    /// send a byte sequence through the local side, and assert it arrives at
+    /// the listener; then close the listener and assert `bridge` returns
+    /// `Ok(())`.
+    #[tokio::test]
+    async fn test_debug_shell_connect() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let socket_path = temp_dir.path().join("test.sock");
+
+        let listener = UnixListener::bind(&socket_path)?;
+
+        // Server side: accept, read the bytes the bridge forwards from the
+        // local "stdin", assert them, then drop the connection (EOF) so the
+        // bridge's socket->stdout copy completes and the function returns Ok.
+        let server = tokio::spawn(async move {
+            let (mut conn, _) = listener.accept().await.expect("accept");
+            let mut buf = [0u8; 5];
+            conn.read_exact(&mut buf)
+                .await
+                .expect("read forwarded bytes");
+            assert_eq!(&buf, b"hello", "bridge should forward stdin to the socket");
+            // Dropping `conn` here closes the socket, signalling disconnect.
+        });
+
+        // Connect to the listener via the production transport path.
+        let stream = uds::connect(&socket_path).await?;
+
+        // Drive `bridge` with an in-memory duplex standing in for the terminal:
+        // `local_test` is the test's handle to the local side; `local_bridge`
+        // is what the bridge treats as stdin/stdout.
+        let (mut local_test, local_bridge) = io::duplex(1024);
+        let bridge_task = tokio::spawn(async move { bridge(local_bridge, stream).await });
+
+        // Write the byte sequence into the local side; the bridge forwards it
+        // to the socket, where the server asserts it. Shutdown signals EOF on
+        // the stdin->socket direction.
+        local_test.write_all(b"hello").await?;
+        local_test.flush().await?;
+        local_test.shutdown().await?;
+
+        server.await?;
+        // on disconnect the bridge returns Ok(()).
+        bridge_task.await??;
+        Ok(())
+    }
+
+    /// (disconnect-only): the guest socket closes while the local stdin
+    /// side stays open; `bridge` must still return promptly so the subcommand
+    /// exits 0. This is the case `copy_bidirectional` would hang on.
+    #[tokio::test]
+    async fn bridge_returns_when_socket_disconnects_with_local_open() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let socket_path = temp_dir.path().join("disc.sock");
+        let listener = UnixListener::bind(&socket_path)?;
+
+        // Server accepts then immediately drops the connection (disconnect).
+        let server = tokio::spawn(async move {
+            let (conn, _) = listener.accept().await.expect("accept");
+            drop(conn);
+        });
+
+        let stream = uds::connect(&socket_path).await?;
+
+        // `_local_test` is deliberately kept alive (never shut down) so the
+        // local stdin->socket direction never hits EOF; only the socket
+        // disconnect can make `bridge` return.
+        let (_local_test, local_bridge) = io::duplex(1024);
+        let bridge_task = tokio::spawn(async move { bridge(local_bridge, stream).await });
+
+        server.await?;
+        // Bound the wait so a regression (hang) fails fast instead of stalling
+        // the suite.
+        let res = tokio::time::timeout(std::time::Duration::from_secs(5), bridge_task)
+            .await
+            .expect("bridge should return promptly on socket disconnect")?;
+        res?;
+        Ok(())
+    }
+}

--- a/crates/minvmd/src/error.rs
+++ b/crates/minvmd/src/error.rs
@@ -1,0 +1,50 @@
+//! User-readable error wrapper.
+//!
+//! minvmd is a standalone bin that owns its own `main` and prints its own
+//! errors, so it carries a small local error type rather than depending on a
+//! shared one.
+//!
+//! Use `anyhow::Error::from(UserFacing::new("message"))` for errors that should
+//! be printed verbatim to the user. For internal/system errors, propagate with
+//! bare `?`.
+
+use std::fmt;
+
+#[derive(Debug)]
+pub struct UserFacing {
+    message: String,
+}
+
+impl UserFacing {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    // Accessor for the message. No caller downcasts to read it yet, so it is
+    // currently unused.
+    #[allow(dead_code)]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for UserFacing {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for UserFacing {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_is_just_the_message() {
+        let e = UserFacing::new("session not found: foo");
+        assert_eq!(e.to_string(), "session not found: foo");
+    }
+}

--- a/crates/minvmd/src/image.rs
+++ b/crates/minvmd/src/image.rs
@@ -1,0 +1,291 @@
+//! `image::ensure_image` — fetch the rootfs and verify its SHA-256 digest.
+//!
+//! Uses `curl` for the download and `sha256sum` (Linux) / `shasum -a 256`
+//! (macOS) for digest verification. Both tools are assumed to be on `$PATH`.
+//!
+//! Environment variables:
+//! - `MINVMD_IMAGE_URL`    (required) — URL of the rootfs archive.
+//! - `MINVMD_IMAGE_SHA256` (required) — hex SHA-256 of the archive.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use sessions::paths::HostAbsPath;
+
+use crate::config::Config;
+use crate::error::UserFacing;
+
+/// Ensure the rootfs image and the qcow2 state disk are present in `vm_dir`.
+///
+/// - Downloads `$MINVMD_IMAGE_URL` to `vm_dir/rootfs.raw` if the file is
+///   absent or its SHA-256 does not match `$MINVMD_IMAGE_SHA256`.
+/// - Removes the partial file and returns an error on digest mismatch.
+/// - Creates `vm_dir/state.qcow2` via `qemu-img create` if absent; its size
+///   is `config.state_size_gib` GiB.
+pub async fn ensure_image(config: &Config, vm_dir: &Path) -> anyhow::Result<()> {
+    let image_url = std::env::var("MINVMD_IMAGE_URL").map_err(|_| {
+        anyhow::Error::from(UserFacing::new(
+            "MINVMD_IMAGE_URL is not set; obtain the image URL from \
+             https://github.com/gominimal/minimal-vm-image and export it \
+             before running `minvmd up`.",
+        ))
+    })?;
+    let image_sha256 = std::env::var("MINVMD_IMAGE_SHA256").map_err(|_| {
+        anyhow::Error::from(UserFacing::new(
+            "MINVMD_IMAGE_SHA256 is not set; obtain the expected digest from \
+             https://github.com/gominimal/minimal-vm-image and export it \
+             before running `minvmd up`.",
+        ))
+    })?;
+
+    tokio::fs::create_dir_all(vm_dir)
+        .await
+        .with_context(|| format!("create vm dir {}", vm_dir.display()))?;
+
+    let rootfs = vm_dir.join("rootfs.raw");
+    fetch_and_verify(&rootfs, &image_url, &image_sha256).await?;
+
+    let qcow2 = vm_dir.join("state.qcow2");
+    if !qcow2.exists() {
+        create_qcow2(&qcow2, config.state_size_gib).await?;
+    }
+
+    Ok(())
+}
+
+/// Download `url` to `dest` (via `curl`), then verify the SHA-256 hex digest
+/// matches `expected_hex`. Removes `dest` and returns an error on mismatch.
+pub(crate) async fn fetch_and_verify(
+    dest: &Path,
+    url: &str,
+    expected_hex: &str,
+) -> anyhow::Result<()> {
+    // Skip the download when the existing file already matches.
+    if dest.exists() {
+        match file_sha256(dest).await {
+            Ok(actual) if actual == expected_hex.to_ascii_lowercase() => return Ok(()),
+            _ => {
+                // File present but digest wrong — remove it and re-download.
+                let _ = tokio::fs::remove_file(dest).await;
+            }
+        }
+    }
+
+    download(dest, url).await?;
+
+    let actual = file_sha256(dest)
+        .await
+        .with_context(|| format!("sha256 of {}", dest.display()))?;
+
+    if actual != expected_hex.to_ascii_lowercase() {
+        let _ = tokio::fs::remove_file(dest).await;
+        return Err(anyhow::anyhow!(
+            "SHA-256 mismatch: expected {expected_hex}, got {actual}"
+        ));
+    }
+
+    Ok(())
+}
+
+/// Download `url` to `dest` via `curl`.
+async fn download(dest: &Path, url: &str) -> anyhow::Result<()> {
+    let status = tokio::process::Command::new("curl")
+        .args(["-fsSL", url, "-o", &dest.to_string_lossy()])
+        .status()
+        .await
+        .context("run curl")?;
+    if !status.success() {
+        anyhow::bail!("curl exited with {status} fetching {url}");
+    }
+    Ok(())
+}
+
+/// Compute the SHA-256 hex digest of a file using the system `sha256sum`
+/// (Linux) or `shasum -a 256` (macOS).
+async fn file_sha256(path: &Path) -> anyhow::Result<String> {
+    // Prefer `sha256sum`; fall back to `shasum -a 256` on macOS.
+    let output = if cfg!(target_os = "macos") {
+        tokio::process::Command::new("shasum")
+            .args(["-a", "256", &path.to_string_lossy()])
+            .output()
+            .await
+            .context("run shasum")?
+    } else {
+        tokio::process::Command::new("sha256sum")
+            .arg(path)
+            .output()
+            .await
+            .context("run sha256sum")?
+    };
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "sha256 tool failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Both `sha256sum` and `shasum` output `<hex>  <filename>`.
+    let hex = stdout
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("unexpected sha256 output: {stdout}"))?;
+    Ok(hex.to_ascii_lowercase())
+}
+
+async fn create_qcow2(path: &Path, size_gib: u32) -> anyhow::Result<()> {
+    let status = tokio::process::Command::new("qemu-img")
+        .args([
+            "create",
+            "-f",
+            "qcow2",
+            &path.to_string_lossy(),
+            &format!("{size_gib}G"),
+        ])
+        .status()
+        .await
+        .context("run qemu-img")?;
+    if !status.success() {
+        anyhow::bail!("qemu-img create failed with {status}");
+    }
+    Ok(())
+}
+
+/// Return the canonical vm dir (`$MINIMAL_HOME/vm/`) for use by callers that
+/// do not want to re-derive the path.
+// Only the macOS `up` path calls this; on the Linux shim build it has no
+// caller and no test exercises it, so allow dead code off-macOS.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn default_vm_dir() -> anyhow::Result<HostAbsPath> {
+    let home = std::env::var_os("MINIMAL_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".minimal")))
+        .ok_or_else(|| anyhow::anyhow!("cannot determine MINIMAL_HOME"))?;
+    let vm_dir = home.join("vm");
+    let utf8 = camino::Utf8PathBuf::from_path_buf(vm_dir)
+        .map_err(|p| anyhow::anyhow!("vm dir is not valid UTF-8: {}", p.display()))?;
+    // `$MINIMAL_HOME` / `~/.minimal` is always absolute, so this is effectively
+    // infallible; surface a clear error if that invariant is ever violated.
+    HostAbsPath::try_new(utf8).context("vm dir must be absolute")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{serial_test::serial, with_isolated_home};
+
+    /// Write `content` to a temp file, compute its SHA-256 with the system tool,
+    /// and return the hex string. Uses a synchronous helper for test setup.
+    fn sha256_of(content: &[u8]) -> String {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("tmp");
+        std::fs::write(&p, content).unwrap();
+        let out = std::process::Command::new("sha256sum")
+            .arg(&p)
+            .output()
+            .unwrap_or_else(|_| {
+                // macOS fallback
+                std::process::Command::new("shasum")
+                    .args(["-a", "256"])
+                    .arg(&p)
+                    .output()
+                    .unwrap()
+            });
+        String::from_utf8_lossy(&out.stdout)
+            .split_whitespace()
+            .next()
+            .unwrap()
+            .to_ascii_lowercase()
+    }
+
+    #[test]
+    #[serial]
+    fn fetch_and_verify_succeeds_on_matching_sha256() {
+        with_isolated_home(|home| {
+            // Write a fixture file that `MINVMD_IMAGE_URL` will point at via file://.
+            let fixture = home.join("fixture.raw");
+            let content = b"fake rootfs content";
+            std::fs::write(&fixture, content).unwrap();
+            let expected_sha = sha256_of(content);
+
+            let dest_dir = home.join("vm");
+            std::fs::create_dir_all(&dest_dir).unwrap();
+            let dest = dest_dir.join("rootfs.raw");
+
+            let url = format!("file://{}", fixture.display());
+
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    fetch_and_verify(&dest, &url, &expected_sha)
+                        .await
+                        .expect("fetch_and_verify should succeed on matching SHA-256");
+                    assert!(dest.exists(), "rootfs.raw must exist after success");
+
+                    // Idempotent: second call with same digest must also succeed.
+                    fetch_and_verify(&dest, &url, &expected_sha)
+                        .await
+                        .expect("second fetch_and_verify should succeed");
+                });
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn fetch_and_verify_fails_and_removes_file_on_bad_sha256() {
+        with_isolated_home(|home| {
+            let fixture = home.join("fixture.raw");
+            std::fs::write(&fixture, b"fake rootfs content").unwrap();
+
+            let dest_dir = home.join("vm");
+            std::fs::create_dir_all(&dest_dir).unwrap();
+            let dest = dest_dir.join("rootfs.raw");
+
+            let bad_sha = "0".repeat(64);
+            let url = format!("file://{}", fixture.display());
+
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    let err = fetch_and_verify(&dest, &url, &bad_sha).await;
+                    assert!(err.is_err(), "should fail on digest mismatch");
+                    assert!(!dest.exists(), "partial file must be removed on mismatch");
+                });
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn ensure_image_errors_when_url_unset() {
+        with_isolated_home(|home| {
+            // SAFETY: serialised by `#[serial]` (via with_isolated_home) so no
+            // other test thread mutates env concurrently.
+            unsafe {
+                std::env::remove_var("MINVMD_IMAGE_URL");
+                std::env::remove_var("MINVMD_IMAGE_SHA256");
+            }
+
+            let vm_dir = home.join("vm");
+            let config = Config::default();
+
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    let err = ensure_image(&config, &vm_dir).await;
+                    assert!(err.is_err(), "expect error when MINVMD_IMAGE_URL is unset");
+                    let msg = format!("{:#}", err.unwrap_err());
+                    assert!(
+                        msg.contains("gominimal/minimal-vm-image"),
+                        "error should reference minimal-vm-image, got: {msg}"
+                    );
+                });
+        });
+    }
+}

--- a/crates/minvmd/src/launchd.rs
+++ b/crates/minvmd/src/launchd.rs
@@ -1,0 +1,1 @@
+//! brew services / launchd integration.

--- a/crates/minvmd/src/lifecycle.rs
+++ b/crates/minvmd/src/lifecycle.rs
@@ -1,0 +1,679 @@
+//! VM lifecycle: ensures krunkit has a running VM before forwarding any traffic.
+//!
+//! Drives `krunkit` as a managed subprocess via the [`KrunkitRunner`] trait
+//! seam. Production uses [`RealRunner`]; tests inject a mock that records
+//! calls and returns scripted results.
+
+use std::ffi::OsString;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use sessions::paths::{HostAbsPath, HostRelPath};
+use tokio::process::Child;
+
+use crate::config::Config;
+use crate::error::UserFacing;
+
+/// VM state as reported by krunkit's REST API (`GET /vm/state`).
+///
+/// krunkit 1.2.1 returns `{"state": "VirtualMachineState<X>"}` over the
+/// `--restful-uri` unix socket (validated: `Running` observed live). The
+/// production `get_state` maps `VirtualMachineStateRunning` → [`VmState::Running`],
+/// `…Stopped` → [`VmState::Stopped`]; an absent socket → [`VmState::NotRunning`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmState {
+    Running,
+    Stopped,
+    NotRunning,
+}
+
+/// Guest vsock port for the control socket `minimald` listens on. krunkit
+/// bridges it host→guest in `connect` mode.
+const CONTROL_VSOCK_PORT: u16 = 1024;
+/// Guest vsock port for the root debug shell.
+const DEBUG_VSOCK_PORT: u16 = 1025;
+
+/// Abstraction over krunkit process management.
+#[async_trait]
+pub trait KrunkitRunner: Send + Sync {
+    /// Start `krunkit` with the given arguments.
+    async fn spawn(&self, args: &[OsString]) -> anyhow::Result<Child>;
+    /// POST `{"state":"Stop"}` to the REST socket.
+    async fn stop(&self, rest_sock: &Path) -> anyhow::Result<()>;
+    /// GET `/vm/state` on the REST socket.
+    async fn get_state(&self, rest_sock: &Path) -> anyhow::Result<VmState>;
+    /// Wait for the child to exit with a timeout.
+    async fn wait(
+        &self,
+        child: &mut Child,
+        timeout: Duration,
+    ) -> anyhow::Result<std::process::ExitStatus>;
+}
+
+/// Paths derived from the vm directory for krunkit sockets and disks.
+///
+/// All paths live on the macOS [`Host`](sessions::paths::Host) filesystem;
+/// the "guest" vsock endpoints are host UDS *socket URLs*, not guest paths.
+struct VmPaths {
+    #[allow(dead_code)]
+    vm_dir: HostAbsPath,
+    rootfs: HostAbsPath,
+    state_disk: HostAbsPath,
+    rest_sock: HostAbsPath,
+    control_sock: HostAbsPath,
+    debug_sock: HostAbsPath,
+    log_serial: HostAbsPath,
+    pidfile: HostAbsPath,
+    /// OVMF EFI variable store. krunkit's libkrun-efi bootloader requires a
+    /// writable NVRAM file; `create` makes it on first boot.
+    efi_vars: HostAbsPath,
+}
+
+impl VmPaths {
+    /// Derive the per-VM paths from `vm_dir`.
+    ///
+    /// `vm_dir` is the canonical VM directory (`$MINIMAL_HOME/vm` or
+    /// `~/.minimal/vm`) and is therefore always an absolute, UTF-8 host path;
+    /// the conversion is effectively infallible, but a clear error is surfaced
+    /// if that invariant is ever violated.
+    fn new(vm_dir: &Path) -> anyhow::Result<Self> {
+        let utf8 = camino::Utf8Path::from_path(vm_dir)
+            .with_context(|| format!("vm dir is not valid UTF-8: {}", vm_dir.display()))?;
+        let vm_dir = HostAbsPath::try_new(utf8.to_owned()).context("vm dir must be absolute")?;
+        let child = |name: &str| -> HostAbsPath {
+            vm_dir.join(&HostRelPath::try_new(name).expect("literal file name is relative"))
+        };
+        Ok(Self {
+            rootfs: child("rootfs.raw"),
+            state_disk: child("state.qcow2"),
+            rest_sock: child("krunkit.sock"),
+            control_sock: child("control.sock"),
+            debug_sock: child("root-debug.sock"),
+            log_serial: child("serial.log"),
+            pidfile: child("krunkit.pid"),
+            efi_vars: child("efivars.fd"),
+            vm_dir,
+        })
+    }
+}
+
+/// Build the krunkit argument vector.
+///
+/// Flags match krunkit 1.2.1 (libkrun-efi), validated empirically:
+/// - `--memory` (not `--mem`); `--device <type>,…` (not `--disk`/`--vsock`/`--serial`).
+/// - `--bootloader efi,…,create`: krunkit only boots via OVMF, which needs a
+///   writable EFI variable store. The boot disk is an EFI-bootable image (ESP +
+///   ext4 root) built by the VM-image package.
+/// - vsock `connect`: host→guest, because `minimald`/the debug shell *listen*
+///   inside the guest and minvmd connects inward. (`listen`, the krunkit
+///   default, is guest→host and would never create the host socket.)
+fn krunkit_args(config: &Config, paths: &VmPaths) -> Vec<OsString> {
+    let mut args: Vec<OsString> = Vec::new();
+
+    // CPU and memory
+    args.push("--cpus".into());
+    args.push(config.cpus.to_string().into());
+    args.push("--memory".into());
+    args.push(config.memory_mib.to_string().into());
+
+    // EFI bootloader with a per-VM variable store (created on first boot).
+    args.push("--bootloader".into());
+    args.push(format!("efi,variable-store={},create", paths.efi_vars.as_str()).into());
+
+    // virtio-blk: bootable rootfs image (raw) and state disk (qcow2). The
+    // kernel mounts its root read-only via the baked-in cmdline, so no
+    // block-layer `ro` is needed (krunkit virtio-blk has no such option).
+    args.push("--device".into());
+    args.push(format!("virtio-blk,path={},format=raw", paths.rootfs.as_str()).into());
+    args.push("--device".into());
+    args.push(format!("virtio-blk,path={},format=qcow2", paths.state_disk.as_str()).into());
+
+    // virtio-vsock: control (1024) and debug shell (1025), host→guest (`connect`).
+    args.push("--device".into());
+    args.push(
+        format!(
+            "virtio-vsock,port={CONTROL_VSOCK_PORT},socketURL={},connect",
+            paths.control_sock.as_str()
+        )
+        .into(),
+    );
+    args.push("--device".into());
+    args.push(
+        format!(
+            "virtio-vsock,port={DEBUG_VSOCK_PORT},socketURL={},connect",
+            paths.debug_sock.as_str()
+        )
+        .into(),
+    );
+
+    // virtio-serial: guest console log.
+    args.push("--device".into());
+    args.push(format!("virtio-serial,logFilePath={}", paths.log_serial.as_str()).into());
+
+    // REST API over a unix socket.
+    args.push("--restful-uri".into());
+    args.push(format!("unix://{}", paths.rest_sock.as_str()).into());
+
+    args
+}
+
+/// Boot the Linux VM.
+pub async fn up(runner: &dyn KrunkitRunner, config: &Config, vm_dir: &Path) -> anyhow::Result<()> {
+    // create vm dir with mode 0700
+    create_dir_restricted(vm_dir)?;
+
+    let paths = VmPaths::new(vm_dir)?;
+    let args = krunkit_args(config, &paths);
+
+    let child = runner.spawn(&args).await.context("spawn krunkit")?;
+
+    // Write pidfile. `id()` is `None` only if the process already exited, which
+    // means krunkit died immediately after spawn — surface that rather than
+    // silently skipping the pidfile and waiting out the readiness timeout.
+    let pid = child
+        .id()
+        .context("krunkit exited immediately after spawn (no pid)")?;
+    tokio::fs::write(paths.pidfile.as_utf8_path().as_std_path(), pid.to_string())
+        .await
+        .context("write pidfile")?;
+
+    // Poll for REST socket and vsock UDS readiness (default 30s timeout)
+    let timeout = Duration::from_secs(30);
+    let poll_interval = Duration::from_millis(100);
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        if paths.rest_sock.as_utf8_path().as_std_path().exists()
+            && paths.control_sock.as_utf8_path().as_std_path().exists()
+            && paths.debug_sock.as_utf8_path().as_std_path().exists()
+        {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow::Error::from(UserFacing::new(format!(
+                "krunkit did not create REST socket and vsock UDS within {}s",
+                timeout.as_secs()
+            ))));
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    // set socket permissions to 0600
+    set_file_mode(paths.control_sock.as_utf8_path().as_std_path(), 0o600)?;
+    set_file_mode(paths.debug_sock.as_utf8_path().as_std_path(), 0o600)?;
+    set_file_mode(paths.rest_sock.as_utf8_path().as_std_path(), 0o600)?;
+
+    Ok(())
+}
+
+/// Query the VM state.
+pub async fn status(runner: &dyn KrunkitRunner, vm_dir: &Path) -> anyhow::Result<VmState> {
+    let paths = VmPaths::new(vm_dir)?;
+    if !paths.rest_sock.as_utf8_path().as_std_path().exists() {
+        return Ok(VmState::NotRunning);
+    }
+    runner
+        .get_state(paths.rest_sock.as_utf8_path().as_std_path())
+        .await
+}
+
+/// Stop the VM.
+pub async fn down(runner: &dyn KrunkitRunner, vm_dir: &Path) -> anyhow::Result<()> {
+    let paths = VmPaths::new(vm_dir)?;
+
+    // If the REST socket is absent the VM is already stopped.
+    if !paths.rest_sock.as_utf8_path().as_std_path().exists() {
+        return Ok(());
+    }
+
+    runner
+        .stop(paths.rest_sock.as_utf8_path().as_std_path())
+        .await
+        .context("POST stop to krunkit")?;
+
+    // Wait for pidfile to disappear (10s)
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if !paths.pidfile.as_utf8_path().as_std_path().exists() {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Pidfile still present: SIGTERM the process and reap.
+    if let Ok(pid_str) = tokio::fs::read_to_string(paths.pidfile.as_utf8_path().as_std_path()).await
+    {
+        if let Ok(pid) = pid_str.trim().parse::<u32>() {
+            let nix_pid = nix::unistd::Pid::from_raw(pid as i32);
+            match nix::sys::signal::kill(nix_pid, nix::sys::signal::Signal::SIGTERM) {
+                Ok(()) => reap_pid(nix_pid),
+                // ESRCH: the process is already gone, nothing to reap.
+                Err(nix::errno::Errno::ESRCH) => {}
+                Err(e) => eprintln!("warn: failed to SIGTERM krunkit pid {pid}: {e}"),
+            }
+        }
+        if let Err(e) = tokio::fs::remove_file(paths.pidfile.as_utf8_path().as_std_path()).await {
+            eprintln!("warn: failed to remove pidfile {}: {e}", paths.pidfile);
+        }
+    }
+
+    Ok(())
+}
+
+/// Reap a child after SIGTERM so it does not linger as a zombie.
+///
+/// Polls `waitpid` with `WNOHANG` for a bounded window. `ECHILD` means the
+/// pid is not a child of this process (e.g. an orphaned krunkit from a prior
+/// run) — there is nothing for us to reap, so it is treated as done.
+fn reap_pid(pid: nix::unistd::Pid) {
+    use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        match waitpid(pid, Some(WaitPidFlag::WNOHANG)) {
+            Ok(WaitStatus::StillAlive) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            // Reaped, or unreapable (not our child / already gone): stop.
+            _ => break,
+        }
+    }
+}
+
+/// Create a directory with mode 0700 if it does not exist.
+///
+/// Uses `DirBuilder::mode` so the directory is created at 0700 atomically,
+/// rather than created at the umask-derived mode and chmod-ed afterward — that
+/// would leave a brief window at looser permissions (umask not relied
+/// upon). `recursive(true)` creates any missing parents, applying the same
+/// 0700 mode to each directory it creates.
+fn create_dir_restricted(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    if !path.exists() {
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)
+            .with_context(|| format!("create dir {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Set a file/directory's permissions to the given mode.
+fn set_file_mode(path: &Path, mode: u32) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    if path.exists() {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+            .with_context(|| format!("chmod {:o} {}", mode, path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{serial_test::serial, with_isolated_home};
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+
+    /// Records of calls made to the mock runner.
+    #[derive(Debug, Clone)]
+    enum MockCall {
+        Spawn(Vec<OsString>),
+        Stop(PathBuf),
+        GetState(PathBuf),
+    }
+
+    /// A mock [`KrunkitRunner`] that records calls and returns scripted
+    /// results without spawning a real process.
+    struct MockRunner {
+        calls: Arc<Mutex<Vec<MockCall>>>,
+        state_sequence: Mutex<Vec<VmState>>,
+        /// Paths to create when `spawn` is called, simulating krunkit creating
+        /// its sockets.
+        create_on_spawn: Mutex<Vec<PathBuf>>,
+    }
+
+    impl MockRunner {
+        fn new() -> Self {
+            Self {
+                calls: Arc::new(Mutex::new(Vec::new())),
+                state_sequence: Mutex::new(Vec::new()),
+                create_on_spawn: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn with_states(mut self, states: Vec<VmState>) -> Self {
+            self.state_sequence = Mutex::new(states);
+            self
+        }
+
+        fn with_socket_creation(mut self, paths: Vec<PathBuf>) -> Self {
+            self.create_on_spawn = Mutex::new(paths);
+            self
+        }
+
+        fn calls(&self) -> Vec<MockCall> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl KrunkitRunner for MockRunner {
+        async fn spawn(&self, args: &[OsString]) -> anyhow::Result<Child> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(MockCall::Spawn(args.to_vec()));
+
+            // Create socket files to simulate krunkit readiness.
+            for path in self.create_on_spawn.lock().unwrap().iter() {
+                if let Some(parent) = path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                std::fs::write(path, b"").unwrap();
+            }
+
+            // Return a dummy child as a stand-in krunkit process so `up` has a
+            // real pid to write. `kill_on_drop` so it is reaped when the Child
+            // drops at test end — otherwise the orphaned `sleep` inherits the
+            // test's stdout fd and a `cargo test | tail` pipe never sees EOF.
+            let child = tokio::process::Command::new("sleep")
+                .arg("3600")
+                .kill_on_drop(true)
+                .spawn()
+                .context("spawn dummy child")?;
+            Ok(child)
+        }
+
+        async fn stop(&self, rest_sock: &Path) -> anyhow::Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(MockCall::Stop(rest_sock.to_path_buf()));
+            Ok(())
+        }
+
+        async fn get_state(&self, rest_sock: &Path) -> anyhow::Result<VmState> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(MockCall::GetState(rest_sock.to_path_buf()));
+            let mut seq = self.state_sequence.lock().unwrap();
+            if seq.is_empty() {
+                Ok(VmState::NotRunning)
+            } else {
+                Ok(seq.remove(0))
+            }
+        }
+
+        async fn wait(
+            &self,
+            child: &mut Child,
+            _timeout: Duration,
+        ) -> anyhow::Result<std::process::ExitStatus> {
+            child.kill().await.ok();
+            child.wait().await.context("wait for child")
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn up_spawns_with_correct_krunkit_args() {
+        with_isolated_home(|home| {
+            let vm_dir = home.join("vm");
+
+            let config = Config {
+                cpus: 4,
+                memory_mib: 8192,
+                state_size_gib: 20,
+            };
+
+            let rest_sock = vm_dir.join("krunkit.sock");
+            let control_sock = vm_dir.join("control.sock");
+            let debug_sock = vm_dir.join("root-debug.sock");
+
+            let runner = MockRunner::new().with_socket_creation(vec![
+                rest_sock.clone(),
+                control_sock.clone(),
+                debug_sock,
+            ]);
+
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    up(&runner, &config, &vm_dir)
+                        .await
+                        .expect("up should succeed");
+                });
+
+            let calls = runner.calls();
+            assert!(!calls.is_empty(), "runner should have been called");
+
+            // First call must be a Spawn
+            let spawn_args = match &calls[0] {
+                MockCall::Spawn(args) => args.clone(),
+                other => panic!("expected Spawn, got {other:?}"),
+            };
+
+            // Verify krunkit argument sequence
+            let args_str: Vec<String> = spawn_args
+                .iter()
+                .map(|a| a.to_string_lossy().into_owned())
+                .collect();
+
+            // All krunkit devices are `--device <type>,…`; collect the values.
+            let device_args: Vec<&String> = args_str
+                .iter()
+                .enumerate()
+                .filter(|(_, a)| a.as_str() == "--device")
+                .map(|(i, _)| &args_str[i + 1])
+                .collect();
+
+            // Two virtio-blk disks: rootfs (raw) then state (qcow2).
+            let blk: Vec<&&String> = device_args
+                .iter()
+                .filter(|d| d.starts_with("virtio-blk,"))
+                .collect();
+            assert_eq!(blk.len(), 2, "expected 2 virtio-blk devices");
+            assert!(
+                blk[0].contains("rootfs.raw") && blk[0].contains("format=raw"),
+                "first disk should be rootfs.raw,format=raw; got {}",
+                blk[0]
+            );
+            assert!(
+                blk[1].contains("state.qcow2") && blk[1].contains("format=qcow2"),
+                "second disk should be state.qcow2,format=qcow2; got {}",
+                blk[1]
+            );
+
+            // Two virtio-vsock devices: control (1024) and debug (1025), `connect`.
+            let vsock: Vec<&&String> = device_args
+                .iter()
+                .filter(|d| d.starts_with("virtio-vsock,"))
+                .collect();
+            assert_eq!(vsock.len(), 2, "expected 2 virtio-vsock devices");
+            assert!(
+                vsock[0].contains("port=1024")
+                    && vsock[0].contains("control.sock")
+                    && vsock[0].ends_with(",connect"),
+                "first vsock should be control.sock port 1024 connect; got {}",
+                vsock[0]
+            );
+            assert!(
+                vsock[1].contains("port=1025")
+                    && vsock[1].contains("root-debug.sock")
+                    && vsock[1].ends_with(",connect"),
+                "second vsock should be root-debug.sock port 1025 connect; got {}",
+                vsock[1]
+            );
+
+            // One virtio-serial log device.
+            let serial: Vec<&&String> = device_args
+                .iter()
+                .filter(|d| d.starts_with("virtio-serial,"))
+                .collect();
+            assert_eq!(serial.len(), 1, "expected 1 virtio-serial device");
+            assert!(
+                serial[0].contains("logFilePath=") && serial[0].contains("serial.log"),
+                "serial device should log to serial.log; got {}",
+                serial[0]
+            );
+
+            // EFI bootloader with a variable store.
+            let boot_idx = args_str.iter().position(|a| a == "--bootloader").unwrap();
+            assert!(
+                args_str[boot_idx + 1].starts_with("efi,")
+                    && args_str[boot_idx + 1].contains("variable-store=")
+                    && args_str[boot_idx + 1].contains("create"),
+                "bootloader should be efi with a created variable-store; got {}",
+                args_str[boot_idx + 1]
+            );
+
+            // Must contain --restful-uri over a unix socket.
+            let rest_idx = args_str.iter().position(|a| a == "--restful-uri").unwrap();
+            assert!(
+                args_str[rest_idx + 1].starts_with("unix://")
+                    && args_str[rest_idx + 1].contains("krunkit.sock"),
+                "--restful-uri value should be unix:// krunkit.sock; got {}",
+                args_str[rest_idx + 1]
+            );
+
+            // CPU and memory
+            let cpus_idx = args_str.iter().position(|a| a == "--cpus").unwrap();
+            assert_eq!(args_str[cpus_idx + 1], "4");
+            let mem_idx = args_str.iter().position(|a| a == "--memory").unwrap();
+            assert_eq!(args_str[mem_idx + 1], "8192");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn status_returns_state_from_runner() {
+        with_isolated_home(|home| {
+            let vm_dir = home.join("vm");
+            std::fs::create_dir_all(&vm_dir).unwrap();
+
+            // Create the REST socket so status calls get_state.
+            let rest_sock = vm_dir.join("krunkit.sock");
+            std::fs::write(&rest_sock, b"").unwrap();
+
+            let runner = MockRunner::new().with_states(vec![VmState::Running]);
+
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    let state = status(&runner, &vm_dir).await.expect("status");
+                    assert_eq!(state, VmState::Running);
+                });
+
+            let calls = runner.calls();
+            assert!(
+                matches!(&calls[0], MockCall::GetState(p) if p == &rest_sock),
+                "status should call get_state on the rest socket"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn status_returns_not_running_when_no_socket() {
+        with_isolated_home(|home| {
+            let vm_dir = home.join("vm");
+            // Do NOT create the rest socket.
+
+            let runner = MockRunner::new();
+
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    let state = status(&runner, &vm_dir).await.expect("status");
+                    assert_eq!(state, VmState::NotRunning);
+                });
+
+            // Runner should not have been called at all.
+            assert!(
+                runner.calls().is_empty(),
+                "no runner calls when socket absent"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn down_calls_stop_and_removes_pidfile() {
+        with_isolated_home(|home| {
+            let vm_dir = home.join("vm");
+            std::fs::create_dir_all(&vm_dir).unwrap();
+            let rest_sock = vm_dir.join("krunkit.sock");
+            std::fs::write(&rest_sock, b"").unwrap();
+            // Create a pidfile that should be cleaned up.
+            let pidfile = vm_dir.join("krunkit.pid");
+            std::fs::write(&pidfile, "99999").unwrap();
+
+            let runner = MockRunner::new();
+
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    // Remove pidfile in a spawned task to simulate the process exiting.
+                    let pf = pidfile.clone();
+                    tokio::spawn(async move {
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+                        let _ = tokio::fs::remove_file(&pf).await;
+                    });
+
+                    down(&runner, &vm_dir).await.expect("down should succeed");
+                });
+
+            let calls = runner.calls();
+            assert!(
+                matches!(&calls[0], MockCall::Stop(p) if p == &rest_sock),
+                "down should call stop on the rest socket"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn up_creates_vm_dir_with_restricted_permissions() {
+        with_isolated_home(|home| {
+            let vm_dir = home.join("vm");
+            assert!(!vm_dir.exists());
+
+            let config = Config::default();
+
+            let rest_sock = vm_dir.join("krunkit.sock");
+            let control_sock = vm_dir.join("control.sock");
+            let debug_sock = vm_dir.join("root-debug.sock");
+
+            let runner =
+                MockRunner::new().with_socket_creation(vec![rest_sock, control_sock, debug_sock]);
+
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    up(&runner, &config, &vm_dir).await.expect("up");
+                });
+
+            // vm_dir should have mode 0700
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&vm_dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "vm dir should be 0700, got {mode:o}");
+        });
+    }
+}

--- a/crates/minvmd/src/main.rs
+++ b/crates/minvmd/src/main.rs
@@ -1,0 +1,49 @@
+//! minvmd — macOS host broker. Brings up the Linux VM via krunkit; bridges UDS
+//! traffic between `minimal` on the host and `minimald` inside the VM.
+//! Not present on Linux installs.
+
+// The broker is macOS-only, but the modules are gated to `macos` *or* `test` so
+// the unit tests still compile and run on Linux CI. No production caller is
+// wired into the dispatch yet, so the surface is dead on the plain bin build —
+// hence the `allow(dead_code)` on the modules that would otherwise warn.
+#[cfg(any(target_os = "macos", test))]
+#[allow(dead_code)]
+mod broker;
+#[cfg(any(target_os = "macos", test))]
+mod config;
+#[cfg(any(target_os = "macos", test))]
+#[allow(dead_code)]
+mod debug_shell;
+#[cfg(any(target_os = "macos", test))]
+mod error;
+#[cfg(any(target_os = "macos", test))]
+mod image;
+#[cfg(target_os = "macos")]
+mod launchd;
+#[cfg(any(target_os = "macos", test))]
+#[allow(dead_code)]
+mod lifecycle;
+#[cfg(any(target_os = "macos", test))]
+mod uds;
+
+#[cfg(test)]
+mod test_support;
+
+// All CLI surface and command dispatch is macOS-only; it lives in one module so
+// the platform gate appears once here rather than scattered across each item.
+#[cfg(target_os = "macos")]
+mod cli;
+
+#[cfg(target_os = "macos")]
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+    cli::run().await
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    eprintln!("minvmd: macOS-only; this binary is a no-op on this platform");
+}

--- a/crates/minvmd/src/test_support.rs
+++ b/crates/minvmd/src/test_support.rs
@@ -1,0 +1,44 @@
+//! Local test helpers.
+//!
+//! minvmd's tests need an isolated `MINIMAL_HOME` and serial execution; the few
+//! pieces they use are inlined here rather than pulled from a shared crate,
+//! compiled only under `cfg(test)`.
+
+#![cfg(test)]
+
+use std::path::Path;
+use std::sync::Mutex;
+use tempfile::TempDir;
+
+/// Re-export so test modules can write `test_support::serial_test::serial`.
+pub use serial_test;
+
+/// Serialises any access to process-wide state (env vars, on-disk caches).
+static STATE_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Run `f` with `MINIMAL_HOME` pointed at a fresh tempdir. The directory is
+/// removed on return; the env var is restored to its previous value.
+pub fn with_isolated_home<F: FnOnce(&Path)>(f: F) {
+    let _guard = STATE_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().expect("tempdir");
+    let prev = std::env::var_os("MINIMAL_HOME");
+
+    // SAFETY: `set_var`/`remove_var` are race-y across threads. The static
+    // mutex above serialises all callers within this process.
+    unsafe {
+        std::env::set_var("MINIMAL_HOME", tmp.path());
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(tmp.path())));
+
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var("MINIMAL_HOME", v),
+            None => std::env::remove_var("MINIMAL_HOME"),
+        }
+    }
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}

--- a/crates/minvmd/src/uds.rs
+++ b/crates/minvmd/src/uds.rs
@@ -1,0 +1,25 @@
+//! Minimal Unix-domain-socket connect/listen helpers.
+//!
+//! minvmd carries these two trivial wrappers itself rather than pulling in a
+//! shared UDS crate: the broker only needs a connect and a listen.
+//!
+//! The broker byte-pumps these streams *opaquely*: it does not parse the
+//! minimald SSH RPC frames riding over them. That layering is preserved.
+
+use std::io;
+use std::path::Path;
+use tokio::net::{UnixListener, UnixStream};
+
+/// Connect to the Unix-domain socket at `path`.
+pub async fn connect(path: &Path) -> io::Result<UnixStream> {
+    UnixStream::connect(path).await
+}
+
+/// Bind a listener on the Unix-domain socket at `path`, removing any stale
+/// socket file first.
+pub async fn listen(path: &Path) -> io::Result<UnixListener> {
+    if path.exists() {
+        std::fs::remove_file(path)?;
+    }
+    UnixListener::bind(path)
+}


### PR DESCRIPTION
Adds `crates/minvmd` — the macOS-only host broker that brings up the Linux VM via `krunkit` (libkrun-efi) and bridges the host control UDS to the guest over vsock, so the `minimal` CLI can reach `minimald` inside the VM. Subcommands: `up`/`down`/`status`/`debug-shell`.

See `crates/minvmd/SPEC.md` for the full landed shape (image sourced from the pkgs registry).

## What's here

- **krunkit lifecycle** behind a `KrunkitRunner` trait seam (mock-tested, no real binary needed): EFI bootloader, two virtio-blk disks (raw image + qcow2 overlay), vsock control/debug on ports 1024/1025 in `connect` mode, virtio-serial log, REST control socket. Flags validated against krunkit 1.2.1 on Apple Silicon.
- **Opaque UDS↔vsock byte-pump broker** — `minimald` terminates the SSH RPC; the broker does not parse frames.
- **EFI image provisioning** + SHA-256 verification; **debug-shell** stdio bridge.
- Paths use `sessions::paths::HostAbsPath` at the boundary.
- macOS-gated, with a Linux no-op shim; unit tests compile and run on Linux CI.

## Status / not yet wired

- Production `KrunkitRunner` + CLI dispatch: `up`/`down`/`status` are stubbed (return "not yet implemented"); no real krunkit subprocess is launched yet. Draft pending that wiring + the pkgs VM-image package.

## Verification

`cargo build -p minvmd`, `cargo test -p minvmd` (15 passing), `cargo clippy -p minvmd --all-targets -- -D warnings`, `cargo fmt -p minvmd --check` all green. (Whole-workspace build on macOS is unrelated-ly blocked by `procfs` via `mctx`/`multi`/`sandbox2`; minvmd has no such dep.)
