### PR TITLE
feat(minimald): implement RPC for creating sessions, index by session name also

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,7 @@ dependencies = [
 name = "minimald"
 version = "0.0.1"
 dependencies = [
+ "bytes",
  "camino",
  "clap",
  "clap_complete",

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+bytes.workspace = true
 camino.workspace = true
 clap.workspace = true
 clap_complete.workspace = true

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -99,7 +99,7 @@ impl GetVersion {
 pub struct ListSessions;
 
 /// An entry in the ListSessions response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ListSessionsEntry {
     pub id: Uuid,
     pub name: Option<String>,
@@ -193,6 +193,46 @@ impl GetSessionRecord {
     }
 }
 
+/// An RPC to create a new session based on the given record.
+pub struct CreateSession;
+
+/// The request for a [`CreateSession`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateSessionRequest {
+    pub record: sessions::Record,
+}
+
+/// The response for a [`CreateSession`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateSessionResponse {
+    pub id: Uuid,
+}
+
+impl OneshotSshRpc for CreateSession {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "CreateSession");
+    type Request<'a> = CreateSessionRequest;
+    type Response = CreateSessionResponse;
+}
+
+impl CreateSession {
+    pub async fn handle(self, s: ServerStateHandle, c: RuChannel<Msg>) {
+        let res = self
+            .handle_channel(c, async |req| {
+                let mngr = s.sessions_manager().await;
+                Ok(CreateSessionResponse {
+                    id: mngr
+                        .create_session(req.record)
+                        .await
+                        .map_err(|e| ConnectionError::Internal(e.to_string()))?,
+                })
+            })
+            .await;
+        if let Err(e) = res {
+            tracing::warn!("RPC handler for {} failed: {}", Self::NAME, e);
+        }
+    }
+}
+
 /// Handles an RPC going over an SSH subsystem channel.
 ///
 /// This method takes ownership of the ssh channel, including
@@ -211,7 +251,7 @@ pub async fn handle_ssh_rpc(
 ) -> Result<(), ConnectionError> {
     // Take the channel from connection state if its a known RPC.
     let channel = match name {
-        GetVersion::NAME | ListSessions::NAME | GetSessionRecord::NAME => {
+        GetVersion::NAME | ListSessions::NAME | GetSessionRecord::NAME | CreateSession::NAME => {
             let mut conn_lock = c.lock().await;
             let c_hnd = match conn_lock.take(id) {
                 None => {
@@ -239,6 +279,7 @@ pub async fn handle_ssh_rpc(
         GetVersion::NAME => spawn(GetVersion.handle(channel)),
         ListSessions::NAME => spawn(ListSessions.handle(s, channel)),
         GetSessionRecord::NAME => spawn(GetSessionRecord.handle(s, channel)),
+        CreateSession::NAME => spawn(CreateSession.handle(s, channel)),
         _ => unreachable!(),
     };
 
@@ -247,6 +288,8 @@ pub async fn handle_ssh_rpc(
 
 #[cfg(test)]
 mod tests {
+    use sessions::paths::HostAbsPath;
+
     use super::*;
     use crate::test_harness::TestServer;
 
@@ -311,5 +354,47 @@ mod tests {
             let resp = client.call::<GetVersion>(&()).await;
             assert_eq!(resp.version, env!("CARGO_PKG_VERSION"));
         }
+    }
+
+    #[tokio::test]
+    async fn create_session_shows_in_get_and_list() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        let create_session = client
+            .call::<CreateSession>(&CreateSessionRequest {
+                record: sessions::Record {
+                    id: Uuid::nil(),
+                    name: Some("my session".to_string()),
+                    username: None,
+                    project_path: HostAbsPath::try_new("/uwu").unwrap(),
+                    attrs: Default::default(),
+                },
+            })
+            .await;
+
+        assert!(create_session.id != Uuid::nil());
+
+        let get_session = client
+            .call::<GetSessionRecord>(&GetSessionRecordRequest::Id(create_session.id))
+            .await;
+        assert_eq!(get_session.record.as_ref().unwrap().id, create_session.id);
+        assert_eq!(
+            get_session.record.as_ref().unwrap().name,
+            Some("my session".to_string())
+        );
+        assert_eq!(
+            get_session.record.as_ref().unwrap().project_path,
+            HostAbsPath::try_new("/uwu").unwrap()
+        );
+
+        let list_sessions = client.call::<ListSessions>(&()).await;
+        assert_eq!(
+            list_sessions.sessions,
+            vec![ListSessionsEntry {
+                id: create_session.id,
+                name: Some("my session".to_string()),
+            }]
+        );
     }
 }

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use crate::session::{Session, SessionHandle};
 use sessions::{
     paths::DaemonAbsPath,
-    store::{DiskLoader, Loader, SessionObject},
+    store::{DiskLoader, Loader, SessionKey, SessionObject},
 };
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
@@ -48,6 +48,7 @@ enum ManagerMessage {
     List(Responder<Vec<SessionInfo>>),
     GetRecord(SessionKeyPredicate, Responder<Option<sessions::Record>>),
     GetSession(SessionKeyPredicate, Responder<Option<SessionHandle>>),
+    CreateSession(sessions::Record, Responder<Uuid>),
 }
 
 /// Manages session instances, and session state on disk.
@@ -155,6 +156,14 @@ impl<L: Loader> Manager<L> {
                 })
                 .await;
             }
+            // Creates a session using the given record.
+            ManagerMessage::CreateSession(record, r) => {
+                r.handle(async {
+                    let k = self.store.create(record)?;
+                    Ok(*k.uuid())
+                })
+                .await;
+            }
         }
     }
 }
