### PR TITLE
refactor(minimald): move minimald RPC types to own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,6 +3441,7 @@ dependencies = [
  "libc",
  "mctx",
  "mfile",
+ "minimald-rpc",
  "nix 0.31.3",
  "ot",
  "path-absolutize",
@@ -3457,6 +3458,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vt100-ctt",
+]
+
+[[package]]
+name = "minimald-rpc"
+version = "0.0.1"
+dependencies = [
+ "constcat",
+ "serde",
+ "sessions",
 ]
 
 [[package]]
@@ -3479,6 +3489,7 @@ dependencies = [
  "dirs",
  "fd-lock",
  "libc",
+ "minimald-rpc",
  "paths",
  "russh",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/minimal",
     "crates/minimal2",
     "crates/minimald",
+    "crates/minimald-rpc",
     "crates/minvmd",
     "crates/remote-client",
     "crates/remote-proto",
@@ -134,6 +135,7 @@ checkouts = { version = "0.0.1", path = "crates/checkouts" }
 common = { version = "0.0.1", path = "crates/common" }
 decode = { version = "0.0.1", path = "crates/decode" }
 mctx = { version = "0.0.1", path = "crates/mctx" }
+minimald-rpc = { version = "0.0.1", path = "crates/minimald-rpc" }
 mfile = { version = "0.0.1", path = "crates/mfile" }
 op = { version = "0.0.1", path = "crates/op" }
 ot = { version = "0.0.1", path = "crates/ot" }

--- a/crates/minimald-rpc/Cargo.toml
+++ b/crates/minimald-rpc/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "minimald-rpc"
+version = "0.0.1"
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+constcat.workspace = true
+serde.workspace = true
+
+sessions.workspace = true

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -1,0 +1,166 @@
+//! Wire contract for minimald's oneshot SSH RPCs.
+//!
+//! This crate holds the protocol surface shared between the minimald server
+//! and its clients: the subsystem names, the request/response payload types,
+//! and the [`OneshotSshRpc`] trait that pairs them. It deliberately carries no
+//! transport or server dependencies (no `russh`, no `tokio`) so that clients
+//! — including the test harness and cross-platform integration tests — encode
+//! and decode requests through the very same types the server handles.
+//!
+//! The server-side serving glue lives in the `minimald` crate.
+
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sessions::SessionId;
+
+pub const RPC_SUBSYSTEM_PREFIX: &str = "minimald-v1-";
+
+/// Describes a minimal-specific RPC method sent over ssh.
+///
+/// Oneshot RPCs are not streaming. The trait pairs a subsystem name with its
+/// request and response schemas; both the server (which decodes the request
+/// and encodes the response) and clients (which do the reverse) implement
+/// against this single contract.
+pub trait OneshotSshRpc {
+    /// The subsystem name used to call for this RPC.
+    const NAME: &'static str;
+    /// The type schema of the request.
+    ///
+    /// Bound on `Serialize` exists so that clients (including the test
+    /// harness) can encode requests through the same type the handler
+    /// decodes them with.
+    type Request<'a>: Deserialize<'a> + Serialize;
+    /// The type schema of the response.
+    ///
+    /// Bound on `DeserializeOwned` exists for symmetry with `Request`:
+    /// clients decode the same type the handler emitted.
+    type Response: Serialize + DeserializeOwned;
+}
+
+/// A convinence wrapper to let a response type be able to carry an error.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum Errorable<S: std::fmt::Debug + PartialEq> {
+    Ok(S),
+    Err { error: String },
+}
+
+impl<S: std::fmt::Debug + PartialEq> Errorable<S> {
+    pub fn unwrap(self) -> S {
+        match self {
+            Self::Ok(s) => s,
+            Errorable::Err { error } => panic!("unwrap of error value: {error}"),
+        }
+    }
+
+    pub fn ok(self) -> Option<S> {
+        match self {
+            Self::Ok(s) => Some(s),
+            Errorable::Err { .. } => None,
+        }
+    }
+    pub fn err(self) -> Option<String> {
+        match self {
+            Self::Ok(_) => None,
+            Errorable::Err { error } => Some(error),
+        }
+    }
+}
+
+impl<T: std::fmt::Debug + PartialEq, E: ToString> From<Result<T, E>> for Errorable<T> {
+    fn from(value: Result<T, E>) -> Self {
+        match value {
+            Err(e) => Self::Err {
+                error: e.to_string(),
+            },
+            Ok(t) => Self::Ok(t),
+        }
+    }
+}
+
+/// An RPC to get the version of minimald.
+pub struct GetVersion;
+
+/// The response to the [`GetVersion`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetVersionResponse {
+    pub version: String,
+    pub long_version: String,
+    pub stdlib_version: String,
+}
+
+impl OneshotSshRpc for GetVersion {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "GetVersion");
+    type Request<'a> = ();
+    type Response = GetVersionResponse;
+}
+
+/// An RPC to list sessions managed by this minimald.
+pub struct ListSessions;
+
+/// An entry in the ListSessions response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListSessionsEntry {
+    pub id: SessionId,
+    pub name: Option<String>,
+}
+
+/// The response to the [`ListSessions`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListSessionsResponse {
+    pub sessions: Vec<ListSessionsEntry>,
+}
+
+impl OneshotSshRpc for ListSessions {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "ListSessions");
+    type Request<'a> = ();
+    type Response = ListSessionsResponse;
+}
+
+/// An RPC to read the session record for a session corresponding to the request.
+pub struct GetSessionRecord;
+
+/// The request for a [`GetSessionRecord`] RPC.
+///
+/// Serialized examples:
+///
+///  * `{"name": "my-session"}`
+///  * `{"id": "<some-uuid>"}`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GetSessionRecordRequest {
+    Name(String),
+    Id(SessionId),
+}
+
+/// The response for a [`GetSessionRecord`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetSessionRecordResponse {
+    pub record: Option<sessions::Record>,
+}
+
+impl OneshotSshRpc for GetSessionRecord {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "GetSessionRecord");
+    type Request<'a> = GetSessionRecordRequest;
+    type Response = GetSessionRecordResponse;
+}
+
+/// An RPC to create a new session based on the given record.
+pub struct CreateSession;
+
+/// The request for a [`CreateSession`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateSessionRequest {
+    pub record: sessions::Record,
+}
+
+/// The response for a [`CreateSession`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreateSessionResponse {
+    pub id: SessionId,
+}
+
+impl OneshotSshRpc for CreateSession {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "CreateSession");
+    type Request<'a> = CreateSessionRequest;
+    type Response = Errorable<CreateSessionResponse>;
+}

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -31,6 +31,7 @@ args.workspace = true
 graph.workspace = true
 mctx.workspace = true
 mfile.workspace = true
