### PR TITLE
Install spectacles SDD suite (ref: v0.1.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,65 @@
+---
+name: Bug
+about: Report defective behavior for the SDD pipeline to spec a fix and build it.
+title: "bug: "
+labels:
+  - kind:bug
+  - sdd:spec
+---
+
+## Summary
+
+One or two sentences describing the defect.
+
+## Expected behavior
+
+What should happen.
+
+## Actual behavior
+
+What happens instead. Include error output or a `file:line` reference where
+you can.
+
+## Reproduction
+
+The smallest set of steps that reliably reproduces the defect.
+
+## Scope notes
+
+Anything in or out of scope, constraints, or related work the agents should
+know. Leave blank if there is nothing to add.
+
+## One-session fix? (optional)
+
+If this looks like a one-file bugfix, a typo, or similarly small,
+comment `/fastpath` on this issue after opening it. The agent will
+compress spec, architecture, and plan into one short run and gate
+execution on a single `/approve`. The full pipeline runs by default;
+`/fastpath` is opt-in. The agent will also propose fast-path on its
+own when the issue body looks like a single-session change.
+
+---
+
+<!-- SDD command vocabulary. Do not edit this footer. -->
+
+This issue is the tracking issue for the fix. It carries the `sdd:spec`
+lifecycle label, so `sdd-spec` will draft a spec PR from it automatically.
+
+Steer the pipeline with these comment commands. Each is gated to commenters
+with write access to the repository.
+
+| Command | Where | Effect |
+|---|---|---|
+| `/spec` | this tracking issue | re-run `sdd-spec` to draft or revise the spec |
+| `/fastpath` | this tracking issue | confirm a single-session change; `sdd-spec` produces a stub spec PR and an execution plan comment in one run (ADR 0012) |
+| `/triage` | this tracking issue, after the spec PR is merged | start `sdd-triage` phase A (architecture) |
+| `/approve` | this tracking issue | full path: confirm the proposed plan so `sdd-triage` creates the Unit and task sub-issues. Fast path: dispatch the execution plan against `sdd-execute-{tier}` |
+| `/dispatch` | this tracking issue (full path only) | arm the cascade across the task tree |
+| `/revise <note>` | a spec, architecture, or implementation PR, or this tracking issue | re-run the owning agent with the note as an added instruction |
+| `/execute` | a task sub-issue | run `sdd-execute` for that task ahead of the schedule |
+
+Merging the spec PR advances to the architecture phase; merging the
+architecture PR advances to a plan-comment phase, where `sdd-triage` posts
+the proposed plan as one comment on this tracking issue. When an agent needs
+a human decision it applies the `needs-human` label and posts one comment;
+clear the label once you have answered and the agent resumes.

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,27 @@
+---
+name: Chore
+about: Track maintenance, refactor, or internal work that is not a feature or bug.
+title: "chore: "
+labels:
+  - kind:chore
+---
+
+## Summary
+
+One or two sentences describing the work.
+
+## Motivation
+
+Why this is worth doing now.
+
+## Scope
+
+What is in scope and what is explicitly not.
+
+---
+
+<!-- A chore is tracked, not specced. -->
+
+A chore does not enter the SDD spec pipeline, so this template applies no
+`sdd:spec` label. If the work turns out to need a spec, open a feature or bug
+issue instead and let `sdd-spec` draft it.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,61 @@
+---
+name: Feature
+about: Propose a new feature or capability for the SDD pipeline to spec and build.
+title: "feature: "
+labels:
+  - kind:feature
+  - sdd:spec
+---
+
+## Summary
+
+One or two sentences describing the feature and who it is for.
+
+## Problem
+
+What is missing or painful today? Describe the situation, not the solution.
+
+## Desired outcome
+
+What should be true once this ships? Describe behavior a person could observe,
+not an implementation.
+
+## Scope notes
+
+Anything in or out of scope, constraints, or related work the agents should
+know. Leave blank if there is nothing to add.
+
+## One-session change? (optional)
+
+If this looks like a one-file copy change, a single-symbol bugfix, or
+similarly small, comment `/fastpath` on this issue after opening it. The
+agent will compress spec, architecture, and plan into one short run and
+gate execution on a single `/approve`. The full pipeline runs by
+default; `/fastpath` is opt-in. The agent will also propose fast-path on
+its own when the issue body looks like a single-session change.
+
+---
+
+<!-- SDD command vocabulary. Do not edit this footer. -->
+
+This issue is the tracking issue for the feature. It carries the `sdd:spec`
+lifecycle label, so `sdd-spec` will draft a spec PR from it automatically.
+
+Steer the pipeline with these comment commands. Each is gated to commenters
+with write access to the repository.
+
+| Command | Where | Effect |
+|---|---|---|
+| `/spec` | this tracking issue | re-run `sdd-spec` to draft or revise the spec |
+| `/fastpath` | this tracking issue | confirm a single-session change; `sdd-spec` produces a stub spec PR and an execution plan comment in one run (ADR 0012) |
+| `/triage` | this tracking issue, after the spec PR is merged | start `sdd-triage` phase A (architecture) |
+| `/approve` | this tracking issue | full path: confirm the proposed plan so `sdd-triage` creates the Unit and task sub-issues. Fast path: dispatch the execution plan against `sdd-execute-{tier}` |
+| `/dispatch` | this tracking issue (full path only) | arm the cascade across the task tree |
+| `/revise <note>` | a spec, architecture, or implementation PR, or this tracking issue | re-run the owning agent with the note as an added instruction |
+| `/execute` | a task sub-issue | run `sdd-execute` for that task ahead of the schedule |
+
+Merging the spec PR advances to the architecture phase; merging the
+architecture PR advances to a plan-comment phase, where `sdd-triage` posts
+the proposed plan as one comment on this tracking issue. When an agent needs
+a human decision it applies the `needs-human` label and posts one comment;
+clear the label once you have answered and the agent resumes.

--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -1,0 +1,62 @@
+---
+name: Specification (from Claude plan)
+about: Hand a Claude plan document to the pipeline to translate into a spec and build.
+title: "feature: "
+labels:
+  - sdd:spec
+  - kind:feature
+  - plan:provided
+---
+
+## Plan
+
+Paste the full Claude plan document here. The plan is the authoritative
+input: `sdd-spec` translates it into a structured spec and `sdd-triage`
+translates its architecture/design section into the architecture record,
+rather than authoring either from scratch. Keep the plan's own structure —
+context, design, the implementation steps, and a verification section.
+
+## Verification
+
+If your plan already has a verification section, leave it above and remove
+this one. Otherwise list, per step, how a person could observe the behavior
+the step produces. `sdd-spec` lifts these into proof artifacts (one to three
+per demoable unit), so prefer behavioral checks over health checks: a plan
+verification that only says "tests pass" or "build succeeds" is dropped, and
+if no step yields a behavioral artifact the agent hands off via `needs-human`.
+
+## Scope notes
+
+Anything in or out of scope, constraints, or related work the agents should
+know. Leave blank if there is nothing to add.
+
+---
+
+<!-- SDD command vocabulary. Do not edit this footer. -->
+
+This issue is the tracking issue for the feature. It carries the `sdd:spec`
+lifecycle label, so `sdd-spec` will draft a spec PR from it automatically.
+The `plan:provided` marker puts `sdd-spec` and `sdd-triage` into translation
+mode: `sdd-spec` translates the plan above into a structured spec, and
+`sdd-triage` translates the plan's architecture/design section into
+`architecture.md`. The marker is cleared once the architecture PR opens (or,
+on the fast path, once the stub spec PR opens).
+
+Steer the pipeline with these comment commands. Each is gated to commenters
+with write access to the repository.
+
+| Command | Where | Effect |
+|---|---|---|
+| `/spec` | this tracking issue | re-run `sdd-spec` to draft or revise the spec |
+| `/fastpath` | this tracking issue | confirm a single-session change; `sdd-spec` produces a stub spec PR and an execution plan comment in one run (ADR 0012) |
+| `/triage` | this tracking issue, after the spec PR is merged | start `sdd-triage` phase A (architecture) |
+| `/approve` | this tracking issue | full path: confirm the proposed plan so `sdd-triage` creates the Unit and task sub-issues. Fast path: dispatch the execution plan against `sdd-execute-{tier}` |
+| `/dispatch` | this tracking issue (full path only) | arm the cascade across the task tree |
+| `/revise <note>` | a spec, architecture, or implementation PR, or this tracking issue | re-run the owning agent with the note as an added instruction |
+| `/execute` | a task sub-issue | run `sdd-execute` for that task ahead of the schedule |
+
+Merging the spec PR advances to the architecture phase; merging the
+architecture PR advances to a plan-comment phase, where `sdd-triage` posts
+the proposed plan as one comment on this tracking issue. When an agent needs
+a human decision it applies the `needs-human` label and posts one comment;
+clear the label once you have answered and the agent resumes.

--- a/.github/workflows/distillery-sync.yml
+++ b/.github/workflows/distillery-sync.yml
@@ -1,0 +1,56 @@
+name: distillery-sync
+
+# Thin wrapper for the distillery-sync agent.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/distillery-sync.lock.yml in the spectacles repository,
+# compiled from distillery-sync.md (which declares on: workflow_call). This
+# wrapper carries the real triggers — a push on merged specs/ADRs, a daily
+# schedule, and manual dispatch — and calls the hosted reusable workflow by
+# pinned ref. A consumer repository installs this wrapper unchanged;
+# scripts/quick-setup.sh rewrites the @ref when --ref is supplied.
+#
+# distillery-sync had no wrapper before the uses: distribution model (ADR
+# 0004): it was a standalone scheduled workflow whose compiled lock the
+# installer copied directly. Under the uses: model every agent — scheduled or
+# event-driven — is a hosted reusable workflow, so distillery-sync gains a
+# wrapper that owns its schedule, exactly as the sdd-* wrappers own their
+# event triggers.
+
+on:
+  # A merged spec or ADR lands in the store immediately, not on the next daily
+  # tick. Push (not pull_request) so it fires on the default branch after merge.
+  push:
+    # main and master cover the common default branches; a spec/ADR feature
+    # branch (spec/*, arch/*) does not match, so this fires only on merge.
+    branches: [main, master]
+    paths:
+      - "docs/specs/**"
+      - "decisions/**"
+  # Daily, off the top of the hour to avoid GitHub scheduler congestion. Also
+  # the safety net that recovers a missed push and refreshes issues/PRs.
+  schedule:
+    - cron: "17 7 * * *"
+  # Manual full sync. The first run against an empty project store backfills
+  # pre-existing docs (see distillery-sync.md); no input is needed.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  distillery-sync:
+    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@v0.1.0
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need issues: write, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read

--- a/.github/workflows/sdd-dispatch.yml
+++ b/.github/workflows/sdd-dispatch.yml
@@ -1,0 +1,506 @@
+name: sdd-dispatch
+
+# Thin wrapper for the sdd-dispatch agent.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-dispatch.lock.yml (compiled from sdd-dispatch.md, which
+# declares on: workflow_call). This wrapper carries the real event triggers,
+# gates the /dispatch comment command to authors with repository write access,
+# walks the feature's task tree to compute the ready set, fans the cascade out
+# by posting /execute on each ready task issue via the App installation token
+# (ADR 0014 — the matching sdd-execute-{tier} wrapper picks the comment up
+# through its existing issue_comment trigger), and manages the tracking
+# issue's lifecycle and sdd:dispatched labels. A consumer repository installs
+# this wrapper unchanged.
+#
+# Selection is graph-driven, not label-driven. The ready set is computed by
+# walking the sub-issue tree (Feature -> Unit -> task per ADR 0005), parsing
+# each open task's `## Task` block for `blocked by` lines, and admitting
+# tasks whose blockers are all closed and which are not already in flight.
+# The `sdd:ready` label is a downstream artifact applied to dispatched tasks
+# as a UI hint; the graph wins.
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A /dispatch comment on a tracking issue from a write-access author.
+  issue_comment:
+    types: [created]
+  # A task sub-issue closing under a tracking issue that carries
+  # sdd:dispatched. The route job walks the parent chain to find the
+  # tracking issue and filters out closures on issues outside an armed
+  # cascade.
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve which situation triggered the wrapper, gate /dispatch to write
+  # access, and on the cascade path find the tracking issue this task sub-issue
+  # belongs to and confirm it carries sdd:dispatched. A non-match leaves
+  # should_run = false so the dispatch jobs are skipped.
+  #
+  # The job-level if: gate skips the route job entirely on issue_comment events
+  # whose body does not start with /dispatch (fixes issue #119 — a /spec or
+  # /execute comment posted on a tracker no longer spawns a route-job runner
+  # on this wrapper).
+  route:
+    # Token-strict match: `/dispatch` alone or followed by whitespace.
+    # `startsWith(body, '/dispatch')` would also fire for `/dispatchfoo`,
+    # consuming a route-job runner before the route step's tokenised
+    # parse rejects it. GitHub Actions expressions do not support regex
+    # matching, so enumerate the boundary characters explicitly.
+    if: |
+      github.event_name != 'issue_comment'
+      || github.event.comment.body == '/dispatch'
+      || startsWith(github.event.comment.body, '/dispatch ')
+      || startsWith(github.event.comment.body, '/dispatch\n')
+      || startsWith(github.event.comment.body, '/dispatch\r\n')
+      || startsWith(github.event.comment.body, '/dispatch\t')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      tracking_issue: ${{ steps.decide.outputs.tracking_issue }}
+      trigger_kind: ${{ steps.decide.outputs.trigger_kind }}
+    steps:
+      - name: Decide whether to run, and find the tracking issue
+        id: decide
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@v0.1.0
+        with:
+          app-id: ${{ vars.APP_ID }}
+          github-token: ${{ github.token }}
+
+  # Compute the ready set from the dependency graph. Walks the tracking
+  # issue's sub-issue tree, parses each open task's `depends on:` block,
+  # admits tasks whose `blocked by` references are all closed and which are
+  # not already in flight. Emits a matrix of {task, tier} pairs that the
+  # dispatch job fans out over.
+  #
+  # Also emits the precondition state on the tracking issue so the
+  # lifecycle and noop-comment jobs know whether to proceed.
+  compute:
+    needs: route
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.route.outputs.trigger_kind != 'fastpath_noop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+      ready_count: ${{ steps.compute.outputs.ready_count }}
+      open_task_count: ${{ steps.compute.outputs.open_task_count }}
+      precondition: ${{ steps.compute.outputs.precondition }}
+      tracking_state: ${{ steps.compute.outputs.tracking_state }}
+      reason: ${{ steps.compute.outputs.reason }}
+    steps:
+      - name: Compute ready set and precondition state
+        id: compute
+        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@v0.1.0
+        with:
+          tracking-issue: ${{ needs.route.outputs.tracking_issue }}
+          trigger-kind: ${{ needs.route.outputs.trigger_kind }}
+          github-token: ${{ github.token }}
+
+  # Fan the cascade out by posting /execute on each ready task issue. The
+  # matrix is the ready set computed above; max-parallel caps concurrent
+  # cells at SDD_DISPATCH_MAX_PARALLEL (default 5). Each cell posts one
+  # comment via the App installation token; the matching
+  # sdd-execute-{tier} wrapper picks the comment up through its existing
+  # issue_comment trigger and routes to the agent. This replaces the prior
+  # workflow_dispatch fan-out, which required an actions:write scope on the
+  # App that consumer installs did not reliably grant (issue #121 /
+  # ADR 0014).
+  dispatch:
+    # lifecycle is in needs so the tracking issue gains `sdd:dispatched`
+    # BEFORE any /execute comment is posted. Without that ordering, a fast
+    # task could close before lifecycle ran; the `issues.closed` cascade
+    # re-fire would see no `sdd:dispatched` on the tracking issue and bail,
+    # stranding any siblings the closure newly unblocked. The fastpath_noop
+    # path is unaffected: compute and lifecycle both skip on that route, so
+    # dispatch inherits the skip through the `needs` chain (GitHub Actions'
+    # default: a skipped need skips the downstream job).
+    needs: [route, compute, lifecycle]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.compute.outputs.precondition == 'ok'
+      && fromJSON(needs.compute.outputs.matrix).include[0] != null
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    strategy:
+      fail-fast: false
+      max-parallel: ${{ fromJSON(vars.SDD_DISPATCH_MAX_PARALLEL || '5') }}
+      matrix: ${{ fromJSON(needs.compute.outputs.matrix) }}
+    steps:
+      # Mint the App installation token. The default GITHUB_TOKEN cannot
+      # trigger another workflow run, but an App installation token can:
+      # the matching sdd-execute-{tier} wrapper sees the /execute comment
+      # posted below as an issue_comment.created event and routes the
+      # cascade to its agent.
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Post /execute on task #${{ matrix.task }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TASK: ${{ matrix.task }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const task = parseInt(process.env.TASK, 10);
+            // Post an /execute comment on the task issue. The matching
+            // sdd-execute-{tier} wrapper picks the comment up through its
+            // wrapper-level command + tier gate; the route step's
+            // App-author accept logic (gated on the configured APP_ID)
+            // admits the cascade-posted comment past the human-permission
+            // check (see ADR 0014). Idempotency: a second /execute on the
+            // same task collapses at the wrapper's per-task-per-tier
+            // concurrency group, so a re-fired cascade does not
+            // double-spawn an in-flight task.
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: task,
+                body: '/execute',
+              });
+              core.info('Posted /execute on task #' + task);
+            } catch (err) {
+              core.setFailed('Failed to post /execute on task #' + task
+                + ': ' + err.message);
+            }
+      - name: Apply sdd:ready hint to dispatched task #${{ matrix.task }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TASK: ${{ matrix.task }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const task = parseInt(process.env.TASK, 10);
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: task,
+                labels: ['sdd:ready'],
+              });
+            } catch (err) {
+              // A 422 here means the label is already present; ignore.
+              core.info('Could not add sdd:ready to #' + task + ': '
+                + err.message);
+            }
+
+  # Manage the tracking issue's lifecycle and sdd:dispatched labels. On the
+  # first /dispatch, move sdd:ready -> sdd:in-progress and add
+  # sdd:dispatched. On a cascade fire, leave the lifecycle label alone but
+  # ensure sdd:dispatched stays present (it was the precondition for the
+  # cascade firing in the first place). When the ready set is empty AND
+  # every task is closed, remove sdd:dispatched so the cascade disarms.
+  lifecycle:
+    needs: [route, compute]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.route.outputs.trigger_kind != 'fastpath_noop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Apply lifecycle and sdd:dispatched labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TRACKING: ${{ needs.route.outputs.tracking_issue }}
+          TRIGGER_KIND: ${{ needs.route.outputs.trigger_kind }}
+          PRECONDITION: ${{ needs.compute.outputs.precondition }}
+          READY_COUNT: ${{ needs.compute.outputs.ready_count }}
+          OPEN_TASK_COUNT: ${{ needs.compute.outputs.open_task_count }}
+          TRACKING_STATE: ${{ needs.compute.outputs.tracking_state }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const tracking = parseInt(process.env.TRACKING, 10);
+            const triggerKind = process.env.TRIGGER_KIND;
+            const precondition = process.env.PRECONDITION;
+            const readyCount = parseInt(process.env.READY_COUNT, 10);
+            const openTaskCount = parseInt(process.env.OPEN_TASK_COUNT, 10);
+            const trackingState = process.env.TRACKING_STATE;
+
+            // A failed precondition on a /dispatch (e.g. sdd:spec) does
+            // nothing to labels: no arm, no move. The noop-comment job
+            // posts the refusal.
+            if (precondition !== 'ok') {
+              return;
+            }
+
+            // First /dispatch: move sdd:ready -> sdd:in-progress and add
+            // sdd:dispatched. Idempotent: only move when the lifecycle is
+            // still sdd:ready, and only add sdd:dispatched if absent.
+            if (triggerKind === 'command') {
+              if (trackingState === 'sdd:ready') {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: tracking,
+                    name: 'sdd:ready',
+                  });
+                } catch (err) {
+                  core.info('Could not remove sdd:ready from #' + tracking
+                    + ': ' + err.message);
+                }
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: tracking,
+                    labels: ['sdd:in-progress'],
+                  });
+                } catch (err) {
+                  core.info('Could not add sdd:in-progress to #' + tracking
+                    + ': ' + err.message);
+                }
+              }
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracking,
+                  labels: ['sdd:dispatched'],
+                });
+              } catch (err) {
+                core.info('Could not add sdd:dispatched to #' + tracking
+                  + ': ' + err.message);
+              }
+            }
+
+            // Tree drained: remove sdd:dispatched and apply the terminal
+            // sdd:done state. sdd-execute's completion sweep (step 8) is
+            // the primary path for sdd:done when the last task closes via
+            // an implementation PR merge; this branch is the fallback for
+            // the drained-via-manual-close path (no impl PR ever merged,
+            // so the sweep never ran). Idempotent: GitHub tolerates
+            // re-adding an existing label, and removeLabel is wrapped in
+            // try/catch so a missing prior label is a no-op. ADR 0005 §4
+            // names sdd-execute as the agent that hands the feature to
+            // sdd:done; this fallback covers the case where no
+            // sdd-execute run ever fires (see issue #147).
+            if (openTaskCount === 0) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracking,
+                  name: 'sdd:dispatched',
+                });
+                core.info('Tree drained; removed sdd:dispatched from #'
+                  + tracking);
+              } catch (err) {
+                core.info('Could not remove sdd:dispatched from #' + tracking
+                  + ': ' + err.message);
+              }
+              for (const stale of ['sdd:in-progress', 'sdd:review']) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: tracking,
+                    name: stale,
+                  });
+                  core.info('Tree drained; removed ' + stale + ' from #'
+                    + tracking);
+                } catch (err) {
+                  core.info('Could not remove ' + stale + ' from #'
+                    + tracking + ': ' + err.message);
+                }
+              }
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracking,
+                  labels: ['sdd:done'],
+                });
+                core.info('Tree drained; applied sdd:done to #' + tracking);
+              } catch (err) {
+                core.info('Could not add sdd:done to #' + tracking + ': '
+                  + err.message);
+              }
+              return;
+            }
+
+            // Mid-cascade idle (some open tasks, but every one is blocked
+            // or in flight): leave sdd:dispatched alone. The next
+            // issues.closed event on a sibling task will resume the
+            // cascade. The noop-comment job posts an informational comment
+            // on the /dispatch path; the cascade path posts none, to keep
+            // the tracking-issue thread quiet between fan-outs.
+            if (readyCount === 0) {
+              core.info('Ready set empty and tasks still open; cascade'
+                + ' remains armed.');
+            }
+
+  # Post one comment naming the noop reason when /dispatch is refused
+  # (precondition failure on sdd:spec, sdd:triage, sdd:review, sdd:done) or
+  # the ready set is empty. On the cascade path with a non-empty ready set,
+  # no comment is posted: the dispatched runs and the subsequent close
+  # events are the user-visible signal, and a tracking-issue comment per
+  # cascade fire would be noise.
+  #
+  # The wrapper writes this comment directly via the App-minted token rather
+  # than routing through the sdd-dispatch agent's add-comment safe-output:
+  # the message body is deterministic (the precondition string from compute
+  # or the empty-set explanation), there is no LLM-generated text in it, and
+  # the entire dispatcher is deterministic by design. The .md agent exists
+  # to document the contract and to compile cleanly under the lint workflow's
+  # compile-drift gate (ADR 0004); it is not invoked at runtime. See the
+  # header note in .github/workflows/sdd-dispatch.md.
+  noop-comment:
+    needs: [route, compute]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.route.outputs.trigger_kind == 'command'
+      && (needs.compute.outputs.precondition != 'ok'
+          || needs.compute.outputs.ready_count == '0')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Post the noop comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TRACKING: ${{ needs.route.outputs.tracking_issue }}
+          PRECONDITION: ${{ needs.compute.outputs.precondition }}
+          REASON: ${{ needs.compute.outputs.reason }}
+          OPEN_TASK_COUNT: ${{ needs.compute.outputs.open_task_count }}
+          READY_COUNT: ${{ needs.compute.outputs.ready_count }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const tracking = parseInt(process.env.TRACKING, 10);
+            const precondition = process.env.PRECONDITION;
+            const reason = process.env.REASON;
+            const openTaskCount = parseInt(process.env.OPEN_TASK_COUNT, 10);
+            const readyCount = parseInt(process.env.READY_COUNT, 10);
+            let body = '';
+            if (precondition === 'refuse_early'
+                || precondition === 'refuse_late'
+                || precondition === 'needs_human') {
+              body = reason;
+            } else if (readyCount === 0 && openTaskCount === 0) {
+              body = 'Every task sub-issue is closed; `sdd:dispatched`'
+                + ' removed and the cascade disarmed. `sdd:done` is'
+                + ' applied here as a fallback when no implementation PR'
+                + ' merge fired `sdd-execute`\'s completion sweep'
+                + ' (ADR 0005).';
+            } else if (readyCount === 0) {
+              body = 'Every open task is either blocked or already in'
+                + ' flight; the cascade remains armed. The next task close'
+                + ' under this tracking issue will resume dispatch.';
+            }
+            if (!body) {
+              return;
+            }
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking,
+                body,
+              });
+            } catch (err) {
+              core.info('Could not post noop comment on #' + tracking
+                + ': ' + err.message);
+            }
+
+  # Fast-path /dispatch noop (ADR 0012).
+  #
+  # /dispatch on a tracking issue carrying a fast-path lifecycle label
+  # (sdd:fastpath, sdd:fastpath-review) does not arm the cascade — the
+  # fast-path flow has one task, so the fan-out machinery is unused.
+  # Post one comment pointing the human at /approve and exit. No labels
+  # are moved; the fast-path flow continues to be steered by sdd-spec's
+  # wrapper.
+  fastpath-noop-comment:
+    needs: route
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.route.outputs.trigger_kind == 'fastpath_noop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Post the fast-path noop comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TRACKING: ${{ needs.route.outputs.tracking_issue }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const tracking = parseInt(process.env.TRACKING, 10);
+            const body = '`/dispatch` is a noop on fast-path tracking'
+              + ' issues. The fast-path flow runs a single implementation'
+              + ' task, so the cascade fan-out is unused. Comment'
+              + ' `/approve` on this tracking issue (after the stub spec'
+              + ' PR merges) to dispatch the implementation directly'
+              + ' against the execution plan comment. See ADR 0012.';
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking,
+                body,
+              });
+            } catch (err) {
+              core.info('Could not post fast-path noop comment on #'
+                + tracking + ': ' + err.message);
+            }

