### PR TITLE
Install spectacles SDD suite (ref: v0.2.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -50,7 +50,7 @@ with write access to the repository.
 
 | Command | Where | Effect |
 |---|---|---|
-| `/spec` | this tracking issue | re-run `sdd-spec` to draft or revise the spec |
+| `/spec` | this tracking issue | re-run `sdd-spec` to draft the spec. To change an **open** spec PR, comment `/revise <note>` on that PR — `/spec` never opens a second spec |
 | `/fastpath` | this tracking issue | confirm a single-session change; `sdd-spec` produces a stub spec PR and an execution plan comment in one run (ADR 0012) |
 | `/triage` | this tracking issue, after the spec PR is merged | start `sdd-triage` phase A (architecture) |
 | `/approve` | this tracking issue | full path: confirm the proposed plan so `sdd-triage` creates the Unit and task sub-issues. Fast path: dispatch the execution plan against `sdd-execute-{tier}` |

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -46,7 +46,7 @@ with write access to the repository.
 
 | Command | Where | Effect |
 |---|---|---|
-| `/spec` | this tracking issue | re-run `sdd-spec` to draft or revise the spec |
+| `/spec` | this tracking issue | re-run `sdd-spec` to draft the spec. To change an **open** spec PR, comment `/revise <note>` on that PR — `/spec` never opens a second spec |
 | `/fastpath` | this tracking issue | confirm a single-session change; `sdd-spec` produces a stub spec PR and an execution plan comment in one run (ADR 0012) |
 | `/triage` | this tracking issue, after the spec PR is merged | start `sdd-triage` phase A (architecture) |
 | `/approve` | this tracking issue | full path: confirm the proposed plan so `sdd-triage` creates the Unit and task sub-issues. Fast path: dispatch the execution plan against `sdd-execute-{tier}` |

--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -47,7 +47,7 @@ with write access to the repository.
 
 | Command | Where | Effect |
 |---|---|---|
-| `/spec` | this tracking issue | re-run `sdd-spec` to draft or revise the spec |
+| `/spec` | this tracking issue | re-run `sdd-spec` to draft the spec. To change an **open** spec PR, comment `/revise <note>` on that PR — `/spec` never opens a second spec |
 | `/fastpath` | this tracking issue | confirm a single-session change; `sdd-spec` produces a stub spec PR and an execution plan comment in one run (ADR 0012) |
 | `/triage` | this tracking issue, after the spec PR is merged | start `sdd-triage` phase A (architecture) |
 | `/approve` | this tracking issue | full path: confirm the proposed plan so `sdd-triage` creates the Unit and task sub-issues. Fast path: dispatch the execution plan against `sdd-execute-{tier}` |

--- a/.github/workflows/distillery-sync.yml
+++ b/.github/workflows/distillery-sync.yml
@@ -40,7 +40,14 @@ permissions:
 
 jobs:
   distillery-sync:
-    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@v0.1.2
+    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@v0.2.0
+    # Thread the consumer's DISTILLERY_DOC_GLOBS variable into the reusable
+    # workflow as an input. A repo variable cannot be read inside the agent
+    # prompt (`vars.*` is not an allowed gh-aw body expression), but a
+    # workflow_call input can. Unset variable → empty string → the agent's
+    # built-in default glob set, so a wrapper that omits this stays correct.
+    with:
+      doc_globs: ${{ vars.DISTILLERY_DOC_GLOBS }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:

--- a/.github/workflows/sdd-dispatch.yml
+++ b/.github/workflows/sdd-dispatch.yml
@@ -33,9 +33,12 @@ on:
   # A task sub-issue closing under a tracking issue that carries
   # sdd:dispatched. The route job walks the parent chain to find the
   # tracking issue and filters out closures on issues outside an armed
-  # cascade.
+  # cascade. The `labeled` type is the opt-in auto-dispatch trigger
+  # (ADR 0025): when the consumer sets SDD_AUTO_DISPATCH, a tracking
+  # issue gaining sdd:ready (sdd-triage phase C completion) arms the
+  # cascade as if a /dispatch had been typed.
   issues:
-    types: [closed]
+    types: [closed, labeled]
 
 permissions:
   contents: read
@@ -56,13 +59,35 @@ jobs:
     # consuming a route-job runner before the route step's tokenised
     # parse rejects it. GitHub Actions expressions do not support regex
     # matching, so enumerate the boundary characters explicitly.
+    #
+    # An `issues: labeled` event only spawns a runner for the sdd:ready
+    # label with SDD_AUTO_DISPATCH set (ADR 0025); every other label
+    # add is skipped here without a runner (the issue #119 discipline).
+    # The SDD_AUTO_DISPATCH comparison matches the composite action's
+    # trim+lowercase parse for case: GitHub Actions expression `==`
+    # ignores case on strings, so 'True'/'TRUE' pass this gate too.
+    # Only a whitespace-padded value diverges (the action would trim
+    # it; this gate skips first), so the effective contract is the
+    # documented exact values '1'/'true', case-insensitively.
     if: |
-      github.event_name != 'issue_comment'
-      || github.event.comment.body == '/dispatch'
-      || startsWith(github.event.comment.body, '/dispatch ')
-      || startsWith(github.event.comment.body, '/dispatch\n')
-      || startsWith(github.event.comment.body, '/dispatch\r\n')
-      || startsWith(github.event.comment.body, '/dispatch\t')
+      (github.event_name != 'issue_comment' && github.event_name != 'issues')
+      || (
+        github.event_name == 'issue_comment'
+        && (
+          github.event.comment.body == '/dispatch'
+          || startsWith(github.event.comment.body, '/dispatch ')
+          || startsWith(github.event.comment.body, '/dispatch\n')
+          || startsWith(github.event.comment.body, '/dispatch\r\n')
+          || startsWith(github.event.comment.body, '/dispatch\t')
+        )
+      )
+      || (github.event_name == 'issues' && github.event.action == 'closed')
+      || (
+        github.event_name == 'issues'
+        && github.event.action == 'labeled'
+        && github.event.label.name == 'sdd:ready'
+        && (vars.SDD_AUTO_DISPATCH == '1' || vars.SDD_AUTO_DISPATCH == 'true')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,10 +100,14 @@ jobs:
     steps:
       - name: Decide whether to run, and find the tracking issue
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@v0.2.0
         with:
           app-id: ${{ vars.APP_ID }}
           github-token: ${{ github.token }}
+          # Opt-in auto-dispatch on phase C completion (ADR 0025). Maps
+          # the consumer's optional SDD_AUTO_DISPATCH variable in; unset
+          # passes empty and the sdd:ready labeled trigger stays inert.
+          auto-dispatch: ${{ vars.SDD_AUTO_DISPATCH }}
 
   # Compute the ready set from the dependency graph. Walks the tracking
   # issue's sub-issue tree, parses each open task's `depends on:` block,
@@ -109,7 +138,7 @@ jobs:
     steps:
       - name: Compute ready set and precondition state
         id: compute
-        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@v0.2.0
         with:
           tracking-issue: ${{ needs.route.outputs.tracking_issue }}
           trigger-kind: ${{ needs.route.outputs.trigger_kind }}

--- a/.github/workflows/sdd-execute-haiku.yml
+++ b/.github/workflows/sdd-execute-haiku.yml
@@ -67,8 +67,9 @@ on:
     types: [unlabeled, closed]
   # A check suite that completed on a pull request this agent opened. A
   # failure conclusion on an `sdd/` branch is treated as an implicit
-  # /revise (issue #203): a required CI check failed and merge is BLOCKED,
-  # so the build is handed back to sdd-execute to fix on the same branch,
+  # /revise (issue #203): by default every failing check qualifies, or only
+  # required checks when SDD_REVISE_ON_CHECKS=required (issue #259), and the
+  # build is handed back to sdd-execute to fix on the same branch,
   # mirroring the CHANGES_REQUESTED path. A success/neutral suite does not
   # trigger a revise. The route step bounds the retries and escalates with
   # needs-human after the cap.
@@ -195,7 +196,7 @@ jobs:
     # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
     # re-trigger workflows, so this does not feed back into the route.
     #
-    # checks: read is needed by the failed-required-check auto-revise branch
+    # checks: read is needed by the failed-check auto-revise branch
     # (issue #203): it lists the check runs in the failing suite to name them
     # in the revise directive. The same branch reuses the iteration-marker /
     # needs-human machinery above.
@@ -210,17 +211,19 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.2.0
         with:
           tier: haiku
           app-id: ${{ vars.APP_ID }}
           max-review-iterations: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}
+          revise-on-checks: ${{ vars.SDD_REVISE_ON_CHECKS }}
+          revise-checks-exclude: ${{ vars.SDD_REVISE_CHECKS_EXCLUDE }}
           github-token: ${{ github.token }}
 
   sdd-execute-haiku:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@v0.1.2
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@v0.2.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -284,7 +287,7 @@ jobs:
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.2.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-haiku.outputs.created_pr_number }}

