### PR TITLE
Install spectacles agentic workflow suite

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,65 @@
+---
+name: Bug
+about: Report defective behavior for the SDD pipeline to spec a fix and build it.
+title: "bug: "
+labels:
+  - kind:bug
+  - sdd:spec
+---
+
+## Summary
+
+One or two sentences describing the defect.
+
+## Expected behavior
+
+What should happen.
+
+## Actual behavior
+
+What happens instead. Include error output or a `file:line` reference where
+you can.
+
+## Reproduction
+
+The smallest set of steps that reliably reproduces the defect.
+
+## Scope notes
+
+Anything in or out of scope, constraints, or related work the agents should
+know. Leave blank if there is nothing to add.
+
+## One-session fix? (optional)
+
+If this looks like a one-file bugfix, a typo, or similarly small,
+comment `/fastpath` on this issue after opening it. The agent will
+compress spec, architecture, and plan into one short run and gate
+execution on a single `/approve`. The full pipeline runs by default;
+`/fastpath` is opt-in. The agent will also propose fast-path on its
+own when the issue body looks like a single-session change.
+
+---
+
+<!-- SDD command vocabulary. Do not edit this footer. -->
+
+This issue is the tracking issue for the fix. It carries the `sdd:spec`
+lifecycle label, so `sdd-spec` will draft a spec PR from it automatically.
+
+Steer the pipeline with these comment commands. Each is gated to commenters
+with write access to the repository.
+
+| Command | Where | Effect |
+|---|---|---|
+| `/spec` | this tracking issue | re-run `sdd-spec` to draft or revise the spec |
+| `/fastpath` | this tracking issue | confirm a single-session change; `sdd-spec` produces a stub spec PR and an execution plan comment in one run (ADR 0012) |
+| `/triage` | this tracking issue, after the spec PR is merged | start `sdd-triage` phase A (architecture) |
+| `/approve` | this tracking issue | full path: confirm the proposed plan so `sdd-triage` creates the Unit and task sub-issues. Fast path: dispatch the execution plan against `sdd-execute-{tier}` |
+| `/dispatch` | this tracking issue (full path only) | arm the cascade across the task tree |
+| `/revise <note>` | a spec, architecture, or implementation PR, or this tracking issue | re-run the owning agent with the note as an added instruction |
+| `/execute` | a task sub-issue | run `sdd-execute` for that task ahead of the schedule |
+
+Merging the spec PR advances to the architecture phase; merging the
+architecture PR advances to a plan-comment phase, where `sdd-triage` posts
+the proposed plan as one comment on this tracking issue. When an agent needs
+a human decision it applies the `needs-human` label and posts one comment;
+clear the label once you have answered and the agent resumes.

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,27 @@
+---
+name: Chore
+about: Track maintenance, refactor, or internal work that is not a feature or bug.
+title: "chore: "
+labels:
+  - kind:chore
+---
+
+## Summary
+
+One or two sentences describing the work.
+
+## Motivation
+
+Why this is worth doing now.
+
+## Scope
+
+What is in scope and what is explicitly not.
+
+---
+
+<!-- A chore is tracked, not specced. -->
+
+A chore does not enter the SDD spec pipeline, so this template applies no
+`sdd:spec` label. If the work turns out to need a spec, open a feature or bug
+issue instead and let `sdd-spec` draft it.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,61 @@
+---
+name: Feature
+about: Propose a new feature or capability for the SDD pipeline to spec and build.
+title: "feature: "
+labels:
+  - kind:feature
+  - sdd:spec
+---
+
+## Summary
+
+One or two sentences describing the feature and who it is for.
+
+## Problem
+
+What is missing or painful today? Describe the situation, not the solution.
+
+## Desired outcome
+
+What should be true once this ships? Describe behavior a person could observe,
+not an implementation.
+
+## Scope notes
+
+Anything in or out of scope, constraints, or related work the agents should
+know. Leave blank if there is nothing to add.
+
+## One-session change? (optional)
+
+If this looks like a one-file copy change, a single-symbol bugfix, or
+similarly small, comment `/fastpath` on this issue after opening it. The
+agent will compress spec, architecture, and plan into one short run and
+gate execution on a single `/approve`. The full pipeline runs by
+default; `/fastpath` is opt-in. The agent will also propose fast-path on
+its own when the issue body looks like a single-session change.
+
+---
+
+<!-- SDD command vocabulary. Do not edit this footer. -->
+
+This issue is the tracking issue for the feature. It carries the `sdd:spec`
+lifecycle label, so `sdd-spec` will draft a spec PR from it automatically.
+
+Steer the pipeline with these comment commands. Each is gated to commenters
+with write access to the repository.
+
+| Command | Where | Effect |
+|---|---|---|
+| `/spec` | this tracking issue | re-run `sdd-spec` to draft or revise the spec |
+| `/fastpath` | this tracking issue | confirm a single-session change; `sdd-spec` produces a stub spec PR and an execution plan comment in one run (ADR 0012) |
+| `/triage` | this tracking issue, after the spec PR is merged | start `sdd-triage` phase A (architecture) |
+| `/approve` | this tracking issue | full path: confirm the proposed plan so `sdd-triage` creates the Unit and task sub-issues. Fast path: dispatch the execution plan against `sdd-execute-{tier}` |
+| `/dispatch` | this tracking issue (full path only) | arm the cascade across the task tree |
+| `/revise <note>` | a spec, architecture, or implementation PR, or this tracking issue | re-run the owning agent with the note as an added instruction |
+| `/execute` | a task sub-issue | run `sdd-execute` for that task ahead of the schedule |
+
+Merging the spec PR advances to the architecture phase; merging the
+architecture PR advances to a plan-comment phase, where `sdd-triage` posts
+the proposed plan as one comment on this tracking issue. When an agent needs
+a human decision it applies the `needs-human` label and posts one comment;
+clear the label once you have answered and the agent resumes.

--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -1,0 +1,62 @@
+---
+name: Specification (from Claude plan)
+about: Hand a Claude plan document to the pipeline to translate into a spec and build.
+title: "feature: "
+labels:
+  - sdd:spec
+  - kind:feature
+  - plan:provided
+---
+
+## Plan
+
+Paste the full Claude plan document here. The plan is the authoritative
+input: `sdd-spec` translates it into a structured spec and `sdd-triage`
+translates its architecture/design section into the architecture record,
+rather than authoring either from scratch. Keep the plan's own structure —
+context, design, the implementation steps, and a verification section.
+
+## Verification
+
+If your plan already has a verification section, leave it above and remove
+this one. Otherwise list, per step, how a person could observe the behavior
+the step produces. `sdd-spec` lifts these into proof artifacts (one to three
+per demoable unit), so prefer behavioral checks over health checks: a plan
+verification that only says "tests pass" or "build succeeds" is dropped, and
+if no step yields a behavioral artifact the agent hands off via `needs-human`.
+
+## Scope notes
+
+Anything in or out of scope, constraints, or related work the agents should
+know. Leave blank if there is nothing to add.
+
+---
+
+<!-- SDD command vocabulary. Do not edit this footer. -->
+
+This issue is the tracking issue for the feature. It carries the `sdd:spec`
+lifecycle label, so `sdd-spec` will draft a spec PR from it automatically.
+The `plan:provided` marker puts `sdd-spec` and `sdd-triage` into translation
+mode: `sdd-spec` translates the plan above into a structured spec, and
+`sdd-triage` translates the plan's architecture/design section into
+`architecture.md`. The marker is cleared once the architecture PR opens (or,
+on the fast path, once the stub spec PR opens).
+
+Steer the pipeline with these comment commands. Each is gated to commenters
+with write access to the repository.
+
+| Command | Where | Effect |
+|---|---|---|
+| `/spec` | this tracking issue | re-run `sdd-spec` to draft or revise the spec |
+| `/fastpath` | this tracking issue | confirm a single-session change; `sdd-spec` produces a stub spec PR and an execution plan comment in one run (ADR 0012) |
+| `/triage` | this tracking issue, after the spec PR is merged | start `sdd-triage` phase A (architecture) |
+| `/approve` | this tracking issue | full path: confirm the proposed plan so `sdd-triage` creates the Unit and task sub-issues. Fast path: dispatch the execution plan against `sdd-execute-{tier}` |
+| `/dispatch` | this tracking issue (full path only) | arm the cascade across the task tree |
+| `/revise <note>` | a spec, architecture, or implementation PR, or this tracking issue | re-run the owning agent with the note as an added instruction |
+| `/execute` | a task sub-issue | run `sdd-execute` for that task ahead of the schedule |
+
+Merging the spec PR advances to the architecture phase; merging the
+architecture PR advances to a plan-comment phase, where `sdd-triage` posts
+the proposed plan as one comment on this tracking issue. When an agent needs
+a human decision it applies the `needs-human` label and posts one comment;
+clear the label once you have answered and the agent resumes.

--- a/.github/workflows/distillery-sync.yml
+++ b/.github/workflows/distillery-sync.yml
@@ -1,0 +1,44 @@
+name: distillery-sync
+
+# Thin wrapper for the distillery-sync agent.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/distillery-sync.lock.yml in the spectacles repository,
+# compiled from distillery-sync.md (which declares on: workflow_call). This
+# wrapper carries the real triggers — a daily schedule and manual dispatch —
+# and calls the hosted reusable workflow by pinned ref. A consumer repository
+# installs this wrapper unchanged; scripts/quick-setup.sh rewrites the @ref
+# when --ref is supplied.
+#
+# distillery-sync had no wrapper before the uses: distribution model (ADR
+# 0004): it was a standalone scheduled workflow whose compiled lock the
+# installer copied directly. Under the uses: model every agent — scheduled or
+# event-driven — is a hosted reusable workflow, so distillery-sync gains a
+# wrapper that owns its schedule, exactly as the sdd-* wrappers own their
+# event triggers.
+
+on:
+  # Daily, off the top of the hour to avoid GitHub scheduler congestion.
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  distillery-sync:
+    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@main
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need issues: write, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read

--- a/.github/workflows/sdd-dispatch.yml
+++ b/.github/workflows/sdd-dispatch.yml
@@ -1,0 +1,1199 @@
+name: sdd-dispatch
+
+# Thin wrapper for the sdd-dispatch agent.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-dispatch.lock.yml (compiled from sdd-dispatch.md, which
+# declares on: workflow_call). This wrapper carries the real event triggers,
+# gates the /dispatch comment command to authors with repository write access,
+# walks the feature's task tree to compute the ready set, fans the cascade out
+# by posting /execute on each ready task issue via the App installation token
+# (ADR 0014 — the matching sdd-execute-{tier} wrapper picks the comment up
+# through its existing issue_comment trigger), and manages the tracking
+# issue's lifecycle and sdd:dispatched labels. A consumer repository installs
+# this wrapper unchanged.
+#
+# Selection is graph-driven, not label-driven. The ready set is computed by
+# walking the sub-issue tree (Feature -> Unit -> task per ADR 0005), parsing
+# each open task's `## Task` block for `blocked by` lines, and admitting
+# tasks whose blockers are all closed and which are not already in flight.
+# The `sdd:ready` label is a downstream artifact applied to dispatched tasks
+# as a UI hint; the graph wins.
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A /dispatch comment on a tracking issue from a write-access author.
+  issue_comment:
+    types: [created]
+  # A task sub-issue closing under a tracking issue that carries
+  # sdd:dispatched. The route job walks the parent chain to find the
+  # tracking issue and filters out closures on issues outside an armed
+  # cascade.
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve which situation triggered the wrapper, gate /dispatch to write
+  # access, and on the cascade path find the tracking issue this task sub-issue
+  # belongs to and confirm it carries sdd:dispatched. A non-match leaves
+  # should_run = false so the dispatch jobs are skipped.
+  #
+  # The job-level if: gate skips the route job entirely on issue_comment events
+  # whose body does not start with /dispatch (fixes issue #119 — a /spec or
+  # /execute comment posted on a tracker no longer spawns a route-job runner
+  # on this wrapper).
+  route:
+    # Token-strict match: `/dispatch` alone or followed by whitespace.
+    # `startsWith(body, '/dispatch')` would also fire for `/dispatchfoo`,
+    # consuming a route-job runner before the route step's tokenised
+    # parse rejects it. GitHub Actions expressions do not support regex
+    # matching, so enumerate the boundary characters explicitly.
+    if: |
+      github.event_name != 'issue_comment'
+      || github.event.comment.body == '/dispatch'
+      || startsWith(github.event.comment.body, '/dispatch ')
+      || startsWith(github.event.comment.body, '/dispatch\n')
+      || startsWith(github.event.comment.body, '/dispatch\r\n')
+      || startsWith(github.event.comment.body, '/dispatch\t')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      tracking_issue: ${{ steps.decide.outputs.tracking_issue }}
+      trigger_kind: ${{ steps.decide.outputs.trigger_kind }}
+    steps:
+      - name: Decide whether to run, and find the tracking issue
+        id: decide
+        uses: actions/github-script@v9
+        env:
+          APP_ID: ${{ vars.APP_ID }}
+        with:
+          script: |
+            const event = context.eventName;
+            const payload = context.payload;
+            let run = false;
+            let tracking = 0;
+            let kind = '';
+
+            // A /dispatch comment from an author with repo write access. The
+            // gate is the actor's real repository permission, not
+            // author_association: a MEMBER of the org need not have push
+            // access on this repo. The collaborators/{user}/permission API
+            // returns the actual permission level; only write, maintain, or
+            // admin may run a command. /dispatch on a pull request is
+            // ignored: it is a tracking-issue command only.
+            //
+            // sdd-monitor (issue #148) posts /dispatch on an armed-but-idle
+            // tracker via the App installation token. The App user is not a
+            // collaborator and would 404 the permission check, so accept the
+            // command when the comment's performed_via_github_app.id matches
+            // the configured APP_ID. Any other bot posting /dispatch is still
+            // rejected. This mirrors the App-author carve-out in
+            // sdd-execute-{tier} for /execute and /revise (ADR 0014).
+            //
+            // Fast-path carve-out (ADR 0012): /dispatch on a tracking
+            // issue carrying any fast-path lifecycle label (sdd:fastpath,
+            // sdd:fastpath-review) is a noop. The fast-path flow has one
+            // task, so the cascade fan-out is unused. The noop-comment
+            // job posts a one-comment explanation pointing the human at
+            // /approve. We mark this by routing with kind='fastpath_noop'
+            // so the noop-comment job knows which message to post and the
+            // compute/dispatch/lifecycle jobs all short-circuit.
+            if (event === 'issue_comment' && payload.action === 'created') {
+              const body = (payload.comment.body || '').trim();
+              const firstWord = body.split(/\s+/)[0];
+              const isPr = !!payload.issue.pull_request;
+              // /dispatch is a tracking-issue command. A tracking issue has
+              // no parent (ADR 0005), a Unit's parent is the tracking issue,
+              // a task's parent is its Unit. If the comment lands on a
+              // sub-issue (Unit or task), the downstream `lifecycle` job
+              // would advance THAT sub-issue's lifecycle label and apply
+              // `sdd:dispatched` to it — both wrong. Reject before the
+              // permission check.
+              const isSubIssue = !!payload.issue.parent_issue_url;
+              if (firstWord === '/dispatch') {
+                if (isPr) {
+                  core.info('/dispatch on a pull request; ignoring.');
+                } else if (isSubIssue) {
+                  core.info('/dispatch on a sub-issue #'
+                    + payload.issue.number
+                    + '; only a tracking issue is valid; ignoring.');
+                } else {
+                  const appId = parseInt(process.env.APP_ID || '0', 10);
+                  const appComment = payload.comment.performed_via_github_app;
+                  const fromConfiguredApp = appId > 0
+                    && appComment
+                    && appComment.id === appId;
+                  const actor = payload.comment.user.login;
+                  let permission = 'none';
+                  if (!fromConfiguredApp) {
+                    try {
+                      const resp = await github.rest.repos
+                        .getCollaboratorPermissionLevel({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          username: actor,
+                        });
+                      permission =
+                        resp.data.role_name || resp.data.permission;
+                    } catch (err) {
+                      core.info(
+                        'Could not resolve repo permission for ' + actor
+                        + ': ' + err.message);
+                    }
+                  }
+                  const canWrite = fromConfiguredApp
+                    || permission === 'write'
+                    || permission === 'maintain' || permission === 'admin';
+                  if (canWrite) {
+                    // Check for the fast-path carve-out before admitting
+                    // the /dispatch. A tracking issue carrying any
+                    // fast-path lifecycle label routes to the noop branch.
+                    // A fast-path tracking issue in `sdd:in-progress` (the
+                    // implementation is running) also routes to noop: it
+                    // has no sub-issues, so /dispatch has nothing to
+                    // cascade. Detect this by the absence of children;
+                    // the full-path `sdd:in-progress` always has a
+                    // sub-issue tree under it (ADR 0010 / ADR 0011).
+                    let isFastpath = false;
+                    try {
+                      const { data } = await github.rest.issues.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: payload.issue.number,
+                      });
+                      const labels = (data.labels || []).map(
+                        (l) => l.name || l);
+                      const hasFastpathLabel = labels.includes('sdd:fastpath')
+                        || labels.includes('sdd:fastpath-review');
+                      let inProgressFastpathHistory = false;
+                      if (!hasFastpathLabel
+                          && !data.parent_issue_url
+                          && labels.includes('sdd:in-progress')
+                          && !labels.includes('sdd:dispatched')) {
+                        try {
+                          const childrenResp = await github.request(
+                            'GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                            {
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: payload.issue.number,
+                              per_page: 1,
+                              page: 1,
+                            });
+                          inProgressFastpathHistory =
+                            (childrenResp.data || []).length === 0;
+                        } catch (subErr) {
+                          // Sub-issues endpoint failure leaves
+                          // inProgressFastpathHistory false; the run
+                          // proceeds as a normal dispatch, which is the
+                          // safer default for a full-path tracking issue.
+                          core.info('Could not list sub-issues for #'
+                            + payload.issue.number + ': ' + subErr.message);
+                        }
+                      }
+                      isFastpath = hasFastpathLabel
+                        || inProgressFastpathHistory;
+                    } catch (err) {
+                      core.info('Could not fetch issue #'
+                        + payload.issue.number + ': ' + err.message);
+                    }
+                    run = true;
+                    tracking = payload.issue.number;
+                    kind = isFastpath ? 'fastpath_noop' : 'command';
+                  } else {
+                    core.info(
+                      '/dispatch from an author without write access ('
+                      + permission + '); ignoring.');
+                  }
+                }
+              }
+            }
+
+            // A task sub-issue closed. Walk the parent chain to find the
+            // tracking issue (Feature -> Unit -> task per ADR 0005). The
+            // cascade fires only when the tracking issue carries
+            // sdd:dispatched; closures on issues outside an armed cascade
+            // are ignored. A closed Unit sub-issue or the tracking issue
+            // itself closing is not a task closure and is ignored too.
+            if (event === 'issues' && payload.action === 'closed') {
+              const closedIssue = payload.issue;
+              // GitHub does not populate the child->parent pointer for
+              // native sub-issues on either the `issues.closed` webhook
+              // payload OR on a re-fetch via REST `GET /issues/{n}`
+              // (`parent_issue_url` / `.parent` is empty in both). A REST
+              // re-fetch therefore cannot seed the walk and the cascade
+              // never fires (issue #133). The authoritative source for
+              // a native sub-issue's parent is GraphQL `Issue.parent`,
+              // which returns the parent node (or null when the issue
+              // is not a sub-issue). Use that as the primary mechanism;
+              // when it returns null we fall back to a reverse lookup
+              // across open `sdd:dispatched` trackers in the same repo.
+
+              // Resolve a parent via GraphQL. Returns an object whose
+              // `kind` discriminates the three outcomes:
+              //   { kind: 'ok', id, number, labels } — parent found
+              //   { kind: 'none' }                   — no parent (root or
+              //                                        not a sub-issue)
+              //   { kind: 'error' }                  — query failed
+              // Distinguishing `none` from `error` matters because a
+              // transient lookup error must not be classified as a clean
+              // "no parent" result — that would silently drop a valid
+              // task closure into the Unit/tracker-closure branch.
+              // Labels are read once here so the caller can apply the
+              // sdd:dispatched gate without a second round-trip.
+              async function parentViaGraphql(nodeId) {
+                if (!nodeId) {
+                  return { kind: 'none' };
+                }
+                try {
+                  const result = await github.graphql(
+                    'query($id: ID!) {' +
+                    '  node(id: $id) {' +
+                    '    ... on Issue {' +
+                    '      parent {' +
+                    '        id number' +
+                    '        labels(first: 50) { nodes { name } }' +
+                    '      }' +
+                    '    }' +
+                    '  }' +
+                    '}',
+                    { id: nodeId });
+                  const parent = result && result.node && result.node.parent;
+                  if (!parent) {
+                    return { kind: 'none' };
+                  }
+                  const labels = ((parent.labels && parent.labels.nodes)
+                    || []).map((l) => l.name);
+                  return {
+                    kind: 'ok',
+                    id: parent.id,
+                    number: parent.number,
+                    labels,
+                  };
+                } catch (err) {
+                  core.info('GraphQL parent lookup failed for node '
+                    + nodeId + ': ' + err.message);
+                  return { kind: 'error' };
+                }
+              }
+
+              // Walk Feature <- Unit <- task using GraphQL parent. Each
+              // hop returns the parent node id, which seeds the next hop.
+              // Returns the tracking-issue object (or null), the number
+              // of hops actually walked, and `stoppedBy` indicating why
+              // the walk ended: 'limit' (reached two hops), 'none'
+              // (parentless ancestor), or 'error' (lookup failed).
+              async function walkViaGraphql(seedNodeId) {
+                let nodeId = seedNodeId;
+                let parent = null;
+                let walked = 0;
+                let stoppedBy = 'limit';
+                while (nodeId && walked < 2) {
+                  const next = await parentViaGraphql(nodeId);
+                  if (next.kind !== 'ok') {
+                    stoppedBy = next.kind;
+                    break;
+                  }
+                  parent = next;
+                  nodeId = next.id;
+                  walked += 1;
+                }
+                return { tracker: parent, walked, stoppedBy };
+              }
+
+              // Reverse lookup: scan open issues in this repo carrying
+              // `sdd:dispatched` and walk their sub-issue trees (Unit,
+              // then task) looking for the closed issue's number. Bounded
+              // by the small number of armed trackers; tolerant of races
+              // because the GraphQL path is primary. Returns the tracking
+              // issue object (with labels) or null.
+              //
+              // Each scan paginates so a closed task beyond the first
+              // 100 trackers/Units/tasks is still discovered — mirrors
+              // the paging that `compute` already does on sub_issues.
+              async function listSubIssuesAll(parentNumber) {
+                const items = [];
+                for (let page = 1; ; page += 1) {
+                  const { data } = await github.request(
+                    'GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                    {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: parentNumber,
+                      per_page: 100,
+                      page,
+                    });
+                  items.push(...data);
+                  if (data.length < 100) {
+                    break;
+                  }
+                }
+                return items;
+              }
+
+              async function listDispatchedTrackersAll() {
+                const items = [];
+                for (let page = 1; ; page += 1) {
+                  const { data } = await github.rest.issues.listForRepo({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    state: 'open',
+                    labels: 'sdd:dispatched',
+                    per_page: 100,
+                    page,
+                  });
+                  items.push(...data);
+                  if (data.length < 100) {
+                    break;
+                  }
+                }
+                return items;
+              }
+
+              async function trackerViaReverseLookup(closedNumber) {
+                let trackers = [];
+                try {
+                  trackers = await listDispatchedTrackersAll();
+                } catch (err) {
+                  core.info('Could not list sdd:dispatched trackers: '
+                    + err.message);
+                  return null;
+                }
+                for (const t of trackers) {
+                  // Skip pull requests; listForRepo returns both.
+                  if (t.pull_request) {
+                    continue;
+                  }
+                  let units = [];
+                  try {
+                    units = await listSubIssuesAll(t.number);
+                  } catch (err) {
+                    core.info('Could not list sub-issues of tracker #'
+                      + t.number + ': ' + err.message);
+                    continue;
+                  }
+                  for (const unit of units) {
+                    let tasks = [];
+                    try {
+                      tasks = await listSubIssuesAll(unit.number);
+                    } catch (err) {
+                      core.info('Could not list sub-issues of unit #'
+                        + unit.number + ': ' + err.message);
+                      continue;
+                    }
+                    if (tasks.some((c) => c.number === closedNumber)) {
+                      return t;
+                    }
+                  }
+                }
+                return null;
+              }
+
+              // Resolve the tracking issue. Primary: GraphQL walk seeded
+              // from the closed issue's node id. Fallback: reverse lookup
+              // across armed trackers. The success condition is unchanged
+              // — a task closure is exactly two hops up from the closed
+              // issue to a tracking issue carrying sdd:dispatched. A
+              // closed Unit (1 hop) or a closed tracking issue (0 hops)
+              // is not a task closure and is ignored.
+              let tracker = null;
+              let walked = 0;
+              const {
+                tracker: gqlTracker,
+                walked: gqlWalked,
+                stoppedBy: gqlStoppedBy,
+              } = await walkViaGraphql(closedIssue.node_id);
+              if (gqlTracker && gqlWalked === 2) {
+                tracker = gqlTracker;
+                walked = gqlWalked;
+              } else if (gqlStoppedBy === 'error') {
+                // A hop failed transiently. Treat the tracker as still
+                // unresolved and try the reverse lookup rather than
+                // misclassifying the closure as a Unit/tracker close.
+                const reverse = await trackerViaReverseLookup(
+                  closedIssue.number);
+                if (reverse) {
+                  const reverseLabels = (reverse.labels || []).map(
+                    (l) => l.name || l);
+                  tracker = {
+                    number: reverse.number,
+                    labels: reverseLabels,
+                  };
+                  walked = 2;
+                } else {
+                  // Reverse lookup also failed to place the closure;
+                  // preserve the partial-walk depth so the diagnostic
+                  // below reflects the GraphQL result.
+                  walked = gqlWalked;
+                }
+              } else if (gqlWalked > 0) {
+                // GraphQL produced a partial walk (e.g. one hop) and
+                // stopped at a parentless ancestor, which means the
+                // closed issue is a Unit or the tracker itself, not a
+                // task. Record the depth so the diagnostic below
+                // reflects the GraphQL result rather than implying a
+                // missing parent.
+                walked = gqlWalked;
+              } else {
+                // GraphQL returned no parent for the closed issue.
+                // Fall back to scanning armed trackers' sub-issue trees.
+                const reverse = await trackerViaReverseLookup(
+                  closedIssue.number);
+                if (reverse) {
+                  // Reverse lookup matched the closed issue under a
+                  // tracker's Unit, which is exactly the two-hop case.
+                  const reverseLabels = (reverse.labels || []).map(
+                    (l) => l.name || l);
+                  tracker = {
+                    number: reverse.number,
+                    labels: reverseLabels,
+                  };
+                  walked = 2;
+                }
+              }
+
+              if (tracker && walked === 2) {
+                const hasDispatched = (tracker.labels || []).some(
+                  (l) => (typeof l === 'string' ? l : l.name)
+                    === 'sdd:dispatched');
+                if (hasDispatched) {
+                  run = true;
+                  tracking = tracker.number;
+                  kind = 'cascade';
+                } else {
+                  core.info('Tracking issue #' + tracker.number
+                    + ' does not carry sdd:dispatched; cascade not armed.');
+                }
+              } else if (walked > 0 && walked < 2) {
+                // Reached a tracker root in fewer than two hops, so this
+                // is a Unit or tracking-issue closure, not a task closure.
+                // Cascade fires on task closures only.
+                core.info('Closed issue #' + closedIssue.number
+                  + ' is not a task sub-issue closure (walked ' + walked
+                  + ' hops); ignoring.');
+              } else {
+                core.info('Closed issue #' + closedIssue.number
+                  + ' has no resolvable tracking issue; ignoring.');
+              }
+            }
+
+            core.setOutput('should_run', run ? 'true' : 'false');
+            core.setOutput('tracking_issue', run ? String(tracking) : '');
+            core.setOutput('trigger_kind', run ? kind : '');
+
+  # Compute the ready set from the dependency graph. Walks the tracking
+  # issue's sub-issue tree, parses each open task's `depends on:` block,
+  # admits tasks whose `blocked by` references are all closed and which are
+  # not already in flight. Emits a matrix of {task, tier} pairs that the
+  # dispatch job fans out over.
+  #
+  # Also emits the precondition state on the tracking issue so the
+  # lifecycle and noop-comment jobs know whether to proceed.
+  compute:
+    needs: route
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.route.outputs.trigger_kind != 'fastpath_noop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+      ready_count: ${{ steps.compute.outputs.ready_count }}
+      open_task_count: ${{ steps.compute.outputs.open_task_count }}
+      precondition: ${{ steps.compute.outputs.precondition }}
+      tracking_state: ${{ steps.compute.outputs.tracking_state }}
+      reason: ${{ steps.compute.outputs.reason }}
+    steps:
+      - name: Compute ready set and precondition state
+        id: compute
+        uses: actions/github-script@v9
+        env:
+          TRACKING_ISSUE: ${{ needs.route.outputs.tracking_issue }}
+          TRIGGER_KIND: ${{ needs.route.outputs.trigger_kind }}
+        with:
+          script: |
+            const tracking = parseInt(process.env.TRACKING_ISSUE, 10);
+            const triggerKind = process.env.TRIGGER_KIND;
+
+            // Read the tracking issue and its lifecycle label.
+            const { data: trackingIssue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: tracking,
+            });
+            const labels = (trackingIssue.labels || []).map(
+              (l) => l.name || l);
+            const lifecycle = labels.find((l) => l.startsWith('sdd:')
+              && l !== 'sdd:dispatched');
+            const hasNeedsHuman = labels.includes('needs-human');
+
+            // Precondition. /dispatch is valid when the tracking issue
+            // carries sdd:ready, sdd:in-progress, or sdd:review. A cascade
+            // fire skips this check (the tracking issue carries
+            // sdd:dispatched, which is only applied alongside
+            // sdd:in-progress or sdd:review). A needs-human label means the
+            // tracking issue is held for the human; defer unconditionally.
+            //
+            // sdd:review is accepted because the tracker can advance there
+            // while open task sub-issues remain unstarted: sdd-execute moves
+            // the feature to sdd:review once the first layer of impl PRs is
+            // open, before later layers are even dispatched. Refusing
+            // /dispatch (and close-triggered re-dispatch) at sdd:review would
+            // wedge the cascade, leaving ready tasks unstarted (issue #134).
+            // Treat sdd:review as armed for the remaining ready tasks: arm
+            // sdd:dispatched and fan out, but leave the lifecycle label
+            // alone (sdd-execute owns the lifecycle transitions).
+            let precondition = 'ok';
+            let reason = '';
+            if (hasNeedsHuman) {
+              precondition = 'needs_human';
+              reason = 'Tracking issue carries needs-human; deferring.';
+            } else if (triggerKind === 'command') {
+              if (lifecycle === 'sdd:ready'
+                  || lifecycle === 'sdd:in-progress'
+                  || lifecycle === 'sdd:review') {
+                precondition = 'ok';
+              } else if (lifecycle === 'sdd:spec'
+                  || lifecycle === 'sdd:triage') {
+                precondition = 'refuse_early';
+                reason = 'Tracking issue is at `' + lifecycle
+                  + '`. /dispatch is valid only on a tracking issue carrying'
+                  + ' `sdd:ready`, `sdd:in-progress`, or `sdd:review`. Merge'
+                  + ' the spec and the architecture PRs, then comment'
+                  + ' `/approve` on the tracking issue to materialize the'
+                  + ' plan and reach `sdd:ready`.';
+              } else if (lifecycle === 'sdd:done') {
+                precondition = 'refuse_late';
+                reason = 'Tracking issue is at `' + lifecycle
+                  + '`; no further dispatch work applies.';
+              } else {
+                precondition = 'refuse_late';
+                reason = 'Tracking issue carries no recognized sdd:*'
+                  + ' lifecycle label; nothing to dispatch.';
+              }
+            }
+            core.setOutput('precondition', precondition);
+            core.setOutput('tracking_state', lifecycle || '');
+            core.setOutput('reason', reason);
+
+            if (precondition !== 'ok') {
+              core.setOutput('matrix', JSON.stringify({ include: [] }));
+              core.setOutput('ready_count', '0');
+              core.setOutput('open_task_count', '0');
+              return;
+            }
+
+            // Walk Feature -> Unit -> task. List sub-issues of the tracking
+            // issue (Units), then for each Unit list its sub-issues (tasks).
+            // The REST sub-issues endpoint returns child issues. A page size
+            // of 100 covers any realistic feature; this loops if needed.
+            async function listChildren(parentNumber) {
+              const items = [];
+              let page = 1;
+              for (;;) {
+                const { data } = await github.request(
+                  'GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: parentNumber,
+                    per_page: 100,
+                    page,
+                  });
+                items.push(...data);
+                if (data.length < 100) {
+                  break;
+                }
+                page += 1;
+              }
+              return items;
+            }
+
+            const units = await listChildren(tracking);
+            const tasks = [];
+            for (const unit of units) {
+              const children = await listChildren(unit.number);
+              for (const child of children) {
+                tasks.push(child);
+              }
+            }
+
+            // Filter to open tasks. We need their full body to parse the
+            // `## Task` block; the sub-issues listing already includes
+            // body, but re-fetch defensively when body is missing.
+            const openTasks = tasks.filter((t) => t.state === 'open');
+            const openTaskCount = openTasks.length;
+            core.setOutput('open_task_count', String(openTaskCount));
+
+            // Parse `blocked by #<N>` and `blocked by <owner>/<repo>#<N>`
+            // lines from the task body. A task with zero blockers is born
+            // ready; a task whose every blocker resolves to a closed issue
+            // is now ready.
+            const blockerRegex =
+              /^\s*-?\s*blocked by\s+(?:([\w.-]+)\/([\w.-]+))?#(\d+)/gim;
+
+            // Build a set of closed task issue numbers in the same repo so
+            // blocker-resolution is O(1). Cross-repo blockers are read via
+            // a per-blocker fetch, but a same-repo blocker — the common
+            // case — is resolved from the tree state we already have.
+            const closedTasksInTree = new Set(
+              tasks.filter((t) => t.state === 'closed').map((t) => t.number));
+
+            async function isBlockerOpen(owner, repo, number) {
+              const isCross = owner && (
+                owner !== context.repo.owner || repo !== context.repo.repo);
+              if (!isCross && closedTasksInTree.has(number)) {
+                return false;
+              }
+              // Look up the blocker. A blocker that is not under this
+              // tracking issue at all (an external dependency in the same
+              // repo, or a cross-repo task) needs an explicit fetch.
+              try {
+                const { data } = await github.rest.issues.get({
+                  owner: owner || context.repo.owner,
+                  repo: repo || context.repo.repo,
+                  issue_number: number,
+                });
+                return data.state === 'open';
+              } catch (err) {
+                // A blocker we cannot resolve is conservatively treated as
+                // open, so we do not dispatch a task whose dependencies
+                // we cannot verify.
+                core.info('Could not resolve blocker #' + number + ': '
+                  + err.message);
+                return true;
+              }
+            }
+
+            // Detect in-flight tasks: those carrying sdd:in-progress, or
+            // those linked to an open implementation pull request. Listing
+            // every open PR once is cheaper than asking per-task. Paginate
+            // across pages of 100 so a repo with more than 100 open PRs
+            // does not silently miss in-flight task links and cause a
+            // re-dispatch of an already-active task.
+            const inFlightFromPrs = new Set();
+            for (let page = 1; ; page += 1) {
+              const { data: openPrs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+                page,
+              });
+              for (const pr of openPrs) {
+                const headRef = (pr.head && pr.head.ref) || '';
+                const headMatch = headRef.match(/^sdd\/(\d+)-/);
+                if (headMatch) {
+                  inFlightFromPrs.add(parseInt(headMatch[1], 10));
+                  continue;
+                }
+                const body = pr.body || '';
+                const closeMatch = body.match(
+                  /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i);
+                if (closeMatch) {
+                  inFlightFromPrs.add(parseInt(closeMatch[1], 10));
+                }
+              }
+              if (openPrs.length < 100) {
+                break;
+              }
+            }
+
+            // Compose the ready set.
+            const ready = [];
+            for (const task of openTasks) {
+              const taskLabels = (task.labels || []).map(
+                (l) => l.name || l);
+              if (taskLabels.includes('needs-human')) {
+                continue;
+              }
+              if (taskLabels.includes('sdd:in-progress')) {
+                continue;
+              }
+              if (inFlightFromPrs.has(task.number)) {
+                continue;
+              }
+              const modelLabels = taskLabels.filter(
+                (l) => l.startsWith('model:'));
+              const supportedTiers = new Set([
+                'model:haiku',
+                'model:sonnet',
+                'model:opus',
+              ]);
+              if (modelLabels.length !== 1
+                  || !supportedTiers.has(modelLabels[0])) {
+                // A task without a model:* tier cannot be routed to a
+                // sdd-execute-{tier} variant; a task with more than one
+                // tier label would wake more than one tier's wrapper;
+                // a single tier label outside {haiku, sonnet, opus}
+                // (e.g. a typo) would post /execute but no wrapper claims
+                // it. All three are triage bugs, not this agent's concern.
+                //
+                // Silently skipping is not enough: the invalid task still
+                // counts toward open_task_count, so the dispatcher would
+                // arm `sdd:dispatched` on the tracking issue and the
+                // lifecycle job would never disarm it (open_task_count
+                // never reaches 0). Refuse the whole /dispatch run with a
+                // clear reason naming the offending task; the human can
+                // fix the labels and re-dispatch.
+                let badness;
+                if (modelLabels.length === 0) {
+                  badness = 'no';
+                } else if (modelLabels.length > 1) {
+                  badness = 'multiple';
+                } else {
+                  badness = 'an unsupported';
+                }
+                const message = 'Task #' + task.number + ' has ' + badness
+                  + ' model:* label(s) (' + modelLabels.join(', ')
+                  + '). Fix the task labels (exactly one of model:haiku,'
+                  + ' model:sonnet, model:opus) and re-comment /dispatch.';
+                core.setOutput('precondition', 'refuse_early');
+                core.setOutput('reason', message);
+                core.setOutput('matrix', JSON.stringify({ include: [] }));
+                core.setOutput('ready_count', '0');
+                return;
+              }
+              const body = task.body || '';
+              const blockers = [];
+              let m;
+              blockerRegex.lastIndex = 0;
+              while ((m = blockerRegex.exec(body)) !== null) {
+                blockers.push({
+                  owner: m[1] || '',
+                  repo: m[2] || '',
+                  number: parseInt(m[3], 10),
+                });
+              }
+              let anyOpen = false;
+              for (const b of blockers) {
+                if (await isBlockerOpen(b.owner, b.repo, b.number)) {
+                  anyOpen = true;
+                  break;
+                }
+              }
+              if (!anyOpen) {
+                // Each ready item is a single task issue number. The fan-out
+                // step posts /execute on the task issue; the matching
+                // sdd-execute-{tier} wrapper picks the comment up via its
+                // wrapper-level command + tier gate (see ADR 0014). The
+                // model:* label is still required upstream (the `if (!tier)`
+                // guard a few lines above) so the matching tier has a
+                // wrapper to route to.
+                ready.push({
+                  task: task.number,
+                });
+              }
+            }
+
+            core.setOutput('ready_count', String(ready.length));
+            // Matrix format: { include: [...] } so each item drives one
+            // matrix cell. The dispatch job fans this out with max-parallel
+            // bounded by SDD_DISPATCH_MAX_PARALLEL.
+            core.setOutput('matrix', JSON.stringify({ include: ready }));
+
+  # Fan the cascade out by posting /execute on each ready task issue. The
+  # matrix is the ready set computed above; max-parallel caps concurrent
+  # cells at SDD_DISPATCH_MAX_PARALLEL (default 5). Each cell posts one
+  # comment via the App installation token; the matching
+  # sdd-execute-{tier} wrapper picks the comment up through its existing
+  # issue_comment trigger and routes to the agent. This replaces the prior
+  # workflow_dispatch fan-out, which required an actions:write scope on the
+  # App that consumer installs did not reliably grant (issue #121 /
+  # ADR 0014).
+  dispatch:
+    # lifecycle is in needs so the tracking issue gains `sdd:dispatched`
+    # BEFORE any /execute comment is posted. Without that ordering, a fast
+    # task could close before lifecycle ran; the `issues.closed` cascade
+    # re-fire would see no `sdd:dispatched` on the tracking issue and bail,
+    # stranding any siblings the closure newly unblocked. The fastpath_noop
+    # path is unaffected: compute and lifecycle both skip on that route, so
+    # dispatch inherits the skip through the `needs` chain (GitHub Actions'
+    # default: a skipped need skips the downstream job).
+    needs: [route, compute, lifecycle]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.compute.outputs.precondition == 'ok'
+      && fromJSON(needs.compute.outputs.matrix).include[0] != null
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    strategy:
+      fail-fast: false
+      max-parallel: ${{ fromJSON(vars.SDD_DISPATCH_MAX_PARALLEL || '5') }}
+      matrix: ${{ fromJSON(needs.compute.outputs.matrix) }}
+    steps:
+      # Mint the App installation token. The default GITHUB_TOKEN cannot
+      # trigger another workflow run, but an App installation token can:
+      # the matching sdd-execute-{tier} wrapper sees the /execute comment
+      # posted below as an issue_comment.created event and routes the
+      # cascade to its agent.
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Post /execute on task #${{ matrix.task }}
+        uses: actions/github-script@v9
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TASK: ${{ matrix.task }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const task = parseInt(process.env.TASK, 10);
+            // Post an /execute comment on the task issue. The matching
+            // sdd-execute-{tier} wrapper picks the comment up through its
+            // wrapper-level command + tier gate; the route step's
+            // App-author accept logic (gated on the configured APP_ID)
+            // admits the cascade-posted comment past the human-permission
+            // check (see ADR 0014). Idempotency: a second /execute on the
+            // same task collapses at the wrapper's per-task-per-tier
+            // concurrency group, so a re-fired cascade does not
+            // double-spawn an in-flight task.
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: task,
+                body: '/execute',
+              });
+              core.info('Posted /execute on task #' + task);
+            } catch (err) {
+              core.setFailed('Failed to post /execute on task #' + task
+                + ': ' + err.message);
+            }
+      - name: Apply sdd:ready hint to dispatched task #${{ matrix.task }}
+        uses: actions/github-script@v9
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TASK: ${{ matrix.task }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const task = parseInt(process.env.TASK, 10);
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: task,
+                labels: ['sdd:ready'],
+              });
+            } catch (err) {
+              // A 422 here means the label is already present; ignore.
+              core.info('Could not add sdd:ready to #' + task + ': '
+                + err.message);
+            }
+
+  # Manage the tracking issue's lifecycle and sdd:dispatched labels. On the
+  # first /dispatch, move sdd:ready -> sdd:in-progress and add
+  # sdd:dispatched. On a cascade fire, leave the lifecycle label alone but
+  # ensure sdd:dispatched stays present (it was the precondition for the
+  # cascade firing in the first place). When the ready set is empty AND
+  # every task is closed, remove sdd:dispatched so the cascade disarms.
+  lifecycle:
+    needs: [route, compute]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.route.outputs.trigger_kind != 'fastpath_noop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Apply lifecycle and sdd:dispatched labels
+        uses: actions/github-script@v9
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TRACKING: ${{ needs.route.outputs.tracking_issue }}
+          TRIGGER_KIND: ${{ needs.route.outputs.trigger_kind }}
+          PRECONDITION: ${{ needs.compute.outputs.precondition }}
+          READY_COUNT: ${{ needs.compute.outputs.ready_count }}
+          OPEN_TASK_COUNT: ${{ needs.compute.outputs.open_task_count }}
+          TRACKING_STATE: ${{ needs.compute.outputs.tracking_state }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const tracking = parseInt(process.env.TRACKING, 10);
+            const triggerKind = process.env.TRIGGER_KIND;
+            const precondition = process.env.PRECONDITION;
+            const readyCount = parseInt(process.env.READY_COUNT, 10);
+            const openTaskCount = parseInt(process.env.OPEN_TASK_COUNT, 10);
+            const trackingState = process.env.TRACKING_STATE;
+
+            // A failed precondition on a /dispatch (e.g. sdd:spec) does
+            // nothing to labels: no arm, no move. The noop-comment job
+            // posts the refusal.
+            if (precondition !== 'ok') {
+              return;
+            }
+
+            // First /dispatch: move sdd:ready -> sdd:in-progress and add
+            // sdd:dispatched. Idempotent: only move when the lifecycle is
+            // still sdd:ready, and only add sdd:dispatched if absent.
+            if (triggerKind === 'command') {
+              if (trackingState === 'sdd:ready') {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: tracking,
+                    name: 'sdd:ready',
+                  });
+                } catch (err) {
+                  core.info('Could not remove sdd:ready from #' + tracking
+                    + ': ' + err.message);
+                }
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: tracking,
+                    labels: ['sdd:in-progress'],
+                  });
+                } catch (err) {
+                  core.info('Could not add sdd:in-progress to #' + tracking
+                    + ': ' + err.message);
+                }
+              }
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracking,
+                  labels: ['sdd:dispatched'],
+                });
+              } catch (err) {
+                core.info('Could not add sdd:dispatched to #' + tracking
+                  + ': ' + err.message);
+              }
+            }
+
+            // Tree drained: remove sdd:dispatched and apply the terminal
+            // sdd:done state. sdd-execute's completion sweep (step 8) is
+            // the primary path for sdd:done when the last task closes via
+            // an implementation PR merge; this branch is the fallback for
+            // the drained-via-manual-close path (no impl PR ever merged,
+            // so the sweep never ran). Idempotent: GitHub tolerates
+            // re-adding an existing label, and removeLabel is wrapped in
+            // try/catch so a missing prior label is a no-op. ADR 0005 §4
+            // names sdd-execute as the agent that hands the feature to
+            // sdd:done; this fallback covers the case where no
+            // sdd-execute run ever fires (see issue #147).
+            if (openTaskCount === 0) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracking,
+                  name: 'sdd:dispatched',
+                });
+                core.info('Tree drained; removed sdd:dispatched from #'
+                  + tracking);
+              } catch (err) {
+                core.info('Could not remove sdd:dispatched from #' + tracking
+                  + ': ' + err.message);
+              }
+              for (const stale of ['sdd:in-progress', 'sdd:review']) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: tracking,
+                    name: stale,
+                  });
+                  core.info('Tree drained; removed ' + stale + ' from #'
+                    + tracking);
+                } catch (err) {
+                  core.info('Could not remove ' + stale + ' from #'
+                    + tracking + ': ' + err.message);
+                }
+              }
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracking,
+                  labels: ['sdd:done'],
+                });
+                core.info('Tree drained; applied sdd:done to #' + tracking);
+              } catch (err) {
+                core.info('Could not add sdd:done to #' + tracking + ': '
+                  + err.message);
+              }
+              return;
+            }
+
+            // Mid-cascade idle (some open tasks, but every one is blocked
+            // or in flight): leave sdd:dispatched alone. The next
+            // issues.closed event on a sibling task will resume the
+            // cascade. The noop-comment job posts an informational comment
+            // on the /dispatch path; the cascade path posts none, to keep
+            // the tracking-issue thread quiet between fan-outs.
+            if (readyCount === 0) {
+              core.info('Ready set empty and tasks still open; cascade'
+                + ' remains armed.');
+            }
+
+  # Post one comment naming the noop reason when /dispatch is refused
+  # (precondition failure on sdd:spec, sdd:triage, sdd:review, sdd:done) or
+  # the ready set is empty. On the cascade path with a non-empty ready set,
+  # no comment is posted: the dispatched runs and the subsequent close
+  # events are the user-visible signal, and a tracking-issue comment per
+  # cascade fire would be noise.
+  #
+  # The wrapper writes this comment directly via the App-minted token rather
+  # than routing through the sdd-dispatch agent's add-comment safe-output:
+  # the message body is deterministic (the precondition string from compute
+  # or the empty-set explanation), there is no LLM-generated text in it, and
+  # the entire dispatcher is deterministic by design. The .md agent exists
+  # to document the contract and to compile cleanly under the lint workflow's
+  # compile-drift gate (ADR 0004); it is not invoked at runtime. See the
+  # header note in .github/workflows/sdd-dispatch.md.
+  noop-comment:
+    needs: [route, compute]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.route.outputs.trigger_kind == 'command'
+      && (needs.compute.outputs.precondition != 'ok'
+          || needs.compute.outputs.ready_count == '0')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Post the noop comment
+        uses: actions/github-script@v9
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TRACKING: ${{ needs.route.outputs.tracking_issue }}
+          PRECONDITION: ${{ needs.compute.outputs.precondition }}
+          REASON: ${{ needs.compute.outputs.reason }}
+          OPEN_TASK_COUNT: ${{ needs.compute.outputs.open_task_count }}
+          READY_COUNT: ${{ needs.compute.outputs.ready_count }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const tracking = parseInt(process.env.TRACKING, 10);
+            const precondition = process.env.PRECONDITION;
+            const reason = process.env.REASON;
+            const openTaskCount = parseInt(process.env.OPEN_TASK_COUNT, 10);
+            const readyCount = parseInt(process.env.READY_COUNT, 10);
+            let body = '';
+            if (precondition === 'refuse_early'
+                || precondition === 'refuse_late'
+                || precondition === 'needs_human') {
+              body = reason;
+            } else if (readyCount === 0 && openTaskCount === 0) {
+              body = 'Every task sub-issue is closed; `sdd:dispatched`'
+                + ' removed and the cascade disarmed. `sdd:done` is'
+                + ' applied here as a fallback when no implementation PR'
+                + ' merge fired `sdd-execute`\'s completion sweep'
+                + ' (ADR 0005).';
+            } else if (readyCount === 0) {
+              body = 'Every open task is either blocked or already in'
+                + ' flight; the cascade remains armed. The next task close'
+                + ' under this tracking issue will resume dispatch.';
+            }
+            if (!body) {
+              return;
+            }
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking,
+                body,
+              });
+            } catch (err) {
+              core.info('Could not post noop comment on #' + tracking
+                + ': ' + err.message);
+            }
+
+  # Fast-path /dispatch noop (ADR 0012).
+  #
+  # /dispatch on a tracking issue carrying a fast-path lifecycle label
+  # (sdd:fastpath, sdd:fastpath-review) does not arm the cascade — the
+  # fast-path flow has one task, so the fan-out machinery is unused.
+  # Post one comment pointing the human at /approve and exit. No labels
+  # are moved; the fast-path flow continues to be steered by sdd-spec's
+  # wrapper.
+  fastpath-noop-comment:
+    needs: route
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.route.outputs.trigger_kind == 'fastpath_noop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Post the fast-path noop comment
+        uses: actions/github-script@v9
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TRACKING: ${{ needs.route.outputs.tracking_issue }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const tracking = parseInt(process.env.TRACKING, 10);
+            const body = '`/dispatch` is a noop on fast-path tracking'
+              + ' issues. The fast-path flow runs a single implementation'
+              + ' task, so the cascade fan-out is unused. Comment'
+              + ' `/approve` on this tracking issue (after the stub spec'
+              + ' PR merges) to dispatch the implementation directly'
+              + ' against the execution plan comment. See ADR 0012.';
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking,
+                body,
+              });
+            } catch (err) {
+              core.info('Could not post fast-path noop comment on #'
+                + tracking + ': ' + err.message);
+            }

