### PR TITLE
Install spectacles SDD suite (ref: v0.1.2)

### DIFF
--- a/.github/workflows/distillery-sync.yml
+++ b/.github/workflows/distillery-sync.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   distillery-sync:
-    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@v0.1.2
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
@@ -49,10 +49,17 @@ jobs:
       # the same mapping every sdd-* wrapper carries.
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
+      # the reusable lock's observability.otlp endpoint resolves; unset is fine
+      # (if-missing: warn). See ADR 0020.
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
       DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
     # Ceiling for the called reusable workflow. Must cover the union of every
     # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
-    # need issues: write, and activation needs actions: read.
+    # need issues: write, discussions: write, and pull-requests: write; the
+    # activation needs actions: read. A reusable workflow whose job requests a
+    # scope above this ceiling fails at startup, so this set must track the
+    # lock's job permissions.
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/sdd-dispatch.yml
+++ b/.github/workflows/sdd-dispatch.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: Decide whether to run, and find the tracking issue
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@v0.1.2
         with:
           app-id: ${{ vars.APP_ID }}
           github-token: ${{ github.token }}
@@ -105,10 +105,11 @@ jobs:
       precondition: ${{ steps.compute.outputs.precondition }}
       tracking_state: ${{ steps.compute.outputs.tracking_state }}
       reason: ${{ steps.compute.outputs.reason }}
+      closeable_units: ${{ steps.compute.outputs.closeable_units }}
     steps:
       - name: Compute ready set and precondition state
         id: compute
-        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@v0.1.2
         with:
           tracking-issue: ${{ needs.route.outputs.tracking_issue }}
           trigger-kind: ${{ needs.route.outputs.trigger_kind }}
@@ -189,7 +190,7 @@ jobs:
               core.setFailed('Failed to post /execute on task #' + task
                 + ': ' + err.message);
             }
-      - name: Apply sdd:ready hint to dispatched task #${{ matrix.task }}
+      - name: Claim dispatched task #${{ matrix.task }} as sdd:in-progress
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           APP_TOKEN: ${{ steps.app.outputs.token }}
@@ -198,17 +199,55 @@ jobs:
           github-token: ${{ env.APP_TOKEN }}
           script: |
             const task = parseInt(process.env.TASK, 10);
+            // Claim the task deterministically at dispatch time: mark it
+            // sdd:in-progress and drop sdd:ready, mirroring the
+            // tracking-issue move in the lifecycle job. Done here (not in
+            // the agent run) so a dispatched-but-not-yet-booted task is
+            // visibly in flight, never indistinguishable from an
+            // un-dispatched sdd:ready task (#200). The write uses the App
+            // token; #143's trigger guard makes execute ignore issues
+            // label events (except `unlabeled needs-human`), so this does
+            // not re-fire or cancel the execute run.
+            // Add sdd:in-progress first; only drop sdd:ready once the task is
+            // confirmed in-progress, so an unexpected add failure (403/5xx)
+            // never leaves the task with neither label. A 422 means the label
+            // is already present (idempotent); any other status is fatal.
+            let inProgressPresent = false;
             try {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: task,
-                labels: ['sdd:ready'],
+                labels: ['sdd:in-progress'],
               });
+              inProgressPresent = true;
             } catch (err) {
-              // A 422 here means the label is already present; ignore.
-              core.info('Could not add sdd:ready to #' + task + ': '
-                + err.message);
+              if (err.status === 422) {
+                inProgressPresent = true;
+              } else {
+                throw err;
+              }
+            }
+            if (inProgressPresent) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: task,
+                  name: 'sdd:ready',
+                });
+              } catch (err) {
+                // A 404 means sdd:ready was already absent; idempotent.
+                // Any other status (permission, transient API failure)
+                // is fatal so dispatch-state drift surfaces as a job
+                // failure rather than being silently swallowed, mirroring
+                // the 422 handling on the paired sdd:in-progress add above.
+                if (err.status === 404) {
+                  core.info('sdd:ready already absent on #' + task);
+                } else {
+                  throw err;
+                }
+              }
             }
 
   # Manage the tracking issue's lifecycle and sdd:dispatched labels. On the
@@ -245,6 +284,7 @@ jobs:
           READY_COUNT: ${{ needs.compute.outputs.ready_count }}
           OPEN_TASK_COUNT: ${{ needs.compute.outputs.open_task_count }}
           TRACKING_STATE: ${{ needs.compute.outputs.tracking_state }}
+          CLOSEABLE_UNITS: ${{ needs.compute.outputs.closeable_units }}
         with:
           github-token: ${{ env.APP_TOKEN }}
           script: |
@@ -260,6 +300,63 @@ jobs:
             // posts the refusal.
             if (precondition !== 'ok') {
               return;
+            }
+
+            // Deterministic Unit-close (#233). compute's tree walk
+            // nominates every Unit under this tracking issue whose every
+            // task child is now closed while the Unit itself is still open
+            // (the fail-closed test lives in sdd-dispatch-compute: a child
+            // whose state cannot be read is not 'closed', so its Unit is
+            // never nominated). We close those Units here, on the same
+            // deterministic event that drains the tree — replacing the
+            // prompt-driven Unit-close that ADR 0005 §4-5 parked on
+            // sdd-execute's step-8 sweep, which only fired on a merged-PR
+            // run and missed manual closes. sdd-execute retains that sweep
+            // as an idempotent backup during the transition (#233).
+            //
+            // Loop safety: closing a Unit re-fires this wrapper on the
+            // Unit's own issues.closed event, but sdd-route-dispatch only
+            // arms the cascade when the closed issue is a *task* (its
+            // parent walk reaches the tracker in exactly two hops). A Unit
+            // is one hop below the tracker, so the walk yields walked === 1,
+            // route emits should_run = false, and every dispatch job skips.
+            // A Unit has no parent Unit, so there is no further Unit to
+            // cascade-close. The close therefore terminates here; the only
+            // downstream effect is that the tracker's existing drain logic
+            // (openTaskCount === 0 -> sdd:done, below) may run on the next
+            // task close. No infinite loop is possible.
+            //
+            // Idempotency: compute only nominates Units that are still open,
+            // but the close is also wrapped in try/catch so a redundant
+            // close on an already-closed Unit (or any transient API error)
+            // is a no-op, mirroring the dual-path sdd:done contract below.
+            // The write uses the App installation token (issues: write),
+            // the same token this job uses to mutate labels.
+            let closeableUnits = [];
+            try {
+              closeableUnits = JSON.parse(process.env.CLOSEABLE_UNITS || '[]');
+            } catch (err) {
+              // A malformed payload must not crash the lifecycle job (which
+              // also owns the sdd:done drain below); treat it as "no Units
+              // to close" — fail-closed, never a false close.
+              core.info('Could not parse CLOSEABLE_UNITS; skipping Unit-close: '
+                + err.message);
+              closeableUnits = [];
+            }
+            for (const unit of closeableUnits) {
+              try {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: unit,
+                  state: 'closed',
+                });
+                core.info('All tasks closed under Unit #' + unit
+                  + '; closed the Unit.');
+              } catch (err) {
+                core.info('Could not close Unit #' + unit + ': '
+                  + err.message);
+              }
             }
 
             // First /dispatch: move sdd:ready -> sdd:in-progress and add