--- a/.github/workflows/sdd-execute-opus.yml
+++ b/.github/workflows/sdd-execute-opus.yml
@@ -67,8 +67,9 @@ on:
     types: [unlabeled, closed]
   # A check suite that completed on a pull request this agent opened. A
   # failure conclusion on an `sdd/` branch is treated as an implicit
-  # /revise (issue #203): a required CI check failed and merge is BLOCKED,
-  # so the build is handed back to sdd-execute to fix on the same branch,
+  # /revise (issue #203): by default every failing check qualifies, or only
+  # required checks when SDD_REVISE_ON_CHECKS=required (issue #259), and the
+  # build is handed back to sdd-execute to fix on the same branch,
   # mirroring the CHANGES_REQUESTED path. A success/neutral suite does not
   # trigger a revise. The route step bounds the retries and escalates with
   # needs-human after the cap.
@@ -195,7 +196,7 @@ jobs:
     # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
     # re-trigger workflows, so this does not feed back into the route.
     #
-    # checks: read is needed by the failed-required-check auto-revise branch
+    # checks: read is needed by the failed-check auto-revise branch
     # (issue #203): it lists the check runs in the failing suite to name them
     # in the revise directive. The same branch reuses the iteration-marker /
     # needs-human machinery above.
@@ -210,17 +211,19 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.2.0
         with:
           tier: opus
           app-id: ${{ vars.APP_ID }}
           max-review-iterations: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}
