### PR TITLE
docs: add session domain model diagram

### DIFF
--- a/docs/session-domain-diag.md
+++ b/docs/session-domain-diag.md
@@ -14,7 +14,6 @@ classDiagram
 
     class Socket {
         <<connection>>
-        +path: $HOME/.minimal/local/[pid].sock
     }
 
     class Provider {
@@ -51,10 +50,10 @@ classDiagram
         <<workload>>
     }
 
-    Minimal "1" --> "*" Socket : discovers via local dir
+    Minimal "1" --> "*" Socket : discovers
     Socket "1" --> "1" Provider : connects to
     Minimal "1" ..> "*" Provider : connects to many
-    Provider "1" --> "1" Socket : creates [pid].sock
+    Provider "1" --> "1" Socket : creates
 
     Provider <|.. Minimald : implements
     Provider <|.. MinVMD : implements
@@ -72,9 +71,9 @@ classDiagram
 
 ```mermaid
 flowchart LR
-    M["Minimal<br/>(client process)"] -. "scans ~/.minimal/local/" .-> DIR[("~/.minimal/local/")]
-    P1["minimald (pid 4001)"] -- "creates" --> SK1["4001.sock"]
-    P2["minvmd (pid 4002)"] -- "creates" --> SK2["4002.sock"]
+    M["Minimal<br/>(client process)"] -. "discovers" .-> DIR[("local provider sockets")]
+    P1["minimald (pid 4001)"] -- "creates" --> SK1["socket"]
+    P2["minvmd (pid 4002)"] -- "creates" --> SK2["socket"]
     SK1 --> DIR
     SK2 --> DIR
     M -- "connects" --> SK1
@@ -84,7 +83,7 @@ flowchart LR
     P2 -- "hosts" --> guest
     P2 -. "proxies guest socket" .-> MD
     subgraph guest["VM (guest)"]
-        MD["minimald (in VM)<br/>~/.minimal/local/&lt;pid&gt;.sock"] --> E3["Session"]
+        MD["minimald (in VM)"] --> E3["Session"]
     end
 ```
 
@@ -94,9 +93,9 @@ macOS has no native `minimald` (it is a Linux provider), so `Minimal` **cannot t
 
 ```mermaid
 flowchart LR
-    M["Minimal<br/>(host, macOS)"] -. "scans ~/.minimal/local/" .-> DIR[("~/.minimal/local/")]
-    P1["minvmd (pid 5001)"] -- "creates" --> SK1["5001.sock"]
-    P2["minvmd (pid 5002)"] -- "creates" --> SK2["5002.sock"]
+    M["Minimal<br/>(host, macOS)"] -. "discovers" .-> DIR[("local provider sockets")]
+    P1["minvmd (pid 5001)"] -- "creates" --> SK1["socket"]
+    P2["minvmd (pid 5002)"] -- "creates" --> SK2["socket"]
     SK1 --> DIR
     SK2 --> DIR
     M -- "connects" --> SK1
@@ -119,7 +118,7 @@ flowchart LR
 
 ## VM socket proxying
 
-- The in-VM `minimald` creates its own `~/.minimal/local/<pid>.sock` inside the guest.
+- The in-VM `minimald` creates its own socket inside the guest.
 - `minvmd` **proxies/forwards** that guest socket back to the host, so host `Minimal` talks to the in-VM `minimald` through `minvmd`.
 - `Minimal` connects to `minvmd`'s host socket; `minvmd` relays traffic across the VM boundary to each VM's `minimald`.
 
@@ -132,22 +131,21 @@ flowchart LR
 
 ## Socket lifecycle
 
-- **Providers own the socket lifecycle**: create `~/.minimal/local/<pid>.sock` on start, remove it on shutdown.
-- One socket per provider process; PID namespaces the socket file.
-- `Minimal` discovers providers by scanning `~/.minimal/local/` and connecting to each `<pid>.sock`.
-- `Minimal` must **detect dead providers**: a `<pid>.sock` may be stale (provider crashed without cleanup). Connect-and-prune or liveness-check on discovery.
+- **Providers own the socket lifecycle**: create their socket on start, remove it on shutdown.
+- One socket per provider process.
+- `Minimal` discovers providers and connects to each socket.
 
 ## Startup / bootstrap
 
 ```mermaid
 flowchart TD
-    START([Minimal starts]) --> SCAN["scan ~/.minimal/local/"]
+    START([Minimal starts]) --> SCAN["discover providers"]
     SCAN --> Q{live sockets found?}
-    Q -- yes --> CONN["connect to each live <pid>.sock"]
+    Q -- yes --> CONN["connect to each live socket"]
     Q -- no --> HASCFG{config present?}
     HASCFG -- yes --> ALL["start ALL providers in config<br/>(config overrides defaults)"]
     HASCFG -- no --> DEF["start system default provider<br/>(e.g. minimald on Linux)"]