@@ -298,8 +395,9 @@ jobs:
                   labels: ['sdd:dispatched'],
                 });
               } catch (err) {
-                core.info('Could not add sdd:dispatched to #' + tracking
+                core.setFailed('Could not add sdd:dispatched to #' + tracking
                   + ': ' + err.message);
+                throw err;
               }
             }
 

--- a/.github/workflows/sdd-execute-haiku.yml
+++ b/.github/workflows/sdd-execute-haiku.yml
@@ -65,6 +65,15 @@ on:
   # directly.
   pull_request:
     types: [unlabeled, closed]
+  # A check suite that completed on a pull request this agent opened. A
+  # failure conclusion on an `sdd/` branch is treated as an implicit
+  # /revise (issue #203): a required CI check failed and merge is BLOCKED,
+  # so the build is handed back to sdd-execute to fix on the same branch,
+  # mirroring the CHANGES_REQUESTED path. A success/neutral suite does not
+  # trigger a revise. The route step bounds the retries and escalates with
+  # needs-human after the cap.
+  check_suite:
+    types: [completed]
 
 permissions:
   contents: read
@@ -108,8 +117,20 @@ permissions:
 # where cancel-in-progress killed the originating run's safe_outputs tail
 # and its auto-merge job. The route step acts only on /execute and
 # /revise comments, so a non-command comment in a unique group is safe.
+#
+# A check_suite.completed event (the CI-failure -> implicit /revise path)
+# carries neither github.event.issue.number nor github.event.pull_request
+# .number — the PR is in github.event.check_suite.pull_requests[]. Without
+# a dedicated branch the expression fell through to the github.run_id
+# fallback, giving every failed suite its own group so cancel-in-progress
+# never collapsed concurrent /revise runs on the same PR (issues #227,
+# #228). Key on the suite's PR number (head_branch fallback when no PR is
+# linked), but ONLY for the same actionable suites the route job acts on:
+# a failure-like conclusion on an sdd/ branch. A success/neutral suite is
+# left on the throwaway github.run_id key so it cannot land in an active
+# /revise group and cancel a running revise before no-opping in route.
 concurrency:
-  group: sdd-execute-haiku-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  group: sdd-execute-haiku-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || (github.event_name == 'check_suite' && github.event.action == 'completed' && startsWith(github.event.check_suite.head_branch, 'sdd/') && (github.event.check_suite.conclusion == 'failure' || github.event.check_suite.conclusion == 'timed_out' || github.event.check_suite.conclusion == 'cancelled' || github.event.check_suite.conclusion == 'action_required') && (github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_branch)) || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -132,7 +153,8 @@ jobs:
   # without an API call).
   route:
     if: |
-      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      (github.event_name != 'issue_comment' && github.event_name != 'issues'
+        && github.event_name != 'check_suite')
       || (
         github.event_name == 'issue_comment'
         && (
@@ -148,6 +170,17 @@ jobs:
         && github.event.action == 'unlabeled'
         && github.event.label.name == 'needs-human'
       )
+      || (
+        github.event_name == 'check_suite'
+        && github.event.action == 'completed'
+        && startsWith(github.event.check_suite.head_branch, 'sdd/')
+        && (
+          github.event.check_suite.conclusion == 'failure'
+          || github.event.check_suite.conclusion == 'timed_out'
+          || github.event.check_suite.conclusion == 'cancelled'
+          || github.event.check_suite.conclusion == 'action_required'
+        )
+      )
     runs-on: ubuntu-latest
     # pull-requests: read is needed for the tier gate on a /revise issue_comment
     # (situation 6): the route fetches the pull request to read its body and
@@ -161,7 +194,13 @@ jobs:
     # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
     # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
     # re-trigger workflows, so this does not feed back into the route.
+    #
+    # checks: read is needed by the failed-required-check auto-revise branch
+    # (issue #203): it lists the check runs in the failing suite to name them
+    # in the revise directive. The same branch reuses the iteration-marker /
+    # needs-human machinery above.
     permissions:
+      checks: read
       contents: read
       issues: write
       pull-requests: write
@@ -171,7 +210,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.2
         with:
           tier: haiku
           app-id: ${{ vars.APP_ID }}
@@ -181,7 +220,7 @@ jobs:
   sdd-execute-haiku:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@v0.1.2
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -189,6 +228,10 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
+      # the reusable lock's observability.otlp endpoint resolves; unset is fine
+      # (if-missing: warn). See ADR 0020.
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
     # Ceiling for the called reusable workflow. Must cover the union of every
     # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
     # need write scopes, and activation needs actions: read.
@@ -220,6 +263,9 @@ jobs:
       # Mint the App token: reading branch protection needs administration:
       # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
       # lacks, and enabling auto-merge needs pull-requests + contents write.
+      # issues: write is needed by the empty-PR guard (issue #204): it labels
+      # a 0-diff PR needs-human, and a label on a PR is written through the
+      # issues endpoint.
       - name: Mint App token
         id: app
         uses: actions/create-github-app-token@v3
@@ -231,13 +277,14 @@ jobs:
           permission-administration: read
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
       # Arm auto-merge (squash, delete-branch) only when the repo allows it
       # and the base branch protection requires at least one status check;
       # otherwise skip (issue #127). Falls back to a direct squash merge when
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.2
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-haiku.outputs.created_pr_number }}