+          revise-on-checks: ${{ vars.SDD_REVISE_ON_CHECKS }}
+          revise-checks-exclude: ${{ vars.SDD_REVISE_CHECKS_EXCLUDE }}
           github-token: ${{ github.token }}
 
   sdd-execute-opus:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@v0.1.2
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@v0.2.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -284,7 +287,7 @@ jobs:
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.2.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-opus.outputs.created_pr_number }}
@@ -343,7 +346,7 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
       - name: Sweep open sdd/ PRs and refresh those behind base
-        uses: norrietaylor/spectacles/.github/actions/sdd-refresh-siblings@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-refresh-siblings@v0.2.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           merged-pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/sdd-execute-sonnet.yml
+++ b/.github/workflows/sdd-execute-sonnet.yml
@@ -67,8 +67,9 @@ on:
     types: [unlabeled, closed]
   # A check suite that completed on a pull request this agent opened. A
   # failure conclusion on an `sdd/` branch is treated as an implicit
-  # /revise (issue #203): a required CI check failed and merge is BLOCKED,
-  # so the build is handed back to sdd-execute to fix on the same branch,
+  # /revise (issue #203): by default every failing check qualifies, or only
+  # required checks when SDD_REVISE_ON_CHECKS=required (issue #259), and the
+  # build is handed back to sdd-execute to fix on the same branch,
   # mirroring the CHANGES_REQUESTED path. A success/neutral suite does not
   # trigger a revise. The route step bounds the retries and escalates with
   # needs-human after the cap.
@@ -195,7 +196,7 @@ jobs:
     # needs-human label. Comments and labels written by the GITHUB_TOKEN do not
     # re-trigger workflows, so this does not feed back into the route.
     #
-    # checks: read is needed by the failed-required-check auto-revise branch
+    # checks: read is needed by the failed-check auto-revise branch
     # (issue #203): it lists the check runs in the failing suite to name them
     # in the revise directive. The same branch reuses the iteration-marker /
     # needs-human machinery above.