--- a/.github/workflows/sdd-execute-haiku.yml
+++ b/.github/workflows/sdd-execute-haiku.yml
@@ -1,0 +1,963 @@
+name: sdd-execute-haiku
+
+# Thin wrapper for the sdd-execute agent, haiku model-tier variant.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-execute-haiku.lock.yml (compiled from
+# sdd-execute-haiku.md, which declares on: workflow_call). This wrapper carries
+# the real event triggers, gates the /execute comment command to authors with
+# repository write access, and passes the triggering entity to the agent
+# through the aw_context input. A consumer repository installs this wrapper
+# unchanged.
+#
+# sdd-execute is compiled into three model-tier variants (haiku, sonnet, opus)
+# that differ only in the engine model and the model:* tier they claim. This
+# wrapper is the haiku-tier caller; sdd-execute-sonnet.yml and
+# sdd-execute-opus.yml are its sonnet and opus siblings.
+#
+# Execution is event-driven, not scheduled. The daily cron that previously
+# drained each tier's queue has been removed: this wrapper now triggers only
+# on workflow_dispatch (from sdd-dispatch's bounded matrix fan-out) and on an
+# explicit /execute comment from a write-access human. The pipeline is
+# /approve -> /dispatch -> cascade-on-close (see issue #81 and ADR 0011).
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A workflow_dispatch from sdd-dispatch (one matrix cell per ready task) or
+  # from an operator running the queue by hand.
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        description: |
+          JSON string naming the triggering entity; mirrors the issue_comment
+          route output. sdd-dispatch fans out one cell per ready task with
+          {trigger: 'command', item_type: 'issue', item_number: <task>}.
+        required: false
+        type: string
+  # A /execute comment on a task sub-issue.
+  issue_comment:
+    types: [created]
+  # A review comment on a pull request this agent opened.
+  pull_request_review_comment:
+    types: [created]
+  # A formal review on a pull request this agent opened. A CHANGES_REQUESTED
+  # review from CodeRabbit or a write-access human on an `sdd/` branch is
+  # treated as an implicit /revise (issue #128). A COMMENTED or APPROVED
+  # review does not trigger a revise.
+  pull_request_review:
+    types: [submitted]
+  # The needs-human label being cleared on a task sub-issue, which re-triggers
+  # the agent to resume a hand-off it applied at step 5 or step 6.
+  issues:
+    types: [unlabeled]
+  # The needs-human label being cleared on a pull request this agent opened,
+  # which re-triggers the agent to resume a hand-off it applied at step 7.
+  # The `closed` action covers the fast-path completion path (ADR 0012): a
+  # merged implementation PR on a `sdd/` branch whose work-item is a
+  # tracking issue (no parent_issue_url, no task sub-issue tree) re-fires
+  # the agent with `entry: 'fastpath-complete'` so step 8's completion
+  # sweep can move the tracking issue from `sdd:in-progress` to `sdd:done`
+  # directly.
+  pull_request:
+    types: [unlabeled, closed]
+
+permissions:
+  contents: read
+
+# Concurrency group keyed on the task issue number AND this variant's tier.
+# A stale sdd-dispatch fan-out racing with a manual /execute on the same task
+# in the same tier collapses to one running cell: cancel-in-progress: true
+# supersedes the in-progress cell with the later trigger so a user-initiated
+# /execute wins over a stale dispatch (and vice versa: a fresh dispatch wins
+# over an earlier in-flight cell). The tier discriminator is required because
+# the three sdd-execute-{haiku,sonnet,opus} wrappers all subscribe to the same
+# event triggers; without the tier suffix a non-matching-tier wake would land
+# in the same group as the matching-tier run and the cancel-in-progress rule
+# could kill the only run doing real work (issue #124). Cancel-in-progress is
+# set on the wrapper itself because the gh-aw lock declares its own
+# activation-level concurrency keyed on the workflow name; this wrapper-level
+# group adds the per-task-per-tier dimension on top.
+#
+# The fromJSON(github.event.inputs.aw_context || '{}') branch reads the
+# dispatcher's well-formed aw_context JSON for the workflow_dispatch path.
+# Manual workflow_dispatch invocations that supply malformed JSON will fail
+# workflow evaluation here, which is the correct failure mode (the route
+# step's try/catch would silently ignore them and the run would do nothing
+# useful).
+#
+# A label-removal event (issues.unlabeled / pull_request.unlabeled) is routed
+# to its own throwaway group (github.run_id) so it never lands in a task's
+# shared per-task-per-tier group. At step 2 the agent removes its own task's
+# sdd:ready label; that self-induced issues.unlabeled event re-fires this
+# wrapper, and without the carve-out it entered the active run's group where
+# cancel-in-progress killed the running agent mid-work (issue #143). The only
+# label-removal the route step acts on is needs-human (a resume), which runs
+# when no agent is in flight, so a unique group is safe there too.
+#
+# An issue_comment whose body is not a recognized command (/execute or
+# /revise) is routed to its own throwaway group for the same reason.
+# gh-aw's create-pull-request fallback-to-issue posts an "Issue created:
+# #<n>" notice on the task issue via the App token (issue #142); that
+# App-authored comment re-fires this wrapper as issue_comment.created,
+# and without the carve-out it landed in the active run's per-task group
+# where cancel-in-progress killed the originating run's safe_outputs tail
+# and its auto-merge job. The route step acts only on /execute and
+# /revise comments, so a non-command comment in a unique group is safe.
+concurrency:
+  group: sdd-execute-haiku-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate below is the wrapper-level command + tier + label
+  # filter (fixes issue #119 and the matching-tier slice of issue #114). It
+  # runs BEFORE the route job's runner is allocated, so a /dispatch comment, a
+  # /spec comment, or any other unrelated comment never spends a runner
+  # minute on this wrapper. The issues clause does the same for label events:
+  # the route step only routes an `issues` event on `unlabeled` `needs-human`
+  # (the step 5/6 resume), so any other label add/remove — e.g. the
+  # `sdd:ready`/`sdd:in-progress`/`sdd:dispatched` mutations a /dispatch
+  # performs on a tracking issue — is skipped here without a runner. The
+  # route step's own tier resolution stays as a defence-in-depth check (it
+  # covers /revise on a sdd/ PR, where the model label lives on the linked
+  # task, not the PR — too expensive to resolve at workflow-evaluation time
+  # without an API call).
+  route:
+    if: |
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          (
+            startsWith(github.event.comment.body, '/execute')
+            && contains(github.event.issue.labels.*.name, 'model:haiku')
+          )
+          || startsWith(github.event.comment.body, '/revise')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && github.event.action == 'unlabeled'
+        && github.event.label.name == 'needs-human'
+      )
+    runs-on: ubuntu-latest
+    # pull-requests: read is needed for the tier gate on a /revise issue_comment
+    # (situation 6): the route fetches the pull request to read its body and
+    # extract the `Closes #<task>` reference. Without this grant, the GET
+    # /repos/{owner}/{repo}/pulls/{N} call returns 403 "Resource not accessible
+    # by integration" and the tier gate defaults to false, skipping every
+    # variant. See #68.
+    #
+    # issues: write and pull-requests: write are needed by the CHANGES_REQUESTED
+    # auto-revise branch (issue #128): it posts a hidden iteration-marker
+    # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
+    # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
+    # re-trigger workflows, so this does not feed back into the route.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: actions/github-script@v9
+        env:
+          # The configured GitHub App ID, used to accept /execute comments
+          # posted by sdd-dispatch's cascade fan-out (ADR 0014). A human's
+          # /execute still goes through the repo-permission check below.
+          APP_ID: ${{ vars.APP_ID }}
+          # Cap on auto-revise cycles per PR for CHANGES_REQUESTED reviews
+          # (issue #128); defaults to 3 when the repo variable is unset.
+          SDD_MAX_REVIEW_ITERATIONS: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}
+        with:
+          script: |
+            const event = context.eventName;
+            const payload = context.payload;
+            let run = false;
+            let ctx = {};
+            // Set true by the CHANGES_REQUESTED auto-revise branch (issue
+            // #128). The cap count, hidden marker, and needs-human side
+            // effects are deferred until AFTER the tier gate below confirms
+            // this variant owns the PR, so the two non-owning tiers never
+            // mutate PR state (they would otherwise inflate the cap count).
+            let reviewAutoRevise = false;
+            let reviewPrNumber = 0;
+
+            // This wrapper is the haiku model tier; the tier gate below
+            // skips a task another tier owns.
+            const TIER = 'haiku';
+
+            // A workflow_dispatch from sdd-dispatch (or from an operator
+            // running the queue by hand) carries an aw_context input naming
+            // the task to implement. The cron-based "schedule" trigger has
+            // been removed (issue #81 / ADR 0011): execution is event-driven
+            // now, dispatched per task from the cascade.
+            if (event === 'workflow_dispatch') {
+              const raw = (payload.inputs && payload.inputs.aw_context) || '';
+              if (raw) {
+                try {
+                  ctx = JSON.parse(raw);
+                  if (ctx && ctx.item_number) {
+                    run = true;
+                  } else {
+                    core.info('workflow_dispatch aw_context missing'
+                      + ' item_number; ignoring.');
+                  }
+                } catch (err) {
+                  core.info('workflow_dispatch aw_context not parseable: '
+                    + err.message);
+                }
+              } else {
+                core.info('workflow_dispatch with no aw_context; ignoring.');
+              }
+            }
+
+            // A /execute or /revise comment from either an author with repo
+            // write access or sdd-dispatch's App identity. The gate is the
+            // actor's real repository permission, not author_association:
+            // author_association reports the relationship to the thread
+            // (OWNER/MEMBER/COLLABORATOR), which is not the same as push
+            // access. A MEMBER of the org need not have write on this repo,
+            // and a COLLABORATOR may be read-only. The
+            // collaborators/{user}/permission API returns the actual
+            // permission level; only write, maintain, or admin may run a
+            // command. /execute on a pull request is ignored: it is a
+            // task-sub-issue command only.
+            //
+            // sdd-dispatch fans the cascade out by posting /execute on each
+            // ready task issue via the App installation token (ADR 0014).
+            // The App user is not a collaborator and would 404 the
+            // permission check, so accept the command when the comment's
+            // performed_via_github_app.id matches the configured APP_ID.
+            // Any other bot posting /execute is still rejected.
+            if (event === 'issue_comment' && payload.action === 'created') {
+              const body = (payload.comment.body || '').trim();
+              const firstWord = body.split(/\s+/)[0];
+              const isPr = !!payload.issue.pull_request;
+              const isExecute = firstWord === '/execute' && !isPr;
+              const isRevise = firstWord === '/revise' && isPr;
+              if (firstWord === '/execute' && isPr) {
+                core.info('/execute on a pull request; ignoring.');
+              } else if (isExecute || isRevise) {
+                const appId = parseInt(process.env.APP_ID || '0', 10);
+                const appComment = payload.comment.performed_via_github_app;
+                const fromConfiguredApp = appId > 0
+                  && appComment
+                  && appComment.id === appId;
+                let permission = 'none';
+                if (!fromConfiguredApp) {
+                  const actor = payload.comment.user.login;
+                  try {
+                    const resp = await github.rest.repos
+                      .getCollaboratorPermissionLevel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        username: actor,
+                      });
+                    // role_name is the precise role
+                    // (write/maintain/triage/...) when present; permission is
+                    // the legacy bucket (admin/write/read/none) that collapses
+                    // maintain into write and triage into read.
+                    permission = resp.data.role_name || resp.data.permission;
+                  } catch (err) {
+                    core.info(
+                      'Could not resolve repo permission for ' + actor
+                      + ': ' + err.message);
+                  }
+                }
+                const canWrite = fromConfiguredApp
+                  || permission === 'write'
+                  || permission === 'maintain'
+                  || permission === 'admin';
+                if (canWrite) {
+                  run = true;
+                  ctx = isRevise
+                    ? {
+                        trigger: 'revise',
+                        item_type: 'pull_request',
+                        item_number: payload.issue.number,
+                        comment_id: payload.comment.id,
+                      }
+                    : {
+                        trigger: 'command',
+                        item_type: 'issue',
+                        item_number: payload.issue.number,
+                        comment_id: payload.comment.id,
+                      };
+                } else {
+                  core.info(
+                    'Command from an author without write access ('
+                    + permission + '); ignoring.');
+                }
+              }
+            }
+
+            // A review comment on a pull request. The agent confirms the pull
+            // request is one it opened (an sdd/<task-id>-<slug> branch) before
+            // pushing follow-up commits.
+            if (event === 'pull_request_review_comment'
+                && payload.action === 'created') {
+              run = true;
+              ctx = {
+                trigger: 'review_comment',
+                item_type: 'pull_request',
+                item_number: payload.pull_request.number,
+                comment_id: payload.comment.id,
+              };
+            }
+
+            // A formal review with state CHANGES_REQUESTED on an sdd/ PR is
+            // treated as an implicit /revise (issue #128). The directive is
+            // the review body plus the unresolved review-comment threads, so
+            // one revise run addresses the whole verdict; the individual
+            // pull_request_review_comment events that co-arrive collapse into
+            // this run at the per-PR-per-tier concurrency group (the existing
+            // dedupe mechanism). A COMMENTED or APPROVED review does not match
+            // and never triggers a revise. The manual /revise path above is
+            // untouched. The agent confirms ownership (sdd/ head ref + body
+            // marker) at step 7 exactly as it does for a review comment.
+            if (event === 'pull_request_review'
+                && payload.action === 'submitted') {
+              const review = payload.review || {};
+              const state = (review.state || '').toLowerCase();
+              const pr = payload.pull_request || {};
+              const headRef = (pr.head && pr.head.ref) || '';
+              if (state === 'changes_requested'
+                  && headRef.startsWith('sdd/')) {
+                // Author scope: accept CodeRabbit's bot review or a review by
+                // an author with repository write access, mirroring the
+                // /revise permission check above. A login of `coderabbitai`
+                // (with or without a `[bot]` suffix) is the CodeRabbit bot.
+                const reviewer = (review.user && review.user.login) || '';
+                const reviewerLc = reviewer.toLowerCase();
+                const isCodeRabbit = reviewerLc === 'coderabbitai'
+                  || reviewerLc === 'coderabbitai[bot]';
+                let reviewerCanWrite = isCodeRabbit;
+                if (!isCodeRabbit && reviewer) {
+                  let permission = 'none';
+                  try {
+                    const resp = await github.rest.repos
+                      .getCollaboratorPermissionLevel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        username: reviewer,
+                      });
+                    permission = resp.data.role_name || resp.data.permission;
+                  } catch (err) {
+                    core.info('Could not resolve repo permission for '
+                      + reviewer + ': ' + err.message);
+                  }
+                  reviewerCanWrite = permission === 'write'
+                    || permission === 'maintain'
+                    || permission === 'admin';
+                }
+                if (!reviewerCanWrite) {
+                  core.info('CHANGES_REQUESTED review by a non-allowed'
+                    + ' reviewer (' + reviewer + '); ignoring.');
+                } else {
+                  const prNumber = pr.number;
+                  // Assemble the directive: the review body plus the
+                  // unresolved review-comment threads. Resolved threads are
+                  // skipped to avoid re-fixing addressed items. Thread
+                  // resolution state is only exposed by GraphQL. This is
+                  // read-only; the cap count and the side-effecting marker /
+                  // needs-human are deferred to the post-tier-gate block so
+                  // only the owning tier mutates PR state.
+                  const parts = [];
+                  if ((review.body || '').trim()) {
+                    parts.push(review.body.trim());
+                  }
+                  try {
+                    const result = await github.graphql(`
+                      query($owner:String!,$repo:String!,$pr:Int!) {
+                        repository(owner:$owner,name:$repo) {
+                          pullRequest(number:$pr) {
+                            reviewThreads(first:100) {
+                              nodes {
+                                isResolved
+                                comments(first:1) { nodes { body path } }
+                              }
+                            }
+                          }
+                        }
+                      }`, {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pr: prNumber,
+                    });
+                    const threads = (result.repository
+                      && result.repository.pullRequest
+                      && result.repository.pullRequest.reviewThreads
+                      && result.repository.pullRequest.reviewThreads.nodes)
+                      || [];
+                    for (const t of threads) {
+                      if (t.isResolved) {
+                        continue;
+                      }
+                      const first = t.comments
+                        && t.comments.nodes
+                        && t.comments.nodes[0];
+                      if (first && (first.body || '').trim()) {
+                        const where = first.path ? (first.path + ': ') : '';
+                        parts.push('- ' + where + first.body.trim());
+                      }
+                    }
+                  } catch (err) {
+                    core.info('Could not read review threads on PR #'
+                      + prNumber + ': ' + err.message);
+                  }
+                  const directive = parts.join('\n').trim()
+                    || 'Address the requested changes.';
+                  run = true;
+                  reviewAutoRevise = true;
+                  reviewPrNumber = prNumber;
+                  ctx = {
+                    trigger: 'revise',
+                    item_type: 'pull_request',
+                    item_number: prNumber,
+                    directive,
+                  };
+                }
+              }
+            }
+
+            // The needs-human label was cleared on a task sub-issue (resume a
+            // step 5 or step 6 hand-off this agent applied). needs-human is
+            // shared by all six SDD agents, so the agent itself confirms the
+            // item is one it handed off before resuming.
+            if (event === 'issues' && payload.action === 'unlabeled') {
+              const label = payload.label && payload.label.name;
+              if (label === 'needs-human') {
+                run = true;
+                ctx = {
+                  trigger: 'resume',
+                  item_type: 'issue',
+                  item_number: payload.issue.number,
+                };
+              }
+            }
+
+            // The needs-human label was cleared on a pull request (resume a
+            // step 7 hand-off this agent applied). needs-human is shared by
+            // all six SDD agents, so the agent itself confirms the pull
+            // request is one it opened before resuming.
+            if (event === 'pull_request' && payload.action === 'unlabeled') {
+              const label = payload.label && payload.label.name;
+              if (label === 'needs-human') {
+                run = true;
+                ctx = {
+                  trigger: 'resume',
+                  item_type: 'pull_request',
+                  item_number: payload.pull_request.number,
+                };
+              }
+            }
+
+            // A fast-path implementation PR was merged. The wrapper detects
+            // a merged PR whose head ref follows the `sdd/<n>-` convention
+            // and whose referenced work-item is the tracking issue itself
+            // (no parent_issue_url, no task sub-issue tree). On that match
+            // the agent is invoked with `entry: 'fastpath-complete'` to run
+            // step 8's completion sweep: `sdd:in-progress → sdd:done` on
+            // the tracking issue, plus `needs-human` for the human's final
+            // close. A merged full-path implementation PR (whose head ref
+            // also follows `sdd/<task-id>-` but whose work-item is a task
+            // sub-issue) is left to the existing flow: the merge closes
+            // the task sub-issue via `Closes #<task>`, the `issues.closed`
+            // event re-fires `sdd-dispatch`, and `sdd-execute`'s next idle
+            // run (step 8) handles the feature-completion sweep. See
+            // ADR 0012.
+            if (event === 'pull_request' && payload.action === 'closed'
+                && payload.pull_request.merged === true) {
+              const headRef = payload.pull_request.head
+                && payload.pull_request.head.ref || '';
+              const headMatch = headRef.match(/^sdd\/(\d+)-/);
+              if (headMatch) {
+                const refNumber = parseInt(headMatch[1], 10);
+                let isFastpath = false;
+                try {
+                  const { data } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: refNumber,
+                  });
+                  // A tracking issue has no parent_issue_url. A task
+                  // sub-issue has its Unit as parent. We treat
+                  // "no parent and currently in-progress" as the
+                  // fast-path completion signal.
+                  const parentUrl = data.parent_issue_url || '';
+                  const labels = (data.labels || []).map(
+                    (l) => l.name || l);
+                  const fastpathSignal = labels.includes('sdd:fastpath')
+                    || labels.includes('sdd:fastpath-review')
+                    || (!parentUrl
+                      && labels.includes('sdd:in-progress')
+                      && !labels.includes('sdd:dispatched'));
+                  if (!parentUrl && fastpathSignal) {
+                    isFastpath = true;
+                  }
+                } catch (err) {
+                  core.info('Could not fetch ref #' + refNumber + ': '
+                    + err.message);
+                }
+                if (isFastpath) {
+                  run = true;
+                  ctx = {
+                    trigger: 'command',
+                    entry: 'fastpath-complete',
+                    item_type: 'issue',
+                    item_number: refNumber,
+                  };
+                }
+              }
+            }
+
+            // Tier gate. sdd-triage assigns each task sub-issue exactly one
+            // model:* label. Every trigger this wrapper handles resolves to a
+            // specific task sub-issue: directly for an issue event, through
+            // the pull request's `Closes #<task>` reference for a
+            // pull-request event, and through the aw_context input for a
+            // workflow_dispatch from sdd-dispatch. This variant runs only
+            // when that sub-issue carries the model:<TIER> label. This stops
+            // the needless agent run, and its inference cost, on the two
+            // tiers the trigger does not belong to. sdd-dispatch already
+            // picks the matching variant per task (the matrix cell selects
+            // the wrapper file by tier), so the tier gate here is a
+            // defence-in-depth check that catches the corner where a task's
+            // model:* label has changed between dispatch and pickup.
+            //
+            // The fast-path entries (`entry: 'fastpath'` from sdd-spec's
+            // /approve, and `entry: 'fastpath-complete'` from a merged
+            // implementation PR) bypass the tier gate: the work-item on a
+            // fast-path entry is the tracking issue, which carries no
+            // model:* label by design. The completion entry only moves
+            // labels and posts a comment; the dispatch entry's tier match
+            // is enforced by sdd-spec when it picks the variant to
+            // workflow_dispatch.
+            const fastpathEntry = ctx && (
+              ctx.entry === 'fastpath' || ctx.entry === 'fastpath-complete');
+            if (run && fastpathEntry && ctx.entry === 'fastpath') {
+              // For the fastpath dispatch entry, the wrapper still confirms
+              // that the variant matches the tier the plan comment names.
+              // sdd-spec is expected to dispatch the matching variant
+              // directly, but a misroute (operator-run workflow_dispatch
+              // with a hand-supplied aw_context) is rejected here.
+              const planTier = (ctx.tier || '').toLowerCase();
+              if (planTier && planTier !== TIER) {
+                core.info('Fast-path dispatch tier (' + planTier
+                  + ') does not match this variant (' + TIER
+                  + '); this variant skips it.');
+                run = false;
+                ctx = {};
+              }
+            }
+            if (run && !fastpathEntry) {
+              let taskIssue = 0;
+              // A pull-request review/revise event on a fast-path
+              // implementation PR identifies the tracking issue (not a
+              // task sub-issue) via the head ref. The tracking issue
+              // has no `model:*` label by design (ADR 0012). Mark this
+              // case so the tier gate accepts a fast-path tracking
+              // issue in lieu of a model-label match. `prBody` is
+              // hoisted to outer scope so the tier-marker scan in the
+              // label-check block can read it.
+              let inferredFastpathFromPr = false;
+              let prBody = '';
+              if (ctx.item_type === 'issue') {
+                taskIssue = ctx.item_number;
+              } else if (ctx.item_type === 'pull_request') {
+                // A pull_request_review_comment event carries the pull
+                // request inline; an issue_comment event (a /revise comment)
+                // does not, so fetch the pull request to read its body and
+                // head ref.
+                prBody = (payload.pull_request
+                  && payload.pull_request.body) || '';
+                let prHeadRef = (payload.pull_request
+                  && payload.pull_request.head
+                  && payload.pull_request.head.ref) || '';
+                if (!prBody || !prHeadRef) {
+                  try {
+                    const { data } = await github.rest.pulls.get({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: ctx.item_number,
+                    });
+                    prBody = prBody || (data.body || '');
+                    prHeadRef = prHeadRef
+                      || (data.head && data.head.ref) || '';
+                  } catch (err) {
+                    core.info('Could not fetch pull request #'
+                      + ctx.item_number + ': ' + err.message);
+                  }
+                }
+                // The pull request body is the documented place for the task
+                // sub-issue reference (`Closes #<task>`); prefer it.
+                const m = prBody.match(
+                  /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i);
+                if (m) {
+                  taskIssue = parseInt(m[1], 10);
+                } else {
+                  // Fall back to the head ref, which this agent encodes as
+                  // `sdd/<task-id>-<slug>` for every implementation pull
+                  // request it opens. This is robust against a future PR
+                  // whose body omits `Closes #<task>` for any reason, and
+                  // makes the route gate independent of body text. See #68.
+                  // A fast-path PR encodes the tracking issue here (no
+                  // `Closes #` reference exists, since the tracking issue
+                  // stays open until a human closes it per ADR 0012).
+                  const refMatch = prHeadRef.match(/^sdd\/(\d+)-/);
+                  if (refMatch) {
+                    taskIssue = parseInt(refMatch[1], 10);
+                    inferredFastpathFromPr = true;
+                  }
+                }
+              }
+              let tierMatch = false;
+              if (taskIssue) {
+                try {
+                  const { data } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: taskIssue,
+                  });
+                  const labels = (data.labels || []).map(
+                    (l) => l.name || l);
+                  const hasTier = labels.includes('model:' + TIER);
+                  // A fast-path tracking issue carries no `model:*` label
+                  // (ADR 0012); identify it by the lifecycle labels and
+                  // the absence of a parent. On a fast-path PR
+                  // review/revise event, prefer the durable PR-body
+                  // tier marker `[sdd-fastpath: tracking=<N>
+                  // tier=<tier>]` written by sdd-execute on PR open
+                  // (per sdd-execute-{tier}.md, step 5 fast-path
+                  // paragraph). The marker is the strong routing
+                  // signal: it pinpoints the tier so only the matching
+                  // variant runs. When the marker is absent (e.g. a
+                  // pre-marker PR), fall back to the
+                  // fast-path-tracking-issue heuristic, which lets all
+                  // three variants pass the route gate; the agent
+                  // itself then noops on tier mismatch.
+                  const isTracking = !data.parent_issue_url;
+                  const isFastpathTracking = isTracking && (
+                    labels.includes('sdd:fastpath')
+                    || labels.includes('sdd:fastpath-review')
+                    || labels.includes('sdd:in-progress')
+                    || labels.includes('sdd:done'));
+                  let fastpathTierMatch = false;
+                  if (inferredFastpathFromPr && isFastpathTracking) {
+                    const markerRe = new RegExp(
+                      '\\[sdd-fastpath:\\s*tracking=\\d+\\s+'
+                      + 'tier=(haiku|sonnet|opus)\\]', 'i');
+                    const markerHit = (prBody || '').match(markerRe);
+                    if (markerHit) {
+                      fastpathTierMatch =
+                        markerHit[1].toLowerCase() === TIER;
+                    } else {
+                      // Marker absent (e.g. an older fast-path PR
+                      // opened before the marker convention landed).
+                      // Resolve the owning tier from the stable
+                      // metadata source: the execution plan comment on
+                      // the tracking issue carries the `model:*` line.
+                      // Walk the comments looking for the
+                      // `[sdd-spec:fastpath-plan]` marker, pick the
+                      // latest such comment (mirrors the wrapper's
+                      // fastpath-approve job logic), and parse its
+                      // `model:` line. Match this variant only when
+                      // the resolved tier equals TIER. This keeps
+                      // tier ownership stable for review/revise even
+                      // without the PR-body marker.
+                      const planMarker = '[sdd-spec:fastpath-plan]';
+                      let planComment = null;
+                      let page = 1;
+                      try {
+                        for (;;) {
+                          const { data } = await github.rest.issues
+                            .listComments({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: taskIssue,
+                              per_page: 100,
+                              page,
+                            });
+                          for (const c of data) {
+                            if ((c.body || '').includes(planMarker)) {
+                              if (!planComment
+                                  || (new Date(c.created_at))
+                                    > (new Date(planComment.created_at))) {
+                                planComment = c;
+                              }
+                            }
+                          }
+                          if (data.length < 100) {
+                            break;
+                          }
+                          page += 1;
+                        }
+                      } catch (planErr) {
+                        core.info('Could not list comments on tracking'
+                          + ' issue #' + taskIssue + ' for tier'
+                          + ' resolution: ' + planErr.message);
+                      }
+                      if (planComment) {
+                        const planTierHit = (planComment.body || '')
+                          .match(
+                            /model\s*:\s*(haiku|sonnet|opus)\b/i);
+                        if (planTierHit) {
+                          fastpathTierMatch =
+                            planTierHit[1].toLowerCase() === TIER;
+                        }
+                      }
+                    }
+                  }
+                  tierMatch = hasTier || fastpathTierMatch;
+                } catch (err) {
+                  core.info('Could not read labels for #' + taskIssue
+                    + ': ' + err.message);
+                }
+              }
+              if (!tierMatch) {
+                core.info('Task is not the model:' + TIER
+                  + ' tier; this variant skips it.');
+                run = false;
+                ctx = {};
+              }
+            }
+
+            // Auto-revise loop bound (issue #128). Only the owning tier
+            // reaches here with run still true (the tier gate above cleared
+            // run for the two non-owning variants), so the cap count and its
+            // side effects happen exactly once per CHANGES_REQUESTED review.
+            // Cap is tracked by a hidden marker comment so no extra label is
+            // needed. On cap, apply needs-human and stop;
+            // SDD_MAX_REVIEW_ITERATIONS defaults to 3.
+            if (run && reviewAutoRevise && reviewPrNumber) {
+              const MARKER = '<!-- sdd-execute:auto-revise -->';
+              const maxIters = parseInt(
+                process.env.SDD_MAX_REVIEW_ITERATIONS || '3', 10);
+              let priorIters = 0;
+              let page = 1;
+              try {
+                for (;;) {
+                  const { data } = await github.rest.issues.listComments({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: reviewPrNumber,
+                    per_page: 100,
+                    page,
+                  });
+                  for (const c of data) {
+                    if ((c.body || '').includes(MARKER)) {
+                      priorIters += 1;
+                    }
+                  }
+                  if (data.length < 100) {
+                    break;
+                  }
+                  page += 1;
+                }
+              } catch (err) {
+                core.info('Could not list comments on PR #' + reviewPrNumber
+                  + ' for iteration count: ' + err.message);
+              }
+              if (priorIters >= maxIters) {
+                core.info('Auto-revise cap (' + maxIters + ') reached on PR #'
+                  + reviewPrNumber + '; applying needs-human.');
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: reviewPrNumber,
+                    labels: ['needs-human'],
+                  });
+                } catch (err) {
+                  core.info('Could not apply needs-human to PR #'
+                    + reviewPrNumber + ': ' + err.message);
+                }
+                run = false;
+                ctx = {};
+              } else {
+                // Post the hidden iteration marker so the next review counts
+                // this cycle toward the cap.
+                try {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: reviewPrNumber,
+                    body: MARKER + '\nAuto-revise ' + (priorIters + 1)
+                      + ' of ' + maxIters
+                      + ' from a CHANGES_REQUESTED review.',
+                  });
+                } catch (err) {
+                  core.info('Could not post auto-revise marker on PR #'
+                    + reviewPrNumber + ': ' + err.message);
+                }
+              }
+            }
+
+            core.setOutput('should_run', run ? 'true' : 'false');
+            core.setOutput('aw_context', run ? JSON.stringify(ctx) : '');
+
+  sdd-execute-haiku:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@main
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+
+  # Enable GitHub auto-merge on the PR sdd-execute just opened (issue #127).
+  # The reusable lock exposes the new PR number via its create_pull_request
+  # safe-output as the workflow_call output created_pr_number; this job reads
+  # it and turns on squash + delete-branch auto-merge so a green cascade PR
+  # merges with no human in the loop. Gated OFF by default: it runs only when
+  # the repo variable SDD_AUTO_MERGE is set to a truthy value, so repos
+  # without branch protection are unaffected (behavior unchanged when unset).
+  auto-merge:
+    needs: [route, sdd-execute-haiku]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.sdd-execute-haiku.outputs.created_pr_number != ''
+      && (vars.SDD_AUTO_MERGE == '1'
+        || vars.SDD_AUTO_MERGE == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Mint the App token: reading branch protection needs administration:
+      # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
+      # lacks, and enabling auto-merge needs pull-requests + contents write.
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+          permission-contents: write
+          permission-pull-requests: write
+      # Only enable auto-merge when the repo allows it AND the base branch
+      # protection defines at least one required status check. If neither
+      # holds, `gh pr merge --auto` errors or the PR merges immediately, so
+      # detect and skip (issue #127). When both hold, enable squash +
+      # delete-branch auto-merge to match the manual-merge convention.
+      #
+      # `enablePullRequestAutoMerge` refuses an UNSTABLE PR even when every
+      # REQUIRED check is green: cancelled sibling-tier check-runs (from
+      # cancelled sibling sdd-execute runs of other model tiers) and
+      # non-required checks such as `auto-merge`/`route` leave the PR UNSTABLE,
+      # so `--auto` errors with "Pull request is in unstable status" and the
+      # cascade PR never merges (issue #135). Branch protection gates only on
+      # the required checks, so when those are all green a direct squash merge
+      # is exactly what auto-merge would do once the non-required noise
+      # settled. The step therefore keys off REQUIRED checks only: it arms
+      # `--auto`, and if that fails because the PR is UNSTABLE with every
+      # required check already green, it falls back to a direct squash merge.
+      - name: Enable auto-merge when protection requires a check
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          PR_NUMBER: ${{ needs.sdd-execute-haiku.outputs.created_pr_number }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          allow=$(gh api "repos/${OWNER}/${REPO}" --jq '.allow_auto_merge')
+          if [ "$allow" != "true" ]; then
+            echo "Repo does not allow auto-merge; skipping."
+            exit 0
+          fi
+          base=$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" \
+            --jq '.base.ref')
+          # URL-encode the base ref so a branch name containing `/` (e.g.
+          # release/2026.05) does not split the protection endpoint path.
+          base_encoded=$(printf '%s' "$base" | jq -sRr @uri)
+          # Read the required status checks on the base branch. The protection
+          # endpoint 404s when no protection is configured; treat that as
+          # "no required checks" and skip. `.checks[].context` (new) and
+          # `.contexts[]` (legacy) cover both shapes; an absent
+          # required_status_checks yields an empty list.
+          required_names=$(gh api \
+            "repos/${OWNER}/${REPO}/branches/${base_encoded}/protection" \
+            --jq '[(.required_status_checks.checks // [] | .[].context),
+              (.required_status_checks.contexts // [] | .[])] | unique | .[]' \
+            2>/dev/null || true)
+          if [ -z "${required_names}" ]; then
+            echo "Base branch ${base} has no required status checks;" \
+              "skipping auto-merge (would merge immediately)."
+            exit 0
+          fi
+          # Arm GitHub auto-merge. This succeeds for a CLEAN or BLOCKED PR and
+          # waits for the required checks to go green before merging.
+          if gh pr merge "${PR_NUMBER}" --auto --squash --delete-branch \
+            --repo "${OWNER}/${REPO}"; then
+            echo "Auto-merge (squash, delete-branch) enabled on PR" \
+              "#${PR_NUMBER}."
+            exit 0
+          fi
+          # Arming failed. The common cause is an UNSTABLE mergeStateStatus:
+          # cancelled sibling-tier check-runs and non-required `auto-merge`/
+          # `route` checks leave the PR UNSTABLE, which
+          # `enablePullRequestAutoMerge` refuses, even though branch
+          # protection gates only on the required checks (issue #135). Key off
+          # REQUIRED checks only: if the PR is UNSTABLE and every required
+          # check has already concluded SUCCESS, the non-required noise is the
+          # only thing blocking the GraphQL mutation, so merge directly — the
+          # same squash + delete-branch merge auto-merge would perform.
+          state=$(gh pr view "${PR_NUMBER}" --repo "${OWNER}/${REPO}" \
+            --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null \
+            || echo UNKNOWN)
+          if [ "${state}" != "UNSTABLE" ]; then
+            echo "Auto-merge could not be armed and PR #${PR_NUMBER} is" \
+              "${state}, not UNSTABLE; leaving for human review." >&2
+            exit 1
+          fi
+          # Confirm every required check has concluded SUCCESS on this PR.
+          rollup=$(gh pr view "${PR_NUMBER}" --repo "${OWNER}/${REPO}" \
+            --json statusCheckRollup \
+            --jq '[.statusCheckRollup[]
+              | {name: (.name // .context),
+                 state: (.conclusion // .state // .status)}]')
+          all_green=true
+          while IFS= read -r name; do
+            [ -z "${name}" ] && continue
+            st=$(printf '%s' "${rollup}" | jq -r \
+              --arg n "${name}" \
+              'map(select(.name == $n)) | (last.state // "MISSING")')
+            if [ "${st}" != "SUCCESS" ]; then
+              echo "Required check '${name}' is '${st}', not SUCCESS;" \
+                "not merging PR #${PR_NUMBER}." >&2
+              all_green=false
+            fi
+          done <<< "${required_names}"
+          if [ "${all_green}" != "true" ]; then
+            exit 1
+          fi
+          gh pr merge "${PR_NUMBER}" --squash --delete-branch \
+            --repo "${OWNER}/${REPO}"
+          echo "PR #${PR_NUMBER} was UNSTABLE with all required checks green;" \
+            "merged directly (squash, delete-branch)."

--- a/.github/workflows/sdd-execute-opus.yml
+++ b/.github/workflows/sdd-execute-opus.yml
@@ -1,0 +1,963 @@
+name: sdd-execute-opus
+
+# Thin wrapper for the sdd-execute agent, opus model-tier variant.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-execute-opus.lock.yml (compiled from
+# sdd-execute-opus.md, which declares on: workflow_call). This wrapper carries
+# the real event triggers, gates the /execute comment command to authors with
+# repository write access, and passes the triggering entity to the agent
+# through the aw_context input. A consumer repository installs this wrapper
+# unchanged.
+#
+# sdd-execute is compiled into three model-tier variants (haiku, sonnet, opus)
+# that differ only in the engine model and the model:* tier they claim. This
+# wrapper is the opus-tier caller; sdd-execute-haiku.yml and
+# sdd-execute-sonnet.yml are its haiku and sonnet siblings.
+#
+# Execution is event-driven, not scheduled. The daily cron that previously
+# drained each tier's queue has been removed: this wrapper now triggers only
+# on workflow_dispatch (from sdd-dispatch's bounded matrix fan-out) and on an
+# explicit /execute comment from a write-access human. The pipeline is
+# /approve -> /dispatch -> cascade-on-close (see issue #81 and ADR 0011).
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A workflow_dispatch from sdd-dispatch (one matrix cell per ready task) or
+  # from an operator running the queue by hand.
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        description: |
+          JSON string naming the triggering entity; mirrors the issue_comment
+          route output. sdd-dispatch fans out one cell per ready task with
+          {trigger: 'command', item_type: 'issue', item_number: <task>}.
+        required: false
+        type: string
+  # A /execute comment on a task sub-issue.
+  issue_comment:
+    types: [created]
+  # A review comment on a pull request this agent opened.
+  pull_request_review_comment:
+    types: [created]
+  # A formal review on a pull request this agent opened. A CHANGES_REQUESTED
+  # review from CodeRabbit or a write-access human on an `sdd/` branch is
+  # treated as an implicit /revise (issue #128). A COMMENTED or APPROVED
+  # review does not trigger a revise.
+  pull_request_review:
+    types: [submitted]
+  # The needs-human label being cleared on a task sub-issue, which re-triggers
+  # the agent to resume a hand-off it applied at step 5 or step 6.
+  issues:
+    types: [unlabeled]
+  # The needs-human label being cleared on a pull request this agent opened,
+  # which re-triggers the agent to resume a hand-off it applied at step 7.
+  # The `closed` action covers the fast-path completion path (ADR 0012): a
+  # merged implementation PR on a `sdd/` branch whose work-item is a
+  # tracking issue (no parent_issue_url, no task sub-issue tree) re-fires
+  # the agent with `entry: 'fastpath-complete'` so step 8's completion
+  # sweep can move the tracking issue from `sdd:in-progress` to `sdd:done`
+  # directly.
+  pull_request:
+    types: [unlabeled, closed]
+
+permissions:
+  contents: read
+
+# Concurrency group keyed on the task issue number AND this variant's tier.
+# A stale sdd-dispatch fan-out racing with a manual /execute on the same task
+# in the same tier collapses to one running cell: cancel-in-progress: true
+# supersedes the in-progress cell with the later trigger so a user-initiated
+# /execute wins over a stale dispatch (and vice versa: a fresh dispatch wins
+# over an earlier in-flight cell). The tier discriminator is required because
+# the three sdd-execute-{haiku,sonnet,opus} wrappers all subscribe to the same
+# event triggers; without the tier suffix a non-matching-tier wake would land
+# in the same group as the matching-tier run and the cancel-in-progress rule
+# could kill the only run doing real work (issue #124). Cancel-in-progress is
+# set on the wrapper itself because the gh-aw lock declares its own
+# activation-level concurrency keyed on the workflow name; this wrapper-level
+# group adds the per-task-per-tier dimension on top.
+#
+# The fromJSON(github.event.inputs.aw_context || '{}') branch reads the
+# dispatcher's well-formed aw_context JSON for the workflow_dispatch path.
+# Manual workflow_dispatch invocations that supply malformed JSON will fail
+# workflow evaluation here, which is the correct failure mode (the route
+# step's try/catch would silently ignore them and the run would do nothing
+# useful).
+#
+# A label-removal event (issues.unlabeled / pull_request.unlabeled) is routed
+# to its own throwaway group (github.run_id) so it never lands in a task's
+# shared per-task-per-tier group. At step 2 the agent removes its own task's
+# sdd:ready label; that self-induced issues.unlabeled event re-fires this
+# wrapper, and without the carve-out it entered the active run's group where
+# cancel-in-progress killed the running agent mid-work (issue #143). The only
+# label-removal the route step acts on is needs-human (a resume), which runs
+# when no agent is in flight, so a unique group is safe there too.
+#
+# An issue_comment whose body is not a recognized command (/execute or
+# /revise) is routed to its own throwaway group for the same reason.
+# gh-aw's create-pull-request fallback-to-issue posts an "Issue created:
+# #<n>" notice on the task issue via the App token (issue #142); that
+# App-authored comment re-fires this wrapper as issue_comment.created,
+# and without the carve-out it landed in the active run's per-task group
+# where cancel-in-progress killed the originating run's safe_outputs tail
+# and its auto-merge job. The route step acts only on /execute and
+# /revise comments, so a non-command comment in a unique group is safe.
+concurrency:
+  group: sdd-execute-opus-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate below is the wrapper-level command + tier + label
+  # filter (fixes issue #119 and the matching-tier slice of issue #114). It
+  # runs BEFORE the route job's runner is allocated, so a /dispatch comment, a
+  # /spec comment, or any other unrelated comment never spends a runner
+  # minute on this wrapper. The issues clause does the same for label events:
+  # the route step only routes an `issues` event on `unlabeled` `needs-human`
+  # (the step 5/6 resume), so any other label add/remove — e.g. the
+  # `sdd:ready`/`sdd:in-progress`/`sdd:dispatched` mutations a /dispatch
+  # performs on a tracking issue — is skipped here without a runner. The
+  # route step's own tier resolution stays as a defence-in-depth check (it
+  # covers /revise on a sdd/ PR, where the model label lives on the linked
+  # task, not the PR — too expensive to resolve at workflow-evaluation time
+  # without an API call).
+  route:
+    if: |
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          (
+            startsWith(github.event.comment.body, '/execute')
+            && contains(github.event.issue.labels.*.name, 'model:opus')
+          )
+          || startsWith(github.event.comment.body, '/revise')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && github.event.action == 'unlabeled'
+        && github.event.label.name == 'needs-human'
+      )
+    runs-on: ubuntu-latest
+    # pull-requests: read is needed for the tier gate on a /revise issue_comment
+    # (situation 6): the route fetches the pull request to read its body and
+    # extract the `Closes #<task>` reference. Without this grant, the GET
+    # /repos/{owner}/{repo}/pulls/{N} call returns 403 "Resource not accessible
+    # by integration" and the tier gate defaults to false, skipping every
+    # variant. See #68.
+    #
+    # issues: write and pull-requests: write are needed by the CHANGES_REQUESTED
+    # auto-revise branch (issue #128): it posts a hidden iteration-marker
+    # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
+    # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
+    # re-trigger workflows, so this does not feed back into the route.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: actions/github-script@v9
+        env:
+          # The configured GitHub App ID, used to accept /execute comments
+          # posted by sdd-dispatch's cascade fan-out (ADR 0014). A human's
+          # /execute still goes through the repo-permission check below.
+          APP_ID: ${{ vars.APP_ID }}
+          # Cap on auto-revise cycles per PR for CHANGES_REQUESTED reviews
+          # (issue #128); defaults to 3 when the repo variable is unset.
+          SDD_MAX_REVIEW_ITERATIONS: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}
+        with:
+          script: |
+            const event = context.eventName;
+            const payload = context.payload;
+            let run = false;
+            let ctx = {};
+            // Set true by the CHANGES_REQUESTED auto-revise branch (issue
+            // #128). The cap count, hidden marker, and needs-human side
+            // effects are deferred until AFTER the tier gate below confirms
+            // this variant owns the PR, so the two non-owning tiers never
+            // mutate PR state (they would otherwise inflate the cap count).
+            let reviewAutoRevise = false;
+            let reviewPrNumber = 0;
+
+            // This wrapper is the opus model tier; the tier gate below
+            // skips a task another tier owns.
+            const TIER = 'opus';
+
+            // A workflow_dispatch from sdd-dispatch (or from an operator
+            // running the queue by hand) carries an aw_context input naming
+            // the task to implement. The cron-based "schedule" trigger has
+            // been removed (issue #81 / ADR 0011): execution is event-driven
+            // now, dispatched per task from the cascade.
+            if (event === 'workflow_dispatch') {
+              const raw = (payload.inputs && payload.inputs.aw_context) || '';
+              if (raw) {
+                try {
+                  ctx = JSON.parse(raw);
+                  if (ctx && ctx.item_number) {
+                    run = true;
+                  } else {
+                    core.info('workflow_dispatch aw_context missing'
+                      + ' item_number; ignoring.');
+                  }
+                } catch (err) {
+                  core.info('workflow_dispatch aw_context not parseable: '
+                    + err.message);
+                }
+              } else {
+                core.info('workflow_dispatch with no aw_context; ignoring.');
+              }
+            }
+
+            // A /execute or /revise comment from either an author with repo
+            // write access or sdd-dispatch's App identity. The gate is the
+            // actor's real repository permission, not author_association:
+            // author_association reports the relationship to the thread
+            // (OWNER/MEMBER/COLLABORATOR), which is not the same as push
+            // access. A MEMBER of the org need not have write on this repo,
+            // and a COLLABORATOR may be read-only. The
+            // collaborators/{user}/permission API returns the actual
+            // permission level; only write, maintain, or admin may run a
+            // command. /execute on a pull request is ignored: it is a
+            // task-sub-issue command only.
+            //
+            // sdd-dispatch fans the cascade out by posting /execute on each
+            // ready task issue via the App installation token (ADR 0014).
+            // The App user is not a collaborator and would 404 the
+            // permission check, so accept the command when the comment's
+            // performed_via_github_app.id matches the configured APP_ID.
+            // Any other bot posting /execute is still rejected.
+            if (event === 'issue_comment' && payload.action === 'created') {
+              const body = (payload.comment.body || '').trim();
+              const firstWord = body.split(/\s+/)[0];
+              const isPr = !!payload.issue.pull_request;
+              const isExecute = firstWord === '/execute' && !isPr;
+              const isRevise = firstWord === '/revise' && isPr;
+              if (firstWord === '/execute' && isPr) {
+                core.info('/execute on a pull request; ignoring.');
+              } else if (isExecute || isRevise) {
+                const appId = parseInt(process.env.APP_ID || '0', 10);
+                const appComment = payload.comment.performed_via_github_app;
+                const fromConfiguredApp = appId > 0
+                  && appComment
+                  && appComment.id === appId;
+                let permission = 'none';
+                if (!fromConfiguredApp) {
+                  const actor = payload.comment.user.login;
+                  try {
+                    const resp = await github.rest.repos
+                      .getCollaboratorPermissionLevel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        username: actor,
+                      });
+                    // role_name is the precise role
+                    // (write/maintain/triage/...) when present; permission is
+                    // the legacy bucket (admin/write/read/none) that collapses
+                    // maintain into write and triage into read.
+                    permission = resp.data.role_name || resp.data.permission;
+                  } catch (err) {
+                    core.info(
+                      'Could not resolve repo permission for ' + actor
+                      + ': ' + err.message);
+                  }
+                }
+                const canWrite = fromConfiguredApp
+                  || permission === 'write'
+                  || permission === 'maintain'
+                  || permission === 'admin';
+                if (canWrite) {
+                  run = true;
+                  ctx = isRevise
+                    ? {
+                        trigger: 'revise',
+                        item_type: 'pull_request',
+                        item_number: payload.issue.number,
+                        comment_id: payload.comment.id,
+                      }
+                    : {
+                        trigger: 'command',
+                        item_type: 'issue',
+                        item_number: payload.issue.number,
+                        comment_id: payload.comment.id,
+                      };
+                } else {
+                  core.info(
+                    'Command from an author without write access ('
+                    + permission + '); ignoring.');
+                }
+              }
+            }
+
+            // A review comment on a pull request. The agent confirms the pull
+            // request is one it opened (an sdd/<task-id>-<slug> branch) before
+            // pushing follow-up commits.
+            if (event === 'pull_request_review_comment'
+                && payload.action === 'created') {
+              run = true;
+              ctx = {
+                trigger: 'review_comment',
+                item_type: 'pull_request',
+                item_number: payload.pull_request.number,
+                comment_id: payload.comment.id,
+              };
+            }
+
+            // A formal review with state CHANGES_REQUESTED on an sdd/ PR is
+            // treated as an implicit /revise (issue #128). The directive is
+            // the review body plus the unresolved review-comment threads, so
+            // one revise run addresses the whole verdict; the individual
+            // pull_request_review_comment events that co-arrive collapse into
+            // this run at the per-PR-per-tier concurrency group (the existing
+            // dedupe mechanism). A COMMENTED or APPROVED review does not match
+            // and never triggers a revise. The manual /revise path above is
+            // untouched. The agent confirms ownership (sdd/ head ref + body
+            // marker) at step 7 exactly as it does for a review comment.
+            if (event === 'pull_request_review'
+                && payload.action === 'submitted') {
+              const review = payload.review || {};
+              const state = (review.state || '').toLowerCase();
+              const pr = payload.pull_request || {};
+              const headRef = (pr.head && pr.head.ref) || '';
+              if (state === 'changes_requested'
+                  && headRef.startsWith('sdd/')) {
+                // Author scope: accept CodeRabbit's bot review or a review by
+                // an author with repository write access, mirroring the
+                // /revise permission check above. A login of `coderabbitai`
+                // (with or without a `[bot]` suffix) is the CodeRabbit bot.
+                const reviewer = (review.user && review.user.login) || '';
+                const reviewerLc = reviewer.toLowerCase();
+                const isCodeRabbit = reviewerLc === 'coderabbitai'
+                  || reviewerLc === 'coderabbitai[bot]';
+                let reviewerCanWrite = isCodeRabbit;
+                if (!isCodeRabbit && reviewer) {
+                  let permission = 'none';
+                  try {
+                    const resp = await github.rest.repos
+                      .getCollaboratorPermissionLevel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        username: reviewer,
+                      });
+                    permission = resp.data.role_name || resp.data.permission;
+                  } catch (err) {
+                    core.info('Could not resolve repo permission for '
+                      + reviewer + ': ' + err.message);
+                  }
+                  reviewerCanWrite = permission === 'write'
+                    || permission === 'maintain'
+                    || permission === 'admin';
+                }
+                if (!reviewerCanWrite) {
+                  core.info('CHANGES_REQUESTED review by a non-allowed'
+                    + ' reviewer (' + reviewer + '); ignoring.');
+                } else {
+                  const prNumber = pr.number;
+                  // Assemble the directive: the review body plus the
+                  // unresolved review-comment threads. Resolved threads are
+                  // skipped to avoid re-fixing addressed items. Thread
+                  // resolution state is only exposed by GraphQL. This is
+                  // read-only; the cap count and the side-effecting marker /
+                  // needs-human are deferred to the post-tier-gate block so
+                  // only the owning tier mutates PR state.
+                  const parts = [];
+                  if ((review.body || '').trim()) {
+                    parts.push(review.body.trim());
+                  }
+                  try {
+                    const result = await github.graphql(`
+                      query($owner:String!,$repo:String!,$pr:Int!) {
+                        repository(owner:$owner,name:$repo) {
+                          pullRequest(number:$pr) {
+                            reviewThreads(first:100) {
+                              nodes {
+                                isResolved
+                                comments(first:1) { nodes { body path } }
+                              }
+                            }
+                          }
+                        }
+                      }`, {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pr: prNumber,
+                    });
+                    const threads = (result.repository
+                      && result.repository.pullRequest
+                      && result.repository.pullRequest.reviewThreads
+                      && result.repository.pullRequest.reviewThreads.nodes)
+                      || [];
+                    for (const t of threads) {
+                      if (t.isResolved) {
+                        continue;
+                      }
+                      const first = t.comments
+                        && t.comments.nodes
+                        && t.comments.nodes[0];
+                      if (first && (first.body || '').trim()) {
+                        const where = first.path ? (first.path + ': ') : '';
+                        parts.push('- ' + where + first.body.trim());
+                      }
+                    }
+                  } catch (err) {
+                    core.info('Could not read review threads on PR #'
+                      + prNumber + ': ' + err.message);
+                  }
+                  const directive = parts.join('\n').trim()
+                    || 'Address the requested changes.';
+                  run = true;
+                  reviewAutoRevise = true;
+                  reviewPrNumber = prNumber;
+                  ctx = {
+                    trigger: 'revise',
+                    item_type: 'pull_request',
+                    item_number: prNumber,
+                    directive,
+                  };
+                }
+              }
+            }
+
+            // The needs-human label was cleared on a task sub-issue (resume a
+            // step 5 or step 6 hand-off this agent applied). needs-human is
+            // shared by all six SDD agents, so the agent itself confirms the
+            // item is one it handed off before resuming.
+            if (event === 'issues' && payload.action === 'unlabeled') {
+              const label = payload.label && payload.label.name;
+              if (label === 'needs-human') {
+                run = true;
+                ctx = {
+                  trigger: 'resume',
+                  item_type: 'issue',
+                  item_number: payload.issue.number,
+                };
+              }
+            }
+
+            // The needs-human label was cleared on a pull request (resume a
+            // step 7 hand-off this agent applied). needs-human is shared by
+            // all six SDD agents, so the agent itself confirms the pull
+            // request is one it opened before resuming.
+            if (event === 'pull_request' && payload.action === 'unlabeled') {
+              const label = payload.label && payload.label.name;
+              if (label === 'needs-human') {
+                run = true;
+                ctx = {
+                  trigger: 'resume',
+                  item_type: 'pull_request',
+                  item_number: payload.pull_request.number,
+                };
+              }
+            }
+
+            // A fast-path implementation PR was merged. The wrapper detects
+            // a merged PR whose head ref follows the `sdd/<n>-` convention
+            // and whose referenced work-item is the tracking issue itself
+            // (no parent_issue_url, no task sub-issue tree). On that match
+            // the agent is invoked with `entry: 'fastpath-complete'` to run
+            // step 8's completion sweep: `sdd:in-progress → sdd:done` on
+            // the tracking issue, plus `needs-human` for the human's final
+            // close. A merged full-path implementation PR (whose head ref
+            // also follows `sdd/<task-id>-` but whose work-item is a task
+            // sub-issue) is left to the existing flow: the merge closes
+            // the task sub-issue via `Closes #<task>`, the `issues.closed`
+            // event re-fires `sdd-dispatch`, and `sdd-execute`'s next idle
+            // run (step 8) handles the feature-completion sweep. See
+            // ADR 0012.
+            if (event === 'pull_request' && payload.action === 'closed'
+                && payload.pull_request.merged === true) {
+              const headRef = payload.pull_request.head
+                && payload.pull_request.head.ref || '';
+              const headMatch = headRef.match(/^sdd\/(\d+)-/);
+              if (headMatch) {
+                const refNumber = parseInt(headMatch[1], 10);
+                let isFastpath = false;
+                try {
+                  const { data } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: refNumber,
+                  });
+                  // A tracking issue has no parent_issue_url. A task
+                  // sub-issue has its Unit as parent. We treat
+                  // "no parent and currently in-progress" as the
+                  // fast-path completion signal.
+                  const parentUrl = data.parent_issue_url || '';
+                  const labels = (data.labels || []).map(
+                    (l) => l.name || l);
+                  const fastpathSignal = labels.includes('sdd:fastpath')
+                    || labels.includes('sdd:fastpath-review')
+                    || (!parentUrl
+                      && labels.includes('sdd:in-progress')
+                      && !labels.includes('sdd:dispatched'));
+                  if (!parentUrl && fastpathSignal) {
+                    isFastpath = true;
+                  }
+                } catch (err) {
+                  core.info('Could not fetch ref #' + refNumber + ': '
+                    + err.message);
+                }
+                if (isFastpath) {
+                  run = true;
+                  ctx = {
+                    trigger: 'command',
+                    entry: 'fastpath-complete',
+                    item_type: 'issue',
+                    item_number: refNumber,
+                  };
+                }
+              }
+            }
+
+            // Tier gate. sdd-triage assigns each task sub-issue exactly one
+            // model:* label. Every trigger this wrapper handles resolves to a
+            // specific task sub-issue: directly for an issue event, through
+            // the pull request's `Closes #<task>` reference for a
+            // pull-request event, and through the aw_context input for a
+            // workflow_dispatch from sdd-dispatch. This variant runs only
+            // when that sub-issue carries the model:<TIER> label. This stops
+            // the needless agent run, and its inference cost, on the two
+            // tiers the trigger does not belong to. sdd-dispatch already
+            // picks the matching variant per task (the matrix cell selects
+            // the wrapper file by tier), so the tier gate here is a
+            // defence-in-depth check that catches the corner where a task's
+            // model:* label has changed between dispatch and pickup.
+            //
+            // The fast-path entries (`entry: 'fastpath'` from sdd-spec's
+            // /approve, and `entry: 'fastpath-complete'` from a merged
+            // implementation PR) bypass the tier gate: the work-item on a
+            // fast-path entry is the tracking issue, which carries no
+            // model:* label by design. The completion entry only moves
+            // labels and posts a comment; the dispatch entry's tier match
+            // is enforced by sdd-spec when it picks the variant to
+            // workflow_dispatch.
+            const fastpathEntry = ctx && (
+              ctx.entry === 'fastpath' || ctx.entry === 'fastpath-complete');
+            if (run && fastpathEntry && ctx.entry === 'fastpath') {
+              // For the fastpath dispatch entry, the wrapper still confirms
+              // that the variant matches the tier the plan comment names.
+              // sdd-spec is expected to dispatch the matching variant
+              // directly, but a misroute (operator-run workflow_dispatch
+              // with a hand-supplied aw_context) is rejected here.
+              const planTier = (ctx.tier || '').toLowerCase();
+              if (planTier && planTier !== TIER) {
+                core.info('Fast-path dispatch tier (' + planTier
+                  + ') does not match this variant (' + TIER
+                  + '); this variant skips it.');
+                run = false;
+                ctx = {};
+              }
+            }
+            if (run && !fastpathEntry) {
+              let taskIssue = 0;
+              // A pull-request review/revise event on a fast-path
+              // implementation PR identifies the tracking issue (not a
+              // task sub-issue) via the head ref. The tracking issue
+              // has no `model:*` label by design (ADR 0012). Mark this
+              // case so the tier gate accepts a fast-path tracking
+              // issue in lieu of a model-label match. `prBody` is
+              // hoisted to outer scope so the tier-marker scan in the
+              // label-check block can read it.
+              let inferredFastpathFromPr = false;
+              let prBody = '';
+              if (ctx.item_type === 'issue') {
+                taskIssue = ctx.item_number;
+              } else if (ctx.item_type === 'pull_request') {
+                // A pull_request_review_comment event carries the pull
+                // request inline; an issue_comment event (a /revise comment)
+                // does not, so fetch the pull request to read its body and
+                // head ref.
+                prBody = (payload.pull_request
+                  && payload.pull_request.body) || '';
+                let prHeadRef = (payload.pull_request
+                  && payload.pull_request.head
+                  && payload.pull_request.head.ref) || '';
+                if (!prBody || !prHeadRef) {
+                  try {
+                    const { data } = await github.rest.pulls.get({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: ctx.item_number,
+                    });
+                    prBody = prBody || (data.body || '');
+                    prHeadRef = prHeadRef
+                      || (data.head && data.head.ref) || '';
+                  } catch (err) {
+                    core.info('Could not fetch pull request #'
+                      + ctx.item_number + ': ' + err.message);
+                  }
+                }
+                // The pull request body is the documented place for the task
+                // sub-issue reference (`Closes #<task>`); prefer it.
+                const m = prBody.match(
+                  /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i);
+                if (m) {
+                  taskIssue = parseInt(m[1], 10);
+                } else {
+                  // Fall back to the head ref, which this agent encodes as
+                  // `sdd/<task-id>-<slug>` for every implementation pull
+                  // request it opens. This is robust against a future PR
+                  // whose body omits `Closes #<task>` for any reason, and
+                  // makes the route gate independent of body text. See #68.
+                  // A fast-path PR encodes the tracking issue here (no
+                  // `Closes #` reference exists, since the tracking issue
+                  // stays open until a human closes it per ADR 0012).
+                  const refMatch = prHeadRef.match(/^sdd\/(\d+)-/);
+                  if (refMatch) {
+                    taskIssue = parseInt(refMatch[1], 10);
+                    inferredFastpathFromPr = true;
+                  }
+                }
+              }
+              let tierMatch = false;
+              if (taskIssue) {
+                try {
+                  const { data } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: taskIssue,
+                  });
+                  const labels = (data.labels || []).map(
+                    (l) => l.name || l);
+                  const hasTier = labels.includes('model:' + TIER);
+                  // A fast-path tracking issue carries no `model:*` label
+                  // (ADR 0012); identify it by the lifecycle labels and
+                  // the absence of a parent. On a fast-path PR
+                  // review/revise event, prefer the durable PR-body
+                  // tier marker `[sdd-fastpath: tracking=<N>
+                  // tier=<tier>]` written by sdd-execute on PR open
+                  // (per sdd-execute-{tier}.md, step 5 fast-path
+                  // paragraph). The marker is the strong routing
+                  // signal: it pinpoints the tier so only the matching
+                  // variant runs. When the marker is absent (e.g. a
+                  // pre-marker PR), fall back to the
+                  // fast-path-tracking-issue heuristic, which lets all
+                  // three variants pass the route gate; the agent
+                  // itself then noops on tier mismatch.
+                  const isTracking = !data.parent_issue_url;
+                  const isFastpathTracking = isTracking && (
+                    labels.includes('sdd:fastpath')
+                    || labels.includes('sdd:fastpath-review')
+                    || labels.includes('sdd:in-progress')
+                    || labels.includes('sdd:done'));
+                  let fastpathTierMatch = false;
+                  if (inferredFastpathFromPr && isFastpathTracking) {
+                    const markerRe = new RegExp(
+                      '\\[sdd-fastpath:\\s*tracking=\\d+\\s+'
+                      + 'tier=(haiku|sonnet|opus)\\]', 'i');
+                    const markerHit = (prBody || '').match(markerRe);
+                    if (markerHit) {
+                      fastpathTierMatch =
+                        markerHit[1].toLowerCase() === TIER;
+                    } else {
+                      // Marker absent (e.g. an older fast-path PR
+                      // opened before the marker convention landed).
+                      // Resolve the owning tier from the stable
+                      // metadata source: the execution plan comment on
+                      // the tracking issue carries the `model:*` line.
+                      // Walk the comments looking for the
+                      // `[sdd-spec:fastpath-plan]` marker, pick the
+                      // latest such comment (mirrors the wrapper's
+                      // fastpath-approve job logic), and parse its
+                      // `model:` line. Match this variant only when
+                      // the resolved tier equals TIER. This keeps
+                      // tier ownership stable for review/revise even
+                      // without the PR-body marker.
+                      const planMarker = '[sdd-spec:fastpath-plan]';
+                      let planComment = null;
+                      let page = 1;
+                      try {
+                        for (;;) {
+                          const { data } = await github.rest.issues
+                            .listComments({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: taskIssue,
+                              per_page: 100,
+                              page,
+                            });
+                          for (const c of data) {
+                            if ((c.body || '').includes(planMarker)) {
+                              if (!planComment
+                                  || (new Date(c.created_at))
+                                    > (new Date(planComment.created_at))) {
+                                planComment = c;
+                              }
+                            }
+                          }
+                          if (data.length < 100) {
+                            break;
+                          }
+                          page += 1;
+                        }
+                      } catch (planErr) {
+                        core.info('Could not list comments on tracking'
+                          + ' issue #' + taskIssue + ' for tier'
+                          + ' resolution: ' + planErr.message);
+                      }
+                      if (planComment) {
+                        const planTierHit = (planComment.body || '')
+                          .match(
+                            /model\s*:\s*(haiku|sonnet|opus)\b/i);
+                        if (planTierHit) {
+                          fastpathTierMatch =
+                            planTierHit[1].toLowerCase() === TIER;
+                        }
+                      }
+                    }
+                  }
+                  tierMatch = hasTier || fastpathTierMatch;
+                } catch (err) {
+                  core.info('Could not read labels for #' + taskIssue
+                    + ': ' + err.message);
+                }
+              }
+              if (!tierMatch) {
+                core.info('Task is not the model:' + TIER
+                  + ' tier; this variant skips it.');
+                run = false;
+                ctx = {};
+              }
+            }
+
+            // Auto-revise loop bound (issue #128). Only the owning tier
+            // reaches here with run still true (the tier gate above cleared
+            // run for the two non-owning variants), so the cap count and its
+            // side effects happen exactly once per CHANGES_REQUESTED review.
+            // Cap is tracked by a hidden marker comment so no extra label is
+            // needed. On cap, apply needs-human and stop;
+            // SDD_MAX_REVIEW_ITERATIONS defaults to 3.
+            if (run && reviewAutoRevise && reviewPrNumber) {
+              const MARKER = '<!-- sdd-execute:auto-revise -->';
+              const maxIters = parseInt(
+                process.env.SDD_MAX_REVIEW_ITERATIONS || '3', 10);
+              let priorIters = 0;
+              let page = 1;
+              try {
+                for (;;) {
+                  const { data } = await github.rest.issues.listComments({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: reviewPrNumber,
+                    per_page: 100,
+                    page,
+                  });
+                  for (const c of data) {
+                    if ((c.body || '').includes(MARKER)) {
+                      priorIters += 1;
+                    }
+                  }
+                  if (data.length < 100) {
+                    break;
+                  }
+                  page += 1;
+                }
+              } catch (err) {
+                core.info('Could not list comments on PR #' + reviewPrNumber
+                  + ' for iteration count: ' + err.message);
+              }
+              if (priorIters >= maxIters) {
+                core.info('Auto-revise cap (' + maxIters + ') reached on PR #'
+                  + reviewPrNumber + '; applying needs-human.');
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: reviewPrNumber,
+                    labels: ['needs-human'],
+                  });
+                } catch (err) {
+                  core.info('Could not apply needs-human to PR #'
+                    + reviewPrNumber + ': ' + err.message);
+                }
+                run = false;
+                ctx = {};
+              } else {
+                // Post the hidden iteration marker so the next review counts
+                // this cycle toward the cap.
+                try {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: reviewPrNumber,
+                    body: MARKER + '\nAuto-revise ' + (priorIters + 1)
+                      + ' of ' + maxIters
+                      + ' from a CHANGES_REQUESTED review.',
+                  });
+                } catch (err) {
+                  core.info('Could not post auto-revise marker on PR #'
+                    + reviewPrNumber + ': ' + err.message);
+                }
+              }
+            }
+
+            core.setOutput('should_run', run ? 'true' : 'false');
+            core.setOutput('aw_context', run ? JSON.stringify(ctx) : '');
+
+  sdd-execute-opus:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@main
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+
+  # Enable GitHub auto-merge on the PR sdd-execute just opened (issue #127).
+  # The reusable lock exposes the new PR number via its create_pull_request
+  # safe-output as the workflow_call output created_pr_number; this job reads
+  # it and turns on squash + delete-branch auto-merge so a green cascade PR
+  # merges with no human in the loop. Gated OFF by default: it runs only when
+  # the repo variable SDD_AUTO_MERGE is set to a truthy value, so repos
+  # without branch protection are unaffected (behavior unchanged when unset).
+  auto-merge:
+    needs: [route, sdd-execute-opus]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.sdd-execute-opus.outputs.created_pr_number != ''
+      && (vars.SDD_AUTO_MERGE == '1'
+        || vars.SDD_AUTO_MERGE == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Mint the App token: reading branch protection needs administration:
+      # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
+      # lacks, and enabling auto-merge needs pull-requests + contents write.
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+          permission-contents: write
+          permission-pull-requests: write
+      # Only enable auto-merge when the repo allows it AND the base branch
+      # protection defines at least one required status check. If neither
+      # holds, `gh pr merge --auto` errors or the PR merges immediately, so
+      # detect and skip (issue #127). When both hold, enable squash +
+      # delete-branch auto-merge to match the manual-merge convention.
+      #
+      # `enablePullRequestAutoMerge` refuses an UNSTABLE PR even when every
+      # REQUIRED check is green: cancelled sibling-tier check-runs (from
+      # cancelled sibling sdd-execute runs of other model tiers) and
+      # non-required checks such as `auto-merge`/`route` leave the PR UNSTABLE,
+      # so `--auto` errors with "Pull request is in unstable status" and the
+      # cascade PR never merges (issue #135). Branch protection gates only on
+      # the required checks, so when those are all green a direct squash merge
+      # is exactly what auto-merge would do once the non-required noise
+      # settled. The step therefore keys off REQUIRED checks only: it arms
+      # `--auto`, and if that fails because the PR is UNSTABLE with every
+      # required check already green, it falls back to a direct squash merge.
+      - name: Enable auto-merge when protection requires a check
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          PR_NUMBER: ${{ needs.sdd-execute-opus.outputs.created_pr_number }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          allow=$(gh api "repos/${OWNER}/${REPO}" --jq '.allow_auto_merge')
+          if [ "$allow" != "true" ]; then
+            echo "Repo does not allow auto-merge; skipping."
+            exit 0
+          fi
+          base=$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" \
+            --jq '.base.ref')
+          # URL-encode the base ref so a branch name containing `/` (e.g.
+          # release/2026.05) does not split the protection endpoint path.
+          base_encoded=$(printf '%s' "$base" | jq -sRr @uri)
+          # Read the required status checks on the base branch. The protection
+          # endpoint 404s when no protection is configured; treat that as
+          # "no required checks" and skip. `.checks[].context` (new) and
+          # `.contexts[]` (legacy) cover both shapes; an absent
+          # required_status_checks yields an empty list.
+          required_names=$(gh api \
+            "repos/${OWNER}/${REPO}/branches/${base_encoded}/protection" \
+            --jq '[(.required_status_checks.checks // [] | .[].context),
+              (.required_status_checks.contexts // [] | .[])] | unique | .[]' \
+            2>/dev/null || true)
+          if [ -z "${required_names}" ]; then
+            echo "Base branch ${base} has no required status checks;" \
+              "skipping auto-merge (would merge immediately)."
+            exit 0
+          fi
+          # Arm GitHub auto-merge. This succeeds for a CLEAN or BLOCKED PR and
+          # waits for the required checks to go green before merging.
+          if gh pr merge "${PR_NUMBER}" --auto --squash --delete-branch \
+            --repo "${OWNER}/${REPO}"; then
+            echo "Auto-merge (squash, delete-branch) enabled on PR" \
+              "#${PR_NUMBER}."
+            exit 0
+          fi
+          # Arming failed. The common cause is an UNSTABLE mergeStateStatus:
+          # cancelled sibling-tier check-runs and non-required `auto-merge`/
+          # `route` checks leave the PR UNSTABLE, which
+          # `enablePullRequestAutoMerge` refuses, even though branch
+          # protection gates only on the required checks (issue #135). Key off
+          # REQUIRED checks only: if the PR is UNSTABLE and every required
+          # check has already concluded SUCCESS, the non-required noise is the
+          # only thing blocking the GraphQL mutation, so merge directly — the
+          # same squash + delete-branch merge auto-merge would perform.
+          state=$(gh pr view "${PR_NUMBER}" --repo "${OWNER}/${REPO}" \
+            --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null \
+            || echo UNKNOWN)
+          if [ "${state}" != "UNSTABLE" ]; then
+            echo "Auto-merge could not be armed and PR #${PR_NUMBER} is" \
+              "${state}, not UNSTABLE; leaving for human review." >&2
+            exit 1
+          fi
+          # Confirm every required check has concluded SUCCESS on this PR.
+          rollup=$(gh pr view "${PR_NUMBER}" --repo "${OWNER}/${REPO}" \
+            --json statusCheckRollup \
+            --jq '[.statusCheckRollup[]
+              | {name: (.name // .context),
+                 state: (.conclusion // .state // .status)}]')
+          all_green=true
+          while IFS= read -r name; do
+            [ -z "${name}" ] && continue
+            st=$(printf '%s' "${rollup}" | jq -r \
+              --arg n "${name}" \
+              'map(select(.name == $n)) | (last.state // "MISSING")')
+            if [ "${st}" != "SUCCESS" ]; then
+              echo "Required check '${name}' is '${st}', not SUCCESS;" \
+                "not merging PR #${PR_NUMBER}." >&2
+              all_green=false
+            fi
+          done <<< "${required_names}"
+          if [ "${all_green}" != "true" ]; then
+            exit 1
+          fi
+          gh pr merge "${PR_NUMBER}" --squash --delete-branch \
+            --repo "${OWNER}/${REPO}"
+          echo "PR #${PR_NUMBER} was UNSTABLE with all required checks green;" \
+            "merged directly (squash, delete-branch)."

--- a/.github/workflows/sdd-execute-sonnet.yml
+++ b/.github/workflows/sdd-execute-sonnet.yml
@@ -1,0 +1,963 @@
+name: sdd-execute-sonnet
+
+# Thin wrapper for the sdd-execute agent, sonnet model-tier variant.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-execute-sonnet.lock.yml (compiled from
+# sdd-execute-sonnet.md, which declares on: workflow_call). This wrapper carries
+# the real event triggers, gates the /execute comment command to authors with
+# repository write access, and passes the triggering entity to the agent
+# through the aw_context input. A consumer repository installs this wrapper
+# unchanged.
+#
+# sdd-execute is compiled into three model-tier variants (haiku, sonnet, opus)
+# that differ only in the engine model and the model:* tier they claim. This
+# wrapper is the sonnet-tier caller; sdd-execute-haiku.yml and
+# sdd-execute-opus.yml are its haiku and opus siblings.
+#
+# Execution is event-driven, not scheduled. The daily cron that previously
+# drained each tier's queue has been removed: this wrapper now triggers only
+# on workflow_dispatch (from sdd-dispatch's bounded matrix fan-out) and on an
+# explicit /execute comment from a write-access human. The pipeline is
+# /approve -> /dispatch -> cascade-on-close (see issue #81 and ADR 0011).
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A workflow_dispatch from sdd-dispatch (one matrix cell per ready task) or
+  # from an operator running the queue by hand.
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        description: |
+          JSON string naming the triggering entity; mirrors the issue_comment
+          route output. sdd-dispatch fans out one cell per ready task with
+          {trigger: 'command', item_type: 'issue', item_number: <task>}.
+        required: false
+        type: string
+  # A /execute comment on a task sub-issue.
+  issue_comment:
+    types: [created]
+  # A review comment on a pull request this agent opened.
+  pull_request_review_comment:
+    types: [created]
+  # A formal review on a pull request this agent opened. A CHANGES_REQUESTED
+  # review from CodeRabbit or a write-access human on an `sdd/` branch is
+  # treated as an implicit /revise (issue #128). A COMMENTED or APPROVED
+  # review does not trigger a revise.
+  pull_request_review:
+    types: [submitted]
+  # The needs-human label being cleared on a task sub-issue, which re-triggers
+  # the agent to resume a hand-off it applied at step 5 or step 6.
+  issues:
+    types: [unlabeled]
+  # The needs-human label being cleared on a pull request this agent opened,
+  # which re-triggers the agent to resume a hand-off it applied at step 7.
+  # The `closed` action covers the fast-path completion path (ADR 0012): a
+  # merged implementation PR on a `sdd/` branch whose work-item is a
+  # tracking issue (no parent_issue_url, no task sub-issue tree) re-fires
+  # the agent with `entry: 'fastpath-complete'` so step 8's completion
+  # sweep can move the tracking issue from `sdd:in-progress` to `sdd:done`
+  # directly.
+  pull_request:
+    types: [unlabeled, closed]
+
+permissions:
+  contents: read
+
+# Concurrency group keyed on the task issue number AND this variant's tier.
+# A stale sdd-dispatch fan-out racing with a manual /execute on the same task
+# in the same tier collapses to one running cell: cancel-in-progress: true
+# supersedes the in-progress cell with the later trigger so a user-initiated
+# /execute wins over a stale dispatch (and vice versa: a fresh dispatch wins
+# over an earlier in-flight cell). The tier discriminator is required because
+# the three sdd-execute-{haiku,sonnet,opus} wrappers all subscribe to the same
+# event triggers; without the tier suffix a non-matching-tier wake would land
+# in the same group as the matching-tier run and the cancel-in-progress rule
+# could kill the only run doing real work (issue #124). Cancel-in-progress is
+# set on the wrapper itself because the gh-aw lock declares its own
+# activation-level concurrency keyed on the workflow name; this wrapper-level
+# group adds the per-task-per-tier dimension on top.
+#
+# The fromJSON(github.event.inputs.aw_context || '{}') branch reads the
+# dispatcher's well-formed aw_context JSON for the workflow_dispatch path.
+# Manual workflow_dispatch invocations that supply malformed JSON will fail
+# workflow evaluation here, which is the correct failure mode (the route
+# step's try/catch would silently ignore them and the run would do nothing
+# useful).
+#
+# A label-removal event (issues.unlabeled / pull_request.unlabeled) is routed
+# to its own throwaway group (github.run_id) so it never lands in a task's
+# shared per-task-per-tier group. At step 2 the agent removes its own task's
+# sdd:ready label; that self-induced issues.unlabeled event re-fires this
+# wrapper, and without the carve-out it entered the active run's group where
+# cancel-in-progress killed the running agent mid-work (issue #143). The only
+# label-removal the route step acts on is needs-human (a resume), which runs
+# when no agent is in flight, so a unique group is safe there too.
+#
+# An issue_comment whose body is not a recognized command (/execute or
+# /revise) is routed to its own throwaway group for the same reason.
+# gh-aw's create-pull-request fallback-to-issue posts an "Issue created:
+# #<n>" notice on the task issue via the App token (issue #142); that
+# App-authored comment re-fires this wrapper as issue_comment.created,
+# and without the carve-out it landed in the active run's per-task group
+# where cancel-in-progress killed the originating run's safe_outputs tail
+# and its auto-merge job. The route step acts only on /execute and
+# /revise comments, so a non-command comment in a unique group is safe.
+concurrency:
+  group: sdd-execute-sonnet-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate below is the wrapper-level command + tier + label
+  # filter (fixes issue #119 and the matching-tier slice of issue #114). It
+  # runs BEFORE the route job's runner is allocated, so a /dispatch comment, a
+  # /spec comment, or any other unrelated comment never spends a runner
+  # minute on this wrapper. The issues clause does the same for label events:
+  # the route step only routes an `issues` event on `unlabeled` `needs-human`
+  # (the step 5/6 resume), so any other label add/remove — e.g. the
+  # `sdd:ready`/`sdd:in-progress`/`sdd:dispatched` mutations a /dispatch
+  # performs on a tracking issue — is skipped here without a runner. The
+  # route step's own tier resolution stays as a defence-in-depth check (it
+  # covers /revise on a sdd/ PR, where the model label lives on the linked
+  # task, not the PR — too expensive to resolve at workflow-evaluation time
+  # without an API call).
+  route:
+    if: |
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          (
+            startsWith(github.event.comment.body, '/execute')
+            && contains(github.event.issue.labels.*.name, 'model:sonnet')
+          )
+          || startsWith(github.event.comment.body, '/revise')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && github.event.action == 'unlabeled'
+        && github.event.label.name == 'needs-human'
+      )
+    runs-on: ubuntu-latest
+    # pull-requests: read is needed for the tier gate on a /revise issue_comment
+    # (situation 6): the route fetches the pull request to read its body and
+    # extract the `Closes #<task>` reference. Without this grant, the GET
+    # /repos/{owner}/{repo}/pulls/{N} call returns 403 "Resource not accessible
+    # by integration" and the tier gate defaults to false, skipping every
+    # variant. See #68.
+    #
+    # issues: write and pull-requests: write are needed by the CHANGES_REQUESTED
+    # auto-revise branch (issue #128): it posts a hidden iteration-marker
+    # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
+    # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
+    # re-trigger workflows, so this does not feed back into the route.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: actions/github-script@v9
+        env:
+          # The configured GitHub App ID, used to accept /execute comments
+          # posted by sdd-dispatch's cascade fan-out (ADR 0014). A human's
+          # /execute still goes through the repo-permission check below.
+          APP_ID: ${{ vars.APP_ID }}
+          # Cap on auto-revise cycles per PR for CHANGES_REQUESTED reviews
+          # (issue #128); defaults to 3 when the repo variable is unset.
+          SDD_MAX_REVIEW_ITERATIONS: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}
+        with:
+          script: |
+            const event = context.eventName;
+            const payload = context.payload;
+            let run = false;
+            let ctx = {};
+            // Set true by the CHANGES_REQUESTED auto-revise branch (issue
+            // #128). The cap count, hidden marker, and needs-human side
+            // effects are deferred until AFTER the tier gate below confirms
+            // this variant owns the PR, so the two non-owning tiers never
+            // mutate PR state (they would otherwise inflate the cap count).
+            let reviewAutoRevise = false;
+            let reviewPrNumber = 0;
+
+            // This wrapper is the sonnet model tier; the tier gate below
+            // skips a task another tier owns.
+            const TIER = 'sonnet';
+
+            // A workflow_dispatch from sdd-dispatch (or from an operator
+            // running the queue by hand) carries an aw_context input naming
+            // the task to implement. The cron-based "schedule" trigger has
+            // been removed (issue #81 / ADR 0011): execution is event-driven
+            // now, dispatched per task from the cascade.
+            if (event === 'workflow_dispatch') {
+              const raw = (payload.inputs && payload.inputs.aw_context) || '';
+              if (raw) {
+                try {
+                  ctx = JSON.parse(raw);
+                  if (ctx && ctx.item_number) {
+                    run = true;
+                  } else {
+                    core.info('workflow_dispatch aw_context missing'
+                      + ' item_number; ignoring.');
+                  }
+                } catch (err) {
+                  core.info('workflow_dispatch aw_context not parseable: '
+                    + err.message);
+                }
+              } else {
+                core.info('workflow_dispatch with no aw_context; ignoring.');
+              }
+            }
+
+            // A /execute or /revise comment from either an author with repo
+            // write access or sdd-dispatch's App identity. The gate is the
+            // actor's real repository permission, not author_association:
+            // author_association reports the relationship to the thread
+            // (OWNER/MEMBER/COLLABORATOR), which is not the same as push
+            // access. A MEMBER of the org need not have write on this repo,
+            // and a COLLABORATOR may be read-only. The
+            // collaborators/{user}/permission API returns the actual
+            // permission level; only write, maintain, or admin may run a
+            // command. /execute on a pull request is ignored: it is a
+            // task-sub-issue command only.
+            //
+            // sdd-dispatch fans the cascade out by posting /execute on each
+            // ready task issue via the App installation token (ADR 0014).
+            // The App user is not a collaborator and would 404 the
+            // permission check, so accept the command when the comment's
+            // performed_via_github_app.id matches the configured APP_ID.
+            // Any other bot posting /execute is still rejected.
+            if (event === 'issue_comment' && payload.action === 'created') {
+              const body = (payload.comment.body || '').trim();
+              const firstWord = body.split(/\s+/)[0];
+              const isPr = !!payload.issue.pull_request;
+              const isExecute = firstWord === '/execute' && !isPr;
+              const isRevise = firstWord === '/revise' && isPr;
+              if (firstWord === '/execute' && isPr) {
+                core.info('/execute on a pull request; ignoring.');
+              } else if (isExecute || isRevise) {
+                const appId = parseInt(process.env.APP_ID || '0', 10);
+                const appComment = payload.comment.performed_via_github_app;
+                const fromConfiguredApp = appId > 0
+                  && appComment
+                  && appComment.id === appId;
+                let permission = 'none';
+                if (!fromConfiguredApp) {
+                  const actor = payload.comment.user.login;
+                  try {
+                    const resp = await github.rest.repos
+                      .getCollaboratorPermissionLevel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        username: actor,
+                      });
+                    // role_name is the precise role
+                    // (write/maintain/triage/...) when present; permission is
+                    // the legacy bucket (admin/write/read/none) that collapses
+                    // maintain into write and triage into read.
+                    permission = resp.data.role_name || resp.data.permission;
+                  } catch (err) {
+                    core.info(
+                      'Could not resolve repo permission for ' + actor
+                      + ': ' + err.message);
+                  }
+                }
+                const canWrite = fromConfiguredApp
+                  || permission === 'write'
+                  || permission === 'maintain'
+                  || permission === 'admin';
+                if (canWrite) {
+                  run = true;
+                  ctx = isRevise
+                    ? {
+                        trigger: 'revise',
+                        item_type: 'pull_request',
+                        item_number: payload.issue.number,
+                        comment_id: payload.comment.id,
+                      }
+                    : {
+                        trigger: 'command',
+                        item_type: 'issue',
+                        item_number: payload.issue.number,
+                        comment_id: payload.comment.id,
+                      };
+                } else {
+                  core.info(
+                    'Command from an author without write access ('
+                    + permission + '); ignoring.');
+                }
+              }
+            }
+
+            // A review comment on a pull request. The agent confirms the pull
+            // request is one it opened (an sdd/<task-id>-<slug> branch) before
+            // pushing follow-up commits.
+            if (event === 'pull_request_review_comment'
+                && payload.action === 'created') {
+              run = true;
+              ctx = {
+                trigger: 'review_comment',
+                item_type: 'pull_request',
+                item_number: payload.pull_request.number,
+                comment_id: payload.comment.id,
+              };
+            }
+
+            // A formal review with state CHANGES_REQUESTED on an sdd/ PR is
+            // treated as an implicit /revise (issue #128). The directive is
+            // the review body plus the unresolved review-comment threads, so
+            // one revise run addresses the whole verdict; the individual
+            // pull_request_review_comment events that co-arrive collapse into
+            // this run at the per-PR-per-tier concurrency group (the existing
+            // dedupe mechanism). A COMMENTED or APPROVED review does not match
+            // and never triggers a revise. The manual /revise path above is
+            // untouched. The agent confirms ownership (sdd/ head ref + body
+            // marker) at step 7 exactly as it does for a review comment.
+            if (event === 'pull_request_review'
+                && payload.action === 'submitted') {
+              const review = payload.review || {};
+              const state = (review.state || '').toLowerCase();
+              const pr = payload.pull_request || {};
+              const headRef = (pr.head && pr.head.ref) || '';
+              if (state === 'changes_requested'
+                  && headRef.startsWith('sdd/')) {
+                // Author scope: accept CodeRabbit's bot review or a review by
+                // an author with repository write access, mirroring the
+                // /revise permission check above. A login of `coderabbitai`
+                // (with or without a `[bot]` suffix) is the CodeRabbit bot.
+                const reviewer = (review.user && review.user.login) || '';
+                const reviewerLc = reviewer.toLowerCase();
+                const isCodeRabbit = reviewerLc === 'coderabbitai'
+                  || reviewerLc === 'coderabbitai[bot]';
+                let reviewerCanWrite = isCodeRabbit;
+                if (!isCodeRabbit && reviewer) {
+                  let permission = 'none';
+                  try {
+                    const resp = await github.rest.repos
+                      .getCollaboratorPermissionLevel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        username: reviewer,
+                      });
+                    permission = resp.data.role_name || resp.data.permission;
+                  } catch (err) {
+                    core.info('Could not resolve repo permission for '
+                      + reviewer + ': ' + err.message);
+                  }
+                  reviewerCanWrite = permission === 'write'
+                    || permission === 'maintain'
+                    || permission === 'admin';
+                }
+                if (!reviewerCanWrite) {
+                  core.info('CHANGES_REQUESTED review by a non-allowed'
+                    + ' reviewer (' + reviewer + '); ignoring.');
+                } else {
+                  const prNumber = pr.number;
+                  // Assemble the directive: the review body plus the
+                  // unresolved review-comment threads. Resolved threads are
+                  // skipped to avoid re-fixing addressed items. Thread
+                  // resolution state is only exposed by GraphQL. This is
+                  // read-only; the cap count and the side-effecting marker /
+                  // needs-human are deferred to the post-tier-gate block so
+                  // only the owning tier mutates PR state.
+                  const parts = [];
+                  if ((review.body || '').trim()) {
+                    parts.push(review.body.trim());
+                  }
+                  try {
+                    const result = await github.graphql(`
+                      query($owner:String!,$repo:String!,$pr:Int!) {
+                        repository(owner:$owner,name:$repo) {
+                          pullRequest(number:$pr) {
+                            reviewThreads(first:100) {
+                              nodes {
+                                isResolved
+                                comments(first:1) { nodes { body path } }
+                              }
+                            }
+                          }
+                        }
+                      }`, {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pr: prNumber,
+                    });
+                    const threads = (result.repository
+                      && result.repository.pullRequest
+                      && result.repository.pullRequest.reviewThreads
+                      && result.repository.pullRequest.reviewThreads.nodes)
+                      || [];
+                    for (const t of threads) {
+                      if (t.isResolved) {
+                        continue;
+                      }
+                      const first = t.comments
+                        && t.comments.nodes
+                        && t.comments.nodes[0];
+                      if (first && (first.body || '').trim()) {
+                        const where = first.path ? (first.path + ': ') : '';
+                        parts.push('- ' + where + first.body.trim());
+                      }
+                    }
+                  } catch (err) {
+                    core.info('Could not read review threads on PR #'
+                      + prNumber + ': ' + err.message);
+                  }
+                  const directive = parts.join('\n').trim()
+                    || 'Address the requested changes.';
+                  run = true;
+                  reviewAutoRevise = true;
+                  reviewPrNumber = prNumber;
+                  ctx = {
+                    trigger: 'revise',
+                    item_type: 'pull_request',
+                    item_number: prNumber,
+                    directive,
+                  };
+                }
+              }
+            }
+
+            // The needs-human label was cleared on a task sub-issue (resume a
+            // step 5 or step 6 hand-off this agent applied). needs-human is
+            // shared by all six SDD agents, so the agent itself confirms the
+            // item is one it handed off before resuming.
+            if (event === 'issues' && payload.action === 'unlabeled') {
+              const label = payload.label && payload.label.name;
+              if (label === 'needs-human') {
+                run = true;
+                ctx = {
+                  trigger: 'resume',
+                  item_type: 'issue',
+                  item_number: payload.issue.number,
+                };
+              }
+            }
+
+            // The needs-human label was cleared on a pull request (resume a
+            // step 7 hand-off this agent applied). needs-human is shared by
+            // all six SDD agents, so the agent itself confirms the pull
+            // request is one it opened before resuming.
+            if (event === 'pull_request' && payload.action === 'unlabeled') {
+              const label = payload.label && payload.label.name;
+              if (label === 'needs-human') {
+                run = true;
+                ctx = {
+                  trigger: 'resume',
+                  item_type: 'pull_request',
+                  item_number: payload.pull_request.number,
+                };
+              }
+            }
+
+            // A fast-path implementation PR was merged. The wrapper detects
+            // a merged PR whose head ref follows the `sdd/<n>-` convention
+            // and whose referenced work-item is the tracking issue itself
+            // (no parent_issue_url, no task sub-issue tree). On that match
+            // the agent is invoked with `entry: 'fastpath-complete'` to run
+            // step 8's completion sweep: `sdd:in-progress → sdd:done` on
+            // the tracking issue, plus `needs-human` for the human's final
+            // close. A merged full-path implementation PR (whose head ref
+            // also follows `sdd/<task-id>-` but whose work-item is a task
+            // sub-issue) is left to the existing flow: the merge closes
+            // the task sub-issue via `Closes #<task>`, the `issues.closed`
+            // event re-fires `sdd-dispatch`, and `sdd-execute`'s next idle
+            // run (step 8) handles the feature-completion sweep. See
+            // ADR 0012.
+            if (event === 'pull_request' && payload.action === 'closed'
+                && payload.pull_request.merged === true) {
+              const headRef = payload.pull_request.head
+                && payload.pull_request.head.ref || '';
+              const headMatch = headRef.match(/^sdd\/(\d+)-/);
+              if (headMatch) {
+                const refNumber = parseInt(headMatch[1], 10);
+                let isFastpath = false;
+                try {
+                  const { data } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: refNumber,
+                  });
+                  // A tracking issue has no parent_issue_url. A task
+                  // sub-issue has its Unit as parent. We treat
+                  // "no parent and currently in-progress" as the
+                  // fast-path completion signal.
+                  const parentUrl = data.parent_issue_url || '';
+                  const labels = (data.labels || []).map(
+                    (l) => l.name || l);
+                  const fastpathSignal = labels.includes('sdd:fastpath')
+                    || labels.includes('sdd:fastpath-review')
+                    || (!parentUrl
+                      && labels.includes('sdd:in-progress')
+                      && !labels.includes('sdd:dispatched'));
+                  if (!parentUrl && fastpathSignal) {
+                    isFastpath = true;
+                  }
+                } catch (err) {
+                  core.info('Could not fetch ref #' + refNumber + ': '
+                    + err.message);
+                }
+                if (isFastpath) {
+                  run = true;
+                  ctx = {
+                    trigger: 'command',
+                    entry: 'fastpath-complete',
+                    item_type: 'issue',
+                    item_number: refNumber,
+                  };
+                }
+              }
+            }
+
+            // Tier gate. sdd-triage assigns each task sub-issue exactly one
+            // model:* label. Every trigger this wrapper handles resolves to a
+            // specific task sub-issue: directly for an issue event, through
+            // the pull request's `Closes #<task>` reference for a
+            // pull-request event, and through the aw_context input for a
+            // workflow_dispatch from sdd-dispatch. This variant runs only
+            // when that sub-issue carries the model:<TIER> label. This stops
+            // the needless agent run, and its inference cost, on the two
+            // tiers the trigger does not belong to. sdd-dispatch already
+            // picks the matching variant per task (the matrix cell selects
+            // the wrapper file by tier), so the tier gate here is a
+            // defence-in-depth check that catches the corner where a task's
+            // model:* label has changed between dispatch and pickup.
+            //
+            // The fast-path entries (`entry: 'fastpath'` from sdd-spec's
+            // /approve, and `entry: 'fastpath-complete'` from a merged
+            // implementation PR) bypass the tier gate: the work-item on a
+            // fast-path entry is the tracking issue, which carries no
+            // model:* label by design. The completion entry only moves
+            // labels and posts a comment; the dispatch entry's tier match
+            // is enforced by sdd-spec when it picks the variant to
+            // workflow_dispatch.
+            const fastpathEntry = ctx && (
+              ctx.entry === 'fastpath' || ctx.entry === 'fastpath-complete');
+            if (run && fastpathEntry && ctx.entry === 'fastpath') {
+              // For the fastpath dispatch entry, the wrapper still confirms
+              // that the variant matches the tier the plan comment names.
+              // sdd-spec is expected to dispatch the matching variant
+              // directly, but a misroute (operator-run workflow_dispatch
+              // with a hand-supplied aw_context) is rejected here.
+              const planTier = (ctx.tier || '').toLowerCase();
+              if (planTier && planTier !== TIER) {
+                core.info('Fast-path dispatch tier (' + planTier
+                  + ') does not match this variant (' + TIER
+                  + '); this variant skips it.');
+                run = false;
+                ctx = {};
+              }
+            }
+            if (run && !fastpathEntry) {
+              let taskIssue = 0;
+              // A pull-request review/revise event on a fast-path
+              // implementation PR identifies the tracking issue (not a
+              // task sub-issue) via the head ref. The tracking issue
+              // has no `model:*` label by design (ADR 0012). Mark this
+              // case so the tier gate accepts a fast-path tracking
+              // issue in lieu of a model-label match. `prBody` is
+              // hoisted to outer scope so the tier-marker scan in the
+              // label-check block can read it.
+              let inferredFastpathFromPr = false;
+              let prBody = '';
+              if (ctx.item_type === 'issue') {
+                taskIssue = ctx.item_number;
+              } else if (ctx.item_type === 'pull_request') {
+                // A pull_request_review_comment event carries the pull
+                // request inline; an issue_comment event (a /revise comment)
+                // does not, so fetch the pull request to read its body and
+                // head ref.
+                prBody = (payload.pull_request
+                  && payload.pull_request.body) || '';
+                let prHeadRef = (payload.pull_request
+                  && payload.pull_request.head
+                  && payload.pull_request.head.ref) || '';
+                if (!prBody || !prHeadRef) {
+                  try {
+                    const { data } = await github.rest.pulls.get({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: ctx.item_number,
+                    });
+                    prBody = prBody || (data.body || '');
+                    prHeadRef = prHeadRef
+                      || (data.head && data.head.ref) || '';
+                  } catch (err) {
+                    core.info('Could not fetch pull request #'
+                      + ctx.item_number + ': ' + err.message);
+                  }
+                }
+                // The pull request body is the documented place for the task
+                // sub-issue reference (`Closes #<task>`); prefer it.
+                const m = prBody.match(
+                  /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i);
+                if (m) {
+                  taskIssue = parseInt(m[1], 10);
+                } else {
+                  // Fall back to the head ref, which this agent encodes as
+                  // `sdd/<task-id>-<slug>` for every implementation pull
+                  // request it opens. This is robust against a future PR
+                  // whose body omits `Closes #<task>` for any reason, and
+                  // makes the route gate independent of body text. See #68.
+                  // A fast-path PR encodes the tracking issue here (no
+                  // `Closes #` reference exists, since the tracking issue
+                  // stays open until a human closes it per ADR 0012).
+                  const refMatch = prHeadRef.match(/^sdd\/(\d+)-/);
+                  if (refMatch) {
+                    taskIssue = parseInt(refMatch[1], 10);
+                    inferredFastpathFromPr = true;
+                  }
+                }
+              }
+              let tierMatch = false;
+              if (taskIssue) {
+                try {
+                  const { data } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: taskIssue,
+                  });
+                  const labels = (data.labels || []).map(
+                    (l) => l.name || l);
+                  const hasTier = labels.includes('model:' + TIER);
+                  // A fast-path tracking issue carries no `model:*` label
+                  // (ADR 0012); identify it by the lifecycle labels and
+                  // the absence of a parent. On a fast-path PR
+                  // review/revise event, prefer the durable PR-body
+                  // tier marker `[sdd-fastpath: tracking=<N>
+                  // tier=<tier>]` written by sdd-execute on PR open
+                  // (per sdd-execute-{tier}.md, step 5 fast-path
+                  // paragraph). The marker is the strong routing
+                  // signal: it pinpoints the tier so only the matching
+                  // variant runs. When the marker is absent (e.g. a
+                  // pre-marker PR), fall back to the
+                  // fast-path-tracking-issue heuristic, which lets all
+                  // three variants pass the route gate; the agent
+                  // itself then noops on tier mismatch.
+                  const isTracking = !data.parent_issue_url;
+                  const isFastpathTracking = isTracking && (
+                    labels.includes('sdd:fastpath')
+                    || labels.includes('sdd:fastpath-review')
+                    || labels.includes('sdd:in-progress')
+                    || labels.includes('sdd:done'));
+                  let fastpathTierMatch = false;
+                  if (inferredFastpathFromPr && isFastpathTracking) {
+                    const markerRe = new RegExp(
+                      '\\[sdd-fastpath:\\s*tracking=\\d+\\s+'
+                      + 'tier=(haiku|sonnet|opus)\\]', 'i');
+                    const markerHit = (prBody || '').match(markerRe);
+                    if (markerHit) {
+                      fastpathTierMatch =
+                        markerHit[1].toLowerCase() === TIER;
+                    } else {
+                      // Marker absent (e.g. an older fast-path PR
+                      // opened before the marker convention landed).
+                      // Resolve the owning tier from the stable
+                      // metadata source: the execution plan comment on
+                      // the tracking issue carries the `model:*` line.
+                      // Walk the comments looking for the
+                      // `[sdd-spec:fastpath-plan]` marker, pick the
+                      // latest such comment (mirrors the wrapper's
+                      // fastpath-approve job logic), and parse its
+                      // `model:` line. Match this variant only when
+                      // the resolved tier equals TIER. This keeps
+                      // tier ownership stable for review/revise even
+                      // without the PR-body marker.
+                      const planMarker = '[sdd-spec:fastpath-plan]';
+                      let planComment = null;
+                      let page = 1;
+                      try {
+                        for (;;) {
+                          const { data } = await github.rest.issues
+                            .listComments({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: taskIssue,
+                              per_page: 100,
+                              page,
+                            });
+                          for (const c of data) {
+                            if ((c.body || '').includes(planMarker)) {
+                              if (!planComment
+                                  || (new Date(c.created_at))
+                                    > (new Date(planComment.created_at))) {
+                                planComment = c;
+                              }
+                            }
+                          }
+                          if (data.length < 100) {
+                            break;
+                          }
+                          page += 1;
+                        }
+                      } catch (planErr) {
+                        core.info('Could not list comments on tracking'
+                          + ' issue #' + taskIssue + ' for tier'
+                          + ' resolution: ' + planErr.message);
+                      }
+                      if (planComment) {
+                        const planTierHit = (planComment.body || '')
+                          .match(
+                            /model\s*:\s*(haiku|sonnet|opus)\b/i);
+                        if (planTierHit) {
+                          fastpathTierMatch =
+                            planTierHit[1].toLowerCase() === TIER;
+                        }
+                      }
+                    }
+                  }
+                  tierMatch = hasTier || fastpathTierMatch;
+                } catch (err) {
+                  core.info('Could not read labels for #' + taskIssue
+                    + ': ' + err.message);
+                }
+              }
+              if (!tierMatch) {
+                core.info('Task is not the model:' + TIER
+                  + ' tier; this variant skips it.');
+                run = false;
+                ctx = {};
+              }
+            }
+
+            // Auto-revise loop bound (issue #128). Only the owning tier
+            // reaches here with run still true (the tier gate above cleared
+            // run for the two non-owning variants), so the cap count and its
+            // side effects happen exactly once per CHANGES_REQUESTED review.
+            // Cap is tracked by a hidden marker comment so no extra label is
+            // needed. On cap, apply needs-human and stop;
+            // SDD_MAX_REVIEW_ITERATIONS defaults to 3.
+            if (run && reviewAutoRevise && reviewPrNumber) {
+              const MARKER = '<!-- sdd-execute:auto-revise -->';
+              const maxIters = parseInt(
+                process.env.SDD_MAX_REVIEW_ITERATIONS || '3', 10);
+              let priorIters = 0;
+              let page = 1;
+              try {
+                for (;;) {
+                  const { data } = await github.rest.issues.listComments({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: reviewPrNumber,
+                    per_page: 100,
+                    page,
+                  });
+                  for (const c of data) {
+                    if ((c.body || '').includes(MARKER)) {
+                      priorIters += 1;
+                    }
+                  }
+                  if (data.length < 100) {
+                    break;
+                  }
+                  page += 1;
+                }
+              } catch (err) {
+                core.info('Could not list comments on PR #' + reviewPrNumber
+                  + ' for iteration count: ' + err.message);
+              }
+              if (priorIters >= maxIters) {
+                core.info('Auto-revise cap (' + maxIters + ') reached on PR #'
+                  + reviewPrNumber + '; applying needs-human.');
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: reviewPrNumber,
+                    labels: ['needs-human'],
+                  });
+                } catch (err) {
+                  core.info('Could not apply needs-human to PR #'
+                    + reviewPrNumber + ': ' + err.message);
+                }
+                run = false;
+                ctx = {};
+              } else {
+                // Post the hidden iteration marker so the next review counts
+                // this cycle toward the cap.
+                try {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: reviewPrNumber,
+                    body: MARKER + '\nAuto-revise ' + (priorIters + 1)
+                      + ' of ' + maxIters
+                      + ' from a CHANGES_REQUESTED review.',
+                  });
+                } catch (err) {
+                  core.info('Could not post auto-revise marker on PR #'
+                    + reviewPrNumber + ': ' + err.message);
+                }
+              }
+            }
+
+            core.setOutput('should_run', run ? 'true' : 'false');
+            core.setOutput('aw_context', run ? JSON.stringify(ctx) : '');
+
+  sdd-execute-sonnet:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@main
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+
+  # Enable GitHub auto-merge on the PR sdd-execute just opened (issue #127).
+  # The reusable lock exposes the new PR number via its create_pull_request
+  # safe-output as the workflow_call output created_pr_number; this job reads
+  # it and turns on squash + delete-branch auto-merge so a green cascade PR
+  # merges with no human in the loop. Gated OFF by default: it runs only when
+  # the repo variable SDD_AUTO_MERGE is set to a truthy value, so repos
+  # without branch protection are unaffected (behavior unchanged when unset).
+  auto-merge:
+    needs: [route, sdd-execute-sonnet]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.sdd-execute-sonnet.outputs.created_pr_number != ''
+      && (vars.SDD_AUTO_MERGE == '1'
+        || vars.SDD_AUTO_MERGE == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Mint the App token: reading branch protection needs administration:
+      # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
+      # lacks, and enabling auto-merge needs pull-requests + contents write.
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+          permission-contents: write
+          permission-pull-requests: write
+      # Only enable auto-merge when the repo allows it AND the base branch
+      # protection defines at least one required status check. If neither
+      # holds, `gh pr merge --auto` errors or the PR merges immediately, so
+      # detect and skip (issue #127). When both hold, enable squash +
+      # delete-branch auto-merge to match the manual-merge convention.
+      #
+      # `enablePullRequestAutoMerge` refuses an UNSTABLE PR even when every
+      # REQUIRED check is green: cancelled sibling-tier check-runs (from
+      # cancelled sibling sdd-execute runs of other model tiers) and
+      # non-required checks such as `auto-merge`/`route` leave the PR UNSTABLE,
+      # so `--auto` errors with "Pull request is in unstable status" and the
+      # cascade PR never merges (issue #135). Branch protection gates only on
+      # the required checks, so when those are all green a direct squash merge
+      # is exactly what auto-merge would do once the non-required noise
+      # settled. The step therefore keys off REQUIRED checks only: it arms
+      # `--auto`, and if that fails because the PR is UNSTABLE with every
+      # required check already green, it falls back to a direct squash merge.
+      - name: Enable auto-merge when protection requires a check
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          PR_NUMBER: ${{ needs.sdd-execute-sonnet.outputs.created_pr_number }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          allow=$(gh api "repos/${OWNER}/${REPO}" --jq '.allow_auto_merge')
+          if [ "$allow" != "true" ]; then
+            echo "Repo does not allow auto-merge; skipping."
+            exit 0
+          fi
+          base=$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" \
+            --jq '.base.ref')
+          # URL-encode the base ref so a branch name containing `/` (e.g.
+          # release/2026.05) does not split the protection endpoint path.
+          base_encoded=$(printf '%s' "$base" | jq -sRr @uri)
+          # Read the required status checks on the base branch. The protection
+          # endpoint 404s when no protection is configured; treat that as
+          # "no required checks" and skip. `.checks[].context` (new) and
+          # `.contexts[]` (legacy) cover both shapes; an absent
+          # required_status_checks yields an empty list.
+          required_names=$(gh api \
+            "repos/${OWNER}/${REPO}/branches/${base_encoded}/protection" \
+            --jq '[(.required_status_checks.checks // [] | .[].context),
+              (.required_status_checks.contexts // [] | .[])] | unique | .[]' \
+            2>/dev/null || true)
+          if [ -z "${required_names}" ]; then
+            echo "Base branch ${base} has no required status checks;" \
+              "skipping auto-merge (would merge immediately)."
+            exit 0
+          fi
+          # Arm GitHub auto-merge. This succeeds for a CLEAN or BLOCKED PR and
+          # waits for the required checks to go green before merging.
+          if gh pr merge "${PR_NUMBER}" --auto --squash --delete-branch \
+            --repo "${OWNER}/${REPO}"; then
+            echo "Auto-merge (squash, delete-branch) enabled on PR" \
+              "#${PR_NUMBER}."
+            exit 0
+          fi
+          # Arming failed. The common cause is an UNSTABLE mergeStateStatus:
+          # cancelled sibling-tier check-runs and non-required `auto-merge`/
+          # `route` checks leave the PR UNSTABLE, which
+          # `enablePullRequestAutoMerge` refuses, even though branch
+          # protection gates only on the required checks (issue #135). Key off
+          # REQUIRED checks only: if the PR is UNSTABLE and every required
+          # check has already concluded SUCCESS, the non-required noise is the
+          # only thing blocking the GraphQL mutation, so merge directly — the
+          # same squash + delete-branch merge auto-merge would perform.
+          state=$(gh pr view "${PR_NUMBER}" --repo "${OWNER}/${REPO}" \
+            --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null \
+            || echo UNKNOWN)
+          if [ "${state}" != "UNSTABLE" ]; then
+            echo "Auto-merge could not be armed and PR #${PR_NUMBER} is" \
+              "${state}, not UNSTABLE; leaving for human review." >&2
+            exit 1
+          fi
+          # Confirm every required check has concluded SUCCESS on this PR.
+          rollup=$(gh pr view "${PR_NUMBER}" --repo "${OWNER}/${REPO}" \
+            --json statusCheckRollup \
+            --jq '[.statusCheckRollup[]
+              | {name: (.name // .context),
+                 state: (.conclusion // .state // .status)}]')
+          all_green=true
+          while IFS= read -r name; do
+            [ -z "${name}" ] && continue
+            st=$(printf '%s' "${rollup}" | jq -r \
+              --arg n "${name}" \
+              'map(select(.name == $n)) | (last.state // "MISSING")')
+            if [ "${st}" != "SUCCESS" ]; then
+              echo "Required check '${name}' is '${st}', not SUCCESS;" \
+                "not merging PR #${PR_NUMBER}." >&2
+              all_green=false
+            fi
+          done <<< "${required_names}"
+          if [ "${all_green}" != "true" ]; then
+            exit 1
+          fi
+          gh pr merge "${PR_NUMBER}" --squash --delete-branch \
+            --repo "${OWNER}/${REPO}"
+          echo "PR #${PR_NUMBER} was UNSTABLE with all required checks green;" \
+            "merged directly (squash, delete-branch)."

--- a/.github/workflows/sdd-monitor.yml
+++ b/.github/workflows/sdd-monitor.yml
@@ -1,0 +1,491 @@
+name: sdd-monitor
+
+# Tier 1 of the sdd-monitor design (issue #148): detect "armed but idle"
+# tracking issues and post one `/dispatch` to unstick them.
+#
+# Why a plain utility workflow, not a gh-aw agent:
+# Tier 1 is purely mechanical — list workflow runs, list pull requests, walk
+# sub-issue trees, check labels, post a comment. There is no judgement call
+# in this loop, so an LLM in the loop only adds cost, latency, and a new
+# failure mode (model output drift). The same backstop pattern is already
+# used by sdd-pr-sanitize and sdd-triage-promote-ready (ADR 0006: a
+# deterministic workflow does the per-item work the agent has no event to
+# react to).
+#
+# Tier 2 (healing: merging UNSTABLE PRs, resetting orphaned tasks, advancing
+# sdd:review to sdd:done) and Tier 3 (escalating unrecoverable stalls to
+# needs-human) are out of scope for this PR. They are tracked as follow-ups
+# on issue #148.
+#
+# Idempotency model:
+#
+# 1. Disabled by default. The first check reads the SDD_MONITOR repo
+#    variable. The workflow only acts when SDD_MONITOR == '1'. A consumer
+#    that has not opted in pays no GitHub Actions cost beyond the no-op run.
+#
+# 2. In-flight gate. If any sdd-execute-{haiku,sonnet,opus} run is
+#    in_progress or queued anywhere in the repo, the pass exits without
+#    dispatching. This is conservative: a run targeting a different tracker
+#    still blocks all monitor dispatches for this pass. The conservatism is
+#    deliberate — correlating a workflow_run back to its tracking issue
+#    requires walking task -> Unit -> tracker per run (the run's input
+#    aw_context only names the task), and the cron backstop fires every
+#    ~10 min so a missed nudge is at most one cycle delayed. The safety
+#    case (do not stack /dispatch comments and trigger the cancellation
+#    storm described in issue #148) dominates.
+#
+# 3. Debounce. For each candidate tracker, the most recent comment whose
+#    body begins with `/dispatch` (any author, monitor-issued or
+#    operator-issued) within SDD_MONITOR_DEBOUNCE_MIN minutes (default 5)
+#    suppresses a new dispatch. This caps the rate at one dispatch per
+#    tracker per window regardless of how often the workflow fires
+#    (workflow_run completion + pull_request close + cron all converge on
+#    the same comment-history check).
+#
+# 4. Single comment per action. The audit line and the `/dispatch`
+#    directive are combined into one comment body so the dispatch
+#    wrapper's token-strict `/dispatch` match (it accepts the literal
+#    `/dispatch` followed by whitespace) still fires while operators see
+#    a one-line `sdd-monitor:` audit on the same comment.
+#
+# Triggers:
+#
+# - workflow_run completed on sdd-execute-{haiku,sonnet,opus}: react to a
+#   run finishing (success, failure, or cancellation) so a tracker that
+#   just lost its last in-flight run gets nudged immediately.
+# - pull_request closed: a merged or closed sdd/ implementation PR is the
+#   moment a task closes and the next layer could be armed.
+# - schedule */10: backstop for events lost to webhook drops or runner
+#   outages.
+
+on:
+  workflow_run:
+    workflows:
+      - sdd-execute-haiku
+      - sdd-execute-sonnet
+      - sdd-execute-opus
+    types: [completed]
+  pull_request:
+    types: [closed]
+  schedule:
+    # Every ten minutes is the backstop for missed webhook events. Tier 1
+    # is itself cheap (a handful of list calls per active tracker), so a
+    # higher cadence would be safe — ten minutes is chosen to match the
+    # debounce window order of magnitude and the typical sdd-execute run
+    # duration so most cron firings find at least one tracker actionable.
+    - cron: '*/10 * * * *'
+
+permissions:
+  contents: read
+  # actions: read is required to list sdd-execute-* workflow runs filtered
+  # by status so the in-flight gate can decide whether to dispatch.
+  actions: read
+  # pull-requests: read lists open sdd/ implementation PRs, which the
+  # armed-but-idle check excludes from candidate trackers.
+  pull-requests: read
+  # issues: read covers walking the sub-issue tree, reading labels, and
+  # listing existing comments. The /dispatch comment itself is posted with
+  # an App installation token (minted in the job below) so the dispatch
+  # wrapper's App-author carve-out admits it past the human-permission
+  # check — the default GITHUB_TOKEN's github-actions[bot] is not a
+  # repository collaborator and would be rejected.
+  issues: read
+
+jobs:
+  monitor:
+    # Top-level enable gate. A consumer that has not set SDD_MONITOR=1
+    # skips the whole job, including the App token mint, so a repo that
+    # has not opted in pays no further cost and does not need APP_ID +
+    # APP_PRIVATE_KEY configured for the monitor specifically. The
+    # second clause filters pull_request events to sdd/ branches;
+    # workflow_run and schedule events have no head ref to gate on at
+    # this level.
+    if: >-
+      vars.SDD_MONITOR == '1'
+      && (github.event_name != 'pull_request'
+        || startsWith(github.event.pull_request.head.ref, 'sdd/'))
+    # Serialize monitor passes for this repo. The three triggers
+    # (workflow_run, pull_request closed, schedule */10) can fire in
+    # close succession; without a concurrency group two passes can both
+    # clear the in-flight and debounce checks before either posts and
+    # then double-post `/dispatch` for the same tracker. cancel-in-
+    # progress is false because a running pass is cheap and worth
+    # finishing — the queued pass picks up any state change the running
+    # one missed.
+    concurrency:
+      group: sdd-monitor-${{ github.repository }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      # Mint the App installation token. The /dispatch comment posted below
+      # must be authored by the configured App so the dispatch wrapper's
+      # App-author carve-out admits it past the human-permission gate; the
+      # default GITHUB_TOKEN's github-actions[bot] is not a collaborator on
+      # the consumer repository. The same APP_ID + APP_PRIVATE_KEY pair
+      # already drives the cascade fan-out in sdd-dispatch (ADR 0014).
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Nudge armed-but-idle trackers
+        uses: actions/github-script@v9
+        env:
+          SDD_MONITOR_DEBOUNCE_MIN: ${{ vars.SDD_MONITOR_DEBOUNCE_MIN }}
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            // The job-level if: gate already ensured SDD_MONITOR == '1';
+            // if execution reaches this script the monitor is enabled.
+
+            const { owner, repo } = context.repo;
+            // Default to 5 minutes; treat a missing, empty, or
+            // non-numeric SDD_MONITOR_DEBOUNCE_MIN as "use the default".
+            // parseInt('', 10) and parseInt('abc', 10) both return NaN,
+            // and Math.max(1, NaN) is NaN — without this guard a typo
+            // in the repo var silently disables the debounce gate
+            // (every `ageMs < NaN` is false).
+            const parsedDebounce = parseInt(
+              process.env.SDD_MONITOR_DEBOUNCE_MIN || '', 10);
+            const debounceMin =
+              Number.isFinite(parsedDebounce) && parsedDebounce > 0
+                ? parsedDebounce
+                : 5;
+            const debounceMs = debounceMin * 60 * 1000;
+
+            // In-flight gate. If any sdd-execute-* run is in_progress or
+            // queued in this repo, exit without dispatching. The dispatch
+            // wrapper's per-task-per-tier concurrency group will cancel an
+            // in-flight cell when a new /dispatch fans out onto the same
+            // task, so even a single stacked /dispatch can kill productive
+            // work. The conservative repo-wide gate is the simplest way
+            // to make Tier 1 storm-proof; the cron backstop reruns every
+            // ten minutes so a missed window is recovered on the next
+            // pass.
+            const variantNames = [
+              'sdd-execute-haiku',
+              'sdd-execute-sonnet',
+              'sdd-execute-opus',
+            ];
+            for (const status of ['in_progress', 'queued']) {
+              for (const wf of variantNames) {
+                let runs = [];
+                try {
+                  runs = await github.paginate(
+                    github.rest.actions.listWorkflowRunsForRepo,
+                    { owner, repo, status, per_page: 50 });
+                } catch (err) {
+                  core.info(
+                    'Could not list ' + status + ' runs: ' + err.message
+                    + '; treating as in-flight to stay safe.');
+                  return;
+                }
+                const hit = runs.find((r) => r.name === wf);
+                if (hit) {
+                  core.info(
+                    'In-flight gate: ' + wf + ' run #' + hit.id + ' is '
+                    + status + '; deferring monitor pass.');
+                  return;
+                }
+              }
+            }
+
+            // Candidate trackers: open issues carrying sdd:dispatched, not
+            // carrying needs-human or sdd:done. The search index can lag a
+            // label change by a few seconds; one pass picks up the lag on
+            // the next firing, so no retry loop is needed here.
+            const trackerQuery =
+              'repo:' + owner + '/' + repo
+              + ' is:issue is:open label:sdd:dispatched'
+              + ' -label:needs-human -label:sdd:done';
+            let trackers = [];
+            try {
+              const resp = await github.paginate(
+                github.rest.search.issuesAndPullRequests,
+                { q: trackerQuery, per_page: 100 });
+              trackers = resp.filter((it) => !it.pull_request);
+            } catch (err) {
+              core.info(
+                'Tracker search failed: ' + err.message + '; nothing to do.');
+              return;
+            }
+            if (!trackers.length) {
+              core.info('No active sdd:dispatched trackers; nothing to do.');
+              return;
+            }
+
+            core.info(
+              'Evaluating ' + trackers.length + ' active tracker(s).');
+
+            // Per-tracker armed-but-idle check.
+            for (const tracker of trackers) {
+              const trackerNum = tracker.number;
+
+              // Debounce against the most recent /dispatch comment on
+              // this tracker, regardless of author. A monitor-issued
+              // dispatch and an operator-issued dispatch both occupy
+              // the same rate-limit slot. The check walks comments from
+              // newest to oldest and stops at the first /dispatch hit.
+              let comments = [];
+              try {
+                comments = await github.paginate(
+                  github.rest.issues.listComments,
+                  { owner, repo, issue_number: trackerNum, per_page: 100 });
+              } catch (err) {
+                core.info(
+                  '#' + trackerNum + ': could not list comments ('
+                  + err.message + '); skipping.');
+                continue;
+              }
+              const now = Date.now();
+              let recentDispatch = null;
+              for (let i = comments.length - 1; i >= 0; i--) {
+                const c = comments[i];
+                const body = (c.body || '').trimStart();
+                const isDispatch =
+                  body === '/dispatch'
+                  || body.startsWith('/dispatch ')
+                  || body.startsWith('/dispatch\n')
+                  || body.startsWith('/dispatch\r\n')
+                  || body.startsWith('/dispatch\t');
+                if (isDispatch) {
+                  recentDispatch = c;
+                  break;
+                }
+              }
+              if (recentDispatch) {
+                const ageMs = now - Date.parse(recentDispatch.created_at);
+                if (ageMs < debounceMs) {
+                  core.info(
+                    '#' + trackerNum + ': last /dispatch was '
+                    + Math.round(ageMs / 1000) + 's ago '
+                    + '(< ' + debounceMin + 'm debounce); skipping.');
+                  continue;
+                }
+              }
+
+              // Open sdd/ implementation PR check. An open PR for any task
+              // under this tracker means a layer is in flight via the PR
+              // side of the cascade; do not nudge. The dispatch wrapper
+              // re-fires on PR close, so this case will be re-evaluated
+              // then.
+              let openPrs = [];
+              try {
+                openPrs = await github.paginate(
+                  github.rest.pulls.list,
+                  { owner, repo, state: 'open', per_page: 100 });
+              } catch (err) {
+                core.info(
+                  '#' + trackerNum + ': could not list open PRs ('
+                  + err.message + '); skipping.');
+                continue;
+              }
+              const sddPrs = openPrs.filter(
+                (p) => (p.head && p.head.ref || '').startsWith('sdd/'));
+              let prInFlight = false;
+              let walkFailed = false;
+              for (const pr of sddPrs) {
+                // The sdd/ branch carries the task issue number as the
+                // first numeric segment after the prefix (ADR 0006). Map
+                // the task back to its tracker by walking two parent
+                // hops; if any open sdd/ PR rolls up to this tracker the
+                // layer is in flight.
+                const m = (pr.head.ref || '').match(/^sdd\/(\d+)-/);
+                if (!m) { continue; }
+                const taskNum = parseInt(m[1], 10);
+                // Fail closed: if the upward walk cannot be completed
+                // (a seed or GraphQL lookup error, the exact failure #133
+                // describes), we cannot prove this PR is unrelated to the
+                // tracker. Treat the unresolved walk as "assume in flight"
+                // and skip the nudge for this tracker only — never nudge a
+                // tracker we could not rule out as in flight.
+                let trackerOfTask;
+                try {
+                  trackerOfTask =
+                    await walkToTracker(github, owner, repo, taskNum);
+                } catch (err) {
+                  core.info(
+                    '#' + trackerNum + ': parent walk for PR task #'
+                    + taskNum + ' failed (' + err.message
+                    + '); assuming in flight and skipping.');
+                  walkFailed = true;
+                  break;
+                }
+                if (trackerOfTask === trackerNum) {
+                  prInFlight = true;
+                  break;
+                }
+              }
+              if (walkFailed) { continue; }
+              if (prInFlight) {
+                core.info(
+                  '#' + trackerNum + ': an open sdd/ PR rolls up to this '
+                  + 'tracker; not armed-but-idle.');
+                continue;
+              }
+
+              // Walk the sub-issue tree: tracker -> Unit -> task. Find
+              // open task sub-issues whose every `blocked by #<N>`
+              // dependency is closed. Tier 1 only needs the count; the
+              // dispatch wrapper recomputes the ready set authoritatively
+              // when it picks up our /dispatch comment.
+              let readyCount = 0;
+              let units = [];
+              try {
+                units = await github.paginate(
+                  'GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                  { owner, repo, issue_number: trackerNum, per_page: 100 });
+              } catch (err) {
+                core.info(
+                  '#' + trackerNum + ': could not list Unit sub-issues ('
+                  + err.message + '); skipping.');
+                continue;
+              }
+              for (const unit of units) {
+                let tasks = [];
+                try {
+                  tasks = await github.paginate(
+                    'GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                    { owner, repo, issue_number: unit.number, per_page: 100 });
+                } catch (err) {
+                  core.info(
+                    '#' + trackerNum + ': could not list tasks under Unit #'
+                    + unit.number + ' (' + err.message + '); skipping unit.');
+                  continue;
+                }
+                for (const task of tasks) {
+                  if (task.state !== 'open') { continue; }
+                  const body = task.body || '';
+                  const blockerNums = [
+                    ...new Set(
+                      [...body.matchAll(/\bblocked by #(\d+)\b/g)].map(
+                        (m) => parseInt(m[1], 10))),
+                  ];
+                  let allClosed = true;
+                  for (const b of blockerNums) {
+                    try {
+                      const got = await github.rest.issues.get({
+                        owner, repo, issue_number: b,
+                      });
+                      if (got.data.pull_request) { continue; }
+                      if (got.data.state !== 'closed') {
+                        allClosed = false;
+                        break;
+                      }
+                    } catch (err) {
+                      core.info(
+                        '#' + trackerNum + ': could not read blocker #' + b
+                        + ' for task #' + task.number
+                        + ' (' + err.message
+                        + '); treating as still blocked.');
+                      allClosed = false;
+                      break;
+                    }
+                  }
+                  if (allClosed) { readyCount += 1; }
+                }
+              }
+
+              if (readyCount === 0) {
+                core.info(
+                  '#' + trackerNum + ': no ready open tasks; not '
+                  + 'armed-but-idle.');
+                continue;
+              }
+
+              // Dispatch. The body's first token is `/dispatch` so the
+              // dispatch wrapper's command match fires; the audit prefix
+              // sits on a following line so operators see the action in
+              // the timeline. The combined comment is one writeable
+              // event, which keeps the timeline cleaner than a two-step
+              // (audit then dispatch) sequence.
+              const auditBody =
+                '/dispatch\n\n'
+                + 'sdd-monitor: armed-but-idle on #' + trackerNum
+                + ' with ' + readyCount + ' task'
+                + (readyCount === 1 ? '' : 's')
+                + ' ready; dispatching.';
+              try {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: trackerNum, body: auditBody,
+                });
+                core.info(
+                  '#' + trackerNum + ': posted monitor /dispatch ('
+                  + readyCount + ' ready task'
+                  + (readyCount === 1 ? '' : 's') + ').');
+              } catch (err) {
+                core.warning(
+                  '#' + trackerNum + ': failed to post /dispatch: '
+                  + err.message);
+              }
+            }
+
+            // walkToTracker: walk a task sub-issue up to its tracking
+            // issue (task -> Unit -> tracker, two hops per ADR 0005).
+            // Returns the tracker issue number, or 0 if the walk does not
+            // resolve to a two-hop root.
+            //
+            // The parent link is read via GraphQL `Issue.parent`, NOT via
+            // the REST `parent_issue_url` field. REST does not populate
+            // the child->parent pointer for native sub-issues reliably:
+            // the field comes back empty on the close webhook and on an
+            // immediate REST re-fetch (issue #133, the cascade-stall
+            // repro on this issue). sdd-dispatch's own route job switched
+            // to GraphQL for exactly this reason; the monitor mirrors it
+            // so the in-flight PR-rollup guard does not silently misfire.
+            //
+            // Fail-closed contract: parentNumberViaGraphql and walkToTracker
+            // distinguish a *resolved* walk (returns a number, or 0 when the
+            // walk legitimately reaches the top of the tree short of two
+            // hops) from an *unresolved* walk caused by a lookup error
+            // (rethrows). A swallowed error that collapsed to "no parent"
+            // would make an open sdd/ PR look unrelated to its tracker, the
+            // in-flight guard would clear, and the monitor would nudge a
+            // tracker whose layer is actually in flight — the cancellation
+            // storm issue #148 exists to prevent. The caller treats a thrown
+            // walk as "assume in flight" and skips the nudge for that
+            // tracker only.
+            async function parentNumberViaGraphql(nodeId) {
+              if (!nodeId) { return null; }
+              const result = await github.graphql(
+                'query($id: ID!) {' +
+                '  node(id: $id) {' +
+                '    ... on Issue { parent { id number } }' +
+                '  }' +
+                '}',
+                { id: nodeId });
+              const parent = result && result.node && result.node.parent;
+              return parent || null;
+            }
+
+            async function walkToTracker(ghCli, ownerArg, repoArg, taskNum) {
+              // Seed the GraphQL walk from the task issue's node id. A seed
+              // or parent lookup error rethrows so the caller fails closed;
+              // it must not be confused with a fully-walked tree that has no
+              // parent. Wrap callers in try/catch and treat a throw as
+              // "assume in flight" for that tracker.
+              const { data } = await ghCli.rest.issues.get({
+                owner: ownerArg, repo: repoArg, issue_number: taskNum,
+              });
+              let nodeId = data.node_id;
+              let parent = null;
+              let walked = 0;
+              while (nodeId && walked < 2) {
+                const next = await parentNumberViaGraphql(nodeId);
+                if (!next) { break; }
+                parent = next;
+                nodeId = next.id;
+                walked += 1;
+              }
+              // A task closure is exactly two hops below a tracking issue.
+              // A shorter walk means the seed was a Unit or the tracker
+              // itself, not a task — not a tracker match for this guard.
+              if (parent && walked === 2) {
+                return parent.number;
+              }
+              return 0;
+            }

--- a/.github/workflows/sdd-pr-sanitize.yml
+++ b/.github/workflows/sdd-pr-sanitize.yml
@@ -1,0 +1,228 @@
+name: sdd-pr-sanitize
+
+# Corrects the issue references in a spec or architecture pull request body,
+# and makes the deliverable link visible on the sub-issue side.
+# Three deterministic corrections, on every spec/* and arch/* pull request:
+#
+# 1. The feature tracking issue must stay open as the lifecycle anchor, so a
+#    spec or architecture pull request must never close it. The agents are told
+#    never to write a closing keyword for the feature, but across three
+#    acceptance runs the agent slipped `Closes`/`Fixes`/`Resolves #<feature>`
+#    into the body anyway. This workflow rewrites every closing keyword that
+#    precedes an issue reference to `Refs`, which GitHub does not treat as a
+#    closing keyword — except the keyword on the deliverable sub-issue (2). A
+#    prompt rule cannot be relied on; this is the deterministic backstop.
+#
+# 2. A spec pull request delivers the spec sub-issue; an architecture pull
+#    request delivers the architecture sub-issue. The agent creates that
+#    sub-issue and the pull request in one run and cannot know the sub-issue
+#    number when it writes the body, so the pull request cannot itself carry
+#    the link. This workflow runs after both exist: it resolves the deliverable
+#    sub-issue under the feature and adds `Closes #<sub-issue>` to the body, so
+#    merging the pull request closes the sub-issue — the way an implementation
+#    pull request's `Closes #<task>` already closes its task.
+#
+# 3. When the sanitizer PATCHes the pull-request body to add `Closes #<sub>`
+#    after the App-authenticated creation, GitHub suppresses the
+#    `cross-referenced` event it would normally emit on the sub-issue, and at
+#    merge time it attributes the close to the merger rather than the pull
+#    request. The closing link exists in the data model (the pull request's
+#    `closingIssuesReferences` returns the sub-issue), but neither of the two
+#    timeline events that normally make the deliverable link visible in the UI
+#    fires (issue #69). This workflow posts one `Delivered by #<pr>.` comment
+#    on the sub-issue, which both produces a visible `commented` event and
+#    causes GitHub to emit the missing `cross-referenced` event from the
+#    `#<pr>` reference in the comment body.
+#
+# All three corrections are owned by ADR 0006; the sub-issue closing model is
+# ADR 0005. Implementation pull requests on sdd/* branches are not touched:
+# their `Closes #<task>` is already correct, and GitHub already emits the
+# normal cross-reference and "closed via #<pr>" events because the closing
+# keyword was present at pull-request creation, not added by a later PATCH.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  # `issues: write` is required to post the `Delivered by #<pr>.` comment on
+  # the deliverable sub-issue. Reading the sub-issue and its comments to
+  # resolve it and to enforce idempotency only needs `issues: read`; the
+  # write scope is solely for the comment add (3) below.
+  issues: write
+  pull-requests: write
+
+jobs:
+  sanitize:
+    # Only spec and architecture pull requests are corrected here. An sdd/*
+    # implementation pull request is left alone.
+    if: >-
+      startsWith(github.event.pull_request.head.ref, 'spec/') ||
+      startsWith(github.event.pull_request.head.ref, 'arch/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Correct the issue references in the pull request body
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const headRef = pr.head.ref || '';
+            // A spec/* pull request delivers the `spec:`-titled sub-issue; an
+            // arch/* pull request delivers the `architecture:`-titled one.
+            const deliverablePrefix =
+              headRef.startsWith('spec/') ? 'spec:' : 'architecture:';
+
+            // Resolve the deliverable sub-issue. It is a sub-issue of the
+            // feature tracking issue, which the body references as `#N`. For
+            // each same-repo issue number in the body, check whether it has a
+            // sub-issue whose title marks it the deliverable; the first match
+            // wins. The sub-issue is created moments before the pull request
+            // (it gets the lower number), so on `opened` it already exists —
+            // retry briefly only to absorb API replication lag.
+            const body0 = pr.body || '';
+            const candidates = [
+              ...new Set(
+                [...body0.matchAll(/(?<![\w/])#(\d+)\b/g)].map(
+                  (m) => parseInt(m[1], 10))),
+            ];
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+            let deliverable = 0;
+            for (let attempt = 0; attempt < 5 && !deliverable; attempt++) {
+              if (attempt) { await sleep(3000); }
+              for (const feature of candidates) {
+                let subs;
+                try {
+                  subs = await github.paginate(
+                    'GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                    { owner, repo, issue_number: feature, per_page: 100 });
+                } catch (err) {
+                  core.info(
+                    'No sub-issues readable for #' + feature + ': '
+                    + err.message);
+                  continue;
+                }
+                const hit = subs.find((s) =>
+                  (s.title || '').trim().toLowerCase()
+                    .startsWith(deliverablePrefix));
+                if (hit) { deliverable = hit.number; break; }
+              }
+            }
+
+            // Rewrite every closing keyword that precedes an issue reference
+            // to `Refs`, except the keyword on the deliverable sub-issue.
+            // GitHub auto-closes an issue named after close/fix/resolve (with
+            // an optional s/d/ed) in a merged pull request body; only the
+            // keyword is rewritten, the issue number itself is kept. The
+            // exemption is scoped to a same-repo reference: a cross-repo
+            // `owner/repo#N` is never the deliverable, even when N collides
+            // with the deliverable's number. The rewrite runs whether or not
+            // the deliverable resolved, so the feature is always protected
+            // from auto-close.
+            const currentRepo = (owner + '/' + repo).toLowerCase();
+            let body = body0.replace(
+              /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b(\s+(?:[\w.-]+\/[\w.-]+)?#(\d+))/gi,
+              (m, _kw, ref, num) => {
+                if (!deliverable || parseInt(num, 10) !== deliverable) {
+                  return 'Refs' + ref;
+                }
+                const scoped = ref.match(/([\w.-]+\/[\w.-]+)#/);
+                const sameRepo =
+                  !scoped || scoped[1].toLowerCase() === currentRepo;
+                return sameRepo ? m : 'Refs' + ref;
+              });
+
+            // Add `Closes #<deliverable>` so merging the pull request closes
+            // the deliverable sub-issue (ADR 0005). Idempotent: skip when the
+            // body already closes it — but only a **bare**, line-anchored
+            // `Closes #N` counts. GitHub does not honor a closing keyword
+            // inside an inline-code span, so a backtick-wrapped mention such as
+            // `` `Closes #162` `` (which agents write in their hand-off prose)
+            // must NOT satisfy this guard, or the real bare line is never
+            // appended and the sub-issue stays open on merge (issue #136). The
+            // line anchor matches exactly the bare line appended below.
+            if (deliverable) {
+              const hasClose = new RegExp(
+                '(^|\\n)[ \\t]*closes?\\s+#' + deliverable + '\\b', 'i')
+                .test(body);
+              if (!hasClose) {
+                body = body.replace(/\s*$/, '')
+                  + '\n\nCloses #' + deliverable + '\n';
+              }
+            }
+
+            // Make the deliverable link visible on the sub-issue side. The
+            // `Closes` keyword that the PR body update below adds closes the
+            // sub-issue on merge, but GitHub does not emit the
+            // `cross-referenced` event it would have emitted had the
+            // keyword been present at pull-request creation: a PATCH from
+            // an App identity suppresses it, and at merge time the close
+            // is attributed to the merger rather than the pull request
+            // (issue #69). Posting one comment on the sub-issue both adds
+            // a visible `commented` event and makes GitHub emit the
+            // missing `cross-referenced` event from the `#<pr>` reference.
+            //
+            // Order of operations: this comment write runs **before** the
+            // PR-body update below. If the comment fails (rate limit,
+            // permission, 5xx), the body update never runs either, so a
+            // failed run leaves zero visible state to diverge from. On a
+            // re-fire (`edited`/`reopened`) the comment write is
+            // idempotent (paginate + marker-startsWith check) so it does
+            // not re-post.
+            if (deliverable) {
+              const marker = 'Delivered by #' + pr.number + '.';
+              let comments;
+              try {
+                comments = await github.paginate(
+                  github.rest.issues.listComments,
+                  { owner, repo, issue_number: deliverable, per_page: 100 });
+              } catch (err) {
+                comments = [];
+                core.info(
+                  'Could not list comments on #' + deliverable + ': '
+                  + err.message + '; will attempt to post.');
+              }
+              const already = comments.some((c) =>
+                (c.body || '').trimStart().startsWith(marker));
+              if (already) {
+                core.info(
+                  'Sub-issue #' + deliverable
+                  + ' already has a `Delivered by` comment for PR #'
+                  + pr.number + '; skipping.');
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: deliverable,
+                  body: marker,
+                });
+                core.info(
+                  'Posted `Delivered by #' + pr.number + '.` on sub-issue #'
+                  + deliverable + '.');
+              }
+            }
+
+            if (body !== body0) {
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pr.number,
+                body,
+              });
+              core.info('Corrected issue references in PR #' + pr.number);
+            } else if (deliverable) {
+              core.info('Pull request body already correct.');
+            }
+
+            // With the deliverable sub-issue unresolved, no `Closes` reference
+            // was added, so the spec or architecture sub-issue would never
+            // close on merge. Fail the run so the anomaly is visible rather
+            // than silently swallowed.
+            if (!deliverable) {
+              core.setFailed(
+                'Deliverable sub-issue for PR #' + pr.number
+                + ' could not be resolved; no `Closes` reference was added. '
+                + 'The spec or architecture sub-issue will not close on merge '
+                + 'until this is fixed.');
+            }

--- a/.github/workflows/sdd-review.yml
+++ b/.github/workflows/sdd-review.yml
@@ -1,0 +1,100 @@
+name: sdd-review
+
+# Thin wrapper for the sdd-review agent.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-review.lock.yml (compiled from sdd-review.md, which
+# declares on: workflow_call). This wrapper carries the real event triggers and
+# passes the triggering pull request to the agent through the aw_context input.
+# A consumer repository installs this wrapper unchanged.
+#
+# sdd-review has no comment-command trigger, so this wrapper performs no
+# repository-permission gate: the gh-aw command:/slash_command trigger is not
+# used here. The only trigger is an implementation pull request opened or
+# synchronized.
+#
+# The pull_request event is gated to pull requests whose head branch carries
+# the sdd-execute implementation branch prefix sdd/. sdd-execute opens
+# implementation PRs on sdd/<task-id>-<slug> branches (see the branch
+# conventions in shared/repo-conventions.md), so this prefix gate keeps the
+# review agent scoped to implementation PRs and off spec/ and arch/ PRs.
+#
+# A PR-boundary needs-human resume needs no separate trigger here. When
+# sdd-review escalates a CRITICAL or HIGH finding, the hand-off is resumed by a
+# fresh pull_request: synchronize, which is the event the human's fix commit
+# naturally fires. Clearing needs-human on a PR without a code change would
+# re-run the same review against the unchanged diff and re-post the same
+# findings; resuming on synchronize ties re-review to an actual fix. The agent
+# treats a needs-human-labelled PR as off-limits and emits noop until a real
+# fix commit arrives.
+
+on:
+  # An implementation pull request was opened or updated. synchronize also
+  # resumes a needs-human hand-off, since the human's fix commit fires it.
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve whether the triggering pull request is an implementation PR and
+  # build the aw_context the reusable workflow consumes. A pull request whose
+  # head branch does not carry the sdd/ implementation prefix leaves
+  # should_run = false so the agent job is skipped.
+  route:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const payload = context.payload;
+            let run = false;
+            let ctx = {};
+
+            // An implementation pull request was opened or synchronized. The
+            // review runs only when the head branch carries the sdd-execute
+            // implementation branch prefix sdd/, which scopes the agent to
+            // implementation PRs. A draft pull request is still reviewed:
+            // review is advisory and never blocks.
+            const action = payload.action;
+            if (action === 'opened' || action === 'synchronize') {
+              const headRef = payload.pull_request.head.ref || '';
+              if (headRef.startsWith('sdd/')) {
+                run = true;
+                ctx = {
+                  item_type: 'pull_request',
+                  item_number: payload.pull_request.number,
+                };
+              }
+            }
+
+            core.setOutput('should_run', run ? 'true' : 'false');
+            core.setOutput('aw_context', run ? JSON.stringify(ctx) : '');
+
+  sdd-review:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@main
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need issues and pull-requests write, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write

--- a/.github/workflows/sdd-spec.yml
+++ b/.github/workflows/sdd-spec.yml
@@ -1,0 +1,712 @@
+name: sdd-spec
+
+# Thin wrapper for the sdd-spec agent.
+#
+# The agent itself is the reusable workflow .github/workflows/sdd-spec.lock.yml
+# (compiled from sdd-spec.md, which declares on: workflow_call). This wrapper
+# carries the real event triggers, gates the comment commands to authors with
+# repository write access, and passes the triggering entity to the agent
+# through the aw_context input. A consumer repository installs this wrapper
+# unchanged.
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A tracking issue gained the sdd:spec label (also fired by the
+  # feature/bug issue templates), or the needs-human label was cleared.
+  issues:
+    types: [labeled, unlabeled]
+  # A /spec or /revise comment on an issue or pull request.
+  issue_comment:
+    types: [created]
+  # A spec pull request was closed; the agent advances the lifecycle only
+  # when it was merged.
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate skips the route job entirely on issue_comment
+  # events whose body does not start with one of the commands this wrapper
+  # owns, and on issues label events whose label this wrapper does not route
+  # (fixes issue #119 — a /dispatch or /execute comment, or the
+  # sdd:in-progress/sdd:dispatched label mutations a /dispatch performs on a
+  # tracker, no longer spawn a route-job runner on this wrapper). The route
+  # step routes an `issues` event only on `labeled` `sdd:spec`/`sdd:fastpath`
+  # or `unlabeled` `needs-human`; every other label add/remove is skipped
+  # here without a runner.
+  route:
+    if: |
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          startsWith(github.event.comment.body, '/spec')
+          || startsWith(github.event.comment.body, '/revise')
+          || startsWith(github.event.comment.body, '/fastpath')
+          || startsWith(github.event.comment.body, '/approve')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && (
+          (
+            github.event.action == 'labeled'
+            && (
+              github.event.label.name == 'sdd:spec'
+              || github.event.label.name == 'sdd:fastpath'
+            )
+          )
+          || (
+            github.event.action == 'unlabeled'
+            && github.event.label.name == 'needs-human'
+          )
+        )
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+      fastpath_approve: ${{ steps.decide.outputs.fastpath_approve }}
+      fastpath_tracking: ${{ steps.decide.outputs.fastpath_tracking }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const event = context.eventName;
+            const payload = context.payload;
+            let run = false;
+            let ctx = {};
+
+            // A tracking issue gained sdd:spec or sdd:fastpath, or
+            // needs-human was cleared on a tracking issue. All three
+            // situations are tracking-issue-scoped: a tracking issue has no
+            // parent (it is the lifecycle anchor), and a task sub-issue has
+            // a parent (its Unit). The `sdd:spec` label and the
+            // `needs-human` label are both shared with sub-issues —
+            // `sdd:spec` is set by the feature/bug templates on the tracking
+            // issue but a human can label any issue, and `needs-human` is
+            // applied by every SDD agent on whatever item it is operating
+            // on. `sdd:fastpath` is applied here by the wrapper on a
+            // `/fastpath` from a write-access author (see the
+            // issue_comment branch below) and travels with the tracking
+            // issue. Filter out any unlabeled event whose item has a parent
+            // so a task sub-issue's `needs-human` removal never re-runs
+            // this agent. The labeled-event path is left unfiltered for
+            // sdd:spec because the feature/bug templates apply `sdd:spec`
+            // on creation, before a parent link can exist; if a sub-issue
+            // is hand-labelled `sdd:spec` the agent itself bails. The
+            // check reads `parent_issue_url` from the standard REST issue
+            // payload — the same field `wrappers/sdd-validate.yml` uses
+            // for the same kind of filter, kept symmetric to keep the two
+            // routing layers in step. A non-empty `parent_issue_url`
+            // means the item is nested under another issue (i.e. a
+            // sub-issue, not a tracking issue).
+            if (event === 'issues') {
+              const action = payload.action;
+              const label = payload.label && payload.label.name;
+              if (action === 'labeled'
+                  && (label === 'sdd:spec' || label === 'sdd:fastpath')) {
+                run = true;
+                // A manually-applied `sdd:fastpath` on a sub-issue must
+                // not route into sdd-spec. The feature/bug templates
+                // apply `sdd:spec` on tracking-issue creation before a
+                // parent link can exist, so that label is left
+                // unfiltered; but `sdd:fastpath` is human-curation only
+                // and may land on a sub-issue by mistake. Filter on the
+                // same `parent_issue_url` check the `needs-human`
+                // unlabeled branch below uses, so only tracking issues
+                // proceed.
+                if (label === 'sdd:fastpath') {
+                  let parentUrl = '';
+                  try {
+                    const { data } = await github.rest.issues.get({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: payload.issue.number,
+                    });
+                    parentUrl = data.parent_issue_url || '';
+                  } catch (err) {
+                    // A transient error falls through to "proceed" so a
+                    // real tracking-issue label gain is never silently
+                    // swallowed; the agent's own situation guards are
+                    // the second line of defence.
+                    core.info(
+                      'Could not fetch issue #' + payload.issue.number
+                      + ': ' + err.message);
+                  }
+                  if (parentUrl) {
+                    core.info('Issue #' + payload.issue.number
+                      + ' has a parent (' + parentUrl
+                      + '); sdd:fastpath on a sub-issue is ignored.');
+                    run = false;
+                  }
+                }
+              } else if (action === 'unlabeled' && label === 'needs-human') {
+                run = true;
+                let parentUrl = '';
+                try {
+                  const { data } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: payload.issue.number,
+                  });
+                  parentUrl = data.parent_issue_url || '';
+                } catch (err) {
+                  // Transient errors fall through to "proceed" so a real
+                  // tracking-issue resume is never silently swallowed. The
+                  // agent's situation-6 noop precondition is the second
+                  // line of defence.
+                  core.info(
+                    'Could not fetch issue #' + payload.issue.number + ': '
+                    + err.message);
+                }
+                if (parentUrl) {
+                  core.info('Issue #' + payload.issue.number
+                    + ' has a parent (' + parentUrl
+                    + '); sdd-spec only acts on tracking issues. Skipping.');
+                  run = false;
+                }
+              }
+              if (run) {
+                ctx = { item_type: 'issue', item_number: payload.issue.number };
+              }
+            }
+
+            // A /spec, /fastpath, /approve, or /revise comment from an
+            // author with repo write access. The gate is the actor's real
+            // repository permission, not author_association:
+            // author_association reports the relationship to the thread
+            // (OWNER/MEMBER/COLLABORATOR), which is not the same as push
+            // access. A MEMBER of the org need not have write on this
+            // repo, and a COLLABORATOR may be read-only. The
+            // collaborators/{user}/permission API returns the actual
+            // permission level; only write, maintain, or admin may run a
+            // command. `/fastpath` is the fast-path confirmation command
+            // from ADR 0012; it is valid only on a tracking issue (not a
+            // pull request) and is ignored on a PR comment. `/approve` on
+            // a tracking issue carrying `sdd:fastpath` routes to the
+            // deterministic fastpath-approve job below; `/approve` on a
+            // full-path tracking issue is left to sdd-triage's wrapper.
+            if (event === 'issue_comment' && payload.action === 'created') {
+              const body = (payload.comment.body || '').trim();
+              const firstWord = body.split(/\s+/)[0];
+              const isPr = !!payload.issue.pull_request;
+              const isFastpath = firstWord === '/fastpath' && !isPr;
+              const isApprove = firstWord === '/approve' && !isPr;
+              if (firstWord === '/fastpath' && isPr) {
+                core.info('/fastpath on a pull request; ignoring.');
+              } else if (isApprove) {
+                // Detect fastpath approval. Only act on /approve when the
+                // tracking issue carries sdd:fastpath; otherwise leave it
+                // to sdd-triage. Confirm write access first.
+                const actor = payload.comment.user.login;
+                let permission = 'none';
+                try {
+                  const resp = await github.rest.repos
+                    .getCollaboratorPermissionLevel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      username: actor,
+                    });
+                  permission = resp.data.role_name || resp.data.permission;
+                } catch (err) {
+                  core.info(
+                    'Could not resolve repo permission for ' + actor
+                    + ': ' + err.message);
+                }
+                const canWrite = permission === 'write'
+                  || permission === 'maintain' || permission === 'admin';
+                if (canWrite) {
+                  let isFastpathTracking = false;
+                  try {
+                    const { data } = await github.rest.issues.get({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: payload.issue.number,
+                    });
+                    const labels = (data.labels || []).map(
+                      (l) => l.name || l);
+                    // Accept /approve on either sdd:fastpath (the
+                    // documented post-stub-merge state, per ADR 0012) or
+                    // sdd:fastpath-review (a human typed /approve before
+                    // the stub PR merged). The fastpath-approve job
+                    // below detects fastpath-review and posts a
+                    // guidance comment instead of dispatching, so this
+                    // carve-out only owns routing — not dispatch policy.
+                    // Kept symmetric with wrappers/sdd-triage.yml's
+                    // skipFastpath check.
+                    isFastpathTracking = labels.includes('sdd:fastpath')
+                      || labels.includes('sdd:fastpath-review');
+                  } catch (err) {
+                    core.info('Could not fetch issue #'
+                      + payload.issue.number + ': ' + err.message);
+                  }
+                  if (isFastpathTracking) {
+                    core.setOutput('fastpath_approve', 'true');
+                    core.setOutput('fastpath_tracking',
+                      String(payload.issue.number));
+                    // Suppress the sdd-spec agent invocation: the
+                    // fastpath-approve job below handles this trigger.
+                  } else {
+                    core.info('/approve on a non-fast-path tracking issue;'
+                      + ' sdd-triage will handle it.');
+                  }
+                } else {
+                  core.info(
+                    '/approve from an author without write access ('
+                    + permission + '); ignoring.');
+                }
+              } else if (firstWord === '/spec'
+                  || firstWord === '/revise'
+                  || isFastpath) {
+                const actor = payload.comment.user.login;
+                let permission = 'none';
+                try {
+                  const resp = await github.rest.repos
+                    .getCollaboratorPermissionLevel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      username: actor,
+                    });
+                  // role_name is the precise role (write/maintain/triage/...)
+                  // when present; permission is the legacy bucket
+                  // (admin/write/read/none) that collapses maintain into
+                  // write and triage into read.
+                  permission = resp.data.role_name || resp.data.permission;
+                } catch (err) {
+                  core.info(
+                    'Could not resolve repo permission for ' + actor
+                    + ': ' + err.message);
+                }
+                const canWrite = permission === 'write'
+                  || permission === 'maintain' || permission === 'admin';
+                if (canWrite) {
+                  run = true;
+                  ctx = {
+                    item_type: isPr ? 'pull_request' : 'issue',
+                    item_number: payload.issue.number,
+                    comment_id: payload.comment.id,
+                  };
+                  if (isFastpath) {
+                    ctx.command = 'fastpath';
+                  }
+                } else {
+                  core.info(
+                    'Command from an author without write access ('
+                    + permission + '); ignoring.');
+                }
+              }
+            }
+
+            // A merged spec pull request. Scoped to spec PRs only: the head
+            // branch must follow the spec/<slug> convention. A merged
+            // non-spec PR is not this agent's concern and is left to no-op.
+            if (event === 'pull_request' && payload.action === 'closed') {
+              const merged = payload.pull_request.merged === true;
+              const headRef = payload.pull_request.head
+                && payload.pull_request.head.ref || '';
+              const isSpecBranch = headRef.startsWith('spec/');
+              if (merged && isSpecBranch) {
+                run = true;
+                ctx = {
+                  item_type: 'pull_request',
+                  item_number: payload.pull_request.number,
+                };
+              } else if (merged) {
+                core.info('Merged PR is not a spec branch; ignoring.');
+              }
+            }
+
+            core.setOutput('should_run', run ? 'true' : 'false');
+            core.setOutput('aw_context', run ? JSON.stringify(ctx) : '');
+
+  # Fast-path /approve handler (ADR 0012).
+  #
+  # On /approve on a tracking issue carrying sdd:fastpath, the route job
+  # sets fastpath_approve=true. This job runs the deterministic dispatch:
+  # find the latest execution-plan comment on the tracking issue (matched
+  # by the `[sdd-spec:fastpath-plan]` plain-text marker), parse its
+  # `model:*` tier, mint an App token, call workflow_dispatch on the
+  # matching sdd-execute-{tier}.yml with `entry: 'fastpath'`, and move
+  # the tracking issue's lifecycle from `sdd:fastpath` to
+  # `sdd:in-progress`. The wrapper handles this entirely; the sdd-spec
+  # agent .md source is not invoked on this path.
+  #
+  # This follows the deterministic-in-wrapper pattern from #81 (ADR
+  # 0011): there is no natural-language judgement on this code path —
+  # walk a comment, parse a tier, call REST.
+  fastpath-approve:
+    needs: route
+    if: needs.route.outputs.fastpath_approve == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Find plan comment and dispatch sdd-execute-{tier}
+        uses: actions/github-script@v9
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TRACKING: ${{ needs.route.outputs.fastpath_tracking }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const tracking = parseInt(process.env.TRACKING, 10);
+            const sentinel = '[sdd-spec:fastpath-plan]';
+
+            // Before dispatching, confirm the tracking issue is in
+            // `sdd:fastpath` (the documented `/approve` state, per ADR
+            // 0012). If it is still in `sdd:fastpath-review` the stub
+            // spec PR has not merged yet; post a guidance comment
+            // pointing at the merge gate and stop. This lets the
+            // route-job carve-out accept either state symmetrically
+            // (kept consistent with sdd-triage's skipFastpath check)
+            // while keeping dispatch policy here.
+            try {
+              const { data: issueData } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking,
+              });
+              const issueLabels = (issueData.labels || []).map(
+                (l) => l.name || l);
+              if (issueLabels.includes('sdd:fastpath-review')
+                  && !issueLabels.includes('sdd:fastpath')) {
+                core.info('/approve on #' + tracking
+                  + ' while sdd:fastpath-review is present; the stub'
+                  + ' spec PR has not merged. Posting guidance and'
+                  + ' exiting without dispatch.');
+                try {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: tracking,
+                    body: 'Fast-path `/approve` is gated on the stub'
+                      + ' spec PR merging. Merge the open stub spec'
+                      + ' pull request first; the tracking issue'
+                      + ' returns to `sdd:fastpath` and then `/approve`'
+                      + ' dispatches the implementation.',
+                  });
+                } catch (e) {
+                  core.info('Could not post guidance comment: '
+                    + e.message);
+                }
+                return;
+              }
+            } catch (err) {
+              // A transient fetch error falls through to the dispatch
+              // path; the agent's lifecycle move below is idempotent
+              // and the worst case is a duplicate run on the right
+              // state.
+              core.info('Could not pre-check labels on #' + tracking
+                + ': ' + err.message);
+            }
+
+            // List comments on the tracking issue and find the latest plan
+            // comment by the sentinel marker. `/revise` between the plan
+            // post and `/approve` posts a new plan comment and hides the
+            // prior one; the latest one is the active plan.
+            let planComment = null;
+            let page = 1;
+            for (;;) {
+              const { data } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking,
+                per_page: 100,
+                page,
+              });
+              for (const c of data) {
+                if ((c.body || '').includes(sentinel)) {
+                  if (!planComment
+                      || (new Date(c.created_at))
+                        > (new Date(planComment.created_at))) {
+                    planComment = c;
+                  }
+                }
+              }
+              if (data.length < 100) {
+                break;
+              }
+              page += 1;
+            }
+            if (!planComment) {
+              core.setFailed('No execution plan comment found on tracking'
+                + ' issue #' + tracking + '. Expected a comment carrying'
+                + ' the `' + sentinel + '` sentinel posted by sdd-spec on'
+                + ' /fastpath. /approve cannot dispatch without a plan.');
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracking,
+                  body: 'Fast-path `/approve` could not find an execution'
+                    + ' plan comment on this tracking issue. Re-run'
+                    + ' `/fastpath` to regenerate the stub spec and plan,'
+                    + ' or comment `/spec` to switch to the full pipeline.',
+                });
+              } catch (e) {
+                core.info('Could not post failure comment: ' + e.message);
+              }
+              return;
+            }
+
+            // Parse the `model:*` tier from the plan body. Accept either
+            // `model: haiku` or `model:haiku` and case-insensitive tier
+            // names; reject anything else with a comment.
+            const tierMatch = (planComment.body || '').match(
+              /model\s*:\s*(haiku|sonnet|opus)\b/i);
+            if (!tierMatch) {
+              core.setFailed('Execution plan comment on #' + tracking
+                + ' is missing a `model:{haiku,sonnet,opus}` tier.');
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracking,
+                  body: 'Fast-path `/approve` could not parse a `model:`'
+                    + ' tier from the execution plan comment. Comment'
+                    + ' `/revise <note>` to re-post the plan with a'
+                    + ' `model: haiku|sonnet|opus` line.',
+                });
+              } catch (e) {
+                core.info('Could not post failure comment: ' + e.message);
+              }
+              return;
+            }
+            const tier = tierMatch[1].toLowerCase();
+
+            // Dispatch sdd-execute-{tier} with the fast-path entry context.
+            // Dispatch *before* moving the lifecycle label so that a
+            // dispatch failure leaves the tracking issue in
+            // `sdd:fastpath` (where the human can simply retype
+            // `/approve`) instead of stranded in `sdd:in-progress` with
+            // no execute run. The sdd-execute fast-path entry bypasses
+            // the route-job tier gate via `fastpathEntry`, so it does
+            // not depend on the lifecycle label being moved first.
+            const workflow = 'sdd-execute-' + tier + '.yml';
+            const awContext = JSON.stringify({
+              trigger: 'command',
+              entry: 'fastpath',
+              item_type: 'issue',
+              item_number: tracking,
+              plan_comment_id: planComment.id,
+              tier: tier,
+            });
+            // Resolve the dispatch ref. `context.ref` is set on
+            // issue_comment events (the branch the workflow file was
+            // loaded from — the default branch by GitHub's rule). When
+            // it is somehow absent, fall back to the repository's
+            // default branch from the REST API, not a hardcoded "main":
+            // the `workflow_dispatch` event payload does not include
+            // `repository.default_branch`, and hardcoding `main`
+            // dispatches to a non-existent ref on repos whose default
+            // branch differs.
+            let dispatchRef = context.ref;
+            if (!dispatchRef) {
+              try {
+                const { data: repoData } = await github.rest.repos.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                });
+                dispatchRef = 'refs/heads/' + repoData.default_branch;
+              } catch (err) {
+                core.setFailed('Could not resolve default branch for '
+                  + 'workflow_dispatch ref: ' + err.message);
+                return;
+              }
+            }
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflow,
+                ref: dispatchRef,
+                inputs: { aw_context: awContext },
+              });
+              core.info('Dispatched ' + workflow + ' for fast-path tracking'
+                + ' issue #' + tracking);
+            } catch (err) {
+              core.setFailed('Failed to dispatch ' + workflow
+                + ' for fast-path #' + tracking + ': ' + err.message);
+              return;
+            }
+
+            // Dispatch succeeded; now move the lifecycle from
+            // sdd:fastpath (or sdd:fastpath-review, if the early-state
+            // pre-check above did not catch the case) to
+            // sdd:in-progress on the tracking issue. The remove and
+            // add are idempotent.
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking,
+                name: 'sdd:fastpath',
+              });
+            } catch (err) {
+              core.info('Could not remove sdd:fastpath from #' + tracking
+                + ': ' + err.message);
+            }
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking,
+                labels: ['sdd:in-progress'],
+              });
+            } catch (err) {
+              core.info('Could not add sdd:in-progress to #' + tracking
+                + ': ' + err.message);
+            }
+
+  sdd-spec:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@main
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+
+  # Agent-failure hand-off (fixes #122, #123).
+  #
+  # When the sdd-spec reusable workflow fails before producing safe-outputs
+  # (e.g. the "Execute GitHub Copilot CLI" step crashes, or any other infra
+  # failure the gh-aw conclusion job does not classify), the agent has posted
+  # nothing: no comment, no needs-human. The failure is invisible to the
+  # reporter and the work stalls with no auto-retry (#122, #123). This job
+  # makes that failure visible and recoverable by minting the App token (same
+  # pattern as fastpath-approve above) and posting a hand-off comment plus
+  # the `needs-human` label on the tracking issue. Clearing `needs-human`
+  # re-fires the agent (situation 6 in sdd-spec.md), so the human-driven
+  # resume stands in for the missing auto-retry.
+  #
+  # Gated on failure() and should_run so it never runs when the agent was
+  # skipped (route decided not to run) or succeeded. The aw_context JSON the
+  # route job built carries the routed item; needs-human is applied only to
+  # an issue item (the tracking issue), which is the lifecycle anchor the
+  # agent re-fires on. A pull-request item (a /revise on a spec PR, or a
+  # merged spec PR) gets a visibility comment so the failure is still
+  # surfaced, but not needs-human: that label re-fires the agent only from
+  # the tracking issue, which is not reliably derivable from a PR here.
+  failure-handoff:
+    needs: [route, sdd-spec]
+    if: failure() && needs.route.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Post failure hand-off to tracking issue
+        uses: actions/github-script@v9
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          AW_CONTEXT: ${{ needs.route.outputs.aw_context }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            let ctx = {};
+            try {
+              ctx = JSON.parse(process.env.AW_CONTEXT || '{}');
+            } catch (err) {
+              core.setFailed('Could not parse aw_context: ' + err.message);
+              return;
+            }
+            const itemType = ctx.item_type;
+            const itemNumber = ctx.item_number;
+            if (!itemNumber) {
+              core.info('No item_number in aw_context; nothing to hand off.');
+              return;
+            }
+            const runUrl = process.env.GITHUB_SERVER_URL + '/'
+              + context.repo.owner + '/' + context.repo.repo
+              + '/actions/runs/' + context.runId;
+            // A pull-request item is a /revise on a spec PR or a merged spec
+            // PR. Apply needs-human only to an issue (the tracking issue):
+            // its removal re-fires the agent (situation 6). On a PR, post a
+            // visibility comment only so the failure is no longer silent.
+            const isIssue = itemType === 'issue';
+            const body = isIssue
+              ? 'The `sdd-spec` agent run failed before it could post a '
+                + 'spec, a comment, or any lifecycle update — the failure '
+                + 'was not classified by the conclusion job (e.g. the '
+                + 'agent step itself crashed). Applying `needs-human` so '
+                + 'this is visible and recoverable. A human should '
+                + 'investigate the failed run and, once ready, clear the '
+                + '`needs-human` label to re-run the spec agent on this '
+                + 'tracking issue. Failed run: ' + runUrl
+              : 'The `sdd-spec` agent run failed before it could post a '
+                + 'comment or any lifecycle update. A human should '
+                + 'investigate the failed run and re-run the agent. '
+                + 'Failed run: ' + runUrl;
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: itemNumber,
+                body,
+              });
+            } catch (err) {
+              core.setFailed('Could not post failure comment on #'
+                + itemNumber + ': ' + err.message);
+              return;
+            }
+            if (isIssue) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: itemNumber,
+                  labels: ['needs-human'],
+                });
+              } catch (err) {
+                core.setFailed('Could not apply needs-human to #'
+                  + itemNumber + ': ' + err.message);
+              }
+            }

