### PR TITLE
[WIP] feat(minimald,minvmd): seeded cache disk + workspace upload for offline session compose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2608,6 +2608,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "imbl-sized-chunks"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,11 +3480,14 @@ dependencies = [
 name = "minimal2"
 version = "0.0.1"
 dependencies = [
+ "async-compression",
+ "async-tar",
  "camino",
  "chrono",
  "clap",
  "clap_complete",
  "dirs",
+ "ignore",
  "minimald-rpc",
  "minvmd",
  "ot",
@@ -3477,9 +3496,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sessions",
+ "tar",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ google-cloud-storage = "1.7"
 hakoniwa = { git = "https://github.com/souk4711/hakoniwa.git", rev = "41ce36e087fa1fcf28d17123042d150e71c09705", features = ["cgroups"] }
 http-body = "1"
 hex = "0.4"
+ignore = "0.4"
 indicatif = "0.18"
 indoc = "^2.0"
 jaq-all = "0.2.0"

--- a/crates/minimal2/Cargo.toml
+++ b/crates/minimal2/Cargo.toml
@@ -5,11 +5,14 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+async-compression.workspace = true
+async-tar.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 camino.workspace = true
 chrono.workspace = true
 dirs.workspace = true
+ignore.workspace = true
 minimald-rpc.workspace = true
 paths.workspace = true
 russh.workspace = true
@@ -22,3 +25,8 @@ tracing-subscriber.workspace = true
 
 minvmd = { path = "../minvmd" }
 ot.workspace = true
+
+[dev-dependencies]
+tar.workspace = true
+tempfile.workspace = true
+zstd.workspace = true

--- a/crates/minimal2/src/client.rs
+++ b/crates/minimal2/src/client.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use minimald_rpc::OneshotSshRpc;
+use minimald_rpc::{MINIMAL_SESSION_ID_ENV, OneshotSshRpc, STREAM_WORKSPACE_FILES};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 /// Max retries when connecting to the daemon UDS.
@@ -128,6 +128,121 @@ impl Client {
         serde_json::from_slice(&resp_buf)
             .map_err(|e| format!("decode response for {}: {e}", R::NAME))
     }
+
+    /// Stream the project directory into the session's workspace
+    /// (copy-on-activate). Builds an ignore-aware `tar.zst` of `project_dir`
+    /// and uploads it over the `WorkspaceFilesTarZst` subsystem; the daemon
+    /// unpacks it into the session worktree. Reports server-side unpack errors
+    /// (relayed on the channel's stderr stream) as `Err`.
+    pub async fn upload_workspace(
+        &mut self,
+        session_id: &str,
+        project_dir: &Path,
+    ) -> Result<(), String> {
+        let payload = build_workspace_tar_zst(project_dir).await?;
+
+        let mut channel = self
+            .handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("open workspace channel: {e}"))?;
+
+        // The server reads the session id from the channel env, captured at
+        // subsystem-request time — so set_env must precede request_subsystem.
+        channel
+            .set_env(true, MINIMAL_SESSION_ID_ENV, session_id)
+            .await
+            .map_err(|e| format!("set_env {MINIMAL_SESSION_ID_ENV}: {e}"))?;
+        channel
+            .request_subsystem(true, STREAM_WORKSPACE_FILES)
+            .await
+            .map_err(|e| format!("request subsystem {STREAM_WORKSPACE_FILES}: {e}"))?;
+
+        channel
+            .data(&payload[..])
+            .await
+            .map_err(|e| format!("stream workspace tarball: {e}"))?;
+        channel
+            .eof()
+            .await
+            .map_err(|e| format!("half-close workspace channel: {e}"))?;
+
+        // Drain until the server closes the channel; it relays any unpack
+        // failure on extended-data stream 1 (stderr).
+        let mut stderr = Vec::new();
+        while let Some(msg) = channel.wait().await {
+            if let russh::ChannelMsg::ExtendedData { data, ext: 1 } = msg {
+                stderr.extend_from_slice(&data);
+            }
+        }
+        if !stderr.is_empty() {
+            return Err(String::from_utf8_lossy(&stderr).trim().to_owned());
+        }
+        Ok(())
+    }
+}
+
+/// Build an ignore-aware zstd-compressed tar of `project_dir`, with entry paths
+/// relative to the project root. Honours `.gitignore`, `.ignore`, and a custom
+/// `.minimalignore` (via the `ignore` crate's gitignore semantics) even outside
+/// a git repo. Dotfiles are kept, but `.git` is always skipped. Symlinks are
+/// not followed. File modes are preserved.
+async fn build_workspace_tar_zst(project_dir: &Path) -> Result<Vec<u8>, String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Collect the file set synchronously (the `ignore` walk is sync), then
+    // stream contents asynchronously below.
+    let mut files = Vec::new();
+    let walker = ignore::WalkBuilder::new(project_dir)
+        // Keep dotfiles (.github, .env, .gitignore, …) — they're part of the
+        // project — but never the VCS dir itself.
+        .hidden(false)
+        .filter_entry(|e| e.file_name() != ".git")
+        // Apply ignore files even when project_dir is not a git working tree.
+        .require_git(false)
+        .add_custom_ignore_filename(".minimalignore")
+        .build();
+    for entry in walker {
+        let entry = entry.map_err(|e| format!("walk project: {e}"))?;
+        if entry.file_type().is_some_and(|t| t.is_file()) {
+            files.push(entry.into_path());
+        }
+    }
+
+    let mut builder = async_tar::Builder::new(Vec::new());
+    for path in &files {
+        let rel = path
+            .strip_prefix(project_dir)
+            .map_err(|e| format!("relativize {}: {e}", path.display()))?;
+        let meta = std::fs::metadata(path).map_err(|e| format!("stat {}: {e}", path.display()))?;
+        let contents = tokio::fs::read(path)
+            .await
+            .map_err(|e| format!("read {}: {e}", path.display()))?;
+
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(meta.permissions().mode() & 0o777);
+        builder
+            .append_data(&mut header, rel, &contents[..])
+            .await
+            .map_err(|e| format!("tar append {}: {e}", rel.display()))?;
+    }
+
+    let tar_bytes = builder
+        .into_inner()
+        .await
+        .map_err(|e| format!("finalize tar: {e}"))?;
+
+    let mut encoder = async_compression::tokio::write::ZstdEncoder::new(Vec::new());
+    encoder
+        .write_all(&tar_bytes)
+        .await
+        .map_err(|e| format!("zstd compress: {e}"))?;
+    encoder
+        .shutdown()
+        .await
+        .map_err(|e| format!("zstd finalize: {e}"))?;
+    Ok(encoder.into_inner())
 }
 
 /// Resolve the daemon socket path.
