### PR TITLE
[WIP] feat(minimald): run attach --command inside the session PTask sandbox (DM2)

### DIFF
--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -374,6 +374,245 @@ impl Process for TokioProcess {
     }
 }
 
+/// Production [`Exec`] for a plain `attach --command <cmd>` request: runs the
+/// argv through `/bin/sh -c` *inside the session's PTask sandbox* — a
+/// `sandbox2`/`hakoniwa` container honouring the session's [`NetworkMode`] —
+/// rather than as a bare host process.
+///
+/// The sandbox is built exactly like the interactive shell launcher
+/// ([`crate::session_host::SandboxLauncher::launch`]) via the shared
+/// [`build_session_env`](crate::session_host::build_session_env) helper, so a
+/// command sees the same rootfs and network namespace an interactive attach
+/// would. A fresh sandbox is built per command (there is no persistent PTask to
+/// reuse yet); that is acceptable for the one-shot exec path.
+///
+/// For [`NetworkMode::OwnIp`] the freshly-unshared network namespace is wired
+/// onto the per-host gvproxy switch (the same `attach_own_ip` the launcher
+/// uses), and the resulting attachment is held alongside `env` for the
+/// command's whole lifetime.
+///
+/// The struct is compiled in all configs so its record→sandbox wiring can be
+/// unit-tested; only the [`Exec`] impl (which builds a real sandbox) is gated
+/// to production, since the sandbox package set is unavailable under test.
+// Under test the `Exec` impl below is not compiled, so the fields the producer
+// reads (argv/name/username/ingress/net_switch) look unused; the wiring is
+// still exercised by `plain_command_carries_session_network_mode`.
+#[cfg_attr(test, allow(dead_code))]
+pub(crate) struct SandboxedExec {
+    /// The shell command line, run as `/bin/sh -c <argv>`.
+    pub argv: String,
+    /// Display name for the sandbox env (derived from the session record).
+    pub name: String,
+    /// Username for the sandbox env; `None` falls back to the env default.
+    pub username: Option<String>,
+    /// The session's network isolation mode, applied to the sandbox.
+    pub network_mode: sessions::NetworkMode,
+    /// Static ingress port mappings to expose on the switch for an `OwnIp`
+    /// command, removed when it exits. `None`/empty for other modes.
+    pub ingress: Option<sessions::IngressPolicy>,
+    /// The daemon-scoped gvproxy switch, used to attach an `OwnIp` command's
+    /// namespace. Ignored for `HostNet`/`NoNet`.
+    pub net_switch: std::sync::Arc<tokio::sync::Mutex<crate::net::GvproxySwitch>>,
+}
+
+impl SandboxedExec {
+    /// Builds the sandboxed exec config from the target session's record and the
+    /// per-host switch, deriving the env name the way the launcher does and
+    /// carrying the record's network mode + static ingress so the command runs
+    /// under the same policy an interactive attach would.
+    pub(crate) fn from_record(
+        argv: String,
+        record: &sessions::Record,
+        net_switch: std::sync::Arc<tokio::sync::Mutex<crate::net::GvproxySwitch>>,
+    ) -> Self {
+        let name = record.name.clone().unwrap_or_else(|| {
+            record
+                .project_path
+                .file_name()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "session".to_string())
+        });
+        Self {
+            argv,
+            name,
+            username: record.username.clone(),
+            network_mode: record.network,
+            // Ingress is only carried for `OwnIp`; `validate_policy` (run at
+            // create/launch time) rejects it on any other mode.
+            ingress: record.policy.ingress.clone(),
+            net_switch,
+        }
+    }
+}
+
+#[cfg(not(test))]
+impl Exec for SandboxedExec {
+    type Process = HakoniwaProcess;
+
+    fn exec(self, session: SessionHandle) -> BoxStream<'static, io::Result<Self::Process>> {
+        // Same 1-slot pull protocol as `TaskExec`: the producer only spawns the
+        // child once the consumer pulls, and parks afterwards so `env` and the
+        // `OwnIp` switch attachment outlive the running child.
+        let (req_tx, req_rx) = mpsc::channel::<()>(1);
+        let (proc_tx, proc_rx) = mpsc::channel::<io::Result<HakoniwaProcess>>(1);
+
+        tokio::spawn(sandboxed_producer(self, session, req_rx, proc_tx));
+
+        stream::unfold((req_tx, proc_rx), |(req_tx, mut proc_rx)| async move {
+            req_tx.send(()).await.ok()?;
+            let item = proc_rx.recv().await?;
+            Some((item, (req_tx, proc_rx)))
+        })
+        .boxed()
+    }
+}
+
+/// Producer side of [`SandboxedExec::exec`]. Builds the session sandbox, spawns
+/// `/bin/sh -c <argv>` in it with piped stdio, optionally attaches the
+/// namespace to the gvproxy switch for `OwnIp`, then parks until the consumer
+/// drops the stream — keeping `env` (the sandbox rootfs files) and the `OwnIp`
+/// attachment alive for the child's whole lifetime, mirroring the launcher's
+/// `(env, own_ip)` guard ownership.
+#[cfg(not(test))]
+async fn sandboxed_producer(
+    exec: SandboxedExec,
+    session: SessionHandle,
+    mut req_rx: mpsc::Receiver<()>,
+    proc_tx: mpsc::Sender<io::Result<HakoniwaProcess>>,
+) {
+    let outcome: io::Result<()> = async {
+        let ctx = session.context().await.map_err(io::Error::other)?;
+        let paths = session.paths().await;
+
+        // Build the sandbox env exactly like the interactive launcher.
+        let mut env = crate::session_host::build_session_env(
+            ctx,
+            exec.name,
+            exec.username.unwrap_or_else(|| "user".to_string()),
+            paths,
+            exec.network_mode,
+        )
+        .await?;
+
+        // Unlike the interactive shell launcher, this one-shot command runs with
+        // piped (non-PTY) stdio, so the container is NOT made a session leader:
+        // `set_session_leader` acquires a controlling TTY (`TIOCSCTTY`), which
+        // fails with `ENOTTY` on a pipe. The `min run` path (`task_producer`)
+        // omits it for the same reason.
+        let container = env.container()?;
+
+        // Wait for the consumer to ask before spawning the child, so we never
+        // orphan a `hakoniwa::Child` the bridge will never pull.
+        if req_rx.recv().await.is_none() {
+            return Ok(());
+        }
+
+        let is_own_ip = matches!(exec.network_mode, sessions::NetworkMode::OwnIp);
+
+        // `OwnIp` has a startup race: the freshly-unshared netns is empty until
+        // `attach_own_ip` moves a tap into it, but a fast one-shot command can
+        // run and *exit* in that window, invalidating the PID `move_tap_into_
+        // netns` targets ("Invalid netns value"). The interactive shell dodges
+        // this because `bash -l` blocks on its PTY; a piped one-shot command
+        // does not. So for `OwnIp` we gate the user's command behind a one-byte
+        // read from stdin and release it only after the attach completes,
+        // keeping the netns-holding PID alive across the attach. `NoNet`/
+        // `HostNet` need no gate — their namespace is ready at spawn.
+        let argv = if is_own_ip {
+            // `IFS= read -r _` consumes exactly the go-line we write below; the
+            // user command then runs with the remaining (bridge-fed) stdin.
+            format!("IFS= read -r _gate; {}", exec.argv)
+        } else {
+            exec.argv.clone()
+        };
+
+        let mut child = {
+            let mut cmd = env
+                .command(&container, "/bin/sh", ["-c", argv.as_str()])
+                .map_err(|e| io::Error::other(format!("building command failed: {e}")))?;
+            cmd.stdin(hakoniwa::Stdio::piped())
+                .stdout(hakoniwa::Stdio::piped())
+                .stderr(hakoniwa::Stdio::piped());
+            cmd.spawn()
+                .map_err(|e| io::Error::other(format!("command launch failed: {e}")))?
+        };
+        // `command`/`container` no longer borrow `env`.
+        drop(container);
+
+        // For an `OwnIp` command, wire its freshly-unshared netns onto the
+        // per-host switch, exactly as `SandboxLauncher::launch` does. The
+        // attachment guard is held below until the child exits; its `Drop`
+        // detaches the PTask and removes any ingress forwards.
+        let _own_ip = if is_own_ip {
+            match crate::session_host::attach_own_ip(
+                &exec.net_switch,
+                child.id(),
+                exec.ingress.as_ref(),
+            )
+            .await
+            {
+                Ok(attachment) => Some(attachment),
+                Err(e) => {
+                    // The attach failed: this command is aborting. A
+                    // `hakoniwa::Child` is not terminated on drop, so kill and
+                    // reap it explicitly (SIGKILL-then-wait) before propagating,
+                    // mirroring the launcher's failure handling.
+                    if let Err(kill_err) = child.kill() {
+                        tracing::warn!(
+                            error = %kill_err,
+                            "killing sandbox command after OwnIp attach failure"
+                        );
+                    }
+                    if let Err(wait_err) = child.wait() {
+                        tracing::warn!(
+                            error = %wait_err,
+                            "reaping sandbox command after OwnIp attach failure"
+                        );
+                    }
+                    return Err(e);
+                }
+            }
+        } else {
+            None
+        };
+
+        // Release an `OwnIp` command's stdin gate now that the tap is in its
+        // namespace: the prologue's `read` consumes this go-line, then the user
+        // command runs against the now-wired network. The byte sits at the front
+        // of the stdin pipe; the bridge's later writes append after it. Borrow
+        // (don't `take`) the stdin handle so the bridge still owns it.
+        if is_own_ip && let Some(stdin) = child.stdin.as_mut() {
+            use std::io::Write;
+            if let Err(e) = stdin.write_all(b"\n").and_then(|()| stdin.flush()) {
+                tracing::warn!(error = %e, "failed to release OwnIp command stdin gate");
+            }
+        }
+
+        let process = HakoniwaProcess::new(child);
+        if let Err(send_err) = proc_tx.send(Ok(process)).await {
+            // Receiver dropped between our `recv` and our `send`; kill the child
+            // we just spawned so it doesn't outlive its sandbox rootfs.
+            if let Ok(mut proc) = send_err.0 {
+                let _ = proc.start_kill();
+            }
+            return Ok(());
+        }
+
+        // Park until the consumer drops the stream, keeping `env` and the
+        // `OwnIp` attachment alive while the bridge drives the child.
+        let _ = req_rx.recv().await;
+        drop(_own_ip);
+        Ok(())
+    }
+    .await;
+
+    if let Err(err) = outcome
+        && req_rx.recv().await.is_some()
+    {
+        let _ = proc_tx.send(Err(err)).await;
+    }
+}
+
 /// An async task which binds some program execution to an ssh channel.
 ///
 /// The `exec` field carries every parameter the process needs (argv,
