### PR TITLE
fix(minimald::rpc::CreateSession): communicate an error if the session name is not unique

### DIFF
--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -1225,6 +1225,7 @@ mod tests {
                     },
                 })
                 .await
+                .unwrap()
                 .id
         }
 

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -61,6 +61,47 @@ pub(crate) trait OneshotSshRpc {
     }
 }
 
+/// A convinence wrapper to let a response type be able to carry an error.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum Errorable<S: std::fmt::Debug + PartialEq> {
+    Ok(S),
+    Err { error: String },
+}
+
+impl<S: std::fmt::Debug + PartialEq> Errorable<S> {
+    pub fn unwrap(self) -> S {
+        match self {
+            Self::Ok(s) => s,
+            Errorable::Err { error } => panic!("unwrap of error value: {error}"),
+        }
+    }
+
+    pub fn ok(self) -> Option<S> {
+        match self {
+            Self::Ok(s) => Some(s),
+            Errorable::Err { .. } => None,
+        }
+    }
+    pub fn err(self) -> Option<String> {
+        match self {
+            Self::Ok(_) => None,
+            Errorable::Err { error } => Some(error),
+        }
+    }
+}
+
+impl<T: std::fmt::Debug + PartialEq, E: ToString> From<Result<T, E>> for Errorable<T> {
+    fn from(value: Result<T, E>) -> Self {
+        match value {
+            Err(e) => Self::Err {
+                error: e.to_string(),
+            },
+            Ok(t) => Self::Ok(t),
+        }
+    }
+}
+
 /// An RPC to get the version of minimald.
 pub struct GetVersion;
 
@@ -203,7 +244,7 @@ pub struct CreateSessionRequest {
 }
 
 /// The response for a [`CreateSession`] RPC.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateSessionResponse {
     pub id: SessionId,
 }
@@ -211,7 +252,7 @@ pub struct CreateSessionResponse {
 impl OneshotSshRpc for CreateSession {
     const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "CreateSession");
     type Request<'a> = CreateSessionRequest;
-    type Response = CreateSessionResponse;
+    type Response = Errorable<CreateSessionResponse>;
 }
 
 impl CreateSession {
@@ -219,11 +260,13 @@ impl CreateSession {
         let res = self
             .handle_channel(c, async |req| {
                 let mngr = s.sessions_manager().await;
-                Ok(CreateSessionResponse {
-                    id: mngr
-                        .create_session(req.record)
-                        .await
-                        .map_err(|e| ConnectionError::Internal(e.to_string()))?,
+
+                Ok(match mngr.create_session(req.record).await {
+                    Ok(id) => Errorable::Ok(CreateSessionResponse { id }),
+                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Errorable::Err {
+                        error: "A session with that name already exists".to_string(),
+                    },
+                    Err(e) => return Err(ConnectionError::Internal(e.to_string())),
                 })
             })
             .await;
@@ -371,7 +414,8 @@ mod tests {
                     attrs: Default::default(),
                 },
             })
-            .await;
+            .await
+            .unwrap();
 
         assert!(create_session.id != SessionId::nil());
 
@@ -395,6 +439,44 @@ mod tests {
                 id: create_session.id,
                 name: Some("my session".to_string()),
             }]
+        );
+    }
+
+    #[tokio::test]
+    async fn create_session_errors_if_name_not_unique() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        let create_session = client
+            .call::<CreateSession>(&CreateSessionRequest {
+                record: sessions::Record {
+                    id: SessionId::nil(),
+                    name: Some("my session".to_string()),
+                    username: None,
+                    project_path: HostAbsPath::try_new("/uwu").unwrap(),
+                    attrs: Default::default(),
+                },
+            })
+            .await
+            .unwrap();
+
+        assert!(create_session.id != SessionId::nil());
+
+        assert_eq!(
+            client
+                .call::<CreateSession>(&CreateSessionRequest {
+                    record: sessions::Record {
+                        id: SessionId::nil(),
+                        name: Some("my session".to_string()),
+                        username: None,
+                        project_path: HostAbsPath::try_new("/uwu").unwrap(),
+                        attrs: Default::default(),
+                    },
+                })
+                .await,
+            Errorable::Err {
+                error: "A session with that name already exists".to_string()
+            }
         );
     }
 }

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -192,6 +192,7 @@ mod tests {
                 },
             })
             .await
