### PR TITLE
feat(minvmd): crate skeleton + CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3388,6 +3388,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "minvmd"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dirs",
+ "serde",
+ "serial_test",
+ "tempfile",
+ "tokio",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/minvmd",
     "crates/args",
     "crates/lcache",
     "crates/rcache",

--- a/crates/minvmd/Cargo.toml
+++ b/crates/minvmd/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name              = "minvmd"
+version           = "0.0.1"
+edition.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "minvmd"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace             = true
+clap.workspace               = true
+dirs.workspace               = true
+serde.workspace              = true
+toml.workspace               = true
+tokio.workspace              = true
+tracing.workspace            = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+serial_test.workspace = true
+tempfile.workspace    = true

--- a/crates/minvmd/SPEC.md
+++ b/crates/minvmd/SPEC.md
@@ -1,0 +1,54 @@
+# minvmd + pkgs-sourced VM image — landed shape
+
+Scope: how `minvmd` and the VM image fit together once both land in `minimal`,
+with the image produced by the package registry rather than a fetched URL.
+
+## Components
+
+| Piece | Where | Role |
+|---|---|---|
+| `minvmd` | `crates/minvmd` (macOS) | Host broker: `up`/`down`/`status`/`debug-shell`. Drives `krunkit`, bridges host UDS ↔ guest vsock. |
+| `alpine-virtio-linux` | pkgs package | Builds `vm-image.raw` (EFI GPT: ESP + ext4 root) + `manifest.json` from `virtio-linux` (kernel) + Alpine rootfs. |
+| `minimald` | `crates/minimald` (Linux, in-VM) | Session orchestrator; terminates the `minimald-v1-*` SSH RPC. |
+
+## Image provisioning (the change vs today)
+
+- The image is a **`minimal` package output**, not a `MINVMD_IMAGE_URL` download. `minvmd` and `minimal` ship in the same repo, so `minvmd` resolves the `alpine-virtio-linux` package through the package manager.
+- `minvmd up` ensures the `alpine-virtio-linux` output is materialized (built or pulled from the binary cache), then stages into `~/.minimal/vm/`:
+  - `rootfs.raw` ← the package's `vm-image.raw` (read-only boot disk)
+  - `state.qcow2` ← created locally (writable overlay)
+  - `efivars.fd` ← created on first boot
+- The package `manifest.json` carries the kernel/rootfs/image sha256s; `minvmd` verifies against it. A `MINVMD_IMAGE_*` env override stays for dev/CI.
+- This retires minvmd's current "single fetched artifact + env digest" contract (R2.x).
+
+## Boot + lifecycle (validated against krunkit 1.2.1)
+
+`minvmd` spawns `krunkit` with:
+
+```
+--cpus N --memory N
+--bootloader efi,variable-store=<vm>/efivars.fd,create
+--device virtio-blk,path=<vm>/rootfs.raw,format=raw
+--device virtio-blk,path=<vm>/state.qcow2,format=qcow2
+--device virtio-vsock,port=1024,socketURL=<vm>/control.sock,connect
+--device virtio-vsock,port=1025,socketURL=<vm>/root-debug.sock,connect
+--device virtio-serial,logFilePath=<vm>/serial.log
+--restful-uri unix://<vm>/krunkit.sock
+```
+
+- Boot path: OVMF → `vmlinuz-efi` on the ESP → ext4 root (`/dev/vda2`) → init. The kernel cmdline is supplied by `virtio-linux` (baked `CONFIG_CMDLINE_FORCE`) — **open decision**, see below.
+- `status` ← REST `GET /vm/state` (`VirtualMachineStateRunning|Stopped`); `down` ← REST `{"state":"Stop"}` then SIGTERM reap.
+- vsock is `connect` (host→guest): `minimald` / the debug shell *listen* inside the guest; `minvmd` dials in. The broker byte-pumps opaquely on port 1024; `minimald` parses the RPC.
+
+## Integration with existing crates
+
+- Paths use `sessions::paths::HostAbsPath` at the `minvmd` boundary; the guest is the `Daemon` realm (future `Translator` seam).
+- Errors via a local `UserFacing` (no repo-wide equivalent exists yet).
+- macOS-only crate; non-macOS builds a no-op shim so the workspace builds on Linux.
+
+## Deferred / open
+
+- **Kernel cmdline delivery**: bake into `virtio-linux` (validated, recommended) vs a bootloader/UKI package. Blocks a bootable image.
+- **Production `KrunkitRunner`** + CLI wiring: `up`/`down`/`status` are stubbed; no real krunkit subprocess is launched yet.
+- **Rootfs dedupe**: `alpine-virtio-linux` re-assembles the Alpine rootfs because build_deps merge into one root and musl collides with the glibc image tools. Cleaner once `alpine-minirootfs` emits a namespaced `rootfs.tar`.
+- **Real init**: `minimald` replaces the boot-verification `stub-init` as guest pid-1.

