### PR TITLE
[WIP] feat(minimald): --gvproxy-bin flag + just recipes for #478 networking/VM bring-up

### DIFF
--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -181,6 +181,13 @@ pub struct ListenArgs {
     #[arg(long)]
     #[clap(hide = true)]
     mount_rootfs: Option<String>,
+
+    /// Path to the gvproxy ("gvisor-tap-vsock") binary backing the per-host
+    /// `OwnIp` switch. Overrides the fixed install path so a dev build can point
+    /// at a fetched binary (e.g. `scripts/fetch-gvproxy.sh`) without installing
+    /// it system-wide.
+    #[arg(long)]
+    gvproxy_bin: Option<std::path::PathBuf>,
 }
 
 /// An error at the top level of minimald.
@@ -234,6 +241,7 @@ async fn async_main() -> Result<(), MainError> {
                 vsock: true,
                 mount_dev: true,
                 mount_rootfs: Some("/dev/vda".to_string()),
+                gvproxy_bin: None,
             }),
             global_args: GlobalArgs {
                 minimal_state_dir: Some(DaemonAbsPath::try_new("/run/minimal").unwrap().into()),
@@ -298,7 +306,7 @@ async fn async_main() -> Result<(), MainError> {
         },
         minimal_state_dir: cli.minimal_state_dir(),
         minimal_cache_dir: cli.minimal_cache_dir(),
-        gvproxy_bin: None,
+        gvproxy_bin: listen_args.gvproxy_bin.clone(),
     };
     // Ensure the SSH host key is accessible in a instance-specific known_hosts file.
     russh::keys::known_hosts::learn_known_hosts_path(

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -29,8 +29,11 @@ pub enum HostKey {
 }
 
 /// Default install path for the gvproxy ("gvisor-tap-vsock") switch binary,
-/// used when [`Config::gvproxy_bin`] is unset. The `GVPROXY_BIN` env var is
-/// scoped to the `#[ignore]` netns proof and is never consulted by the daemon.
+/// used when [`Config::gvproxy_bin`] is unset. Override it for a dev build with
+/// `minimald run --gvproxy-bin <path>` (e.g. a binary fetched by
+/// `scripts/fetch-gvproxy.sh`) to avoid installing it system-wide. The
+/// `GVPROXY_BIN` env var is scoped to the `#[ignore]` netns proof and is never
+/// consulted by the daemon.
 const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy";
 
 /// Global Configuration for the minimald server.

--- a/justfile
+++ b/justfile
@@ -9,3 +9,80 @@
 codesign-minvmd:
     cargo build -p minvmd --release
     codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/release/minvmd
+
+# --- Networking / VM bring-up (epic #478) ---------------------------------
+#
+# Lane A = native minimald on the host (DM2). Lane B = minvmd microVM (DM1, KVM).
+# These recipes mirror the CI lanes (.github/workflows/ci-netns.yml and
+# ci-linux-kvm.yml) so a dev reproduces them locally with one command each.
+# Lane A needs passwordless sudo; Lane B needs /dev/kvm (see `setup-kvm-group`).
+
+# Host arch, used to name guest artifacts and the musl target.
+# Override per-invocation: `just arch=x86_64 setup-minvmd`.
+arch := `uname -m`
+
+# libkrun runtime/link prefix for Lane B. Override with the KRUN_PREFIX env var.
+krun_prefix := env_var_or_default("KRUN_PREFIX", env_var("HOME") / ".krun")
+
+# Fetch the pinned gvproxy switch binary into .scratch/ (no sudo, no install).
+fetch-gvproxy:
+    @mkdir -p .scratch
+    ./scripts/fetch-gvproxy.sh .scratch/gvproxy
+
+# Lane A — netns proofs: UC1 (no-net refuses egress) + UC6 (PTask-to-PTask).
+test-netns: fetch-gvproxy
+    MINIMALD_NETNS_TEST=1 GVPROXY_BIN="{{justfile_directory()}}/.scratch/gvproxy" \
+        cargo test -p minimald -p sandbox2 -p minimald-rpc netns -- --include-ignored --nocapture
+
+# Lane A — UC7 WireGuard mesh netns proof (builds unprivileged, runs as root).
+test-mesh-netns: fetch-gvproxy
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bin=$(cargo test -p minimald --features networking-wg --test mesh_uc7 \
+            --no-run --message-format=json \
+          | jq -r 'select(.executable != null and (.target.name? == "mesh_uc7")) | .executable' \
+          | tail -1)
+    echo "mesh_uc7 binary: $bin"
+    sudo -E MINIMALD_NETNS_TEST=1 GVPROXY_BIN="$PWD/.scratch/gvproxy" \
+        "$bin" --include-ignored --nocapture
+
+# Lane A — networking feature unit suites (networking-wg + networking-proxy).
+test-net-features:
+    cargo test -p minimald --features networking-wg
+    cargo test -p minimald --features networking-proxy
+
+# Lane A — netns proofs + mesh proof + feature suites.
+test-net-lane-a: test-netns test-mesh-netns test-net-features
+
+# Lane B — one-time setup: fetch libkrun + guest kernel/rootfs, build initramfs.
+# build-initramfs.sh uses `cross` (Docker); on a native-arch host you can skip
+# Docker — see crates/minvmd/README.md ("No Docker?") for the musl-gcc path.
+setup-minvmd:
+    @mkdir -p .scratch
+    ./scripts/fetch-libkrun.sh "{{krun_prefix}}" "{{arch}}"
+    ./scripts/fetch-artifact.sh virtio-kernel .scratch/vmlinuz    "{{arch}}"
+    ./scripts/fetch-artifact.sh minvmd-rootfs .scratch/rootfs.img "{{arch}}"
+    ./scripts/build-initramfs.sh .scratch/initramfs.cpio "{{arch}}-unknown-linux-musl"
+
+# Lane B — minvmd VM E2E: boot READY round-trip + session command over the bridge.
+test-minvmd-e2e:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    krun="{{krun_prefix}}"
+    common="LIBKRUN_PREFIX=$krun LD_LIBRARY_PATH=$krun MINVMD_E2E=1 \
+        MINVMD_KERNEL_PATH=$PWD/.scratch/vmlinuz \
+        MINVMD_ROOTFS_PATH=$PWD/.scratch/rootfs.img \
+        MINVMD_INITRAMFS=$PWD/.scratch/initramfs.cpio"
+    sg kvm -c "env $common MINVMD_BOOT_LOG=$PWD/.scratch/boot-e2e.log \
+        cargo test -p minvmd --test boot_e2e -- --include-ignored --nocapture"
+    sg kvm -c "env $common \
+        cargo test -p minvmd --test minimald_session_e2e -- --include-ignored --nocapture --exact minimald_exec_over_bridge"
+
+# Lane B — print the one-time `sudo usermod -aG kvm` step (durable /dev/kvm access).
+setup-kvm-group:
+    @echo "Run once, then re-login (or prefix VM commands with 'sg kvm -c ...'):"
+    @echo "  sudo usermod -aG kvm $USER"
+
+# Run a native minimald (DM2) foreground, OwnIp switch -> fetched gvproxy (no install).
+run-minimald *ARGS: fetch-gvproxy
+    cargo run -p minimald -- run --gvproxy-bin "{{justfile_directory()}}/.scratch/gvproxy" {{ARGS}}


### PR DESCRIPTION
Dev-ergonomics for working the #478 networking epic locally. Two independent commits, no behavior change to existing flows.

## Commits
- **`feat(minimald): add --gvproxy-bin flag`** — the daemon resolved the gvproxy ("gvisor-tap-vsock") switch binary only from the fixed install path `/usr/lib/minimal/bin/gvproxy`, so exercising the OwnIp data plane on a dev host meant installing gvproxy system-wide (sudo). Adds `minimald run --gvproxy-bin <path>` to point the per-host switch at any binary — e.g. one fetched by `scripts/fetch-gvproxy.sh` — with no system install. Unset preserves the previous default path.
- **`build: add just recipes for #478 bring-up`** — captures the Lane A (native netns proofs, mesh proof, networking feature suites) and Lane B (minvmd VM E2E) command sequences as `just` recipes that mirror `ci-netns.yml` and `ci-linux-kvm.yml`, so a dev reproduces each lane with one command instead of reassembling the env-var soup. Adds `fetch-gvproxy`, `setup-minvmd`, `setup-kvm-group`, `test-netns`, `test-mesh-netns`, `test-net-features`, `test-minvmd-e2e`, and a `run-minimald` recipe that wires the new `--gvproxy-bin` flag to a fetched gvproxy.

## Verification
- `cargo build -p minimald` — clean
- `cargo fmt -p minimald -- --check` — clean
- `cargo clippy -p minimald --all-targets -- -D warnings` — clean
- `just --list` parses; recipes exercised locally (`just test-netns` / `test-net-features` / `test-mesh-netns` green; `--gvproxy-bin` used to run a privileged dev daemon with no system gvproxy install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional command-line flag to let you override the path to the networking helper binary.
  * Added several new convenience commands for running networking checks, VM setup, and end-to-end local testing.
  * Added a ready-to-use command for starting the service with the custom binary path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->