### PR TITLE
fix(minimald): guest pid-1 robustness — no panic on SSH disconnect; set guest PATH

### DIFF
--- a/crates/minimald/src/connection.rs
+++ b/crates/minimald/src/connection.rs
@@ -135,7 +135,7 @@ impl Connection {
         c: Arc<RuConfig>,
         serv: ServerStateHandle,
         is_local: bool,
-    ) -> (ConnectionHandle, RunningSession<ConnectionHandler>)
+    ) -> Result<(ConnectionHandle, RunningSession<ConnectionHandler>), ConnectionError>
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
@@ -146,12 +146,12 @@ impl Connection {
             serv,
         })));
 
-        (
-            h.clone(),
-            russh::server::run_stream(c, s, ConnectionHandler(h))
-                .await
-                .unwrap(),
-        )
+        // A handshake failure (e.g. a client that connects then drops) must not
+        // propagate as a panic: in the guest, minimald is pid-1, so a panic here
+        // kills init and takes down the whole VM. Surface the error so the accept
+        // loop can drop the connection and keep serving.
+        let session = russh::server::run_stream(c, s, ConnectionHandler(h.clone())).await?;
+        Ok((h, session))
     }
 
     pub(crate) fn pending_config_mut(&mut self, id: ChannelId) -> Option<&mut ChannelConfig> {

--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -121,6 +121,21 @@ pub fn enter_rootfs(device: &str) -> std::io::Result<()> {
     }
     std::env::set_current_dir("/")?;
 
+    // pid-1 inherits no PATH from the kernel. Set the conventional guest PATH so
+    // minimald's own tool lookups against the rootfs userland resolve — notably
+    // `git`, which the session-context init shells out to for the upstream
+    // checkout (`checkouts::command_exists`); without it, interactive attach
+    // fails with "git command was not found in path".
+    // SAFETY: runs once on the guest boot path (pid-1, just after chroot) before
+    // the SSH server accepts connections or spawns any session task, so no other
+    // thread is reading the environment concurrently.
+    unsafe {
+        std::env::set_var(
+            "PATH",
+            "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin",
+        );
+    }
+
     tracing::info!(device, "switched to upstream rootfs (pivot_root)");
     Ok(())
 }

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -203,9 +203,23 @@ impl Server {
 
             let (stream, peer) = listener.accept().await?;
             tracing::info!(?peer, transport = L::TRANSPORT, "accepted connection");
-            let (_conn_hnd, session_fut) =
-                Connection::from_stream(stream, russh_config.clone(), state.clone(), L::IS_LOCAL)
-                    .await;
+            let (_conn_hnd, session_fut) = match Connection::from_stream(
+                stream,
+                russh_config.clone(),
+                state.clone(),
+                L::IS_LOCAL,
+            )
+            .await
+            {
+                Ok(conn) => conn,
+                Err(e) => {
+                    // A handshake failure must not take the daemon down — in
+                    // the guest minimald is pid-1. Drop this connection and
+                    // keep accepting.
+                    tracing::warn!(error = %e, transport = L::TRANSPORT, "SSH handshake failed; dropping connection");
+                    continue;
+                }
+            };
             // Log session errors instead of silently dropping the spawned
             // future, so a failed handshake is visible on any transport.
             session_set.spawn(async move {

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -93,7 +93,9 @@ impl TestServer {
         let state = self.state.clone();
         let server_setup = async move {
             let (_conn, session_fut) =
-                Connection::from_stream(server_side, russh_config, state, true).await;
+                Connection::from_stream(server_side, russh_config, state, true)
+                    .await
+                    .expect("handshake in test harness");
             tokio::spawn(session_fut);
         };
 
@@ -123,7 +125,10 @@ impl TestServer {
                 let state = state.clone();
                 tokio::spawn(async move {
                     let (_conn, session_fut) =
-                        Connection::from_stream(socket, russh_config, state, true).await;
+                        match Connection::from_stream(socket, russh_config, state, true).await {
+                            Ok(conn) => conn,
+                            Err(_) => return,
+                        };
                     let _ = session_fut.await;
                 });
             }


### PR DESCRIPTION
Two independent guest-daemon (pid-1) robustness fixes on the boot/connection path.

## 1. Don't panic pid-1 on SSH handshake failure

`Connection::from_stream` unwrapped `russh::server::run_stream`, so a client that connects then drops during the handshake yields `Err(Protocol(Disconnect))` and panics. In the guest, minimald is the initramfs pid-1, so the panic kills init and brings down the whole VM:

```
called `Result::unwrap()` on an `Err` value: Protocol(Disconnect)
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00006500
```

Any failed handshake was a full-VM DoS — a `minimal ls`/`activate` that opens an RPC channel and drops trips it. `from_stream` now returns the error and the accept loop logs + drops the connection (mirroring how it already handles a failed session future).

## 2. Set a guest PATH after chroot

The guest pid-1 inherits no `PATH` from the kernel, so minimald's own subprocess lookups (`command_exists` / `Command::new`) failed against the rootfs userland even when the tool was installed — notably the session context init shelling out to `git` (`checkouts`), failing with "The git command was not found in path" despite `/usr/bin/git` existing. `enter_rootfs` now sets the conventional guest PATH right after chroot.

## Validation

Reproduced and fixed on a real macOS libkrun VM: pre-fix, `minimal ls` against the guest panicked init (kernel panic above); post-fix the VM survives repeated `ls`/`activate`/`attach` cycles, and with `git` in the rootfs the session context init resolves `git` and proceeds. Daemon unit tests run on Linux CI (the crate doesn't build on the macOS host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)