@@ -163,4 +278,81 @@ pub fn resolve_socket_path(
     }
     #[cfg(target_os = "macos")]
     minvmd::sock::resolve_uds_path()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::build_workspace_tar_zst;
+
+    /// Decompress + read the tar produced by `build_workspace_tar_zst` and
+    /// return its entry paths.
+    fn entry_paths(tar_zst: &[u8]) -> BTreeSet<String> {
+        let tar_bytes = zstd::stream::decode_all(tar_zst).expect("zstd decode");
+        let mut archive = tar::Archive::new(&tar_bytes[..]);
+        archive
+            .entries()
+            .expect("entries")
+            .map(|e| {
+                e.expect("entry")
+                    .path()
+                    .expect("path")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect()
+    }
+
+    fn write(root: &std::path::Path, rel: &str, contents: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[tokio::test]
+    async fn workspace_tar_honours_ignore_files_keeps_dotfiles_skips_git() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // Kept: project files and non-git dotfiles.
+        write(root, "minimal.toml", "name = \"p\"\n");
+        write(root, "src/main.rs", "fn main() {}\n");
+        write(root, ".github/workflows/ci.yml", "on: push\n");
+
+        // .gitignore excludes build output; .minimalignore excludes a secret.
+        write(root, ".gitignore", "ignored.txt\n/target\n");
+        write(root, ".minimalignore", "secret.txt\n");
+        write(root, "ignored.txt", "nope");
+        write(root, "secret.txt", "nope");
+        write(root, "target/junk.o", "nope");
+
+        // The VCS dir is always skipped even though dotfiles are kept.
+        write(root, ".git/config", "[core]\n");
+
+        let paths = entry_paths(&build_workspace_tar_zst(root).await.unwrap());
+
+        assert!(paths.contains("minimal.toml"), "got {paths:?}");
+        assert!(paths.contains("src/main.rs"), "got {paths:?}");
+        assert!(
+            paths.contains(".github/workflows/ci.yml"),
+            "dotfiles kept; got {paths:?}"
+        );
+        // .gitignore and .minimalignore themselves ship (they're project files).
+        assert!(paths.contains(".gitignore"), "got {paths:?}");
+
+        assert!(!paths.contains("ignored.txt"), ".gitignore; got {paths:?}");
+        assert!(
+            !paths.contains("secret.txt"),
+            ".minimalignore; got {paths:?}"
+        );
+        assert!(
+            !paths.iter().any(|p| p.starts_with("target/")),
+            "target/ gitignored; got {paths:?}"
+        );
+        assert!(
+            !paths.iter().any(|p| p.starts_with(".git/")),
+            ".git skipped; got {paths:?}"
+        );
+    }
 }

--- a/crates/minimal2/src/main.rs
+++ b/crates/minimal2/src/main.rs
@@ -434,6 +434,8 @@ async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), ()>
 
     let project_path = std::fs::canonicalize(&args.path)
         .map_err(|e| eprintln!("Cannot resolve project path '{}': {e}", args.path))?;
+    // Retained for the copy-on-activate workspace upload below.
+    let project_dir = project_path.clone();
 
     let utf8_path = camino::Utf8PathBuf::from_path_buf(project_path)
         .map_err(|_| eprintln!("Project path is not valid UTF-8"))?;
@@ -493,6 +495,16 @@ async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), ()>
     };
 
     println!("{}", created.id);
