### PR TITLE
feat(sessions): Add composability/resolution to loadouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "136d3e02915a2cea4d74caa8681e2d44b1c3254bdbf17d11d41d587ff858832c"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "copy_dir"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2906,6 +2915,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "kinded"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4bdbb2f423660b19f0e9f7115182214732d8dd5f840cd0a3aee3e22562f34c"
+dependencies = [
+ "kinded_macros",
+]
+
+[[package]]
+name = "kinded_macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13b4ddc5dcb32f45dac3d6f606da2a52fdb9964a18427e63cd5ef6c0d13288d"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3719,6 +3749,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "nutype"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70587a780088c67dad31bf722b875c5616096b4d8c0ded8b7de03294ffb9bbb5"
+dependencies = [
+ "nutype_macros",
+]
+
+[[package]]
+name = "nutype_macros"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148934b975faeddd8f0679d7cf11280b50c4c5495d6fe72bdaf07c932874b404"
+dependencies = [
+ "cfg-if",
+ "kinded",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "urlencoding",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,6 +4088,7 @@ version = "0.0.1"
 dependencies = [
  "camino",
  "serde",
+ "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
 ]
 
@@ -5506,12 +5561,15 @@ dependencies = [
  "camino",
  "common",
  "globset",
+ "nutype",
  "paths",
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ lzma-rs = "0.3"
 nickel-lang-core = { version = "0.18", default-features = false, features = ["format"] }
 
 nix = { version = "0.31", features = ["fs"] }
+nutype = { version = "0.6", features = ["serde"] }
 object = { version = "0.39", default-features = false, features = ["archive", "elf", "read_core", "std"] }
 oci-spec = "0.10"
 path-absolutize = "3.1"
@@ -101,6 +102,7 @@ tonic-prost = "0.14.6"
 tonic-prost-build = "0.14.6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+thiserror = "2"
 url = "2" # keep in sync with reqwest
 uuid = { version = "1.23", features = ["v4", "v7", "serde"] }
 zstd = "0.13"

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 camino.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -118,24 +118,15 @@ pub type ConfigRelPath = RelPath<ConfigRelative>;
 
 /// Errors produced when constructing a path.
 #[non_exhaustive]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
     /// An [`AbsPath`] was constructed from a non-absolute input.
+    #[error("expected an absolute path, got: {0}")]
     NotAbsolute(Utf8PathBuf),
     /// A [`RelPath`] was constructed from an absolute input.
+    #[error("expected a relative path, got: {0}")]
     IsAbsolute(Utf8PathBuf),
 }
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NotAbsolute(p) => write!(f, "expected an absolute path, got: {p}"),
-            Self::IsAbsolute(p) => write!(f, "expected a relative path, got: {p}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 #[doc(hidden)]
 pub const fn _validate_subdir(s: &str) {
@@ -196,6 +187,34 @@ impl<R: Realm> AbsPath<R> {
             })
         } else {
             Err(Error::NotAbsolute(inner))
+        }
+    }
+
+    /// Construct an [`AbsPath`] without verifying that `p` is
+    /// absolute.
+    ///
+    /// Use only when the caller has already proven absoluteness by
+    /// other means (e.g. the path came from `walkdir::WalkDir::new`
+    /// rooted at an absolute path). A `debug_assert!` catches misuse
+    /// in development builds; release builds skip the check.
+    pub fn new_unchecked(p: impl Into<Utf8PathBuf>) -> Self {
+        let p = p.into();
+        debug_assert!(p.is_absolute());
+        Self {
+            inner: p,
+            _realm: PhantomData,
+        }
+    }
+
+    /// Returns the root path (`/`), assuming a POSIX-like system.
+    ///
+    /// This is a convenience for places that need a known-absolute
+    /// root in the [`Realm`] of the caller. Not appropriate on
+    /// Windows, where the root concept differs.
+    pub fn root() -> Self {
+        Self {
+            inner: Utf8PathBuf::from("/"),
+            _realm: PhantomData,
         }
     }
 
@@ -412,6 +431,22 @@ impl<R: Realm> RelPath<R> {
                 inner,
                 _realm: PhantomData,
             })
+        }
+    }
+
+    /// Construct a [`RelPath`] without verifying that `p` is
+    /// relative.
+    ///
+    /// Use only when the caller has already proven relativity by other
+    /// means (e.g. the path was produced by `strip_prefix` against a
+    /// known absolute root). A `debug_assert!` catches misuse in
+    /// development builds; release builds skip the check.
+    pub fn new_unchecked(p: impl Into<Utf8PathBuf>) -> Self {
+        let p = p.into();
+        debug_assert!(p.is_relative());
+        Self {
+            inner: p,
+            _realm: PhantomData,
         }
     }
 
@@ -842,39 +877,17 @@ impl CwdResolvable for Daemon {}
 /// Errors produced when resolving a [`CwdRelative`] against the
 /// process current working directory.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CwdResolveError {
     /// `std::env::current_dir` failed.
-    Cwd(std::io::Error),
+    #[error("failed to read the current working directory")]
+    Cwd(#[source] std::io::Error),
     /// The cwd is not valid UTF-8.
+    #[error("current working directory `{}` is not valid UTF-8", .0.display())]
     NonUtf8Cwd(std::path::PathBuf),
     /// The cwd is somehow not absolute (an OS-level invariant violation).
+    #[error("current working directory `{0}` is not absolute")]
     CwdNotAbsolute(Utf8PathBuf),
-}
-
-impl fmt::Display for CwdResolveError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Cwd(_) => f.write_str("failed to read the current working directory"),
-            Self::NonUtf8Cwd(p) => write!(
-                f,
-                "current working directory `{}` is not valid UTF-8",
-                p.display(),
-            ),
-            Self::CwdNotAbsolute(p) => {
-                write!(f, "current working directory `{p}` is not absolute")
-            }
-        }
-    }
-}
-
-impl std::error::Error for CwdResolveError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Cwd(e) => Some(e),
-            _ => None,
-        }
-    }
 }
 
 /// A CLI-supplied path: absolute is taken as-is, relative is captured

--- a/crates/sessions/Cargo.toml
+++ b/crates/sessions/Cargo.toml
@@ -8,10 +8,13 @@ publish.workspace = true
 common.workspace = true
 globset.workspace = true
 camino.workspace = true
+nutype.workspace = true
 paths.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 uuid.workspace = true
+walkdir.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/sessions/docs/RESOLUTION.md
+++ b/crates/sessions/docs/RESOLUTION.md
@@ -1,0 +1,172 @@
+# Session Resolution Data Flow
+
+How contributions move through the session-construction pipeline, from
+declarative sources (loadout, project, packages) to the final
+`Resolution` consumed by the apply layer.
+
+```
+┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
+│  user Loadout   │  │ project config  │  │  package specs  │
+│  (Loadout)      │  │ (mfile-derived) │  │  (per package)  │
+└────────┬────────┘  └────────┬────────┘  └────────┬────────┘
+         │                    │                    │
+         │  Composable::contribute(env) -> Contribution
+         │                    │                    │
+         └────────────────────┼────────────────────┘
+                              ▼
+                  ┌───────────────────────┐
+                  │      Composer         │  Composer::add(c) drains
+                  │                       │  each contributor's
+                  │  vars:       Vec<PV>  │  Contribution into here.
+                  │  patches:    Vec<PP>  │
+                  │  packages:   Vec<Pkg> │   PV  = ProvenancedVar
+                  │  lifecycle:  Vec<H>   │   PP  = ProvenancedPatch
+                  │  env:        lookup   │   Pkg = ProvenancedPackage
+                  └───────────┬───────────┘   H   = ProvenancedHook
+                              │
+                              │ Composer::resolve(
+                              │   UserPolicy,        ◄── consumed by value
+                              │   &dyn PolicyHooks,
+                              │   ResolveOptions,    ◄── follow_symlinks etc.
+                              │ ) -> (Resolution, UserPolicy)
+                              │                     ◄── returned with any
+                              │                         hook-applied updates
+                              ▼
+        ┌─────────────────────┼─────────────────────┐
+        │                     │                     │
+        ▼                     ▼                     ▼
+┌────────────────┐  ┌──────────────────┐  ┌────────────────────┐
+│ resolve_vars   │  │ resolve_patches  │  │ packages, hooks    │
+│ (policy-gated) │  │ (policy-gated)   │  │ (pass-through; no  │
+└───────┬────────┘  └────────┬─────────┘  │  policy gate)      │
+        │                    │            └─────────┬──────────┘
+        │                    │ for each Patch:      │
+        │                    │   FileSet::resolve() │
+        │                    │   ── walkdir + glob ►│
+        │                    │   Vec<PatchFile>     │
+        │                    │   (per-file fanout)  │
+        │                    │                      │
+        ▼                    ▼                      │
+┌─────────────────────────────────────────────────────────────┐
+│  PASS 1 — Categorize (vars + patches only)                  │
+│  ──────────────────────────────────────────                 │
+│  For each item (item: T where T: Provenanced):              │
+│    Policy::check(name_or_path, item)                        │
+│      ignore matches?              ─── Ignored, drop         │
+│      else, source == UserLoadout? ─── Allowed (bypass)      │
+│      else, deny matches?          ─── Denied, error         │
+│      else, allow matches?         ─── Allowed, push         │
+│      else                         ─── NeedsApproval, batch  │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+                             │ unapproved.is_empty()?
+                             ├─── yes ──► return allowed
+                             │
+                             ▼ no
+┌─────────────────────────────────────────────────────────────┐
+│  PASS 2 — Prompt (batch)                                    │
+│  ───────────────────────                                    │
+│  hooks.on_*_unapproved(                                     │
+│      Policy,           ◄── owned copy; hook cannot mutate   │
+│                            the resolver's state directly    │
+│      &[Unapproved<_>]                                       │
+│  ) -> HookResult<Policy>                                    │
+│       │                                                     │
+│       ├── Abort       ── return ResolveError::Aborted       │
+│       └── Decided { decisions, updated_policy }             │
+│              │                                              │
+│              │  updated_policy: Some(p) installs p          │
+│              │  before Pass 3 re-checks `UseRule` items     │
+│              │  decisions length must match unapproved.len()│
+│              │  else ─── ResolveError::HookContract         │
+│              ▼                                              │
+└──────────────┬──────────────────────────────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────────────────────────────┐
+│  PASS 3 — Apply                                             │
+│  ──────────────                                             │
+│  For each (item, decision):                                 │
+│    AllowOnce ── push to `allowed`                           │
+│    DenyOnce  ── return ResolveError::Denied                 │
+│    UseRule   ── Policy::check(item) again                   │
+│                  → Ignored / Allowed / Denied as before     │
+│                  → NeedsApproval ── ResolveError::HookContract
+└────────────────────────────┬────────────────────────────────┘
+                             │
+                             │       ┌─── packages, hooks (unchanged) ───┐
+                             ▼       ▼                                    │
+                  ┌──────────────────────────────────────────┐            │
+                  │             Resolution                   │◄───────────┘
+                  │                                          │
+                  │  vars()            -> &[SV]              │   SV = SessionVar
+                  │  patches()         -> &[SP]              │        { var, source }
+                  │  packages()        -> &[Pkg]             │   SP = SessionPatch
+                  │  lifecycle_hooks() -> &[H]               │        { patch, source }
+                  │  into_parts() -> (vars, patches,         │
+                  │                   packages, hooks)       │
+                  └────────────────────┬─────────────────────┘
+                                       │
+                                       ▼
+                  (downstream: apply layer builds sandbox,
+                   materializes vars, copies files, installs hooks)
+```
+
+## Key invariants
+
+- **Composer accumulates; resolve decides.** All contribution happens
+  first, then a single resolution pass. No interleaving.
+- **`Composable::contribute` is the only entry point.** Contributors
+  produce a [`Contribution`] value; `Composer::add` drains it into the
+  composer's internal accumulators. There is no public way to push raw
+  primitives — the boundary forces every item to have a known source.
+- **Env lookup lives on the composer.** `Composer::new()` defaults to
+  `std::env::var`; `Composer::with_env(...)` pins a custom closure for
+  tests. Each `add` call threads the lookup into `contribute` so
+  inheriting var values can be resolved at contribute time.
+- **Source travels end-to-end.** Every primitive (vars, patches,
+  packages, lifecycle hooks) carries its `Source` through resolution
+  and into `Resolution`, so downstream layers (audit, inspection
+  commands, error reporting) can attribute every surviving item back
+  to its contributor.
+- **Vars and patches are policy-gated; packages and hooks are not.**
+  Package selection happens in the graph layer downstream; lifecycle
+  hooks run inside the sandbox's isolated environment. Neither needs
+  an `allow`/`deny`/`ignore` gate at this layer.
+- **User-origin items bypass `allow`/`deny`.** Pass 1's `check`
+  short-circuits to `Allowed` for `Source::UserLoadout` after the
+  `ignore` test. The user is the authority for their own Loadout;
+  `allow`/`deny` only gate other sources. `ignore` still applies
+  uniformly.
+- **Patches fan out before policy check.** A single `Patch` with a
+  glob source becomes N `PatchFile`s; each is checked independently. A
+  `Denied` on any one file kills the whole session.
+- **Hook gets narrow policy by value.** The resolver hands the hook an
+  owned `VarsPolicy` or `PatchPolicy` — never `&mut UserPolicy`. Hooks
+  cannot cross domains and cannot mutate the resolver's state in place.
+  To add a rule, the hook returns the modified copy in
+  `HookResult::Decided.updated_policy`; the resolver installs it before
+  Pass 3 re-checks `UseRule` items.
+- **`HookContract` is the safety net.** Two ways it fires: decision
+  count mismatch, or `UseRule` returning to a check that still says
+  `NeedsApproval`. Both mean the application lied to the resolver. The
+  error variant carries a context string naming the offending item.
+- **Patch enumeration errors split by audience.** All errors are
+  accumulated. After the walk, they're partitioned: configuration
+  errors (`NoWalkRoot` — unfixable without changing the loadout)
+  surface as `ResolveError::PatchConfig` and take priority over
+  transient IO failures, which surface as `ResolveError::PatchWalk`.
+  Nothing is silently dropped.
+- **`Composer::merge` is pure aggregation today.** Two contributors
+  pushing the same var name both survive into `Resolution.vars()`.
+  Conflict resolution (precedence, dedup, error-on-conflict) will live
+  in this single internal method when it lands; the merge site is
+  intentionally one place to make that change local.
+- **Internal invariants panic, not error.** `compute_dest` documents
+  two preconditions (`enumerate_patch_files` upholds them) and panics
+  with a precise message if either is violated. These are bug signals,
+  not recoverable conditions.
+- **Five failure modes terminate.** `Denied` (explicit policy reject),
+  `Aborted` (user cancelled), `HookContract` (application bug),
+  `PatchConfig` (loadout has unwalkable patterns), `PatchWalk` (IO-level
+  walk failures).

