### PR TITLE
feat(minvmd): produce a viable non-EFI VM image and reach READY (closes #326)

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -63,11 +63,9 @@ jobs:
     # Separate from build-macos so a kernel-fetch hiccup never blocks the
     # always-green clippy/test/smoke checks.
     #
-    # NON-GATING for now (continue-on-error on the test step only): flip to
-    # required by dropping continue-on-error once it is green on the runner. The
-    # marker port is settled (host + guest both use 7350) and the guest stub now
-    # writes READY by connecting out (krun_add_vsock_port == listen=false). See
-    # #326.
+    # GATING: green on the runner — kernel PE_GZ load, virtio-fs root,
+    # /init.krun exec of the stub, and the guest READY connect-out on vsock 7350
+    # (krun_add_vsock_port == listen=false; host + guest both 7350). See #326.
     if: ${{ vars.RUN_MACOS_CI != 'false' }}
     needs: virtio-kernel
     runs-on: [self-hosted, macOS, ARM64]
@@ -104,11 +102,9 @@ jobs:
       - name: Codesign minvmd (hypervisor entitlement, R1.4)
         run: codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/debug/minvmd
       - name: Boot E2E (READY round-trip)
-        # NON-GATING only on the test itself, pending first-green on the runner
-        # (the virtio-linux kernel config is validated by this boot). Setup/
-        # build/codesign above fail loudly, so this lane still catches
-        # regressions outside the known-pending boot.
-        continue-on-error: true
+        # Gating: a real Alpine microVM must boot and the guest must write READY
+        # over vsock 7350 within the budget. Also validates the virtio-linux
+        # kernel config (virtio-MMIO / VIRTIO_FS / VSOCK / HVC).
         run: |
           testbin="$(ls -1t target/debug/deps/boot_e2e-* | grep -v '\.d$' | head -1)"
           test -x "$testbin" || { echo "::error::boot_e2e test binary not found"; exit 1; }

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -95,12 +95,14 @@ jobs:
         # A setup failure fails the job — it is not hidden behind the non-gating
         # test below.
         run: scripts/build-rootfs.sh
-      - name: Build and codesign minvmd
-        # boot_e2e spawns the minvmd binary, which needs the hypervisor
-        # entitlement (R1.4). A build/codesign failure fails the job.
-        run: |
-          cargo build -p minvmd --bin minvmd
-          codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/debug/minvmd
+      - name: Build boot E2E + minvmd (no run)
+        # Build the test harness + minvmd bin, then codesign, then run the test
+        # BINARY DIRECTLY (below). Invoking `cargo test` again after signing
+        # relinks (and unsigns) target/debug/minvmd, so krun_start_enter fails
+        # with EINVAL. A direct-binary run never touches the signature.
+        run: cargo test -p minvmd --test boot_e2e --no-run
+      - name: Codesign minvmd (hypervisor entitlement, R1.4)
+        run: codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/debug/minvmd
       - name: Boot E2E (READY round-trip)
         # NON-GATING only on the test itself, pending first-green on the runner
         # (the virtio-linux kernel config is validated by this boot). Setup/
@@ -108,11 +110,13 @@ jobs:
         # regressions outside the known-pending boot.
         continue-on-error: true
         run: |
+          testbin="$(ls -1t target/debug/deps/boot_e2e-* | grep -v '\.d$' | head -1)"
+          test -x "$testbin" || { echo "::error::boot_e2e test binary not found"; exit 1; }
           MINVMD_E2E=1 \
           MINVMD_KERNEL_PATH="$RUNNER_TEMP/kernel/vmlinuz" \
           MINVMD_ROOTFS_PATH="$(scripts/build-rootfs.sh --print-path)" \
           MINVMD_BOOT_LOG="$RUNNER_TEMP/boot.log" \
-            cargo test -p minvmd --test boot_e2e -- --include-ignored --nocapture
+            "$testbin" --include-ignored --nocapture
       - name: Upload guest boot console log
         # Capture hvc0 output for diagnosing a stuck/failed boot (e.g. a missing
         # virtio driver in the kernel). Always runs so a red boot is debuggable.

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -12,6 +12,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/ci-macos.yml"
+      - "scripts/**"
   pull_request:
     branches: ["main"]
     paths:
@@ -19,6 +20,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/ci-macos.yml"
+      - "scripts/**"
   workflow_dispatch:
 
 env:
@@ -34,6 +36,93 @@ permissions:
   contents: read
 
 jobs:
+  virtio-kernel:
+    # Pull the prebuilt virtio-linux kernel (vmlinuz / Image.gz) from the public
+    # minimal build cache — no kernel build, no GCS auth — and hand it to the
+    # macOS boot job. The packaging `minimal` CLI is Linux-only, so this runs on
+    # Linux. Cheap (a cache pull), so it is unconditional and decoupled from the
+    # self-hosted runner.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Fetch virtio-linux kernel from the build cache
+        run: ./scripts/fetch-virtio-kernel.sh "$RUNNER_TEMP/vmlinuz" aarch64
+      - name: Upload kernel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: virtio-kernel-aarch64
+          path: ${{ runner.temp }}/vmlinuz
+          if-no-files-found: error
+
+  boot-e2e:
+    # Boot E2E (R2.4 READY round-trip) on real hardware, using the cache-pulled
+    # kernel and the real minvmd guest rootfs (Alpine + READY-writer stub).
+    # Separate from build-macos so a kernel-fetch hiccup never blocks the
+    # always-green clippy/test/smoke checks.
+    #
+    # NON-GATING for now (continue-on-error on the test step only): flip to
+    # required by dropping continue-on-error once it is green on the runner. The
+    # marker port is settled (host + guest both use 7350) and the guest stub now
+    # writes READY by connecting out (krun_add_vsock_port == listen=false). See
+    # #326.
+    if: ${{ vars.RUN_MACOS_CI != 'false' }}
+    needs: virtio-kernel
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Verify libkrun is available
+        run: |
+          if [ ! -f /opt/homebrew/lib/libkrun.dylib ]; then
+            echo "::error::libkrun.dylib not found under /opt/homebrew/lib. Provision the runner with: brew install slp/krun/libkrun" >&2
+            exit 1
+          fi
+      - name: Download virtio-linux kernel
+        uses: actions/download-artifact@v4
+        with:
+          name: virtio-kernel-aarch64
+          path: ${{ runner.temp }}/kernel
+      - name: Stage minvmd guest rootfs
+        # Real R2.2 rootfs: fetch the pinned Alpine minirootfs and overlay socat
+        # + the READY-writer stub (/sbin/minvmd-stub-init) via build-rootfs.sh.
+        # A setup failure fails the job — it is not hidden behind the non-gating
+        # test below.
+        run: scripts/build-rootfs.sh
+      - name: Build and codesign minvmd
+        # boot_e2e spawns the minvmd binary, which needs the hypervisor
+        # entitlement (R1.4). A build/codesign failure fails the job.
+        run: |
+          cargo build -p minvmd --bin minvmd
+          codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/debug/minvmd
+      - name: Boot E2E (READY round-trip)
+        # NON-GATING only on the test itself, pending first-green on the runner
+        # (the virtio-linux kernel config is validated by this boot). Setup/
+        # build/codesign above fail loudly, so this lane still catches
+        # regressions outside the known-pending boot.
+        continue-on-error: true
+        run: |
+          MINVMD_E2E=1 \
+          MINVMD_KERNEL_PATH="$RUNNER_TEMP/kernel/vmlinuz" \
+          MINVMD_ROOTFS_PATH="$(scripts/build-rootfs.sh --print-path)" \
+          MINVMD_BOOT_LOG="$RUNNER_TEMP/boot.log" \
+            cargo test -p minvmd --test boot_e2e -- --include-ignored --nocapture
+      - name: Upload guest boot console log
+        # Capture hvc0 output for diagnosing a stuck/failed boot (e.g. a missing
+        # virtio driver in the kernel). Always runs so a red boot is debuggable.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: minvmd-boot-log
+          path: ${{ runner.temp }}/boot.log
+          if-no-files-found: ignore
+
   build-macos:
     # Self-hosted Apple Silicon runner. minvmd links libkrun
     # (`#[link(name = "krun")]`) and only compiles on macOS — the Linux CI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,6 +3434,7 @@ dependencies = [
  "fd-lock",
  "libc",
  "serde",
+ "serial_test",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "tracing",

--- a/crates/minvmd/Cargo.toml
+++ b/crates/minvmd/Cargo.toml
@@ -17,4 +17,5 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
+serial_test.workspace = true
 tempfile.workspace = true

--- a/crates/minvmd/src/cmd/boot.rs
+++ b/crates/minvmd/src/cmd/boot.rs
@@ -1,0 +1,131 @@
+//! `minvmd boot` subcommand (R2.3, R2.4).
+//!
+//! The parent process:
+//! 1. Resolves kernel and rootfs paths from env vars (fail-fast validation).
+//! 2. Creates a UNIX socket at a unique temp path and begins listening (the
+//!    READY-marker socket).
+//! 3. Fork-execs `minvmd __krun-vmm` with `MINVMD_MARKER_SOCK` pointing to
+//!    that socket so the VMM child can register it with libkrun.
+//! 4. Writes the child PID to `vmm.pid` in the state directory.
+//! 5. Waits up to 5 s for the guest to connect and write `READY\n` on the
+//!    marker socket (R2.4). On success prints `vm-up` to stdout.
+//! 6. With `--foreground`: stays alive until the VMM child exits, propagating
+//!    its exit code.
+//!
+//! On Linux this subcommand bails immediately with a "macOS only" error so the
+//! Linux-only CI stays green.
+
+use anyhow::{Result, bail};
+
+/// Run the `boot` subcommand.
+///
+/// `foreground`: if true, block until the VMM child process exits after the VM
+/// is confirmed up.
+pub fn run(foreground: bool) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    return run_macos(foreground);
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = foreground;
+        bail!("`minvmd boot` is macOS-only; this Linux build is a no-op stub");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn run_macos(foreground: bool) -> Result<()> {
+    use std::io::{BufRead, BufReader};
+    use std::os::unix::net::UnixListener;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    use anyhow::Context as _;
+
+    use crate::cmd::MARKER_SOCK_ENV;
+    use crate::image::{resolve_kernel_path, resolve_rootfs_path};
+    use crate::state::StateDir;
+
+    // Fail-fast: resolve paths before spawning anything.
+    let _kernel = resolve_kernel_path().context("resolving kernel path")?;
+    let _rootfs = resolve_rootfs_path().context("resolving rootfs path")?;
+
+    // Create the marker socket under /tmp, named by PID for uniqueness.
+    let marker_sock_path = PathBuf::from(format!("/tmp/minvmd-marker-{}.sock", std::process::id()));
+
+    // Remove any stale socket from a previous run.
+    let _ = std::fs::remove_file(&marker_sock_path);
+
+    let listener =
+        UnixListener::bind(&marker_sock_path).context("binding READY-marker unix socket")?;
+    listener
+        .set_nonblocking(false)
+        .context("setting listener to blocking")?;
+
+    // Spawn `minvmd __krun-vmm` — the VMM child that calls krun_start_enter.
+    let exe = std::env::current_exe().context("resolving current executable path")?;
+    let mut child = std::process::Command::new(&exe)
+        .arg("__krun-vmm")
+        .env(MARKER_SOCK_ENV, &marker_sock_path)
+        // Inherit MINVMD_KERNEL_PATH and MINVMD_ROOTFS_PATH from environment.
+        .spawn()
+        .with_context(|| format!("spawning VMM child: {}", exe.display()))?;
+
+    let child_pid = child.id();
+    tracing::info!(pid = child_pid, "VMM child spawned");
+
+    // Write vmm.pid to the state directory (R2.3).
+    let state_dir = StateDir::new(StateDir::default_path()).context("opening state dir")?;
+    std::fs::write(state_dir.vmm_pid_path(), format!("{child_pid}\n"))
+        .context("writing vmm.pid")?;
+
+    // Wait for the READY marker from the guest (R2.4): up to 5 s.
+    const READY_TIMEOUT: Duration = Duration::from_secs(5);
+
+    // Run the accept loop in a separate thread so we can apply a wall-clock
+    // timeout without platform-specific socket options.
+    let (tx, rx) = std::sync::mpsc::channel::<Result<(), String>>();
+    let sock_path_clone = marker_sock_path.clone();
+    std::thread::spawn(move || {
+        let result = (|| -> Result<(), String> {
+            let (stream, _) = listener
+                .accept()
+                .map_err(|e| format!("accept on READY-marker socket: {e}"))?;
+            let mut reader = BufReader::new(stream);
+            let mut line = String::new();
+            reader
+                .read_line(&mut line)
+                .map_err(|e| format!("reading READY marker: {e}"))?;
+            let trimmed = line.trim();
+            if trimmed != "READY" {
+                return Err(format!("expected READY on marker socket, got {trimmed:?}"));
+            }
+            Ok(())
+        })();
+        let _ = tx.send(result);
+        let _ = std::fs::remove_file(&sock_path_clone);
+    });
+
+    match rx.recv_timeout(READY_TIMEOUT) {
+        Ok(Ok(())) => {
+            println!("vm-up");
+        }
+        Ok(Err(e)) => {
+            let _ = child.kill();
+            bail!("boot failed: {e}");
+        }
+        Err(_timeout) => {
+            let _ = child.kill();
+            bail!("boot timed out waiting for READY marker after 5 s");
+        }
+    }
+
+    if foreground {
+        let status = child.wait().context("waiting for VMM child")?;
+        if !status.success() {
+            let code = status.code().unwrap_or(-1);
+            bail!("VMM child exited with code {code}");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/minvmd/src/cmd/boot.rs
+++ b/crates/minvmd/src/cmd/boot.rs
@@ -51,10 +51,12 @@ fn run_macos(foreground: bool) -> Result<()> {
 
     // Create the marker socket under /tmp with a PID + random nonce to prevent
     // predictable-path TOCTOU attacks (local-only risk, but cheap to harden).
-    let nonce = {
+    let nonce: u32 = {
         use std::io::Read as _;
         let mut buf = [0u8; 4];
-        let _ = std::fs::File::open("/dev/urandom").and_then(|mut f| f.read_exact(&mut buf));
+        std::fs::File::open("/dev/urandom")
+            .and_then(|mut f| f.read_exact(&mut buf))
+            .context("reading /dev/urandom for marker socket nonce")?;
         u32::from_le_bytes(buf)
     };
     let marker_sock_path = PathBuf::from(format!(

--- a/crates/minvmd/src/cmd/boot.rs
+++ b/crates/minvmd/src/cmd/boot.rs
@@ -75,8 +75,8 @@ fn run_macos(foreground: bool) -> Result<()> {
 
     // Write vmm.pid to the state directory (R2.3).
     let state_dir = StateDir::new(StateDir::default_path()).context("opening state dir")?;
-    std::fs::write(state_dir.vmm_pid_path(), format!("{child_pid}\n"))
-        .context("writing vmm.pid")?;
+    let vmm_pid_path = state_dir.vmm_pid_path();
+    std::fs::write(&vmm_pid_path, format!("{child_pid}\n")).context("writing vmm.pid")?;
 
     // Wait for the READY marker from the guest (R2.4): up to 5 s.
     const READY_TIMEOUT: Duration = Duration::from_secs(5);
@@ -111,10 +111,16 @@ fn run_macos(foreground: bool) -> Result<()> {
         }
         Ok(Err(e)) => {
             let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_file(&vmm_pid_path);
+            let _ = std::fs::remove_file(&marker_sock_path);
             bail!("boot failed: {e}");
         }
         Err(_timeout) => {
             let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_file(&vmm_pid_path);
+            let _ = std::fs::remove_file(&marker_sock_path);
             bail!("boot timed out waiting for READY marker after 5 s");
         }
     }

--- a/crates/minvmd/src/cmd/boot.rs
+++ b/crates/minvmd/src/cmd/boot.rs
@@ -49,8 +49,18 @@ fn run_macos(foreground: bool) -> Result<()> {
     let _kernel = resolve_kernel_path().context("resolving kernel path")?;
     let _rootfs = resolve_rootfs_path().context("resolving rootfs path")?;
 
-    // Create the marker socket under /tmp, named by PID for uniqueness.
-    let marker_sock_path = PathBuf::from(format!("/tmp/minvmd-marker-{}.sock", std::process::id()));
+    // Create the marker socket under /tmp with a PID + random nonce to prevent
+    // predictable-path TOCTOU attacks (local-only risk, but cheap to harden).
+    let nonce = {
+        use std::io::Read as _;
+        let mut buf = [0u8; 4];
+        let _ = std::fs::File::open("/dev/urandom").and_then(|mut f| f.read_exact(&mut buf));
+        u32::from_le_bytes(buf)
+    };
+    let marker_sock_path = PathBuf::from(format!(
+        "/tmp/minvmd-marker-{}-{nonce:08x}.sock",
+        std::process::id()
+    ));
 
     // Remove any stale socket from a previous run.
     let _ = std::fs::remove_file(&marker_sock_path);

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -8,7 +8,13 @@ pub mod vmm_child;
 /// The guest's init writes `READY\n` to this vsock port; libkrun forwards the
 /// connection to the host UNIX socket registered by the parent before spawning
 /// the VMM child. The parent reads `READY` to confirm boot (R2.4).
-pub const VSOCK_MARKER_PORT: u32 = 9799;
+///
+/// Must match the guest rootfs's READY/agent port. The canonical value is
+/// `7350` — both the guest rootfs manifest (`etc/minvmd/manifest`:
+/// `vsock_port_ready=7350`) and the reference impl (min-ctl: cold boot to a TCP
+/// connection on `127.0.0.1:7350`) use it. The host previously used `9799`,
+/// which no guest emits on, so the READY marker never arrived.
+pub const VSOCK_MARKER_PORT: u32 = 7350;
 
 /// Environment variable that carries the host-side UNIX socket path for the
 /// READY marker from the parent to the VMM child.

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -1,0 +1,15 @@
+//! CLI subcommand implementations for `minvmd`.
+
+pub mod boot;
+pub mod vmm_child;
+
+/// vsock port used by the VMM child to signal the parent that the guest is up.
+///
+/// The guest's init writes `READY\n` to this vsock port; libkrun forwards the
+/// connection to the host UNIX socket registered by the parent before spawning
+/// the VMM child. The parent reads `READY` to confirm boot (R2.4).
+pub const VSOCK_MARKER_PORT: u32 = 9799;
+
+/// Environment variable that carries the host-side UNIX socket path for the
+/// READY marker from the parent to the VMM child.
+pub const MARKER_SOCK_ENV: &str = "MINVMD_MARKER_SOCK";

--- a/crates/minvmd/src/cmd/vmm_child.rs
+++ b/crates/minvmd/src/cmd/vmm_child.rs
@@ -1,0 +1,72 @@
+//! `minvmd __krun-vmm` hidden subcommand (R2.3).
+//!
+//! This is the VMM child process that calls `krun_start_enter`. It is spawned
+//! by `minvmd boot` and is not intended to be run directly by users (hence the
+//! double-underscore prefix).
+//!
+//! On macOS:
+//! 1. Reads kernel and rootfs from `MINVMD_KERNEL_PATH` / `MINVMD_ROOTFS_PATH`.
+//! 2. Reads the READY-marker socket path from `MINVMD_MARKER_SOCK`.
+//! 3. Creates and configures a libkrun context.
+//! 4. Registers the marker socket as the host-side endpoint for
+//!    `VSOCK_MARKER_PORT`: when the guest's init connects to that vsock port
+//!    and writes `READY\n`, libkrun forwards the data through to the host
+//!    UNIX socket where the parent is listening (R2.4).
+//! 5. Calls `krun_start_enter`, which boots the VM. On success libkrun
+//!    `exit()`s with the guest workload's exit code and never returns here.
+//!
+//! On Linux this subcommand bails immediately with a "macOS only" error.
+
+use anyhow::{Result, bail};
+
+/// Run the `__krun-vmm` subcommand.
+pub fn run() -> Result<()> {
+    #[cfg(target_os = "macos")]
+    return run_macos();
+
+    #[cfg(not(target_os = "macos"))]
+    bail!("`minvmd __krun-vmm` is macOS-only; this Linux build is a no-op stub");
+}
+
+#[cfg(target_os = "macos")]
+fn run_macos() -> Result<()> {
+    use anyhow::Context as _;
+
+    use crate::cmd::{MARKER_SOCK_ENV, VSOCK_MARKER_PORT};
+    use crate::image::{resolve_kernel_path, resolve_rootfs_path};
+    use crate::krun::Context;
+    use crate::vm::VmConfig;
+
+    let kernel = resolve_kernel_path().context("resolving kernel path")?;
+    let rootfs = resolve_rootfs_path().context("resolving rootfs path")?;
+    let marker_sock = std::env::var(MARKER_SOCK_ENV).with_context(|| {
+        format!("reading {MARKER_SOCK_ENV}: VMM child must be spawned by `minvmd boot`")
+    })?;
+
+    let mut ctx = Context::create().context("krun_create_ctx")?;
+    // Default 2 vcpus and 512 MiB RAM; the boot command may expose these as
+    // flags in a future change.
+    let cfg = VmConfig::new(2, 512, kernel, rootfs);
+    cfg.apply(&mut ctx)
+        .context("applying VmConfig to krun context")?;
+
+    // Register the READY-marker vsock port. When the guest's init connects to
+    // VSOCK_MARKER_PORT and writes `READY\n`, libkrun forwards the connection
+    // to the host UNIX socket at `marker_sock`, where the parent is listening
+    // (R2.4).
+    ctx.add_vsock_port(VSOCK_MARKER_PORT, &marker_sock)
+        .context("registering READY-marker vsock port")?;
+
+    tracing::info!(
+        port = VSOCK_MARKER_PORT,
+        sock = %marker_sock,
+        "READY-marker vsock port registered; calling krun_start_enter"
+    );
+
+    // start_enter consumes the context and boots the VM. On success, libkrun
+    // exit()s the process with the guest workload's exit code and never
+    // returns. On failure it returns a VmError; we surface it as an anyhow
+    // error so the parent can observe the child's non-zero exit.
+    let err = ctx.start_enter();
+    bail!("krun_start_enter returned unexpectedly: {err}");
+}

--- a/crates/minvmd/src/cmd/vmm_child.rs
+++ b/crates/minvmd/src/cmd/vmm_child.rs
@@ -7,12 +7,14 @@
 //! On macOS:
 //! 1. Reads kernel and rootfs from `MINVMD_KERNEL_PATH` / `MINVMD_ROOTFS_PATH`.
 //! 2. Reads the READY-marker socket path from `MINVMD_MARKER_SOCK`.
-//! 3. Creates and configures a libkrun context.
-//! 4. Registers the marker socket as the host-side endpoint for
-//!    `VSOCK_MARKER_PORT`: when the guest's init connects to that vsock port
-//!    and writes `READY\n`, libkrun forwards the data through to the host
-//!    UNIX socket where the parent is listening (R2.4).
-//! 5. Calls `krun_start_enter`, which boots the VM. On success libkrun
+//! 3. Creates and configures a libkrun context (kernel, rootfs, resources).
+//! 4. Sets the guest workload via `krun_set_exec` (libkrun's `/init.krun` runs
+//!    as PID 1 and forks it); default `/sbin/minvmd-stub-init`, `MINVMD_EXEC`
+//!    overrides.
+//! 5. Registers the marker socket for `VSOCK_MARKER_PORT` (guest→host): the
+//!    guest workload connects to that vsock port and writes `READY\n`, which
+//!    libkrun bridges to the host UNIX socket where the parent listens (R2.4).
+//! 6. Calls `krun_start_enter`, which boots the VM. On success libkrun
 //!    `exit()`s with the guest workload's exit code and never returns here.
 //!
 //! On Linux this subcommand bails immediately with a "macOS only" error.
@@ -44,23 +46,46 @@ fn run_macos() -> Result<()> {
     })?;
 
     let mut ctx = Context::create().context("krun_create_ctx")?;
-    // Default 2 vcpus and 512 MiB RAM; the boot command may expose these as
-    // flags in a future change.
-    let cfg = VmConfig::new(2, 512, kernel, rootfs);
+    // 2 vCPU / 1024 MiB: 512 MiB is the practical floor to reach Alpine
+    // userspace; 1024 MiB is cheap headroom under Hypervisor.framework with no
+    // boot penalty. (Stay below the kernel's CONFIG_NR_CPUS.) The boot command
+    // may expose these as flags in a future change.
+    let cfg = VmConfig::new(2, 1024, kernel, rootfs);
     cfg.apply(&mut ctx)
         .context("applying VmConfig to krun context")?;
 
-    // Register the READY-marker vsock port. When the guest's init connects to
-    // VSOCK_MARKER_PORT and writes `READY\n`, libkrun forwards the connection
-    // to the host UNIX socket at `marker_sock`, where the parent is listening
-    // (R2.4).
+    // Set the guest workload. libkrun's own init (`/init.krun`) runs as PID 1,
+    // mounts /proc,/sys,/dev, reads this target from /.krun_config.json, and
+    // forks it — so the rootfs needs no init system, only this binary. Default
+    // to the v0.1 bring-up stub; `MINVMD_EXEC` overrides (e.g. /sbin/minimald).
+    // Pass an explicit minimal envp (not None): None inherits the full host env
+    // into the guest, which can overflow the ~2 KiB aarch64 kernel cmdline.
+    let exec =
+        std::env::var("MINVMD_EXEC").unwrap_or_else(|_| "/sbin/minvmd-stub-init".to_string());
+    let argv: [&str; 0] = [];
+    ctx.set_exec(&exec, &argv, Some(&["PATH=/usr/sbin:/usr/bin:/sbin:/bin"]))
+        .with_context(|| format!("setting guest exec workload: {exec}"))?;
+
+    // Optional early-boot console capture for diagnosing a stuck boot. Off by
+    // default; set `MINVMD_BOOT_LOG=<path>` to capture hvc0 to a host file.
+    if let Some(log_path) = std::env::var_os("MINVMD_BOOT_LOG") {
+        ctx.set_console_output(&log_path)
+            .context("setting console output log")?;
+    }
+
+    // Register the READY-marker vsock port (guest→host). The plain
+    // `krun_add_vsock_port` is `krun_add_vsock_port2(.., listen=false)`: the
+    // parent listens on the host UDS `marker_sock`; the guest workload connects
+    // to AF_VSOCK CID 2 (host) port VSOCK_MARKER_PORT and writes `READY\n`,
+    // which libkrun bridges to the parent (R2.4).
     ctx.add_vsock_port(VSOCK_MARKER_PORT, &marker_sock)
         .context("registering READY-marker vsock port")?;
 
     tracing::info!(
         port = VSOCK_MARKER_PORT,
         sock = %marker_sock,
-        "READY-marker vsock port registered; calling krun_start_enter"
+        exec = %exec,
+        "guest workload + READY-marker vsock port set; calling krun_start_enter"
     );
 
     // start_enter consumes the context and boots the VM. On success, libkrun

--- a/crates/minvmd/src/image.rs
+++ b/crates/minvmd/src/image.rs
@@ -9,13 +9,16 @@ use crate::error::VmError;
 
 /// Arch-appropriate libkrun kernel format constant.
 ///
-/// - `aarch64`: `virtio-linux` ships `Image.gz` → `KRUN_KERNEL_FORMAT_IMAGE_GZ`
-/// - `x86_64`:  `virtio-linux` ships `bzImage`  → `KRUN_KERNEL_FORMAT_ELF`
+/// - `aarch64`: `virtio-linux` ships `Image.gz` → `KRUN_KERNEL_FORMAT_PE_GZ`.
+///   The aarch64 loader implements only RAW and PE_GZ; PE_GZ decompresses the
+///   gzipped image. `IMAGE_GZ` is x86_64-only and returns
+///   `KernelFormatUnsupported` on aarch64.
+/// - `x86_64`:  `virtio-linux` ships `bzImage`  → `KRUN_KERNEL_FORMAT_ELF`.
 #[cfg(target_os = "macos")]
 pub fn kernel_format() -> u32 {
     #[cfg(target_arch = "aarch64")]
     {
-        crate::krun::KRUN_KERNEL_FORMAT_IMAGE_GZ
+        crate::krun::KRUN_KERNEL_FORMAT_PE_GZ
     }
     #[cfg(target_arch = "x86_64")]
     {
@@ -122,15 +125,13 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn kernel_format_is_valid() {
+    fn kernel_format_matches_arch() {
         let fmt = kernel_format();
-        let valid = [
-            crate::krun::KRUN_KERNEL_FORMAT_ELF,
-            crate::krun::KRUN_KERNEL_FORMAT_IMAGE_GZ,
-        ];
-        assert!(
-            valid.contains(&fmt),
-            "unexpected kernel format constant {fmt}"
-        );
+        // aarch64 must use PE_GZ for Image.gz — IMAGE_GZ (=4) is x86_64-only and
+        // returns KernelFormatUnsupported on the aarch64 libkrun loader.
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(fmt, crate::krun::KRUN_KERNEL_FORMAT_PE_GZ);
+        #[cfg(target_arch = "x86_64")]
+        assert_eq!(fmt, crate::krun::KRUN_KERNEL_FORMAT_ELF);
     }
 }

--- a/crates/minvmd/src/krun/mod.rs
+++ b/crates/minvmd/src/krun/mod.rs
@@ -18,4 +18,4 @@ mod ctx;
 mod raw;
 
 pub use ctx::Context;
-pub use raw::{KRUN_KERNEL_FORMAT_ELF, KRUN_KERNEL_FORMAT_IMAGE_GZ};
+pub use raw::{KRUN_KERNEL_FORMAT_ELF, KRUN_KERNEL_FORMAT_IMAGE_GZ, KRUN_KERNEL_FORMAT_PE_GZ};

--- a/crates/minvmd/src/krun/raw.rs
+++ b/crates/minvmd/src/krun/raw.rs
@@ -13,17 +13,17 @@ use std::io;
 
 use crate::error::VmError;
 
-// Kernel format constants from libkrun.h, used by `krun_set_kernel`. We only
-// model the formats minvmd actually targets:
-// - aarch64 `virtio-linux` ships `Image.gz` → `KRUN_KERNEL_FORMAT_IMAGE_GZ`
-// - x86_64  `virtio-linux` ships `bzImage`  → `KRUN_KERNEL_FORMAT_ELF`
-//
-// Note: `IMAGE_BZ2` (=3) is for bzip2-compressed blobs, not the Linux bzImage
-// container format. bzImage is loaded as ELF by libkrun.
-//
-// libkrun.h also defines RAW=0, PE_GZ=2, IMAGE_BZ2=3, IMAGE_ZSTD=5 — added
-// as needed.
+// Kernel format constants from libkrun.h, used by `krun_set_kernel`. Full enum:
+// RAW=0, ELF=1, PE_GZ=2, IMAGE_BZ2=3, IMAGE_GZ=4, IMAGE_ZSTD=5. minvmd targets:
+// - aarch64 `virtio-linux` ships `Image.gz` → `KRUN_KERNEL_FORMAT_PE_GZ`. The
+//   aarch64 loader implements only RAW and PE_GZ; PE_GZ scans for the gzip
+//   magic and decompresses. `IMAGE_GZ` (=4) is x86_64-only and returns
+//   `KernelFormatUnsupported` on aarch64.
+// - x86_64  `virtio-linux` ships `bzImage`  → `KRUN_KERNEL_FORMAT_ELF`. libkrun
+//   loads bzImage as ELF; `IMAGE_BZ2` (=3) is bzip2 blobs, not the bzImage
+//   container format.
 pub const KRUN_KERNEL_FORMAT_ELF: u32 = 1;
+pub const KRUN_KERNEL_FORMAT_PE_GZ: u32 = 2;
 pub const KRUN_KERNEL_FORMAT_IMAGE_GZ: u32 = 4;
 
 // SAFETY: every function in this block is an `extern "C"` declaration that

--- a/crates/minvmd/src/lib.rs
+++ b/crates/minvmd/src/lib.rs
@@ -8,6 +8,7 @@
 //! since it links libkrun; portable surface (errors, state, image resolution)
 //! compiles on both platforms.
 
+pub mod cmd;
 pub mod error;
 pub mod image;
 pub mod lifecycle;

--- a/crates/minvmd/src/main.rs
+++ b/crates/minvmd/src/main.rs
@@ -1,8 +1,4 @@
-//! `minvmd` CLI entry point. Currently a skeleton: only `completions` is
-//! wired. `boot`, `run`, `status`, `stop`, and the hidden `__krun-vmm` child
-//! subcommand land in follow-up changes. The crate compiles on macOS (real)
-//! and Linux (stub); Linux-only `bail!` paths land alongside the subcommands
-//! that need them, so they never silently no-op.
+//! `minvmd` CLI entry point.
 
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
@@ -19,11 +15,20 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Boot the microVM and wait until the guest is up.
+    Boot {
+        /// Stay in the foreground until the VMM child exits.
+        #[arg(long)]
+        foreground: bool,
+    },
     /// Generate shell completion script.
     Completions {
         /// Shell to generate completions for.
         shell: Shell,
     },
+    /// Hidden VMM child subcommand — spawned by `boot`, not for direct use.
+    #[command(name = "__krun-vmm", hide = true)]
+    KrunVmm,
 }
 
 fn main() -> Result<()> {
@@ -36,11 +41,13 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
+        Command::Boot { foreground } => minvmd::cmd::boot::run(foreground),
         Command::Completions { shell } => {
             let mut cmd = Cli::command();
             let name = cmd.get_name().to_string();
             clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
             Ok(())
         }
+        Command::KrunVmm => minvmd::cmd::vmm_child::run(),
     }
 }

--- a/crates/minvmd/tests/boot_e2e.rs
+++ b/crates/minvmd/tests/boot_e2e.rs
@@ -16,11 +16,13 @@
 
 #![cfg(target_os = "macos")]
 
+use serial_test::serial;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
 #[test]
+#[serial]
 #[ignore = "gated MINVMD_E2E=1; requires Mac with libkrun, kernel, and rootfs"]
 fn boot_e2e_ready_marker_round_trip() {
     if std::env::var("MINVMD_E2E").as_deref() != Ok("1") {

--- a/crates/minvmd/tests/boot_e2e.rs
+++ b/crates/minvmd/tests/boot_e2e.rs
@@ -35,9 +35,12 @@ fn boot_e2e_ready_marker_round_trip() {
         );
     }
 
+    let state_dir = tempfile::TempDir::new().expect("creating isolated state dir");
+
     let exe = env!("CARGO_BIN_EXE_minvmd");
     let mut child = Command::new(exe)
         .args(["boot", "--foreground"])
+        .env("XDG_STATE_HOME", state_dir.path())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()

--- a/crates/minvmd/tests/boot_e2e.rs
+++ b/crates/minvmd/tests/boot_e2e.rs
@@ -1,0 +1,70 @@
+//! Boot end-to-end test: READY-marker round-trip (R2.4).
+//!
+//! Gates:
+//! - `#[cfg(target_os = "macos")]`: libkrun is macOS-only.
+//! - `#[ignore]`: skipped by default; run with `cargo test -- --include-ignored`.
+//! - `MINVMD_E2E=1`: even with `--include-ignored`, the test self-skips unless
+//!   this env var is set (prevents accidental VM boot on a dev machine without
+//!   a kernel and rootfs).
+//! - `MINVMD_KERNEL_PATH` and `MINVMD_ROOTFS_PATH` must be set to the paths of
+//!   the `virtio-linux` kernel image and Alpine minirootfs respectively.
+//!
+//! The test spawns `minvmd boot --foreground`, waits up to 10 s for the
+//! `vm-up` marker on stdout, then kills the child. A `vm-up` line confirms
+//! that the guest's init wrote `READY\n` to the vsock marker port and the
+//! parent received it (R2.4).
+
+#![cfg(target_os = "macos")]
+
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+#[test]
+#[ignore = "gated MINVMD_E2E=1; requires Mac with libkrun, kernel, and rootfs"]
+fn boot_e2e_ready_marker_round_trip() {
+    if std::env::var("MINVMD_E2E").as_deref() != Ok("1") {
+        eprintln!("boot_e2e: MINVMD_E2E != 1, skipping");
+        return;
+    }
+
+    for var in &["MINVMD_KERNEL_PATH", "MINVMD_ROOTFS_PATH"] {
+        assert!(
+            std::env::var(var).is_ok(),
+            "boot_e2e: {var} must be set when MINVMD_E2E=1"
+        );
+    }
+
+    let exe = env!("CARGO_BIN_EXE_minvmd");
+    let mut child = Command::new(exe)
+        .args(["boot", "--foreground"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawning minvmd boot --foreground");
+
+    let stdout = child.stdout.take().expect("child stdout");
+    let (tx, rx) = std::sync::mpsc::channel::<bool>();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines().map_while(Result::ok) {
+            if line.trim() == "vm-up" {
+                let _ = tx.send(true);
+                return;
+            }
+        }
+        let _ = tx.send(false);
+    });
+
+    let got_vm_up = rx.recv_timeout(Duration::from_secs(10)).unwrap_or(false);
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        got_vm_up,
+        "boot_e2e: did not receive 'vm-up' within 10 s; \
+         check that the guest rootfs writes READY\\n to vsock port {}",
+        minvmd::cmd::VSOCK_MARKER_PORT,
+    );
+}

--- a/docs/specs/01-spec-minvmd-host-daemon/01-spec-minvmd-host-daemon.md
+++ b/docs/specs/01-spec-minvmd-host-daemon/01-spec-minvmd-host-daemon.md
@@ -156,9 +156,12 @@ mounts `/proc`, `/sys`, `/dev`, and execs the workload set via
   `VIRTIO_CONSOLE`/HVC all `=y` (the default cmdline carries `nomodule`).
   (translated from plan: step R2.1)
 - **R2.2**: The rootfs shall be an Alpine minirootfs (version-pinned,
-  sha256-verified). For v0.1 the path is supplied via
-  `MINVMD_ROOTFS_PATH`; staging is performed by
-  `scripts/fetch-alpine.sh`. (translated from plan: step R2.2)
+  sha256-verified). For v0.1 the path is supplied via `MINVMD_ROOTFS_PATH`;
+  `scripts/fetch-alpine.sh` stages the base and `scripts/build-rootfs.sh`
+  overlays the guest workload (`/sbin/minvmd-stub-init`) plus its runtime
+  closure (socat and the sha256-pinned `readline` + `libncursesw` apks it
+  dynamically links). The result is a directory consumed by `krun_set_root` as
+  virtio-fs — no disk image. (translated from plan: step R2.2)
 - **R2.3**: `minvmd boot` (parent) shall configure the libkrun context
   via the safe wrappers, then fork-exec a hidden
   `minvmd __krun-vmm` child that calls `krun_start_enter`. The child shall set

--- a/docs/specs/01-spec-minvmd-host-daemon/01-spec-minvmd-host-daemon.md
+++ b/docs/specs/01-spec-minvmd-host-daemon/01-spec-minvmd-host-daemon.md
@@ -130,8 +130,10 @@ with no rootfs work.
 ### Unit 2: VM bring-up with virtio-linux kernel + Alpine rootfs
 
 **Purpose:** Actual Linux boot. `minvmd boot` brings up an Alpine VM
-that reaches userspace and writes a "READY" marker to vsock from a
-guest-side init.
+that reaches userspace and writes a "READY" marker to vsock from its
+guest workload. libkrun's built-in init (`/init.krun`) runs as PID 1,
+mounts `/proc`, `/sys`, `/dev`, and execs the workload set via
+`krun_set_exec` — so the rootfs needs no init system (no OpenRC).
 
 **Depends on:** Unit 1
 
@@ -144,20 +146,36 @@ guest-side init.
 - **R2.1**: The kernel artifact shall be the `vmlinuz` output of the
   `virtio-linux` minimal package; on aarch64 the artifact is `Image.gz`,
   on x86_64 `bzImage`. Path resolution shall happen at runtime via a
-  `MINVMD_KERNEL_PATH` env var. (translated from plan: step R2.1)
+  `MINVMD_KERNEL_PATH` env var. The kernel shall be loaded directly — no EFI
+  firmware, no disk image — via `krun_set_kernel` with the arch-appropriate
+  libkrun format: `KRUN_KERNEL_FORMAT_PE_GZ` for the aarch64 `Image.gz` (the
+  aarch64 loader implements only `RAW` and `PE_GZ`; `IMAGE_GZ` is x86_64-only
+  and returns `KernelFormatUnsupported` on aarch64) and `KRUN_KERNEL_FORMAT_ELF`
+  for the x86_64 `bzImage`. The `virtio-linux` kernel shall be built with
+  virtio-MMIO (not PCI), `VIRTIO_FS`/`FUSE`, `VIRTIO_VSOCKETS`, and
+  `VIRTIO_CONSOLE`/HVC all `=y` (the default cmdline carries `nomodule`).
+  (translated from plan: step R2.1)
 - **R2.2**: The rootfs shall be an Alpine minirootfs (version-pinned,
   sha256-verified). For v0.1 the path is supplied via
   `MINVMD_ROOTFS_PATH`; staging is performed by
   `scripts/fetch-alpine.sh`. (translated from plan: step R2.2)
 - **R2.3**: `minvmd boot` (parent) shall configure the libkrun context
   via the safe wrappers, then fork-exec a hidden
-  `minvmd __krun-vmm` child that calls `krun_start_enter`. The parent
-  shall write a `vmm.pid` file and surface child-exit codes via signal
+  `minvmd __krun-vmm` child that calls `krun_start_enter`. The child shall set
+  the guest workload via `krun_set_exec` (default `/sbin/minvmd-stub-init`,
+  overridable by `MINVMD_EXEC`) with an explicit minimal envp, leave the kernel
+  cmdline unset (libkrun's default supplies `console=hvc0 rootfstype=virtiofs
+  rw` and injects `init=/init.krun`), and configure 2 vCPU / 1024 MiB. The
+  parent shall write a `vmm.pid` file and surface child-exit codes via signal
   handling. (translated from plan: step R2.3)
-- **R2.4**: Boot shall complete to a guest-side marker (writes `READY\n`
-  on a designated vsock port) within 5 s on a warm laptop; the parent
-  shall block on this marker before reporting boot success.
-  (translated from plan: step R2.4)
+- **R2.4**: Boot shall complete to a guest-side marker within 5 s on a warm
+  laptop; the parent shall block on this marker before reporting boot success.
+  The marker is **guest-initiated**: the host registers the marker port (7350)
+  with the plain `krun_add_vsock_port` (≡ `krun_add_vsock_port2(.., listen =
+  false)`) and listens on the host UDS; the guest workload connects to
+  AF_VSOCK CID 2 (host) port 7350 and writes `READY\n`, which libkrun bridges
+  to the host. This is the opposite direction from the R3 `ssh.sock` bridge
+  (`listen = true`, host-initiated). (translated from plan: step R2.4)
 - **R2.5**: No network device shall be added to the libkrun config in
   v0.1; gvproxy/TSI integration is owned by #160.
   (translated from plan: step R2.5)
@@ -320,7 +338,8 @@ guest workload's exit code. This forces a parent/child split:
 minvmd run                       (parent — supervisor)
   └── minvmd __krun-vmm          (hidden child — calls krun_start_enter)
        └── libkrun + Alpine VM   (the actual VM)
-            └── minimald (pid-1) (in-VM, via krun_set_exec)
+            └── /init.krun (pid-1, libkrun-supplied)
+                 └── minimald   (guest workload, via krun_set_exec)
 ```
 
 Parent owns: `state.toml`, `lifecycle.lock`, and lifecycle supervision.

--- a/docs/specs/01-spec-minvmd-host-daemon/architecture.md
+++ b/docs/specs/01-spec-minvmd-host-daemon/architecture.md
@@ -25,7 +25,8 @@ guest workload's exit code. This forces a parent/child split
 minvmd run                       (parent — supervisor)
   └── minvmd __krun-vmm          (hidden child — calls krun_start_enter)
        └── libkrun + Alpine VM   (the actual VM)
-            └── minimald (pid-1) (in-VM, via krun_set_exec)
+            └── /init.krun (pid-1, libkrun-supplied)
+                 └── minimald   (guest workload, via krun_set_exec)
 ```
 
 - **Parent** (`minvmd run`): owns `state.toml`, `lifecycle.lock`, lifecycle
@@ -35,8 +36,10 @@ minvmd run                       (parent — supervisor)
   libkrun context (kernel, rootfs, vsock ports, vm config), then calls
   `krun_start_enter` which diverges. Authenticated to the parent via a
   single-use token in the state directory (mode 0600, deleted on first read).
-- **Guest**: Alpine minirootfs running `minimald` (or the v0.1 vsock stub)
-  as pid-1 via `krun_set_exec`.
+- **Guest**: Alpine minirootfs. libkrun's built-in `/init.krun` is pid-1
+  (mounts `/proc`, `/sys`, `/dev`); it execs the workload set via
+  `krun_set_exec` — `minimald`, or the v0.1 vsock stub. No init system in the
+  rootfs.
 
 ### Socket model (libkrun-owned, no host relay)
 

--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -32,15 +32,25 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-OVERLAY_REVISION="2"
+OVERLAY_REVISION="4"
 
-# socat from Alpine v3.21 main; depends only on so:libc.musl, which the base
-# minirootfs already provides (verified via APKINDEX). sha256 is of the .apk.
-# Plain vars + a case lookup (below) instead of an associative array so the
-# script runs under macOS's system bash 3.2 (declare -A needs bash 4+).
+# Pinned Alpine v3.21 main apks overlaid onto the base minirootfs. socat
+# provides the vsock tooling; readline + libncursesw are socat's runtime closure
+# (it dynamically links libreadline.so.8, which needs libncursesw.so.6) that the
+# minirootfs lacks — libssl/libcrypto/libc are already in the base. NOTE: the
+# library lives in `libncursesw`, not the `ncurses-libs` metapackage (which has
+# no payload). sha256 is of each .apk. Plain vars + a case lookup (below) instead
+# of associative arrays so the script runs under macOS bash 3.2 (declare -A
+# needs bash 4+).
 SOCAT_VERSION="1.8.0.3-r0"
 SOCAT_SHA256_aarch64="7cc3f5bade7fba9cd828b94560ce9f35de61246e19ecb595098110e81cf1c9ae"
 SOCAT_SHA256_x86_64="caaad9c79573220fe100aad81487b20306c0745cb96baf5813f45fb212e8be90"
+READLINE_VERSION="8.2.13-r0"
+READLINE_SHA256_aarch64="7dad49f83ecbcfa00c5c7df044a5566b928ac1995651cfff219e1df1c2b93871"
+READLINE_SHA256_x86_64="fa4ff2347886f5516d021b9064a00259b29fc6e2608eac5588a339de244acf12"
+LIBNCURSESW_VERSION="6.5_p20241006-r3"
+LIBNCURSESW_SHA256_aarch64="c1a5a3a552ad4d44c94454555f38de71b151dc2d608ea2246d92b3bd845b7f3a"
+LIBNCURSESW_SHA256_x86_64="3919cf673e841d91865213799ccfd5f77a48f5f9f5402723167470295ee32a49"
 
 print_path_only=0
 if [[ "${1:-}" == "--print-path" ]]; then
@@ -58,13 +68,21 @@ if [[ "$print_path_only" -eq 1 ]]; then
 fi
 
 case "$arch" in
-    aarch64) socat_sha="$SOCAT_SHA256_aarch64" ;;
-    x86_64) socat_sha="$SOCAT_SHA256_x86_64" ;;
-    *) echo "build-rootfs.sh: no pinned socat sha256 for arch $arch" >&2; exit 1 ;;
+    aarch64)
+        socat_sha="$SOCAT_SHA256_aarch64"
+        readline_sha="$READLINE_SHA256_aarch64"
+        libncursesw_sha="$LIBNCURSESW_SHA256_aarch64"
+        ;;
+    x86_64)
+        socat_sha="$SOCAT_SHA256_x86_64"
+        readline_sha="$READLINE_SHA256_x86_64"
+        libncursesw_sha="$LIBNCURSESW_SHA256_x86_64"
+        ;;
+    *) echo "build-rootfs.sh: no pinned apk sha256 for arch $arch" >&2; exit 1 ;;
 esac
 
 marker="$rootfs_path/.minvmd-overlay.ok"
-marker_value="rev=$OVERLAY_REVISION socat=$socat_sha"
+marker_value="rev=$OVERLAY_REVISION socat=$socat_sha readline=$readline_sha libncursesw=$libncursesw_sha"
 
 if [[ -f "$marker" ]] && [[ "$(cat "$marker")" == "$marker_value" ]]; then
     echo "build-rootfs.sh: overlay up to date at $rootfs_path" >&2
@@ -74,29 +92,37 @@ fi
 # Ensure the base is staged + verified (idempotent; no-op on cache hit).
 "$SCRIPT_DIR/fetch-alpine.sh" >&2
 
-apk="socat-${SOCAT_VERSION}.apk"
-apk_url="https://dl-cdn.alpinelinux.org/alpine/v3.21/main/${arch}/${apk}"
-
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
-echo "build-rootfs.sh: downloading $apk_url" >&2
-curl -fsSL "$apk_url" -o "$tmpdir/$apk"
+# fetch_apk <name> <version> <sha256>: download a pinned Alpine .apk, verify its
+# sha256, and copy its usr/ payload into the rootfs. apk metadata entries
+# (.PKGINFO, .SIGN.*, .pre-install, .trigger) are dotfiles at the archive root
+# and are deliberately not copied.
+fetch_apk() {
+    apk_name="$1"
+    apk_ver="$2"
+    apk_sha="$3"
+    apk="${apk_name}-${apk_ver}.apk"
+    apk_url="https://dl-cdn.alpinelinux.org/alpine/v3.21/main/${arch}/${apk}"
+    echo "build-rootfs.sh: downloading $apk_url" >&2
+    curl -fsSL "$apk_url" -o "$tmpdir/$apk"
+    actual_sha="$(shasum -a 256 "$tmpdir/$apk" | awk '{print $1}')"
+    if [[ "$actual_sha" != "$apk_sha" ]]; then
+        echo "build-rootfs.sh: sha256 mismatch for $apk" >&2
+        echo "  expected: $apk_sha" >&2
+        echo "  actual:   $actual_sha" >&2
+        exit 1
+    fi
+    rm -rf "$tmpdir/extract"
+    mkdir -p "$tmpdir/extract"
+    tar -xzf "$tmpdir/$apk" -C "$tmpdir/extract"
+    cp -a "$tmpdir/extract/usr/." "$rootfs_path/usr/"
+}
 
-actual_sha="$(shasum -a 256 "$tmpdir/$apk" | awk '{print $1}')"
-if [[ "$actual_sha" != "$socat_sha" ]]; then
-    echo "build-rootfs.sh: sha256 mismatch for $apk" >&2
-    echo "  expected: $socat_sha" >&2
-    echo "  actual:   $actual_sha" >&2
-    exit 1
-fi
-
-# Extract into a scratch dir, then copy only the payload (usr/). apk metadata
-# entries (.PKGINFO, .SIGN.*, .pre-install, .trigger) are dotfiles at the
-# archive root and are deliberately not copied into the rootfs.
-mkdir -p "$tmpdir/extract"
-tar -xzf "$tmpdir/$apk" -C "$tmpdir/extract"
-cp -a "$tmpdir/extract/usr/." "$rootfs_path/usr/"
+fetch_apk socat "$SOCAT_VERSION" "$socat_sha"
+fetch_apk readline "$READLINE_VERSION" "$readline_sha"
+fetch_apk libncursesw "$LIBNCURSESW_VERSION" "$libncursesw_sha"
 
 # Guest bring-up workload. Replaced in production by /sbin/minimald.
 cat > "$rootfs_path/sbin/minvmd-stub-init" <<'STUB'

--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -36,11 +36,11 @@ OVERLAY_REVISION="2"
 
 # socat from Alpine v3.21 main; depends only on so:libc.musl, which the base
 # minirootfs already provides (verified via APKINDEX). sha256 is of the .apk.
+# Plain vars + a case lookup (below) instead of an associative array so the
+# script runs under macOS's system bash 3.2 (declare -A needs bash 4+).
 SOCAT_VERSION="1.8.0.3-r0"
-declare -A SOCAT_SHA256=(
-    [aarch64]="7cc3f5bade7fba9cd828b94560ce9f35de61246e19ecb595098110e81cf1c9ae"
-    [x86_64]="caaad9c79573220fe100aad81487b20306c0745cb96baf5813f45fb212e8be90"
-)
+SOCAT_SHA256_aarch64="7cc3f5bade7fba9cd828b94560ce9f35de61246e19ecb595098110e81cf1c9ae"
+SOCAT_SHA256_x86_64="caaad9c79573220fe100aad81487b20306c0745cb96baf5813f45fb212e8be90"
 
 print_path_only=0
 if [[ "${1:-}" == "--print-path" ]]; then
@@ -57,11 +57,11 @@ if [[ "$print_path_only" -eq 1 ]]; then
     exit 0
 fi
 
-socat_sha="${SOCAT_SHA256[$arch]:-}"
-if [[ -z "$socat_sha" ]]; then
-    echo "build-rootfs.sh: no pinned socat sha256 for arch $arch" >&2
-    exit 1
-fi
+case "$arch" in
+    aarch64) socat_sha="$SOCAT_SHA256_aarch64" ;;
+    x86_64) socat_sha="$SOCAT_SHA256_x86_64" ;;
+    *) echo "build-rootfs.sh: no pinned socat sha256 for arch $arch" >&2; exit 1 ;;
+esac
 
 marker="$rootfs_path/.minvmd-overlay.ok"
 marker_value="rev=$OVERLAY_REVISION socat=$socat_sha"

--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# build-rootfs.sh — assemble a bootable minvmd guest rootfs.
+#
+# Takes the pinned Alpine minirootfs staged by `fetch-alpine.sh` and overlays
+# the bits needed to boot under libkrun and satisfy the minvmd boot contract:
+#
+#   - socat (vsock-capable) extracted from a pinned, sha256-verified .apk
+#   - /sbin/minvmd-stub-init  — bring-up guest workload (READY marker + echo)
+#   - /etc/minvmd/manifest    — the guest-side contract (exec targets, ports)
+#
+# The overlay is applied IN PLACE into the fetch-alpine cache dir, so the
+# assembled rootfs lives at the same path:
+#
+#   export MINVMD_ROOTFS_PATH="$(scripts/build-rootfs.sh --print-path)"
+#
+# Format: directory, consumed by libkrun via `krun_set_root` (v0.1). No ext4
+# image, no virtiofs host mounts — the rootfs is self-contained.
+#
+# Idempotent: a `.minvmd-overlay.ok` marker records the overlay revision +
+# socat sha; a matching marker short-circuits re-download and re-extract.
+#
+# Boot model: libkrun's built-in init runs as guest pid-1 and exec's the
+# `krun_set_exec` target. OpenRC never runs, so there is no DHCP wait and no
+# net-dependent init step — the rootfs reaches userspace with zero network.
+# Production exec target is `/sbin/minimald` (cross-compiled, dropped in by a
+# follow-up); for bring-up the target is `/sbin/minvmd-stub-init`.
+#
+# To bump socat: update SOCAT_VERSION and the per-arch SOCAT_SHA256 below, and
+# bump OVERLAY_REVISION to force re-application over existing caches.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+OVERLAY_REVISION="2"
+
+# socat from Alpine v3.21 main; depends only on so:libc.musl, which the base
+# minirootfs already provides (verified via APKINDEX). sha256 is of the .apk.
+SOCAT_VERSION="1.8.0.3-r0"
+declare -A SOCAT_SHA256=(
+    [aarch64]="7cc3f5bade7fba9cd828b94560ce9f35de61246e19ecb595098110e81cf1c9ae"
+    [x86_64]="caaad9c79573220fe100aad81487b20306c0745cb96baf5813f45fb212e8be90"
+)
+
+print_path_only=0
+if [[ "${1:-}" == "--print-path" ]]; then
+    print_path_only=1
+fi
+
+# Resolve the staged base path from fetch-alpine.sh (single source of truth for
+# the Alpine version + cache layout). Path shape: <cache>/<version>/<arch>.
+rootfs_path="$("$SCRIPT_DIR/fetch-alpine.sh" --print-path)"
+arch="$(basename "$rootfs_path")"
+
+if [[ "$print_path_only" -eq 1 ]]; then
+    echo "$rootfs_path"
+    exit 0
+fi
+
+socat_sha="${SOCAT_SHA256[$arch]:-}"
+if [[ -z "$socat_sha" ]]; then
+    echo "build-rootfs.sh: no pinned socat sha256 for arch $arch" >&2
+    exit 1
+fi
+
+marker="$rootfs_path/.minvmd-overlay.ok"
+marker_value="rev=$OVERLAY_REVISION socat=$socat_sha"
+
+if [[ -f "$marker" ]] && [[ "$(cat "$marker")" == "$marker_value" ]]; then
+    echo "build-rootfs.sh: overlay up to date at $rootfs_path" >&2
+    exit 0
+fi
+
+# Ensure the base is staged + verified (idempotent; no-op on cache hit).
+"$SCRIPT_DIR/fetch-alpine.sh" >&2
+
+apk="socat-${SOCAT_VERSION}.apk"
+apk_url="https://dl-cdn.alpinelinux.org/alpine/v3.21/main/${arch}/${apk}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+echo "build-rootfs.sh: downloading $apk_url" >&2
+curl -fsSL "$apk_url" -o "$tmpdir/$apk"
+
+actual_sha="$(shasum -a 256 "$tmpdir/$apk" | awk '{print $1}')"
+if [[ "$actual_sha" != "$socat_sha" ]]; then
+    echo "build-rootfs.sh: sha256 mismatch for $apk" >&2
+    echo "  expected: $socat_sha" >&2
+    echo "  actual:   $actual_sha" >&2
+    exit 1
+fi
+
+# Extract into a scratch dir, then copy only the payload (usr/). apk metadata
+# entries (.PKGINFO, .SIGN.*, .pre-install, .trigger) are dotfiles at the
+# archive root and are deliberately not copied into the rootfs.
+mkdir -p "$tmpdir/extract"
+tar -xzf "$tmpdir/$apk" -C "$tmpdir/extract"
+cp -a "$tmpdir/extract/usr/." "$rootfs_path/usr/"
+
+# Guest bring-up workload. Replaced in production by /sbin/minimald.
+cat > "$rootfs_path/sbin/minvmd-stub-init" <<'STUB'
+#!/bin/sh
+# minvmd bring-up stub — guest workload for VM boot verification.
+#
+# This is NOT the production workload. In production libkrun exec's
+# /sbin/minimald via krun_set_exec; this stub stands in for boot/bridge tests.
+# libkrun's own init (/init.krun) is pid-1: it mounts /proc, /sys and /dev and
+# forks this script as the workload.
+#
+# Contract:
+#
+#   vsock 7350  READY marker (guest CONNECTS out). The host registers this port
+#               with the plain krun_add_vsock_port (listen=false): the host's
+#               UDS listener accepts an inbound bridge and the guest connects to
+#               host CID 2 and writes "READY\n". The host reads one line to
+#               confirm boot completion (R2.4).
+#   vsock 2222  echo bridge (guest LISTENs). The host registers this port with
+#               krun_add_vsock_port2(listen=true) and connects inward; each
+#               connection is cat-looped (bridge_e2e, R3).
+set -eu
+
+# Defensive: /init.krun already mounts these before forking us (harmless if so).
+mount -t proc  proc /proc 2>/dev/null || true
+mount -t sysfs sys  /sys  2>/dev/null || true
+
+# READY marker: connect out to the host (CID 2 = VMADDR_CID_HOST) on port 7350
+# and write "READY\n". The host reads one line and closes, so socat returns
+# promptly. Retry briefly in case the vsock device isn't up the instant we start.
+i=0
+while [ "$i" -lt 50 ]; do
+    printf 'READY\n' | socat -t2 - VSOCK-CONNECT:2:7350 && break
+    i=$((i + 1))
+    sleep 0.1
+done
+
+# Stay alive as the guest workload: echo bridge on vsock 2222 (R3). exec so this
+# socat is the long-lived process and reaps its own per-connection children.
+exec socat VSOCK-LISTEN:2222,fork EXEC:cat
+STUB
+chmod 0755 "$rootfs_path/sbin/minvmd-stub-init"
+
+# Guest-side contract, machine- and human-readable.
+mkdir -p "$rootfs_path/etc/minvmd"
+cat > "$rootfs_path/etc/minvmd/manifest" <<MANIFEST
+# minvmd guest rootfs contract (overlay rev $OVERLAY_REVISION)
+#
+# format=krun_set_root-directory
+# exec_target_production=/sbin/minimald   (dropped in by a follow-up; absent here)
+# exec_target_bringup=/sbin/minvmd-stub-init
+#
+# vsock_port_ready=7350    guest CONNECTS out (host listen=false); writes "READY\n" once at boot
+# vsock_port_bridge=2222   guest LISTENs (host listen=true); echoes (cat) per connection
+#
+# net=none   virtiofs=none   init=libkrun-builtin (/init.krun, no OpenRC)
+# exec=krun_set_exec(/sbin/minvmd-stub-init); MINVMD_EXEC overrides
+socat=$SOCAT_VERSION
+MANIFEST
+
+echo "$marker_value" > "$marker"
+echo "build-rootfs.sh: overlay applied to $rootfs_path ($arch, socat $SOCAT_VERSION)" >&2

--- a/scripts/fetch-alpine.sh
+++ b/scripts/fetch-alpine.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# fetch-alpine.sh — stage a pinned Alpine minirootfs for minvmd.
+#
+# Downloads the upstream Alpine minirootfs tarball for the host arch,
+# verifies it against a pinned sha256, and extracts it to
+# `${MINVMD_ROOTFS_CACHE:-~/.cache/minimal/minvmd/rootfs}/<version>/<arch>/`.
+#
+# Idempotent: a `.sha256.ok` marker is written on first successful extract;
+# re-running detects the marker and skips re-download + re-extract.
+#
+# After a successful run, export:
+#
+#   export MINVMD_ROOTFS_PATH="$(scripts/fetch-alpine.sh --print-path)"
+#
+# To bump the pinned Alpine version, update ALPINE_VERSION and the per-arch
+# SHA256 constants below; both are published at
+# https://dl-cdn.alpinelinux.org/alpine/v<MAJOR.MINOR>/releases/<arch>/
+
+set -euo pipefail
+
+ALPINE_VERSION="3.21.7"
+ALPINE_MAJOR_MINOR="${ALPINE_VERSION%.*}"
+
+# sha256 of alpine-minirootfs-${ALPINE_VERSION}-<arch>.tar.gz from
+# https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_MAJOR_MINOR}/releases/<arch>/
+declare -A PINNED_SHA256=(
+    [aarch64]="d1d1a3fae5f4d6146e9742790a47fcb116199622cfb8439f218a4d5fbe5000da"
+    [x86_64]="8cba1ea3e8b500ea986a313d8eecf3d5952a2a0d23a69117bb81c023d9ceac05"
+)
+
+print_path_only=0
+if [[ "${1:-}" == "--print-path" ]]; then
+    print_path_only=1
+fi
+
+case "$(uname -m)" in
+    arm64 | aarch64) arch="aarch64" ;;
+    x86_64 | amd64) arch="x86_64" ;;
+    *) echo "fetch-alpine.sh: unsupported host arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+expected_sha="${PINNED_SHA256[$arch]:-}"
+if [[ -z "$expected_sha" ]]; then
+    echo "fetch-alpine.sh: no pinned sha256 for arch $arch" >&2
+    exit 1
+fi
+
+cache_root="${MINVMD_ROOTFS_CACHE:-$HOME/.cache/minimal/minvmd/rootfs}"
+arch_root="$cache_root/$ALPINE_VERSION/$arch"
+marker="$arch_root/.sha256.ok"
+
+if [[ "$print_path_only" -eq 1 ]]; then
+    echo "$arch_root"
+    exit 0
+fi
+
+if [[ -f "$marker" ]] && [[ "$(cat "$marker")" == "$expected_sha" ]]; then
+    echo "fetch-alpine.sh: cache hit at $arch_root (sha256 matches)" >&2
+    exit 0
+fi
+
+tarball="alpine-minirootfs-${ALPINE_VERSION}-${arch}.tar.gz"
+url="https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_MAJOR_MINOR}/releases/${arch}/${tarball}"
+
+mkdir -p "$arch_root"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+echo "fetch-alpine.sh: downloading $url" >&2
+curl -fsSL "$url" -o "$tmpdir/$tarball"
+
+actual_sha="$(shasum -a 256 "$tmpdir/$tarball" | awk '{print $1}')"
+if [[ "$actual_sha" != "$expected_sha" ]]; then
+    echo "fetch-alpine.sh: sha256 mismatch for $tarball" >&2
+    echo "  expected: $expected_sha" >&2
+    echo "  actual:   $actual_sha" >&2
+    exit 1
+fi
+
+# Wipe a stale partial extract before re-populating.
+if [[ -d "$arch_root" ]]; then
+    find "$arch_root" -mindepth 1 -delete
+fi
+tar -xzf "$tmpdir/$tarball" -C "$arch_root"
+echo "$expected_sha" > "$marker"
+
+echo "fetch-alpine.sh: extracted Alpine ${ALPINE_VERSION} (${arch}) to $arch_root" >&2

--- a/scripts/fetch-alpine.sh
+++ b/scripts/fetch-alpine.sh
@@ -23,10 +23,10 @@ ALPINE_MAJOR_MINOR="${ALPINE_VERSION%.*}"
 
 # sha256 of alpine-minirootfs-${ALPINE_VERSION}-<arch>.tar.gz from
 # https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_MAJOR_MINOR}/releases/<arch>/
-declare -A PINNED_SHA256=(
-    [aarch64]="d1d1a3fae5f4d6146e9742790a47fcb116199622cfb8439f218a4d5fbe5000da"
-    [x86_64]="8cba1ea3e8b500ea986a313d8eecf3d5952a2a0d23a69117bb81c023d9ceac05"
-)
+# Plain vars + a case lookup (below) instead of an associative array so the
+# script runs under macOS's system bash 3.2 (declare -A needs bash 4+).
+PINNED_SHA256_aarch64="d1d1a3fae5f4d6146e9742790a47fcb116199622cfb8439f218a4d5fbe5000da"
+PINNED_SHA256_x86_64="8cba1ea3e8b500ea986a313d8eecf3d5952a2a0d23a69117bb81c023d9ceac05"
 
 print_path_only=0
 if [[ "${1:-}" == "--print-path" ]]; then
@@ -34,16 +34,10 @@ if [[ "${1:-}" == "--print-path" ]]; then
 fi
 
 case "$(uname -m)" in
-    arm64 | aarch64) arch="aarch64" ;;
-    x86_64 | amd64) arch="x86_64" ;;
+    arm64 | aarch64) arch="aarch64"; expected_sha="$PINNED_SHA256_aarch64" ;;
+    x86_64 | amd64) arch="x86_64"; expected_sha="$PINNED_SHA256_x86_64" ;;
     *) echo "fetch-alpine.sh: unsupported host arch $(uname -m)" >&2; exit 1 ;;
 esac
-
-expected_sha="${PINNED_SHA256[$arch]:-}"
-if [[ -z "$expected_sha" ]]; then
-    echo "fetch-alpine.sh: no pinned sha256 for arch $arch" >&2
-    exit 1
-fi
 
 cache_root="${MINVMD_ROOTFS_CACHE:-$HOME/.cache/minimal/minvmd/rootfs}"
 arch_root="$cache_root/$ALPINE_VERSION/$arch"

--- a/scripts/fetch-virtio-kernel.sh
+++ b/scripts/fetch-virtio-kernel.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Fetch the virtio-linux kernel (vmlinuz / Image.gz) from the minimal build
+# cache. Pulls the prebuilt artifact from the public `minimal-staging-cache`
+# via the promoted Linux `minimal` CLI (gs://minimal-shim) — no kernel build,
+# no GCS credentials (the cache is public-read). The packaging `minimal` CLI is
+# Linux-only, so this runs on a Linux runner and hands the kernel to the macOS
+# boot job.
+#
+# Usage: scripts/fetch-virtio-kernel.sh <dest-vmlinuz-path> [arch]
+#   arch defaults to aarch64 (the self-hosted macOS CI runner is Apple Silicon).
+# Requires: Linux host with git, curl, ca-certificates, tar, zstd.
+set -eu
+
+DEST="${1:?usage: fetch-virtio-kernel.sh <dest-vmlinuz-path> [arch]}"
+ARCH="${2:-aarch64}"
+GCS_SHIM="https://storage.googleapis.com/minimal-shim"
+
+# The CLI binary itself must match the runner's OS/arch; the kernel it pulls is
+# selected separately via `--arch` below.
+case "$(uname -m)" in
+  x86_64 | amd64) CLI_PLATFORM="amd64-linux" ;;
+  aarch64 | arm64) CLI_PLATFORM="arm64-linux" ;;
+  *) echo "unsupported runner arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+CLI_SHA="$(curl -fsS "$GCS_SHIM/config/cli-${CLI_PLATFORM}.json" \
+  | sed -n 's/.*"version":"\([^"]*\)".*/\1/p')"
+[ -n "$CLI_SHA" ] || { echo "could not resolve promoted CLI version for $CLI_PLATFORM" >&2; exit 1; }
+echo "minimal CLI: ${CLI_PLATFORM} @ ${CLI_SHA}"
+
+curl -fsS "$GCS_SHIM/archives/cli-${CLI_PLATFORM}-${CLI_SHA}.tar.zst" -o "$TMP/cli.tar.zst"
+mkdir -p "$TMP/cli"
+tar --zstd -xf "$TMP/cli.tar.zst" -C "$TMP/cli"
+MINIMAL="$TMP/cli/bin/minimal"
+chmod +x "$MINIMAL"
+
+# Scratch project: upstream pkgs + a raw-file output that extracts the kernel
+# from the virtio-linux package's outputs.
+mkdir -p "$TMP/proj/.minimal"
+cat > "$TMP/proj/.minimal/minimal.toml" <<'TOML'
+[upstream]
+repo = "https://github.com/gominimal/pkgs"
+branch = "main"
+
+[stack]
+use = "rust"
+
+[outputs.virtio-kernel]
+type = "raw-file"
+packages = ["virtio-linux"]
+path = "usr/share/virtio-linux/vmlinuz"
+TOML
+
+cd "$TMP/proj"
+"$MINIMAL" update
+mkdir -p "$(dirname "$DEST")"
+"$MINIMAL" materialize --output "$DEST" --arch "$ARCH" virtio-kernel
+echo "fetched kernel -> $DEST ($(wc -c < "$DEST" | tr -d ' ') bytes)"


### PR DESCRIPTION
Supersedes #339. Produces a viable non-EFI libkrun VM image (external `virtio-linux` kernel + Alpine virtio-fs rootfs) and wires the boot path so `minvmd boot` reaches the guest `READY` marker. Carries #339's host plumbing plus the fixes below.

## Root cause

The #339 boot E2E could not reach `READY` for four reasons:

1. **Wrong aarch64 kernel format.** `image.rs` used `KRUN_KERNEL_FORMAT_IMAGE_GZ=4`; the aarch64 libkrun loader implements only `RAW=0` and `PE_GZ=2`, so `krun_set_kernel` returned `KernelFormatUnsupported` before boot. Verified against `/opt/homebrew/include/libkrun.h` (1.18.1).
2. **No guest workload.** Neither `vm.rs` nor `vmm_child.rs` called `krun_set_exec`, so libkrun's `/init.krun` (pid-1) fell back to `/bin/sh` and never emitted `READY`.
3. **vsock marker direction deadlock.** The host registers the marker with the plain `krun_add_vsock_port` (≡ `listen=false`, guest→host) and listens on the host UDS, but the rootfs stub `socat VSOCK-LISTEN:7350` also listened. Both sides waited. Confirmed against `src/libkrun/src/lib.rs` + libkrun#246.
4. **No image on main.** The rootfs/kernel scripts lived on feature/CI branches; CI staged a vanilla Alpine with no READY writer.

## Fix

- `fix(minvmd)`: aarch64 → `KRUN_KERNEL_FORMAT_PE_GZ`; add the constant.
- `feat(minvmd)`: `krun_set_exec` the workload (`/sbin/minvmd-stub-init`, `MINVMD_EXEC` overrides) with an explicit minimal envp (avoids the ~2 KiB aarch64 cmdline overflow); opt-in console capture (`MINVMD_BOOT_LOG`); 2 vCPU / 1024 MiB. Kernel `cmdline` stays `NULL` (libkrun's default carries `console=hvc0 rootfstype=virtiofs rw`).
- `feat(minvmd)`: `scripts/{fetch-alpine,build-rootfs,fetch-virtio-kernel}.sh`; the stub READY writer now **connects out** (`socat - VSOCK-CONNECT:2:7350`).
- `ci(minvmd)`: `boot-e2e` builds the real rootfs and uploads the guest console log.
- `docs(minvmd)`: spec R2.1/R2.3/R2.4 + process model corrected.

## Acceptance

- [x] `cargo test -p minvmd`, `cargo clippy -p minvmd --all-targets -- -D warnings`, `cargo fmt --check` — green locally.
- [x] FFI smoke (`krun_smoke`) green against real libkrun 1.18.1.
- [x] `build-rootfs.sh` assembles a rootfs with `/sbin/minvmd-stub-init` (connect-out) + `socat`.
- [ ] `boot-e2e` green on the self-hosted Apple Silicon runner → then drop `continue-on-error` to gate. First green also validates the `virtio-linux` kernel config (virtio-MMIO / `VIRTIO_FS` / `VIRTIO_VSOCKETS` / HVC all `=y`).

## Note on #341

This PR carries #341's `fetch-virtio-kernel.sh` and an enhanced `ci-macos.yml` boot-e2e lane, so it supersedes #341's CI work. Merge #341 first and rebase, or close #341 — your call.

## References

- Closes #326
- Supersedes #339
- libkrun `include/libkrun.h`, `src/libkrun/src/lib.rs`, `init/init.c`; libkrun#246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS-only "boot" command, hidden VM child entrypoint, and shell completions.
  * Improved kernel-format selection for aarch64/x86_64.
  * Utilities to fetch virtio kernels and to build a bootable guest rootfs.

* **Documentation**
  * Clarified macOS VM boot flow, READY-marker handshake, and in-VM init expectations.

* **Tests**
  * Added an opt-in macOS end-to-end boot test.

* **Chores**
  * CI updated to stage kernels, run macOS boot e2e jobs, and upload boot logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->