--- a/.github/workflows/sdd-triage-dedupe-tasks.yml
+++ b/.github/workflows/sdd-triage-dedupe-tasks.yml
@@ -1,0 +1,190 @@
+name: sdd-triage-dedupe-tasks
+
+# Closes a duplicate phase-C task sub-issue under the same Unit.
+#
+# sdd-triage phase C decomposes each Unit sub-issue into one implementation
+# task sub-issue per single-session unit of work. The agent emits one
+# `create-issue` safe-output per task, with `parent` set to the Unit, and the
+# "each task single-session sized" rule is enforced only in prose. An
+# acceptance run (issue #62) showed the agent emitting two `create_issue`
+# payloads with identical titles and identical bodies under the same Unit:
+# the prompt rule does not prevent a duplicate emission, and the gh-aw
+# safe-output handler does not collapse identical sibling `create_issue`
+# calls. A prompt rule cannot be relied on; this is the deterministic
+# backstop in the spirit of ADR 0006 and ADR 0007.
+#
+# On every issue opened in the consumer repository, this workflow checks
+# whether the new issue is a phase-C task sub-issue, finds its parent Unit,
+# enumerates that Unit's sub-issues, and — if an earlier-numbered sibling
+# carries the same title — closes the new issue as a duplicate with a
+# comment naming the original. Lower issue number always wins, so two
+# near-simultaneous duplicate runs converge on the same survivor.
+#
+# Scoped narrowly. A non-task issue (no structured `## Task` block) is
+# ignored. An issue without a parent is ignored. An issue whose parent has
+# only one sub-issue with that title is ignored.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  dedupe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close a duplicate phase-C task sub-issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const { owner, repo } = context.repo;
+
+            // A phase-C task sub-issue carries the structured `## Task`
+            // block documented in .github/workflows/sdd-triage.md step 6.
+            // Filter on that block so a regular hand-filed issue, a Unit
+            // sub-issue, or the spec/architecture sub-issues do not match.
+            const body = issue.body || '';
+            const looksLikeTask = /^##\s+Task\b/m.test(body)
+              && /\brepo:\s/i.test(body)
+              && /\bproof artifacts:\s*$/im.test(body);
+            if (!looksLikeTask) {
+              core.info(
+                'Issue #' + issue.number + ' is not a phase-C task; '
+                + 'skipping.');
+              return;
+            }
+
+            // Resolve the parent Unit. The sub-issues preview API exposes a
+            // direct parent lookup; an issue without a parent is not a
+            // sub-issue and is left alone. Retry briefly to absorb API
+            // replication lag — the parent link is created in the same
+            // safe-output as the issue itself.
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+            let parent = 0;
+            for (let attempt = 0; attempt < 5 && !parent; attempt++) {
+              if (attempt) { await sleep(3000); }
+              try {
+                const resp = await github.request(
+                  'GET /repos/{owner}/{repo}/issues/{issue_number}/parent',
+                  { owner, repo, issue_number: issue.number });
+                if (resp.data && resp.data.number) {
+                  parent = resp.data.number;
+                }
+              } catch (err) {
+                core.info(
+                  'No parent resolvable for #' + issue.number + ' yet: '
+                  + err.message);
+              }
+            }
+            if (!parent) {
+              core.info(
+                'Issue #' + issue.number + ' has no parent; skipping.');
+              return;
+            }
+
+            // List the parent Unit's sub-issues. The original of any
+            // duplicate pair is the sibling with the lower issue number,
+            // which exists in the listing before the duplicate. Two
+            // near-simultaneous duplicate runs both see the lower-numbered
+            // sibling and both pick the same survivor.
+            //
+            // The listing can race the create-issue calls in the same
+            // safe-output job: B's run may list children of the Unit
+            // before A is visible. Retry the listing until either an
+            // earlier-numbered same-title sibling is present, or the
+            // retry budget is exhausted. A's own listing safely returns
+            // no earlier sibling (the `< issue.number` filter keeps A
+            // from matching itself), so the retry only changes B's view.
+            const titleKey = (issue.title || '').trim().toLowerCase();
+            const isSameTitleEarlierTask = (s) =>
+              (s.title || '').trim().toLowerCase() === titleKey
+              && s.number < issue.number;
+            let siblings = [];
+            let original;
+            for (let attempt = 0; attempt < 5; attempt++) {
+              if (attempt) { await sleep(3000); }
+              try {
+                siblings = await github.paginate(
+                  'GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                  { owner, repo, issue_number: parent, per_page: 100 });
+              } catch (err) {
+                core.info(
+                  'Could not list sub-issues of Unit #' + parent + ' on '
+                  + 'attempt ' + (attempt + 1) + ': ' + err.message);
+                continue;
+              }
+              original = siblings
+                .filter(isSameTitleEarlierTask)
+                .sort((a, b) => a.number - b.number)[0];
+              if (original) { break; }
+            }
+
+            // The matched sibling must itself be a phase-C task. A
+            // collision against a hand-filed issue with the same title
+            // (no `## Task` block) would otherwise close this run's
+            // legitimate task. Fetch the sibling's full body and re-check.
+            if (original) {
+              try {
+                const full = await github.rest.issues.get({
+                  owner, repo, issue_number: original.number,
+                });
+                const sbody = (full.data && full.data.body) || '';
+                const siblingIsTask = /^##\s+Task\b/m.test(sbody)
+                  && /\brepo:\s/i.test(sbody)
+                  && /\bproof artifacts:\s*$/im.test(sbody);
+                if (!siblingIsTask) {
+                  core.info(
+                    'Earlier sibling #' + original.number
+                    + ' carries the same title but no `## Task` block; '
+                    + 'not closing #' + issue.number + ' against it.');
+                  original = undefined;
+                }
+              } catch (err) {
+                core.info(
+                  'Could not read body of sibling #' + original.number
+                  + '; conservatively not closing #' + issue.number + ': '
+                  + err.message);
+                original = undefined;
+              }
+            }
+
+            if (!original) {
+              core.info(
+                'No earlier sibling of #' + issue.number + ' under Unit #'
+                + parent + ' matches; not a duplicate.');
+              return;
+            }
+
+            // The duplicate may already have moved on (closed by a prior
+            // run, or labelled by phase C's lifecycle step). Idempotent:
+            // close only when still open.
+            if (issue.state !== 'open') {
+              core.info(
+                'Issue #' + issue.number + ' already closed; nothing to do.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issue.number,
+              body:
+                'Closing as a duplicate of #' + original.number + '. Phase C '
+                + 'emitted two `create-issue` safe-outputs with the same '
+                + 'title under Unit #' + parent + '; the lower-numbered '
+                + 'sibling is kept (ADR 0008; backstop pattern in ADR 0006).',
+            });
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });
+            core.info(
+              'Closed #' + issue.number + ' as a duplicate of #'
+              + original.number + ' under Unit #' + parent + '.');

