### PR TITLE
feat(ot)!: refactor ot to prepare for tracking operations per-session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,6 +3824,7 @@ name = "ot"
 version = "0.0.1"
 dependencies = [
  "indicatif",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -216,7 +216,14 @@ async fn run_cli(cli: Cli) -> Result<(), Error> {
         global_args,
     } = cli;
 
+    // One operation tree for this CLI invocation, rendered to stderr. Threaded
+    // into the Context so all operations attach to it (replacing the former
+    // process-global root).
+    let ot_root = ot::OpTracker::new_root();
+    ot::render_to_stderr(ot_root.clone());
+
     let mut config = ConfigBuilder::new()
+        .with_operation_tracker(ot_root)
         .with_no_cache(global_args.no_cache)
         .with_no_fetch(global_args.no_fetch)
         .with_offline(global_args.offline);

--- a/crates/ot/Cargo.toml
+++ b/crates/ot/Cargo.toml
@@ -6,5 +6,15 @@ license = "MIT OR Apache-2.0"
 edition.workspace = true
 publish.workspace = true
 
+[features]
+default = ["indicatif"]
+# The indicatif renderer (legacy single-terminal CLI path). Disable to build the
+# pure operation-tracking core with no rendering dependency.
+indicatif = ["dep:indicatif", "tokio/rt"]
+
 [dependencies]
-indicatif.workspace = true
+indicatif = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/crates/ot/src/indicatif_shim.rs
+++ b/crates/ot/src/indicatif_shim.rs
@@ -1,0 +1,340 @@
+//! Indicatif renderer for the operation tree.
+//!
+//! A thin shim that *observes* the render-agnostic state core
+//! ([`crate::OpTracker`]) and draws it with `indicatif` progress bars. It owns
+//! all styling — the core stores only semantic [`Operation`]s and numeric
+//! [`Progress`](crate::Progress) — so a future renderer (e.g. the daemon's
+//! per-channel ANSI path, or `strides`) can replace it without touching the
+//! core. This is the legacy single-terminal CLI path.
+//!
+//! The shim runs as a Tokio task: it waits on [`OpTracker::changed`], takes a
+//! [`OpTracker::snapshot`], and reconciles a set of live `ProgressBar`s against
+//! it. See `docs/specs/04-spec-ot-render-decoupling`.
+
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::mem::Discriminant;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+use crate::{OpId, OpSnapshot, OpTracker, Operation};
+
+/// The process-global `MultiProgress` representing the single CLI terminal,
+/// shared by the renderer and [`StdoutWriter`] so plain stdout writes can
+/// suspend bar drawing.
+static MP: OnceLock<MultiProgress> = OnceLock::new();
+
+fn global_progress() -> MultiProgress {
+    MP.get_or_init(MultiProgress::new).clone()
+}
+
+/// Spawns an indicatif renderer that draws `root`'s operation tree to stderr,
+/// onto the same `MultiProgress` that [`StdoutWriter`] suspends.
+///
+/// Call once per process: the CLI owns a single terminal and a single root.
+/// Must be called from within a Tokio runtime (the CLI `main`s are
+/// `#[tokio::main]`).
+pub fn render_to_stderr(root: OpTracker) {
+    tokio::spawn(IndicatifShim::new(global_progress()).run(root));
+}
+
+/// Observes an [`OpTracker`] tree and renders it as a stack of `indicatif`
+/// progress bars.
+pub struct IndicatifShim {
+    mp: MultiProgress,
+    bars: HashMap<OpId, Bar>,
+}
+
+/// A live progress bar plus the [`Operation`] variant it was built for, so a
+/// change of operation type on the same node rebuilds the bar.
+struct Bar {
+    pg: ProgressBar,
+    kind: Discriminant<Operation>,
+}
+
+impl IndicatifShim {
+    /// Creates a shim that draws onto `mp`.
+    pub fn new(mp: MultiProgress) -> Self {
+        Self {
+            mp,
+            bars: HashMap::new(),
+        }
+    }
+
+    /// Drives the renderer until `root` is dropped: render the current state,
+    /// then repaint on each change. Intended to be `tokio::spawn`ed.
+    pub async fn run(mut self, root: OpTracker) {
+        let mut last = root.version();
+        self.reconcile(&root.snapshot());
+        loop {
+            root.changed().await;
+            let v = root.version();
+            if v == last {
+                continue;
+            }
+            last = v;
+            self.reconcile(&root.snapshot());
+        }
+    }
+
+    /// Brings the live bars in line with `snap`: create bars for newly active
+    /// operations, update messages/positions, rebuild on operation-type change,
+    /// and clear bars whose operation has finished or whose node is gone. New
+    /// bars are positioned to preserve the snapshot's pre-order.
+    fn reconcile(&mut self, snap: &[OpSnapshot]) {
+        let mut seen: HashSet<OpId> = HashSet::with_capacity(snap.len());
+        let mut prev: Option<ProgressBar> = None;
+
+        for row in snap {
+            let Some(op) = &row.op else {
+                // A node with no active operation draws nothing and does not
+                // anchor positioning.
+                continue;
+            };
+            seen.insert(row.id);
+            let kind = std::mem::discriminant(op);
+
+            let pg = match self.bars.get(&row.id) {
+                Some(existing) if existing.kind == kind => {
+                    // Same operation: refresh dynamic text and progress.
+                    existing.pg.set_message(op_message(op));
+                    apply_progress(&existing.pg, row);
+                    existing.pg.clone()
+                }
+                other => {
+                    // New node, or the operation type changed: (re)build a bar.
+                    if let Some(stale) = other {
+                        stale.pg.finish_and_clear();
+                    }
+                    let pg = match &prev {
+                        Some(after) => self.mp.insert_after(after, make_bar(op, row.depth)),
+                        None => self.mp.insert(0, make_bar(op, row.depth)),
+                    };
+                    apply_progress(&pg, row);
+                    self.bars.insert(
+                        row.id,
+                        Bar {
+                            pg: pg.clone(),
+                            kind,
+                        },
+                    );
+                    pg
+                }
+            };
+            prev = Some(pg);
+        }
+
+        // Drop bars for operations that completed or nodes that disappeared.
+        self.bars.retain(|id, bar| {
+            let keep = seen.contains(id);
+            if !keep {
+                bar.pg.finish_and_clear();
+            }
+            keep
+        });
+    }
+}
+
+/// Pushes a node's numeric progress onto its bar (length first so the position
+/// is interpreted against the right total).
+fn apply_progress(pg: &ProgressBar, row: &OpSnapshot) {
+    if let Some(p) = row.progress {
+        if let Some(len) = p.len {
+            pg.set_length(len);
+        }
+        pg.set_position(p.pos);
+    }
+}
+
+/// Builds a styled, hidden progress bar for `op`, indented by tree `depth`.
+fn make_bar(op: &Operation, depth: usize) -> ProgressBar {
+    let pg = ProgressBar::hidden().with_style(op_style(op));
+    pg.set_message(op_message(op));
+    if let Some(tick) = op_tick(op) {
+        pg.enable_steady_tick(tick);
+    }
+    // Top-level operations (depth 1) are flush-left; deeper nodes are indented.
+    if depth > 1 {
+        pg.set_prefix(format!("{}{}", "  ".repeat((depth - 1) * 2), "↳ "));
+    }
+    pg
+}
+
+/// The bar style for each operation variant.
+fn op_style(op: &Operation) -> ProgressStyle {
+    let template = match op {
+        Operation::PackageBuild { .. } => "{prefix}{spinner} Building package: {msg}",
+        Operation::CollectOutputs { .. } => "{prefix}{spinner} Collect outputs for {msg}",
+        Operation::ExtractPkg { .. } => "{prefix}{spinner} Extract: {msg}",
+        Operation::CompressPkg { .. } => "{prefix}{spinner} Compress: {msg}",
+        Operation::Check { .. } => "{prefix}{spinner} Checking: {msg}",
+        Operation::StandaloneTest { .. } => "{prefix}{spinner} Test: {msg}",
+        Operation::FetchPkg { .. } => {
+            "{prefix}Fetch: {msg:35!} [{wide_bar}]     {decimal_bytes:9!} / {decimal_total_bytes:9!}   ETA: {eta:5!}"
+        }
+        Operation::FetchIndex => {
+            "{prefix}Update remote index  {msg:35!} [{wide_bar}]     {decimal_bytes:9!} / {decimal_total_bytes:9!}   ETA: {eta:5!}"
+        }
+        Operation::FetchSource { .. } => {
+            "{prefix}Fetch source: {msg:35!} [{wide_bar}]     {decimal_bytes:9!} / {decimal_total_bytes:9!}   ETA: {eta:5!}"
+        }
+    };
+    let style = ProgressStyle::with_template(template).expect("static template is valid");
+    // The byte-oriented fetch bars use a custom fill.
+    match op {
+        Operation::FetchPkg { .. } | Operation::FetchIndex | Operation::FetchSource { .. } => {
+            style.progress_chars("=> ")
+        }
+        _ => style,
+    }
+}
+
+/// The steady-tick interval for spinner-style operations; `None` for the
+/// byte-progress fetch bars, which advance via [`apply_progress`].
+fn op_tick(op: &Operation) -> Option<Duration> {
+    let ms = match op {
+        Operation::PackageBuild { .. } | Operation::Check { .. } => 100,
+        Operation::CompressPkg { .. } => 80,
+        Operation::CollectOutputs { .. }
+        | Operation::ExtractPkg { .. }
+        | Operation::StandaloneTest { .. } => 50,
+        Operation::FetchPkg { .. } | Operation::FetchIndex | Operation::FetchSource { .. } => {
+            return None;
+        }
+    };
+    Some(Duration::from_millis(ms))
+}
+
+/// The bar message (the `{msg}` field) for an operation.
+fn op_message(op: &Operation) -> String {
+    match op {
+        Operation::PackageBuild { name }
+        | Operation::ExtractPkg { name }
+        | Operation::CompressPkg { name }
+        | Operation::FetchPkg { name }
+        | Operation::StandaloneTest { name } => name.clone(),
+        Operation::FetchSource { url } => url.clone(),
+        Operation::FetchIndex => String::new(),
+        Operation::Check { kind, name } => format!("{kind} {name}"),
+        Operation::CollectOutputs { name, outputs } => {
+            let joined = outputs.join(" ");
+            let shown = match joined.char_indices().nth(30) {
+                Some((idx, _)) => format!("{}...", &joined[..idx]),
+                None => joined,
+            };
+            format!("{name}: {shown}")
+        }
+    }
+}
+
+/// A writer to stdout which coordinates with progress-bar drawing by
+/// suspending the shared [`MultiProgress`] for the duration of each write.
+pub struct StdoutWriter(MultiProgress);
+
+impl Default for StdoutWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StdoutWriter {
+    pub fn new() -> Self {
+        StdoutWriter(global_progress())
+    }
+}
+
+impl io::Write for StdoutWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.suspend(|| io::stdout().write(buf))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.suspend(|| io::stdout().flush())
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.0.suspend(|| io::stdout().write_vectored(bufs))
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.suspend(|| io::stdout().write_all(buf))
+    }
+
+    fn write_fmt(&mut self, fmt: std::fmt::Arguments<'_>) -> io::Result<()> {
+        self.0.suspend(|| io::stdout().write_fmt(fmt))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indicatif::ProgressDrawTarget;
+
+    use super::*;
+    use crate::CheckKind;
+
+    // A shim whose bars draw nowhere, so reconcile logic can be exercised
+    // without touching a terminal.
+    fn hidden_shim() -> IndicatifShim {
+        IndicatifShim::new(MultiProgress::with_draw_target(ProgressDrawTarget::hidden()))
+    }
+
+    #[test]
+    fn reconcile_tracks_active_operations() {
+        let root = OpTracker::new_root();
+        let a = root.new_child();
+        a.set_op(Operation::PackageBuild { name: "a".into() });
+        let b = root.new_child();
+        b.set_op(Operation::FetchPkg { name: "b".into() });
+
+        let mut shim = hidden_shim();
+        shim.reconcile(&root.snapshot());
+        assert_eq!(shim.bars.len(), 2);
+
+        // Completing one operation drops its bar on the next reconcile; the
+        // other survives.
+        a.set_done();
+        shim.reconcile(&root.snapshot());
+        assert_eq!(shim.bars.len(), 1);
+    }
+
+    #[test]
+    fn reconcile_is_stable_across_repeated_snapshots() {
+        let root = OpTracker::new_root();
+        let n = root.new_child();
+        n.set_op(Operation::Check {
+            kind: CheckKind::CheckPackages,
+            name: "p".into(),
+        });
+
+        let mut shim = hidden_shim();
+        shim.reconcile(&root.snapshot());
+        let id = *shim.bars.keys().next().unwrap();
+        // A no-op reconcile must keep the same bar (no churn / re-create).
+        shim.reconcile(&root.snapshot());
+        assert_eq!(shim.bars.len(), 1);
+        assert!(shim.bars.contains_key(&id));
+    }
+
+    #[test]
+    fn reconcile_rebuilds_bar_when_operation_kind_changes() {
+        let root = OpTracker::new_root();
+        let n = root.new_child();
+        n.set_op(Operation::PackageBuild { name: "p".into() });
+
+        let mut shim = hidden_shim();
+        shim.reconcile(&root.snapshot());
+        let kind_before = shim.bars.values().next().unwrap().kind;
+
+        n.set_op(Operation::CollectOutputs {
+            name: "p".into(),
+            outputs: vec!["o".into()],
+        });
+        shim.reconcile(&root.snapshot());
+
+        assert_eq!(shim.bars.len(), 1);
+        let kind_after = shim.bars.values().next().unwrap().kind;
+        assert_ne!(kind_before, kind_after, "bar should be rebuilt for new op");
+    }
+}

