### PR TITLE
feat(mctx)!: configure separate state and cache directories

### DIFF
--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -49,9 +49,11 @@ pub struct ConfigBuilder {
     offline: Option<bool>,
     num_parallel_builds: Option<usize>,
 
-    minimal_dir: Option<PathBuf>,
+    minimal_state_dir: Option<PathBuf>,
+    minimal_cache_dir: Option<PathBuf>,
     stdlib_dir: Option<PathBuf>,
     repo_dir: Option<PathBuf>,
+
     vcs_manager: Option<ManagerHandle>,
     ot: Option<OpTracker>,
     remote_cache_bucket: Option<String>,
@@ -95,9 +97,14 @@ impl ConfigBuilder {
         self.num_parallel_builds = Some(num_parallel_builds);
         self
     }
-    /// Overrides the base directory for system state.
+    /// Overrides the base directory for minimal state.
     pub fn with_state_dir(mut self, dir: impl Into<PathBuf>) -> Self {
-        self.minimal_dir = Some(dir.into());
+        self.minimal_state_dir = Some(dir.into());
+        self
+    }
+    /// Overrides the base directory for minimal cache.
+    pub fn with_cache_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.minimal_cache_dir = Some(dir.into());
         self
     }
     /// Overrides loading of the standard library, getting it from the given path instead.
