### PR TITLE
refactor(sessions::paths): move paths to own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3395,6 +3395,7 @@ dependencies = [
  "futures",
  "ot",
  "path-absolutize",
+ "paths",
  "russh",
  "russh-sftp",
  "serde",
@@ -3989,6 +3990,15 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "paths"
+version = "0.0.1"
+dependencies = [
+ "camino",
+ "serde",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -5498,6 +5508,7 @@ dependencies = [
  "camino",
  "common",
  "globset",
+ "paths",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/op",
     "crates/ot",
     "crates/orchestrator",
+    "crates/paths",
     "crates/minimal",
     "crates/minimal2",
     "crates/minimald",
@@ -124,6 +125,7 @@ multi = { version = "0.0.1", path = "crates/multi" }
 op = { version = "0.0.1", path = "crates/op" }
 ot = { version = "0.0.1", path = "crates/ot" }
 orchestrator = { version = "0.0.1", path = "crates/orchestrator" }
+paths = { version = "0.0.1", path = "crates/paths" }
 remote-proto = { version = "0.0.1", path = "crates/remote-proto" }
 remote-client = { version = "0.0.1", path = "crates/remote-client" }
 sandbox2 = { version = "0.0.1", path = "crates/sandbox2" }

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -25,6 +25,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 ot.workspace = true
+paths.workspace = true
 sessions.workspace = true
 stdlib.workspace = true
 

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -4,10 +4,7 @@
 use camino::Utf8PathBuf;
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
-use sessions::{
-    paths::{CwdRelative, Daemon, DaemonAbsPath, DaemonRelPath},
-    sub_path,
-};
+use paths::{CwdRelative, Daemon, DaemonAbsPath, DaemonRelPath, sub_path};
 use tokio::net::UnixListener;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -288,7 +288,7 @@ pub async fn handle_ssh_rpc(
 
 #[cfg(test)]
 mod tests {
-    use sessions::paths::HostAbsPath;
+    use paths::HostAbsPath;
 
     use super::*;
     use crate::test_harness::TestServer;

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -1,4 +1,4 @@
-use ::sessions::paths::DaemonAbsPath;
+use ::paths::DaemonAbsPath;
 use russh::keys::key::safe_rng;
 use russh::keys::{PrivateKey, ssh_key::Error as KeyError};
 use serde::{Deserialize, Serialize};

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1,4 +1,5 @@
-use sessions::{paths::DaemonAbsPath, store::SessionObject};
+use paths::DaemonAbsPath;
+use sessions::store::SessionObject;
 use tokio::sync::{mpsc, oneshot};
 
 enum SessionMessage {

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
 use crate::session::{Session, SessionHandle};
+use paths::DaemonAbsPath;
 use sessions::{
     SessionId,
-    paths::DaemonAbsPath,
     store::{DiskLoader, Loader, SessionKey, SessionObject},
 };
 use tokio::sync::{mpsc, oneshot};

--- a/crates/minimald/src/sftp.rs
+++ b/crates/minimald/src/sftp.rs
@@ -15,13 +15,13 @@ use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 
 use path_absolutize::Absolutize;
+use paths::DaemonAbsPath;
 use russh::ChannelId;
 use russh::server::Session;
 use russh_sftp::protocol::{
     Attrs, Data, File, FileAttributes, Handle, Name, OpenFlags, Status, StatusCode,
 };
 use sessions::SessionId;
-use sessions::paths::DaemonAbsPath;
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::task::spawn;
@@ -464,10 +464,10 @@ pub(crate) async fn handle_sftp_subsystem(
 
 #[cfg(test)]
 mod tests {
+    use paths::HostAbsPath;
     use russh_sftp::client::error::Error as SftpClientError;
     use russh_sftp::protocol::{OpenFlags, StatusCode};
     use sessions::SessionId;
-    use sessions::paths::HostAbsPath;
     use tokio::io::AsyncWriteExt;
 
     use crate::rpc::{CreateSession, CreateSessionRequest};

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -20,9 +20,9 @@
 use std::sync::Arc;
 
 use camino::Utf8PathBuf;
+use paths::DaemonAbsPath;
 use russh::keys::ssh_key;
 use sessions::SessionId;
-use sessions::paths::DaemonAbsPath;
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -1,20 +1,14 @@
 [package]
-name = "sessions"
+name = "paths"
 version = "0.0.1"
 edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-common.workspace = true
-globset.workspace = true
 camino.workspace = true
-paths.workspace = true
 serde.workspace = true
-serde_json.workspace = true
-uuid.workspace = true
 
 [dev-dependencies]
-tempfile.workspace = true
 toml.workspace = true
 
 [lints.clippy]

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -6,7 +6,7 @@
 //! to pass a host path to code that expects a sandbox-internal path, and the
 //! type checker will not stop you.
 //!
-//! This module encodes the filesystem a path belongs to as a *phantom type
+//! This crate encodes the filesystem a path belongs to as a *phantom type
 //! parameter*, splits absolute and relative paths into distinct types, and
 //! requires crossing realms to go through an explicit [`Translator`].
 //!
@@ -26,7 +26,7 @@
 //! # Example
 //!
 //! ```
-//! use sessions::paths::{AbsPath, Host, RelPath};
+//! use paths::{AbsPath, Host, RelPath};
 //!
 //! let base: AbsPath<Host> = AbsPath::try_new("/etc/minimal").unwrap();
 //! let rel: RelPath<Host> = RelPath::try_new("hooks/cleanup.sh").unwrap();
@@ -162,7 +162,7 @@ pub const fn _validate_subdir(s: &str) {
 macro_rules! sub_path {
     ($base:expr, $dir:literal) => {{
         #[allow(clippy::used_underscore_items)]
-        const _: () = $crate::paths::_validate_subdir($dir);
+        const _: () = $crate::_validate_subdir($dir);
         ($base).sub_path_unchecked($dir)
     }};
 }
@@ -608,7 +608,7 @@ impl<'de, R: Realm> serde::Deserialize<'de> for RelPath<R> {
 /// tag is needed — every UTF-8 path is unambiguously one or the other.
 ///
 /// ```
-/// use sessions::paths::HostPath;
+/// use paths::HostPath;
 ///
 /// let abs: HostPath = toml::from_str::<Wrap>(r#"x = "/etc/minimal""#).unwrap().x;
 /// let rel: HostPath = toml::from_str::<Wrap>(r#"x = "etc/minimal""#).unwrap().x;
@@ -886,7 +886,7 @@ impl std::error::Error for CwdResolveError {
 /// #[derive(clap::Parser)]
 /// struct Args {
 ///     #[arg(long)]
-///     minimal_dir: Option<sessions::paths::CwdRelative<sessions::paths::Daemon>>,
+///     minimal_dir: Option<paths::CwdRelative<paths::Daemon>>,
 /// }
 /// ```
 ///
@@ -899,7 +899,7 @@ impl std::error::Error for CwdResolveError {
 /// `CwdRelative<Sandbox>` is not spellable:
 ///
 /// ```compile_fail
-/// use sessions::paths::{CwdRelative, Sandbox};
+/// use paths::{CwdRelative, Sandbox};
 /// let _: CwdRelative<Sandbox>;
 /// ```
 pub struct CwdRelative<R: CwdResolvable>(EitherPath<R>);

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -7,12 +7,11 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::paths::HostAbsPath;
+use paths::HostAbsPath;
 
 pub mod lifecyclehook;
 pub mod loadout;
 pub mod patches;
-pub mod paths;
 pub mod policy;
 pub mod store;
 pub mod vars;

--- a/crates/sessions/src/lifecyclehook.rs
+++ b/crates/sessions/src/lifecyclehook.rs
@@ -6,9 +6,9 @@
 //! [`LifecycleHook::builder`] or deserialize them from configuration; both paths
 //! enforce the same invariant.
 
-use crate::paths::{self, ConfigRelPath};
 use camino::Utf8PathBuf;
 use core::fmt;
+use paths::ConfigRelPath;
 
 /// Errors produced when constructing a [`LifecycleHook`].
 #[non_exhaustive]

--- a/crates/sessions/src/patches.rs
+++ b/crates/sessions/src/patches.rs
@@ -49,9 +49,9 @@
 //! ignore = ["**/.DS_Store", "**/*.bak", "**/*.swp"]
 //! ```
 
-use crate::paths::{HostPath, SandboxPath};
 use camino::{Utf8Component, Utf8PathBuf};
 use core::fmt;
+use paths::{HostPath, SandboxPath};
 
 /// Errors produced when constructing patch types.
 #[non_exhaustive]
@@ -308,7 +308,7 @@ impl<'de> serde::Deserialize<'de> for FileSet {
 /// Wraps a [`SandboxPath`], so the realm tag is preserved through to the
 /// apply layer. No `AsRef<std::path::Path>` is provided on purpose: a
 /// destination path cannot be passed to host I/O without going through a
-/// [`crate::paths::Translator`] first.
+/// [`paths::Translator`] first.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PatchDest(SandboxPath);
 

--- a/crates/sessions/src/store.rs
+++ b/crates/sessions/src/store.rs
@@ -5,8 +5,9 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::paths::{DaemonAbsPath, DaemonRelPath};
-use crate::{Record, SessionId, sub_path};
+use paths::{DaemonAbsPath, DaemonRelPath, sub_path};
+
+use crate::{Record, SessionId};
 
 /// Describes the session object yielded by [`Loader`].
 pub trait SessionObject: Sized + Send + 'static + std::fmt::Debug {
@@ -294,7 +295,7 @@ impl Loader for DiskLoader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::paths::HostAbsPath;
+    use paths::HostAbsPath;
     use std::{collections::BTreeSet, io::ErrorKind};
     use tempfile::TempDir;
 


### PR DESCRIPTION
~The diffbase includes https://github.com/gominimal/minimal/pull/275 which hasnt merged yet cuz slow~, but otherwise this is a mechanical change to move `sessions::paths` (which is bigggg and we want to use it everywhere) to its own crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated path handling into a dedicated crate and simplified imports across the workspace.
  * Removed previous re-exports for clearer module boundaries.

* **Documentation**
  * Updated crate docs and examples to reference the new paths crate and revised import patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->