### PR TITLE
feat(sessions): wire form types for client/daemon session creation communication

### DIFF
--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -210,3 +210,48 @@ impl OneshotSshRpc for RenameSession {
     type Request<'a> = RenameSessionRequest;
     type Response = Errorable<RenameSessionResponse>;
 }
+
+// ---------------------------------------------------------------------------
+// Session-creation flow (multi-round contribution composition).
+//
+// Distinct from the simpler [`CreateSession`] above: that one takes a
+// fully-formed [`sessions::Record`]; the flow below composes the record
+// by walking client contributions and daemon-side closures across one or
+// more rounds. Each call returns a [`SessionStep`]: either the next round
+// of pending items or a protocol-level fault.
+//
+// TODO: these three RPCs are the building blocks for what is eventually
+// going to subsume `CreateSession` — once the multi-round flow lands on
+// the daemon, the terminal `SessionStep` will assemble a `sessions::Record`
+// and the single-shot `CreateSession` becomes redundant. Keeping them
+// separate for now so the existing `CreateSession` callers stay working
+// while the contribution flow is built out.
+
+/// An RPC to open a new session and receive the first round of items
+/// the client must resolve.
+pub struct SessionCreate;
+
+impl OneshotSshRpc for SessionCreate {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "SessionCreate");
+    type Request<'a> = sessions::wire::request::SessionCreateRequest;
+    type Response = Errorable<sessions::wire::request::SessionStep>;
+}
+
+/// An RPC to submit the client's verdicts for one round and receive the
+/// next round (or a `complete` signal in [`sessions::wire::request::ContributionResponse`]).
+pub struct SubmitVerdict;
+
+impl OneshotSshRpc for SubmitVerdict {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "SubmitVerdict");
+    type Request<'a> = sessions::wire::request::ContributionVerdict;
+    type Response = Errorable<sessions::wire::request::SessionStep>;
+}
+
+/// An RPC to abort an in-flight session-creation flow.
+pub struct SessionAbort;
+
+impl OneshotSshRpc for SessionAbort {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "SessionAbort");
+    type Request<'a> = sessions::wire::request::Abort;
+    type Response = Errorable<()>;
+}

--- a/crates/sessions/src/core/source.rs
+++ b/crates/sessions/src/core/source.rs
@@ -140,8 +140,7 @@ impl ProvenancedPackage {
         }
     }
 