--- a/.github/workflows/sdd-triage-promote-ready.yml
+++ b/.github/workflows/sdd-triage-promote-ready.yml
@@ -1,0 +1,250 @@
+name: sdd-triage-promote-ready
+
+# Promotes a phase-C task sub-issue to `sdd:ready` when its last blocker
+# closes.
+#
+# ADR 0009 (`fix/63`, PR #72) attaches `sdd:ready` at task-creation time on
+# tasks born **without** a `blocked by` dependency. A task born **with** a
+# `blocked by` dependency is intentionally created without `sdd:ready` and
+# stays that way until something promotes it. Nothing in the current
+# pipeline does that: `sdd-triage` phase C runs once per `/approve` and
+# does not re-fire on a task close, and `sdd-execute`'s eligibility check
+# skips a task without `sdd:ready`. The result is a stalled cascade where
+# the work is structurally ready but the label is missing.
+#
+# This wrapper closes that gap. On every issue close in the consumer
+# repository:
+#
+# 1. Identify the closed issue as a phase-C task by its structured
+#    `## Task` block.
+# 2. Find every other open task in the same repo that references the
+#    closed task on a `blocked by #<N>` line (one GitHub code search,
+#    not a tree walk).
+# 3. For each match, parse its full `depends on:` list, fetch each
+#    referenced issue, and apply `sdd:ready` only when every blocker is
+#    now closed.
+#
+# Search is the right primitive because dependencies cross Unit
+# boundaries: a task in Unit 2 may depend on a task in Unit 1, and the
+# closed task's parent Unit alone is not enough to find all promotable
+# siblings (issue #78's "Unit's sub-issues" wording is conservative;
+# this implementation broadens to the search-driven set, which
+# subsumes it).
+#
+# Idempotent: a task that already carries `sdd:ready` is skipped. Two
+# concurrent runs that resolve the same task converge on the same
+# label state (GitHub's `add_labels` is a set-union).
+#
+# Backstop pattern of ADR 0006 (deterministic workflow does the
+# per-item work the agent has no event to react to). Companion to
+# `sdd-pr-sanitize`, `sdd-triage-dedupe-tasks`. ADR 0013 records the
+# full reasoning.
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  # `issues: write` is required to apply the `sdd:ready` label on a
+  # promoted task. Reading the closed issue's body, walking the search
+  # results, and reading each blocker's state need only `issues: read`;
+  # the write scope is solely for `addLabels` below.
+  issues: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Promote tasks whose last blocker just closed
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const closed = context.payload.issue;
+            const { owner, repo } = context.repo;
+
+            // Only phase-C task sub-issues are interesting. A non-task
+            // close (a Unit, a tracker, a hand-filed issue) cannot
+            // unblock anything in this model because dependencies are
+            // expressed only between tasks.
+            const closedBody = closed.body || '';
+            const looksLikeTask =
+              /^##\s+Task\b/m.test(closedBody)
+              && /\brepo:\s/i.test(closedBody)
+              && /\bproof artifacts:\s*$/im.test(closedBody);
+            if (!looksLikeTask) {
+              core.info(
+                'Closed issue #' + closed.number
+                + ' is not a phase-C task; nothing to promote.');
+              return;
+            }
+
+            // Find every open issue in this repo that references the
+            // closed task on a `blocked by #<N>` line. One code-search
+            // call covers the cross-Unit case without walking every
+            // task in the tree.
+            //
+            // The search index can lag the close event by a few
+            // seconds. Retry briefly to absorb that lag — the same
+            // pattern sdd-pr-sanitize and sdd-triage-dedupe-tasks use
+            // for sub-issue API replication.
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+            const phrase = '"blocked by #' + closed.number + '"';
+            const query =
+              'repo:' + owner + '/' + repo
+              + ' is:issue is:open ' + phrase;
+            let candidates = [];
+            for (let attempt = 0; attempt < 5; attempt++) {
+              if (attempt) { await sleep(3000); }
+              try {
+                const resp = await github.paginate(
+                  github.rest.search.issuesAndPullRequests,
+                  { q: query, per_page: 100 });
+                candidates = resp.filter((it) => !it.pull_request);
+                if (candidates.length) { break; }
+              } catch (err) {
+                core.info(
+                  'Code search failed on attempt ' + (attempt + 1)
+                  + ': ' + err.message);
+              }
+            }
+            if (!candidates.length) {
+              core.info(
+                'No open issues reference `blocked by #' + closed.number
+                + '`; nothing to promote.');
+              return;
+            }
+
+            core.info(
+              'Found ' + candidates.length + ' candidate(s) referencing '
+              + '`blocked by #' + closed.number + '`.');
+
+            // Per-candidate promotion. Each step is conservative: any
+            // failure to verify a blocker is treated as "still blocked",
+            // not as "ready". Promoting too eagerly would let
+            // sdd-execute pick a task whose dependencies are still
+            // open, which is a worse failure than this backstop being a
+            // no-op for one run (the next blocker close will retry).
+            for (const cand of candidates) {
+              // Re-read the candidate; the search payload omits labels
+              // and the body may have been edited since indexing.
+              let full;
+              try {
+                full = await github.rest.issues.get({
+                  owner, repo, issue_number: cand.number,
+                });
+              } catch (err) {
+                core.info(
+                  'Could not read #' + cand.number + '; skipping: '
+                  + err.message);
+                continue;
+              }
+              if (full.data.state !== 'open') {
+                core.info(
+                  '#' + cand.number + ' is no longer open; skipping.');
+                continue;
+              }
+
+              // Idempotent: skip a task that already carries
+              // `sdd:ready`. A re-fire after a no-op close, or two
+              // concurrent runs racing the same task, both reach this
+              // branch and exit without writing.
+              const labels = (full.data.labels || []).map(
+                (l) => (typeof l === 'string' ? l : l.name));
+              if (labels.indexOf('sdd:ready') !== -1) {
+                core.info(
+                  '#' + cand.number + ' already carries `sdd:ready`; '
+                  + 'skipping.');
+                continue;
+              }
+
+              // The candidate must itself be a phase-C task. A
+              // hand-filed issue that happens to mention "blocked by
+              // #<N>" in prose is not promotable.
+              const cbody = full.data.body || '';
+              const candIsTask =
+                /^##\s+Task\b/m.test(cbody)
+                && /\brepo:\s/i.test(cbody)
+                && /\bproof artifacts:\s*$/im.test(cbody);
+              if (!candIsTask) {
+                core.info(
+                  '#' + cand.number + ' is not a phase-C task '
+                  + '(no `## Task` block); skipping.');
+                continue;
+              }
+
+              // Parse the candidate's full `depends on:` block. The
+              // structured form (sdd-triage step 6) lists every
+              // dependency as `blocked by #<task>` on its own line
+              // under a `depends on:` header. Pulling the references
+              // from the full body — not just the search-matched line
+              // — is what makes the "every blocker closed" check
+              // correct in the multi-blocker case.
+              const blockerNums = [
+                ...new Set(
+                  [...cbody.matchAll(/\bblocked by #(\d+)\b/g)].map(
+                    (m) => parseInt(m[1], 10))),
+              ];
+              if (!blockerNums.length) {
+                core.info(
+                  '#' + cand.number + ' has no parsable `blocked by` '
+                  + 'references; skipping.');
+                continue;
+              }
+
+              // Verify every blocker is closed. A cross-repo blocker
+              // (`blocked by owner/repo#<N>`) is not produced by
+              // sdd-triage today (cross-repo task routing is a
+              // documented future extension), but if one appears it
+              // will not match this regex and the task is left
+              // unpromoted — conservative, and correct under the
+              // current model.
+              let allClosed = true;
+              for (const b of blockerNums) {
+                try {
+                  const got = await github.rest.issues.get({
+                    owner, repo, issue_number: b,
+                  });
+                  // `pull_request` field present => the referenced
+                  // number is a PR, not a task issue. Treat as a
+                  // non-blocker (closed PR is closed; open PR can't
+                  // block a task in this model anyway).
+                  if (got.data.pull_request) { continue; }
+                  if (got.data.state !== 'closed') {
+                    allClosed = false;
+                    break;
+                  }
+                } catch (err) {
+                  core.info(
+                    'Could not read blocker #' + b + ' for #'
+                    + cand.number + '; conservatively leaving '
+                    + 'unpromoted: ' + err.message);
+                  allClosed = false;
+                  break;
+                }
+              }
+
+              if (!allClosed) {
+                core.info(
+                  '#' + cand.number + ' still has open blocker(s); '
+                  + 'skipping.');
+                continue;
+              }
+
+              // Promote. `add_labels` is a set-union: applying
+              // `sdd:ready` to a task that has somehow gained it in
+              // the brief window since the labels read is a no-op.
+              try {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: cand.number,
+                  labels: ['sdd:ready'],
+                });
+                core.info(
+                  'Promoted #' + cand.number + ' to `sdd:ready` '
+                  + '(last blocker #' + closed.number + ' closed).');
+              } catch (err) {
+                core.warning(
+                  'Could not apply `sdd:ready` to #' + cand.number
+                  + ': ' + err.message);
+              }
+            }