@@ -210,17 +211,19 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.2.0
         with:
           tier: sonnet
           app-id: ${{ vars.APP_ID }}
           max-review-iterations: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}
+          revise-on-checks: ${{ vars.SDD_REVISE_ON_CHECKS }}
+          revise-checks-exclude: ${{ vars.SDD_REVISE_CHECKS_EXCLUDE }}
           github-token: ${{ github.token }}
 
   sdd-execute-sonnet:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@v0.1.2
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@v0.2.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -284,7 +287,7 @@ jobs:
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.2.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-sonnet.outputs.created_pr_number }}

--- a/.github/workflows/sdd-monitor.yml
+++ b/.github/workflows/sdd-monitor.yml
@@ -17,6 +17,14 @@ name: sdd-monitor
 # needs-human) are out of scope for this PR. They are tracked as follow-ups
 # on issue #148.
 #
+# The same composite action also runs CodeRabbit stall detection (issue
+# #257): an open non-draft sdd/ PR whose head commit has aged past
+# SDD_CODERABBIT_STALL_MIN minutes with no review or comment from
+# coderabbitai[bot] draws a bounded App-authored "@coderabbitai review"
+# nudge (SDD_CODERABBIT_NUDGE_MAX per head sha), then needs-human. Enabled
+# when a .coderabbit.yaml/.yml exists at the repo root or SDD_CODERABBIT=1;
+# SDD_CODERABBIT=0 force-disables.
+#
 # Idempotency model:
 #
 # 1. Disabled by default. The first check reads the SDD_MONITOR repo
@@ -76,9 +84,15 @@ on:
     - cron: '*/10 * * * *'
 
 permissions:
+  # contents: read also backs the CodeRabbit config presence probe
+  # (.coderabbit.yaml/.yml via getContent), which rides runs-token so the
+  # App token never needs the Contents permission.
   contents: read
-  # actions: read is required to list sdd-execute-* workflow runs filtered
-  # by status so the in-flight gate can decide whether to dispatch.
+  # actions: read on the workflow GITHUB_TOKEN backs the in-flight gate's
+  # listWorkflowRunsForRepo call. The token is passed to the sdd-monitor
+  # action as runs-token; the App token deliberately does NOT request this
+  # scope (issue #249), so the gate's Actions access rides on GITHUB_TOKEN
+  # here, never on the App installation grant.
   actions: read
   # pull-requests: read lists open sdd/ implementation PRs, which the
   # armed-but-idle check excludes from candidate trackers.
@@ -132,17 +146,44 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           # Least-privilege scope. Without permission-* inputs the minted
-          # token inherits the App installation's full grant; the
-          # sdd-monitor action only needs:
-          #   actions:read        list sdd-execute-* runs (in-flight gate)
-          #   pull-requests:read  list open sdd/ implementation PRs
-          #   issues:write        label + post /dispatch on tracking issues
-          # It reads no repo contents, so contents is omitted.
-          permission-actions: read
+          # token inherits the App installation's full grant; the App token
+          # only needs:
+          #   pull-requests:read  list open sdd/ implementation PRs, plus
+          #                       their reviews/commits for the CodeRabbit
+          #                       stall check
+          #   issues:write        label + post /dispatch on tracking issues,
+          #                       plus the CodeRabbit nudge/escalation
+          #                       comments and needs-human on a stalled PR
+          # It reads no repo contents, so contents is omitted (the CodeRabbit
+          # config probe rides runs-token instead).
+          #
+          # NOT actions:read. The in-flight run-status gate
+          # (listWorkflowRunsForRepo) runs on the workflow GITHUB_TOKEN
+          # (runs-token below), which carries actions:read from the job
+          # permissions. Requesting actions:read here would 422 the entire
+          # mint on any App installation that was not granted the Actions
+          # permission, taking the whole monitor down (issue #249). Keeping it
+          # off GITHUB_TOKEN decouples the monitor from the App install's
+          # Actions grant.
           permission-pull-requests: read
           permission-issues: write
       - name: Nudge armed-but-idle trackers
-        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@v0.2.0
         with:
+          # App token: PR/issue reads + the /dispatch comment (App-authored so
+          # the dispatch wrapper's carve-out admits it).
           github-token: ${{ steps.app.outputs.token }}
