### PR TITLE
[#159] Implement the minimal client interface (ls, activate, attach, destroy)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3322,10 +3322,20 @@ dependencies = [
 name = "minimal2"
 version = "0.0.1"
 dependencies = [
+ "camino",
+ "chrono",
  "clap",
  "clap_complete",
+ "dirs",
+ "libc",
+ "minimald-rpc",
  "minvmd",
  "ot",
+ "paths",
+ "russh",
+ "serde",
+ "serde_json",
+ "sessions",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/minimal2/Cargo.toml
+++ b/crates/minimal2/Cargo.toml
@@ -7,9 +7,19 @@ publish.workspace = true
 [dependencies]
 clap.workspace = true
 clap_complete.workspace = true
+camino.workspace = true
+chrono.workspace = true
+dirs.workspace = true
+libc.workspace = true
+minimald-rpc.workspace = true
+paths.workspace = true
+russh.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sessions.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
-ot.workspace = true
 minvmd = { path = "../minvmd" }
+ot.workspace = true

--- a/crates/minimal2/src/client.rs
+++ b/crates/minimal2/src/client.rs
@@ -1,0 +1,166 @@
+//! SSH client transport for talking to minimald over the UDS bridge.
+//!
+//! Provides a `russh`-based client that connects to `minimald` over the UNIX
+//! domain socket, authenticates (passwordless), and invokes oneshot RPCs
+//! defined in the `minimald-rpc` wire contract.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use minimald_rpc::OneshotSshRpc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Max retries when connecting to the daemon UDS.
+const CONNECT_RETRIES: u32 = 20;
+/// Delay between connection retries.
+const CONNECT_RETRY_DELAY: Duration = Duration::from_millis(100);
+
+/// russh client handler that accepts any ephemeral host key.
+///
+/// The daemon generates a fresh host key on every boot. Since we connect over
+/// a local UDS (not the network), TOFU trust is acceptable here.
+struct MinimalClientHandler;
+
+impl russh::client::Handler for MinimalClientHandler {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        _key: &russh::keys::ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+/// An authenticated SSH session to minimald.
+pub struct Client {
+    handle: russh::client::Handle<MinimalClientHandler>,
+}
+
+impl Client {
+    /// Connect to minimald over the UDS at `sock_path`, authenticate, and
+    /// return a ready [`Client`].
+    ///
+    /// Retries the UDS connect for up to ~2 seconds to absorb the post-boot
+    /// race on macOS where the libkrun bridge UDS appears slightly after the
+    /// `vm-up` line.
+    pub async fn connect(sock_path: &Path) -> Result<Self, String> {
+        let stream = {
+            let mut conn = None;
+            let mut last_err = None;
+            for _ in 0..CONNECT_RETRIES {
+                match tokio::net::UnixStream::connect(sock_path).await {
+                    Ok(s) => {
+                        conn = Some(s);
+                        break;
+                    }
+                    Err(e) => {
+                        last_err = Some(e);
+                        tokio::time::sleep(CONNECT_RETRY_DELAY).await;
+                    }
+                }
+            }
+            conn.ok_or_else(|| {
+                format!(
+                    "connect to daemon at {}: {}",
+                    sock_path.display(),
+                    last_err.unwrap()
+                )
+            })?
+        };
+
+        let config = Arc::new(russh::client::Config::default());
+        let mut handle = russh::client::connect_stream(config, stream, MinimalClientHandler)
+            .await
+            .map_err(|e| format!("ssh connect: {e}"))?;
+
+        let auth = handle
+            .authenticate_none("minimal-cli")
+            .await
+            .map_err(|e| format!("authenticate: {e}"))?;
+
+        if !auth.success() {
+            return Err("authentication rejected by daemon".into());
+        }
+
+        Ok(Client { handle })
+    }
+
+    /// Issue a oneshot RPC: open a channel, request the subsystem, write the
+    /// serialized request, half-close, and decode the response.
+    ///
+    /// The type parameter `R` picks the RPC from the wire contract; `request`
+    /// is serialized to JSON and the response is deserialized from JSON.
+    pub async fn oneshot_rpc<R: OneshotSshRpc>(
+        &mut self,
+        request: R::Request<'_>,
+    ) -> Result<R::Response, String>
+    where
+        <R as OneshotSshRpc>::Response: serde::de::DeserializeOwned,
+    {
+        let channel = self
+            .handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("open channel for {}: {e}", R::NAME))?;
+
+        channel
+            .request_subsystem(false, R::NAME)
+            .await
+            .map_err(|e| format!("request subsystem {}: {e}", R::NAME))?;
+
+        let body = serde_json::to_vec(&request).map_err(|e| format!("serialize request: {e}"))?;
+
+        let mut rpc = channel.into_stream();
+        rpc.write_all(&body)
+            .await
+            .map_err(|e| format!("write request: {e}"))?;
+        rpc.shutdown()
+            .await
+            .map_err(|e| format!("shutdown write half: {e}"))?;
+
+        let mut resp_buf = Vec::with_capacity(256);
+        rpc.read_to_end(&mut resp_buf)
+            .await
+            .map_err(|e| format!("read response: {e}"))?;
+
+        serde_json::from_slice(&resp_buf)
+            .map_err(|e| format!("decode response for {}: {e}", R::NAME))
+    }
+}
+
+/// Resolve the daemon socket path.
+///
+/// On Linux: `$XDG_STATE_HOME/minimal/providers/local-0/ssh.sock` (matching
+/// `minimald`'s `listen_on()`).
+///
+/// On macOS: delegates to `minvmd::sock::resolve_uds_path()` (the bridge
+/// socket created by the minvmd host daemon).
+///
+/// If `--minimal-dir` is set, use `<minimal_dir>/providers/local-0/ssh.sock`
+/// on Linux, or `<minimal_dir>/minimald.sock` on macOS.
+pub fn resolve_socket_path(
+    minimal_dir_override: Option<&std::path::Path>,
+) -> std::io::Result<std::path::PathBuf> {
+    if let Some(dir) = minimal_dir_override {
+        #[cfg(target_os = "linux")]
+        return Ok(dir.join("providers/local-0/ssh.sock"));
+        #[cfg(target_os = "macos")]
+        return Ok(dir.join("minimald.sock"));
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let state = dirs::state_dir()
+            .or_else(|| dirs::home_dir().map(|h| h.join(".local/state")))
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "cannot determine state directory; set --minimal-dir",
+                )
+            })?;
+        Ok(state.join("minimal/providers/local-0/ssh.sock"))
+    }
+    #[cfg(target_os = "macos")]
+    minvmd::sock::resolve_uds_path()
+}

