### PR TITLE
fix(distillery-sync): wrapper APP_PRIVATE_KEY + write permissions for the v0.1.0 lock

### DIFF
--- a/.github/workflows/distillery-sync.yml
+++ b/.github/workflows/distillery-sync.yml
@@ -44,6 +44,10 @@ jobs:
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
+      # The agent's safe-outputs mint an App token (github-app:) to upsert the
+      # persistent status issue, so the wrapper must pass the App private key —
+      # the same mapping every sdd-* wrapper carries.
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
     # Ceiling for the called reusable workflow. Must cover the union of every

--- a/.github/workflows/distillery-sync.yml
+++ b/.github/workflows/distillery-sync.yml
@@ -57,4 +57,5 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
+      discussions: write


### PR DESCRIPTION
The installed `distillery-sync.yml` wrapper predates spectacles #191, which made the agent's safe-outputs mint a GitHub App token (`github-app:`) to upsert its status issue. The pinned `@v0.1.0` reusable lock now expects that path, but this wrapper does not map `APP_PRIVATE_KEY` — causing a `startup_failure` on dispatch.

Add the `APP_PRIVATE_KEY` secret mapping (the same one every `sdd-*` wrapper carries). Wrapper-only change; no ref bump.

After merge, set `APP_ID` (var) + `APP_PRIVATE_KEY` (secret) if not already present, then re-dispatch `distillery-sync`.