### PR TITLE
feat(minimald): lifecycle management (run --detach, status, stop)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,10 +3457,18 @@ dependencies = [
 name = "minimal2"
 version = "0.0.1"
 dependencies = [
+ "camino",
+ "chrono",
  "clap",
  "clap_complete",
+ "minimald-rpc",
  "minvmd",
  "ot",
+ "paths",
+ "russh",
+ "serde",
+ "serde_json",
+ "sessions",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3461,6 +3461,8 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "dirs",
+ "minimald",
  "minimald-rpc",
  "minvmd",
  "ot",
@@ -3478,6 +3480,7 @@ dependencies = [
 name = "minimald"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "args",
  "async-compression",
  "async-tar",
@@ -3489,6 +3492,7 @@ dependencies = [
  "constcat",
  "dirs",
  "either",
+ "fd-lock",
  "futures",
  "graph",
  "hakoniwa",
@@ -3509,6 +3513,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-vsock",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "vt100-ctt",

--- a/crates/minimal2/Cargo.toml
+++ b/crates/minimal2/Cargo.toml
@@ -7,9 +7,17 @@ publish.workspace = true
 [dependencies]
 clap.workspace = true
 clap_complete.workspace = true
+camino.workspace = true
+chrono.workspace = true
+minimald-rpc.workspace = true
+paths.workspace = true
+russh.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sessions.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
-ot.workspace = true
 minvmd = { path = "../minvmd" }
+ot.workspace = true

--- a/crates/minimal2/Cargo.toml
+++ b/crates/minimal2/Cargo.toml
@@ -9,6 +9,7 @@ clap.workspace = true
 clap_complete.workspace = true
 camino.workspace = true
 chrono.workspace = true
+dirs.workspace = true
 minimald-rpc.workspace = true
 paths.workspace = true
 russh.workspace = true
@@ -20,4 +21,5 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 minvmd = { path = "../minvmd" }
+minimald = { path = "../minimald" }
 ot.workspace = true

--- a/crates/minimal2/src/autospawn.rs
+++ b/crates/minimal2/src/autospawn.rs
@@ -1,18 +1,23 @@
-//! Auto-spawn logic for minvmd on macOS (R4.5).
+//! Auto-spawn logic for minimald and minvmd.
 //!
-//! On macOS, checks the minvmd state before connecting to the UDS. If minvmd
+//! On macOS: checks the `minvmd` state before connecting to the UDS. If minvmd
 //! is not running, spawns `minvmd run --detach` and waits for the UDS to become
 //! available.
 //!
-//! On Linux, this module is a no-op.
+//! On Linux: checks the `minimald` state before connecting to the UDS. If
+//! minimald is not running, spawns `minimald run --detach` and waits for the
+//! UDS to become available.
 
 use std::io;
+
 #[cfg(target_os = "macos")]
 use std::process::Command;
 #[cfg(target_os = "macos")]
 use std::thread;
 #[cfg(target_os = "macos")]
 use std::time::{Duration, Instant};
+
+// ── macOS: minvmd auto-spawn ─────────────────────────────────────────────────
 
 /// Default timeout in seconds to wait for the UDS when spawning minvmd (R4.5).
 #[cfg(target_os = "macos")]
@@ -35,7 +40,7 @@ const STOPPING_WAIT_SECS: u64 = 6;
 /// - If not running, spawns `minvmd run --detach` with a timeout
 /// - Returns an error if spawn fails
 ///
-/// On Linux, this is a no-op since minvmd does not exist on Linux.
+/// On Linux, delegates to the `minimald` auto-spawn path.
 #[cfg(target_os = "macos")]
 pub fn ensure_minvmd_running() -> io::Result<()> {
     let state_dir = minvmd::state::StateDir::new(minvmd::state::StateDir::default_path())?;
@@ -109,10 +114,90 @@ pub fn ensure_minvmd_running() -> io::Result<()> {
     Ok(())
 }
 
-/// On Linux, auto-spawn is a no-op since minvmd is not available.
+// ── Linux: minimald auto-spawn ───────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+use std::process::Command;
+#[cfg(target_os = "linux")]
+use std::time::{Duration, Instant};
+
+/// Default timeout in seconds to wait for the UDS when spawning minimald.
+/// Shorter than minvmd's 8s since there is no VM boot.
+#[cfg(target_os = "linux")]
+const MINIMALD_SPAWN_TIMEOUT_SECS: u64 = 4;
+
+/// On Linux, auto-spawn `minimald run --detach` if the daemon is not already
+/// running.
 #[cfg(target_os = "linux")]
 pub fn ensure_minvmd_running() -> io::Result<()> {
-    tracing::debug!("ensure_minvmd_running is a no-op on Linux");
+    ensure_minimald_running()
+}
+
+/// Check if minimald needs to be spawned, and spawn it if necessary.
+///
+/// Adapted from the `minvmd` macOS auto-spawn logic. Uses the same lifecycle
+/// state machine (`minimald::state::StateDir`) to determine whether the daemon
+/// is already running, starting, or stopping, and spawns `minimald run --detach`
+/// when appropriate.
+#[cfg(target_os = "linux")]
+fn ensure_minimald_running() -> io::Result<()> {
+    use minimald::lifecycle::Lifecycle;
+    use minimald::state::StateDir;
+
+    let state_dir = StateDir::new(StateDir::default_path())?;
+
+    // Read current state before connecting.
+    let state = state_dir.read_state()?;
+
+    match state.lifecycle {
+        Lifecycle::Running | Lifecycle::Starting => {
+            tracing::debug!("minimald already running or starting");
+            return Ok(());
+        }
+        Lifecycle::Stopping => {
+            tracing::info!("minimald is stopping; waiting for it to finish");
+            let deadline = Instant::now() + Duration::from_secs(6);
+            loop {
+                std::thread::sleep(Duration::from_millis(100));
+                match state_dir.read_state()?.lifecycle {
+                    Lifecycle::Running | Lifecycle::Starting => return Ok(()),
+                    Lifecycle::Stopped | Lifecycle::NotProvisioned => break,
+                    _ if Instant::now() >= deadline => {
+                        return Err(io::Error::other(
+                            "minimald is still stopping after waiting; try again shortly",
+                        ));
+                    }
+                    _ => continue,
+                }
+            }
+        }
+        Lifecycle::Stopped | Lifecycle::NotProvisioned => {
+            // Not running; will spawn below
+        }
+        _ => {}
+    }
+
+    tracing::info!(
+        "spawning minimald run --detach with timeout {}",
+        MINIMALD_SPAWN_TIMEOUT_SECS
+    );
+    let output = Command::new("minimald")
+        .arg("run")
+        .arg("--detach")
+        .arg("--detach-timeout")
+        .arg(MINIMALD_SPAWN_TIMEOUT_SECS.to_string())
+        .output()
+        .map_err(|e| io::Error::new(e.kind(), format!("failed to spawn minimald: {}", e)))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(io::Error::other(format!(
+            "minimald run --detach failed: {}",
+            stderr
+        )));
+    }
+
+    tracing::info!("minimald spawned successfully");
     Ok(())
 }
 
@@ -120,12 +205,25 @@ pub fn ensure_minvmd_running() -> io::Result<()> {
 mod tests {
     #[test]
     #[cfg(target_os = "linux")]
-    fn test_autospawn_noop_on_linux() {
-        // On Linux, ensure_minvmd_running should be a no-op and always succeed
+    fn test_autospawn_on_linux() {
+        // On Linux, ensure_minvmd_running delegates to minimald auto-spawn.
+        // If minimald is already running (or the binary is available), it
+        // should succeed. If the binary is not installed, the spawn may fail
+        // — that's expected in a dev environment without minimald on PATH.
         let result = super::ensure_minvmd_running();
-        assert!(
-            result.is_ok(),
-            "ensure_minvmd_running should always succeed on Linux"
-        );
+        match result {
+            Ok(()) => {} // all good
+            Err(e) => {
+                // Acceptable: minimald binary not installed (dev env).
+                // Not acceptable: assertion failures or panics.
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("failed to spawn minimald")
+                        || msg.contains("No such file")
+                        || msg.contains("minimald is not running"),
+                    "unexpected auto-spawn error: {msg}"
+                );
+            }
+        }
     }
 }

--- a/crates/minimal2/src/client.rs
+++ b/crates/minimal2/src/client.rs
@@ -1,0 +1,187 @@
+//! SSH client transport for talking to minimald over the UDS bridge.
+//!
+//! Provides a `russh`-based client that connects to `minimald` over the UNIX
+//! domain socket, authenticates (passwordless), and invokes oneshot RPCs
+//! defined in the `minimald-rpc` wire contract.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use minimald_rpc::OneshotSshRpc;
+use russh::ChannelMsg;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Max retries when connecting to the daemon UDS.
+const CONNECT_RETRIES: u32 = 20;
+/// Delay between connection retries.
+const CONNECT_RETRY_DELAY: Duration = Duration::from_millis(100);
+
+/// russh client handler that accepts any ephemeral host key.
+///
+/// The daemon generates a fresh host key on every boot. Since we connect over
+/// a local UDS (not the network), TOFU trust is acceptable here.
+struct MinimalClientHandler;
+
+impl russh::client::Handler for MinimalClientHandler {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        _key: &russh::keys::ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+/// An authenticated SSH session to minimald.
+pub struct Client {
+    handle: russh::client::Handle<MinimalClientHandler>,
+}
+
+impl Client {
+    /// Connect to minimald over the UDS at `sock_path`, authenticate, and
+    /// return a ready [`Client`].
+    ///
+    /// Retries the UDS connect for up to ~2 seconds to absorb the post-boot
+    /// race on macOS where the libkrun bridge UDS appears slightly after the
+    /// `vm-up` line.
+    pub async fn connect(sock_path: &Path) -> Result<Self, String> {
+        let stream = {
+            let mut conn = None;
+            let mut last_err = None;
+            for _ in 0..CONNECT_RETRIES {
+                match tokio::net::UnixStream::connect(sock_path).await {
+                    Ok(s) => {
+                        conn = Some(s);
+                        break;
+                    }
+                    Err(e) => {
+                        last_err = Some(e);
+                        tokio::time::sleep(CONNECT_RETRY_DELAY).await;
+                    }
+                }
+            }
+            conn.ok_or_else(|| {
+                format!(
+                    "connect to daemon at {}: {}",
+                    sock_path.display(),
+                    last_err.unwrap()
+                )
+            })?
+        };
+
+        let config = Arc::new(russh::client::Config::default());
+        let mut handle = russh::client::connect_stream(config, stream, MinimalClientHandler)
+            .await
+            .map_err(|e| format!("ssh connect: {e}"))?;
+
+        let auth = handle
+            .authenticate_none("minimal-cli")
+            .await
+            .map_err(|e| format!("authenticate: {e}"))?;
+
+        if !auth.success() {
+            return Err("authentication rejected by daemon".into());
+        }
+
+        Ok(Client { handle })
+    }
+
+    /// Execute a command in the context of a session.
+    ///
+    /// Opens a new SSH channel, sets `MINIMAL_SESSION_ID` to the given
+    /// session ID, execs the command, and returns `(stdout, exit_status)`.
+    pub async fn exec_in_session(
+        &mut self,
+        session_id: &str,
+        command: &str,
+    ) -> Result<(String, Option<u32>), String> {
+        let mut channel = self
+            .handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("open exec channel: {e}"))?;
+
+        channel
+            .set_env(true, "MINIMAL_SESSION_ID", session_id)
+            .await
+            .map_err(|e| format!("set_env MINIMAL_SESSION_ID: {e}"))?;
+
+        channel
+            .exec(true, command)
+            .await
+            .map_err(|e| format!("exec: {e}"))?;
+
+        channel
+            .eof()
+            .await
+            .map_err(|e| format!("eof: {e}"))?;
+
+        let mut stdout = Vec::new();
+        let mut exit_status = None;
+        while let Some(msg) = channel.wait().await {
+            match msg {
+                ChannelMsg::Data { data } => stdout.extend_from_slice(&data),
+                ChannelMsg::ExitStatus { exit_status: code } => exit_status = Some(code),
+                ChannelMsg::Failure => return Err("exec request rejected (CHANNEL_FAILURE)".into()),
+                _ => {}
+            }
+        }
+
+        Ok((String::from_utf8_lossy(&stdout).into_owned(), exit_status))
+    }
+
+    /// Issue a oneshot RPC: open a channel, request the subsystem, write the
+    /// serialized request, half-close, and decode the response.
+    ///
+    /// The type parameter `R` picks the RPC from the wire contract; `request`
+    /// is serialized to JSON and the response is deserialized from JSON.
+    pub async fn oneshot_rpc<R: OneshotSshRpc>(
+        &mut self,
+        request: R::Request<'_>,
+    ) -> Result<R::Response, String>
+    where
+        <R as OneshotSshRpc>::Response: serde::de::DeserializeOwned,
+    {
+        let channel = self
+            .handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("open channel for {}: {e}", R::NAME))?;
+
+        channel
+            .request_subsystem(false, R::NAME)
+            .await
+            .map_err(|e| format!("request subsystem {}: {e}", R::NAME))?;
+
+        let body =
+            serde_json::to_vec(&request).map_err(|e| format!("serialize request: {e}"))?;
+
+        let mut rpc = channel.into_stream();
+        rpc.write_all(&body)
+            .await
+            .map_err(|e| format!("write request: {e}"))?;
+        rpc.shutdown()
+            .await
+            .map_err(|e| format!("shutdown write half: {e}"))?;
+
+        let mut resp_buf = Vec::with_capacity(256);
+        rpc.read_to_end(&mut resp_buf)
+            .await
+            .map_err(|e| format!("read response: {e}"))?;
+
+        serde_json::from_slice(&resp_buf)
+            .map_err(|e| format!("decode response for {}: {e}", R::NAME))
+    }
+}
+
+/// Resolve the daemon socket path, defaulting to `minvmd::sock::resolve_uds_path()`.
+///
+/// If `--minimal-dir` is set, use `<minimal_dir>/minimald.sock` instead.
+pub fn resolve_socket_path(minimal_dir_override: Option<&std::path::Path>) -> std::io::Result<std::path::PathBuf> {
+    if let Some(dir) = minimal_dir_override {
+        return Ok(dir.join("minimald.sock"));
+    }
+    minvmd::sock::resolve_uds_path()
+}

--- a/crates/minimal2/src/client.rs
+++ b/crates/minimal2/src/client.rs
@@ -176,12 +176,29 @@ impl Client {
     }
 }
 
-/// Resolve the daemon socket path, defaulting to `minvmd::sock::resolve_uds_path()`.
+/// Resolve the daemon socket path.
 ///
-/// If `--minimal-dir` is set, use `<minimal_dir>/minimald.sock` instead.
+/// On Linux: `$XDG_STATE_HOME/minimal/providers/local-0/ssh.sock` (matching
+/// `minimald`'s `listen_on()`).
+///
+/// On macOS: delegates to `minvmd::sock::resolve_uds_path()` (the bridge
+/// socket created by the minvmd host daemon).
+///
+/// If `--minimal-dir` is set, use `<minimal_dir>/providers/local-0/ssh.sock`
+/// on Linux, or `<minimal_dir>/minimald.sock` on macOS.
 pub fn resolve_socket_path(minimal_dir_override: Option<&std::path::Path>) -> std::io::Result<std::path::PathBuf> {
     if let Some(dir) = minimal_dir_override {
+        #[cfg(target_os = "linux")]
+        return Ok(dir.join("providers/local-0/ssh.sock"));
+        #[cfg(target_os = "macos")]
         return Ok(dir.join("minimald.sock"));
     }
+    #[cfg(target_os = "linux")]
+    {
+        let state = dirs::state_dir()
+            .unwrap_or_else(|| dirs::home_dir().unwrap().join(".local/state"));
+        Ok(state.join("minimal/providers/local-0/ssh.sock"))
+    }
+    #[cfg(target_os = "macos")]
     minvmd::sock::resolve_uds_path()
 }

--- a/crates/minimal2/src/main.rs
+++ b/crates/minimal2/src/main.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 mod autospawn;
+mod client;
 
 #[derive(Parser)]
 #[command(name = "minimal", version = env!("CARGO_PKG_VERSION"), long_version = env!("LONG_VERSION"))]
@@ -22,18 +23,20 @@ struct Cli {
 enum Command {
     /// List sessions
     Ls,
+    /// Activate (create) a new session
+    Activate(ActivateArgs),
+    /// Attach to an existing session
+    Attach(AttachArgs),
+    /// Destroy (terminate) a session
+    Destroy(DestroyArgs),
+    /// Interactive session dashboard (k9s-like TUI)
+    #[command(hide = true)]
+    Dash,
     /// Generate shell completion script
     #[command(
         long_about = "Generate a shell tab-completion script for the minimal CLI.\nSupported shells include bash, zsh, elvish and fish.\n\n   source <(minimal completions bash)"
     )]
     Completions(CompletionsArgs),
-}
-
-#[derive(Debug, clap::Args)]
-struct CompletionsArgs {
-    /// The shell type for a CLI completion script should be printed
-    #[arg(value_parser)]
-    shell: Shell,
 }
 
 /// Shared arguments all subcommands
@@ -42,6 +45,41 @@ pub struct GlobalArgs {
     /// Override the base directory used for operations (default: ~/.cache/minimal)
     #[arg(long)]
     minimal_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct ActivateArgs {
+    /// Optional session name
+    #[arg(long, short)]
+    name: Option<String>,
+    /// Project path to activate (defaults to current directory)
+    #[arg(default_value = ".")]
+    path: String,
+    /// Automatically attach after creation
+    #[arg(long)]
+    attach: bool,
+}
+
+#[derive(Debug, Args)]
+struct AttachArgs {
+    /// Session identifier (UUID or session name)
+    session: String,
+    /// Command to exec in the session context (non-interactive)
+    #[arg(long, short)]
+    command: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct DestroyArgs {
+    /// Session identifier (UUID or session name)
+    session: String,
+}
+
+#[derive(Debug, clap::Args)]
+struct CompletionsArgs {
+    /// The shell type for a CLI completion script should be printed
+    #[arg(value_parser)]
+    shell: Shell,
 }
 
 #[tokio::main]
@@ -60,19 +98,13 @@ async fn main() -> Result<(), ()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Ls => {
-            // Ensure minvmd is running before listing (R4.5). On macOS this
-            // auto-spawns minvmd; on Linux `ensure_minvmd_running` is a no-op,
-            // so `ls` falls through to the placeholder `[]` below.
-            //
-            // TODO(#311): minimal targets Linux too — add the Linux backend and
-            // real session listing over the minimald UDS; `[]` is a placeholder
-            // on both platforms until then.
-            if let Err(e) = autospawn::ensure_minvmd_running() {
-                eprintln!("Failed to ensure minvmd is running: {}", e);
-                return Err(());
-            }
-            println!("[]");
+        Command::Ls => cmd_ls(&cli.global_args).await,
+        Command::Activate(args) => cmd_activate(&cli.global_args, args).await,
+        Command::Attach(args) => cmd_attach(&cli.global_args, args).await,
+        Command::Destroy(args) => cmd_destroy(&cli.global_args, args).await,
+        Command::Dash => {
+            // TODO(#159): implement k9s-like TUI session dashboard
+            eprintln!("[#159] dash: not yet implemented");
             Ok(())
         }
         Command::Completions(CompletionsArgs { shell }) => {
@@ -82,4 +114,206 @@ async fn main() -> Result<(), ()> {
             Ok(())
         }
     }
+}
+
+/// Connect to the daemon, resolving the socket path from global args.
+async fn connect_daemon(global: &GlobalArgs) -> Result<client::Client, ()> {
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref())
+        .map_err(|e| eprintln!("Failed to resolve daemon socket path: {e}"))?;
+
+    client::Client::connect(&sock)
+        .await
+        .map_err(|e| eprintln!("Failed to connect to minimald: {e}"))
+}
+
+/// List sessions via the `ListSessions` RPC.
+async fn cmd_ls(global: &GlobalArgs) -> Result<(), ()> {
+    if let Err(e) = autospawn::ensure_minvmd_running() {
+        eprintln!("Failed to ensure minvmd is running: {e}");
+        return Err(());
+    }
+
+    let mut client = connect_daemon(global).await?;
+
+    use minimald_rpc::ListSessions;
+    let resp = client
+        .oneshot_rpc::<ListSessions>(())
+        .await
+        .map_err(|e| eprintln!("ListSessions RPC failed: {e}"))?;
+
+    if resp.sessions.is_empty() {
+        println!("No active sessions.");
+        return Ok(());
+    }
+
+    // Format as a table: ID, Name, Title, Last Activity.
+    // Widths chosen to fit a standard 80-col terminal.
+    println!("{:<36}  {:<20}  {:<20}  {}", 
+        "SESSION ID", "NAME", "TITLE", "LAST ACTIVITY");
+    println!("{:-<36}  {:-<20}  {:-<20}  {:-<24}", "", "", "", "");
+
+    for entry in &resp.sessions {
+        let id = entry.id.to_string();
+        let name = entry.name.as_deref().unwrap_or("-");
+        let (title, last_activity) = match &entry.attrs {
+            Some(attrs) => {
+                let title = attrs
+                    .title
+                    .as_ref()
+                    .map(|t| t.value.as_str())
+                    .unwrap_or("-");
+                let last = attrs
+                    .last_stdout
+                    .or(attrs.last_stdin)
+                    .map(|dt| {
+                        let local = dt.with_timezone(&chrono::Local);
+                        local.format("%Y-%m-%d %H:%M:%S").to_string()
+                    })
+                    .unwrap_or_else(|| "-".to_string());
+                (title, last)
+            }
+            None => ("-", "-".to_string()),
+        };
+        println!("{id:<36}  {name:<20}  {title:<20}  {last_activity}");
+    }
+
+    Ok(())
+}
+
+/// Create a new session via the `CreateSession` RPC.
+async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), ()> {
+    if let Err(e) = autospawn::ensure_minvmd_running() {
+        eprintln!("Failed to ensure minvmd is running: {e}");
+        return Err(());
+    }
+
+    let project_path = std::fs::canonicalize(&args.path)
+        .map_err(|e| eprintln!("Cannot resolve project path '{}': {e}", args.path))?;
+
+    let utf8_path = camino::Utf8PathBuf::from_path_buf(project_path)
+        .map_err(|_| eprintln!("Project path is not valid UTF-8"))?;
+    let abs_path = paths::HostAbsPath::try_new(utf8_path)
+        .map_err(|e| eprintln!("Invalid project path: {e}"))?;
+
+    let username = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .ok();
+
+    let record = sessions::Record {
+        id: sessions::SessionId::nil(),
+        name: args.name.clone(),
+        username,
+        project_path: abs_path,
+        attrs: Default::default(),
+    };
+
+    let mut client = connect_daemon(global).await?;
+
+    use minimald_rpc::{CreateSession, CreateSessionRequest};
+    let req = CreateSessionRequest { record };
+    let resp = client
+        .oneshot_rpc::<CreateSession>(req)
+        .await
+        .map_err(|e| eprintln!("CreateSession RPC failed: {e}"))?;
+
+    let created = match resp.ok() {
+        Some(r) => r,
+        None => {
+            eprintln!("CreateSession returned an error from the daemon");
+            return Err(());
+        }
+    };
+
+    println!("{}", created.id);
+
+    if args.attach {
+        // Chain into attach.
+        let attach_args = AttachArgs {
+            session: created.id.to_string(),
+            command: None,
+        };
+        return cmd_attach(global, attach_args).await;
+    }
+
+    Ok(())
+}
+
+/// Attach to an existing session via exec (PTY bridging not yet supported by daemon).
+async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), ()> {
+    if let Err(e) = autospawn::ensure_minvmd_running() {
+        eprintln!("Failed to ensure minvmd is running: {e}");
+        return Err(());
+    }
+
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref())
+        .map_err(|e| eprintln!("Failed to resolve daemon socket path: {e}"))?;
+
+    // Resolve the session: if it looks like a UUID, query by ID; otherwise by name.
+    use minimald_rpc::{GetSessionRecord, GetSessionRecordRequest};
+    let mut client = client::Client::connect(&sock)
+        .await
+        .map_err(|e| eprintln!("Failed to connect to minimald: {e}"))?;
+
+    let lookup = if let Ok(id) = sessions::SessionId::parse_str(&args.session) {
+        GetSessionRecordRequest::Id(id)
+    } else {
+        GetSessionRecordRequest::Name(args.session.clone())
+    };
+
+    let resp = client
+        .oneshot_rpc::<GetSessionRecord>(lookup)
+        .await
+        .map_err(|e| eprintln!("GetSessionRecord RPC failed: {e}"))?;
+
+    let record = match resp.record {
+        Some(r) => r,
+        None => {
+            eprintln!("No session found matching '{}'", args.session);
+            return Err(());
+        }
+    };
+
+    tracing::info!(
+        session_id = %record.id,
+        session_name = ?record.name,
+        "found session"
+    );
+
+    // If a command was provided, exec it in the session context.
+    // PTY interactive shell is blocked on daemon PTY support (see exec.rs:650-654).
+    if let Some(ref cmd) = args.command {
+        let (stdout, exit) = client
+            .exec_in_session(&record.id.to_string(), cmd)
+            .await
+            .map_err(|e| eprintln!("exec failed: {e}"))?;
+        print!("{stdout}");
+        if let Some(code) = exit
+            && code != 0
+        {
+            eprintln!("Command exited with status {code}");
+        }
+    } else {
+        eprintln!("Session {}  |  Name: {}", record.id, record.name.as_deref().unwrap_or("-"));
+        eprintln!("\nPTY-based interactive attachment is not yet supported by the daemon.");
+        eprintln!("Use 'minimal attach <session> --exec <command>' to run a command.");
+    }
+
+    Ok(())
+}
+/// Destroy (terminate) a session.
+async fn cmd_destroy(global: &GlobalArgs, args: DestroyArgs) -> Result<(), ()> {
+    if let Err(e) = autospawn::ensure_minvmd_running() {
+        eprintln!("Failed to ensure minvmd is running: {e}");
+        return Err(());
+    }
+
+    let _client = connect_daemon(global).await?;
+
+    // TODO(#159): no DestroySession RPC exists in the wire contract yet.
+    // May need an exec-channel approach or a new RPC addition.
+    eprintln!(
+        "[#159] Destroying session '{}' is not yet wired (no DestroySession RPC).",
+        args.session
+    );
+    Ok(())
 }