--- a/crates/minimal2/src/main.rs
+++ b/crates/minimal2/src/main.rs
@@ -2,10 +2,13 @@
 
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
+use std::os::unix::process::CommandExt as _;
 use std::path::PathBuf;
+use tokio::io::AsyncWriteExt as _;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 mod autospawn;
+mod client;
 
 #[derive(Parser)]
 #[command(name = "minimal", version = env!("CARGO_PKG_VERSION"), long_version = env!("LONG_VERSION"))]
@@ -21,19 +24,21 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// List sessions
-    Ls,
+    Ls(LsArgs),
+    /// Activate (create) a new session
+    Activate(ActivateArgs),
+    /// Attach to an existing session
+    Attach(AttachArgs),
+    /// Destroy (terminate) a session
+    Destroy(DestroyArgs),
+    /// Proxy stdio to a daemon UDS socket (used as an SSH ProxyCommand).
+    #[command(hide = true)]
+    Proxy(ProxyArgs),
     /// Generate shell completion script
     #[command(
         long_about = "Generate a shell tab-completion script for the minimal CLI.\nSupported shells include bash, zsh, elvish and fish.\n\n   source <(minimal completions bash)"
     )]
     Completions(CompletionsArgs),
-}
-
-#[derive(Debug, clap::Args)]
-struct CompletionsArgs {
-    /// The shell type for a CLI completion script should be printed
-    #[arg(value_parser)]
-    shell: Shell,
 }
 
 /// Shared arguments all subcommands
