### PR TITLE
docs(minvmd): minvmd host-daemon spec

### DIFF
--- a/docs/specs/spec-minvmd-host-daemon/crate-scaffold-ffi-wrappers-libkrun-smoke-test.feature
+++ b/docs/specs/spec-minvmd-host-daemon/crate-scaffold-ffi-wrappers-libkrun-smoke-test.feature
@@ -1,0 +1,56 @@
+# Source: docs/specs/spec-minvmd-host-daemon/spec-minvmd-host-daemon.md
+# Pattern: CLI/Process (build + smoke test)
+# Recommended test type: Integration
+
+Feature: Crate scaffold, FFI wrappers, libkrun smoke test
+
+  Scenario: Crate compiles on macOS aarch64 target
+    Given a checkout of the minimal workspace on an aarch64-apple-darwin host
+    When the user runs "cargo build -p minvmd --target aarch64-apple-darwin"
+    Then the command exits with code 0
+    And the binary "target/aarch64-apple-darwin/debug/minvmd" is produced
+
+  Scenario: Crate compiles on macOS x86_64 target
+    Given a checkout of the minimal workspace on a host with the x86_64-apple-darwin toolchain installed
+    When the user runs "cargo build -p minvmd --target x86_64-apple-darwin"
+    Then the command exits with code 0
+    And the binary "target/x86_64-apple-darwin/debug/minvmd" is produced
+
+  Scenario: Linux build produces a no-op shim that keeps CI green
+    Given a checkout of the minimal workspace on an x86_64-unknown-linux-gnu host
+    When the user runs "cargo build -p minvmd"
+    Then the command exits with code 0
+    And running the resulting "minvmd" binary with any subcommand exits non-zero with a stderr message naming macOS as the only supported platform
+
+  Scenario: FFI return codes surface as typed VmError::Backend with preserved errno
+    Given a safe wrapper around a libkrun FFI call configured to receive a known failure return code from the backend
+    When the wrapper is invoked with inputs that pass safe-Rust validation but trigger the backend failure
+    Then the wrapper returns Err(VmError::Backend { op, code }) where op names the FFI function and code equals the original errno magnitude returned by libkrun
+    And no panic, abort, or process exit occurs
+
+  Scenario: Safe wrappers reject invalid inputs before crossing the FFI boundary
+    Given a safe wrapper that requires a NUL-terminated path argument
+    When the wrapper is called with a Rust string containing an interior NUL byte
+    Then the wrapper returns a typed validation error
+    And no libkrun FFI function is invoked
+
+  Scenario: Release binary is code-signed with the hypervisor entitlement via justfile
+    Given a release build of minvmd has been produced on macOS
+    When the user runs the justfile signing target
+    Then the command exits with code 0
+    And "codesign -d --entitlements - target/release/minvmd" prints an entitlements plist containing "com.apple.security.hypervisor"
+    And the printed entitlements plist contains no other entitlement keys
+
+  Scenario: Smoke test boots libkrun with /bin/true and exits cleanly
+    Given a macOS host with libkrun installed
+    And the environment variable "MINVMD_E2E" is set to "1"
+    When the user runs "cargo test -p minvmd --test krun_smoke -- --include-ignored"
+    Then the command exits with code 0
+    And the test output reports the smoke test as passing
+
+  Scenario: Smoke test is skipped by default to keep unit-test runs hermetic
+    Given a checkout of the minimal workspace
+    And the environment variable "MINVMD_E2E" is unset
+    When the user runs "cargo test -p minvmd"
+    Then the command exits with code 0
+    And the krun_smoke test is reported as ignored rather than executed