@@ -700,23 +939,95 @@ pub(crate) async fn handle_exec(
             };
             exec_task.run(channel).await;
         } else {
-            let paths = session_handle.paths().await;
-            let exec_task = ExecTask {
-                conn,
+            run_plain_command(
                 serv,
-                session: session_handle,
-                channel_id: id,
-                exec: TokioExec {
-                    argv,
-                    cwd: paths.working,
-                    env: config.env_vars,
-                },
-            };
-            exec_task.run(channel).await;
+                conn,
+                session_handle,
+                session_id,
+                id,
+                argv,
+                config,
+                channel,
+            )
+            .await;
         };
     });
 
     Ok(())
+}
+
+/// Runs a plain (non-`min run`, non-git) `attach --command` request.
+///
+/// In production the command runs *inside* the session's PTask sandbox
+/// ([`SandboxedExec`]), honouring the session's [`sessions::NetworkMode`] and
+/// static ingress. Under `cfg(test)` a real sandbox cannot be built (the
+/// package set is unavailable in the unit-test tempdir — the same reason
+/// `session_host` swaps in a mock launcher), so the end-to-end bridge tests run
+/// the command through host `/bin/sh` ([`TokioExec`]) instead; the production
+/// sandbox wiring is covered by the unit test in this module.
+#[cfg(not(test))]
+#[allow(clippy::too_many_arguments)]
+async fn run_plain_command(
+    serv: ServerStateHandle,
+    conn: ConnectionHandle,
+    session_handle: SessionHandle,
+    session_id: SessionId,
+    id: ChannelId,
+    argv: String,
+    _config: ChannelConfig,
+    channel: Channel<Msg>,
+) {
+    let mngr = serv.sessions_manager().await;
+    // Read the session's network mode + static ingress from its record so the
+    // sandbox honours the same policy an interactive attach would; the switch
+    // is the one per-host switch the launcher attaches to.
+    let record = match mngr.get_record(SessionKeyPredicate::Id(session_id)).await {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            tracing::warn!(%id, "exec: session record vanished before launch");
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(%id, error = %e, "exec: failed to read session record");
+            return;
+        }
+    };
+    let net_switch = mngr.net_switch().await;
+    let exec_task = ExecTask {
+        conn,
+        serv,
+        session: session_handle,
+        channel_id: id,
+        exec: SandboxedExec::from_record(argv, &record, net_switch),
+    };
+    exec_task.run(channel).await;
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+async fn run_plain_command(
+    serv: ServerStateHandle,
+    conn: ConnectionHandle,
+    session_handle: SessionHandle,
+    _session_id: SessionId,
+    id: ChannelId,
+    argv: String,
+    config: ChannelConfig,
+    channel: Channel<Msg>,
+) {
+    let paths = session_handle.paths().await;
+    let exec_task = ExecTask {
+        conn,
+        serv,
+        session: session_handle,
+        channel_id: id,
+        exec: TokioExec {
+            argv,
+            cwd: paths.working,
+            env: config.env_vars,
+        },
+    };
+    exec_task.run(channel).await;
 }
 
 async fn handle_git_receive(
@@ -988,6 +1299,51 @@ mod tests {
 
     use super::bridge;
     use super::testing::{MockEndpoints, build_mock, build_mock_seq};
+
+    /// The plain `attach --command` exec path must carry the session record's
+    /// `NetworkMode` (and ingress) into the sandbox config, so the command runs
+    /// in the session's network namespace rather than the host's. This asserts
+    /// the production record→`SandboxedExec` wiring (`from_record`) for each
+    /// mode; the heavier "command actually runs in that namespace" behaviour is
+    /// proven empirically against a live daemon (see the PR's data-plane proof).
+    #[test]
+    fn plain_command_carries_session_network_mode() {
+        use std::sync::Arc;
+
+        use paths::HostAbsPath;
+        use sessions::{NetworkMode, Record, SessionId};
+        use tokio::sync::Mutex;
+
+        let switch = Arc::new(Mutex::new(crate::net::GvproxySwitch::new(
+            "/usr/lib/minimal/bin/gvproxy",
+            "/tmp/exec-test-gvproxy",
+        )));
+
+        let record_with = |network: NetworkMode| Record {
+            id: SessionId::nil(),
+            name: Some("netproj".to_string()),
+            username: Some("alice".to_string()),
+            project_path: HostAbsPath::try_new("/tmp/netproj").unwrap(),
+            network,
+            policy: Default::default(),
+            attrs: Default::default(),
+        };
+
+        for mode in [NetworkMode::NoNet, NetworkMode::HostNet, NetworkMode::OwnIp] {
+            let exec = super::SandboxedExec::from_record(
+                "ip -4 addr".to_string(),
+                &record_with(mode),
+                Arc::clone(&switch),
+            );
+            assert_eq!(
+                exec.network_mode, mode,
+                "exec path must apply the session's network mode",
+            );
+            assert_eq!(exec.name, "netproj");
+            assert_eq!(exec.username.as_deref(), Some("alice"));
+            assert_eq!(exec.argv, "ip -4 addr");
+        }
+    }
 
     /// Bytes flow client→child stdin and child stdout/stderr→client,
     /// and the child's exit code propagates to the bridge's return.

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -642,6 +642,56 @@ impl Drop for OwnIpAttachment {
     }
 }
 
+/// Builds the sandbox [`Env`](crate::env::Env) shared by every PTask launch:
+/// the interactive shell ([`SandboxLauncher::launch`]) and the one-shot
+/// `attach --command` exec path ([`crate::exec::SandboxedExec`]). Both run in
+/// the same rootfs (same package set + `PS1`) honouring the session's
+/// [`NetworkMode`], so the env construction lives in one place to keep them
+/// from drifting apart.
+///
+/// `graph_from_all_packages` is CPU-heavy (nickel evaluation, graph
+/// construction), so it runs on the blocking pool rather than stalling the
+/// async executor. The returned `Env` owns the context, graph and the sandbox
+/// files backing the rootfs, so it is `Send + 'static` and can be moved into
+/// the caller's guard slot to keep those files alive for the process's life.
+#[cfg(not(test))]
+pub(crate) async fn build_session_env(
+    ctx: mctx::Context,
+    name: String,
+    username: String,
+    paths: SessionPaths,
+    network_mode: NetworkMode,
+) -> io::Result<crate::env::Env> {
+    let (ctx, graph_result) = tokio::task::spawn_blocking(move || {
+        let mut ctx = ctx;
+        let r = ctx.graph_from_all_packages().map_err(|e| e.to_string());
+        (ctx, r)
+    })
+    .await
+    .map_err(io::Error::other)?;
+    let graph = graph_result.map_err(io::Error::other)?;
+
+    crate::env::Env::build(
+        ctx,
+        graph,
+        crate::env::EnvArgs::new(name, paths.working, paths.home, paths.cache)
+            .with_packages(["base", "bash", "socat", "coreutils", "claude-code"])
+            .with_env_vars(
+                [(
+                    "PS1".to_string(),
+                    EnvVarValue::Value(
+                        r"\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "
+                            .to_string(),
+                    ),
+                )]
+                .into(),
+            )
+            .with_network_mode(network_mode)
+            .with_username(username),
+    )
+    .await
+}
+
 /// Attaches an `OwnIp` PTask (identified by its sandbox process's netns-holding
 /// PID) to the shared gvproxy switch: allocate a lease and ensure gvproxy is up,
 /// open a host-side tap, move it into the PTask's network namespace and
@@ -649,7 +699,7 @@ impl Drop for OwnIpAttachment {
 /// `minimald::net` calls live here (the `minimald` side); `sandbox2` only
 /// unshared the namespace and surfaced the PID (no dependency cycle).
 #[cfg(not(test))]
-async fn attach_own_ip(
+pub(crate) async fn attach_own_ip(
     switch: &std::sync::Arc<tokio::sync::Mutex<crate::net::GvproxySwitch>>,
     netns_pid: u32,
     ingress: Option<&sessions::IngressPolicy>,
@@ -743,41 +793,12 @@ impl SessionLauncher for SandboxLauncher {
         // Move the ingress policy out of `self` up front so it can be applied
         // after the switch attach below (the rest of `self` is consumed first).
         let ingress = self.ingress;
-        // `graph_from_all_packages` is CPU-heavy (nickel evaluation,
-        // graph construction) — run it on the blocking pool so it
-        // doesn't stall the async executor.
-        let (ctx, graph_result) = tokio::task::spawn_blocking(move || {
-            let mut ctx = ctx;
-            let r = ctx.graph_from_all_packages().map_err(|e| e.to_string());
-            (ctx, r)
-        })
-        .await
-        .map_err(io::Error::other)?;
-        let graph = graph_result.map_err(io::Error::other)?;
 
         // The env owns the context, graph and the sandbox files backing the
         // running process's rootfs, so it is `Send + 'static` and can be moved
         // into the host as the guard that keeps those files alive — no leaking
         // or self-referential borrows required.
-        let mut env = crate::env::Env::build(
-            ctx,
-            graph,
-            crate::env::EnvArgs::new(name, paths.working, paths.home, paths.cache)
-                .with_packages(["base", "bash", "socat", "coreutils", "claude-code"])
-                .with_env_vars(
-                    [(
-                        "PS1".to_string(),
-                        EnvVarValue::Value(
-                            r"\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "
-                                .to_string(),
-                        ),
-                    )]
-                    .into(),
-                )
-                .with_network_mode(self.network_mode)
-                .with_username(username),
-        )
-        .await?;
+        let mut env = build_session_env(ctx, name, username, paths, self.network_mode).await?;
 
         let mut container = env.container()?;
         container.set_session_leader();

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -71,6 +71,15 @@ enum ManagerMessage {
     CreateSession(sessions::Record, Responder<SessionId>),
     RenameSession(SessionId, String, Responder<()>),
     DestroySession(SessionId, Responder<()>),
+    /// Hands back a clone of the daemon-scoped gvproxy switch `Arc`, so the
+    /// `attach --command` exec path can attach a one-shot `OwnIp` PTask to the
+    /// same per-host switch the interactive launcher uses (R1.5).
+    ///
+    // Only the production (`cfg(not(test))`) exec path consumes this; under test
+    // the plain-command path runs through host `/bin/sh`, so the variant is
+    // unused there.
+    #[cfg_attr(test, allow(dead_code))]
+    GetNetSwitch(oneshot::Sender<Arc<Mutex<crate::net::GvproxySwitch>>>),
 }
 
 /// Manages session instances, and session state on disk.
@@ -290,6 +299,11 @@ impl<L: Loader> Manager<L> {
                 })
                 .await
             }
+            // Hands back the shared switch `Arc` (a cheap clone) for the exec
+            // path to attach a one-shot `OwnIp` PTask to.
+            ManagerMessage::GetNetSwitch(r) => {
+                let _ = r.send(Arc::clone(&self.net_switch));
+            }
         }
     }
 }