@@ -42,6 +47,55 @@ pub struct GlobalArgs {
     /// Override the base directory used for operations (default: ~/.cache/minimal)
     #[arg(long)]
     minimal_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct ActivateArgs {
+    /// Optional session name
+    #[arg(long, short)]
+    name: Option<String>,
+    /// Project path to activate (defaults to current directory)
+    #[arg(default_value = ".")]
+    path: String,
+    /// Automatically attach after creation
+    #[arg(long)]
+    attach: bool,
+}
+
+#[derive(Debug, Args)]
+struct AttachArgs {
+    /// Session identifier (UUID or session name)
+    session: String,
+    /// Command to exec in the session context (non-interactive)
+    #[arg(long, short)]
+    command: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct LsArgs {
+    /// Output raw session IDs (one per line) for piping into scripts
+    #[arg(long)]
+    raw: bool,
+}
+
+#[derive(Debug, Args)]
+struct DestroyArgs {
+    /// Session identifier (UUID or session name)
+    session: String,
+}
+
+#[derive(Debug, Args)]
+struct ProxyArgs {
+    /// UDS socket path to connect to
+    #[arg(long)]
+    socket: String,
+}
+
+#[derive(Debug, clap::Args)]
+struct CompletionsArgs {
+    /// The shell type for a CLI completion script should be printed
+    #[arg(value_parser)]
+    shell: Shell,
 }
 
 #[tokio::main]
@@ -60,21 +114,11 @@ async fn main() -> Result<(), ()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Ls => {
-            // Ensure minvmd is running before listing (R4.5). On macOS and Linux
-            // this auto-spawns minvmd (`minvmd run --detach`); on other targets
-            // `ensure_minvmd_running` is a no-op.
-            //
-            // TODO(#311): real session listing over the minimald UDS is still
-            // pending, so `ls` falls through to the placeholder `[]` below even
-            // once minvmd is up.
-            if let Err(e) = autospawn::ensure_minvmd_running() {
-                eprintln!("Failed to ensure minvmd is running: {}", e);
-                return Err(());
-            }
-            println!("[]");
-            Ok(())
-        }
+        Command::Ls(args) => cmd_ls(&cli.global_args, args).await,
+        Command::Activate(args) => cmd_activate(&cli.global_args, args).await,
+        Command::Attach(args) => cmd_attach(&cli.global_args, args).await,
+        Command::Destroy(args) => cmd_destroy(&cli.global_args, args).await,
+        Command::Proxy(args) => cmd_proxy(args).await,
         Command::Completions(CompletionsArgs { shell }) => {
             let mut cmd = Cli::command();
             let name = cmd.get_name().to_string();
@@ -82,4 +126,295 @@ async fn main() -> Result<(), ()> {
             Ok(())
         }
     }
+}
+
+/// Connect to the daemon, resolving the socket path from global args.
+async fn connect_daemon(global: &GlobalArgs) -> Result<client::Client, ()> {
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref())
+        .map_err(|e| eprintln!("Failed to resolve daemon socket path: {e}"))?;
+
+    client::Client::connect(&sock)
+        .await
+        .map_err(|e| eprintln!("Failed to connect to minimald: {e}"))
+}
+
+/// Bidirectionally pipe stdio to a daemon UDS socket.
+///
+/// Intended for use as an SSH `ProxyCommand`: ssh writes to our stdin and
+/// reads from our stdout, while we bridge both directions to the UDS.
+async fn cmd_proxy(args: ProxyArgs) -> Result<(), ()> {
+    let stream = tokio::net::UnixStream::connect(&args.socket)
+        .await
+        .map_err(|e| eprintln!("connect to {}: {e}", args.socket))?;
+
+    let (mut rx, mut tx) = stream.into_split();
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = tokio::io::stdout();
+
+    let to_sock = async {
+        tokio::io::copy(&mut stdin, &mut tx).await?;
+        tx.shutdown().await
+    };
+    let from_sock = tokio::io::copy(&mut rx, &mut stdout);
+
+    tokio::try_join!(to_sock, from_sock).map_err(|e| eprintln!("proxy: {e}"))?;
+    Ok(())
+}
+
+/// List sessions via the `ListSessions` RPC.
+async fn cmd_ls(global: &GlobalArgs, args: LsArgs) -> Result<(), ()> {
+    if let Err(e) = autospawn::ensure_minvmd_running() {
+        eprintln!("Failed to ensure minvmd is running: {e}");
+        return Err(());
+    }
+
+    let mut client = connect_daemon(global).await?;
+
+    use minimald_rpc::ListSessions;
+    let resp = client
+        .oneshot_rpc::<ListSessions>(())
+        .await
+        .map_err(|e| eprintln!("ListSessions RPC failed: {e}"))?;
+
+    if resp.sessions.is_empty() {
+        if !args.raw {
+            println!("No active sessions.");
+        }
+        return Ok(());
+    }
+
+    if args.raw {
+        for entry in &resp.sessions {
+            println!("{}", entry.id);
+        }
+        return Ok(());
+    }
+
+    // Format as a table: ID, Name, Title, Last Activity.
+    // Widths chosen to fit a standard 80-col terminal.
+    println!(
+        "{:<36}  {:<20}  {:<20}  LAST ACTIVITY",
+        "SESSION ID", "NAME", "TITLE"
+    );
+    println!("{:-<36}  {:-<20}  {:-<20}  {:-<24}", "", "", "", "");
+
+    for entry in &resp.sessions {
+        let id = entry.id.to_string();
+        let name = entry.name.as_deref().unwrap_or("-");
+        let (title, last_activity) = match &entry.attrs {
+            Some(attrs) => {
+                let title = attrs
+                    .title
+                    .as_ref()
+                    .map(|t| t.value.as_str())
+                    .unwrap_or("-");
+                let last = attrs
+                    .last_stdout
+                    .or(attrs.last_stdin)
+                    .map(|dt| {
+                        let local = dt.with_timezone(&chrono::Local);
+                        local.format("%Y-%m-%d %H:%M:%S").to_string()
+                    })
+                    .unwrap_or_else(|| "-".to_string());
+                (title, last)
+            }
+            None => ("-", "-".to_string()),
+        };
+        println!("{id:<36}  {name:<20}  {title:<20}  {last_activity}");
+    }
+
+    Ok(())
+}
+
+/// Create a new session via the `CreateSession` RPC.
+async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), ()> {
+    if let Err(e) = autospawn::ensure_minvmd_running() {
+        eprintln!("Failed to ensure minvmd is running: {e}");
+        return Err(());
+    }
+
+    let project_path = std::fs::canonicalize(&args.path)
+        .map_err(|e| eprintln!("Cannot resolve project path '{}': {e}", args.path))?;
+
+    let utf8_path = camino::Utf8PathBuf::from_path_buf(project_path)
+        .map_err(|_| eprintln!("Project path is not valid UTF-8"))?;
+    let abs_path = paths::HostAbsPath::try_new(utf8_path)
+        .map_err(|e| eprintln!("Invalid project path: {e}"))?;
+
+    let username = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .ok();
+
+    let record = sessions::Record {
+        id: sessions::SessionId::nil(),
+        name: args.name.clone(),
+        username,
+        project_path: abs_path,
+        attrs: Default::default(),
+    };
+
+    let mut client = connect_daemon(global).await?;
+
+    use minimald_rpc::{CreateSession, CreateSessionRequest};
+    let req = CreateSessionRequest { record };
+    let resp = client
+        .oneshot_rpc::<CreateSession>(req)
+        .await
+        .map_err(|e| eprintln!("CreateSession RPC failed: {e}"))?;
+
+    let created = match resp.ok() {
+        Some(r) => r,
+        None => {
+            eprintln!("CreateSession returned an error from the daemon");
+            return Err(());
+        }
+    };
+
+    println!("{}", created.id);
+
+    if args.attach {
+        // Chain into attach.
+        let attach_args = AttachArgs {
+            session: created.id.to_string(),
+            command: None,
+        };
+        return cmd_attach(global, attach_args).await;
+    }
+
+    Ok(())
+}
+
+/// Shell-quote a string for safe interpolation into `sh -c`.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\"'\"'"))
+}
+
+/// Attach to an existing session. Both interactive and `--command` paths
+/// shell out to `ssh` — the daemon's shell_request handler mints a PTY-backed
+/// session shell, and ssh handles termios/PTY management for us.
+async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), ()> {
+    if let Err(e) = autospawn::ensure_minvmd_running() {
+        eprintln!("Failed to ensure minvmd is running: {e}");
+        return Err(());
+    }
+
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref())
+        .map_err(|e| eprintln!("Failed to resolve daemon socket path: {e}"))?;
+
+    // Resolve the session: if it looks like a UUID, query by ID; otherwise by name.
+    use minimald_rpc::{GetSessionRecord, GetSessionRecordRequest};
+    let mut client = client::Client::connect(&sock)
+        .await
+        .map_err(|e| eprintln!("Failed to connect to minimald: {e}"))?;
+
+    let lookup = if let Ok(id) = sessions::SessionId::parse_str(&args.session) {
+        GetSessionRecordRequest::Id(id)
+    } else {
+        GetSessionRecordRequest::Name(args.session.clone())
+    };
+
+    let resp = client
+        .oneshot_rpc::<GetSessionRecord>(lookup)
+        .await
+        .map_err(|e| eprintln!("GetSessionRecord RPC failed: {e}"))?;
+
+    let record = match resp.record {
+        Some(r) => r,
+        None => {
+            eprintln!("No session found matching '{}'", args.session);
+            return Err(());
+        }
+    };
+
+    tracing::info!(
+        session_id = %record.id,
+        session_name = ?record.name,
+        "found session"
+    );
+
+    // Shell out to ssh for both interactive and --command attachment.
+    // ProxyCommand points at our own `proxy` subcommand so we don't
+    // depend on socat or nc being installed.
+    let exe =
+        std::env::current_exe().map_err(|e| eprintln!("cannot determine current exe: {e}"))?;
+    let proxy_cmd = format!(
+        "{} proxy --socket {}",
+        shell_quote(&exe.display().to_string()),
+        shell_quote(&sock.display().to_string()),
+    );
+
+    let mut ssh = std::process::Command::new("ssh");
+    ssh.env("MINIMAL_SESSION_ID", record.id.to_string()).args([
+        "-o",
+        "SendEnv=MINIMAL_SESSION_ID",
+        "-o",
+        &format!("ProxyCommand={proxy_cmd}"),
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "local-0",
+    ]);
+
+    // If a command was provided, pass it to ssh (non-interactive exec).
+    // Otherwise, ssh opens an interactive shell via shell_request.
+    if let Some(ref cmd) = args.command {
+        ssh.arg(cmd);
+    }
+
+    let err = ssh.exec();
+    // exec() only returns on failure
+    eprintln!("failed to exec ssh: {err}");
+    Err(())
+}
+
+/// Destroy (terminate) a session.
+async fn cmd_destroy(global: &GlobalArgs, args: DestroyArgs) -> Result<(), ()> {
+    if let Err(e) = autospawn::ensure_minvmd_running() {
+        eprintln!("Failed to ensure minvmd is running: {e}");
+        return Err(());
+    }
+
+    let mut client = connect_daemon(global).await?;
+
+    // Resolve the session: if it looks like a UUID, query by ID; otherwise by name.
+    use minimald_rpc::{
+        DestroySession, DestroySessionRequest, GetSessionRecord, GetSessionRecordRequest,
+    };
+    let lookup = if let Ok(id) = sessions::SessionId::parse_str(&args.session) {
+        GetSessionRecordRequest::Id(id)
+    } else {
+        GetSessionRecordRequest::Name(args.session.clone())
+    };
+
+    let resp = client
+        .oneshot_rpc::<GetSessionRecord>(lookup)
+        .await
+        .map_err(|e| eprintln!("GetSessionRecord RPC failed: {e}"))?;
+
+    let record = match resp.record {
+        Some(r) => r,
+        None => {
+            eprintln!("No session found matching '{}'", args.session);
+            return Err(());
+        }
+    };
+
+    let resp = client
+        .oneshot_rpc::<DestroySession>(DestroySessionRequest { id: record.id })
+        .await
+        .map_err(|e| eprintln!("DestroySession RPC failed: {e}"))?;
+
+    if resp.ok().is_some() {
+        println!(
+            "Destroyed session {} ({})",
+            record.id,
+            record.name.as_deref().unwrap_or("-")
+        );
+    } else {
+        eprintln!("DestroySession returned an error from the daemon");
+        return Err(());
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Closes gominimal/inbox#159

Implements the client-side CLI interface in `crates/minimal2` to interact with `minimald` over the SSH-based control protocol.

## What's implemented

- **`ls`** — Lists sessions via `ListSessions` RPC. `--raw` outputs one session ID per line for scripting (`minimal ls --raw | fzf | xargs minimal attach`).
- **`activate`** — Creates a session via `CreateSession` RPC with optional `--name` and project path. `--attach` chains into attach after creation.
- **`attach`** — Resolves a session by UUID or name via `GetSessionRecord`, then shells out to `ssh` for interactive PTY attachment. `--command` runs a non-interactive command in the session context. Uses a hidden `proxy` subcommand as the SSH `ProxyCommand` (no `socat`/`nc` dependency).
- **`destroy`** — Resolves by UUID or name, then calls `DestroySession` RPC (#462).
- **`completions`** — Shell completion script generation via `clap_complete`.

## Auto-spawn

On Linux, the CLI auto-spawns `minimald run` as a detached background process if the daemon UDS isn't connectable, then polls until ready (4s timeout). On macOS, auto-spawns `minvmd` via the existing state machine. No lifecycle state machine or `state.toml` — just socket polling. The lifecycle management PR (#435) can layer richer state tracking on top later.

## Design decisions

- The client binary (`minimal2`) has **zero** dependency on `minimald` internals — it talks exclusively through the `minimald-rpc` wire contract over SSH.
- Both interactive and `--command` attach shell out to `ssh` rather than reimplementing termios/PTY management. The daemon's `shell_request` handler mints the PTY-backed session shell; ssh handles terminal reconfiguration and cleanup.
- `exec_in_session` was removed entirely — per @twitchyliquid64's feedback, it used the daemon's old exec codepath which doesn't hit the sessions module. exec_request remains on the daemon side for git-receive-pack / vscode remote only.

## Removed

- `dash` subcommand — temporary fzf-based picker, removed in favor of a future proper TUI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added `ls` command to list active sessions
- Added `activate` command to create and activate new sessions
- Added `attach` command to connect to existing sessions
- Added `destroy` command to remove sessions
- CLI now supports comprehensive session management capabilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->