### PR TITLE
ci: cut PR build cost and skip docs-only runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,26 @@ name: CI
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
   workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
+
+# Cancel an in-progress run when a newer commit is pushed to the same ref.
+# main is excluded so release/promote on main never get cancelled mid-flight.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: write
@@ -61,6 +75,7 @@ jobs:
 
   build-release-amd64:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies
@@ -81,6 +96,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-amd64-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-amd64-cargo-release-
       - name: Build static release binary
         run: cargo build --release --package minimal --target x86_64-unknown-linux-musl
       - name: Upload binary artifact
@@ -92,6 +108,7 @@ jobs:
 
   build-release-arm64:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
       - name: Install cross
@@ -107,6 +124,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-arm64-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-arm64-cargo-release-
       - name: Build static release binary
         run: cross build --release --package minimal --target aarch64-unknown-linux-musl
       - name: Upload binary artifact


### PR DESCRIPTION
## Changes

`.github/workflows/ci.yml`:

- **Gate release builds to push-on-main** — `build-release-amd64` and `build-release-arm64` (the latter cross-compiles under QEMU) only feed the `release` job, which already runs on `main` only. They no longer run on PRs.
- **Concurrency cancellation** — a new push to a PR cancels the prior in-flight run. `main` excluded so release/promote never get killed mid-flight.
- **`paths-ignore`** — `**.md`, `docs/**`, `LICENSE` skip the workflow. No branch protection exists, so no required check is left pending.
- **`restore-keys` on release caches** — a `Cargo.lock` bump now restores the nearest prior cache instead of building cold.

## Effect

PRs drop the two slowest jobs and stop stacking redundant runs on rapid pushes. Docs-only commits skip CI entirely. On-main behavior (release, promote) is unchanged.

## Not included

- `.github/**` deliberately not in `paths-ignore` — workflow edits should re-run CI to validate themselves.
- `build-in-minimal` / `minimal-check` dogfood jobs left running on every PR per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)