### PR TITLE
feat(minimald): implement populating session files using a tarball

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-tar"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6affe71e5b6180fb5eaf9e8127a243694baf6ae1120c199227167302f56c14b"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.7.5",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +873,23 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
@@ -3428,6 +3471,8 @@ name = "minimald"
 version = "0.0.1"
 dependencies = [
  "args",
+ "async-compression",
+ "async-tar",
  "bytes",
  "camino",
  "chrono",
@@ -4025,7 +4070,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -4511,7 +4556,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -4802,6 +4847,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -6001,7 +6055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ codegen-units = 16
 
 [workspace.dependencies]
 anyhow = "1.0"
+async-compression = { version = "0.4", features = ["tokio", "zstd"] }
+async-tar = { version = "0.6", default-features = false, features = ["runtime-tokio"] }
 blake3 = { version = "1", features = ["serde"] }
 bytes = "1.11" # keep in sync with reqwest
 bzip2 = "0.6"

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+async-compression.workspace = true
+async-tar.workspace = true
 bytes.workspace = true
 camino.workspace = true
 clap.workspace = true

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -1,18 +1,21 @@
 use minimald_rpc::{
     CreateSession, CreateSessionResponse, Errorable, GetSessionRecord, GetSessionRecordRequest,
     GetSessionRecordResponse, GetVersion, GetVersionResponse, ListSessions, ListSessionsEntry,
-    ListSessionsResponse, OneshotSshRpc,
+    ListSessionsResponse, OneshotSshRpc, RPC_SUBSYSTEM_PREFIX,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
     server::{Msg, Session},
 };
+use sessions::SessionId;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::task::spawn;
 
 use crate::{
+    ChannelConfig,
     connection::{ConnectionError, ConnectionHandle},
     server::ServerStateHandle,
+    sessions::SessionKeyPredicate,
 };
 
 /// Server-side serving glue for [`OneshotSshRpc`]s.
@@ -148,6 +151,56 @@ async fn serve_create_session(s: ServerStateHandle, c: RuChannel<Msg>) {
     }
 }
 
+pub(crate) const STREAM_WORKSPACE_FILES: &str =
+    constcat::concat!(RPC_SUBSYSTEM_PREFIX, "WorkspaceFilesTarZst");
+
+async fn serve_stream_workspace_files(
+    s: ServerStateHandle,
+    config: ChannelConfig,
+    mut c: RuChannel<Msg>,
+) {
+    if let Err(msg) = unpack_workspace_files(&s, &config, &mut c).await {
+        let _ = c.extended_data_bytes(1, msg).await;
+    }
+    let _ = c.close().await;
+}
+
+/// Unpacks the zstd-compressed tarball streamed over `c` into the
+/// workspace directory of the session named by the channel environment.
+///
+/// On failure, returns the human-readable message to relay back to the
+/// client over the channel's extended-data stream.
+async fn unpack_workspace_files(
+    s: &ServerStateHandle,
+    config: &ChannelConfig,
+    c: &mut RuChannel<Msg>,
+) -> Result<(), String> {
+    let session_id_str = config
+        .env_vars
+        .get(crate::MINIMAL_SESSION_ID_ENV)
+        .ok_or("missing env-var MINIMAL_SESSION_ID")?;
+    let session_id =
+        SessionId::parse_str(session_id_str).map_err(|e| format!("parsing session UUID: {e}"))?;
+
+    let mngr = s.sessions_manager().await;
+    let session_handle = mngr
+        .get_session(SessionKeyPredicate::Id(session_id))
+        .await
+        .map_err(|e| format!("session UUID lookup failed: {e}"))?
+        .ok_or("unknown session UUID")?;
+    let workspace_path = session_handle.workspace_path().await;
+
+    let reader = async_compression::tokio::bufread::ZstdDecoder::new(tokio::io::BufReader::new(
+        c.make_reader(),
+    ));
+    async_tar::Archive::new(reader)
+        .unpack(workspace_path.as_utf8_path())
+        .await
+        .map_err(|e| format!("unpack failed: {e}"))?;
+
+    Ok(())
+}
+
 /// Handles an RPC going over an SSH subsystem channel.
 ///
 /// This method takes ownership of the ssh channel, including
