### PR TITLE
fix(minvmd): bridge-socket permissions, boot bench hardening, exec example

### DIFF
--- a/crates/minvmd/examples/exec.rs
+++ b/crates/minvmd/examples/exec.rs
@@ -99,7 +99,7 @@ async fn main() {
                 "\x1b[2m→ exit {}\x1b[0m",
                 exit.map(|c| c as i32).unwrap_or(-1)
             );
-            std::process::exit(exit.unwrap_or(0) as i32);
+            std::process::exit(exit.map(|c| c as i32).unwrap_or(1));
         }
         Err(e) => {
             eprintln!("error: {e}");

--- a/crates/minvmd/examples/exec.rs
+++ b/crates/minvmd/examples/exec.rs
@@ -1,0 +1,221 @@
+//! Demo client — run a command *inside the minimald guest* over the libkrun
+//! bridge, from the macOS host.
+//!
+//! Boot a VM first (another terminal):
+//!
+//! ```text
+//! MINVMD_KERNEL_PATH=… MINVMD_ROOTFS_PATH=… MINVMD_INITRAMFS=… \
+//!   target/debug/minvmd boot --foreground
+//! ```
+//!
+//! Then run commands in it:
+//!
+//! ```text
+//! cargo run -q -p minvmd --example exec -- uname -a
+//! cargo run -q -p minvmd --example exec -- cat /etc/os-release
+//! cargo run -q -p minvmd --example exec -- 'echo hello from $(hostname)'
+//! ```
+//!
+//! It connects to the host↔guest bridge UDS (the same path `minvmd` registers;
+//! override with `MINVMD_BRIDGE_SOCK`), opens a session, and execs the command
+//! in the guest — printing its stdout and propagating its exit status.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use russh::ChannelMsg;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// SSH subsystem for the CreateSession RPC (mirrors minimald's
+/// `RPC_SUBSYSTEM_PREFIX` + "CreateSession").
+const CREATE_SESSION_SUBSYSTEM: &str = "minimald-v1-CreateSession";
+/// Env var minimald reads to scope an exec to a session.
+const MINIMAL_SESSION_ID_ENV: &str = "MINIMAL_SESSION_ID";
+
+#[derive(serde::Serialize)]
+struct CreateSessionRequest {
+    record: sessions::Record,
+}
+
+#[derive(serde::Deserialize)]
+struct CreateSessionResponse {
+    id: sessions::SessionId,
+}
+
+/// russh client handler: accept the guest's ephemeral host key.
+struct ClientHandler;
+
+impl russh::client::Handler for ClientHandler {
+    type Error = russh::Error;
+    async fn check_server_key(
+        &mut self,
+        _key: &russh::keys::ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() {
+    let command = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
+    if command.trim().is_empty() {
+        eprintln!("usage: cargo run -p minvmd --example exec -- <command...>");
+        std::process::exit(2);
+    }
+
+    let sock = match std::env::var("MINVMD_BRIDGE_SOCK") {
+        Ok(p) if !p.is_empty() => PathBuf::from(p),
+        _ => minvmd::sock::resolve_uds_path().expect("resolving bridge socket path"),
+    };
+    if !sock.exists() {
+        eprintln!(
+            "bridge socket not found at {} — is `minvmd boot` running?\n\
+             (set MINVMD_BRIDGE_SOCK to point elsewhere)",
+            sock.display()
+        );
+        std::process::exit(1);
+    }
+    eprintln!("\x1b[2m→ {}  ::  {}\x1b[0m", sock.display(), command);
+
+    // A couple of attempts to absorb a just-booted guest still settling.
+    let mut result = Err("not attempted".to_string());
+    for attempt in 1..=4 {
+        result = run_session_exec(&sock, &command).await;
+        if result.is_ok() {
+            break;
+        }
+        if attempt < 4 {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        }
+    }
+
+    match result {
+        Ok((stdout, exit)) => {
+            print!("{stdout}");
+            use std::io::Write as _;
+            let _ = std::io::stdout().flush();
+            eprintln!(
+                "\x1b[2m→ exit {}\x1b[0m",
+                exit.map(|c| c as i32).unwrap_or(-1)
+            );
+            std::process::exit(exit.unwrap_or(0) as i32);
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Open a russh client over the bridge UDS, authenticate, create a session, and
+/// exec `command` in it. Returns `(stdout, exit_status)`.
+async fn run_session_exec(
+    sock_path: &Path,
+    command: &str,
+) -> Result<(String, Option<u32>), String> {
+    let stream = {
+        let mut conn = None;
+        let mut last_err = None;
+        for _ in 0..20 {
+            match tokio::net::UnixStream::connect(sock_path).await {
+                Ok(s) => {
+                    conn = Some(s);
+                    break;
+                }
+                Err(e) => {
+                    last_err = Some(e);
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+        conn.ok_or_else(|| format!("connect to bridge UDS: {}", last_err.unwrap()))?
+    };
+
+    let config = Arc::new(russh::client::Config::default());
+    let mut handle = russh::client::connect_stream(config, stream, ClientHandler)
+        .await
+        .map_err(|e| format!("ssh connect: {e}"))?;
+
+    let auth = handle
+        .authenticate_none("minvmd-demo")
+        .await
+        .map_err(|e| format!("authenticate_none: {e}"))?;
+    if !auth.success() {
+        return Err("auth_none rejected".into());
+    }
+
+    // CreateSession: open a channel, request the subsystem, write the JSON
+    // request, half-close, read the JSON response.
+    let session_id = {
+        let channel = handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("open CreateSession channel: {e}"))?;
+        channel
+            .request_subsystem(false, CREATE_SESSION_SUBSYSTEM)
+            .await
+            .map_err(|e| format!("request_subsystem: {e}"))?;
+
+        // Unique name per invocation — minimald dedups sessions by name, so a
+        // fixed name would only let the first command through.
+        let uniq = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let req = CreateSessionRequest {
+            record: sessions::Record {
+                id: sessions::SessionId::nil(),
+                name: Some(format!("minvmd-demo-{uniq:x}")),
+                username: None,
+                project_path: paths::HostAbsPath::try_new("/tmp")
+                    .map_err(|e| format!("project_path: {e}"))?,
+                attrs: Default::default(),
+            },
+        };
+        let body = serde_json::to_vec(&req).map_err(|e| format!("serialize request: {e}"))?;
+
+        let mut rpc = channel.into_stream();
+        rpc.write_all(&body)
+            .await
+            .map_err(|e| format!("write request: {e}"))?;
+        rpc.shutdown()
+            .await
+            .map_err(|e| format!("shutdown write half: {e}"))?;
+        let mut resp_buf = Vec::with_capacity(256);
+        rpc.read_to_end(&mut resp_buf)
+            .await
+            .map_err(|e| format!("read response: {e}"))?;
+        let resp: CreateSessionResponse =
+            serde_json::from_slice(&resp_buf).map_err(|e| format!("decode response: {e}"))?;
+        resp.id
+    };
+
+    // Exec the command in that session.
+    let mut channel = handle
+        .channel_open_session()
+        .await
+        .map_err(|e| format!("open exec channel: {e}"))?;
+    channel
+        .set_env(true, MINIMAL_SESSION_ID_ENV, session_id.to_string())
+        .await
+        .map_err(|e| format!("set_env: {e}"))?;
+    channel
+        .exec(true, command)
+        .await
+        .map_err(|e| format!("exec: {e}"))?;
+    channel.eof().await.map_err(|e| format!("eof: {e}"))?;
+
+    let mut stdout = Vec::new();
+    let mut exit_status = None;
+    while let Some(msg) = channel.wait().await {
+        match msg {
+            ChannelMsg::Data { data } => stdout.extend_from_slice(&data),
+            ChannelMsg::ExitStatus { exit_status: code } => exit_status = Some(code),
+            ChannelMsg::Failure => return Err("exec request rejected (CHANNEL_FAILURE)".into()),
+            _ => {}
+        }
+    }
+
+    Ok((String::from_utf8_lossy(&stdout).into_owned(), exit_status))
+}

--- a/crates/minvmd/src/cmd/boot.rs
+++ b/crates/minvmd/src/cmd/boot.rs
@@ -121,15 +121,18 @@ fn run_macos(foreground: bool) -> Result<()> {
         Ok(Ok(())) => {
             println!("vm-up");
             // R3.2: by the time READY arrives, libkrun has created and is
-            // listening on the minimald bridge socket. Verify it is
-            // owner-only (0600) from the parent process.
+            // listening on the minimald bridge socket. libkrun creates it with
+            // default permissions, so tighten it to owner-only (0600) from the
+            // parent process.
             match crate::sock::resolve_uds_path() {
                 Ok(uds_path) => {
-                    if let Err(e) = crate::sock::verify_socket_permissions(&uds_path) {
+                    if let Err(e) = crate::sock::enforce_socket_permissions(&uds_path)
+                        .and_then(|()| crate::sock::verify_socket_permissions(&uds_path))
+                    {
                         tracing::warn!(
                             path = %uds_path.display(),
                             error = %e,
-                            "minimald bridge socket permissions check failed",
+                            "could not secure minimald bridge socket to 0600",
                         );
                     }
                 }

--- a/crates/minvmd/src/sock.rs
+++ b/crates/minvmd/src/sock.rs
@@ -105,6 +105,17 @@ pub fn verify_socket_permissions(socket_path: &std::path::Path) -> io::Result<()
     Ok(())
 }
 
+/// Tighten the bridge socket at `socket_path` to owner-only (0600).
+///
+/// libkrun creates the listening socket with default permissions (typically
+/// 0755), so the parent enforces 0600 once the socket exists — only the owner
+/// should be able to connect to the daemon. (The containing dir is already
+/// 0700, so this is defense in depth.)
+pub fn enforce_socket_permissions(socket_path: &std::path::Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600))
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
@@ -180,6 +191,17 @@ mod tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
         let err = verify_socket_permissions(&path).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn enforce_socket_permissions_tightens_to_0600() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("test.sock");
+        std::fs::File::create(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        enforce_socket_permissions(&path).unwrap();
+        verify_socket_permissions(&path).unwrap();
     }
 
     #[test]

--- a/scripts/bench-minvmd-boot.sh
+++ b/scripts/bench-minvmd-boot.sh
@@ -21,27 +21,53 @@ BIN="${2:-./target/debug/minvmd}"
 
 : "${MINVMD_KERNEL_PATH:?set MINVMD_KERNEL_PATH to the (uncompressed) kernel image}"
 : "${MINVMD_ROOTFS_PATH:?set MINVMD_ROOTFS_PATH to the rootfs ext4 image}"
+: "${MINVMD_INITRAMFS:?set MINVMD_INITRAMFS to the guest initramfs cpio (minvmd boot needs all three)}"
+for v in MINVMD_KERNEL_PATH MINVMD_ROOTFS_PATH MINVMD_INITRAMFS; do
+  [ -f "${!v}" ] || { echo "$v points at a missing file: ${!v}" >&2; exit 1; }
+done
 [ -x "$BIN" ] || { echo "minvmd binary not found/executable: $BIN" >&2; exit 1; }
 command -v perl >/dev/null || { echo "perl required for sub-ms timing" >&2; exit 1; }
 
+# A healthy boot reaches READY in well under a second; cap each attempt so a
+# broken setup fails fast instead of looking hung for minutes.
+#
+# Boot invocations below redirect stdin from /dev/null: GNU timeout runs the
+# command in its own (background) process group, and with a TTY on stdin and
+# MINVMD_BOOT_LOG unset, libkrun's console setup tcsetattr()s the terminal —
+# SIGTTOU then stops the whole group and the boot dies silently at the timeout.
+BOOT_TIMEOUT=12
+OUT="$(mktemp -t bench-minvmd.XXXXXX)"
+
 now_ms() { perl -MTime::HiRes=time -e 'printf "%d", time()*1000'; }
-teardown() { pkill -f "__krun-vmm" 2>/dev/null; sleep 0.5; }
+# SIGKILL, not TERM: a VM in krun_start_enter ignores SIGTERM, so a leaked
+# __krun-vmm (e.g. from a Ctrl-C'd foreground boot) would otherwise hold the
+# bridge socket and make every subsequent boot fail.
+teardown() { pkill -9 -f "__krun-vmm" 2>/dev/null; pkill -9 -f "$BIN boot" 2>/dev/null; sleep 0.3; }
 
-trap teardown EXIT
+# Tear down on normal exit AND on Ctrl-C / kill, so an interrupt never leaves a
+# detached VM running (and the run stops promptly instead of deferring).
+trap 'teardown; rm -f "$OUT"' EXIT
+trap 'echo; echo "interrupted — tearing down" >&2; teardown; exit 130' INT TERM
 
-# Warmup (page-cache the kernel/rootfs; first boot is cold).
+# Warmup (page-cache the kernel/rootfs; the first boot is cold). Fail loudly here
+# if the artifacts/codesign are wrong, rather than silently N times below.
+echo "warming up (cold boot, discarded)…" >&2
 teardown
-timeout 20 "$BIN" boot >/dev/null 2>&1
+if ! timeout "$BOOT_TIMEOUT" "$BIN" boot </dev/null >"$OUT" 2>&1 || ! grep -q vm-up "$OUT"; then
+  echo "warmup boot did not reach vm-up — check artifacts, codesign, and libkrun:" >&2
+  tail -6 "$OUT" >&2
+  exit 1
+fi
 teardown
 
 samples=()
-for _ in $(seq 1 "$N"); do
+for i in $(seq 1 "$N"); do
   t0="$(now_ms)"
-  if timeout 20 "$BIN" boot >/tmp/.bench-minvmd.out 2>/dev/null && grep -q vm-up /tmp/.bench-minvmd.out; then
-    t1="$(now_ms)"
-    samples+=( "$(( t1 - t0 ))" )
+  if timeout "$BOOT_TIMEOUT" "$BIN" boot </dev/null >"$OUT" 2>/dev/null && grep -q vm-up "$OUT"; then
+    t1="$(now_ms)"; ms="$(( t1 - t0 ))"; samples+=( "$ms" )
+    printf 'run %2d/%d: %4d ms\n' "$i" "$N" "$ms" >&2
   else
-    echo "warning: a boot did not reach vm-up" >&2
+    printf 'run %2d/%d: FAILED (no vm-up)\n' "$i" "$N" >&2
   fi
   teardown
 done

--- a/scripts/bench-minvmd-boot.sh
+++ b/scripts/bench-minvmd-boot.sh
@@ -27,6 +27,7 @@ for v in MINVMD_KERNEL_PATH MINVMD_ROOTFS_PATH MINVMD_INITRAMFS; do
 done
 [ -x "$BIN" ] || { echo "minvmd binary not found/executable: $BIN" >&2; exit 1; }
 command -v perl >/dev/null || { echo "perl required for sub-ms timing" >&2; exit 1; }
+command -v timeout >/dev/null || { echo "timeout required (install GNU coreutils)" >&2; exit 1; }
 
 # A healthy boot reaches READY in well under a second; cap each attempt so a
 # broken setup fails fast instead of looking hung for minutes.
@@ -53,7 +54,7 @@ trap 'echo; echo "interrupted — tearing down" >&2; teardown; exit 130' INT TER
 # if the artifacts/codesign are wrong, rather than silently N times below.
 echo "warming up (cold boot, discarded)…" >&2
 teardown
-if ! timeout "$BOOT_TIMEOUT" "$BIN" boot </dev/null >"$OUT" 2>&1 || ! grep -q vm-up "$OUT"; then
+if ! timeout "$BOOT_TIMEOUT" "$BIN" boot </dev/null >"$OUT" 2>&1 || ! grep -qx vm-up "$OUT"; then
   echo "warmup boot did not reach vm-up — check artifacts, codesign, and libkrun:" >&2
   tail -6 "$OUT" >&2
   exit 1
@@ -63,7 +64,7 @@ teardown
 samples=()
 for i in $(seq 1 "$N"); do
   t0="$(now_ms)"
-  if timeout "$BOOT_TIMEOUT" "$BIN" boot </dev/null >"$OUT" 2>/dev/null && grep -q vm-up "$OUT"; then
+  if timeout "$BOOT_TIMEOUT" "$BIN" boot </dev/null >"$OUT" 2>/dev/null && grep -qx vm-up "$OUT"; then
     t1="$(now_ms)"; ms="$(( t1 - t0 ))"; samples+=( "$ms" )
     printf 'run %2d/%d: %4d ms\n' "$i" "$N" "$ms" >&2
   else


### PR DESCRIPTION
Follow-ups to [#374](https://github.com/gominimal/minimal/pull/374). Three commits, independent.

## Bridge socket permissions

libkrun creates the listening UDS with default permissions (0755); the existing verify-only check warned on every boot. `enforce_socket_permissions` chmods it to 0600 from the parent once the socket exists, then verifies. Containing dir is already 0700 — defense in depth. Unit test included.

## Boot bench hardening (`scripts/bench-minvmd-boot.sh`)

- Boot invocations redirect stdin from `/dev/null`: GNU timeout runs the command in a background process group, and libkrun's console `tcsetattr()` with a TTY on stdin raises SIGTTOU, stopping the group until the timeout fires — boots looked hung for 20s and failed silently.
- `MINVMD_INITRAMFS` required; all three artifact paths validated up front.
- Teardown SIGKILLs leaked `__krun-vmm` (a VM in `krun_start_enter` ignores SIGTERM and holds the bridge socket, failing every subsequent boot).
- INT/TERM traps tear down on Ctrl-C.
- Warmup failure prints the boot log tail and exits; per-run timings printed.

## exec example

`cargo run -p minvmd --example exec -- <command>` — russh client over the bridge UDS: auth_none, CreateSession subsystem, exec scoped to the session, stdout + exit status propagated. Deps already present as dev-dependencies.

## Acceptance

- `cargo test -p minvmd -- --include-ignored`: 57 passed
- `cargo clippy -p minvmd --all-targets -- -D warnings`: clean
- `cargo fmt`: applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Rust exec demo to run user commands inside a guest via the host↔guest bridge.

* **Improvements**
  * Hardened bridge socket permissions on macOS to enforce owner-only access.
  * Strengthened benchmark script with additional preflight checks, per-run temp output, tighter timeouts, and clearer diagnostics.

* **Tests**
  * Added a unit test verifying socket-permission tightening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->