+
+    // Copy-on-activate: stream the project into the session worktree so the
+    // interactive shell (mctx) finds minimal.toml and the project files.
+    if let Err(e) = client
+        .upload_workspace(&created.id.to_string(), &project_dir)
+        .await
+    {
+        eprintln!("Failed to upload workspace to session: {e}");
+        return Err(());
+    }
 
     if args.attach {
         // Chain into attach.

--- a/crates/minimal2/src/main.rs
+++ b/crates/minimal2/src/main.rs
@@ -112,9 +112,69 @@ struct ActivateArgs {
     /// Project path to activate (defaults to current directory)
     #[arg(default_value = ".")]
     path: String,
+    /// Network mode: no-net, host-net (default), or own-ip.
+    #[arg(long, value_enum, default_value_t = CliNetworkMode::HostNet)]
+    network: CliNetworkMode,
+    /// Static ingress port mapping `EXT:INT[/PROTO]` (PROTO = tcp|udp, default
+    /// tcp). Repeatable. Requires `--network own-ip`.
+    #[arg(long = "ingress", value_name = "EXT:INT[/PROTO]")]
+    ingress: Vec<String>,
     /// Automatically attach after creation
     #[arg(long)]
     attach: bool,
+}
+
+/// CLI surface for [`sessions::NetworkMode`]. A local `ValueEnum` keeps the
+/// `sessions` crate free of a clap dependency.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum CliNetworkMode {
+    NoNet,
+    HostNet,
+    OwnIp,
+}
+
+impl From<CliNetworkMode> for sessions::NetworkMode {
+    fn from(m: CliNetworkMode) -> Self {
+        match m {
+            CliNetworkMode::NoNet => sessions::NetworkMode::NoNet,
+            CliNetworkMode::HostNet => sessions::NetworkMode::HostNet,
+            CliNetworkMode::OwnIp => sessions::NetworkMode::OwnIp,
+        }
+    }
+}
+
+/// Parse an `--ingress EXT:INT[/PROTO]` spec into a [`sessions::PortMapping`].
+/// PROTO defaults to tcp; only tcp/udp are accepted (gvproxy's static forwarder
+/// exposes no other transport).
+fn parse_ingress_mapping(spec: &str) -> Result<sessions::PortMapping, String> {
+    let (ports, proto) = match spec.split_once('/') {
+        Some((ports, proto)) => (ports, parse_ingress_proto(proto)?),
+        None => (spec, sessions::IpProto::Tcp),
+    };
+    let (ext, int) = ports
+        .split_once(':')
+        .ok_or_else(|| format!("ingress '{spec}': expected EXT:INT[/PROTO]"))?;
+    let external_port = ext
+        .parse::<u16>()
+        .map_err(|_| format!("ingress '{spec}': invalid external port '{ext}'"))?;
+    let internal_port = int
+        .parse::<u16>()
+        .map_err(|_| format!("ingress '{spec}': invalid internal port '{int}'"))?;
+    Ok(sessions::PortMapping {
+        external_port,
+        internal_port,
+        proto,
+    })
+}
+
+fn parse_ingress_proto(proto: &str) -> Result<sessions::IpProto, String> {
+    match proto.to_ascii_lowercase().as_str() {
+        "tcp" => Ok(sessions::IpProto::Tcp),
+        "udp" => Ok(sessions::IpProto::Udp),
+        other => Err(format!(
+            "ingress: unsupported protocol '{other}' (use tcp or udp)"
+        )),
+    }
 }
 
 #[derive(Debug, Args)]
@@ -327,13 +387,31 @@ async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), ()>
         .or_else(|_| std::env::var("LOGNAME"))
         .ok();
 
+    let mut port_mappings = Vec::with_capacity(args.ingress.len());
+    for spec in &args.ingress {
+        match parse_ingress_mapping(spec) {
+            Ok(mapping) => port_mappings.push(mapping),
+            Err(e) => {
+                eprintln!("{e}");
+                return Err(());
+            }
+        }
+    }
+    let policy = sessions::SessionPolicy {
+        egress: None,
+        ingress: (!port_mappings.is_empty()).then_some(sessions::IngressPolicy {
+            port_mappings,
+            dynamic_allowed_range: None,
+        }),
+    };
+
     let record = sessions::Record {
         id: sessions::SessionId::nil(),
         name: args.name.clone(),
         username,
         project_path: abs_path,
-        network: sessions::NetworkMode::default(),
-        policy: Default::default(),
+        network: args.network.into(),
+        policy,
         attrs: Default::default(),
     };
 
@@ -346,10 +424,13 @@ async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), ()>
         .await
         .map_err(|e| eprintln!("CreateSession RPC failed: {e}"))?;
 