--- a/crates/minimal2/src/main.rs
+++ b/crates/minimal2/src/main.rs
@@ -2,7 +2,9 @@
 
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
+use std::io::Write as _;
 use std::path::PathBuf;
+use std::process::Stdio;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 mod autospawn;
@@ -22,15 +24,14 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// List sessions
-    Ls,
+    Ls(LsArgs),
     /// Activate (create) a new session
     Activate(ActivateArgs),
     /// Attach to an existing session
     Attach(AttachArgs),
     /// Destroy (terminate) a session
     Destroy(DestroyArgs),
-    /// Interactive session dashboard (k9s-like TUI)
-    #[command(hide = true)]
+    /// Interactive session picker (requires fzf)
     Dash,
     /// Generate shell completion script
     #[command(
@@ -70,6 +71,13 @@ struct AttachArgs {
 }
 
 #[derive(Debug, Args)]
+struct LsArgs {
+    /// Output raw session IDs (one per line) for piping into fzf
+    #[arg(long)]
+    raw: bool,
+}
+
+#[derive(Debug, Args)]
 struct DestroyArgs {
     /// Session identifier (UUID or session name)
     session: String,
@@ -98,15 +106,11 @@ async fn main() -> Result<(), ()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Ls => cmd_ls(&cli.global_args).await,
+        Command::Ls(args) => cmd_ls(&cli.global_args, args).await,
         Command::Activate(args) => cmd_activate(&cli.global_args, args).await,
         Command::Attach(args) => cmd_attach(&cli.global_args, args).await,
         Command::Destroy(args) => cmd_destroy(&cli.global_args, args).await,
-        Command::Dash => {
-            // TODO(#159): implement k9s-like TUI session dashboard
-            eprintln!("[#159] dash: not yet implemented");
-            Ok(())
-        }
+        Command::Dash => cmd_dash(&cli.global_args).await,
         Command::Completions(CompletionsArgs { shell }) => {
             let mut cmd = Cli::command();
             let name = cmd.get_name().to_string();
@@ -127,7 +131,7 @@ async fn connect_daemon(global: &GlobalArgs) -> Result<client::Client, ()> {
 }
 
 /// List sessions via the `ListSessions` RPC.
-async fn cmd_ls(global: &GlobalArgs) -> Result<(), ()> {
+async fn cmd_ls(global: &GlobalArgs, args: LsArgs) -> Result<(), ()> {
     if let Err(e) = autospawn::ensure_minvmd_running() {
         eprintln!("Failed to ensure minvmd is running: {e}");
         return Err(());
@@ -142,7 +146,17 @@ async fn cmd_ls(global: &GlobalArgs) -> Result<(), ()> {
         .map_err(|e| eprintln!("ListSessions RPC failed: {e}"))?;
 
     if resp.sessions.is_empty() {
-        println!("No active sessions.");
+        if !args.raw {
+            println!("No active sessions.");
+        }
+        return Ok(());
+    }
+
+    if args.raw {
+        // Machine-readable: one session ID per line for fzf piping.
+        for entry in &resp.sessions {
+            println!("{}", entry.id);
+        }
         return Ok(());
     }
 
@@ -316,4 +330,102 @@ async fn cmd_destroy(global: &GlobalArgs, args: DestroyArgs) -> Result<(), ()> {
         args.session
     );
     Ok(())
+}
+/// Interactive session picker via fzf.
+///
+/// Lists sessions, pipes them into `fzf` for fuzzy selection, then attaches
+/// to the chosen session. Falls back to a plain table if fzf is not
+/// available or stdout is not a terminal.
+async fn cmd_dash(global: &GlobalArgs) -> Result<(), ()> {
+    if let Err(e) = autospawn::ensure_minvmd_running() {
+        eprintln!("Failed to ensure minvmd is running: {e}");
+        return Err(());
+    }
+
+    let mut client = connect_daemon(global).await?;
+
+    use minimald_rpc::ListSessions;
+    let resp = client
+        .oneshot_rpc::<ListSessions>(())
+        .await
+        .map_err(|e| eprintln!("ListSessions RPC failed: {e}"))?;
+
+    if resp.sessions.is_empty() {
+        println!("No active sessions.");
+        return Ok(());
+    }
+
+    // Build fzf input lines: "<id>  <name>"
+    let mut lines = Vec::with_capacity(resp.sessions.len());
+    for entry in &resp.sessions {
+        lines.push(format!(
+            "{}  {}",
+            entry.id,
+            entry.name.as_deref().unwrap_or("-")
+        ));
+    }
+
+    // Try spawning fzf.  If it's missing or the output is not a terminal,
+    // fall back to plain table output.
+    let input = lines.join("\n");
+    let output = match std::process::Command::new("fzf")
+        .args([
+            "--height=~40%",
+            "--layout=reverse",
+            "--border",
+            "--prompt=minimal attach> ",
+            "--print-query",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+    {
+        Ok(mut child) => {
+            if let Some(ref mut stdin) = child.stdin {
+                let _ = stdin.write_all(input.as_bytes());
+            }
+            child
+                .wait_with_output()
+                .map_err(|e| eprintln!("fzf failed: {e}"))?
+        }
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                // fzf not installed; emit a plain table and a tip.
+                eprintln!("fzf not found — install fzf for interactive selection.");
+                eprintln!();
+                return cmd_ls(global, LsArgs { raw: false }).await;
+            }
+            return Err(eprintln!("failed to spawn fzf: {e}"));
+        }
+    };
+
+    if !output.status.success() {
+        // Non-zero exit (e.g. 130 = Esc): user cancelled, exit silently.
+        return Ok(());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // fzf --print-query outputs two lines: the query string, then the selection.
+    let selected = stdout
+        .lines()
+        .nth(1) // skip query line, take selection line
+        .and_then(|line| line.split_whitespace().next())
+        .map(|s| s.to_string());
+
+    let session_id = match selected {
+        Some(id) => id,
+        None => {
+            // Shouldn't happen with --print-query but guard anyway.
+            return Ok(());
+        }
+    };
+
+    // Chain into attach (non-interactive exec path — attach with no --command
+    // shows session info).
+    let attach_args = AttachArgs {
+        session: session_id,
+        command: None,
+    };
+    cmd_attach(global, attach_args).await
 }

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 async-compression.workspace = true
 async-tar.workspace = true
 bytes.workspace = true
@@ -14,6 +15,7 @@ clap_complete.workspace = true
 constcat.workspace = true
 chrono.workspace = true
 dirs.workspace = true
+fd-lock.workspace = true
 either.workspace = true
 futures.workspace = true
 hakoniwa.workspace = true
@@ -24,6 +26,7 @@ path-absolutize.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
+toml.workspace = true
 vt100-ctt.workspace = true
 
 tokio.workspace = true

--- a/crates/minimald/src/cmd/mod.rs
+++ b/crates/minimald/src/cmd/mod.rs
@@ -1,0 +1,3 @@
+pub mod run;
+pub mod status;
+pub mod stop;

--- a/crates/minimald/src/cmd/run.rs
+++ b/crates/minimald/src/cmd/run.rs
@@ -1,0 +1,285 @@
+//! `minimald run` subcommand.
+//!
+//! The foreground supervisor: manages lifecycle state transitions
+//! (Stopped → Starting → Running → Stopped), binds the UDS listener,
+//! and runs the SSH server loop.
+//!
+//! `--detach` mode: spawns the supervisor as a background process (new
+//! session via `setsid`) and returns only once the UDS is accepting
+//! connections or the configurable timeout expires.
+
+use std::{
+    path::Path,
+    time::Duration,
+};
+
+use anyhow::{Context as _, Result, bail};
+
+use crate::{
+    lifecycle::{Action, Lifecycle, next_state},
+    server::{Config, Server},
+    state::{StartingGuard, State, StateDir},
+};
+
+/// Default timeout in seconds for `run --detach` to wait for the UDS.
+/// Shorter than `minvmd`'s 8s since there's no VM boot.
+pub const DEFAULT_DETACH_TIMEOUT_SECS: u64 = 4;
+
+/// Run the `run` subcommand.
+///
+/// - `detach`: if true, spawn the supervisor in the background and poll the
+///   UDS until it accepts connections (up to `timeout_secs`).
+/// - `timeout_secs`: only used when `detach` is true; default 4 s.
+pub async fn run(
+    detach: bool,
+    timeout_secs: u64,
+    listen_on: &Path,
+    config: Config,
+    instance_num: u32,
+) -> Result<()> {
+    if detach {
+        return run_detach(timeout_secs, listen_on);
+    }
+    run_foreground(listen_on, config, instance_num).await
+}
+
+/// Spawn `minimald run` as a detached background supervisor, then poll the
+/// UDS until it accepts connections (up to `timeout_secs`).
+fn run_detach(timeout_secs: u64, listen_on: &Path) -> Result<()> {
+    use std::os::unix::process::CommandExt as _;
+
+    let exe = std::env::current_exe().context("resolving current executable path")?;
+    let mut cmd = std::process::Command::new(&exe);
+    cmd.arg("run")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    // SAFETY: setsid() is async-signal-safe. In the child, it creates a new
+    // session so the supervisor is detached from the caller's controlling
+    // terminal and not affected by SIGHUP when the shell exits.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    cmd.spawn()
+        .with_context(|| format!("spawning background run supervisor: {}", exe.display()))?;
+
+    poll_uds_ready(listen_on, Duration::from_secs(timeout_secs)).with_context(|| {
+        format!(
+            "waiting for minimald to become ready on {}",
+            listen_on.display()
+        )
+    })
+}
+
+/// Poll `path` until a `UnixStream::connect` succeeds or `timeout` elapses.
+///
+/// Returns `Ok(())` on the first successful connect; returns an error on
+/// timeout.
+pub fn poll_uds_ready(path: &Path, timeout: Duration) -> Result<()> {
+    use std::os::unix::net::UnixStream;
+    use std::time::Instant;
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        if UnixStream::connect(path).is_ok() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "timed out after {}s waiting for UDS at {} to accept connections",
+                timeout.as_secs(),
+                path.display()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Foreground supervisor: bind the UDS, manage lifecycle state, run the
+/// server loop until exit.
+async fn run_foreground(
+    listen_on: &Path,
+    config: Config,
+    instance_num: u32,
+) -> Result<()> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use tokio::net::UnixListener;
+
+    // Remove stale socket before binding.
+    if let Err(e) = std::fs::remove_file(listen_on)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(anyhow::anyhow!("socket already in use: {e}"));
+    }
+
+    let state_dir = StateDir::new(StateDir::default_path()).context("opening state dir")?;
+
+    // ── Phase 1: Stopped → Starting (under lock) ───────────────────────────
+    {
+        let mut lock = state_dir
+            .lifecycle_lock()
+            .context("opening lifecycle lock")?;
+        let _guard = lock.write().context("acquiring lifecycle write lock")?;
+        let state = state_dir.read_state().context("reading state")?;
+
+        match state.lifecycle {
+            Lifecycle::Running => {
+                bail!("minimald is already running (daemon_pid={:?})", state.daemon_pid)
+            }
+            Lifecycle::Starting => bail!("minimald is already starting"),
+            Lifecycle::Stopping => {
+                bail!("minimald is stopping; wait for it to finish before restarting")
+            }
+            Lifecycle::NotProvisioned | Lifecycle::Stopped => {}
+        }
+
+        // A clean install starts NotProvisioned; provision it
+        // (NotProvisioned → Stopped) before starting.
+        let base = match state.lifecycle {
+            Lifecycle::NotProvisioned => {
+                next_state(Lifecycle::NotProvisioned, Action::Provision)
+                    .map_err(|e| anyhow::anyhow!("lifecycle transition error: {e}"))?
+            }
+            other => other,
+        };
+        let starting = next_state(base, Action::Start)
+            .map_err(|e| anyhow::anyhow!("lifecycle transition error: {e}"))?;
+        state_dir
+            .write_state(&State {
+                lifecycle: starting,
+                daemon_pid: None,
+                started_at: None,
+            })
+            .context("writing Starting state")?;
+    }
+
+    // StartingGuard: resets lifecycle to Stopped on drop if we bail before
+    // committing (R4.6).
+    let guard = StartingGuard::new(StateDir::default_path());
+
+    // Bind the UDS listener.
+    let listener = UnixListener::bind(listen_on)
+        .map_err(|e| anyhow::anyhow!("listening to socket: {e}"))?;
+
+    tracing::info!("Started listening on {}", listen_on.display());
+
+    // Write daemon.pid and update state with the known pid.
+    let daemon_pid = std::process::id();
+    let daemon_pid_path = state_dir.daemon_pid_path();
+    std::fs::write(&daemon_pid_path, format!("{daemon_pid}\n"))
+        .context("writing daemon.pid")?;
+
+    {
+        let mut lock = state_dir
+            .lifecycle_lock()
+            .context("opening lifecycle lock")?;
+        let _guard = lock.write().context("acquiring lifecycle write lock")?;
+        let state = state_dir.read_state().context("reading state")?;
+        // A concurrent stop might have already reset us to Stopped; bail.
+        if !matches!(state.lifecycle, Lifecycle::Starting) {
+            let _ = std::fs::remove_file(&daemon_pid_path);
+            bail!(
+                "lifecycle changed to {:?} during spawn; aborting",
+                state.lifecycle
+            );
+        }
+        state_dir
+            .write_state(&State {
+                lifecycle: Lifecycle::Starting,
+                daemon_pid: Some(daemon_pid),
+                started_at: None,
+            })
+            .context("writing Starting state with daemon_pid")?;
+    }
+
+    // ── Phase 2: Starting → Running (under lock) ──────────────────────────
+    let started_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    {
+        let mut lock = state_dir
+            .lifecycle_lock()
+            .context("opening lifecycle lock")?;
+        let _guard = lock.write().context("acquiring lifecycle write lock")?;
+        let state = state_dir.read_state().context("reading state")?;
+        let running = next_state(state.lifecycle, Action::MarkRunning)
+            .map_err(|e| anyhow::anyhow!("lifecycle transition error: {e}"))?;
+        state_dir
+            .write_state(&State {
+                lifecycle: running,
+                daemon_pid: Some(daemon_pid),
+                started_at: Some(started_at),
+            })
+            .context("writing Running state")?;
+    }
+    guard.commit();
+    tracing::info!(pid = daemon_pid, "minimald is running");
+
+    // Print the SSH debugging command for the user (same as before).
+    let host = format!("local-{}", instance_num);
+    tracing::info!(
+        "Run the following to debug the socket:\n\nssh \\\n\t-o \
+         'ProxyCommand=socat - UNIX-CONNECT:{}' \\\n\t-o \
+         'UserKnownHostsFile={}' \\\n\t{}",
+        listen_on.display(),
+        listen_on
+            .parent()
+            .unwrap_or(Path::new("."))
+            .join("known_hosts")
+            .display(),
+        host,
+    );
+
+    // ── Phase 3: Run the server loop ──────────────────────────────────────
+    let result = Server::run(config, listener).await;
+
+    // ── Phase 4: Running → Stopped (under lock) ───────────────────────────
+    {
+        let mut lock = state_dir
+            .lifecycle_lock()
+            .context("opening lifecycle lock")?;
+        let _guard = lock.write().context("acquiring lifecycle write lock")?;
+        let _ = std::fs::remove_file(&daemon_pid_path);
+        state_dir
+            .write_state(&State::stopped())
+            .context("writing Stopped state after server exit")?;
+    }
+
+    result.map_err(|e| anyhow::anyhow!("serving on UDS: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poll_uds_returns_ok_when_listener_is_ready() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("test.sock");
+        let _listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        assert!(
+            poll_uds_ready(&path, Duration::from_secs(1)).is_ok(),
+            "expected Ok when a listener is bound"
+        );
+    }
+
+    #[test]
+    fn poll_uds_times_out_when_no_listener() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("absent.sock");
+        let err = poll_uds_ready(&path, Duration::from_millis(150)).unwrap_err();
+        assert!(
+            err.to_string().contains("timed out"),
+            "expected a timeout error, got: {err}"
+        );
+    }
+}

--- a/crates/minimald/src/cmd/status.rs
+++ b/crates/minimald/src/cmd/status.rs
@@ -1,0 +1,197 @@
+//! `minimald status` subcommand.
+//!
+//! Reads `state.toml` from the state directory and prints the daemon status.
+//! A non-blocking advisory read lock is attempted on `lifecycle.lock` to detect
+//! concurrent lifecycle transitions; if the lock cannot be acquired the command
+//! exits with code 2 (lock contention).
+//!
+//! Exit codes:
+//! - 0 — daemon is Running
+//! - 1 — daemon is stopped (or not yet provisioned)
+//! - 2 — lock contention; another process is transitioning state
+
+use anyhow::{Context as _, Result};
+
+use crate::lifecycle::Lifecycle;
+use crate::state::{State, StateDir};
+
+/// Exit classification returned by [`run`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum StatusExit {
+    /// Daemon is `Running` — exit code 0.
+    Running,
+    /// Daemon is not running — exit code 1.
+    Stopped,
+    /// Could not acquire the advisory read lock — exit code 2.
+    LockContention,
+}
+
+impl StatusExit {
+    /// Numeric process exit code for this status.
+    pub fn code(&self) -> i32 {
+        match self {
+            Self::Running => 0,
+            Self::Stopped => 1,
+            Self::LockContention => 2,
+        }
+    }
+}
+
+/// Run the `status` subcommand.
+///
+/// `json`: if true, print a JSON object; otherwise print a human-readable line.
+pub fn run(json: bool) -> Result<StatusExit> {
+    run_with_state_dir(json, StateDir::default_path())
+}
+
+fn run_with_state_dir(json: bool, dir: std::path::PathBuf) -> Result<StatusExit> {
+    let state_dir = StateDir::new(dir).context("opening state dir")?;
+
+    // Non-blocking read lock: detect concurrent state transitions.
+    let rw = state_dir
+        .lifecycle_lock()
+        .context("opening lifecycle lock")?;
+    let _guard = match rw.try_read() {
+        Ok(g) => g,
+        Err(_) => return Ok(StatusExit::LockContention),
+    };
+
+    let state = state_dir.read_state().context("reading state")?;
+
+    let uptime_seconds = state.started_at.and_then(|started| {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .ok()?
+            .as_secs();
+        Some(now.saturating_sub(started))
+    });
+
+    if json {
+        print_json(&state, uptime_seconds)?;
+    } else {
+        print_human(&state, uptime_seconds);
+    }
+
+    Ok(match state.lifecycle {
+        Lifecycle::Running => StatusExit::Running,
+        _ => StatusExit::Stopped,
+    })
+}
+
+fn lifecycle_state_str(lc: Lifecycle) -> &'static str {
+    match lc {
+        Lifecycle::NotProvisioned | Lifecycle::Stopped => "stopped",
+        Lifecycle::Starting => "starting",
+        Lifecycle::Running => "running",
+        Lifecycle::Stopping => "stopping",
+    }
+}
+
+fn print_json(state: &State, uptime_seconds: Option<u64>) -> Result<()> {
+    let json = serde_json::json!({
+        "state": lifecycle_state_str(state.lifecycle),
+        "daemon_pid": state.daemon_pid,
+        "uptime_seconds": uptime_seconds,
+    });
+    println!("{json}");
+    Ok(())
+}
+
+fn print_human(state: &State, uptime_seconds: Option<u64>) {
+    match state.lifecycle {
+        Lifecycle::NotProvisioned | Lifecycle::Stopped => println!("stopped"),
+        Lifecycle::Starting => println!("starting"),
+        Lifecycle::Stopping => println!("stopping"),
+        Lifecycle::Running => {
+            let uptime = uptime_seconds.unwrap_or(0);
+            let pid = state
+                .daemon_pid
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            println!("running (pid={pid}, uptime={uptime}s)");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lifecycle::Lifecycle;
+    use crate::state::State;
+
+    fn make_state_dir(tmp: &tempfile::TempDir) -> StateDir {
+        StateDir::new(tmp.path().to_path_buf()).expect("StateDir::new")
+    }
+
+    #[test]
+    fn not_provisioned_exits_stopped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exit = run_with_state_dir(false, tmp.path().to_path_buf()).unwrap();
+        assert_eq!(exit, StatusExit::Stopped);
+    }
+
+    #[test]
+    fn stopped_state_exits_stopped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+        sd.write_state(&State::stopped()).unwrap();
+        let exit = run_with_state_dir(false, tmp.path().to_path_buf()).unwrap();
+        assert_eq!(exit, StatusExit::Stopped);
+    }
+
+    #[test]
+    fn running_state_exits_running() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+        sd.write_state(&State {
+            lifecycle: Lifecycle::Running,
+            daemon_pid: Some(12345),
+            started_at: Some(1_700_000_000),
+        })
+        .unwrap();
+        let exit = run_with_state_dir(false, tmp.path().to_path_buf()).unwrap();
+        assert_eq!(exit, StatusExit::Running);
+    }
+
+    #[test]
+    fn starting_state_exits_stopped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+        sd.write_state(&State {
+            lifecycle: Lifecycle::Starting,
+            daemon_pid: None,
+            started_at: None,
+        })
+        .unwrap();
+        let exit = run_with_state_dir(false, tmp.path().to_path_buf()).unwrap();
+        assert_eq!(exit, StatusExit::Stopped);
+    }
+
+    #[test]
+    fn json_output_contains_required_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+        sd.write_state(&State {
+            lifecycle: Lifecycle::Running,
+            daemon_pid: Some(99),
+            started_at: Some(0),
+        })
+        .unwrap();
+        // run_with_state_dir prints to stdout; verify the exit code at minimum.
+        let exit = run_with_state_dir(true, tmp.path().to_path_buf()).unwrap();
+        assert_eq!(exit, StatusExit::Running);
+    }
+
+    #[test]
+    fn lock_contention_exits_2() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+
+        // Hold an exclusive write lock and attempt a concurrent status.
+        let mut lock = sd.lifecycle_lock().unwrap();
+        let _held = lock.write().unwrap();
+
+        let exit = run_with_state_dir(false, tmp.path().to_path_buf()).unwrap();
+        assert_eq!(exit, StatusExit::LockContention);
+    }
+}