--- a/crates/ot/src/lib.rs
+++ b/crates/ot/src/lib.rs
@@ -1,13 +1,18 @@
 //! Tracking of long-running operations, so that pretty progress bars
 //! can be printed.
 
-use std::{
-    fmt::Display,
-    sync::{Arc, Mutex, OnceLock, Weak},
-    time::Duration,
+use std::fmt::Display;
+use std::sync::{
+    Arc, Mutex, Weak,
+    atomic::{AtomicU64, Ordering},
 };
 
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use tokio::sync::Notify;
+
+#[cfg(feature = "indicatif")]
+mod indicatif_shim;
+#[cfg(feature = "indicatif")]
+pub use indicatif_shim::{IndicatifShim, StdoutWriter, render_to_stderr};
 
 #[derive(Debug, Clone)]
 pub enum CheckKind {
@@ -39,125 +44,105 @@ pub enum Operation {
     FetchIndex,
 }
 
+/// A stable identifier for a node in the operation tree.
+///
+/// Ids are unique within a single tree (i.e. per [`RootShared`]) and never
+/// reused, so a renderer can diff successive snapshots to learn which rows
+/// appeared, changed, or vanished. `0` is reserved for the root node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct OpId(u64);
+
+/// Quantitative progress of an operation: how far through, and the total if
+/// known. Stored in the state core so a renderer can draw a bar without
+/// reaching into indicatif.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Progress {
+    pub pos: u64,
+    pub len: Option<u64>,
+}
+
+/// State shared by every node of a single operation tree, owned via `Arc`.
+///
+/// Created once per root (see [`OpTracker::new_root`]) and cloned into each
+/// child so the whole tree shares one change counter and wakeup primitive.
 #[derive(Debug, Default)]
+struct RootShared {
+    /// Bumped on every mutation anywhere in the tree. The source of truth a
+    /// driver polls to decide whether a repaint is due.
+    version: AtomicU64,
+    /// Wakeup for the tree's driver awaiting the next change. A tree has a
+    /// single consumer (one renderer per root), so `notify_one` is used: a
+    /// mutation that races ahead of the driver leaves a stored permit rather
+    /// than being lost, and `version` reconciles coalesced bumps.
+    notify: Notify,
+    /// Allocator for [`OpId`]s within this tree.
+    next_id: AtomicU64,
+}
+
+impl RootShared {
+    /// Records a mutation: bump the version and wake the driver (or leave a
+    /// permit if it is not currently parked).
+    fn bump(&self) {
+        self.version.fetch_add(1, Ordering::Relaxed);
+        self.notify.notify_one();
+    }
+
+    /// Allocates the next unique [`OpId`] for this tree (root is `0`).
+    fn alloc_id(&self) -> OpId {
+        OpId(self.next_id.fetch_add(1, Ordering::Relaxed) + 1)
+    }
+}
+
+/// An immutable view of one operation, produced by [`OpTracker::snapshot`].
+///
+/// A flat `Vec<OpSnapshot>` in pre-order is the "slice of progress" a renderer
+/// consumes: already in display order, with `depth` carrying the indentation.
+#[derive(Debug, Clone)]
+pub struct OpSnapshot {
+    pub id: OpId,
+    pub depth: usize,
+    pub op: Option<Operation>,
+    pub progress: Option<Progress>,
+}
+
+#[derive(Debug)]
 struct TrackerInner {
+    id: OpId,
     depth: usize,
+    // Strong reference to the parent, pinning the ancestor chain alive so a live
+    // node stays reachable from the root during `snapshot` traversal, which
+    // descends through `children` (held only by `Weak`). Never read directly;
+    // its role is purely to own the chain upward.
+    #[allow(dead_code)]
     parent: Option<OpTracker>,
     op: Option<Operation>,
+    progress: Option<Progress>,
     children: Vec<Weak<Mutex<TrackerInner>>>,
-    pg: Option<ProgressBar>,
+    shared: Arc<RootShared>,
 }
 
 impl TrackerInner {
-    fn set_length(&self, length: u64) {
-        if let Some(pg) = &self.pg {
-            pg.set_length(length);
-        }
+    fn set_length(&mut self, length: u64) {
+        self.progress = Some(Progress {
+            pos: self.progress.map_or(0, |p| p.pos),
+            len: Some(length),
+        });
+        self.shared.bump();
     }
-    fn increment(&self, amt: u64) {
-        if let Some(pg) = &self.pg {
-            pg.inc(amt);
-        }
+    fn increment(&mut self, amt: u64) {
+        self.progress = Some(Progress {
+            pos: self.progress.map_or(amt, |p| p.pos + amt),
+            len: self.progress.and_then(|p| p.len),
+        });
+        self.shared.bump();
     }
 
-    pub fn set_op(&mut self, op: Option<Operation>) {
+    fn set_op(&mut self, op: Option<Operation>) {
         self.op = op;
-
-        // Depending on the operation type, create a progress bar.
-        match (&self.op, &self.pg) {
-            (Some(Operation::PackageBuild { name }), _) => {
-                let new_pg = ProgressBar::hidden().with_style(
-                    ProgressStyle::with_template("{prefix}{spinner} Building package: {msg}")
-                        .unwrap(),
-                );
-                new_pg.set_message(name.clone());
-                new_pg.enable_steady_tick(Duration::from_millis(100));
-                self.install(new_pg);
-            }
-            (Some(Operation::CollectOutputs { name, outputs }), _) => {
-                let new_pg = ProgressBar::hidden().with_style(
-                    ProgressStyle::with_template("{prefix}{spinner} Collect outputs for {msg}")
-                        .unwrap(),
-                );
-
-                let s = outputs.to_vec().join(" ");
-                let outputs_str = match s.char_indices().nth(30) {
-                    Some((idx, _)) => format!("{}...", &s[..idx]),
-                    None => s.to_string(),
-                };
-                new_pg.set_message(format!("{name}: {outputs_str}"));
-                new_pg.enable_steady_tick(Duration::from_millis(50));
-                self.install(new_pg);
-            }
-            (Some(Operation::ExtractPkg { name }), _) => {
-                let new_pg = ProgressBar::hidden().with_style(
-                    ProgressStyle::with_template("{prefix}{spinner} Extract: {msg}").unwrap(),
-                );
-                new_pg.set_message(name.clone());
-                new_pg.enable_steady_tick(Duration::from_millis(50));
-                self.install(new_pg);
-            }
-            (Some(Operation::CompressPkg { name }), _) => {
-                let new_pg = ProgressBar::hidden().with_style(
-                    ProgressStyle::with_template("{prefix}{spinner} Compress: {msg}").unwrap(),
-                );
-                new_pg.set_message(name.clone());
-                new_pg.enable_steady_tick(Duration::from_millis(80));
-                self.install(new_pg);
-            }
-            (Some(Operation::FetchPkg { name }), _) => {
-                let new_pg = ProgressBar::hidden()
-                    .with_style(ProgressStyle::with_template("{prefix}Fetch: {msg:35!} [{wide_bar}]     {decimal_bytes:9!} / {decimal_total_bytes:9!}   ETA: {eta:5!}").unwrap().progress_chars("=> "));
-                new_pg.set_message(name.clone());
-                self.install(new_pg);
-            }
-            (Some(Operation::FetchIndex), _) => {
-                let new_pg = ProgressBar::hidden()
-                    .with_style(ProgressStyle::with_template("{prefix}Update remote index  {msg:35!} [{wide_bar}]     {decimal_bytes:9!} / {decimal_total_bytes:9!}   ETA: {eta:5!}").unwrap().progress_chars("=> "));
-                new_pg.set_message("");
-                self.install(new_pg);
-            }
-            (Some(Operation::FetchSource { url }), _) => {
-                let new_pg = ProgressBar::hidden()
-                    .with_style(ProgressStyle::with_template("{prefix}Fetch source: {msg:35!} [{wide_bar}]     {decimal_bytes:9!} / {decimal_total_bytes:9!}   ETA: {eta:5!}").unwrap().progress_chars("=> "));
-                new_pg.set_message(url.clone());
-                self.install(new_pg);
-            }
-            (Some(Operation::Check { kind, name }), _) => {
-                let new_pg = ProgressBar::hidden().with_style(
-                    ProgressStyle::with_template("{prefix}{spinner} Checking: {msg}").unwrap(),
-                );
-                new_pg.set_message(format!("{} {}", kind, name));
-                new_pg.enable_steady_tick(Duration::from_millis(100));
-                self.install(new_pg);
-            }
-            (Some(Operation::StandaloneTest { name }), _) => {
-                let new_pg = ProgressBar::hidden().with_style(
-                    ProgressStyle::with_template("{prefix}{spinner} Test: {msg}").unwrap(),
-                );
-                new_pg.set_message(name.clone());
-                new_pg.enable_steady_tick(Duration::from_millis(50));
-                self.install(new_pg);
-            }
-            // No operation remains but a progress bar exists. Set it to finished and remove our reference.
-            (None, Some(pg)) => {
-                pg.finish_and_clear();
-                self.pg = None;
-            }
-            _ => {}
-        }
-    }
-
-    fn install(&mut self, pg: ProgressBar) {
-        if self.depth > 1 {
-            pg.set_prefix(format!("{}{}", "  ".repeat((self.depth - 1) * 2), "↳ "));
-        }
-        if let Some(p) = &self.parent {
-            p.install_progress(pg.clone());
-        } else {
-            global_progress().add(pg.clone());
-        }
-        self.pg = Some(pg);
+        // A fresh operation starts with no measured progress; FetchPkg & co.
+        // call set_length once they learn the content length.
+        self.progress = None;
+        self.shared.bump();
     }
 }
 
@@ -171,31 +156,53 @@ pub struct OpTracker {
 }
 
 impl OpTracker {
-    /// Creates a new OpTracker which is a child of the given root, if any.
+    /// Creates a fresh root of a new operation tree, with its own change
+    /// counter and wakeup primitive. Each independent rendering context (the
+    /// CLI process, or a single daemon session) owns one root.
+    pub fn new_root() -> OpTracker {
+        OpTracker {
+            inner: Arc::new(Mutex::new(TrackerInner {
+                id: OpId(0),
+                depth: 0,
+                parent: None,
+                op: None,
+                progress: None,
+                children: Vec::with_capacity(32),
+                shared: Arc::new(RootShared::default()),
+            })),
+        }
+    }
+
+    /// Creates a new operation node as a child of the given root.
+    ///
+    /// `None` means "untracked": the node is created under a fresh, unrendered
+    /// throwaway tree, so progress calls on it are valid no-ops. Pass `Some` to
+    /// attach the operation to a real, rendered tree.
     pub fn new_with_root(root_op: &Option<OpTracker>) -> OpTracker {
         match root_op {
-            None => root().new_child(),
+            None => OpTracker::new_root().new_child(),
             Some(root) => root.new_child(),
         }
     }
 
     /// Creates and returns a new operation which is a child of self.
     pub fn new_child(&self) -> OpTracker {
-        let depth = self.depth();
+        let mut parent = self.inner.lock().unwrap();
+        let shared = parent.shared.clone();
 
         let new = OpTracker {
             inner: Arc::new(Mutex::new(TrackerInner {
-                depth: depth + 1,
+                id: shared.alloc_id(),
+                depth: parent.depth + 1,
                 parent: Some(self.clone()),
-                ..Default::default()
+                op: None,
+                progress: None,
+                children: Vec::new(),
+                shared,
             })),
         };
 
-        self.inner
-            .lock()
-            .unwrap()
-            .children
-            .push(Arc::downgrade(&new.inner));
+        parent.children.push(Arc::downgrade(&new.inner));
         new
     }
 
@@ -221,88 +228,70 @@ impl OpTracker {
         self.inner.lock().unwrap().depth
     }
 
-    /// Called by a child to register their new progress bar.
-    fn install_progress(&self, pg: ProgressBar) {
-        let s = self.inner.lock().unwrap();
-        match (&s.pg, &s.parent) {
-            // We (parent) have a progress bar, child should follow
-            (Some(parent_pg), _) => {
-                global_progress().insert_after(parent_pg, pg);
-            }
-            // Parent has no progress but theres a grandparent, recurse
-            (None, Some(parent)) => parent.install_progress(pg),
-            // Root node with no progress bar, directly add to global MultiProgress
-            (None, None) => {
-                global_progress().add(pg);
-            }
+    /// Returns a pre-order (depth-first) snapshot of this subtree, in display
+    /// order. The returned `Vec` is decoupled from the live tree: a renderer
+    /// can hold and diff it without keeping any lock.
+    pub fn snapshot(&self) -> Vec<OpSnapshot> {
+        let mut out = Vec::new();
+        self.snapshot_into(&mut out);
+        out
+    }
+
+    fn snapshot_into(&self, out: &mut Vec<OpSnapshot>) {
+        // Collect this node's row and its live children under a single brief
+        // lock, then recurse with the lock released so we never hold two node
+        // locks at once.
+        let children = {
+            let s = self.inner.lock().unwrap();
+            out.push(OpSnapshot {
+                id: s.id,
+                depth: s.depth,
+                op: s.op.clone(),
+                progress: s.progress,
+            });
+            s.children
+                .iter()
+                .filter_map(Weak::upgrade)
+                .map(|inner| OpTracker { inner })
+                .collect::<Vec<_>>()
+        };
+        for child in children {
+            child.snapshot_into(out);
         }
     }
-}
 
-static ROOT: OnceLock<OpTracker> = OnceLock::new();
-
-/// Returns the root operation tracker.
-pub fn root() -> OpTracker {
-    ROOT.get_or_init(|| OpTracker {
-        inner: Arc::new(Mutex::new(TrackerInner {
-            children: Vec::with_capacity(32),
-            ..Default::default()
-        })),
-    })
-    .clone()
-}
-
-static MP: OnceLock<MultiProgress> = OnceLock::new();
-
-fn global_progress() -> MultiProgress {
-    MP.get_or_init(MultiProgress::new).clone()
-}
-
-use std::io;
-
-/// A writer to stdout which coordinates with printing progress bars.
-pub struct StdoutWriter(MultiProgress);
-
-impl Default for StdoutWriter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl StdoutWriter {
-    pub fn new() -> Self {
-        StdoutWriter(global_progress())
-    }
-}
-
-impl io::Write for StdoutWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.suspend(|| io::stdout().write(buf))
+    /// Returns the tree's current change version. Increases on every mutation
+    /// anywhere in the tree; a driver polls this to decide whether to repaint.
+    pub fn version(&self) -> u64 {
+        self.inner
+            .lock()
+            .unwrap()
+            .shared
+            .version
+            .load(Ordering::Relaxed)
     }
 
-    fn flush(&mut self) -> io::Result<()> {
-        self.0.suspend(|| io::stdout().flush())
-    }
-
-    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
-        self.0.suspend(|| io::stdout().write_vectored(bufs))
-    }
-
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.0.suspend(|| io::stdout().write_all(buf))
-    }
-
-    fn write_fmt(&mut self, fmt: std::fmt::Arguments<'_>) -> io::Result<()> {
-        self.0.suspend(|| io::stdout().write_fmt(fmt))
+    /// Awaits the next change anywhere in the tree.
+    ///
+    /// [`version`](Self::version) is the source of truth; pair the two. The
+    /// tree assumes a single consumer (one renderer per root): a mutation that
+    /// races ahead of an un-parked driver leaves a stored permit, so the next
+    /// `changed()` returns immediately rather than missing the update. Drivers
+    /// render, read the version, `await changed()`, then re-check the version.
+    pub async fn changed(&self) {
+        let shared = self.inner.lock().unwrap().shared.clone();
+        shared.notify.notified().await;
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
-    // Each test creates a child of the global root tracker.
-    // ProgressBar::hidden() is used inside set_op, so no terminal output occurs.
+    // Each test creates a child of the global root tracker. The core no longer
+    // renders, so these exercise pure state transitions with no terminal output.
 
     fn make_tracker() -> OpTracker {
         OpTracker::new_with_root(&None)
@@ -440,5 +429,136 @@ mod tests {
         let parent_depth = parent.depth();
         let child = parent.new_child();
         assert_eq!(child.depth(), parent_depth + 1);
+    }
+
+    #[test]
+    fn snapshot_is_preorder_with_node_and_children() {
+        let root = OpTracker::new_root();
+        root.set_op(Operation::PackageBuild {
+            name: "root".into(),
+        });
+        let a = root
+            .new_child()
+            .with_op(Operation::ExtractPkg { name: "a".into() });
+        let _b = root
+            .new_child()
+            .with_op(Operation::CompressPkg { name: "b".into() });
+        let _a1 = a
+            .new_child()
+            .with_op(Operation::FetchPkg { name: "a1".into() });
+
+        let snap = root.snapshot();
+        // root, a, a1, b — pre-order: a's subtree before sibling b.
+        let names: Vec<_> = snap
+            .iter()
+            .map(|s| match &s.op {
+                Some(Operation::PackageBuild { name })
+                | Some(Operation::ExtractPkg { name })
+                | Some(Operation::CompressPkg { name })
+                | Some(Operation::FetchPkg { name }) => name.clone(),
+                other => format!("{other:?}"),
+            })
+            .collect();
+        assert_eq!(names, vec!["root", "a", "a1", "b"]);
+        // Depth carries indentation: root at 0, children at 1, grandchild at 2.
+        assert_eq!(
+            snap.iter().map(|s| s.depth).collect::<Vec<_>>(),
+            vec![0, 1, 2, 1]
+        );
+    }
+
+    #[test]
+    fn snapshot_ids_are_unique_within_a_tree() {
+        let root = OpTracker::new_root();
+        let _a = root.new_child();
+        let _b = root.new_child();
+        let mut ids: Vec<_> = root.snapshot().iter().map(|s| s.id).collect();
+        let total = ids.len();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), total, "ids must be unique");
+    }
+
+    #[test]
+    fn version_advances_on_each_mutation() {
+        let root = OpTracker::new_root();
+        let child = root.new_child();
+        let v0 = root.version();
+        child.set_op(Operation::FetchPkg { name: "p".into() });
+        let v1 = root.version();
+        child.set_length(100);
+        let v2 = root.version();
+        child.increment(10);
+        let v3 = root.version();
+        child.set_done();
+        let v4 = root.version();
+        assert!(v0 < v1 && v1 < v2 && v2 < v3 && v3 < v4);
+    }
+
+    #[test]
+    fn progress_is_tracked_in_state() {
+        let root = OpTracker::new_root();
+        let child = root.new_child();
+        child.set_op(Operation::FetchPkg { name: "p".into() });
+        child.set_length(100);
+        child.increment(30);
+        child.increment(12);
+
+        let row = root
+            .snapshot()
+            .into_iter()
+            .find(|s| s.depth == 1)
+            .expect("child row present");
+        assert_eq!(
+            row.progress,
+            Some(Progress {
+                pos: 42,
+                len: Some(100)
+            })
+        );
+    }
+
+    #[test]
+    fn set_op_resets_progress() {
+        let root = OpTracker::new_root();
+        let child = root.new_child();
+        child.set_op(Operation::FetchPkg { name: "p".into() });
+        child.set_length(100);
+        child.increment(50);
+        // Transitioning to a new operation clears the measured progress.
+        child.set_op(Operation::ExtractPkg { name: "p".into() });
+
+        let row = root
+            .snapshot()
+            .into_iter()
+            .find(|s| s.depth == 1)
+            .expect("child row present");
+        assert_eq!(row.progress, None);
+    }
+
+    #[test]
+    fn distinct_roots_have_independent_versions() {
+        let r1 = OpTracker::new_root();
+        let r2 = OpTracker::new_root();
+        r1.new_child()
+            .set_op(Operation::PackageBuild { name: "x".into() });
+        assert!(r1.version() > 0);
+        assert_eq!(r2.version(), 0, "mutating one tree must not touch another");
+    }
+
+    #[tokio::test]
+    async fn changed_wakes_on_mutation() {
+        let root = OpTracker::new_root();
+        let child = root.new_child();
+        let waiter = root.clone();
+        // Register the wait, then mutate from another task; the notify must wake.
+        let h = tokio::spawn(async move { waiter.changed().await });
+        // Yield so the spawned task reaches the await point before we notify.
+        tokio::task::yield_now().await;
+        child.set_op(Operation::PackageBuild { name: "x".into() });
+        tokio::time::timeout(Duration::from_secs(1), h)
+            .await
+            .expect("changed() should wake within timeout")
+            .expect("waiter task should not panic");
     }
 }

--- a/docs/specs/04-spec-ot-render-decoupling/04-spec-ot-render-decoupling.md
+++ b/docs/specs/04-spec-ot-render-decoupling/04-spec-ot-render-decoupling.md
@@ -1,0 +1,221 @@
+---
+id: spec-ot-render-decoupling
+title: "ot render decoupling — separate operation state from indicatif, render per SSH channel"
+kind: spec
+status: planned
+tracking-issue:
+supersedes:
+---
+
+# ot render decoupling — separate operation state from indicatif, render per SSH channel
+
+## Context
+
+`crates/ot` tracks a hierarchy of long-running operations (package builds,
+fetches, checks, …) so progress can be drawn to the terminal. It was written
+when `minimal` was a one-shot CLI: a single process owned a single terminal.
+
+Today `ot` conflates three responsibilities inside one
+`Arc<Mutex<TrackerInner>>` (`crates/ot/src/lib.rs`):
+
+1. **Operation-tree state** — `depth`, `parent`, `children`, `op:
+   Option<Operation>`. The genuinely reusable part.
+2. **Progress data** — not actually stored; position/length live only inside
+   the indicatif `ProgressBar`.
+3. **Rendering** — `set_op` directly builds an indicatif `ProgressBar` with a
+   hardcoded `ProgressStyle`, installs it into a process-global
+   `static MP: MultiProgress`, which renders to **stderr** from indicatif's own
+   thread. `StdoutWriter` exists only to `suspend()` that global render so
+   plain logs do not collide with the bars.
+
+Two process-global statics — `static ROOT` and `static MP` — encode the
+assumption "one process == one terminal."
+
+That assumption is now wrong. `minimal` is becoming a daemon (`minimald`) whose
+long-running sessions are driven over an in-process SSH server. Progress must be
+drawn to a **specific SSH channel** — one per session, each its own terminal,
+each an async `AsyncWrite` (`Binding` in `crates/minimald/src/session_host.rs`
+owns `ws.make_writer()`), none of them this process's stderr. There can be many
+concurrent.
+
+The plumbing is already in the right shape: `Option<OpTracker>` is threaded
+through `mctx` (`config.rs`, `with_operation_tracker`), `minimald/src/env.rs`,
+`op`, `rcache`, etc., via `OpTracker::new_with_root(&Option<OpTracker>)`. Almost
+nothing outside `ot` needs to change except **where the root comes from** and
+**who renders it**.
+
+A future move to the `strides` crate for rendering should require no change to
+the state core — only a new renderer.
+
+## Introduction/Overview
+
+Split `ot` into three layers:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Layer 3  Drivers (per-context, own the I/O loop)            │
+│   • IndicatifShim    → local CLI, renders tree to stderr     │
+│   • (daemon) Host select! arm → renders subtree, sends       │
+│                        bytes to the Binding actor            │
+│   • (future) StridesDriver                                   │
+├─────────────────────────────────────────────────────────────┤
+│ Layer 2  Observation (pure data, no I/O)                     │
+│   • OpTracker::snapshot() -> Vec<OpSnapshot>  (the "slice")  │
+│   • OpTracker::version() / changed()          (change signal)│
+├─────────────────────────────────────────────────────────────┤
+│ Layer 1  State core (`ot`, no render deps)                  │
+│   • OpTracker / TrackerInner: tree + Progress{pos,len}       │
+│   • no indicatif, no process globals                         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The `Operation` enum stays **semantic only**. All template/styling strings move
+out of the core and into the drivers, so each renderer (indicatif now, strides
+later, the daemon ANSI path) styles independently.
+
+## Layer 1 — pure state core
+
+`TrackerInner` drops the indicatif `ProgressBar` and stores progress numbers
+itself:
+
+```rust
+pub struct OpId(u64);                 // stable id, for renderer diffing
+
+#[derive(Clone, Debug)]
+pub struct Progress { pub pos: u64, pub len: Option<u64> }
+
+struct TrackerInner {
+    id: OpId,
+    depth: usize,
+    parent: Option<OpTracker>,
+    op: Option<Operation>,
+    progress: Option<Progress>,
+    children: Vec<Weak<Mutex<TrackerInner>>>,
+    shared: Arc<RootShared>,          // every node points at its root's shared bits
+}
+
+struct RootShared {
+    version: AtomicU64,               // bumped on every mutation
+    notify: tokio::sync::Notify,      // wakes async drivers; notify_* is sync-callable
+    next_id: AtomicU64,
+}
+```
+
+Every mutator (`set_op`, `set_done`, `set_length`, `increment`) bumps `version`
+and notifies — both callable from sync code, so the synchronous build threads in
+`op`/`graph` are unchanged and still wake the async renderer.
+
+`OpTracker`'s public mutation API (`with_op`, `set_op`, `set_done`,
+`set_length`, `increment`, `new_child`, `depth`) stays **identical**, so the
+~20 call sites do not change. What changes is `new_with_root`'s fallback:
+instead of a process-global `root()`, callers construct an explicit root via
+`OpTracker::new_root()`. The CLI builds one; `minimald` builds one **per
+session**.
+
+### Decision: `tokio sync` in the core
+
+`ot` gains `tokio = { workspace = true, features = ["sync"] }` for `Notify` and
+the atomics' ergonomics. Pragmatic, matches the rest of the repo, async drivers
+wake cheaply. (The dependency-free alternative — an `Arc<dyn Fn()>` callback —
+was rejected as clunkier wiring for no real portability win here.)
+
+## Layer 2 — observation (the "handle to a slice of progress")
+
+A driver never touches the live tree under its render loop. It takes an
+immutable snapshot (lock briefly, clone, release) and renders without holding
+the lock:
+
+```rust
+#[derive(Clone, Debug)]
+pub struct OpSnapshot {
+    pub id: OpId,
+    pub depth: usize,
+    pub op: Option<Operation>,
+    pub progress: Option<Progress>,
+}
+
+impl OpTracker {
+    /// Pre-order DFS flatten of this subtree, in display order.
+    pub fn snapshot(&self) -> Vec<OpSnapshot>;
+    /// Current change version; cheap to poll.
+    pub fn version(&self) -> u64;
+    /// Await the next change (best-effort wake; pair with version()).
+    pub async fn changed(&self);
+}
+```
+
+A flat `Vec<OpSnapshot>` with `depth` is deliberately better than a nested tree:
+it is already in render order, maps trivially to "rows," and is what both
+indicatif and strides ultimately want. This Vec **is** the slice of progress a
+renderer takes a handle to.
+
+`changed()` is a best-effort wake; `version()` is the source of truth. Drivers
+loop: render, read version, `changed().await`, re-check version. Per root there
+is at most one driver, so missed-wakeup races are bounded and reconciled by the
+version check plus a steady tick (needed anyway for spinners).
+
+## Layer 3 — drivers
+
+A driver owns its I/O loop: wait for a change (or a tick) → `snapshot()` →
+paint.
+
+- **`IndicatifShim`** (deferred; see Decisions): keeps a `MultiProgress` + a
+  `HashMap<OpId, ProgressBar>`, diffs each snapshot against live bars (add new
+  ids, update pos/len/message, `finish_and_clear` vanished ids). All the
+  `ProgressStyle` templates from today's `set_op` move here. Preserves current
+  CLI behavior and the `StdoutWriter`/`suspend` log coordination, with no
+  global — the shim owns its `MultiProgress`.
+
+- **Daemon path (no separate writer).** `Binding`
+  (`session_host.rs`) already owns the channel writer and is the single
+  serialized writer via its `select!` loop. `Host` (the surrounding
+  process-management actor) owns the session lifecycle, the vt100 `parser`
+  screen, and the live binding's mailbox. Therefore:
+
+  - Render is a **pure function** in `ot`:
+    `render_frame(&[OpSnapshot], &mut RenderState) -> Vec<u8>` — produces the
+    ANSI diff (cursor moves, clears, repaint) against the previous frame. No
+    I/O.
+  - The **`Host`** drives repaints: it holds the session `OpTracker` root and a
+    persistent `RenderState`; its `mainloop` `select!` gains one arm = the
+    root's `changed()` future plus a steady tick. On fire → `snapshot()` →
+    `render_frame()` → send bytes to the binding.
+  - The **`Binding`** just writes bytes: a new `BindingMsg::Progress(Bytes)`
+    variant is written in the same `select!` family as process stdout, so
+    progress and process output are serialized by construction — zero tearing,
+    no extra lock.
+
+  Render state lives in the `Host`, not the `Binding`, because it must survive
+  detach/re-attach: the `Host` already replays
+  `parser.screen().state_formatted()` on `attach()`, so the progress overlay
+  repaints there alongside it.
+
+- **`StridesDriver`** (future) — additive, Layers 1–2 untouched.
+
+## Migration plan
+
+Each step compiles and keeps tests green.
+
+| Step | Change | Blast radius |
+|---|---|---|
+| 1 | Add `Progress{pos,len}`, `OpId`, `RootShared` to the core; keep the `ProgressBar` field, feed both. Add `snapshot()`, `version()`, `changed()`. | `ot` only; existing tests pass |
+| 2 | Carve `set_op`'s indicatif templates into an `IndicatifShim` that renders from `snapshot()`. Drop `pg` from `TrackerInner`; move indicatif behind a feature. **Core is now render-dep-free.** | `ot` only |
+| 3 | Replace `static ROOT`/`root()` with `OpTracker::new_root()`. CLI builds one root; `minimald` builds one per session. Audit the `new_with_root(&None)` sites. | `ot` + entry points |
+| 4 | Daemon render: `render_frame` + `RenderState`, a `Host` `select!` arm, and `BindingMsg::Progress`. Thread the session root via existing builders. | `minimald` |
+| 5 | *(future)* `StridesDriver`. | new driver only |
+
+## Decisions
+
+- **Defer the CLI side.** indicatif stays as a thin shim over the new core
+  (step 2); no effort re-imagining the local TTY UX now. It is an isolated
+  later swap touching only Layer 3.
+- **`tokio sync` in the core** for change signalling (above).
+- **Styling moves wholesale into drivers**; the state core stays semantic.
+
+## Non-Goals
+
+- Re-designing the local CLI progress UX (deferred).
+- The vt100/overlay interaction in the daemon (whether progress renders in a
+  reserved bottom region or is fed through the parser) — resolved in step 4; it
+  affects only the daemon render path, not the `ot` core.
+- Adopting `strides` (future, additive).


### PR DESCRIPTION
Refactors the operations tracker to:

 * Have multiple roots (i.e. in the future there will be one per session)
 * Track all state internally rather than rely on storing some fields like progress in indicatif types
 * Separate the tree of operations from the render, and have an async-friendly notify
 * Move the render path for the legacy CLI into its own async task that uses the notify and the operation tree to print progress

A future PR can chain this up to minimald sessions and print progress down the ssh channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now initializes a per-run operation tracker and renders operation progress to stderr for improved real-time visibility.
  * Operation rendering is now driven by a dedicated renderer shim, enabling progress output per session without interfering with stdout.

* **Chores**
  * Refactored operation tracking to be render-agnostic, providing snapshot-based observation and async change signaling.
  * Made terminal progress rendering optional by gating it behind a feature flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->