@@ -340,6 +354,22 @@ impl ManagerHandle {
         let (send, recv) = Responder::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(ManagerMessage::GetSession(pred, send)).await;
+        recv.await.expect("corresponding sessions manager is dead")
+    }
+
+    /// Returns a clone of the daemon-scoped gvproxy switch `Arc`.
+    ///
+    /// The exec path (`attach --command`) uses this to attach a one-shot
+    /// `OwnIp` PTask to the same per-host switch the interactive launcher
+    /// attaches to (R1.5), keeping a single gvproxy and address allocator for
+    /// the host.
+    // Only the production exec path calls this; under test the plain-command
+    // path runs through host `/bin/sh`.
+    #[cfg_attr(test, allow(dead_code))]
+    pub(crate) async fn net_switch(&self) -> Arc<Mutex<crate::net::GvproxySwitch>> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.0.send(ManagerMessage::GetNetSwitch(send)).await;
         recv.await.expect("corresponding sessions manager is dead")
     }
 


### PR DESCRIPTION
`minimal2 attach <session> --command <cmd>` ran `<cmd>` as a plain host process (`TokioExec` → `/bin/sh -c` on the host), ignoring the session entirely — so it never entered the PTask sandbox or its network namespace. This routes it through a real sandbox2/hakoniwa container built with the session's `NetworkMode`, mirroring the interactive-shell launch path.