--- a/.github/workflows/sdd-execute-opus.yml
+++ b/.github/workflows/sdd-execute-opus.yml
@@ -65,6 +65,15 @@ on:
   # directly.
   pull_request:
     types: [unlabeled, closed]
+  # A check suite that completed on a pull request this agent opened. A
+  # failure conclusion on an `sdd/` branch is treated as an implicit
+  # /revise (issue #203): a required CI check failed and merge is BLOCKED,
+  # so the build is handed back to sdd-execute to fix on the same branch,
+  # mirroring the CHANGES_REQUESTED path. A success/neutral suite does not
+  # trigger a revise. The route step bounds the retries and escalates with
+  # needs-human after the cap.
+  check_suite:
+    types: [completed]
 
 permissions:
   contents: read
@@ -108,8 +117,20 @@ permissions:
 # where cancel-in-progress killed the originating run's safe_outputs tail
 # and its auto-merge job. The route step acts only on /execute and
 # /revise comments, so a non-command comment in a unique group is safe.
+#
+# A check_suite.completed event (the CI-failure -> implicit /revise path)
+# carries neither github.event.issue.number nor github.event.pull_request
+# .number — the PR is in github.event.check_suite.pull_requests[]. Without
+# a dedicated branch the expression fell through to the github.run_id
+# fallback, giving every failed suite its own group so cancel-in-progress
+# never collapsed concurrent /revise runs on the same PR (issues #227,
+# #228). Key on the suite's PR number (head_branch fallback when no PR is
+# linked), but ONLY for the same actionable suites the route job acts on:
+# a failure-like conclusion on an sdd/ branch. A success/neutral suite is
+# left on the throwaway github.run_id key so it cannot land in an active
+# /revise group and cancel a running revise before no-opping in route.
 concurrency:
-  group: sdd-execute-opus-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  group: sdd-execute-opus-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || (github.event_name == 'check_suite' && github.event.action == 'completed' && startsWith(github.event.check_suite.head_branch, 'sdd/') && (github.event.check_suite.conclusion == 'failure' || github.event.check_suite.conclusion == 'timed_out' || github.event.check_suite.conclusion == 'cancelled' || github.event.check_suite.conclusion == 'action_required') && (github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_branch)) || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -132,7 +153,8 @@ jobs:
   # without an API call).
   route:
     if: |
-      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      (github.event_name != 'issue_comment' && github.event_name != 'issues'
+        && github.event_name != 'check_suite')
       || (
         github.event_name == 'issue_comment'
         && (
@@ -148,6 +170,17 @@ jobs:
         && github.event.action == 'unlabeled'
         && github.event.label.name == 'needs-human'
       )
+      || (
+        github.event_name == 'check_suite'
+        && github.event.action == 'completed'
+        && startsWith(github.event.check_suite.head_branch, 'sdd/')
+        && (
+          github.event.check_suite.conclusion == 'failure'
+          || github.event.check_suite.conclusion == 'timed_out'
+          || github.event.check_suite.conclusion == 'cancelled'
+          || github.event.check_suite.conclusion == 'action_required'
+        )
+      )
     runs-on: ubuntu-latest
     # pull-requests: read is needed for the tier gate on a /revise issue_comment
     # (situation 6): the route fetches the pull request to read its body and
@@ -161,7 +194,13 @@ jobs:
     # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
     # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
     # re-trigger workflows, so this does not feed back into the route.
+    #
+    # checks: read is needed by the failed-required-check auto-revise branch
+    # (issue #203): it lists the check runs in the failing suite to name them
+    # in the revise directive. The same branch reuses the iteration-marker /
+    # needs-human machinery above.
     permissions:
+      checks: read
       contents: read
       issues: write
       pull-requests: write
@@ -171,7 +210,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.2
         with:
           tier: opus
           app-id: ${{ vars.APP_ID }}
@@ -181,7 +220,7 @@ jobs:
   sdd-execute-opus:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@v0.1.2
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -189,6 +228,10 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
+      # the reusable lock's observability.otlp endpoint resolves; unset is fine
+      # (if-missing: warn). See ADR 0020.
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
     # Ceiling for the called reusable workflow. Must cover the union of every
     # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
     # need write scopes, and activation needs actions: read.
@@ -220,6 +263,9 @@ jobs:
       # Mint the App token: reading branch protection needs administration:
       # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
       # lacks, and enabling auto-merge needs pull-requests + contents write.
+      # issues: write is needed by the empty-PR guard (issue #204): it labels
+      # a 0-diff PR needs-human, and a label on a PR is written through the
+      # issues endpoint.
       - name: Mint App token
         id: app
         uses: actions/create-github-app-token@v3
@@ -231,15 +277,74 @@ jobs:
           permission-administration: read
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
       # Arm auto-merge (squash, delete-branch) only when the repo allows it
       # and the base branch protection requires at least one status check;
       # otherwise skip (issue #127). Falls back to a direct squash merge when
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.2
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-opus.outputs.created_pr_number }}
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
+
+  # Refresh open sdd/ sibling PRs after a sibling task's PR merges (issue
+  # #207). When the cascade merges one task's PR into main, every other open
+  # sdd/ PR that touches the same files goes behind base and strands as
+  # CONFLICTING — nothing rebases or resolves it. This job sweeps the open
+  # sdd/ PRs on the merge of any sdd/ PR: a PR merely BEHIND base is refreshed
+  # in place (update-branch, which re-runs CI); a CONFLICTING PR is handed back
+  # to sdd-execute as an implicit /revise carrying a resolve-conflict directive,
+  # bounded by a hidden marker, escalating needs-human only after the cap. The
+  # posted /revise then routes to whichever tier owns each conflicting PR's
+  # linked task through that wrapper's own tier gate.
+  #
+  # DELIBERATE SINGLE-HOST SWEEP — NOT a per-tier job and NOT an omission in the
+  # haiku/sonnet wrappers. The sweep is a property of main advancing (a sibling
+  # sdd/ PR merging), not of any one tier executing, so it must fire exactly
+  # once per merge from exactly one place. All three sdd-execute-{haiku,sonnet,
+  # opus} wrappers subscribe to the same pull_request.closed event, so hosting
+  # this job in every wrapper would sweep three times per merge (triple /revise,
+  # triple update-branch). It therefore lives only here, in the opus wrapper,
+  # chosen as the arbitrary singleton host; do NOT copy it into the haiku/sonnet
+  # wrappers.
+  #
+  # Independent of the opus tier actually running: this is a top-level job whose
+  # only gate is the main-advance event below. It has no `needs:` on route /
+  # sdd-execute-opus and mints its own App token, so it fires on every merged
+  # sdd/ PR even when the merged PR (and every conflicting sibling) belongs to
+  # the haiku or sonnet tier and the opus route/execute jobs are skipped.
+  refresh-siblings:
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.action == 'closed'
+      && github.event.pull_request.merged == true
+      && startsWith(github.event.pull_request.head.ref, 'sdd/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Mint the App token: update-branch needs contents:write and posting the
+      # /revise comment needs pull-requests:write. The App identity is required
+      # so the posted /revise re-triggers the owning-tier sdd-execute wrapper
+      # (a GITHUB_TOKEN comment would not).
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+      - name: Sweep open sdd/ PRs and refresh those behind base
+        uses: norrietaylor/spectacles/.github/actions/sdd-refresh-siblings@v0.1.2
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          merged-pr-number: ${{ github.event.pull_request.number }}
+          max-resolve-iterations: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}