-    /// The package name (typically the form `name@version` used to
-    /// identify a package in the graph).
+    /// The package name used to identify it in the graph.
     #[must_use]
     pub fn package(&self) -> &str {
         &self.package

--- a/crates/sessions/src/wire/errors.rs
+++ b/crates/sessions/src/wire/errors.rs
@@ -1,0 +1,135 @@
+//! Wire-form error envelope.
+//!
+//! Rich local error types — [`ResolveError`], `PatchError`, `VarError`,
+//! `ExpandError` — stay local. They carry source chains, IO errors,
+//! and other non-serializable detail. Anything that needs to cross the
+//! RPC boundary collapses to [`WireError`] with a string summary.
+//!
+//! Conversions live here so the boundary is the only place a rich
+//! error is degraded.
+//!
+//! [`ResolveError`]: crate::client::composer::ResolveError
+
+/// Errors the daemon may send back to the client (or vice versa) in
+/// response to a wire-form request.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, thiserror::Error)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WireError {
+    /// The client's contribution failed validation. `message` is a
+    /// human-readable explanation; structured detail (which var,
+    /// which patch) is intentionally omitted to keep the wire schema
+    /// small. Use telemetry for forensic detail.
+    #[error("invalid contribution: {message}")]
+    InvalidContribution {
+        /// Free-form explanation.
+        message: String,
+    },
+    /// The wire protocol version the client sent is not one the
+    /// daemon supports.
+    #[error("unsupported protocol version {got}; daemon supports {supported}")]
+    UnknownProtocolVersion {
+        /// Version the client sent.
+        got: u32,
+        /// Highest version the daemon understands.
+        supported: u32,
+    },
+    /// A response referenced a session id the daemon doesn't have.
+    /// Typically means the session was torn down (timeout, abort)
+    /// before this message arrived.
+    #[error("unknown session id")]
+    UnknownSessionId,
+    /// Anything else — daemon-internal bug, transient infrastructure
+    /// failure, etc. Clients should surface as a generic failure and
+    /// not retry blindly.
+    #[error("internal: {message}")]
+    Internal {
+        /// Free-form explanation.
+        message: String,
+    },
+}
+
+impl From<crate::client::composer::ResolveError> for WireError {
+    /// Collapse a rich local resolve error to the wire envelope. The
+    /// `Display` summary is used; the source chain is dropped at the
+    /// boundary.
+    fn from(e: crate::client::composer::ResolveError) -> Self {
+        Self::Internal {
+            message: e.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip<T>(value: &T) -> T
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        let json = serde_json::to_string(value).expect("serialize");
+        serde_json::from_str(&json).expect("deserialize")
+    }
+
+    #[test]
+    fn round_trips_all_variants() {
+        let cases = [
+            WireError::InvalidContribution {
+                message: "vars[3] has no name".into(),
+            },
+            WireError::UnknownProtocolVersion {
+                got: 99,
+                supported: 1,
+            },
+            WireError::UnknownSessionId,
+            WireError::Internal {
+                message: "fs walk failed".into(),
+            },
+        ];
+        for e in cases {
+            assert_eq!(round_trip(&e), e);
+        }
+    }
+
+    #[test]
+    fn uses_explicit_kind_tag() {
+        let e = WireError::UnknownSessionId;
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(
+            json.contains(r#""kind":"unknown_session_id""#),
+            "expected `kind` tag, got: {json}"
+        );
+    }
+
+    /// `Display` (via `thiserror`) gives a human-readable summary for
+    /// each variant. Used by callers logging errors locally.
+    #[test]
+    fn display_formats_each_variant_readably() {
+        assert_eq!(
+            WireError::UnknownSessionId.to_string(),
+            "unknown session id",
+        );
+        assert_eq!(
+            WireError::UnknownProtocolVersion {
+                got: 99,
+                supported: 1
+            }
+            .to_string(),
+            "unsupported protocol version 99; daemon supports 1",
+        );
+    }
+
+    /// `From<ResolveError>` collapses to `Internal` with the local
+    /// error's `Display` text. Verifies the conversion exists and
+    /// doesn't accidentally expand the wire schema with structured
+    /// fields.
+    #[test]
+    fn from_resolve_error_collapses_to_internal() {
+        let local = crate::client::composer::ResolveError::Aborted;
+        let wire: WireError = local.into();
+        assert!(
+            matches!(wire, WireError::Internal { .. }),
+            "expected Internal, got: {wire:?}",
+        );
+    }
+}

--- a/crates/sessions/src/wire/mod.rs
+++ b/crates/sessions/src/wire/mod.rs
@@ -1,7 +1,13 @@
 //! Wire-form types for client/daemon RPC.
 //!
-//! Submodules land in subsequent steps of the split. This module is a
-//! placeholder; once the wire schema lands, it will host JSON-shaped
-//! mirrors of the local domain types in [`crate::core`], kept separate
-//! so the wire schema can evolve independently of the TOML loadout
-//! schema.
+//! These types mirror the local domain types in [`crate::core`] but
+//! are kept entirely separate so the wire schema can evolve
+//! independently of the TOML loadout schema and other local forms.
+//! All types here are JSON-friendly: enums use an explicit `kind`
+//! tag, newtypes are `#[serde(transparent)]`, and rich error sources
+//! collapse at the boundary (see [`errors`]).
+
+pub mod errors;
+pub mod policy;
+pub mod primitives;
+pub mod request;

--- a/crates/sessions/src/wire/policy.rs
+++ b/crates/sessions/src/wire/policy.rs
@@ -1,0 +1,122 @@
+//! Wire-form policy verdicts.
+//!
+//! Sent from the client to the daemon in response to the daemon's
+//! batch of pending items ([`super::primitives::WirePendingVar`] /
+//! [`super::primitives::WirePendingPatch`]). Each verdict carries the
+//! [`PendingId`] from the corresponding pending item so the daemon
+//! can correlate without relying on slice ordering.
+
+use super::primitives::{PendingId, WireResolvedVar};
+
+/// The client's decision about one pending variable.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WireVarVerdict {
+    /// User policy or prompt approved this var. The value is included
+    /// because the daemon doesn't have the client's env.
+    Approved {
+        /// Matches the corresponding `WirePendingVar::id`.
+        id: PendingId,
+        /// Resolved name + value.
+        value: WireResolvedVar,
+    },
+    /// User policy or prompt rejected this var.
+    Denied {
+        /// Matches the corresponding `WirePendingVar::id`.
+        id: PendingId,
+    },
+    /// User policy's `ignore` rule matched; silently drop.
+    Ignored {
+        /// Matches the corresponding `WirePendingVar::id`.
+        id: PendingId,
+    },
+}
+
+/// The client's decision about one pending patch.
+///
+/// Approved patches' file contents arrive separately as a tarball
+/// stream — not in this message.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WirePatchVerdict {
+    /// User policy or prompt approved. Content streamed out-of-band.
+    Approved {
+        /// Matches the corresponding `WirePendingPatch::id`.
+        id: PendingId,
+    },
+    /// User policy or prompt rejected.
+    Denied {
+        /// Matches the corresponding `WirePendingPatch::id`.
+        id: PendingId,
+    },
+    /// User policy's `ignore` rule matched; silently drop.
+    Ignored {
+        /// Matches the corresponding `WirePendingPatch::id`.
+        id: PendingId,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip<T>(value: &T) -> T
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        let json = serde_json::to_string(value).expect("serialize");
+        serde_json::from_str(&json).expect("deserialize")
+    }
+
+    #[test]
+    fn var_verdict_round_trips_all_variants() {
+        let cases = [
+            WireVarVerdict::Approved {
+                id: PendingId::new(1),
+                value: WireResolvedVar {
+                    name: "EDITOR".into(),
+                    value: "hx".into(),
+                },
+            },
+            WireVarVerdict::Denied {
+                id: PendingId::new(2),
+            },
+            WireVarVerdict::Ignored {
+                id: PendingId::new(3),
+            },
+        ];
+        for v in cases {
+            assert_eq!(round_trip(&v), v);
+        }
+    }
+
+    #[test]
+    fn patch_verdict_round_trips_all_variants() {
+        let cases = [
+            WirePatchVerdict::Approved {
+                id: PendingId::new(1),
+            },
+            WirePatchVerdict::Denied {
+                id: PendingId::new(2),
+            },
+            WirePatchVerdict::Ignored {
+                id: PendingId::new(3),
+            },
+        ];
+        for v in cases {
+            assert_eq!(round_trip(&v), v);
+        }
+    }
+
+    #[test]
+    fn var_verdict_uses_explicit_kind_tag() {
+        let v = WireVarVerdict::Denied {
+            id: PendingId::new(7),
+        };
+        let json = serde_json::to_string(&v).unwrap();
+        assert!(
+            json.contains(r#""kind":"denied""#),
+            "expected `kind` tag, got: {json}"
+        );
+    }
+}

--- a/crates/sessions/src/wire/primitives.rs
+++ b/crates/sessions/src/wire/primitives.rs
@@ -1,0 +1,416 @@
+//! Wire-form primitives for client/daemon RPC.
+//!
+//! These are JSON-shaped mirrors of the local domain types. They live
+//! in their own module — and have their own `serde` derives — so that
+//! the wire schema can evolve independently of the TOML wire forms
+//! used at config load. Nothing here uses `#[serde(untagged)]`.
+
+/// Origin of a contributed item. Mirrors [`crate::core::source::Source`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WireSource {
+    /// User loadout, identified by name.
+    UserLoadout {
+        /// Loadout name.
+        name: String,
+    },
+    /// Project (`minimal.toml`) at the given host path.
+    Project {
+        /// Host path to the project directory.
+        path: paths::HostPath,
+    },
+    /// Package, identified by name.
+    Package {
+        /// Package name.
+        name: String,
+    },
+}
+
+/// A fully-resolved variable: name and value as plain strings.
+///
+/// Mirrors [`crate::core::primitives::ResolvedVar`] in a form
+/// guaranteed to be JSON-serializable without reaching for any
+/// validating newtype.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WireResolvedVar {
+    /// Variable name.
+    pub name: String,
+    /// Resolved value.
+    pub value: String,
+}
+
+/// How a variable should resolve. Mirrors
+/// [`crate::core::primitives::VarValue`] but uses an explicitly tagged
+/// enum so JSON round-trips deterministically.
+///
+/// `Inherit` and `InheritWithDefault` are only meaningful before
+/// resolution — once the client has resolved a value, it ships as
+/// `WireResolvedVar`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WireVarSpec {
+    /// Literal value, takes effect verbatim.
+    Specified {
+        /// Variable value.
+        value: String,
+    },
+    /// Inherit from the parent environment; the client resolves.
+    Inherit,
+    /// Inherit from the parent environment; if unset, use `default`.
+    InheritWithDefault {
+        /// Fallback when the parent env has no entry.
+        default: String,
+    },
+}
+
+/// A resolved patch: where it lives on the host and where it lands in
+/// the sandbox. Mirrors [`crate::core::primitives::ResolvedPatch`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WireResolvedPatch {
+    /// Absolute host path of the source file.
+    pub host_path: paths::HostAbsPath,
+    /// Destination inside the sandbox, relative to the sandbox user's
+    /// home directory. Deserialization rejects absolute paths.
+    pub destination: paths::SandboxRelPath,
+}
+
+/// A resolved variable + its origin. Mirrors
+/// [`crate::client::composer::SessionVar`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WireSessionVar {
+    /// Resolved variable.
+    pub var: WireResolvedVar,
+    /// Where it came from.
+    pub source: WireSource,
+}
+
+/// A resolved patch + its origin. Mirrors
+/// [`crate::client::composer::SessionPatch`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WireSessionPatch {
+    /// Resolved patch.
+    pub patch: WireResolvedPatch,
+    /// Where it came from.
+    pub source: WireSource,
+}
+
+/// A lifecycle hook script. Mirrors
+/// [`crate::core::lifecyclehook::HookScript`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WireHookScript {
+    /// Script body stored inline.
+    Inline {
+        /// Script body.
+        body: String,
+    },
+    /// Path to a script file, resolved against the config dir at
+    /// apply time.
+    External {
+        /// Config-relative path to the script.
+        path: paths::ConfigRelPath,
+    },
+}
+
+/// A lifecycle hook. Mirrors
+/// [`crate::core::lifecyclehook::LifecycleHook`].
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WireLifecycleHook {
+    /// Run on session activation, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_activate: Option<WireHookScript>,
+    /// Run on session destruction, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_destroy: Option<WireHookScript>,
+    /// Run on session failure, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_failure: Option<WireHookScript>,
+}
+
+/// A lifecycle hook + its origin. Mirrors
+/// [`crate::core::source::ProvenancedHook`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WireProvenancedHook {
+    /// The hook.
+    pub hook: WireLifecycleHook,
+    /// Where it came from.
+    pub source: WireSource,
+}
+
+/// A package the client requested be installed. Mirrors
+/// [`crate::core::source::ProvenancedPackage`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WirePackageRef {
+    /// Package name.
+    pub name: String,
+    /// Where it was requested from.
+    pub source: WireSource,
+}
+
+/// Daemon-issued correlation token for a single pending item. Scoped
+/// to a single `(session_id, round)` pair on the wire.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(transparent)]
+pub struct PendingId(u32);
+
+impl PendingId {
+    /// Construct from a raw id. The daemon is responsible for
+    /// uniqueness within a round.
+    #[must_use]
+    pub fn new(id: u32) -> Self {
+        Self(id)
+    }
+
+    /// Underlying integer.
+    #[must_use]
+    pub fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// Daemon → Client: a variable from a package or the project that
+/// needs the client to resolve (if inherit-shaped) and run through
+/// user policy.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WirePendingVar {
+    /// Correlation id; client echoes it back on the verdict.
+    pub id: PendingId,
+    /// Variable name.
+    pub name: String,
+    /// How to resolve. Inherit-shaped variants require client-side env
+    /// lookup.
+    pub spec: WireVarSpec,
+    /// Where it came from.
+    pub source: WireSource,
+}
+
+/// Daemon → Client: a patch from a package or the project that needs
+/// the client to expand any `$VAR` references (against the client's
+/// already-resolved vars) and run through user policy.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WirePendingPatch {
+    /// Correlation id; client echoes it back on the verdict.
+    pub id: PendingId,
+    /// Raw, unexpanded source path expression. Client expands using
+    /// its resolved vars + tilde-fallback.
+    pub source_pattern: String,
+    /// Destination inside the sandbox, relative to the sandbox user's
+    /// home directory. Deserialization rejects absolute paths.
+    pub destination: paths::SandboxRelPath,
+    /// Optional free-form description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Where it came from.
+    pub source: WireSource,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip<T>(value: &T) -> T
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        let json = serde_json::to_string(value).expect("serialize");
+        serde_json::from_str(&json).expect("deserialize")
+    }
+
+    fn user_source() -> WireSource {
+        WireSource::UserLoadout { name: "dev".into() }
+    }
+
+    #[test]
+    fn source_round_trips_all_variants() {
+        let cases = [
+            WireSource::UserLoadout { name: "dev".into() },
+            WireSource::Project {
+                path: paths::HostPath::new("/repo"),
+            },
+            WireSource::Package {
+                name: "helix".into(),
+            },
+        ];
+        for s in cases {
+            assert_eq!(round_trip(&s), s);
+        }
+    }
+
+    #[test]
+    fn source_uses_explicit_kind_tag() {
+        let json = serde_json::to_string(&user_source()).unwrap();
+        assert!(
+            json.contains(r#""kind":"user_loadout""#),
+            "expected `kind` tag, got: {json}"
+        );
+    }
+
+    #[test]
+    fn var_spec_round_trips_all_variants() {
+        let cases = [
+            WireVarSpec::Specified { value: "hx".into() },
+            WireVarSpec::Inherit,
+            WireVarSpec::InheritWithDefault {
+                default: "C".into(),
+            },
+        ];
+        for s in cases {
+            assert_eq!(round_trip(&s), s);
+        }
+    }
+
+    #[test]
+    fn resolved_var_round_trips() {
+        let v = WireResolvedVar {
+            name: "EDITOR".into(),
+            value: "hx".into(),
+        };
+        assert_eq!(round_trip(&v), v);
+    }
+
+    #[test]
+    fn resolved_patch_round_trips() {
+        let p = WireResolvedPatch {
+            host_path: paths::HostAbsPath::try_new("/home/u/.gitconfig").unwrap(),
+            destination: paths::SandboxRelPath::try_new(".gitconfig").unwrap(),
+        };
+        assert_eq!(round_trip(&p), p);
+    }
+
+    #[test]
+    fn session_var_round_trips() {
+        let v = WireSessionVar {
+            var: WireResolvedVar {
+                name: "EDITOR".into(),
+                value: "hx".into(),
+            },
+            source: user_source(),
+        };
+        assert_eq!(round_trip(&v), v);
+    }
+
+    #[test]
+    fn session_patch_round_trips() {
+        let p = WireSessionPatch {
+            patch: WireResolvedPatch {
+                host_path: paths::HostAbsPath::try_new("/home/u/.gitconfig").unwrap(),
+                destination: paths::SandboxRelPath::try_new(".gitconfig").unwrap(),
+            },
+            source: user_source(),
+        };
+        assert_eq!(round_trip(&p), p);
+    }
+
+    #[test]
+    fn hook_script_round_trips_both_variants() {
+        let cases = [
+            WireHookScript::Inline {
+                body: "echo hi".into(),
+            },
+            WireHookScript::External {
+                path: paths::ConfigRelPath::try_new("hooks/run.sh").unwrap(),
+            },
+        ];
+        for s in cases {
+            assert_eq!(round_trip(&s), s);
+        }
+    }
+
+    #[test]
+    fn lifecycle_hook_round_trips_with_optional_fields() {
+        let h = WireLifecycleHook {
+            on_activate: Some(WireHookScript::Inline {
+                body: "echo activated".into(),
+            }),
+            on_destroy: None,
+            on_failure: Some(WireHookScript::External {
+                path: paths::ConfigRelPath::try_new("fail.sh").unwrap(),
+            }),
+        };
+        assert_eq!(round_trip(&h), h);
+    }
+
+    #[test]
+    fn empty_lifecycle_hook_omits_unset_fields() {
+        let h = WireLifecycleHook::default();
+        let json = serde_json::to_string(&h).unwrap();
+        assert_eq!(json, "{}");
+        assert_eq!(round_trip(&h), h);
+    }
+
+    #[test]
+    fn provenanced_hook_round_trips() {
+        let h = WireProvenancedHook {
+            hook: WireLifecycleHook {
+                on_activate: Some(WireHookScript::Inline {
+                    body: "echo hi".into(),
+                }),
+                ..Default::default()
+            },
+            source: user_source(),
+        };
+        assert_eq!(round_trip(&h), h);
+    }
+
+    #[test]
+    fn package_ref_round_trips() {
+        let p = WirePackageRef {
+            name: "helix".into(),
+            source: user_source(),
+        };
+        assert_eq!(round_trip(&p), p);
+    }
+
+    #[test]
+    fn pending_id_round_trips_transparently() {
+        let id = PendingId::new(42);
+        let json = serde_json::to_string(&id).unwrap();
+        // `serde(transparent)` produces a bare integer.
+        assert_eq!(json, "42");
+        assert_eq!(round_trip(&id), id);
+    }
+
+    #[test]
+    fn pending_var_round_trips() {
+        let v = WirePendingVar {
+            id: PendingId::new(1),
+            name: "RUSTC".into(),
+            spec: WireVarSpec::InheritWithDefault {
+                default: "rustc".into(),
+            },
+            source: WireSource::Package {
+                name: "rust-toolchain".into(),
+            },
+        };
+        assert_eq!(round_trip(&v), v);
+    }
+
+    #[test]
+    fn pending_patch_round_trips() {
+        let p = WirePendingPatch {
+            id: PendingId::new(2),
+            source_pattern: "$XDG_CONFIG_HOME/helix/**/*.toml".into(),
+            destination: paths::SandboxRelPath::try_new(".config/helix/").unwrap(),
+            description: Some("helix configs".into()),
+            source: WireSource::Package {
+                name: "helix".into(),
+            },
+        };
+        assert_eq!(round_trip(&p), p);
+    }
+
+    #[test]
+    fn pending_patch_omits_description_when_none() {
+        let p = WirePendingPatch {
+            id: PendingId::new(2),
+            source_pattern: "$HOME/.gitconfig".into(),
+            destination: paths::SandboxRelPath::try_new(".gitconfig").unwrap(),
+            description: None,
+            source: WireSource::UserLoadout { name: "dev".into() },
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(!json.contains("description"), "got: {json}");
+    }
+}

--- a/crates/sessions/src/wire/request.rs
+++ b/crates/sessions/src/wire/request.rs
@@ -1,0 +1,330 @@
+//! Wire-form request / response envelopes for client/daemon RPC.
+//!
+//! Flow:
+//!
+//! 1. Client → daemon: [`SessionCreateRequest`] containing the
+//!    [`ResolvedContribution`] composed from the user's loadouts.
+//! 2. Daemon → client: zero or more [`ContributionResponse`]
+//!    messages with package- and project-sourced items that need
+//!    client-side policy gating. `complete` signals the last one.
+//! 3. Client → daemon: [`ContributionVerdict`] per response, OR
+//!    [`Abort`] to bail.
+
+use super::errors::WireError;
+use super::policy::{WirePatchVerdict, WireVarVerdict};
+use super::primitives::{
+    WirePackageRef, WirePendingPatch, WirePendingVar, WireProvenancedHook, WireSessionPatch,
+    WireSessionVar, WireSource,
+};
+use crate::SessionId;
+
+/// Client → Daemon: open a new session.
+///
+/// Carries everything the client can resolve on its own — the
+/// composited user loadouts. No session id (the daemon issues one),
+/// no user policy (it's a client-side concern).
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SessionCreateRequest {
+    /// Wire protocol version. Daemon rejects unrecognized versions.
+    pub protocol_version: u32,
+    /// Absolute host path to the project directory.
+    pub project_path: paths::HostAbsPath,
+    /// Already-resolved contribution from the user's loadouts.
+    pub contribution: ResolvedContribution,
+}
+
+/// What the client has already resolved + policy-gated for the daemon.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ResolvedContribution {
+    /// Resolved variables that survived user policy.
+    pub vars: Vec<WireSessionVar>,
+    /// Resolved patch files that survived user policy. File contents
+    /// stream out-of-band.
+    pub patches: Vec<WireSessionPatch>,
+    /// Lifecycle hooks (no policy applies).
+    pub lifecycle_hooks: Vec<WireProvenancedHook>,
+    /// Packages the client requested be brought in.
+    pub requested_packages: Vec<WirePackageRef>,
+}
+
+/// Daemon → Client: items from the daemon-side closure (packages,
+/// project config) that need client-side policy + prompts.
+///
+/// More than one response may flow per session: if a hook adds a
+/// rule, or a newly approved package pulls more transitive deps that
+/// themselves contribute items, the daemon emits another response.
+/// `complete = true` on the final one.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ContributionResponse {
+    /// Session id assigned by the daemon on the first response.
+    pub session_id: SessionId,
+    /// Zero-based round counter. Verdicts must echo this back.
+    pub round: u32,
+    /// Pending variables awaiting policy + prompt.
+    pub vars: Vec<WirePendingVar>,
+    /// Pending patches awaiting policy + prompt.
+    pub patches: Vec<WirePendingPatch>,
+    /// Lifecycle hooks (no policy applies; pass through to client).
+    pub lifecycle_hooks: Vec<WireProvenancedHook>,
+    /// `true` if this is the final response — daemon is ready to
+    /// assemble the session once it receives this round's verdict.
+    pub complete: bool,
+}
+
+/// Client → Daemon: per-item verdicts on one response's pending items.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ContributionVerdict {
+    /// Matches [`ContributionResponse::session_id`].
+    pub session_id: SessionId,
+    /// Matches [`ContributionResponse::round`].
+    pub round: u32,
+    /// One verdict per pending var.
+    pub vars: Vec<WireVarVerdict>,
+    /// One verdict per pending patch.
+    pub patches: Vec<WirePatchVerdict>,
+}
+
+/// Client → Daemon: bail mid-flow.
+///
+/// Distinct from a `ContributionVerdict` because aborts are
+/// terminal — the daemon should tear down session state — and they
+/// carry structured reasons for telemetry / user-facing messages.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Abort {
+    /// Session being aborted.
+    pub session_id: SessionId,
+    /// Why.
+    pub reason: AbortReason,
+}
+
+/// Why the client aborted.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AbortReason {
+    /// User policy explicitly denied a contributed item. The daemon
+    /// can use `what` + `from` for telemetry without re-running the
+    /// policy itself.
+    PolicyDenied {
+        /// Human-readable identifier of the denied item (var name or
+        /// patch source path).
+        what: String,
+        /// Where the denied item came from.
+        from: WireSource,
+    },
+    /// User cancelled at a prompt.
+    UserCancelled,
+    /// A `PolicyHooks` callback violated its contract. Diagnostic
+    /// only — the message is for telemetry, not the user.
+    HookContract {
+        /// Short categorical label for the contract violation.
+        category: String,
+        /// Free-form context naming the offending item or batch.
+        context: String,
+    },
+    /// Anything else; the daemon should treat as opaque.
+    Other {
+        /// Free-form message.
+        message: String,
+    },
+}
+
+/// One step of the session-creation flow as seen by the client.
+///
+/// Returned by every round-advancing RPC (`SessionCreate`,
+/// `SubmitVerdict`). Either the daemon has another (possibly terminal)
+/// round of pending items — distinguish via
+/// [`ContributionResponse::complete`] — or it surfaces a protocol-level
+/// fault that the transport layer didn't catch.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SessionStep {
+    /// Next batch of pending items. `ContributionResponse::complete`
+    /// flags the terminal round.
+    Round {
+        /// The round payload.
+        response: ContributionResponse,
+    },
+    /// Protocol-level failure detected by the daemon (e.g. unknown
+    /// session id, version mismatch). Distinct from a transport error.
+    Fault {
+        /// Structured fault detail. Nested under a field so its own
+        /// `kind` discriminator doesn't collide with this enum's tag.
+        error: WireError,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::primitives::{
+        PendingId, WireHookScript, WireLifecycleHook, WireResolvedPatch, WireResolvedVar,
+        WireVarSpec,
+    };
+
+    fn round_trip<T>(value: &T) -> T
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        let json = serde_json::to_string(value).expect("serialize");
+        serde_json::from_str(&json).expect("deserialize")
+    }
+
+    fn session_id() -> SessionId {
+        SessionId::parse_str("00000000-0000-0000-0000-000000000001").unwrap()
+    }
+
+    fn user_source() -> WireSource {
+        WireSource::UserLoadout { name: "dev".into() }
+    }
+
+    #[test]
+    fn session_create_request_round_trips() {
+        let req = SessionCreateRequest {
+            protocol_version: 1,
+            project_path: paths::HostAbsPath::try_new("/repo").unwrap(),
+            contribution: ResolvedContribution {
+                vars: vec![WireSessionVar {
+                    var: WireResolvedVar {
+                        name: "EDITOR".into(),
+                        value: "hx".into(),
+                    },
+                    source: user_source(),
+                }],
+                patches: vec![WireSessionPatch {
+                    patch: WireResolvedPatch {
+                        host_path: paths::HostAbsPath::try_new("/home/u/.gitconfig").unwrap(),
+                        destination: paths::SandboxRelPath::try_new(".gitconfig").unwrap(),
+                    },
+                    source: user_source(),
+                }],
+                lifecycle_hooks: vec![WireProvenancedHook {
+                    hook: WireLifecycleHook {
+                        on_activate: Some(WireHookScript::Inline {
+                            body: "echo hi".into(),
+                        }),
+                        ..Default::default()
+                    },
+                    source: user_source(),
+                }],
+                requested_packages: vec![WirePackageRef {
+                    name: "helix".into(),
+                    source: user_source(),
+                }],
+            },
+        };
+        assert_eq!(round_trip(&req), req);
+    }
+
+    #[test]
+    fn empty_contribution_round_trips() {
+        let c = ResolvedContribution::default();
+        assert_eq!(round_trip(&c), c);
+    }
+
+    #[test]
+    fn contribution_response_round_trips() {
+        let r = ContributionResponse {
+            session_id: session_id(),
+            round: 0,
+            vars: vec![WirePendingVar {
+                id: PendingId::new(1),
+                name: "RUSTC".into(),
+                spec: WireVarSpec::Inherit,
+                source: WireSource::Package {
+                    name: "rust".into(),
+                },
+            }],
+            patches: vec![],
+            lifecycle_hooks: vec![],
+            complete: false,
+        };
+        assert_eq!(round_trip(&r), r);
+    }
+
+    #[test]
+    fn contribution_verdict_round_trips() {
+        let v = ContributionVerdict {
+            session_id: session_id(),
+            round: 0,
+            vars: vec![WireVarVerdict::Approved {
+                id: PendingId::new(1),
+                value: WireResolvedVar {
+                    name: "RUSTC".into(),
+                    value: "/usr/bin/rustc".into(),
+                },
+            }],
+            patches: vec![WirePatchVerdict::Denied {
+                id: PendingId::new(2),
+            }],
+        };
+        assert_eq!(round_trip(&v), v);
+    }
+
+    #[test]
+    fn abort_round_trips_all_reasons() {
+        let cases = [
+            AbortReason::PolicyDenied {
+                what: "AWS_SECRET_KEY".into(),
+                from: WireSource::Package {
+                    name: "evil".into(),
+                },
+            },
+            AbortReason::UserCancelled,
+            AbortReason::HookContract {
+                category: "decision count mismatch".into(),
+                context: "expected 3, got 2".into(),
+            },
+            AbortReason::Other {
+                message: "fs walk panicked".into(),
+            },
+        ];
+        for reason in cases {
+            let a = Abort {
+                session_id: session_id(),
+                reason,
+            };
+            assert_eq!(round_trip(&a), a);
+        }
+    }
+
+    #[test]
+    fn abort_reason_uses_explicit_kind_tag() {
+        let a = AbortReason::UserCancelled;
+        let json = serde_json::to_string(&a).unwrap();
+        assert!(
+            json.contains(r#""kind":"user_cancelled""#),
+            "expected `kind` tag, got: {json}"
+        );
+    }
+
+    #[test]
+    fn session_step_round_trips_both_variants() {
+        let round = SessionStep::Round {
+            response: ContributionResponse {
+                session_id: session_id(),
+                round: 0,
+                vars: vec![],
+                patches: vec![],
+                lifecycle_hooks: vec![],
+                complete: true,
+            },
+        };
+        let fault = SessionStep::Fault {
+            error: WireError::UnknownSessionId,
+        };
+        assert_eq!(round_trip(&round), round);
+        assert_eq!(round_trip(&fault), fault);
+    }
+
+    #[test]
+    fn session_step_uses_explicit_kind_tag() {
+        let s = SessionStep::Fault {
+            error: WireError::UnknownSessionId,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(
+            json.contains(r#""kind":"fault""#),
+            "expected `kind` tag, got: {json}"
+        );
+    }
+}


### PR DESCRIPTION
Basically title. Having separate JSON friendly primitive types for the communication between the daemon and client seemed like the safest way to go. I have a separate `SessionCreate` struct mostly to guard against type-related regressions until this gets combined into `CreateSession`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-round session-creation RPC flow enabling clients to interact with sessions across multiple rounds.
  * Introduced three new RPC endpoints for creating sessions, submitting verdicts on pending decisions, and aborting in-flight sessions.
  * Enhanced error handling and policy decision types for improved client-daemon communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->