### PR TITLE
feat(minimald): scaffolding for the attachable session process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,11 +3428,13 @@ name = "minimald"
 version = "0.0.1"
 dependencies = [
  "args",
+ "bytes",
  "camino",
  "clap",
  "clap_complete",
  "constcat",
  "dirs",
+ "either",
  "futures",
  "graph",
  "hakoniwa",
@@ -3453,6 +3455,7 @@ dependencies = [
  "tokio-vsock",
  "tracing",
  "tracing-subscriber",
+ "vt100-ctt",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "hakoniwa"
 version = "1.7.0"
-source = "git+https://github.com/souk4711/hakoniwa.git?rev=65d12eaae6786cd312aa74784514eb3a072dfe38#65d12eaae6786cd312aa74784514eb3a072dfe38"
+source = "git+https://github.com/souk4711/hakoniwa.git?rev=41ce36e087fa1fcf28d17123042d150e71c09705#41ce36e087fa1fcf28d17123042d150e71c09705"
 dependencies = [
  "bitflags",
  "caps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ google-cloud-gax = "1.13"
 google-cloud-auth = "1.5"
 google-cloud-storage = "1.7"
 # Revert back to crates.io dep once new version is released.
-hakoniwa = { git = "https://github.com/souk4711/hakoniwa.git", rev = "65d12eaae6786cd312aa74784514eb3a072dfe38", features = ["cgroups"] }
+hakoniwa = { git = "https://github.com/souk4711/hakoniwa.git", rev = "41ce36e087fa1fcf28d17123042d150e71c09705", features = ["cgroups"] }
 http-body = "1"
 hex = "0.4"
 indicatif = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 thiserror = "2"
 url = "2" # keep in sync with reqwest
 uuid = { version = "1.23", features = ["v4", "v7", "serde"] }
+vt100-ctt = "0.17"
 zstd = "0.13"
 
 moka = { version = "0.12", default-features = false, features = ["sync"] }

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -5,11 +5,13 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+bytes.workspace = true
 camino.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 constcat.workspace = true
 dirs.workspace = true
+either.workspace = true
 futures.workspace = true
 hakoniwa.workspace = true
 libc.workspace = true
@@ -19,6 +21,7 @@ path-absolutize.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
+vt100-ctt.workspace = true
 
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/minimald/src/connection.rs
+++ b/crates/minimald/src/connection.rs
@@ -2,6 +2,7 @@ use russh::{
     Channel as RuChannel, ChannelId,
     server::{Config as RuConfig, Msg, RunningSession, Session},
 };
+use sessions::SessionId;
 use std::{
     collections::BTreeMap,
     fmt,
@@ -17,6 +18,7 @@ use crate::{
     ChannelConfig, RequestedPty, exec,
     rpc::{self},
     server::ServerStateHandle,
+    sessions::SessionKeyPredicate,
     sftp,
 };
 
@@ -369,7 +371,54 @@ impl russh::server::Handler for ConnectionHandler {
         session: &mut Session,
     ) -> Result<(), Self::Error> {
         protocol_trace!("Got shell_request on channel {id}");
-        session.channel_failure(id)?; // TODO: handle shell request
+
+        let conn = self.0.clone();
+        let serv = conn.0.lock().await.serv.clone();
+        let mut conn_lock = conn.lock().await;
+        let Some((channel, config)) = conn_lock.take(id) else {
+            session.channel_failure(id)?;
+            return Ok(());
+        };
+        drop(conn_lock);
+        if config.pty.is_none() {
+            tracing::warn!("channel {id}: pty not requested for shell session",);
+            session.channel_failure(id)?;
+            return Ok(());
+        }
+
+        let Some(session_id_str) = config.env_vars.get(crate::MINIMAL_SESSION_ID_ENV) else {
+            tracing::warn!("shell request rejected on channel {id}: missing MINIMAL_SESSION_ID",);
+            session.channel_failure(id)?;
+            return Ok(());
+        };
+        let Ok(session_id) = SessionId::parse_str(session_id_str) else {
+            tracing::warn!(
+                value = %session_id_str,
+                "shell request rejected on channel {id}: not a uuid",
+            );
+            session.channel_failure(id)?;
+            return Ok(());
+        };
+
+        let mngr = serv.sessions_manager().await;
+        let session_handle = match mngr.get_session(SessionKeyPredicate::Id(session_id)).await {
+            Ok(Some(h)) => h,
+            Ok(None) => {
+                tracing::warn!(%session_id, "shell request rejected: unknown session");
+                session.channel_failure(id)?;
+                return Ok(());
+            }
+            Err(e) => {
+                tracing::warn!(%session_id, error = %e, "shell request rejected: lookup failed");
+                session.channel_failure(id)?;
+                return Ok(());
+            }
+        };
+
+        session.channel_success(id)?;
+        tokio::spawn(async move {
+            session_handle.attach(channel, config).await;
+        });
         Ok(())
     }
 

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -7,6 +7,7 @@ pub mod guest;
 pub mod rpc;
 pub mod server;
 mod session;
+pub mod session_host;
 mod sessions;
 mod sftp;
 #[cfg(test)]

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -5,7 +5,7 @@ use camino::Utf8PathBuf;
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 use paths::{CwdRelative, Daemon, DaemonAbsPath, DaemonRelPath, sub_path};
-use tokio::net::UnixListener;
+use tokio::{net::UnixListener, runtime::Builder};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 use minimald::server::{Config, HostKey, Server};
@@ -126,8 +126,17 @@ pub enum MainError {
     IO(std::io::Error, &'static str),
 }
 
-#[tokio::main]
-async fn main() -> Result<(), MainError> {
+fn main() -> Result<(), MainError> {
+    let runtime = Builder::new_multi_thread()
+        .thread_name("minimald-worker")
+        .thread_stack_size(8 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async_main())
+}
+
+async fn async_main() -> Result<(), MainError> {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new("info")
             .add_directive("topiary=off".parse().unwrap())

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1,11 +1,18 @@
 use mctx::ConfigBuilder;
 use paths::DaemonAbsPath;
+use russh::{Channel, server::Msg};
 use sessions::store::SessionObject;
 use tokio::sync::{mpsc, oneshot};
+
+use crate::{
+    ChannelConfig,
+    session_host::{self, WinSize},
+};
 
 enum SessionMessage {
     GetWorkspacePath(oneshot::Sender<DaemonAbsPath>),
     MakeContext(oneshot::Sender<Result<mctx::Context, String>>),
+    Attach(SessionHandle, Channel<Msg>, ChannelConfig),
 }
 
 /// Manages a running session.
@@ -17,6 +24,8 @@ pub struct Session<S: SessionObject> {
     minimal_state_dir: DaemonAbsPath,
     minimal_cache_dir: DaemonAbsPath,
     session: S,
+
+    host: Option<session_host::HostHandle>,
 }
 
 impl<S: SessionObject> Session<S> {
@@ -28,6 +37,7 @@ impl<S: SessionObject> Session<S> {
     ) -> Result<SessionHandle, std::io::Error> {
         let (sender, receiver) = mpsc::channel(8);
         let mngr = Self {
+            host: None,
             receiver,
             session,
             minimal_state_dir,
@@ -54,22 +64,63 @@ impl<S: SessionObject> Session<S> {
                 let _ = r.send(wsp);
             }
             SessionMessage::MakeContext(r) => {
-                let wsp = self.session.workspace_path();
-                std::fs::create_dir_all(&wsp).unwrap();
-                let config = match ConfigBuilder::new()
-                    .with_repo_dir(wsp.as_utf8_path())
-                    .with_cache_dir(self.minimal_cache_dir.as_utf8_path())
-                    .with_state_dir(self.minimal_state_dir.as_utf8_path())
-                    .build()
-                {
-                    Err(e) => {
-                        let _ = r.send(Err(mctx::Error::from(e).to_string()));
-                        return;
-                    }
-                    Ok(c) => c,
-                };
-                let _ = r.send(mctx::Context::new(config).map_err(|e| e.to_string()));
+                let _ = r.send(self.context());
             }
+            SessionMessage::Attach(session_hnd, channel, config) => {
+                self.attach(session_hnd, channel, config).await
+            }
+        }
+    }
+
+    async fn attach(
+        &mut self,
+        session_hnd: SessionHandle,
+        channel: Channel<Msg>,
+        config: ChannelConfig,
+    ) {
+        let sz = WinSize::from(config.pty.as_ref().unwrap());
+        match &mut self.host {
+            None => self.mint_session_host(session_hnd, channel, sz).await,
+            Some(h) => {
+                match h.attach(channel, sz).await {
+                    Ok(()) => {}
+                    Err((channel, sz)) => {
+                        // session host is dead
+                        self.mint_session_host(session_hnd, channel, sz).await;
+                    }
+                };
+            }
+        }
+    }
+
+    async fn mint_session_host(
+        &mut self,
+        session_hnd: SessionHandle,
+        channel: Channel<Msg>,
+        sz: WinSize,
+    ) {
+        let h = Box::pin(crate::session_host::Host::spawn(
+            sz,
+            Some(channel),
+            self.context().unwrap(),
+            session_hnd,
+        ))
+        .await
+        .unwrap();
+        self.host = Some(h);
+    }
+
+    fn context(&mut self) -> Result<mctx::Context, String> {
+        let wsp = self.session.workspace_path();
+        std::fs::create_dir_all(&wsp).unwrap();
+        match ConfigBuilder::new()
+            .with_repo_dir(wsp.as_utf8_path())
+            .with_cache_dir(self.minimal_cache_dir.as_utf8_path())
+            .with_state_dir(self.minimal_state_dir.as_utf8_path())
+            .build()
+        {
+            Err(e) => Err(mctx::Error::from(e).to_string()),
+            Ok(c) => mctx::Context::new(c).map_err(|e| e.to_string()),
         }
     }
 }
@@ -93,5 +144,12 @@ impl SessionHandle {
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(SessionMessage::MakeContext(send)).await;
         recv.await.expect("corresponding session is dead")
+    }
+
+    pub async fn attach(&self, channel: Channel<Msg>, config: ChannelConfig) {
+        self.0
+            .send(SessionMessage::Attach(self.clone(), channel, config))
+            .await
+            .expect("corresponding session is dead");
     }
 }

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -99,15 +99,29 @@ impl<S: SessionObject> Session<S> {
         channel: Channel<Msg>,
         sz: WinSize,
     ) {
-        let h = Box::pin(crate::session_host::Host::spawn(
-            sz,
-            Some(channel),
-            self.context().unwrap(),
-            session_hnd,
-        ))
-        .await
-        .unwrap();
+        let launcher = self.session_launcher(session_hnd);
+        let h = Box::pin(session_host::Host::spawn(launcher, sz, Some(channel)))
+            .await
+            .unwrap();
         self.host = Some(h);
+    }
+
+    /// Builds the session launcher used to mint a session host: the real
+    /// sandboxed shell in production.
+    #[cfg(not(test))]
+    fn session_launcher(&mut self, session: SessionHandle) -> session_host::SandboxLauncher {
+        session_host::SandboxLauncher {
+            ctx: self.context().unwrap(),
+            session,
+        }
+    }
+
+    /// Under test, swap in a mock launcher that runs a plain host process wired
+    /// to the pty, exercising the session-host runtime without building a real
+    /// sandbox (which needs packages unavailable in the unit-test tempdir).
+    #[cfg(test)]
+    fn session_launcher(&mut self, _session: SessionHandle) -> session_host::MockLauncher {
+        session_host::MockLauncher
     }
 
     fn context(&mut self) -> Result<mctx::Context, String> {
@@ -151,5 +165,226 @@ impl SessionHandle {
             .send(SessionMessage::Attach(self.clone(), channel, config))
             .await
             .expect("corresponding session is dead");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use paths::HostAbsPath;
+    use russh::ChannelMsg;
+    use sessions::SessionId;
+
+    use crate::rpc::{CreateSession, CreateSessionRequest};
+    use crate::test_harness::{TestClient, TestServer};
+
+    /// Creates a fresh session on the server and returns its id.
+    async fn create_session(client: &mut TestClient) -> SessionId {
+        client
+            .call::<CreateSession>(&CreateSessionRequest {
+                record: sessions::Record {
+                    id: SessionId::nil(),
+                    name: Some("shell-test".to_string()),
+                    username: None,
+                    project_path: HostAbsPath::try_new("/uwu").unwrap(),
+                    attrs: Default::default(),
+                },
+            })
+            .await
+            .id
+    }
+
+    /// Drives the full SSH path into the session host with the mock launcher:
+    /// create a session, request a pty + shell, feed stdin, observe the echoed
+    /// stdout, then confirm the host tears down when the process exits.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shell_round_trips_stdin_to_stdout_then_tears_down() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        let mut channel = client.open_shell(session_id).await;
+
+        // Echo round trip: the mock echoes each line back as `got:<line>`.
+        // Read until we observe the echo, proving the stdin -> program ->
+        // stdout path works while the process is still alive.
+        channel.data_bytes(b"hello\n".to_vec()).await.unwrap();
+        let mut stdout = Vec::new();
+        loop {
+            match channel.wait().await {
+                Some(ChannelMsg::Data { data }) => {
+                    stdout.extend_from_slice(&data);
+                    if String::from_utf8_lossy(&stdout).contains("got:hello") {
+                        break;
+                    }
+                }
+                Some(_) => {}
+                None => {
+                    let stdout = String::from_utf8_lossy(&stdout);
+                    panic!("channel closed before the echo arrived; stdout: {stdout:?}");
+                }
+            }
+        }
+
+        // Now ask the mock to exit and confirm the host tears the channel down.
+        channel
+            .data_bytes(format!("{}\n", crate::session_host::MOCK_EXIT_LINE).into_bytes())
+            .await
+            .unwrap();
+        let mut saw_exit_status = false;
+        let mut closed = false;
+        while let Ok(msg) = tokio::time::timeout(Duration::from_secs(10), channel.wait()).await {
+            match msg {
+                Some(ChannelMsg::ExitStatus { .. }) => saw_exit_status = true,
+                Some(_) => {}
+                None => {
+                    closed = true;
+                    break;
+                }
+            }
+        }
+        assert!(closed, "channel should close once the mock process exits");
+        assert!(saw_exit_status, "expected an exit status on teardown");
+    }
+
+    /// A second shell request to the same session takes over the running host:
+    /// the new channel is flushed the current terminal state (so it sees the
+    /// earlier `hello` output), and the original channel is disconnected.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn second_shell_takes_over_session_and_closes_the_first() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        // First attachment: drive an echo so the host's terminal state holds
+        // `got:hello`, confirming it before we take the session over.
+        let mut first = client.open_shell(session_id).await;
+        first.data_bytes(b"hello\n".to_vec()).await.unwrap();
+        let mut first_out = Vec::new();
+        loop {
+            match first.wait().await {
+                Some(ChannelMsg::Data { data }) => {
+                    first_out.extend_from_slice(&data);
+                    if String::from_utf8_lossy(&first_out).contains("got:hello") {
+                        break;
+                    }
+                }
+                Some(_) => {}
+                None => {
+                    let first_out = String::from_utf8_lossy(&first_out);
+                    panic!("first channel closed before the echo arrived; got: {first_out:?}");
+                }
+            }
+        }
+
+        // Second attachment to the same session takes over.
+        let mut second = client.open_shell(session_id).await;
+
+        // The takeover flushes the current terminal state to the new channel,
+        // so the earlier `got:hello` shows up in what it's sent on attach. The
+        // session stays live (no teardown), so read with a timeout rather than
+        // draining to close.
+        let mut flushed = Vec::new();
+        while let Ok(Some(msg)) = tokio::time::timeout(Duration::from_secs(5), second.wait()).await
+        {
+            if let ChannelMsg::Data { data } = msg {
+                flushed.extend_from_slice(&data);
+                if String::from_utf8_lossy(&flushed).contains("got:hello") {
+                    break;
+                }
+            }
+        }
+        let flushed = String::from_utf8_lossy(&flushed);
+        assert!(
+            flushed.contains("got:hello"),
+            "takeover should flush prior terminal state to the new channel, got: {flushed:?}",
+        );
+
+        // The original channel should have been disconnected by the takeover.
+        let mut first_closed = false;
+        while let Ok(msg) = tokio::time::timeout(Duration::from_secs(5), first.wait()).await {
+            if msg.is_none() {
+                first_closed = true;
+                break;
+            }
+        }
+        assert!(
+            first_closed,
+            "first channel should be closed once the session is taken over",
+        );
+    }
+
+    /// The ctrl-w detach chord (a single `0x17` byte) detaches the current
+    /// channel — sending a detach notice down it before it closes — without
+    /// tearing the session down, so a later channel resumes it (the earlier
+    /// `got:hello` is flushed on reattach).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ctrl_w_detaches_channel_then_session_resumes_on_reattach() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        // First attachment: drive an echo so the terminal state holds
+        // `got:hello` before we detach.
+        let mut first = client.open_shell(session_id).await;
+        first.data_bytes(b"hello\n".to_vec()).await.unwrap();
+        let mut first_out = Vec::new();
+        loop {
+            match first.wait().await {
+                Some(ChannelMsg::Data { data }) => {
+                    first_out.extend_from_slice(&data);
+                    if String::from_utf8_lossy(&first_out).contains("got:hello") {
+                        break;
+                    }
+                }
+                Some(_) => {}
+                None => {
+                    let first_out = String::from_utf8_lossy(&first_out);
+                    panic!("first channel closed before the echo arrived; got: {first_out:?}");
+                }
+            }
+        }
+
+        // Send the detach chord. The host writes a detach notice down the
+        // channel and then closes it.
+        first.data_bytes(vec![0x17]).await.unwrap();
+        let mut detach_out = Vec::new();
+        let mut first_closed = false;
+        while let Ok(msg) = tokio::time::timeout(Duration::from_secs(5), first.wait()).await {
+            match msg {
+                Some(ChannelMsg::Data { data }) => detach_out.extend_from_slice(&data),
+                Some(_) => {}
+                None => {
+                    first_closed = true;
+                    break;
+                }
+            }
+        }
+        let detach_out = String::from_utf8_lossy(&detach_out);
+        assert!(
+            detach_out.contains("Detaching due to ctrl-w."),
+            "expected a detach notice on the channel before it closed, got: {detach_out:?}",
+        );
+        assert!(first_closed, "channel should close after the detach chord");
+
+        // Reattach: a second channel resumes the same (still-live) session, so
+        // the earlier `got:hello` is flushed to it on connect.
+        let mut second = client.open_shell(session_id).await;
+        let mut flushed = Vec::new();
+        while let Ok(Some(msg)) = tokio::time::timeout(Duration::from_secs(5), second.wait()).await
+        {
+            if let ChannelMsg::Data { data } = msg {
+                flushed.extend_from_slice(&data);
+                if String::from_utf8_lossy(&flushed).contains("got:hello") {
+                    break;
+                }
+            }
+        }
+        let flushed = String::from_utf8_lossy(&flushed);
+        assert!(
+            flushed.contains("got:hello"),
+            "reattaching should flush prior terminal state, got: {flushed:?}",
+        );
     }
 }

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -331,6 +331,53 @@ pub struct Host {
 
     // Temporary buffer for reading from the pty master (i.e. 'stdout').
     stdout_buf: Vec<u8>,
+
+    // Keeps the session's `Env` — and the `Context` and `Graph` it borrows —
+    // alive for as long as this host (and thus the session process) lives.
+    // Declared last so it is dropped after `process`: the process is torn down
+    // before the sandbox files backing its rootfs are removed. Never read; held
+    // purely for its `Drop`.
+    _session_env: SessionEnv,
+}
+
+/// Owns the [`mctx::Env`] for a session, along with the [`mctx::Context`] and
+/// [`graph::Graph`] it borrows, keeping all three alive for the session.
+///
+/// `Env<'a>` borrows the context and graph mutably and owns the temp dirs and
+/// sandbox base directory that hold the running process's rootfs. We can't
+/// store the env next to the values it borrows (that would be a self-referential
+/// struct), so the context and graph are leaked to obtain `'static` borrows for
+/// the env; the raw pointers are retained here so the leaked allocations can be
+/// reclaimed once the env is dropped.
+struct SessionEnv {
+    /// `Some` for the whole lifetime of the value; taken in `drop` so the env
+    /// is dropped before the context and graph it borrows are freed.
+    env: Option<mctx::Env<'static>>,
+    ctx: *mut mctx::Context,
+    graph: *mut graph::Graph,
+}
+
+// SAFETY: `mctx::Context`, `graph::Graph`, and `mctx::Env` are all `Send`
+// (the context and graph round-trip through `spawn_blocking`, and the env is
+// held across `.await` in `Host::spawn`). The raw pointers merely retain
+// ownership of the leaked allocations so they can be freed in `drop`; they are
+// never dereferenced concurrently with the `&'static mut` borrows held by `env`.
+unsafe impl Send for SessionEnv {}
+
+impl Drop for SessionEnv {
+    fn drop(&mut self) {
+        // Drop the env first, so its sandbox (and the listener thread holding
+        // the borrowed context/graph) is torn down while the context and graph
+        // are still valid.
+        self.env = None;
+        // SAFETY: `ctx`/`graph` were produced by `Box::into_raw` in
+        // `Host::spawn` and have not been freed. Their only borrower, `env`,
+        // was just dropped above, so no references into them remain.
+        unsafe {
+            drop(Box::from_raw(self.graph));
+            drop(Box::from_raw(self.ctx));
+        }
+    }
 }
 
 impl Host {
@@ -343,18 +390,41 @@ impl Host {
         // `graph_from_all_packages` is CPU-heavy (nickel evaluation,
         // graph construction) — run it on the blocking pool so it
         // doesn't stall the async executor.
-        let (mut ctx, graph_result) = tokio::task::spawn_blocking(move || {
+        let (ctx, graph_result) = tokio::task::spawn_blocking(move || {
             let r = ctx.graph_from_all_packages().map_err(|e| e.to_string());
             (ctx, r)
         })
         .await
         .map_err(io::Error::other)?;
-        let mut graph = graph_result.map_err(io::Error::other)?;
+        let graph = graph_result.map_err(io::Error::other)?;
 
-        let mut env = ctx
+        // Leak the context and graph so the env can borrow them for `'static`.
+        // The env owns the sandbox base dir and temp dirs backing the running
+        // process's rootfs; if it (and the values it borrows) were dropped when
+        // `spawn` returns, those files would be deleted out from under the live
+        // process. The returned `SessionEnv` keeps all three alive for the
+        // session and frees the leaked allocations when the host is dropped.
+        // The addresses are carried as `usize` (not `*mut`) so this future
+        // stays `Send` across the `make_env` await below; they are cast back to
+        // pointers only when building the `SessionEnv`.
+        let ctx_addr = Box::into_raw(Box::new(ctx)) as usize;
+        let graph_addr = Box::into_raw(Box::new(graph)) as usize;
+        // SAFETY: both addresses were just produced by `Box::into_raw`, so they
+        // point to valid, aligned, uniquely owned allocations. We hand out a
+        // single `&'static mut` for each to `make_env`; the allocations are not
+        // accessed again through these addresses until `SessionEnv::drop`
+        // reclaims them, after the borrowing env has been dropped.
+        let (ctx_ref, graph_ref) = unsafe {
+            (
+                &mut *(ctx_addr as *mut mctx::Context),
+                &mut *(graph_addr as *mut graph::Graph),
+            )
+        };
+
+        let mut env = ctx_ref
             .make_env(
                 "session",
-                &mut graph,
+                graph_ref,
                 None,
                 Some(&"default-state".to_string()),
                 None,
@@ -390,19 +460,29 @@ impl Host {
             let file = unsafe { std::fs::File::from_raw_fd(master.into_raw_fd()) };
             AsyncFd::new(file)?
         };
+        let process = command
+            .spawn()
+            .map_err(|e| io::Error::other(format!("exec failed: {}", e)))?;
+        // `command`/`container` no longer borrow `env`, so it can be moved into
+        // the host (via `SessionEnv`) to keep its backing files alive.
+        drop(container);
+
         let mut host = Host {
             receiver,
             remote: None,
             sz,
             parser,
-            process: command
-                .spawn()
-                .map_err(|e| io::Error::other(format!("exec failed: {}", e)))?,
+            process,
             master,
 
             remote_tx,
             remote_rx,
             stdout_buf: vec![0u8; 8 * 1024],
+            _session_env: SessionEnv {
+                env: Some(env),
+                ctx: ctx_addr as *mut mctx::Context,
+                graph: graph_addr as *mut graph::Graph,
+            },
         };
         if let Some(channel) = channel {
             host.attach(channel, sz, true).await;

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -323,14 +323,20 @@ pub struct Host {
     /// The master-side fd of the Pty.
     master: AsyncFd<std::fs::File>,
 
-    // Writer for bytes coming from the remote - i.e. 'stdin' that needs to
-    // get written to the pty.
+    // Writer for bytes coming from the remote - i.e. 'stdin' keystrokes
+    // that need to get written to the pty. Clones of this sender are
+    // given to [`Binding::spawn`].
     remote_tx: mpsc::Sender<Either<bytes::Bytes, RequestedPty>>,
-    // Recieve end for bytes coming from the remote.
+    // Recieve-end for bytes coming from the remote - i.e. 'stdin' keystrokes.
+    // We process this end.
     remote_rx: mpsc::Receiver<Either<bytes::Bytes, RequestedPty>>,
 
     // Temporary buffer for reading from the pty master (i.e. 'stdout').
     stdout_buf: Vec<u8>,
+    // Bytes that need to be written to the pty master (i.e. 'stdin').
+    //
+    // (<buffer>, <number of bytes from buffer already written>)
+    stdin_buf: Option<(bytes::Bytes, usize)>,
 
     // Keeps the session's `Env` — and the `Context` and `Graph` it borrows —
     // alive for as long as this host (and thus the session process) lives.
@@ -478,6 +484,7 @@ impl Host {
             remote_tx,
             remote_rx,
             stdout_buf: vec![0u8; 8 * 1024],
+            stdin_buf: None,
             _session_env: SessionEnv {
                 env: Some(env),
                 ctx: ctx_addr as *mut mctx::Context,
@@ -552,29 +559,39 @@ impl Host {
                     Err(_would_block) => {},
                 }
             },
-            // Read from remote (ssh channel) - these bytes need writing to session process stdin
-            Some(msg) = self.remote_rx.recv() => {
+            // Read from remote (ssh channel) - these keystrokes need writing to the pty.
+            //
+            // To ensure we never block service of reads from the master side of the pty ('stdout'),
+            // we only consume new keystrokes if we have none waiting to be written to the pty, and
+            // pending writes to the pty are serviced async by their own select arm (below).
+            Some(msg) = self.remote_rx.recv(), if self.stdin_buf.is_none() => {
                 match msg {
                     Either::Left(b) => {
-                        let mut b = &b[..];
-                        while !b.is_empty() {
-                            match self.master.writable().await.expect("todo write handle error").try_io(|fd|fd.get_ref().write(b)) {
-                                Ok(Ok(0)) => {},
-                                Ok(Ok(n)) => {
-                                    b = &b[n..];
-                                }
-                                Ok(Err(e)) => {
-                                    todo!("handle error writing to stdin: {e}");
-                                }
-                                Err(_would_block) => {},
-                            }
-                        }
+                        self.stdin_buf = Some((b, 0));
                     }
                     Either::Right(sz) => {
                         self.set_size(WinSize::from(&sz));
                     },
                 }
             },
+            // Write buffered keystrokes into the pty, if any,
+            w = self.master.writable(), if self.stdin_buf.is_some() => {
+                let (buff, n) = self.stdin_buf.as_mut().unwrap();
+                match w.expect("todo write handle error").try_io(|fd|fd.get_ref().write(&buff[*n..])) {
+                    Ok(Ok(extra)) => {
+                        if (*n+extra) == buff.len() {
+                            self.stdin_buf = None;
+                        } else {
+                            *n += extra;
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        todo!("handle error writing to stdin: {e}");
+                    }
+                    Err(_would_block) => {},
+                }
+            }
+
         }
 
         Ok(())

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -170,6 +170,7 @@ enum BindingMsg {
     Stdin(Vec<u8>),
     TeardownDueToStdoutErr(std::io::Error),
     TeardownDueToSuperceded,
+    TeardownDueToDetach,
 }
 
 /// A connection between a [`Host`] and an SSH channel.
@@ -258,6 +259,10 @@ impl Binding {
                         }
                         BindingMsg::TeardownDueToSuperceded => {
                             let _ = w.write_all(b"\r\nDisconnecting - session attached to from a different connection\r\n").await;
+                            break;
+                        }
+                        BindingMsg::TeardownDueToDetach => {
+                            let _ = w.write_all(b"\r\nDetaching due to ctrl-w.\r\n").await;
                             break;
                         }
                     };
@@ -567,6 +572,17 @@ impl Host {
             Some(msg) = self.remote_rx.recv(), if self.stdin_buf.is_none() => {
                 match msg {
                     Either::Left(b) => {
+                        if b.len() == 1 && b[0] == 0x17 { // ctrl-w
+                            if let Some((tx, _hnd)) = self.remote.as_mut() {
+                                match tx.send(BindingMsg::TeardownDueToDetach).await {
+                                    Ok(()) => {},
+                                    Err(e) => {
+                                        tracing::warn!("failed sending detach signal to remote: {e}");
+                                    }
+                                };
+                                self.remote = None;
+                            }
+                        };
                         self.stdin_buf = Some((b, 0));
                     }
                     Either::Right(sz) => {

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -1,0 +1,620 @@
+//! The running state of an active session.
+//!
+//! The [`Pty`] struct owns a master/slave pseudo-terminal pair created via
+//! `openpty(3)`, exposing its file descriptors and window-size controls.
+//!
+//! The [`Host`] struct holds the running state of an active session.
+
+use either::Either;
+use russh::Channel;
+use russh::server::Msg;
+use std::io;
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use tokio::io::AsyncWriteExt;
+use tokio::io::unix::AsyncFd;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::SendError;
+use tokio::task::JoinHandle;
+
+use crate::RequestedPty;
+use crate::session::SessionHandle;
+
+/// The dimensions of a terminal.
+///
+/// This is the libc-facing view of a terminal size, mirroring `libc::winsize`.
+/// The SSH layer's [`RequestedPty`] carries the same dimensions (plus `term`
+/// and terminal modes) as `u32`s; convert via [`From`] when opening a PTY.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WinSize {
+    pub rows: u16,
+    pub cols: u16,
+    pub xpixel: u16,
+    pub ypixel: u16,
+}
+
+impl From<&RequestedPty> for WinSize {
+    /// Extracts the terminal dimensions, ignoring `term` and modes.
+    ///
+    /// SSH carries sizes as `u32`; terminal dimensions never exceed `u16`, so
+    /// out-of-range values are clamped rather than wrapped.
+    fn from(pty: &RequestedPty) -> Self {
+        let (cols, rows) = pty.char_sizes;
+        let (xpixel, ypixel) = pty.pixel_sizes;
+        Self {
+            rows: rows.min(u16::MAX as u32) as u16,
+            cols: cols.min(u16::MAX as u32) as u16,
+            xpixel: xpixel.min(u16::MAX as u32) as u16,
+            ypixel: ypixel.min(u16::MAX as u32) as u16,
+        }
+    }
+}
+
+/// A pseudo-terminal pair (master + slave).
+#[derive(Debug)]
+pub struct Pty {
+    master: OwnedFd,
+    slave: OwnedFd,
+}
+
+impl Pty {
+    /// Creates a new PTY pair via `openpty(3)` with the given initial size.
+    pub fn open(size: WinSize) -> io::Result<Self> {
+        let mut master: RawFd = -1;
+        let mut slave: RawFd = -1;
+
+        let ws = libc::winsize {
+            ws_row: size.rows,
+            ws_col: size.cols,
+            ws_xpixel: size.xpixel,
+            ws_ypixel: size.ypixel,
+        };
+
+        // SAFETY: We pass valid pointers for the output fds and winsize, and
+        // NULL for the optional name/termios parameters.
+        let ret = unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &ws,
+            )
+        };
+        if ret != 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // SAFETY: `openpty` returned successfully, so both fds are valid and
+        // open. We take ownership immediately.
+        let master = unsafe { OwnedFd::from_raw_fd(master) };
+        let slave = unsafe { OwnedFd::from_raw_fd(slave) };
+
+        Ok(Self { master, slave })
+    }
+
+    /// Returns the raw file descriptor for the master side.
+    pub fn master_fd(&self) -> RawFd {
+        self.master.as_raw_fd()
+    }
+
+    /// Returns the raw file descriptor for the slave side.
+    pub fn slave_fd(&self) -> RawFd {
+        self.slave.as_raw_fd()
+    }
+
+    /// Returns a duplicate file descriptor for the slave side.
+    pub fn dup_slave_fd(&self) -> io::Result<OwnedFd> {
+        dup_fd(&self.slave)
+    }
+
+    /// Consumes the PTY pair, returning the owned master and slave fds.
+    pub fn into_fds(self) -> (OwnedFd, OwnedFd) {
+        (self.master, self.slave)
+    }
+
+    /// Gets the current terminal size of the slave side.
+    pub fn get_size(&self) -> io::Result<WinSize> {
+        get_winsize(self.master.as_raw_fd())
+    }
+
+    /// Sets the terminal size of the slave side.
+    pub fn set_size(&self, size: WinSize) -> io::Result<()> {
+        set_winsize(self.master.as_raw_fd(), size)
+    }
+}
+
+/// Duplicates an `OwnedFd` into a new, independent `OwnedFd` via `dup(2)`.
+fn dup_fd(fd: &OwnedFd) -> io::Result<OwnedFd> {
+    let raw = unsafe { libc::dup(fd.as_raw_fd()) };
+    if raw < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `dup` succeeded, so `raw` is a valid, open fd.
+    Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+/// Reads the terminal window size for the given fd.
+fn get_winsize(fd: RawFd) -> io::Result<WinSize> {
+    let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+    // SAFETY: `ws` is a valid, zeroed `winsize` struct and `fd` is an open fd.
+    let ret = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(WinSize {
+        rows: ws.ws_row,
+        cols: ws.ws_col,
+        xpixel: ws.ws_xpixel,
+        ypixel: ws.ws_ypixel,
+    })
+}
+
+/// Sets the terminal window size for the given fd.
+fn set_winsize(fd: RawFd, size: WinSize) -> io::Result<()> {
+    let ws = libc::winsize {
+        ws_row: size.rows,
+        ws_col: size.cols,
+        ws_xpixel: size.xpixel,
+        ws_ypixel: size.ypixel,
+    };
+    // SAFETY: `ws` is a valid `winsize` struct and `fd` is an open fd.
+    let ret = unsafe { libc::ioctl(fd, libc::TIOCSWINSZ, &ws) };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+enum BindingMsg {
+    Stdin(Vec<u8>),
+    TeardownDueToStdoutErr(std::io::Error),
+    TeardownDueToSuperceded,
+}
+
+/// A connection between a [`Host`] and an SSH channel.
+///
+/// The [`Binding`] is owned by the spawned async task, but the
+/// host owns (and communicates via) the [`mpsc::Receiver`] end of
+/// `stdin_tx`, and the [`mpsc::Sender`] end of `receiver`.
+struct Binding {
+    /// The remote end of this binding.
+    channel: Channel<Msg>,
+    /// Channel the binding writes down to communicate stdin to the host.
+    stdin_tx: mpsc::Sender<Either<bytes::Bytes, RequestedPty>>,
+    /// Channel the [`Host`] uses to communicate with this [`Binding`].
+    receiver: mpsc::Receiver<BindingMsg>,
+}
+
+impl Binding {
+    /// Spawns a new binding task for a given channel, returning objects
+    /// which the owning [`Host`] should own to communicate with it.
+    pub(crate) async fn spawn(
+        channel: Channel<Msg>,
+        stdin_tx: mpsc::Sender<Either<bytes::Bytes, RequestedPty>>,
+    ) -> (mpsc::Sender<BindingMsg>, JoinHandle<()>) {
+        let (tx, rx) = mpsc::channel(4);
+
+        let binding = Self {
+            channel,
+            stdin_tx,
+            receiver: rx,
+        };
+
+        (tx, tokio::spawn(binding.run()))
+    }
+
+    async fn run(mut self) {
+        let (mut rs, ws) = self.channel.split();
+        let mut w = ws.make_writer();
+
+        // Reading from the remote stops once it sends EOF;
+        // the loop lives on to keep forwarding stdout.
+        let mut remote_open = true;
+        loop {
+            tokio::select! {
+                // Remote (ssh channel) => session stdin.
+                res = rs.wait(), if remote_open => match res {
+                    None => remote_open = false,
+                    Some(msg) => {
+                        match msg {
+                            russh::ChannelMsg::Data{ data } => {
+                                let _ = self.stdin_tx.send(Either::Left(data)).await;
+                            }
+                            russh::ChannelMsg::RequestPty {
+                                want_reply: _,
+                                term,
+                                col_width,
+                                row_height,
+                                pix_width,
+                                pix_height,
+                                terminal_modes,
+                            } => {
+                                let _ = self.stdin_tx.send(Either::Right(RequestedPty {
+                                    char_sizes: (col_width, row_height),
+                                    pixel_sizes: (pix_width, pix_height),
+                                    term: term.to_string(),
+                                    modes: terminal_modes.to_vec(),
+                                })).await;
+                            },
+                            _ => tracing::warn!("skipping msg: {:?}", msg),
+                        };
+                    }
+                },
+                // Session stdout => remote (ssh channel).
+                // A closed channel means the host is gone;
+                // tear the attachment down.
+                msg = self.receiver.recv() => {
+                    let Some(msg) = msg else { break };
+                    match msg {
+                        BindingMsg::Stdin(b) => {
+                            let _ = w.write_all(&b).await;
+                        },
+                        BindingMsg::TeardownDueToStdoutErr(e) => {
+                            if e.raw_os_error() != Some(5) {
+                                let _ = w.write_all(format!("Error reading stdout: {e}\n").as_bytes()).await;
+                            }
+                            break;
+                        }
+                        BindingMsg::TeardownDueToSuperceded => {
+                            let _ = w.write_all(b"\r\nDisconnecting - session attached to from a different connection\r\n").await;
+                            break;
+                        }
+                    };
+
+                }
+            }
+        }
+
+        tracing::debug!("Binding shutting down");
+        let _ = ws.eof().await;
+        let _ = ws.exit_status(0).await; // TODO: Only report this if process terminates
+        let _ = ws.close().await; // needed to release the remote
+    }
+}
+
+/// Actor messages to a [`Host`].
+enum Message {
+    Kill,
+    Attach(Channel<Msg>, WinSize),
+}
+
+/// The handle to the session host - the running process.
+#[derive(Debug, Clone)]
+pub struct HostHandle {
+    sender: mpsc::Sender<Message>,
+}
+
+impl HostHandle {
+    pub async fn kill(&self) -> Result<(), ()> {
+        match self.sender.send(Message::Kill).await {
+            Ok(()) => Ok(()),
+            Err(_e) => Err(()), // closed
+        }
+    }
+    pub async fn attach(
+        &self,
+        c: Channel<Msg>,
+        sz: WinSize,
+    ) -> Result<(), (Channel<Msg>, WinSize)> {
+        match self.sender.send(Message::Attach(c, sz)).await {
+            Ok(()) => Ok(()),
+            Err(SendError(Message::Attach(c, sz))) => Err((c, sz)),
+            Err(e) => unreachable!("{:?}", e),
+        }
+    }
+}
+
+/// The state of the session process.
+pub struct Host {
+    /// Channel for actor messages via [`HostHandle`].
+    receiver: mpsc::Receiver<Message>,
+
+    /// The async task and its channel that wires the session
+    /// to the ssh channel, if currently attached.
+    remote: Option<(mpsc::Sender<BindingMsg>, JoinHandle<()>)>,
+
+    /// The last-set pty terminal size.
+    sz: WinSize,
+    /// In-memory representation of the terminal state.
+    parser: vt100_ctt::Parser,
+    /// The session process.
+    process: hakoniwa::Child,
+    /// The master-side fd of the Pty.
+    master: AsyncFd<std::fs::File>,
+
+    // Writer for bytes coming from the remote - i.e. 'stdin' that needs to
+    // get written to the pty.
+    remote_tx: mpsc::Sender<Either<bytes::Bytes, RequestedPty>>,
+    // Recieve end for bytes coming from the remote.
+    remote_rx: mpsc::Receiver<Either<bytes::Bytes, RequestedPty>>,
+
+    // Temporary buffer for reading from the pty master (i.e. 'stdout').
+    stdout_buf: Vec<u8>,
+}
+
+impl Host {
+    pub async fn spawn(
+        sz: WinSize,
+        channel: Option<Channel<Msg>>,
+        mut ctx: mctx::Context,
+        _session: SessionHandle,
+    ) -> Result<HostHandle, std::io::Error> {
+        // `graph_from_all_packages` is CPU-heavy (nickel evaluation,
+        // graph construction) — run it on the blocking pool so it
+        // doesn't stall the async executor.
+        let (mut ctx, graph_result) = tokio::task::spawn_blocking(move || {
+            let r = ctx.graph_from_all_packages().map_err(|e| e.to_string());
+            (ctx, r)
+        })
+        .await
+        .map_err(io::Error::other)?;
+        let mut graph = graph_result.map_err(io::Error::other)?;
+
+        let mut env = ctx
+            .make_env(
+                "session",
+                &mut graph,
+                None,
+                Some(&"default-state".to_string()),
+                None,
+                None,
+                vec![
+                    "base".to_string(),
+                    "bash".to_string(),
+                    "socat".to_string(),
+                    "coreutils".to_string(),
+                ],
+            )
+            .await
+            .map_err(|e| io::Error::other(e.to_string()))?;
+
+        let container = env
+            .container()
+            .map_err(|e| io::Error::other(format!("building container failed: {}", e)))?;
+
+        let pty = Pty::open(sz)?;
+        let mut command = env
+            .command(&container, "/bin/bash", ["--noprofile", "-l"])
+            .map_err(|e| io::Error::other(format!("building command failed: {}", e)))?;
+        command.stdin(hakoniwa::Stdio::from(pty.dup_slave_fd()?));
+        command.stdout(hakoniwa::Stdio::from(pty.dup_slave_fd()?));
+        let (master, slave) = pty.into_fds();
+        command.stderr(hakoniwa::Stdio::from(slave));
+
+        let parser = vt100_ctt::Parser::new(sz.rows, sz.cols, 0);
+        let (sender, receiver) = mpsc::channel(8);
+        let (remote_tx, remote_rx) = mpsc::channel(4);
+        let master = {
+            set_nonblocking(master.as_raw_fd())?;
+            let file = unsafe { std::fs::File::from_raw_fd(master.into_raw_fd()) };
+            AsyncFd::new(file)?
+        };
+        let mut host = Host {
+            receiver,
+            remote: None,
+            sz,
+            parser,
+            process: command
+                .spawn()
+                .map_err(|e| io::Error::other(format!("exec failed: {}", e)))?,
+            master,
+
+            remote_tx,
+            remote_rx,
+            stdout_buf: vec![0u8; 8 * 1024],
+        };
+        if let Some(channel) = channel {
+            host.attach(channel, sz, true).await;
+        }
+        tokio::spawn(host.mainloop());
+
+        Ok(HostHandle { sender })
+    }
+
+    pub async fn mainloop(mut self) -> Result<hakoniwa::ExitStatus, std::io::Error> {
+        loop {
+            match self
+                .process
+                .try_wait()
+                .map_err(|e| io::Error::other(format!("wait failed: {}", e)))?
+            {
+                None => {}
+                Some(exit_status) => return Ok(exit_status),
+            }
+
+            if let Err(()) = self.step().await {
+                return self
+                    .process
+                    .wait()
+                    .map_err(|e| io::Error::other(format!("wait failed: {}", e)));
+            };
+        }
+    }
+
+    pub async fn step(&mut self) -> Result<(), ()> {
+        tokio::select! {
+            // Read actor messages.
+            Some(msg) = self.receiver.recv() => {
+                match msg {
+                    Message::Kill => {
+                        tracing::info!("kill res: {:?}", self.process.kill());
+                    }
+                    Message::Attach(channel, sz) => {
+                        self.attach(channel, sz, false).await;
+                    }
+                }
+            },
+            // Read from master - stdout of session process => ssh channel (if any)
+            r = self.master.readable() => {
+                match r.expect("todo read handle error").try_io(|fd| fd.get_ref().read(&mut self.stdout_buf)) {
+                    Ok(Ok(0)) => {},
+                    Ok(Ok(n)) => {
+                        let b = &self.stdout_buf[..n];
+                        self.parser.process(b);
+                        if let Some((tx, _hnd)) = self.remote.as_mut() {
+                            match tx.send(BindingMsg::Stdin(b.to_vec())).await {
+                                Ok(()) => {},
+                                Err(e) => {
+                                    tracing::warn!("failed stdout=>remote send: {e}");
+                                    self.remote = None;
+                                }
+                            };
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!(error = %e, "Reading pty master");
+                        if let Some((tx, _hnd)) = self.remote.as_mut() {
+                            let _ = tx.send(BindingMsg::TeardownDueToStdoutErr(e)).await;
+                        }
+                        return Err(());
+                    },
+                    Err(_would_block) => {},
+                }
+            },
+            // Read from remote (ssh channel) - these bytes need writing to session process stdin
+            Some(msg) = self.remote_rx.recv() => {
+                match msg {
+                    Either::Left(b) => {
+                        let mut b = &b[..];
+                        while !b.is_empty() {
+                            match self.master.writable().await.expect("todo write handle error").try_io(|fd|fd.get_ref().write(b)) {
+                                Ok(Ok(0)) => {},
+                                Ok(Ok(n)) => {
+                                    b = &b[n..];
+                                }
+                                Ok(Err(e)) => {
+                                    todo!("handle error writing to stdin: {e}");
+                                }
+                                Err(_would_block) => {},
+                            }
+                        }
+                    }
+                    Either::Right(sz) => {
+                        self.set_size(WinSize::from(&sz));
+                    },
+                }
+            },
+        }
+
+        Ok(())
+    }
+
+    async fn attach(&mut self, channel: Channel<Msg>, sz: WinSize, skip_flush: bool) {
+        if !skip_flush {
+            self.parser.screen_mut().set_size(sz.rows, sz.cols);
+            let _ = channel
+                .make_writer()
+                .write_all(&self.parser.screen().state_formatted())
+                .await;
+        }
+        let new_binding = Binding::spawn(channel, self.remote_tx.clone()).await;
+
+        if let Some((old_tx, old_join_hnd)) = self.remote.replace(new_binding) {
+            // If there was a binding we just swapped out, tell it to
+            // shut down and wait for it to finish.
+            let _ = old_tx.send(BindingMsg::TeardownDueToSuperceded).await;
+            let _ = old_join_hnd.await;
+        }
+
+        self.set_size(sz);
+    }
+    fn set_size(&mut self, sz: WinSize) {
+        // If the terminal size changed, reconfigure the pty.
+        if sz != self.sz {
+            if let Err(e) = set_winsize(self.master.as_raw_fd(), sz) {
+                tracing::warn!(error = %e, "set_winsize failed, ignoring");
+            }
+            self.parser.screen_mut().set_size(sz.rows, sz.cols);
+            self.sz = sz;
+        }
+    }
+}
+
+/// Puts a file descriptor into non-blocking mode.
+fn set_nonblocking(fd: RawFd) -> io::Result<()> {
+    // SAFETY: fd is a valid open file descriptor.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DEFAULT_SIZE: WinSize = WinSize {
+        rows: 24,
+        cols: 80,
+        xpixel: 0,
+        ypixel: 0,
+    };
+
+    #[test]
+    fn open_and_get_fds() {
+        let pty = Pty::open(DEFAULT_SIZE).expect("failed to open pty");
+        assert!(pty.master_fd() >= 0);
+        assert!(pty.slave_fd() >= 0);
+        assert_ne!(pty.master_fd(), pty.slave_fd());
+    }
+
+    #[test]
+    fn open_sets_initial_size() {
+        let size = WinSize {
+            rows: 40,
+            cols: 120,
+            xpixel: 0,
+            ypixel: 0,
+        };
+        let pty = Pty::open(size).expect("failed to open pty");
+
+        let got = pty.get_size().expect("failed to get size");
+        assert_eq!(got.rows, 40);
+        assert_eq!(got.cols, 120);
+    }
+
+    #[test]
+    fn dup_fd_produces_independent_fd() {
+        let pty = Pty::open(DEFAULT_SIZE).expect("failed to open pty");
+        let (master, _slave) = pty.into_fds();
+        let duped = dup_fd(&master).expect("failed to dup fd");
+        assert!(duped.as_raw_fd() >= 0);
+        assert_ne!(master.as_raw_fd(), duped.as_raw_fd());
+    }
+
+    #[test]
+    fn win_size_from_requested_pty_clamps_oversized() {
+        let requested = RequestedPty {
+            char_sizes: (u32::MAX, u32::MAX),
+            pixel_sizes: (0, 0),
+            term: String::new(),
+            modes: Vec::new(),
+        };
+        let size = WinSize::from(&requested);
+        assert_eq!(size.cols, u16::MAX);
+        assert_eq!(size.rows, u16::MAX);
+    }
+
+    #[test]
+    fn set_and_get_size() {
+        let pty = Pty::open(DEFAULT_SIZE).expect("failed to open pty");
+
+        let size = WinSize {
+            rows: 50,
+            cols: 200,
+            xpixel: 0,
+            ypixel: 0,
+        };
+        pty.set_size(size).expect("failed to set size");
+
+        let got = pty.get_size().expect("failed to get size");
+        assert_eq!(got.rows, 50);
+        assert_eq!(got.cols, 200);
+    }
+}

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -558,6 +558,7 @@ impl SessionLauncher for SandboxLauncher {
                     "bash".to_string(),
                     "socat".to_string(),
                     "coreutils".to_string(),
+                    "claude-code".to_string(),
                 ],
             )
             .await

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -8,6 +8,7 @@
 use either::Either;
 use russh::Channel;
 use russh::server::Msg;
+use std::future::Future;
 use std::io;
 use std::io::{Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
@@ -18,6 +19,7 @@ use tokio::sync::mpsc::error::SendError;
 use tokio::task::JoinHandle;
 
 use crate::RequestedPty;
+#[cfg(not(test))]
 use crate::session::SessionHandle;
 
 /// The dimensions of a terminal.
@@ -90,6 +92,15 @@ impl Pty {
         let master = unsafe { OwnedFd::from_raw_fd(master) };
         let slave = unsafe { OwnedFd::from_raw_fd(slave) };
 
+        // `openpty` returns fds without close-on-exec. Set it so these fds
+        // don't leak into unrelated child processes that happen to `fork`
+        // concurrently: a leaked slave fd would keep this master from ever
+        // seeing EOF when our own child exits, stalling teardown. The child we
+        // intend to wire up still gets its stdio via `dup2`, which is unaffected
+        // by the source fd's close-on-exec flag.
+        set_cloexec(master.as_raw_fd())?;
+        set_cloexec(slave.as_raw_fd())?;
+
         Ok(Self { master, slave })
     }
 
@@ -124,13 +135,18 @@ impl Pty {
     }
 }
 
-/// Duplicates an `OwnedFd` into a new, independent `OwnedFd` via `dup(2)`.
+/// Duplicates an `OwnedFd` into a new, independent close-on-exec `OwnedFd`.
+///
+/// Uses `F_DUPFD_CLOEXEC` rather than `dup(2)` so the duplicate is born
+/// close-on-exec — otherwise a slave dup awaiting a `spawn` could be inherited
+/// by an unrelated child `fork`ed concurrently and keep the pty open past our
+/// own child's exit.
 fn dup_fd(fd: &OwnedFd) -> io::Result<OwnedFd> {
-    let raw = unsafe { libc::dup(fd.as_raw_fd()) };
+    let raw = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
     if raw < 0 {
         return Err(io::Error::last_os_error());
     }
-    // SAFETY: `dup` succeeded, so `raw` is a valid, open fd.
+    // SAFETY: `fcntl(F_DUPFD_CLOEXEC)` succeeded, so `raw` is a valid, open fd.
     Ok(unsafe { OwnedFd::from_raw_fd(raw) })
 }
 
@@ -278,6 +294,53 @@ impl Binding {
     }
 }
 
+/// A handle to a launched session process.
+///
+/// Abstracts the process the [`Host`] supervises so its runtime loop can be
+/// driven against a real sandboxed process or a test double. The unused
+/// `hakoniwa::ExitStatus` payload is reduced to a portable exit code.
+pub(crate) trait SessionProcess: Send + 'static {
+    /// Returns `Some(code)` if the process has exited, `None` if still running.
+    fn try_wait(&mut self) -> io::Result<Option<i32>>;
+    /// Blocks until the process exits, returning its exit code.
+    fn wait(&mut self) -> io::Result<i32>;
+    /// Sends a kill signal to the process.
+    fn kill(&mut self) -> io::Result<()>;
+}
+
+/// Opens a PTY of the requested size, launches the session process wired to the
+/// slave side, and yields the master side plus a handle to the process.
+///
+/// This is the seam between the generic [`Host`] runtime and the backend that
+/// actually creates a process (building the context/graph/env/container and the
+/// launch command). The launcher owns PTY creation because the slave side is
+/// consumed differently per backend — duplicated into the process's
+/// stdin/stdout/stderr for the real sandbox, or retained for a test double.
+pub(crate) trait SessionLauncher {
+    /// The running-process handle this launcher produces.
+    type Process: SessionProcess;
+    /// A value held for the session's lifetime purely for its `Drop` (e.g. the
+    /// sandbox files backing the running process's rootfs). Dropped after
+    /// [`Self::Process`].
+    type Guard: Send + 'static;
+
+    fn launch(
+        self,
+        sz: WinSize,
+    ) -> impl Future<Output = io::Result<Launched<Self::Process, Self::Guard>>> + Send;
+}
+
+/// The product of [`SessionLauncher::launch`].
+pub(crate) struct Launched<P, G> {
+    /// Master side of the launched process's PTY; the slave is wired to the
+    /// process. The [`Host`] reads its stdout and writes its stdin here.
+    master: OwnedFd,
+    /// Handle used to wait on / signal the launched process.
+    process: P,
+    /// Kept alive for the session; see [`SessionLauncher::Guard`].
+    guard: G,
+}
+
 /// Actor messages to a [`Host`].
 enum Message {
     Kill,
@@ -311,7 +374,11 @@ impl HostHandle {
 }
 
 /// The state of the session process.
-pub struct Host {
+///
+/// Generic over the [`SessionProcess`] it supervises and the [`SessionLauncher`]
+/// guard kept alive for the session, so the runtime loop can be driven against a
+/// real sandboxed process or a test double.
+pub(crate) struct Host<P: SessionProcess, G: Send + 'static> {
     /// Channel for actor messages via [`HostHandle`].
     receiver: mpsc::Receiver<Message>,
 
@@ -324,7 +391,7 @@ pub struct Host {
     /// In-memory representation of the terminal state.
     parser: vt100_ctt::Parser,
     /// The session process.
-    process: hakoniwa::Child,
+    process: P,
     /// The master-side fd of the Pty.
     master: AsyncFd<std::fs::File>,
 
@@ -343,16 +410,17 @@ pub struct Host {
     // (<buffer>, <number of bytes from buffer already written>)
     stdin_buf: Option<(bytes::Bytes, usize)>,
 
-    // Keeps the session's `Env` — and the `Context` and `Graph` it borrows —
-    // alive for as long as this host (and thus the session process) lives.
-    // Declared last so it is dropped after `process`: the process is torn down
-    // before the sandbox files backing its rootfs are removed. Never read; held
-    // purely for its `Drop`.
-    _session_env: SessionEnv,
+    // Keeps launcher-owned resources (e.g. the session's `Env` and the
+    // `Context`/`Graph` it borrows) alive for as long as this host (and thus the
+    // session process) lives. Declared last so it is dropped after `process`:
+    // the process is torn down before the sandbox files backing its rootfs are
+    // removed. Never read; held purely for its `Drop`.
+    _guard: G,
 }
 
 /// Owns the [`mctx::Env`] for a session, along with the [`mctx::Context`] and
-/// [`graph::Graph`] it borrows, keeping all three alive for the session.
+/// [`graph::Graph`] it borrows, keeping all three alive for the session. Used
+/// as the [`SandboxLauncher`]'s [`SessionLauncher::Guard`].
 ///
 /// `Env<'a>` borrows the context and graph mutably and owns the temp dirs and
 /// sandbox base directory that hold the running process's rootfs. We can't
@@ -360,7 +428,8 @@ pub struct Host {
 /// struct), so the context and graph are leaked to obtain `'static` borrows for
 /// the env; the raw pointers are retained here so the leaked allocations can be
 /// reclaimed once the env is dropped.
-struct SessionEnv {
+#[cfg(not(test))]
+pub(crate) struct SessionEnv {
     /// `Some` for the whole lifetime of the value; taken in `drop` so the env
     /// is dropped before the context and graph it borrows are freed.
     env: Option<mctx::Env<'static>>,
@@ -370,11 +439,14 @@ struct SessionEnv {
 
 // SAFETY: `mctx::Context`, `graph::Graph`, and `mctx::Env` are all `Send`
 // (the context and graph round-trip through `spawn_blocking`, and the env is
-// held across `.await` in `Host::spawn`). The raw pointers merely retain
-// ownership of the leaked allocations so they can be freed in `drop`; they are
-// never dereferenced concurrently with the `&'static mut` borrows held by `env`.
+// held across `.await` in `SandboxLauncher::launch`). The raw pointers merely
+// retain ownership of the leaked allocations so they can be freed in `drop`;
+// they are never dereferenced concurrently with the `&'static mut` borrows held
+// by `env`.
+#[cfg(not(test))]
 unsafe impl Send for SessionEnv {}
 
+#[cfg(not(test))]
 impl Drop for SessionEnv {
     fn drop(&mut self) {
         // Drop the env first, so its sandbox (and the listener thread holding
@@ -382,8 +454,9 @@ impl Drop for SessionEnv {
         // are still valid.
         self.env = None;
         // SAFETY: `ctx`/`graph` were produced by `Box::into_raw` in
-        // `Host::spawn` and have not been freed. Their only borrower, `env`,
-        // was just dropped above, so no references into them remain.
+        // `SandboxLauncher::launch` and have not been freed. Their only
+        // borrower, `env`, was just dropped above, so no references into them
+        // remain.
         unsafe {
             drop(Box::from_raw(self.graph));
             drop(Box::from_raw(self.ctx));
@@ -391,17 +464,57 @@ impl Drop for SessionEnv {
     }
 }
 
-impl Host {
-    pub async fn spawn(
-        sz: WinSize,
-        channel: Option<Channel<Msg>>,
-        mut ctx: mctx::Context,
-        _session: SessionHandle,
-    ) -> Result<HostHandle, std::io::Error> {
+/// A launched session process backed by a sandboxed [`hakoniwa::Child`].
+#[cfg(not(test))]
+pub(crate) struct SandboxProcess(hakoniwa::Child);
+
+#[cfg(not(test))]
+impl SessionProcess for SandboxProcess {
+    fn try_wait(&mut self) -> io::Result<Option<i32>> {
+        self.0
+            .try_wait()
+            .map(|status| status.map(|s| s.code))
+            .map_err(|e| io::Error::other(format!("wait failed: {e}")))
+    }
+
+    fn wait(&mut self) -> io::Result<i32> {
+        self.0
+            .wait()
+            .map(|s| s.code)
+            .map_err(|e| io::Error::other(format!("wait failed: {e}")))
+    }
+
+    fn kill(&mut self) -> io::Result<()> {
+        self.0
+            .kill()
+            .map_err(|e| io::Error::other(format!("kill failed: {e}")))
+    }
+}
+
+/// The real [`SessionLauncher`]: evaluates a minimal context into a graph,
+/// builds a sandboxed `/bin/bash`, and wires it to a freshly opened PTY.
+#[cfg(not(test))]
+pub(crate) struct SandboxLauncher {
+    pub(crate) ctx: mctx::Context,
+    // The session this host belongs to. Not yet read, but retained so the
+    // launcher carries the full session identity for future use (and to mirror
+    // the prior `Host::spawn` signature).
+    #[allow(dead_code)]
+    pub(crate) session: SessionHandle,
+}
+
+#[cfg(not(test))]
+impl SessionLauncher for SandboxLauncher {
+    type Process = SandboxProcess;
+    type Guard = SessionEnv;
+
+    async fn launch(self, sz: WinSize) -> io::Result<Launched<SandboxProcess, SessionEnv>> {
+        let ctx = self.ctx;
         // `graph_from_all_packages` is CPU-heavy (nickel evaluation,
         // graph construction) — run it on the blocking pool so it
         // doesn't stall the async executor.
         let (ctx, graph_result) = tokio::task::spawn_blocking(move || {
+            let mut ctx = ctx;
             let r = ctx.graph_from_all_packages().map_err(|e| e.to_string());
             (ctx, r)
         })
@@ -412,7 +525,7 @@ impl Host {
         // Leak the context and graph so the env can borrow them for `'static`.
         // The env owns the sandbox base dir and temp dirs backing the running
         // process's rootfs; if it (and the values it borrows) were dropped when
-        // `spawn` returns, those files would be deleted out from under the live
+        // `launch` returns, those files would be deleted out from under the live
         // process. The returned `SessionEnv` keeps all three alive for the
         // session and frees the leaked allocations when the host is dropped.
         // The addresses are carried as `usize` (not `*mut`) so this future
@@ -464,6 +577,123 @@ impl Host {
         let (master, slave) = pty.into_fds();
         command.stderr(hakoniwa::Stdio::from(slave));
 
+        let process = command
+            .spawn()
+            .map_err(|e| io::Error::other(format!("exec failed: {}", e)))?;
+        // `command`/`container` no longer borrow `env`, so it can be moved into
+        // the host (via `SessionEnv`) to keep its backing files alive.
+        drop(container);
+
+        Ok(Launched {
+            master,
+            process: SandboxProcess(process),
+            guard: SessionEnv {
+                env: Some(env),
+                ctx: ctx_addr as *mut mctx::Context,
+                graph: graph_addr as *mut graph::Graph,
+            },
+        })
+    }
+}
+
+/// A launched session process backed by a plain host [`std::process::Child`].
+#[cfg(test)]
+pub(crate) struct MockProcess(std::process::Child);
+
+#[cfg(test)]
+impl SessionProcess for MockProcess {
+    fn try_wait(&mut self) -> io::Result<Option<i32>> {
+        Ok(self.0.try_wait()?.map(|s| s.code().unwrap_or(-1)))
+    }
+
+    fn wait(&mut self) -> io::Result<i32> {
+        Ok(self.0.wait()?.code().unwrap_or(-1))
+    }
+
+    fn kill(&mut self) -> io::Result<()> {
+        self.0.kill()
+    }
+}
+
+/// The sentinel stdin line that makes [`MockLauncher`]'s program exit; any
+/// other line is echoed back. Lets a test observe an echo round trip while the
+/// process is still alive, then trigger teardown deterministically.
+#[cfg(test)]
+pub(crate) const MOCK_EXIT_LINE: &str = "quit";
+
+/// A test [`SessionLauncher`] that wires a plain, un-sandboxed host process to a
+/// freshly opened PTY — so the [`Host`] runtime can be exercised end-to-end
+/// without building a real sandbox (which needs packages unavailable in the
+/// unit-test environment).
+///
+/// The launched program echoes each line of stdin back prefixed with `got:`,
+/// and exits only on the [`MOCK_EXIT_LINE`] sentinel — so a test can confirm
+/// stdin delivery and stdout forwarding before deterministically triggering
+/// process-exit teardown.
+#[cfg(test)]
+pub(crate) struct MockLauncher;
+
+#[cfg(test)]
+impl SessionLauncher for MockLauncher {
+    type Process = MockProcess;
+    type Guard = ();
+
+    async fn launch(self, sz: WinSize) -> io::Result<Launched<MockProcess, ()>> {
+        let pty = Pty::open(sz)?;
+
+        let script = format!(
+            r#"while read line; do [ "$line" = {MOCK_EXIT_LINE} ] && exit 0; printf 'got:%s\n' "$line"; done"#
+        );
+        let mut command = std::process::Command::new("/bin/sh");
+        command.arg("-c").arg(&script);
+        command.stdin(std::process::Stdio::from(pty.dup_slave_fd()?));
+        command.stdout(std::process::Stdio::from(pty.dup_slave_fd()?));
+        let (master, slave) = pty.into_fds();
+        command.stderr(std::process::Stdio::from(slave));
+
+        let process = command.spawn()?;
+
+        Ok(Launched {
+            master,
+            process: MockProcess(process),
+            guard: (),
+        })
+    }
+}
+
+impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
+    /// Spawns a session host from the given launcher, wiring it to `channel` if
+    /// one is supplied, and drives its runtime loop on a background task.
+    pub async fn spawn<L>(
+        launcher: L,
+        sz: WinSize,
+        channel: Option<Channel<Msg>>,
+    ) -> Result<HostHandle, std::io::Error>
+    where
+        L: SessionLauncher<Process = P, Guard = G>,
+    {
+        let (host, handle) = Self::build(launcher, sz, channel).await?;
+        tokio::spawn(host.mainloop());
+        Ok(handle)
+    }
+
+    /// Builds the host and its handle from a launcher without spawning the
+    /// runtime loop, so callers (notably tests) can drive [`Self::step`]
+    /// directly and observe the host's state.
+    async fn build<L>(
+        launcher: L,
+        sz: WinSize,
+        channel: Option<Channel<Msg>>,
+    ) -> Result<(Self, HostHandle), std::io::Error>
+    where
+        L: SessionLauncher<Process = P, Guard = G>,
+    {
+        let Launched {
+            master,
+            process,
+            guard,
+        } = launcher.launch(sz).await?;
+
         let parser = vt100_ctt::Parser::new(sz.rows, sz.cols, 0);
         let (sender, receiver) = mpsc::channel(8);
         let (remote_tx, remote_rx) = mpsc::channel(4);
@@ -472,12 +702,6 @@ impl Host {
             let file = unsafe { std::fs::File::from_raw_fd(master.into_raw_fd()) };
             AsyncFd::new(file)?
         };
-        let process = command
-            .spawn()
-            .map_err(|e| io::Error::other(format!("exec failed: {}", e)))?;
-        // `command`/`container` no longer borrow `env`, so it can be moved into
-        // the host (via `SessionEnv`) to keep its backing files alive.
-        drop(container);
 
         let mut host = Host {
             receiver,
@@ -491,37 +715,24 @@ impl Host {
             remote_rx,
             stdout_buf: vec![0u8; 8 * 1024],
             stdin_buf: None,
-            _session_env: SessionEnv {
-                env: Some(env),
-                ctx: ctx_addr as *mut mctx::Context,
-                graph: graph_addr as *mut graph::Graph,
-            },
+            _guard: guard,
         };
         if let Some(channel) = channel {
             host.attach(channel, sz, true).await;
         }
-        tokio::spawn(host.mainloop());
 
-        Ok(HostHandle { sender })
+        Ok((host, HostHandle { sender }))
     }
 
-    pub async fn mainloop(mut self) -> Result<hakoniwa::ExitStatus, std::io::Error> {
+    pub async fn mainloop(mut self) -> Result<i32, std::io::Error> {
         loop {
-            match self
-                .process
-                .try_wait()
-                .map_err(|e| io::Error::other(format!("wait failed: {}", e)))?
-            {
-                None => {}
-                Some(exit_status) => return Ok(exit_status),
+            if let Some(exit_code) = self.process.try_wait()? {
+                return Ok(exit_code);
             }
 
-            if let Err(()) = self.step().await {
-                return self
-                    .process
-                    .wait()
-                    .map_err(|e| io::Error::other(format!("wait failed: {}", e)));
-            };
+            if self.step().await.is_err() {
+                return self.process.wait();
+            }
         }
     }
 
@@ -653,6 +864,20 @@ fn set_nonblocking(fd: RawFd) -> io::Result<()> {
         return Err(io::Error::last_os_error());
     }
     let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Marks a file descriptor close-on-exec (`FD_CLOEXEC`).
+fn set_cloexec(fd: RawFd) -> io::Result<()> {
+    // SAFETY: fd is a valid open file descriptor.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let ret = unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) };
     if ret < 0 {
         return Err(io::Error::last_os_error());
     }

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -450,9 +450,10 @@ impl Host {
             .await
             .map_err(|e| io::Error::other(e.to_string()))?;
 
-        let container = env
+        let mut container = env
             .container()
             .map_err(|e| io::Error::other(format!("building container failed: {}", e)))?;
+        container.set_session_leader();
 
         let pty = Pty::open(sz)?;
         let mut command = env

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -795,8 +795,9 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
                                 };
                                 self.remote = None;
                             }
+                        } else {
+                            self.stdin_buf = Some((b, 0));
                         };
-                        self.stdin_buf = Some((b, 0));
                     }
                     Either::Right(sz) => {
                         self.set_size(WinSize::from(&sz));

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -178,6 +178,27 @@ impl TestClient {
             .unwrap()
     }
 
+    /// Opens an interactive shell channel attached to the given minimald
+    /// session, mirroring what a real client does: sets `MINIMAL_SESSION_ID`,
+    /// negotiates a PTY, then issues a `shell` request. Returns the live
+    /// channel so the caller can write stdin and drain stdout/teardown itself.
+    pub(crate) async fn open_shell(
+        &mut self,
+        session_id: SessionId,
+    ) -> russh::Channel<russh::client::Msg> {
+        let channel = self.handle.channel_open_session().await.unwrap();
+        channel
+            .set_env(true, crate::MINIMAL_SESSION_ID_ENV, session_id.to_string())
+            .await
+            .unwrap();
+        channel
+            .request_pty(true, "xterm", 80, 24, 0, 0, &[])
+            .await
+            .unwrap();
+        channel.request_shell(true).await.unwrap();
+        channel
+    }
+
     /// Opens a fresh session channel, applies `env` and optionally a PTY,
     /// fires an `exec` request for `command`, writes `stdin`, then drains
     /// the channel to completion.

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -297,6 +297,12 @@ impl AsRef<hakoniwa::Container> for Container {
 }
 
 impl Container {
+    /// Instructs the container to perform the setsid() & associate controlling
+    /// terminal dance.
+    pub fn set_session_leader(&mut self) {
+        self.container.runctl(hakoniwa::Runctl::NewSession);
+    }
+
     fn command_inner<C, I, IE, ArgS, EnvK, EnvV>(
         &self,
         sandbox: &Sandbox<C>,


### PR DESCRIPTION
The beginnings of attachable sessions.

Remaining TODOs:
 - [x] Fix the lifecycle of the sandboxed environment, which is being torn down even with the process still in it
 - [x] Fix job control + Ctrl-C not working
   - needs https://github.com/souk4711/hakoniwa/pull/174
 - [x] Add a million tests for all the state/race/sequence invariants
 - [x] Implement detaching via a key-chord

Given an existing session with a `minimal.toml` in it, you should be able to spawn or reattach to the session by doing:

```shell
$> MINIMAL_SESSION_ID=<session-uuid> ssh -o SendEnv=MINIMAL_SESSION_ID \
    -o ProxyCommand='socat - UNIX-CONNECT:/home/xxx/.local/state/minimal/providers/local-0/ssh.sock' \
    -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' local
```

AKA a 'request shell' ssh session - one with no command trailing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive SSH shell support with PTY-backed terminal I/O, window-size handling, attach/detach and resume behavior preserving terminal state.
  * Exposed session host controls enabling programmatic attach and kill of session hosts.
  * Added API to set sandboxed container as session leader.

* **Refactor**
  * Reworked startup to build a custom Tokio runtime and moved async startup into a separate entry function.

* **Chores**
  * Updated workspace dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->