--- a/crates/minvmd/src/cli.rs
+++ b/crates/minvmd/src/cli.rs
@@ -1,0 +1,49 @@
+//! CLI surface and command dispatch (macOS-only).
+
+use clap::{Parser, Subcommand};
+
+use crate::config;
+use crate::error::UserFacing;
+
+#[derive(Parser)]
+#[command(name = "minvmd", about = "macOS VM host broker for minimald")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Boot the Linux VM.
+    Up,
+    /// Stop the Linux VM.
+    Down,
+    /// Print the VM status (Running, Stopped, or NotRunning).
+    Status,
+    /// Open a root shell inside the guest.
+    DebugShell,
+}
+
+/// Parse argv and run the requested subcommand.
+pub async fn run() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    tracing::info!("minvmd starting");
+    match cli.command {
+        Command::Up => {
+            // Config loads here; the lifecycle/image work is wired in later.
+            let _cfg = config::Config::load_default()?;
+            Err(anyhow::Error::from(UserFacing::new(
+                "not yet implemented: minvmd up",
+            )))
+        }
+        Command::Down => Err(anyhow::Error::from(UserFacing::new(
+            "not yet implemented: minvmd down",
+        ))),
+        Command::Status => Err(anyhow::Error::from(UserFacing::new(
+            "not yet implemented: minvmd status",
+        ))),
+        Command::DebugShell => Err(anyhow::Error::from(UserFacing::new(
+            "not yet implemented: minvmd debug-shell",
+        ))),
+    }
+}

