### PR TITLE
feat!(sessions): newtype session ID, refactor store index

### DIFF
--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -3,9 +3,9 @@ use russh::{
     server::{Msg, Session},
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sessions::SessionId;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::task::spawn;
-use uuid::Uuid;
 
 use crate::{
     connection::{ConnectionError, ConnectionHandle},
@@ -101,7 +101,7 @@ pub struct ListSessions;
 /// An entry in the ListSessions response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ListSessionsEntry {
-    pub id: Uuid,
+    pub id: SessionId,
     pub name: Option<String>,
 }
 
@@ -155,7 +155,7 @@ pub struct GetSessionRecord;
 #[serde(rename_all = "snake_case")]
 pub enum GetSessionRecordRequest {
     Name(String),
-    Id(Uuid),
+    Id(SessionId),
 }
 
 /// The response for a [`GetSessionRecord`] RPC.
@@ -205,7 +205,7 @@ pub struct CreateSessionRequest {
 /// The response for a [`CreateSession`] RPC.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateSessionResponse {
-    pub id: Uuid,
+    pub id: SessionId,
 }
 
 impl OneshotSshRpc for CreateSession {
@@ -337,7 +337,7 @@ mod tests {
         let mut client = server.connect().await;
 
         let resp = client
-            .call::<GetSessionRecord>(&GetSessionRecordRequest::Id(Uuid::nil()))
+            .call::<GetSessionRecord>(&GetSessionRecordRequest::Id(SessionId::nil()))
             .await;
 
         assert!(resp.record.is_none());
@@ -364,7 +364,7 @@ mod tests {
         let create_session = client
             .call::<CreateSession>(&CreateSessionRequest {
                 record: sessions::Record {
-                    id: Uuid::nil(),
+                    id: SessionId::nil(),
                     name: Some("my session".to_string()),
                     username: None,
                     project_path: HostAbsPath::try_new("/uwu").unwrap(),
@@ -373,7 +373,7 @@ mod tests {
             })
             .await;
 
-        assert!(create_session.id != Uuid::nil());
+        assert!(create_session.id != SessionId::nil());
 
         let get_session = client
             .call::<GetSessionRecord>(&GetSessionRecordRequest::Id(create_session.id))

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -2,23 +2,23 @@ use std::collections::BTreeMap;
 
 use crate::session::{Session, SessionHandle};
 use sessions::{
+    SessionId,
     paths::DaemonAbsPath,
     store::{DiskLoader, Loader, SessionKey, SessionObject},
 };
 use tokio::sync::{mpsc, oneshot};
-use uuid::Uuid;
 
 /// A short summary of the metadata of a session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionInfo {
-    pub id: Uuid,
+    pub id: SessionId,
     pub name: Option<String>,
 }
 
 /// A key you can use to identify a session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionKeyPredicate {
-    Id(Uuid),
+    Id(SessionId),
     Name(String),
 }
 
@@ -48,7 +48,7 @@ enum ManagerMessage {
     List(Responder<Vec<SessionInfo>>),
     GetRecord(SessionKeyPredicate, Responder<Option<sessions::Record>>),
     GetSession(SessionKeyPredicate, Responder<Option<SessionHandle>>),
-    CreateSession(sessions::Record, Responder<Uuid>),
+    CreateSession(sessions::Record, Responder<SessionId>),
 }
 
 /// Manages session instances, and session state on disk.
@@ -82,7 +82,7 @@ impl Manager {
 impl<L: Loader> Manager<L> {
     fn key_for(&self, pred: &SessionKeyPredicate) -> Result<Option<L::Key>, std::io::Error> {
         match pred {
-            SessionKeyPredicate::Id(id) => self.store.find_by_uuid(id),
+            SessionKeyPredicate::Id(id) => self.store.find_by_id(id),
             SessionKeyPredicate::Name(name) => self.store.find_by_name(name),
         }
     }
@@ -102,7 +102,7 @@ impl<L: Loader> Manager<L> {
             ManagerMessage::List(r) => {
                 r.handle(async {
                     self.store
-                        .list()
+                        .keys()
                         .map(|k| {
                             let s = self.store.get(&k)?;
                             let r = s.record();
@@ -121,7 +121,7 @@ impl<L: Loader> Manager<L> {
                     Ok::<_, ResponseError>(match pred {
                         SessionKeyPredicate::Id(id) => self
                             .store
-                            .find_by_uuid(&id)?
+                            .find_by_id(&id)?
                             .map(|k| self.store.get(&k).unwrap().record().clone()),
                         SessionKeyPredicate::Name(name) => self
                             .store
@@ -160,7 +160,7 @@ impl<L: Loader> Manager<L> {
             ManagerMessage::CreateSession(record, r) => {
                 r.handle(async {
                     let k = self.store.create(record)?;
-                    Ok(*k.uuid())
+                    Ok(*k.id())
                 })
                 .await;
             }
@@ -193,7 +193,10 @@ impl ManagerHandle {
     }
 
     /// Creates a session based on the given record.
-    pub async fn create_session(&self, record: sessions::Record) -> Result<Uuid, ResponseError> {
+    pub async fn create_session(
+        &self,
+        record: sessions::Record,
+    ) -> Result<SessionId, ResponseError> {
         let (send, recv) = Responder::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self

--- a/crates/minimald/src/sftp.rs
+++ b/crates/minimald/src/sftp.rs
@@ -20,11 +20,11 @@ use russh::server::Session;
 use russh_sftp::protocol::{
     Attrs, Data, File, FileAttributes, Handle, Name, OpenFlags, Status, StatusCode,
 };
+use sessions::SessionId;
 use sessions::paths::DaemonAbsPath;
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::task::spawn;
-use uuid::Uuid;
 
 use crate::connection::{ConnectionError, ConnectionHandle};
 use crate::server::ServerStateHandle;
@@ -428,7 +428,7 @@ pub(crate) async fn handle_sftp_subsystem(
         session.channel_failure(id)?;
         return Ok(());
     };
-    let Ok(session_uuid) = Uuid::parse_str(session_id_str) else {
+    let Ok(session_id) = SessionId::parse_str(session_id_str) else {
         tracing::warn!(
             value = %session_id_str,
             "sftp subsystem rejected on channel {id}: {MINIMAL_SESSION_ID_ENV} is not a uuid",
@@ -438,18 +438,15 @@ pub(crate) async fn handle_sftp_subsystem(
     };
 
     let mngr = s.sessions_manager().await;
-    let session_handle = match mngr
-        .get_session(SessionKeyPredicate::Id(session_uuid))
-        .await
-    {
+    let session_handle = match mngr.get_session(SessionKeyPredicate::Id(session_id)).await {
         Ok(Some(h)) => h,
         Ok(None) => {
-            tracing::warn!(%session_uuid, "sftp subsystem rejected: unknown session");
+            tracing::warn!(%session_id, "sftp subsystem rejected: unknown session");
             session.channel_failure(id)?;
             return Ok(());
         }
         Err(e) => {
-            tracing::warn!(%session_uuid, error = %e, "sftp subsystem rejected: lookup failed");
+            tracing::warn!(%session_id, error = %e, "sftp subsystem rejected: lookup failed");
             session.channel_failure(id)?;
             return Ok(());
         }
@@ -469,9 +466,9 @@ pub(crate) async fn handle_sftp_subsystem(
 mod tests {
     use russh_sftp::client::error::Error as SftpClientError;
     use russh_sftp::protocol::{OpenFlags, StatusCode};
+    use sessions::SessionId;
     use sessions::paths::HostAbsPath;
     use tokio::io::AsyncWriteExt;
-    use uuid::Uuid;
 
     use crate::rpc::{CreateSession, CreateSessionRequest};
     use crate::test_harness::TestServer;
@@ -479,11 +476,11 @@ mod tests {
     /// Creates a fresh session through the public CreateSession RPC and
     /// returns its uuid, mirroring how a real client would set things up
     /// before opening an SFTP channel.
-    async fn fresh_session(client: &mut crate::test_harness::TestClient) -> Uuid {
+    async fn fresh_session(client: &mut crate::test_harness::TestClient) -> SessionId {
         client
             .call::<CreateSession>(&CreateSessionRequest {
                 record: sessions::Record {
-                    id: Uuid::nil(),
+                    id: SessionId::nil(),
                     name: Some("sftp-test".to_string()),
                     username: None,
                     project_path: HostAbsPath::try_new("/tmp").unwrap(),

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -21,12 +21,11 @@ use std::sync::Arc;
 
 use camino::Utf8PathBuf;
 use russh::keys::ssh_key;
+use sessions::SessionId;
 use sessions::paths::DaemonAbsPath;
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
-
-use uuid::Uuid;
 
 use crate::connection::Connection;
 use crate::rpc::OneshotSshRpc;
@@ -142,7 +141,10 @@ impl TestClient {
     /// Sets `MINIMAL_SESSION_ID` on the channel (the env-var contract the
     /// server uses to scope the SFTP subsystem to a session), then requests
     /// the `sftp` subsystem and hands the channel stream to the SFTP client.
-    pub(crate) async fn open_sftp(&mut self, session_id: Uuid) -> russh_sftp::client::SftpSession {
+    pub(crate) async fn open_sftp(
+        &mut self,
+        session_id: SessionId,
+    ) -> russh_sftp::client::SftpSession {
         let channel = self.handle.channel_open_session().await.unwrap();
         channel
             .set_env(true, "MINIMAL_SESSION_ID", session_id.to_string())

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -2,6 +2,7 @@
 //! shape of a Minimal session.
 
 use std::collections::BTreeMap;
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -16,12 +17,44 @@ pub mod policy;
 pub mod store;
 pub mod vars;
 
+/// A session ID, a newtype over a UUID.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SessionId(Uuid);
+
+impl SessionId {
+    #[must_use]
+    pub fn nil() -> Self {
+        Self(Uuid::nil())
+    }
+
+    /// Parses the given UUID as a session ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the given string is not a UUID.
+    pub fn parse_str(s: &str) -> Result<Self, uuid::Error> {
+        Uuid::parse_str(s).map(Self)
+    }
+}
+
+impl AsRef<Uuid> for SessionId {
+    fn as_ref(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// The on-disk row/record pertaining to a session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Record {
     /// Unique ID describing this session.
-    #[serde(default = "Uuid::nil")]
-    pub id: Uuid,
+    #[serde(default = "SessionId::nil")]
+    pub id: SessionId,
     /// The name a user assigned to this session, if
     /// one was specifically assigned.
     ///

--- a/crates/sessions/src/store.rs
+++ b/crates/sessions/src/store.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::paths::{DaemonAbsPath, DaemonRelPath};
-use crate::{Record, sub_path};
+use crate::{Record, SessionId, sub_path};
 
 /// Describes the session object yielded by [`Loader`].
 pub trait SessionObject: Sized + Send + 'static + std::fmt::Debug {
@@ -20,8 +20,8 @@ pub trait SessionObject: Sized + Send + 'static + std::fmt::Debug {
 /// Describes the primary key a [`Loader`] uses to reference
 /// sessions.
 pub trait SessionKey: Sized + Send + 'static + std::fmt::Debug + Clone + Eq + Ord {
-    /// Returns the UUID of the session.
-    fn uuid(&self) -> &Uuid;
+    /// Returns the ID of the session.
+    fn id(&self) -> &SessionId;
 }
 
 /// A type which can load sessions.
@@ -30,7 +30,7 @@ pub trait Loader {
     type Object: SessionObject<Key = Self::Key>;
 
     /// Lists all sessions known to this loader, by key.
-    fn list(&self) -> impl Iterator<Item = Self::Key>;
+    fn keys(&self) -> impl Iterator<Item = Self::Key>;
 
     /// Gets a session.
     ///
@@ -47,7 +47,7 @@ pub trait Loader {
     ///
     /// Returns an I/O error if the backing record cannot be read or
     /// deserialized.
-    fn find_by_uuid(&self, id: &Uuid) -> Result<Option<Self::Key>, std::io::Error>;
+    fn find_by_id(&self, id: &SessionId) -> Result<Option<Self::Key>, std::io::Error>;
 
     /// Returns a lookup key corresponding to the given session name, if
     /// a session with that name is known.
@@ -73,13 +73,13 @@ pub trait Loader {
 /// The concrete key used to identify sessions from [`DiskLoader`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DiskSessionKey {
-    session_uuid: Uuid,
+    session_id: SessionId,
     dir_key: DaemonRelPath,
 }
 
 impl SessionKey for DiskSessionKey {
-    fn uuid(&self) -> &Uuid {
-        &self.session_uuid
+    fn id(&self) -> &SessionId {
+        &self.session_id
     }
 }
 
@@ -109,16 +109,39 @@ impl SessionObject for DiskSession {
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct Index {
-    short_to_uuid: BTreeMap<String, Uuid>,
-    name_to_uuid: BTreeMap<String, Uuid>,
+    short_to_id: BTreeMap<String, SessionId>,
+    name_to_id: BTreeMap<String, SessionId>,
 }
 
 impl Index {
-    pub fn insert(&mut self, short: String, uuid: Uuid, name: Option<String>) {
-        self.short_to_uuid.insert(short, uuid);
+    pub fn insert(&mut self, short: String, id: SessionId, name: Option<String>) {
+        self.short_to_id.insert(short, id);
         if let Some(name) = name {
-            self.name_to_uuid.insert(name, uuid);
+            self.name_to_id.insert(name, id);
         }
+    }
+
+    /// Iterates over all (shortname, session id) pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &SessionId)> {
+        self.short_to_id.iter()
+    }
+
+    /// Returns the session ID corresponding to the given session name, if known.
+    pub fn find_by_name<S: AsRef<str>>(&self, name: S) -> Option<&SessionId> {
+        self.name_to_id.get(name.as_ref())
+    }
+
+    /// Returns the session ID corresponding to the given short name, if known.
+    pub fn find_by_short<S: AsRef<str>>(&self, name: S) -> Option<&SessionId> {
+        self.short_to_id.get(name.as_ref())
+    }
+
+    /// Returns the short corresponding to the given session ID, if known.
+    pub fn short_by_id(&self, id: &SessionId) -> Option<&String> {
+        self.short_to_id
+            .iter()
+            .find(|(_short, iter_id)| *iter_id == id)
+            .map(|(short, _)| short)
     }
 }
 
@@ -131,6 +154,8 @@ impl Index {
 /// ./<short-dir-name>/record.json is the session record.
 pub struct DiskLoader {
     minimal_dir: DaemonAbsPath,
+    /// Keeps track of a mapping from shortname to UUID, as well as name to UUID.
+    /// Always kept up to date.
     index: Index,
 }
 
@@ -184,7 +209,7 @@ impl Loader for DiskLoader {
 
     fn create(&mut self, mut record: Record) -> Result<Self::Key, std::io::Error> {
         if let Some(name) = &record.name
-            && self.index.name_to_uuid.contains_key(name)
+            && self.index.name_to_id.contains_key(name)
         {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::AlreadyExists,
@@ -193,14 +218,14 @@ impl Loader for DiskLoader {
         }
 
         let uuid = Uuid::now_v7();
-        record.id = uuid;
+        record.id = SessionId(uuid);
 
         let uuid_str = uuid.simple().to_string();
         let mut short = uuid_str[uuid_str.len() - 5..].to_string();
         // We got unlucky and the short name collided, 20 bits of entropy
         // so rare but very possible. Increment the short name past
         // any collisions in this case.
-        while self.index.short_to_uuid.contains_key(&short) {
+        while self.index.find_by_short(&short).is_some() {
             let n = u32::from_str_radix(&short, 16)
                 .expect("short dir name is always 5 hex chars from a UUID suffix");
             short = format!("{:05x}", n.wrapping_add(1));
@@ -215,46 +240,39 @@ impl Loader for DiskLoader {
         let record_file = session_dir.join("record.json");
         serde_json::to_writer(std::fs::File::create(record_file)?, &record)?;
 
-        self.index.insert(short.clone(), uuid, record.name);
+        self.index
+            .insert(short.clone(), SessionId(uuid), record.name);
         self.flush()?;
 
         Ok(DiskSessionKey {
-            session_uuid: uuid,
+            session_id: SessionId(uuid),
             dir_key: DaemonRelPath::try_new(short).unwrap(),
         })
     }
 
-    fn list(&self) -> impl Iterator<Item = Self::Key> {
-        self.index
-            .short_to_uuid
-            .iter()
-            .map(|(short, id)| Self::Key {
-                session_uuid: *id,
-                dir_key: DaemonRelPath::try_new(short).unwrap(),
-            })
+    fn keys(&self) -> impl Iterator<Item = Self::Key> {
+        self.index.iter().map(|(short, id)| Self::Key {
+            session_id: *id,
+            dir_key: DaemonRelPath::try_new(short).unwrap(),
+        })
     }
 
-    fn find_by_uuid(&self, id: &Uuid) -> Result<Option<Self::Key>, std::io::Error> {
-        Ok(self
-            .index
-            .short_to_uuid
-            .iter()
-            .find(|(_short, iter_id)| *iter_id == id)
-            .map(|(short, id)| Self::Key {
-                dir_key: DaemonRelPath::try_new(short).unwrap(),
-                session_uuid: *id,
-            }))
+    fn find_by_id(&self, id: &SessionId) -> Result<Option<Self::Key>, std::io::Error> {
+        Ok(self.index.short_by_id(id).map(|short| Self::Key {
+            dir_key: DaemonRelPath::try_new(short).unwrap(),
+            session_id: *id,
+        }))
     }
     fn find_by_name<S: AsRef<str>>(&self, name: S) -> Result<Option<Self::Key>, std::io::Error> {
-        match self.index.name_to_uuid.get(name.as_ref()) {
-            Some(uuid) => self.find_by_uuid(uuid),
+        match self.index.find_by_name(name) {
+            Some(uuid) => self.find_by_id(uuid),
             None => Ok(None),
         }
     }
 
     fn get(&self, key: &Self::Key) -> Result<Self::Object, std::io::Error> {
         assert!(
-            self.index.short_to_uuid.contains_key(key.dir_key.as_str()),
+            self.index.find_by_short(&key.dir_key).is_some(),
             "key {:?} not present in index — Keys are only handed out for sessions that exist",
             key.dir_key,
         );
@@ -286,7 +304,7 @@ mod tests {
 
     fn sample_record() -> Record {
         Record {
-            id: Uuid::nil(),
+            id: SessionId::nil(),
             name: Some("my-session".to_string()),
             username: Some("alice".to_string()),
             project_path: HostAbsPath::try_new("/home/alice/proj").unwrap(),
@@ -312,9 +330,9 @@ mod tests {
         assert_eq!(got.record().project_path, input.project_path);
         assert_eq!(got.record().attrs, input.attrs);
 
-        // Check find_by_uuid as well.
+        // Check find_by_id as well.
         assert_eq!(
-            loader.find_by_uuid(&got.record.id).unwrap().as_ref(),
+            loader.find_by_id(&got.record.id).unwrap().as_ref(),
             Some(&key)
         );
         // Check find_by_name as well.
@@ -330,12 +348,12 @@ mod tests {
         let mut loader = DiskLoader::new(loader_dir(&tmp)).unwrap();
 
         let mut input = sample_record();
-        input.id = Uuid::nil();
+        input.id = SessionId::nil();
         let key = loader.create(input).unwrap();
 
-        assert_ne!(key.uuid(), &Uuid::nil(), "create must overwrite caller id");
+        assert_ne!(key.id().0, Uuid::nil(), "create must overwrite caller id");
         let stored = loader.get(&key).unwrap();
-        assert_eq!(&stored.record().id, key.uuid());
+        assert_eq!(&stored.record().id, key.id());
     }
 
     #[test]
@@ -355,7 +373,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut loader = DiskLoader::new(loader_dir(&tmp)).unwrap();
 
-        let created: BTreeSet<Uuid> = (0..5)
+        let created: BTreeSet<SessionId> = (0..5)
             .map(|i| {
                 *loader
                     .create({
@@ -364,10 +382,10 @@ mod tests {
                         record
                     })
                     .unwrap()
-                    .uuid()
+                    .id()
             })
             .collect();
-        let listed: BTreeSet<Uuid> = loader.list().map(|k| *k.uuid()).collect();
+        let listed: BTreeSet<SessionId> = loader.keys().map(|k| *k.id()).collect();
 
         assert_eq!(listed, created);
     }
@@ -382,11 +400,11 @@ mod tests {
 
         let reloaded = DiskLoader::new(loader_dir(&tmp)).unwrap();
         let key = reloaded
-            .list()
-            .find(|k| k.uuid() == original.uuid())
+            .keys()
+            .find(|k| k.id() == original.id())
             .expect("previously-created session should be visible after reinit");
         let stored = reloaded.get(&key).unwrap();
-        assert_eq!(&stored.record().id, original.uuid());
+        assert_eq!(&stored.record().id, original.id());
         assert_eq!(stored.record().name.as_deref(), Some("my-session"));
     }
 }


### PR DESCRIPTION
Implements some followups from #265, most notably a newtype for session IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Session identifiers unified to a domain-specific SessionId across RPC, session manager, SFTP, and storage for stronger typing and consistent behavior.
* **Bug Fixes**
  * Improved session creation, lookup, and SFTP handling with clearer failure logging and more robust ID resolution.
* **Tests**
  * Updated tests to cover the new SessionId behavior, including creation, listing, lookup, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->