### PR TITLE
feat(minvmd): UDS<->vsock broker + debug-shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,6 +3402,7 @@ dependencies = [
  "sessions",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",

--- a/crates/minvmd/Cargo.toml
+++ b/crates/minvmd/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace              = true
 sessions                     = { path = "../sessions" }
 toml.workspace               = true
 tokio.workspace              = true
+tokio-util.workspace         = true
 tracing.workspace            = true
 tracing-subscriber.workspace = true
 

--- a/crates/minvmd/src/broker.rs
+++ b/crates/minvmd/src/broker.rs
@@ -1,0 +1,153 @@
+//! Bidirectional UDS bridge: host socket <-> in-VM minimald socket.
+
+use crate::uds;
+use anyhow::{Context as _, Result};
+use std::path::Path;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+/// Byte-pump between the host control socket and the in-VM minimald socket.
+///
+/// Listens on `host_sock` and, for each accepted connection, connects to
+/// `vsock_sock` and copies bytes bidirectionally. Runs until
+/// `token` is cancelled, then drains all in-flight relay tasks before
+/// returning.
+///
+/// The pump is *opaque*: minvmd never parses the minimald SSH RPC frames that
+/// ride over these streams — that is terminated by minimald inside the guest.
+pub async fn serve(host_sock: &Path, vsock_sock: &Path, token: CancellationToken) -> Result<()> {
+    // create parent dir with mode 0700
+    if let Some(parent) = host_sock.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        create_dir_restricted(parent)?;
+    }
+
+    // bind host socket
+    let listener = uds::listen(host_sock).await.context("bind host socket")?;
+
+    // set the host socket to mode 0600 after bind. We use a path-based
+    // chmod rather than fchmod because fchmod on a Unix-domain socket fd
+    // returns EINVAL on macOS (Darwin) — the only platform this broker runs on
+    // in production. The socket lives inside the 0700 parent created above, so
+    // no other user can traverse to it during the brief post-bind window.
+    set_file_mode(host_sock, 0o600)?;
+
+    // Accept loop with cancellation. Spawned relay tasks are
+    // tracked in a JoinSet and carry a clone of the token so cancellation
+    // drops both streams; serve drains them before returning.
+    let mut pumps: JoinSet<()> = JoinSet::new();
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => break,
+            result = listener.accept() => {
+                let (mut client, _) = result.context("accept on host socket")?;
+                let vsock_path = vsock_sock.to_path_buf();
+                let task_token = token.clone();
+                pumps.spawn(async move {
+                    // connect to in-VM minimald
+                    match uds::connect(&vsock_path).await {
+                        Ok(mut server) => {
+                            // opaque bidirectional byte pump. Cancellation
+                            // drops both streams, terminating the pump cleanly.
+                            tokio::select! {
+                                _ = task_token.cancelled() => {}
+                                _ = tokio::io::copy_bidirectional(&mut client, &mut server) => {}
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("broker: vsock connect failed: {e}");
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    // drain in-flight pumps so serve does not return while bytes are
+    // still being relayed.
+    while pumps.join_next().await.is_some() {}
+    Ok(())
+}
+
+fn create_dir_restricted(path: &Path) -> Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    if !path.exists() {
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)
+            .with_context(|| format!("create dir {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn set_file_mode(path: &Path, mode: u32) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .with_context(|| format!("chmod {mode:o} {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{UnixListener, UnixStream};
+
+    #[tokio::test]
+    async fn byte_pump_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let host_path = dir.path().join("host.sock");
+        let vsock_path = dir.path().join("vsock.sock");
+
+        // Bind the "vsock" server (mimics minimald inside the VM).
+        let vsock_server = UnixListener::bind(&vsock_path).unwrap();
+
+        let token = CancellationToken::new();
+        let cancel = token.clone();
+        let hp = host_path.clone();
+        let vp = vsock_path.clone();
+
+        tokio::spawn(async move {
+            serve(&hp, &vp, cancel).await.unwrap();
+        });
+
+        // Connect as the "minimal" client once the broker has bound, retrying
+        // until the host socket is ready rather than sleeping a fixed amount.
+        let mut client = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                match UnixStream::connect(&host_path).await {
+                    Ok(stream) => break stream,
+                    Err(err)
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+                        ) =>
+                    {
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+                    Err(err) => panic!("failed to connect to broker: {err}"),
+                }
+            }
+        })
+        .await
+        .expect("broker did not bind in time");
+
+        // Accept on the vsock side (mimics minimald accepting).
+        let (mut vm_side, _) = vsock_server.accept().await.unwrap();
+
+        // client → VM
+        client.write_all(b"hello from minimal").await.unwrap();
+        let mut buf = vec![0u8; 18];
+        vm_side.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello from minimal");
+
+        // VM → client
+        vm_side.write_all(b"hello from minimald").await.unwrap();
+        let mut buf2 = vec![0u8; 19];
+        client.read_exact(&mut buf2).await.unwrap();
+        assert_eq!(&buf2, b"hello from minimald");
+
+        token.cancel();
+    }
+}

--- a/crates/minvmd/src/cli.rs
+++ b/crates/minvmd/src/cli.rs
@@ -3,7 +3,7 @@
 use clap::{Parser, Subcommand};
 
 use crate::error::UserFacing;
-use crate::{config, image};
+use crate::{config, debug_shell, image};
 
 #[derive(Parser)]
 #[command(name = "minvmd", about = "macOS VM host broker for minimald")]
@@ -43,8 +43,9 @@ pub async fn run() -> anyhow::Result<()> {
         Command::Status => Err(anyhow::Error::from(UserFacing::new(
             "not yet implemented: minvmd status",
         ))),
-        Command::DebugShell => Err(anyhow::Error::from(UserFacing::new(
-            "not yet implemented: minvmd debug-shell",
-        ))),
+        Command::DebugShell => {
+            let socket_path = debug_shell::debug_shell_socket_path()?;
+            debug_shell::connect_debug_shell(socket_path.as_utf8_path().as_std_path()).await
+        }
     }
 }

--- a/crates/minvmd/src/debug_shell.rs
+++ b/crates/minvmd/src/debug_shell.rs
@@ -1,0 +1,159 @@
+//! Connect to the guest root debug shell via vsock.
+
+use crate::error::UserFacing;
+use crate::uds;
+use anyhow::{Context as _, Result};
+use sessions::paths::HostAbsPath;
+use std::path::Path;
+use tokio::io::{self, AsyncRead, AsyncWrite};
+
+/// Default path to the root debug shell socket on the host.
+///
+/// Anchored at the user's home directory (`~/.minimal/vm/root-debug.sock`),
+/// which is always absolute.
+pub fn debug_shell_socket_path() -> Result<HostAbsPath> {
+    let home = dirs::home_dir().context("cannot determine home directory")?;
+    let path = home.join(".minimal/vm/root-debug.sock");
+    let utf8 = camino::Utf8PathBuf::from_path_buf(path).map_err(|p| {
+        anyhow::anyhow!(
+            "debug shell socket path is not valid UTF-8: {}",
+            p.display()
+        )
+    })?;
+    HostAbsPath::try_new(utf8).context("debug shell socket path must be absolute")
+}
+
+/// Connect to the root debug shell and forward stdin/stdout bidirectionally.
+pub async fn connect_debug_shell(socket_path: &Path) -> Result<()> {
+    // a missing socket is the only user-facing condition. Check existence
+    // up front so the connect call below can propagate every *other* failure
+    // (e.g. permission denied) with `?` rather than masking it as "not found".
+    if !socket_path.exists() {
+        return Err(anyhow::Error::from(UserFacing::new(format!(
+            "debug shell socket not found: {}",
+            socket_path.display()
+        ))));
+    }
+
+    let stream = uds::connect(socket_path).await?;
+
+    // Bridge the host terminal (stdin/stdout) to the socket. join() pairs the
+    // read-only stdin with the write-only stdout into one duplex.
+    let local = io::join(io::stdin(), io::stdout());
+    bridge(local, stream).await
+}
+
+/// Forward bytes both ways between a local duplex and the debug-shell socket.
+///
+/// `local` carries the host terminal (stdin -> socket, socket -> stdout).
+///
+/// Drives the two directions independently and returns as soon as *either*
+/// completes. `copy_bidirectional` is unsuitable here: it returns only after
+/// *both* directions reach EOF, so a guest disconnect (socket -> stdout hits
+/// EOF) while the local stdin stays open would leave the stdin -> socket copy
+/// waiting forever and the subcommand would hang. Returning on the first
+/// direction to finish makes "exit on socket disconnect" hold (-> exit 0).
+async fn bridge<L, S>(local: L, stream: S) -> Result<()>
+where
+    L: AsyncRead + AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let (mut local_rd, mut local_wr) = io::split(local);
+    let (mut sock_rd, mut sock_wr) = io::split(stream);
+
+    tokio::select! {
+        // Guest disconnect: socket -> stdout hits EOF; return so we exit 0.
+        r = io::copy(&mut sock_rd, &mut local_wr) => { r?; }
+        // Local stdin closed (e.g. EOF / Ctrl-D): stdin -> socket finishes.
+        r = io::copy(&mut local_rd, &mut sock_wr) => { r?; }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixListener;
+
+    /// proof artifact: bind an in-process `UnixListener`, invoke the
+    /// debug-shell connect path (`bridge` over a real `uds::connect` stream),
+    /// send a byte sequence through the local side, and assert it arrives at
+    /// the listener; then close the listener and assert `bridge` returns
+    /// `Ok(())`.
+    #[tokio::test]
+    async fn test_debug_shell_connect() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let socket_path = temp_dir.path().join("test.sock");
+
+        let listener = UnixListener::bind(&socket_path)?;
+
+        // Server side: accept, read the bytes the bridge forwards from the
+        // local "stdin", assert them, then drop the connection (EOF) so the
+        // bridge's socket->stdout copy completes and the function returns Ok.
+        let server = tokio::spawn(async move {
+            let (mut conn, _) = listener.accept().await.expect("accept");
+            let mut buf = [0u8; 5];
+            conn.read_exact(&mut buf)
+                .await
+                .expect("read forwarded bytes");
+            assert_eq!(&buf, b"hello", "bridge should forward stdin to the socket");
+            // Dropping `conn` here closes the socket, signalling disconnect.
+        });
+
+        // Connect to the listener via the production transport path.
+        let stream = uds::connect(&socket_path).await?;
+
+        // Drive `bridge` with an in-memory duplex standing in for the terminal:
+        // `local_test` is the test's handle to the local side; `local_bridge`
+        // is what the bridge treats as stdin/stdout.
+        let (mut local_test, local_bridge) = io::duplex(1024);
+        let bridge_task = tokio::spawn(async move { bridge(local_bridge, stream).await });
+
+        // Write the byte sequence into the local side; the bridge forwards it
+        // to the socket, where the server asserts it. Shutdown signals EOF on
+        // the stdin->socket direction.
+        local_test.write_all(b"hello").await?;
+        local_test.flush().await?;
+        local_test.shutdown().await?;
+
+        server.await?;
+        // on disconnect the bridge returns Ok(()).
+        bridge_task.await??;
+        Ok(())
+    }
+
+    /// (disconnect-only): the guest socket closes while the local stdin
+    /// side stays open; `bridge` must still return promptly so the subcommand
+    /// exits 0. This is the case `copy_bidirectional` would hang on.
+    #[tokio::test]
+    async fn bridge_returns_when_socket_disconnects_with_local_open() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let socket_path = temp_dir.path().join("disc.sock");
+        let listener = UnixListener::bind(&socket_path)?;
+
+        // Server accepts then immediately drops the connection (disconnect).
+        let server = tokio::spawn(async move {
+            let (conn, _) = listener.accept().await.expect("accept");
+            drop(conn);
+        });
+
+        let stream = uds::connect(&socket_path).await?;
+
+        // `_local_test` is deliberately kept alive (never shut down) so the
+        // local stdin->socket direction never hits EOF; only the socket
+        // disconnect can make `bridge` return.
+        let (_local_test, local_bridge) = io::duplex(1024);
+        let bridge_task = tokio::spawn(async move { bridge(local_bridge, stream).await });
+
+        server.await?;
+        // Bound the wait so a regression (hang) fails fast instead of stalling
+        // the suite.
+        let res = tokio::time::timeout(std::time::Duration::from_secs(5), bridge_task)
+            .await
+            .expect("bridge should return promptly on socket disconnect")?;
+        res?;
+        Ok(())
+    }
+}

--- a/crates/minvmd/src/main.rs
+++ b/crates/minvmd/src/main.rs
@@ -4,8 +4,18 @@
 
 // The broker is macOS-only, but the modules are gated to `macos` *or* `test` so
 // the unit tests still compile and run on Linux CI.
+// broker ships serve() — the UDS↔vsock byte-pump. No production caller is
+// wired into the dispatch yet, so the surface is dead on the plain bin build.
+#[cfg(any(target_os = "macos", test))]
+#[allow(dead_code)]
+mod broker;
 #[cfg(any(target_os = "macos", test))]
 mod config;
+// debug_shell's connect path is reached only via the macOS dispatch, so on the
+// Linux (cfg(test)) build it has no caller.
+#[cfg(any(target_os = "macos", test))]
+#[allow(dead_code)]
+mod debug_shell;
 #[cfg(any(target_os = "macos", test))]
 mod error;
 #[cfg(any(target_os = "macos", test))]
@@ -17,6 +27,8 @@ mod launchd;
 #[cfg(any(target_os = "macos", test))]
 #[allow(dead_code)]
 mod lifecycle;
+#[cfg(any(target_os = "macos", test))]
+mod uds;
 
 #[cfg(test)]
 mod test_support;

--- a/crates/minvmd/src/uds.rs
+++ b/crates/minvmd/src/uds.rs
@@ -1,0 +1,25 @@
+//! Minimal Unix-domain-socket connect/listen helpers.
+//!
+//! minvmd carries these two trivial wrappers itself rather than pulling in a
+//! shared UDS crate: the broker only needs a connect and a listen.
+//!
+//! The broker byte-pumps these streams *opaquely*: it does not parse the
+//! minimald SSH RPC frames riding over them. That layering is preserved.
+
+use std::io;
+use std::path::Path;
+use tokio::net::{UnixListener, UnixStream};
+
+/// Connect to the Unix-domain socket at `path`.
+pub async fn connect(path: &Path) -> io::Result<UnixStream> {
+    UnixStream::connect(path).await
+}
+
+/// Bind a listener on the Unix-domain socket at `path`, removing any stale
+/// socket file first.
+pub async fn listen(path: &Path) -> io::Result<UnixListener> {
+    if path.exists() {
+        std::fs::remove_file(path)?;
+    }
+    UnixListener::bind(path)
+}


### PR DESCRIPTION
Stack 3/3 — based on 2/3 (`norrie/minvmd-image-lifecycle`).

- `broker::serve`: opaque bidirectional byte-pump (host control UDS ↔ guest vsock) with graceful cancellation; minimald terminates the SSH RPC over it.
- `debug-shell`: bridge host stdin/stdout to the guest root-debug vsock socket; wires the subcommand.
- `uds`: shared connect/listen helpers.

Adds tokio-util. `cargo {build,test,clippy,fmt} -p minvmd` green (15 tests).