@@ -165,15 +218,19 @@ pub async fn handle_ssh_rpc(
     session: &mut Session,
 ) -> Result<(), ConnectionError> {
     // Take the channel from connection state if its a known RPC.
-    let channel = match name {
-        GetVersion::NAME | ListSessions::NAME | GetSessionRecord::NAME | CreateSession::NAME => {
+    let res = match name {
+        GetVersion::NAME
+        | ListSessions::NAME
+        | GetSessionRecord::NAME
+        | CreateSession::NAME
+        | STREAM_WORKSPACE_FILES => {
             let mut conn_lock = c.lock().await;
             let c_hnd = match conn_lock.take(id) {
                 None => {
                     session.channel_failure(id)?;
                     return Ok(());
                 }
-                Some((channel, _p)) => channel,
+                Some((channel, config)) => (channel, config),
             };
             drop(conn_lock);
             session.channel_success(id)?;
@@ -184,8 +241,8 @@ pub async fn handle_ssh_rpc(
             None
         }
     };
-    let channel = match channel {
-        Some(c) => c,
+    let (channel, config) = match res {
+        Some((channel, config)) => (channel, config),
         None => return Ok(()),
     };
 
@@ -195,6 +252,7 @@ pub async fn handle_ssh_rpc(
         ListSessions::NAME => spawn(serve_list_sessions(s, channel)),
         GetSessionRecord::NAME => spawn(serve_get_session_record(s, channel)),
         CreateSession::NAME => spawn(serve_create_session(s, channel)),
+        STREAM_WORKSPACE_FILES => spawn(serve_stream_workspace_files(s, config, channel)),
         _ => unreachable!(),
     };
 
@@ -203,12 +261,131 @@ pub async fn handle_ssh_rpc(
 
 #[cfg(test)]
 mod tests {
-    use minimald_rpc::CreateSessionRequest;
+    use minimald_rpc::{CreateSession, CreateSessionRequest};
     use paths::HostAbsPath;
     use sessions::SessionId;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
-    use crate::test_harness::TestServer;
+    use crate::MINIMAL_SESSION_ID_ENV;
+    use crate::sessions::SessionKeyPredicate;
+    use crate::test_harness::{TestClient, TestServer};
+
+    /// Serializes `(path, contents)` entries into a tar archive and
+    /// zstd-compresses it, producing exactly the wire format that
+    /// [`serve_stream_workspace_files`] decodes.
+    async fn tar_zst(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut tar = async_tar::Builder::new(Vec::new());
+        for (path, contents) in entries {
+            let mut header = async_tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            tar.append_data(&mut header, path, *contents).await.unwrap();
+        }
+        let tar_bytes = tar.into_inner().await.unwrap();
+
+        let mut encoder = async_compression::tokio::write::ZstdEncoder::new(Vec::new());
+        encoder.write_all(&tar_bytes).await.unwrap();
+        encoder.shutdown().await.unwrap();
+        encoder.into_inner()
+    }
+
+    /// Creates a session through the public RPC and returns its id.
+    async fn fresh_session(client: &mut TestClient) -> SessionId {
+        client
+            .call::<CreateSession>(&CreateSessionRequest {
+                record: sessions::Record {
+                    id: SessionId::nil(),
+                    name: Some("stream-test".to_string()),
+                    username: None,
+                    project_path: HostAbsPath::try_new("/tmp").unwrap(),
+                    attrs: Default::default(),
+                },
+            })
+            .await
+            .unwrap()
+            .id
+    }
+
+    #[tokio::test]
+    async fn stream_workspace_files_unpacks_tarball_into_workspace() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let payload = tar_zst(&[
+            ("hello.txt", b"hello world\n"),
+            ("dir/nested.txt", b"nested contents"),
+        ])
+        .await;
+
+        let channel = client
+            .open_subsystem(
+                STREAM_WORKSPACE_FILES,
+                &[(MINIMAL_SESSION_ID_ENV, &session_id.to_string())],
+            )
+            .await;
+        let mut stream = channel.into_stream();
+        stream.write_all(&payload).await.unwrap();
+        // Half-close so the server's decoder sees EOF; then read to the
+        // server's channel close so the unpack has completed on-disk
+        // before we assert.
+        stream.shutdown().await.unwrap();
+        let mut trailing = Vec::new();
+        stream.read_to_end(&mut trailing).await.unwrap();
+
+        let mngr = server.state.sessions_manager().await;
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("freshly-created session should be retrievable");
+        let workspace = handle.workspace_path().await;
+
+        assert_eq!(
+            tokio::fs::read(workspace.as_utf8_path().join("hello.txt"))
+                .await
+                .unwrap(),
+            b"hello world\n",
+        );
+        assert_eq!(
+            tokio::fs::read(workspace.as_utf8_path().join("dir/nested.txt"))
+                .await
+                .unwrap(),
+            b"nested contents",
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_workspace_files_rejects_unknown_session() {
+        use russh::ChannelMsg;
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        // A well-formed but unknown session id: the handler should report
+        // an error on stderr (ssh extended data) rather than unpacking.
+        let mut channel = client
+            .open_subsystem(
+                STREAM_WORKSPACE_FILES,
+                &[(MINIMAL_SESSION_ID_ENV, &SessionId::nil().to_string())],
+            )
+            .await;
+        channel.eof().await.unwrap();
+
+        let mut stderr = Vec::new();
+        while let Some(msg) = channel.wait().await {
+            if let ChannelMsg::ExtendedData { data, ext: 1 } = msg {
+                stderr.extend_from_slice(&data);
+            }
+        }
+
+        assert!(
+            String::from_utf8_lossy(&stderr).contains("unknown session"),
+            "expected an unknown-session error on stderr, got {:?}",
+            String::from_utf8_lossy(&stderr),
+        );
+    }
 
     #[tokio::test]
     async fn get_version_returns_compiled_in_versions() {

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -179,6 +179,22 @@ impl TestClient {
             .unwrap()
     }
 
+    /// Opens a session channel, applies `env`, and requests the named
+    /// subsystem, returning the live channel so the caller can stream
+    /// arbitrary bytes through it (e.g. a zstd-compressed tarball).
+    pub(crate) async fn open_subsystem(
+        &mut self,
+        subsystem: &str,
+        env: &[(&str, &str)],
+    ) -> russh::Channel<russh::client::Msg> {
+        let channel = self.handle.channel_open_session().await.unwrap();
+        for (name, value) in env {
+            channel.set_env(true, *name, *value).await.unwrap();
+        }
+        channel.request_subsystem(true, subsystem).await.unwrap();
+        channel
+    }
+
     /// Opens an interactive shell channel attached to the given minimald
     /// session, mirroring what a real client does: sets `MINIMAL_SESSION_ID`,
     /// negotiates a PTY, then issues a `shell` request. Returns the live


### PR DESCRIPTION
Lets you populate workspace files by streaming a tarball. You can drive it manually like this:

```shell

$> tar -v -cf - -C 'my/workspace' ./ | zstd -c -T0 | \
    MINIMAL_SESSION_ID=aaaa019eb7a0-36d9-7d41-8286-265d76e9b3ab ssh -s -o SendEnv=MINIMAL_SESSION_ID \
    -o ProxyCommand="socat - UNIX-CONNECT:$XDG_STATE_DIR/minimal/providers/local-0/ssh.sock" \
    -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' local-0 \
    minimald-v1-WorkspaceFilesTarZst
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new SSH subsystem that streams a compressed tar archive and unpacks it into a target session’s workspace directory.

* **Chores**
  * Updated workspace dependencies to enable async streaming and compressed archive handling.

* **Tests**
  * Added coverage for successful streamed unpacking and for handling an unknown session identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->