+          # Workflow GITHUB_TOKEN: actions:read for the in-flight gate and
+          # contents:read for the CodeRabbit config presence probe.
+          runs-token: ${{ github.token }}
           debounce-min: ${{ vars.SDD_MONITOR_DEBOUNCE_MIN }}
+          # CodeRabbit stall detection (issue #257). All three optional;
+          # unset vars pass through empty and the action falls back to
+          # auto-detect / 30 / 2.
+          coderabbit: ${{ vars.SDD_CODERABBIT }}
+          coderabbit-stall-min: ${{ vars.SDD_CODERABBIT_STALL_MIN }}
+          coderabbit-nudge-max: ${{ vars.SDD_CODERABBIT_NUDGE_MAX }}
+          # Same App id the token mint above uses: the nudge/escalation
+          # marker budget counts only comments performed via this App, so
+          # a pasted marker from another commenter cannot game it.
+          app-id: ${{ vars.APP_ID }}

--- a/.github/workflows/sdd-pr-sanitize.yml
+++ b/.github/workflows/sdd-pr-sanitize.yml
@@ -63,6 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Correct the issue references in the pull request body
-        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@v0.2.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-review.yml
+++ b/.github/workflows/sdd-review.yml
@@ -52,14 +52,14 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@v0.2.0
         with:
           github-token: ${{ github.token }}
 
   sdd-review:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@v0.1.2
+    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@v0.2.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -120,7 +120,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-pull-requests: write
       - name: Resolve App-bot advisory review threads
-        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@v0.2.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           bot-login: ${{ steps.app.outputs.app-slug }}[bot]

--- a/.github/workflows/sdd-spec.yml
+++ b/.github/workflows/sdd-spec.yml
@@ -20,11 +20,15 @@ on:
   # feature/bug issue templates), or the needs-human label was cleared.
   issues:
     types: [labeled, unlabeled]
-  # A /spec or /revise comment on an issue or pull request.
+  # A /spec, /revise, /fastpath (or /agile), or /approve comment on an
+  # issue or pull request.
   issue_comment:
     types: [created]
-  # A spec pull request was closed; the agent advances the lifecycle only
-  # when it was merged.
+  # A spec pull request was closed. Merged: the agent advances the
+  # lifecycle — or, when the sdd:approved marker is recorded, the
+  # approved-merge-dispatch job dispatches deterministically (ADR 0024).
+  # Closed without merge: the approved-clear job drops a stale
+  # sdd:approved marker.
   pull_request:
     types: [closed]
 
@@ -54,6 +58,7 @@ jobs:
           startsWith(github.event.comment.body, '/spec')
           || startsWith(github.event.comment.body, '/revise')
           || startsWith(github.event.comment.body, '/fastpath')
+          || startsWith(github.event.comment.body, '/agile')
           || startsWith(github.event.comment.body, '/approve')
         )
       )
@@ -82,24 +87,32 @@ jobs:
       aw_context: ${{ steps.decide.outputs.aw_context }}
       fastpath_approve: ${{ steps.decide.outputs.fastpath_approve }}
       fastpath_tracking: ${{ steps.decide.outputs.fastpath_tracking }}
+      approved_dispatch: ${{ steps.decide.outputs.approved_dispatch }}
+      approved_clear: ${{ steps.decide.outputs.approved_clear }}
+      approved_tracking: ${{ steps.decide.outputs.approved_tracking }}
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@v0.2.0
         with:
           github-token: ${{ github.token }}
 
-  # Fast-path /approve handler (ADR 0012).
+  # Fast-path /approve handler (ADR 0012, amended by ADR 0024).
   #
