### PR TITLE
feat(minimald): handle git pushes natively

### DIFF
--- a/.minimal/minimal.toml
+++ b/.minimal/minimal.toml
@@ -5,6 +5,7 @@ locked_commit = "0da02c7fe4cff292388c1b9ebd611feceabb22fe"
 
 [harness]
 use = "rust"
+runtime_packages = ["socat"]
 
 [defaults]
 profile = "dev"

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -18,6 +18,7 @@ russh-sftp.workspace = true
 path-absolutize.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 
 tokio.workspace = true
 tracing.workspace = true
@@ -31,6 +32,3 @@ ot.workspace = true
 paths.workspace = true
 sessions.workspace = true
 stdlib.workspace = true
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/crates/minimald/git-remote-min
+++ b/crates/minimald/git-remote-min
@@ -1,0 +1,20 @@
+#!/bin/sh
+# git-remote-min <remote-name> <url>
+
+while read -r cmd arg; do
+    case "$cmd" in
+    capabilities)
+        echo connect
+        echo            # blank line ends the capabilities list
+        ;;
+    connect)
+        echo            # blank line: connection established
+        exec ssh -o ProxyCommand="socat - UNIX-CONNECT:$HOME/.local/state/minimal/providers/local-0/ssh.sock" \
+		 -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' \
+		 local "$arg" "$2"
+        ;;
+    '')
+        exit 0
+        ;;
+    esac
+done

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -20,6 +20,7 @@ use russh::{
     server::{Msg, Session},
 };
 use sessions::SessionId;