## Scope: DM2 (native Linux) only
This is the **native minimald** exec-into-PTask path (DM2), where minimald spawns gvproxy locally and the OwnIp PTask attaches via fd-pass. The VM-boundary deployments (DM1 macOS, DM3/DM4 Linux+minvmd) need the host-gvproxy + per-PTask vsock shuttle from **#572** — out of scope here. DM2 is "correct as-is" per #572.

## Changes
- **`exec.rs`** — new `SandboxedExec` (replaces `TokioExec` for the plain-command branch under `cfg(not(test))`); builds an `Env` from the session record with `.with_network_mode(...)`, runs `/bin/sh -c <cmd>` in the container, bridges stdio through the existing `bridge()`/`Process` machinery. For `NetworkMode::OwnIp` it wires the namespace to the per-host switch via `attach_own_ip` and holds the `(env, own_ip)` guard for the command's lifetime. `min run` and git-receive paths unchanged.
- **`session_host.rs`** — factored the launcher's env construction into a shared `pub(crate) build_session_env` (exec and the interactive shell now build identical sandboxes); made `attach_own_ip` `pub(crate)` so exec reuses the exact tap/relay/ingress logic (no duplication).
- **`sessions.rs`** — `pub(crate) ManagerHandle::net_switch()` accessor so the exec path reaches the one per-host `GvproxySwitch`.