@@ -180,6 +189,17 @@ impl ManagerHandle {
         let (send, recv) = Responder::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(ManagerMessage::GetRecord(pred, send)).await;
+        recv.await.expect("corresponding sessions manager is dead")
+    }
+
+    /// Creates a session based on the given record.
+    pub async fn create_session(&self, record: sessions::Record) -> Result<Uuid, ResponseError> {
+        let (send, recv) = Responder::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .0
+            .send(ManagerMessage::CreateSession(record, send))
+            .await;
         recv.await.expect("corresponding sessions manager is dead")
     }
 

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -19,6 +19,7 @@ pub mod vars;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Record {
     /// Unique ID describing this session.
+    #[serde(default = "Uuid::nil")]
     pub id: Uuid,
     /// The name a user assigned to this session, if
     /// one was specifically assigned.

--- a/crates/sessions/src/store.rs
+++ b/crates/sessions/src/store.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::paths::{DaemonAbsPath, DaemonRelPath};
@@ -106,6 +107,21 @@ impl SessionObject for DiskSession {
     }
 }
 
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct Index {
+    short_to_uuid: BTreeMap<String, Uuid>,
+    name_to_uuid: BTreeMap<String, Uuid>,
+}
+
+impl Index {
+    pub fn insert(&mut self, short: String, uuid: Uuid, name: Option<String>) {
+        self.short_to_uuid.insert(short, uuid);
+        if let Some(name) = name {
+            self.name_to_uuid.insert(name, uuid);
+        }
+    }
+}
+
 /// A loader of session state based on <minimal-state-dir>/sessions.
 ///
 /// ./index.json maps short directory names to session UUIDs. Typically
