### PR TITLE
chore(sessions): Implemented var and var policy primitive types + code ergonomics

### DIFF
--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -12,6 +12,7 @@ pub mod lifecyclehook;
 pub mod loadout;
 pub mod patches;
 pub mod paths;
+pub mod policy;
 pub mod store;
 pub mod vars;
 

--- a/crates/sessions/src/lifecyclehook.rs
+++ b/crates/sessions/src/lifecyclehook.rs
@@ -6,7 +6,8 @@
 //! [`LifecycleHook::builder`] or deserialize them from configuration; both paths
 //! enforce the same invariant.
 
-use crate::paths::ConfigRelPath;
+use crate::paths::{self, ConfigRelPath};
+use camino::Utf8PathBuf;
 use core::fmt;
 
 /// Errors produced when constructing a [`LifecycleHook`].
@@ -60,6 +61,24 @@ pub enum HookScript {
     External(ConfigRelPath),
 }
 
+impl HookScript {
+    /// Construct an [`Inline`](Self::Inline) script.
+    #[must_use]
+    pub fn inline(s: impl Into<String>) -> Self {
+        Self::Inline(s.into())
+    }
+
+    /// Construct an [`External`](Self::External) script.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`paths::Error::IsAbsolute`] if `p` is an absolute path;
+    /// external script paths are anchored to the config directory.
+    pub fn try_external(p: impl Into<Utf8PathBuf>) -> Result<Self, paths::Error> {
+        Ok(Self::External(ConfigRelPath::try_new(p)?))
+    }
+}
+
 /// A set of scripts to run at lifecycle transition points of a host resource.
 ///
 /// At least one of `on_activate`, `on_destroy`, or `on_failure` must be set.
