### PR TITLE
chore(ci): bump spectacles reusable workflows/actions to v0.1.1

### DIFF
--- a/.github/workflows/distillery-sync.yml
+++ b/.github/workflows/distillery-sync.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   distillery-sync:
-    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@v0.1.1
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
@@ -52,7 +52,10 @@ jobs:
       DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
     # Ceiling for the called reusable workflow. Must cover the union of every
     # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
-    # need issues: write, and activation needs actions: read.
+    # need issues: write, discussions: write, and pull-requests: write; the
+    # activation needs actions: read. A reusable workflow whose job requests a
+    # scope above this ceiling fails at startup, so this set must track the
+    # lock's job permissions.
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/sdd-dispatch.yml
+++ b/.github/workflows/sdd-dispatch.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: Decide whether to run, and find the tracking issue
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@v0.1.1
         with:
           app-id: ${{ vars.APP_ID }}
           github-token: ${{ github.token }}
@@ -108,7 +108,7 @@ jobs:
     steps:
       - name: Compute ready set and precondition state
         id: compute
-        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@v0.1.1
         with:
           tracking-issue: ${{ needs.route.outputs.tracking_issue }}
           trigger-kind: ${{ needs.route.outputs.trigger_kind }}
@@ -189,7 +189,7 @@ jobs:
               core.setFailed('Failed to post /execute on task #' + task
                 + ': ' + err.message);
             }
-      - name: Apply sdd:ready hint to dispatched task #${{ matrix.task }}
+      - name: Claim dispatched task #${{ matrix.task }} as sdd:in-progress
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           APP_TOKEN: ${{ steps.app.outputs.token }}
@@ -198,17 +198,48 @@ jobs:
           github-token: ${{ env.APP_TOKEN }}
           script: |
             const task = parseInt(process.env.TASK, 10);
+            // Claim the task deterministically at dispatch time: mark it
+            // sdd:in-progress and drop sdd:ready, mirroring the
+            // tracking-issue move in the lifecycle job. Done here (not in
+            // the agent run) so a dispatched-but-not-yet-booted task is
+            // visibly in flight, never indistinguishable from an
+            // un-dispatched sdd:ready task (#200). The write uses the App
+            // token; #143's trigger guard makes execute ignore issues
+            // label events (except `unlabeled needs-human`), so this does
+            // not re-fire or cancel the execute run.
+            // Add sdd:in-progress first; only drop sdd:ready once the task is
+            // confirmed in-progress, so an unexpected add failure (403/5xx)
+            // never leaves the task with neither label. A 422 means the label
+            // is already present (idempotent); any other status is fatal.
+            let inProgressPresent = false;
             try {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: task,
-                labels: ['sdd:ready'],
+                labels: ['sdd:in-progress'],
               });
+              inProgressPresent = true;
             } catch (err) {
-              // A 422 here means the label is already present; ignore.
-              core.info('Could not add sdd:ready to #' + task + ': '
-                + err.message);
+              if (err.status === 422) {
+                inProgressPresent = true;
+              } else {
+                throw err;
+              }
+            }
+            if (inProgressPresent) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: task,
+                  name: 'sdd:ready',
+                });
+              } catch (err) {
+                // A 404 here means sdd:ready was not present; ignore.
+                core.info('Could not remove sdd:ready from #' + task + ': '
+                  + err.message);
+              }
             }
 
   # Manage the tracking issue's lifecycle and sdd:dispatched labels. On the
@@ -298,8 +329,9 @@ jobs:
                   labels: ['sdd:dispatched'],
                 });
               } catch (err) {
-                core.info('Could not add sdd:dispatched to #' + tracking
+                core.setFailed('Could not add sdd:dispatched to #' + tracking
                   + ': ' + err.message);
+                throw err;
               }
             }
 

--- a/.github/workflows/sdd-execute-haiku.yml
+++ b/.github/workflows/sdd-execute-haiku.yml
@@ -65,6 +65,15 @@ on:
   # directly.
   pull_request:
     types: [unlabeled, closed]