--- a/.github/workflows/sdd-execute-sonnet.yml
+++ b/.github/workflows/sdd-execute-sonnet.yml
@@ -65,6 +65,15 @@ on:
   # directly.
   pull_request:
     types: [unlabeled, closed]
+  # A check suite that completed on a pull request this agent opened. A
+  # failure conclusion on an `sdd/` branch is treated as an implicit
+  # /revise (issue #203): a required CI check failed and merge is BLOCKED,
+  # so the build is handed back to sdd-execute to fix on the same branch,
+  # mirroring the CHANGES_REQUESTED path. A success/neutral suite does not
+  # trigger a revise. The route step bounds the retries and escalates with
+  # needs-human after the cap.
+  check_suite:
+    types: [completed]
 
 permissions:
   contents: read
@@ -108,8 +117,20 @@ permissions:
 # where cancel-in-progress killed the originating run's safe_outputs tail
 # and its auto-merge job. The route step acts only on /execute and
 # /revise comments, so a non-command comment in a unique group is safe.
+#
+# A check_suite.completed event (the CI-failure -> implicit /revise path)
+# carries neither github.event.issue.number nor github.event.pull_request
+# .number — the PR is in github.event.check_suite.pull_requests[]. Without
+# a dedicated branch the expression fell through to the github.run_id
+# fallback, giving every failed suite its own group so cancel-in-progress
+# never collapsed concurrent /revise runs on the same PR (issues #227,
+# #228). Key on the suite's PR number (head_branch fallback when no PR is
+# linked), but ONLY for the same actionable suites the route job acts on:
+# a failure-like conclusion on an sdd/ branch. A success/neutral suite is
+# left on the throwaway github.run_id key so it cannot land in an active
+# /revise group and cancel a running revise before no-opping in route.
 concurrency:
-  group: sdd-execute-sonnet-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  group: sdd-execute-sonnet-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || (github.event_name == 'check_suite' && github.event.action == 'completed' && startsWith(github.event.check_suite.head_branch, 'sdd/') && (github.event.check_suite.conclusion == 'failure' || github.event.check_suite.conclusion == 'timed_out' || github.event.check_suite.conclusion == 'cancelled' || github.event.check_suite.conclusion == 'action_required') && (github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_branch)) || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -132,7 +153,8 @@ jobs:
   # without an API call).
   route:
     if: |
-      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      (github.event_name != 'issue_comment' && github.event_name != 'issues'
+        && github.event_name != 'check_suite')
       || (
         github.event_name == 'issue_comment'
         && (
@@ -148,6 +170,17 @@ jobs:
         && github.event.action == 'unlabeled'
         && github.event.label.name == 'needs-human'
       )
+      || (
+        github.event_name == 'check_suite'
+        && github.event.action == 'completed'
+        && startsWith(github.event.check_suite.head_branch, 'sdd/')
+        && (
+          github.event.check_suite.conclusion == 'failure'
+          || github.event.check_suite.conclusion == 'timed_out'
+          || github.event.check_suite.conclusion == 'cancelled'
+          || github.event.check_suite.conclusion == 'action_required'
+        )
+      )
     runs-on: ubuntu-latest
     # pull-requests: read is needed for the tier gate on a /revise issue_comment
     # (situation 6): the route fetches the pull request to read its body and
@@ -161,7 +194,13 @@ jobs:
     # comment on the PR and, on hitting SDD_MAX_REVIEW_ITERATIONS, applies the
     # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
     # re-trigger workflows, so this does not feed back into the route.
+    #
+    # checks: read is needed by the failed-required-check auto-revise branch
+    # (issue #203): it lists the check runs in the failing suite to name them
+    # in the revise directive. The same branch reuses the iteration-marker /
+    # needs-human machinery above.
     permissions:
+      checks: read
       contents: read
       issues: write
       pull-requests: write
@@ -171,7 +210,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.2
         with:
           tier: sonnet
           app-id: ${{ vars.APP_ID }}
@@ -181,7 +220,7 @@ jobs:
   sdd-execute-sonnet:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@v0.1.2
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -189,6 +228,10 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
+      # the reusable lock's observability.otlp endpoint resolves; unset is fine
+      # (if-missing: warn). See ADR 0020.
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
     # Ceiling for the called reusable workflow. Must cover the union of every
     # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
     # need write scopes, and activation needs actions: read.
@@ -220,6 +263,9 @@ jobs:
       # Mint the App token: reading branch protection needs administration:
       # read (the gh-aw locks request it too), which the default GITHUB_TOKEN
       # lacks, and enabling auto-merge needs pull-requests + contents write.
+      # issues: write is needed by the empty-PR guard (issue #204): it labels
+      # a 0-diff PR needs-human, and a label on a PR is written through the
+      # issues endpoint.
       - name: Mint App token
         id: app
         uses: actions/create-github-app-token@v3
@@ -231,13 +277,14 @@ jobs:
           permission-administration: read
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
       # Arm auto-merge (squash, delete-branch) only when the repo allows it
       # and the base branch protection requires at least one status check;
       # otherwise skip (issue #127). Falls back to a direct squash merge when
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.2
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-sonnet.outputs.created_pr_number }}