@@ -115,7 +131,7 @@ impl SessionObject for DiskSession {
 /// ./<short-dir-name>/record.json is the session record.
 pub struct DiskLoader {
     minimal_dir: DaemonAbsPath,
-    index: BTreeMap<String, Uuid>,
+    index: Index,
 }
 
 impl DiskLoader {
@@ -132,7 +148,7 @@ impl DiskLoader {
         let index = if std::fs::exists(&index_file)? {
             serde_json::from_reader(std::fs::File::open(index_file)?)?
         } else {
-            BTreeMap::new()
+            Index::default()
         };
 
         Ok(Self { minimal_dir, index })
@@ -167,6 +183,15 @@ impl Loader for DiskLoader {
     type Object = DiskSession;
 
     fn create(&mut self, mut record: Record) -> Result<Self::Key, std::io::Error> {
+        if let Some(name) = &record.name
+            && self.index.name_to_uuid.contains_key(name)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!("a session with name `{name}` already exists"),
+            ));
+        }
+
         let uuid = Uuid::now_v7();
         record.id = uuid;
 
@@ -175,7 +200,7 @@ impl Loader for DiskLoader {
         // We got unlucky and the short name collided, 20 bits of entropy
         // so rare but very possible. Increment the short name past
         // any collisions in this case.
-        while self.index.contains_key(&short) {
+        while self.index.short_to_uuid.contains_key(&short) {
             let n = u32::from_str_radix(&short, 16)
                 .expect("short dir name is always 5 hex chars from a UUID suffix");
             short = format!("{:05x}", n.wrapping_add(1));
@@ -190,7 +215,7 @@ impl Loader for DiskLoader {
         let record_file = session_dir.join("record.json");
         serde_json::to_writer(std::fs::File::create(record_file)?, &record)?;
 
-        self.index.insert(short.clone(), uuid);
+        self.index.insert(short.clone(), uuid, record.name);
         self.flush()?;
 
         Ok(DiskSessionKey {
@@ -200,15 +225,19 @@ impl Loader for DiskLoader {
     }
 
     fn list(&self) -> impl Iterator<Item = Self::Key> {
-        self.index.iter().map(|(short, id)| Self::Key {
-            session_uuid: *id,
-            dir_key: DaemonRelPath::try_new(short).unwrap(),
-        })
+        self.index
+            .short_to_uuid
+            .iter()
+            .map(|(short, id)| Self::Key {
+                session_uuid: *id,
+                dir_key: DaemonRelPath::try_new(short).unwrap(),
+            })
     }
 
     fn find_by_uuid(&self, id: &Uuid) -> Result<Option<Self::Key>, std::io::Error> {
         Ok(self
             .index
+            .short_to_uuid
             .iter()
             .find(|(_short, iter_id)| *iter_id == id)
             .map(|(short, id)| Self::Key {
@@ -217,20 +246,15 @@ impl Loader for DiskLoader {
             }))
     }
     fn find_by_name<S: AsRef<str>>(&self, name: S) -> Result<Option<Self::Key>, std::io::Error> {
-        for k in self.list() {
-            let record = self.get(&k)?;
-            if let Some(stored_name) = &record.record().name
-                && stored_name == name.as_ref()
-            {
-                return Ok(Some(k));
-            }
+        match self.index.name_to_uuid.get(name.as_ref()) {
+            Some(uuid) => self.find_by_uuid(uuid),
+            None => Ok(None),
         }
-        Ok(None)
     }
 
     fn get(&self, key: &Self::Key) -> Result<Self::Object, std::io::Error> {
         assert!(
-            self.index.contains_key(key.dir_key.as_str()),
+            self.index.short_to_uuid.contains_key(key.dir_key.as_str()),
             "key {:?} not present in index — Keys are only handed out for sessions that exist",
             key.dir_key,
         );
@@ -253,7 +277,7 @@ impl Loader for DiskLoader {
 mod tests {
     use super::*;
     use crate::paths::HostAbsPath;
-    use std::collections::BTreeSet;
+    use std::{collections::BTreeSet, io::ErrorKind};
     use tempfile::TempDir;
 
     fn loader_dir(tmp: &TempDir) -> DaemonAbsPath {
@@ -315,12 +339,33 @@ mod tests {
     }
 
     #[test]
+    fn create_errors_on_non_unique_name() {
+        let tmp = TempDir::new().unwrap();
+        let mut loader = DiskLoader::new(loader_dir(&tmp)).unwrap();
+
+        loader.create(sample_record()).unwrap();
+        assert_eq!(
+            loader.create(sample_record()).err().map(|e| e.kind()),
+            Some(ErrorKind::AlreadyExists)
+        );
+    }
+
+    #[test]
     fn list_yields_a_key_for_every_created_session() {
         let tmp = TempDir::new().unwrap();
         let mut loader = DiskLoader::new(loader_dir(&tmp)).unwrap();
 
         let created: BTreeSet<Uuid> = (0..5)
-            .map(|_| *loader.create(sample_record()).unwrap().uuid())
+            .map(|i| {
+                *loader
+                    .create({
+                        let mut record = sample_record();
+                        record.name = Some(format!("session-{i}"));
+                        record
+                    })
+                    .unwrap()
+                    .uuid()
+            })
             .collect();
         let listed: BTreeSet<Uuid> = loader.list().map(|k| *k.uuid()).collect();
 


### PR DESCRIPTION
 * Session names are now unique, and `DiskLoader` indexes by name also
 * Implements `CreateSession` RPC.

This is technically breaking the format of `index.json`, except there was never a path to write it before, so it should be empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can now be created remotely via the SSH RPC interface for programmatic session management.

* **Improvements**
  * Session names must be unique; creating a session with a duplicate name is rejected.
  * Session storage and indexing improved for more reliable listing and lookups.
  * Session records missing an ID are now accepted and given a default ID.

* **Chores**
  * Added a dependency used by session handling.

* **Tests**
  * New/updated tests validate session creation, storage, and listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->