+  # A check suite that completed on a pull request this agent opened. A
+  # failure conclusion on an `sdd/` branch is treated as an implicit
+  # /revise (issue #203): a required CI check failed and merge is BLOCKED,
+  # so the build is handed back to sdd-execute to fix on the same branch,
+  # mirroring the CHANGES_REQUESTED path. A success/neutral suite does not
+  # trigger a revise. The route step bounds the retries and escalates with
+  # needs-human after the cap.
+  check_suite:
+    types: [completed]
 
 permissions:
   contents: read
@@ -132,7 +141,8 @@ jobs:
   # without an API call).
   route:
     if: |
-      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      (github.event_name != 'issue_comment' && github.event_name != 'issues'
+        && github.event_name != 'check_suite')
       || (
         github.event_name == 'issue_comment'
         && (
@@ -148,6 +158,17 @@ jobs:
         && github.event.action == 'unlabeled'
         && github.event.label.name == 'needs-human'
       )
+      || (
+        github.event_name == 'check_suite'
+        && github.event.action == 'completed'
+        && startsWith(github.event.check_suite.head_branch, 'sdd/')
+        && (
+          github.event.check_suite.conclusion == 'failure'
+          || github.event.check_suite.conclusion == 'timed_out'
+          || github.event.check_suite.conclusion == 'cancelled'
+          || github.event.check_suite.conclusion == 'action_required'
+        )
+      )
     runs-on: ubuntu-latest
     # pull-requests: read is needed for the tier gate on a /revise issue_comment
     # (situation 6): the route fetches the pull request to read its body and
@@ -161,7 +182,13 @@ jobs:
     # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
     # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
     # re-trigger workflows, so this does not feed back into the route.
+    #
+    # checks: read is needed by the failed-required-check auto-revise branch
+    # (issue #203): it lists the check runs in the failing suite to name them
+    # in the revise directive. The same branch reuses the iteration-marker /
+    # needs-human machinery above.
     permissions:
+      checks: read
       contents: read
       issues: write
       pull-requests: write
@@ -171,7 +198,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.1
         with:
           tier: haiku
           app-id: ${{ vars.APP_ID }}
@@ -181,7 +208,7 @@ jobs:
   sdd-execute-haiku:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@v0.1.1
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -220,6 +247,9 @@ jobs:
       # Mint the App token: reading branch protection needs administration:
       # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
       # lacks, and enabling auto-merge needs pull-requests + contents write.
+      # issues: write is needed by the empty-PR guard (issue #204): it labels
+      # a 0-diff PR needs-human, and a label on a PR is written through the
+      # issues endpoint.
       - name: Mint App token
         id: app
         uses: actions/create-github-app-token@v3
@@ -231,13 +261,14 @@ jobs:
           permission-administration: read
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
       # Arm auto-merge (squash, delete-branch) only when the repo allows it
       # and the base branch protection requires at least one status check;
       # otherwise skip (issue #127). Falls back to a direct squash merge when
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.1
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-haiku.outputs.created_pr_number }}

--- a/.github/workflows/sdd-execute-opus.yml
+++ b/.github/workflows/sdd-execute-opus.yml
@@ -65,6 +65,15 @@ on:
   # directly.
   pull_request:
     types: [unlabeled, closed]
+  # A check suite that completed on a pull request this agent opened. A
+  # failure conclusion on an `sdd/` branch is treated as an implicit
+  # /revise (issue #203): a required CI check failed and merge is BLOCKED,
+  # so the build is handed back to sdd-execute to fix on the same branch,
+  # mirroring the CHANGES_REQUESTED path. A success/neutral suite does not
+  # trigger a revise. The route step bounds the retries and escalates with
+  # needs-human after the cap.
+  check_suite:
+    types: [completed]
 
 permissions:
   contents: read
@@ -132,7 +141,8 @@ jobs:
   # without an API call).
   route:
     if: |