--- a/.github/workflows/sdd-monitor.yml
+++ b/.github/workflows/sdd-monitor.yml
@@ -131,8 +131,18 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          # Least-privilege scope. Without permission-* inputs the minted
+          # token inherits the App installation's full grant; the
+          # sdd-monitor action only needs:
+          #   actions:read        list sdd-execute-* runs (in-flight gate)
+          #   pull-requests:read  list open sdd/ implementation PRs
+          #   issues:write        label + post /dispatch on tracking issues
+          # It reads no repo contents, so contents is omitted.
+          permission-actions: read
+          permission-pull-requests: read
+          permission-issues: write
       - name: Nudge armed-but-idle trackers
-        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@v0.1.2
         with:
           github-token: ${{ steps.app.outputs.token }}
           debounce-min: ${{ vars.SDD_MONITOR_DEBOUNCE_MIN }}

--- a/.github/workflows/sdd-pr-sanitize.yml
+++ b/.github/workflows/sdd-pr-sanitize.yml
@@ -63,6 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Correct the issue references in the pull request body
-        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@v0.1.2
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-review.yml
+++ b/.github/workflows/sdd-review.yml
@@ -52,14 +52,14 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@v0.1.2
         with:
           github-token: ${{ github.token }}
 
   sdd-review:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@v0.1.2
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -67,6 +67,10 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
+      # the reusable lock's observability.otlp endpoint resolves; unset is fine
+      # (if-missing: warn). See ADR 0020.
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
     # Ceiling for the called reusable workflow. Must cover the union of every
     # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
     # need issues and pull-requests write, and activation needs actions: read.
@@ -116,7 +120,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-pull-requests: write
       - name: Resolve App-bot advisory review threads
-        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@v0.1.2
         with:
           github-token: ${{ steps.app.outputs.token }}
           bot-login: ${{ steps.app.outputs.app-slug }}[bot]

--- a/.github/workflows/sdd-spec.yml
+++ b/.github/workflows/sdd-spec.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@v0.1.2
         with:
           github-token: ${{ github.token }}
 
@@ -121,7 +121,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Find plan comment and dispatch sdd-execute-{tier}
-        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.1.2
         with:
           github-token: ${{ steps.app.outputs.token }}
           tracking: ${{ needs.route.outputs.fastpath_tracking }}
@@ -129,7 +129,7 @@ jobs:
   sdd-spec:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@v0.1.2
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -137,6 +137,10 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
+      # the reusable lock's observability.otlp endpoint resolves; unset is fine
+      # (if-missing: warn). See ADR 0020.
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
       DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
     # Ceiling for the called reusable workflow. Must cover the union of every
     # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
@@ -186,7 +190,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Post failure hand-off to tracking issue
-        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@v0.1.2
         with:
           github-token: ${{ steps.app.outputs.token }}
           aw-context: ${{ needs.route.outputs.aw_context }}

--- a/.github/workflows/sdd-spike-actuator.yml
+++ b/.github/workflows/sdd-spike-actuator.yml
@@ -1,0 +1,118 @@
+name: sdd-spike-actuator
+
+# Deterministic actuator for the spike wave (issue #229).
+#
+# sdd-triage phase A (step 4a) materializes one kind:spike sub-issue per
+# needs-spike assumption, a direct child of the tracking issue. Those spike
+# sub-issues need to run as agent work, but sdd-triage materializes them and
+# then ends its turn — nothing fires sdd-execute on a freshly-created spike.
+# This wrapper closes that gap: when a kind:spike sub-issue is opened (or gains
+# the kind:spike label) under a tracking issue that is still in triage, it posts
+# `/execute` on the spike sub-issue via the App installation token. The matching
+# sdd-execute-{tier} wrapper picks that comment up through its existing
+# issue_comment trigger and runs the spike, exactly as sdd-dispatch fans the
+# main task cascade out.
+#
+# Why a /execute comment, not workflow_dispatch (ADR 0014): the App
+# installations consumers grant do not reliably include actions:write, so a
+# workflow_dispatch dispatch 403s on a consumer repo (issue #121). ADR 0014
+# moved the whole fan-out onto a comment posted via the App installation token,
+# which only needs issues:write and re-triggers the downstream wrapper as an
+# issue_comment.created event. The spike actuator reuses that exact mechanism so
+# it inherits the same proven cross-install behavior.
+#
+# This wrapper is DETERMINISTIC — no LLM, no engine: block — like sdd-monitor
+# and sdd-dispatch's wrapper jobs, so it carries no OTEL frontmatter (ADR 0020
+# exempts the deterministic wrappers).
+#
+# Runtime risk (untestable locally): this is novel wiring. The parent walk
+# depends on GitHub populating GraphQL Issue.parent for the spike sub-issue at
+# the instant the labeled/opened webhook fires; if the sub-issue link has not
+# propagated yet, the walk resolves no parent and the post is skipped. The
+# opened event and the labeled event both fire for a create-issue that sets
+# kind:spike at creation, so the labeled retry covers a not-yet-linked opened
+# event in practice, but this has not been exercised end to end.
+
+on:
+  # A kind:spike sub-issue being opened, or gaining the kind:spike label. The
+  # job-level if: filters to the kind:spike label so an unrelated issue/label
+  # event spends no runner.
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  actuate:
+    # Fire only on a kind:spike opened/labeled event. On `opened` the label is
+    # read from the issue's label set (sdd-triage sets kind:spike at creation);
+    # on `labeled` it is the label just added. Either path that does not name
+    # kind:spike is skipped without a runner.
+    if: |
+      (github.event_name == 'issues'
+        && github.event.action == 'opened'
+        && contains(github.event.issue.labels.*.name, 'kind:spike'))
+      || (github.event_name == 'issues'
+        && github.event.action == 'labeled'
+        && github.event.label.name == 'kind:spike')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      # Resolve the spike's parent tracking issue and confirm it is still in
+      # triage. armed=false (no parent, parent not a triage tracker, or the
+      # walk errored) means this is not a spike-wave member to actuate.
+      - name: Resolve the parent tracking issue
+        id: tree
+        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.1.2
+        with:
+          mode: actuator
+          spike-issue: ${{ github.event.issue.number }}
+          github-token: ${{ github.token }}
+      # Mint the App installation token. The default GITHUB_TOKEN cannot
+      # trigger another workflow run; an App installation token can, so the
+      # /execute comment posted below re-fires the matching sdd-execute-{tier}
+      # wrapper. The route-execute App-author carve-out (gated on APP_ID)
+      # admits the comment past the human-permission check (ADR 0014).
+      - name: Mint App token
+        id: app
+        if: steps.tree.outputs.armed == 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Post /execute on the spike sub-issue
+        if: steps.tree.outputs.armed == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          SPIKE: ${{ github.event.issue.number }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const spike = parseInt(process.env.SPIKE, 10);
+            // Post an /execute comment on the spike sub-issue. The matching
+            // sdd-execute-{tier} wrapper (the tier sdd-triage set on the
+            // spike via create-issue.labels) picks it up through its
+            // issue_comment trigger; the route-execute App-author accept
+            // logic admits the cascade-posted comment past the
+            // human-permission check (ADR 0014). Idempotency: a second
+            // /execute on the same spike collapses at the execute wrapper's
+            // per-task-per-tier concurrency group, so a re-fired opened +
+            // labeled pair does not double-spawn the in-flight spike.
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: spike,
+                body: '/execute',
+              });
+              core.info('Posted /execute on spike #' + spike);
+            } catch (err) {
+              core.setFailed('Failed to post /execute on spike #' + spike
+                + ': ' + err.message);
+            }