--- a/.github/workflows/sdd-triage.yml
+++ b/.github/workflows/sdd-triage.yml
@@ -1,0 +1,231 @@
+name: sdd-triage
+
+# Thin wrapper for the sdd-triage agent.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-triage.lock.yml (compiled from sdd-triage.md, which
+# declares on: workflow_call). This wrapper carries the real event triggers,
+# gates the comment commands to authors with repository write access, and
+# passes the triggering entity to the agent through the aw_context input. A
+# consumer repository installs this wrapper unchanged.
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A tracking issue gained the sdd:triage label (phase A), or the needs-human
+  # label was cleared (resume).
+  issues:
+    types: [labeled, unlabeled]
+  # A /triage, /approve, or /revise comment on an issue or pull request.
+  issue_comment:
+    types: [created]
+  # An architecture pull request was closed; the agent runs phase B only when
+  # it was merged and the head branch follows the arch/<slug> convention.
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate skips the route job entirely on issue_comment
+  # events whose body does not start with one of the commands this wrapper
+  # owns, and on issues label events whose label this wrapper does not route
+  # (fixes issue #119 — a /dispatch or /execute comment, or the
+  # sdd:in-progress/sdd:dispatched label mutations a /dispatch performs on a
+  # tracker, no longer spawn a route-job runner on this wrapper). The route
+  # step routes an `issues` event only on `labeled` `sdd:triage` or
+  # `unlabeled` `needs-human`; every other label add/remove is skipped here
+  # without a runner.
+  route:
+    if: |
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          startsWith(github.event.comment.body, '/triage')
+          || startsWith(github.event.comment.body, '/approve')
+          || startsWith(github.event.comment.body, '/revise')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && (
+          (
+            github.event.action == 'labeled'
+            && github.event.label.name == 'sdd:triage'
+          )
+          || (
+            github.event.action == 'unlabeled'
+            && github.event.label.name == 'needs-human'
+          )
+        )
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const event = context.eventName;
+            const payload = context.payload;
+            let run = false;
+            let ctx = {};
+
+            // A tracking issue gained sdd:triage (phase A), or needs-human was
+            // cleared (resume).
+            if (event === 'issues') {
+              const action = payload.action;
+              const label = payload.label && payload.label.name;
+              if (action === 'labeled' && label === 'sdd:triage') {
+                run = true;
+              } else if (action === 'unlabeled' && label === 'needs-human') {
+                run = true;
+              }
+              if (run) {
+                ctx = { item_type: 'issue', item_number: payload.issue.number };
+              }
+            }
+
+            // A /triage, /approve, or /revise comment from an author with repo
+            // write access. The gate is the actor's real repository
+            // permission, not author_association: author_association reports
+            // the relationship to the thread (OWNER/MEMBER/COLLABORATOR),
+            // which is not the same as push access. A MEMBER of the org need
+            // not have write on this repo, and a COLLABORATOR may be
+            // read-only. The collaborators/{user}/permission API returns the
+            // actual permission level; only write, maintain, or admin may run
+            // a command.
+            if (event === 'issue_comment' && payload.action === 'created') {
+              const body = (payload.comment.body || '').trim();
+              const firstWord = body.split(/\s+/)[0];
+              const isCommand = firstWord === '/triage'
+                || firstWord === '/approve' || firstWord === '/revise';
+              if (isCommand) {
+                const actor = payload.comment.user.login;
+                let permission = 'none';
+                try {
+                  const resp = await github.rest.repos
+                    .getCollaboratorPermissionLevel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      username: actor,
+                    });
+                  // role_name is the precise role (write/maintain/triage/...)
+                  // when present; permission is the legacy bucket
+                  // (admin/write/read/none) that collapses maintain into
+                  // write and triage into read.
+                  permission = resp.data.role_name || resp.data.permission;
+                } catch (err) {
+                  core.info(
+                    'Could not resolve repo permission for ' + actor
+                    + ': ' + err.message);
+                }
+                const canWrite = permission === 'write'
+                  || permission === 'maintain' || permission === 'admin';
+                if (canWrite) {
+                  // Fast-path carve-out (ADR 0012): /approve on a tracking
+                  // issue carrying sdd:fastpath (or sdd:fastpath-review,
+                  // when the human typed /approve before the stub spec PR
+                  // merged) is handled by the sdd-spec wrapper's
+                  // fastpath-approve job (it dispatches sdd-execute-{tier}
+                  // directly, or noops with a guidance comment when the
+                  // stub PR is still open). This wrapper skips /approve in
+                  // both cases so the two wrappers do not both fire on the
+                  // same comment.
+                  const isPr = !!payload.issue.pull_request;
+                  let skipFastpath = false;
+                  if (firstWord === '/approve' && !isPr) {
+                    try {
+                      const { data } = await github.rest.issues.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: payload.issue.number,
+                      });
+                      const labels = (data.labels || []).map(
+                        (l) => l.name || l);
+                      if (labels.includes('sdd:fastpath')
+                          || labels.includes('sdd:fastpath-review')) {
+                        skipFastpath = true;
+                        core.info('/approve on a fast-path tracking'
+                          + ' issue; sdd-spec wrapper will handle it.');
+                      }
+                    } catch (err) {
+                      core.info('Could not fetch issue #'
+                        + payload.issue.number + ': ' + err.message);
+                    }
+                  }
+                  if (!skipFastpath) {
+                    run = true;
+                    ctx = {
+                      item_type: isPr ? 'pull_request' : 'issue',
+                      item_number: payload.issue.number,
+                      comment_id: payload.comment.id,
+                    };
+                  }
+                } else {
+                  core.info(
+                    'Command from an author without write access ('
+                    + permission + '); ignoring.');
+                }
+              }
+            }
+
+            // A merged architecture pull request. Scoped to architecture PRs
+            // only: the head branch must follow the arch/<slug> convention. A
+            // merged non-architecture PR is not this agent's concern and is
+            // left to no-op.
+            if (event === 'pull_request' && payload.action === 'closed') {
+              const merged = payload.pull_request.merged === true;
+              const headRef = payload.pull_request.head
+                && payload.pull_request.head.ref || '';
+              const isArchBranch = headRef.startsWith('arch/');
+              if (merged && isArchBranch) {
+                run = true;
+                ctx = {
+                  item_type: 'pull_request',
+                  item_number: payload.pull_request.number,
+                };
+              } else if (merged) {
+                core.info('Merged PR is not an arch branch; ignoring.');
+              }
+            }
+
+            core.setOutput('should_run', run ? 'true' : 'false');
+            core.setOutput('aw_context', run ? JSON.stringify(ctx) : '');
+
+  sdd-triage:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@main
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write