--- a/docs/specs/spec-minvmd-host-daemon/lifecycle-daemon-auto-spawn-status-stop.feature
+++ b/docs/specs/spec-minvmd-host-daemon/lifecycle-daemon-auto-spawn-status-stop.feature
@@ -1,0 +1,106 @@
+# Source: docs/specs/spec-minvmd-host-daemon/spec-minvmd-host-daemon.md
+# Pattern: State + CLI/Process (lifecycle, atomic persistence, auto-spawn)
+# Recommended test type: Integration
+
+Feature: Lifecycle daemon — auto-spawn, status, stop
+
+  Scenario: state.toml, vmm.pid, and lifecycle.lock live under XDG_STATE_HOME
+    Given XDG_STATE_HOME is set to a temporary directory
+    When minvmd is started with "minvmd run --detach"
+    Then the file "$XDG_STATE_HOME/minimal/minvmd/state.toml" exists and parses as TOML containing fields "state", "vmm_pid", and "started_at"
+    And the file "$XDG_STATE_HOME/minimal/minvmd/vmm.pid" exists and contains the PID of the VMM child process
+    And the file "$XDG_STATE_HOME/minimal/minvmd/lifecycle.lock" exists
+
+  Scenario: state.toml writes are atomic across a crash mid-write
+    Given a running minvmd with a populated state.toml whose "state" field is "running"
+    When the parent supervisor is SIGKILLed at any point during a state transition write
+    Then state.toml on disk parses cleanly as TOML on every read
+    And the "state" field is either the prior committed value or the new committed value, never partial
+
+  Scenario: minvmd run --detach returns only once the host UDS accepts connections
+    Given no minvmd is currently running and the state directory is empty
+    When the user runs "minvmd run --detach"
+    Then the command exits with code 0 within the default 8 second timeout
+    And immediately after the command returns, a client can connect to the host UDS at "$XDG_RUNTIME_DIR/minimal/minimald.sock" successfully
+
+  Scenario: minvmd run --detach times out and exits non-zero if the UDS never opens
+    Given no minvmd is currently running
+    And the kernel/rootfs configuration is invalid so the VM cannot reach READY
+    When the user runs "minvmd run --detach" with the default 8 second timeout
+    Then the command exits non-zero within 8 seconds plus a small grace period
+    And stderr names the boot or UDS-readiness failure
+
+  Scenario: minvmd status --json prints structured fields when running
+    Given a running minvmd attached to a booted VM configured with 2 vcpus and 1024 MiB of RAM
+    When the user runs "minvmd status --json"
+    Then the command exits with code 0
+    And stdout is a single JSON object containing the keys "state", "vmm_pid", "uptime_seconds", "vcpus", and "ram_mib"
+    And "state" equals "running", "vcpus" equals 2, and "ram_mib" equals 1024
+
+  Scenario: minvmd status exits 1 when stopped
+    Given no minvmd is running and state.toml reports "stopped"
+    When the user runs "minvmd status --json"
+    Then the command exits with code 1
+    And stdout is a JSON object whose "state" field equals "stopped"
+
+  Scenario: minvmd status exits 2 on lock contention
+    Given the lifecycle.lock file is held exclusively by another process performing a state transition
+    When the user runs "minvmd status --json"
+    Then the command exits with code 2
+    And stderr names the lock contention
+
+  Scenario: minvmd stop terminates the child, cleans up files, and resets state
+    Given a running minvmd with a live VMM child and a populated vmm.pid file
+    When the user runs "minvmd stop"
+    Then the command exits with code 0 within 5 seconds
+    And the VMM child process is no longer present in the process table
+    And the file "vmm.pid" no longer exists in the state directory
+    And state.toml's "state" field is "stopped"
+
+  Scenario: minvmd stop escalates to SIGKILL if the child does not exit within 5 seconds
+    Given a running minvmd whose VMM child ignores SIGTERM
+    When the user runs "minvmd stop"
+    Then the VMM child process is no longer present in the process table within 6 seconds of the command starting
+    And the command exits with code 0
+    And state.toml's "state" field is "stopped"
+
+  Scenario: minvmd stop is idempotent on an already-stopped VM
+    Given no minvmd is running and state.toml reports "stopped"
+    When the user runs "minvmd stop"
+    Then the command exits with code 0
+    And state.toml's "state" field remains "stopped"
+
+  Scenario: First minimal call on macOS auto-spawns minvmd and warm second call is fast
+    Given a macOS host with no minvmd process running and an empty minvmd state directory
+    When the user runs "minimal ls"
+    Then the command exits with code 0 within 8 seconds
+    And after the command returns, "minvmd status --json" reports "state" equal to "running"
+    When the user immediately runs "minimal ls" a second time
+    Then the second command exits with code 0 in under 500 milliseconds
+
+  Scenario: Auto-spawn is a no-op on Linux
+    Given a Linux host with no minvmd installed and a running native minimald
+    When the user runs "minimal ls"
+    Then the command exits with code 0
+    And no "minvmd" process is spawned during the call
+    And the CLI connects directly to the native minimald UDS
+
+  Scenario: Concurrent CLI invocations cannot race the lifecycle
+    Given no minvmd is currently running
+    When 5 "minimal ls" processes are launched concurrently on a macOS host
+    Then exactly one minvmd parent supervisor process is started
+    And all 5 client commands exit with code 0
+    And state.toml's "state" field ends as "running" with a single consistent vmm_pid
+
+  Scenario: A panicking Starting transition is recovered to Stopped by the RAII guard
+    Given a minvmd run process that is forced to panic during the Starting transition before commit
+    When the process exits due to the panic
+    Then state.toml's "state" field is "stopped" once the panicking process has fully exited
+    And no orphaned VMM child remains in the process table
+
+  Scenario: Pure next_state function accepts legal transitions and rejects illegal ones
+    Given the lifecycle states "NotProvisioned", "Stopped", "Starting", "Running", "Stopping"
+    When the unit tests in "crates/minvmd/src/lifecycle.rs" are executed via "cargo test -p minvmd lifecycle::"
+    Then every test case exercising a legal transition returns Ok with the expected next state
+    And every test case exercising an illegal transition returns Err(InvalidTransition)
+    And the test suite exits with code 0