-    ALL --> MKSOCK["each provider creates <pid>.sock"]
+    ALL --> MKSOCK["each provider creates its socket"]
     DEF --> MKSOCK
     MKSOCK --> CONN
     CONN --> READY([ready])
@@ -156,8 +154,7 @@ flowchart TD
 **Bootstrap rules:**
 - No config → start the single system-default provider for the OS.
 - Config present → start **all** providers listed; config fully overrides defaults.
-- A spawned provider creates its `<pid>.sock`, then `Minimal` connects.
-- Stale `<pid>.sock` files (dead provider) are skipped/pruned during the scan.
+- A spawned provider creates its socket, then `Minimal` connects.
 
 ## Glossary
 

--- a/docs/session-domain-diag.md
+++ b/docs/session-domain-diag.md
@@ -169,6 +169,6 @@ flowchart TD
 | minvmd | VM provider — hosts VMs; each VM runs a minimald and minvmd proxies its socket to the host. |
 | minhosted | Hosted provider — hosts sessions on an externally managed backend. |
 | mincloud | Cloud provider — hosts sessions on a cloud backend. |
+| Minimal | Client process; discovers providers via sockets, starts a default/config provider when none exist. |
 
 > Note: `minhosted` and `mincloud` are placeholders. They could be specialized into neocloud or hyperscaler-specific backends (e.g. a per-provider daemon for a specific neocloud, or AWS/GCP/Azure).
-| Minimal | Client process; discovers providers via sockets, starts a default/config provider when none exist. |