--- a/.github/workflows/sdd-spike-reentry.yml
+++ b/.github/workflows/sdd-spike-reentry.yml
@@ -1,0 +1,128 @@
+name: sdd-spike-reentry
+
+# Deterministic re-entry for the spike wave (issue #229).
+#
+# sdd-triage phase A (step 4a) materializes a wave of kind:spike sub-issues
+# under a tracking issue, and phase B holds the plan comment until that wave
+# drains. But phase B's natural trigger — the architecture PR merging — already
+# fired before any spike existed, so the wave draining cannot re-fire phase B
+# through a real webhook. This wrapper synthesizes that re-entry: when a
+# kind:spike child of a triage tracking issue closes (its experiment resolved),
+# or a parked spike's needs-human is cleared, and ZERO open kind:spike children
+# remain, it re-enters sdd-triage phase B for the tracking issue so the resolved
+# spikes' findings fold into the plan.
+#
+# Triggers:
+# - issues.closed: a spike sub-issue closed (its implementation PR merged, or a
+#   human closed it). This is the normal drain signal.
+# - issues.unlabeled: needs-human cleared on a parked spike. Clearing
+#   needs-human does NOT itself re-run the failed experiment — the actuator only
+#   fires on opened/labeled, not on unlabeled — it only lets the re-entry
+#   re-check the wave. Phase B re-enters only when the wave is genuinely drained
+#   to zero open spikes; a still-open parked spike leaves the wave armed and the
+#   human owns the next move on that spike (see sdd-triage situation 7).
+#
+# This wrapper is DETERMINISTIC — no LLM in the drain check — like sdd-monitor,
+# so it carries no OTEL frontmatter of its own (ADR 0020 exempts the
+# deterministic wrappers). It DOES call the sdd-triage agent lock, which is an
+# engine: workflow, so it maps the same secrets sdd-triage's own wrapper maps —
+# including GH_AW_OTEL_ENDPOINT, which a cross-owner workflow_call does not
+# inherit and the called lock's observability.otlp endpoint needs to resolve.
+#
+# Runtime risk (untestable locally): this is novel wiring. The drain count
+# depends on GitHub having propagated the spike sub-issue's closed state and the
+# tracking issue's sub_issue list at the instant the webhook fires; a lagging
+# index could under- or over-count open spikes for one cycle. The walk fails
+# closed (drained='false' on any listing error), so the failure mode is "phase B
+# re-entry delayed", not "plan posted on an undrained wave" — a missed drain is
+# recovered by the next spike-close event, or by an operator /revise.
+
+on:
+  issues:
+    types: [closed, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  # Confirm the event is a kind:spike child of a triage tracking issue and
+  # decide whether the wave has drained. The job-level if: filters to kind:spike
+  # issues (a closed kind:spike, or needs-human cleared on a kind:spike) so an
+  # unrelated close/unlabel spends no runner.
+  walk:
+    if: |
+      (github.event_name == 'issues'
+        && github.event.action == 'closed'
+        && contains(github.event.issue.labels.*.name, 'kind:spike'))
+      || (github.event_name == 'issues'
+        && github.event.action == 'unlabeled'
+        && github.event.label.name == 'needs-human'
+        && contains(github.event.issue.labels.*.name, 'kind:spike'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      armed: ${{ steps.tree.outputs.armed }}
+      tracking_issue: ${{ steps.tree.outputs.tracking_issue }}
+      drained: ${{ steps.tree.outputs.drained }}
+    steps:
+      - name: Resolve the tracking issue and the drain state
+        id: tree
+        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.1.2
+        with:
+          mode: reentry
+          spike-issue: ${{ github.event.issue.number }}
+          github-token: ${{ github.token }}
+
+  # Build the canonical aw_context for the re-entry. Only runs when the spike's
+  # parent is an armed triage tracker AND the wave has drained to zero open
+  # kind:spike children. Routes through sdd-route-triage's re-entry case so the
+  # aw_context shape and the phase output match the normal triage path.
+  route:
+    needs: walk
+    if: |
+      needs.walk.outputs.armed == 'true'
+      && needs.walk.outputs.drained == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      aw_context: ${{ steps.decide.outputs.aw_context }}
+    steps:
+      - name: Build the phase-B re-entry context
+        id: decide
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.1.2
+        with:
+          github-token: ${{ github.token }}
+          reentry-tracking-issue: ${{ needs.walk.outputs.tracking_issue }}
+
+  # Re-enter sdd-triage phase B for the tracking issue. Calls the same reusable
+  # lock the sdd-triage wrapper calls, mapping the same secrets explicitly
+  # (cross-owner workflow_call does not inherit them) — including
+  # GH_AW_OTEL_ENDPOINT so the lock's observability.otlp endpoint resolves.
+  sdd-triage:
+    needs: route
+    if: needs.route.outputs.should_run == 'true'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.1.2
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
+      # the reusable lock's observability.otlp endpoint resolves; unset is fine
+      # (if-missing: warn). See ADR 0020.
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
+      DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
+    # Ceiling for the called reusable workflow. Must cover the union of every
+    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
+    # need write scopes, and activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write

--- a/.github/workflows/sdd-triage-dedupe-tasks.yml
+++ b/.github/workflows/sdd-triage-dedupe-tasks.yml
@@ -37,6 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close a duplicate phase-C task sub-issue
-        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@v0.1.2
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage-promote-ready.yml
+++ b/.github/workflows/sdd-triage-promote-ready.yml
@@ -57,6 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Promote tasks whose last blocker just closed
-        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@v0.1.2
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage.yml
+++ b/.github/workflows/sdd-triage.yml
@@ -76,17 +76,19 @@ jobs:
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
       aw_context: ${{ steps.decide.outputs.aw_context }}
+      phase: ${{ steps.decide.outputs.phase }}
+      item_number: ${{ steps.decide.outputs.item_number }}
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.1.2
         with:
           github-token: ${{ github.token }}
 
   sdd-triage:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.1.2
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -94,6 +96,10 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
+      # the reusable lock's observability.otlp endpoint resolves; unset is fine
+      # (if-missing: warn). See ADR 0020.
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
       DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
     # Ceiling for the called reusable workflow. Must cover the union of every
     # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
@@ -104,3 +110,107 @@ jobs:
       discussions: write
       issues: write
       pull-requests: write
+
+  # Deterministic DAG backstop for phase C (ADR 0010, issue #229).
+  #
+  # The agent's in-prompt cycle check is the PRIMARY guarantee: it upholds
+  # zero-create-issue-on-cycle, refusing to materialize a tree whose plan
+  # implies a cycle. This job is the AUTHORITATIVE backstop for a cycle that
+  # slips past the LLM. It runs AFTER the agent materializes the tree
+  # (needs: sdd-triage), walks the Feature -> Unit -> task sub-issues
+  # deterministically, and parks the tracking issue with needs-human if a
+  # cycle (or an incomplete tree it cannot fully resolve) is found. It gates
+  # on phase == 'C' (the /approve materialization) so it never runs on the
+  # design or plan-preview phases, which create no task tree to check.
+  cycle-detect:
+    needs: [route, sdd-triage]
+    # always(): the backstop must also run when sdd-triage FAILS partway
+    # through phase C, because a partial materialization can leave a cyclic
+    # or incomplete tree on the issues — exactly the state the deterministic
+    # cycle/tree_incomplete park exists to catch. Gate on route succeeding
+    # (so phase is a valid value) and on sdd-triage having actually run
+    # (result != 'skipped'); a non-phase-C run still no-ops on the phase
+    # check.
+    if: >-
+      always()
+      && needs.route.result == 'success'
+      && needs.route.outputs.phase == 'C'
+      && needs.sdd-triage.result != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Detect a dependency cycle in the materialized tree
+        id: detect
+        uses: norrietaylor/spectacles/.github/actions/sdd-cycle-detect@v0.1.2
+        with:
+          tracking-issue: ${{ needs.route.outputs.item_number }}
+          github-token: ${{ github.token }}
+      # Park the tree only when the detector found a real cycle or could not
+      # fully resolve the tree. Mint the App token the same way the other
+      # deterministic jobs do (sdd-dispatch's lifecycle/noop jobs) so the
+      # label write and comment carry the App identity.
+      - name: Mint App token
+        id: app
+        if: steps.detect.outputs.cycle == 'true' || steps.detect.outputs.tree_incomplete == 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Park the tracking issue with needs-human
+        if: steps.detect.outputs.cycle == 'true' || steps.detect.outputs.tree_incomplete == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          TRACKING: ${{ needs.route.outputs.item_number }}
+          CYCLE: ${{ steps.detect.outputs.cycle }}
+          CYCLE_PATH: ${{ steps.detect.outputs.cycle_path }}
+          TREE_INCOMPLETE: ${{ steps.detect.outputs.tree_incomplete }}
+        with:
+          github-token: ${{ env.APP_TOKEN }}
+          script: |
+            const tracking = parseInt(process.env.TRACKING, 10);
+            const cycle = process.env.CYCLE === 'true';
+            const cyclePath = process.env.CYCLE_PATH || '';
+            const treeIncomplete = process.env.TREE_INCOMPLETE === 'true';
+            let body;
+            if (cycle) {
+              body = 'Deterministic DAG backstop: the materialized task tree'
+                + ' has a dependency cycle (' + cyclePath + '). The agent\'s'
+                + ' in-prompt cycle check did not catch it (ADR 0010), so this'
+                + ' backstop parked the tracking issue. Break the cycle by'
+                + ' editing the `blocked by` lines on the named tasks, then'
+                + ' clear `needs-human` to resume triage.';
+            } else {
+              body = 'Deterministic DAG backstop: a `blocked by` reference on a'
+                + ' task points at a number that is neither in the walked'
+                + ' Feature -> Unit -> task tree nor a resolvable issue in this'
+                + ' repository, so the dependency graph could not be fully'
+                + ' verified for cycles. Fix the dangling `blocked by`'
+                + ' reference, then clear `needs-human` to resume triage.';
+            }
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking,
+                labels: ['needs-human'],
+              });
+            } catch (err) {
+              core.info('Could not add needs-human to #' + tracking + ': '
+                + err.message);
+            }
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking,
+                body,
+              });
+            } catch (err) {
+              core.setFailed('Could not post backstop comment on #'
+                + tracking + ': ' + err.message);
+            }