@@ -105,11 +124,8 @@ pub enum HookScript {
 /// ```
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(try_from = "LifecycleHookBuilder", into = "LifecycleHookBuilder")]
-#[expect(
-    clippy::struct_field_names,
-    reason = "field prefixes mirror lifecycle event names"
-)]
 pub struct LifecycleHook {
+    description: Option<String>,
     on_activate: Option<HookScript>,
     on_destroy: Option<HookScript>,
     on_failure: Option<HookScript>,
@@ -119,7 +135,7 @@ impl LifecycleHook {
     /// Returns a fresh [`LifecycleHookBuilder`].
     #[must_use]
     pub fn builder() -> LifecycleHookBuilder {
-        LifecycleHookBuilder::new()
+        LifecycleHookBuilder::default()
     }
 
     /// The script to run on activation, if any.
@@ -153,11 +169,9 @@ impl TryFrom<LifecycleHookBuilder> for LifecycleHook {
 /// Doubles as the on-the-wire deserialization shape for `LifecycleHook` — every
 /// field is optional, and validation runs at [`build`](Self::build) time.
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-#[expect(
-    clippy::struct_field_names,
-    reason = "field prefixes mirror lifecycle event names"
-)]
 pub struct LifecycleHookBuilder {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     on_activate: Option<HookScript>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -167,14 +181,6 @@ pub struct LifecycleHookBuilder {
 }
 
 impl LifecycleHookBuilder {
-    /// Creates a new builder with all fields unset.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
-    }
-
     /// Sets the script to run on activation.
     #[must_use]
     pub fn with_on_activate(self, on_activate: HookScript) -> Self {
@@ -213,6 +219,7 @@ impl LifecycleHookBuilder {
             return Err(Error::EmptyLifecycleHook);
         }
         Ok(LifecycleHook {
+            description: self.description,
             on_activate: self.on_activate,
             on_destroy: self.on_destroy,
             on_failure: self.on_failure,
@@ -223,6 +230,7 @@ impl LifecycleHookBuilder {
 impl From<LifecycleHook> for LifecycleHookBuilder {
     fn from(value: LifecycleHook) -> Self {
         Self {
+            description: value.description,
             on_activate: value.on_activate,
             on_destroy: value.on_destroy,
             on_failure: value.on_failure,
@@ -308,6 +316,35 @@ mod tests {
             Some(HookScript::External(p)) if p.as_str() == "./fail.sh"
         ));
         assert!(parsed.on_destroy().is_none());
+    }
+
+    #[test]
+    fn hook_script_try_external_helper() {
+        let s = HookScript::try_external("./run.sh").unwrap();
+        assert!(matches!(s, HookScript::External(ref p) if p.as_str() == "./run.sh"));
+    }
+
+    #[test]
+    fn hook_script_try_external_rejects_absolute() {
+        let err = HookScript::try_external("/abs").unwrap_err();
+        assert!(matches!(err, paths::Error::IsAbsolute(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn hook_script_external_round_trips_through_toml_in_isolation() {
+        // Pin the External wire form independent of the full LifecycleHook
+        // round-trip — if the ConfigRelPath serde shape changes underneath
+        // us, this test fires first.
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Wrap {
+            hook: HookScript,
+        }
+        let original = Wrap {
+            hook: HookScript::try_external("./run.sh").unwrap(),
+        };
+        let s = toml::to_string(&original).unwrap();
+        let parsed: Wrap = toml::from_str(&s).unwrap();
+        assert!(matches!(parsed.hook, HookScript::External(ref p) if p.as_str() == "./run.sh"),);
     }
 
     #[test]

--- a/crates/sessions/src/loadout.rs
+++ b/crates/sessions/src/loadout.rs
@@ -1,13 +1,350 @@
+//! User-level loadout: packages, variables, patches, and lifecycle
+//! hooks the user wants in their session.
+//!
+//! # Example: helix + zellij with the user's dotfiles
+//!
+//! Top-level keys (`packages`, `patches`) come first because every key
+//! following a `[section]` header in TOML is scoped to that section
+//! until the next header; an empty line is *not* a scope reset.
+//!
+//! ```toml
+//! packages = ["helix", "zellij"]
+//!
+//! # `dest` paths are inside the sandbox; `source` paths are on the host.
+//! # `~` on either side is expanded at apply time (sandbox-home for dest,
+//! # host-home for source).
+//! patches = [
+//!     # Helix: single config files plus a themes directory.
+//!     { dest = "~/.config/helix/config.toml",
+//!       source = "~/dotfiles/helix/config.toml" },
+//!     { dest = "~/.config/helix/languages.toml",
+//!       source = "~/dotfiles/helix/languages.toml" },
+//!     { dest = "~/.config/helix/themes/",
+//!       source = { base = "~/dotfiles/helix/themes", patterns = ["**/*.toml"] } },
+//!
+//!     # Zellij: single config file plus a layouts directory.
+//!     { dest = "~/.config/zellij/config.kdl",
+//!       source = "~/dotfiles/zellij/config.kdl" },
+//!     { dest = "~/.config/zellij/layouts/",
+//!       source = { base = "~/dotfiles/zellij/layouts", patterns = ["**/*.kdl"] } },
+//! ]
+//!
+//! [vars]
+//! EDITOR    = "hx"
+//! VISUAL    = "hx"
+//! TERM      = { inherit = true, default = "xterm-256color" }
+//! COLORTERM = { inherit = true }
+//!
+//! # Warm helix's tree-sitter grammar cache the first time the session
+//! # comes up. Best-effort; failures don't tank activation.
+//! [[lifecycle_hooks]]
+//! on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || true" }
+//! ```
+
 use std::collections::BTreeMap;
 
 use crate::lifecyclehook::LifecycleHook;
-use crate::vars::Var;
+use crate::patches::{Patch, Patches};
+use crate::vars::{LenientVarEntry, StrictVarName, VarName, VarValue};
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct Loadout {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    // Packages to be installed
+    // TODO: Newtype for `Package`?
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    packages: Vec<String>,
+    /// Variables with POSIX-shaped names — the common case.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    vars: BTreeMap<String, Var>,
+    vars: BTreeMap<StrictVarName, VarValue>,
+    /// Variables with Linux-permissive names — explicit opt-in for the
+    /// rare case where a non-POSIX name is necessary.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    vars_lenient: Vec<LenientVarEntry>,
+    /// Patches contributed by this loadout.
+    #[serde(default, skip_serializing_if = "Patches::is_empty")]
+    patches: Patches,
+    /// Scripts run at session-level transition points.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     lifecycle_hooks: Vec<LifecycleHook>,
-    // #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+}
+
+impl Loadout {
+    /// Construct an empty loadout. Build it up via the additive
+    /// `with_*` methods:
+    ///
+    /// ```
+    /// use sessions::loadout::Loadout;
+    /// use sessions::vars::{StrictVarName, VarValue};
+    ///
+    /// let l = Loadout::empty()
+    ///     .with_package("helix")
+    ///     .with_var(StrictVarName::try_new("EDITOR").unwrap(), VarValue::specified("hx"));
+    /// assert_eq!(l.packages(), &["helix"]);
+    /// assert_eq!(l.vars().len(), 1);
+    /// ```
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Append a package dependency.
+    #[must_use]
+    pub fn with_package(self, package: impl Into<String>) -> Self {
+        let mut new = self;
+        new.packages.push(package.into());
+        new
+    }
+
+    /// Insert a strict-name variable. Replaces any existing entry with
+    /// the same name (consistent with [`std::collections::BTreeMap`]
+    /// semantics).
+    #[must_use]
+    pub fn with_var(self, name: StrictVarName, value: VarValue) -> Self {
+        let mut new = self;
+        new.vars.insert(name, value);
+        new
+    }
+
+    /// Append a lenient-name variable.
+    #[must_use]
+    pub fn with_var_lenient(self, entry: LenientVarEntry) -> Self {
+        let mut new = self;
+        new.vars_lenient.push(entry);
+        new
+    }
+
+    /// Append a patch.
+    #[must_use]
+    pub fn with_patch(self, patch: Patch) -> Self {
+        Self {
+            patches: self.patches.with_patch(patch),
+            ..self
+        }
+    }
+
+    /// Append a lifecycle hook.
+    #[must_use]
+    pub fn with_lifecycle_hook(self, hook: LifecycleHook) -> Self {
+        let mut new = self;
+        new.lifecycle_hooks.push(hook);
+        new
+    }
+
+    /// Packages this loadout requires.
+    #[must_use]
+    pub fn packages(&self) -> &[String] {
+        &self.packages
+    }
+
+    /// Variables with POSIX-shaped names (raw wire-form accessor).
+    #[must_use]
+    pub fn vars(&self) -> &BTreeMap<StrictVarName, VarValue> {
+        &self.vars
+    }
+
+    /// Variables with Linux-permissive names (raw wire-form accessor).
+    #[must_use]
+    pub fn vars_lenient(&self) -> &[LenientVarEntry] {
+        &self.vars_lenient
+    }
+
+    /// Iterate over every variable this loadout declares — strict and
+    /// lenient unified into a single stream of
+    /// `(`[`VarName`]`, &`[`VarValue`]`)` pairs.
+    ///
+    /// Hides the wire-form asymmetry between [`Self::vars`] and
+    /// [`Self::vars_lenient`]; callers that simply want "all variables
+    /// to apply" should reach for this rather than merging the two
+    /// fields themselves.
+    ///
+    /// Iteration order is strict-first (in [`StrictVarName`] order via
+    /// the underlying [`BTreeMap`]), then lenient (in declaration order).
+    pub fn all_vars(&self) -> impl Iterator<Item = (VarName, &VarValue)> {
+        let strict = self
+            .vars
+            .iter()
+            .map(|(n, v)| (VarName::Strict(n.clone()), v));
+        let lenient = self
+            .vars_lenient
+            .iter()
+            .map(|e| (VarName::Lenient(e.name().clone()), e.value()));
+        strict.chain(lenient)
+    }
+
+    /// Patches contributed by this loadout.
+    #[must_use]
+    pub fn patches(&self) -> &Patches {
+        &self.patches
+    }
+
+    /// Lifecycle hooks attached to this loadout.
+    #[must_use]
+    pub fn lifecycle_hooks(&self) -> &[LifecycleHook] {
+        &self.lifecycle_hooks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lifecyclehook::HookScript;
+    use crate::patches::{FileSet, PatchDest};
+    use crate::vars::LenientVarName;
+
+    #[test]
+    fn all_vars_yields_strict_then_lenient() {
+        let src = r#"
+            [vars]
+            EDITOR = "vim"
+            LANG = { inherit = true, default = "C" }
+
+            [[vars_lenient]]
+            name = "weird-thing"
+            value = "x"
+        "#;
+        let l: Loadout = toml::from_str(src).unwrap();
+        let collected: Vec<_> = l
+            .all_vars()
+            .map(|(n, v)| (n.as_str().to_owned(), v.clone()))
+            .collect();
+        assert_eq!(collected.len(), 3);
+
+        // BTreeMap order on the strict side: EDITOR before LANG.
+        assert_eq!(collected[0].0, "EDITOR");
+        assert!(matches!(collected[0].1, VarValue::Specified { .. }));
+        assert_eq!(collected[1].0, "LANG");
+        assert!(matches!(
+            collected[1].1,
+            VarValue::InheritWithDefault { .. }
+        ));
+
+        // Lenient comes after strict, in declaration order.
+        assert_eq!(collected[2].0, "weird-thing");
+    }
+
+    #[test]
+    fn all_vars_distinguishes_strict_from_lenient() {
+        let src = r#"
+            [vars]
+            EDITOR = "vim"
+
+            [[vars_lenient]]
+            name = "EDITOR"     # same spelling, different realm
+            value = "emacs"
+        "#;
+        let l: Loadout = toml::from_str(src).unwrap();
+        let collected: Vec<_> = l.all_vars().collect();
+        assert!(matches!(collected[0].0, VarName::Strict(_)));
+        assert!(matches!(collected[1].0, VarName::Lenient(_)));
+    }
+
+    #[test]
+    fn default_loadout_is_empty() {
+        let l = Loadout::default();
+        assert!(l.packages().is_empty());
+        assert_eq!(l.all_vars().count(), 0);
+        assert!(l.patches().is_empty());
+        assert!(l.lifecycle_hooks().is_empty());
+    }
+
+    #[test]
+    fn lenient_var_entry_round_trips_through_toml() {
+        let src = r#"
+            [[vars_lenient]]
+            name = "weird-thing"
+            value = "x"
+        "#;
+        let l: Loadout = toml::from_str(src).unwrap();
+        let entry = &l.vars_lenient()[0];
+        assert_eq!(
+            entry.name(),
+            &LenientVarName::try_new("weird-thing").unwrap()
+        );
+        assert!(matches!(entry.value(), VarValue::Specified { value } if value == "x"),);
+    }
+
+    #[test]
+    fn builder_surface_assembles_every_field() {
+        let hook = LifecycleHook::builder()
+            .with_on_activate(HookScript::inline("echo hi"))
+            .build()
+            .unwrap();
+        let patch = Patch::new(
+            FileSet::try_new(None, ["a"]).unwrap(),
+            PatchDest::try_new("/a").unwrap(),
+        );
+
+        let l = Loadout::empty()
+            .with_package("helix")
+            .with_package("zellij")
+            .with_var(
+                StrictVarName::try_new("EDITOR").unwrap(),
+                VarValue::specified("hx"),
+            )
+            .with_var_lenient(
+                LenientVarEntry::try_new("weird-thing", VarValue::specified("x")).unwrap(),
+            )
+            .with_patch(patch)
+            .with_lifecycle_hook(hook);
+
+        assert_eq!(l.packages(), &["helix", "zellij"]);
+        assert_eq!(l.vars().len(), 1);
+        assert_eq!(l.vars_lenient().len(), 1);
+        assert_eq!(l.patches().len(), 1);
+        assert_eq!(l.lifecycle_hooks().len(), 1);
+    }
+
+    #[test]
+    fn with_var_replaces_existing_strict_entry() {
+        let name = StrictVarName::try_new("EDITOR").unwrap();
+        let l = Loadout::empty()
+            .with_var(name.clone(), VarValue::specified("hx"))
+            .with_var(name.clone(), VarValue::specified("vim"));
+        assert_eq!(l.vars().len(), 1);
+        assert_eq!(l.vars().get(&name), Some(&VarValue::specified("vim")));
+    }
+
+    #[test]
+    fn full_loadout_round_trips_through_toml() {
+        // Exercise every field at once: packages, both strict and lenient
+        // vars, patches with multiple source shapes, and a lifecycle hook.
+        let src = r#"
+            packages = ["helix", "zellij"]
+
+            patches = [
+                { dest = "/etc/foo", source = "./foo" },
+                { dest = "/etc/bar", source = ["b1", "b2"] },
+                { dest = "/themes/", source = { base = "./themes", patterns = ["**/*.toml"] } },
+            ]
+
+            [vars]
+            EDITOR = "hx"
+            LANG   = { inherit = true, default = "C" }
+
+            [[vars_lenient]]
+            name  = "weird-thing"
+            value = "x"
+
+            [[lifecycle_hooks]]
+            on_activate = { type = "inline", value = "echo hi" }
+        "#;
+        let original: Loadout = toml::from_str(src).unwrap();
+        let serialized = toml::to_string(&original).unwrap();
+        let parsed: Loadout = toml::from_str(&serialized).unwrap();
+
+        assert_eq!(parsed.packages(), &["helix", "zellij"]);
+        assert_eq!(parsed.patches().len(), 3);
+        assert_eq!(parsed.vars().len(), 2);
+        assert_eq!(parsed.vars_lenient().len(), 1);
+        assert_eq!(parsed.lifecycle_hooks().len(), 1);
+
+        // The original-vs-parsed equality check would require Loadout: Eq,
+        // which it isn't (Patches / VarValue / LifecycleHook all skip it).
+        // Re-serialize and compare strings instead — same effect, no derive
+        // creep.
+        let reserialized = toml::to_string(&parsed).unwrap();
+        assert_eq!(serialized, reserialized);
+    }
 }

--- a/crates/sessions/src/patches.rs
+++ b/crates/sessions/src/patches.rs
@@ -1,28 +1,16 @@
-//! Patches: descriptions of files brought into a session, the provenance of
-//! each patch, and the policy controlling which non-user patches are honored.
+//! Patches: descriptions of files brought into a session and the policy
+//! controlling which non-user patches are honored.
 //!
-//! # Sources of patches
+//! # Sources
 //!
-//! Patches enter the session from three distinct origins (see [`PatchOrigin`]):
+//! Patches can be declared by three kinds of source — a user [`Loadout`],
+//! a project's `minimal.toml`, and individual package specs — and each
+//! source contributes its patches to the session. The primitives here
+//! are origin-free: provenance is known to the session-construction
+//! layer that combines the three sources, and that layer is where the
+//! [`PatchPolicy`] gate applies (see [`PatchPolicy`] for the rules).
 //!
-//! - **User** — the user's personal config. Implicit trust: only [`PatchPolicy::ignore`]
-//!   applies; `allow` and `deny` are bypassed (the user *is* the policy).
-//! - **Project** — the shared `minimal.toml` in the project. Subject to the
-//!   full policy (`allow`, `deny`, `ignore`) — a project config can't
-//!   silently read from your `~/.ssh`.
-//! - **Package** — declared by an installed package's spec. Subject to the
-//!   full policy. Carries the package name so prompts/errors can attribute
-//!   the request.
-//!
-//! # Wire form vs domain form
-//!
-//! TOML files describe patches without origin information — the *loader*
-//! attaches the origin based on which file the declaration came from. The
-//! split is reflected in the types:
-//!
-//! - [`PatchDecl`] / [`PatchDecls`] — wire form. Deserialized from TOML.
-//! - [`Patch`] / [`Patches`] — domain form. Built from a [`PatchDecls`] plus
-//!   a [`PatchOrigin`] via [`PatchDecls::promote`].
+//! [`Loadout`]: crate::loadout::Loadout
 //!
 //! # The `FileSet` primitive
 //!
@@ -109,32 +97,6 @@ impl std::error::Error for Error {
 }
 
 // =====================================================================
-// PatchOrigin
-// =====================================================================
-
-/// Where a patch came from. Determines how [`PatchPolicy`] applies:
-///
-/// | Origin    | `allow` / `deny` | `ignore` |
-/// |-----------|------------------|----------|
-/// | `User`    | bypassed         | applies  |
-/// | `Project` | applies          | applies  |
-/// | `Package` | applies          | applies  |
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub enum PatchOrigin {
-    /// From the user's personal config.
-    User,
-    /// From the shared project config (`minimal.toml`).
-    Project,
-    /// Declared by an installed package's spec.
-    Package {
-        /// Name (or identifier) of the package that declared the patch.
-        /// Used in permission prompts and error messages.
-        package: String,
-    },
-}
-
-// =====================================================================
 // FileSet
 // =====================================================================
 
@@ -213,6 +175,38 @@ impl FileSet {
             patterns: Vec::new(),
             compiled: Vec::new(),
         }
+    }
+
+    /// Set the base directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::EmptyBase`] if `base`'s underlying path is empty.
+    pub fn try_with_base(self, base: HostPath) -> Result<Self, Error> {
+        if base.as_str().is_empty() {
+            return Err(Error::EmptyBase);
+        }
+        Ok(Self {
+            base: Some(base),
+            ..self
+        })
+    }
+
+    /// Append a single pattern.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidGlob`] if the pattern fails to parse.
+    pub fn try_with_pattern(self, pattern: impl Into<String>) -> Result<Self, Error> {
+        let pattern = pattern.into();
+        let glob = globset::Glob::new(&pattern).map_err(|source| Error::InvalidGlob {
+            pattern: pattern.clone(),
+            source,
+        })?;
+        let mut new = self;
+        new.patterns.push(pattern);
+        new.compiled.push(glob);
+        Ok(new)
     }
 
     /// The base directory for relative patterns, if set.
@@ -360,128 +354,38 @@ impl<'de> serde::Deserialize<'de> for PatchDest {
 }
 
 // =====================================================================
-// PatchDecl / PatchDecls — wire form
+// Patch / Patches
 // =====================================================================
 
-/// A patch as declared in a config file, **before** origin is attached.
-///
-/// This is the form that comes out of deserializing TOML — the file itself
-/// doesn't say where it came from, so origin is supplied by the loader via
-/// [`Self::promote`] (or in bulk via [`PatchDecls::promote`]).
-#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct PatchDecl {
-    source: FileSet,
-    dest: PatchDest,
-}
-
-impl PatchDecl {
-    /// Construct a declaration without origin.
-    #[must_use]
-    pub fn new(source: FileSet, dest: PatchDest) -> Self {
-        Self { source, dest }
-    }
-
-    /// The source fileset.
-    #[must_use]
-    pub fn source(&self) -> &FileSet {
-        &self.source
-    }
-
-    /// The destination path.
-    #[must_use]
-    pub fn dest(&self) -> &PatchDest {
-        &self.dest
-    }
-
-    /// Attach an origin and produce a fully-typed [`Patch`].
-    #[must_use]
-    pub fn promote(self, origin: PatchOrigin) -> Patch {
-        Patch {
-            source: self.source,
-            dest: self.dest,
-            origin,
-        }
-    }
-}
-
-/// An ordered collection of [`PatchDecl`] entries — the wire form of a
-/// `patches = [...]` array.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[serde(transparent)]
-pub struct PatchDecls(Vec<PatchDecl>);
-
-impl PatchDecls {
-    /// Construct from a vector of declarations.
-    #[must_use]
-    pub fn new(decls: Vec<PatchDecl>) -> Self {
-        Self(decls)
-    }
-
-    /// Returns `true` if there are no declarations.
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Number of declarations.
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Iterate over the declarations.
-    pub fn iter(&self) -> std::slice::Iter<'_, PatchDecl> {
-        self.0.iter()
-    }
-
-    /// Promote every declaration to a [`Patch`] with the given origin.
-    #[must_use]
-    pub fn promote(self, origin: &PatchOrigin) -> Patches {
-        Patches(
-            self.0
-                .into_iter()
-                .map(|d| d.promote(origin.clone()))
-                .collect(),
-        )
-    }
-}
-
-impl<'a> IntoIterator for &'a PatchDecls {
-    type Item = &'a PatchDecl;
-    type IntoIter = std::slice::Iter<'a, PatchDecl>;
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
-}
-
-// =====================================================================
-// Patch / Patches — domain form
-// =====================================================================
-
-/// A single patch entry with its origin attached.
+/// A single patch: a source fileset and the destination it should land
+/// at inside the sandbox.
 ///
 /// For single-file sources, `dest` is the destination file path. For
 /// multi-file sources (lists, globs, directory copies), `dest` is the
-/// destination *directory*. Enforcing this invariant requires expanded paths
-/// and is the apply layer's responsibility.
+/// destination *directory*. Enforcing this invariant requires expanded
+/// paths and is the apply layer's responsibility.
 ///
-/// Construct via [`Patch::new`] or by promoting a [`PatchDecl`] with
-/// [`PatchDecl::promote`].
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// Patches carry no provenance: which source declared a patch is known
+/// to the session-construction layer that combines a [`Loadout`], a
+/// project config, and package specs.
+///
+/// [`Loadout`]: crate::loadout::Loadout
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Patch {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
     source: FileSet,
     dest: PatchDest,
-    origin: PatchOrigin,
 }
 
 impl Patch {
     /// Construct a new patch.
     #[must_use]
-    pub fn new(source: FileSet, dest: PatchDest, origin: PatchOrigin) -> Self {
+    pub fn new(source: FileSet, dest: PatchDest) -> Self {
         Self {
             source,
             dest,
-            origin,
+            description: None,
         }
     }
 
@@ -491,32 +395,44 @@ impl Patch {
         &self.source
     }
 
-    /// The destination path.
+    /// The destination path inside the sandbox.
     #[must_use]
     pub fn dest(&self) -> &PatchDest {
         &self.dest
     }
-
-    /// Where the patch came from.
-    #[must_use]
-    pub fn origin(&self) -> &PatchOrigin {
-        &self.origin
-    }
 }
 
-/// An ordered collection of [`Patch`] entries.
-///
-/// Not directly deserializable — patches require an origin, which the wire
-/// format doesn't carry. Build from a [`PatchDecls`] via
-/// [`PatchDecls::promote`].
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+/// An ordered collection of [`Patch`] entries — the wire form of a
+/// `patches = [...]` array.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 pub struct Patches(Vec<Patch>);
 
 impl Patches {
+    /// Construct an empty collection. Useful as the start of a builder
+    /// chain.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
     /// Construct from a vector of patches.
     #[must_use]
     pub fn new(patches: Vec<Patch>) -> Self {
         Self(patches)
+    }
+
+    /// Append a patch and return the modified collection (builder style).
+    #[must_use]
+    pub fn with_patch(self, patch: Patch) -> Self {
+        let mut new = self;
+        new.0.push(patch);
+        new
+    }
+
+    /// Append a patch in place.
+    pub fn push(&mut self, patch: Patch) {
+        self.0.push(patch);
     }
 
     /// Returns `true` if there are no patches.
@@ -542,6 +458,12 @@ impl Patches {
     }
 }
 
+impl FromIterator<Patch> for Patches {
+    fn from_iter<I: IntoIterator<Item = Patch>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
 impl<'a> IntoIterator for &'a Patches {
     type Item = &'a Patch;
     type IntoIter = std::slice::Iter<'a, Patch>;
@@ -556,19 +478,21 @@ impl<'a> IntoIterator for &'a Patches {
 
 /// Policy gating which patches are honored.
 ///
-/// Applied to patches based on their [`PatchOrigin`]:
+/// Applied at the session-construction layer based on a patch's source:
 ///
-/// - **User-origin patches**: only [`ignore`](Self::ignore) applies.
-///   `allow` and `deny` are bypassed — the user is the policy for their own
-///   declarations.
+/// - **User-origin patches** (from a [`Loadout`]): only
+///   [`ignore`](Self::ignore) applies. `allow` and `deny` are bypassed —
+///   the user is the policy for their own declarations.
 /// - **Project- and Package-origin patches**: all three fields apply.
-///   A patch is honored iff its destination matches `allow`, does not match
-///   `deny`, and does not match `ignore`. Patches matching only `ignore`
-///   are silently dropped; matching `deny` is an error/prompt; matching
-///   neither `allow` nor `ignore` triggers a permission prompt.
+///   A patch is honored iff its destination matches `allow`, does not
+///   match `deny`, and does not match `ignore`. Patches matching only
+///   `ignore` are silently dropped; matching `deny` is an error/prompt;
+///   matching neither `allow` nor `ignore` triggers a permission prompt.
 ///
 /// Precedence within the policy: `ignore` first (silent), then `deny`
 /// (reject), then `allow` (permit). Anything else prompts.
+///
+/// [`Loadout`]: crate::loadout::Loadout
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PatchPolicy {
     #[serde(default, skip_serializing_if = "FileSet::is_empty")]
@@ -580,32 +504,87 @@ pub struct PatchPolicy {
 }
 
 impl PatchPolicy {
-    /// Construct a policy from its three filesets.
+    /// Construct an empty policy. Build it up with [`Self::with_allow`],
+    /// [`Self::with_deny`], and [`Self::with_ignore`] (or their
+    /// pattern-accepting `try_with_*` variants).
     #[must_use]
-    pub fn new(allow: FileSet, deny: FileSet, ignore: FileSet) -> Self {
-        Self {
-            allow,
-            deny,
-            ignore,
-        }
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Replace the `allow` set.
+    #[must_use]
+    pub fn with_allow(self, allow: FileSet) -> Self {
+        Self { allow, ..self }
+    }
+
+    /// Replace the `deny` set.
+    #[must_use]
+    pub fn with_deny(self, deny: FileSet) -> Self {
+        Self { deny, ..self }
+    }
+
+    /// Replace the `ignore` set.
+    #[must_use]
+    pub fn with_ignore(self, ignore: FileSet) -> Self {
+        Self { ignore, ..self }
+    }
+
+    /// Replace the `allow` set, constructing it from raw patterns.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidGlob`] if any pattern fails to parse.
+    pub fn try_with_allow<I, S>(self, patterns: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Ok(self.with_allow(FileSet::try_new(None, patterns)?))
+    }
+
+    /// Replace the `deny` set, constructing it from raw patterns.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidGlob`] if any pattern fails to parse.
+    pub fn try_with_deny<I, S>(self, patterns: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Ok(self.with_deny(FileSet::try_new(None, patterns)?))
+    }
+
+    /// Replace the `ignore` set, constructing it from raw patterns.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidGlob`] if any pattern fails to parse.
+    pub fn try_with_ignore<I, S>(self, patterns: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Ok(self.with_ignore(FileSet::try_new(None, patterns)?))
     }
 
     /// Paths non-user patches **may** target. Does not apply to
-    /// [`PatchOrigin::User`].
+    /// user-origin patches.
     #[must_use]
     pub fn allow(&self) -> &FileSet {
         &self.allow
     }
 
     /// Paths non-user patches **must not** target. Does not apply to
-    /// [`PatchOrigin::User`].
+    /// user-origin patches.
     #[must_use]
     pub fn deny(&self) -> &FileSet {
         &self.deny
     }
 
-    /// Paths to silently drop without prompting. **Applies to every origin
-    /// including [`PatchOrigin::User`].**
+    /// Paths to silently drop without prompting. **Applies to every
+    /// origin, user-origin included.**
     #[must_use]
     pub fn ignore(&self) -> &FileSet {
         &self.ignore
@@ -702,77 +681,40 @@ mod tests {
     }
 
     #[test]
-    fn patchdest_accepts_absolute_and_home_paths() {
-        assert!(PatchDest::try_new("/etc/foo").is_ok());
-        assert!(PatchDest::try_new("~/.gitconfig").is_ok());
-    }
-
-    #[test]
-    fn patchdest_classifies_absolute_into_sandbox_abs_variant() {
-        let dest = PatchDest::try_new("/etc/foo").unwrap();
-        assert!(dest.as_sandbox_path().is_absolute());
+    fn patchdest_classifies_absolute_and_home_paths() {
+        let abs = PatchDest::try_new("/etc/foo").unwrap();
+        assert!(abs.as_sandbox_path().is_absolute());
         // Tilde-prefixed paths classify as Rel — apply layer expands them.
         let home = PatchDest::try_new("~/.gitconfig").unwrap();
         assert!(!home.as_sandbox_path().is_absolute());
     }
 
     #[test]
-    fn patchdecl_deserialize_rejects_bad_dest() {
-        let err = toml::from_str::<Wrap<PatchDecl>>(r#"x = { dest = "foo/../bar", source = "a" }"#)
+    fn patch_deserialize_rejects_bad_dest() {
+        let err = toml::from_str::<Wrap<Patch>>(r#"x = { dest = "foo/../bar", source = "a" }"#)
             .unwrap_err();
         assert!(err.to_string().contains(".."), "got: {err}");
     }
 
-    // ---- PatchDecl / PatchDecls / promote ----
+    // ---- Patch / Patches ----
 
     #[test]
-    fn patchdecl_with_string_source() {
-        let d: PatchDecl = parse(r#"x = { dest = "/etc/foo.conf", source = "./foo.conf" }"#);
-        assert_eq!(d.dest().as_sandbox_path().as_str(), "/etc/foo.conf");
-        assert_eq!(d.source().raw_patterns(), &["./foo.conf"]);
+    fn patch_with_string_source() {
+        let p: Patch = parse(r#"x = { dest = "/etc/foo.conf", source = "./foo.conf" }"#);
+        assert_eq!(p.dest().as_sandbox_path().as_str(), "/etc/foo.conf");
+        assert_eq!(p.source().raw_patterns(), &["./foo.conf"]);
     }
 
     #[test]
-    fn patchdecls_deserialize_from_array() {
+    fn patches_deserialize_from_array() {
         let src = r#"
             x = [
                 { dest = "/a", source = "a" },
                 { dest = "/b", source = ["b1", "b2"] },
             ]
         "#;
-        let ds: PatchDecls = parse(src);
-        assert_eq!(ds.len(), 2);
-    }
-
-    #[test]
-    fn promote_attaches_origin_to_every_patch() {
-        let src = r#"
-            x = [
-                { dest = "/a", source = "a" },
-                { dest = "/b", source = "b" },
-            ]
-        "#;
-        let decls: PatchDecls = parse(src);
-        let patches = decls.promote(&PatchOrigin::Project);
-        assert_eq!(patches.len(), 2);
-        for p in &patches {
-            assert_eq!(p.origin(), &PatchOrigin::Project);
-        }
-    }
-
-    #[test]
-    fn promote_with_package_origin_preserves_package_name() {
-        let decl = PatchDecl::new(
-            FileSet::try_new(None, ["a"]).unwrap(),
-            PatchDest::try_new("/a").unwrap(),
-        );
-        let patch = decl.promote(PatchOrigin::Package {
-            package: "git".into(),
-        });
-        match patch.origin() {
-            PatchOrigin::Package { package } => assert_eq!(package, "git"),
-            other => panic!("expected Package origin, got {other:?}"),
-        }
+        let ps: Patches = parse(src);
+        assert_eq!(ps.len(), 2);
     }
 
     // ---- PatchPolicy ----
@@ -796,5 +738,97 @@ mod tests {
         assert!(policy.allow().is_empty());
         assert!(policy.deny().is_empty());
         assert!(policy.ignore().is_empty());
+    }
+
+    #[test]
+    fn patch_policy_builder_methods() {
+        let p = PatchPolicy::empty()
+            .try_with_allow(["~/.config/**"])
+            .unwrap()
+            .try_with_deny(["~/.ssh/**", "**/*.pem"])
+            .unwrap()
+            .try_with_ignore(["**/.DS_Store"])
+            .unwrap();
+        assert_eq!(p.allow().raw_patterns(), &["~/.config/**"]);
+        assert_eq!(p.deny().raw_patterns(), &["~/.ssh/**", "**/*.pem"]);
+        assert_eq!(p.ignore().raw_patterns(), &["**/.DS_Store"]);
+    }
+
+    #[test]
+    fn patch_policy_try_with_allow_propagates_invalid_glob() {
+        let err = PatchPolicy::empty().try_with_allow(["[bad"]).unwrap_err();
+        assert!(matches!(err, Error::InvalidGlob { .. }), "got: {err:?}");
+    }
+
+    // ---- FileSet builders ----
+
+    #[test]
+    fn fileset_try_with_base_and_pattern_chain() {
+        let fs = FileSet::empty()
+            .try_with_base(HostPath::new("./themes"))
+            .unwrap()
+            .try_with_pattern("**/*")
+            .unwrap()
+            .try_with_pattern("**/*.toml")
+            .unwrap();
+        assert_eq!(fs.base().map(HostPath::as_str), Some("./themes"));
+        assert_eq!(fs.raw_patterns(), &["**/*", "**/*.toml"]);
+    }
+
+    #[test]
+    fn fileset_try_with_base_rejects_empty() {
+        let err = FileSet::empty()
+            .try_with_base(HostPath::new(""))
+            .unwrap_err();
+        assert!(matches!(err, Error::EmptyBase), "got: {err:?}");
+    }
+
+    #[test]
+    fn fileset_try_with_pattern_propagates_invalid_glob() {
+        let err = FileSet::empty().try_with_pattern("[bad").unwrap_err();
+        assert!(matches!(err, Error::InvalidGlob { .. }), "got: {err:?}");
+    }
+
+    // ---- Patches builders ----
+
+    #[test]
+    fn patches_builder_surfaces_compose() {
+        let make = |s: &str| {
+            Patch::new(
+                FileSet::try_new(None, [s]).unwrap(),
+                PatchDest::try_new(format!("/{s}")).unwrap(),
+            )
+        };
+
+        // collect / with_patch / push all feed the same internal Vec.
+        let collected: Patches = ["a", "b"].into_iter().map(make).collect();
+        let mut built = Patches::empty().with_patch(make("a"));
+        built.push(make("b"));
+        assert_eq!(collected, built);
+        assert_eq!(collected.len(), 2);
+    }
+
+    #[test]
+    fn patches_extend_appends_other_collection() {
+        let make = |s: &str| {
+            Patch::new(
+                FileSet::try_new(None, [s]).unwrap(),
+                PatchDest::try_new(format!("/{s}")).unwrap(),
+            )
+        };
+        let mut ps: Patches = ["a", "b"].into_iter().map(make).collect();
+        let extra: Patches = ["c", "d"].into_iter().map(make).collect();
+        ps.extend(extra);
+        let dests: Vec<_> = ps
+            .iter()
+            .map(|p| p.dest().as_sandbox_path().as_str().to_owned())
+            .collect();
+        assert_eq!(dests, ["/a", "/b", "/c", "/d"]);
+    }
+
+    #[test]
+    fn fileset_accepts_absolute_base() {
+        let fs = FileSet::try_new(Some(HostPath::new("/etc/xdg")), ["**/*.conf"]).unwrap();
+        assert_eq!(fs.base().map(HostPath::as_str), Some("/etc/xdg"));
     }
 }

--- a/crates/sessions/src/policy.rs
+++ b/crates/sessions/src/policy.rs
@@ -1,0 +1,148 @@
+//! User policy: what the user permits projects and packages to do
+//! within their session.
+//!
+//! [`UserPolicy`] bundles the per-domain policies — [`VarsPolicy`] for
+//! environment variables and [`PatchPolicy`] for file patches. Both
+//! gate *non-user* declarations only; user-origin declarations from a
+//! [`Loadout`] are subject to each domain's `ignore` rule but bypass
+//! `allow` / `deny`.
+//!
+//! Kept separate from [`Loadout`] on purpose: the user's policy is
+//! about what they let other sources contribute, not about what *they*
+//! contribute. Composing multiple Loadouts doesn't compose policy.
+//!
+//! [`Loadout`]: crate::loadout::Loadout
+//!
+//! # Example
+//!
+//! ```toml
+//! [vars]
+//! allow  = ["MY_APP_*", "RUST_*"]
+//! deny   = ["AWS_*", "*_TOKEN"]
+//! ignore = ["_*"]
+//!
+//! [patches]
+//! allow  = ["~/.config/**", "/etc/xdg/**"]
+//! deny   = ["~/.ssh/**", "**/*.pem"]
+//! ignore = ["**/.DS_Store"]
+//! ```
+
+use crate::patches::PatchPolicy;
+use crate::vars::VarsPolicy;
+
+/// The user's policy for what projects and packages may contribute to a
+/// session.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct UserPolicy {
+    #[serde(default, skip_serializing_if = "vars_policy_is_default")]
+    vars: VarsPolicy,
+    #[serde(default, skip_serializing_if = "patch_policy_is_default")]
+    patches: PatchPolicy,
+}
+
+impl UserPolicy {
+    /// Construct an empty policy — equivalent to [`Default::default`].
+    /// Build it up via [`Self::with_vars`] and [`Self::with_patches`]:
+    ///
+    /// ```
+    /// use sessions::policy::UserPolicy;
+    /// use sessions::vars::{VarNameGlobs, VarsPolicy};
+    ///
+    /// let p = UserPolicy::empty().with_vars(
+    ///     VarsPolicy::empty()
+    ///         .with_allow(VarNameGlobs::try_new(["MY_APP_*"]).unwrap()),
+    /// );
+    /// assert_eq!(p.vars().allow().raw_patterns(), &["MY_APP_*"]);
+    /// ```
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Replace the variables policy.
+    #[must_use]
+    pub fn with_vars(self, vars: VarsPolicy) -> Self {
+        Self { vars, ..self }
+    }
+
+    /// Replace the patches policy.
+    #[must_use]
+    pub fn with_patches(self, patches: PatchPolicy) -> Self {
+        Self { patches, ..self }
+    }
+
+    /// The variables policy in effect.
+    #[must_use]
+    pub fn vars(&self) -> &VarsPolicy {
+        &self.vars
+    }
+
+    /// The patches policy in effect.
+    #[must_use]
+    pub fn patches(&self) -> &PatchPolicy {
+        &self.patches
+    }
+}
+
+fn vars_policy_is_default(p: &VarsPolicy) -> bool {
+    p == &VarsPolicy::default()
+}
+
+fn patch_policy_is_default(p: &PatchPolicy) -> bool {
+    p == &PatchPolicy::default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vars::VarNameGlobs;
+
+    #[test]
+    fn empty_round_trips_through_toml() {
+        let p = UserPolicy::empty();
+        let s = toml::to_string(&p).unwrap();
+        let parsed: UserPolicy = toml::from_str(&s).unwrap();
+        assert_eq!(parsed, p);
+    }
+
+    #[test]
+    fn deserializes_with_both_sections() {
+        let src = r#"
+            [vars]
+            allow = ["MY_APP_*"]
+            deny  = ["AWS_*"]
+
+            [patches]
+            allow = ["~/.config/**"]
+            deny  = ["~/.ssh/**"]
+        "#;
+        let p: UserPolicy = toml::from_str(src).unwrap();
+        assert_eq!(p.vars().allow().raw_patterns(), &["MY_APP_*"]);
+        assert_eq!(p.vars().deny().raw_patterns(), &["AWS_*"]);
+        assert_eq!(p.patches().allow().raw_patterns(), &["~/.config/**"]);
+        assert_eq!(p.patches().deny().raw_patterns(), &["~/.ssh/**"]);
+    }
+
+    #[test]
+    fn deserializes_with_only_one_section() {
+        let src = r#"
+            [vars]
+            allow = ["X"]
+        "#;
+        let p: UserPolicy = toml::from_str(src).unwrap();
+        assert_eq!(p.vars().allow().raw_patterns(), &["X"]);
+        assert_eq!(p.patches(), &PatchPolicy::default());
+    }
+
+    #[test]
+    fn skips_default_sections_on_serialize() {
+        let p = UserPolicy::empty()
+            .with_vars(VarsPolicy::empty().with_allow(VarNameGlobs::try_new(["X"]).unwrap()));
+        let s = toml::to_string(&p).unwrap();
+        assert!(s.contains("[vars"), "expected vars section, got: {s}");
+        assert!(
+            !s.contains("[patches"),
+            "expected no patches section, got: {s}"
+        );
+    }
+}

--- a/crates/sessions/src/vars.rs
+++ b/crates/sessions/src/vars.rs
@@ -1,6 +1,962 @@
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub enum Var {
+//! Environment variable primitives: how a session declares which variables
+//! to set, how those declarations are sourced, and which the session
+//! policy permits.
+//!
+//! # Names
+//!
+//! Two flavors of name are recognized:
+//!
+//! - [`StrictVarName`] — POSIX-shaped (`[A-Z_][A-Z0-9_]*`). The default; what
+//!   the bare-string wire form decodes into. Catches typos like `MY VAR`
+//!   at config-load time.
+//! - [`LenientVarName`] — anything the Linux kernel accepts (no `=`, no
+//!   NUL). Loud, explicit opt-in via the `vars_lenient` array form on
+//!   [`crate::loadout::Loadout`]; never produced by the bare-string path.
+//!
+//! [`VarName`] is the sum of the two for places that need to hold either.
+//!
+//! # Values
+//!
+//! [`VarValue`] is what the variable should resolve to:
+//!
+//! - [`Inherit`](VarValue::Inherit) — pass through from the parent env.
+//! - [`InheritWithDefault`](VarValue::InheritWithDefault) — pass through
+//!   from the parent, fall back to `default` if unset.
+//! - [`Specified`](VarValue::Specified) — set to a specific value,
+//!   ignoring the parent.
+//!
+//! # Provenance
+//!
+//! The primitives in this module are origin-free. A variable's provenance
+//! is determined by which source file it appears in — a [`Loadout`] is
+//! always user-originated; equivalent project / package primitives carry
+//! their own origins by virtue of where they live. The session-construction
+//! layer combines the three sources and attaches origin per-source.
+//!
+//! [`Loadout`]: crate::loadout::Loadout
+//!
+//! # Example
+//!
+//! ```toml
+//! [vars]
+//! EDITOR = "vim"                                # → Specified
+//! HOME   = { inherit = true }                   # → Inherit
+//! LANG   = { inherit = true, default = "C" }    # → InheritWithDefault
+//!
+//! # Lenient names go in their own array — POSIX-strict by default.
+//! [[vars_lenient]]
+//! name  = "weird-thing"
+//! value = "x"
+//!
+//! [vars_policy]
+//! allow  = ["MY_APP_*", "RUST_*"]
+//! deny   = ["AWS_*", "*_TOKEN", "LD_PRELOAD"]
+//! ignore = ["_*"]
+//! ```
+
+use core::fmt;
+use std::str::FromStr;
+
+// =====================================================================
+// Errors
+// =====================================================================
+
+/// Errors produced when constructing var primitives.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum Error {
+    /// A var name was empty.
+    EmptyName,
+    /// A var name failed POSIX validation (used by [`StrictVarName`]).
+    NotPosixName(String),
+    /// A var name contained `=` or NUL, which the kernel won't accept.
+    InvalidLenientName(String),
+    /// A pattern string failed to parse as a glob.
+    InvalidGlob {
+        pattern: String,
+        source: globset::Error,
+    },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyName => f.write_str("variable name must not be empty"),
+            Self::NotPosixName(s) => write!(
+                f,
+                "variable name `{s}` is not POSIX-shaped \
+                 (expected `[A-Z_][A-Z0-9_]*`); use the `vars_lenient` \
+                 form for non-POSIX names",
+            ),
+            Self::InvalidLenientName(s) => write!(
+                f,
+                "variable name `{s}` contains `=` or NUL, which the kernel rejects",
+            ),
+            Self::InvalidGlob { pattern, source } => {
+                write!(f, "invalid glob pattern `{pattern}`: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidGlob { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+// =====================================================================
+// Names
+// =====================================================================
+
+/// A POSIX-shaped environment variable name: `[A-Z_][A-Z0-9_]*`.
+///
+/// Stricter than what the kernel will accept, intentionally — the strict
+/// form catches typos at config-load time and matches the convention
+/// every well-behaved program in the ecosystem expects.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct StrictVarName(String);
+
+impl StrictVarName {
+    /// Construct after validating against POSIX rules.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::EmptyName`] for empty input, or
+    /// [`Error::NotPosixName`] if the name contains anything outside
+    /// `[A-Z_][A-Z0-9_]*`.
+    pub fn try_new(s: impl Into<String>) -> Result<Self, Error> {
+        let s = s.into();
+        let mut chars = s.chars();
+        let Some(first) = chars.next() else {
+            return Err(Error::EmptyName);
+        };
+        if !(first.is_ascii_uppercase() || first == '_') {
+            return Err(Error::NotPosixName(s));
+        }
+        for c in chars {
+            if !(c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_') {
+                return Err(Error::NotPosixName(s));
+            }
+        }
+        Ok(Self(s))
+    }
+
+    /// Borrow the underlying name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for StrictVarName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for StrictVarName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl serde::Serialize for StrictVarName {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StrictVarName {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::try_new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl FromStr for StrictVarName {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_new(s)
+    }
+}
+
+/// A lenient environment variable name: anything the Linux kernel
+/// accepts (no `=`, no NUL byte).
+///
+/// Use sparingly — programs reading the env almost universally assume
+/// POSIX-shaped names. Reach for this only when integrating with an
+/// existing system that already publishes weird names.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct LenientVarName(String);
+
+impl LenientVarName {
+    /// Construct after rejecting `=` and NUL.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::EmptyName`] for empty input, or
+    /// [`Error::InvalidLenientName`] if the name contains `=` or NUL.
+    pub fn try_new(s: impl Into<String>) -> Result<Self, Error> {
+        let s = s.into();
+        if s.is_empty() {
+            return Err(Error::EmptyName);
+        }
+        if s.contains('=') || s.contains('\0') {
+            return Err(Error::InvalidLenientName(s));
+        }
+        Ok(Self(s))
+    }
+
+    /// Borrow the underlying name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for LenientVarName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for LenientVarName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl serde::Serialize for LenientVarName {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for LenientVarName {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::try_new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl FromStr for LenientVarName {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_new(s)
+    }
+}
+
+/// One entry in the lenient-vars array form.
+///
+/// Used by [`crate::loadout::Loadout`] as the wire-form representation
+/// of a single non-POSIX variable. The map form (`vars = { ... }`) can't
+/// carry the strict/lenient distinction in its keys, so lenient names
+/// require a separate array (`[[vars_lenient]]`); each element is one
+/// of these.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LenientVarEntry {
+    name: LenientVarName,
+    value: VarValue,
+}
+
+impl LenientVarEntry {
+    /// Construct an entry from a pre-validated name.
+    #[must_use]
+    pub fn new(name: LenientVarName, value: VarValue) -> Self {
+        Self { name, value }
+    }
+
+    /// Construct an entry from a raw string name, validating it.
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`Error`] from [`LenientVarName::try_new`] if `name`
+    /// is empty or contains `=` / NUL.
+    pub fn try_new(name: impl Into<String>, value: VarValue) -> Result<Self, Error> {
+        Ok(Self {
+            name: LenientVarName::try_new(name)?,
+            value,
+        })
+    }
+
+    /// The variable's name.
+    #[must_use]
+    pub fn name(&self) -> &LenientVarName {
+        &self.name
+    }
+
+    /// The resolution rule.
+    #[must_use]
+    pub fn value(&self) -> &VarValue {
+        &self.value
+    }
+}
+
+impl From<(LenientVarName, VarValue)> for LenientVarEntry {
+    fn from((name, value): (LenientVarName, VarValue)) -> Self {
+        Self { name, value }
+    }
+}
+
+/// A variable name — either [`Strict`](Self::Strict) (POSIX) or
+/// [`Lenient`](Self::Lenient) (Linux-permissive).
+///
+/// Used in unified contexts where either kind may appear (e.g.
+/// [`crate::loadout::Loadout::all_vars`]). The wire form on
+/// [`crate::loadout::Loadout`] itself keeps strict and lenient in
+/// separate fields so a bare-string TOML key can never accidentally
+/// smuggle a non-POSIX name through.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum VarName {
+    /// POSIX-shaped.
+    Strict(StrictVarName),
+    /// Linux-permissive.
+    Lenient(LenientVarName),
+}
+
+impl VarName {
+    /// Borrow the underlying name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Strict(n) => n.as_str(),
+            Self::Lenient(n) => n.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for VarName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<StrictVarName> for VarName {
+    fn from(n: StrictVarName) -> Self {
+        Self::Strict(n)
+    }
+}
+
+impl From<LenientVarName> for VarName {
+    fn from(n: LenientVarName) -> Self {
+        Self::Lenient(n)
+    }
+}
+
+// =====================================================================
+// VarValue
+// =====================================================================
+
+/// The resolution rule for a variable: inherited, inherited with a
+/// fallback, or set to a literal value.
+///
+/// # Wire form
+///
+/// Untagged — the shape distinguishes the variant:
+///
+/// ```toml
+/// EDITOR = "vim"                                # → Specified
+/// HOME   = { inherit = true }                   # → Inherit
+/// LANG   = { inherit = true, default = "C" }    # → InheritWithDefault
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum VarValue {
+    /// Pass through from the parent environment.
     Inherit,
-    InheritWithDefault { default: String },
-    Specified { value: String },
+    /// Pass through; fall back to `default` if the parent is unset.
+    InheritWithDefault {
+        /// Value to use when the parent env has no entry.
+        default: String,
+    },
+    /// Set to `value`, ignoring the parent environment.
+    Specified {
+        /// Literal value.
+        value: String,
+    },
+}
+
+impl VarValue {
+    /// Construct a [`Specified`](Self::Specified) value.
+    #[must_use]
+    pub fn specified(value: impl Into<String>) -> Self {
+        Self::Specified {
+            value: value.into(),
+        }
+    }
+
+    /// Construct an [`InheritWithDefault`](Self::InheritWithDefault) value.
+    #[must_use]
+    pub fn inherit_with_default(default: impl Into<String>) -> Self {
+        Self::InheritWithDefault {
+            default: default.into(),
+        }
+    }
+}
+
+impl serde::Serialize for VarValue {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        match self {
+            Self::Specified { value } => ser.serialize_str(value),
+            Self::Inherit => {
+                let mut st = ser.serialize_struct("Inherit", 1)?;
+                st.serialize_field("inherit", &true)?;
+                st.end()
+            }
+            Self::InheritWithDefault { default } => {
+                let mut st = ser.serialize_struct("InheritWithDefault", 2)?;
+                st.serialize_field("inherit", &true)?;
+                st.serialize_field("default", default)?;
+                st.end()
+            }
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for VarValue {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Specified(String),
+            Inherit {
+                inherit: bool,
+                #[serde(default)]
+                default: Option<String>,
+            },
+        }
+        match Repr::deserialize(deserializer)? {
+            Repr::Specified(value) => Ok(Self::Specified { value }),
+            Repr::Inherit {
+                inherit: true,
+                default: Some(default),
+            } => Ok(Self::InheritWithDefault { default }),
+            Repr::Inherit {
+                inherit: true,
+                default: None,
+            } => Ok(Self::Inherit),
+            Repr::Inherit { inherit: false, .. } => Err(serde::de::Error::custom(
+                "`inherit = false` is not a meaningful variable specification; \
+                 omit the variable entirely instead",
+            )),
+        }
+    }
+}
+
+// =====================================================================
+// VarsPolicy
+// =====================================================================
+
+/// A set of glob patterns matching variable names.
+///
+/// Patterns are compiled at construction time so malformed ones fail at
+/// config load. Used by [`VarsPolicy`] to express allow/deny/ignore
+/// lists.
+#[derive(Clone, Debug, Default)]
+pub struct VarNameGlobs {
+    patterns: Vec<String>,
+    compiled: Vec<globset::Glob>,
+}
+
+impl VarNameGlobs {
+    /// Construct an empty set. Useful as the start of a builder chain.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Construct from raw patterns.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidGlob`] if any pattern fails to parse.
+    pub fn try_new<I, S>(patterns: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let raw: Vec<String> = patterns.into_iter().map(Into::into).collect();
+        let compiled = raw
+            .iter()
+            .map(|p| {
+                globset::Glob::new(p).map_err(|source| Error::InvalidGlob {
+                    pattern: p.clone(),
+                    source,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            patterns: raw,
+            compiled,
+        })
+    }
+
+    /// Append a single pattern.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidGlob`] if the pattern fails to parse;
+    /// the set is consumed.
+    pub fn with_pattern(self, pattern: impl Into<String>) -> Result<Self, Error> {
+        let pattern = pattern.into();
+        let glob = globset::Glob::new(&pattern).map_err(|source| Error::InvalidGlob {
+            pattern: pattern.clone(),
+            source,
+        })?;
+        let mut new = self;
+        new.patterns.push(pattern);
+        new.compiled.push(glob);
+        Ok(new)
+    }
+
+    /// The original pattern strings (suitable for re-serialization).
+    #[must_use]
+    pub fn raw_patterns(&self) -> &[String] {
+        &self.patterns
+    }
+
+    /// The compiled glob patterns.
+    #[must_use]
+    pub fn globs(&self) -> &[globset::Glob] {
+        &self.compiled
+    }
+
+    /// Returns `true` if there are no patterns.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+}
+
+impl PartialEq for VarNameGlobs {
+    fn eq(&self, other: &Self) -> bool {
+        self.patterns == other.patterns
+    }
+}
+impl Eq for VarNameGlobs {}
+
+impl std::hash::Hash for VarNameGlobs {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.patterns.hash(state);
+    }
+}
+
+impl serde::Serialize for VarNameGlobs {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        self.patterns.serialize(ser)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for VarNameGlobs {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Many(Vec<String>),
+            One(String),
+        }
+        let patterns = match Repr::deserialize(deserializer)? {
+            Repr::Many(v) => v,
+            Repr::One(s) => vec![s],
+        };
+        Self::try_new(patterns).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Policy gating which variable declarations are honored.
+///
+/// Applied at the session-construction layer based on a declaration's
+/// source:
+///
+/// - **User-origin** (variables coming from a [`Loadout`]): only
+///   [`ignore`](Self::ignore) applies. `allow` and `deny` are bypassed
+///   — the user is the policy for their own declarations.
+/// - **Project- and Package-origin**: all three fields apply. A
+///   declaration is honored iff its name matches `allow`, does not match
+///   `deny`, and does not match `ignore`. Matching `ignore` is silent;
+///   matching `deny` is an error/prompt; matching neither `allow` nor
+///   `ignore` triggers a permission prompt.
+///
+/// [`Loadout`]: crate::loadout::Loadout
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VarsPolicy {
+    #[serde(default, skip_serializing_if = "VarNameGlobs::is_empty")]
+    allow: VarNameGlobs,
+    #[serde(default, skip_serializing_if = "VarNameGlobs::is_empty")]
+    deny: VarNameGlobs,
+    #[serde(default, skip_serializing_if = "VarNameGlobs::is_empty")]
+    ignore: VarNameGlobs,
+}
+
+impl VarsPolicy {
+    /// Construct an empty policy. Build it up with [`Self::with_allow`],
+    /// [`Self::with_deny`], and [`Self::with_ignore`]:
+    ///
+    /// ```
+    /// use sessions::vars::{VarNameGlobs, VarsPolicy};
+    /// let p = VarsPolicy::empty()
+    ///     .with_allow(VarNameGlobs::try_new(["MY_APP_*", "RUST_*"]).unwrap())
+    ///     .with_deny(VarNameGlobs::try_new(["AWS_*"]).unwrap());
+    /// assert_eq!(p.allow().raw_patterns().len(), 2);
+    /// assert!(p.ignore().is_empty());
+    /// ```
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Replace the `allow` set.
+    #[must_use]
+    pub fn with_allow(self, allow: VarNameGlobs) -> Self {
+        Self { allow, ..self }
+    }
+
+    /// Replace the `deny` set.
+    #[must_use]
+    pub fn with_deny(self, deny: VarNameGlobs) -> Self {
+        Self { deny, ..self }
+    }
+
+    /// Replace the `ignore` set.
+    #[must_use]
+    pub fn with_ignore(self, ignore: VarNameGlobs) -> Self {
+        Self { ignore, ..self }
+    }
+
+    /// Replace the `allow` set, constructing it from raw patterns.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidGlob`] if any pattern fails to parse.
+    pub fn try_with_allow<I, S>(self, patterns: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Ok(self.with_allow(VarNameGlobs::try_new(patterns)?))
+    }
+
+    /// Replace the `deny` set, constructing it from raw patterns.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidGlob`] if any pattern fails to parse.
+    pub fn try_with_deny<I, S>(self, patterns: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Ok(self.with_deny(VarNameGlobs::try_new(patterns)?))
+    }
+
+    /// Replace the `ignore` set, constructing it from raw patterns.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidGlob`] if any pattern fails to parse.
+    pub fn try_with_ignore<I, S>(self, patterns: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Ok(self.with_ignore(VarNameGlobs::try_new(patterns)?))
+    }
+
+    /// Names non-user declarations may set. Does not apply to
+    /// user-origin declarations.
+    #[must_use]
+    pub fn allow(&self) -> &VarNameGlobs {
+        &self.allow
+    }
+
+    /// Names non-user declarations must not set. Does not apply to
+    /// user-origin declarations.
+    #[must_use]
+    pub fn deny(&self) -> &VarNameGlobs {
+        &self.deny
+    }
+
+    /// Names to silently drop without prompting. Applies to every
+    /// origin, user-origin included.
+    #[must_use]
+    pub fn ignore(&self) -> &VarNameGlobs {
+        &self.ignore
+    }
+}
+
+// =====================================================================
+// Tests
+// =====================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, serde::Deserialize, serde::Serialize)]
+    struct Wrap<T> {
+        x: T,
+    }
+
+    fn parse<T: serde::de::DeserializeOwned>(toml_str: &str) -> T {
+        toml::from_str::<Wrap<T>>(toml_str).unwrap().x
+    }
+
+    // ---- StrictVarName ----
+
+    #[test]
+    fn strict_accepts_canonical_names() {
+        for n in ["FOO", "_BAR", "MY_APP_HOME", "X1", "_"] {
+            assert!(StrictVarName::try_new(n).is_ok(), "rejected: {n}");
+        }
+    }
+
+    #[test]
+    fn strict_rejects_non_posix_shapes() {
+        for n in ["", "lowercase", "1FOO", "FOO-BAR", "FOO BAR", "FOO=BAR"] {
+            assert!(StrictVarName::try_new(n).is_err(), "accepted: {n}");
+        }
+    }
+
+    #[test]
+    fn strict_deserialize_rejects_lowercase() {
+        let err = toml::from_str::<Wrap<StrictVarName>>(r#"x = "foo""#).unwrap_err();
+        assert!(err.to_string().contains("POSIX"), "got: {err}");
+    }
+
+    #[test]
+    fn strict_round_trips_through_toml() {
+        let original = StrictVarName::try_new("MY_APP_HOME").unwrap();
+        let s = toml::to_string(&Wrap {
+            x: original.clone(),
+        })
+        .unwrap();
+        let parsed: StrictVarName = parse(&s);
+        assert_eq!(parsed, original);
+    }
+
+    // ---- LenientVarName ----
+
+    #[test]
+    fn lenient_accepts_unusual_but_kernel_legal_names() {
+        for n in ["weird-thing", "lowercase", "1foo", "foo.bar"] {
+            assert!(LenientVarName::try_new(n).is_ok(), "rejected: {n}");
+        }
+    }
+
+    #[test]
+    fn lenient_rejects_kernel_illegal_names() {
+        assert!(LenientVarName::try_new("").is_err());
+        assert!(LenientVarName::try_new("foo=bar").is_err());
+        assert!(LenientVarName::try_new("foo\0bar").is_err());
+    }
+
+    // ---- VarValue ----
+
+    #[test]
+    fn varvalue_rejects_inherit_false() {
+        let err = toml::from_str::<Wrap<VarValue>>(r"x = { inherit = false }").unwrap_err();
+        assert!(err.to_string().contains("inherit = false"), "got: {err}");
+    }
+
+    #[test]
+    fn varvalue_specified_round_trips_as_bare_string() {
+        let v = VarValue::Specified {
+            value: "vim".into(),
+        };
+        let s = toml::to_string(&Wrap { x: v.clone() }).unwrap();
+        assert_eq!(s.trim(), r#"x = "vim""#);
+        let parsed: VarValue = parse(&s);
+        assert_eq!(parsed, v);
+    }
+
+    #[test]
+    fn varvalue_inherit_round_trips_as_table() {
+        for original in [
+            VarValue::Inherit,
+            VarValue::InheritWithDefault {
+                default: "C".into(),
+            },
+        ] {
+            let s = toml::to_string(&Wrap {
+                x: original.clone(),
+            })
+            .unwrap();
+            let parsed: VarValue = parse(&s);
+            assert_eq!(parsed, original);
+        }
+    }
+
+    // ---- VarsPolicy ----
+
+    #[test]
+    fn vars_policy_full_example() {
+        let src = r#"
+            allow  = ["MY_APP_*", "RUST_*"]
+            deny   = ["AWS_*", "*_TOKEN"]
+            ignore = ["_*"]
+        "#;
+        let policy: VarsPolicy = toml::from_str(src).unwrap();
+        assert_eq!(policy.allow().raw_patterns().len(), 2);
+        assert_eq!(policy.deny().raw_patterns().len(), 2);
+        assert_eq!(policy.ignore().raw_patterns().len(), 1);
+    }
+
+    #[test]
+    fn vars_policy_defaults_when_omitted() {
+        let policy: VarsPolicy = toml::from_str("").unwrap();
+        assert!(policy.allow().is_empty());
+        assert!(policy.deny().is_empty());
+        assert!(policy.ignore().is_empty());
+    }
+
+    #[test]
+    fn vars_policy_accepts_bare_string_for_each_field() {
+        let policy: VarsPolicy = toml::from_str(r#"deny = "AWS_*""#).unwrap();
+        assert_eq!(policy.deny().raw_patterns(), &["AWS_*"]);
+    }
+
+    #[test]
+    fn vars_policy_rejects_invalid_glob() {
+        let err = toml::from_str::<VarsPolicy>(r#"allow = "[bad""#).unwrap_err();
+        assert!(err.to_string().contains("invalid glob"), "got: {err}");
+    }
+
+    // ---- Builder ergonomics ----
+
+    #[test]
+    fn var_name_globs_with_pattern_chains() {
+        let g = VarNameGlobs::empty()
+            .with_pattern("MY_APP_*")
+            .unwrap()
+            .with_pattern("RUST_*")
+            .unwrap();
+        assert_eq!(g.raw_patterns(), &["MY_APP_*", "RUST_*"]);
+        assert_eq!(g.globs().len(), 2);
+    }
+
+    #[test]
+    fn var_name_globs_with_pattern_reports_invalid() {
+        let err = VarNameGlobs::empty().with_pattern("[bad").unwrap_err();
+        assert!(matches!(err, Error::InvalidGlob { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn vars_policy_builder_assembles_independent_fields() {
+        let p = VarsPolicy::empty()
+            .with_allow(VarNameGlobs::try_new(["MY_APP_*"]).unwrap())
+            .with_deny(VarNameGlobs::try_new(["AWS_*"]).unwrap())
+            .with_ignore(VarNameGlobs::try_new(["_*"]).unwrap());
+        assert_eq!(p.allow().raw_patterns(), &["MY_APP_*"]);
+        assert_eq!(p.deny().raw_patterns(), &["AWS_*"]);
+        assert_eq!(p.ignore().raw_patterns(), &["_*"]);
+    }
+
+    #[test]
+    fn vars_policy_with_methods_replace_rather_than_merge() {
+        let p = VarsPolicy::empty()
+            .with_allow(VarNameGlobs::try_new(["A"]).unwrap())
+            .with_allow(VarNameGlobs::try_new(["B"]).unwrap());
+        assert_eq!(p.allow().raw_patterns(), &["B"]);
+    }
+
+    #[test]
+    fn vars_policy_skips_default_fields_on_serialize() {
+        // Only `allow` is set; serialized output must omit `deny` / `ignore`.
+        let p = VarsPolicy::empty().try_with_allow(["A"]).unwrap();
+        let s = toml::to_string(&p).unwrap();
+        assert!(s.contains("allow"), "expected allow, got: {s}");
+        assert!(!s.contains("deny"), "expected no deny, got: {s}");
+        assert!(!s.contains("ignore"), "expected no ignore, got: {s}");
+    }
+
+    // ---- Pattern-accepting builder variants ----
+
+    #[test]
+    fn vars_policy_try_with_methods_accept_pattern_iterators() {
+        let p = VarsPolicy::empty()
+            .try_with_allow(["MY_APP_*", "RUST_*"])
+            .unwrap()
+            .try_with_deny(["AWS_*"])
+            .unwrap()
+            .try_with_ignore(["_*"])
+            .unwrap();
+        assert_eq!(p.allow().raw_patterns(), &["MY_APP_*", "RUST_*"]);
+        assert_eq!(p.deny().raw_patterns(), &["AWS_*"]);
+        assert_eq!(p.ignore().raw_patterns(), &["_*"]);
+    }
+
+    #[test]
+    fn vars_policy_try_with_allow_propagates_invalid_glob() {
+        let err = VarsPolicy::empty().try_with_allow(["[bad"]).unwrap_err();
+        assert!(matches!(err, Error::InvalidGlob { .. }), "got: {err:?}");
+    }
+
+    // ---- VarValue helpers ----
+
+    #[test]
+    fn varvalue_specified_helper() {
+        let v = VarValue::specified("vim");
+        assert_eq!(
+            v,
+            VarValue::Specified {
+                value: "vim".into()
+            }
+        );
+    }
+
+    #[test]
+    fn varvalue_inherit_with_default_helper() {
+        let v = VarValue::inherit_with_default("C");
+        assert_eq!(
+            v,
+            VarValue::InheritWithDefault {
+                default: "C".into()
+            }
+        );
+    }
+
+    // ---- Name FromStr ----
+
+    #[test]
+    fn strict_var_name_parses_via_from_str() {
+        let n: StrictVarName = "EDITOR".parse().unwrap();
+        assert_eq!(n.as_str(), "EDITOR");
+        let err = "lowercase".parse::<StrictVarName>().unwrap_err();
+        assert!(matches!(err, Error::NotPosixName(_)));
+    }
+
+    #[test]
+    fn lenient_var_name_parses_via_from_str() {
+        let n: LenientVarName = "weird-thing".parse().unwrap();
+        assert_eq!(n.as_str(), "weird-thing");
+        let err = "foo=bar".parse::<LenientVarName>().unwrap_err();
+        assert!(matches!(err, Error::InvalidLenientName(_)));
+    }
+
+    // ---- LenientVarEntry helpers ----
+
+    #[test]
+    fn lenient_entry_try_new_validates_name() {
+        let e = LenientVarEntry::try_new("weird-thing", VarValue::specified("x")).unwrap();
+        assert_eq!(e.name().as_str(), "weird-thing");
+    }
+
+    #[test]
+    fn lenient_entry_try_new_rejects_bad_name() {
+        let err = LenientVarEntry::try_new("a=b", VarValue::specified("x")).unwrap_err();
+        assert!(matches!(err, Error::InvalidLenientName(_)));
+    }
+
+    #[test]
+    fn lenient_entry_from_tuple() {
+        let n = LenientVarName::try_new("x").unwrap();
+        let v = VarValue::specified("1");
+        let e: LenientVarEntry = (n.clone(), v.clone()).into();
+        assert_eq!(e.name(), &n);
+        assert_eq!(e.value(), &v);
+    }
 }


### PR DESCRIPTION
- Dropped the provenance stuff from primitives, that stuff should be injected later
- Added implementation for variables
    - They can be either: specified, inherited, or inherited with a default (inherited will error if it is not defined)
    - Two versions: strict and lenient: This is because POSIX is strict about variable names but Linux is more lenient. In most cases we want the POSIX checking as this helps produce better error messages for certain types of typos, but we still need the lenient escape hatch
    - The different shape is to make it serialize, deserialize to more ergonomic toml
- Bunch of other tweaks to other primitives for code ergonomic reasons (mostly builder pattern stuff)
- Added a primitive for user policies since we have policies for vars and patches now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sessions now support package installation alongside existing features
  * Added optional descriptions to lifecycle hooks and session loadouts
  * Introduced flexible variable handling with strict and lenient variable types
  * New policy system for controlling environment variable and file patch configurations
  * Enhanced builder-style APIs for constructing and modifying session configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->