### PR TITLE
chore: add free-disk-space steps to some github actions

### DIFF
--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -55,6 +55,18 @@ jobs:
     runs-on: ubuntu-latest # x86_64; KVM-capable
     timeout-minutes: 60
     steps:
+      - name: Free Disk Space
+        # The full minvmd e2e (build + libkrun prefix + kernel image + rootfs
+        # image + cargo test) routinely exceeds the ~14 GB free on a fresh
+        # GitHub-hosted Ubuntu runner. `remove_tool_cache: true` reclaims
+        # `/opt/hostedtoolcache` (~14 GB); the dtolnay step below reinstalls
+        # the Rust toolchain we actually need.
+        uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
       - uses: actions/checkout@v6
         with:
           persist-credentials: false

--- a/.github/workflows/ci-netns.yml
+++ b/.github/workflows/ci-netns.yml
@@ -51,6 +51,16 @@ jobs:
     runs-on: ubuntu-latest # x86_64; unprivileged userns + sudo for netns/tap
     timeout-minutes: 30
     steps:
+      - name: Free Disk Space
+        # Headroom for the cargo target dir + rust-cache restore. Builds
+        # `minimald` + `sandbox2` + `minimald-rpc` test binaries plus the
+        # WG-gated mesh proof binary; the rust-cache restore alone pulls
+        # multi-GB of cached `target/`.
+        uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
       - uses: actions/checkout@v6
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,19 @@ jobs:
     timeout-minutes: 45
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
+      - name: Free Disk Space
+        # Static release build of the full workspace; the cargo target dir
+        # is the largest in any of the linux jobs. `remove_tool_cache: true`
+        # is safe even without a `dtolnay/rust-toolchain` step — the
+        # pre-installed Rust toolchain on ubuntu-latest lives in
+        # `~/.rustup` + `~/.cargo`, not `/opt/hostedtoolcache`, so
+        # `rustup target add` below still resolves.
+        uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
       - uses: actions/checkout@v6
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y musl-tools protobuf-compiler


### PR DESCRIPTION
We were running out of disk space in some CI workflows (see https://github.com/gominimal/minimal/actions/runs/28251278261/job/83703128010?pr=584). We have been using endersonmenezes/free-disk-space to free this in some other instances, so I've added it to a few other good candidates for it as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple CI jobs to reclaim disk space earlier by removing unused preinstalled components and clearing the tool cache before builds and integration tests.
  * Improves reliability on hosted runners by reducing the risk of running out of disk during compilation and caching steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->