--- a/.github/workflows/sdd-validate.yml
+++ b/.github/workflows/sdd-validate.yml
@@ -81,14 +81,14 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@v0.1.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@v0.1.2
         with:
           github-token: ${{ github.token }}
 
   sdd-validate:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@v0.1.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@v0.1.2
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -96,6 +96,10 @@ jobs:
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
+      # the reusable lock's observability.otlp endpoint resolves; unset is fine
+      # (if-missing: warn). See ADR 0020.
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
     # Ceiling for the called reusable workflow. Must cover the union of every
     # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
     # need write scopes, and activation needs actions: read. sdd-validate

--- a/docs/spikes/README.md
+++ b/docs/spikes/README.md
@@ -1,0 +1,91 @@
+# Spikes
+
+A spike is a bounded experiment that resolves a load-bearing assumption before
+planning commits to it. A `kind:spike` sub-issue's deliverable is a written
+finding — never a code change. Each spike lands one file in this directory and
+nothing else.
+
+This README is operational hygiene for spike authors. The full protocol is in
+the suite's spike fragment; what follows is what you must honor when you run a
+spike on this repository.
+
+## What a spike writes
+
+A spike writes exactly one file: `docs/spikes/<date>-<slug>.md`, where `<date>`
+is the spike's open date (`YYYY-MM-DD`) and `<slug>` is a short hyphenated
+subject from the spike sub-issue's title. It writes no other path. A spike
+never edits source, config, or any build surface — if your experiment seems to
+need one, that is a signal to park (see below), not to widen the diff.
+
+## Branch and close convention
+
+A spike uses the **standard** implementation branch `sdd/<spike-issue-id>-<slug>`
+— the same convention every implementation pull request uses. Do not invent a
+custom branch prefix for spikes; a non-standard prefix breaks the suite's
+in-flight detection and produces a duplicate pull request. The pull request body
+carries `Closes #<spike-issue>` so merging it closes the spike sub-issue.
+
+## The doc
+
+Each `docs/spikes/<date>-<slug>.md` carries YAML frontmatter followed by a fixed
+set of sections.
+
+Frontmatter:
+
+- `id` — the spike sub-issue number.
+- `title` — the spike's one-line subject.
+- `status` — one of the status values below.
+- `date` — the open date (`YYYY-MM-DD`).
+- `authors` — who ran the experiment.
+- `budget_hours` — the time box the spike was given.
+- `actual_hours` — the time the experiment actually took.
+- `related` — issues, pull requests, or ADRs the spike informs.
+- `tags` — free-form topic tags.
+
+Sections, in order: **Question**, **Hypothesis**, **Method**, **Findings**,
+**Conclusion**, **Action items**, **Artifacts**. Findings carry their evidence
+inline — the exact commands and their output, measurement tables, and links to
+the sources inspected. Action items group what the finding changes downstream:
+spec amendments, ADR follow-ups, risk-register entries, and follow-up spikes.
+
+### Status values
+
+- `proved` — the hypothesis held; the assumption is now load-bearing-safe.
+- `disproved` — the hypothesis failed; the plan must change.
+- `partial` — the spike resolved part of the question and queued follow-up
+  spikes for the rest. This is a legitimate outcome, not a failure.
+- `parked` — the experiment could not run to completion in the sandbox (see
+  below).
+
+## Honor the budget
+
+`budget_hours` is a box, not a target. When you reach it, stop and write up what
+you have: a `partial` finding with the remainder queued as follow-up spikes is
+more useful than an over-budget experiment with no written outcome. Record the
+real `actual_hours` so the next planner can calibrate.
+
+## Quote denials verbatim
+
+When the experiment needs runtime or hardware the sandbox lacks, or a guardrail
+denies an action it requires, **park** the spike — never fabricate a result.
+Commit a `status: parked` partial doc and, in Findings, quote the denial or the
+missing-capability message **verbatim** as the evidence for why the experiment
+could not finish. Do not paraphrase it, and do not invent measurements or a
+conclusion the evidence does not support. Queue the remaining work as follow-up
+spikes, and hand off to a human via the suite's `needs-human` contract.
+
+A parked spike opens a normal (non-draft) pull request carrying the parked doc
+plus the `needs-human` hand-off — the suite's pull-request configuration is
+static and cannot mint a literal draft, so the parked doc and the `needs-human`
+label together carry the "do not merge yet" signal a draft would.
+
+## Clean up after the experiment
+
+A spike often spins up infrastructure to take a measurement: containers, a local
+server, a database, a long-running process, scratch files outside
+`docs/spikes/`. Tear all of it down before you finish. Stop and remove any
+container or process you started, kill background servers, and delete scratch
+files so the only thing your diff lands is `docs/spikes/<date>-<slug>.md`. A
+leftover container or a stray file outside `docs/spikes/` widens the diff,
+trips the suite's docs-only exemption, and forces the full build/test gate to
+run against a tree it should never have seen.


### PR DESCRIPTION
Installs the spectacles SDD agent suite (ADR 0004) via `scripts/quick-setup.sh`. Wrappers pin hosted reusable workflows at `@v0.1.2`. Labels, variables, and secrets were applied directly; the file artifacts in this PR honor the protected default branch. Merge to activate the workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated spike execution and re-entry workflows for deterministic spike-wave management.

* **Documentation**
  * Added spike protocol guide for authors covering branch naming, required frontmatter, status values, and cleanup requirements.

* **Chores**
  * Updated workflow action versions to v0.1.2 across multiple pipelines.
  * Added explicit observability endpoint configuration support.
  * Enhanced workflow permissions for improved security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->