+use tempfile::TempDir;
 use tokio::net::unix::pipe;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -30,7 +31,7 @@ use tokio::{
 };
 
 use crate::{
-    MINIMAL_SESSION_ID_ENV,
+    ChannelConfig, MINIMAL_SESSION_ID_ENV,
     connection::{ConnectionError, ConnectionHandle},
     server::ServerStateHandle,
     session::SessionHandle,
@@ -642,6 +643,10 @@ pub(crate) async fn handle_exec(
     };
     drop(conn_lock);
 
+    if let Some(ident) = argv.strip_prefix("git-receive-pack min://") {
+        return handle_git_receive(ident, serv, conn, id, session, channel, config).await;
+    }
+
     if config.pty.is_some() {
         tracing::warn!("channel {id}: pty requested but not yet supported",);
         session.channel_failure(id)?;
@@ -709,6 +714,122 @@ pub(crate) async fn handle_exec(
             };
             exec_task.run(channel).await;
         };
+    });
+
+    Ok(())
+}
+
+async fn handle_git_receive(
+    ident: &str,
+    serv: ServerStateHandle,
+    conn: ConnectionHandle,
+    id: ChannelId,
+    session: &mut Session,
+    channel: Channel<Msg>,
+    config: ChannelConfig,
+) -> Result<(), ConnectionError> {
+    let session_pred = {
+        match config.env_vars.get(MINIMAL_SESSION_ID_ENV) {
+            Some(id_str) => match SessionId::parse_str(id_str) {
+                Ok(id) => SessionKeyPredicate::Id(id),
+                Err(_e) => {
+                    tracing::warn!(
+                        value = %id_str,
+                        "git-receive-pack rejected on channel {id}: {MINIMAL_SESSION_ID_ENV} is not a uuid",
+                    );
+                    session.channel_failure(id)?;
+                    return Ok(());
+                }
+            },
+            None => match SessionId::parse_str(ident) {
+                Ok(id) => SessionKeyPredicate::Id(id),
+                Err(_e) => SessionKeyPredicate::Name(ident.to_string()),
+            },
+        }
+    };
+
+    let mngr = serv.sessions_manager().await;
+    let session_handle = match mngr.get_session(session_pred).await {
+        Ok(Some(h)) => h,
+        Ok(None) => {
+            tracing::warn!("git-receive-pack rejected: unknown session");
+            session.channel_failure(id)?;
+            return Ok(());
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "git-receive-pack rejected: lookup failed");
+            session.channel_failure(id)?;
+            return Ok(());
+        }
+    };
+    session.channel_success(id)?;
+
+    spawn(async move {
+        let workspace = session_handle.workspace_path().await;
+
+        let dotgit_dir = workspace.as_utf8_path().join(".git");
+        if let Ok(false) = tokio::fs::try_exists(&dotgit_dir).await {
+            // No .git directory exists, so this is likely
+            // the first push to populate. Create an empty git
+            // repo, and make sure its configured to checkout
+            // the ref it recieves.
+            let res = tokio::process::Command::new("git")
+                .arg("init")
+                .current_dir(workspace.as_utf8_path())
+                .output()
+                .await;
+            if let Err(e) = res {
+                tracing::warn!(error = %e, "git init failed");
+                channel.close().await.unwrap();
+                return;
+            }
+        }
+        let hooks_tmp = TempDir::new().unwrap();
+        tokio::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o755)
+            .open(hooks_tmp.path().join("post-receive"))
+            .await
+            .unwrap()
+            .write_all(
+                r#"#!/bin/sh
+                GIT_DIR_ABS=$(pwd -P)
+                WORK_TREE=$(dirname "$GIT_DIR_ABS")
+                unset GIT_DIR GIT_WORK_TREE GIT_QUARANTINE_PATH
+                g() { git --git-dir="$GIT_DIR_ABS" --work-tree="$WORK_TREE" "$@"; }
+
+                while read -r old new ref; do
+                    case "$ref" in refs/heads/*) ;; *) continue ;; esac
+                    branch=${ref#refs/heads/}
+
+                    if ! g diff --quiet || ! g diff --cached --quiet; then
+                        echo "remote worktree has uncommitted changes; skipping checkout of $branch" >&2
+                        continue
+                    fi
+                    g checkout -f "$branch"
+                done"#
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let exec_task = ExecTask {
+            conn,
+            serv,
+            session: session_handle,
+            channel_id: id,
+            exec: TokioExec {
+                argv: format!(
+                    "git -c core.hooksPath={} receive-pack .",
+                    hooks_tmp.path().to_str().unwrap()
+                ),
+                cwd: workspace,
+                env: BTreeMap::new(),
+            },
+        };
+        exec_task.run(channel).await;
+        drop(hooks_tmp);
     });
 
     Ok(())
@@ -1191,6 +1312,104 @@ mod tests {
             let observed = String::from_utf8(out.stdout).unwrap();
             let observed = std::path::PathBuf::from(observed.trim_end());
             assert_eq!(observed, expected);
+        }
+
+        /// End-to-end: `git push min://<session-id>` driven by an
+        /// OpenSSH process going through a modified `git-remote-min`
+        /// helper lands the pushed commit in the session workspace, with
+        /// the post-receive hook checking out the branch on disk.
+        #[ignore]
+        #[tokio::test]
+        async fn git_receive_pack_lands_pushed_commit_in_workspace() {
+            use std::os::unix::fs::PermissionsExt;
+
+            use tempfile::TempDir;
+            use tokio::process::Command;
+
+            async fn run_git(cwd: &std::path::Path, args: &[&str]) {
+                let out = Command::new("git")
+                    .current_dir(cwd)
+                    .args(args)
+                    .output()
+                    .await
+                    .expect("git should be invocable");
+                assert!(
+                    out.status.success(),
+                    "git {args:?} failed: {}",
+                    String::from_utf8_lossy(&out.stderr),
+                );
+            }
+
+            let server = TestServer::new().await;
+            let sock_dir = TempDir::new().unwrap();
+            let sock_path = sock_dir.path().join("ssh.sock");
+            server.listen_on_uds(&sock_path).await;
+
+            let mut client = server.connect().await;
+            let session_id = fresh_session(&mut client).await;
+
+            // Drop a `git-remote-min` into a tempdir and prepend that
+            // tempdir to PATH so `git push min://…` resolves to it. The
+            // script is the production one with its hard-coded socket
+            // path swapped for the test server's UDS.
+            let helpers_dir = TempDir::new().unwrap();
+            let helper_path = helpers_dir.path().join("git-remote-min");
+            let template = include_str!("../git-remote-min");
+            let script = template.replace(
+                "$HOME/.local/state/minimal/providers/local-0/ssh.sock",
+                sock_path.to_str().unwrap(),
+            );
+            tokio::fs::write(&helper_path, script).await.unwrap();
+            tokio::fs::set_permissions(&helper_path, std::fs::Permissions::from_mode(0o755))
+                .await
+                .unwrap();
+
+            // Source repo with a single commit on `main`. Local
+            // user.email/user.name to keep the test independent of any
+            // global git config.
+            let src_dir = TempDir::new().unwrap();
+            let src_path = src_dir.path();
+            run_git(src_path, &["init", "-q", "-b", "main"]).await;
+            run_git(src_path, &["config", "user.email", "t@example.com"]).await;
+            run_git(src_path, &["config", "user.name", "Test"]).await;
+            tokio::fs::write(src_path.join("hello.txt"), b"hi there\n")
+                .await
+                .unwrap();
+            run_git(src_path, &["add", "hello.txt"]).await;
+            run_git(src_path, &["commit", "-q", "-m", "first commit"]).await;
+
+            let inherited_path = std::env::var("PATH").unwrap_or_default();
+            let path_with_helper = format!("{}:{}", helpers_dir.path().display(), inherited_path);
+            let url = format!("min://{session_id}");
+            let push = Command::new("git")
+                .current_dir(src_path)
+                .env("PATH", &path_with_helper)
+                .args(["push", &url, "main"])
+                .output()
+                .await
+                .expect("git push should run");
+            assert!(
+                push.status.success(),
+                "git push failed: stdout={} stderr={}",
+                String::from_utf8_lossy(&push.stdout),
+                String::from_utf8_lossy(&push.stderr),
+            );
+
+            // The post-receive hook checks out `refs/heads/main` into
+            // the worktree, so the pushed file should be readable from
+            // the session workspace.
+            let mngr = server.state.sessions_manager().await;
+            let session_handle = mngr
+                .get_session(SessionKeyPredicate::Id(session_id))
+                .await
+                .unwrap()
+                .expect("session should be retrievable");
+            let workspace = session_handle.workspace_path().await;
+            let pushed = workspace.as_utf8_path().join("hello.txt");
+            let contents = tokio::fs::read(&pushed)
+                .await
+                .unwrap_or_else(|e| panic!("reading pushed file {pushed} failed: {e}"));
+            assert_eq!(contents, b"hi there\n");
         }
     }
 }

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -17,6 +17,7 @@
 
 #![cfg(test)]
 
+use std::path::Path;
 use std::sync::Arc;
 
 use camino::Utf8PathBuf;
@@ -25,7 +26,7 @@ use russh::keys::ssh_key;
 use sessions::SessionId;
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixStream;
+use tokio::net::{UnixListener, UnixStream};
 
 use crate::connection::Connection;
 use crate::rpc::OneshotSshRpc;
@@ -105,6 +106,27 @@ impl TestServer {
         assert!(auth.success(), "auth_none should succeed on local UDS");
 
         TestClient { handle }
+    }
+
+    /// Binds a `UnixListener` at `sock` and spawns an accept loop wired
+    /// through the same russh stack `connect()` uses, so external clients
+    /// (e.g. an OpenSSH process driven by `git push`) can dial the test
+    /// server over a real UDS rather than the in-memory pair.
+    pub(crate) async fn listen_on_uds(&self, sock: &Path) {
+        let listener = UnixListener::bind(sock).unwrap();
+        let russh_config = self.russh_config.clone();
+        let state = self.state.clone();
+        tokio::spawn(async move {
+            while let Ok((socket, _)) = listener.accept().await {
+                let russh_config = russh_config.clone();
+                let state = state.clone();
+                tokio::spawn(async move {
+                    let (_conn, session_fut) =
+                        Connection::from_socket(socket, russh_config, state, true).await;
+                    let _ = session_fut.await;
+                });
+            }
+        });
     }
 }
 


### PR DESCRIPTION
If you install the `git-remote-min` script (in this PR) in your path, you will be able to

`git push min://<session id>` or `git push min://<session name>`

which is kinda cool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added git repository push functionality using the `min://` protocol, enabling users to push code to remote sessions and automatically check out changes in the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->