--- a/.github/workflows/sdd-validate.yml
+++ b/.github/workflows/sdd-validate.yml
@@ -1,0 +1,157 @@
+name: sdd-validate
+
+# Thin wrapper for the sdd-validate agent.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-validate.lock.yml (compiled from sdd-validate.md, which
+# declares on: workflow_call). This wrapper carries the real event triggers and
+# passes the triggering entity to the agent through the aw_context input. A
+# consumer repository installs this wrapper unchanged.
+#
+# sdd-validate has no comment-command trigger, so this wrapper performs no
+# repository-permission gate: the gh-aw command:/slash_command trigger is not
+# used here. The triggers are a pull request opened or synchronized and a
+# tracking issue gaining the sdd:ready label.
+#
+# No needs-human-removal resume is wired here. When sdd-validate escalates a
+# Blocker on a pull request, the hand-off is resumed by a fresh
+# pull_request: synchronize — the human's fix commit — not by an unlabeled
+# event: clearing needs-human without a code change would only re-run the same
+# gate set against the unchanged diff and re-post the same Blocker. A Blocker
+# at the triage boundary is advisory (validation gates neither a merge nor
+# /approve), so it needs no agent re-run. The wrapper therefore subscribes to
+# no unlabeled event. See the "Triggers this agent handles" section of
+# .github/workflows/sdd-validate.md.
+
+on:
+  # A pull request was opened or updated: the spec, architecture, or
+  # implementation boundary. synchronize also resumes a PR-boundary needs-human
+  # hand-off, since the human's fix commit fires it.
+  pull_request:
+    types: [opened, synchronize]
+  # A tracking issue gained sdd:ready: the non-pull-request triage boundary.
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate skips the route job entirely on issues label events
+  # whose label this wrapper does not route (fixes issue #119 — the
+  # sdd:in-progress/sdd:dispatched label mutations a /dispatch performs on a
+  # tracker no longer spawn a route-job runner on this wrapper). The route
+  # step routes an `issues` event only on `labeled` `sdd:ready`; every other
+  # label add is skipped here without a runner. pull_request events pass
+  # through unchanged.
+  route:
+    if: |
+      github.event_name != 'issues'
+      || (
+        github.event.action == 'labeled'
+        && github.event.label.name == 'sdd:ready'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const event = context.eventName;
+            const payload = context.payload;
+            let run = false;
+            let ctx = {};
+
+            // A pull request was opened or synchronized. Every such event is
+            // validated; the agent resolves the boundary from the changed
+            // files. A draft pull request is still validated: validation is
+            // advisory and never blocks.
+            if (event === 'pull_request') {
+              const action = payload.action;
+              if (action === 'opened' || action === 'synchronize') {
+                run = true;
+                ctx = {
+                  item_type: 'pull_request',
+                  item_number: payload.pull_request.number,
+                };
+              }
+            }
+
+            // A tracking issue gained sdd:ready: the triage boundary. This
+            // agent has no needs-human-removal resume, so an unlabeled event
+            // is not routed (see the header comment).
+            //
+            // sdd:ready is also applied by sdd-triage phase C to every
+            // unblocked task sub-issue, so the labelled item may be a task,
+            // not a tracking issue. The triage boundary is the tracking
+            // issue only: filter the event by the absence of a parent issue.
+            // A tracking issue has no parent; a Unit and a task each have
+            // one (their parent in the feature tree). The REST issue object
+            // exposes `parent_issue_url` for the sub-issues feature; a
+            // non-empty value means the labelled item is nested under
+            // another issue and is therefore not a tracking issue.
+            if (event === 'issues') {
+              const action = payload.action;
+              const label = payload.label && payload.label.name;
+              if (action === 'labeled' && label === 'sdd:ready') {
+                let parentUrl = '';
+                try {
+                  const { data } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: payload.issue.number,
+                  });
+                  parentUrl = data.parent_issue_url || '';
+                } catch (err) {
+                  core.info('Could not fetch issue #'
+                    + payload.issue.number + ': ' + err.message);
+                }
+                if (parentUrl) {
+                  core.info('Issue #' + payload.issue.number
+                    + ' has a parent (' + parentUrl
+                    + '); not a tracking issue, ignoring.');
+                } else {
+                  run = true;
+                  ctx = {
+                    item_type: 'issue',
+                    item_number: payload.issue.number,
+                  };
+                }
+              }
+            }
+
+            core.setOutput('should_run', run ? 'true' : 'false');
+            core.setOutput('aw_context', run ? JSON.stringify(ctx) : '');
+
+  sdd-validate:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@main
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read. sdd-validate
+    # opens no pull request, so contents stays read.
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+      issues: write
+      pull-requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+
+# Serena MCP working-tree state (spectacles quick-setup).
+.serena/


