### PR TITLE
[WIP] feat(minvmd,minimald): host gvproxy + per-PTask vsock shuttle for DM1/3/4 (#572)

### DIFF
--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -299,6 +299,10 @@ async fn async_main() -> Result<(), MainError> {
         minimal_state_dir: cli.minimal_state_dir(),
         minimal_cache_dir: cli.minimal_cache_dir(),
         gvproxy_bin: None,
+        // The vsock listen path is exactly the libkrun-VM (DM1/3/4) case: an
+        // `OwnIp` PTask must attach to the host gvproxy over the vsock shuttle,
+        // not spawn gvproxy in-guest (issue #572). The UDS path is DM2.
+        in_microvm: listen_args.vsock,
     };
     // Ensure the SSH host key is accessible in a instance-specific known_hosts file.
     russh::keys::known_hosts::learn_known_hosts_path(

--- a/crates/minimald/src/net/mod.rs
+++ b/crates/minimald/src/net/mod.rs
@@ -53,6 +53,44 @@ pub const DEFAULT_MTU: u16 = 1500;
 /// Stable, locally-administered MAC for the switch gateway.
 pub const GATEWAY_MAC: MacAddr = MacAddr([0x5a, 0x94, 0xef, 0xe4, 0x0c, 0xdd]);
 
+/// AF_VSOCK CID of the host as seen from inside a libkrun guest. Well-known:
+/// `VMADDR_CID_HOST == 2`. The per-PTask shuttle dials this CID to reach the
+/// host gvproxy switch (issue #572, DM1/3/4).
+pub const VSOCK_HOST_CID: u32 = 2;
+
+/// vsock port the per-PTask shuttle connects to on the host to reach the host
+/// gvproxy switch (issue #572). Must match `minvmd`'s
+/// `net::VSOCK_GVPROXY_SHUTTLE_PORT`; libkrun bridges this guest-initiated
+/// connection to the host gvproxy `-listen` socket.
+pub const VSOCK_GVPROXY_SHUTTLE_PORT: u32 = 1024;
+
+/// How the per-host gvproxy switch is reached, selected by deployment model
+/// (issue #572).
+///
+/// On DM2 (native Linux) `minimald` owns gvproxy: it is spawned locally and
+/// PTask taps attach over its `-listen` UNIX socket. On DM1/3/4 (a libkrun VM)
+/// `minvmd` owns the host gvproxy; the in-guest `minimald` does **not** spawn
+/// gvproxy — each PTask tap attaches over an AF_VSOCK shuttle to the host
+/// switch. Keeping the two as an enum (rather than an `Option<sock>` plus a
+/// bool) makes the illegal "spawn locally *and* shuttle to host" state
+/// unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SwitchTransport {
+    /// DM2: `minimald` spawns + owns gvproxy locally; taps attach over its UNIX
+    /// control socket.
+    LocalSpawn,
+    /// DM1/3/4: gvproxy runs on the host (owned by `minvmd`); taps attach over a
+    /// vsock shuttle to `(cid, port)`. `minimald` never spawns gvproxy here.
+    HostShuttle { cid: u32, port: u32 },
+}
+
+impl Default for SwitchTransport {
+    fn default() -> Self {
+        Self::LocalSpawn
+    }
+}
+
 /// How long to wait for gvproxy's control socket to appear after spawn.
 const SOCKET_READY_TIMEOUT: Duration = Duration::from_secs(5);
 /// How long to wait for gvproxy to exit after `SIGTERM` before escalating to
@@ -354,11 +392,15 @@ pub struct GvproxySwitch {
     allocator: IpAllocator,
     /// Number of attached PTasks; the switch runs while this is non-zero.
     attached: usize,
-    /// The running gvproxy child, if started.
+    /// The running gvproxy child, if started. Always `None` in
+    /// [`SwitchTransport::HostShuttle`] mode (the host owns gvproxy).
     child: Option<Child>,
     /// Signals attached PTasks when gvproxy exits unexpectedly. Replaced
     /// on each unexpected exit so new attachers get a fresh receiver.
     exit_tx: watch::Sender<bool>,
+    /// How PTask taps reach the switch (issue #572): local spawn (DM2) or a
+    /// vsock shuttle to the host gvproxy (DM1/3/4).
+    transport: SwitchTransport,
 }
 
 impl GvproxySwitch {
@@ -384,7 +426,24 @@ impl GvproxySwitch {
             attached: 0,
             child: None,
             exit_tx,
+            transport: SwitchTransport::default(),
         }
+    }
+
+    /// Sets how PTask taps reach the switch (issue #572). The DM2 default is
+    /// [`SwitchTransport::LocalSpawn`]; in a libkrun VM (DM1/3/4) the caller sets
+    /// [`SwitchTransport::HostShuttle`] so this `minimald` attaches taps to the
+    /// host-owned gvproxy over vsock instead of spawning gvproxy in-guest.
+    #[must_use]
+    pub fn with_transport(mut self, transport: SwitchTransport) -> Self {
+        self.transport = transport;
+        self
+    }
+
+    /// How this switch's PTask taps reach the gvproxy switch (issue #572).
+    #[must_use]
+    pub fn transport(&self) -> SwitchTransport {
+        self.transport
     }
 
     /// The control socket path gvproxy listens on (host side only).
@@ -420,8 +479,13 @@ impl GvproxySwitch {
     /// Propagates config-write, spawn, and socket-readiness failures.
     pub async fn attach(&mut self) -> Result<AttachResult, NetError> {
         let lease = self.allocator.allocate()?;
-        self.write_config().await?;
-        self.ensure_running().await?;
+        // DM2 spawns + configures gvproxy locally; DM1/3/4 (HostShuttle) leaves
+        // gvproxy to `minvmd` on the host, so skip the spawn/config steps and
+        // only track the attach count (issue #572).
+        if matches!(self.transport, SwitchTransport::LocalSpawn) {
+            self.write_config().await?;
+            self.ensure_running().await?;
+        }
         self.attached += 1;
         tracing::info!(
             ip = %lease.ip,
@@ -716,5 +780,45 @@ mod tests {
         let cfg = render_gvproxy_config(SwitchSubnet::default(), &[]);
         assert!(cfg.contains("dhcpStaticLeases:"));
         assert!(cfg.contains("{}"));
+    }
+
+    #[test]
+    fn transport_defaults_to_local_spawn() {
+        let switch = GvproxySwitch::new("/usr/bin/gvproxy", "/run/minimal/gvproxy");
+        assert_eq!(switch.transport(), SwitchTransport::LocalSpawn);
+    }
+
+    #[test]
+    fn with_transport_selects_host_shuttle() {
+        let switch = GvproxySwitch::new("/usr/bin/gvproxy", "/run/minimal/gvproxy").with_transport(
+            SwitchTransport::HostShuttle {
+                cid: VSOCK_HOST_CID,
+                port: VSOCK_GVPROXY_SHUTTLE_PORT,
+            },
+        );
+        assert_eq!(
+            switch.transport(),
+            SwitchTransport::HostShuttle { cid: 2, port: 1024 }
+        );
+    }
+
+    #[tokio::test]
+    async fn host_shuttle_attach_allocates_without_spawning_gvproxy() {
+        // In HostShuttle mode `minvmd` owns gvproxy, so `attach` must not try to
+        // spawn the (here nonexistent) binary: it allocates a lease and only
+        // tracks the attach count. A LocalSpawn switch pointed at the same
+        // missing binary would instead fail in `ensure_running`.
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut switch =
+            GvproxySwitch::new("/nonexistent/gvproxy-binary", dir.path().join("gvproxy"))
+                .with_transport(SwitchTransport::HostShuttle {
+                    cid: VSOCK_HOST_CID,
+                    port: VSOCK_GVPROXY_SHUTTLE_PORT,
+                });
+
+        let result = switch.attach().await.expect("host-shuttle attach");
+        assert_eq!(result.lease.ip, Ipv4Addr::new(100, 64, 0, 2));
+        // No gvproxy child was spawned; detach just decrements the count.
+        switch.detach().await.expect("detach");
     }
 }

--- a/crates/minimald/src/net/switch.rs
+++ b/crates/minimald/src/net/switch.rs
@@ -273,8 +273,8 @@ impl Drop for SwitchRelay {
     }
 }
 
-/// Attaches `tap_fd` to the gvproxy switch listening on `api_sock` and starts
-/// relaying frames between them.
+/// Attaches `tap_fd` to the gvproxy switch listening on `api_sock` (DM2, native
+/// Linux) and starts relaying frames between them.
 ///
 /// Spawns two background tasks — tap→switch and switch→tap — and returns a
 /// [`SwitchRelay`] handle whose lifetime keeps the attachment alive.
@@ -287,7 +287,51 @@ impl Drop for SwitchRelay {
 pub async fn attach_to_switch(tap_fd: OwnedFd, api_sock: &Path) -> io::Result<SwitchRelay> {
     let mut sock = UnixStream::connect(api_sock).await?;
     sock.write_all(CONNECT_REQUEST).await?;
+    let (sock_rx, sock_tx) = sock.into_split();
+    spawn_relay(tap_fd, sock_rx, sock_tx)
+}
 
+/// Attaches `tap_fd` to the **host** gvproxy switch over AF_VSOCK (issue #572,
+/// DM1/3/4) and starts relaying frames between them.
+///
+/// On a libkrun VM the gvproxy switch runs on the host; the guest reaches it by
+/// connecting to `cid` (CID 2 = the host) on `port`, which libkrun bridges to
+/// the host gvproxy `-listen` socket (`minvmd` registers this via
+/// `krun_add_vsock_port2(.., listen = false)`). This is the same HyperKit-framed
+/// raw-L2 relay as [`attach_to_switch`] — the shuttle is *not* a second TCP/IP
+/// stack — so exactly one gVisor stack (the host gvproxy) sits in the path.
+///
+/// # Errors
+///
+/// Returns an error if the vsock connection cannot be established, the connect
+/// request cannot be written, or the tap fd cannot be put into non-blocking
+/// mode for epoll-driven I/O.
+pub async fn attach_to_switch_vsock(
+    tap_fd: OwnedFd,
+    cid: u32,
+    port: u32,
+) -> io::Result<SwitchRelay> {
+    let mut sock =
+        tokio_vsock::VsockStream::connect(tokio_vsock::VsockAddr::new(cid, port)).await?;
+    // `VsockStream` has an inherent (blocking, std::io) `write_all` that shadows
+    // the async trait method, so disambiguate to the tokio trait — same hazard
+    // `guest.rs` notes for `shutdown`.
+    AsyncWriteExt::write_all(&mut sock, CONNECT_REQUEST).await?;
+    let (sock_rx, sock_tx) = tokio::io::split(sock);
+    spawn_relay(tap_fd, sock_rx, sock_tx)
+}
+
+/// Wires `tap_fd` into the bidirectional frame relay against an already-connected,
+/// `/connect`-upgraded switch stream split into `sock_rx`/`sock_tx`.
+///
+/// Shared by the DM2 UDS path ([`attach_to_switch`]) and the DM1/3/4 vsock path
+/// ([`attach_to_switch_vsock`]); the relay loops are transport-agnostic
+/// (`AsyncRead`/`AsyncWrite`), so only the connect step differs.
+fn spawn_relay<R, W>(tap_fd: OwnedFd, sock_rx: R, sock_tx: W) -> io::Result<SwitchRelay>
+where
+    R: AsyncReadExt + Unpin + Send + 'static,
+    W: AsyncWriteExt + Unpin + Send + 'static,
+{
     // A tap character device does not support pread/pwrite, so `tokio::fs::File`
     // (which routes through the blocking pool via positional I/O) cannot drive
     // it. Use plain read/write in non-blocking mode with `AsyncFd` for epoll
@@ -298,7 +342,6 @@ pub async fn attach_to_switch(tap_fd: OwnedFd, api_sock: &Path) -> io::Result<Sw
     set_nonblocking(tap_file.as_raw_fd())?;
     let tap = Arc::new(AsyncFd::new(tap_file)?);
 
-    let (sock_rx, sock_tx) = sock.into_split();
     let tap_to_switch = tokio::spawn(relay_tap_to_switch(Arc::clone(&tap), sock_tx));
     let switch_to_tap = tokio::spawn(relay_switch_to_tap(sock_rx, tap));
     Ok(SwitchRelay {

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -43,6 +43,12 @@ pub struct Config {
     /// to [`DEFAULT_GVPROXY_BIN`] when unset.
     #[serde(default)]
     pub gvproxy_bin: Option<PathBuf>,
+    /// Whether this `minimald` runs inside a `minvmd` libkrun VM (DM1/3/4). When
+    /// `true`, `OwnIp` PTasks attach to the **host** gvproxy (owned by `minvmd`)
+    /// over a vsock shuttle instead of spawning gvproxy in-guest (issue #572).
+    /// `false` (DM2, native Linux) keeps the local-spawn + tap relay path.
+    #[serde(default)]
+    pub in_microvm: bool,
 }
 
 impl Config {
@@ -119,10 +125,24 @@ impl ServerState {
         // live under a dedicated subdir of the daemon state dir. The shared
         // `Arc` is the single source of truth, injected into every per-launch
         // `SandboxLauncher` through the sessions manager.
-        let net_switch = Arc::new(Mutex::new(crate::net::GvproxySwitch::new(
-            config.gvproxy_bin_path(),
-            minimal_state_dir.as_utf8_path().join("gvproxy"),
-        )));
+        // DM1/3/4 (in a libkrun VM): attach `OwnIp` PTasks to the host gvproxy
+        // (owned by `minvmd`) over a vsock shuttle. DM2 (native Linux): spawn +
+        // own gvproxy locally (issue #572).
+        let transport = if config.in_microvm {
+            crate::net::SwitchTransport::HostShuttle {
+                cid: crate::net::VSOCK_HOST_CID,
+                port: crate::net::VSOCK_GVPROXY_SHUTTLE_PORT,
+            }
+        } else {
+            crate::net::SwitchTransport::LocalSpawn
+        };
+        let net_switch = Arc::new(Mutex::new(
+            crate::net::GvproxySwitch::new(
+                config.gvproxy_bin_path(),
+                minimal_state_dir.as_utf8_path().join("gvproxy"),
+            )
+            .with_transport(transport),
+        ));
 
         // Generate the TLS CA once at daemon startup so the HTTPS proxy and the
         // IssueClientCert RPC share the same trust anchor for the lifetime of

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -654,12 +654,15 @@ async fn attach_own_ip(
     netns_pid: u32,
     ingress: Option<&sessions::IngressPolicy>,
 ) -> io::Result<OwnIpAttachment> {
-    use crate::net::switch::{attach_to_switch, move_tap_into_netns, open_tap};
+    use crate::net::SwitchTransport;
+    use crate::net::switch::{
+        attach_to_switch, attach_to_switch_vsock, move_tap_into_netns, open_tap,
+    };
 
     // Allocate a lease and ensure gvproxy is running, snapshotting the control
-    // socket and subnet under one lock; the slow tap/relay work runs unlocked so
-    // concurrent attaches don't serialize on the namespace plumbing.
-    let (lease, sock, subnet) = {
+    // socket, subnet, and transport under one lock; the slow tap/relay work runs
+    // unlocked so concurrent attaches don't serialize on the namespace plumbing.
+    let (lease, sock, subnet, transport) = {
         let mut s = switch.lock().await;
         let attach = s
             .attach()
@@ -668,7 +671,7 @@ async fn attach_own_ip(
         // gvproxy's unexpected-exit closes the control socket, which ends the
         // relay's switch-side read on its own, so the relay self-terminates; we
         // do not additionally watch `attach.exit_signal` here.
-        (attach.lease, s.control_socket(), s.subnet())
+        (attach.lease, s.control_socket(), s.subnet(), s.transport())
     };
 
     // A locally-administered tap name unique within the switch /16 (its low two
@@ -682,7 +685,16 @@ async fn attach_own_ip(
     let relay = match async {
         let tap_fd = open_tap(&tap)?;
         move_tap_into_netns(&tap, netns_pid, lease, subnet).await?;
-        attach_to_switch(tap_fd, &sock).await
+        // DM2 attaches the tap to the local gvproxy `-listen` socket; DM1/3/4
+        // (HostShuttle) relays the tap's raw frames over vsock to the host
+        // gvproxy `minvmd` owns (issue #572). Both are the same HyperKit-framed
+        // L2 relay — one gVisor stack in the path either way.
+        match transport {
+            SwitchTransport::LocalSpawn => attach_to_switch(tap_fd, &sock).await,
+            SwitchTransport::HostShuttle { cid, port } => {
+                attach_to_switch_vsock(tap_fd, cid, port).await
+            }
+        }
     }
     .await
     {
@@ -697,7 +709,26 @@ async fn attach_own_ip(
     // forwards on the switch control socket, retaining handles to remove on
     // exit. A failure here rolls the whole attach back (drop the relay, then
     // detach) so a half-configured PTask is never left running.
+    //
+    // Issue #572 gap: ingress port-forwards are applied via gvproxy's HTTP API
+    // on its control socket. On DM2 that socket is local; on DM1/3/4
+    // (HostShuttle) gvproxy is on the host and its API is not reachable from the
+    // guest over the frame-only shuttle. Egress (the focus of #572) needs no
+    // such call, so for now ingress on the VM path is skipped with a warning
+    // rather than silently appearing to work — a host-side ingress API path is
+    // follow-up work.
     let exposed = match ingress {
+        Some(ingress)
+            if !ingress.port_mappings.is_empty()
+                && matches!(transport, SwitchTransport::HostShuttle { .. }) =>
+        {
+            tracing::warn!(
+                ip = %lease.ip,
+                "static ingress on a VM (DM1/3/4) own-IP PTask is not yet wired to the \
+                 host gvproxy port-forward API; egress works, ingress is skipped (issue #572)"
+            );
+            Vec::new()
+        }
         Some(ingress) if !ingress.port_mappings.is_empty() => {
             match crate::net::policy::apply_ingress(&sock, lease.ip, ingress).await {
                 Ok(exposed) => exposed,

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -56,6 +56,7 @@ impl TestServer {
             minimal_state_dir: state_dir,
             minimal_cache_dir: cache_dir,
             gvproxy_bin: None,
+            in_microvm: false,
         };
         let state = ServerStateHandle::new(config).await.unwrap();
 

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -23,6 +23,23 @@ pub const VSOCK_MARKER_PORT: u32 = 7350;
 /// READY marker from the parent to the VMM child.
 pub const MARKER_SOCK_ENV: &str = "MINVMD_MARKER_SOCK";
 
+/// Environment variable selecting an own-IP VM (issue #572). When set to a
+/// truthy value (`1`/`true`), the supervisor spawns the host gvproxy switch and
+/// the VMM child registers the per-PTask shuttle vsock bridge + sets the VM's
+/// network mode to `OwnIp`. Read by both the parent supervisor (to decide
+/// whether to spawn gvproxy) and the VMM child (to configure the VM), so the two
+/// processes stay consistent. Unset/false ⇒ a `HostNet` VM with no host gvproxy.
+pub const OWN_IP_ENV: &str = "MINVMD_VM_OWN_IP";
+
+/// Whether [`OWN_IP_ENV`] requests an own-IP VM (issue #572).
+#[must_use]
+pub fn own_ip_requested() -> bool {
+    matches!(
+        std::env::var(OWN_IP_ENV).as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE")
+    )
+}
+
 /// Verify the host hypervisor backend is accessible before booting a VM (R2.4).
 ///
 /// On Linux, libkrun drives KVM, which needs a readable `/dev/kvm`. Probe it

--- a/crates/minvmd/src/cmd/run.rs
+++ b/crates/minvmd/src/cmd/run.rs
@@ -199,6 +199,23 @@ fn run_foreground() -> Result<()> {
         .set_nonblocking(false)
         .context("setting listener to blocking")?;
 
+    // Issue #572: for an own-IP VM, spawn + supervise the host gvproxy switch
+    // before the VMM child boots, so its `-listen` switch socket exists when
+    // libkrun dials it for the guest shuttle. The handle lives for the VM's
+    // lifetime and stops gvproxy on drop (after the VMM child exits below).
+    let _gvproxy = if crate::cmd::own_ip_requested() {
+        let switch_sock = crate::net::resolve_switch_sock().context("resolving switch socket")?;
+        crate::sock::prepare_socket_dir(&switch_sock).context("preparing switch socket dir")?;
+        crate::sock::remove_stale_socket(&switch_sock).context("removing stale switch socket")?;
+        let binary = crate::image::resolve_gvproxy_path();
+        let gvproxy = crate::net::HostGvproxy::spawn(binary, switch_sock)
+            .context("spawning host gvproxy switch")?;
+        tracing::info!(pid = gvproxy.pid(), "host gvproxy switch up for own-IP VM");
+        Some(gvproxy)
+    } else {
+        None
+    };
+
     let exe = std::env::current_exe().context("resolving current executable path")?;
     let mut child = std::process::Command::new(&exe)
         .arg("__krun-vmm")

--- a/crates/minvmd/src/cmd/vmm_child.rs
+++ b/crates/minvmd/src/cmd/vmm_child.rs
@@ -54,7 +54,14 @@ fn run_vmm() -> Result<()> {
     // penalty. (Stay below the kernel's CONFIG_NR_CPUS.) The boot command may
     // expose these as flags in a future change. `apply` configures the kernel +
     // initramfs, the ext4 root disk, and the vsock bridge.
-    let cfg = VmConfig::new(2, 1024, kernel, rootfs, initramfs);
+    let mut cfg = VmConfig::new(2, 1024, kernel, rootfs, initramfs);
+    // Issue #572: an own-IP VM registers the per-PTask gvproxy shuttle vsock
+    // bridge in `apply`; the host gvproxy is spawned by the parent supervisor.
+    // The env var keeps the parent's gvproxy-spawn decision and this child's VM
+    // config in lock-step.
+    if crate::cmd::own_ip_requested() {
+        cfg = cfg.with_network_mode(minimald_rpc::NetworkMode::OwnIp);
+    }
     cfg.apply(&mut ctx)
         .context("applying VmConfig to krun context")?;
 

--- a/crates/minvmd/src/image.rs
+++ b/crates/minvmd/src/image.rs
@@ -80,6 +80,25 @@ pub fn resolve_initramfs_path() -> Result<PathBuf, VmError> {
     Ok(PathBuf::from(val))
 }
 
+/// Default install path for the host gvproxy ("gvisor-tap-vsock") binary, used
+/// when `MINVMD_GVPROXY_BIN` is unset. Fetched + SHA-256-verified by
+/// `scripts/fetch-gvproxy.sh` (issue #495).
+pub const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy";
+
+/// Resolve the host gvproxy binary path from `MINVMD_GVPROXY_BIN`, falling back
+/// to [`DEFAULT_GVPROXY_BIN`] when unset or empty.
+///
+/// Unlike the kernel/rootfs/initramfs resolvers this never errors on a missing
+/// env var: gvproxy is only spawned for an own-IP VM (issue #572), so an absent
+/// override is the common case and the fixed install path is the default.
+#[must_use]
+pub fn resolve_gvproxy_path() -> PathBuf {
+    match std::env::var("MINVMD_GVPROXY_BIN") {
+        Ok(val) if !val.is_empty() => PathBuf::from(val),
+        _ => PathBuf::from(DEFAULT_GVPROXY_BIN),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;

--- a/crates/minvmd/src/net.rs
+++ b/crates/minvmd/src/net.rs
@@ -56,6 +56,9 @@ mod relay;
 #[cfg(target_os = "linux")]
 pub use relay::{SwitchRelay, attach_to_switch, open_tap};
 
+mod shuttle;
+pub use shuttle::{VSOCK_GVPROXY_SHUTTLE_PORT, resolve_switch_sock};
+
 /// Default time to wait for gvproxy to exit on SIGTERM before escalating to
 /// SIGKILL.
 pub const DEFAULT_TERM_TIMEOUT: Duration = Duration::from_secs(3);
@@ -878,6 +881,147 @@ fn signal_child(pid: libc::pid_t, signal: libc::c_int, signal_name: &str) {
     }
 }
 
+/// A host gvproxy switch owned by `minvmd`'s synchronous supervisor (issue
+/// #572), running on its own dedicated current-thread tokio runtime.
+///
+/// `minvmd`'s `run`/`boot` supervisor is synchronous, but [`GvproxyConfig::spawn`]
+/// and [`GvproxySwitch::stop`] need a tokio runtime (background exit-detection
+/// and timer-driven teardown). [`HostGvproxy::spawn`] stands up a single-threaded
+/// runtime on a dedicated thread, spawns + supervises gvproxy there, and keeps
+/// the runtime alive for the VM's lifetime. [`HostGvproxy::stop`] (or `Drop`)
+/// tears gvproxy down and joins the thread.
+///
+/// The switch is started with an **empty** static-lease table: the guest's
+/// per-PTask shuttle configures each PTask's switch IP statically (the spike's
+/// static-lease recipe), so `minvmd` does not need to own the per-PTask address
+/// book — gvproxy still provides the subnet gateway and the host-loopback NAT
+/// alias from the config YAML.
+#[derive(Debug)]
+#[must_use = "dropping HostGvproxy stops the host gvproxy switch"]
+pub struct HostGvproxy {
+    /// Channel that tells the runtime thread to stop the switch and exit.
+    stop_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    /// The runtime thread; joined on [`stop`](Self::stop) / `Drop`.
+    thread: Option<std::thread::JoinHandle<()>>,
+    /// PID of the spawned gvproxy, surfaced for logging/diagnostics.
+    pid: u32,
+}
+
+impl HostGvproxy {
+    /// Spawn and supervise the host gvproxy switch on a dedicated runtime.
+    ///
+    /// `binary` is the gvproxy binary; `switch_sock` is the host `-listen` UNIX
+    /// socket libkrun bridges the guest shuttle to (see
+    /// [`resolve_switch_sock`]). Blocks only until gvproxy is spawned
+    /// and its PID known; supervision continues on the background runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns the I/O error if the runtime cannot be built, the config cannot
+    /// be written, or the gvproxy binary cannot be launched.
+    pub fn spawn(binary: PathBuf, switch_sock: PathBuf) -> io::Result<Self> {
+        let config = GvproxyConfig::new(binary, switch_sock);
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<io::Result<u32>>();
+
+        let thread = std::thread::Builder::new()
+            .name("minvmd-gvproxy".into())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        let _ = ready_tx.send(Err(e));
+                        return;
+                    }
+                };
+                runtime.block_on(async move {
+                    // Empty lease table: the guest assigns PTask IPs statically.
+                    let (switch, exit) = match config.spawn(&[]) {
+                        Ok(pair) => pair,
+                        Err(e) => {
+                            let _ = ready_tx.send(Err(e));
+                            return;
+                        }
+                    };
+                    let pid = switch.pid();
+                    if ready_tx.send(Ok(pid)).is_err() {
+                        // Caller went away before learning the PID; tear down.
+                        switch.stop().await;
+                        return;
+                    }
+                    // Wait for either an explicit stop or an unexpected gvproxy
+                    // exit, then tear down cleanly.
+                    tokio::select! {
+                        _ = stop_rx => {
+                            switch.stop().await;
+                        }
+                        status = exit.recv() => {
+                            tracing::error!(
+                                pid,
+                                code = status.and_then(|s| s.code()),
+                                "host gvproxy switch exited unexpectedly",
+                            );
+                            // gvproxy is already gone; drop the handle (no signal).
+                            drop(switch);
+                        }
+                    }
+                });
+            })?;
+
+        match ready_rx.recv() {
+            Ok(Ok(pid)) => Ok(Self {
+                stop_tx: Some(stop_tx),
+                thread: Some(thread),
+                pid,
+            }),
+            Ok(Err(e)) => {
+                let _ = thread.join();
+                Err(e)
+            }
+            // The runtime thread panicked before reporting; surface a clear error.
+            Err(_) => {
+                let _ = thread.join();
+                Err(io::Error::other(
+                    "host gvproxy supervisor thread exited before reporting readiness",
+                ))
+            }
+        }
+    }
+
+    /// The PID of the supervised gvproxy process.
+    #[must_use]
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    /// Stop the switch and join the supervising runtime thread.
+    pub fn stop(mut self) {
+        self.shutdown();
+    }
+
+    fn shutdown(&mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            // A failed send means the runtime thread already exited (e.g. gvproxy
+            // crashed); nothing more to signal.
+            let _ = stop_tx.send(());
+        }
+        if let Some(thread) = self.thread.take()
+            && thread.join().is_err()
+        {
+            tracing::warn!(pid = self.pid, "host gvproxy supervisor thread panicked");
+        }
+    }
+}
+
+impl Drop for HostGvproxy {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
 /// VM-wide egress policy stub (R2.5 / Unit 2), aligned with the per-PTask egress
 /// types: a VM may restrict all of its traffic to the listed subnets, DNS
 /// hosts, and protocols. An empty policy ([`VmEgressPolicy::allow_all`]) imposes
@@ -1256,6 +1400,52 @@ mod tests {
             Some(libc::ESRCH),
             "errno must be ESRCH — not a recycled-PID hit",
         );
+    }
+
+    #[test]
+    fn host_gvproxy_spawns_supervises_and_stops() {
+        // `sleep` stands in for gvproxy: HostGvproxy::spawn only needs a binary
+        // it can launch and read a PID from; the socket is dialed by libkrun in
+        // production, not by this supervisor. Use a temp socket path so no real
+        // file is needed (gvproxy would bind it; sleep ignores its argv).
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let sock = dir.path().join("gvproxy-switch.sock");
+        let gvproxy = HostGvproxy::spawn(PathBuf::from("sleep"), sock).expect("spawn host gvproxy");
+        let pid = gvproxy.pid();
+        assert!(
+            pid_is_alive(pid),
+            "host gvproxy should be alive after spawn"
+        );
+        gvproxy.stop();
+        // stop() signals SIGTERM and joins the supervising runtime thread, which
+        // only returns once gvproxy has been reaped.
+        assert!(
+            !pid_is_alive(pid),
+            "host gvproxy must be stopped after stop()"
+        );
+    }
+
+    #[test]
+    fn host_gvproxy_drop_stops_the_switch() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let sock = dir.path().join("gvproxy-switch.sock");
+        let gvproxy = HostGvproxy::spawn(PathBuf::from("sleep"), sock).expect("spawn host gvproxy");
+        let pid = gvproxy.pid();
+        assert!(pid_is_alive(pid));
+        drop(gvproxy);
+        assert!(
+            !pid_is_alive(pid),
+            "dropping HostGvproxy must stop the switch"
+        );
+    }
+
+    #[test]
+    fn host_gvproxy_spawn_reports_launch_failure() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let sock = dir.path().join("gvproxy-switch.sock");
+        let err = HostGvproxy::spawn(PathBuf::from("/nonexistent/definitely/not/gvproxy"), sock)
+            .expect_err("spawning a missing binary must fail");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
     }
 
     #[test]

--- a/crates/minvmd/src/net/shuttle.rs
+++ b/crates/minvmd/src/net/shuttle.rs
@@ -1,0 +1,84 @@
+//! Host↔guest plumbing for the per-PTask gvproxy vsock shuttle (issue #572).
+//!
+//! On DM1/DM3/DM4 (a libkrun VM) gvproxy runs on the **host**, supervised by
+//! `minvmd`, and listens on a host UNIX socket (the `-listen` switch socket; see
+//! [`crate::net::GvproxyConfig`]). An own-IP PTask lives inside the guest, where
+//! its tap device is provisioned in the PTask's netns. The guest cannot connect
+//! to the host UNIX socket directly, so each PTask runs a small **shuttle** that
+//! relays its tap's raw Ethernet frames over an AF_VSOCK connection to the host
+//! gvproxy. The shuttle is *not* a second TCP/IP stack — it is a pure L2 frame
+//! relay (the same HyperKit-framed protocol the DM2 native relay uses), so there
+//! is still exactly one gVisor stack in the path (the host gvproxy).
+//!
+//! libkrun provides the host↔guest vsock bridge. `minvmd` registers
+//! [`VSOCK_GVPROXY_SHUTTLE_PORT`] via
+//! `krun_add_vsock_port2(port, switch_sock, listen = false)`: with `listen =
+//! false` the guest *initiates* the connection (AF_VSOCK CID 2 / the host, the
+//! given port) and libkrun dials the host UNIX socket that gvproxy is listening
+//! on, splicing the two. This is the mirror image of the READY-marker port
+//! ([`crate::cmd::VSOCK_MARKER_PORT`]), which also uses `listen = false` for a
+//! guest-initiated connection.
+//!
+//! ```text
+//!  guest                              libkrun                 host
+//!  ┌──────────────┐  AF_VSOCK CID 2   ┌─────────┐  UNIX sock  ┌─────────┐
+//!  │ PTask tap fd │◀── shuttle ──────▶│ vsock   │◀───────────▶│ gvproxy │
+//!  │ (in netns)   │   raw L2 frames   │ bridge  │  switch sock│ (NAT)   │
+//!  └──────────────┘                   └─────────┘             └─────────┘
+//! ```
+
+use std::io;
+use std::path::PathBuf;
+
+/// vsock port the per-PTask guest shuttle connects to (AF_VSOCK CID 2 = host)
+/// to reach the host gvproxy switch (issue #572).
+///
+/// Distinct from [`crate::cmd::VSOCK_MARKER_PORT`] (7350, READY marker) and
+/// [`crate::sock::VSOCK_BRIDGE_PORT`] (2222, minimald SSH bridge). libkrun
+/// bridges this port to the host gvproxy `-listen` UNIX socket via
+/// `krun_add_vsock_port2(.., listen = false)`.
+pub const VSOCK_GVPROXY_SHUTTLE_PORT: u32 = 1024;
+
+/// Resolve the host UNIX socket path the gvproxy switch listens on.
+///
+/// Placed alongside the minimald bridge socket (same parent dir, already created
+/// with mode 0700 by [`crate::sock::prepare_socket_dir`]). libkrun's vsock
+/// bridge dials this path when the guest shuttle connects to
+/// [`VSOCK_GVPROXY_SHUTTLE_PORT`].
+///
+/// # Errors
+///
+/// Propagates [`crate::sock::resolve_uds_path`]'s error when neither
+/// `XDG_RUNTIME_DIR` nor a home directory can be determined.
+pub fn resolve_switch_sock() -> io::Result<PathBuf> {
+    let uds = crate::sock::resolve_uds_path()?;
+    Ok(uds
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join("gvproxy-switch.sock"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shuttle_port_is_distinct_from_other_vsock_ports() {
+        assert_ne!(VSOCK_GVPROXY_SHUTTLE_PORT, crate::cmd::VSOCK_MARKER_PORT);
+        assert_ne!(VSOCK_GVPROXY_SHUTTLE_PORT, crate::sock::VSOCK_BRIDGE_PORT);
+    }
+
+    #[test]
+    fn switch_sock_sits_beside_the_bridge_socket() {
+        // Pin XDG_RUNTIME_DIR so the path is deterministic; the switch socket
+        // shares the minimald bridge's parent dir.
+        // SAFETY: single-threaded test; restored before returning.
+        unsafe { std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000") };
+        let sock = resolve_switch_sock().unwrap();
+        unsafe { std::env::remove_var("XDG_RUNTIME_DIR") };
+        assert_eq!(
+            sock,
+            PathBuf::from("/run/user/1000/minimal/gvproxy-switch.sock")
+        );
+    }
+}

--- a/crates/minvmd/src/vm.rs
+++ b/crates/minvmd/src/vm.rs
@@ -217,6 +217,24 @@ impl VmConfig {
         // practical ceiling is ~62 concurrent connections on this port before
         // new ones queue. Acceptable for v0.1 workloads (<10 concurrent).
         ctx.add_vsock_port2(crate::sock::VSOCK_BRIDGE_PORT, &uds_path, true)?;
+
+        // Issue #572: per-PTask gvproxy shuttle bridge. An own-IP VM's guest
+        // shuttle connects to AF_VSOCK CID 2 (the host) on
+        // VSOCK_GVPROXY_SHUTTLE_PORT; with `listen = false` libkrun dials the
+        // host gvproxy `-listen` switch socket and splices the two, carrying raw
+        // L2 frames between the PTask tap and the host gvproxy (the single
+        // gVisor stack). Only registered for an own-IP VM — HostNet/NoNet never
+        // attach to the switch.
+        if self.is_own_ip() {
+            let switch_sock = crate::net::resolve_switch_sock()
+                .map_err(|source| crate::error::VmError::Io { source })?;
+            ctx.add_vsock_port2(crate::net::VSOCK_GVPROXY_SHUTTLE_PORT, &switch_sock, false)?;
+            tracing::info!(
+                port = crate::net::VSOCK_GVPROXY_SHUTTLE_PORT,
+                switch_sock = %switch_sock.display(),
+                "registered gvproxy shuttle vsock bridge for own-IP VM",
+            );
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## What & why

Wherever `minimald` runs inside a `minvmd` libkrun VM (DM1 macOS/HVF, DM3/DM4 Linux/KVM), gvproxy was being spawned **inside the guest**, which has no host uplink — so an `OwnIp` PTask got a `100.64.x.x` switch IP but no real egress. Per the spec (`docs/specs/03-spec-networking/{networking-with-diagrams.md,architecture.md}`, decisions `shared-gvproxy-per-host`, `minvmd-owns-vm-gvproxy`, `ownip-ptask-fd-pass`), gvproxy must run on the **host** (minvmd-owned) with a per-PTask **vsock shuttle** in the guest relaying raw L2 frames. DM2 (native Linux, no VM) is correct as-is and is left untouched.

## Design

```
 guest (minimald)                    libkrun                 host (minvmd)
 ┌──────────────┐  AF_VSOCK CID 2     ┌─────────┐  UNIX sock  ┌─────────┐
 │ PTask tap fd │◀── per-PTask ──────▶│ vsock   │◀───────────▶│ gvproxy │
 │ (in netns)   │   shuttle (raw L2)  │ bridge  │  switch sock│ (NAT)   │
 └──────────────┘                     └─────────┘             └─────────┘
```

Invariant preserved: exactly **one** gVisor TCP/IP stack in the path — the host gvproxy. The guest shuttle is a pure L2 frame relay (the same HyperKit `/connect` framing the DM2 native relay uses), **not** a second gvproxy.

### The three pieces

1. **minvmd spawns + supervises the host gvproxy** (`crates/minvmd`). New `net::HostGvproxy` RAII supervisor reuses the existing `GvproxyConfig::spawn`/`GvproxySwitch` on a dedicated current-thread tokio runtime (minvmd's `run`/`boot` supervisor is synchronous; the switch lifecycle is async). `run --foreground` spawns it before the VMM child boots — so the `-listen` switch socket exists when libkrun dials it — and holds the handle for the VM's lifetime (stop-on-drop). Started with an **empty** static-lease table: the guest configures each PTask's switch IP statically, so minvmd need not own the per-PTask address book.

2. **Per-PTask vsock shuttle** (`crates/minvmd/src/vm.rs` + `crates/minimald/src/net/switch.rs`). `VmConfig::apply` registers `add_vsock_port2(VSOCK_GVPROXY_SHUTTLE_PORT=1024, switch_sock, listen=false)` for an own-IP VM — `listen=false` means the guest initiates the vsock connection and libkrun dials the host gvproxy `-listen` socket, splicing the two (the same direction as the READY-marker port). In the guest, the switch relay was generalized: `attach_to_switch` (DM2, UDS) and the new `attach_to_switch_vsock` (DM1/3/4) share a transport-agnostic `spawn_relay`; the bidirectional frame loops already work over any `AsyncRead`/`AsyncWrite`.

3. **minimald deployment-model branch** (`crates/minimald`). New `net::SwitchTransport` enum (`LocalSpawn` vs `HostShuttle { cid, port }`) makes "spawn locally" and "shuttle to host" mutually exclusive in the type system. `GvproxySwitch::with_transport` selects it; in `HostShuttle` mode `attach()` skips the local gvproxy spawn/config and `attach_own_ip` relays the tap over vsock. **DM-detection signal:** the `vsock` listen-arg already cleanly distinguishes the libkrun-VM path (DM1/3/4) from the UDS path (DM2) in `main.rs` — it is the VM boundary. It is threaded through `Config::in_microvm` into the transport selection. (`is_minimal_microvm()` / argv0==`/init` is the same population, but `vsock` is the precise per-listener signal already at hand.) DM2 (`in_microvm=false`) keeps the local-spawn + tap-relay path verbatim.

## Verified

- `cargo fmt` — clean.
- `cargo build -p minvmd`, `cargo clippy -p minvmd --all-targets -- -D warnings` — clean (libkrun build on the macOS host).
- `cargo test -p minvmd` — 90 passed, incl. 3 new `HostGvproxy` tests (spawn/supervise/stop, drop-stops, launch-failure surfaces `NotFound`).
- minimald unit tests added + run under `cross test ... --lib net::` (QEMU): 39 passed, 0 failed — incl. `transport_defaults_to_local_spawn`, `with_transport_selects_host_shuttle`, and `host_shuttle_attach_allocates_without_spawning_gvproxy` (a `HostShuttle` switch attaches without spawning the binary).
- `cross build -p minimald --profile initramfs --target aarch64-unknown-linux-musl --features networking-proxy,networking-wg` — **succeeded** (`Finished initramfs profile`). Note: in this worktree the cross build initially failed in `crates/minimald/build.rs` (`git rev-parse` returns empty inside the container because the worktree's `.git` is a file pointing outside the mounted dir — a pre-existing build-script fragility, unrelated to this change); building with the parent `.git` bind-mounted into the container confirms the crate itself compiles clean.

## NOT verified (pending)

- **Full e2e egress (TC2/TC3/TC4):** a booted VM where an own-ip PTask resolves DNS + reaches the internet. This needs the seeded-cache disk from #573 and a manual VM boot; it is not runnable in this environment. The data-plane wiring is unit/compile-verified but the live frame round-trip through libkrun's vsock to the host gvproxy is unverified.
- **Own-IP VM CLI surface:** the VM network mode is selected via the `MINVMD_VM_OWN_IP` env var (read consistently by both the supervisor and the VMM child). No `minvmd` CLI flag is added — the VMM child still defaults to `HostNet` unless the env is set.
- **Ingress on the VM path:** gvproxy's port-forward HTTP API lives on its control socket, which on DM1/3/4 is host-side and unreachable from the guest over the frame-only shuttle. Egress (the #572 focus) needs no such call; static ingress on a VM own-IP PTask is currently **skipped with a warning** rather than silently appearing to work. A host-side ingress-API path is follow-up.

## Coordination

PR #575 (branch `feat/exec-in-session-ptask`, not merged) makes `attach_own_ip` `pub(crate)` and factors `build_session_env` in `session_host.rs`. This branch is based on origin/main (which lacks #575), so it carries the private versions. The `session_host.rs` `attach_own_ip` seam will need a trivial rebase against #575 whenever both land (per #575's note); the changes here are confined to the body of `attach_own_ip` and do not touch its signature beyond what #575 already changes.

Refs #572


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for “own-IP” VM networking with automatic host-side networking setup when enabled.
  * Introduced a new connection path so VM traffic can reach the host networking service through a vsock shuttle.

* **Bug Fixes**
  * Improved how networking is attached inside VMs, choosing the correct path for VM-based vs. native Linux environments.
  * Skips unsupported static port-forward setup in the new shuttle mode to avoid incorrect exposure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->