### PR TITLE
feat(minimald): implement session destroy + RPC

### DIFF
--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -211,6 +211,25 @@ impl OneshotSshRpc for RenameSession {
     type Response = Errorable<RenameSessionResponse>;
 }
 
+/// An RPC to destroy an existing session.
+pub struct DestroySession;
+
+/// The request for a [`DestroySession`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DestroySessionRequest {
+    pub id: SessionId,
+}
+
+/// The response for a [`DestroySession`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DestroySessionResponse;
+
+impl OneshotSshRpc for DestroySession {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "DestroySession");
+    type Request<'a> = DestroySessionRequest;
+    type Response = Errorable<DestroySessionResponse>;
+}
+
 // ---------------------------------------------------------------------------
 // Session-creation flow (multi-round contribution composition).
 //

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -1,8 +1,8 @@
 use minimald_rpc::{
-    CreateSession, CreateSessionResponse, Errorable, GetSessionRecord, GetSessionRecordRequest,
-    GetSessionRecordResponse, GetVersion, GetVersionResponse, ListSessions, ListSessionsEntry,
-    ListSessionsResponse, OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession,
-    RenameSessionResponse,
+    CreateSession, CreateSessionResponse, DestroySession, DestroySessionResponse, Errorable,
+    GetSessionRecord, GetSessionRecordRequest, GetSessionRecordResponse, GetVersion,
+    GetVersionResponse, ListSessions, ListSessionsEntry, ListSessionsResponse, OneshotSshRpc,
+    RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
@@ -173,6 +173,23 @@ async fn serve_rename_session(s: ServerStateHandle, c: RuChannel<Msg>) {
     }
 }
 
+async fn serve_destroy_session(s: ServerStateHandle, c: RuChannel<Msg>) {
+    let res = DestroySession
+        .handle_channel(c, async |req| {
+            let res = s.sessions_manager().await.destroy_session(req.id).await;
+            match res {
+                Ok(()) => Ok(Errorable::Ok(DestroySessionResponse)),
+                Err(e) => Ok(Errorable::Err {
+                    error: e.to_string(),
+                }),
+            }
+        })
+        .await;
+    if let Err(e) = res {
+        tracing::warn!("RPC handler for {} failed: {}", DestroySession::NAME, e);
+    }
+}
+
 pub(crate) const STREAM_WORKSPACE_FILES: &str =
     constcat::concat!(RPC_SUBSYSTEM_PREFIX, "WorkspaceFilesTarZst");
 