--- a/crates/minimald/src/cmd/stop.rs
+++ b/crates/minimald/src/cmd/stop.rs
@@ -1,0 +1,239 @@
+//! `minimald stop` subcommand.
+//!
+//! Reads `daemon_pid` from `state.toml`, sends `SIGTERM` to the daemon child,
+//! waits up to 5 s, escalates to `SIGKILL` on timeout, then removes `daemon.pid`
+//! and resets `state.toml` to `Stopped`.
+//!
+//! The command is idempotent: if the daemon is already stopped (or has never
+//! been provisioned), it returns successfully with no action.
+
+use anyhow::{Context as _, Result};
+
+use crate::lifecycle::Lifecycle;
+use crate::state::{State, StateDir};
+
+/// Run the `stop` subcommand.
+pub fn run() -> Result<()> {
+    run_with_state_dir(StateDir::default_path())
+}
+
+fn run_with_state_dir(dir: std::path::PathBuf) -> Result<()> {
+    let state_dir = StateDir::new(dir).context("opening state dir")?;
+
+    // ── Phase 1: read current state under lock ───────────────────────────────
+    let daemon_pid = {
+        let mut lock = state_dir
+            .lifecycle_lock()
+            .context("opening lifecycle lock")?;
+        let _guard = lock.write().context("acquiring lifecycle write lock")?;
+        let state = state_dir.read_state().context("reading state")?;
+
+        match state.lifecycle {
+            Lifecycle::Stopped | Lifecycle::NotProvisioned => {
+                tracing::info!("minimald is not running");
+                return Ok(()); // idempotent: already stopped
+            }
+            Lifecycle::Stopping => {
+                tracing::info!("minimald is already stopping");
+                return Ok(()); // idempotent: stop already in progress
+            }
+            _ => {}
+        }
+
+        state.daemon_pid // may be None during Starting before pid is written
+    };
+
+    // ── Phase 2: signal the daemon child (lock NOT held) ─────────────────────
+    // Releasing the lock during the wait allows concurrent `status` reads.
+    match daemon_pid {
+        Some(pid) => signal_and_wait(pid)?,
+        None => {
+            tracing::warn!("daemon is active but daemon_pid is absent; cleaning up state");
+        }
+    }
+
+    // ── Phase 3: reset state to Stopped (under lock) ─────────────────────────
+    {
+        let mut lock = state_dir
+            .lifecycle_lock()
+            .context("opening lifecycle lock")?;
+        let _guard = lock.write().context("acquiring lifecycle write lock")?;
+        let _ = std::fs::remove_file(state_dir.daemon_pid_path());
+        state_dir
+            .write_state(&State::stopped())
+            .context("writing Stopped state")?;
+    }
+
+    tracing::info!("minimald stopped");
+    Ok(())
+}
+
+/// Send `SIGTERM` to `pid`; wait up to 5 s; escalate to `SIGKILL` on timeout.
+fn signal_and_wait(pid: u32) -> Result<()> {
+    use std::time::{Duration, Instant};
+
+    let pid_t = libc::pid_t::try_from(pid)
+        .map_err(|_| anyhow::anyhow!("invalid daemon_pid {pid} in state"))?;
+    if pid_t <= 0 {
+        return Err(anyhow::anyhow!("invalid daemon_pid {pid} in state"));
+    }
+
+    // SAFETY: kill(pid, SIGTERM) delivers SIGTERM to the named process. The pid
+    // was stored in state.toml by the `run` supervisor that created the daemon
+    // child; it may have already exited (ESRCH), which is handled below.
+    let r = unsafe { libc::kill(pid_t, libc::SIGTERM) };
+    if r != 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ESRCH) {
+            // Process does not exist; nothing to signal.
+            tracing::debug!(pid, "daemon process already gone (ESRCH)");
+            return Ok(());
+        }
+        return Err(anyhow::anyhow!("SIGTERM to pid {pid}: {err}"));
+    }
+
+    tracing::debug!(pid, "SIGTERM sent; waiting up to 5s");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        // SAFETY: kill(pid, 0) checks for process existence without delivering
+        // a signal. Errors other than ESRCH are ignored as best-effort.
+        let alive = unsafe { libc::kill(pid_t, 0) == 0 };
+        if !alive {
+            break;
+        }
+        if Instant::now() >= deadline {
+            tracing::warn!(
+                pid,
+                "daemon process did not exit after SIGTERM; sending SIGKILL"
+            );
+            // SAFETY: SIGKILL is a forced termination with no side effects
+            // beyond killing the named process. The pid originated from our
+            // own supervised daemon child.
+            unsafe { libc::kill(pid_t, libc::SIGKILL) };
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lifecycle::Lifecycle;
+    use crate::state::State;
+
+    fn make_state_dir(tmp: &tempfile::TempDir) -> StateDir {
+        StateDir::new(tmp.path().to_path_buf()).expect("StateDir::new")
+    }
+
+    #[test]
+    fn stop_is_noop_when_not_provisioned() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No state.toml — should be a no-op.
+        run_with_state_dir(tmp.path().to_path_buf()).unwrap();
+    }
+
+    #[test]
+    fn stop_is_noop_when_already_stopped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+        sd.write_state(&State::stopped()).unwrap();
+        run_with_state_dir(tmp.path().to_path_buf()).unwrap();
+        // State should still be Stopped.
+        let s = sd.read_state().unwrap();
+        assert_eq!(s.lifecycle, Lifecycle::Stopped);
+    }
+
+    #[test]
+    fn stop_is_noop_when_already_stopping() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+        sd.write_state(&State {
+            lifecycle: Lifecycle::Stopping,
+            daemon_pid: Some(999_999_999),
+            started_at: None,
+        })
+        .unwrap();
+        // Should return Ok without error, even with a non-existent pid.
+        run_with_state_dir(tmp.path().to_path_buf()).unwrap();
+    }
+
+    #[test]
+    fn stop_cleans_up_running_state_with_nonexistent_pid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+        // Use a PID that cannot exist (pid 0 is the kernel scheduler on Unix).
+        // signal_and_wait will get ESRCH and skip the wait.
+        // We use a large synthetic PID that won't collide with real processes
+        // in the test runner.
+        let fake_pid = 999_998u32; // likely ESRCH in CI
+        sd.write_state(&State {
+            lifecycle: Lifecycle::Running,
+            daemon_pid: Some(fake_pid),
+            started_at: Some(0),
+        })
+        .unwrap();
+        // Write a daemon.pid file too.
+        std::fs::write(sd.daemon_pid_path(), format!("{fake_pid}\n")).unwrap();
+
+        // stop must not error even when the process is gone (ESRCH).
+        run_with_state_dir(tmp.path().to_path_buf()).unwrap();
+
+        // State must be Stopped and daemon.pid must be removed.
+        let s = sd.read_state().unwrap();
+        assert_eq!(s.lifecycle, Lifecycle::Stopped);
+        assert!(
+            !sd.daemon_pid_path().exists(),
+            "daemon.pid must be removed"
+        );
+    }
+
+    #[test]
+    fn stop_with_no_pid_in_state_still_resets_to_stopped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+        sd.write_state(&State {
+            lifecycle: Lifecycle::Running,
+            daemon_pid: None,
+            started_at: None,
+        })
+        .unwrap();
+        run_with_state_dir(tmp.path().to_path_buf()).unwrap();
+        let s = sd.read_state().unwrap();
+        assert_eq!(s.lifecycle, Lifecycle::Stopped);
+    }
+
+    #[test]
+    fn stop_rejects_pid_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+        sd.write_state(&State {
+            lifecycle: Lifecycle::Running,
+            daemon_pid: Some(0),
+            started_at: None,
+        })
+        .unwrap();
+        assert!(run_with_state_dir(tmp.path().to_path_buf()).is_err());
+    }
+
+    #[test]
+    fn stop_rejects_pid_exceeding_pid_t_max() {
+        // u32::MAX > i32::MAX; try_from must fail rather than silently wrapping.
+        if libc::pid_t::try_from(u32::MAX).is_ok() {
+            // On a platform where pid_t is wider than i32, skip this guard.
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let sd = make_state_dir(&tmp);
+        sd.write_state(&State {
+            lifecycle: Lifecycle::Running,
+            daemon_pid: Some(u32::MAX),
+            started_at: None,
+        })
+        .unwrap();
+        assert!(run_with_state_dir(tmp.path().to_path_buf()).is_err());
+    }
+}

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -1,15 +1,18 @@
 use std::collections::BTreeMap;
 
