### PR TITLE
ci: enforce Conventional Commits with commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,18 @@
+name: Commitlint
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Lint PR commits
+        uses: wagoid/commitlint-github-action@v6

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,23 @@
+// Conventional Commits enforcement. See docs/commit-conventions.md.
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert",
+      ],
+    ],
+  },
+};


### PR DESCRIPTION
Adds CI enforcement for the Conventional Commits standard introduced in #263.

## Changes

- `.github/workflows/commitlint.yml` — runs [`wagoid/commitlint-github-action@v6`](https://github.com/wagoid/commitlint-github-action) on every PR to `main`, linting all commits in the PR. No Node/npm setup needed; the action bundles commitlint.
- `commitlint.config.js` — extends `@commitlint/config-conventional`, pins the `type-enum` to the set documented in `docs/commit-conventions.md`.

## Behavior

- Triggers on `pull_request` to `main` with `fetch-depth: 0` so the full commit range is available.
- Fails the check on any non-conforming commit message (bad type, missing colon, empty subject, etc.).
- `permissions: contents: read` only.

## Notes

- Depends on #263 for `docs/commit-conventions.md` (referenced in a config comment). Merge order is not enforced — the config works standalone.
- Existing history is not rewritten; enforcement applies to commits in new PRs.
- If squash-merging, consider linting the PR title instead/additionally — easy to add via the action's `title` input. Not included here since current merges preserve commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)