### PR TITLE
ci(minvmd): virtio-linux kernel-fetch lane + non-gating boot E2E

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -34,6 +34,80 @@ permissions:
   contents: read
 
 jobs:
+  virtio-kernel:
+    # Pull the prebuilt virtio-linux kernel (vmlinuz / Image.gz) from the public
+    # minimal build cache — no kernel build, no GCS auth — and hand it to the
+    # macOS boot job. The packaging `minimal` CLI is Linux-only, so this runs on
+    # Linux. Cheap (a cache pull), so it is unconditional and decoupled from the
+    # self-hosted runner.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Fetch virtio-linux kernel from the build cache
+        run: ./scripts/fetch-virtio-kernel.sh "$RUNNER_TEMP/vmlinuz" aarch64
+      - name: Upload kernel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: virtio-kernel-aarch64
+          path: ${{ runner.temp }}/vmlinuz
+          if-no-files-found: error
+
+  boot-e2e:
+    # Boot E2E (R2.4 READY round-trip) on real hardware, using the cache-pulled
+    # kernel. Separate from build-macos so a kernel-fetch hiccup never blocks the
+    # always-green clippy/test/smoke checks.
+    #
+    # NON-GATING for now (continue-on-error): the round-trip needs the R3.4 guest
+    # vsock stub (#328) and a settled marker-port contract (host
+    # VSOCK_MARKER_PORT=9799 vs the guest rootfs's 7350), and R2.2 rootfs staging
+    # (`scripts/fetch-alpine.sh`) is not yet on main. The lane is wired so it
+    # flips to required by dropping continue-on-error once those land. See #339.
+    if: ${{ vars.RUN_MACOS_CI != 'false' }}
+    needs: virtio-kernel
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Verify libkrun is available
+        run: |
+          if [ ! -f /opt/homebrew/lib/libkrun.dylib ]; then
+            echo "::error::libkrun.dylib not found under /opt/homebrew/lib. Provision the runner with: brew install slp/krun/libkrun" >&2
+            exit 1
+          fi
+      - name: Download virtio-linux kernel
+        uses: actions/download-artifact@v4
+        with:
+          name: virtio-kernel-aarch64
+          path: ${{ runner.temp }}/kernel
+      - name: Boot E2E (READY round-trip)
+        # Expected red until #328 (guest stub) + the marker-port contract land.
+        continue-on-error: true
+        run: |
+          set -x
+          # R2.2 rootfs staging (scripts/fetch-alpine.sh) is not yet on main;
+          # stage a vanilla Alpine aarch64 minirootfs inline for now. Note this
+          # rootfs has no guest READY-writer, so the round-trip cannot pass until
+          # the R3.4 stub exists — that is why this step is non-gating.
+          ROOTFS="$RUNNER_TEMP/rootfs"
+          mkdir -p "$ROOTFS"
+          curl -fsSL https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-minirootfs-3.21.7-aarch64.tar.gz \
+            | tar -xz -C "$ROOTFS"
+          # boot_e2e spawns the minvmd binary, which needs the hypervisor
+          # entitlement (R1.4) — codesign the just-built debug binary.
+          cargo build -p minvmd --bin minvmd
+          codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/debug/minvmd
+          MINVMD_E2E=1 \
+          MINVMD_KERNEL_PATH="$RUNNER_TEMP/kernel/vmlinuz" \
+          MINVMD_ROOTFS_PATH="$ROOTFS" \
+            cargo test -p minvmd --test boot_e2e -- --include-ignored --nocapture
+
   build-macos:
     # Self-hosted Apple Silicon runner. minvmd links libkrun
     # (`#[link(name = "krun")]`) and only compiles on macOS — the Linux CI

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -12,6 +12,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/ci-macos.yml"
+      - "scripts/fetch-virtio-kernel.sh"
   pull_request:
     branches: ["main"]
     paths:
@@ -19,6 +20,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/ci-macos.yml"
+      - "scripts/fetch-virtio-kernel.sh"
   workflow_dispatch:
 
 env:
@@ -86,26 +88,32 @@ jobs:
         with:
           name: virtio-kernel-aarch64
           path: ${{ runner.temp }}/kernel
-      - name: Boot E2E (READY round-trip)
-        # Expected red until #328 (guest stub) + the marker-port contract land.
-        continue-on-error: true
+      - name: Stage Alpine rootfs
+        # R2.2 rootfs staging (scripts/fetch-alpine.sh) is not yet on main; stage
+        # a vanilla Alpine aarch64 minirootfs inline for now. (No guest READY-writer
+        # yet, so the round-trip can't pass until the R3.4 stub lands — see #339.)
+        # A real setup failure here fails the job — it is not hidden behind the
+        # non-gating test below.
         run: |
-          set -x
-          # R2.2 rootfs staging (scripts/fetch-alpine.sh) is not yet on main;
-          # stage a vanilla Alpine aarch64 minirootfs inline for now. Note this
-          # rootfs has no guest READY-writer, so the round-trip cannot pass until
-          # the R3.4 stub exists — that is why this step is non-gating.
           ROOTFS="$RUNNER_TEMP/rootfs"
           mkdir -p "$ROOTFS"
           curl -fsSL https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-minirootfs-3.21.7-aarch64.tar.gz \
             | tar -xz -C "$ROOTFS"
-          # boot_e2e spawns the minvmd binary, which needs the hypervisor
-          # entitlement (R1.4) — codesign the just-built debug binary.
+      - name: Build and codesign minvmd
+        # boot_e2e spawns the minvmd binary, which needs the hypervisor
+        # entitlement (R1.4). A build/codesign failure fails the job.
+        run: |
           cargo build -p minvmd --bin minvmd
           codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/debug/minvmd
