### PR TITLE
ci: add job timeout caps + commitlint concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
   dogfood:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   fmt:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Run rustfmt
@@ -37,6 +38,7 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Free Disk Space
         uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
@@ -55,6 +57,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - name: Free Disk Space
         uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
@@ -81,6 +84,7 @@ jobs:
 
   dogfood:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-minimal
@@ -89,6 +93,7 @@ jobs:
 
   build-release-amd64:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
@@ -122,6 +127,7 @@ jobs:
 
   build-release-arm64:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
@@ -150,12 +156,14 @@ jobs:
 
   cargo-deny:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: EmbarkStudios/cargo-deny-action@v2
 
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [ci-success, build-release-amd64, build-release-arm64]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
@@ -235,6 +243,7 @@ jobs:
 
   minimal-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-minimal
@@ -247,6 +256,7 @@ jobs:
     if: always()
     needs: [fmt, clippy, test, dogfood, cargo-deny, minimal-check]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Verify all gating jobs succeeded
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,9 +8,14 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: commitlint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Root cause
No job in `ci.yml` set `timeout-minutes` — a hung job inherits GitHub's 6h ceiling. One June run already burned 191 min. minimal is the org's 2nd-largest runner-minute consumer (~18.5k min/mo MTD), and CI is the bulk of it.

`commitlint.yml` had no `concurrency` — stacked PR-push runs all ran to completion.

## Fix
Per-job caps on all 10 ci.yml jobs (sized above observed p95):

| Job | Cap |
|---|---|
| fmt / dogfood / cargo-deny / minimal-check / ci-success | 10 |
| clippy | 30 |
| test | 40 |
| build-release-amd64 / build-release-arm64 | 45 |
| release | 30 |

commitlint: `cancel-in-progress` concurrency + 5-min cap.

## Unchanged
`ci.yml` already has correct concurrency (`cancel-in-progress` on non-main refs).

## Acceptance
- Each job shows its cap in the run UI.
- A second push to a PR cancels the prior commitlint run.

Source: org-wide Actions-minute audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline reliability with execution timeout limits across multiple jobs.
  * Improved workflow concurrency management for commit linting processes to optimize resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->