### PR TITLE
chore: temporarily ignore RUSTSEC-2026-0173 until it is fixed upstream

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,9 @@ ignore = [
     "RUSTSEC-2024-0436",
     # RSA crate timing side-channel, not accessible when using ed25519 host keys
     "RUSTSEC-2023-0071",
+    # proc-macro-error2 is no longer maintained. oci-spec depends on getset which depends on it
+    # Ignore until it is replaced upstream
+    "RUSTSEC-2026-0173",
 ]
 
 [licenses]


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2026-0173

The crate `proc-macro-error2` is unmaintained. We depend on it as a transitive dependency most directly through `oci-spec -> getset -> proc-macro-error2`.

The maintainer of `getset` is aware of the issue https://github.com/jbaublitz/getset/issues/132

This PR adds `RUSTSEC-2026-0173` to our `cargo-deny` ignore list until the issue has been fixed upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security advisory configuration to address a deprecated dependency.

---

**Note:** This is an internal configuration update with no direct impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->