Two incidental fixes found while verifying: a piped one-shot command must not `set_session_leader()` (ENOTTY on a pipe), and the OwnIp startup race (command exits before the tap is in the netns) is gated behind a one-byte stdin handshake released after the attach completes.

## Coordination with #572 — shared seam
This and #572 both touch the OwnIp attach path. **Overlap is in `session_host.rs` around `attach_own_ip`** (here: made `pub(crate)` + factored `build_session_env`; #572: adds the DM1/3/4 tap→shuttle branch). Otherwise orthogonal (DM2 local-spawn+fd-pass vs DM1/3/4 host-gvproxy+vsock-shuttle). Whoever lands second rebases the `attach_own_ip` seam.

## Dependencies for end-to-end CLI testing
The exec code is independent and compiles/tests on `main`, but driving it end-to-end from `minimal2` needs:
- **#570** (`--network`/`--ingress`) to create own-ip/ingress sessions from the CLI, and
- **#573** (workspace upload) to populate the session worktree — without it a freshly-activated session is empty and compose fails at `minimal.toml not found`.

## Verification
- `cargo build/test/clippy/fmt -p minimald` — clean (incl. the existing `exec.rs` e2e tests + a new `plain_command_carries_session_network_mode`).
- Empirical, native daemon (DM2): **no-net** `attach --command` → only `lo`, no `eth0`, curl fails; **own-ip** → switch tap `mtap0_2` + `100.64.x.x` IP (daemon log: "attached OwnIp PTask to gvproxy switch ip=100.64.0.3"). Before: both showed the host's `eth0`/`192.168.5.x`. (Worktree hand-seeded for the test pending #573.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plain `attach --command` requests now run in the target session’s sandboxed environment.
  * Commands can now use the session’s network setup, including isolated “own IP” mode.

* **Bug Fixes**
  * Improved reliability for short-running commands in isolated networking mode.
  * Prevented commands from exiting before networking is fully ready, reducing intermittent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->