-  # On /approve on a tracking issue carrying sdd:fastpath, the route job
-  # sets fastpath_approve=true. This job runs the deterministic dispatch:
-  # find the latest execution-plan comment on the tracking issue (matched
-  # by the `[sdd-spec:fastpath-plan]` plain-text marker), parse its
-  # `model:*` tier, mint an App token, call workflow_dispatch on the
-  # matching sdd-execute-{tier}.yml with `entry: 'fastpath'`, and move
-  # the tracking issue's lifecycle from `sdd:fastpath` to
-  # `sdd:in-progress`. The wrapper handles this entirely; the sdd-spec
-  # agent .md source is not invoked on this path.
+  # On /approve on a tracking issue carrying sdd:fastpath or
+  # sdd:fastpath-review, the route job sets fastpath_approve=true. This
+  # job runs the deterministic approval handling. With the spec PR merged
+  # (sdd:fastpath): find the latest execution-plan comment on the tracking
+  # issue (matched by the `[sdd-spec:fastpath-plan]` plain-text marker),
+  # parse its `model:*` tier, mint an App token, call workflow_dispatch on
+  # the matching sdd-execute-{tier}.yml with `entry: 'fastpath'`, and move
+  # the tracking issue's lifecycle to `sdd:in-progress`. With the spec PR
+  # still open (sdd:fastpath-review): record the approval as the
+  # orthogonal sdd:approved marker and — when SDD_AUTO_MERGE is set — arm
+  # squash auto-merge on the spec PR, so the merge event dispatches via
+  # the approved-merge-dispatch job below; merge and approve commute. The
+  # wrapper handles this entirely; the sdd-spec agent .md source is not
+  # invoked on this path.
   #
   # This follows the deterministic-in-wrapper pattern from #81 (ADR
   # 0011): there is no natural-language judgement on this code path —
@@ -120,18 +133,81 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
-      - name: Find plan comment and dispatch sdd-execute-{tier}
-        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.1.2
+      - name: Record approval or dispatch sdd-execute-{tier}
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.2.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           tracking: ${{ needs.route.outputs.fastpath_tracking }}
+          mode: approve
+          auto-merge: ${{ vars.SDD_AUTO_MERGE }}
+
+  # Deterministic merge dispatch (ADR 0024). A spec PR merged while the
+  # tracking issue carries the sdd:approved marker (the human approved
+  # before merging): dispatch the single sdd-execute-{tier} run against
+  # the execution plan comment, clear sdd:approved, and advance the
+  # lifecycle to sdd:in-progress. The sdd-spec agent is suppressed for
+  # this trigger (the route job sets should_run=false), so the
+  # merge-side lifecycle handling has exactly one owner.
+  approved-merge-dispatch:
+    needs: route
+    if: needs.route.outputs.approved_dispatch == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Dispatch sdd-execute-{tier} for the approved merged spec PR
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.2.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          tracking: ${{ needs.route.outputs.approved_tracking }}
+          mode: merged
+
+  # Stale-approval clear (ADR 0024). A spec PR closed *without* merging
+  # while the tracking issue carries sdd:approved: the recorded approval
+  # no longer refers to a mergeable spec, so drop the marker. Re-approval
+  # is required once a new spec PR exists.
+  approved-clear:
+    needs: route
+    if: needs.route.outputs.approved_clear == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Clear the stale sdd:approved marker
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.2.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          tracking: ${{ needs.route.outputs.approved_tracking }}
+          mode: clear
 
   sdd-spec:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@v0.1.2