@@ -246,6 +263,7 @@ pub async fn handle_ssh_rpc(
         | GetSessionRecord::NAME
         | CreateSession::NAME
         | RenameSession::NAME
+        | DestroySession::NAME
         | STREAM_WORKSPACE_FILES => {
             let mut conn_lock = c.lock().await;
             let c_hnd = match conn_lock.take(id) {
@@ -276,6 +294,7 @@ pub async fn handle_ssh_rpc(
         GetSessionRecord::NAME => spawn(serve_get_session_record(s, channel)),
         CreateSession::NAME => spawn(serve_create_session(s, channel)),
         RenameSession::NAME => spawn(serve_rename_session(s, channel)),
+        DestroySession::NAME => spawn(serve_destroy_session(s, channel)),
         STREAM_WORKSPACE_FILES => spawn(serve_stream_workspace_files(s, config, channel)),
         _ => unreachable!(),
     };
@@ -285,7 +304,9 @@ pub async fn handle_ssh_rpc(
 
 #[cfg(test)]
 mod tests {
-    use minimald_rpc::{CreateSession, CreateSessionRequest, RenameSessionRequest};
+    use minimald_rpc::{
+        CreateSession, CreateSessionRequest, DestroySessionRequest, RenameSessionRequest,
+    };
     use paths::HostAbsPath;
     use sessions::SessionId;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -604,6 +625,49 @@ mod tests {
             .call::<RenameSession>(&RenameSessionRequest {
                 id: SessionId::nil(),
                 new_name: "renamed".to_string(),
+            })
+            .await;
+
+        assert!(
+            matches!(resp, Errorable::Err { error } if error.contains("no session with ID")),
+            "expected an unknown-id error",
+        );
+    }
+
+    #[tokio::test]
+    async fn destroy_session_removes_it_from_get_and_list() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let resp = client
+            .call::<DestroySession>(&DestroySessionRequest { id: session_id })
+            .await;
+        assert_eq!(resp, Errorable::Ok(DestroySessionResponse));
+
+        // The record is gone: it no longer resolves by id...
+        let get_session = client
+            .call::<GetSessionRecord>(&GetSessionRecordRequest::Id(session_id))
+            .await;
+        assert!(get_session.record.is_none());
+
+        // ...and it's dropped from the listing.
+        let list_sessions = client.call::<ListSessions>(&()).await;
+        assert!(
+            list_sessions.sessions.is_empty(),
+            "destroyed session should not be listed, got {:?}",
+            list_sessions.sessions,
+        );
+    }
+
+    #[tokio::test]
+    async fn destroy_session_errors_for_unknown_id() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        let resp = client
+            .call::<DestroySession>(&DestroySessionRequest {
+                id: SessionId::nil(),
             })
             .await;
 

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -7,7 +7,9 @@ use paths::DaemonAbsPath;
 use russh::{Channel, server::Msg};
 use sessions::{Record, store::SessionObject};
 use std::fmt::{self};
+use std::ops::ControlFlow;
 use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
 
 /// An error that occurred when attaching to a running session/its-shell.
 #[derive(Debug)]
@@ -49,6 +51,7 @@ enum SessionMessage {
     ),
     GetHostAttrs(oneshot::Sender<Option<HostAttrs>>),
     RefreshRecord(Record),
+    Destroy(oneshot::Sender<()>),
     #[cfg(test)]
     GetRecord(oneshot::Sender<Record>),
 }
@@ -63,7 +66,12 @@ pub struct Session<S: SessionObject> {
     minimal_cache_dir: DaemonAbsPath,
     session: S,
 
-    host: Option<session_host::HostHandle>,
+    /// The running host, if minted, paired with the `JoinHandle` of its runtime
+    /// loop so teardown can be awaited on destroy.
+    host: Option<(
+        session_host::HostHandle,
+        JoinHandle<Result<i32, std::io::Error>>,
+    )>,
 }
 
 impl<S: SessionObject> Session<S> {
@@ -94,12 +102,17 @@ impl<S: SessionObject> Session<S> {
     /// session.
     async fn mainloop(mut self) {
         while let Some(msg) = self.receiver.recv().await {
-            self.handle_message(msg).await;
+            if self.handle_message(msg).await.is_break() {
+                break;
+            }
         }
     }
 
     /// Handles a specific message recieved by the session.
-    async fn handle_message(&mut self, msg: SessionMessage) {
+    ///
+    /// Returns [`ControlFlow::Break`] when the session has been destroyed and
+    /// the actor loop should exit.
+    async fn handle_message(&mut self, msg: SessionMessage) -> ControlFlow<()> {
         match msg {
             SessionMessage::GetPaths(r) => {
                 let _ = r.send(self.paths());
@@ -116,16 +129,34 @@ impl<S: SessionObject> Session<S> {
             SessionMessage::GetHostAttrs(r) => {
                 let _ = r.send(match self.host.as_ref() {
                     None => None,
-                    Some(h) => h.get_attrs().await.ok(),
+                    Some((h, _)) => h.get_attrs().await.ok(),
                 });
             }
             SessionMessage::RefreshRecord(r) => {
                 self.session.refresh_from_record(r);
             }
+            SessionMessage::Destroy(r) => {
+                self.destroy().await;
+                let _ = r.send(());
+                return ControlFlow::Break(());
+            }
             #[cfg(test)]
             SessionMessage::GetRecord(r) => {
                 let _ = r.send(self.session.record().clone());
             }
+        }
+        ControlFlow::Continue(())
+    }
+
+    /// Tears down the running host, if any, waiting for the process to be reaped
+    /// and the sandbox guard to be dropped before returning.
+    async fn destroy(&mut self) {
+        if let Some((host, task)) = self.host.take() {
+            // Signal the process to die, then await the runtime loop so the
+            // sandbox files backing its rootfs are released before the caller
+            // removes the session's directory tree.
+            let _ = host.kill().await;
+            let _ = task.await;
         }
     }
 
@@ -146,7 +177,7 @@ impl<S: SessionObject> Session<S> {
                 self.mint_session_host(session_hnd, conn_username, channel, sz)
                     .await
             }
-            Some(h) => {
+            Some((h, _)) => {
                 match h.attach(channel, sz).await {
                     Ok(()) => Ok(()),
                     Err((channel, sz)) => {
@@ -284,6 +315,16 @@ impl SessionHandle {
             .send(SessionMessage::RefreshRecord(new_record))
             .await
             .expect("corresponding session is dead");
+    }
+
+    /// Tears down the session: kills its host (if any), waits for teardown, and
+    /// stops the actor. The handle is dead once this returns.
+    pub(crate) async fn destroy(&self) {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.0.send(SessionMessage::Destroy(send)).await;
+        // If the actor died before acking, the session is gone all the same.
+        let _ = recv.await;
     }
 
     pub async fn attach(

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -721,6 +721,10 @@ impl SessionLauncher for MockLauncher {
 impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
     /// Spawns a session host from the given launcher, wiring it to `channel` if
     /// one is supplied, and drives its runtime loop on a background task.
+    ///
+    /// Returns the [`HostHandle`] alongside the [`JoinHandle`] of the runtime
+    /// loop, so the owner can await full teardown (process reaped, sandbox guard
+    /// dropped) after issuing a [`HostHandle::kill`].
     pub async fn spawn<L>(
         launcher: L,
         name: String,
@@ -728,13 +732,13 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
         paths: SessionPaths,
         sz: WinSize,
         channel: Option<Channel<Msg>>,
-    ) -> Result<HostHandle, std::io::Error>
+    ) -> Result<(HostHandle, JoinHandle<Result<i32, std::io::Error>>), std::io::Error>
     where
         L: SessionLauncher<Process = P, Guard = G>,
     {
         let (host, handle) = Self::build(launcher, name, username, paths, sz, channel).await?;
-        tokio::spawn(host.mainloop());
-        Ok(handle)
+        let task = tokio::spawn(host.mainloop());
+        Ok((handle, task))
     }
 
     /// Builds the host and its handle from a launcher without spawning the
@@ -809,13 +813,42 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
         }
     }
 
+    /// Notifies the attached binding (if any) that the pty master has errored,
+    /// so it can tear the ssh channel down.
+    ///
+    /// Used on any pty read/write failure — in practice the process dying closes
+    /// every slave fd, so the master reports `EIO`; this is the signal to unwind
+    /// the host. The binding suppresses the (expected) `EIO` text on its end.
+    ///
+    /// The notice is sent best-effort with `try_send`, never awaited: the
+    /// binding drains this queue in the same `select!` as its (potentially
+    /// blocking) write to the ssh remote, so awaiting a full queue could wedge
+    /// teardown behind a stuck remote. If the queue is full the notice is
+    /// dropped — the host returns regardless, and dropping its sender closes the
+    /// binding on its next turn.
+    async fn notify_remote_pty_err(&mut self, e: std::io::Error) {
+        tracing::warn!(error = %e, "pty master error; tearing down host");
+        if let Some((tx, _hnd)) = self.remote.as_mut() {
+            let _ = tx.try_send(BindingMsg::TeardownDueToStdoutErr(e));
+        }
+    }
+
     pub async fn step(&mut self) -> Result<(), ()> {
         tokio::select! {
             // Read actor messages.
             Some(msg) = self.receiver.recv() => {
                 match msg {
                     Message::Kill => {
-                        tracing::info!("kill res: {:?}", self.process.kill());
+                        if let Err(e) = self.process.kill() {
+                            tracing::warn!(error = %e, "killing session process");
+                        }
+                        // Drive teardown directly rather than waiting for the
+                        // pty to report the death: a hangup on the master does
+                        // not reliably wake `readable()`, so a killed process
+                        // that produced no draining output would otherwise leave
+                        // the loop parked forever. Returning `Err` makes
+                        // `mainloop` reap via `wait()` and return.
+                        return Err(());
                     }
                     Message::Attach(channel, sz) => {
                         self.attach(channel, sz, false).await;
@@ -840,7 +873,16 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
             },
             // Read from master - stdout of session process => ssh channel (if any)
             r = self.master.readable() => {
-                match r.expect("todo read handle error").try_io(|fd| fd.get_ref().read(&mut self.stdout_buf)) {
+                let mut guard = match r {
+                    Ok(g) => g,
+                    Err(e) => {
+                        // The io reactor failed to report readiness; the master
+                        // is unusable, so unwind rather than panic.
+                        self.notify_remote_pty_err(e).await;
+                        return Err(());
+                    }
+                };
+                match guard.try_io(|fd| fd.get_ref().read(&mut self.stdout_buf)) {
                     Ok(Ok(0)) => {},
                     Ok(Ok(n)) => {
                         let b = &self.stdout_buf[..n];
@@ -857,10 +899,7 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
                         }
                     }
                     Ok(Err(e)) => {
-                        tracing::warn!(error = %e, "Reading pty master");
-                        if let Some((tx, _hnd)) = self.remote.as_mut() {
-                            let _ = tx.send(BindingMsg::TeardownDueToStdoutErr(e)).await;
-                        }
+                        self.notify_remote_pty_err(e).await;
                         return Err(());
                     },
                     Err(_would_block) => {},
@@ -903,8 +942,18 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
             },
             // Write buffered keystrokes into the pty, if any,
             w = self.master.writable(), if self.stdin_buf.is_some() => {
+                let mut guard = match w {
+                    Ok(g) => g,
+                    Err(e) => {
+                        // The io reactor failed to report writability; the master
+                        // is unusable, so unwind rather than panic.
+                        self.notify_remote_pty_err(e).await;
+                        return Err(());
+                    }
+                };
                 let (buff, n) = self.stdin_buf.as_mut().unwrap();
-                match w.expect("todo write handle error").try_io(|fd|fd.get_ref().write(&buff[*n..])) {
+                let res = guard.try_io(|fd| fd.get_ref().write(&buff[*n..]));
+                match res {
                     Ok(Ok(extra)) => {
                         if (*n+extra) == buff.len() {
                             self.stdin_buf = None;
@@ -912,8 +961,13 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
                             *n += extra;
                         }
                     }
+                    // A write failure means the slave side is gone (the process
+                    // died, e.g. on kill): EIO closes every slave fd. Tear the
+                    // host down so it gets reaped, instead of panicking and
+                    // leaking the process as a zombie.
                     Ok(Err(e)) => {
-                        todo!("handle error writing to stdin: {e}");
+                        self.notify_remote_pty_err(e).await;
+                        return Err(());
                     }
                     Err(_would_block) => {},
                 }
@@ -1154,6 +1208,41 @@ mod tests {
         assert!(
             attrs.stdout_last.is_some(),
             "stdout_last should be stamped after the echo arrived",
+        );
+    }
+
+    /// Killing a host tears it down cleanly: the runtime loop observes the
+    /// process die (its slave fds close, so the master reports `EIO`), reaps it,
+    /// and returns — the task terminates without panicking or leaking a zombie.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn kill_tears_down_host_and_reaps_process() {
+        let (host, handle) = Host::build(
+            MockLauncher,
+            "test-session".to_string(),
+            "user".to_string(),
+            SessionPaths {
+                working: DaemonAbsPath::root(),
+                cache: DaemonAbsPath::root(),
+                home: DaemonAbsPath::root(),
+            },
+            DEFAULT_SIZE,
+            None,
+        )
+        .await
+        .expect("failed to build host");
+        let task = tokio::spawn(host.mainloop());
+
+        handle.kill().await.expect("kill should reach the host");
+
+        // The mainloop must terminate (task resolves) without panicking. A
+        // `JoinError` here would mean the host task panicked during teardown.
+        let outcome = tokio::time::timeout(Duration::from_secs(10), task)
+            .await
+            .expect("host mainloop should terminate after kill")
+            .expect("host task should not panic during teardown");
+        assert!(
+            outcome.is_ok(),
+            "mainloop should return the reaped exit status, got: {outcome:?}",
         );
     }
 }

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -54,6 +54,7 @@ enum ManagerMessage {
     GetSession(SessionKeyPredicate, Responder<Option<SessionHandle>>),
     CreateSession(sessions::Record, Responder<SessionId>),
     RenameSession(SessionId, String, Responder<()>),
+    DestroySession(SessionId, Responder<()>),
 }
 
 /// Manages session instances, and session state on disk.
@@ -205,6 +206,27 @@ impl<L: Loader> Manager<L> {
                 })
                 .await
             }
+            // Destroys a session: tears down its running host and actor (if
+            // any), then removes its on-disk record.
+            ManagerMessage::DestroySession(id, r) => {
+                r.handle(async {
+                    let k = self.store.find_by_id(&id)?.ok_or_else(|| {
+                        std::io::Error::new(
+                            NotFound,
+                            format!("no session with ID `{}`", id.as_ref()),
+                        )
+                    })?;
+                    // Stop the live session first (killing its host and waiting
+                    // for the sandbox to be released) so the on-disk tree is
+                    // free to remove.
+                    if let Some(hnd) = self.running.remove(&k) {
+                        hnd.destroy().await;
+                    }
+                    self.store.delete(&k)?;
+                    Ok(())
+                })
+                .await
+            }
         }
     }
 }
@@ -271,5 +293,114 @@ impl ManagerHandle {
             .send(ManagerMessage::RenameSession(id, new_name, send))
             .await;
         recv.await.expect("corresponding sessions manager is dead")
+    }
+
+    /// Destroys the session with the given ID, cascadingly tearing down its
+    /// running host and actor (if any) before removing its on-disk record.
+    ///
+    /// Returns a `NotFound` error if no session with that ID is known.
+    pub async fn destroy_session(&self, id: SessionId) -> Result<(), SessionsError> {
+        let (send, recv) = Responder::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.0.send(ManagerMessage::DestroySession(id, send)).await;
+        recv.await.expect("corresponding sessions manager is dead")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paths::HostAbsPath;
+    use std::io::ErrorKind;
+    use tempfile::TempDir;
+
+    fn daemon_dir(tmp: &TempDir) -> DaemonAbsPath {
+        DaemonAbsPath::try_new(tmp.path().to_str().unwrap()).unwrap()
+    }
+
+    fn sample_record() -> sessions::Record {
+        sessions::Record {
+            id: SessionId::nil(),
+            name: Some("doomed".to_string()),
+            username: None,
+            project_path: HostAbsPath::try_new("/proj").unwrap(),
+            attrs: Default::default(),
+        }
+    }
+
+    async fn manager() -> (TempDir, TempDir, ManagerHandle) {
+        let state = TempDir::new().unwrap();
+        let cache = TempDir::new().unwrap();
+        let mngr = Manager::init(daemon_dir(&state), daemon_dir(&cache))
+            .await
+            .unwrap();
+        (state, cache, mngr)
+    }
+
+    /// Destroying a known-but-not-running session removes its record so it no
+    /// longer resolves or lists, and frees its name for reuse.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn destroy_removes_a_non_running_session() {
+        let (_state, _cache, mngr) = manager().await;
+        let id = mngr.create_session(sample_record()).await.unwrap();
+
+        mngr.destroy_session(id).await.unwrap();
+
+        assert!(
+            mngr.get_record(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .is_none(),
+            "the record should be gone after destroy"
+        );
+        assert!(mngr.list().await.unwrap().is_empty());
+        // The name index entry was dropped, so the name can be taken again.
+        mngr.create_session(sample_record()).await.unwrap();
+    }
+
+    /// Destroying a session that has been brought up (its actor is running, but
+    /// no host is attached) tears the actor down and removes the record.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn destroy_tears_down_a_running_session() {
+        let (_state, _cache, mngr) = manager().await;
+        let id = mngr.create_session(sample_record()).await.unwrap();
+
+        // Bring the session actor up (populating the running map) without
+        // attaching a host.
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(id))
+            .await
+            .unwrap()
+            .expect("session should resolve");
+
+        mngr.destroy_session(id).await.unwrap();
+
+        // The destroy cascade completed: the record is gone, and a fresh
+        // get_session no longer resolves the (now removed) session.
+        assert!(
+            mngr.get_record(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            mngr.get_session(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .is_none(),
+            "the session should no longer resolve after destroy"
+        );
+        drop(handle);
+    }
+
+    /// Destroying an unknown ID is a `NotFound` error.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn destroy_unknown_id_errors() {
+        let (_state, _cache, mngr) = manager().await;
+        let err = mngr
+            .destroy_session(SessionId::nil())
+            .await
+            .expect_err("destroying an unknown id should error");
+        assert_eq!(err.kind(), ErrorKind::NotFound);
     }
 }

--- a/crates/sessions/src/store.rs
+++ b/crates/sessions/src/store.rs
@@ -1,6 +1,9 @@
 //! Manages session state on disk.
 
-use std::{collections::BTreeMap, io::ErrorKind::AlreadyExists};
+use std::{
+    collections::BTreeMap,
+    io::ErrorKind::{AlreadyExists, NotFound},
+};
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -82,6 +85,15 @@ pub trait Loader {
     /// cannot be written.
     /// `AlreadyExists` is returned if a session with that name already exists.
     fn rename(&mut self, key: &Self::Key, new_name: String) -> Result<(), std::io::Error>;
+
+    /// Deletes the session with the given key, dropping its index entries and
+    /// removing its on-disk directory tree (record, workspace, home, cache).
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the record cannot be read or the index cannot be
+    /// flushed. A missing directory tree is not an error.
+    fn delete(&mut self, key: &Self::Key) -> Result<(), std::io::Error>;
 }
 
 /// The concrete key used to identify sessions from [`DiskLoader`].
@@ -152,6 +164,14 @@ impl Index {
         }
     }
 
+    /// Removes a session's entries from both the short and name indexes.
+    pub fn remove(&mut self, short: &str, name: Option<&str>) {
+        self.short_to_id.remove(short);
+        if let Some(name) = name {
+            self.name_to_id.remove(name);
+        }
+    }
+
     /// Iterates over all (shortname, session id) pairs.
     pub fn iter(&self) -> impl Iterator<Item = (&String, &SessionId)> {
         self.short_to_id.iter()
@@ -173,6 +193,14 @@ impl Index {
             .iter()
             .find(|(_short, iter_id)| *iter_id == id)
             .map(|(short, _)| short)
+    }
+
+    /// Returns the name corresponding to the given session ID, if it has one.
+    pub fn name_by_id(&self, id: &SessionId) -> Option<&String> {
+        self.name_to_id
+            .iter()
+            .find(|(_name, iter_id)| *iter_id == id)
+            .map(|(name, _)| name)
     }
 }
 
@@ -361,6 +389,34 @@ impl Loader for DiskLoader {
         self.flush_index()?;
 
         Ok(())
+    }
+
+    fn delete(&mut self, key: &Self::Key) -> Result<(), std::io::Error> {
+        let short = key.dir_key.to_string();
+        // Discover the name index entry from the index itself, not by reading
+        // the record: index cleanup must not depend on the on-disk tree still
+        // existing, or a half-deleted session (dir gone, index entries left)
+        // could never be scrubbed.
+        let name = self.index.name_by_id(key.id()).cloned();
+
+        // Drop the index entries and flush before touching the filesystem: the
+        // index is the source of truth for `keys()`, so removing it first means
+        // a crash mid-delete can only ever orphan a directory (invisible and
+        // harmless), never leave a key pointing at a removed tree.
+        self.index.remove(&short, name.as_deref());
+        self.flush_index()?;
+
+        let session_dir = self
+            .minimal_dir
+            .as_utf8_path()
+            .join("sessions")
+            .join(&short);
+        match std::fs::remove_dir_all(&session_dir) {
+            Ok(()) => Ok(()),
+            // A missing tree is fine — the session is gone either way.
+            Err(e) if e.kind() == NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -567,6 +623,77 @@ mod tests {
         );
         // The failed rename left the original name intact.
         assert_eq!(loader.find_by_name("my-session").unwrap(), Some(first));
+    }
+
+    #[test]
+    fn delete_removes_record_and_index_entries() {
+        let tmp = TempDir::new().unwrap();
+        let mut loader = DiskLoader::new(loader_dir(&tmp)).unwrap();
+
+        let key = loader.create(sample_record()).unwrap();
+        let dir = tmp.path().join("sessions").join(&key.dir_key);
+        assert!(dir.exists(), "session dir should exist before delete");
+
+        loader.delete(&key).unwrap();
+
+        // The on-disk tree is gone, and neither lookup resolves any more.
+        assert!(!dir.exists(), "session dir should be removed after delete");
+        assert_eq!(loader.find_by_id(key.id()).unwrap(), None);
+        assert_eq!(loader.find_by_name("my-session").unwrap(), None);
+        assert!(
+            loader.keys().next().is_none(),
+            "keys() should be empty after the only session is deleted"
+        );
+    }
+
+    #[test]
+    fn delete_scrubs_index_when_directory_is_already_missing() {
+        let tmp = TempDir::new().unwrap();
+        let mut loader = DiskLoader::new(loader_dir(&tmp)).unwrap();
+
+        let key = loader.create(sample_record()).unwrap();
+
+        // Simulate a half-deleted session: the directory tree is gone but the
+        // index entries remain. delete() must still succeed (a missing tree is
+        // not an error) and scrub the stale index entries.
+        let dir = tmp.path().join("sessions").join(&key.dir_key);
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        loader.delete(&key).unwrap();
+
+        assert_eq!(loader.find_by_id(key.id()).unwrap(), None);
+        assert_eq!(loader.find_by_name("my-session").unwrap(), None);
+        assert!(
+            loader.keys().next().is_none(),
+            "stale index entries should be removed even with the dir missing"
+        );
+    }
+
+    #[test]
+    fn delete_frees_the_name_for_reuse() {
+        let tmp = TempDir::new().unwrap();
+        let mut loader = DiskLoader::new(loader_dir(&tmp)).unwrap();
+
+        let key = loader.create(sample_record()).unwrap();
+        loader.delete(&key).unwrap();
+
+        // The name index entry was dropped, so the same name can be taken again.
+        loader.create(sample_record()).unwrap();
+    }
+
+    #[test]
+    fn delete_persists_across_loader_reinit() {
+        let tmp = TempDir::new().unwrap();
+
+        let mut loader = DiskLoader::new(loader_dir(&tmp)).unwrap();
+        let key = loader.create(sample_record()).unwrap();
+        loader.delete(&key).unwrap();
+        drop(loader);
+
+        // The index flush survived the reload: the session stays gone.
+        let reloaded = DiskLoader::new(loader_dir(&tmp)).unwrap();
+        assert_eq!(reloaded.find_by_id(key.id()).unwrap(), None);
+        assert!(reloaded.keys().next().is_none());
     }
 
     #[test]


### PR DESCRIPTION
```shell
$> echo "{\"id\": \"019eb7a0-36d9-7d41-8286-265d76e9b3ab\"}" | \
    ssh -s  -o ProxyCommand="socat - UNIX-CONNECT:$XDG_STATE_DIR/minimal/providers/local-0/ssh.sock" \
                -o 'UserKnownHostsFile=/home/xxx/.local/state/minimal/providers/local-0/known_hosts' \
                local-0 minimald-v1-DestroySession
$> 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added session-destroy support that cleanly stops running sessions and deletes their on-disk records.
- Sessions manager now removes destroyed sessions from listings and frees names for reuse.
- Teardown is now acknowledged, allowing callers to await completion.
- Exposed the capability via a new SSH oneshot RPC endpoint.

## Bug Fixes
- Improved PTY master error handling to prevent panics and ensure orderly teardown on read/write readiness and IO failures.
- Improved teardown reliability to ensure the session process is reaped and termination outcomes are handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->