### PR TITLE
ci: unblock docs-only PRs from the required `build` check

### DIFF
--- a/.github/workflows/ci-docs-skip.yml
+++ b/.github/workflows/ci-docs-skip.yml
@@ -1,0 +1,40 @@
+name: CI (docs skip)
+
+# Companion to ci.yml. The `build` job is a REQUIRED status check (ruleset on
+# main), but ci.yml is skipped for docs/markdown changes via paths-ignore — and
+# GitHub does NOT auto-pass a required check that a path filter skipped, so a
+# docs-only PR would block forever waiting for `build` to report.
+#
+# This workflow runs on exactly the paths ci.yml ignores and provides a no-op
+# job ALSO named `build`, so the required `build` context reports success for
+# docs-only changes. ci.yml owns the real `build` for everything else.
+#
+# The trigger paths here are the exact inverse of ci.yml's paths-ignore — keep
+# the two lists in sync.
+#
+# Caveat: a PR touching BOTH code and docs triggers ci.yml (real build) and this
+# workflow (no-op build), producing two `build` checks. The real one still runs
+# and must be read on its own; don't rely on this no-op to reflect code health.
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No build needed for docs-only changes
+        run: echo "Docs-only change — ci.yml is path-skipped; reporting required 'build' check as passed."


### PR DESCRIPTION
## Problem
`build` is a **required** status check (ruleset on `main`), but `ci.yml` is skipped for docs/markdown via `paths-ignore: ["**.md", "docs/**", "LICENSE"]`. GitHub does **not** auto-pass a required check that a path filter skipped — it waits for `build` to report, forever. So any docs-only PR is permanently `BLOCKED` (e.g. #282, and the doc-drift bot PRs).

## Fix
Add a companion workflow (`ci-docs-skip.yml`) triggered on **exactly** the paths `ci.yml` ignores, with a no-op job **also named `build`**. For a docs-only change, this reports the required `build` context as passed; `ci.yml` still owns the real `build` for code changes.

- Does not touch the real `build` job.
- `permissions: contents: read`.
- Keep the trigger `paths` in sync with `ci.yml`'s `paths-ignore` (commented in the file).

## Caveat
A PR touching **both** code and docs triggers `ci.yml` (real build) and this workflow (no-op), producing two `build` checks. The real one still runs and must be read on its own. If you want that edge fully airtight later, the alternative is to drop `paths-ignore` and gate the heavy work inside an always-running `build` job.

## After merge
#282 (and other open docs PRs) need a re-trigger to pick up the new base-branch workflow — push an empty commit or re-run checks, and the no-op `build` will report. (They still need their 1 approval per the ruleset.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)