+    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@v0.2.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
+      # Single-PR classifier diff ceiling (ADR 0024). Maps the consumer's
+      # optional SDD_AGILE_MAX variable into the lock's agile_max input;
+      # unset passes empty and the agent falls back to 800.
+      agile_max: ${{ vars.SDD_AGILE_MAX }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
@@ -190,7 +266,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Post failure hand-off to tracking issue
-        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@v0.2.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           aw-context: ${{ needs.route.outputs.aw_context }}

--- a/.github/workflows/sdd-spike-actuator.yml
+++ b/.github/workflows/sdd-spike-actuator.yml
@@ -66,7 +66,7 @@ jobs:
       # walk errored) means this is not a spike-wave member to actuate.
       - name: Resolve the parent tracking issue
         id: tree
-        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.2.0
         with:
           mode: actuator
           spike-issue: ${{ github.event.issue.number }}

--- a/.github/workflows/sdd-spike-reentry.yml
+++ b/.github/workflows/sdd-spike-reentry.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Resolve the tracking issue and the drain state
         id: tree
-        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.2.0
         with:
           mode: reentry
           spike-issue: ${{ github.event.issue.number }}
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Build the phase-B re-entry context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.2.0
         with:
           github-token: ${{ github.token }}
           reentry-tracking-issue: ${{ needs.walk.outputs.tracking_issue }}
@@ -106,7 +106,7 @@ jobs:
   sdd-triage:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.1.2
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.2.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     secrets:

--- a/.github/workflows/sdd-status.yml
+++ b/.github/workflows/sdd-status.yml
@@ -1,0 +1,134 @@
+name: sdd-status
+
+# Deterministic status surface for SDD tracking issues (issue #254).
+#
+# Maintains exactly one self-updating status comment per tracking issue,
+# located by the `<!-- sdd-status -->` sentinel and edited in place. Comment
+# edits do not notify, so `needs-human` and agent hand-off comments stay the
+# only pings (ADR 0001). Each refresh derives the phase line, a deterministic
+# "Your move" decision line, a per-task state table, progress counts with
+# in-flight run links, and a last-updated footer — entirely from labels, the
+# sub-issue tree, open sdd/ PRs, and Actions runs. Precedents for the
+# sentinel: `<!-- sdd-triage:plan -->` (ADR 0010) and the auto-revise markers
+# in sdd-route-execute.
+#
+# Why a plain utility workflow, not a gh-aw agent: the output is 100%
+# derivable from API state, so an LLM in the loop only adds cost, latency,
+# and drift — and would drag in the ADR 0020 OTLP block. There is no
+# `engine:` here, so no `.lock.yml` is compiled and the observability
+# mandate's deterministic exemption (ADR 0020 §5) applies.
+#
+# Why not extend sdd-monitor (issue #254):
+# 1. The monitor's repository-wide in-flight gate defers exactly when status
+#    matters most (during execute runs).
+# 2. Opposite concurrency semantics (monitor: cancel-in-progress false; here
+#    the latest pass wins, so stale refreshes are cancelled).
+# 3. Different trust posture: the monitor is a mutator (opt-in, App token);
+#    status is a reporter whose only write is one non-command comment, so the
+#    plain GITHUB_TOKEN suffices and no App mint is needed.
+#
+# Enablement: default-on once installed — status never mutates pipeline
+# state, deviating deliberately from SDD_MONITOR's opt-in. Set the
+# SDD_STATUS repository variable to '0' to opt out.
+#
+# /status is the forced-refresh command: token-strict match at the job gate
+# (same enumeration idiom as wrappers/sdd-dispatch.yml), then gated inside
+# the action to authors with real repository write access (the explicit
+# permission check copied from sdd-route-dispatch). The ack is an eyes
+# reaction on the command comment — no new comment; the refreshed status
+# comment is the response.
+
+on:
+  # Lifecycle and marker label moves, plus tree-shape changes (a task or
+  # Unit closing/reopening), on the tracking issue or any sub-issue.
+  issues:
+    types: [labeled, unlabeled, closed, reopened]
+  # The token-strict /status forced refresh.
+  issue_comment:
+    types: [created]
+  # sdd/ implementation, spec, and architecture PRs opening and closing.
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review]
+  # Review state changes on sdd/ PRs feed the "Your move" decision table.
+  pull_request_review:
+    types: [submitted]
+  # Check rollups landing on sdd/ branches.
+  check_suite:
+    types: [completed]
+  # Agent runs completing: re-derive "agent running" rows and run links.
+  # V1 correlates fuzzily (repo-wide refresh of active trackers) because a
+  # run is not reliably attributable to one tracker without aw_context
+  # reads (issue #254, open question 2).
+  workflow_run:
+    workflows:
+      - sdd-spec
+      - sdd-triage
+      - sdd-validate
+      - sdd-review
+      - sdd-execute-haiku
+      - sdd-execute-sonnet
+      - sdd-execute-opus
+    types: [completed]
+
+permissions:
+  contents: read
+  # issues: write covers the status comment upsert and the eyes-reaction
+  # ack on /status. The comment is a report, never a command, so the plain
+  # GITHUB_TOKEN is enough — no App mint (the github-actions[bot] author is
+  # fine because no wrapper routes on this comment).
+  issues: write
+  # pull-requests: read lists open sdd/ PRs and their review decisions.
+  pull-requests: read
+  # actions: read lists in-flight sdd-execute-* runs for the per-task
+  # "agent running" rows and the progress footer's run links.
+  actions: read
+  # checks: read backs the statusCheckRollup per open sdd/ PR.
+  checks: read
+
+# Latest pass wins: status refreshes are idempotent re-derivations of the
+# same surface, so a newer event makes the in-flight pass worthless.
+# Deliberately the opposite of sdd-monitor's cancel-in-progress: false.
+concurrency:
+  group: sdd-status-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+  status:
+    # Default-on with an explicit opt-out (SDD_STATUS=0), then per-event
+    # relevance filters so irrelevant events do not spend a runner:
+    # - issues: closed/reopened always pass (tree shape changed); labeled/
+    #   unlabeled only for sdd:* and needs-human labels.
+    # - issue_comment: token-strict /status. `startsWith(body, '/status')`
+    #   alone would also fire for `/statusfoo`; GitHub Actions expressions
+    #   do not support regex matching, so enumerate the boundary
+    #   characters explicitly (same idiom as wrappers/sdd-dispatch.yml).
+    #   The write-access gate runs inside the action.
+    # - pull_request / pull_request_review / check_suite: sdd/ refs only.
+    # - workflow_run: always relevant (the listed workflows are all sdd-*).
+    if: >-
+      vars.SDD_STATUS != '0'
+      && (
+        (github.event_name == 'issues'
+          && (github.event.action == 'closed'
+            || github.event.action == 'reopened'
+            || startsWith(github.event.label.name, 'sdd:')
+            || github.event.label.name == 'needs-human'))
+        || (github.event_name == 'issue_comment'
+          && (github.event.comment.body == '/status'
+            || startsWith(github.event.comment.body, '/status ')
+            || startsWith(github.event.comment.body, '/status\n')
+            || startsWith(github.event.comment.body, '/status\r\n')
+            || startsWith(github.event.comment.body, '/status\t')))
+        || ((github.event_name == 'pull_request'
+            || github.event_name == 'pull_request_review')
+          && startsWith(github.event.pull_request.head.ref, 'sdd/'))
+        || (github.event_name == 'check_suite'
+          && startsWith(github.event.check_suite.head_branch, 'sdd/'))
+        || github.event_name == 'workflow_run'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refresh the status comment
+        uses: norrietaylor/spectacles/.github/actions/sdd-status@v0.2.0
+        with:
+          github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage-dedupe-tasks.yml
+++ b/.github/workflows/sdd-triage-dedupe-tasks.yml
@@ -37,6 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close a duplicate phase-C task sub-issue
-        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@v0.2.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage-promote-ready.yml
+++ b/.github/workflows/sdd-triage-promote-ready.yml
@@ -57,6 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Promote tasks whose last blocker just closed
-        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@v0.2.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage.yml
+++ b/.github/workflows/sdd-triage.yml
@@ -81,16 +81,20 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.2.0
         with:
           github-token: ${{ github.token }}
 
   sdd-triage:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.1.2
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.2.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
+      # Task-bundling diff floor (ADR 0022). Maps the consumer's optional
+      # SDD_TRIAGE_MIN_TASK variable into the lock's min_task input; unset
+      # passes empty and the agent falls back to 300.
+      min_task: ${{ vars.SDD_TRIAGE_MIN_TASK }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
@@ -143,7 +147,7 @@ jobs:
     steps:
       - name: Detect a dependency cycle in the materialized tree
         id: detect
-        uses: norrietaylor/spectacles/.github/actions/sdd-cycle-detect@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-cycle-detect@v0.2.0
         with:
           tracking-issue: ${{ needs.route.outputs.item_number }}
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-validate.yml
+++ b/.github/workflows/sdd-validate.yml
@@ -81,14 +81,14 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@v0.1.2
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@v0.2.0
         with:
           github-token: ${{ github.token }}
 
   sdd-validate:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@v0.1.2
+    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@v0.2.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets


### PR DESCRIPTION
Installs the spectacles SDD agent suite (ADR 0004) via `scripts/quick-setup.sh`. Wrappers pin hosted reusable workflows at `@v0.2.0`. Labels, variables, and secrets were applied directly; the file artifacts in this PR honor the protected default branch. Merge to activate the workflows.