### PR TITLE
[WIP] fix(minimal2): serialize concurrent attach establishment (#588)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3486,6 +3486,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "dirs",
+ "libc",
  "minimald-rpc",
  "minvmd",
  "ot",

--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -10,6 +10,7 @@ clap_complete.workspace = true
 camino.workspace = true
 chrono.workspace = true
 dirs.workspace = true
+libc.workspace = true
 minimald-rpc.workspace = true
 paths.workspace = true
 russh.workspace = true

--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -38,6 +38,11 @@ enum Command {
     /// Proxy stdio to a daemon UDS socket (used as an SSH ProxyCommand).
     #[command(hide = true)]
     Proxy(ProxyArgs),
+    /// Hold the attach-establishment lock briefly, then exit. Internal: spawned
+    /// by `attach` to serialize concurrent session handshakes around the libkrun
+    /// vsock concurrency bug (#588). Prints `ok` once the lock is held.
+    #[command(hide = true)]
+    AttachLock(AttachLockArgs),
     /// Forward a local TCP port to a remote address inside a PTask via SSH
     /// (R4.8, R4.9).
     ///
@@ -263,6 +268,18 @@ struct ProxyArgs {
     socket: String,
 }
 
+/// Arguments for the internal `attach-lock` helper.
+#[derive(Debug, Args)]
+struct AttachLockArgs {
+    /// Path to the establishment lock file to hold.
+    #[arg(long)]
+    lock_path: PathBuf,
+    /// Milliseconds to hold the lock after acquiring it (the establishment
+    /// window during which a concurrent attach must not race the handshake).
+    #[arg(long)]
+    window_ms: u64,
+}
+
 /// Arguments for `minimal ssh-forward`.
 #[derive(Debug, Args)]
 struct SshForwardArgs {
@@ -321,6 +338,7 @@ async fn main() -> Result<(), ()> {
             MeshCommand::Leave => cmd_mesh_leave(&cli.global_args),
         },
         Command::Proxy(args) => cmd_proxy(args).await,
+        Command::AttachLock(args) => cmd_attach_lock(args),
         Command::SshForward(args) => cmd_ssh_forward(&cli.global_args, args).await,
         Command::Login(args) => cmd_login(&cli.global_args, args).await,
         Command::Completions(CompletionsArgs { shell }) => {
@@ -576,6 +594,47 @@ async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), ()> {
     // depend on socat or nc being installed.
     let exe =
         std::env::current_exe().map_err(|e| eprintln!("cannot determine current exe: {e}"))?;
+
+    // Serialize attach establishment to dodge the libkrun vsock concurrency bug
+    // (#588): concurrent session handshakes racing through the host→guest muxer
+    // can leave one wedged. A short-lived detached holder takes an exclusive
+    // `flock` for the establishment window; we wait until it reports the lock is
+    // held, then exec ssh. A concurrent attach blocks on the same lock until this
+    // window elapses, so handshakes don't overlap. Best-effort: if the helper
+    // can't spawn we proceed unserialized rather than block the attach.
+    let window_ms: u64 = std::env::var("MINIMAL_ATTACH_ESTABLISH_WINDOW_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(4000);
+    if window_ms > 0 {
+        let lock_path = sock
+            .parent()
+            .map(|p| p.join(".attach-establish.lock"))
+            .unwrap_or_else(|| std::path::PathBuf::from("/tmp/.minimal-attach-establish.lock"));
+        match std::process::Command::new(&exe)
+            .arg("attach-lock")
+            .arg("--lock-path")
+            .arg(&lock_path)
+            .arg("--window-ms")
+            .arg(window_ms.to_string())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+        {
+            Ok(mut child) => {
+                // Block until the holder reports `ok` (lock acquired) or dies.
+                if let Some(mut out) = child.stdout.take() {
+                    use std::io::Read;
+                    let mut buf = [0u8; 3];
+                    let _ = out.read(&mut buf);
+                }
+                // Leave the holder running detached; it releases after the window.
+            }
+            Err(e) => {
+                tracing::warn!("attach-lock helper failed to spawn ({e}); attaching unserialized");
+            }
+        }
+    }
+
     let proxy_cmd = format!(
         "{} proxy --socket {}",
         shell_quote(&exe.display().to_string()),
@@ -615,6 +674,53 @@ async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), ()> {
     // exec() only returns on failure
     eprintln!("failed to exec ssh: {err}");
     Err(())
+}
+
+/// Internal helper spawned by `cmd_attach`: hold an exclusive establishment lock
+/// for a bounded window, then exit (releasing it).
+///
+/// Works around the libkrun vsock concurrency bug (#588) where concurrent session
+/// handshakes racing through the host→guest muxer can leave one wedged. By holding
+/// this lock for the establishment window, concurrent attaches serialize their
+/// handshakes (the next blocks until the current window elapses) instead of
+/// racing. Prints `ok` to stdout once the lock is held so the parent can exec
+/// ssh, then keeps holding it in the background until the window expires.
+///
+/// Uses a blocking `flock(LOCK_EX)` — the same primitive `lcache` uses for its
+/// read-tracker, minus `LOCK_NB` so a contender waits rather than failing. flock
+/// works on Darwin (BSD) and Linux alike, and the lock is tied to the open file
+/// description, so it releases when this process exits.
+fn cmd_attach_lock(args: AttachLockArgs) -> Result<(), ()> {
+    use std::io::Write;
+    use std::os::unix::io::AsRawFd;
+
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false) // the file is only a flock target; never written
+        .open(&args.lock_path)
+        .map_err(|e| eprintln!("attach-lock: open {}: {e}", args.lock_path.display()))?;
+
+    // Block until the exclusive lock is held; a concurrent holder releases it
+    // when its own window elapses (and on process exit).
+    // SAFETY: `file` owns a valid open fd for the duration of this call.
+    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if ret != 0 {
+        eprintln!(
+            "attach-lock: flock {}: {}",
+            args.lock_path.display(),
+            std::io::Error::last_os_error()
+        );
+        return Err(());
+    }
+
+    // Signal the parent that establishment may proceed.
+    println!("ok");
+    let _ = std::io::stdout().flush();
+
+    std::thread::sleep(std::time::Duration::from_millis(args.window_ms));
+    // `file` drops here, closing the fd and releasing the flock.
+    Ok(())
 }
 
 /// Print the effective networking policy for a session as JSON.


### PR DESCRIPTION
Mitigation for [#588](https://github.com/gominimal/minimal/issues/588): a second overlapping `minimal2 attach` to an own-ip session wedges (no shell).

Stacked on [#581](https://github.com/gominimal/minimal/pull/581) (base branch `feat/networking-host-exposure`) because it depends on that PR's own-ip attach path.

## Root cause
Two own-ip session SSH handshakes racing through **libkrun's host→guest virtio-vsock muxer** leave one session wedged — its `RequestShell` is never delivered to `session_host`, so the second concurrent attach hangs. Verified the defect is in libkrun's vsock device under concurrent connections (not `tokio-vsock`, which is correct; not minimald logic). libkrun 1.19.0 fixed only the *sequential* direct-vsock case. Full investigation in [#588](https://github.com/gominimal/minimal/issues/588).

## Fix (in-repo workaround, pending the upstream libkrun fix)
`minimal2 attach` spawns a short-lived detached `attach-lock` helper that holds an exclusive `flock` for a bounded establishment window (default 4000ms, `MINIMAL_ATTACH_ESTABLISH_WINDOW_MS`) before exec-ing ssh:

- A concurrent attach blocks on the same lock and starts its SSH handshake ~one window later, so the racy handshake/`RequestShell` phase is **serialized** instead of overlapping the muxer.
- Single attaches are uncontended — the parent only waits for the lock-acquired signal, not the full window — so steady-state latency is unchanged.
- `exec ssh` is preserved (clean interactive TTY); the helper holds the lock in the background and releases on window expiry.

## Verification (macOS/HVF, DM1)
- Two concurrent own-ip attaches both reach a shell with working egress: **3/3** rounds (HTTP 200 each), **20/20** establish-only. Daemon boot.log confirms both get `RequestShell` + `attached OwnIp PTask`, with session B attaching ~4s after A (the flock window).
- Pre-fix: first-spawned wedged **3/3**.
- `cargo fmt` / `cargo clippy -p minimal2 --all-targets -D warnings` / `cargo test -p minimal2` clean.

## Notes
- Unblocks concurrent own-ip sessions (e.g. `docs/specs/03-spec-networking/test-plan.sh` TC2 same-host peer) without waiting on the upstream libkrun fix.
- The upstream defect remains tracked in [#588](https://github.com/gominimal/minimal/issues/588); a draft upstream issue (with the build/repro notes) is prepared for containers/libkrun.

References: [#588](https://github.com/gominimal/minimal/issues/588)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attach reliability by reducing race conditions when starting interactive sessions.
  * Added a short coordination window during connection setup to help prevent intermittent failures in environments with socket concurrency issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->