--- a/docs/specs/spec-minvmd-host-daemon/spec-minvmd-host-daemon.md
+++ b/docs/specs/spec-minvmd-host-daemon/spec-minvmd-host-daemon.md
@@ -1,0 +1,233 @@
+# spec-minvmd-host-daemon
+
+**Source:** [gominimal/inbox#164](https://github.com/gominimal/inbox/issues/164) · parent [#151](https://github.com/gominimal/inbox/issues/151) · proposal [Minimal as a Session Manager](https://www.notion.so/360040938a8981cc9e01f675b40b071d) · kernel dep [gominimal/pkgs#154](https://github.com/gominimal/pkgs/pull/154) · reference impl `~/code/min-ctl`
+
+## Introduction/Overview
+
+`minvmd` is the macOS-only host daemon that brings up a Linux microVM via libkrun, supervises its lifecycle, and bridges a host UDS to a vsock port inside the VM so the `minimal` CLI can talk to `minimald` transparently — exactly as it does natively on Linux. It is the third process in the Minimal One architecture (alongside `minimal` and `minimald`) and exists solely to absorb the VM boundary that macOS imposes.
+
+The crate is reimplemented clean in the minimal workspace, drawing patterns and hard-won lessons from `~/code/min-ctl` (FFI safety, lifecycle state machine, RAII recovery guards, error fidelity, no `$HOME` virtiofs, TSI connection-cap awareness) but not vendoring its code. Networking is explicitly deferred to #160.
+
+## Goals
+
+1. New `crates/minvmd` builds green on macOS (aarch64 + x86_64), no-op shim on Linux, no CI regressions on the Linux-only workflow.
+2. `minimal` CLI on macOS opens a connection to in-VM `minimald` over a host UDS without knowing a VM exists (transparent vsock bridge).
+3. VM boots from a `virtio-linux` kernel + Alpine rootfs in under ~5s cold; warm reattach is sub-second.
+4. `minvmd` auto-spawns on first CLI call (Docker-Desktop model per #151) and survives client exit.
+5. `minvmd status` / `minvmd stop` work; PID and socket discovery follow XDG conventions; concurrent CLI invocations don't race lifecycle.
+
+## User Stories
+
+- As a Mac user, I want to run `minimal ls` on a fresh install so that I get `[]` end-to-end without manually starting a VM.
+- As a Mac user, I want my second `minimal ls` to be instant so that the VM cold-start cost is amortized.
+- As a Mac user, I want to run `minvmd status` so that I can see VM state, vcpus, ram, and uptime.
+- As a Mac user, I want to run `minvmd stop` so that the VM shuts down gracefully and the next `minimal` call cold-starts a fresh VM.
+- As a Linux user, I want `minvmd` to not be installed at all so that my install path stays simple.
+
+## Demoable Units of Work
+
+> Requirement IDs use the format **R{unit}.{seq}** (R1.1, R1.2 for Unit 1; R2.1 for Unit 2). These IDs are referenced directly by the planner — do not renumber after approval.
+
+### Unit 1: Crate scaffold, FFI wrappers, libkrun smoke test
+
+**Purpose:** Land the bones — crate, FFI bindings, build script, codesign step. Boot a libkrun context to the marker "VM started, exited cleanly" with no rootfs work.
+
+**Depends on:** None
+
+**Affected areas:** `crates/minvmd/` (new), `crates/minvmd/src/krun/` (new), `crates/minvmd/minvmd.entitlements` (new), `crates/minvmd/build.rs` (new), `Cargo.toml` (workspace), `justfile`
+
+**Functional Requirements:**
+- **R1.1**: The `minvmd` crate shall compile on `aarch64-apple-darwin` and `x86_64-apple-darwin` and shall compile to a no-op stub on `target_os = "linux"` so the existing Linux-only CI stays green.
+- **R1.2**: FFI bindings shall live in a single `src/krun/raw.rs` module; every `unsafe` call shall carry a `// SAFETY:` comment naming the libkrun preconditions (pointer lifetime, NUL-termination, range bounds, ownership transfer).
+- **R1.3**: Safe wrappers (`src/krun/ctx.rs`) shall validate all inputs in safe Rust (range checks, NUL-termination, allocation lifetimes) before crossing the FFI boundary; FFI return codes shall be translated to a typed `VmError::Backend { op: &'static str, source: std::io::Error }` preserving the original errno, built via `io::Error::from_raw_os_error(ret.checked_neg().unwrap_or(libc::EOVERFLOW))`. The return-code translation lives as a free function in the `krun` FFI module, not as a method on `VmError`.
+- **R1.4**: Release builds shall be code-signed with `minvmd.entitlements` granting `com.apple.security.hypervisor` and nothing else; a `justfile` target shall reproduce the signing step locally.
+- **R1.5**: A smoke test `tests/krun_smoke.rs` (gated on `MINVMD_E2E=1`, marked `#[ignore]` by default) shall create a libkrun context, configure 1 vcpu + 512 MiB, set `/bin/true` as exec, and confirm `krun_start_enter` exits cleanly.
+
+**Proof Artifacts:**
+- File: `crates/minvmd/src/krun/raw.rs` contains FFI declarations for the libkrun functions used in this unit (`krun_create_ctx`, `krun_set_vm_config`, `krun_set_exec`, `krun_start_enter`, `krun_free_ctx`) with `// SAFETY:` comments demonstrates the FFI scaffold and safety discipline.
+- CLI: `MINVMD_E2E=1 cargo test -p minvmd --test krun_smoke -- --include-ignored` exits 0 on a Mac with libkrun installed demonstrates end-to-end FFI bring-up.
+
+---
+
+### Unit 2: VM bring-up with virtio-linux kernel + Alpine rootfs
+
+**Purpose:** Actual Linux boot. `minvmd boot` brings up an Alpine VM that reaches userspace and writes a "READY" marker to vsock from a guest-side init.
+
+**Depends on:** Unit 1
+
+**Affected areas:** `crates/minvmd/src/image.rs` (new), `crates/minvmd/src/vm.rs` (new), `crates/minvmd/src/cmd/boot.rs` (new), `crates/minvmd/src/cmd/vmm_child.rs` (new)
+
+**Functional Requirements:**
+- **R2.1**: The kernel artifact shall be the `vmlinuz` output of the `virtio-linux` minimal package (pkgs#154); on aarch64 the artifact is `Image.gz`, on x86_64 `bzImage`. Path resolution shall happen at runtime via a `MINVMD_KERNEL_PATH` env var so the package-graph wiring can land in a follow-up without changing this spec.
+- **R2.2**: The rootfs shall be an Alpine minirootfs (version-pinned, sha256-verified). For v0.1 the path is supplied via `MINVMD_ROOTFS_PATH`; staging is performed by `scripts/fetch-alpine.sh` (downloads upstream Alpine minirootfs, verifies sha256, extracts to `~/.cache/minimal/minvmd/rootfs/`). Migration to a sibling `alpine-minirootfs` minimal package is tracked as an open question.
+- **R2.3**: `minvmd boot` (parent) shall configure the libkrun context via the safe wrappers, then `exec`-spawn a hidden `minvmd __krun-vmm` child that calls `krun_start_enter` (the parent does not block on `krun_start_enter` because that call never returns on success). The parent shall write a `vmm.pid` file and surface child-exit codes via signal handling.
+- **R2.4**: Boot shall complete to a guest-side marker (writes `READY\n` on a designated vsock port) within 5s on a warm laptop; the parent shall block on this marker before reporting boot success.
+- **R2.5**: No network device shall be added to the libkrun config in v0.1; gvproxy/TSI integration is owned by #160. Default libkrun vsock is acceptable since v0.1 does not expose TCP to the guest.
+
+**Proof Artifacts:**
+- CLI: `MINVMD_KERNEL_PATH=/tmp/vmlinuz MINVMD_ROOTFS_PATH=/tmp/alpine-minirootfs minvmd boot --foreground` boots and prints `vm-up` to stdout within 5s, and a host-side reader on the vsock marker socket reads `READY` demonstrates kernel+rootfs come up.
+- Test: `tests/boot_e2e.rs` (gated `MINVMD_E2E=1`, `#[ignore]`) asserts the marker round-trip end-to-end.
+
+---
+
+### Unit 3: UDS↔vsock bridge for `ssh.sock`
+
+**Purpose:** The product feature — a host UDS the CLI talks to, bridged by libkrun to the in-VM vsock port where `minimald` listens. Bidirectional, transport-agnostic, multiple concurrent connections. **minvmd does not relay bytes itself** — libkrun owns the host UDS and the vsock forwarding.
+
+**Depends on:** Unit 2
+
+**Affected areas:** `crates/minvmd/src/krun/raw.rs` (add `krun_add_vsock_port2`), `crates/minvmd/src/krun/ctx.rs` (wrap it), `crates/minvmd/src/vm.rs` (register the vsock port before boot), `crates/minvmd/src/sock.rs` (host UDS path resolution, parent-dir + permissions), guest-side vsock→UDS shim (see R3.4)
+
+**Socket model (Option A — libkrun-owned, no host relay).** Tom's `minimald` speaks SSH (russh) over a raw `UnixListener` stream and works over *any* bidirectional byte stream (its test harness drives it over an in-memory `UnixStream` pair). The provider socket therefore needs only a faithful, multiplexed bytestream — nothing protocol-aware. libkrun's `krun_add_vsock_port2` delivers exactly that, so minvmd stays a thin lifecycle/transport daemon rather than a userspace byte relay (the rejected Option B). The provider-owns-socket and connect-and-prune discovery rules in `docs/session-domain-diag.md` hold under this model: the host UDS *is* the provider socket; a stale socket after a crash fails connect-and-check and is pruned by `minimal`.
+
+**Functional Requirements:**
+- **R3.1**: Before `krun_start_enter`, `minvmd` shall register the host UDS via `krun_add_vsock_port2(ctx, VSOCK_PORT, HOST_UDS_PATH, listen = true)`. Per libkrun's header, `listen = true` means connections are initiated from the host side: libkrun **listens** on the host UDS and bridges each accepted connection to a guest process listening on vsock `VSOCK_PORT`. This matches the SSH direction — host `minimal` is the client, in-VM `minimald` is the server. (The `listen = false` default is the guest-initiated direction and is wrong here.)
+- **R3.2**: The host UDS path shall be `$XDG_RUNTIME_DIR/minimal/minimald.sock` (fallback `~/.minimal/local/minimald.sock`). Because libkrun binds the socket, `minvmd` shall create the parent directory (mode 0700) before boot, set `umask` so the bound socket is owner-only (0600), and verify/`chmod` the path to 0600 once it appears.
+- **R3.3**: libkrun shall multiplex multiple concurrent host connections, each bridged to an independent vsock connection to `VSOCK_PORT`; `minvmd` carries no per-connection state. The path is transport-agnostic — bytes in, bytes out, no SSH/russh parsing (russh subsystem dispatch lives in `minimald`, per #156).
+- **R3.4**: **v0.1 uses a vsock stub.** The guest-side responder for bring-up is a small stub that listens on vsock `VSOCK_PORT` directly and answers the health / `list-sessions` ping with an empty list — no shim, no real `minimald` in the guest. This is sufficient to prove the full host→guest path (Units 1–3) and is the only guest-side component this spec implements. The real `minimald` listens on a **UNIX socket**, not vsock, so swapping it in later requires either a vsock→UDS shim or a vsock-native `minimald`; that decision is deferred (Open Questions #3) — `minimald` is Tom's crate.
+- **R3.5**: On guest unavailability (VM crash, `minimald` exit, no guest listener), a host connect/exchange shall fail at the libkrun bridge; `minvmd` shall `tracing::warn!` where observable, and `minimal`'s provider discovery shall treat the failed connect as "stale provider — prune and continue", not a hard error. The TSI loopback ~62-concurrent-connection cap (per `~/code/min-ctl` lessons.md) shall be documented as a comment near the vsock registration; v0.1 needs <10 concurrent connections.
+
+**Proof Artifacts:**
+- Test: `tests/bridge_e2e.rs` (gated `MINVMD_E2E=1`, `#[ignore]`) boots a VM whose guest listens on vsock `VSOCK_PORT` (stub or shim, e.g. `socat VSOCK-LISTEN:VSOCK_PORT,fork EXEC:cat`), opens 5 concurrent host UDS connections, each writes a distinct payload and reads it back. All 5 succeed demonstrates libkrun-multiplexed bidirectional bridging.
+- CLI: With a stub `minimald` reachable on vsock `VSOCK_PORT`, running `nc -U $XDG_RUNTIME_DIR/minimal/minimald.sock` from the host (or a CLI integration) yields the empty `list-sessions` response end-to-end demonstrates the host→guest path.
+
+---
+
+### Unit 4: Lifecycle daemon — auto-spawn, status, stop
+
+**Purpose:** Daemon UX. `minimal` calling `minvmd` for the first time auto-spawns it; subsequent calls reuse; `minvmd status` introspects; `minvmd stop` shuts down gracefully.
+
+**Depends on:** Unit 3
+
+**Affected areas:** `crates/minvmd/src/cmd/{run,status,stop}.rs` (new), `crates/minvmd/src/state.rs` (new), `crates/minvmd/src/lifecycle.rs` (new), `crates/minimal2/src/main.rs` (extend)
+
+**Functional Requirements:**
+- **R4.1**: State and PID files shall live under `$XDG_STATE_HOME/minimal/minvmd/` (default `~/.local/state/minimal/minvmd/`): `state.toml` (lifecycle enum + `vmm_pid` + `started_at`), `vmm.pid`, `lifecycle.lock`. `state.toml` writes shall be atomic (tmp + rename + fsync).
+- **R4.2**: `minvmd run` shall be a foreground supervisor (parent of the libkrun child + owner of the bridge); `minvmd run --detach` shall background-spawn and return only after the host UDS is accepting connections, with a configurable timeout (default 8s).
+- **R4.3**: `minvmd status` shall print human-readable status by default and JSON with `--json` (fields: `state`, `vmm_pid`, `uptime_seconds`, `vcpus`, `ram_mib`). Exit code 0 if running, 1 if stopped, 2 on lock contention.
+- **R4.4**: `minvmd stop` shall SIGTERM the vmm child, wait up to 5s, SIGKILL on timeout, then remove `vmm.pid` and reset `state.toml` to `Stopped`. The command shall be idempotent — stopping an already-stopped VM exits 0.
+- **R4.5**: On macOS, `crates/minimal2` shall check `state.toml` before connecting to the UDS; if no `minvmd` is running it shall spawn `minvmd run --detach` and wait (with timeout) for the UDS. On Linux this path shall be a no-op.
+- **R4.6**: State transitions shall be guarded by an `fd-lock`-style file lock on `lifecycle.lock` so concurrent CLI invocations cannot race. Recovery from a panicking transition (e.g. crash mid-`Starting`) shall be handled by an RAII guard modelled on `min-ctl`'s `StartingGuard` — drop without explicit commit resets to `Stopped`.
+- **R4.7**: All lifecycle transitions shall pass through a pure `next_state(current: Lifecycle, action: Action) -> Result<Lifecycle, InvalidTransition>` function with no I/O, exhaustively unit-tested.
+
+**Proof Artifacts:**
+- Test: `crates/minvmd/src/lifecycle.rs` includes table-driven `#[test]`s for every legal and illegal transition; `cargo test -p minvmd lifecycle::` passes demonstrates the pure state machine.
+- CLI: `minvmd stop && minvmd status --json` prints `{"state":"stopped",...}` and exits 1 demonstrates stop + status semantics.
+- CLI: From a clean state (no minvmd running), `minimal ls` on a Mac succeeds within 8s and a subsequent `minvmd status` reports `running`; a second `minimal ls` completes in <500ms demonstrates auto-spawn + warm reuse.
+
+## Non-Goals (Out of Scope)
+
+- **Networking** — gated on #160 (gvproxy spike). v0.1 VMs have no net device; in-session package installs and outbound git operations will not work yet. Document loudly.
+- **Multi-VM / multi-tenant** — single named VM (`default`); multi-VM is a v0.2+ concern.
+- **`minvmd init` / OCI image fetch / cosign verification** — kernel and rootfs paths are passed in via env. Image-fetch pipelines are a separate concern (`virtio-linux` + a future Alpine package + the minimal graph).
+- **Virtiofs / live host mounts** — per `~/code/min-ctl` lessons (TCC + provenance xattr issues, fd starvation), v0.1 has zero live mounts. File transport into the VM is `minimald`'s problem (tar push/pull per #151).
+- **`brew services` registration** — auto-spawn from the CLI suffices for v0.1; a brew service can layer on later without changing the contract.
+- **PTY supervision / session sandboxing** — those live in `minimald`, not `minvmd`.
+- **Linux build of `minvmd`** beyond the no-op shim — nothing to run on Linux.
+- **OS suspend/resume of the VM, RAM resizing, vcpu hot-add** — deferred.
+- **Lifting code from `min-ctl`** — we reference patterns only; no code vendoring.
+
+## Design Considerations
+
+### Process model
+
+`krun_start_enter` never returns on success — it `exit()`s with the guest workload's exit code. This forces a parent/child split:
+
+```
+minvmd run                       (parent — supervisor)
+  └── minvmd __krun-vmm          (hidden child — calls krun_start_enter)
+       └── libkrun + Alpine VM   (the actual VM)
+            └── minimald (pid-1) (in-VM, via krun_set_exec)
+```
+
+Parent owns: `state.toml`, `lifecycle.lock`, and lifecycle supervision. The host UDS is **not** a parent-owned accept loop — libkrun binds and forwards it (registered via `krun_add_vsock_port2` before the child enters), so neither parent nor child runs a userspace byte relay. Child owns: libkrun context, kernel/rootfs paths. They communicate via a single-use auth token (written to state dir mode 0600, verified by child, deleted immediately) plus signals. This pattern is lifted from `~/code/min-ctl/src/cmd/vmm_child.rs` and `~/code/min-ctl/src/cmd/start.rs`.
+
+### Reference patterns (no code vendored)
+
+| Pattern | min-ctl reference |
+|---|---|
+| FFI safety wrappers | `src/vm/krun/raw.rs` |
+| Lifecycle state machine | `src/vm/lifecycle.rs` |
+| `StartingGuard` RAII recovery | `src/cmd/start.rs:64-138` |
+| Atomic state persistence | `src/vm/state.rs` |
+| Child VMM entry pattern | `src/cmd/vmm_child.rs` |
+| Single-use auth token (T36) | `src/cmd/start.rs` |
+| XDG home resolution | `src/home.rs` |
+
+### Hard lessons baked in
+
+- **No `$HOME` virtiofs** — TCC + provenance xattr issues on macOS Tahoe. Zero virtiofs mounts in v0.1.
+- **TSI ~62 concurrent connection cap** — fine for v0.1 (<10 concurrent), document the constraint, revisit when networking lands.
+- **Error fidelity** — never collapse `Backend { op, source: io::Error }` into a `String`; the errno survives via `io::Error::from_raw_os_error` and `Error::source()`.
+- **Stubs are sticky** — every stub shall `panic!`/`bail!`/`unimplemented!` explicitly; no silent no-ops.
+
+### What we deliberately do not do (vs min-ctl)
+
+- No OCI image fetch + cosign — the package graph owns image integrity.
+- No K8s quantity / Go duration parsers, no `config.toml` — overkill for v0.1.
+- No `shell` / `attach` / `exec` / `push` / `pull` / `mount` / `logs` / `mcp` subcommands — those are min-ctl's product surface, not minvmd's. minvmd is a pure transport-and-VM-lifecycle daemon.
+
+## Repository Standards
+
+- Workspace conventions from `CLAUDE.md`: workspace-pinned deps; `cargo fmt && cargo test -- --include-ignored`; `cargo clippy --allow-dirty --fix --all-targets -- -D warnings`; no `println!`/`eprintln!` outside the CLI surface (use `tracing`); structured fields not interpolated strings (`tracing::info!(pkg = %name, "msg")`); typed error enums in library code, `anyhow::Result` only at CLI boundaries.
+- Naming: `minvmd` (matches `minimald`).
+- Platform gates: `#[cfg(target_os = "macos")]` for all libkrun-touching code; a stub Linux entry that `bail!`s.
+- Tests: integration tests under `tests/`; libkrun-touching tests `#[ignore]` and gated on `MINVMD_E2E=1`; pure state-machine + parser tests run unconditionally.
+- Unsafe: every `unsafe` block carries a `// SAFETY:` comment justifying every caller invariant.
+- Dependencies: `nix`, `tokio`, `anyhow`, `serde`, `toml`, `tracing` (already in workspace); `fd-lock` (new, workspace-pin). Link libkrun directly via `build.rs`; do not pull a `libkrun` crate dependency.
+
+## Verification
+
+**Project maturity:** Established
+
+**Available commands:**
+| Check | Command |
+|---|---|
+| Lint  | `cargo clippy --allow-dirty --fix --all-targets -- -D warnings` |
+| Build | `cargo build -p minvmd` (Linux: shim; macOS: full) |
+| Test  | `cargo test -p minvmd` (unit + pure); `MINVMD_E2E=1 cargo test -p minvmd -- --include-ignored` (full) |
+
+**Greenfield bootstrapping:** N/A — all commands available
+
+**End-to-end manual verification (Mac):**
+1. `cargo build -p minvmd --release && codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/release/minvmd`
+2. Build `virtio-linux` (pkgs#154); stage an Alpine minirootfs via `scripts/fetch-alpine.sh`; export `MINVMD_KERNEL_PATH` and `MINVMD_ROOTFS_PATH`.
+3. `minvmd run --detach && minvmd status --json` → reports `{"state":"running",...}`.
+4. `nc -U ~/.local/state/minimal/minvmd/minimald.sock` reaches a stub `minimald` running in the VM.
+5. `minvmd stop && minvmd status` → reports `stopped`, exit 1.
+
+**CI gate:** existing Linux-only CI stays green via the no-op shim. Optional `build-macos` job that runs `cargo check -p minvmd` once a Mac runner is available.
+
+## Technical Considerations
+
+- **libkrun linking** — pinned to a known-good version (initially the slp/krun Homebrew tap version used by min-ctl, currently v1.18.0). `build.rs` emits `cargo:rustc-link-search` and `cargo:rustc-link-arg=-Wl,-rpath` pointing at `/opt/homebrew/lib` with a `LIBKRUN_PREFIX` env override.
+- **Hidden `__krun-vmm` subcommand** — modelled on min-ctl's `src/cmd/vmm_child.rs`. Not in `--help`; verified-via-auth-token; the only entry point that calls `krun_start_enter`.
+- **State file format** — TOML with serde; one file per VM (in v0.1, only `default`). Lifecycle enum is `NotProvisioned | Stopped | Starting | Running | Stopping`.
+- **Auto-spawn from `minimal2`** — implementation lives in `crates/minimal2/src/main.rs` behind `#[cfg(target_os = "macos")]`. On Linux it is a no-op; the CLI talks to `minimald` directly.
+
+## Security Considerations
+
+- Single entitlement: `com.apple.security.hypervisor`. No network, no file-access-outside-home, no Apple Developer Program membership required (ad-hoc signing via `codesign -s -`).
+- Host UDS perms: mode 0600, owner-only. `LOCAL_PEERCRED` check recommended but not required at v0.1 since the UDS perms already gate access.
+- No authentication on the bridge — fine because access is mode-gated. Do not expose the bridge over TCP without rethinking auth.
+- Single-use auth token between parent `minvmd run` and child `minvmd __krun-vmm` (T36 pattern from min-ctl): written to `$XDG_STATE_HOME/minimal/minvmd/vmm.auth` mode 0600, verified by child, deleted on first read. Prevents stray re-execs of the hidden subcommand.
+- Image provenance is deferred — v0.1 reads kernel + rootfs from caller-supplied paths. Once the minimal package graph wires the artifacts, content-addressed hashes already provide integrity.
+
+## Success Metrics
+
+- Mac developer runs `minimal ls` on a fresh install with no setup beyond install + first-time package fetch and gets a result in < 8s cold, < 500ms warm.
+- Crate compiles green in CI on Linux (no-op shim) and is buildable on Mac.
+- Smoke test (`MINVMD_E2E=1`) covers FFI bring-up, boot-to-marker, and 5-way concurrent bridge connections.
+- Zero `unsafe` blocks without a `// SAFETY:` comment. Zero `unwrap()` outside `#[cfg(test)]`. Zero `println!`/`eprintln!` outside the CLI surface.
+
+## Open Questions
+
+1. **Alpine rootfs source.** v0.1 spec specifies `scripts/fetch-alpine.sh` (download + sha256-verify upstream Alpine minirootfs to `~/.cache/minimal/minvmd/rootfs/`). Migration path: write a sibling `alpine-minirootfs` minimal package in `gominimal/pkgs` once `virtio-linux` (#154) merges, then minvmd consumes both via the package graph instead of env vars. Track as a follow-up issue.
+2. **Vsock port for `minimald`.** Proposed 2222 (avoids min-ctl's agent port 7350 so they can coexist on a Mac dev box). Confirm with #156 owner. (`VSOCK_PORT` is a named constant either way.)
+3. **Guest-side vsock terminator for the *real* `minimald`.** Bring-up is settled: v0.1 uses a vsock stub that listens on `VSOCK_PORT` directly (R3.4), so no terminator is needed yet. The open decision is how the *real* `minimald` gets reached once it replaces the stub, since it binds a **UNIX socket**, not vsock:
+   - **(a) vsock→UDS shim** — a tiny in-guest process listens on `VSOCK_PORT` and forwards each connection 1:1 to `minimald`'s `ssh.sock` (e.g. `socat VSOCK-LISTEN:VSOCK_PORT,fork UNIX-CONNECT:ssh.sock`). Keeps `minimald` byte-identical across host-Linux and in-VM; adds a process and a hop.
+   - **(b) vsock-native `minimald`** — generalize the listener edge (`Connection::from_socket` / `Server::run_on_uds`) over `impl AsyncRead + AsyncWrite`, which russh already supports, and add a `run_on_vsock`. No protocol change, one fewer hop; gives `minimald` a second listen mode.
+
+   Leaning (b) because russh is already stream-agnostic, so it's a small generalization rather than a new moving part — but `minimald` is Tom's crate, so **pending a conversation with Tom**. Resolved sub-point: the `add_vsock_port2` `listen` flag is `true` for our host-initiated direction, per the installed `libkrun.h`.
+4. **In-VM `minimald` supervision.** Run `minimald` as pid-1 via `krun_set_exec(..., "minimald")`, or boot a tiny init (busybox/OpenRC) that launches it? Pid-1 is simpler but `minimald` then owns signal forwarding + zombie reaping. Proposed: pid-1 for v0.1; revisit if reaping becomes painful.
+5. **Brew distribution.** Out of scope per non-goals, but flagging that the codesign step must be reproducible on contributors' machines — justfile target covers this.

--- a/docs/specs/spec-minvmd-host-daemon/uds-vsock-bridge.feature
+++ b/docs/specs/spec-minvmd-host-daemon/uds-vsock-bridge.feature
@@ -1,0 +1,49 @@
+# Source: docs/specs/spec-minvmd-host-daemon/spec-minvmd-host-daemon.md
+# Pattern: CLI/Process + Async (libkrun-owned UDS<->vsock bridge, host-initiated)
+# Recommended test type: Integration
+
+Feature: UDS to vsock bridge for minimald
+
+  # minvmd registers the host UDS via krun_add_vsock_port2(.., listen=true) before
+  # boot; libkrun owns the bind and the forwarding. minvmd runs no byte relay.
+
+  Scenario: Host UDS is created with 0600 mode owned by the invoking user
+    Given minvmd has registered the host UDS via krun_add_vsock_port2 with listen=true
+    And the VM has started
+    Then a Unix domain socket exists at "$XDG_RUNTIME_DIR/minimal/minimald.sock"
+    And the socket file mode is 0600
+    And the socket file is owned by the invoking user's UID
+
+  Scenario: Host UDS falls back to ~/.minimal/local/minimald.sock when XDG_RUNTIME_DIR is unset
+    Given the environment variable XDG_RUNTIME_DIR is unset
+    And minvmd has registered the host UDS via krun_add_vsock_port2 with listen=true
+    And the VM has started
+    Then a Unix domain socket exists at "~/.minimal/local/minimald.sock"
+    And the socket file mode is 0600
+
+  Scenario: Five concurrent host UDS connections each round-trip distinct payloads
+    Given a booted minvmd VM with a guest listener on vsock port VSOCK_PORT running "socat VSOCK-LISTEN:VSOCK_PORT,fork EXEC:cat"
+    When 5 host processes connect concurrently to the host UDS, each writes a distinct payload, and each reads a response
+    Then each of the 5 connections reads back exactly the payload it wrote
+    And all 5 connections complete without error
+    And minvmd holds no per-connection state because libkrun multiplexes the connections
+
+  Scenario: Bridge is transport-agnostic and forwards arbitrary bytes unchanged
+    Given a booted minvmd VM with an echo service on vsock port VSOCK_PORT
+    When a host client writes a 4 KiB random binary payload to the host UDS and reads until EOF
+    Then the bytes read back equal the bytes written byte-for-byte
+    And no minvmd-side code parses, reframes, or rewrites the payload
+
+  Scenario: Guest unavailability surfaces as a connect failure the client can recover from
+    Given the host UDS is registered and the VM is running
+    And no guest process is listening on vsock port VSOCK_PORT
+    When a host client connects to the host UDS and attempts to exchange bytes
+    Then the connection fails at the libkrun bridge
+    And minimal's provider discovery treats the failed connect as a stale provider, pruning it and continuing
+    And the host UDS registration is not torn down, so a later connection can succeed once a guest listener returns
+
+  Scenario: End-to-end CLI call reaches a stub minimald in the VM
+    Given a booted minvmd VM with a stub minimald reachable on vsock port VSOCK_PORT that responds to "list-sessions" with an empty list
+    When the host runs a client that sends "list-sessions" over the host UDS at "$XDG_RUNTIME_DIR/minimal/minimald.sock"
+    Then the client receives the empty-list response
+    And the exchange completes without the host needing to know a VM exists

--- a/docs/specs/spec-minvmd-host-daemon/vm-bring-up-with-virtio-linux-kernel-and-alpine-rootfs.feature
+++ b/docs/specs/spec-minvmd-host-daemon/vm-bring-up-with-virtio-linux-kernel-and-alpine-rootfs.feature
@@ -1,0 +1,46 @@
+# Source: docs/specs/spec-minvmd-host-daemon/spec-minvmd-host-daemon.md
+# Pattern: CLI/Process + Async (boot to READY marker)
+# Recommended test type: Integration
+
+Feature: VM bring-up with virtio-linux kernel and Alpine rootfs
+
+  Scenario: minvmd boot brings up the VM and prints vm-up within 5 seconds
+    Given a macOS host with libkrun installed
+    And MINVMD_KERNEL_PATH points to a valid virtio-linux vmlinuz artifact for the host architecture
+    And MINVMD_ROOTFS_PATH points to a staged Alpine minirootfs directory
+    When the user runs "minvmd boot --foreground"
+    Then stdout contains the line "vm-up" within 5 seconds
+    And the process remains running until interrupted
+
+  Scenario: Guest writes READY marker on the designated vsock port
+    Given minvmd boot --foreground has been started with valid kernel and rootfs paths
+    And a host-side reader is connected to the marker vsock port
+    When the guest userspace init runs
+    Then the host-side reader reads the bytes "READY\n" from the marker socket within 5 seconds
+
+  Scenario: Parent does not block on krun_start_enter and supervises a hidden child
+    Given minvmd boot --foreground has been started
+    When the VM has reached the READY marker
+    Then a file "vmm.pid" exists in the minvmd state directory containing the PID of the child VMM process
+    And that PID belongs to a running "minvmd __krun-vmm" process distinct from the parent supervisor PID
+
+  Scenario: Child VMM exit is surfaced by the parent supervisor
+    Given minvmd boot --foreground is running with a booted VM
+    When the child VMM process exits with a non-zero status
+    Then the parent supervisor exits with a non-zero status
+    And the parent's stderr or tracing output names the child exit code
+
+  Scenario: No network device is added to the libkrun configuration in v0.1
+    Given a macOS host with libkrun installed
+    And valid MINVMD_KERNEL_PATH and MINVMD_ROOTFS_PATH are exported
+    When the user runs "MINVMD_E2E=1 cargo test -p minvmd --test boot_e2e -- --include-ignored"
+    Then the command exits with code 0
+    And the guest, while booted, has no network interfaces beyond loopback when probed via the guest init
+
+  Scenario: Boot fails fast and cleanly when the kernel path is missing
+    Given the environment variable MINVMD_KERNEL_PATH points to a non-existent file
+    And MINVMD_ROOTFS_PATH points to a valid Alpine minirootfs directory
+    When the user runs "minvmd boot --foreground"
+    Then the command exits non-zero within 1 second
+    And stderr names the missing kernel path
+    And no "vmm.pid" file is created in the minvmd state directory


### PR DESCRIPTION
Spec for the macOS `minvmd` VM provider — committing the working doc.

## Scope
Boots a Linux microVM via libkrun, supervises lifecycle, bridges a host UDS to the in-VM `minimald`. Four demoable units with Gherkin feature files:
1. Crate scaffold, FFI wrappers, libkrun smoke test
2. VM bring-up (virtio-linux kernel + Alpine rootfs)
3. UDS↔vsock bridge
4. Lifecycle daemon (auto-spawn, status, stop)

## Socket model (Option A)
libkrun owns the host UDS via `krun_add_vsock_port2(listen=true)`; `minvmd` runs no byte relay. Fits Tom's russh-over-any-stream protocol — a transport-agnostic, multiplexed bytestream. `listen=true` confirmed against the installed `libkrun.h` (host-initiated direction).

## Open question for @twitchyliquid64
v0.1 bring-up uses a **vsock stub**. Reaching the *real* `minimald` needs a guest-side terminator since it binds a UNIX socket, not vsock:
- **(a)** vsock→UDS shim — keeps `minimald` unchanged
- **(b)** vsock-native `minimald` — small generalization of `Connection::from_socket`/`Server::run_on_uds` over `impl AsyncRead + AsyncWrite` (russh is already stream-agnostic)

Leaning (b); your call since it's your crate. See Open Questions #3.

Draft — not numbered yet; rename to `NN-spec-…` on merge if that's the convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specifications for minvmd host daemon covering VM lifecycle management, auto-spawn behavior, state persistence, and concurrent connection handling.
  * Documented UDS-to-vsock bridge communication patterns and VM boot-up process requirements with kernel and rootfs integration.
  * Added integration test specifications for FFI wrapper validation, error propagation, and macOS security entitlements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->