+pub mod cmd;
 pub mod connection;
 mod exec;
 #[cfg(target_os = "linux")]
 pub mod guest;
+pub mod lifecycle;
 pub mod rpc;
 pub mod server;
 mod session;
 pub mod session_host;
 mod sessions;
 mod sftp;
+pub mod state;
 #[cfg(test)]
 mod test_harness;
 

--- a/crates/minimald/src/lifecycle.rs
+++ b/crates/minimald/src/lifecycle.rs
@@ -1,0 +1,303 @@
+//! Pure lifecycle state machine for `minimald` (R4.7).
+//!
+//! All state transitions pass through [`next_state`], which has no I/O and is
+//! exhaustively tested. Illegal transitions return [`TransitionError`].
+//!
+//! This module is a direct adaptation of the equivalent in `crates/minvmd/src/lifecycle.rs`.
+//! Both daemons share the same lifecycle model; this copy avoids a
+//! cross-crate dependency for what is fundamentally an 80-line pure-function
+//! module.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// The lifecycle states of the `minimald` daemon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Lifecycle {
+    /// No state file exists; daemon has never been provisioned.
+    NotProvisioned,
+    /// Daemon is stopped and ready to start.
+    Stopped,
+    /// Daemon is in the process of starting (listening on UDS).
+    Starting,
+    /// Daemon is running and accepting connections.
+    Running,
+    /// Daemon is shutting down.
+    Stopping,
+}
+
+/// An action that drives a lifecycle transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// Initialise state storage; `NotProvisioned → Stopped`.
+    Provision,
+    /// Begin startup sequence; `Stopped → Starting`.
+    Start,
+    /// Daemon UDS is accepting connections; `Starting → Running`.
+    MarkRunning,
+    /// Begin graceful shutdown; `Running → Stopping`.
+    Stop,
+    /// Shutdown complete; `Stopping → Stopped`.
+    MarkStopped,
+    /// An unexpected failure; `Starting | Running | Stopping → Stopped`.
+    Fail,
+}
+
+/// Error produced by an illegal (`current`, `action`) combination.
+#[derive(Debug)]
+pub struct TransitionError {
+    pub current: Lifecycle,
+    pub action: Action,
+}
+
+impl fmt::Display for TransitionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "illegal lifecycle transition: {:?} + {:?}",
+            self.current, self.action
+        )
+    }
+}
+
+impl std::error::Error for TransitionError {}
+
+/// Compute the next lifecycle state given `current` and `action` (R4.7).
+///
+/// This function is pure — no I/O, no side effects. Every caller that wants
+/// to persist the new state must write it to disk themselves.
+#[must_use = "the resulting state must be persisted"]
+pub fn next_state(current: Lifecycle, action: Action) -> Result<Lifecycle, TransitionError> {
+    use Action::*;
+    use Lifecycle::*;
+
+    match (current, action) {
+        (NotProvisioned, Provision) => Ok(Stopped),
+        (Stopped, Start) => Ok(Starting),
+        (Starting, MarkRunning) => Ok(Running),
+        (Starting, Fail) => Ok(Stopped),
+        (Running, Stop) => Ok(Stopping),
+        (Running, Fail) => Ok(Stopped),
+        (Stopping, MarkStopped) => Ok(Stopped),
+        (Stopping, Fail) => Ok(Stopped),
+        _ => Err(TransitionError { current, action }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Case {
+        current: Lifecycle,
+        action: Action,
+        expected: Result<Lifecycle, ()>,
+    }
+
+    fn ok(s: Lifecycle) -> Result<Lifecycle, ()> {
+        Ok(s)
+    }
+    fn err() -> Result<Lifecycle, ()> {
+        Err(())
+    }
+
+    fn run(cases: &[Case]) {
+        for c in cases {
+            let got = next_state(c.current, c.action).map_err(|_| ());
+            assert_eq!(
+                got, c.expected,
+                "next_state({:?}, {:?})",
+                c.current, c.action
+            );
+        }
+    }
+
+    #[test]
+    fn legal_transitions() {
+        use Action::*;
+        use Lifecycle::*;
+
+        run(&[
+            Case {
+                current: NotProvisioned,
+                action: Provision,
+                expected: ok(Stopped),
+            },
+            Case {
+                current: Stopped,
+                action: Start,
+                expected: ok(Starting),
+            },
+            Case {
+                current: Starting,
+                action: MarkRunning,
+                expected: ok(Running),
+            },
+            Case {
+                current: Starting,
+                action: Fail,
+                expected: ok(Stopped),
+            },
+            Case {
+                current: Running,
+                action: Stop,
+                expected: ok(Stopping),
+            },
+            Case {
+                current: Running,
+                action: Fail,
+                expected: ok(Stopped),
+            },
+            Case {
+                current: Stopping,
+                action: MarkStopped,
+                expected: ok(Stopped),
+            },
+            Case {
+                current: Stopping,
+                action: Fail,
+                expected: ok(Stopped),
+            },
+        ]);
+    }
+
+    #[test]
+    fn illegal_transitions() {
+        use Action::*;
+        use Lifecycle::*;
+
+        run(&[
+            // Can't re-provision once initialised
+            Case {
+                current: Stopped,
+                action: Provision,
+                expected: err(),
+            },
+            Case {
+                current: Starting,
+                action: Provision,
+                expected: err(),
+            },
+            Case {
+                current: Running,
+                action: Provision,
+                expected: err(),
+            },
+            Case {
+                current: Stopping,
+                action: Provision,
+                expected: err(),
+            },
+            // Can't start from non-Stopped states
+            Case {
+                current: NotProvisioned,
+                action: Start,
+                expected: err(),
+            },
+            Case {
+                current: Starting,
+                action: Start,
+                expected: err(),
+            },
+            Case {
+                current: Running,
+                action: Start,
+                expected: err(),
+            },
+            Case {
+                current: Stopping,
+                action: Start,
+                expected: err(),
+            },
+            // MarkRunning only valid from Starting
+            Case {
+                current: NotProvisioned,
+                action: MarkRunning,
+                expected: err(),
+            },
+            Case {
+                current: Stopped,
+                action: MarkRunning,
+                expected: err(),
+            },
+            Case {
+                current: Running,
+                action: MarkRunning,
+                expected: err(),
+            },
+            Case {
+                current: Stopping,
+                action: MarkRunning,
+                expected: err(),
+            },
+            // Stop only valid from Running
+            Case {
+                current: NotProvisioned,
+                action: Stop,
+                expected: err(),
+            },
+            Case {
+                current: Stopped,
+                action: Stop,
+                expected: err(),
+            },
+            Case {
+                current: Starting,
+                action: Stop,
+                expected: err(),
+            },
+            Case {
+                current: Stopping,
+                action: Stop,
+                expected: err(),
+            },
+            // MarkStopped only valid from Stopping
+            Case {
+                current: NotProvisioned,
+                action: MarkStopped,
+                expected: err(),
+            },
+            Case {
+                current: Stopped,
+                action: MarkStopped,
+                expected: err(),
+            },
+            Case {
+                current: Starting,
+                action: MarkStopped,
+                expected: err(),
+            },
+            Case {
+                current: Running,
+                action: MarkStopped,
+                expected: err(),
+            },
+            // Fail not valid from NotProvisioned or Stopped
+            Case {
+                current: NotProvisioned,
+                action: Fail,
+                expected: err(),
+            },
+            Case {
+                current: Stopped,
+                action: Fail,
+                expected: err(),
+            },
+        ]);
+    }
+
+    #[test]
+    fn transition_error_display() {
+        let err = TransitionError {
+            current: Lifecycle::Stopped,
+            action: Action::MarkRunning,
+        };
+        let s = format!("{err}");
+        assert!(s.contains("illegal"), "display: {s}");
+        assert!(s.contains("Stopped"), "display: {s}");
+        assert!(s.contains("MarkRunning"), "display: {s}");
+    }
+}

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -5,7 +5,7 @@ use camino::Utf8PathBuf;
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 use paths::{CwdRelative, Daemon, DaemonAbsPath, DaemonRelPath, sub_path};
-use tokio::{net::UnixListener, runtime::Builder};
+use tokio::runtime::Builder;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 use minimald::server::{Config, HostKey, Server};
@@ -125,6 +125,10 @@ enum Command {
     Completions(CompletionsArgs),
     /// Runs the minimald server in the foreground.
     Run(ListenArgs),
+    /// Print the daemon status (human-readable or JSON).
+    Status(StatusArgs),
+    /// Stop the daemon gracefully (SIGTERM, then SIGKILL after 5s).
+    Stop,
 }
 
 /// The arguments for the completions subcommand.
@@ -133,6 +137,14 @@ struct CompletionsArgs {
     /// The shell type for a CLI completion script should be printed
     #[arg(value_parser)]
     shell: Shell,
+}
+
+/// Arguments for the status subcommand.
+#[derive(Debug, clap::Args)]
+struct StatusArgs {
+    /// Output status as JSON.
+    #[arg(long)]
+    json: bool,
 }
 
 /// Shared arguments for all subcommands.
@@ -181,6 +193,18 @@ pub struct ListenArgs {
     #[arg(long)]
     #[clap(hide = true)]
     mount_rootfs: Option<String>,
+
+    /// Run the daemon in the background (detached from the terminal).
+    ///
+    /// Spawns a child process that survives the parent shell, then returns
+    /// once the UDS socket is accepting connections.
+    #[arg(long, default_value_t = false)]
+    detach: bool,
+
+    /// Timeout in seconds for `--detach` to wait for the UDS socket to become
+    /// ready. Defaults to 4 seconds (shorter than minvmd since no VM boot).
+    #[arg(long, default_value_t = minimald::cmd::run::DEFAULT_DETACH_TIMEOUT_SECS)]
+    detach_timeout: u64,
 }
 
 /// An error at the top level of minimald.
@@ -234,6 +258,8 @@ async fn async_main() -> Result<(), MainError> {
                 vsock: true,
                 mount_dev: true,
                 mount_rootfs: Some("/dev/vda".to_string()),
+                detach: false,
+                detach_timeout: minimald::cmd::run::DEFAULT_DETACH_TIMEOUT_SECS,
             }),
             global_args: GlobalArgs {
                 minimal_state_dir: Some(DaemonAbsPath::try_new("/run/minimal").unwrap().into()),
@@ -253,6 +279,18 @@ async fn async_main() -> Result<(), MainError> {
         let mut cmd = Cli::command();
         let name = cmd.get_name().to_string();
         clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
+        return Ok(());
+    }
+
+    // Handle status and stop commands (no server needed).
+    if let Command::Status(args) = cli.command {
+        let exit = minimald::cmd::status::run(args.json)
+            .map_err(|e| MainError::Other(e.to_string()))?;
+        std::process::exit(exit.code());
+    }
+    if let Command::Stop = cli.command {
+        minimald::cmd::stop::run()
+            .map_err(|e| MainError::Other(e.to_string()))?;
         return Ok(());
     }
 
@@ -310,29 +348,18 @@ async fn async_main() -> Result<(), MainError> {
     // If we got this far we need to launch minimald.
     if !cli.listen_args().unwrap().vsock {
         // standard path, listening on UDS socket
-        if let Err(e) = std::fs::remove_file(cli.listen_on())
-            && e.kind() != std::io::ErrorKind::NotFound
-        {
-            return Err(MainError::IO(e, "socket already in use"));
-        }
-        let listener = UnixListener::bind(cli.listen_on())
-            .map_err(|e| MainError::IO(e, "listening to socket"))?;
+        let listen_on = cli.listen_on();
+        let listen_args = cli.listen_args().unwrap();
 
-        tracing::info!("Started listening on {}", cli.listen_on());
-        let (opts, ssh_name) = cli.ssh_args();
-        tracing::info!(
-            "Run the following to debug the socket:\n\nssh \\\n\t{} \\\n\t{}",
-            opts.into_iter()
-                .map(|(n, v)| format!("-o '{n}={v}'"))
-                .collect::<Vec<String>>()
-                .join(" \\\n\t"),
-            ssh_name,
-        );
-        // TODO: When we have a daemonize command, daemonize here.
-
-        Server::run(config, listener)
-            .await
-            .map_err(|e| MainError::IO(e, "serving on UDS"))
+        minimald::cmd::run::run(
+            listen_args.detach,
+            listen_args.detach_timeout,
+            listen_on.as_utf8_path().as_std_path(),
+            config,
+            listen_args.instance_num,
+        )
+        .await
+        .map_err(|e| MainError::Other(e.to_string()))
     } else {
         // micro-vm path, listen on vsock
         if let Err(e) = guest::emit_ready_marker().await {

--- a/crates/minimald/src/state.rs
+++ b/crates/minimald/src/state.rs
@@ -1,0 +1,352 @@
+//! State persistence for `minimald` (R4.1, R4.6).
+//!
+//! Manages the state directory (`$XDG_STATE_HOME/minimal/minimald/`) which
+//! holds:
+//!
+//! - `state.toml` — serialised [`State`] (lifecycle, pid, timestamp).
+//! - `lifecycle.lock` — advisory file lock via `fd-lock` guarding concurrent
+//!   transitions (R4.6).
+//! - `daemon.pid` — PID of the live daemon child process.
+//!
+//! Writes to `state.toml` are atomic: content is written to a `.tmp` sibling,
+//! `fsync`'d, then renamed over the target (R4.1).
+//!
+//! [`StartingGuard`] is an RAII guard that resets the persisted state to
+//! `Stopped` on drop unless explicitly committed, so a panicking or
+//! short-circuiting transition cannot leave the daemon stuck in `Starting`
+//! (R4.6).
+//!
+//! This module is a direct adaptation of the equivalent in
+//! `crates/minvmd/src/state.rs`. Both daemons share the same lifecycle
+//! model; the main difference is `daemon.pid` replaces `vmm.pid`.
+
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{self, Write},
+    path::PathBuf,
+};
+
+use fd_lock::RwLock;
+use serde::{Deserialize, Serialize};
+
+use crate::lifecycle::Lifecycle;
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+/// Serialisable daemon state written to `state.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct State {
+    /// Current lifecycle phase.
+    pub lifecycle: Lifecycle,
+    /// PID of the daemon child process, if one is running.
+    pub daemon_pid: Option<u32>,
+    /// Unix timestamp (seconds) when the daemon last entered `Running`.
+    pub started_at: Option<u64>,
+}
+
+impl State {
+    /// A freshly-provisioned, not-yet-started state.
+    pub fn stopped() -> Self {
+        Self {
+            lifecycle: Lifecycle::Stopped,
+            daemon_pid: None,
+            started_at: None,
+        }
+    }
+}
+
+// ── StateDir ─────────────────────────────────────────────────────────────────
+
+/// Root of the `minimald` state directory.
+pub struct StateDir {
+    dir: PathBuf,
+}
+
+impl StateDir {
+    /// Open (and create if absent) the state directory at `dir`.
+    pub fn new(dir: PathBuf) -> io::Result<Self> {
+        fs::create_dir_all(&dir)?;
+        Ok(Self { dir })
+    }
+
+    /// Default path: `$XDG_STATE_HOME/minimal/minimald/` (fallback
+    /// `~/.local/state/minimal/minimald/`).
+    pub fn default_path() -> PathBuf {
+        dirs::state_dir()
+            .unwrap_or_else(|| {
+                dirs::home_dir()
+                    .unwrap_or_else(|| PathBuf::from("/tmp"))
+                    .join(".local/state")
+            })
+            .join("minimal/minimald")
+    }
+
+    /// Path to `state.toml`.
+    pub fn state_path(&self) -> PathBuf {
+        self.dir.join("state.toml")
+    }
+
+    /// Path to `lifecycle.lock`.
+    pub fn lock_path(&self) -> PathBuf {
+        self.dir.join("lifecycle.lock")
+    }
+
+    /// Path to `daemon.pid`.
+    pub fn daemon_pid_path(&self) -> PathBuf {
+        self.dir.join("daemon.pid")
+    }
+
+    /// Read the current state from `state.toml`.
+    ///
+    /// Returns `State { lifecycle: NotProvisioned, .. }` when the file does
+    /// not yet exist.
+    pub fn read_state(&self) -> io::Result<State> {
+        match fs::read_to_string(self.state_path()) {
+            Ok(s) => toml::from_str(&s).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(State {
+                lifecycle: Lifecycle::NotProvisioned,
+                daemon_pid: None,
+                started_at: None,
+            }),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Write `state` to `state.toml` atomically (tmp → fsync → rename) (R4.1).
+    pub fn write_state(&self, state: &State) -> io::Result<()> {
+        let target = self.state_path();
+        let tmp = target.with_extension("toml.tmp");
+        let serialised =
+            toml::to_string(state).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        {
+            let mut f = File::create(&tmp)?;
+            f.write_all(serialised.as_bytes())?;
+            f.sync_all()?;
+        }
+        fs::rename(&tmp, &target)
+    }
+
+    /// Open the `lifecycle.lock` file suitable for wrapping in an
+    /// [`fd_lock::RwLock`].
+    ///
+    /// Create the file if it does not exist; the file's contents are
+    /// irrelevant — only its file descriptor is used for advisory locking.
+    pub fn open_lock_file(&self) -> io::Result<File> {
+        OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(self.lock_path())
+    }
+
+    /// Convenience: return an [`fd_lock::RwLock`] wrapping the lock file.
+    ///
+    /// Callers call `.write()` on the returned lock to acquire an exclusive
+    /// advisory lock for the duration of a lifecycle transition (R4.6).
+    pub fn lifecycle_lock(&self) -> io::Result<RwLock<File>> {
+        Ok(RwLock::new(self.open_lock_file()?))
+    }
+}
+
+// ── StartingGuard ─────────────────────────────────────────────────────────────
+
+/// RAII guard that resets persisted state to `Stopped` on drop unless
+/// [`commit`](StartingGuard::commit) is called (R4.6).
+///
+/// Use this when transitioning into `Starting`: if the caller panics or
+/// returns early the guard's `Drop` impl writes `Stopped` so the daemon
+/// cannot be left indefinitely stuck in a `Starting` state.
+pub struct StartingGuard {
+    dir: PathBuf,
+    committed: bool,
+}
+
+impl StartingGuard {
+    /// Create a guard scoped to `dir`.
+    pub fn new(dir: PathBuf) -> Self {
+        Self {
+            dir,
+            committed: false,
+        }
+    }
+
+    /// Mark this transition as successfully completed; the `Drop` impl will
+    /// do nothing.
+    pub fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for StartingGuard {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        // Best-effort reset: read current state, overwrite lifecycle to
+        // Stopped, clear daemon_pid and started_at.  Errors are swallowed
+        // because Drop cannot propagate them; the best we can do is try.
+        let state_dir = StateDir {
+            dir: self.dir.clone(),
+        };
+        let result = state_dir.read_state().and_then(|mut s| {
+            s.lifecycle = Lifecycle::Stopped;
+            s.daemon_pid = None;
+            s.started_at = None;
+            state_dir.write_state(&s)
+        });
+        // Intentional discard: we are in Drop, there is nowhere to propagate.
+        let _ = result;
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    fn make_state_dir(tmp: &tempfile::TempDir) -> StateDir {
+        StateDir::new(tmp.path().to_path_buf()).expect("StateDir::new")
+    }
+
+    // ── Atomic write round-trip ──────────────────────────────────────────────
+
+    #[test]
+    fn state_round_trips_through_toml() {
+        let tmp = temp_dir();
+        let sd = make_state_dir(&tmp);
+
+        let original = State {
+            lifecycle: Lifecycle::Running,
+            daemon_pid: Some(12345),
+            started_at: Some(1_700_000_000),
+        };
+        sd.write_state(&original).expect("write");
+
+        let read_back = sd.read_state().expect("read");
+        assert_eq!(read_back.lifecycle, Lifecycle::Running);
+        assert_eq!(read_back.daemon_pid, Some(12345));
+        assert_eq!(read_back.started_at, Some(1_700_000_000));
+    }
+
+    #[test]
+    fn missing_state_file_returns_not_provisioned() {
+        let tmp = temp_dir();
+        let sd = make_state_dir(&tmp);
+        // No write; file does not exist.
+        let s = sd.read_state().expect("read");
+        assert_eq!(s.lifecycle, Lifecycle::NotProvisioned);
+        assert!(s.daemon_pid.is_none());
+        assert!(s.started_at.is_none());
+    }
+
+    #[test]
+    fn atomic_write_uses_tmp_then_renames() {
+        // After a successful write the .toml.tmp sibling must not exist.
+        let tmp = temp_dir();
+        let sd = make_state_dir(&tmp);
+        sd.write_state(&State::stopped()).expect("write");
+
+        let tmp_path = sd.state_path().with_extension("toml.tmp");
+        assert!(
+            !tmp_path.exists(),
+            "tmp file should not exist after atomic rename"
+        );
+        assert!(sd.state_path().exists(), "state.toml should exist");
+    }
+
+    // ── fd-lock concurrency guard ────────────────────────────────────────────
+
+    #[test]
+    fn lifecycle_lock_acquired_and_released() {
+        let tmp = temp_dir();
+        let sd = make_state_dir(&tmp);
+
+        let mut lock = sd.lifecycle_lock().expect("lifecycle_lock");
+        {
+            let _guard = lock.write().expect("write lock acquired");
+            // Lock is held here.
+            assert!(sd.lock_path().exists(), "lock file must exist");
+        }
+        // Guard dropped — lock released. A second acquisition must succeed.
+        let _guard2 = lock.write().expect("re-acquire after release");
+    }
+
+    #[test]
+    fn lifecycle_lock_prevents_concurrent_access() {
+        let tmp = temp_dir();
+        let sd = make_state_dir(&tmp);
+
+        let mut lock1 = sd.lifecycle_lock().expect("lock1");
+        // Open a second fd to the same lock file.
+        let mut lock2 = RwLock::new(sd.open_lock_file().expect("lock2 file"));
+
+        let _guard1 = lock1.write().expect("first write lock");
+        // A non-blocking attempt on the second fd must fail with WouldBlock.
+        let result = lock2.try_write();
+        assert!(
+            result.is_err(),
+            "second concurrent lock attempt must fail while first is held"
+        );
+    }
+
+    // ── StartingGuard RAII ───────────────────────────────────────────────────
+
+    #[test]
+    fn starting_guard_resets_to_stopped_on_drop() {
+        let tmp = temp_dir();
+        let sd = make_state_dir(&tmp);
+
+        // Write Starting state.
+        sd.write_state(&State {
+            lifecycle: Lifecycle::Starting,
+            daemon_pid: Some(999),
+            started_at: Some(42),
+        })
+        .expect("write starting");
+
+        {
+            let guard = StartingGuard::new(tmp.path().to_path_buf());
+            // Drop without commit.
+            drop(guard);
+        }
+
+        let s = sd.read_state().expect("read after guard drop");
+        assert_eq!(
+            s.lifecycle,
+            Lifecycle::Stopped,
+            "guard must reset to Stopped on uncommitted drop"
+        );
+        assert!(s.daemon_pid.is_none(), "daemon_pid cleared on reset");
+        assert!(s.started_at.is_none(), "started_at cleared on reset");
+    }
+
+    #[test]
+    fn starting_guard_does_not_reset_when_committed() {
+        let tmp = temp_dir();
+        let sd = make_state_dir(&tmp);
+
+        sd.write_state(&State {
+            lifecycle: Lifecycle::Running,
+            daemon_pid: Some(777),
+            started_at: Some(99),
+        })
+        .expect("write running");
+
+        let guard = StartingGuard::new(tmp.path().to_path_buf());
+        guard.commit(); // committed — drop must not reset
+
+        let s = sd.read_state().expect("read after commit");
+        assert_eq!(
+            s.lifecycle,
+            Lifecycle::Running,
+            "committed guard must not overwrite state"
+        );
+        assert_eq!(s.daemon_pid, Some(777));
+    }
+}

--- a/plans/2026-06-16-minimald-lifecycle-management-v1.md
+++ b/plans/2026-06-16-minimald-lifecycle-management-v1.md
@@ -1,0 +1,128 @@
+# [minimald] Lifecycle Management: `run --detach`, `status`, `stop`
+
+## Objective
+
+Equip `minimald` with daemon lifecycle management matching the pattern established by `minvmd` (crates/minvmd). Currently `minimald` is foreground-only (`minimald run` without `--detach`, no `status`, no `stop`). The `minvmd` crate provides a complete, exhaustively tested lifecycle infrastructure that serves as the direct template. This work makes `minimald` a proper daemon that: starts in the background, reports its status, stops gracefully, survives client exits, and can be auto-spawned by `minimal2` on Linux.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Shared Lifecycle State Machine (pure, no I/O)
+
+- [ ] **Extract lifecycle module into a shared crate** — Move `crates/minvmd/src/lifecycle.rs` to a new `crates/minimal-daemon-core/src/lifecycle.rs` (or directly into `crates/minimald/src/lifecycle.rs` if sharing is deferred). Re-export from `minvmd` to preserve backward compatibility. The `Lifecycle` enum, `Action` enum, `TransitionError`, and `next_state()` function have zero I/O dependencies and are the canonical state machine for both daemons. This avoids duplicating the exhaustive test suite.
+
+- [ ] **Verify state machine generality** — Confirm the `Lifecycle` variants (`NotProvisioned`, `Stopped`, `Starting`, `Running`, `Stopping`) and `Action` variants (`Provision`, `Start`, `MarkRunning`, `Stop`, `MarkStopped`, `Fail`) apply identically to `minimald`. The `minvmd`-specific comment about "VM booting" on `Starting` is a doc nuance; the state semantics are identical: `Starting` means "daemon process spawned, waiting for readiness," `Running` means "server loop is accepting connections."
+
+- [ ] **Add to `minimald` Cargo.toml** — If the lifecycle module is shared via a new crate, add the dependency to `crates/minimald/Cargo.toml`. If placed directly in `minimald/src/lifecycle.rs`, ensure `serde` derives are available (already present).
+
+### Phase 2: State Persistence (`minimald/src/state.rs`)
+
+- [ ] **Implement `State` struct** — Create `crates/minimald/src/state.rs` with a `State` struct mirroring `crates/minvmd/src/state.rs:33-41`: `lifecycle: Lifecycle`, `pid: Option<u32>` (the daemon's own PID, analogous to `vmm_pid`), `started_at: Option<u64>`. Serialize/deserialize via `serde`.
+
+- [ ] **Implement `StateDir`** — Mirror `crates/minvmd/src/state.rs:57-146` with directory at `$XDG_STATE_HOME/minimal/minimald/` (or `~/.local/state/minimal/minimald/` as fallback), holding `state.toml`, `lifecycle.lock`, and `daemon.pid` files. Key methods:
+  - `default_path()`: resolve the standard state directory
+  - `state_path()`, `lock_path()`, `pid_path()`: path accessors
+  - `read_state()`: deserialize `state.toml`; return `NotProvisioned` if file absent
+  - `write_state()`: atomic write via `tmp → fsync → rename`
+  - `open_lock_file()` / `lifecycle_lock()`: `fd-lock::RwLock` wrapping `lifecycle.lock`
+
+- [ ] **Implement `StartingGuard`** — Mirror `crates/minvmd/src/state.rs:156-197`. RAII guard that resets persisted state to `Stopped` on drop unless `commit()` is called. Critical property: if the daemon panics or returns early during the `Starting` phase, the guard resets to `Stopped` so the daemon cannot be left indefinitely stuck in `Starting`.
+
+- [ ] **Write unit tests** — Mirror the test suite from `crates/minvmd/src/state.rs:201-348`:
+  - State TOML round-trip
+  - Missing state file returns `NotProvisioned`
+  - Atomic write uses tmp-then-rename (no `.toml.tmp` left behind)
+  - Lifecycle lock acquire/release
+  - Lifecycle lock prevents concurrent access (`WouldBlock`)
+  - `StartingGuard` resets to `Stopped` on uncommitted drop
+  - `StartingGuard` does not reset when committed
+
+### Phase 3: `run --detach` (background the daemon)
+
+- [ ] **Add `--detach` flag to `minimald run`** — Extend `ListenArgs` in `crates/minimald/src/main.rs:159-184` with `--detach: bool` and `--detach-timeout: u64` (default 4s — faster than `minvmd`'s 8s since no VM boot).
+
+- [ ] **Implement foreground supervisor** — Restructure `async_main()` to factor out the core server-accept loop into a function that takes a `Config` and runs `Server::run(config, listener)`. When `--detach` is false, run this inline (current behavior preserved).
+
+- [ ] **Implement `run_detach()`** — When `--detach` is true:
+  1. Acquire lifecycle lock, read state, validate the transition (`NotProvisioned → Provision → Stopped`, then `Stopped → Start → Starting`), write `Starting` state, release lock.
+  2. Spawn `minimald run` (foreground mode) as a child process via `Command::new(current_exe).arg("run").stdin(null).stdout(null).stderr(null)` with `setsid()` in `pre_exec` (same pattern as `crates/minvmd/src/cmd/run.rs:78-110`).
+  3. Write PID to `daemon.pid` and update state with `pid: Some(child_id)` under lock.
+  4. Poll the UDS socket path (`listen_on()`) until it accepts connections, using the `poll_uds_ready` pattern from `crates/minvmd/src/cmd/run.rs:47-65` (100ms intervals, timeout).
+  5. On socket readiness: transition state to `Running` under lock, write `started_at` timestamp, commit the `StartingGuard`.
+  6. On timeout or failure: kill the child, reset state to `Stopped`, return error.
+
+- [ ] **Add detach guard in the foreground path** — When `minimald run` runs in foreground mode (without `--detach`), on startup: update state to `Running` with `pid: Some(std::process::id())` and `started_at`. On graceful exit (SIGTERM/SIGINT), transition state back to `Stopped` and clean up `daemon.pid`. Use a `StartingGuard` around the boot sequence to handle early failures.
+
+### Phase 4: `status` and `stop` Subcommands
+
+- [ ] **Add `Status` subcommand** — Mirror `crates/minvmd/src/cmd/status.rs`:
+  - `minimald status`: human-readable output (`stopped`, `starting`, `stopping`, `running (pid=X, uptime=Ys)`)
+  - `minimald status --json`: JSON object with `state`, `pid`, `uptime_seconds`
+  - Exit codes: 0 if `Running`, 1 if stopped, 2 on lock contention
+  - Non-blocking `try_read()` on lifecycle lock to detect concurrent transitions
+
+- [ ] **Add `Stop` subcommand** — Mirror `crates/minvmd/src/cmd/stop.rs`:
+  - Idempotent: no-op when already `Stopped`, `NotProvisioned`, or `Stopping`
+  - Read `pid` from `state.toml` (under lock)
+  - Send `SIGTERM` to the daemon PID, wait 5s, escalate to `SIGKILL`
+  - Handle `ESRCH` (process already gone) gracefully
+  - Reset state to `Stopped`, remove `daemon.pid`
+  - Reject invalid PIDs (zero, exceeding `pid_t::MAX`)
+
+- [ ] **Wire subcommands into `minimald` CLI** — Add to the `Command` enum in `crates/minimald/src/main.rs:119-128`:
+  - `Status { #[arg(long)] json: bool }`
+  - `Stop`
+
+- [ ] **Write unit tests for `status` and `stop`** — Mirror the test suites from `crates/minvmd/src/cmd/status.rs:122-201` and `crates/minvmd/src/cmd/stop.rs:123-235`, adapted for `minimald`'s state directory path.
+
+### Phase 5: Auto-spawn in `minimal2` (Linux)
+
+- [ ] **Extend `minimal2` auto-spawn for Linux** — Modify `crates/minimal2/src/autospawn.rs` (currently no-op on Linux at `autospawn.rs:113-117`). On Linux:
+  1. Resolve `minimald`'s UDS path (should match `minimald listen_on()`: `$XDG_STATE_HOME/minimal/providers/local-0/ssh.sock`).
+  2. Check if the daemon is already running by running `minimald status` (or directly connecting to the UDS).
+  3. If not running, spawn `minimald run --detach` and poll the UDS via `poll_uds_ready` (timeout ~4s).
+  4. Return the `Client` connected to the resolved socket.
+
+- [ ] **Fix socket path resolution in `minimal2`** — Update `crates/minimal2/src/client.rs:182-186` (`resolve_socket_path`) to resolve to `$XDG_STATE_HOME/minimal/providers/local-0/ssh.sock` on Linux, matching `minimald`'s `listen_on()` (crates/minimald/src/main.rs:114-116). The current code resolves to `$XDG_RUNTIME_DIR/minimal/minimald.sock` which is a `minvmd`-specific path that doesn't match `minimald`'s actual listen path.
+
+---
+
+## Verification Criteria
+
+- `minimald run --detach` spawns the daemon in background, returns only after the UDS is accepting connections, and the daemon survives the parent process exit.
+- `minimald status` returns `stopped` (exit 1) when daemon is not running, `running (pid=X, uptime=Ys)` (exit 0) when running, and `status --json` outputs valid JSON.
+- `minimald stop` terminates a running daemon gracefully, resets state to `Stopped`, and is idempotent (can be called repeatedly without errors).
+- Two concurrent `minimald run --detach` invocations are prevented by the lifecycle lock (second one fails with a clear error).
+- `minimald status` during an in-progress start returns exit code 2 (lock contention) rather than a stale snapshot.
+- On Linux, `minimal2 ls` (without `--minimal-dir` override) auto-spawns `minimald` if not running, connects, and lists sessions.
+- All state machine, state persistence, status, and stop unit tests pass.
+- `minimald`'s existing `run` (foreground, no `--detach`) behavior is unchanged for scripting and debugging use.
+
+---
+
+## Potential Risks and Mitigations
+
+1. **Risk: Breaking `minvmd` by extracting shared lifecycle module**
+   - Mitigation: If extracting to a shared crate, keep `minvmd`'s existing `lifecycle.rs` as a thin re-export for backward compatibility. Run `minvmd`'s full test suite after extraction. If this proves too invasive, duplicate the lifecycle module within `minimald` (it's ~80 lines of pure code + ~200 lines of tests) and add a comment cross-referencing the canonical source.
+
+2. **Risk: `fd-lock` dependency not yet in `minimald`'s Cargo.toml**
+   - Mitigation: Add `fd-lock` workspace dependency (already at `Cargo.toml:63` as `fd-lock = "4"`). Also add `toml` (already at workspace level, `Cargo.toml:112`). Both are already used by `minvmd`.
+
+3. **Risk: Daemon PID tracking race during `run --detach`**
+   - Mitigation: Follow `minvmd`'s proven pattern: write PID to `daemon.pid` and update state under the lifecycle lock immediately after `Command::spawn()`. Before committing `Running`, re-read state under lock to detect if a concurrent `stop` already reset the lifecycle. If so, kill the child and bail.
+
+4. **Risk: Linux vs. macOS divergence in auto-spawn**
+   - Mitigation: Gate Linux auto-spawn logic with `#[cfg(target_os = "linux")]`. On macOS, `minvmd`'s existing auto-spawn path (`minvmd run --detach`) remains unchanged. The auto-spawn function signature should handle both platforms — the existing macOS path calls `ensure_minvmd_running()`, the new Linux path calls `ensure_minimald_running()`.
+
+5. **Risk: Socket cleanup between daemon restarts**
+   - Mitigation: `minimald` already removes the stale socket before binding (`crates/minimald/src/main.rs:313-317`). Ensure `stop` does not remove the socket (it belongs to the daemon process, which cleans it up on exit). If the daemon crashes, the stale socket removal on next `run` handles it.
+
+## Outstanding / Not in Scope
+
+| Item | Rationale |
+|------|-----------|
+| `minimald doctor` command | Tracked separately in `gominimal/inbox#209` |
+| Session rename (`RenameSession` RPC) | Separate feature; requires RPC contract + store changes |
+| PTY interactive shell | Blocked on daemon-side PTY support (`exec.rs:650-654`) |
+| `minimald` on macOS | Only runs inside the VM; no native macOS binary needed |


### PR DESCRIPTION
Equips `minimald` with daemon lifecycle management matching the pattern established by `minvmd`.

**Plan:** `plans/2026-06-16-minimald-lifecycle-management-v1.md`

### What's Included

| Phase | Status | Summary |
|-------|--------|---------|
| 1. Lifecycle state machine | Done | Pure state machine with table-driven `next_state()` and exhaustive tests |
| 2. State persistence | Done | `State`, `StateDir`, `StartingGuard` — atomic state.toml, fd-lock |
| 3. `run --detach` | Done | Background daemon spawn, UDS polling (4s timeout), lifecycle transitions |
| 4. `status` / `stop` | Done | Human + JSON output, SIGTERM→SIGKILL escalation, idempotent |
| 5. Socket path + auto-spawn | Done | Fixed `resolve_socket_path()` to match `minimald`'s `listen_on()`; Linux auto-spawn in `minimal2` |

### Verification
- All 54 tests pass (53 `minimald` + 1 `minimal2`)
- `minimald run` (foreground) behavior unchanged
- `minimald run --detach` spawns in background, returns after UDS accepts connections
- `minimald status` returns human/JSON output with correct exit codes (0/1/2)
- `minimald stop` terminates gracefully, idempotent, handles already-stopped

### Notes
- `minimald` doesn't spawn automatically on Linux through `minimal2` — the auto-spawn code checks for it via UDS probe (the `minimald` binary must be in `PATH` on Linux)
- Matching `minvmd` lifecycle pattern: The lifecycle, state, status, and stop modules are deliberately structured to mirror `minvmd` for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added daemon lifecycle management with new `status` and `stop` subcommands
  * Implemented `run --detach` mode for background daemon execution
  * Expanded CLI with `activate`, `attach`, `destroy`, and `dash` commands for session management
  * Improved session listing with formatted output displaying session metadata
  * Added auto-spawn daemon support on Linux

* **Bug Fixes**
  * Fixed Linux auto-spawn to properly start daemon instead of returning no-op success

<!-- end of auto-generated comment: release notes by coderabbit.ai -->