-      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      (github.event_name != 'issue_comment' && github.event_name != 'issues'
+        && github.event_name != 'check_suite')
       || (
         github.event_name == 'issue_comment'
         && (
@@ -148,6 +158,17 @@ jobs:
         && github.event.action == 'unlabeled'
         && github.event.label.name == 'needs-human'
       )
+      || (
+        github.event_name == 'check_suite'
+        && github.event.action == 'completed'
+        && startsWith(github.event.check_suite.head_branch, 'sdd/')
+        && (
+          github.event.check_suite.conclusion == 'failure'
+          || github.event.check_suite.conclusion == 'timed_out'
+          || github.event.check_suite.conclusion == 'cancelled'
+          || github.event.check_suite.conclusion == 'action_required'
+        )
+      )
     runs-on: ubuntu-latest
     # pull-requests: read is needed for the tier gate on a /revise issue_comment
     # (situation 6): the route fetches the pull request to read its body and
@@ -161,7 +182,13 @@ jobs:
     # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
     # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
     # re-trigger workflows, so this does not feed back into the route.
+    #
+    # checks: read is needed by the failed-required-check auto-revise branch
+    # (issue #203): it lists the check runs in the failing suite to name them
+    # in the revise directive. The same branch reuses the iteration-marker /
+    # needs-human machinery above.
     permissions:
+      checks: read
       contents: read
       issues: write
       pull-requests: write
@@ -171,7 +198,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.1
         with:
           tier: opus
           app-id: ${{ vars.APP_ID }}
@@ -181,7 +208,7 @@ jobs:
   sdd-execute-opus:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@v0.1.1
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -220,6 +247,9 @@ jobs:
       # Mint the App token: reading branch protection needs administration:
       # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
       # lacks, and enabling auto-merge needs pull-requests + contents write.
+      # issues: write is needed by the empty-PR guard (issue #204): it labels
+      # a 0-diff PR needs-human, and a label on a PR is written through the
+      # issues endpoint.
       - name: Mint App token
         id: app
         uses: actions/create-github-app-token@v3
@@ -231,15 +261,74 @@ jobs:
           permission-administration: read
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
       # Arm auto-merge (squash, delete-branch) only when the repo allows it
       # and the base branch protection requires at least one status check;
       # otherwise skip (issue #127). Falls back to a direct squash merge when
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.1
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-opus.outputs.created_pr_number }}
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
+
+  # Refresh open sdd/ sibling PRs after a sibling task's PR merges (issue
+  # #207). When the cascade merges one task's PR into main, every other open
+  # sdd/ PR that touches the same files goes behind base and strands as
+  # CONFLICTING — nothing rebases or resolves it. This job sweeps the open
+  # sdd/ PRs on the merge of any sdd/ PR: a PR merely BEHIND base is refreshed
+  # in place (update-branch, which re-runs CI); a CONFLICTING PR is handed back
+  # to sdd-execute as an implicit /revise carrying a resolve-conflict directive,
+  # bounded by a hidden marker, escalating needs-human only after the cap. The
+  # posted /revise then routes to whichever tier owns each conflicting PR's
+  # linked task through that wrapper's own tier gate.
+  #
+  # DELIBERATE SINGLE-HOST SWEEP — NOT a per-tier job and NOT an omission in the
+  # haiku/sonnet wrappers. The sweep is a property of main advancing (a sibling
+  # sdd/ PR merging), not of any one tier executing, so it must fire exactly
+  # once per merge from exactly one place. All three sdd-execute-{haiku,sonnet,
+  # opus} wrappers subscribe to the same pull_request.closed event, so hosting
+  # this job in every wrapper would sweep three times per merge (triple /revise,
+  # triple update-branch). It therefore lives only here, in the opus wrapper,
+  # chosen as the arbitrary singleton host; do NOT copy it into the haiku/sonnet
+  # wrappers.
+  #
+  # Independent of the opus tier actually running: this is a top-level job whose
+  # only gate is the main-advance event below. It has no `needs:` on route /
+  # sdd-execute-opus and mints its own App token, so it fires on every merged
+  # sdd/ PR even when the merged PR (and every conflicting sibling) belongs to
+  # the haiku or sonnet tier and the opus route/execute jobs are skipped.
+  refresh-siblings:
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.action == 'closed'
+      && github.event.pull_request.merged == true
+      && startsWith(github.event.pull_request.head.ref, 'sdd/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Mint the App token: update-branch needs contents:write and posting the
+      # /revise comment needs pull-requests:write. The App identity is required
+      # so the posted /revise re-triggers the owning-tier sdd-execute wrapper
+      # (a GITHUB_TOKEN comment would not).
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+      - name: Sweep open sdd/ PRs and refresh those behind base
+        uses: norrietaylor/spectacles/.github/actions/sdd-refresh-siblings@v0.1.1
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          merged-pr-number: ${{ github.event.pull_request.number }}
+          max-resolve-iterations: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}