+      - name: Boot E2E (READY round-trip)
+        # NON-GATING only on the test itself: expected red until #328 (guest stub)
+        # and the marker-port contract land. Setup/build/codesign above fail loudly,
+        # so this lane still catches regressions outside the known-missing pieces.
+        continue-on-error: true
+        run: |
           MINVMD_E2E=1 \
           MINVMD_KERNEL_PATH="$RUNNER_TEMP/kernel/vmlinuz" \
-          MINVMD_ROOTFS_PATH="$ROOTFS" \
+          MINVMD_ROOTFS_PATH="$RUNNER_TEMP/rootfs" \
             cargo test -p minvmd --test boot_e2e -- --include-ignored --nocapture
 
   build-macos:

--- a/scripts/fetch-virtio-kernel.sh
+++ b/scripts/fetch-virtio-kernel.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Fetch the virtio-linux kernel (vmlinuz / Image.gz) from the minimal build
+# cache. Pulls the prebuilt artifact from the public `minimal-staging-cache`
+# via the promoted Linux `minimal` CLI (gs://minimal-shim) — no kernel build,
+# no GCS credentials (the cache is public-read). The packaging `minimal` CLI is
+# Linux-only, so this runs on a Linux runner and hands the kernel to the macOS
+# boot job.
+#
+# Usage: scripts/fetch-virtio-kernel.sh <dest-vmlinuz-path> [arch]
+#   arch defaults to aarch64 (the self-hosted macOS CI runner is Apple Silicon).
+# Requires: Linux host with git, curl, ca-certificates, tar, zstd.
+set -eu
+
+DEST="${1:?usage: fetch-virtio-kernel.sh <dest-vmlinuz-path> [arch]}"
+ARCH="${2:-aarch64}"
+GCS_SHIM="https://storage.googleapis.com/minimal-shim"
+
+# The CLI binary itself must match the runner's OS/arch; the kernel it pulls is
+# selected separately via `--arch` below.
+case "$(uname -m)" in
+  x86_64 | amd64) CLI_PLATFORM="amd64-linux" ;;
+  aarch64 | arm64) CLI_PLATFORM="arm64-linux" ;;
+  *) echo "unsupported runner arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+CLI_SHA="$(curl -fsS "$GCS_SHIM/config/cli-${CLI_PLATFORM}.json" \
+  | sed -n 's/.*"version":"\([^"]*\)".*/\1/p')"
+[ -n "$CLI_SHA" ] || { echo "could not resolve promoted CLI version for $CLI_PLATFORM" >&2; exit 1; }
+echo "minimal CLI: ${CLI_PLATFORM} @ ${CLI_SHA}"
+
+curl -fsS "$GCS_SHIM/archives/cli-${CLI_PLATFORM}-${CLI_SHA}.tar.zst" -o "$TMP/cli.tar.zst"
+mkdir -p "$TMP/cli"
+tar --zstd -xf "$TMP/cli.tar.zst" -C "$TMP/cli"
+MINIMAL="$TMP/cli/bin/minimal"
+chmod +x "$MINIMAL"
+
+# Scratch project: upstream pkgs + a raw-file output that extracts the kernel
+# from the virtio-linux package's outputs.
+mkdir -p "$TMP/proj/.minimal"
+cat > "$TMP/proj/.minimal/minimal.toml" <<'TOML'
+[upstream]
+repo = "https://github.com/gominimal/pkgs"
+branch = "main"
+
+[stack]
+use = "rust"
+
+[outputs.virtio-kernel]
+type = "raw-file"
+packages = ["virtio-linux"]
+path = "usr/share/virtio-linux/vmlinuz"
+TOML
+
+cd "$TMP/proj"
+"$MINIMAL" update
+mkdir -p "$(dirname "$DEST")"
+"$MINIMAL" materialize --output "$DEST" --arch "$ARCH" virtio-kernel
+echo "fetched kernel -> $DEST ($(wc -c < "$DEST" | tr -d ' ') bytes)"


### PR DESCRIPTION
## What

Adds a CI lane that pulls the prebuilt **virtio-linux kernel** from the public minimal build cache and runs the minvmd **boot E2E** on the self-hosted macOS runner.

- `scripts/fetch-virtio-kernel.sh` — fetches the promoted Linux `minimal` CLI from `gs://minimal-shim`, then `minimal materialize`s `virtio-linux`'s `vmlinuz` from the public `minimal-staging-cache` (no kernel build, no GCS auth). Verified locally: produces a 14 MB `Image.gz`.
- `.github/workflows/ci-macos.yml`:
  - `virtio-kernel` job (ubuntu) → uploads the `vmlinuz` artifact.
  - `boot-e2e` job (self-hosted macOS) → downloads the kernel, stages a rootfs, codesigns the binary (R1.4 hypervisor entitlement), runs `boot_e2e`.

## Non-gating for now

`boot-e2e` is `continue-on-error: true`. The R2.4 READY round-trip cannot pass yet:
- guest vsock stub (R3.4) is #328, still downstream;
- marker-port contract unsettled: host `VSOCK_MARKER_PORT=9799` vs guest rootfs `7350`;
- R2.2 rootfs staging (`scripts/fetch-alpine.sh`) is not on main (staged inline here as a stopgap; vanilla Alpine has no READY-writer).

Drop `continue-on-error` to make it a required check once #328 and the port contract land. The kernel-fetch lane is the durable, reusable piece.


Refs: #339 · kernel dep gominimal/pkgs virtio-linux


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated kernel artifact retrieval for CI to streamline test assets provisioning.
  * Added Apple Silicon end-to-end boot testing in CI: downloads kernel artifact, stages a minimal rootfs, builds and signs a debug binary, and runs non-blocking boot tests (tests do not gate the workflow).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->