+            .unwrap()
             .id
     }
 

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -23,14 +23,14 @@ pub enum SessionKeyPredicate {
 }
 
 /// Transport / internal error when communicating with the sessions actor.
-pub type ResponseError = std::io::Error;
+type SessionsError = std::io::Error;
 
 /// Encapsulates the return channel for messages back from the actor.
-struct Responder<T>(oneshot::Sender<Result<T, ResponseError>>);
+struct Responder<T>(oneshot::Sender<Result<T, SessionsError>>);
 
 impl<T> Responder<T> {
     /// Constructs both ends of the return channel.
-    pub fn channel() -> (Self, oneshot::Receiver<Result<T, ResponseError>>) {
+    pub fn channel() -> (Self, oneshot::Receiver<Result<T, SessionsError>>) {
         let (send, recv) = oneshot::channel();
         (Self(send), recv)
     }
@@ -38,7 +38,7 @@ impl<T> Responder<T> {
     /// Awaits the provided future, transmitting its result to the caller.
     pub async fn handle<F>(self, fut: F)
     where
-        F: Future<Output = Result<T, ResponseError>>,
+        F: Future<Output = Result<T, SessionsError>>,
     {
         let _ = self.0.send(fut.await);
     }
@@ -114,7 +114,7 @@ impl<L: Loader> Manager<L> {
                         .map(|k| {
                             let s = self.store.get(&k)?;
                             let r = s.record();
-                            Ok::<_, ResponseError>(SessionInfo {
+                            Ok::<_, SessionsError>(SessionInfo {
                                 id: r.id,
                                 name: r.name.clone(),
                             })
@@ -126,7 +126,7 @@ impl<L: Loader> Manager<L> {
             // Gets the record for a specific session.
             ManagerMessage::GetRecord(pred, r) => {
                 r.handle(async {
-                    Ok::<_, ResponseError>(match pred {
+                    Ok::<_, SessionsError>(match pred {
                         SessionKeyPredicate::Id(id) => self
                             .store
                             .find_by_id(&id)?
@@ -186,7 +186,7 @@ pub struct ManagerHandle(mpsc::Sender<ManagerMessage>);
 
 impl ManagerHandle {
     /// Lists the sessions known to this (minimald) instance.
-    pub async fn list(&self) -> Result<Vec<SessionInfo>, ResponseError> {
+    pub async fn list(&self) -> Result<Vec<SessionInfo>, SessionsError> {
         let (send, recv) = Responder::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(ManagerMessage::List(send)).await;
@@ -197,7 +197,7 @@ impl ManagerHandle {
     pub async fn get_record(
         &self,
         pred: SessionKeyPredicate,
-    ) -> Result<Option<sessions::Record>, ResponseError> {
+    ) -> Result<Option<sessions::Record>, SessionsError> {
         let (send, recv) = Responder::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(ManagerMessage::GetRecord(pred, send)).await;
@@ -208,7 +208,7 @@ impl ManagerHandle {
     pub async fn create_session(
         &self,
         record: sessions::Record,
-    ) -> Result<SessionId, ResponseError> {
+    ) -> Result<SessionId, SessionsError> {
         let (send, recv) = Responder::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self
@@ -222,7 +222,7 @@ impl ManagerHandle {
     pub async fn get_session(
         &self,
         pred: SessionKeyPredicate,
-    ) -> Result<Option<SessionHandle>, ResponseError> {
+    ) -> Result<Option<SessionHandle>, SessionsError> {
         let (send, recv) = Responder::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(ManagerMessage::GetSession(pred, send)).await;

--- a/crates/minimald/src/sftp.rs
+++ b/crates/minimald/src/sftp.rs
@@ -485,6 +485,7 @@ mod tests {
                 },
             })
             .await
+            .unwrap()
             .id
     }
 


### PR DESCRIPTION
Fixes that cheeky no-error-but-didnt-create-a-session we saw during the demo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Remote procedure call failures now return detailed error messages to clients instead of causing silent failures.
  * Session creation operations now properly validate and fail gracefully with error reporting.

* **New Features**
  * Attempting to create a session with a duplicate name now returns a specific error message, providing clear feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->