### PR TITLE
ci(netns): network-namespace integration job for gvproxy proofs

### DIFF
--- a/.github/workflows/ci-netns.yml
+++ b/.github/workflows/ci-netns.yml
@@ -1,0 +1,79 @@
+name: CI netns (gvproxy integration)
+
+# Runs the network-namespace integration proofs for the minimald networking
+# stack (UC1 no-net isolation, UC6 same-host PTask-to-PTask over the gvproxy
+# switch). These tests are #[ignore] by default and additionally gated on the
+# MINIMALD_NETNS_TEST env var, so they only execute here. ubuntu-latest grants
+# unprivileged user namespaces + passwordless sudo, which is all that netns +
+# tap creation needs (no KVM); the gvproxy switch itself is userspace.
+#
+# CONTRACT for the implementation (issue #496, Unit 1):
+#   - Mark UC1/UC6 integration tests `#[ignore]` and have them early-return
+#     unless `MINIMALD_NETNS_TEST` is set (mirrors the MINVMD_E2E gate pattern).
+#   - Read the gvproxy binary path from `GVPROXY_BIN` (this job fetches + pins it
+#     via scripts/fetch-gvproxy.sh and exports it).
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "crates/minimald/**"
+      - "crates/sandbox2/**"
+      - "crates/minimald-rpc/**"
+      - "scripts/fetch-gvproxy.sh"
+      - "vendor/gvproxy/**"
+      - ".github/workflows/ci-netns.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "crates/minimald/**"
+      - "crates/sandbox2/**"
+      - "crates/minimald-rpc/**"
+      - "scripts/fetch-gvproxy.sh"
+      - "vendor/gvproxy/**"
+      - ".github/workflows/ci-netns.yml"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ci-netns-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  netns-integration:
+    runs-on: ubuntu-latest # x86_64; unprivileged userns + sudo for netns/tap
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Cache cargo + build
+        uses: Swatinem/rust-cache@v2
+      - name: Fetch pinned gvproxy switch binary
+        run: ./scripts/fetch-gvproxy.sh "$RUNNER_TEMP/gvproxy"
+      - name: Confirm unprivileged netns is available on this runner
+        # Fail fast with a clear message if the runner image ever drops userns,
+        # rather than letting every gated test mis-skip.
+        run: |
+          if ! unshare --user --net true 2>/dev/null && ! sudo ip netns add _ci_probe; then
+            echo "::error::runner cannot create a network namespace (no userns and no sudo netns)" >&2
+            exit 1
+          fi
+          sudo ip netns del _ci_probe 2>/dev/null || true
+          echo "netns capability: OK"
+      - name: Run netns proof tests (UC1 no-net, UC6 PTask-to-PTask)
+        env:
+          MINIMALD_NETNS_TEST: "1"
+          GVPROXY_BIN: ${{ runner.temp }}/gvproxy
+        # --include-ignored runs the #[ignore] proofs; the env gate ensures they
+        # actually exercise (vs early-return). Until Unit 1 lands these tests this
+        # is a green no-op build of the affected crates.
+        run: cargo test -p minimald -p sandbox2 -p minimald-rpc -- --include-ignored --nocapture

--- a/.github/workflows/ci-netns.yml
+++ b/.github/workflows/ci-netns.yml
@@ -8,8 +8,11 @@ name: CI netns (gvproxy integration)
 # tap creation needs (no KVM); the gvproxy switch itself is userspace.
 #
 # CONTRACT for the implementation (issue #496, Unit 1):
-#   - Mark UC1/UC6 integration tests `#[ignore]` and have them early-return
-#     unless `MINIMALD_NETNS_TEST` is set (mirrors the MINVMD_E2E gate pattern).
+#   - Put the UC1/UC6 proofs where their test path contains `netns` (e.g. a
+#     `tests/netns_*.rs` integration target or a `mod netns_*`); this job's
+#     `cargo test ... netns` filter is what selects them.
+#   - Mark them `#[ignore]` and have them early-return unless `MINIMALD_NETNS_TEST`
+#     is set (mirrors the MINVMD_E2E gate pattern).
 #   - Read the gvproxy binary path from `GVPROXY_BIN` (this job fetches + pins it
 #     via scripts/fetch-gvproxy.sh and exports it).
 on:
@@ -73,7 +76,10 @@ jobs:
         env:
           MINIMALD_NETNS_TEST: "1"
           GVPROXY_BIN: ${{ runner.temp }}/gvproxy
-        # --include-ignored runs the #[ignore] proofs; the env gate ensures they
-        # actually exercise (vs early-return). Until Unit 1 lands these tests this
-        # is a green no-op build of the affected crates.
-        run: cargo test -p minimald -p sandbox2 -p minimald-rpc -- --include-ignored --nocapture
+        # Runs only proofs whose test path contains `netns`, so the broad suite
+        # (incl. tests needing extra system deps like socat — already covered by
+        # ci.yml) is not re-run here. --include-ignored exercises the #[ignore]
+        # proofs; the env gate makes them run vs early-return. Until Unit 1 lands
+        # these tests the filter matches nothing: a green no-op that still compiles
+        # the affected crates' test targets.
+        run: cargo test -p minimald -p sandbox2 -p minimald-rpc netns -- --include-ignored --nocapture


### PR DESCRIPTION
Establishes the CI verification path for Unit 1 of the minimald networking epic, so the implementation tasks (#496/#497) can ship CI-provable proofs instead of handing off.

## Why
#496 (U1-T2) handed off (`needs-human`) because:
- its proof artifacts (UC1 no-net, UC6 PTask-to-PTask over the gvproxy switch) need a **real network namespace + tap + live gvproxy** — the execute agent sandbox denies `unshare --net`;
- the only gvproxy CI job (`ci-gvproxy.yml`) just downloads + checksums the binary; it does not run integration tests;
- so there was **no executable proof path**, and the agent (correctly) would not open an unverifiable PR.

## Change
`ci-netns.yml` on `ubuntu-latest` (unprivileged userns + passwordless sudo — netns/tap need no KVM; the gvproxy switch is userspace):
- fetches the pinned gvproxy via `scripts/fetch-gvproxy.sh`;
- a fail-fast probe that the runner can create a netns;
- runs `cargo test -p minimald -p sandbox2 -p minimald-rpc -- --include-ignored` with `MINIMALD_NETNS_TEST=1` and `GVPROXY_BIN` exported.

## Contract for the Unit 1 implementation (issue #496)
- gate UC1/UC6 tests `#[ignore]` + on `MINIMALD_NETNS_TEST`;
- read the gvproxy binary path from `GVPROXY_BIN`.

Until those tests land this job is a **green no-op** build of the affected crates. After they land, clearing `needs-human` on #496 lets the agent ship with a runnable proof path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new CI workflow for network-namespace integration testing with gvproxy support. It runs on pull requests and pushes to `main` when relevant files change (or via manual dispatch), includes a preflight verification for namespace creation, and executes the gated `netns`-filtered integration test suite for the `minimald`, `sandbox2`, and `minimald-rpc` crates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->