-    let created = match resp.ok() {
-        Some(r) => r,
-        None => {
-            eprintln!("CreateSession returned an error from the daemon");
+    // Surface the daemon's typed policy/network-mode validation error (e.g.
+    // ingress on a non-own-ip session, privileged host port) rather than a
+    // generic failure line.
+    let created = match resp {
+        minimald_rpc::Errorable::Ok(r) => r,
+        minimald_rpc::Errorable::Err { error } => {
+            eprintln!("CreateSession failed: {error}");
             return Err(());
         }
     };
@@ -712,4 +793,32 @@ async fn cmd_login(global: &GlobalArgs, args: LoginArgs) -> Result<(), ()> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ingress_spec_defaults_to_tcp() {
+        let m = parse_ingress_mapping("18080:80").unwrap();
+        assert_eq!(m.external_port, 18080);
+        assert_eq!(m.internal_port, 80);
+        assert_eq!(m.proto, sessions::IpProto::Tcp);
+    }
+
+    #[test]
+    fn ingress_spec_parses_explicit_proto() {
+        let m = parse_ingress_mapping("5353:53/udp").unwrap();
+        assert_eq!(m.external_port, 5353);
+        assert_eq!(m.internal_port, 53);
+        assert_eq!(m.proto, sessions::IpProto::Udp);
+    }
+
+    #[test]
+    fn ingress_spec_rejects_malformed_and_bad_proto() {
+        assert!(parse_ingress_mapping("18080").is_err());
+        assert!(parse_ingress_mapping("notaport:80").is_err());
+        assert!(parse_ingress_mapping("18080:80/icmp").is_err());
+    }
 }

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -17,6 +17,19 @@ pub use sessions::{EgressPolicy, IngressPolicy, IpProto, NetworkMode, PortMappin
 
 pub const RPC_SUBSYSTEM_PREFIX: &str = "minimald-v1-";
 
+/// Channel env-var naming the session a subsystem request operates on. Set on
+/// the SSH channel before requesting a session-scoped subsystem (e.g. the
+/// workspace upload), and read server-side from the channel config.
+pub const MINIMAL_SESSION_ID_ENV: &str = "MINIMAL_SESSION_ID";
+
+/// Subsystem name for streaming a session's workspace as a zstd-compressed tar.
+/// The client opens this subsystem (with [`MINIMAL_SESSION_ID_ENV`] set),
+/// writes the `tar.zst` bytes, and half-closes; the server unpacks them into
+/// the session's workspace directory. Errors come back on the channel's
+/// extended-data (stderr) stream.
+pub const STREAM_WORKSPACE_FILES: &str =
+    constcat::concat!(RPC_SUBSYSTEM_PREFIX, "WorkspaceFilesTarZst");
+
 /// Describes a minimal-specific RPC method sent over ssh.
 ///
 /// Oneshot RPCs are not streaming. The trait pairs a subsystem name with its

--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -109,9 +109,19 @@ pub fn enter_rootfs(device: &str) -> std::io::Result<()> {
     std::fs::create_dir_all(NEWROOT)?;
     raw_mount(device, NEWROOT, "ext4", libc::MS_RDONLY)?;
     raw_mount("devtmpfs", &format!("{NEWROOT}/dev"), "devtmpfs", 0)?;
+    // devtmpfs provides `/dev/ptmx` but not the `/dev/pts` slave directory, so
+    // `openpty(3)` (interactive session PTY) fails ENOENT without a devpts
+    // mount. Create the mountpoint on the freshly-mounted devtmpfs and mount it.
+    let devpts = format!("{NEWROOT}/dev/pts");
+    let _ = std::fs::create_dir_all(&devpts);
+    raw_mount("devpts", &devpts, "devpts", 0)?;
     raw_mount("proc", &format!("{NEWROOT}/proc"), "proc", 0)?;
     raw_mount("sysfs", &format!("{NEWROOT}/sys"), "sysfs", 0)?;
     raw_mount("tmpfs", &format!("{NEWROOT}/run"), "tmpfs", 0)?;
+    // The rootfs is mounted read-only, but hakoniwa stages its per-container
+    // mount namespace under /tmp (e.g. /tmp/hakoniwa-XXXX); without a writable
+    // /tmp the interactive session sandbox fails to spawn with EROFS.
+    raw_mount("tmpfs", &format!("{NEWROOT}/tmp"), "tmpfs", 0)?;
 
     let to_io = |_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in chroot path");
     let c_newroot = CString::new(NEWROOT).map_err(to_io)?;
@@ -137,6 +147,50 @@ pub fn enter_rootfs(device: &str) -> std::io::Result<()> {
     }
 
     tracing::info!(device, "switched to upstream rootfs (pivot_root)");
+    Ok(())
+}
+
+/// Mount the seeded-cache block `device` (ext4, read-write) at the guest cache
+/// dir so session sandboxes compose offline from the pre-built closure.
+///
+/// Must run **after** [`enter_rootfs`] (so the chroot and the `/run` tmpfs are
+/// in place) and **before** the daemon serves. The mountpoint lives on the
+/// `/run` tmpfs, so it is created here. Read-write: mctx creates cache
+/// subdirs / lockfiles, and writes persist to the host image file.
+pub fn mount_cache(device: &str) -> std::io::Result<()> {
+    // Must match `minimal_cache_dir`/`minimal_state_dir` for the microvm init in
+    // `main.rs` (state is co-located here so package hardlinks stay on one fs).
+    const CACHE_DIR: &str = "/run/minimal/cache";
+    std::fs::create_dir_all(CACHE_DIR)?;
+    raw_mount(device, CACHE_DIR, "ext4", 0)?;
+
+    // The cache disk is a reusable, writable seeded artifact that also backs the
+    // daemon's state dir. Reset any runtime state left by a prior boot — keep
+    // only the seeded cache dirs; the host key (providers/), sandboxes, tasks,
+    // and other state are regenerated. Without this a stale/corrupt host key
+    // persisted on the image fails startup (`host_key` only regenerates on a
+    // *missing* key, not a corrupt one).
+    const SEED_KEEP: &[&str] = &["built", "vcs", "lc", "stdlib", "lost+found"];
+    if let Ok(entries) = std::fs::read_dir(CACHE_DIR) {
+        for entry in entries.flatten() {
+            if SEED_KEEP
+                .iter()
+                .any(|k| std::ffi::OsStr::new(k) == entry.file_name())
+            {
+                continue;
+            }
+            let path = entry.path();
+            let r = if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_file(&path)
+            };
+            if let Err(e) = r {
+                tracing::warn!(error = %e, path = %path.display(), "resetting stale cache-disk state");
+            }
+        }
+    }
+    tracing::info!(device, dir = CACHE_DIR, "mounted seeded cache disk");
     Ok(())
 }
 

--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -157,6 +157,10 @@ pub fn enter_rootfs(device: &str) -> std::io::Result<()> {
 /// in place) and **before** the daemon serves. The mountpoint lives on the
 /// `/run` tmpfs, so it is created here. Read-write: mctx creates cache
 /// subdirs / lockfiles, and writes persist to the host image file.
+///
+/// On each boot the per-boot runtime state is reset by removing `providers/`
+/// (the SSH host key) so a stale persisted key never lingers; the seed dirs
+/// and per-session trees are left untouched (see inline comment).
 pub fn mount_cache(device: &str) -> std::io::Result<()> {
     // Must match `minimal_cache_dir`/`minimal_state_dir` for the microvm init in
     // `main.rs` (state is co-located here so package hardlinks stay on one fs).
@@ -165,29 +169,18 @@ pub fn mount_cache(device: &str) -> std::io::Result<()> {
     raw_mount(device, CACHE_DIR, "ext4", 0)?;
 
     // The cache disk is a reusable, writable seeded artifact that also backs the
-    // daemon's state dir. Reset any runtime state left by a prior boot — keep
-    // only the seeded cache dirs; the host key (providers/), sandboxes, tasks,
-    // and other state are regenerated. Without this a stale/corrupt host key
-    // persisted on the image fails startup (`host_key` only regenerates on a
-    // *missing* key, not a corrupt one).
-    const SEED_KEEP: &[&str] = &["built", "vcs", "lc", "stdlib", "lost+found"];
-    if let Ok(entries) = std::fs::read_dir(CACHE_DIR) {
-        for entry in entries.flatten() {
-            if SEED_KEEP
-                .iter()
-                .any(|k| std::ffi::OsStr::new(k) == entry.file_name())
-            {
-                continue;
-            }
-            let path = entry.path();
-            let r = if entry.file_type().is_ok_and(|t| t.is_dir()) {
-                std::fs::remove_dir_all(&path)
-            } else {
-                std::fs::remove_file(&path)
-            };
-            if let Err(e) = r {
-                tracing::warn!(error = %e, path = %path.display(), "resetting stale cache-disk state");
-            }
+    // daemon's state dir. Reset only the runtime state that must be fresh each
+    // boot — primarily `providers/`, which holds the SSH host key. The daemon
+    // regenerates a missing key on startup, so dropping the dir guarantees a
+    // clean key even if the persisted one is stale. The large per-session
+    // `sandboxes`/`tasks` trees are left in place: stale entries are harmless
+    // (GC is a separate concern) and a boot-time `rm -rf` of them is O(session
+    // state) and walks corrupt directory blocks, blowing the READY timeout.
+    // Seed dirs (built/vcs/lc/stdlib) are untouched. Errors are tolerated.
+    let providers = std::path::Path::new(CACHE_DIR).join("providers");
+    if let Err(e) = std::fs::remove_dir_all(&providers) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(error = %e, path = %providers.display(), "resetting stale cache-disk state");
         }
     }
     tracing::info!(device, dir = CACHE_DIR, "mounted seeded cache disk");

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -16,9 +16,10 @@ mod sftp;
 #[cfg(test)]
 mod test_harness;
 
-/// Env var that the client must set (via `env_request`) before the SFTP
-/// subsystem request, naming which session the SFTP channel attaches to.
-const MINIMAL_SESSION_ID_ENV: &str = "MINIMAL_SESSION_ID";
+/// Env var that the client must set (via `env_request`) before a
+/// session-scoped subsystem request, naming which session the channel attaches
+/// to. Re-exported from the wire-contract crate so client and server agree.
+pub(crate) use minimald_rpc::MINIMAL_SESSION_ID_ENV;
 
 /// Represents the parameters of a requested PTY.
 #[derive(Debug, Clone)]

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -181,6 +181,12 @@ pub struct ListenArgs {
     #[arg(long)]
     #[clap(hide = true)]
     mount_rootfs: Option<String>,
+
+    /// Mounts the given device (a seeded minimal cache, ext4) at the guest cache
+    /// dir so session sandboxes compose offline. Applied after `mount_rootfs`.
+    #[arg(long)]
+    #[clap(hide = true)]
+    mount_cache: Option<String>,
 }
 
 /// An error at the top level of minimald.
@@ -234,9 +240,20 @@ async fn async_main() -> Result<(), MainError> {
                 vsock: true,
                 mount_dev: true,
                 mount_rootfs: Some("/dev/vda".to_string()),
+                // Second block device (minvmd attaches the seeded cache here);
+                // mounting a missing device is non-fatal (logged below).
+                mount_cache: Some("/dev/vdb".to_string()),
             }),
             global_args: GlobalArgs {
-                minimal_state_dir: Some(DaemonAbsPath::try_new("/run/minimal").unwrap().into()),
+                // State lives on the SAME filesystem as the cache (the seeded
+                // cache disk mounted at /run/minimal/cache). The session
+                // compose hardlinks package files from `cache/built` into the
+                // sandbox rootfs under `state/...`; hardlinks cannot cross
+                // filesystems, so co-locating state on the cache disk keeps
+                // them cheap (vs. copying the whole closure into RAM/tmpfs).
+                minimal_state_dir: Some(
+                    DaemonAbsPath::try_new("/run/minimal/cache").unwrap().into(),
+                ),
                 minimal_cache_dir: Some(
                     DaemonAbsPath::try_new("/run/minimal/cache").unwrap().into(),
                 ),
@@ -272,6 +289,16 @@ async fn async_main() -> Result<(), MainError> {
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
         }
+    }
+
+    // After entering the rootfs, mount the optional seeded-cache disk at the
+    // guest cache dir. A missing/absent disk is non-fatal: the session compose
+    // then falls back to building from scratch (and fails offline as before),
+    // so booting without a cache disk still works.
+    if let Some(cache_dev) = &listen_args.mount_cache
+        && let Err(e) = guest::mount_cache(cache_dev)
+    {
+        tracing::warn!(error = %e, device = %cache_dev, "no seeded cache disk mounted");
     }
 
     if let Err(e) = std::fs::create_dir_all(cli.minimal_state_dir())

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -5,7 +5,7 @@ use minimald_rpc::{
     GetMeshStatus, GetSessionPolicy, GetSessionPolicyRequest, GetSessionRecord,
     GetSessionRecordRequest, GetSessionRecordResponse, GetVersion, GetVersionResponse,
     IssueClientCert, IssueClientCertRequest, ListSessions, ListSessionsEntry, ListSessionsResponse,
-    OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse,
+    OneshotSshRpc, RenameSession, RenameSessionResponse,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
@@ -280,8 +280,7 @@ async fn serve_get_mesh_status(s: ServerStateHandle, c: RuChannel<Msg>) {
     }
 }
 
-pub(crate) const STREAM_WORKSPACE_FILES: &str =
-    constcat::concat!(RPC_SUBSYSTEM_PREFIX, "WorkspaceFilesTarZst");
+pub(crate) use minimald_rpc::STREAM_WORKSPACE_FILES;
 
 async fn serve_stream_workspace_files(
     s: ServerStateHandle,

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -79,6 +79,16 @@ impl Config {
                         Err(KeyError::Io(std::io::ErrorKind::NotFound))
                     }
                 }
+                // A corrupt key on the writable cache disk (e.g. truncated by an
+                // unclean VM shutdown) would otherwise brick boot. When we own
+                // the key (`create_if_missing`), treat a parse failure like a
+                // missing key: regenerate and overwrite a fresh one.
+                Err(e) if *create_if_missing => {
+                    tracing::warn!(error = %e, path = %path.display(), "host key unreadable; regenerating");
+                    let key = PrivateKey::random(&mut safe_rng(), russh::keys::Algorithm::Ed25519)?;
+                    key.write_openssh_file(path, russh::keys::ssh_key::LineEnding::LF)?;
+                    Ok(key)
+                }
                 Err(e) => Err(e),
             },
             HostKey::Raw(r) => Ok(PrivateKey::from_openssh(r.as_bytes())?),

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -296,6 +296,10 @@ impl<S: SessionObject> Session<S> {
             .with_repo_dir(wsp.as_utf8_path())
             .with_cache_dir(self.minimal_cache_dir.as_utf8_path())
             .with_state_dir(self.minimal_state_dir.as_utf8_path())
+            // The guest has no network: compose must resolve entirely from the
+            // seeded cache disk. Offline turns a VCS/source cache miss into a
+            // clean `OfflineCacheMiss` instead of a doomed git fetch.
+            .with_offline(true)
             .build()
         {
             Err(e) => Err(mctx::Error::from(e).to_string()),

--- a/crates/minvmd/src/cmd/vmm_child.rs
+++ b/crates/minvmd/src/cmd/vmm_child.rs
@@ -37,13 +37,18 @@ fn run_vmm() -> Result<()> {
     use anyhow::Context as _;
 
     use crate::cmd::{MARKER_SOCK_ENV, VSOCK_MARKER_PORT};
-    use crate::image::{resolve_initramfs_path, resolve_kernel_path, resolve_rootfs_path};
+    use crate::image::{
+        resolve_cache_path, resolve_initramfs_path, resolve_kernel_path, resolve_rootfs_path,
+    };
     use crate::krun::Context;
     use crate::vm::VmConfig;
 
     let kernel = resolve_kernel_path().context("resolving kernel path")?;
     let rootfs = resolve_rootfs_path().context("resolving rootfs path")?;
     let initramfs = resolve_initramfs_path().context("resolving initramfs path")?;
+    // Optional: a seeded-cache disk attached as /dev/vdb when MINVMD_CACHE_PATH
+    // is set; absent means the guest boots without an offline cache.
+    let cache_path = resolve_cache_path();
     let marker_sock = std::env::var(MARKER_SOCK_ENV).with_context(|| {
         format!("reading {MARKER_SOCK_ENV}: VMM child must be spawned by `minvmd boot`")
     })?;
@@ -54,7 +59,7 @@ fn run_vmm() -> Result<()> {
     // penalty. (Stay below the kernel's CONFIG_NR_CPUS.) The boot command may
     // expose these as flags in a future change. `apply` configures the kernel +
     // initramfs, the ext4 root disk, and the vsock bridge.
-    let cfg = VmConfig::new(2, 1024, kernel, rootfs, initramfs);
+    let cfg = VmConfig::new(2, 1024, kernel, rootfs, initramfs).with_cache_path(cache_path);
     cfg.apply(&mut ctx)
         .context("applying VmConfig to krun context")?;
 

--- a/crates/minvmd/src/image.rs
+++ b/crates/minvmd/src/image.rs
@@ -64,6 +64,21 @@ pub fn resolve_rootfs_path() -> Result<PathBuf, VmError> {
     Ok(PathBuf::from(val))
 }
 
+/// Resolve the optional seeded-cache disk path from `MINVMD_CACHE_PATH`.
+///
+/// This is an ext4 image whose filesystem is a populated minimal cache
+/// (`built/`, `vcs/`, `lc/`, `stdlib/`), attached as a second block device so
+/// the guest can compose session sandboxes offline. Unlike the kernel/rootfs/
+/// initramfs vars, this one is optional: an unset or empty value means no cache
+/// disk is attached (returns `Ok(None)`), so a VM without a seeded cache still
+/// boots.
+pub fn resolve_cache_path() -> Option<PathBuf> {
+    match std::env::var("MINVMD_CACHE_PATH") {
+        Ok(val) if !val.is_empty() => Some(PathBuf::from(val)),
+        _ => None,
+    }
+}
+
 /// Resolve the initramfs path from `MINVMD_INITRAMFS`.
 ///
 /// This is the cpio initramfs whose `/init` is minimald (booted as pid-1).

--- a/crates/minvmd/src/vm.rs
+++ b/crates/minvmd/src/vm.rs
@@ -53,6 +53,10 @@ pub struct VmConfig {
     /// `/init` (minimald as pid-1), instead of booting a block-device root. This
     /// is how minimald is shipped as pid-1 without baking it into the rootfs.
     pub initramfs: PathBuf,
+    /// Optional seeded-cache ext4 image attached as a second block device
+    /// (`/dev/vdb`); the guest mounts it at its cache dir so session sandboxes
+    /// compose offline. `None` means no cache disk is attached.
+    pub cache_path: Option<PathBuf>,
     /// How this VM attaches to the per-host gvproxy switch (R1.5). Defaults to
     /// [`NetworkMode::HostNet`]; an `OwnIp` VM is wired to the switch as a
     /// client via the per-PTask vsock shuttle.
@@ -82,7 +86,16 @@ impl VmConfig {
             initramfs,
             network_mode: NetworkMode::default(),
             vm_egress: None,
+            cache_path: None,
         }
+    }
+
+    /// Attach a seeded-cache disk image as a second block device, consuming and
+    /// returning `self`. `None` leaves the VM without a cache disk.
+    #[must_use]
+    pub fn with_cache_path(mut self, cache_path: Option<PathBuf>) -> Self {
+        self.cache_path = cache_path;
+        self
     }
 
     /// Set the VM network mode (R1.5), consuming and returning `self`.
@@ -194,6 +207,14 @@ impl VmConfig {
             crate::krun::DiskFormat::Raw,
             true,
         )?;
+        // Optional seeded-cache disk (/dev/vdb): a populated minimal cache the
+        // guest mounts at its cache dir so session sandboxes compose offline.
+        // Read-write (v1) so mctx can create cache subdirs / lockfiles and a
+        // user can add packages within the session; writes persist to the host
+        // image file (fine with a single VM).
+        if let Some(cache_path) = &self.cache_path {
+            ctx.add_disk("cache", cache_path, crate::krun::DiskFormat::Raw, false)?;
+        }
         // Network attachment (R1.5): the VM joins the per-host gvproxy switch
         // supervised by `crate::net` according to `network_mode`. The libkrun
         // device wiring (tap fd handed to gvproxy over the per-PTask vsock

--- a/scripts/build-session-cache.sh
+++ b/scripts/build-session-cache.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Build a "seeded cache" ext4 image: a populated minimal cache containing the
+# offline-compose closure for the session package set, so a guest minimald can
+# compose a session sandbox with no network. minvmd attaches the image as a
+# second block device (MINVMD_CACHE_PATH -> /dev/vdb) and minimald mounts it at
+# the guest cache dir /run/minimal/cache.
+#
+# Mirrors scripts/build-initramfs.sh's "produce a guest artifact via Docker on
+# macOS" pattern. The closure is built/fetched into an ISOLATED cache (fresh
+# $HOME) so the image contains ONLY the closure, then packed with `mkfs.ext4 -d`
+# (populates at creation; no loopback / mount needed).
+#
+# Usage: scripts/build-session-cache.sh <dest-image> [arch]
+#   arch defaults to aarch64 (the guest arch). The image is arch-keyed: it must
+#   match the guest VM's arch and the project's upstream pin.
+set -euo pipefail
+
+DEST="${1:?usage: build-session-cache.sh <dest-image> [arch]}"
+ARCH="${2:-aarch64}"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Session package set — keep in sync with crates/minimald/src/session_host.rs
+# (`with_packages([...])`). These plus their transitive runtime/build deps are
+# the offline closure.
+PKGS="base bash socat coreutils claude-code"
+
+# Upstream pin the guest projects use; must match .minimal/minimal.toml so the
+# seeded built/ SpecHashes match what the guest compose looks up.
+PIN="$(sed -n 's/^locked_commit = "\(.*\)"/\1/p' .minimal/minimal.toml | head -1)"
+REPO="$(sed -n 's/^repo = "\(.*\)"/\1/p' .minimal/minimal.toml | head -1)"
+[ -n "$PIN" ] && [ -n "$REPO" ] || { echo "could not read upstream pin from .minimal/minimal.toml" >&2; exit 1; }
+
+RUST_MUSL="${ARCH}-unknown-linux-musl"
+command -v cross >/dev/null || cargo install cross --locked
+
+# 1. Cross-compile a static `minimal` for the container (runs in arm64 Linux).
+echo ">> cross build minimal ($RUST_MUSL)"
+cross build -p minimal --release --target "$RUST_MUSL"
+MIN_BIN="$ROOT/target/$RUST_MUSL/release/minimal"
+[ -x "$MIN_BIN" ] || { echo "minimal not built at $MIN_BIN" >&2; exit 1; }
+
+# 2. Throwaway project carrying the upstream pin (minimal needs an upstream to
+#    resolve the package names).
+PROJ="$(mktemp -d)"
+CACHEROOT=""
+STAGE=""
+trap 'rm -rf "$PROJ" "${CACHEROOT:-}" "${STAGE:-}" 2>/dev/null || true' EXIT
+cat > "$PROJ/minimal.toml" <<EOF
+[upstream]
+repo = "$REPO"
+branch = "main"
+locked_commit = "$PIN"
+
+[stack]
+use = "rust"
+EOF
+
+# 3. Build/fetch the closure into an ISOLATED cache (fresh HOME) in a native
+#    arm64 container with network. --privileged: sandbox2 needs (nested) userns
+#    for any package not already in the remote cache. The bind-mounted HOME
+#    captures the populated cache for us.
+CACHEROOT="$(mktemp -d)"
+# The container platform IS the target arch, so `minimal package` (which has no
+# --arch flag) builds for it natively — no cross-arch flag needed.
+echo ">> build closure [$PKGS] @ ${PIN:0:7} arch=$ARCH (isolated cache)"
+docker run --rm --platform "linux/${ARCH/x86_64/amd64}" --privileged \
+  -v "$MIN_BIN:/usr/local/bin/minimal:ro" \
+  -v "$PROJ:/proj" \
+  -v "$CACHEROOT:/cacheroot" \
+  -e HOME=/cacheroot \
+  -w /proj \
+  debian:stable-slim \
+  sh -euc '
+    apt-get update -qq && apt-get install -y -qq git ca-certificates e2fsprogs >/dev/null 2>&1
+    minimal package '"$PKGS"'
+  '
+
+CACHE="$CACHEROOT/.cache/minimal"
+[ -d "$CACHE/built" ] || { echo "closure build produced no built/ in $CACHE" >&2; exit 1; }
+
+# 4. Prune the captured cache to the offline-compose set (drop downloads/, idx/,
+#    runtime state) and pack it into an ext4 image with mkfs.ext4 -d.
+STAGE="$(mktemp -d)"
+for d in built vcs lc stdlib; do
+  [ -d "$CACHE/$d" ] && cp -a "$CACHE/$d" "$STAGE/$d"
+done
+
+SIZE_KB="$(du -sk "$STAGE" | cut -f1)"
+IMG_MB=$(( (SIZE_KB / 1024) * 13 / 10 + 64 ))   # +30% slack, 64 MiB floor headroom
+echo ">> packing ext4 (${IMG_MB} MiB) from $(du -sh "$STAGE" | cut -f1) staged cache"
+mkdir -p "$(dirname "$DEST")"
+rm -f "$DEST"
+IMG_NAME="$(basename "$DEST")"
+# Make an empty ext4, then loop-mount and `cp -a` the staged cache in: the
+# kernel ext4 driver reproduces symlinks, hardlinks, and xattrs faithfully,
+# unlike `mkfs.ext4 -d` populate-mode (which chokes on package-file xattrs).
+# Native arm64 (avoid qemu-emulated mkfs segfaults); --privileged for loop mount.
+docker run --rm --platform linux/arm64 --privileged \
+  -v "$STAGE:/stage:ro" -v "$(dirname "$DEST"):/out" \
+  debian:stable-slim \
+  sh -euc '
+    apt-get update -qq && apt-get install -y -qq e2fsprogs >/dev/null 2>&1
+    truncate -s '"${IMG_MB}"'M "/out/'"$IMG_NAME"'"
+    mkfs.ext4 -q -F "/out/'"$IMG_NAME"'"
+    mkdir -p /mnt/img
+    mount -o loop "/out/'"$IMG_NAME"'" /mnt/img
+    cp -a /stage/. /mnt/img/
+    sync
+    umount /mnt/img
+    echo "=== validate: built/ + vcs/state.json present ==="
+    mount -o loop,ro "/out/'"$IMG_NAME"'" /mnt/img
+    ls /mnt/img/built | head -3
+    test -f /mnt/img/vcs/state.json && echo "VCS_STATE_OK"
+    umount /mnt/img
+  '
+
+echo "built session cache -> $DEST ($(du -h "$DEST" | cut -f1))"


### PR DESCRIPTION
Lets the macOS guest VM compose a session sandbox with no network, so interactive `minimal2 attach` works end-to-end.

## Problem
On macOS the session runs in a networkless libkrun VM with an empty cache, so two things blocked an interactive session:
1. The session worktree was empty → interactive attach died at `minimal.toml not found` (conformance R§3.1.4).
2. Composing the sandbox failed with `no such package: base` — the guest can't fetch the package closure.

## Changes (3 commits)
- **`feat(minimal2,minimald): upload project workspace on activate`** — copy-on-activate. `Client::upload_workspace` streams an ignore-aware `tar.zst` of the project (honours `.gitignore`/`.ignore`/`.minimalignore` via the `ignore` crate, keeps dotfiles, skips `.git`, preserves modes) over the existing `WorkspaceFilesTarZst` subsystem into the worktree. Shared subsystem/env-var consts moved into the `minimald-rpc` wire-contract crate.
- **`feat(minvmd,minimald): seeded cache disk for offline session compose`** — `MINVMD_CACHE_PATH` attaches a pre-seeded ext4 as `/dev/vdb`; minimald (guest pid-1) mounts it at `/run/minimal/cache` and sets the state dir equal to the cache dir so compose's package hardlinks stay on one filesystem (cross-fs hardlink = EXDEV). `.with_offline(true)` on the session context. Guest-env fixes surfaced once compose worked: mount **devpts** (`openpty` for the PTY) and a **tmpfs at `/tmp`** (hakoniwa stages there; rootfs is read-only). New `scripts/build-session-cache.sh` builds the seed (closure fetched from the remote cache, packed via loop-mount).
- **`fix(minimald): harden seeded cache disk against corrupt host key and slow boot reset`** — the writable image co-locates state, so an unclean shutdown can corrupt it: `Config::host_key` now regenerates an unreadable/corrupt key (was: only a missing one → boot brick); the boot reset drops only `providers/` instead of `rm -rf`-ing all non-seed state (the old reset was O(session state) and could blow the 5 s READY timeout).

## Verification
- Proven end-to-end on Apple Silicon: seed → mount → offline compose resolves the closure → interactive `attach` composes the hakoniwa sandbox (`CLONE_NEWNET`) → own-ip PTask attaches to the switch (`ip=100.64.0.2`).
- `cross build -p minimald --profile initramfs --features networking-proxy,networking-wg` green; `minimal2` builds + tests pass (incl. the new ignore-semantics test in `client.rs`); `cargo fmt`, `cargo clippy -p minvmd -D warnings` clean. minimald is Linux-only (host can't build it) — verified via cross.

## Scope / follow-ups
- This is the compose/file-transfer enablement only. Real egress (DNS, outbound) is **not** here: gvproxy currently runs in the guest with no host uplink. The correct DM1/3/4 design (host gvproxy + per-PTask vsock shuttle, `minvmd-owns-vm-gvproxy`) is tracked in #572. A gvproxy-in-guest staging hack was tried and reverted.
- Writable-image durability beyond the corrupt-key/boot-reset hardening (e.g. read-only seed + ephemeral state) is left for later.

## Notes
- Stacks logically on #570 (the `--network`/`--ingress` flags). #570 isn't on `origin/main` yet, so until it merges this PR's diff also shows #570's commit; it cleans up once #570 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for copying a project workspace into an activated session.
  * Added optional session network modes and custom ingress port mappings.
  * Added support for attaching a seeded cache disk to sessions and VM runs.

* **Bug Fixes**
  * Improved handling of host keys when an existing key is unreadable.
  * Enabled `/dev/pts` support in the guest for better terminal behavior.
  * Workspace uploads now respect ignore rules and exclude hidden/system paths as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->