--- a/crates/minvmd/src/config.rs
+++ b/crates/minvmd/src/config.rs
@@ -1,0 +1,108 @@
+//! `Config` — minvmd daemon configuration.
+//!
+//! Reads `~/.minimal/vm/minvmd.toml`; falls back to defaults when the file is
+//! absent. Unknown keys are silently ignored (forward-compatible).
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+// TODO(unit-2): wire into lifecycle::up. `Config` is consumed by
+// image::ensure_image in Sub-task 2.1 and lifecycle in Sub-task 3.1. Until
+// those land, only tests construct it, so the bin target flags dead code.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub cpus: u32,
+    pub memory_mib: u64,
+    pub state_size_gib: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            cpus: 2,
+            memory_mib: 2048,
+            state_size_gib: 10,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl Config {
+    /// Load config from `path`. If the file does not exist, returns defaults.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => Ok(toml::from_str(&contents)?),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Load from the canonical path `$MINIMAL_HOME/vm/minvmd.toml`.
+    /// `$MINIMAL_HOME` defaults to `~/.minimal` when unset.
+    pub fn load_default() -> anyhow::Result<Self> {
+        let home = std::env::var_os("MINIMAL_HOME")
+            .map(std::path::PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|h| h.join(".minimal")))
+            .ok_or_else(|| anyhow::anyhow!("cannot determine MINIMAL_HOME"))?;
+        Self::load(&home.join("vm").join("minvmd.toml"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{serial_test::serial, with_isolated_home};
+
+    #[test]
+    #[serial]
+    fn default_config_when_no_file() {
+        with_isolated_home(|_home| {
+            let cfg = Config::load_default().expect("load");
+            assert_eq!(cfg.cpus, 2);
+            assert_eq!(cfg.memory_mib, 2048);
+            assert_eq!(cfg.state_size_gib, 10);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn load_default_resolves_minimal_home_and_reads_file() {
+        with_isolated_home(|home| {
+            let vm_dir = home.join("vm");
+            std::fs::create_dir_all(&vm_dir).unwrap();
+            std::fs::write(
+                vm_dir.join("minvmd.toml"),
+                "cpus = 8\nmemory_mib = 16384\nstate_size_gib = 40\n",
+            )
+            .unwrap();
+
+            let cfg = Config::load_default().expect("load_default");
+            assert_eq!(cfg.cpus, 8);
+            assert_eq!(cfg.memory_mib, 16384);
+            assert_eq!(cfg.state_size_gib, 40);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn overrides_from_toml_file() {
+        with_isolated_home(|home| {
+            let vm_dir = home.join("vm");
+            std::fs::create_dir_all(&vm_dir).unwrap();
+            let toml_path = vm_dir.join("minvmd.toml");
+            std::fs::write(
+                &toml_path,
+                "cpus = 4\nmemory_mib = 8192\nstate_size_gib = 20\n",
+            )
+            .unwrap();
+
+            let cfg = Config::load(&toml_path).expect("load");
+            assert_eq!(cfg.cpus, 4);
+            assert_eq!(cfg.memory_mib, 8192);
+            assert_eq!(cfg.state_size_gib, 20);
+        });
+    }
+}

--- a/crates/minvmd/src/error.rs
+++ b/crates/minvmd/src/error.rs
@@ -1,0 +1,50 @@
+//! User-readable error wrapper.
+//!
+//! minvmd is a standalone bin that owns its own `main` and prints its own
+//! errors, so it carries a small local error type rather than depending on a
+//! shared one.
+//!
+//! Use `anyhow::Error::from(UserFacing::new("message"))` for errors that should
+//! be printed verbatim to the user. For internal/system errors, propagate with
+//! bare `?`.
+
+use std::fmt;
+
+#[derive(Debug)]
+pub struct UserFacing {
+    message: String,
+}
+
+impl UserFacing {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    // Accessor for the message. No caller downcasts to read it yet, so it is
+    // currently unused.
+    #[allow(dead_code)]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for UserFacing {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for UserFacing {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_is_just_the_message() {
+        let e = UserFacing::new("session not found: foo");
+        assert_eq!(e.to_string(), "session not found: foo");
+    }
+}

--- a/crates/minvmd/src/launchd.rs
+++ b/crates/minvmd/src/launchd.rs
@@ -1,0 +1,1 @@
+//! brew services / launchd integration.

--- a/crates/minvmd/src/main.rs
+++ b/crates/minvmd/src/main.rs
@@ -1,0 +1,34 @@
+//! minvmd — macOS host broker. Brings up the Linux VM via krunkit; bridges UDS
+//! traffic between `minimal` on the host and `minimald` inside the VM.
+//! Not present on Linux installs.
+
+// The broker is macOS-only, but the modules are gated to `macos` *or* `test` so
+// the unit tests still compile and run on Linux CI.
+#[cfg(any(target_os = "macos", test))]
+mod config;
+#[cfg(any(target_os = "macos", test))]
+mod error;
+#[cfg(target_os = "macos")]
+mod launchd;
+
+#[cfg(test)]
+mod test_support;
+
+// All CLI surface and command dispatch is macOS-only; it lives in one module so
+// the platform gate appears once here rather than scattered across each item.
+#[cfg(target_os = "macos")]
+mod cli;
+
+#[cfg(target_os = "macos")]
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+    cli::run().await
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    eprintln!("minvmd: macOS-only; this binary is a no-op on this platform");
+}

--- a/crates/minvmd/src/test_support.rs
+++ b/crates/minvmd/src/test_support.rs
@@ -1,0 +1,44 @@
+//! Local test helpers.
+//!
+//! minvmd's tests need an isolated `MINIMAL_HOME` and serial execution; the few
+//! pieces they use are inlined here rather than pulled from a shared crate,
+//! compiled only under `cfg(test)`.
+
+#![cfg(test)]
+
+use std::path::Path;
+use std::sync::Mutex;
+use tempfile::TempDir;
+
+/// Re-export so test modules can write `test_support::serial_test::serial`.
+pub use serial_test;
+
+/// Serialises any access to process-wide state (env vars, on-disk caches).
+static STATE_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Run `f` with `MINIMAL_HOME` pointed at a fresh tempdir. The directory is
+/// removed on return; the env var is restored to its previous value.
+pub fn with_isolated_home<F: FnOnce(&Path)>(f: F) {
+    let _guard = STATE_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().expect("tempdir");
+    let prev = std::env::var_os("MINIMAL_HOME");
+
+    // SAFETY: `set_var`/`remove_var` are race-y across threads. The static
+    // mutex above serialises all callers within this process.
+    unsafe {
+        std::env::set_var("MINIMAL_HOME", tmp.path());
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(tmp.path())));
+
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var("MINIMAL_HOME", v),
+            None => std::env::remove_var("MINIMAL_HOME"),
+        }
+    }
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}


### PR DESCRIPTION
Stack 1/3 for the `minvmd` macOS host broker.

Adds `crates/minvmd`: workspace member, clap CLI (`up`/`down`/`status`/`debug-shell`), local user-facing error type, daemon `Config` (cpus/memory/state-disk), and `SPEC.md` (landed shape). Subcommands are stubbed; image/lifecycle/broker land in 2/3 and 3/3. macOS-gated with a Linux no-op shim; unit tests run on Linux CI.

`cargo {build,test,clippy,fmt} -p minvmd` green (4 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `minvmd`, a new macOS-based tool for virtual machine management, providing CLI commands for VM lifecycle operations (boot, shutdown, status monitoring, debugging).
  * Added configurable VM resource settings: CPU count, memory size, and storage allocation with sensible defaults.

* **Documentation**
  * Published specification detailing the minvmd integration with VM image artifacts and operational workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gominimal/minimal/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->