--- a/.github/workflows/sdd-execute-haiku.yml
+++ b/.github/workflows/sdd-execute-haiku.yml
@@ -1,0 +1,245 @@
+name: sdd-execute-haiku
+
+# Thin wrapper for the sdd-execute agent, haiku model-tier variant.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-execute-haiku.lock.yml (compiled from
+# sdd-execute-haiku.md, which declares on: workflow_call). This wrapper carries
+# the real event triggers, gates the /execute comment command to authors with
+# repository write access, and passes the triggering entity to the agent
+# through the aw_context input. A consumer repository installs this wrapper
+# unchanged.
+#
+# sdd-execute is compiled into three model-tier variants (haiku, sonnet, opus)
+# that differ only in the engine model and the model:* tier they claim. This
+# wrapper is the haiku-tier caller; sdd-execute-sonnet.yml and
+# sdd-execute-opus.yml are its sonnet and opus siblings.
+#
+# Execution is event-driven, not scheduled. The daily cron that previously
+# drained each tier's queue has been removed: this wrapper now triggers only
+# on workflow_dispatch (from sdd-dispatch's bounded matrix fan-out) and on an
+# explicit /execute comment from a write-access human. The pipeline is
+# /approve -> /dispatch -> cascade-on-close (see issue #81 and ADR 0011).
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A workflow_dispatch from sdd-dispatch (one matrix cell per ready task) or
+  # from an operator running the queue by hand.
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        description: |
+          JSON string naming the triggering entity; mirrors the issue_comment
+          route output. sdd-dispatch fans out one cell per ready task with
+          {trigger: 'command', item_type: 'issue', item_number: <task>}.
+        required: false
+        type: string
+  # A /execute comment on a task sub-issue.
+  issue_comment:
+    types: [created]
+  # A review comment on a pull request this agent opened.
+  pull_request_review_comment:
+    types: [created]
+  # A formal review on a pull request this agent opened. A CHANGES_REQUESTED
+  # review from CodeRabbit or a write-access human on an `sdd/` branch is
+  # treated as an implicit /revise (issue #128). A COMMENTED or APPROVED
+  # review does not trigger a revise.
+  pull_request_review:
+    types: [submitted]
+  # The needs-human label being cleared on a task sub-issue, which re-triggers
+  # the agent to resume a hand-off it applied at step 5 or step 6.
+  issues:
+    types: [unlabeled]
+  # The needs-human label being cleared on a pull request this agent opened,
+  # which re-triggers the agent to resume a hand-off it applied at step 7.
+  # The `closed` action covers the fast-path completion path (ADR 0012): a
+  # merged implementation PR on a `sdd/` branch whose work-item is a
+  # tracking issue (no parent_issue_url, no task sub-issue tree) re-fires
+  # the agent with `entry: 'fastpath-complete'` so step 8's completion
+  # sweep can move the tracking issue from `sdd:in-progress` to `sdd:done`
+  # directly.
+  pull_request:
+    types: [unlabeled, closed]
+
+permissions:
+  contents: read
+
+# Concurrency group keyed on the task issue number AND this variant's tier.
+# A stale sdd-dispatch fan-out racing with a manual /execute on the same task
+# in the same tier collapses to one running cell: cancel-in-progress: true
+# supersedes the in-progress cell with the later trigger so a user-initiated
+# /execute wins over a stale dispatch (and vice versa: a fresh dispatch wins
+# over an earlier in-flight cell). The tier discriminator is required because
+# the three sdd-execute-{haiku,sonnet,opus} wrappers all subscribe to the same
+# event triggers; without the tier suffix a non-matching-tier wake would land
+# in the same group as the matching-tier run and the cancel-in-progress rule
+# could kill the only run doing real work (issue #124). Cancel-in-progress is
+# set on the wrapper itself because the gh-aw lock declares its own
+# activation-level concurrency keyed on the workflow name; this wrapper-level
+# group adds the per-task-per-tier dimension on top.
+#
+# The fromJSON(github.event.inputs.aw_context || '{}') branch reads the
+# dispatcher's well-formed aw_context JSON for the workflow_dispatch path.
+# Manual workflow_dispatch invocations that supply malformed JSON will fail
+# workflow evaluation here, which is the correct failure mode (the route
+# step's try/catch would silently ignore them and the run would do nothing
+# useful).
+#
+# A label-removal event (issues.unlabeled / pull_request.unlabeled) is routed
+# to its own throwaway group (github.run_id) so it never lands in a task's
+# shared per-task-per-tier group. At step 2 the agent removes its own task's
+# sdd:ready label; that self-induced issues.unlabeled event re-fires this
+# wrapper, and without the carve-out it entered the active run's group where
+# cancel-in-progress killed the running agent mid-work (issue #143). The only
+# label-removal the route step acts on is needs-human (a resume), which runs
+# when no agent is in flight, so a unique group is safe there too.
+#
+# An issue_comment whose body is not a recognized command (/execute or
+# /revise) is routed to its own throwaway group for the same reason.
+# gh-aw's create-pull-request fallback-to-issue posts an "Issue created:
+# #<n>" notice on the task issue via the App token (issue #142); that
+# App-authored comment re-fires this wrapper as issue_comment.created,
+# and without the carve-out it landed in the active run's per-task group
+# where cancel-in-progress killed the originating run's safe_outputs tail
+# and its auto-merge job. The route step acts only on /execute and
+# /revise comments, so a non-command comment in a unique group is safe.
+concurrency:
+  group: sdd-execute-haiku-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate below is the wrapper-level command + tier + label
+  # filter (fixes issue #119 and the matching-tier slice of issue #114). It
+  # runs BEFORE the route job's runner is allocated, so a /dispatch comment, a
+  # /spec comment, or any other unrelated comment never spends a runner
+  # minute on this wrapper. The issues clause does the same for label events:
+  # the route step only routes an `issues` event on `unlabeled` `needs-human`
+  # (the step 5/6 resume), so any other label add/remove — e.g. the
+  # `sdd:ready`/`sdd:in-progress`/`sdd:dispatched` mutations a /dispatch
+  # performs on a tracking issue — is skipped here without a runner. The
+  # route step's own tier resolution stays as a defence-in-depth check (it
+  # covers /revise on a sdd/ PR, where the model label lives on the linked
+  # task, not the PR — too expensive to resolve at workflow-evaluation time
+  # without an API call).
+  route:
+    if: |
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          (
+            startsWith(github.event.comment.body, '/execute')
+            && contains(github.event.issue.labels.*.name, 'model:haiku')
+          )
+          || startsWith(github.event.comment.body, '/revise')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && github.event.action == 'unlabeled'
+        && github.event.label.name == 'needs-human'
+      )
+    runs-on: ubuntu-latest
+    # pull-requests: read is needed for the tier gate on a /revise issue_comment
+    # (situation 6): the route fetches the pull request to read its body and
+    # extract the `Closes #<task>` reference. Without this grant, the GET
+    # /repos/{owner}/{repo}/pulls/{N} call returns 403 "Resource not accessible
+    # by integration" and the tier gate defaults to false, skipping every
+    # variant. See #68.
+    #
+    # issues: write and pull-requests: write are needed by the CHANGES_REQUESTED
+    # auto-revise branch (issue #128): it posts a hidden iteration-marker
+    # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
+    # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
+    # re-trigger workflows, so this does not feed back into the route.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.0
+        with:
+          tier: haiku
+          app-id: ${{ vars.APP_ID }}
+          max-review-iterations: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}
+          github-token: ${{ github.token }}
+
+  sdd-execute-haiku:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@v0.1.0
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+
+  # Enable GitHub auto-merge on the PR sdd-execute just opened (issue #127).
+  # The reusable lock exposes the new PR number via its create_pull_request
+  # safe-output as the workflow_call output created_pr_number; this job reads
+  # it and turns on squash + delete-branch auto-merge so a green cascade PR
+  # merges with no human in the loop. Gated OFF by default: it runs only when
+  # the repo variable SDD_AUTO_MERGE is set to a truthy value, so repos
+  # without branch protection are unaffected (behavior unchanged when unset).
+  auto-merge:
+    needs: [route, sdd-execute-haiku]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.sdd-execute-haiku.outputs.created_pr_number != ''
+      && (vars.SDD_AUTO_MERGE == '1'
+        || vars.SDD_AUTO_MERGE == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Mint the App token: reading branch protection needs administration:
+      # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
+      # lacks, and enabling auto-merge needs pull-requests + contents write.
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+          permission-contents: write
+          permission-pull-requests: write
+      # Arm auto-merge (squash, delete-branch) only when the repo allows it
+      # and the base branch protection requires at least one status check;
+      # otherwise skip (issue #127). Falls back to a direct squash merge when
+      # the PR is UNSTABLE with every required check green (issue #135). The
+      # mechanics live in the sdd-auto-merge composite action.
+      - name: Enable auto-merge when protection requires a check
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          pr-number: ${{ needs.sdd-execute-haiku.outputs.created_pr_number }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}

--- a/.github/workflows/sdd-execute-opus.yml
+++ b/.github/workflows/sdd-execute-opus.yml
@@ -1,0 +1,245 @@
+name: sdd-execute-opus
+
+# Thin wrapper for the sdd-execute agent, opus model-tier variant.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-execute-opus.lock.yml (compiled from
+# sdd-execute-opus.md, which declares on: workflow_call). This wrapper carries
+# the real event triggers, gates the /execute comment command to authors with
+# repository write access, and passes the triggering entity to the agent
+# through the aw_context input. A consumer repository installs this wrapper
+# unchanged.
+#
+# sdd-execute is compiled into three model-tier variants (haiku, sonnet, opus)
+# that differ only in the engine model and the model:* tier they claim. This
+# wrapper is the opus-tier caller; sdd-execute-haiku.yml and
+# sdd-execute-sonnet.yml are its haiku and sonnet siblings.
+#
+# Execution is event-driven, not scheduled. The daily cron that previously
+# drained each tier's queue has been removed: this wrapper now triggers only
+# on workflow_dispatch (from sdd-dispatch's bounded matrix fan-out) and on an
+# explicit /execute comment from a write-access human. The pipeline is
+# /approve -> /dispatch -> cascade-on-close (see issue #81 and ADR 0011).
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A workflow_dispatch from sdd-dispatch (one matrix cell per ready task) or
+  # from an operator running the queue by hand.
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        description: |
+          JSON string naming the triggering entity; mirrors the issue_comment
+          route output. sdd-dispatch fans out one cell per ready task with
+          {trigger: 'command', item_type: 'issue', item_number: <task>}.
+        required: false
+        type: string
+  # A /execute comment on a task sub-issue.
+  issue_comment:
+    types: [created]
+  # A review comment on a pull request this agent opened.
+  pull_request_review_comment:
+    types: [created]
+  # A formal review on a pull request this agent opened. A CHANGES_REQUESTED
+  # review from CodeRabbit or a write-access human on an `sdd/` branch is
+  # treated as an implicit /revise (issue #128). A COMMENTED or APPROVED
+  # review does not trigger a revise.
+  pull_request_review:
+    types: [submitted]
+  # The needs-human label being cleared on a task sub-issue, which re-triggers
+  # the agent to resume a hand-off it applied at step 5 or step 6.
+  issues:
+    types: [unlabeled]
+  # The needs-human label being cleared on a pull request this agent opened,
+  # which re-triggers the agent to resume a hand-off it applied at step 7.
+  # The `closed` action covers the fast-path completion path (ADR 0012): a
+  # merged implementation PR on a `sdd/` branch whose work-item is a
+  # tracking issue (no parent_issue_url, no task sub-issue tree) re-fires
+  # the agent with `entry: 'fastpath-complete'` so step 8's completion
+  # sweep can move the tracking issue from `sdd:in-progress` to `sdd:done`
+  # directly.
+  pull_request:
+    types: [unlabeled, closed]
+
+permissions:
+  contents: read
+
+# Concurrency group keyed on the task issue number AND this variant's tier.
+# A stale sdd-dispatch fan-out racing with a manual /execute on the same task
+# in the same tier collapses to one running cell: cancel-in-progress: true
+# supersedes the in-progress cell with the later trigger so a user-initiated
+# /execute wins over a stale dispatch (and vice versa: a fresh dispatch wins
+# over an earlier in-flight cell). The tier discriminator is required because
+# the three sdd-execute-{haiku,sonnet,opus} wrappers all subscribe to the same
+# event triggers; without the tier suffix a non-matching-tier wake would land
+# in the same group as the matching-tier run and the cancel-in-progress rule
+# could kill the only run doing real work (issue #124). Cancel-in-progress is
+# set on the wrapper itself because the gh-aw lock declares its own
+# activation-level concurrency keyed on the workflow name; this wrapper-level
+# group adds the per-task-per-tier dimension on top.
+#
+# The fromJSON(github.event.inputs.aw_context || '{}') branch reads the
+# dispatcher's well-formed aw_context JSON for the workflow_dispatch path.
+# Manual workflow_dispatch invocations that supply malformed JSON will fail
+# workflow evaluation here, which is the correct failure mode (the route
+# step's try/catch would silently ignore them and the run would do nothing
+# useful).
+#
+# A label-removal event (issues.unlabeled / pull_request.unlabeled) is routed
+# to its own throwaway group (github.run_id) so it never lands in a task's
+# shared per-task-per-tier group. At step 2 the agent removes its own task's
+# sdd:ready label; that self-induced issues.unlabeled event re-fires this
+# wrapper, and without the carve-out it entered the active run's group where
+# cancel-in-progress killed the running agent mid-work (issue #143). The only
+# label-removal the route step acts on is needs-human (a resume), which runs
+# when no agent is in flight, so a unique group is safe there too.
+#
+# An issue_comment whose body is not a recognized command (/execute or
+# /revise) is routed to its own throwaway group for the same reason.
+# gh-aw's create-pull-request fallback-to-issue posts an "Issue created:
+# #<n>" notice on the task issue via the App token (issue #142); that
+# App-authored comment re-fires this wrapper as issue_comment.created,
+# and without the carve-out it landed in the active run's per-task group
+# where cancel-in-progress killed the originating run's safe_outputs tail
+# and its auto-merge job. The route step acts only on /execute and
+# /revise comments, so a non-command comment in a unique group is safe.
+concurrency:
+  group: sdd-execute-opus-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate below is the wrapper-level command + tier + label
+  # filter (fixes issue #119 and the matching-tier slice of issue #114). It
+  # runs BEFORE the route job's runner is allocated, so a /dispatch comment, a
+  # /spec comment, or any other unrelated comment never spends a runner
+  # minute on this wrapper. The issues clause does the same for label events:
+  # the route step only routes an `issues` event on `unlabeled` `needs-human`
+  # (the step 5/6 resume), so any other label add/remove — e.g. the
+  # `sdd:ready`/`sdd:in-progress`/`sdd:dispatched` mutations a /dispatch
+  # performs on a tracking issue — is skipped here without a runner. The
+  # route step's own tier resolution stays as a defence-in-depth check (it
+  # covers /revise on a sdd/ PR, where the model label lives on the linked
+  # task, not the PR — too expensive to resolve at workflow-evaluation time
+  # without an API call).
+  route:
+    if: |
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          (
+            startsWith(github.event.comment.body, '/execute')
+            && contains(github.event.issue.labels.*.name, 'model:opus')
+          )
+          || startsWith(github.event.comment.body, '/revise')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && github.event.action == 'unlabeled'
+        && github.event.label.name == 'needs-human'
+      )
+    runs-on: ubuntu-latest
+    # pull-requests: read is needed for the tier gate on a /revise issue_comment
+    # (situation 6): the route fetches the pull request to read its body and
+    # extract the `Closes #<task>` reference. Without this grant, the GET
+    # /repos/{owner}/{repo}/pulls/{N} call returns 403 "Resource not accessible
+    # by integration" and the tier gate defaults to false, skipping every
+    # variant. See #68.
+    #
+    # issues: write and pull-requests: write are needed by the CHANGES_REQUESTED
+    # auto-revise branch (issue #128): it posts a hidden iteration-marker
+    # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
+    # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
+    # re-trigger workflows, so this does not feed back into the route.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.0
+        with:
+          tier: opus
+          app-id: ${{ vars.APP_ID }}
+          max-review-iterations: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}
+          github-token: ${{ github.token }}
+
+  sdd-execute-opus:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@v0.1.0
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+
+  # Enable GitHub auto-merge on the PR sdd-execute just opened (issue #127).
+  # The reusable lock exposes the new PR number via its create_pull_request
+  # safe-output as the workflow_call output created_pr_number; this job reads
+  # it and turns on squash + delete-branch auto-merge so a green cascade PR
+  # merges with no human in the loop. Gated OFF by default: it runs only when
+  # the repo variable SDD_AUTO_MERGE is set to a truthy value, so repos
+  # without branch protection are unaffected (behavior unchanged when unset).
+  auto-merge:
+    needs: [route, sdd-execute-opus]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.sdd-execute-opus.outputs.created_pr_number != ''
+      && (vars.SDD_AUTO_MERGE == '1'
+        || vars.SDD_AUTO_MERGE == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Mint the App token: reading branch protection needs administration:
+      # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
+      # lacks, and enabling auto-merge needs pull-requests + contents write.
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+          permission-contents: write
+          permission-pull-requests: write
+      # Arm auto-merge (squash, delete-branch) only when the repo allows it
+      # and the base branch protection requires at least one status check;
+      # otherwise skip (issue #127). Falls back to a direct squash merge when
+      # the PR is UNSTABLE with every required check green (issue #135). The
+      # mechanics live in the sdd-auto-merge composite action.
+      - name: Enable auto-merge when protection requires a check
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          pr-number: ${{ needs.sdd-execute-opus.outputs.created_pr_number }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}

--- a/.github/workflows/sdd-execute-sonnet.yml
+++ b/.github/workflows/sdd-execute-sonnet.yml
@@ -1,0 +1,245 @@
+name: sdd-execute-sonnet
+
+# Thin wrapper for the sdd-execute agent, sonnet model-tier variant.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-execute-sonnet.lock.yml (compiled from
+# sdd-execute-sonnet.md, which declares on: workflow_call). This wrapper carries
+# the real event triggers, gates the /execute comment command to authors with
+# repository write access, and passes the triggering entity to the agent
+# through the aw_context input. A consumer repository installs this wrapper
+# unchanged.
+#
+# sdd-execute is compiled into three model-tier variants (haiku, sonnet, opus)
+# that differ only in the engine model and the model:* tier they claim. This
+# wrapper is the sonnet-tier caller; sdd-execute-haiku.yml and
+# sdd-execute-opus.yml are its haiku and opus siblings.
+#
+# Execution is event-driven, not scheduled. The daily cron that previously
+# drained each tier's queue has been removed: this wrapper now triggers only
+# on workflow_dispatch (from sdd-dispatch's bounded matrix fan-out) and on an
+# explicit /execute comment from a write-access human. The pipeline is
+# /approve -> /dispatch -> cascade-on-close (see issue #81 and ADR 0011).
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A workflow_dispatch from sdd-dispatch (one matrix cell per ready task) or
+  # from an operator running the queue by hand.
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        description: |
+          JSON string naming the triggering entity; mirrors the issue_comment
+          route output. sdd-dispatch fans out one cell per ready task with
+          {trigger: 'command', item_type: 'issue', item_number: <task>}.
+        required: false
+        type: string
+  # A /execute comment on a task sub-issue.
+  issue_comment:
+    types: [created]
+  # A review comment on a pull request this agent opened.
+  pull_request_review_comment:
+    types: [created]
+  # A formal review on a pull request this agent opened. A CHANGES_REQUESTED
+  # review from CodeRabbit or a write-access human on an `sdd/` branch is
+  # treated as an implicit /revise (issue #128). A COMMENTED or APPROVED
+  # review does not trigger a revise.
+  pull_request_review:
+    types: [submitted]
+  # The needs-human label being cleared on a task sub-issue, which re-triggers
+  # the agent to resume a hand-off it applied at step 5 or step 6.
+  issues:
+    types: [unlabeled]
+  # The needs-human label being cleared on a pull request this agent opened,
+  # which re-triggers the agent to resume a hand-off it applied at step 7.
+  # The `closed` action covers the fast-path completion path (ADR 0012): a
+  # merged implementation PR on a `sdd/` branch whose work-item is a
+  # tracking issue (no parent_issue_url, no task sub-issue tree) re-fires
+  # the agent with `entry: 'fastpath-complete'` so step 8's completion
+  # sweep can move the tracking issue from `sdd:in-progress` to `sdd:done`
+  # directly.
+  pull_request:
+    types: [unlabeled, closed]
+
+permissions:
+  contents: read
+
+# Concurrency group keyed on the task issue number AND this variant's tier.
+# A stale sdd-dispatch fan-out racing with a manual /execute on the same task
+# in the same tier collapses to one running cell: cancel-in-progress: true
+# supersedes the in-progress cell with the later trigger so a user-initiated
+# /execute wins over a stale dispatch (and vice versa: a fresh dispatch wins
+# over an earlier in-flight cell). The tier discriminator is required because
+# the three sdd-execute-{haiku,sonnet,opus} wrappers all subscribe to the same
+# event triggers; without the tier suffix a non-matching-tier wake would land
+# in the same group as the matching-tier run and the cancel-in-progress rule
+# could kill the only run doing real work (issue #124). Cancel-in-progress is
+# set on the wrapper itself because the gh-aw lock declares its own
+# activation-level concurrency keyed on the workflow name; this wrapper-level
+# group adds the per-task-per-tier dimension on top.
+#
+# The fromJSON(github.event.inputs.aw_context || '{}') branch reads the
+# dispatcher's well-formed aw_context JSON for the workflow_dispatch path.
+# Manual workflow_dispatch invocations that supply malformed JSON will fail
+# workflow evaluation here, which is the correct failure mode (the route
+# step's try/catch would silently ignore them and the run would do nothing
+# useful).
+#
+# A label-removal event (issues.unlabeled / pull_request.unlabeled) is routed
+# to its own throwaway group (github.run_id) so it never lands in a task's
+# shared per-task-per-tier group. At step 2 the agent removes its own task's
+# sdd:ready label; that self-induced issues.unlabeled event re-fires this
+# wrapper, and without the carve-out it entered the active run's group where
+# cancel-in-progress killed the running agent mid-work (issue #143). The only
+# label-removal the route step acts on is needs-human (a resume), which runs
+# when no agent is in flight, so a unique group is safe there too.
+#
+# An issue_comment whose body is not a recognized command (/execute or
+# /revise) is routed to its own throwaway group for the same reason.
+# gh-aw's create-pull-request fallback-to-issue posts an "Issue created:
+# #<n>" notice on the task issue via the App token (issue #142); that
+# App-authored comment re-fires this wrapper as issue_comment.created,
+# and without the carve-out it landed in the active run's per-task group
+# where cancel-in-progress killed the originating run's safe_outputs tail
+# and its auto-merge job. The route step acts only on /execute and
+# /revise comments, so a non-command comment in a unique group is safe.
+concurrency:
+  group: sdd-execute-sonnet-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate below is the wrapper-level command + tier + label
+  # filter (fixes issue #119 and the matching-tier slice of issue #114). It
+  # runs BEFORE the route job's runner is allocated, so a /dispatch comment, a
+  # /spec comment, or any other unrelated comment never spends a runner
+  # minute on this wrapper. The issues clause does the same for label events:
+  # the route step only routes an `issues` event on `unlabeled` `needs-human`
+  # (the step 5/6 resume), so any other label add/remove — e.g. the
+  # `sdd:ready`/`sdd:in-progress`/`sdd:dispatched` mutations a /dispatch
+  # performs on a tracking issue — is skipped here without a runner. The
+  # route step's own tier resolution stays as a defence-in-depth check (it
+  # covers /revise on a sdd/ PR, where the model label lives on the linked
+  # task, not the PR — too expensive to resolve at workflow-evaluation time
+  # without an API call).
+  route:
+    if: |
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          (
+            startsWith(github.event.comment.body, '/execute')
+            && contains(github.event.issue.labels.*.name, 'model:sonnet')
+          )
+          || startsWith(github.event.comment.body, '/revise')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && github.event.action == 'unlabeled'
+        && github.event.label.name == 'needs-human'
+      )
+    runs-on: ubuntu-latest
+    # pull-requests: read is needed for the tier gate on a /revise issue_comment
+    # (situation 6): the route fetches the pull request to read its body and
+    # extract the `Closes #<task>` reference. Without this grant, the GET
+    # /repos/{owner}/{repo}/pulls/{N} call returns 403 "Resource not accessible
+    # by integration" and the tier gate defaults to false, skipping every
+    # variant. See #68.
+    #
+    # issues: write and pull-requests: write are needed by the CHANGES_REQUESTED
+    # auto-revise branch (issue #128): it posts a hidden iteration-marker
+    # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
+    # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
+    # re-trigger workflows, so this does not feed back into the route.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.0
+        with:
+          tier: sonnet
+          app-id: ${{ vars.APP_ID }}
+          max-review-iterations: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}
+          github-token: ${{ github.token }}
+
+  sdd-execute-sonnet:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@v0.1.0
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+
+  # Enable GitHub auto-merge on the PR sdd-execute just opened (issue #127).
+  # The reusable lock exposes the new PR number via its create_pull_request
+  # safe-output as the workflow_call output created_pr_number; this job reads
+  # it and turns on squash + delete-branch auto-merge so a green cascade PR
+  # merges with no human in the loop. Gated OFF by default: it runs only when
+  # the repo variable SDD_AUTO_MERGE is set to a truthy value, so repos
+  # without branch protection are unaffected (behavior unchanged when unset).
+  auto-merge:
+    needs: [route, sdd-execute-sonnet]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && needs.sdd-execute-sonnet.outputs.created_pr_number != ''
+      && (vars.SDD_AUTO_MERGE == '1'
+        || vars.SDD_AUTO_MERGE == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Mint the App token: reading branch protection needs administration:
+      # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
+      # lacks, and enabling auto-merge needs pull-requests + contents write.
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+          permission-contents: write
+          permission-pull-requests: write
+      # Arm auto-merge (squash, delete-branch) only when the repo allows it
+      # and the base branch protection requires at least one status check;
+      # otherwise skip (issue #127). Falls back to a direct squash merge when
+      # the PR is UNSTABLE with every required check green (issue #135). The
+      # mechanics live in the sdd-auto-merge composite action.
+      - name: Enable auto-merge when protection requires a check
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          pr-number: ${{ needs.sdd-execute-sonnet.outputs.created_pr_number }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}

--- a/.github/workflows/sdd-monitor.yml
+++ b/.github/workflows/sdd-monitor.yml
@@ -1,0 +1,138 @@
+name: sdd-monitor
+
+# Tier 1 of the sdd-monitor design (issue #148): detect "armed but idle"
+# tracking issues and post one `/dispatch` to unstick them.
+#
+# Why a plain utility workflow, not a gh-aw agent:
+# Tier 1 is purely mechanical — list workflow runs, list pull requests, walk
+# sub-issue trees, check labels, post a comment. There is no judgement call
+# in this loop, so an LLM in the loop only adds cost, latency, and a new
+# failure mode (model output drift). The same backstop pattern is already
+# used by sdd-pr-sanitize and sdd-triage-promote-ready (ADR 0006: a
+# deterministic workflow does the per-item work the agent has no event to
+# react to).
+#
+# Tier 2 (healing: merging UNSTABLE PRs, resetting orphaned tasks, advancing
+# sdd:review to sdd:done) and Tier 3 (escalating unrecoverable stalls to
+# needs-human) are out of scope for this PR. They are tracked as follow-ups
+# on issue #148.
+#
+# Idempotency model:
+#
+# 1. Disabled by default. The first check reads the SDD_MONITOR repo
+#    variable. The workflow only acts when SDD_MONITOR == '1'. A consumer
+#    that has not opted in pays no GitHub Actions cost beyond the no-op run.
+#
+# 2. In-flight gate. If any sdd-execute-{haiku,sonnet,opus} run is
+#    in_progress or queued anywhere in the repo, the pass exits without
+#    dispatching. This is conservative: a run targeting a different tracker
+#    still blocks all monitor dispatches for this pass. The conservatism is
+#    deliberate — correlating a workflow_run back to its tracking issue
+#    requires walking task -> Unit -> tracker per run (the run's input
+#    aw_context only names the task), and the cron backstop fires every
+#    ~10 min so a missed nudge is at most one cycle delayed. The safety
+#    case (do not stack /dispatch comments and trigger the cancellation
+#    storm described in issue #148) dominates.
+#
+# 3. Debounce. For each candidate tracker, the most recent comment whose
+#    body begins with `/dispatch` (any author, monitor-issued or
+#    operator-issued) within SDD_MONITOR_DEBOUNCE_MIN minutes (default 5)
+#    suppresses a new dispatch. This caps the rate at one dispatch per
+#    tracker per window regardless of how often the workflow fires
+#    (workflow_run completion + pull_request close + cron all converge on
+#    the same comment-history check).
+#
+# 4. Single comment per action. The audit line and the `/dispatch`
+#    directive are combined into one comment body so the dispatch
+#    wrapper's token-strict `/dispatch` match (it accepts the literal
+#    `/dispatch` followed by whitespace) still fires while operators see
+#    a one-line `sdd-monitor:` audit on the same comment.
+#
+# Triggers:
+#
+# - workflow_run completed on sdd-execute-{haiku,sonnet,opus}: react to a
+#   run finishing (success, failure, or cancellation) so a tracker that
+#   just lost its last in-flight run gets nudged immediately.
+# - pull_request closed: a merged or closed sdd/ implementation PR is the
+#   moment a task closes and the next layer could be armed.
+# - schedule */10: backstop for events lost to webhook drops or runner
+#   outages.
+
+on:
+  workflow_run:
+    workflows:
+      - sdd-execute-haiku
+      - sdd-execute-sonnet
+      - sdd-execute-opus
+    types: [completed]
+  pull_request:
+    types: [closed]
+  schedule:
+    # Every ten minutes is the backstop for missed webhook events. Tier 1
+    # is itself cheap (a handful of list calls per active tracker), so a
+    # higher cadence would be safe — ten minutes is chosen to match the
+    # debounce window order of magnitude and the typical sdd-execute run
+    # duration so most cron firings find at least one tracker actionable.
+    - cron: '*/10 * * * *'
+
+permissions:
+  contents: read
+  # actions: read is required to list sdd-execute-* workflow runs filtered
+  # by status so the in-flight gate can decide whether to dispatch.
+  actions: read
+  # pull-requests: read lists open sdd/ implementation PRs, which the
+  # armed-but-idle check excludes from candidate trackers.
+  pull-requests: read
+  # issues: read covers walking the sub-issue tree, reading labels, and
+  # listing existing comments. The /dispatch comment itself is posted with
+  # an App installation token (minted in the job below) so the dispatch
+  # wrapper's App-author carve-out admits it past the human-permission
+  # check — the default GITHUB_TOKEN's github-actions[bot] is not a
+  # repository collaborator and would be rejected.
+  issues: read
+
+jobs:
+  monitor:
+    # Top-level enable gate. A consumer that has not set SDD_MONITOR=1
+    # skips the whole job, including the App token mint, so a repo that
+    # has not opted in pays no further cost and does not need APP_ID +
+    # APP_PRIVATE_KEY configured for the monitor specifically. The
+    # second clause filters pull_request events to sdd/ branches;
+    # workflow_run and schedule events have no head ref to gate on at
+    # this level.
+    if: >-
+      vars.SDD_MONITOR == '1'
+      && (github.event_name != 'pull_request'
+        || startsWith(github.event.pull_request.head.ref, 'sdd/'))
+    # Serialize monitor passes for this repo. The three triggers
+    # (workflow_run, pull_request closed, schedule */10) can fire in
+    # close succession; without a concurrency group two passes can both
+    # clear the in-flight and debounce checks before either posts and
+    # then double-post `/dispatch` for the same tracker. cancel-in-
+    # progress is false because a running pass is cheap and worth
+    # finishing — the queued pass picks up any state change the running
+    # one missed.
+    concurrency:
+      group: sdd-monitor-${{ github.repository }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      # Mint the App installation token. The /dispatch comment posted below
+      # must be authored by the configured App so the dispatch wrapper's
+      # App-author carve-out admits it past the human-permission gate; the
+      # default GITHUB_TOKEN's github-actions[bot] is not a collaborator on
+      # the consumer repository. The same APP_ID + APP_PRIVATE_KEY pair
+      # already drives the cascade fan-out in sdd-dispatch (ADR 0014).
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Nudge armed-but-idle trackers
+        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@v0.1.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          debounce-min: ${{ vars.SDD_MONITOR_DEBOUNCE_MIN }}

--- a/.github/workflows/sdd-pr-sanitize.yml
+++ b/.github/workflows/sdd-pr-sanitize.yml
@@ -1,0 +1,68 @@
+name: sdd-pr-sanitize
+
+# Corrects the issue references in a spec or architecture pull request body,
+# and makes the deliverable link visible on the sub-issue side.
+# Three deterministic corrections, on every spec/* and arch/* pull request:
+#
+# 1. The feature tracking issue must stay open as the lifecycle anchor, so a
+#    spec or architecture pull request must never close it. The agents are told
+#    never to write a closing keyword for the feature, but across three
+#    acceptance runs the agent slipped `Closes`/`Fixes`/`Resolves #<feature>`
+#    into the body anyway. This workflow rewrites every closing keyword that
+#    precedes an issue reference to `Refs`, which GitHub does not treat as a
+#    closing keyword — except the keyword on the deliverable sub-issue (2). A
+#    prompt rule cannot be relied on; this is the deterministic backstop.
+#
+# 2. A spec pull request delivers the spec sub-issue; an architecture pull
+#    request delivers the architecture sub-issue. The agent creates that
+#    sub-issue and the pull request in one run and cannot know the sub-issue
+#    number when it writes the body, so the pull request cannot itself carry
+#    the link. This workflow runs after both exist: it resolves the deliverable
+#    sub-issue under the feature and adds `Closes #<sub-issue>` to the body, so
+#    merging the pull request closes the sub-issue — the way an implementation
+#    pull request's `Closes #<task>` already closes its task.
+#
+# 3. When the sanitizer PATCHes the pull-request body to add `Closes #<sub>`
+#    after the App-authenticated creation, GitHub suppresses the
+#    `cross-referenced` event it would normally emit on the sub-issue, and at
+#    merge time it attributes the close to the merger rather than the pull
+#    request. The closing link exists in the data model (the pull request's
+#    `closingIssuesReferences` returns the sub-issue), but neither of the two
+#    timeline events that normally make the deliverable link visible in the UI
+#    fires (issue #69). This workflow posts one `Delivered by #<pr>.` comment
+#    on the sub-issue, which both produces a visible `commented` event and
+#    causes GitHub to emit the missing `cross-referenced` event from the
+#    `#<pr>` reference in the comment body.
+#
+# All three corrections are owned by ADR 0006; the sub-issue closing model is
+# ADR 0005. Implementation pull requests on sdd/* branches are not touched:
+# their `Closes #<task>` is already correct, and GitHub already emits the
+# normal cross-reference and "closed via #<pr>" events because the closing
+# keyword was present at pull-request creation, not added by a later PATCH.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  # `issues: write` is required to post the `Delivered by #<pr>.` comment on
+  # the deliverable sub-issue. Reading the sub-issue and its comments to
+  # resolve it and to enforce idempotency only needs `issues: read`; the
+  # write scope is solely for the comment add (3) below.
+  issues: write
+  pull-requests: write
+
+jobs:
+  sanitize:
+    # Only spec and architecture pull requests are corrected here. An sdd/*
+    # implementation pull request is left alone.
+    if: >-
+      startsWith(github.event.pull_request.head.ref, 'spec/') ||
+      startsWith(github.event.pull_request.head.ref, 'arch/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Correct the issue references in the pull request body
+        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@v0.1.0
+        with:
+          github-token: ${{ github.token }}

--- a/.github/workflows/sdd-review.yml
+++ b/.github/workflows/sdd-review.yml
@@ -1,0 +1,125 @@
+name: sdd-review
+
+# Thin wrapper for the sdd-review agent.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-review.lock.yml (compiled from sdd-review.md, which
+# declares on: workflow_call). This wrapper carries the real event triggers and
+# passes the triggering pull request to the agent through the aw_context input.
+# A consumer repository installs this wrapper unchanged.
+#
+# sdd-review has no comment-command trigger, so this wrapper performs no
+# repository-permission gate: the gh-aw command:/slash_command trigger is not
+# used here. The only trigger is an implementation pull request opened or
+# synchronized.
+#
+# The pull_request event is gated to pull requests whose head branch carries
+# the sdd-execute implementation branch prefix sdd/. sdd-execute opens
+# implementation PRs on sdd/<task-id>-<slug> branches (see the branch
+# conventions in shared/repo-conventions.md), so this prefix gate keeps the
+# review agent scoped to implementation PRs and off spec/ and arch/ PRs.
+#
+# A PR-boundary needs-human resume needs no separate trigger here. When
+# sdd-review escalates a CRITICAL or HIGH finding, the hand-off is resumed by a
+# fresh pull_request: synchronize, which is the event the human's fix commit
+# naturally fires. Clearing needs-human on a PR without a code change would
+# re-run the same review against the unchanged diff and re-post the same
+# findings; resuming on synchronize ties re-review to an actual fix. The agent
+# treats a needs-human-labelled PR as off-limits and emits noop until a real
+# fix commit arrives.
+
+on:
+  # An implementation pull request was opened or updated. synchronize also
+  # resumes a needs-human hand-off, since the human's fix commit fires it.
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve whether the triggering pull request is an implementation PR and
+  # build the aw_context the reusable workflow consumes. A pull request whose
+  # head branch does not carry the sdd/ implementation prefix leaves
+  # should_run = false so the agent job is skipped.
+  route:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@v0.1.0
+        with:
+          github-token: ${{ github.token }}
+
+  sdd-review:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@v0.1.0
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need issues and pull-requests write, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+
+  # Resolve the App bot's own advisory review threads once sdd-review has
+  # posted them, so they do not deadlock the auto-merge sdd-execute armed
+  # (ADR 0016). sdd-review is advisory and never gates a merge, but each
+  # line-anchored finding opens a review thread, and a base branch with
+  # required_conversation_resolution turns every unresolved thread into a hard
+  # blocker — mergeStateStatus stays BLOCKED forever and the cascade stalls.
+  #
+  # Gated on SDD_AUTO_MERGE, the same switch that arms auto-merge in the
+  # sdd-execute tiers: only a repo that opted into hands-off merging
+  # auto-resolves advisory threads. When the switch is off a human owns the
+  # merge and the threads stay open for triage — behavior unchanged. Only the
+  # App bot's own threads are resolved; a human reviewer's thread or a
+  # CodeRabbit CHANGES_REQUESTED thread is left intact so it still gates.
+  #
+  # needs sdd-review so the reusable workflow's safe_outputs job has posted the
+  # inline comments before this job reads them. The PR number comes straight
+  # from the pull_request event payload this wrapper triggers on.
+  resolve-advisory-threads:
+    needs: [route, sdd-review]
+    if: |
+      needs.route.outputs.should_run == 'true'
+      && (vars.SDD_AUTO_MERGE == '1' || vars.SDD_AUTO_MERGE == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Mint the App token: resolving a review thread needs
+      # pull-requests:write, which the default GITHUB_TOKEN in this wrapper
+      # (contents: read) lacks. app-slug names the bot whose threads to
+      # resolve.
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-pull-requests: write
+      - name: Resolve App-bot advisory review threads
+        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@v0.1.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          bot-login: ${{ steps.app.outputs.app-slug }}[bot]
+          pr-number: ${{ github.event.pull_request.number }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}

--- a/.github/workflows/sdd-spec.yml
+++ b/.github/workflows/sdd-spec.yml
@@ -1,0 +1,192 @@
+name: sdd-spec
+
+# Thin wrapper for the sdd-spec agent.
+#
+# The agent itself is the reusable workflow .github/workflows/sdd-spec.lock.yml
+# (compiled from sdd-spec.md, which declares on: workflow_call). This wrapper
+# carries the real event triggers, gates the comment commands to authors with
+# repository write access, and passes the triggering entity to the agent
+# through the aw_context input. A consumer repository installs this wrapper
+# unchanged.
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A tracking issue gained the sdd:spec label (also fired by the
+  # feature/bug issue templates), or the needs-human label was cleared.
+  issues:
+    types: [labeled, unlabeled]
+  # A /spec or /revise comment on an issue or pull request.
+  issue_comment:
+    types: [created]
+  # A spec pull request was closed; the agent advances the lifecycle only
+  # when it was merged.
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate skips the route job entirely on issue_comment
+  # events whose body does not start with one of the commands this wrapper
+  # owns, and on issues label events whose label this wrapper does not route
+  # (fixes issue #119 — a /dispatch or /execute comment, or the
+  # sdd:in-progress/sdd:dispatched label mutations a /dispatch performs on a
+  # tracker, no longer spawn a route-job runner on this wrapper). The route
+  # step routes an `issues` event only on `labeled` `sdd:spec`/`sdd:fastpath`
+  # or `unlabeled` `needs-human`; every other label add/remove is skipped
+  # here without a runner.
+  route:
+    if: |
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          startsWith(github.event.comment.body, '/spec')
+          || startsWith(github.event.comment.body, '/revise')
+          || startsWith(github.event.comment.body, '/fastpath')
+          || startsWith(github.event.comment.body, '/approve')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && (
+          (
+            github.event.action == 'labeled'
+            && (
+              github.event.label.name == 'sdd:spec'
+              || github.event.label.name == 'sdd:fastpath'
+            )
+          )
+          || (
+            github.event.action == 'unlabeled'
+            && github.event.label.name == 'needs-human'
+          )
+        )
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+      fastpath_approve: ${{ steps.decide.outputs.fastpath_approve }}
+      fastpath_tracking: ${{ steps.decide.outputs.fastpath_tracking }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@v0.1.0
+        with:
+          github-token: ${{ github.token }}
+
+  # Fast-path /approve handler (ADR 0012).
+  #
+  # On /approve on a tracking issue carrying sdd:fastpath, the route job
+  # sets fastpath_approve=true. This job runs the deterministic dispatch:
+  # find the latest execution-plan comment on the tracking issue (matched
+  # by the `[sdd-spec:fastpath-plan]` plain-text marker), parse its
+  # `model:*` tier, mint an App token, call workflow_dispatch on the
+  # matching sdd-execute-{tier}.yml with `entry: 'fastpath'`, and move
+  # the tracking issue's lifecycle from `sdd:fastpath` to
+  # `sdd:in-progress`. The wrapper handles this entirely; the sdd-spec
+  # agent .md source is not invoked on this path.
+  #
+  # This follows the deterministic-in-wrapper pattern from #81 (ADR
+  # 0011): there is no natural-language judgement on this code path —
+  # walk a comment, parse a tier, call REST.
+  fastpath-approve:
+    needs: route
+    if: needs.route.outputs.fastpath_approve == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Find plan comment and dispatch sdd-execute-{tier}
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.1.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          tracking: ${{ needs.route.outputs.fastpath_tracking }}
+
+  sdd-spec:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@v0.1.0
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+
+  # Agent-failure hand-off (fixes #122, #123).
+  #
+  # When the sdd-spec reusable workflow fails before producing safe-outputs
+  # (e.g. the "Execute GitHub Copilot CLI" step crashes, or any other infra
+  # failure the gh-aw conclusion job does not classify), the agent has posted
+  # nothing: no comment, no needs-human. The failure is invisible to the
+  # reporter and the work stalls with no auto-retry (#122, #123). This job
+  # makes that failure visible and recoverable by minting the App token (same
+  # pattern as fastpath-approve above) and posting a hand-off comment plus
+  # the `needs-human` label on the tracking issue. Clearing `needs-human`
+  # re-fires the agent (situation 6 in sdd-spec.md), so the human-driven
+  # resume stands in for the missing auto-retry.
+  #
+  # Gated on failure() and should_run so it never runs when the agent was
+  # skipped (route decided not to run) or succeeded. The aw_context JSON the
+  # route job built carries the routed item; needs-human is applied only to
+  # an issue item (the tracking issue), which is the lifecycle anchor the
+  # agent re-fires on. A pull-request item (a /revise on a spec PR, or a
+  # merged spec PR) gets a visibility comment so the failure is still
+  # surfaced, but not needs-human: that label re-fires the agent only from
+  # the tracking issue, which is not reliably derivable from a PR here.
+  failure-handoff:
+    needs: [route, sdd-spec]
+    if: failure() && needs.route.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Post failure hand-off to tracking issue
+        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@v0.1.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          aw-context: ${{ needs.route.outputs.aw_context }}

--- a/.github/workflows/sdd-triage-dedupe-tasks.yml
+++ b/.github/workflows/sdd-triage-dedupe-tasks.yml
@@ -1,0 +1,42 @@
+name: sdd-triage-dedupe-tasks
+
+# Closes a duplicate phase-C task sub-issue under the same Unit.
+#
+# sdd-triage phase C decomposes each Unit sub-issue into one implementation
+# task sub-issue per single-session unit of work. The agent emits one
+# `create-issue` safe-output per task, with `parent` set to the Unit, and the
+# "each task single-session sized" rule is enforced only in prose. An
+# acceptance run (issue #62) showed the agent emitting two `create_issue`
+# payloads with identical titles and identical bodies under the same Unit:
+# the prompt rule does not prevent a duplicate emission, and the gh-aw
+# safe-output handler does not collapse identical sibling `create_issue`
+# calls. A prompt rule cannot be relied on; this is the deterministic
+# backstop in the spirit of ADR 0006 and ADR 0007.
+#
+# On every issue opened in the consumer repository, this workflow checks
+# whether the new issue is a phase-C task sub-issue, finds its parent Unit,
+# enumerates that Unit's sub-issues, and — if an earlier-numbered sibling
+# carries the same title — closes the new issue as a duplicate with a
+# comment naming the original. Lower issue number always wins, so two
+# near-simultaneous duplicate runs converge on the same survivor.
+#
+# Scoped narrowly. A non-task issue (no structured `## Task` block) is
+# ignored. An issue without a parent is ignored. An issue whose parent has
+# only one sub-issue with that title is ignored.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  dedupe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close a duplicate phase-C task sub-issue
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@v0.1.0
+        with:
+          github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage-promote-ready.yml
+++ b/.github/workflows/sdd-triage-promote-ready.yml
@@ -1,0 +1,62 @@
+name: sdd-triage-promote-ready
+
+# Promotes a phase-C task sub-issue to `sdd:ready` when its last blocker
+# closes.
+#
+# ADR 0009 (`fix/63`, PR #72) attaches `sdd:ready` at task-creation time on
+# tasks born **without** a `blocked by` dependency. A task born **with** a
+# `blocked by` dependency is intentionally created without `sdd:ready` and
+# stays that way until something promotes it. Nothing in the current
+# pipeline does that: `sdd-triage` phase C runs once per `/approve` and
+# does not re-fire on a task close, and `sdd-execute`'s eligibility check
+# skips a task without `sdd:ready`. The result is a stalled cascade where
+# the work is structurally ready but the label is missing.
+#
+# This wrapper closes that gap. On every issue close in the consumer
+# repository:
+#
+# 1. Identify the closed issue as a phase-C task by its structured
+#    `## Task` block.
+# 2. Find every other open task in the same repo that references the
+#    closed task on a `blocked by #<N>` line (one GitHub code search,
+#    not a tree walk).
+# 3. For each match, parse its full `depends on:` list, fetch each
+#    referenced issue, and apply `sdd:ready` only when every blocker is
+#    now closed.
+#
+# Search is the right primitive because dependencies cross Unit
+# boundaries: a task in Unit 2 may depend on a task in Unit 1, and the
+# closed task's parent Unit alone is not enough to find all promotable
+# siblings (issue #78's "Unit's sub-issues" wording is conservative;
+# this implementation broadens to the search-driven set, which
+# subsumes it).
+#
+# Idempotent: a task that already carries `sdd:ready` is skipped. Two
+# concurrent runs that resolve the same task converge on the same
+# label state (GitHub's `add_labels` is a set-union).
+#
+# Backstop pattern of ADR 0006 (deterministic workflow does the
+# per-item work the agent has no event to react to). Companion to
+# `sdd-pr-sanitize`, `sdd-triage-dedupe-tasks`. ADR 0013 records the
+# full reasoning.
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  # `issues: write` is required to apply the `sdd:ready` label on a
+  # promoted task. Reading the closed issue's body, walking the search
+  # results, and reading each blocker's state need only `issues: read`;
+  # the write scope is solely for `addLabels` below.
+  issues: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Promote tasks whose last blocker just closed
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@v0.1.0
+        with:
+          github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage.yml
+++ b/.github/workflows/sdd-triage.yml
@@ -1,0 +1,106 @@
+name: sdd-triage
+
+# Thin wrapper for the sdd-triage agent.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-triage.lock.yml (compiled from sdd-triage.md, which
+# declares on: workflow_call). This wrapper carries the real event triggers,
+# gates the comment commands to authors with repository write access, and
+# passes the triggering entity to the agent through the aw_context input. A
+# consumer repository installs this wrapper unchanged.
+#
+# The gh-aw command:/slash_command trigger (with its roles: gate) is not used
+# here: that trigger is gh-aw frontmatter and only takes effect when gh aw
+# compiles a workflow. This wrapper is a hand-written GitHub Actions workflow,
+# not a gh-aw source file, so gh aw never processes it. The gating is therefore
+# done explicitly below with a real repository-permission check.
+
+on:
+  # A tracking issue gained the sdd:triage label (phase A), or the needs-human
+  # label was cleared (resume).
+  issues:
+    types: [labeled, unlabeled]
+  # A /triage, /approve, or /revise comment on an issue or pull request.
+  issue_comment:
+    types: [created]
+  # An architecture pull request was closed; the agent runs phase B only when
+  # it was merged and the head branch follows the arch/<slug> convention.
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate skips the route job entirely on issue_comment
+  # events whose body does not start with one of the commands this wrapper
+  # owns, and on issues label events whose label this wrapper does not route
+  # (fixes issue #119 — a /dispatch or /execute comment, or the
+  # sdd:in-progress/sdd:dispatched label mutations a /dispatch performs on a
+  # tracker, no longer spawn a route-job runner on this wrapper). The route
+  # step routes an `issues` event only on `labeled` `sdd:triage` or
+  # `unlabeled` `needs-human`; every other label add/remove is skipped here
+  # without a runner.
+  route:
+    if: |
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          startsWith(github.event.comment.body, '/triage')
+          || startsWith(github.event.comment.body, '/approve')
+          || startsWith(github.event.comment.body, '/revise')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && (
+          (
+            github.event.action == 'labeled'
+            && github.event.label.name == 'sdd:triage'
+          )
+          || (
+            github.event.action == 'unlabeled'
+            && github.event.label.name == 'needs-human'
+          )
+        )
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.1.0
+        with:
+          github-token: ${{ github.token }}
+
+  sdd-triage:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.1.0
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write

--- a/.github/workflows/sdd-validate.yml
+++ b/.github/workflows/sdd-validate.yml
@@ -1,0 +1,108 @@
+name: sdd-validate
+
+# Thin wrapper for the sdd-validate agent.
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-validate.lock.yml (compiled from sdd-validate.md, which
+# declares on: workflow_call). This wrapper carries the real event triggers and
+# passes the triggering entity to the agent through the aw_context input. A
+# consumer repository installs this wrapper unchanged.
+#
+# sdd-validate has no comment-command trigger, so this wrapper performs no
+# repository-permission gate: the gh-aw command:/slash_command trigger is not
+# used here. The triggers are a pull request opened or synchronized on a suite
+# branch (head ref `spec/`, `arch/`, or `sdd/`) and a tracking issue gaining
+# the sdd:ready label. The branch-prefix gate keeps the agent from commenting
+# on PRs the suite did not create — dependabot bumps, external contributions,
+# and unrelated human PRs. Suite PRs carry no distinguishing label (the
+# lifecycle label lives on the tracking issue), so the head ref is the signal,
+# matching CLAUDE.md's branch conventions and the sdd-execute/sdd-dispatch
+# wrappers' head-ref routing.
+#
+# No needs-human-removal resume is wired here. When sdd-validate escalates a
+# Blocker on a pull request, the hand-off is resumed by a fresh
+# pull_request: synchronize — the human's fix commit — not by an unlabeled
+# event: clearing needs-human without a code change would only re-run the same
+# gate set against the unchanged diff and re-post the same Blocker. A Blocker
+# at the triage boundary is advisory (validation gates neither a merge nor
+# /approve), so it needs no agent re-run. The wrapper therefore subscribes to
+# no unlabeled event. See the "Triggers this agent handles" section of
+# .github/workflows/sdd-validate.md.
+
+on:
+  # A pull request was opened or updated: the spec, architecture, or
+  # implementation boundary. synchronize also resumes a PR-boundary needs-human
+  # hand-off, since the human's fix commit fires it.
+  pull_request:
+    types: [opened, synchronize]
+  # A tracking issue gained sdd:ready: the non-pull-request triage boundary.
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve which situation triggered the wrapper and build the aw_context the
+  # reusable workflow consumes. A non-match leaves should_run = false so the
+  # agent job is skipped.
+  #
+  # The job-level if: gate skips the route job entirely for events this wrapper
+  # does not route, so no runner spins up for them. It admits two cases:
+  #   - a pull_request whose head ref is a suite branch (`spec/`, `arch/`, or
+  #     `sdd/`); a PR on any other branch is not a suite PR and is skipped,
+  #     keeping the agent off dependabot, external, and unrelated human PRs;
+  #   - an `issues` `labeled` event for `sdd:ready` only (fixes issue #119 — the
+  #     sdd:in-progress/sdd:dispatched label mutations a /dispatch performs on a
+  #     tracker no longer spawn a route-job runner on this wrapper). Every other
+  #     label add is skipped here without a runner.
+  route:
+    if: |
+      (
+        github.event_name == 'pull_request'
+        && (
+          startsWith(github.event.pull_request.head.ref, 'spec/')
+          || startsWith(github.event.pull_request.head.ref, 'arch/')
+          || startsWith(github.event.pull_request.head.ref, 'sdd/')
+        )
+      )
+      || (
+        github.event_name == 'issues'
+        && github.event.action == 'labeled'
+        && github.event.label.name == 'sdd:ready'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Decide whether to run and build aw_context
+        id: decide
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@v0.1.0
+        with:
+          github-token: ${{ github.token }}
+
+  sdd-validate:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@v0.1.0
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read. sdd-validate
+    # opens no pull request, so contents stays read.
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+      issues: write
+      pull-requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+# Serena MCP working-tree state (spectacles quick-setup).
+.serena/


### PR DESCRIPTION
Installs the spectacles SDD agent suite (ADR 0004) via `scripts/quick-setup.sh`. Wrappers pin hosted reusable workflows at `@v0.1.0`. Labels, variables, and secrets were applied directly; the file artifacts in this PR honor the protected default branch. Merge to activate the workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub issue templates for bug reports, feature requests, chores, and specifications with structured guidance
  * Introduced automated workflows for issue triage, task dispatch, review, and execution
  * Added automated monitoring and deduplication for issue tracking
  * Implemented auto-merge capabilities for pull requests

* **Documentation**
  * Added SDD command vocabulary documentation in issue templates (e.g., `/spec`, `/fastpath`, `/approve`, `/dispatch`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->