--- a/.github/workflows/sdd-execute-sonnet.yml
+++ b/.github/workflows/sdd-execute-sonnet.yml
@@ -65,6 +65,15 @@ on:
   # directly.
   pull_request:
     types: [unlabeled, closed]
+  # A check suite that completed on a pull request this agent opened. A
+  # failure conclusion on an `sdd/` branch is treated as an implicit
+  # /revise (issue #203): a required CI check failed and merge is BLOCKED,
+  # so the build is handed back to sdd-execute to fix on the same branch,
+  # mirroring the CHANGES_REQUESTED path. A success/neutral suite does not
+  # trigger a revise. The route step bounds the retries and escalates with
+  # needs-human after the cap.
+  check_suite:
+    types: [completed]
 
 permissions:
   contents: read
@@ -132,7 +141,8 @@ jobs:
   # without an API call).
   route:
     if: |
-      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      (github.event_name != 'issue_comment' && github.event_name != 'issues'
+        && github.event_name != 'check_suite')
       || (
         github.event_name == 'issue_comment'
         && (
@@ -148,6 +158,17 @@ jobs:
         && github.event.action == 'unlabeled'
         && github.event.label.name == 'needs-human'
       )
+      || (
+        github.event_name == 'check_suite'
+        && github.event.action == 'completed'
+        && startsWith(github.event.check_suite.head_branch, 'sdd/')
+        && (
+          github.event.check_suite.conclusion == 'failure'
+          || github.event.check_suite.conclusion == 'timed_out'
+          || github.event.check_suite.conclusion == 'cancelled'
+          || github.event.check_suite.conclusion == 'action_required'
+        )
+      )
     runs-on: ubuntu-latest
     # pull-requests: read is needed for the tier gate on a /revise issue_comment
     # (situation 6): the route fetches the pull request to read its body and
@@ -161,7 +182,13 @@ jobs:
     # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
     # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
     # re-trigger workflows, so this does not feed back into the route.
+    #
+    # checks: read is needed by the failed-required-check auto-revise branch
+    # (issue #203): it lists the check runs in the failing suite to name them
+    # in the revise directive. The same branch reuses the iteration-marker /
+    # needs-human machinery above.
     permissions:
+      checks: read
       contents: read
       issues: write
       pull-requests: write
@@ -171,7 +198,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.1
         with:
           tier: sonnet
           app-id: ${{ vars.APP_ID }}
@@ -181,7 +208,7 @@ jobs:
   sdd-execute-sonnet:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@v0.1.1
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -220,6 +247,9 @@ jobs:
       # Mint the App token: reading branch protection needs administration:
       # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
       # lacks, and enabling auto-merge needs pull-requests + contents write.
+      # issues: write is needed by the empty-PR guard (issue #204): it labels
+      # a 0-diff PR needs-human, and a label on a PR is written through the
+      # issues endpoint.
       - name: Mint App token
         id: app
         uses: actions/create-github-app-token@v3
@@ -231,13 +261,14 @@ jobs:
           permission-administration: read
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
       # Arm auto-merge (squash, delete-branch) only when the repo allows it
       # and the base branch protection requires at least one status check;
       # otherwise skip (issue #127). Falls back to a direct squash merge when
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.1
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-sonnet.outputs.created_pr_number }}