--- a/docs/session-domain-diag.md
+++ b/docs/session-domain-diag.md
@@ -1,0 +1,174 @@
+# Session Domain Model
+
+> Vernacular: the isolation environment is a **Session**. The thing that creates and hosts them is a **Provider**.
+
+## Main diagram
+
+```mermaid
+classDiagram
+    class Minimal {
+        <<client process>>
+        +instantiate()
+        +discoverSocket()
+    }
+
+    class Socket {
+        <<connection>>
+        +path: $HOME/.minimal/local/[pid].sock
+    }
+
+    class Provider {
+        <<interface>>
+        +listSessions()
+        +createSession()
+    }
+
+    class Minimald {
+        <<provider>>
+        backend: Linux
+    }
+
+    class MinVMD {
+        <<provider>>
+        backend: VMs
+    }
+
+    class MinHosted {
+        <<provider>>
+        backend: Hosted
+    }
+
+    class MinCloud {
+        <<provider>>
+        backend: Cloud
+    }
+
+    class VM {
+        <<host>>
+    }
+
+    class Session {
+        <<workload>>
+    }
+
+    Minimal "1" --> "*" Socket : discovers via local dir
+    Socket "1" --> "1" Provider : connects to
+    Minimal "1" ..> "*" Provider : connects to many
+    Provider "1" --> "1" Socket : creates [pid].sock
+
+    Provider <|.. Minimald : implements
+    Provider <|.. MinVMD : implements
+    Provider <|.. MinHosted : implements
+    Provider <|.. MinCloud : implements
+
+    Minimald  "1" *-- "*" Session : hosts (Linux)
+    MinHosted "1" *-- "*" Session : hosts (Hosted)
+    MinCloud  "1" *-- "*" Session : hosts (Cloud)
+    MinVMD    "1" *-- "*" VM : hosts
+    VM        "1" --> "1" Minimald : instantiates
+```
+
+## Local Linux deployment
+
+```mermaid
+flowchart LR
+    M["Minimal<br/>(client process)"] -. "scans ~/.minimal/local/" .-> DIR[("~/.minimal/local/")]
+    P1["minimald (pid 4001)"] -- "creates" --> SK1["4001.sock"]
+    P2["minvmd (pid 4002)"] -- "creates" --> SK2["4002.sock"]
+    SK1 --> DIR
+    SK2 --> DIR
+    M -- "connects" --> SK1
+    M -- "connects" --> SK2
+    P1 --> E1["Session 1"]
+    P1 --> E2["Session N"]
+    P2 -- "hosts" --> guest
+    P2 -. "proxies guest socket" .-> MD
+    subgraph guest["VM (guest)"]
+        MD["minimald (in VM)<br/>~/.minimal/local/&lt;pid&gt;.sock"] --> E3["Session"]
+    end
+```
+
+## Local macOS deployment
+
+macOS has no native `minimald` (it is a Linux provider), so `Minimal` **cannot talk to a `minimald` directly**. All sessions are reached through a VM. `Minimal` may run **multiple `minvmd`s**, each hosting a VM that runs an in-VM `minimald` whose socket is proxied back to the host.
+
+```mermaid
+flowchart LR
+    M["Minimal<br/>(host, macOS)"] -. "scans ~/.minimal/local/" .-> DIR[("~/.minimal/local/")]
+    P1["minvmd (pid 5001)"] -- "creates" --> SK1["5001.sock"]
+    P2["minvmd (pid 5002)"] -- "creates" --> SK2["5002.sock"]
+    SK1 --> DIR
+    SK2 --> DIR
+    M -- "connects" --> SK1
+    M -- "connects" --> SK2
+    P1 -- "hosts" --> g1
+    P2 -- "hosts" --> g2
+    P1 -. "proxies guest socket" .-> MD1
+    P2 -. "proxies guest socket" .-> MD2
+    subgraph g1["VM (guest)"]
+        MD1["minimald (in VM)"] --> E1["Session"]
+    end
+    subgraph g2["VM (guest)"]
+        MD2["minimald (in VM)"] --> E2["Session"]
+    end
+```
+
+- No direct `minimald` on macOS; isolation requires a Linux VM.
+- Multiple `minvmd`s are allowed, each a separate provider with its own host socket.
+- The host never sees the guest `minimald` except through the `minvmd` proxy.
+
+## VM socket proxying
+
+- The in-VM `minimald` creates its own `~/.minimal/local/<pid>.sock` inside the guest.
+- `minvmd` **proxies/forwards** that guest socket back to the host, so host `Minimal` talks to the in-VM `minimald` through `minvmd`.
+- `Minimal` connects to `minvmd`'s host socket; `minvmd` relays traffic across the VM boundary to each VM's `minimald`.
+
+```mermaid
+flowchart LR
+    M["Minimal (host)"] -- "host socket" --> P["minvmd"]
+    P == "forward / relay" ==> G["minimald (guest)"]
+    G --> E["Session"]
+```
+
+## Socket lifecycle
+
+- **Providers own the socket lifecycle**: create `~/.minimal/local/<pid>.sock` on start, remove it on shutdown.
+- One socket per provider process; PID namespaces the socket file.
+- `Minimal` discovers providers by scanning `~/.minimal/local/` and connecting to each `<pid>.sock`.
+- `Minimal` must **detect dead providers**: a `<pid>.sock` may be stale (provider crashed without cleanup). Connect-and-prune or liveness-check on discovery.
+
+## Startup / bootstrap
+
+```mermaid
+flowchart TD
+    START([Minimal starts]) --> SCAN["scan ~/.minimal/local/"]
+    SCAN --> Q{live sockets found?}
+    Q -- yes --> CONN["connect to each live <pid>.sock"]
+    Q -- no --> HASCFG{config present?}
+    HASCFG -- yes --> ALL["start ALL providers in config<br/>(config overrides defaults)"]
+    HASCFG -- no --> DEF["start system default provider<br/>(e.g. minimald on Linux)"]
+    ALL --> MKSOCK["each provider creates <pid>.sock"]
+    DEF --> MKSOCK
+    MKSOCK --> CONN
+    CONN --> READY([ready])
+```
+
+**Bootstrap rules:**
+- No config → start the single system-default provider for the OS.
+- Config present → start **all** providers listed; config fully overrides defaults.
+- A spawned provider creates its `<pid>.sock`, then `Minimal` connects.
+- Stale `<pid>.sock` files (dead provider) are skipped/pruned during the scan.
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| Session | The isolation environment. |
+| Provider | Creates and hosts sessions; exposes a socket. |
+| minimald | Linux provider — hosts sessions directly. Also runs inside a VM. |
+| minvmd | VM provider — hosts VMs; each VM runs a minimald and minvmd proxies its socket to the host. |
+| minhosted | Hosted provider — hosts sessions on an externally managed backend. |
+| mincloud | Cloud provider — hosts sessions on a cloud backend. |
+
+> Note: `minhosted` and `mincloud` are placeholders. They could be specialized into neocloud or hyperscaler-specific backends (e.g. a per-provider daemon for a specific neocloud, or AWS/GCP/Azure).
+| Minimal | Client process; discovers providers via sockets, starts a default/config provider when none exist. |


### PR DESCRIPTION
Adds `docs/session-domain-diag.md`: domain model for the session architecture.

Covers:
- Session (workload) / Provider (creator + host) vernacular
- Class diagram of `Minimal` client → `Socket` discovery → `Provider` implementations (`minimald`, `minvmd`, hosted, cloud)
- Local Linux deployment flow
- Local macOS deployment flow (no native `minimald`; sessions reached via VM-hosted `minimald` proxied to host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Session domain documentation: clear terminology (Session, Provider), how discovery and connections work, architecture diagrams, platform deployment scenarios (Linux/macOS), VM/socket proxying and lifecycle behavior, startup/bootstrap rules (scan/start providers), stale-socket handling, and a glossary clarifying hosting lifecycles and future backend placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->