### PR DESCRIPTION
Installs the spectacles agentic workflow agent suite onto this repo via the two-layer distribution model. Wrappers pin hosted reusable workflows at `@main`.

Direct-to-default-branch writes from `scripts/quick-setup.sh` are blocked by branch protection (PR + `build` check required), so the file artifacts are delivered as this PR. Labels and repo variables were applied out-of-band (non-branch APIs).

## Contents
- 13 workflow wrappers under `.github/workflows/` (8 `sdd-*` agents, `distillery-sync`, `sdd-pr-sanitize`, `sdd-triage-dedupe-tasks`, `sdd-triage-promote-ready`, `sdd-monitor`)
- 4 issue templates under `.github/ISSUE_TEMPLATE/`
- `.gitignore`: `.serena/` exclusion (Serena working-tree state)

## Already applied (outside this PR)
- 20 labels (`needs-human`, `kind:*`, `priority:*`, `sdd:*`, `model:*`, `plan:provided`)
- Variables: `DISTILLERY_PROJECT=minimal`, `SERENA_LANGUAGE_SERVERS=rust-analyzer`

## Operator config still required
Repo or org level:
- Variables: `APP_ID`, optional `SDD_DISPATCH_MAX_PARALLEL` (default 5)
- Secrets: `APP_PRIVATE_KEY`, `COPILOT_GITHUB_TOKEN`, `LEAK_DENYLIST`

Distillery (`DISTILLERY_MCP_URL`, `DISTILLERY_OAUTH_TOKEN`) is provided at the org level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added structured issue templates for bug reports, feature requests, chores, and specifications to improve issue reporting consistency.

* **Chores**
  * Added GitHub Actions workflows to automate repository operations including issue triage, validation, monitoring, and pull request management.
  * Updated repository configuration to support internal development tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->