--- a/.github/workflows/sdd-monitor.yml
+++ b/.github/workflows/sdd-monitor.yml
@@ -132,7 +132,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Nudge armed-but-idle trackers
-        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@v0.1.1
         with:
           github-token: ${{ steps.app.outputs.token }}
           debounce-min: ${{ vars.SDD_MONITOR_DEBOUNCE_MIN }}

--- a/.github/workflows/sdd-pr-sanitize.yml
+++ b/.github/workflows/sdd-pr-sanitize.yml
@@ -63,6 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Correct the issue references in the pull request body
-        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@v0.1.1
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-review.yml
+++ b/.github/workflows/sdd-review.yml
@@ -52,14 +52,14 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@v0.1.1
         with:
           github-token: ${{ github.token }}
 
   sdd-review:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@v0.1.1
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -116,7 +116,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-pull-requests: write
       - name: Resolve App-bot advisory review threads
-        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@v0.1.1
         with:
           github-token: ${{ steps.app.outputs.token }}
           bot-login: ${{ steps.app.outputs.app-slug }}[bot]

--- a/.github/workflows/sdd-spec.yml
+++ b/.github/workflows/sdd-spec.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@v0.1.1
         with:
           github-token: ${{ github.token }}
 
@@ -121,7 +121,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Find plan comment and dispatch sdd-execute-{tier}
-        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.1.1
         with:
           github-token: ${{ steps.app.outputs.token }}
           tracking: ${{ needs.route.outputs.fastpath_tracking }}
@@ -129,7 +129,7 @@ jobs:
   sdd-spec:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@v0.1.1
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -186,7 +186,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Post failure hand-off to tracking issue
-        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@v0.1.1
         with:
           github-token: ${{ steps.app.outputs.token }}
           aw-context: ${{ needs.route.outputs.aw_context }}

--- a/.github/workflows/sdd-triage-dedupe-tasks.yml
+++ b/.github/workflows/sdd-triage-dedupe-tasks.yml
@@ -37,6 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close a duplicate phase-C task sub-issue
-        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@v0.1.1
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage-promote-ready.yml
+++ b/.github/workflows/sdd-triage-promote-ready.yml
@@ -57,6 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Promote tasks whose last blocker just closed
-        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@v0.1.1
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage.yml
+++ b/.github/workflows/sdd-triage.yml
@@ -79,14 +79,14 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.1.1
         with:
           github-token: ${{ github.token }}
 
   sdd-triage:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.1.1
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets

--- a/.github/workflows/sdd-validate.yml
+++ b/.github/workflows/sdd-validate.yml
@@ -81,14 +81,14 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@v0.1.1
         with:
           github-token: ${{ github.token }}
 
   sdd-validate:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@v0.1.1
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets


### PR DESCRIPTION
Update all 13 SDD thin wrappers to spectacles `v0.1.1`, re-rendered from the v0.1.1 wrapper sources (not a version-string sed) so the wrapper bodies track the release.

## Pins
All `norrietaylor/spectacles` reusable-workflow (`.lock.yml`) and composite-action refs bumped `@v0.1.0` → `@v0.1.1`.

## Wrapper-body changes pulled from v0.1.1
[v0.1.0...v0.1.1](https://github.com/norrietaylor/spectacles/compare/v0.1.0...v0.1.1)

- `sdd-dispatch`, `sdd-execute-{haiku,sonnet,opus}`: v0.1.1 wrapper-body updates
- `distillery-sync`: grant `discussions: write` and `pull-requests: write` on the nested-job permissions ceiling to match the lock's job permissions ([899c74f](https://github.com/norrietaylor/spectacles/commit/899c74f))

## Scope
13 files under `.github/workflows/` (`sdd-*.yml`, `distillery-sync.yml`). No other files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation infrastructure components to v0.1.1 across all workflows.
  * Enhanced handling of failed and blocked build check completions with automatic remediation routing.
  * Improved error handling for critical workflow steps with stricter failure detection.
  * Extended automation permissions to support additional safeguards and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->