### PR TITLE
Install spectacles SDD suite (ref: v0.3.0)

### DIFF
--- a/.github/workflows/distillery-sync.yml
+++ b/.github/workflows/distillery-sync.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   distillery-sync:
-    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@v0.2.0
+    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@v0.3.0
     # Thread the consumer's DISTILLERY_DOC_GLOBS variable into the reusable
     # workflow as an input. A repo variable cannot be read inside the agent
     # prompt (`vars.*` is not an allowed gh-aw body expression), but a
@@ -55,7 +55,7 @@ jobs:
       # persistent status issue, so the wrapper must pass the App private key —
       # the same mapping every sdd-* wrapper carries.
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
       # the reusable lock's observability.otlp endpoint resolves; unset is fine
       # (if-missing: warn). See ADR 0020.

--- a/.github/workflows/sdd-derive.yml
+++ b/.github/workflows/sdd-derive.yml
@@ -1,0 +1,217 @@
+name: sdd-derive
+
+# Thin wrapper for the sdd-derive agent (ADR 0027).
+#
+# The agent itself is the reusable workflow
+# .github/workflows/sdd-derive.lock.yml (compiled from sdd-derive.md, which
+# declares on: workflow_call). This wrapper carries the real event triggers,
+# performs the deterministic size-gated offer, gates the /derive-spec command
+# to authors with repository write access, and fans the agent out across a set
+# of pull requests. A consumer repository installs this wrapper unchanged.
+#
+# Two entry points, one agent:
+#   - pull_request opened/synchronize -> the route job decides (deterministic,
+#     size-gated, idempotent) whether the PR is unspecced and large enough to
+#     warrant a spec; the offer job then posts one offer comment and the
+#     needs-spec marker. No engine runs on this path.
+#   - issue_comment /derive-spec -> the route job gates the command on write
+#     access and builds the run matrix (one cell on a PR, one cell per #N on
+#     the weekly roll-up issue); the derive job fans the agent out.
+#
+# The gh-aw command: trigger is not used: this is a hand-written workflow, so
+# the write-access gate is a real repository-permission check inside the
+# sdd-route-derive composite action (ADR 0015).
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Collapse rapid re-fires on one PR (a fast sequence of synchronize events)
+  # or one roll-up issue. Distinct PRs/issues run in parallel.
+  group: sdd-derive-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  # Resolve the situation and build outputs. The job-level if: skips the runner
+  # entirely on issue_comment events whose body is not /derive-spec, so an
+  # unrelated comment never spawns a route runner.
+  route:
+    if: |
+      github.event_name == 'pull_request'
+      || (
+        github.event_name == 'issue_comment'
+        && startsWith(github.event.comment.body, '/derive-spec')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    outputs:
+      should_offer: ${{ steps.decide.outputs.should_offer }}
+      offer_pr: ${{ steps.decide.outputs.offer_pr }}
+      has_runs: ${{ steps.decide.outputs.has_runs }}
+      run_matrix: ${{ steps.decide.outputs.run_matrix }}
+    steps:
+      - name: Decide whether to offer or run, and build the run matrix
+        id: decide
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-derive@v0.3.0
+        with:
+          github-token: ${{ github.token }}
+          # Net-changed-line floor for the offer; unset falls back to 400
+          # (ADR 0026, ADR 0027).
+          min-unit: ${{ vars.SDD_SPEC_MIN_UNIT }}
+
+  # Deterministic offer (no engine). Post one offer comment and the needs-spec
+  # marker on an unspecced, large-enough PR. The comment carries the
+  # <!-- sdd-derive:offer --> marker the route job reads for idempotency.
+  offer:
+    needs: route
+    if: needs.route.outputs.should_offer == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Post the derive-spec offer
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          OFFER_PR: ${{ needs.route.outputs.offer_pr }}
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          script: |
+            const n = parseInt(process.env.OFFER_PR, 10);
+            const body = [
+              '<!-- sdd-derive:offer -->',
+              'This pull request has no accompanying spec. Comment '
+                + '`/derive-spec` to have one derived retrospectively from the '
+                + 'code — it opens a separate `spec/<slug>` documentation PR '
+                + 'with demoable units, acceptance criteria, and a gap analysis '
+                + '(implementation gaps, missing failure paths, weak acceptance '
+                + 'criteria). Ignore this to defer; the weekly unspecced-PR '
+                + 'scan will re-surface it. See ADR 0027.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: n, body,
+            });
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: n, labels: ['needs-spec'],
+              });
+            } catch (err) {
+              core.info('Could not add needs-spec label: ' + err.message);
+            }
+
+  # Fan the agent out across the run matrix: one cell per pull request to
+  # derive. fail-fast: false so one PR's failure does not cancel the others.
+  derive:
+    needs: route
+    if: needs.route.outputs.has_runs == 'true'
+    strategy:
+      fail-fast: false
+      max-parallel: ${{ fromJSON(vars.SDD_DERIVE_MAX_PARALLEL || '5') }}
+      matrix: ${{ fromJSON(needs.route.outputs.run_matrix) }}
+    uses: norrietaylor/spectacles/.github/workflows/sdd-derive.lock.yml@v0.3.0
+    with:
+      aw_context: ${{ matrix.aw_context }}
+    # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
+    # to a reusable workflow in a different owner than the caller.
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      # OTLP collector URL (write-only ingest key embedded). Mapped explicitly
+      # so the reusable lock's observability.otlp endpoint resolves; unset is
+      # fine (if-missing: warn). See ADR 0020.
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
+      DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
+    # Ceiling for the called reusable workflow: the union of every nested job's
+    # permissions. The gh-aw conclusion and safe_outputs jobs need write scopes
+    # to open the spec PR and comment; activation needs actions: read.
+    permissions:
+      actions: read
+      contents: write
+      discussions: write
+      issues: write
+      pull-requests: write
+
+  # Deterministic command acknowledgment (issue #294). Adds a 👀 reaction to the
+  # triggering comment as soon as the route job decides to act, before the agent
+  # starts, so the human sees the command was received. Gated on a comment being
+  # present, so label/PR/dispatch triggers (no comment) never react. Reacts as
+  # the App so the 👀 matches the pipeline's bot identity. Best-effort: the
+  # sdd-ack-reaction action never fails the step.
+  ack:
+    needs: route
+    if: ${{ (needs.route.outputs.has_runs == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      reaction_id: ${{ steps.ack.outputs.reaction-id }}
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Ack the command with 👀
+        id: ack
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: ack
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+
+  # Terminal reaction (issue #294). Clears the 👀 and adds the run's outcome
+  # (🚀 ran / 😕 noop / 👎 failed), derived deterministically from the job
+  # results above — never from the agent. Runs always() so a failed run still
+  # replaces the ack.
+  ack-terminal:
+    needs: [route, ack, derive]
+    if: ${{ always() && (needs.route.outputs.has_runs == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Replace 👀 with the run outcome
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: terminal
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+          ack-reaction-id: ${{ needs.ack.outputs.reaction_id }}
+          outcome: ${{ needs.derive.result == 'success' && 'ran' || 'failed' }}

--- a/.github/workflows/sdd-dispatch.yml
+++ b/.github/workflows/sdd-dispatch.yml
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: Decide whether to run, and find the tracking issue
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@v0.3.0
         with:
           app-id: ${{ vars.APP_ID }}
           github-token: ${{ github.token }}
@@ -138,7 +138,7 @@ jobs:
     steps:
       - name: Compute ready set and precondition state
         id: compute
-        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@v0.3.0
         with:
           tracking-issue: ${{ needs.route.outputs.tracking_issue }}
           trigger-kind: ${{ needs.route.outputs.trigger_kind }}
@@ -631,3 +631,68 @@ jobs:
               core.info('Could not post fast-path noop comment on #'
                 + tracking + ': ' + err.message);
             }
+
+  # Deterministic command acknowledgment (issue #294). Adds a 👀 reaction to the
+  # triggering comment as soon as the route job decides to act, before the agent
+  # starts, so the human sees the command was received. Gated on a comment being
+  # present, so label/PR/dispatch triggers (no comment) never react. Reacts as
+  # the App so the 👀 matches the pipeline's bot identity. Best-effort: the
+  # sdd-ack-reaction action never fails the step.
+  ack:
+    needs: route
+    if: ${{ (needs.route.outputs.should_run == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      reaction_id: ${{ steps.ack.outputs.reaction-id }}
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Ack the command with 👀
+        id: ack
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: ack
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+
+  # Terminal reaction (issue #294). Clears the 👀 and adds the run's outcome
+  # (🚀 ran / 😕 noop / 👎 failed), derived deterministically from the job
+  # results above — never from the agent. Runs always() so a failed run still
+  # replaces the ack.
+  ack-terminal:
+    needs: [route, ack, compute, lifecycle, dispatch, noop-comment, fastpath-noop-comment]
+    if: ${{ always() && (needs.route.outputs.should_run == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Replace 👀 with the run outcome
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: terminal
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+          ack-reaction-id: ${{ needs.ack.outputs.reaction_id }}
+          outcome: ${{ (needs.compute.result == 'failure' || needs.compute.result == 'cancelled' || needs.lifecycle.result == 'failure' || needs.lifecycle.result == 'cancelled' || needs.dispatch.result == 'failure' || needs.dispatch.result == 'cancelled') && 'failed' || (needs.dispatch.result == 'success' && 'ran' || 'noop') }}

--- a/.github/workflows/sdd-execute-haiku.yml
+++ b/.github/workflows/sdd-execute-haiku.yml
@@ -79,59 +79,38 @@ on:
 permissions:
   contents: read
 
-# Concurrency group keyed on the task issue number AND this variant's tier.
-# A stale sdd-dispatch fan-out racing with a manual /execute on the same task
-# in the same tier collapses to one running cell: cancel-in-progress: true
-# supersedes the in-progress cell with the later trigger so a user-initiated
-# /execute wins over a stale dispatch (and vice versa: a fresh dispatch wins
-# over an earlier in-flight cell). The tier discriminator is required because
-# the three sdd-execute-{haiku,sonnet,opus} wrappers all subscribe to the same
-# event triggers; without the tier suffix a non-matching-tier wake would land
-# in the same group as the matching-tier run and the cancel-in-progress rule
-# could kill the only run doing real work (issue #124). Cancel-in-progress is
-# set on the wrapper itself because the gh-aw lock declares its own
-# activation-level concurrency keyed on the workflow name; this wrapper-level
-# group adds the per-task-per-tier dimension on top.
+# Concurrency: cancellation is scoped to ISSUE-keyed runs only. PR-attached
+# triggers (pull_request, pull_request_review, pull_request_review_comment,
+# check_suite, and a /revise issue_comment on a PR) each get a unique
+# github.run_id group, so they NEVER cancel-in-progress. A cancelled run renders
+# as a red check on the PR and reads as failed CI even though it was only
+# superseded; scoping cancellation off the PR-attached surface removes that
+# false signal (issue #271 option 3, ADR 0030). The single-revise collapse those
+# runs used to get from cancellation when concurrent failed-check suites landed
+# on the same head (issues #227, #228) is now provided cooperatively by
+# sdd-route-execute's sha-keyed revise claim: the first run claims the head sha,
+# a later run for the same head defers (no-op success) instead of being killed.
+#
+# Cancellation survives for the issue-keyed agent runs that do NOT attach to a
+# PR: a /execute comment on a task sub-issue and a workflow_dispatch from
+# sdd-dispatch share the per-task-per-tier group, so a stale dispatch racing a
+# manual /execute on the same task collapses to one running cell (issue #124).
+# The tier suffix keeps a non-matching-tier wake out of the matching tier's
+# group. cancel-in-progress is set on the wrapper because the gh-aw lock has its
+# own activation-level concurrency keyed on the workflow name; this wrapper
+# group adds the per-task-per-tier dimension. These cancellations never attach
+# to a PR, so they never paint a red check.
 #
 # The fromJSON(github.event.inputs.aw_context || '{}') branch reads the
 # dispatcher's well-formed aw_context JSON for the workflow_dispatch path.
-# Manual workflow_dispatch invocations that supply malformed JSON will fail
-# workflow evaluation here, which is the correct failure mode (the route
-# step's try/catch would silently ignore them and the run would do nothing
-# useful).
 #
-# A label-removal event (issues.unlabeled / pull_request.unlabeled) is routed
-# to its own throwaway group (github.run_id) so it never lands in a task's
-# shared per-task-per-tier group. At step 2 the agent removes its own task's
-# sdd:ready label; that self-induced issues.unlabeled event re-fires this
-# wrapper, and without the carve-out it entered the active run's group where
-# cancel-in-progress killed the running agent mid-work (issue #143). The only
-# label-removal the route step acts on is needs-human (a resume), which runs
-# when no agent is in flight, so a unique group is safe there too.
-#
-# An issue_comment whose body is not a recognized command (/execute or
-# /revise) is routed to its own throwaway group for the same reason.
-# gh-aw's create-pull-request fallback-to-issue posts an "Issue created:
-# #<n>" notice on the task issue via the App token (issue #142); that
-# App-authored comment re-fires this wrapper as issue_comment.created,
-# and without the carve-out it landed in the active run's per-task group
-# where cancel-in-progress killed the originating run's safe_outputs tail
-# and its auto-merge job. The route step acts only on /execute and
-# /revise comments, so a non-command comment in a unique group is safe.
-#
-# A check_suite.completed event (the CI-failure -> implicit /revise path)
-# carries neither github.event.issue.number nor github.event.pull_request
-# .number — the PR is in github.event.check_suite.pull_requests[]. Without
-# a dedicated branch the expression fell through to the github.run_id
-# fallback, giving every failed suite its own group so cancel-in-progress
-# never collapsed concurrent /revise runs on the same PR (issues #227,
-# #228). Key on the suite's PR number (head_branch fallback when no PR is
-# linked), but ONLY for the same actionable suites the route job acts on:
-# a failure-like conclusion on an sdd/ branch. A success/neutral suite is
-# left on the throwaway github.run_id key so it cannot land in an active
-# /revise group and cancel a running revise before no-opping in route.
+# A label-removal (issues.unlabeled resume) and a non-command issue_comment keep
+# their own throwaway run_id groups: the agent's self-induced sdd:ready unlabeled
+# event (issue #143) and gh-aw's App-authored "Issue created" comment (issue
+# #142) re-fire this wrapper and must not land in an active per-task group where
+# cancel-in-progress would kill the run doing real work.
 concurrency:
-  group: sdd-execute-haiku-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || (github.event_name == 'check_suite' && github.event.action == 'completed' && startsWith(github.event.check_suite.head_branch, 'sdd/') && (github.event.check_suite.conclusion == 'failure' || github.event.check_suite.conclusion == 'timed_out' || github.event.check_suite.conclusion == 'cancelled' || github.event.check_suite.conclusion == 'action_required') && (github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_branch)) || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  group: sdd-execute-haiku-${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' || github.event_name == 'check_suite') && github.run_id || (github.event_name == 'issue_comment' && github.event.issue.pull_request) && github.run_id || github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -211,7 +190,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.3.0
         with:
           tier: haiku
           app-id: ${{ vars.APP_ID }}
@@ -223,14 +202,14 @@ jobs:
   sdd-execute-haiku:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@v0.2.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
       # the reusable lock's observability.otlp endpoint resolves; unset is fine
       # (if-missing: warn). See ADR 0020.
@@ -287,9 +266,74 @@ jobs:
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-haiku.outputs.created_pr_number }}
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
+
+  # Deterministic command acknowledgment (issue #294). Adds a 👀 reaction to the
+  # triggering comment as soon as the route job decides to act, before the agent
+  # starts, so the human sees the command was received. Gated on a comment being
+  # present, so label/PR/dispatch triggers (no comment) never react. Reacts as
+  # the App so the 👀 matches the pipeline's bot identity. Best-effort: the
+  # sdd-ack-reaction action never fails the step.
+  ack:
+    needs: route
+    if: ${{ (needs.route.outputs.should_run == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      reaction_id: ${{ steps.ack.outputs.reaction-id }}
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Ack the command with 👀
+        id: ack
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: ack
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+
+  # Terminal reaction (issue #294). Clears the 👀 and adds the run's outcome
+  # (🚀 ran / 😕 noop / 👎 failed), derived deterministically from the job
+  # results above — never from the agent. Runs always() so a failed run still
+  # replaces the ack.
+  ack-terminal:
+    needs: [route, ack, sdd-execute-haiku]
+    if: ${{ always() && (needs.route.outputs.should_run == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Replace 👀 with the run outcome
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: terminal
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+          ack-reaction-id: ${{ needs.ack.outputs.reaction_id }}
+          outcome: ${{ needs.sdd-execute-haiku.result == 'success' && 'ran' || 'failed' }}

--- a/.github/workflows/sdd-execute-opus.yml
+++ b/.github/workflows/sdd-execute-opus.yml
@@ -79,59 +79,38 @@ on:
 permissions:
   contents: read
 
-# Concurrency group keyed on the task issue number AND this variant's tier.
-# A stale sdd-dispatch fan-out racing with a manual /execute on the same task
-# in the same tier collapses to one running cell: cancel-in-progress: true
-# supersedes the in-progress cell with the later trigger so a user-initiated
-# /execute wins over a stale dispatch (and vice versa: a fresh dispatch wins
-# over an earlier in-flight cell). The tier discriminator is required because
-# the three sdd-execute-{haiku,sonnet,opus} wrappers all subscribe to the same
-# event triggers; without the tier suffix a non-matching-tier wake would land
-# in the same group as the matching-tier run and the cancel-in-progress rule
-# could kill the only run doing real work (issue #124). Cancel-in-progress is
-# set on the wrapper itself because the gh-aw lock declares its own
-# activation-level concurrency keyed on the workflow name; this wrapper-level
-# group adds the per-task-per-tier dimension on top.
+# Concurrency: cancellation is scoped to ISSUE-keyed runs only. PR-attached
+# triggers (pull_request, pull_request_review, pull_request_review_comment,
+# check_suite, and a /revise issue_comment on a PR) each get a unique
+# github.run_id group, so they NEVER cancel-in-progress. A cancelled run renders
+# as a red check on the PR and reads as failed CI even though it was only
+# superseded; scoping cancellation off the PR-attached surface removes that
+# false signal (issue #271 option 3, ADR 0030). The single-revise collapse those
+# runs used to get from cancellation when concurrent failed-check suites landed
+# on the same head (issues #227, #228) is now provided cooperatively by
+# sdd-route-execute's sha-keyed revise claim: the first run claims the head sha,
+# a later run for the same head defers (no-op success) instead of being killed.
+#
+# Cancellation survives for the issue-keyed agent runs that do NOT attach to a
+# PR: a /execute comment on a task sub-issue and a workflow_dispatch from
+# sdd-dispatch share the per-task-per-tier group, so a stale dispatch racing a
+# manual /execute on the same task collapses to one running cell (issue #124).
+# The tier suffix keeps a non-matching-tier wake out of the matching tier's
+# group. cancel-in-progress is set on the wrapper because the gh-aw lock has its
+# own activation-level concurrency keyed on the workflow name; this wrapper
+# group adds the per-task-per-tier dimension. These cancellations never attach
+# to a PR, so they never paint a red check.
 #
 # The fromJSON(github.event.inputs.aw_context || '{}') branch reads the
 # dispatcher's well-formed aw_context JSON for the workflow_dispatch path.
-# Manual workflow_dispatch invocations that supply malformed JSON will fail
-# workflow evaluation here, which is the correct failure mode (the route
-# step's try/catch would silently ignore them and the run would do nothing
-# useful).
 #
-# A label-removal event (issues.unlabeled / pull_request.unlabeled) is routed
-# to its own throwaway group (github.run_id) so it never lands in a task's
-# shared per-task-per-tier group. At step 2 the agent removes its own task's
-# sdd:ready label; that self-induced issues.unlabeled event re-fires this
-# wrapper, and without the carve-out it entered the active run's group where
-# cancel-in-progress killed the running agent mid-work (issue #143). The only
-# label-removal the route step acts on is needs-human (a resume), which runs
-# when no agent is in flight, so a unique group is safe there too.
-#
-# An issue_comment whose body is not a recognized command (/execute or
-# /revise) is routed to its own throwaway group for the same reason.
-# gh-aw's create-pull-request fallback-to-issue posts an "Issue created:
-# #<n>" notice on the task issue via the App token (issue #142); that
-# App-authored comment re-fires this wrapper as issue_comment.created,
-# and without the carve-out it landed in the active run's per-task group
-# where cancel-in-progress killed the originating run's safe_outputs tail
-# and its auto-merge job. The route step acts only on /execute and
-# /revise comments, so a non-command comment in a unique group is safe.
-#
-# A check_suite.completed event (the CI-failure -> implicit /revise path)
-# carries neither github.event.issue.number nor github.event.pull_request
-# .number — the PR is in github.event.check_suite.pull_requests[]. Without
-# a dedicated branch the expression fell through to the github.run_id
-# fallback, giving every failed suite its own group so cancel-in-progress
-# never collapsed concurrent /revise runs on the same PR (issues #227,
-# #228). Key on the suite's PR number (head_branch fallback when no PR is
-# linked), but ONLY for the same actionable suites the route job acts on:
-# a failure-like conclusion on an sdd/ branch. A success/neutral suite is
-# left on the throwaway github.run_id key so it cannot land in an active
-# /revise group and cancel a running revise before no-opping in route.
+# A label-removal (issues.unlabeled resume) and a non-command issue_comment keep
+# their own throwaway run_id groups: the agent's self-induced sdd:ready unlabeled
+# event (issue #143) and gh-aw's App-authored "Issue created" comment (issue
+# #142) re-fire this wrapper and must not land in an active per-task group where
+# cancel-in-progress would kill the run doing real work.
 concurrency:
-  group: sdd-execute-opus-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || (github.event_name == 'check_suite' && github.event.action == 'completed' && startsWith(github.event.check_suite.head_branch, 'sdd/') && (github.event.check_suite.conclusion == 'failure' || github.event.check_suite.conclusion == 'timed_out' || github.event.check_suite.conclusion == 'cancelled' || github.event.check_suite.conclusion == 'action_required') && (github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_branch)) || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  group: sdd-execute-opus-${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' || github.event_name == 'check_suite') && github.run_id || (github.event_name == 'issue_comment' && github.event.issue.pull_request) && github.run_id || github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -211,7 +190,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.3.0
         with:
           tier: opus
           app-id: ${{ vars.APP_ID }}
@@ -223,14 +202,14 @@ jobs:
   sdd-execute-opus:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@v0.2.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
       # the reusable lock's observability.otlp endpoint resolves; unset is fine
       # (if-missing: warn). See ADR 0020.
@@ -287,7 +266,7 @@ jobs:
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-opus.outputs.created_pr_number }}
@@ -346,8 +325,73 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
       - name: Sweep open sdd/ PRs and refresh those behind base
-        uses: norrietaylor/spectacles/.github/actions/sdd-refresh-siblings@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-refresh-siblings@v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           merged-pr-number: ${{ github.event.pull_request.number }}
           max-resolve-iterations: ${{ vars.SDD_MAX_REVIEW_ITERATIONS }}
+
+  # Deterministic command acknowledgment (issue #294). Adds a 👀 reaction to the
+  # triggering comment as soon as the route job decides to act, before the agent
+  # starts, so the human sees the command was received. Gated on a comment being
+  # present, so label/PR/dispatch triggers (no comment) never react. Reacts as
+  # the App so the 👀 matches the pipeline's bot identity. Best-effort: the
+  # sdd-ack-reaction action never fails the step.
+  ack:
+    needs: route
+    if: ${{ (needs.route.outputs.should_run == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      reaction_id: ${{ steps.ack.outputs.reaction-id }}
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Ack the command with 👀
+        id: ack
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: ack
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+
+  # Terminal reaction (issue #294). Clears the 👀 and adds the run's outcome
+  # (🚀 ran / 😕 noop / 👎 failed), derived deterministically from the job
+  # results above — never from the agent. Runs always() so a failed run still
+  # replaces the ack.
+  ack-terminal:
+    needs: [route, ack, sdd-execute-opus]
+    if: ${{ always() && (needs.route.outputs.should_run == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Replace 👀 with the run outcome
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: terminal
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+          ack-reaction-id: ${{ needs.ack.outputs.reaction_id }}
+          outcome: ${{ needs.sdd-execute-opus.result == 'success' && 'ran' || 'failed' }}

--- a/.github/workflows/sdd-execute-sonnet.yml
+++ b/.github/workflows/sdd-execute-sonnet.yml
@@ -79,59 +79,38 @@ on:
 permissions:
   contents: read
 
-# Concurrency group keyed on the task issue number AND this variant's tier.
-# A stale sdd-dispatch fan-out racing with a manual /execute on the same task
-# in the same tier collapses to one running cell: cancel-in-progress: true
-# supersedes the in-progress cell with the later trigger so a user-initiated
-# /execute wins over a stale dispatch (and vice versa: a fresh dispatch wins
-# over an earlier in-flight cell). The tier discriminator is required because
-# the three sdd-execute-{haiku,sonnet,opus} wrappers all subscribe to the same
-# event triggers; without the tier suffix a non-matching-tier wake would land
-# in the same group as the matching-tier run and the cancel-in-progress rule
-# could kill the only run doing real work (issue #124). Cancel-in-progress is
-# set on the wrapper itself because the gh-aw lock declares its own
-# activation-level concurrency keyed on the workflow name; this wrapper-level
-# group adds the per-task-per-tier dimension on top.
+# Concurrency: cancellation is scoped to ISSUE-keyed runs only. PR-attached
+# triggers (pull_request, pull_request_review, pull_request_review_comment,
+# check_suite, and a /revise issue_comment on a PR) each get a unique
+# github.run_id group, so they NEVER cancel-in-progress. A cancelled run renders
+# as a red check on the PR and reads as failed CI even though it was only
+# superseded; scoping cancellation off the PR-attached surface removes that
+# false signal (issue #271 option 3, ADR 0030). The single-revise collapse those
+# runs used to get from cancellation when concurrent failed-check suites landed
+# on the same head (issues #227, #228) is now provided cooperatively by
+# sdd-route-execute's sha-keyed revise claim: the first run claims the head sha,
+# a later run for the same head defers (no-op success) instead of being killed.
+#
+# Cancellation survives for the issue-keyed agent runs that do NOT attach to a
+# PR: a /execute comment on a task sub-issue and a workflow_dispatch from
+# sdd-dispatch share the per-task-per-tier group, so a stale dispatch racing a
+# manual /execute on the same task collapses to one running cell (issue #124).
+# The tier suffix keeps a non-matching-tier wake out of the matching tier's
+# group. cancel-in-progress is set on the wrapper because the gh-aw lock has its
+# own activation-level concurrency keyed on the workflow name; this wrapper
+# group adds the per-task-per-tier dimension. These cancellations never attach
+# to a PR, so they never paint a red check.
 #
 # The fromJSON(github.event.inputs.aw_context || '{}') branch reads the
 # dispatcher's well-formed aw_context JSON for the workflow_dispatch path.
-# Manual workflow_dispatch invocations that supply malformed JSON will fail
-# workflow evaluation here, which is the correct failure mode (the route
-# step's try/catch would silently ignore them and the run would do nothing
-# useful).
 #
-# A label-removal event (issues.unlabeled / pull_request.unlabeled) is routed
-# to its own throwaway group (github.run_id) so it never lands in a task's
-# shared per-task-per-tier group. At step 2 the agent removes its own task's
-# sdd:ready label; that self-induced issues.unlabeled event re-fires this
-# wrapper, and without the carve-out it entered the active run's group where
-# cancel-in-progress killed the running agent mid-work (issue #143). The only
-# label-removal the route step acts on is needs-human (a resume), which runs
-# when no agent is in flight, so a unique group is safe there too.
-#
-# An issue_comment whose body is not a recognized command (/execute or
-# /revise) is routed to its own throwaway group for the same reason.
-# gh-aw's create-pull-request fallback-to-issue posts an "Issue created:
-# #<n>" notice on the task issue via the App token (issue #142); that
-# App-authored comment re-fires this wrapper as issue_comment.created,
-# and without the carve-out it landed in the active run's per-task group
-# where cancel-in-progress killed the originating run's safe_outputs tail
-# and its auto-merge job. The route step acts only on /execute and
-# /revise comments, so a non-command comment in a unique group is safe.
-#
-# A check_suite.completed event (the CI-failure -> implicit /revise path)
-# carries neither github.event.issue.number nor github.event.pull_request
-# .number — the PR is in github.event.check_suite.pull_requests[]. Without
-# a dedicated branch the expression fell through to the github.run_id
-# fallback, giving every failed suite its own group so cancel-in-progress
-# never collapsed concurrent /revise runs on the same PR (issues #227,
-# #228). Key on the suite's PR number (head_branch fallback when no PR is
-# linked), but ONLY for the same actionable suites the route job acts on:
-# a failure-like conclusion on an sdd/ branch. A success/neutral suite is
-# left on the throwaway github.run_id key so it cannot land in an active
-# /revise group and cancel a running revise before no-opping in route.
+# A label-removal (issues.unlabeled resume) and a non-command issue_comment keep
+# their own throwaway run_id groups: the agent's self-induced sdd:ready unlabeled
+# event (issue #143) and gh-aw's App-authored "Issue created" comment (issue
+# #142) re-fire this wrapper and must not land in an active per-task group where
+# cancel-in-progress would kill the run doing real work.
 concurrency:
-  group: sdd-execute-sonnet-${{ github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || (github.event_name == 'check_suite' && github.event.action == 'completed' && startsWith(github.event.check_suite.head_branch, 'sdd/') && (github.event.check_suite.conclusion == 'failure' || github.event.check_suite.conclusion == 'timed_out' || github.event.check_suite.conclusion == 'cancelled' || github.event.check_suite.conclusion == 'action_required') && (github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_branch)) || github.event.issue.number || github.event.pull_request.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
+  group: sdd-execute-sonnet-${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment' || github.event_name == 'check_suite') && github.run_id || (github.event_name == 'issue_comment' && github.event.issue.pull_request) && github.run_id || github.event.action == 'unlabeled' && github.run_id || (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/execute') && !startsWith(github.event.comment.body, '/revise')) && github.run_id || github.event.issue.number || fromJSON(github.event.inputs.aw_context || '{}').item_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -211,7 +190,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.3.0
         with:
           tier: sonnet
           app-id: ${{ vars.APP_ID }}
@@ -223,14 +202,14 @@ jobs:
   sdd-execute-sonnet:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@v0.2.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
       # the reusable lock's observability.otlp endpoint resolves; unset is fine
       # (if-missing: warn). See ADR 0020.
@@ -287,9 +266,74 @@ jobs:
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-sonnet.outputs.created_pr_number }}
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
+
+  # Deterministic command acknowledgment (issue #294). Adds a 👀 reaction to the
+  # triggering comment as soon as the route job decides to act, before the agent
+  # starts, so the human sees the command was received. Gated on a comment being
+  # present, so label/PR/dispatch triggers (no comment) never react. Reacts as
+  # the App so the 👀 matches the pipeline's bot identity. Best-effort: the
+  # sdd-ack-reaction action never fails the step.
+  ack:
+    needs: route
+    if: ${{ (needs.route.outputs.should_run == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      reaction_id: ${{ steps.ack.outputs.reaction-id }}
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Ack the command with 👀
+        id: ack
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: ack
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+
+  # Terminal reaction (issue #294). Clears the 👀 and adds the run's outcome
+  # (🚀 ran / 😕 noop / 👎 failed), derived deterministically from the job
+  # results above — never from the agent. Runs always() so a failed run still
+  # replaces the ack.
+  ack-terminal:
+    needs: [route, ack, sdd-execute-sonnet]
+    if: ${{ always() && (needs.route.outputs.should_run == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Replace 👀 with the run outcome
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: terminal
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+          ack-reaction-id: ${{ needs.ack.outputs.reaction_id }}
+          outcome: ${{ needs.sdd-execute-sonnet.result == 'success' && 'ran' || 'failed' }}

--- a/.github/workflows/sdd-monitor.yml
+++ b/.github/workflows/sdd-monitor.yml
@@ -168,7 +168,7 @@ jobs:
           permission-pull-requests: read
           permission-issues: write
       - name: Nudge armed-but-idle trackers
-        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@v0.3.0
         with:
           # App token: PR/issue reads + the /dispatch comment (App-authored so
           # the dispatch wrapper's carve-out admits it).

--- a/.github/workflows/sdd-pr-sanitize.yml
+++ b/.github/workflows/sdd-pr-sanitize.yml
@@ -63,6 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Correct the issue references in the pull request body
-        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@v0.3.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-review.yml
+++ b/.github/workflows/sdd-review.yml
@@ -52,21 +52,21 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@v0.3.0
         with:
           github-token: ${{ github.token }}
 
   sdd-review:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@v0.2.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
       # the reusable lock's observability.otlp endpoint resolves; unset is fine
       # (if-missing: warn). See ADR 0020.
@@ -120,7 +120,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-pull-requests: write
       - name: Resolve App-bot advisory review threads
-        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           bot-login: ${{ steps.app.outputs.app-slug }}[bot]

--- a/.github/workflows/sdd-spec.yml
+++ b/.github/workflows/sdd-spec.yml
@@ -82,6 +82,14 @@ jobs:
     permissions:
       contents: read
       issues: read
+      # pull-requests: read is required by the sdd-route-spec action: on a
+      # merged spec PR it calls pulls.listFiles + getContent (with this job's
+      # GITHUB_TOKEN) to read the spec file's `tracking-issue` frontmatter and
+      # decide approved_dispatch. Without it the call 403s ("Resource not
+      # accessible by integration"), the error is swallowed, approved_dispatch
+      # is never set, and the fast-path /approve implementation never
+      # dispatches. See issue #289.
+      pull-requests: read
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
       aw_context: ${{ steps.decide.outputs.aw_context }}
@@ -93,7 +101,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@v0.3.0
         with:
           github-token: ${{ github.token }}
 
@@ -134,7 +142,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Record approval or dispatch sdd-execute-{tier}
-        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           tracking: ${{ needs.route.outputs.fastpath_tracking }}
@@ -165,7 +173,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Dispatch sdd-execute-{tier} for the approved merged spec PR
-        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           tracking: ${{ needs.route.outputs.approved_tracking }}
@@ -192,7 +200,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Clear the stale sdd:approved marker
-        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           tracking: ${{ needs.route.outputs.approved_tracking }}
@@ -201,18 +209,22 @@ jobs:
   sdd-spec:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@v0.2.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
       # Single-PR classifier diff ceiling (ADR 0024). Maps the consumer's
       # optional SDD_AGILE_MAX variable into the lock's agile_max input;
       # unset passes empty and the agent falls back to 800.
       agile_max: ${{ vars.SDD_AGILE_MAX }}
+      # Demoable-unit bundling floor (ADR 0026). Maps the consumer's optional
+      # SDD_SPEC_MIN_UNIT variable into the lock's min_unit input; unset passes
+      # empty and the agent falls back to 400.
+      min_unit: ${{ vars.SDD_SPEC_MIN_UNIT }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
       # the reusable lock's observability.otlp endpoint resolves; unset is fine
       # (if-missing: warn). See ADR 0020.
@@ -231,7 +243,7 @@ jobs:
   # Agent-failure hand-off (fixes #122, #123).
   #
   # When the sdd-spec reusable workflow fails before producing safe-outputs
-  # (e.g. the "Execute GitHub Copilot CLI" step crashes, or any other infra
+  # (e.g. the "Execute Claude Code CLI" step crashes, or any other infra
   # failure the gh-aw conclusion job does not classify), the agent has posted
   # nothing: no comment, no needs-human. The failure is invisible to the
   # reporter and the work stalls with no auto-retry (#122, #123). This job
@@ -266,7 +278,72 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Post failure hand-off to tracking issue
-        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           aw-context: ${{ needs.route.outputs.aw_context }}
+
+  # Deterministic command acknowledgment (issue #294). Adds a 👀 reaction to the
+  # triggering comment as soon as the route job decides to act, before the agent
+  # starts, so the human sees the command was received. Gated on a comment being
+  # present, so label/PR/dispatch triggers (no comment) never react. Reacts as
+  # the App so the 👀 matches the pipeline's bot identity. Best-effort: the
+  # sdd-ack-reaction action never fails the step.
+  ack:
+    needs: route
+    if: ${{ (needs.route.outputs.should_run == 'true' || needs.route.outputs.fastpath_approve == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      reaction_id: ${{ steps.ack.outputs.reaction-id }}
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Ack the command with 👀
+        id: ack
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: ack
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+
+  # Terminal reaction (issue #294). Clears the 👀 and adds the run's outcome
+  # (🚀 ran / 😕 noop / 👎 failed), derived deterministically from the job
+  # results above — never from the agent. Runs always() so a failed run still
+  # replaces the ack.
+  ack-terminal:
+    needs: [route, ack, sdd-spec, fastpath-approve]
+    if: ${{ always() && (needs.route.outputs.should_run == 'true' || needs.route.outputs.fastpath_approve == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Replace 👀 with the run outcome
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: terminal
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+          ack-reaction-id: ${{ needs.ack.outputs.reaction_id }}
+          outcome: ${{ (needs.sdd-spec.result == 'failure' || needs.sdd-spec.result == 'cancelled' || needs['fastpath-approve'].result == 'failure' || needs['fastpath-approve'].result == 'cancelled') && 'failed' || 'ran' }}

--- a/.github/workflows/sdd-spike-actuator.yml
+++ b/.github/workflows/sdd-spike-actuator.yml
@@ -66,7 +66,7 @@ jobs:
       # walk errored) means this is not a spike-wave member to actuate.
       - name: Resolve the parent tracking issue
         id: tree
-        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.3.0
         with:
           mode: actuator
           spike-issue: ${{ github.event.issue.number }}

--- a/.github/workflows/sdd-spike-reentry.yml
+++ b/.github/workflows/sdd-spike-reentry.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Resolve the tracking issue and the drain state
         id: tree
-        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.3.0
         with:
           mode: reentry
           spike-issue: ${{ github.event.issue.number }}
@@ -94,35 +94,42 @@ jobs:
     steps:
       - name: Build the phase-B re-entry context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.3.0
         with:
           github-token: ${{ github.token }}
           reentry-tracking-issue: ${{ needs.walk.outputs.tracking_issue }}
 
-  # Re-enter sdd-triage phase B for the tracking issue. Calls the same reusable
-  # lock the sdd-triage wrapper calls, mapping the same secrets explicitly
-  # (cross-owner workflow_call does not inherit them) — including
-  # GH_AW_OTEL_ENDPOINT so the lock's observability.otlp endpoint resolves.
+  # Re-enter the plan phase for the tracking issue. The spike-wave drain
+  # re-enters phase B (the plan), so this calls the per-phase plan lock
+  # (issue #271, ADR 0029), mapping the same secrets explicitly (cross-owner
+  # workflow_call does not inherit them) — including GH_AW_OTEL_ENDPOINT so the
+  # lock's observability.otlp endpoint resolves. The plan phase carries no MCP,
+  # so no DISTILLERY_OAUTH_TOKEN.
   sdd-triage:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.2.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-plan.lock.yml@v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
+      min_task: ${{ vars.SDD_TRIAGE_MIN_TASK }}
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
       # the reusable lock's observability.otlp endpoint resolves; unset is fine
       # (if-missing: warn). See ADR 0020.
       GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
-      DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
-    # Ceiling for the called reusable workflow. Must cover the union of every
-    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
-    # need write scopes, and activation needs actions: read.
+    # Ceiling for the called reusable workflow. The plan phase only comments and
+    # labels (no file writes), so the ceiling matches the sdd-triage wrapper's
+    # plan job.
     permissions:
       actions: read
-      contents: write
+      contents: read
       discussions: write
       issues: write
+      # write (not read): the called sdd-triage-plan lock's gh-aw
+      # safe_outputs/conclusion jobs request pull-requests: write, and a reusable
+      # callee may not exceed the caller job's grant — read here startup_fails
+      # the whole workflow on every issue close/unlabel. See issue #298 (same
+      # class as #295/#296, which fixed the sdd-triage wrapper's plan job).
       pull-requests: write

--- a/.github/workflows/sdd-status.yml
+++ b/.github/workflows/sdd-status.yml
@@ -129,6 +129,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Refresh the status comment
-        uses: norrietaylor/spectacles/.github/actions/sdd-status@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-status@v0.3.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage-dedupe-tasks.yml
+++ b/.github/workflows/sdd-triage-dedupe-tasks.yml
@@ -37,6 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close a duplicate phase-C task sub-issue
-        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@v0.3.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage-promote-ready.yml
+++ b/.github/workflows/sdd-triage-promote-ready.yml
@@ -57,6 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Promote tasks whose last blocker just closed
-        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@v0.3.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage.yml
+++ b/.github/workflows/sdd-triage.yml
@@ -1,13 +1,15 @@
 name: sdd-triage
 
-# Thin wrapper for the sdd-triage agent.
+# Thin wrapper for the sdd-triage agents.
 #
-# The agent itself is the reusable workflow
-# .github/workflows/sdd-triage.lock.yml (compiled from sdd-triage.md, which
-# declares on: workflow_call). This wrapper carries the real event triggers,
-# gates the comment commands to authors with repository write access, and
-# passes the triggering entity to the agent through the aw_context input. A
-# consumer repository installs this wrapper unchanged.
+# sdd-triage is split into three per-phase reusable workflows (issue #271,
+# ADR 0029): sdd-triage-arch.lock.yml (architecture), sdd-triage-plan.lock.yml
+# (plan comment), and sdd-triage-materialize.lock.yml (Unit/task tree), each
+# compiled from its sdd-triage-<phase>.md source. This wrapper carries the real
+# event triggers, gates the comment commands to authors with repository write
+# access, resolves a deterministic target through the sdd-route-triage action,
+# and dispatches the triggering entity to the matching phase workflow through
+# the aw_context input. A consumer repository installs this wrapper unchanged.
 #
 # The gh-aw command:/slash_command trigger (with its roles: gate) is not used
 # here: that trigger is gh-aw frontmatter and only takes effect when gh aw
@@ -73,46 +75,102 @@ jobs:
     permissions:
       contents: read
       issues: read
+      # The route action reads a PR's head ref to gate a /revise to arch PRs.
+      pull-requests: read
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
       aw_context: ${{ steps.decide.outputs.aw_context }}
       phase: ${{ steps.decide.outputs.phase }}
+      target: ${{ steps.decide.outputs.target }}
       item_number: ${{ steps.decide.outputs.item_number }}
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.3.0
         with:
           github-token: ${{ github.token }}
 
-  sdd-triage:
+  # Per-phase fan-out (issue #271, ADR 0029). The route action resolves a
+  # deterministic `target`; exactly one of the three phase jobs runs. The former
+  # single sdd-triage mega-workflow is split so each phase loads only its own
+  # prompt and only the MCP servers it calls: arch carries Serena + Distillery,
+  # plan and materialize carry none.
+  #
+  # arch: design and persist architecture.md (sdd:triage label, /triage, or
+  # /revise on an arch PR). Needs Distillery (DISTILLERY_OAUTH_TOKEN) and the
+  # full write ceiling (it opens a PR).
+  arch:
     needs: route
-    if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-triage.lock.yml@v0.2.0
+    if: needs.route.outputs.should_run == 'true' && needs.route.outputs.target == 'arch'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-arch.lock.yml@v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
-      # Task-bundling diff floor (ADR 0022). Maps the consumer's optional
-      # SDD_TRIAGE_MIN_TASK variable into the lock's min_task input; unset
-      # passes empty and the agent falls back to 300.
       min_task: ${{ vars.SDD_TRIAGE_MIN_TASK }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
       # the reusable lock's observability.otlp endpoint resolves; unset is fine
       # (if-missing: warn). See ADR 0020.
       GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
       DISTILLERY_OAUTH_TOKEN: ${{ secrets.DISTILLERY_OAUTH_TOKEN }}
-    # Ceiling for the called reusable workflow. Must cover the union of every
-    # nested job's permissions: the gh-aw conclusion and safe_outputs jobs
-    # need write scopes, and activation needs actions: read.
     permissions:
       actions: read
       contents: write
       discussions: write
       issues: write
+      pull-requests: write
+
+  # plan: post the proposed plan as one comment (arch PR merged, or resume with a
+  # plan already posted). No MCP, so no DISTILLERY_OAUTH_TOKEN.
+  plan:
+    needs: route
+    if: needs.route.outputs.should_run == 'true' && needs.route.outputs.target == 'plan'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-plan.lock.yml@v0.3.0
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+      min_task: ${{ vars.SDD_TRIAGE_MIN_TASK }}
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+      issues: write
+      # write (not read): the called sdd-triage-{plan,materialize} lock's gh-aw
+      # safe_outputs/conclusion jobs request pull-requests: write, and a reusable
+      # callee may not request a permission beyond the caller job's grant — so
+      # read here startup_fails the entire workflow. See issue #295.
+      pull-requests: write
+
+  # materialize: commit the Unit/task tree and advance to sdd:ready (/approve).
+  # No MCP, so no DISTILLERY_OAUTH_TOKEN.
+  materialize:
+    needs: route
+    if: needs.route.outputs.should_run == 'true' && needs.route.outputs.target == 'materialize'
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-materialize.lock.yml@v0.3.0
+    with:
+      aw_context: ${{ needs.route.outputs.aw_context }}
+      # Task-bundling diff floor (ADR 0022). Maps the consumer's optional
+      # SDD_TRIAGE_MIN_TASK variable into the lock's min_task input.
+      min_task: ${{ vars.SDD_TRIAGE_MIN_TASK }}
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      GH_AW_OTEL_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+      issues: write
+      # write (not read): the called sdd-triage-{plan,materialize} lock's gh-aw
+      # safe_outputs/conclusion jobs request pull-requests: write, and a reusable
+      # callee may not request a permission beyond the caller job's grant — so
+      # read here startup_fails the entire workflow. See issue #295.
       pull-requests: write
 
   # Deterministic DAG backstop for phase C (ADR 0010, issue #229).
@@ -127,19 +185,18 @@ jobs:
   # on phase == 'C' (the /approve materialization) so it never runs on the
   # design or plan-preview phases, which create no task tree to check.
   cycle-detect:
-    needs: [route, sdd-triage]
-    # always(): the backstop must also run when sdd-triage FAILS partway
-    # through phase C, because a partial materialization can leave a cyclic
-    # or incomplete tree on the issues — exactly the state the deterministic
+    needs: [route, materialize]
+    # always(): the backstop must also run when materialize FAILS partway
+    # through, because a partial materialization can leave a cyclic or
+    # incomplete tree on the issues — exactly the state the deterministic
     # cycle/tree_incomplete park exists to catch. Gate on route succeeding
-    # (so phase is a valid value) and on sdd-triage having actually run
-    # (result != 'skipped'); a non-phase-C run still no-ops on the phase
-    # check.
+    # (so target is a valid value) and on materialize having actually run
+    # (result != 'skipped'); only the materialize phase creates a tree.
     if: >-
       always()
       && needs.route.result == 'success'
-      && needs.route.outputs.phase == 'C'
-      && needs.sdd-triage.result != 'skipped'
+      && needs.route.outputs.target == 'materialize'
+      && needs.materialize.result != 'skipped'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -147,7 +204,7 @@ jobs:
     steps:
       - name: Detect a dependency cycle in the materialized tree
         id: detect
-        uses: norrietaylor/spectacles/.github/actions/sdd-cycle-detect@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-cycle-detect@v0.3.0
         with:
           tracking-issue: ${{ needs.route.outputs.item_number }}
           github-token: ${{ github.token }}
@@ -218,3 +275,68 @@ jobs:
               core.setFailed('Could not post backstop comment on #'
                 + tracking + ': ' + err.message);
             }
+
+  # Deterministic command acknowledgment (issue #294). Adds a 👀 reaction to the
+  # triggering comment as soon as the route job decides to act, before the agent
+  # starts, so the human sees the command was received. Gated on a comment being
+  # present, so label/PR/dispatch triggers (no comment) never react. Reacts as
+  # the App so the 👀 matches the pipeline's bot identity. Best-effort: the
+  # sdd-ack-reaction action never fails the step.
+  ack:
+    needs: route
+    if: ${{ (needs.route.outputs.should_run == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      reaction_id: ${{ steps.ack.outputs.reaction-id }}
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Ack the command with 👀
+        id: ack
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: ack
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+
+  # Terminal reaction (issue #294). Clears the 👀 and adds the run's outcome
+  # (🚀 ran / 😕 noop / 👎 failed), derived deterministically from the job
+  # results above — never from the agent. Runs always() so a failed run still
+  # replaces the ack.
+  ack-terminal:
+    needs: [route, ack, arch, plan, materialize, cycle-detect]
+    if: ${{ always() && (needs.route.outputs.should_run == 'true') && github.event.comment.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token
+        id: app
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+      - name: Replace 👀 with the run outcome
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          mode: terminal
+          comment-id: ${{ github.event.comment.id }}
+          comment-type: ${{ github.event_name == 'pull_request_review_comment' && 'review' || 'issue' }}
+          ack-reaction-id: ${{ needs.ack.outputs.reaction_id }}
+          outcome: ${{ (needs.arch.result == 'failure' || needs.arch.result == 'cancelled' || needs.plan.result == 'failure' || needs.plan.result == 'cancelled' || needs.materialize.result == 'failure' || needs.materialize.result == 'cancelled' || needs['cycle-detect'].result == 'failure' || needs['cycle-detect'].result == 'cancelled') && 'failed' || 'ran' }}

--- a/.github/workflows/sdd-validate.yml
+++ b/.github/workflows/sdd-validate.yml
@@ -81,21 +81,21 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@v0.2.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@v0.3.0
         with:
           github-token: ${{ github.token }}
 
   sdd-validate:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@v0.2.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
     # to a reusable workflow in a different owner than the caller.
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # OTLP collector URL (write-only ingest key embedded). Mapped explicitly so
       # the reusable lock's observability.otlp endpoint resolves; unset is fine
       # (if-missing: warn). See ADR 0020.


### PR DESCRIPTION
Installs the spectacles SDD agent suite (ADR 0004) via `scripts/quick-setup.sh`. Wrappers pin hosted reusable workflows at `@v0.3.0`. Labels, variables, and secrets were applied directly; the file artifacts in this PR honor the protected default branch. Merge to activate the workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added spec derivation workflow with command acknowledgment via reaction indicators.

* **Improvements**
  * Enhanced concurrency handling to prevent unintended job cancellations across workflows.
  * Introduced deterministic command acknowledgment reactions (👀 → outcome emoji) for better user feedback.
  * Updated authentication token integration across all command-processing workflows.
  * Improved workflow routing with phase-based architecture and explicit permission scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->