@@ -146,7 +153,26 @@ impl ConfigBuilder {
                 .num_parallel_builds
                 .unwrap_or_else(common::default_parallelism),
 
-            minimal_dir: self.minimal_dir.unwrap_or_else(|| {
+            // TODO: Update default to
+            //
+            // dirs::state_dir()
+            //  .unwrap_or_else(|| dirs::home_dir().unwrap().join(".local/state"))
+            //  .join("minimal")
+            //
+            // Once Minimal One is the primary surface.
+            minimal_state_dir: self.minimal_state_dir.unwrap_or_else(|| {
+                dirs::cache_dir()
+                    .unwrap_or_else(|| PathBuf::from("~/.cache"))
+                    .join("minimal")
+            }),
+            // TODO: Update default to
+            //
+            // dirs::cache_dir()
+            //  .unwrap_or_else(|| dirs::home_dir().unwrap().join(".local/cache"))
+            //  .join("minimal")
+            //
+            // Once Minimal One is the primary surface.
+            minimal_cache_dir: self.minimal_cache_dir.unwrap_or_else(|| {
                 dirs::cache_dir()
                     .unwrap_or_else(|| PathBuf::from("~/.cache"))
                     .join("minimal")
@@ -169,7 +195,8 @@ impl Config {
             no_fetch: Some(self.no_fetch),
             offline: Some(self.offline),
             num_parallel_builds: Some(self.num_parallel_builds),
-            minimal_dir: Some(self.minimal_dir),
+            minimal_state_dir: Some(self.minimal_state_dir),
+            minimal_cache_dir: Some(self.minimal_cache_dir),
             stdlib_dir: self.stdlib_dir,
             repo_dir: self.repo_dir,
             vcs_manager: self.vcs_manager,
@@ -192,12 +219,15 @@ pub struct Config {
     /// Maximum number of concurrent builds.
     num_parallel_builds: usize,
 
-    /// Path to the base of the minimal state directory, typically `~/.cache/minimal`.
-    pub(crate) minimal_dir: PathBuf,
-    /// Overrides where the standard directory is loaded from.
+    /// Path to the base of the minimal state directory, typically `$XDG_STATE_DIR/minimal`.
+    pub(crate) minimal_state_dir: PathBuf,
+    /// Path to the base of the minimal cache directory, typically `$XDG_CACHE_DIR/minimal`.
+    pub(crate) minimal_cache_dir: PathBuf,
+    /// Overrides where the standard library is loaded from.
     stdlib_dir: Option<PathBuf>,
     /// Overrides the base/project/repo directory.
     repo_dir: Option<PathBuf>,
+
     /// Use the specified vcs manager instead of initializing one from disk.
     vcs_manager: Option<ManagerHandle>,
     /// The [OpTracker] to use instead of the root.
@@ -248,32 +278,32 @@ impl Config {
         &self.remote_cache_bucket
     }
 
-    pub(crate) fn cache_dir(&self) -> PathBuf {
-        self.minimal_dir.join("built")
+    pub(crate) fn built_cache_dir(&self) -> PathBuf {
+        self.minimal_cache_dir.join("built")
     }
     pub(crate) fn downloads_dir(&self) -> PathBuf {
-        self.minimal_dir.join("downloads")
+        self.minimal_cache_dir.join("downloads")
     }
     pub(crate) fn builds_base_dir(&self) -> PathBuf {
-        self.minimal_dir.join("sandboxes")
+        self.minimal_state_dir.join("sandboxes")
     }
     pub(crate) fn state_base_dir(&self) -> PathBuf {
-        self.minimal_dir.join("state")
+        self.minimal_state_dir.join("state")
     }
     pub(crate) fn task_base_dir(&self) -> PathBuf {
-        self.minimal_dir.join("tasks")
+        self.minimal_state_dir.join("tasks")
     }
     pub(crate) fn vcs_dir(&self) -> PathBuf {
-        self.minimal_dir.join("vcs")
+        self.minimal_cache_dir.join("vcs")
     }
     pub(crate) fn index_dir(&self) -> PathBuf {
-        self.minimal_dir.join("idx")
+        self.minimal_cache_dir.join("idx")
     }
     pub(crate) fn stdlib_dir(&self) -> PathBuf {
-        self.minimal_dir.join("stdlib")
+        self.minimal_cache_dir.join("stdlib")
     }
     pub(crate) fn layer_cache_dir(&self) -> PathBuf {
-        self.minimal_dir.join("lc")
+        self.minimal_cache_dir.join("lc")
     }
 }
 

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -1001,6 +1001,7 @@ mod tests {
     #[test]
     fn env_channel_add_session() {
         let (state_dir, mut ctx, mut graph) = setup_ctx_and_graph();
+        let rootfs = ctx.cache.temp_dir().unwrap();
         let mut chan = EnvChannel {
             graph: &mut graph,
             ctx: &mut ctx,
@@ -1010,7 +1011,6 @@ mod tests {
             ot: None,
         };
 
-        let rootfs = tempdir().unwrap();
         assert!(!std::fs::exists(rootfs.path().join("bin")).unwrap());
 
         let (mut ours, theirs) = std::os::unix::net::UnixStream::pair().unwrap();

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -202,7 +202,8 @@ impl Context {
             .map_err(|e| Error::setup_dirs(e, config.downloads_dir()))?;
         create_dir_all(config.builds_base_dir())
             .map_err(|e| Error::setup_dirs(e, config.builds_base_dir()))?;
-        create_dir_all(config.cache_dir()).map_err(|e| Error::setup_dirs(e, config.cache_dir()))?;
+        create_dir_all(config.built_cache_dir())
+            .map_err(|e| Error::setup_dirs(e, config.built_cache_dir()))?;
         create_dir_all(config.state_base_dir())
             .map_err(|e| Error::setup_dirs(e, config.state_base_dir()))?;
         create_dir_all(config.task_base_dir())
@@ -223,7 +224,7 @@ impl Context {
             // operation. Pre-populate `vcs_dir()` for the workflow that needs this.
             VcsManager::new_in_dir_with_offline(config.vcs_dir(), config.is_offline())?
         };
-        let cache = Cache::at_dir(config.cache_dir())
+        let cache = Cache::at_dir(config.built_cache_dir())
             .map_err(|e| Error::Other(anyhow!("initializing local cache: {}", e)))?;
 
         // Figure out a path to the standard library. Roughly speaking this is loaded from:
@@ -325,7 +326,7 @@ impl Context {
     /// DO NOT USE unless you really know what you
     /// are doing - prefer [Context::local_cache] instead.
     pub fn cache_base_dir(&self) -> PathBuf {
-        self.config.cache_dir()
+        self.config.built_cache_dir()
     }
     /// Returns the base directory where source checkouts are stored.
     pub fn vcs_dir(&self) -> PathBuf {
@@ -351,7 +352,11 @@ impl Context {
         &self.stdlib_dir
     }
 
-    /// Returns the minimal file loaded from disk.
+    /// Returns the minimal file configuring this context.
+    ///
+    /// This usually maps to a `minimal.toml` read from disk,
+    /// but not always. Methods like [`mfile::File::repo_path`]
+    /// return None if not read from disk.
     pub fn minimal_file(&self) -> &mfile::File {
         &self.mfile
     }


### PR DESCRIPTION
Under Minimal One, we are going to have minimal state (like sandboxes, sessions etc) live in one directory (typically `$XDG_STATE_DIR/minimal` or `$HOME/.local/state/minimal`) and cached objects (like the artifact cache, fetched sources etc) live in another (`$XDG_CACHE_DIR/minimal` or `$HOME/.local/cache/minimal`). This separation better follows the XDG specification.

The default remains the same when the directories are not specified via the `mctx::ConfigBuilder`. We should pick a date in the future to make a hard switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Separated state and cache storage into distinct base directories and updated local built-artifact cache handling. This clarifies where state vs. cache data live, improves isolation of cached artifacts, and makes cache initialization and access more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->