+minimald-rpc.workspace = true
 ot.workspace = true
 paths.workspace = true
 sessions.workspace = true

--- a/crates/minimald/src/connection.rs
+++ b/crates/minimald/src/connection.rs
@@ -425,7 +425,7 @@ impl russh::server::Handler for ConnectionHandler {
     ) -> Result<(), Self::Error> {
         protocol_trace!("Got subsystem_request on channel {id}: subsystem={name}");
 
-        if name.starts_with(rpc::RPC_SUBSYSTEM_PREFIX) {
+        if name.starts_with(minimald_rpc::RPC_SUBSYSTEM_PREFIX) {
             let c = self.0.clone();
             let s = c.0.lock().await.serv.clone();
             rpc::handle_ssh_rpc(s, c, name, id, session).await?;

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -1205,8 +1205,9 @@ mod tests {
         use paths::HostAbsPath;
         use sessions::SessionId;
 
+        use minimald_rpc::{CreateSession, CreateSessionRequest};
+
         use crate::MINIMAL_SESSION_ID_ENV;
-        use crate::rpc::{CreateSession, CreateSessionRequest};
         use crate::sessions::SessionKeyPredicate;
         use crate::test_harness::{TestClient, TestServer};
 

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -1,9 +1,12 @@
+use minimald_rpc::{
+    CreateSession, CreateSessionResponse, Errorable, GetSessionRecord, GetSessionRecordRequest,
+    GetSessionRecordResponse, GetVersion, GetVersionResponse, ListSessions, ListSessionsEntry,
+    ListSessionsResponse, OneshotSshRpc,
+};
 use russh::{
     Channel as RuChannel, ChannelId,
     server::{Msg, Session},
 };
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use sessions::SessionId;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::task::spawn;
 
@@ -12,26 +15,14 @@ use crate::{
     server::ServerStateHandle,
 };
 
-pub const RPC_SUBSYSTEM_PREFIX: &str = "minimald-v1-";
-
-/// Describes a minimal-specific RPC method sent over ssh.
+/// Server-side serving glue for [`OneshotSshRpc`]s.
 ///
-/// Oneshot RPCs are not streaming.
-pub(crate) trait OneshotSshRpc {
-    /// The subsystem name used to call for this RPC.
-    const NAME: &'static str;
-    /// The type schema of the request.
-    ///
-    /// Bound on `Serialize` exists so that clients (including the test
-    /// harness) can encode requests through the same type the handler
-    /// decodes them with.
-    type Request<'a>: Deserialize<'a> + Serialize;
-    /// The type schema of the response.
-    ///
-    /// Bound on `DeserializeOwned` exists for symmetry with `Request`:
-    /// clients decode the same type the handler emitted.
-    type Response: Serialize + DeserializeOwned;
-
+/// The wire contract (names, request/response schemas) lives in the
+/// `minimald-rpc` crate so clients can share it; this extension trait keeps
+/// the transport-bound half — reading the request and writing the response
+/// over an SSH channel — local to the server, where `russh` and
+/// [`ConnectionError`] are available.
+trait ServeOneshot: OneshotSshRpc {
     /// Helper to deserialize the request and serialize the response
     /// down the given SSH channel, calling the provided async handler
     /// function to compute the response.
@@ -61,218 +52,83 @@ pub(crate) trait OneshotSshRpc {
     }
 }
 
-/// A convinence wrapper to let a response type be able to carry an error.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum Errorable<S: std::fmt::Debug + PartialEq> {
-    Ok(S),
-    Err { error: String },
-}
+impl<T: OneshotSshRpc> ServeOneshot for T {}
 
-impl<S: std::fmt::Debug + PartialEq> Errorable<S> {
-    pub fn unwrap(self) -> S {
-        match self {
-            Self::Ok(s) => s,
-            Errorable::Err { error } => panic!("unwrap of error value: {error}"),
-        }
-    }
-
-    pub fn ok(self) -> Option<S> {
-        match self {
-            Self::Ok(s) => Some(s),
-            Errorable::Err { .. } => None,
-        }
-    }
-    pub fn err(self) -> Option<String> {
-        match self {
-            Self::Ok(_) => None,
-            Errorable::Err { error } => Some(error),
-        }
-    }
-}
-
-impl<T: std::fmt::Debug + PartialEq, E: ToString> From<Result<T, E>> for Errorable<T> {
-    fn from(value: Result<T, E>) -> Self {
-        match value {
-            Err(e) => Self::Err {
-                error: e.to_string(),
-            },
-            Ok(t) => Self::Ok(t),
-        }
-    }
-}
-
-/// An RPC to get the version of minimald.
-pub struct GetVersion;
-
-/// The response to the [`GetVersion`] RPC.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetVersionResponse {
-    pub version: String,
-    pub long_version: String,
-    pub stdlib_version: String,
-}
-
-impl OneshotSshRpc for GetVersion {
-    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "GetVersion");
-    type Request<'a> = ();
-    type Response = GetVersionResponse;
-}
-
-impl GetVersion {
-    pub async fn handle(self, c: RuChannel<Msg>) {
-        let res = self
-            .handle_channel(c, async |_req| {
-                Ok(GetVersionResponse {
-                    version: env!("CARGO_PKG_VERSION").to_string(),
-                    long_version: env!("LONG_VERSION").to_string(),
-                    stdlib_version: stdlib::VERSION.to_string(),
-                })
+async fn serve_get_version(c: RuChannel<Msg>) {
+    let res = GetVersion
+        .handle_channel(c, async |_req| {
+            Ok(GetVersionResponse {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                long_version: env!("LONG_VERSION").to_string(),
+                stdlib_version: stdlib::VERSION.to_string(),
             })
-            .await;
-        if let Err(e) = res {
-            tracing::warn!("RPC handler for {} failed: {}", Self::NAME, e);
-        }
+        })
+        .await;
+    if let Err(e) = res {
+        tracing::warn!("RPC handler for {} failed: {}", GetVersion::NAME, e);
     }
 }
 
-/// An RPC to list sessions managed by this minimald.
-pub struct ListSessions;
-
-/// An entry in the ListSessions response.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ListSessionsEntry {
-    pub id: SessionId,
-    pub name: Option<String>,
-}
-
-/// The response to the [`ListSessions`] RPC.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ListSessionsResponse {
-    pub sessions: Vec<ListSessionsEntry>,
-}
-
-impl OneshotSshRpc for ListSessions {
-    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "ListSessions");
-    type Request<'a> = ();
-    type Response = ListSessionsResponse;
-}
-
-impl ListSessions {
-    pub async fn handle(self, s: ServerStateHandle, c: RuChannel<Msg>) {
-        let res = self
-            .handle_channel(c, async |_req| {
-                let mngr = s.sessions_manager().await;
-                Ok(ListSessionsResponse {
-                    sessions: mngr
-                        .list()
-                        .await
-                        .map_err(|e| ConnectionError::Internal(e.to_string()))?
-                        .into_iter()
-                        .map(|i| ListSessionsEntry {
-                            id: i.id,
-                            name: i.name,
-                        })
-                        .collect(),
-                })
+async fn serve_list_sessions(s: ServerStateHandle, c: RuChannel<Msg>) {
+    let res = ListSessions
+        .handle_channel(c, async |_req| {
+            let mngr = s.sessions_manager().await;
+            Ok(ListSessionsResponse {
+                sessions: mngr
+                    .list()
+                    .await
+                    .map_err(|e| ConnectionError::Internal(e.to_string()))?
+                    .into_iter()
+                    .map(|i| ListSessionsEntry {
+                        id: i.id,
+                        name: i.name,
+                    })
+                    .collect(),
             })
-            .await;
-        if let Err(e) = res {
-            tracing::warn!("RPC handler for {} failed: {}", Self::NAME, e);
-        }
+        })
+        .await;
+    if let Err(e) = res {
+        tracing::warn!("RPC handler for {} failed: {}", ListSessions::NAME, e);
     }
 }
 
-/// An RPC to read the session record for a session corresponding to the request.
-pub struct GetSessionRecord;
-
-/// The request for a [`GetSessionRecord`] RPC.
-///
-/// Serialized examples:
-///
-///  * `{"name": "my-session"}`
-///  * `{"id": "<some-uuid>"}`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum GetSessionRecordRequest {
-    Name(String),
-    Id(SessionId),
-}
-
-/// The response for a [`GetSessionRecord`] RPC.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetSessionRecordResponse {
-    pub record: Option<sessions::Record>,
-}
-
-impl OneshotSshRpc for GetSessionRecord {
-    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "GetSessionRecord");
-    type Request<'a> = GetSessionRecordRequest;
-    type Response = GetSessionRecordResponse;
-}
-
-impl GetSessionRecord {
-    pub async fn handle(self, s: ServerStateHandle, c: RuChannel<Msg>) {
-        use crate::sessions::SessionKeyPredicate;
-        let res = self
-            .handle_channel(c, async |req| {
-                let mngr = s.sessions_manager().await;
-                Ok(GetSessionRecordResponse {
-                    record: mngr
-                        .get_record(match req {
-                            GetSessionRecordRequest::Id(id) => SessionKeyPredicate::Id(id),
-                            GetSessionRecordRequest::Name(name) => SessionKeyPredicate::Name(name),
-                        })
-                        .await
-                        .map_err(|e| ConnectionError::Internal(e.to_string()))?,
-                })
+async fn serve_get_session_record(s: ServerStateHandle, c: RuChannel<Msg>) {
+    use crate::sessions::SessionKeyPredicate;
+    let res = GetSessionRecord
+        .handle_channel(c, async |req| {
+            let mngr = s.sessions_manager().await;
+            Ok(GetSessionRecordResponse {
+                record: mngr
+                    .get_record(match req {
+                        GetSessionRecordRequest::Id(id) => SessionKeyPredicate::Id(id),
+                        GetSessionRecordRequest::Name(name) => SessionKeyPredicate::Name(name),
+                    })
+                    .await
+                    .map_err(|e| ConnectionError::Internal(e.to_string()))?,
             })
-            .await;
-        if let Err(e) = res {
-            tracing::warn!("RPC handler for {} failed: {}", Self::NAME, e);
-        }
+        })
+        .await;
+    if let Err(e) = res {
+        tracing::warn!("RPC handler for {} failed: {}", GetSessionRecord::NAME, e);
     }
 }
 
-/// An RPC to create a new session based on the given record.
-pub struct CreateSession;
+async fn serve_create_session(s: ServerStateHandle, c: RuChannel<Msg>) {
+    let res = CreateSession
+        .handle_channel(c, async |req| {
+            let mngr = s.sessions_manager().await;
 
-/// The request for a [`CreateSession`] RPC.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateSessionRequest {
-    pub record: sessions::Record,
-}
-
-/// The response for a [`CreateSession`] RPC.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CreateSessionResponse {
-    pub id: SessionId,
-}
-
-impl OneshotSshRpc for CreateSession {
-    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "CreateSession");
-    type Request<'a> = CreateSessionRequest;
-    type Response = Errorable<CreateSessionResponse>;
-}
-
-impl CreateSession {
-    pub async fn handle(self, s: ServerStateHandle, c: RuChannel<Msg>) {
-        let res = self
-            .handle_channel(c, async |req| {
-                let mngr = s.sessions_manager().await;
-
-                Ok(match mngr.create_session(req.record).await {
-                    Ok(id) => Errorable::Ok(CreateSessionResponse { id }),
-                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Errorable::Err {
-                        error: "A session with that name already exists".to_string(),
-                    },
-                    Err(e) => return Err(ConnectionError::Internal(e.to_string())),
-                })
+            Ok(match mngr.create_session(req.record).await {
+                Ok(id) => Errorable::Ok(CreateSessionResponse { id }),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Errorable::Err {
+                    error: "A session with that name already exists".to_string(),
+                },
+                Err(e) => return Err(ConnectionError::Internal(e.to_string())),
             })
-            .await;
-        if let Err(e) = res {
-            tracing::warn!("RPC handler for {} failed: {}", Self::NAME, e);
-        }
+        })
+        .await;
+    if let Err(e) = res {
+        tracing::warn!("RPC handler for {} failed: {}", CreateSession::NAME, e);
     }
 }
 
@@ -319,10 +175,10 @@ pub async fn handle_ssh_rpc(
 
     // Handle the named RPC.
     match name {
-        GetVersion::NAME => spawn(GetVersion.handle(channel)),
-        ListSessions::NAME => spawn(ListSessions.handle(s, channel)),
-        GetSessionRecord::NAME => spawn(GetSessionRecord.handle(s, channel)),
-        CreateSession::NAME => spawn(CreateSession.handle(s, channel)),
+        GetVersion::NAME => spawn(serve_get_version(channel)),
+        ListSessions::NAME => spawn(serve_list_sessions(s, channel)),
+        GetSessionRecord::NAME => spawn(serve_get_session_record(s, channel)),
+        CreateSession::NAME => spawn(serve_create_session(s, channel)),
         _ => unreachable!(),
     };
 
@@ -331,7 +187,9 @@ pub async fn handle_ssh_rpc(
 
 #[cfg(test)]
 mod tests {
+    use minimald_rpc::CreateSessionRequest;
     use paths::HostAbsPath;
+    use sessions::SessionId;
 
     use super::*;
     use crate::test_harness::TestServer;

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -222,7 +222,8 @@ mod tests {
     use russh::ChannelMsg;
     use sessions::SessionId;
 
-    use crate::rpc::{CreateSession, CreateSessionRequest};
+    use minimald_rpc::{CreateSession, CreateSessionRequest};
+
     use crate::test_harness::{TestClient, TestServer};
 
     /// Creates a fresh session on the server and returns its id.

--- a/crates/minimald/src/sftp.rs
+++ b/crates/minimald/src/sftp.rs
@@ -467,7 +467,8 @@ mod tests {
     use sessions::SessionId;
     use tokio::io::AsyncWriteExt;
 
-    use crate::rpc::{CreateSession, CreateSessionRequest};
+    use minimald_rpc::{CreateSession, CreateSessionRequest};
+
     use crate::test_harness::TestServer;
 
     /// Creates a fresh session through the public CreateSession RPC and

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -28,8 +28,9 @@ use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 
+use minimald_rpc::OneshotSshRpc;
+
 use crate::connection::Connection;
-use crate::rpc::OneshotSshRpc;
 use crate::server::{Config, HostKey, ServerStateHandle};
 
 /// A minimald instance running against a tempdir, ready to accept

--- a/crates/minvmd/Cargo.toml
+++ b/crates/minvmd/Cargo.toml
@@ -25,3 +25,7 @@ russh.workspace = true
 tokio.workspace = true
 sessions.workspace = true
 paths.workspace = true
+# Shares minimald's RPC wire types so the test encodes/decodes through the
+# same definitions the server uses (minimald itself is Linux-only and cannot
+# be imported into this macOS test, but the wire-types crate is portable).
+minimald-rpc.workspace = true

--- a/crates/minvmd/tests/minimald_session_e2e.rs
+++ b/crates/minvmd/tests/minimald_session_e2e.rs
@@ -31,10 +31,6 @@ use tempfile::TempDir;
 
 const BOOT_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// SSH subsystem name for the CreateSession RPC (mirrors
-/// `minimald::rpc::RPC_SUBSYSTEM_PREFIX` + "CreateSession"; minimald is
-/// Linux-only so it cannot be imported into this macOS test).
-const CREATE_SESSION_SUBSYSTEM: &str = "minimald-v1-CreateSession";
 /// Env var the server reads to scope an exec to a session
 /// (mirrors `minimald::MINIMAL_SESSION_ID_ENV`).
 const MINIMAL_SESSION_ID_ENV: &str = "MINIMAL_SESSION_ID";
@@ -129,18 +125,6 @@ impl Guest {
 
 // --- Full session: russh client → CreateSession → exec → stdout ---
 
-/// CreateSession request payload (mirrors `minimald::rpc::CreateSessionRequest`).
-#[derive(serde::Serialize)]
-struct CreateSessionRequest {
-    record: sessions::Record,
-}
-
-/// CreateSession response payload (mirrors `minimald::rpc::CreateSessionResponse`).
-#[derive(serde::Deserialize)]
-struct CreateSessionResponse {
-    id: sessions::SessionId,
-}
-
 /// russh client handler: accept the guest's ephemeral host key.
 struct ClientHandler;
 
@@ -192,6 +176,7 @@ async fn run_session_exec(
     sock_path: &Path,
     command: &str,
 ) -> Result<(String, Option<u32>), String> {
+    use minimald_rpc::{CreateSession, CreateSessionRequest, OneshotSshRpc};
     use russh::ChannelMsg;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -235,7 +220,7 @@ async fn run_session_exec(
             .await
             .map_err(|e| format!("open CreateSession channel: {e}"))?;
         channel
-            .request_subsystem(false, CREATE_SESSION_SUBSYSTEM)
+            .request_subsystem(false, CreateSession::NAME)
             .await
             .map_err(|e| format!("request_subsystem: {e}"))?;
 
@@ -262,9 +247,11 @@ async fn run_session_exec(
         rpc.read_to_end(&mut resp_buf)
             .await
             .map_err(|e| format!("read response: {e}"))?;
-        let resp: CreateSessionResponse =
+        let resp: <CreateSession as OneshotSshRpc>::Response =
             serde_json::from_slice(&resp_buf).map_err(|e| format!("decode response: {e}"))?;
-        resp.id
+        resp.ok()
+            .ok_or_else(|| "CreateSession returned an error".to_string())?
+            .id
     };
 
     // Exec the command in that session.


### PR DESCRIPTION
Should help with driving minimald from other crates.

Also removed the duplication in minvmd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Extracted RPC protocol definitions and message types into a dedicated shared crate, improving code organization and maintainability.
  * Refactored oneshot RPC server-side request handling logic for better separation of concerns and reusability across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->