--- a/crates/sessions/src/composable.rs
+++ b/crates/sessions/src/composable.rs
@@ -1,0 +1,1929 @@
+use core::fmt;
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+use paths::{HostAbsPath, HostPath, SandboxRelPath};
+
+use crate::{
+    patches::{Patch, PatchPolicy, ResolvedPatch},
+    policy::UserPolicy,
+    vars::{ResolvedVar, VarsPolicy},
+};
+
+/// Errors produced while composing a [`Composable`] into a [`Composer`].
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A variable declaration failed validation or resolution.
+    #[error("variable contribution failed: {source}")]
+    Var {
+        #[from]
+        source: crate::vars::Error,
+    },
+    /// A patch declaration failed validation.
+    #[error("patch contribution failed: {source}")]
+    Patch {
+        #[from]
+        source: crate::patches::Error,
+    },
+    /// A lifecycle hook declaration failed validation.
+    #[error("lifecycle hook contribution failed: {source}")]
+    LifecycleHook {
+        #[from]
+        source: crate::lifecyclehook::Error,
+    },
+}
+
+/// Where a contribution came from — the provenance attached to every
+/// item that flows through the resolver.
+///
+/// `Source` is what makes the user-origin bypass possible
+/// ([`VarsPolicy::check`](crate::vars::VarsPolicy::check) /
+/// [`PatchPolicy::check`](crate::patches::PatchPolicy::check) inspect
+/// this) and what error messages name when an item is rejected.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Source {
+    /// The user's own [`Loadout`](crate::loadout::Loadout). Bypasses
+    /// `allow`/`deny` checks (only `ignore` still applies).
+    UserLoadout { name: String },
+    /// A project's `minimal.toml`, identified by the path of the
+    /// config file.
+    Project { path: HostPath },
+    /// A specific package's declaration, identified by package name.
+    Package { name: String },
+}
+
+impl fmt::Display for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UserLoadout { name } => write!(f, "user loadout `{name}`"),
+            Self::Project { path } => write!(f, "project `{path}`"),
+            Self::Package { name } => write!(f, "package `{name}`"),
+        }
+    }
+}
+
+/// Trait for types that know which [`Source`] contributed them.
+///
+/// The resolver takes `T: Provenanced` so policy `check` methods can
+/// query the source without the caller having to thread it through
+/// alongside the item.
+pub trait Provenanced {
+    /// The [`Source`] this item came from.
+    fn source(&self) -> &Source;
+}
+
+/// A [`ResolvedVar`] tagged with its [`Source`] for the resolver.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ProvenancedVar {
+    var: ResolvedVar,
+    source: Source,
+}
+
+impl ProvenancedVar {
+    /// Construct a [`ProvenancedVar`] from a resolved variable and its
+    /// origin.
+    #[must_use]
+    pub fn new(var: ResolvedVar, source: Source) -> Self {
+        Self { var, source }
+    }
+
+    /// The wrapped [`ResolvedVar`].
+    #[must_use]
+    pub fn var(&self) -> &ResolvedVar {
+        &self.var
+    }
+}
+
+impl Provenanced for ProvenancedVar {
+    fn source(&self) -> &Source {
+        &self.source
+    }
+}
+
+/// A [`Patch`] tagged with its [`Source`] for the resolver.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ProvenancedPatch {
+    patch: Patch,
+    source: Source,
+}
+
+impl ProvenancedPatch {
+    /// Construct a [`ProvenancedPatch`] from a patch declaration and
+    /// its origin.
+    #[must_use]
+    pub fn new(patch: Patch, source: Source) -> Self {
+        Self { patch, source }
+    }
+
+    /// The wrapped [`Patch`].
+    #[must_use]
+    pub fn patch(&self) -> &Patch {
+        &self.patch
+    }
+}
+
+impl Provenanced for ProvenancedPatch {
+    fn source(&self) -> &Source {
+        &self.source
+    }
+}
+
+/// A package name tagged with its [`Source`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ProvenancedPackage {
+    package: String,
+    source: Source,
+}
+
+impl ProvenancedPackage {
+    /// Construct a [`ProvenancedPackage`] from a package name and its
+    /// origin.
+    #[must_use]
+    pub fn new(package: impl Into<String>, source: Source) -> Self {
+        Self {
+            package: package.into(),
+            source,
+        }
+    }
+
+    /// The package name (typically the form `name@version` used to
+    /// identify a package in the graph).
+    #[must_use]
+    pub fn package(&self) -> &str {
+        &self.package
+    }
+}
+
+impl Provenanced for ProvenancedPackage {
+    fn source(&self) -> &Source {
+        &self.source
+    }
+}
+
+/// A [`LifecycleHook`](crate::lifecyclehook::LifecycleHook) tagged with
+/// its [`Source`].
+///
+/// Lifecycle hooks run inside the sandbox (or its equivalent isolated
+/// environment), so they don't go through the policy gate — they
+/// pass through resolution unchanged.
+#[derive(Clone, Debug)]
+pub struct ProvenancedHook {
+    hook: crate::lifecyclehook::LifecycleHook,
+    source: Source,
+}
+
+impl ProvenancedHook {
+    /// Construct a [`ProvenancedHook`] from a hook declaration and its
+    /// origin.
+    #[must_use]
+    pub fn new(hook: crate::lifecyclehook::LifecycleHook, source: Source) -> Self {
+        Self { hook, source }
+    }
+
+    /// The wrapped [`LifecycleHook`](crate::lifecyclehook::LifecycleHook).
+    #[must_use]
+    pub fn hook(&self) -> &crate::lifecyclehook::LifecycleHook {
+        &self.hook
+    }
+}
+
+impl Provenanced for ProvenancedHook {
+    fn source(&self) -> &Source {
+        &self.source
+    }
+}
+
+/// A single source's contribution to a session, materialized as a
+/// concrete value rather than streamed into a [`Composer`].
+///
+/// Returned by [`Composable::contribute`]. The composer drains
+/// `Contribution`s as it accumulates them — the indirection through
+/// this struct keeps the boundary between contributor and composer
+/// crisp:
+///
+/// - **Contributors** build a `Contribution` (often with the builder
+///   methods) and hand it back. They don't need any access to
+///   [`Composer`] internals.
+/// - **Tests** can verify a contributor's output in isolation
+///   (`loadout.contribute()` returns the same `Contribution` regardless
+///   of which composer it's fed into).
+/// - **The composer** owns the merge step in one place — useful when
+///   conflict-resolution semantics are added later.
+#[derive(Clone, Debug, Default)]
+pub struct Contribution {
+    vars: Vec<ProvenancedVar>,
+    patches: Vec<ProvenancedPatch>,
+    packages: Vec<ProvenancedPackage>,
+    lifecycle_hooks: Vec<ProvenancedHook>,
+}
+
+impl Contribution {
+    /// Construct an empty contribution.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a var (builder style).
+    #[must_use]
+    pub fn with_var(mut self, v: ProvenancedVar) -> Self {
+        self.vars.push(v);
+        self
+    }
+
+    /// Append a patch (builder style).
+    #[must_use]
+    pub fn with_patch(mut self, p: ProvenancedPatch) -> Self {
+        self.patches.push(p);
+        self
+    }
+
+    /// Append a package (builder style).
+    #[must_use]
+    pub fn with_package(mut self, p: ProvenancedPackage) -> Self {
+        self.packages.push(p);
+        self
+    }
+
+    /// Append a lifecycle hook (builder style).
+    #[must_use]
+    pub fn with_hook(mut self, h: ProvenancedHook) -> Self {
+        self.lifecycle_hooks.push(h);
+        self
+    }
+
+    /// Append a var in place. Useful inside a loop.
+    pub fn push_var(&mut self, v: ProvenancedVar) {
+        self.vars.push(v);
+    }
+
+    /// Append a patch in place.
+    pub fn push_patch(&mut self, p: ProvenancedPatch) {
+        self.patches.push(p);
+    }
+
+    /// Append a package in place.
+    pub fn push_package(&mut self, p: ProvenancedPackage) {
+        self.packages.push(p);
+    }
+
+    /// Append a lifecycle hook in place.
+    pub fn push_hook(&mut self, h: ProvenancedHook) {
+        self.lifecycle_hooks.push(h);
+    }
+
+    /// All vars contributed so far.
+    #[must_use]
+    pub fn vars(&self) -> &[ProvenancedVar] {
+        &self.vars
+    }
+
+    /// All patches contributed so far.
+    #[must_use]
+    pub fn patches(&self) -> &[ProvenancedPatch] {
+        &self.patches
+    }
+
+    /// All packages contributed so far.
+    #[must_use]
+    pub fn packages(&self) -> &[ProvenancedPackage] {
+        &self.packages
+    }
+
+    /// All lifecycle hooks contributed so far.
+    #[must_use]
+    pub fn lifecycle_hooks(&self) -> &[ProvenancedHook] {
+        &self.lifecycle_hooks
+    }
+}
+
+/// A lookup function for resolving inherited environment variables.
+///
+/// Threaded through [`Composable::contribute`] so var declarations
+/// with `inherit = true` (or `InheritWithDefault`) can be resolved
+/// against an arbitrary environment — production callers pass
+/// [`std::env::var`]; tests pass a synthetic closure.
+pub type EnvLookup<'a> = &'a dyn Fn(&str) -> Result<String, std::env::VarError>;
+
+/// Anything that can contribute primitives (vars, patches, packages,
+/// lifecycle hooks) to a [`Composer`] during session construction.
+///
+/// Implementors are user-curated sources of session state — loadouts,
+/// project configs, and package specs. The trait is the funnel that
+/// brings their declarations into one place to be resolved against the
+/// user's [`UserPolicy`].
+///
+/// The trait does *not* require [`Provenanced`]: a contributor isn't
+/// itself an "item" — it's the *source* of items. Each contributor
+/// knows its own [`Source`] and tags its primitives accordingly.
+pub trait Composable {
+    /// Produce this source's [`Contribution`].
+    ///
+    /// Consuming `self` matches the one-shot nature of contribution:
+    /// each contributor is "spent" once it hands off its primitives.
+    /// `env` resolves any inherited variables the contributor needs to
+    /// materialize.
+    ///
+    /// # Errors
+    ///
+    /// Implementations return an [`Error`] when their primitives fail
+    /// their own construction-time validation (e.g. an invalid glob,
+    /// an empty patch destination, or an env lookup that surfaced an
+    /// error).
+    fn contribute(self, env: EnvLookup<'_>) -> Result<Contribution, Error>;
+}
+
+// =====================================================================
+// Resolution: deciding what survives the user's policy
+// =====================================================================
+
+/// What the policy decided about a single item.
+///
+/// `Ignored` carries no payload — the caller silently drops the item.
+/// `Allowed` and `Denied` carry the item through so callers can collect
+/// it (or, in the case of `Denied`, name it in the error).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Decision<T> {
+    /// The item passes the policy and should be included.
+    Allowed(T),
+    /// The item matches an `ignore` rule and should be silently dropped.
+    Ignored,
+    /// The item is explicitly forbidden; session construction aborts.
+    Denied(T),
+}
+
+/// The outcome of a single policy `check`.
+///
+/// `NeedsApproval` hands the item back so the resolve loop can prompt
+/// for it via a [`PolicyHooks`] callback and re-check.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum CheckOutcome<T> {
+    /// The policy reached a verdict on its own.
+    Decided(Decision<T>),
+    /// No rule matched; the item must be referred to a [`PolicyHooks`]
+    /// callback for an application-level decision.
+    NeedsApproval(T),
+}
+
+/// One item the policy could not decide. The item is held by reference
+/// so the resolve loop retains ownership for the second pass.
+///
+/// Constructed only by the resolver; hooks receive these as borrowed
+/// slices. The fields are inaccessible to outside code on purpose —
+/// nothing prevents constructing one, but the lifetimes are tied to
+/// the resolver's frame and there's no sensible way to manufacture
+/// matched references elsewhere.
+#[derive(Clone, Debug)]
+pub struct Unapproved<'a, T: ?Sized> {
+    item: &'a T,
+    source: &'a Source,
+}
+
+impl<'a, T: ?Sized> Unapproved<'a, T> {
+    /// The item the policy couldn't decide on (e.g. a variable name or
+    /// patch source path).
+    #[must_use]
+    pub fn item(&self) -> &'a T {
+        self.item
+    }
+
+    /// The [`Source`] that contributed this item — useful for prompts
+    /// like "project `~/foo` wants to set `AWS_KEY`."
+    #[must_use]
+    pub fn source(&self) -> &'a Source {
+        self.source
+    }
+}
+
+/// One application-supplied decision per `Unapproved` item, returned by
+/// a [`PolicyHooks`] callback in the same order the items were given.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ItemDecision {
+    /// Approve this item without recording a rule.
+    AllowOnce,
+    /// Reject this item without recording a rule.
+    DenyOnce,
+    /// Re-check against the (possibly mutated) policy.
+    UseRule,
+}
+
+/// The hook's response to the batch of unapproved items.
+///
+/// Hooks **cannot** mutate the policy directly. If the application
+/// updates the policy in response to the prompt, it returns the updated
+/// copy in `updated_policy`. `None` means "no rule changes." The
+/// resolver installs `updated_policy` (if `Some`) before re-checking
+/// any `UseRule` decisions in this batch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HookResult<P> {
+    /// Per-item decisions, indexed parallel to the input slice, plus
+    /// an optional updated policy snapshot.
+    Decided {
+        decisions: Vec<ItemDecision>,
+        updated_policy: Option<P>,
+    },
+    /// User chose to abort session construction.
+    Abort,
+}
+
+impl<P> HookResult<P> {
+    /// Construct a [`Decided`](Self::Decided) result that leaves the
+    /// policy unchanged.
+    #[must_use]
+    pub fn decided(decisions: Vec<ItemDecision>) -> Self {
+        Self::Decided {
+            decisions,
+            updated_policy: None,
+        }
+    }
+
+    /// Construct a [`Decided`](Self::Decided) result that installs a
+    /// new policy snapshot.
+    #[must_use]
+    pub fn decided_with_policy(decisions: Vec<ItemDecision>, updated_policy: P) -> Self {
+        Self::Decided {
+            decisions,
+            updated_policy: Some(updated_policy),
+        }
+    }
+
+    /// Construct an [`Abort`](Self::Abort) result.
+    #[must_use]
+    pub fn abort() -> Self {
+        Self::Abort
+    }
+}
+
+/// Application-supplied hooks for handling items the policy couldn't
+/// decide on its own.
+///
+/// Hooks receive an owned copy of the *narrow* domain policy
+/// (`VarsPolicy` / `PatchPolicy`); they cannot mutate the resolver's
+/// state directly. To add rules, return a modified policy snapshot in
+/// [`HookResult::Decided::updated_policy`] — wider mutations to the
+/// full [`UserPolicy`] are not exposed here.
+pub trait PolicyHooks {
+    fn on_var_unapproved(
+        &self,
+        policy: VarsPolicy,
+        items: &[Unapproved<'_, str>],
+    ) -> HookResult<VarsPolicy>;
+
+    fn on_patch_unapproved(
+        &self,
+        policy: PatchPolicy,
+        items: &[Unapproved<'_, camino::Utf8Path>],
+    ) -> HookResult<PatchPolicy>;
+}
+
+/// Errors raised by the resolution pass.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum ResolveError {
+    /// Policy explicitly denied an item; session construction aborts.
+    ///
+    /// `from` is the contributor whose item was rejected. The field is
+    /// not named `source` because thiserror auto-promotes that name to
+    /// [`std::error::Error::source`] and [`Source`] is provenance
+    /// metadata, not an error.
+    #[error("policy denied `{what}` (from {from})")]
+    Denied { what: String, from: Source },
+    /// User cancelled at the prompt.
+    #[error("user aborted session construction")]
+    Aborted,
+    /// Hook returned a result that violates the contract: wrong number
+    /// of decisions, or `UseRule` for an item the policy still couldn't
+    /// decide after mutation. `context` names the offending item or
+    /// batch so the message points somewhere concrete.
+    #[error("policy hook contract violation: {kind} ({context})")]
+    HookContract { kind: &'static str, context: String },
+    /// A patch source has an unwalkable configuration — typically a
+    /// pattern with no literal path prefix. The user must fix their
+    /// loadout/project config; retrying without changes will not help.
+    ///
+    /// Surfaced separately from [`PatchWalk`](Self::PatchWalk) because
+    /// configuration errors and transient IO failures have different
+    /// audiences (the loadout author vs. the operator).
+    #[error("patch source configuration is invalid ({} error(s)):{}", sources.len(), DisplayJoin(sources))]
+    PatchConfig { sources: Vec<crate::patches::Error> },
+    /// One or more patch source filesystem walks failed with IO-level
+    /// errors (permission denied, non-UTF-8 paths, etc.). All errors
+    /// surfaced by every `FileSet::resolve` invocation are accumulated
+    /// — none are discarded.
+    #[error("patch resolution failed ({} error(s)):{}", sources.len(), DisplayJoin(sources))]
+    PatchWalk { sources: Vec<crate::patches::Error> },
+}
+
+/// Render a slice of `Display`-able errors as one indented bullet per
+/// line, for embedding inside a parent error message.
+struct DisplayJoin<'a, E: fmt::Display>(&'a [E]);
+
+impl<E: fmt::Display> fmt::Display for DisplayJoin<'_, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for e in self.0 {
+            write!(f, "\n  - {e}")?;
+        }
+        Ok(())
+    }
+}
+
+/// One environment variable that survived policy resolution, paired
+/// with its origin.
+///
+/// The source is retained so downstream layers (CLI inspection, audit
+/// logs, error reporting) can attribute each decision back to the
+/// contributor that asked for it.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SessionVar {
+    var: ResolvedVar,
+    source: Source,
+}
+
+impl SessionVar {
+    /// The resolved variable that survived policy resolution.
+    #[must_use]
+    pub fn var(&self) -> &ResolvedVar {
+        &self.var
+    }
+}
+
+impl Provenanced for SessionVar {
+    fn source(&self) -> &Source {
+        &self.source
+    }
+}
+
+/// One patch file that survived policy resolution, paired with its
+/// origin. See [`SessionVar`] for the rationale.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SessionPatch {
+    patch: ResolvedPatch,
+    source: Source,
+}
+
+impl SessionPatch {
+    /// The resolved patch (host path + sandbox destination).
+    #[must_use]
+    pub fn patch(&self) -> &ResolvedPatch {
+        &self.patch
+    }
+}
+
+impl Provenanced for SessionPatch {
+    fn source(&self) -> &Source {
+        &self.source
+    }
+}
+
+/// Everything that survived policy resolution.
+///
+/// Vars and patches are policy-gated. Packages and lifecycle hooks
+/// pass through unchanged — packages are graph-resolved downstream,
+/// and hooks execute inside an isolated environment, so neither has a
+/// policy in this layer.
+#[derive(Clone, Debug, Default)]
+pub struct Resolution {
+    vars: Vec<SessionVar>,
+    patches: Vec<SessionPatch>,
+    packages: Vec<ProvenancedPackage>,
+    lifecycle_hooks: Vec<ProvenancedHook>,
+}
+
+impl Resolution {
+    /// The vars that survived resolution, each paired with its source.
+    #[must_use]
+    pub fn vars(&self) -> &[SessionVar] {
+        &self.vars
+    }
+
+    /// The patches that survived resolution, each paired with its
+    /// source. Multi-file patches appear as one [`SessionPatch`] per
+    /// matched file.
+    #[must_use]
+    pub fn patches(&self) -> &[SessionPatch] {
+        &self.patches
+    }
+
+    /// The packages contributed to the session, each paired with its
+    /// source. Pass-through; no policy gate.
+    #[must_use]
+    pub fn packages(&self) -> &[ProvenancedPackage] {
+        &self.packages
+    }
+
+    /// The lifecycle hooks contributed to the session, each paired
+    /// with its source. Pass-through; no policy gate.
+    #[must_use]
+    pub fn lifecycle_hooks(&self) -> &[ProvenancedHook] {
+        &self.lifecycle_hooks
+    }
+
+    /// Consume the [`Resolution`] and return the underlying vectors
+    /// for moving into downstream layers.
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        Vec<SessionVar>,
+        Vec<SessionPatch>,
+        Vec<ProvenancedPackage>,
+        Vec<ProvenancedHook>,
+    ) {
+        (self.vars, self.patches, self.packages, self.lifecycle_hooks)
+    }
+}
+
+/// Configuration for [`Composer::resolve`].
+///
+/// Defaults to symlink-safe behavior (no following) — appropriate for
+/// dotfile trees where a symlink may legitimately point outside the
+/// patch source.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ResolveOptions {
+    /// If `true`, [`FileSet::resolve`](crate::patches::FileSet::resolve)
+    /// follows symlinks while walking patch sources. Off by default.
+    pub follow_symlinks: bool,
+}
+
+// =====================================================================
+// Composer
+// =====================================================================
+
+/// Accumulator for contributions from one or more [`Composable`]
+/// sources, drained by [`Composer::resolve`] into a [`Resolution`].
+///
+/// Contributors push vars and patches; the composer does no policy
+/// work until `resolve` is called. This separates declarative
+/// accumulation from the (potentially interactive) resolution pass.
+/// Boxed env-lookup closure stored in [`Composer`].
+type StoredEnv = Box<dyn Fn(&str) -> Result<String, std::env::VarError>>;
+
+pub struct Composer {
+    vars: Vec<ProvenancedVar>,
+    patches: Vec<ProvenancedPatch>,
+    packages: Vec<ProvenancedPackage>,
+    lifecycle_hooks: Vec<ProvenancedHook>,
+    env: StoredEnv,
+}
+
+impl fmt::Debug for Composer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Composer")
+            .field("vars", &self.vars)
+            .field("patches", &self.patches)
+            .field("packages", &self.packages)
+            .field("lifecycle_hooks", &self.lifecycle_hooks)
+            .field("env", &"<closure>")
+            .finish()
+    }
+}
+
+impl Default for Composer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Composer {
+    /// Construct an empty composer with [`std::env::var`] as the env
+    /// lookup. Suitable for production code.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_env(Box::new(|name| std::env::var(name)))
+    }
+
+    /// Construct an empty composer with a custom env lookup. Useful for
+    /// tests that want to pin env behavior without touching the
+    /// process environment.
+    #[must_use]
+    pub fn with_env(env: StoredEnv) -> Self {
+        Self {
+            vars: Vec::new(),
+            patches: Vec::new(),
+            packages: Vec::new(),
+            lifecycle_hooks: Vec::new(),
+            env,
+        }
+    }
+
+    /// Take a [`Composable`]'s contribution and merge it into this
+    /// composer. The canonical entry point for populating a composer.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error the contributor surfaces from [`Composable::contribute`].
+    pub fn add(&mut self, c: impl Composable) -> Result<(), Error> {
+        self.merge(c.contribute(&*self.env)?);
+        Ok(())
+    }
+
+    /// Add every [`Composable`] in `items` in order. Stops at the
+    /// first failure and returns that error.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`Error`] surfaced by any contributor.
+    pub fn add_all<C, I>(&mut self, items: I) -> Result<(), Error>
+    where
+        C: Composable,
+        I: IntoIterator<Item = C>,
+    {
+        for c in items {
+            self.add(c)?;
+        }
+        Ok(())
+    }
+
+    /// Drain a [`Contribution`] into the composer.
+    ///
+    /// This is the single internal merge step — when conflict
+    /// resolution lands, it lives here. Today: pure aggregation, no
+    /// dedup / no merge policy.
+    fn merge(&mut self, mut c: Contribution) {
+        self.vars.append(&mut c.vars);
+        self.patches.append(&mut c.patches);
+        self.packages.append(&mut c.packages);
+        self.lifecycle_hooks.append(&mut c.lifecycle_hooks);
+    }
+
+    /// Resolve every accumulated contribution against `policy`.
+    ///
+    /// Invokes `hooks` once per domain to handle items the policy
+    /// couldn't decide; hooks may return updated policy snapshots
+    /// mid-flight. The (possibly updated) [`UserPolicy`] is returned
+    /// alongside the [`Resolution`] so callers can persist any rules
+    /// the hook added.
+    ///
+    /// The whole resolution aborts on the first explicit `Denied`,
+    /// the hook returning `Abort`, or a hook contract violation. On
+    /// error, the policy is consumed and lost; callers wanting to
+    /// retain it across a failed resolution must clone beforehand.
+    ///
+    /// # Errors
+    ///
+    /// See [`ResolveError`].
+    pub fn resolve(
+        self,
+        policy: UserPolicy,
+        hooks: &dyn PolicyHooks,
+        options: ResolveOptions,
+    ) -> Result<(Resolution, UserPolicy), ResolveError> {
+        let (vars_policy, patches_policy) = policy.into_parts();
+        let (vars, vars_policy) = resolve_vars(self.vars, vars_policy, hooks)?;
+        let (patches, patches_policy) =
+            resolve_patches(self.patches, patches_policy, hooks, options)?;
+        let final_policy = UserPolicy::empty()
+            .with_vars(vars_policy)
+            .with_patches(patches_policy);
+        let resolution = Resolution {
+            vars,
+            patches,
+            packages: self.packages,
+            lifecycle_hooks: self.lifecycle_hooks,
+        };
+        Ok((resolution, final_policy))
+    }
+}
+
+// =====================================================================
+// Per-domain resolution
+// =====================================================================
+
+/// Push, drop, or fail on a single [`Decision`].
+///
+/// Used by Pass 1 (categorizing every item) and by Pass 3's `UseRule`
+/// branch (re-checking after the hook mutated the policy). The caller
+/// supplies extractors for the `Denied` arm so the helper stays
+/// agnostic to whether items are vars or patches. Closures are `Fn` so
+/// they're reusable across loop iterations.
+fn apply_decision<T>(
+    decision: Decision<T>,
+    allowed: &mut Vec<T>,
+    name_of: impl Fn(&T) -> String,
+    source_of: impl Fn(T) -> Source,
+) -> Result<(), ResolveError> {
+    match decision {
+        Decision::Allowed(t) => allowed.push(t),
+        Decision::Ignored => {}
+        Decision::Denied(t) => {
+            let what = name_of(&t);
+            return Err(ResolveError::Denied {
+                what,
+                from: source_of(t),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn resolve_vars(
+    items: Vec<ProvenancedVar>,
+    mut policy: VarsPolicy,
+    hooks: &dyn PolicyHooks,
+) -> Result<(Vec<SessionVar>, VarsPolicy), ResolveError> {
+    let name_of = |pv: &ProvenancedVar| pv.var.name().to_owned();
+    let source_of = |pv: ProvenancedVar| pv.source;
+
+    // Pass 1: categorize.
+    let mut allowed: Vec<ProvenancedVar> = Vec::new();
+    let mut unapproved: Vec<ProvenancedVar> = Vec::new();
+    for pv in items {
+        let name = pv.var.name().to_owned();
+        match policy.check(&name, pv) {
+            CheckOutcome::Decided(d) => apply_decision(d, &mut allowed, name_of, source_of)?,
+            CheckOutcome::NeedsApproval(pv) => unapproved.push(pv),
+        }
+    }
+    if !unapproved.is_empty() {
+        // Pass 2: prompt. Hand the hook an owned copy of the policy
+        // so it cannot mutate ours directly.
+        let view: Vec<Unapproved<'_, str>> = unapproved
+            .iter()
+            .map(|pv| Unapproved {
+                item: pv.var.name(),
+                source: &pv.source,
+            })
+            .collect();
+        let decisions = match hooks.on_var_unapproved(policy.clone(), &view) {
+            HookResult::Decided {
+                decisions,
+                updated_policy,
+            } => {
+                if let Some(new_policy) = updated_policy {
+                    policy = new_policy;
+                }
+                decisions
+            }
+            HookResult::Abort => return Err(ResolveError::Aborted),
+        };
+        if decisions.len() != unapproved.len() {
+            return Err(ResolveError::HookContract {
+                kind: "var-domain hook returned the wrong number of decisions",
+                context: format!("expected {}, got {}", unapproved.len(), decisions.len()),
+            });
+        }
+        // Pass 3: apply.
+        for (pv, decision) in unapproved.into_iter().zip(decisions) {
+            match decision {
+                ItemDecision::AllowOnce => allowed.push(pv),
+                ItemDecision::DenyOnce => {
+                    return Err(ResolveError::Denied {
+                        what: name_of(&pv),
+                        from: source_of(pv),
+                    });
+                }
+                ItemDecision::UseRule => {
+                    let name = pv.var.name().to_owned();
+                    match policy.check(&name, pv) {
+                        CheckOutcome::Decided(d) => {
+                            apply_decision(d, &mut allowed, name_of, source_of)?;
+                        }
+                        CheckOutcome::NeedsApproval(pv) => {
+                            return Err(ResolveError::HookContract {
+                                kind: "UseRule returned for a var the policy still cannot decide",
+                                context: format!("variable `{}`", pv.var.name()),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((
+        allowed
+            .into_iter()
+            .map(|pv| SessionVar {
+                var: pv.var,
+                source: pv.source,
+            })
+            .collect(),
+        policy,
+    ))
+}
+
+/// Per-file entry derived from a [`Patch`] after its source [`FileSet`]
+/// is walked.
+struct PatchFile {
+    /// Absolute host path to the file.
+    source_path: Utf8PathBuf,
+    /// Destination inside the sandbox for this file.
+    dest: SandboxRelPath,
+    /// The original patch's provenance.
+    provenance: Source,
+}
+
+impl Provenanced for PatchFile {
+    fn source(&self) -> &Source {
+        &self.provenance
+    }
+}
+
+/// Enumerate every file each `Patch` source glob expands to.
+///
+/// All errors are accumulated. After the walk, errors are partitioned
+/// by kind: configuration errors (e.g. [`patches::Error::NoWalkRoot`])
+/// take priority over transient IO walk errors, so the user fixes the
+/// config first. If only IO errors occurred, those surface as
+/// [`ResolveError::PatchWalk`].
+///
+/// [`patches::Error::NoWalkRoot`]: crate::patches::Error::NoWalkRoot
+fn enumerate_patch_files(
+    items: Vec<ProvenancedPatch>,
+    follow_symlinks: bool,
+) -> Result<Vec<PatchFile>, ResolveError> {
+    let mut out = Vec::new();
+    let mut accumulated_errors = Vec::new();
+    for pp in items {
+        let Some(walk_root) = pp.patch.source().walk_root() else {
+            // FileSet::resolve will also report NoWalkRoot; we still
+            // call it for symmetry of error accumulation.
+            let (_files, errors) = pp.patch.source().resolve(follow_symlinks);
+            accumulated_errors.extend(errors);
+            continue;
+        };
+        let (files, errors) = pp.patch.source().resolve(follow_symlinks);
+        accumulated_errors.extend(errors);
+        let dest_root = pp.patch.dest().as_sandbox_path().as_utf8_path();
+        for file in files {
+            let source_path = file.as_utf8_path().to_path_buf();
+            let dest = compute_dest(&source_path, &walk_root, dest_root);
+            out.push(PatchFile {
+                source_path,
+                dest,
+                provenance: pp.source.clone(),
+            });
+        }
+    }
+    if accumulated_errors.is_empty() {
+        return Ok(out);
+    }
+    let (config, walk): (Vec<_>, Vec<_>) = accumulated_errors
+        .into_iter()
+        .partition(is_patch_config_error);
+    if !config.is_empty() {
+        return Err(ResolveError::PatchConfig { sources: config });
+    }
+    Err(ResolveError::PatchWalk { sources: walk })
+}
+
+/// `true` for errors that mean "the user's loadout/project config is
+/// wrong" rather than "the host filesystem misbehaved."
+fn is_patch_config_error(e: &crate::patches::Error) -> bool {
+    matches!(e, crate::patches::Error::NoWalkRoot { .. })
+}
+
+/// Compute the sandbox destination for a single source file under a
+/// patch's `dest`.
+///
+/// - **Single-file patches** (`walk_root == source_path`): `dest` is
+///   used verbatim.
+/// - **Multi-file patches**: the source path's components beneath
+///   `walk_root` are appended to `dest`. The strip is path-component
+///   aware (camino's `strip_prefix`), so `/etc/xdg` will not match
+///   `/etc/xdgfoo/`.
+///
+/// # Invariants (panic conditions)
+///
+/// Both panics describe resolver-internal contracts that
+/// `enumerate_patch_files` is responsible for upholding. They should
+/// be unreachable in normal operation; if one fires, it indicates a
+/// bug in this crate.
+///
+/// 1. `walk_root` must be a path-component prefix of `source_path`.
+///    `enumerate_patch_files` walks `walk_root`, so every file it
+///    yields is a descendant.
+/// 2. `dest_root` is relative (it came from a [`SandboxRelPath`]) and
+///    `suffix` is relative (it's the stripped tail), so the join
+///    cannot produce an absolute path.
+fn compute_dest(
+    source_path: &Utf8Path,
+    walk_root: &HostPath,
+    dest_root: &Utf8Path,
+) -> SandboxRelPath {
+    let root_path = walk_root.as_utf8_path();
+    let joined: Utf8PathBuf = if source_path == root_path {
+        dest_root.to_path_buf()
+    } else {
+        let suffix = source_path.strip_prefix(root_path).unwrap_or_else(|_| {
+            panic!(
+                "resolver invariant: source path {source_path} is outside walk root {root_path}",
+            )
+        });
+        if dest_root.as_str().is_empty() {
+            suffix.to_path_buf()
+        } else {
+            dest_root.join(suffix)
+        }
+    };
+    SandboxRelPath::try_new(joined)
+        .expect("resolver invariant: dest_root and suffix are both relative")
+}
+
+fn resolve_patches(
+    items: Vec<ProvenancedPatch>,
+    mut policy: PatchPolicy,
+    hooks: &dyn PolicyHooks,
+    options: ResolveOptions,
+) -> Result<(Vec<SessionPatch>, PatchPolicy), ResolveError> {
+    let name_of = |pf: &PatchFile| pf.source_path.as_str().to_owned();
+    let source_of = |pf: PatchFile| pf.provenance;
+
+    let files = enumerate_patch_files(items, options.follow_symlinks)?;
+
+    // Pass 1: categorize per file.
+    let mut allowed: Vec<PatchFile> = Vec::new();
+    let mut unapproved: Vec<PatchFile> = Vec::new();
+    for pf in files {
+        let path = pf.source_path.clone();
+        match policy.check(&path, pf) {
+            CheckOutcome::Decided(d) => apply_decision(d, &mut allowed, name_of, source_of)?,
+            CheckOutcome::NeedsApproval(pf) => unapproved.push(pf),
+        }
+    }
+    if !unapproved.is_empty() {
+        // Pass 2: prompt.
+        let view: Vec<Unapproved<'_, Utf8Path>> = unapproved
+            .iter()
+            .map(|pf| Unapproved {
+                item: pf.source_path.as_path(),
+                source: &pf.provenance,
+            })
+            .collect();
+        let decisions = match hooks.on_patch_unapproved(policy.clone(), &view) {
+            HookResult::Decided {
+                decisions,
+                updated_policy,
+            } => {
+                if let Some(new_policy) = updated_policy {
+                    policy = new_policy;
+                }
+                decisions
+            }
+            HookResult::Abort => return Err(ResolveError::Aborted),
+        };
+        if decisions.len() != unapproved.len() {
+            return Err(ResolveError::HookContract {
+                kind: "patch-domain hook returned the wrong number of decisions",
+                context: format!("expected {}, got {}", unapproved.len(), decisions.len()),
+            });
+        }
+        // Pass 3: apply.
+        for (pf, decision) in unapproved.into_iter().zip(decisions) {
+            match decision {
+                ItemDecision::AllowOnce => allowed.push(pf),
+                ItemDecision::DenyOnce => {
+                    return Err(ResolveError::Denied {
+                        what: name_of(&pf),
+                        from: source_of(pf),
+                    });
+                }
+                ItemDecision::UseRule => {
+                    let path = pf.source_path.clone();
+                    match policy.check(&path, pf) {
+                        CheckOutcome::Decided(d) => {
+                            apply_decision(d, &mut allowed, name_of, source_of)?;
+                        }
+                        CheckOutcome::NeedsApproval(pf) => {
+                            return Err(ResolveError::HookContract {
+                                kind: "UseRule returned for a patch file the policy still cannot decide",
+                                context: format!("source path `{}`", pf.source_path),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((
+        allowed
+            .into_iter()
+            .map(|pf| SessionPatch {
+                patch: ResolvedPatch::new(HostAbsPath::new_unchecked(pf.source_path), pf.dest),
+                source: pf.provenance,
+            })
+            .collect(),
+        policy,
+    ))
+}
+
+// =====================================================================
+// Tests
+// =====================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::patches::{FileSet, PatchDest};
+    use crate::vars::{ResolvedVar, VarValue};
+    use std::cell::RefCell;
+
+    // =================================================================
+    // Shared helpers + hook fixtures
+    // =================================================================
+
+    fn user_source() -> Source {
+        Source::UserLoadout {
+            name: "test".into(),
+        }
+    }
+
+    fn project_source() -> Source {
+        Source::Project {
+            path: HostPath::new("/repo"),
+        }
+    }
+
+    fn pv_with(name: &str, source: Source) -> ProvenancedVar {
+        ProvenancedVar::new(
+            ResolvedVar::resolve_with(name.into(), VarValue::specified("x"), |_| {
+                Err(std::env::VarError::NotPresent)
+            })
+            .unwrap(),
+            source,
+        )
+    }
+
+    /// Default `pv` uses a Project source so allow/deny/prompt logic
+    /// actually exercises — user origin would short-circuit via the
+    /// bypass.
+    fn pv(name: &str) -> ProvenancedVar {
+        pv_with(name, project_source())
+    }
+
+    type VarsPolicyMutator = Box<dyn Fn(&mut VarsPolicy)>;
+
+    /// Hook driver: enqueue var-domain responses; panic on patch-domain.
+    /// `with_mutator` lets a test mutate the *owned copy* of the policy
+    /// before the hook's response is consumed; the resulting copy is
+    /// what's returned in `updated_policy`.
+    struct ScriptedHook {
+        var_responses: RefCell<Vec<HookResult<VarsPolicy>>>,
+        var_mutate: RefCell<Vec<VarsPolicyMutator>>,
+    }
+
+    impl ScriptedHook {
+        fn new(responses: Vec<HookResult<VarsPolicy>>) -> Self {
+            Self {
+                var_responses: RefCell::new(responses),
+                var_mutate: RefCell::new(Vec::new()),
+            }
+        }
+        fn with_mutator<F: Fn(&mut VarsPolicy) + 'static>(mut self, f: F) -> Self {
+            self.var_mutate.get_mut().push(Box::new(f));
+            self
+        }
+    }
+
+    impl PolicyHooks for ScriptedHook {
+        fn on_var_unapproved(
+            &self,
+            mut policy: VarsPolicy,
+            _items: &[Unapproved<'_, str>],
+        ) -> HookResult<VarsPolicy> {
+            let mutated = self
+                .var_mutate
+                .borrow_mut()
+                .pop()
+                .inspect(|m| m(&mut policy));
+            let response = self
+                .var_responses
+                .borrow_mut()
+                .pop()
+                .unwrap_or_else(|| panic!("ScriptedHook: ran out of queued var responses"));
+            // If a mutator ran and the response didn't already specify
+            // an updated_policy, install the mutated copy.
+            if mutated.is_some() {
+                match response {
+                    HookResult::Decided {
+                        decisions,
+                        updated_policy: None,
+                    } => HookResult::decided_with_policy(decisions, policy),
+                    other => other,
+                }
+            } else {
+                response
+            }
+        }
+
+        fn on_patch_unapproved(
+            &self,
+            _policy: PatchPolicy,
+            _items: &[Unapproved<'_, camino::Utf8Path>],
+        ) -> HookResult<PatchPolicy> {
+            panic!("patch hook not expected in these tests")
+        }
+    }
+
+    /// Hook that panics on either domain. Used by tests asserting that
+    /// the hook MUST NOT be reached — typically because a bypass or
+    /// other short-circuit was supposed to fire first.
+    struct PanicHook;
+    impl PolicyHooks for PanicHook {
+        fn on_var_unapproved(
+            &self,
+            _: VarsPolicy,
+            _: &[Unapproved<'_, str>],
+        ) -> HookResult<VarsPolicy> {
+            panic!("var hook should not have been invoked")
+        }
+        fn on_patch_unapproved(
+            &self,
+            _: PatchPolicy,
+            _: &[Unapproved<'_, camino::Utf8Path>],
+        ) -> HookResult<PatchPolicy> {
+            panic!("patch hook should not have been invoked")
+        }
+    }
+
+    /// Hook that approves everything (`AllowOnce` for every item). Used
+    /// when the test cares about flow rather than hook semantics.
+    struct PassThroughHook;
+    impl PolicyHooks for PassThroughHook {
+        fn on_var_unapproved(
+            &self,
+            _: VarsPolicy,
+            items: &[Unapproved<'_, str>],
+        ) -> HookResult<VarsPolicy> {
+            HookResult::decided(vec![ItemDecision::AllowOnce; items.len()])
+        }
+        fn on_patch_unapproved(
+            &self,
+            _: PatchPolicy,
+            items: &[Unapproved<'_, camino::Utf8Path>],
+        ) -> HookResult<PatchPolicy> {
+            HookResult::decided(vec![ItemDecision::AllowOnce; items.len()])
+        }
+    }
+
+    /// Build a `Patch` with a single-file source rooted at a tempdir.
+    /// Returns the tempdir guard (caller keeps alive) and the patch.
+    fn single_file_patch(name: &str, dest: &str) -> (tempfile::TempDir, Patch) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap().to_path_buf();
+        let file = root.join(name);
+        std::fs::write(file.as_std_path(), "x").unwrap();
+        let patch = Patch::new(
+            FileSet::try_new(file.as_str()).unwrap(),
+            PatchDest::try_new(dest).unwrap(),
+        );
+        (tmp, patch)
+    }
+
+    // =================================================================
+    // Vars resolution
+    // =================================================================
+
+    mod vars_resolution {
+        use super::*;
+
+        #[test]
+        fn allow_passes_through_with_source_preserved() {
+            let policy = VarsPolicy::empty().try_with_allow(["A_*"]).unwrap();
+            let (out, _) = resolve_vars(vec![pv("A_FOO")], policy, &PanicHook).unwrap();
+            assert_eq!(out.len(), 1);
+            assert_eq!(out[0].var().name(), "A_FOO");
+            assert_eq!(out[0].source(), &project_source());
+        }
+
+        #[test]
+        fn ignore_drops_silently() {
+            let policy = VarsPolicy::empty().try_with_ignore(["_*"]).unwrap();
+            let (out, _) = resolve_vars(vec![pv("_TMP")], policy, &PanicHook).unwrap();
+            assert!(out.is_empty());
+        }
+
+        #[test]
+        fn deny_errors() {
+            let policy = VarsPolicy::empty().try_with_deny(["AWS_*"]).unwrap();
+            let err = resolve_vars(vec![pv("AWS_KEY")], policy, &PanicHook).unwrap_err();
+            assert!(matches!(err, ResolveError::Denied { .. }), "got: {err:?}");
+        }
+
+        /// User-origin items bypass `allow`/`deny` and never reach the
+        /// hook. `PanicHook` ensures that path stays cold.
+        #[test]
+        fn user_loadout_bypasses_deny_without_prompting() {
+            let policy = VarsPolicy::empty().try_with_deny(["AWS_*"]).unwrap();
+            let (out, _) =
+                resolve_vars(vec![pv_with("AWS_KEY", user_source())], policy, &PanicHook).unwrap();
+            assert_eq!(out.len(), 1);
+            assert_eq!(out[0].var().name(), "AWS_KEY");
+        }
+
+        /// Even user-origin items are still subject to `ignore`.
+        #[test]
+        fn user_loadout_still_honors_ignore() {
+            let policy = VarsPolicy::empty().try_with_ignore(["_*"]).unwrap();
+            let (out, _) =
+                resolve_vars(vec![pv_with("_TMP", user_source())], policy, &PanicHook).unwrap();
+            assert!(out.is_empty());
+        }
+
+        /// The bypass is user-only — `Source::Package` items still hit
+        /// `deny`.
+        #[test]
+        fn package_origin_still_denied() {
+            let policy = VarsPolicy::empty().try_with_deny(["AWS_*"]).unwrap();
+            let pkg_pv = pv_with(
+                "AWS_KEY",
+                Source::Package {
+                    name: "evil-pkg".into(),
+                },
+            );
+            let err = resolve_vars(vec![pkg_pv], policy, &PanicHook).unwrap_err();
+            assert!(matches!(err, ResolveError::Denied { .. }), "got: {err:?}");
+        }
+
+        #[test]
+        fn hook_allow_once() {
+            let policy = VarsPolicy::empty();
+            let hook = ScriptedHook::new(vec![HookResult::decided(vec![ItemDecision::AllowOnce])]);
+            let (out, _) = resolve_vars(vec![pv("MY_FOO")], policy, &hook).unwrap();
+            assert_eq!(out.len(), 1);
+        }
+
+        #[test]
+        fn hook_deny_once() {
+            let policy = VarsPolicy::empty();
+            let hook = ScriptedHook::new(vec![HookResult::decided(vec![ItemDecision::DenyOnce])]);
+            let err = resolve_vars(vec![pv("MY_FOO")], policy, &hook).unwrap_err();
+            assert!(matches!(err, ResolveError::Denied { .. }));
+        }
+
+        #[test]
+        fn hook_use_rule_without_mutation_errors_as_hook_contract() {
+            let policy = VarsPolicy::empty();
+            let hook = ScriptedHook::new(vec![HookResult::decided(vec![ItemDecision::UseRule])]);
+            let err = resolve_vars(vec![pv("MY_FOO")], policy, &hook).unwrap_err();
+            assert!(
+                matches!(err, ResolveError::HookContract { .. }),
+                "got: {err:?}"
+            );
+        }
+
+        #[test]
+        fn hook_abort_propagates() {
+            let policy = VarsPolicy::empty();
+            let hook = ScriptedHook::new(vec![HookResult::Abort]);
+            let err = resolve_vars(vec![pv("MY_FOO")], policy, &hook).unwrap_err();
+            assert!(matches!(err, ResolveError::Aborted));
+        }
+
+        #[test]
+        fn hook_decision_count_mismatch_errors() {
+            let policy = VarsPolicy::empty();
+            let hook = ScriptedHook::new(vec![HookResult::decided(vec![
+                ItemDecision::AllowOnce,
+                ItemDecision::AllowOnce,
+            ])]);
+            let err = resolve_vars(vec![pv("MY_FOO")], policy, &hook).unwrap_err();
+            assert!(
+                matches!(err, ResolveError::HookContract { .. }),
+                "got: {err:?}"
+            );
+        }
+
+        /// Hook returns three different decisions over three items;
+        /// mutator adds a rule the middle `UseRule` consults. Catches
+        /// zip-ordering regressions in Pass 3.
+        #[test]
+        fn hook_mixed_batch_applies_decisions_in_order() {
+            let policy = VarsPolicy::empty();
+            let hook = ScriptedHook::new(vec![HookResult::decided(vec![
+                ItemDecision::AllowOnce,
+                ItemDecision::UseRule,
+                ItemDecision::AllowOnce,
+            ])])
+            .with_mutator(|p| {
+                *p = p.clone().try_with_allow(["MIDDLE_*"]).unwrap();
+            });
+            let (out, _) = resolve_vars(
+                vec![pv("FIRST"), pv("MIDDLE_OK"), pv("LAST")],
+                policy,
+                &hook,
+            )
+            .unwrap();
+            let names: Vec<_> = out.iter().map(|sv| sv.var().name()).collect();
+            assert_eq!(names, ["FIRST", "MIDDLE_OK", "LAST"]);
+        }
+    }
+
+    // =================================================================
+    // Patches resolution
+    // =================================================================
+
+    mod patches_resolution {
+        use super::*;
+
+        /// User origin + empty policy: short-circuits at Pass 1.
+        /// `PanicHook` proves no prompt is needed.
+        #[test]
+        fn user_origin_single_file_short_circuits() {
+            let (_tmp, patch) = single_file_patch("hello.txt", "config/hello.txt");
+            let pp = ProvenancedPatch::new(patch, user_source());
+            let policy = PatchPolicy::empty();
+            let (resolved, _) =
+                resolve_patches(vec![pp], policy, &PanicHook, ResolveOptions::default()).unwrap();
+            assert_eq!(resolved.len(), 1);
+            assert_eq!(resolved[0].source(), &user_source());
+        }
+
+        /// Project origin + empty policy: must prompt; `PassThroughHook`
+        /// approves.
+        #[test]
+        fn project_origin_goes_through_prompt() {
+            let (_tmp, patch) = single_file_patch("conf.toml", "etc/conf.toml");
+            let pp = ProvenancedPatch::new(patch, project_source());
+            let policy = PatchPolicy::empty();
+            let (resolved, _) = resolve_patches(
+                vec![pp],
+                policy,
+                &PassThroughHook,
+                ResolveOptions::default(),
+            )
+            .unwrap();
+            assert_eq!(resolved.len(), 1);
+            assert_eq!(resolved[0].source(), &project_source());
+        }
+
+        #[test]
+        fn deny_via_policy_errors() {
+            let (_tmp, patch) = single_file_patch("secret.pem", "config/x");
+            let pp = ProvenancedPatch::new(patch, project_source());
+            let policy = PatchPolicy::empty().try_with_deny(["**/*.pem"]).unwrap();
+            let err = resolve_patches(
+                vec![pp],
+                policy,
+                &PassThroughHook,
+                ResolveOptions::default(),
+            )
+            .unwrap_err();
+            assert!(matches!(err, ResolveError::Denied { .. }), "got: {err:?}");
+        }
+
+        /// User-origin patches bypass `deny`. `PanicHook` ensures bypass
+        /// at Pass 1, not via the prompt.
+        #[test]
+        fn user_loadout_bypasses_deny() {
+            let (_tmp, patch) = single_file_patch("secret.pem", "config/x");
+            let pp = ProvenancedPatch::new(patch, user_source());
+            let policy = PatchPolicy::empty().try_with_deny(["**/*.pem"]).unwrap();
+            let (resolved, _) =
+                resolve_patches(vec![pp], policy, &PanicHook, ResolveOptions::default()).unwrap();
+            assert_eq!(resolved.len(), 1);
+        }
+
+        #[test]
+        fn user_loadout_still_honors_ignore() {
+            let (_tmp, patch) = single_file_patch("trash.bak", "config/x");
+            let pp = ProvenancedPatch::new(patch, user_source());
+            let policy = PatchPolicy::empty().try_with_ignore(["**/*.bak"]).unwrap();
+            let (resolved, _) =
+                resolve_patches(vec![pp], policy, &PanicHook, ResolveOptions::default()).unwrap();
+            assert!(resolved.is_empty());
+        }
+
+        /// Multi-file glob expands to N `SessionPatch`es with dests
+        /// rebuilt from the relative tail.
+        #[test]
+        fn multi_file_glob_fans_out_with_relative_dest() {
+            let tmp = tempfile::tempdir().unwrap();
+            let root = Utf8Path::from_path(tmp.path()).unwrap().to_path_buf();
+            std::fs::write(root.join("a.lua").as_std_path(), "a").unwrap();
+            std::fs::create_dir_all(root.join("sub").as_std_path()).unwrap();
+            std::fs::write(root.join("sub/b.lua").as_std_path(), "b").unwrap();
+            std::fs::write(root.join("skip.txt").as_std_path(), "x").unwrap();
+
+            let pattern = format!("{root}/**/*.lua");
+            let patch = Patch::new(
+                FileSet::try_new(pattern).unwrap(),
+                PatchDest::try_new("nvim").unwrap(),
+            );
+            let pp = ProvenancedPatch::new(patch, user_source());
+            let policy = PatchPolicy::empty();
+            let (mut resolved, _) =
+                resolve_patches(vec![pp], policy, &PanicHook, ResolveOptions::default()).unwrap();
+            resolved.sort();
+            let dests: Vec<_> = resolved
+                .iter()
+                .map(|sp| sp.patch().destination().as_str())
+                .collect();
+            assert_eq!(dests, ["nvim/a.lua", "nvim/sub/b.lua"]);
+        }
+
+        /// Walking a non-existent directory surfaces as
+        /// `ResolveError::PatchWalk` (IO-shaped), not `PatchConfig`.
+        #[test]
+        fn walk_failure_surfaces_as_patch_walk() {
+            let patch = Patch::new(
+                FileSet::try_new("/definitely/does/not/exist/*").unwrap(),
+                PatchDest::try_new("x").unwrap(),
+            );
+            let pp = ProvenancedPatch::new(patch, user_source());
+            let policy = PatchPolicy::empty();
+            let err = resolve_patches(vec![pp], policy, &PanicHook, ResolveOptions::default())
+                .unwrap_err();
+            assert!(
+                matches!(err, ResolveError::PatchWalk { ref sources } if !sources.is_empty()),
+                "got: {err:?}",
+            );
+        }
+
+        /// A pattern with no walk root surfaces as `PatchConfig`,
+        /// distinct from `PatchWalk`.
+        #[test]
+        fn no_walk_root_surfaces_as_patch_config() {
+            let patch = Patch::new(
+                FileSet::try_new("**/*.pem").unwrap(),
+                PatchDest::try_new("x").unwrap(),
+            );
+            let pp = ProvenancedPatch::new(patch, user_source());
+            let policy = PatchPolicy::empty();
+            let err = resolve_patches(vec![pp], policy, &PanicHook, ResolveOptions::default())
+                .unwrap_err();
+            assert!(
+                matches!(err, ResolveError::PatchConfig { ref sources } if !sources.is_empty()),
+                "got: {err:?}",
+            );
+        }
+    }
+
+    // =================================================================
+    // compute_dest invariants
+    // =================================================================
+
+    mod compute_dest_invariants {
+        use super::*;
+
+        #[test]
+        fn multi_file_appends_relative_path() {
+            let source = Utf8Path::new("/etc/xdg/sub/file.conf");
+            let walk_root = HostPath::new("/etc/xdg");
+            let dest = compute_dest(source, &walk_root, Utf8Path::new("config"));
+            assert_eq!(dest.as_str(), "config/sub/file.conf");
+        }
+
+        #[test]
+        fn single_file_uses_dest_verbatim() {
+            let source = Utf8Path::new("/home/u/file.conf");
+            let walk_root = HostPath::new("/home/u/file.conf");
+            let dest = compute_dest(source, &walk_root, Utf8Path::new("etc/foo.conf"));
+            assert_eq!(dest.as_str(), "etc/foo.conf");
+        }
+
+        /// Regression for component-boundary strip — `/etc/xdg` must
+        /// not match `/etc/xdgfoo/bar`. Resolver invariant; we panic
+        /// rather than produce a garbage dest.
+        #[test]
+        #[should_panic(expected = "outside walk root")]
+        fn panics_on_source_outside_walk_root() {
+            let source = Utf8Path::new("/etc/xdgfoo/bar");
+            let walk_root = HostPath::new("/etc/xdg");
+            let _ = compute_dest(source, &walk_root, Utf8Path::new("dst"));
+        }
+    }
+
+    // =================================================================
+    // Composer public API
+    // =================================================================
+
+    mod composer_api {
+        use super::*;
+
+        #[test]
+        fn empty_composer_yields_empty_resolution() {
+            let composer = Composer::new();
+            let (resolution, _) = composer
+                .resolve(UserPolicy::empty(), &PanicHook, ResolveOptions::default())
+                .unwrap();
+            assert!(resolution.vars().is_empty());
+            assert!(resolution.patches().is_empty());
+        }
+
+        #[test]
+        fn minimal_session_round_trips() {
+            let (_tmp, patch) = single_file_patch("conf.toml", "etc/conf.toml");
+            let loadout = FakeLoadout {
+                source: user_source(),
+                var_names: vec!["EDITOR"],
+                patches: vec![patch],
+            };
+            let mut composer = Composer::new();
+            composer.add(loadout).unwrap();
+            let (resolution, _policy_out) = composer
+                .resolve(UserPolicy::empty(), &PanicHook, ResolveOptions::default())
+                .unwrap();
+            assert_eq!(resolution.vars().len(), 1);
+            assert_eq!(resolution.patches().len(), 1);
+        }
+
+        /// When a hook returns `updated_policy: Some(new)`, the
+        /// returned `UserPolicy` carries that mutation. Project-origin
+        /// item forces a prompt; hook returns an updated `VarsPolicy`
+        /// with an `allow = ["MUT_*"]` rule.
+        #[test]
+        fn returned_policy_carries_hook_mutation() {
+            struct MutatingHook;
+            impl PolicyHooks for MutatingHook {
+                fn on_var_unapproved(
+                    &self,
+                    policy: VarsPolicy,
+                    items: &[Unapproved<'_, str>],
+                ) -> HookResult<VarsPolicy> {
+                    let updated = policy.try_with_allow(["MUT_*"]).unwrap();
+                    HookResult::decided_with_policy(
+                        vec![ItemDecision::UseRule; items.len()],
+                        updated,
+                    )
+                }
+                fn on_patch_unapproved(
+                    &self,
+                    _: PatchPolicy,
+                    items: &[Unapproved<'_, camino::Utf8Path>],
+                ) -> HookResult<PatchPolicy> {
+                    HookResult::decided(vec![ItemDecision::AllowOnce; items.len()])
+                }
+            }
+
+            let mut composer = Composer::new();
+            composer
+                .add(FakeLoadout::vars(project_source(), vec!["MUT_FOO"]))
+                .unwrap();
+
+            let (_resolution, policy_out) = composer
+                .resolve(
+                    UserPolicy::empty(),
+                    &MutatingHook,
+                    ResolveOptions::default(),
+                )
+                .unwrap();
+            assert!(
+                policy_out.vars().allow().is_match("MUT_FOO"),
+                "expected MUT_* allow rule on returned policy, got: {:?}",
+                policy_out.vars().allow(),
+            );
+        }
+
+        /// Test scaffold: a tiny Composable that contributes a fixed
+        /// set of vars and patches sharing one source.
+        struct FakeLoadout {
+            source: Source,
+            var_names: Vec<&'static str>,
+            patches: Vec<Patch>,
+        }
+
+        impl FakeLoadout {
+            fn vars(source: Source, var_names: Vec<&'static str>) -> Self {
+                Self {
+                    source,
+                    var_names,
+                    patches: Vec::new(),
+                }
+            }
+        }
+
+        impl Provenanced for FakeLoadout {
+            fn source(&self) -> &Source {
+                &self.source
+            }
+        }
+
+        impl Composable for FakeLoadout {
+            fn contribute(self, _env: EnvLookup<'_>) -> Result<Contribution, Error> {
+                let mut c = Contribution::new();
+                for name in self.var_names {
+                    c.push_var(pv_with(name, self.source.clone()));
+                }
+                for patch in self.patches {
+                    c.push_patch(ProvenancedPatch::new(patch, self.source.clone()));
+                }
+                Ok(c)
+            }
+        }
+
+        /// `Composer::add` drives the canonical contributor path.
+        #[test]
+        fn add_drains_a_composable() {
+            let loadout = FakeLoadout::vars(user_source(), vec!["EDITOR", "LANG"]);
+            let mut composer = Composer::new();
+            composer.add(loadout).unwrap();
+            let (resolution, _) = composer
+                .resolve(UserPolicy::empty(), &PanicHook, ResolveOptions::default())
+                .unwrap();
+            assert_eq!(resolution.vars().len(), 2);
+        }
+
+        /// `Composer::add_all` runs a sequence of contributors. Multiple
+        /// sources accumulate independently.
+        #[test]
+        fn add_all_runs_a_sequence_of_contributors() {
+            let loadouts = vec![
+                FakeLoadout::vars(user_source(), vec!["EDITOR"]),
+                FakeLoadout::vars(project_source(), vec!["LANG", "TZ"]),
+            ];
+            let mut composer = Composer::new();
+            composer.add_all(loadouts).unwrap();
+            let (resolution, _) = composer
+                .resolve(
+                    UserPolicy::empty(),
+                    &PassThroughHook,
+                    ResolveOptions::default(),
+                )
+                .unwrap();
+            assert_eq!(resolution.vars().len(), 3);
+            let by_source: Vec<_> = resolution.vars().iter().map(SessionVar::source).collect();
+            assert!(by_source.contains(&&user_source()));
+            assert!(by_source.contains(&&project_source()));
+        }
+
+        /// `Composer::add` propagates a contributor's error verbatim.
+        #[test]
+        fn add_propagates_contributor_error() {
+            struct FailingLoadout;
+            impl Provenanced for FailingLoadout {
+                fn source(&self) -> &Source {
+                    static S: std::sync::OnceLock<Source> = std::sync::OnceLock::new();
+                    S.get_or_init(|| Source::UserLoadout {
+                        name: "failing".into(),
+                    })
+                }
+            }
+            impl Composable for FailingLoadout {
+                fn contribute(self, _env: EnvLookup<'_>) -> Result<Contribution, Error> {
+                    // Trigger a real construction-time error from one of
+                    // the underlying domains.
+                    FileSet::try_new("[invalid").map_err(Error::from)?;
+                    unreachable!()
+                }
+            }
+            let mut composer = Composer::new();
+            let err = composer.add(FailingLoadout).unwrap_err();
+            assert!(matches!(err, Error::Patch { .. }), "got: {err:?}");
+        }
+
+        /// Packages and lifecycle hooks contributed via a Composable
+        /// pass through to the final Resolution unchanged.
+        #[test]
+        fn packages_and_hooks_pass_through() {
+            use crate::lifecyclehook::{HookScript, LifecycleHook};
+
+            struct LoadoutWithExtras;
+            impl Composable for LoadoutWithExtras {
+                fn contribute(self, _env: EnvLookup<'_>) -> Result<Contribution, Error> {
+                    let hook = LifecycleHook::builder()
+                        .with_on_activate(HookScript::inline("echo go"))
+                        .build()?;
+                    Ok(Contribution::new()
+                        .with_package(ProvenancedPackage::new("helix", user_source()))
+                        .with_package(ProvenancedPackage::new("zellij", user_source()))
+                        .with_hook(ProvenancedHook::new(hook, user_source())))
+                }
+            }
+
+            let mut composer = Composer::new();
+            composer.add(LoadoutWithExtras).unwrap();
+            let (resolution, _) = composer
+                .resolve(UserPolicy::empty(), &PanicHook, ResolveOptions::default())
+                .unwrap();
+            assert_eq!(resolution.packages().len(), 2);
+            assert_eq!(resolution.packages()[0].package(), "helix");
+            assert_eq!(resolution.lifecycle_hooks().len(), 1);
+            assert_eq!(resolution.lifecycle_hooks()[0].source(), &user_source());
+        }
+
+        /// `Composer::with_env` lets tests pin env behavior without
+        /// touching the process environment. The provided closure
+        /// resolves `LANG` when a contributor's var is `inherit = true`.
+        #[test]
+        fn with_env_overrides_lookup_for_inheriting_vars() {
+            use crate::loadout::{Loadout, LoadoutName};
+            use crate::vars::{StrictVarName, VarValue};
+
+            let loadout = Loadout::new(LoadoutName::try_new("dev").unwrap())
+                .with_var(StrictVarName::try_new("LANG").unwrap(), VarValue::Inherit);
+
+            let mut composer = Composer::with_env(Box::new(|name| {
+                if name == "LANG" {
+                    Ok("en_US.UTF-8".into())
+                } else {
+                    Err(std::env::VarError::NotPresent)
+                }
+            }));
+            composer.add(loadout).unwrap();
+            let (resolution, _) = composer
+                .resolve(UserPolicy::empty(), &PanicHook, ResolveOptions::default())
+                .unwrap();
+            assert_eq!(resolution.vars().len(), 1);
+            assert_eq!(resolution.vars()[0].var().name(), "LANG");
+            assert_eq!(resolution.vars()[0].var().value(), "en_US.UTF-8");
+        }
+
+        /// End-to-end test that `Loadout` is now a real `Composable`.
+        /// Push a loadout with vars, patches, packages, and a hook;
+        /// verify all four kinds reach the Resolution.
+        #[test]
+        fn loadout_contributes_all_four_kinds() {
+            use crate::lifecyclehook::{HookScript, LifecycleHook};
+            use crate::loadout::{Loadout, LoadoutName};
+            use crate::patches::{FileSet, PatchDest};
+            use crate::vars::{StrictVarName, VarValue};
+
+            let (_tmp, patch) = single_file_patch("conf.toml", "etc/conf.toml");
+            let _ = FileSet::try_new("ignored").unwrap();
+            let _ = PatchDest::try_new("ignored").unwrap();
+
+            let hook = LifecycleHook::builder()
+                .with_on_activate(HookScript::inline("echo hi"))
+                .build()
+                .unwrap();
+
+            let loadout = Loadout::new(LoadoutName::try_new("dev").unwrap())
+                .with_var(
+                    StrictVarName::try_new("EDITOR").unwrap(),
+                    VarValue::specified("hx"),
+                )
+                .with_package("helix")
+                .with_patch(patch)
+                .with_lifecycle_hook(hook);
+
+            let mut composer = Composer::new();
+            composer.add(loadout).unwrap();
+            let (resolution, _) = composer
+                .resolve(UserPolicy::empty(), &PanicHook, ResolveOptions::default())
+                .unwrap();
+            assert_eq!(resolution.vars().len(), 1);
+            assert_eq!(resolution.patches().len(), 1);
+            assert_eq!(resolution.packages().len(), 1);
+            assert_eq!(resolution.lifecycle_hooks().len(), 1);
+
+            // All four share the same UserLoadout source.
+            let expected = Source::UserLoadout { name: "dev".into() };
+            assert_eq!(resolution.vars()[0].source(), &expected);
+            assert_eq!(resolution.patches()[0].source(), &expected);
+            assert_eq!(resolution.packages()[0].source(), &expected);
+            assert_eq!(resolution.lifecycle_hooks()[0].source(), &expected);
+        }
+    }
+
+    // =================================================================
+    // FileSet::resolve direct (unit, not via resolver)
+    // =================================================================
+
+    #[test]
+    fn fileset_resolve_errors_when_pattern_has_no_walk_root() {
+        let fs = FileSet::try_new("**/*.pem").unwrap();
+        let (paths, errors) = fs.resolve(false);
+        assert!(paths.is_empty());
+        assert_eq!(errors.len(), 1);
+        assert!(
+            matches!(&errors[0], crate::patches::Error::NoWalkRoot { .. }),
+            "got: {:?}",
+            errors[0],
+        );
+    }
+
+    // =================================================================
+    // Display snapshots — guard the user-facing error strings.
+    // =================================================================
+
+    mod display_snapshots {
+        use super::*;
+
+        #[test]
+        fn resolve_error_denied() {
+            let err = ResolveError::Denied {
+                what: "AWS_KEY".into(),
+                from: user_source(),
+            };
+            assert_eq!(
+                err.to_string(),
+                "policy denied `AWS_KEY` (from user loadout `test`)",
+            );
+        }
+
+        #[test]
+        fn resolve_error_aborted() {
+            assert_eq!(
+                ResolveError::Aborted.to_string(),
+                "user aborted session construction",
+            );
+        }
+
+        #[test]
+        fn source_variants() {
+            assert_eq!(user_source().to_string(), "user loadout `test`");
+            assert_eq!(project_source().to_string(), "project `/repo`");
+            assert_eq!(
+                Source::Package {
+                    name: "evil".into(),
+                }
+                .to_string(),
+                "package `evil`",
+            );
+        }
+    }
+}

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 use paths::HostAbsPath;
 
+pub mod composable;
 pub mod lifecyclehook;
 pub mod loadout;
 pub mod patches;

--- a/crates/sessions/src/lifecyclehook.rs
+++ b/crates/sessions/src/lifecyclehook.rs
@@ -7,33 +7,20 @@
 //! enforce the same invariant.
 
 use camino::Utf8PathBuf;
-use core::fmt;
 use paths::ConfigRelPath;
 
 /// Errors produced when constructing a [`LifecycleHook`].
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// No hook script was provided.
     ///
     /// Returned by [`LifecycleHookBuilder::build`] (and therefore by
     /// deserialization) when none of `on_activate`, `on_destroy`, or
     /// `on_failure` is set.
+    #[error("At least one of on_activate, on_destroy, or on_failure must be specified")]
     EmptyLifecycleHook,
 }
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::EmptyLifecycleHook => write!(
-                f,
-                "At least one of on_activate, on_destroy, or on_failure must be specified"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A script executed by a lifecycle hook.
 ///

--- a/crates/sessions/src/loadout.rs
+++ b/crates/sessions/src/loadout.rs
@@ -43,15 +43,38 @@
 
 use std::collections::BTreeMap;
 
+use nutype::nutype;
+
 use crate::lifecyclehook::LifecycleHook;
 use crate::patches::{Patch, Patches};
 use crate::vars::{LenientVarEntry, StrictVarName, VarName, VarValue};
 
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+/// A loadout's identifier — trimmed, non-empty, and free of path
+/// separators and NUL bytes.
+///
+/// Names appear in user-facing contexts (selection menus, error
+/// messages) and may be used as filesystem-key fragments by the loader,
+/// so they're constrained at construction time rather than at point of
+/// use.
+#[nutype(
+    sanitize(trim),
+    validate(not_empty, predicate = |s: &str| !s.contains(['/', '\\', '\0'])),
+    derive(
+        Clone, Debug, Display, AsRef, PartialEq, Eq, Hash, PartialOrd, Ord,
+        Serialize, Deserialize,
+    ),
+)]
+pub struct LoadoutName(String);
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Loadout {
+    /// Identifier — user-facing, used in selection and error messages.
+    name: LoadoutName,
+    /// Free-form description, shown alongside the name in user-facing
+    /// contexts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
-    // Packages to be installed
+    /// Packages to bring into the session.
     // TODO: Newtype for `Package`?
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     packages: Vec<String>,
@@ -71,22 +94,51 @@ pub struct Loadout {
 }
 
 impl Loadout {
-    /// Construct an empty loadout. Build it up via the additive
-    /// `with_*` methods:
+    /// Construct a loadout with a pre-validated name. Build it up via
+    /// the additive `with_*` methods:
     ///
     /// ```
-    /// use sessions::loadout::Loadout;
+    /// use sessions::loadout::{Loadout, LoadoutName};
     /// use sessions::vars::{StrictVarName, VarValue};
     ///
-    /// let l = Loadout::empty()
+    /// let l = Loadout::new(LoadoutName::try_new("dev").unwrap())
     ///     .with_package("helix")
     ///     .with_var(StrictVarName::try_new("EDITOR").unwrap(), VarValue::specified("hx"));
     /// assert_eq!(l.packages(), &["helix"]);
     /// assert_eq!(l.vars().len(), 1);
     /// ```
     #[must_use]
-    pub fn empty() -> Self {
-        Self::default()
+    pub fn new(name: LoadoutName) -> Self {
+        Self {
+            name,
+            description: None,
+            packages: Vec::new(),
+            vars: BTreeMap::new(),
+            vars_lenient: Vec::new(),
+            patches: Patches::empty(),
+            lifecycle_hooks: Vec::new(),
+        }
+    }
+
+    /// Set a free-form description.
+    #[must_use]
+    pub fn with_description(self, description: impl Into<String>) -> Self {
+        Self {
+            description: Some(description.into()),
+            ..self
+        }
+    }
+
+    /// The loadout's identifier.
+    #[must_use]
+    pub fn name(&self) -> &LoadoutName {
+        &self.name
+    }
+
+    /// The loadout's free-form description, if any.
+    #[must_use]
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
     }
 
     /// Append a package dependency.
@@ -186,6 +238,51 @@ impl Loadout {
     }
 }
 
+impl crate::composable::Composable for Loadout {
+    /// Materialize the loadout as a [`Contribution`](crate::composable::Contribution),
+    /// tagging every primitive with [`Source::UserLoadout`].
+    ///
+    /// Inherited / default-bearing var values are resolved via `env`
+    /// at this point.
+    ///
+    /// [`Source::UserLoadout`]: crate::composable::Source::UserLoadout
+    fn contribute(
+        self,
+        env: crate::composable::EnvLookup<'_>,
+    ) -> Result<crate::composable::Contribution, crate::composable::Error> {
+        use crate::composable::{
+            Contribution, ProvenancedHook, ProvenancedPackage, ProvenancedPatch, ProvenancedVar,
+            Source,
+        };
+        use crate::vars::ResolvedVar;
+
+        let source = Source::UserLoadout {
+            name: self.name.into_inner(),
+        };
+        let mut c = Contribution::new();
+
+        for (name, value) in self.vars {
+            let resolved = ResolvedVar::resolve_with(name.into_inner(), value, env)?;
+            c.push_var(ProvenancedVar::new(resolved, source.clone()));
+        }
+        for entry in self.vars_lenient {
+            let (name, value) = entry.into_parts();
+            let resolved = ResolvedVar::resolve_with(name.into_inner(), value, env)?;
+            c.push_var(ProvenancedVar::new(resolved, source.clone()));
+        }
+        for patch in self.patches {
+            c.push_patch(ProvenancedPatch::new(patch, source.clone()));
+        }
+        for pkg in self.packages {
+            c.push_package(ProvenancedPackage::new(pkg, source.clone()));
+        }
+        for hook in self.lifecycle_hooks {
+            c.push_hook(ProvenancedHook::new(hook, source.clone()));
+        }
+        Ok(c)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -196,6 +293,8 @@ mod tests {
     #[test]
     fn all_vars_yields_strict_then_lenient() {
         let src = r#"
+            name = "dev"
+
             [vars]
             EDITOR = "vim"
             LANG = { inherit = true, default = "C" }
@@ -227,6 +326,8 @@ mod tests {
     #[test]
     fn all_vars_distinguishes_strict_from_lenient() {
         let src = r#"
+            name = "dev"
+
             [vars]
             EDITOR = "vim"
 
@@ -241,8 +342,27 @@ mod tests {
     }
 
     #[test]
+    fn loadout_name_rejects_empty_and_path_chars() {
+        assert!(LoadoutName::try_new("").is_err());
+        assert!(LoadoutName::try_new("   ").is_err()); // trimmed → empty
+        assert!(LoadoutName::try_new("a/b").is_err());
+        assert!(LoadoutName::try_new("a\\b").is_err());
+        assert!(LoadoutName::try_new("a\0b").is_err());
+        let n = LoadoutName::try_new("  dev  ").unwrap();
+        assert_eq!(n.as_ref(), "dev");
+    }
+
+    #[test]
+    fn name_and_description_accessors_round_trip_through_builder() {
+        let l = Loadout::new(LoadoutName::try_new("dev").unwrap())
+            .with_description("primary dev session");
+        assert_eq!(l.name().as_ref(), "dev");
+        assert_eq!(l.description(), Some("primary dev session"));
+    }
+
+    #[test]
     fn default_loadout_is_empty() {
-        let l = Loadout::default();
+        let l = Loadout::new(LoadoutName::try_new("Test").unwrap());
         assert!(l.packages().is_empty());
         assert_eq!(l.all_vars().count(), 0);
         assert!(l.patches().is_empty());
@@ -252,6 +372,8 @@ mod tests {
     #[test]
     fn lenient_var_entry_round_trips_through_toml() {
         let src = r#"
+            name = "dev"
+
             [[vars_lenient]]
             name = "weird-thing"
             value = "x"
@@ -272,11 +394,11 @@ mod tests {
             .build()
             .unwrap();
         let patch = Patch::new(
-            FileSet::try_new(None, ["a"]).unwrap(),
-            PatchDest::try_new("/a").unwrap(),
+            FileSet::try_new("a").unwrap(),
+            PatchDest::try_new("a").unwrap(),
         );
 
-        let l = Loadout::empty()
+        let l = Loadout::new(LoadoutName::try_new("Test").unwrap())
             .with_package("helix")
             .with_package("zellij")
             .with_var(
@@ -299,7 +421,7 @@ mod tests {
     #[test]
     fn with_var_replaces_existing_strict_entry() {
         let name = StrictVarName::try_new("EDITOR").unwrap();
-        let l = Loadout::empty()
+        let l = Loadout::new(LoadoutName::try_new("Test").unwrap())
             .with_var(name.clone(), VarValue::specified("hx"))
             .with_var(name.clone(), VarValue::specified("vim"));
         assert_eq!(l.vars().len(), 1);
@@ -311,12 +433,14 @@ mod tests {
         // Exercise every field at once: packages, both strict and lenient
         // vars, patches with multiple source shapes, and a lifecycle hook.
         let src = r#"
-            packages = ["helix", "zellij"]
+            name        = "dev"
+            description = "Editor + terminal multiplexer"
+            packages    = ["helix", "zellij"]
 
             patches = [
-                { dest = "/etc/foo", source = "./foo" },
-                { dest = "/etc/bar", source = ["b1", "b2"] },
-                { dest = "/themes/", source = { base = "./themes", patterns = ["**/*.toml"] } },
+                { dest = "etc/foo", source = "./foo" },
+                { dest = "etc/bar", source = ["b1", "b2"] },
+                { dest = "themes/", source = "./themes/**/*.toml" },
             ]
 
             [vars]
@@ -334,8 +458,12 @@ mod tests {
         let serialized = toml::to_string(&original).unwrap();
         let parsed: Loadout = toml::from_str(&serialized).unwrap();
 
+        assert_eq!(parsed.name().as_ref(), "dev");
+        assert_eq!(parsed.description(), Some("Editor + terminal multiplexer"));
         assert_eq!(parsed.packages(), &["helix", "zellij"]);
-        assert_eq!(parsed.patches().len(), 3);
+        // Row 2 (`source = ["b1", "b2"]`) fans out into two patches, so the
+        // three rows yield four Patch entries.
+        assert_eq!(parsed.patches().len(), 4);
         assert_eq!(parsed.vars().len(), 2);
         assert_eq!(parsed.vars_lenient().len(), 1);
         assert_eq!(parsed.lifecycle_hooks().len(), 1);

--- a/crates/sessions/src/patches.rs
+++ b/crates/sessions/src/patches.rs
@@ -14,9 +14,10 @@
 //!
 //! # The `FileSet` primitive
 //!
-//! [`FileSet`] is the description of "which files" — reused for patch
-//! sources, allowlists, denylists, and ignore lists. The wire form accepts
-//! three shapes (bare string, list, table); see its docs.
+//! [`FileSet`] is the description of "which files" — a single glob pattern,
+//! reused for patch sources, allowlists, denylists, and ignore lists. The
+//! wire form is always a bare string; lists of patterns live one level
+//! up (at the patches array or in policy fields).
 //!
 //! Path expansion (`~`, `$VAR`) and canonicalization are **not** performed
 //! by this module — `FileSet` stores patterns as written. Callers must
@@ -32,13 +33,13 @@
 //! # Only `ignore` from `[patch_policy]` filters these; `allow`/`deny` are
 //! # bypassed.
 //! patches = [
-//!     { dest = "~/.gitconfig",                       source = "~/dotfiles/gitconfig" },
-//!     { dest = "~/.config/alacritty/alacritty.toml", source = "~/dotfiles/alacritty.toml" },
-//!     { dest = "~/.config/nvim/",                    source = { base = "~/dotfiles/nvim", patterns = ["**/*"] } },
+//!     { dest = ".gitconfig",                       source = "~/dotfiles/gitconfig" },
+//!     { dest = ".config/alacritty/alacritty.toml", source = "~/dotfiles/alacritty.toml" },
+//!     { dest = ".config/nvim/",                    source = "~/dotfiles/nvim/**/*" },
 //!
-//!     # Multi-glob to one dest:
-//!     { dest = "~/Pictures/wallpapers/",             source = ["~/dotfiles/wallpapers/*.jpg",
-//!                                                              "~/dotfiles/wallpapers/*.png"] },
+//!     # Multi-pattern to one dest fans out into one entry per pattern:
+//!     { dest = "Pictures/wallpapers/",             source = ["~/dotfiles/wallpapers/*.jpg",
+//!                                                            "~/dotfiles/wallpapers/*.png"] },
 //! ]
 //!
 //! # Policy for non-user patches (project and package origins).
@@ -49,245 +50,225 @@
 //! ignore = ["**/.DS_Store", "**/*.bak", "**/*.swp"]
 //! ```
 
-use camino::{Utf8Component, Utf8PathBuf};
-use core::fmt;
-use paths::{HostPath, SandboxPath};
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+use paths::{HostAbsPath, HostPath, SandboxRelPath};
 
 /// Errors produced when constructing patch types.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// A pattern string failed to parse as a glob.
+    #[error("invalid glob pattern `{pattern}`: {source}")]
     InvalidGlob {
         pattern: String,
+        #[source]
         source: globset::Error,
     },
-    /// A `FileSet` had an empty `base` (e.g. `base = ""`).
-    EmptyBase,
     /// A patch destination was empty.
+    #[error("patch destination must not be empty")]
     EmptyDest,
     /// A patch destination contained a `..` component, which is rejected
     /// before path canonicalization to avoid traversal attacks.
+    #[error("patch destination `{0}` must not contain `..` components")]
     DestTraversal(Utf8PathBuf),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidGlob { pattern, source } => {
-                write!(f, "invalid glob pattern `{pattern}`: {source}")
-            }
-            Self::EmptyBase => f.write_str("`base` must not be the empty string"),
-            Self::EmptyDest => f.write_str("patch destination must not be empty"),
-            Self::DestTraversal(p) => write!(
-                f,
-                "patch destination `{p}` must not contain `..` components",
-            ),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::InvalidGlob { source, .. } => Some(source),
-            _ => None,
-        }
-    }
+    /// A patch destination decoded to an absolute path. Dests must be
+    /// relative to the sandbox/home root.
+    #[error("Patch destination must be relative to the home directory: {0}")]
+    AbsoluteDestPath(#[source] paths::Error),
+    /// A directory walk failed while enumerating a [`FileSet`]'s
+    /// matches — typically due to permission denial or a missing
+    /// directory.
+    #[error("Failed to walk {root}: {source}")]
+    WalkFailure {
+        root: Utf8PathBuf,
+        #[source]
+        source: walkdir::Error,
+    },
+    /// A directory walk yielded an entry whose path is not valid
+    /// UTF-8. We carry the lossy form for the error message.
+    #[error("Cannot handle non-utf8 path {path_lossy}")]
+    NonUtf8Path { path_lossy: String },
+    /// The [`FileSet`] pattern has no literal path prefix (e.g.
+    /// `**/*.pem`, `*.lua`). Walking such a pattern would have to
+    /// descend from `/`, which is almost never what the user wants and
+    /// can be catastrophically expensive. Patterns must anchor to a
+    /// concrete directory.
+    #[error(
+        "pattern `{pattern}` has no literal path prefix; \
+         anchor it to a directory (e.g. `~/dotfiles/{pattern}`)"
+    )]
+    NoWalkRoot { pattern: String },
 }
 
 // =====================================================================
 // FileSet
 // =====================================================================
 
-/// A description of a set of files on the *host* filesystem: an optional
-/// base directory plus glob patterns interpreted relative to it.
+/// A set of host-filesystem files described by a single glob pattern.
 ///
-/// Patterns are parsed as globs at construction time, so malformed patterns
-/// fail at config load with a useful error rather than at apply time. Use
-/// [`FileSet::raw_patterns`] to recover the original pattern strings (e.g.
-/// for re-serialization).
+/// Patterns are parsed at construction time, so malformed input fails at
+/// config load with a useful error rather than at apply time. The
+/// underlying pattern string is recoverable via [`Self::pattern`].
 ///
-/// Absolute or `~`-prefixed patterns are valid; the [`base`](Self::base)
-/// field is meaningful only for relative patterns. `~`-prefixed bases
-/// classify as [`HostPath::Rel`] — the apply layer is responsible for
-/// expansion. The apply layer should follow `Utf8PathBuf::join` semantics
-/// when combining a base with a pattern (an absolute right-hand side
-/// replaces the left).
+/// # Walk root
+///
+/// To *enumerate* matching files, the caller walks a directory and
+/// filters with the glob. [`Self::walk_root`] returns the longest literal
+/// path prefix — the directory the walker should start from. For
+/// `~/dotfiles/nvim/**/*.lua` that's `Some("~/dotfiles/nvim")`; for
+/// `**/*.pem` it's [`None`] (no literal prefix). The host realm and `~`
+/// expansion are the caller's responsibility.
 ///
 /// # Wire format
 ///
-/// `FileSet` accepts three forms when deserialized — pick whichever is least
-/// noisy at the call site:
+/// A bare string. Lists of patterns live one level up — at the patches
+/// array, or in the policy fields — where each entry is its own
+/// `FileSet`.
 ///
 /// ```toml
-/// allow  = "~/.config/**"                                           # bare string
-/// deny   = ["~/.ssh/**", "**/id_rsa*"]                              # list
-/// source = { base = "~/dotfiles/nvim", patterns = ["**/*"] }        # full table
+/// allow  = ["~/.config/**", "/etc/xdg/**"]
+/// source = "~/dotfiles/nvim/**/*.lua"
 /// ```
 #[derive(Clone, Debug)]
 pub struct FileSet {
-    base: Option<HostPath>,
-    patterns: Vec<String>,
-    compiled: Vec<globset::Glob>,
+    glob: globset::Glob,
+    matcher: globset::GlobMatcher,
 }
 
 impl FileSet {
-    /// Construct a [`FileSet`] from raw patterns and an optional base.
+    /// Construct a [`FileSet`] from a raw pattern.
     ///
     /// # Errors
     ///
-    /// Returns [`Error::InvalidGlob`] if any pattern fails to parse, or
-    /// [`Error::EmptyBase`] if `base` is `Some` but empty.
-    pub fn try_new<I, S>(base: Option<HostPath>, patterns: I) -> Result<Self, Error>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<String>,
-    {
-        if let Some(b) = &base
-            && b.as_str().is_empty()
-        {
-            return Err(Error::EmptyBase);
-        }
-        let raw: Vec<String> = patterns.into_iter().map(Into::into).collect();
-        let compiled = raw
-            .iter()
-            .map(|p| {
-                globset::Glob::new(p).map_err(|source| Error::InvalidGlob {
-                    pattern: p.clone(),
-                    source,
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Self {
-            base,
-            patterns: raw,
-            compiled,
-        })
-    }
-
-    /// Construct an empty `FileSet`. Useful as a `Default` for policy fields
-    /// where "matches nothing" is a meaningful default.
-    #[must_use]
-    pub fn empty() -> Self {
-        Self {
-            base: None,
-            patterns: Vec::new(),
-            compiled: Vec::new(),
-        }
-    }
-
-    /// Set the base directory.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::EmptyBase`] if `base`'s underlying path is empty.
-    pub fn try_with_base(self, base: HostPath) -> Result<Self, Error> {
-        if base.as_str().is_empty() {
-            return Err(Error::EmptyBase);
-        }
-        Ok(Self {
-            base: Some(base),
-            ..self
-        })
-    }
-
-    /// Append a single pattern.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::InvalidGlob`] if the pattern fails to parse.
-    pub fn try_with_pattern(self, pattern: impl Into<String>) -> Result<Self, Error> {
+    /// Returns [`Error::InvalidGlob`] if `pattern` fails to parse.
+    pub fn try_new(pattern: impl Into<String>) -> Result<Self, Error> {
         let pattern = pattern.into();
-        let glob = globset::Glob::new(&pattern).map_err(|source| Error::InvalidGlob {
-            pattern: pattern.clone(),
-            source,
-        })?;
-        let mut new = self;
-        new.patterns.push(pattern);
-        new.compiled.push(glob);
-        Ok(new)
+        let glob = globset::Glob::new(&pattern)
+            .map_err(|source| Error::InvalidGlob { pattern, source })?;
+        let matcher = glob.compile_matcher();
+        Ok(Self { glob, matcher })
     }
 
-    /// The base directory for relative patterns, if set.
+    /// The original pattern string (suitable for re-serialization).
     #[must_use]
-    pub fn base(&self) -> Option<&HostPath> {
-        self.base.as_ref()
+    pub fn pattern(&self) -> &str {
+        self.glob.glob()
     }
 
-    /// The original pattern strings (suitable for re-serialization).
+    /// The compiled glob, for matching.
     #[must_use]
-    pub fn raw_patterns(&self) -> &[String] {
-        &self.patterns
+    pub fn glob(&self) -> &globset::Glob {
+        &self.glob
     }
 
-    /// The compiled glob patterns.
+    /// `true` iff this pattern matches `path`.
     #[must_use]
-    pub fn globs(&self) -> &[globset::Glob] {
-        &self.compiled
+    pub fn is_match(&self, path: impl AsRef<std::path::Path>) -> bool {
+        self.matcher.is_match(path.as_ref())
     }
 
-    /// Returns `true` if the set contains no patterns.
+    /// The longest literal path prefix in the pattern — the directory a
+    /// walker should start from to enumerate matches.
+    ///
+    /// Returns [`None`] when the pattern has no literal prefix (e.g.
+    /// `**/*.pem`, `*.lua`); callers needing a concrete walk root must
+    /// substitute (typically the current directory, or an error).
+    /// Otherwise returns the prefix up to — but not including — the slash
+    /// before the first metacharacter (`*`, `?`, `[`, `{`) as a
+    /// [`HostPath`]. Patterns with no metacharacters return the whole
+    /// pattern.
+    ///
+    /// The returned [`HostPath`] is unexpanded — `~` and `$VAR` are still
+    /// raw. Resolving those is the caller's responsibility.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.patterns.is_empty()
+    pub fn walk_root(&self) -> Option<HostPath> {
+        let pattern = self.pattern();
+        let mut last_slash = None;
+        for (i, c) in pattern.bytes().enumerate() {
+            match c {
+                b'/' => last_slash = Some(i),
+                b'*' | b'?' | b'[' | b'{' => {
+                    return last_slash.map(|i| HostPath::new(&pattern[..i]));
+                }
+                _ => {}
+            }
+        }
+        Some(HostPath::new(pattern))
     }
-}
 
-impl Default for FileSet {
-    fn default() -> Self {
-        Self::empty()
+    /// Walk the host filesystem under [`Self::walk_root`] and collect
+    /// every file whose path matches this pattern.
+    ///
+    /// Per-entry failures (walk errors, non-UTF-8 paths) are accumulated
+    /// into the returned `Vec<Error>` rather than aborting the walk —
+    /// callers decide whether a partial result is acceptable.
+    ///
+    /// `~` and `$VAR` are **not** expanded; the walker passes the raw
+    /// prefix to the OS. Expand before invoking, or accept that
+    /// `~/...` patterns resolve to nothing.
+    ///
+    /// Patterns with no literal path prefix (e.g. `**/*.pem`, `*.lua`)
+    /// would have to start their walk from `/` — virtually never what
+    /// the caller wants. Such patterns produce an empty result with a
+    /// single [`Error::NoWalkRoot`] entry instead of walking the entire
+    /// root filesystem.
+    #[must_use]
+    pub fn resolve(&self, follow_links: bool) -> (Vec<HostPath>, Vec<Error>) {
+        let Some(root) = self.walk_root() else {
+            return (
+                Vec::new(),
+                vec![Error::NoWalkRoot {
+                    pattern: self.pattern().to_owned(),
+                }],
+            );
+        };
+        let root_path = root.as_utf8_path().to_path_buf();
+
+        let mut paths = Vec::new();
+        let mut errors = Vec::new();
+        for entry_result in walkdir::WalkDir::new(&root).follow_links(follow_links) {
+            match entry_result {
+                Ok(entry) if !entry.file_type().is_file() => {}
+                Ok(entry) => match Utf8PathBuf::from_path_buf(entry.into_path()) {
+                    Ok(p) if self.is_match(&p) => paths.push(HostPath::new(p)),
+                    Ok(_) => {}
+                    Err(p) => errors.push(Error::NonUtf8Path {
+                        path_lossy: p.to_string_lossy().into_owned(),
+                    }),
+                },
+                Err(source) => errors.push(Error::WalkFailure {
+                    root: root_path.clone(),
+                    source,
+                }),
+            }
+        }
+        (paths, errors)
     }
 }
 
 impl PartialEq for FileSet {
     fn eq(&self, other: &Self) -> bool {
-        // `compiled` is derived from `patterns`, so equality on the raw inputs
-        // implies equality of the compiled forms.
-        self.base == other.base && self.patterns == other.patterns
+        self.pattern() == other.pattern()
     }
 }
 impl Eq for FileSet {}
 
 impl std::hash::Hash for FileSet {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.base.hash(state);
-        self.patterns.hash(state);
+        self.pattern().hash(state);
     }
 }
 
 impl serde::Serialize for FileSet {
     fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeStruct;
-        let len = 1 + usize::from(self.base.is_some());
-        let mut st = ser.serialize_struct("FileSet", len)?;
-        if let Some(b) = &self.base {
-            st.serialize_field("base", b)?;
-        }
-        st.serialize_field("patterns", &self.patterns)?;
-        st.end()
+        ser.serialize_str(self.pattern())
     }
 }
 
 impl<'de> serde::Deserialize<'de> for FileSet {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        #[derive(serde::Deserialize)]
-        #[serde(untagged)]
-        enum Repr {
-            Full {
-                #[serde(default)]
-                base: Option<HostPath>,
-                patterns: Vec<String>,
-            },
-            Many(Vec<String>),
-            One(String),
-        }
-        let (base, patterns) = match Repr::deserialize(deserializer)? {
-            Repr::Full { base, patterns } => (base, patterns),
-            Repr::Many(p) => (None, p),
-            Repr::One(p) => (None, vec![p]),
-        };
-        Self::try_new(base, patterns).map_err(serde::de::Error::custom)
+        let s = String::deserialize(deserializer)?;
+        Self::try_new(s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -310,7 +291,7 @@ impl<'de> serde::Deserialize<'de> for FileSet {
 /// destination path cannot be passed to host I/O without going through a
 /// [`paths::Translator`] first.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct PatchDest(SandboxPath);
+pub struct PatchDest(SandboxRelPath);
 
 impl PatchDest {
     /// Construct a `PatchDest` after validation.
@@ -330,12 +311,13 @@ impl PatchDest {
         {
             return Err(Error::DestTraversal(path));
         }
-        Ok(Self(SandboxPath::new(path)))
+        Ok(Self(
+            SandboxRelPath::try_new(path).map_err(Error::AbsoluteDestPath)?,
+        ))
     }
 
     /// Borrow the underlying sandbox path.
-    #[must_use]
-    pub fn as_sandbox_path(&self) -> &SandboxPath {
+    pub fn as_sandbox_path(&self) -> &SandboxRelPath {
         &self.0
     }
 }
@@ -404,9 +386,58 @@ impl Patch {
 
 /// An ordered collection of [`Patch`] entries — the wire form of a
 /// `patches = [...]` array.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+///
+/// At the wire layer, a single row may carry either one `source` pattern
+/// or a list. List-shaped rows fan out into one [`Patch`] per pattern
+/// (the `description` and `dest` are shared across the fan-out). After
+/// deserialization every [`Patch`] holds exactly one [`FileSet`].
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize)]
 #[serde(transparent)]
 pub struct Patches(Vec<Patch>);
+
+impl<'de> serde::Deserialize<'de> for Patches {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum Source {
+            One(FileSet),
+            Many(Vec<FileSet>),
+        }
+        #[derive(serde::Deserialize)]
+        struct Row {
+            #[serde(default)]
+            description: Option<String>,
+            source: Source,
+            dest: PatchDest,
+        }
+        let rows: Vec<Row> = Vec::deserialize(deserializer)?;
+        let mut out = Vec::with_capacity(rows.len());
+        for Row {
+            description,
+            source,
+            dest,
+        } in rows
+        {
+            match source {
+                Source::One(fs) => out.push(Patch {
+                    description,
+                    source: fs,
+                    dest,
+                }),
+                Source::Many(fss) => {
+                    for fs in fss {
+                        out.push(Patch {
+                            description: description.clone(),
+                            source: fs,
+                            dest: dest.clone(),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(Self(out))
+    }
+}
 
 impl Patches {
     /// Construct an empty collection. Useful as the start of a builder
@@ -472,35 +503,76 @@ impl<'a> IntoIterator for &'a Patches {
     }
 }
 
+impl IntoIterator for Patches {
+    type Item = Patch;
+    type IntoIter = std::vec::IntoIter<Patch>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 // =====================================================================
 // PatchPolicy
 // =====================================================================
 
 /// Policy gating which patches are honored.
 ///
-/// Applied at the session-construction layer based on a patch's source:
+/// Patches are checked **per source file** after the patch's
+/// [`FileSet`] is walked on the host filesystem. Each enumerated source
+/// path runs through this policy; the patch's `dest` is *not* matched.
 ///
 /// - **User-origin patches** (from a [`Loadout`]): only
 ///   [`ignore`](Self::ignore) applies. `allow` and `deny` are bypassed —
 ///   the user is the policy for their own declarations.
 /// - **Project- and Package-origin patches**: all three fields apply.
-///   A patch is honored iff its destination matches `allow`, does not
-///   match `deny`, and does not match `ignore`. Patches matching only
-///   `ignore` are silently dropped; matching `deny` is an error/prompt;
-///   matching neither `allow` nor `ignore` triggers a permission prompt.
+///   A source file is honored iff its host path matches `allow`, does
+///   not match `deny`, and does not match `ignore`. Files matching only
+///   `ignore` are silently dropped; matching `deny` is an error;
+///   matching neither `allow` nor `ignore` triggers a permission prompt
+///   via [`PolicyHooks`](crate::composable::PolicyHooks).
 ///
-/// Precedence within the policy: `ignore` first (silent), then `deny`
-/// (reject), then `allow` (permit). Anything else prompts.
+/// Precedence: `ignore` first (silent), then `deny` (reject), then
+/// `allow` (permit). Anything else prompts.
 ///
 /// [`Loadout`]: crate::loadout::Loadout
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PatchPolicy {
-    #[serde(default, skip_serializing_if = "FileSet::is_empty")]
-    allow: FileSet,
-    #[serde(default, skip_serializing_if = "FileSet::is_empty")]
-    deny: FileSet,
-    #[serde(default, skip_serializing_if = "FileSet::is_empty")]
-    ignore: FileSet,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_one_or_many"
+    )]
+    allow: Vec<FileSet>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_one_or_many"
+    )]
+    deny: Vec<FileSet>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_one_or_many"
+    )]
+    ignore: Vec<FileSet>,
+}
+
+/// Accepts either a single pattern (bare string) or a list of patterns.
+fn deserialize_one_or_many<'de, D>(d: D) -> Result<Vec<FileSet>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        One(FileSet),
+        Many(Vec<FileSet>),
+    }
+    Ok(match Repr::deserialize(d)? {
+        Repr::One(f) => vec![f],
+        Repr::Many(v) => v,
+    })
 }
 
 impl PatchPolicy {
@@ -514,19 +586,19 @@ impl PatchPolicy {
 
     /// Replace the `allow` set.
     #[must_use]
-    pub fn with_allow(self, allow: FileSet) -> Self {
+    pub fn with_allow(self, allow: Vec<FileSet>) -> Self {
         Self { allow, ..self }
     }
 
     /// Replace the `deny` set.
     #[must_use]
-    pub fn with_deny(self, deny: FileSet) -> Self {
+    pub fn with_deny(self, deny: Vec<FileSet>) -> Self {
         Self { deny, ..self }
     }
 
     /// Replace the `ignore` set.
     #[must_use]
-    pub fn with_ignore(self, ignore: FileSet) -> Self {
+    pub fn with_ignore(self, ignore: Vec<FileSet>) -> Self {
         Self { ignore, ..self }
     }
 
@@ -540,7 +612,7 @@ impl PatchPolicy {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        Ok(self.with_allow(FileSet::try_new(None, patterns)?))
+        Ok(self.with_allow(try_collect_filesets(patterns)?))
     }
 
     /// Replace the `deny` set, constructing it from raw patterns.
@@ -553,7 +625,7 @@ impl PatchPolicy {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        Ok(self.with_deny(FileSet::try_new(None, patterns)?))
+        Ok(self.with_deny(try_collect_filesets(patterns)?))
     }
 
     /// Replace the `ignore` set, constructing it from raw patterns.
@@ -566,28 +638,123 @@ impl PatchPolicy {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        Ok(self.with_ignore(FileSet::try_new(None, patterns)?))
+        Ok(self.with_ignore(try_collect_filesets(patterns)?))
     }
 
     /// Paths non-user patches **may** target. Does not apply to
     /// user-origin patches.
     #[must_use]
-    pub fn allow(&self) -> &FileSet {
+    pub fn allow(&self) -> &[FileSet] {
         &self.allow
     }
 
     /// Paths non-user patches **must not** target. Does not apply to
     /// user-origin patches.
     #[must_use]
-    pub fn deny(&self) -> &FileSet {
+    pub fn deny(&self) -> &[FileSet] {
         &self.deny
     }
 
     /// Paths to silently drop without prompting. **Applies to every
     /// origin, user-origin included.**
     #[must_use]
-    pub fn ignore(&self) -> &FileSet {
+    pub fn ignore(&self) -> &[FileSet] {
         &self.ignore
+    }
+
+    /// Categorize a single source-file path against this policy.
+    ///
+    /// Precedence: `ignore` first, then a source-aware branch. For
+    /// user-origin items ([`Source::UserLoadout`]), `allow` and `deny`
+    /// do not apply — anything not ignored is implicitly allowed. For
+    /// every other source, the precedence continues `deny` → `allow` →
+    /// `NeedsApproval`.
+    ///
+    /// `item` reports its provenance via [`Provenanced`]; the resolver
+    /// constructs `T` types that carry their own source, so the caller
+    /// doesn't have to clone-and-borrow at the call site.
+    ///
+    /// Per-pattern provenance is preserved on the `FileSet` slices for a
+    /// later inspection command; the decision itself does not name it.
+    ///
+    /// [`Source::UserLoadout`]: crate::composable::Source::UserLoadout
+    /// [`Provenanced`]: crate::composable::Provenanced
+    #[must_use]
+    pub fn check<T: crate::composable::Provenanced>(
+        &self,
+        path: &Utf8Path,
+        item: T,
+    ) -> crate::composable::CheckOutcome<T> {
+        use crate::composable::{CheckOutcome, Decision, Source};
+        if filesets_match(&self.ignore, path) {
+            return CheckOutcome::Decided(Decision::Ignored);
+        }
+        if matches!(item.source(), Source::UserLoadout { .. }) {
+            return CheckOutcome::Decided(Decision::Allowed(item));
+        }
+        if filesets_match(&self.deny, path) {
+            CheckOutcome::Decided(Decision::Denied(item))
+        } else if filesets_match(&self.allow, path) {
+            CheckOutcome::Decided(Decision::Allowed(item))
+        } else {
+            CheckOutcome::NeedsApproval(item)
+        }
+    }
+}
+
+/// `true` iff any `FileSet` in `sets` matches `path`.
+fn filesets_match(sets: &[FileSet], path: &Utf8Path) -> bool {
+    sets.iter().any(|fs| fs.is_match(path))
+}
+
+fn try_collect_filesets<I, S>(patterns: I) -> Result<Vec<FileSet>, Error>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    patterns.into_iter().map(FileSet::try_new).collect()
+}
+
+/// A single patch's resolved endpoints: where the file lives on the
+/// host, and where it lands inside the sandbox.
+///
+/// The field is `host_path` (not `source`) so it doesn't collide with
+/// [`Provenanced::source`](crate::composable::Provenanced::source) when
+/// accessed via `SessionPatch::patch().host_path()`.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ResolvedPatch {
+    host_path: HostAbsPath,
+    destination: SandboxRelPath,
+}
+
+impl ResolvedPatch {
+    #[must_use]
+    pub fn new(host_path: HostAbsPath, destination: SandboxRelPath) -> Self {
+        Self {
+            host_path,
+            destination,
+        }
+    }
+
+    /// The absolute host path of the file being copied.
+    pub fn host_path(&self) -> &HostAbsPath {
+        &self.host_path
+    }
+
+    /// The sandbox-relative destination the file is copied to.
+    pub fn destination(&self) -> &SandboxRelPath {
+        &self.destination
+    }
+}
+
+impl core::fmt::Display for ResolvedPatch {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{} → {}",
+            self.host_path.as_str(),
+            self.destination.as_str(),
+        )
     }
 }
 
@@ -608,28 +775,16 @@ mod tests {
         toml::from_str::<Wrap<T>>(toml_str).unwrap().x
     }
 
+    fn patterns(sets: &[FileSet]) -> Vec<&str> {
+        sets.iter().map(FileSet::pattern).collect()
+    }
+
     // ---- FileSet ----
 
     #[test]
     fn fileset_from_bare_string() {
         let fs: FileSet = parse(r#"x = "~/.gitconfig""#);
-        assert_eq!(fs.raw_patterns(), &["~/.gitconfig"]);
-        assert!(fs.base().is_none());
-        assert_eq!(fs.globs().len(), 1);
-    }
-
-    #[test]
-    fn fileset_from_list() {
-        let fs: FileSet = parse(r#"x = ["**/*.jpg", "**/*.png"]"#);
-        assert_eq!(fs.raw_patterns(), &["**/*.jpg", "**/*.png"]);
-        assert_eq!(fs.globs().len(), 2);
-    }
-
-    #[test]
-    fn fileset_from_full_table() {
-        let fs: FileSet = parse(r#"x = { base = "./assets", patterns = ["**/*.jpg"] }"#);
-        assert_eq!(fs.base().map(HostPath::as_str), Some("./assets"));
-        assert_eq!(fs.raw_patterns(), &["**/*.jpg"]);
+        assert_eq!(fs.pattern(), "~/.gitconfig");
     }
 
     #[test]
@@ -639,30 +794,33 @@ mod tests {
     }
 
     #[test]
-    fn fileset_rejects_empty_base() {
-        let err =
-            toml::from_str::<Wrap<FileSet>>(r#"x = { base = "", patterns = ["a"] }"#).unwrap_err();
-        assert!(err.to_string().contains("base"), "got: {err}");
-    }
-
-    #[test]
-    fn fileset_round_trip() {
-        let original =
-            FileSet::try_new(Some(HostPath::new("./themes")), ["**/*", "**/*.toml"]).unwrap();
+    fn fileset_round_trips_as_bare_string() {
+        let original = FileSet::try_new("./themes/**/*.toml").unwrap();
         let s = toml::to_string(&Wrap {
             x: original.clone(),
         })
         .unwrap();
+        assert_eq!(s.trim(), r#"x = "./themes/**/*.toml""#);
         let parsed: FileSet = parse(&s);
         assert_eq!(parsed, original);
     }
 
     #[test]
-    fn fileset_serializes_without_base_when_none() {
-        let fs = FileSet::try_new(None, ["a"]).unwrap();
-        let s = toml::to_string(&Wrap { x: fs }).unwrap();
-        assert!(s.contains("patterns"));
-        assert!(!s.contains("base"));
+    fn fileset_walk_root_extracts_literal_prefix() {
+        let cases = [
+            ("~/dotfiles/nvim/**/*.lua", Some("~/dotfiles/nvim")),
+            ("/etc/xdg/**", Some("/etc/xdg")),
+            ("~/.gitconfig", Some("~/.gitconfig")),
+            ("**/*.pem", None),
+            ("*.lua", None),
+            ("src/?oo.rs", Some("src")),
+            ("a/b/{c,d}", Some("a/b")),
+        ];
+        for (pattern, expected) in cases {
+            let fs = FileSet::try_new(pattern).unwrap();
+            let expected = expected.map(HostPath::new);
+            assert_eq!(fs.walk_root(), expected, "pattern: {pattern}");
+        }
     }
 
     // ---- PatchDest ----
@@ -681,15 +839,6 @@ mod tests {
     }
 
     #[test]
-    fn patchdest_classifies_absolute_and_home_paths() {
-        let abs = PatchDest::try_new("/etc/foo").unwrap();
-        assert!(abs.as_sandbox_path().is_absolute());
-        // Tilde-prefixed paths classify as Rel — apply layer expands them.
-        let home = PatchDest::try_new("~/.gitconfig").unwrap();
-        assert!(!home.as_sandbox_path().is_absolute());
-    }
-
-    #[test]
     fn patch_deserialize_rejects_bad_dest() {
         let err = toml::from_str::<Wrap<Patch>>(r#"x = { dest = "foo/../bar", source = "a" }"#)
             .unwrap_err();
@@ -700,21 +849,55 @@ mod tests {
 
     #[test]
     fn patch_with_string_source() {
-        let p: Patch = parse(r#"x = { dest = "/etc/foo.conf", source = "./foo.conf" }"#);
-        assert_eq!(p.dest().as_sandbox_path().as_str(), "/etc/foo.conf");
-        assert_eq!(p.source().raw_patterns(), &["./foo.conf"]);
+        let p: Patch = parse(r#"x = { dest = "etc/foo.conf", source = "./foo.conf" }"#);
+        assert_eq!(p.dest().as_sandbox_path().as_str(), "etc/foo.conf");
+        assert_eq!(p.source().pattern(), "./foo.conf");
     }
 
     #[test]
     fn patches_deserialize_from_array() {
         let src = r#"
             x = [
-                { dest = "/a", source = "a" },
-                { dest = "/b", source = ["b1", "b2"] },
+                { dest = "a", source = "a" },
+                { dest = "b", source = "b" },
             ]
         "#;
         let ps: Patches = parse(src);
         assert_eq!(ps.len(), 2);
+    }
+
+    #[test]
+    fn patches_fan_out_multi_pattern_source() {
+        let src = r#"
+            x = [
+                { dest = "wallpapers", source = ["a/*.jpg", "a/*.png"] },
+            ]
+        "#;
+        let ps: Patches = parse(src);
+        // One row, two patterns → two patches with the same dest.
+        assert_eq!(ps.len(), 2);
+        let dests: Vec<_> = ps
+            .iter()
+            .map(|p| p.dest().as_sandbox_path().as_str().to_owned())
+            .collect();
+        assert_eq!(dests, ["wallpapers", "wallpapers"]);
+        let sources: Vec<_> = ps.iter().map(|p| p.source().pattern().to_owned()).collect();
+        assert_eq!(sources, ["a/*.jpg", "a/*.png"]);
+    }
+
+    #[test]
+    fn patches_fan_out_propagates_description() {
+        let src = r#"
+            x = [
+                { description = "lovely-fonts", dest = "fonts", source = ["a.ttf", "b.ttf"] },
+            ]
+        "#;
+        let ps: Patches = parse(src);
+        assert_eq!(ps.len(), 2);
+        // `description` is private; the Debug output reveals it. Both
+        // fan-out entries must carry the same description as the source row.
+        let dbg = format!("{ps:?}");
+        assert_eq!(dbg.matches("lovely-fonts").count(), 2);
     }
 
     // ---- PatchPolicy ----
@@ -727,9 +910,9 @@ mod tests {
             ignore = ["**/.DS_Store"]
         "#;
         let policy: PatchPolicy = toml::from_str(src).unwrap();
-        assert_eq!(policy.allow().raw_patterns().len(), 2);
-        assert_eq!(policy.deny().raw_patterns().len(), 2);
-        assert_eq!(policy.ignore().raw_patterns().len(), 1);
+        assert_eq!(patterns(policy.allow()), ["~/.config/**", "/etc/xdg/**"]);
+        assert_eq!(patterns(policy.deny()), ["~/.ssh/**", "**/*.pem"]);
+        assert_eq!(patterns(policy.ignore()), ["**/.DS_Store"]);
     }
 
     #[test]
@@ -741,6 +924,12 @@ mod tests {
     }
 
     #[test]
+    fn patch_policy_accepts_bare_string_for_each_field() {
+        let policy: PatchPolicy = toml::from_str(r#"deny = "~/.ssh/**""#).unwrap();
+        assert_eq!(patterns(policy.deny()), ["~/.ssh/**"]);
+    }
+
+    #[test]
     fn patch_policy_builder_methods() {
         let p = PatchPolicy::empty()
             .try_with_allow(["~/.config/**"])
@@ -749,9 +938,9 @@ mod tests {
             .unwrap()
             .try_with_ignore(["**/.DS_Store"])
             .unwrap();
-        assert_eq!(p.allow().raw_patterns(), &["~/.config/**"]);
-        assert_eq!(p.deny().raw_patterns(), &["~/.ssh/**", "**/*.pem"]);
-        assert_eq!(p.ignore().raw_patterns(), &["**/.DS_Store"]);
+        assert_eq!(patterns(p.allow()), ["~/.config/**"]);
+        assert_eq!(patterns(p.deny()), ["~/.ssh/**", "**/*.pem"]);
+        assert_eq!(patterns(p.ignore()), ["**/.DS_Store"]);
     }
 
     #[test]
@@ -760,47 +949,22 @@ mod tests {
         assert!(matches!(err, Error::InvalidGlob { .. }), "got: {err:?}");
     }
 
-    // ---- FileSet builders ----
-
     #[test]
-    fn fileset_try_with_base_and_pattern_chain() {
-        let fs = FileSet::empty()
-            .try_with_base(HostPath::new("./themes"))
-            .unwrap()
-            .try_with_pattern("**/*")
-            .unwrap()
-            .try_with_pattern("**/*.toml")
-            .unwrap();
-        assert_eq!(fs.base().map(HostPath::as_str), Some("./themes"));
-        assert_eq!(fs.raw_patterns(), &["**/*", "**/*.toml"]);
-    }
-
-    #[test]
-    fn fileset_try_with_base_rejects_empty() {
-        let err = FileSet::empty()
-            .try_with_base(HostPath::new(""))
-            .unwrap_err();
-        assert!(matches!(err, Error::EmptyBase), "got: {err:?}");
-    }
-
-    #[test]
-    fn fileset_try_with_pattern_propagates_invalid_glob() {
-        let err = FileSet::empty().try_with_pattern("[bad").unwrap_err();
-        assert!(matches!(err, Error::InvalidGlob { .. }), "got: {err:?}");
+    fn patch_policy_skips_empty_fields_on_serialize() {
+        let p = PatchPolicy::empty().try_with_allow(["A"]).unwrap();
+        let s = toml::to_string(&p).unwrap();
+        assert!(s.contains("allow"), "expected allow, got: {s}");
+        assert!(!s.contains("deny"), "expected no deny, got: {s}");
+        assert!(!s.contains("ignore"), "expected no ignore, got: {s}");
     }
 
     // ---- Patches builders ----
 
     #[test]
     fn patches_builder_surfaces_compose() {
-        let make = |s: &str| {
-            Patch::new(
-                FileSet::try_new(None, [s]).unwrap(),
-                PatchDest::try_new(format!("/{s}")).unwrap(),
-            )
-        };
+        let make =
+            |s: &str| Patch::new(FileSet::try_new(s).unwrap(), PatchDest::try_new(s).unwrap());
 
-        // collect / with_patch / push all feed the same internal Vec.
         let collected: Patches = ["a", "b"].into_iter().map(make).collect();
         let mut built = Patches::empty().with_patch(make("a"));
         built.push(make("b"));
@@ -810,12 +974,8 @@ mod tests {
 
     #[test]
     fn patches_extend_appends_other_collection() {
-        let make = |s: &str| {
-            Patch::new(
-                FileSet::try_new(None, [s]).unwrap(),
-                PatchDest::try_new(format!("/{s}")).unwrap(),
-            )
-        };
+        let make =
+            |s: &str| Patch::new(FileSet::try_new(s).unwrap(), PatchDest::try_new(s).unwrap());
         let mut ps: Patches = ["a", "b"].into_iter().map(make).collect();
         let extra: Patches = ["c", "d"].into_iter().map(make).collect();
         ps.extend(extra);
@@ -823,12 +983,6 @@ mod tests {
             .iter()
             .map(|p| p.dest().as_sandbox_path().as_str().to_owned())
             .collect();
-        assert_eq!(dests, ["/a", "/b", "/c", "/d"]);
-    }
-
-    #[test]
-    fn fileset_accepts_absolute_base() {
-        let fs = FileSet::try_new(Some(HostPath::new("/etc/xdg")), ["**/*.conf"]).unwrap();
-        assert_eq!(fs.base().map(HostPath::as_str), Some("/etc/xdg"));
+        assert_eq!(dests, ["a", "b", "c", "d"]);
     }
 }

--- a/crates/sessions/src/policy.rs
+++ b/crates/sessions/src/policy.rs
@@ -82,6 +82,16 @@ impl UserPolicy {
     pub fn patches(&self) -> &PatchPolicy {
         &self.patches
     }
+
+    /// Consume the policy and return the underlying narrow policies.
+    ///
+    /// Used by the resolution loop, which moves each narrow policy
+    /// into the corresponding per-domain resolver and rebuilds a
+    /// `UserPolicy` from the (possibly updated) results.
+    #[must_use]
+    pub fn into_parts(self) -> (VarsPolicy, PatchPolicy) {
+        (self.vars, self.patches)
+    }
 }
 
 fn vars_policy_is_default(p: &VarsPolicy) -> bool {
@@ -119,8 +129,20 @@ mod tests {
         let p: UserPolicy = toml::from_str(src).unwrap();
         assert_eq!(p.vars().allow().raw_patterns(), &["MY_APP_*"]);
         assert_eq!(p.vars().deny().raw_patterns(), &["AWS_*"]);
-        assert_eq!(p.patches().allow().raw_patterns(), &["~/.config/**"]);
-        assert_eq!(p.patches().deny().raw_patterns(), &["~/.ssh/**"]);
+        let allow: Vec<&str> = p
+            .patches()
+            .allow()
+            .iter()
+            .map(crate::patches::FileSet::pattern)
+            .collect();
+        let deny: Vec<&str> = p
+            .patches()
+            .deny()
+            .iter()
+            .map(crate::patches::FileSet::pattern)
+            .collect();
+        assert_eq!(allow, ["~/.config/**"]);
+        assert_eq!(deny, ["~/.ssh/**"]);
     }
 
     #[test]

--- a/crates/sessions/src/vars.rs
+++ b/crates/sessions/src/vars.rs
@@ -63,49 +63,45 @@ use std::str::FromStr;
 
 /// Errors produced when constructing var primitives.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// A var name was empty.
+    #[error("variable name must not be empty")]
     EmptyName,
     /// A var name failed POSIX validation (used by [`StrictVarName`]).
+    #[error(
+        "variable name `{0}` is not POSIX-shaped (expected `[A-Z_][A-Z0-9_]*`); \
+         use the `vars_lenient` form for non-POSIX names"
+    )]
     NotPosixName(String),
     /// A var name contained `=` or NUL, which the kernel won't accept.
+    #[error("variable name `{0}` contains `=` or NUL, which the kernel rejects")]
     InvalidLenientName(String),
     /// A pattern string failed to parse as a glob.
+    #[error("invalid glob pattern `{pattern}`: {source}")]
     InvalidGlob {
         pattern: String,
+        #[source]
         source: globset::Error,
     },
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::EmptyName => f.write_str("variable name must not be empty"),
-            Self::NotPosixName(s) => write!(
-                f,
-                "variable name `{s}` is not POSIX-shaped \
-                 (expected `[A-Z_][A-Z0-9_]*`); use the `vars_lenient` \
-                 form for non-POSIX names",
-            ),
-            Self::InvalidLenientName(s) => write!(
-                f,
-                "variable name `{s}` contains `=` or NUL, which the kernel rejects",
-            ),
-            Self::InvalidGlob { pattern, source } => {
-                write!(f, "invalid glob pattern `{pattern}`: {source}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::InvalidGlob { source, .. } => Some(source),
-            _ => None,
-        }
-    }
+    /// Resolving an inherited variable's value via the environment lookup
+    /// (default: [`std::env::var`]) failed.
+    #[error("unable to get value of environment variable {name}: {source}")]
+    ResolutionFailure {
+        name: String,
+        #[source]
+        source: std::env::VarError,
+    },
+    /// Compiling the precomputed [`globset::GlobSet`] matcher failed.
+    /// Each individual pattern was already validated by
+    /// [`globset::Glob::new`]; this error covers failures of the
+    /// *combined* regex — typically size or complexity limits when
+    /// many patterns alternate together.
+    #[error("failed to compile combined glob matcher: {source}")]
+    InvalidGlobSet {
+        #[source]
+        source: globset::Error,
+    },
 }
 
 // =====================================================================
@@ -149,6 +145,12 @@ impl StrictVarName {
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Consume the newtype and return the underlying [`String`].
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
     }
 }
 
@@ -215,6 +217,12 @@ impl LenientVarName {
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Consume the newtype and return the underlying [`String`].
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
     }
 }
 
@@ -293,6 +301,12 @@ impl LenientVarEntry {
     #[must_use]
     pub fn value(&self) -> &VarValue {
         &self.value
+    }
+
+    /// Consume the entry and return its components.
+    #[must_use]
+    pub fn into_parts(self) -> (LenientVarName, VarValue) {
+        (self.name, self.value)
     }
 }
 
@@ -456,10 +470,21 @@ impl<'de> serde::Deserialize<'de> for VarValue {
 /// Patterns are compiled at construction time so malformed ones fail at
 /// config load. Used by [`VarsPolicy`] to express allow/deny/ignore
 /// lists.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct VarNameGlobs {
     patterns: Vec<String>,
     compiled: Vec<globset::Glob>,
+    set: globset::GlobSet,
+}
+
+impl Default for VarNameGlobs {
+    fn default() -> Self {
+        Self {
+            patterns: Vec::new(),
+            compiled: Vec::new(),
+            set: globset::GlobSet::empty(),
+        }
+    }
 }
 
 impl VarNameGlobs {
@@ -489,9 +514,11 @@ impl VarNameGlobs {
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
+        let set = build_set(&compiled)?;
         Ok(Self {
             patterns: raw,
             compiled,
+            set,
         })
     }
 
@@ -510,6 +537,7 @@ impl VarNameGlobs {
         let mut new = self;
         new.patterns.push(pattern);
         new.compiled.push(glob);
+        new.set = build_set(&new.compiled)?;
         Ok(new)
     }
 
@@ -530,6 +558,22 @@ impl VarNameGlobs {
     pub fn is_empty(&self) -> bool {
         self.patterns.is_empty()
     }
+
+    /// `true` iff any pattern in this set matches `name`.
+    #[must_use]
+    pub fn is_match(&self, name: &str) -> bool {
+        self.set.is_match(name)
+    }
+}
+
+fn build_set(globs: &[globset::Glob]) -> Result<globset::GlobSet, Error> {
+    let mut b = globset::GlobSetBuilder::new();
+    for g in globs {
+        b.add(g.clone());
+    }
+    // Individual `Glob::new` validation does not bound the *combined*
+    // regex, which can hit `regex` crate size/complexity limits.
+    b.build().map_err(|source| Error::InvalidGlobSet { source })
 }
 
 impl PartialEq for VarNameGlobs {
@@ -685,6 +729,137 @@ impl VarsPolicy {
     #[must_use]
     pub fn ignore(&self) -> &VarNameGlobs {
         &self.ignore
+    }
+
+    /// Categorize a single variable against this policy.
+    ///
+    /// Precedence: `ignore` first, then a source-aware branch. For
+    /// user-origin items ([`Source::UserLoadout`]), `allow` and `deny`
+    /// do not apply — anything not ignored is implicitly allowed. For
+    /// every other source, the precedence continues `deny` → `allow` →
+    /// `NeedsApproval`.
+    ///
+    /// `item` reports its provenance via [`Provenanced`]; the resolver
+    /// constructs `T` types that carry their own source, so the caller
+    /// doesn't have to clone-and-borrow at the call site.
+    ///
+    /// Provenance of the *matched pattern* is not reported here; surface
+    /// that via a separate inspection command.
+    ///
+    /// [`Source::UserLoadout`]: crate::composable::Source::UserLoadout
+    /// [`Provenanced`]: crate::composable::Provenanced
+    #[must_use]
+    pub fn check<T: crate::composable::Provenanced>(
+        &self,
+        name: &str,
+        item: T,
+    ) -> crate::composable::CheckOutcome<T> {
+        use crate::composable::{CheckOutcome, Decision, Source};
+        if self.ignore.is_match(name) {
+            return CheckOutcome::Decided(Decision::Ignored);
+        }
+        if matches!(item.source(), Source::UserLoadout { .. }) {
+            return CheckOutcome::Decided(Decision::Allowed(item));
+        }
+        if self.deny.is_match(name) {
+            CheckOutcome::Decided(Decision::Denied(item))
+        } else if self.allow.is_match(name) {
+            CheckOutcome::Decided(Decision::Allowed(item))
+        } else {
+            CheckOutcome::NeedsApproval(item)
+        }
+    }
+}
+
+/// A variable name paired with the value it should resolve to after
+/// applying [`VarValue`] semantics (inheriting from the environment,
+/// falling back to a default, or taking a literal).
+///
+/// Both fields are raw strings: by the time a session is being
+/// activated, the OS is the next consumer and doesn't care about our
+/// strict/lenient name distinction. The newtype invariants are still
+/// upheld upstream — `ResolvedVar` only stores the post-resolution
+/// snapshot.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ResolvedVar {
+    name: String,
+    value: String,
+}
+
+impl ResolvedVar {
+    /// The variable's name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The resolved value.
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Resolve a variable against an arbitrary environment-lookup function.
+    /// The thread-able shape lets tests pin every branch without touching
+    /// the process environment.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ResolutionFailure`] if `lookup` returns an error
+    /// that the variant's semantics surface (every error for
+    /// [`VarValue::Inherit`]; only [`std::env::VarError::NotUnicode`] for
+    /// [`VarValue::InheritWithDefault`]).
+    pub fn resolve_with<F>(name: String, value: VarValue, lookup: F) -> Result<Self, Error>
+    where
+        F: FnOnce(&str) -> Result<String, std::env::VarError>,
+    {
+        let resolved_value = match value {
+            VarValue::Specified { value } => value,
+            VarValue::Inherit => lookup(&name).map_err(|source| Error::ResolutionFailure {
+                name: name.clone(),
+                source,
+            })?,
+            VarValue::InheritWithDefault { default } => match lookup(&name) {
+                Ok(value) => value,
+                Err(std::env::VarError::NotPresent) => default,
+                Err(source @ std::env::VarError::NotUnicode(_)) => {
+                    return Err(Error::ResolutionFailure {
+                        name: name.clone(),
+                        source,
+                    });
+                }
+            },
+        };
+        Ok(Self {
+            name,
+            value: resolved_value,
+        })
+    }
+
+    /// Resolve a variable against the process environment via
+    /// [`std::env::var`]. Sugar for [`Self::resolve_with`] with the
+    /// default lookup.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::resolve_with`].
+    pub fn resolve(name: String, value: VarValue) -> Result<Self, Error> {
+        Self::resolve_with(name, value, |l| std::env::var(l))
+    }
+}
+
+impl TryFrom<(StrictVarName, VarValue)> for ResolvedVar {
+    type Error = Error;
+    fn try_from((name, value): (StrictVarName, VarValue)) -> Result<Self, Error> {
+        Self::resolve(name.into_inner(), value)
+    }
+}
+
+impl TryFrom<LenientVarEntry> for ResolvedVar {
+    type Error = Error;
+    fn try_from(entry: LenientVarEntry) -> Result<Self, Self::Error> {
+        let (name, value) = entry.into_parts();
+        Self::resolve(name.into_inner(), value)
     }
 }
 
@@ -958,5 +1133,90 @@ mod tests {
         let e: LenientVarEntry = (n.clone(), v.clone()).into();
         assert_eq!(e.name(), &n);
         assert_eq!(e.value(), &v);
+    }
+
+    // ---- ResolvedVar ----
+
+    fn make_lookup<'a>(
+        entries: &'a [(&'a str, &'a str)],
+    ) -> impl Fn(&str) -> Result<String, std::env::VarError> + 'a {
+        move |name| {
+            entries
+                .iter()
+                .find_map(|(k, v)| (*k == name).then(|| (*v).to_owned()))
+                .ok_or(std::env::VarError::NotPresent)
+        }
+    }
+
+    #[test]
+    fn resolved_var_specified_does_not_consult_lookup() {
+        let r = ResolvedVar::resolve_with("EDITOR".into(), VarValue::specified("hx"), |_| {
+            panic!("lookup must not be called for Specified")
+        })
+        .unwrap();
+        assert_eq!(r.name(), "EDITOR");
+        assert_eq!(r.value(), "hx");
+    }
+
+    #[test]
+    fn resolved_var_inherit_returns_lookup_value() {
+        let lookup = make_lookup(&[("LANG", "en_US.UTF-8")]);
+        let r = ResolvedVar::resolve_with("LANG".into(), VarValue::Inherit, lookup).unwrap();
+        assert_eq!(r.value(), "en_US.UTF-8");
+    }
+
+    #[test]
+    fn resolved_var_inherit_surfaces_not_present_as_error() {
+        let lookup = make_lookup(&[]);
+        let err = ResolvedVar::resolve_with("LANG".into(), VarValue::Inherit, lookup).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ResolutionFailure {
+                source: std::env::VarError::NotPresent,
+                ..
+            },
+        ));
+    }
+
+    #[test]
+    fn resolved_var_inherit_with_default_falls_back_when_unset() {
+        let lookup = make_lookup(&[]);
+        let r =
+            ResolvedVar::resolve_with("LANG".into(), VarValue::inherit_with_default("C"), lookup)
+                .unwrap();
+        assert_eq!(r.value(), "C");
+    }
+
+    #[test]
+    fn resolved_var_inherit_with_default_prefers_env_value() {
+        let lookup = make_lookup(&[("LANG", "en_US.UTF-8")]);
+        let r =
+            ResolvedVar::resolve_with("LANG".into(), VarValue::inherit_with_default("C"), lookup)
+                .unwrap();
+        assert_eq!(r.value(), "en_US.UTF-8");
+    }
+
+    #[test]
+    fn resolved_var_inherit_with_default_surfaces_not_unicode_as_error() {
+        use std::ffi::OsString;
+        let lookup = |_: &str| Err(std::env::VarError::NotUnicode(OsString::from("bad")));
+        let err =
+            ResolvedVar::resolve_with("LANG".into(), VarValue::inherit_with_default("C"), lookup)
+                .unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ResolutionFailure {
+                source: std::env::VarError::NotUnicode(_),
+                ..
+            },
+        ));
+    }
+
+    #[test]
+    fn resolved_var_error_source_chain_includes_var_error() {
+        let lookup = make_lookup(&[]);
+        let err = ResolvedVar::resolve_with("LANG".into(), VarValue::Inherit, lookup).unwrap_err();
+        let source = std::error::Error::source(&err);
+        assert!(source.is_some(), "expected source on ResolutionFailure");
     }
 }


### PR DESCRIPTION
Summary

  Adds the composability layer that turns a [Loadout] (and, eventually, project configs and packages) into a Resolution of vars, patches, packages, and lifecycle hooks ready for the apply layer.

  The core flow:

```
  contributors (Loadout, …)  ──Composer::add()──►  Composer
                                                      │
                                    Composer::resolve(policy, hooks, opts)
                                                      │
                                                      ▼
                                                Resolution
```

  What's in here

  New composable module (crates/sessions/src/composable.rs):

  - Composable trait: contributors implement fn contribute(self, env) -> Result<Contribution, Error>. Drops a Provenanced constraint that didn't fit (contributors aren't items).
  - Contribution: typed accumulator for vars, patches, packages, and lifecycle hooks, with builder + mutating APIs. Single canonical type — Composable impls never see Composer internals.
  - Composer: takes Composables one at a time (add) or in batches (add_all); resolves against UserPolicy. Stores a swappable env-lookup closure (Composer::with_env(...) for tests).
  - Resolution: the policy-gated output. Exposes vars(), patches(), packages(), lifecycle_hooks() (sealed fields; consume via into_parts()).

  Policy resolution (var + patch domains):

  - Three-pass per domain: categorize → batched hook prompt → apply.
  - Source-aware bypass: Source::UserLoadout items skip allow/deny (ignore still applies). Documented and tested for Source::Project / Source::Package not bypassing.
  - Hooks receive an owned policy snapshot; they cannot mutate the resolver's state and must return any rule additions via HookResult::Decided.updated_policy.
  - Error variants split between configuration (PatchConfig — e.g. patterns with no walk root) and IO walk failures (PatchWalk), each accumulated rather than first-wins.

  impl Composable for Loadout: materializes Source::UserLoadout, resolves inherited vars through the env closure, and emits all four primitive kinds. End-to-end test covers all four reaching Resolution.

  thiserror adopted across paths and sessions error enums (replaces manual Display/Error impls). Adds thiserror = "2" workspace dep.

  paths crate gains AbsPath::new_unchecked, AbsPath::root(), and RelPath::new_unchecked for the resolver's by-construction-absolute paths.

  patches crate gets:
  - FileSet as a single-glob newtype (was a base + patterns table). Refused **/*-style patterns without a literal prefix would walk /; they now surface as Error::NoWalkRoot.
  - PatchPolicy::check with the source-aware bypass.
  - IntoIterator for Patches so Loadout::contribute can consume.

  vars crate gets VarsPolicy::check (matching the patches one).

  policy::UserPolicy gets into_parts() -> (VarsPolicy, PatchPolicy). Resolver moves narrow policies by value; no &mut threading.

  Docs: crates/sessions/docs/RESOLUTION.md — data-flow diagram and invariants.

  Deferred (intentional)

  - Conflict resolution. Composer::merge is pure aggregation today — two contributors setting EDITOR both survive. The single merge site is where dedup / precedence will land. Doc comment says so.
  - Hook policy gating. Lifecycle hooks run inside the isolated environment, so no allow/deny/ignore for them.
  - CLI/TUI PolicyHooks impl. Downstream of this crate.
  - Project and contributing Package types. Live in mfile / graph once they exist; both just implement Composable.

  Test plan

  - cargo test -p sessions --lib (118 tests pass)
  - cargo test -p sessions (lib + doc tests)
  - cargo clippy -p paths -p sessions --all-targets -- -D warnings clean
  - Resolver paths covered: allow / deny / ignore, user-bypass, package-not-bypassing, prompt + AllowOnce / DenyOnce / UseRule, mixed-batch ordering, hook contract violations, walk failures vs. config failures
  - Composable flow covered: add, add_all, contributor error propagation, packages + hooks pass-through, with_env overriding the lookup, Loadout contributing all four kinds end-to-end
  - No downstream callers yet — surface is new

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composable session pipeline to merge loadouts, variables, patches, and lifecycle hooks; richer resolution results and APIs.
  * Loadouts now require validated names and use builder-style construction.
  * Patch handling: single-glob filesets, fan-out of sources, and improved patch destination semantics.

* **Bug Fixes**
  * Stricter validation and clearer errors for loadout names, patch destinations, and variable resolution.
  * Improved variable matching, resolution outcomes, and policy evaluation order.

* **Chores**
  * Workspace dependencies added to support new error/serde utilities.

* **Documentation**
  * Added comprehensive session resolution documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->