### PR TITLE
feat(minimald): refactor progress, display session setup on first attach

### DIFF
--- a/crates/minimald/src/channel_progress.rs
+++ b/crates/minimald/src/channel_progress.rs
@@ -1,0 +1,57 @@
+//! Scoped progress rendering onto an SSH channel.
+//!
+//! [`ChannelProgress`] is the `russh`-concrete wrapper around
+//! [`ot::render_operations_while`]: it consumes an SSH [`Channel`], an
+//! [`OpTracker`], and a future, paints the tracker's live operation tree onto
+//! the channel as indicatif progress bars while the future runs, and hands the
+//! channel back (with the future's output) once it resolves.
+//!
+//! The renderer takes **exclusive** use of the channel for the future's
+//! duration — the wrapped operation must not also write to it. This is the
+//! "compute under a progress bar, then print the result" model; live output
+//! interleaved with progress is out of scope (see
+//! `docs/specs/04-spec-ot-render-decoupling`).
+
+use std::future::Future;
+
+use ot::OpTracker;
+use russh::Channel;
+use russh::server::Msg;
+
+/// Renders an [`OpTracker`] onto an SSH channel for the lifetime of a future.
+///
+/// Construct with [`ChannelProgress::new`], then drive a future with
+/// [`run`](ChannelProgress::run); the channel is returned alongside the
+/// future's output so the caller can resume writing to it.
+pub struct ChannelProgress {
+    channel: Channel<Msg>,
+    tracker: OpTracker,
+    /// Terminal dimensions `(cols, rows)` indicatif lays bars out against —
+    /// from the session's PTY size.
+    size: (u16, u16),
+}
+
+impl ChannelProgress {
+    /// Creates a renderer that will paint `tracker` onto `channel`, sized for a
+    /// `(cols, rows)` terminal.
+    #[must_use]
+    pub fn new(channel: Channel<Msg>, tracker: OpTracker, size: (u16, u16)) -> Self {
+        Self {
+            channel,
+            tracker,
+            size,
+        }
+    }
+
+    /// Renders progress onto the channel while `fut` runs, returning the channel
+    /// and the future's output once it resolves.
+    ///
+    /// The channel is borrowed (via an independent writer) during rendering and
+    /// returned intact — the writer only ever writes data frames, never an EOF,
+    /// so the caller can keep using the channel afterwards.
+    pub async fn run<F: Future>(self, fut: F) -> (Channel<Msg>, F::Output) {
+        let writer = self.channel.make_writer();
+        let out = ot::render_operations_while(&self.tracker, writer, self.size, fut).await;
+        (self.channel, out)
+    }
+}

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+pub mod channel_progress;
 pub mod connection;
 pub mod env;
 mod exec;

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1,8 +1,10 @@
+use crate::channel_progress::ChannelProgress;
 use crate::{
     ChannelConfig,
     session_host::{self, HostAttrs, WinSize},
 };
 use mctx::ConfigBuilder;
+use ot::OpTracker;
 use paths::DaemonAbsPath;
 use russh::{Channel, server::Msg};
 use sessions::{Record, store::SessionObject};
@@ -92,6 +94,12 @@ pub struct Session<S: SessionObject> {
         session_host::HostHandle,
         JoinHandle<Result<i32, std::io::Error>>,
     )>,
+
+    /// The root of this session's operation tree. Created once for the session
+    /// and wired into the context each launch builds against, so package
+    /// fetches/builds report into it; the channel renderer paints it onto the
+    /// SSH channel while a host is being minted.
+    tracker: OpTracker,
 }
 
 impl<S: SessionObject> Session<S> {
@@ -114,6 +122,7 @@ impl<S: SessionObject> Session<S> {
             minimal_state_dir,
             minimal_cache_dir,
             net_switch,
+            tracker: OpTracker::new_root(),
         };
 
         tokio::spawn(mngr.mainloop());
@@ -231,17 +240,34 @@ impl<S: SessionObject> Session<S> {
             }
         };
 
+        // The launcher's context reports into this session's operation tree (see
+        // `context`). Render that tree onto the channel for the duration of the
+        // launch (graph build + package builds + sandbox assembly), then take
+        // the channel back. The host is spawned without a channel so the
+        // renderer has exclusive use of it while building; once the bars are
+        // cleared we attach the channel to the now-running host.
         let launcher = self.session_launcher(session_hnd)?;
-        let h = Box::pin(session_host::Host::spawn(
-            launcher,
-            name,
-            conn_username,
-            self.paths(),
-            sz,
-            Some(channel),
-        ))
-        .await
-        .map_err(AttachError::SpawnFailed)?;
+        let progress = ChannelProgress::new(channel, self.tracker.clone(), (sz.cols, sz.rows));
+        let (channel, spawned) = progress
+            .run(Box::pin(session_host::Host::spawn(
+                launcher,
+                name,
+                conn_username,
+                self.paths(),
+                sz,
+                None,
+            )))
+            .await;
+        let h = spawned.map_err(AttachError::SpawnFailed)?;
+
+        // Wire the channel to the freshly launched host. A failure here means
+        // the host died in the window between launch and attach; surface it as
+        // a spawn failure rather than leaving a dead, channel-less host.
+        h.0.attach(channel, sz).await.map_err(|_| {
+            AttachError::SpawnFailed(std::io::Error::other(
+                "session host exited before its channel could attach",
+            ))
+        })?;
         self.host = Some(h);
         Ok(())
     }
@@ -296,6 +322,11 @@ impl<S: SessionObject> Session<S> {
             .with_repo_dir(wsp.as_utf8_path())
             .with_cache_dir(self.minimal_cache_dir.as_utf8_path())
             .with_state_dir(self.minimal_state_dir.as_utf8_path())
+            // Every context this session builds reports into its operation tree.
+            // The host-mint path renders that tree onto the SSH channel; the
+            // task-exec path (via `MakeContext`) also feeds it, so task builds
+            // surface on the same tracker even though only a mint renders it.
+            .with_operation_tracker(self.tracker.clone())
             .build()
         {
             Err(e) => Err(mctx::Error::from(e).to_string()),

--- a/crates/ot/Cargo.toml
+++ b/crates/ot/Cargo.toml
@@ -8,13 +8,18 @@ publish.workspace = true
 
 [features]
 default = ["indicatif"]
-# The indicatif renderer (legacy single-terminal CLI path). Disable to build the
-# pure operation-tracking core with no rendering dependency.
-indicatif = ["dep:indicatif", "tokio/rt"]
+# The indicatif renderer (legacy single-terminal CLI path) and the scoped
+# per-sink renderer. Disable to build the pure operation-tracking core with no
+# rendering dependency.
+indicatif = ["dep:indicatif", "tokio/rt", "tokio/macros", "tokio/io-util"]
 
 [dependencies]
 indicatif = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync"] }
 
+# `rt-multi-thread` is test-only: `render_operations_while`'s integration test
+# runs on a `#[tokio::test(flavor = "multi_thread")]` runtime so its pump task
+# drains concurrently with the driven future. Production code needs only `rt`
+# (see the `indicatif` feature), so this stays out of the production deps.
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "time"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/ot/src/indicatif_shim.rs
+++ b/crates/ot/src/indicatif_shim.rs
@@ -12,14 +12,32 @@
 //! it. See `docs/specs/04-spec-ot-render-decoupling`.
 
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::io;
 use std::mem::Discriminant;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle, TermLike};
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::sync::mpsc;
 
 use crate::{OpId, OpSnapshot, OpTracker, Operation};
+
+/// Redraw rate (Hz) for the per-channel renderer. Bounds how often the full bar
+/// block is repainted onto the (potentially slow) sink, regardless of how many
+/// spinner ticks or state changes occur. Low enough to keep a remote link
+/// uncongested, high enough that the spinner still reads as smooth motion.
+const REMOTE_REFRESH_HZ: u8 = 12;
+
+/// Begin Synchronized Update — DEC private mode 2026. A terminal that supports
+/// it buffers everything until the matching [`END_SYNC_UPDATE`] and applies the
+/// frame in one atomic swap, so a clear-then-redraw never shows a half-painted
+/// (flickering) intermediate state. Terminals that don't recognise the mode
+/// ignore it harmlessly.
+const BEGIN_SYNC_UPDATE: &[u8] = b"\x1b[?2026h";
+/// End Synchronized Update — see [`BEGIN_SYNC_UPDATE`].
+const END_SYNC_UPDATE: &[u8] = b"\x1b[?2026l";
 
 /// The process-global `MultiProgress` representing the single CLI terminal,
 /// shared by the renderer and [`StdoutWriter`] so plain stdout writes can
@@ -38,6 +56,182 @@ fn global_progress() -> MultiProgress {
 /// `#[tokio::main]`).
 pub fn render_to_stderr(root: OpTracker) {
     tokio::spawn(IndicatifShim::new(global_progress()).run(root));
+}
+
+/// Renders `root`'s operation tree as indicatif progress bars onto an arbitrary
+/// async byte sink for as long as `fut` is pending, returning `fut`'s output.
+///
+/// This is the render-agnostic core of the daemon's scoped progress path: it
+/// takes **exclusive** use of `sink` while `fut` runs (the wrapped operation
+/// must not also write to it), paints the live tree there, and on completion
+/// clears the bars and flushes before returning — so the caller can hand the
+/// sink (e.g. an SSH channel) back and resume writing to it. Generic over the
+/// sink so it is testable against an in-memory pipe; `minimald` wraps it with a
+/// `russh` channel.
+///
+/// `size` is `(cols, rows)` — the terminal dimensions indicatif lays bars out
+/// against. Must be supplied by the caller (from the session's PTY size); there
+/// is deliberately no hardcoded fallback.
+///
+/// Must be called from within a Tokio runtime: a background task pumps rendered
+/// bytes to `sink`, and `fut` is driven on the current task.
+pub async fn render_operations_while<W, F>(
+    root: &OpTracker,
+    sink: W,
+    size: (u16, u16),
+    fut: F,
+) -> F::Output
+where
+    W: AsyncWrite + Unpin + Send + 'static,
+    F: Future,
+{
+    // indicatif draws synchronously from its own steady-tick threads, which must
+    // never block on an async write. A `TermLike` shim turns each draw into a
+    // frame of ANSI bytes pushed onto this channel; the pump task owns `sink`
+    // and writes the frames. Unbounded because a frame is a stateful cursor
+    // sequence — dropping one mid-stream under backpressure would corrupt the
+    // render — and frames are small and rate-limited by indicatif's refresh.
+    let (tx, rx) = mpsc::unbounded_channel();
+    let pump = tokio::spawn(pump_frames(rx, sink));
+
+    let (cols, rows) = size;
+    let term = ChannelTerm::new(cols, rows, tx);
+    // `term_like` (the no-`hz` constructor) installs *no* rate limiter, so
+    // indicatif redraws the whole bar block on every spinner tick *and* every
+    // state mutation. Over a slow SSH link those frames pile up faster than the
+    // wire can drain them, wasting bandwidth and amplifying flicker. Cap the
+    // redraw rate so the spinner still animates smoothly but far fewer full
+    // repaints cross the wire.
+    let mp = MultiProgress::with_draw_target(ProgressDrawTarget::term_like_with_hz(
+        Box::new(term),
+        REMOTE_REFRESH_HZ,
+    ));
+
+    // `render_while` clears the bars on completion, then dropping the shim drops
+    // the `MultiProgress` and the `ChannelTerm`, closing `tx`.
+    let out = IndicatifShim::new(mp).render_while(root, fut).await;
+
+    // `tx` is now dropped, so the pump drains the final frames (including the
+    // clear) and exits; await it so every byte reaches `sink` before returning.
+    let _ = pump.await;
+    out
+}
+
+/// Drains rendered ANSI frames onto the sink until the renderer drops its
+/// sender, flushing after each so progress appears promptly. A write error
+/// (the remote went away) just ends the pump; the renderer's own teardown is
+/// unaffected.
+async fn pump_frames<W: AsyncWrite + Unpin>(mut rx: mpsc::UnboundedReceiver<Vec<u8>>, mut sink: W) {
+    while let Some(frame) = rx.recv().await {
+        if sink.write_all(&frame).await.is_err() || sink.flush().await.is_err() {
+            return;
+        }
+    }
+}
+
+/// An indicatif [`TermLike`] that renders into ANSI byte frames instead of a
+/// real terminal.
+///
+/// indicatif's draw calls (cursor moves, line writes, clears) are translated to
+/// the equivalent escape sequences and accumulated in `buf`; a draw ends with
+/// [`flush`](TermLike::flush), at which point the whole frame is sent as one
+/// message — coalescing a draw into a single sink write. Newlines are emitted as
+/// `\r\n` so the render is correct on a raw channel with no `ONLCR` translation
+/// (mirroring the net effect indicatif relies on from a cooked TTY).
+#[derive(Debug)]
+struct ChannelTerm {
+    cols: u16,
+    rows: u16,
+    tx: mpsc::UnboundedSender<Vec<u8>>,
+    // Interior mutability: `TermLike` is all `&self`. A sync `Mutex` is fine —
+    // it is never held across an `.await` (these methods are synchronous, called
+    // from indicatif's draw, not from async code).
+    buf: Mutex<Vec<u8>>,
+}
+
+impl ChannelTerm {
+    fn new(cols: u16, rows: u16, tx: mpsc::UnboundedSender<Vec<u8>>) -> Self {
+        Self {
+            cols,
+            rows,
+            tx,
+            buf: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn push(&self, bytes: &[u8]) {
+        self.buf
+            .lock()
+            .expect("ChannelTerm buf poisoned")
+            .extend_from_slice(bytes);
+    }
+
+    /// Emits a Cursor Up/Down/Forward/Back sequence, skipping the no-op `n == 0`
+    /// case (`CSI 0 <x>` still moves one cell on some terminals).
+    fn move_cursor(&self, n: usize, dir: u8) -> io::Result<()> {
+        if n > 0 {
+            self.push(format!("\x1b[{n}{}", dir as char).as_bytes());
+        }
+        Ok(())
+    }
+}
+
+impl TermLike for ChannelTerm {
+    fn width(&self) -> u16 {
+        self.cols
+    }
+    fn height(&self) -> u16 {
+        self.rows
+    }
+
+    fn move_cursor_up(&self, n: usize) -> io::Result<()> {
+        self.move_cursor(n, b'A')
+    }
+    fn move_cursor_down(&self, n: usize) -> io::Result<()> {
+        self.move_cursor(n, b'B')
+    }
+    fn move_cursor_right(&self, n: usize) -> io::Result<()> {
+        self.move_cursor(n, b'C')
+    }
+    fn move_cursor_left(&self, n: usize) -> io::Result<()> {
+        self.move_cursor(n, b'D')
+    }
+
+    fn write_line(&self, s: &str) -> io::Result<()> {
+        self.push(s.as_bytes());
+        self.push(b"\r\n");
+        Ok(())
+    }
+    fn write_str(&self, s: &str) -> io::Result<()> {
+        self.push(s.as_bytes());
+        Ok(())
+    }
+    fn clear_line(&self) -> io::Result<()> {
+        // Carriage-return to column 0, then erase to end of line.
+        self.push(b"\r\x1b[K");
+        Ok(())
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        // End of a draw (indicatif calls `flush` exactly once per complete
+        // redraw): ship the accumulated frame as one message. An empty buffer
+        // means nothing was drawn, so send nothing. A closed receiver (pump
+        // gone) is ignored — the render tears down on its own.
+        let frame = std::mem::take(&mut *self.buf.lock().expect("ChannelTerm buf poisoned"));
+        if !frame.is_empty() {
+            // Bracket the whole redraw in a synchronized update so a supporting
+            // terminal swaps it in atomically rather than flickering through the
+            // clear-then-rewrite. The wrapper is harmless on terminals that
+            // don't implement it.
+            let mut msg =
+                Vec::with_capacity(BEGIN_SYNC_UPDATE.len() + frame.len() + END_SYNC_UPDATE.len());
+            msg.extend_from_slice(BEGIN_SYNC_UPDATE);
+            msg.extend_from_slice(&frame);
+            msg.extend_from_slice(END_SYNC_UPDATE);
+            let _ = self.tx.send(msg);
+        }
+        Ok(())
+    }
 }
 
 /// Observes an [`OpTracker`] tree and renders it as a stack of `indicatif`
@@ -63,20 +257,49 @@ impl IndicatifShim {
         }
     }
 
-    /// Drives the renderer until `root` is dropped: render the current state,
-    /// then repaint on each change. Intended to be `tokio::spawn`ed.
+    /// Drives the renderer: render the current state, then repaint on each
+    /// change. Intended to be `tokio::spawn`ed for the life of the CLI process,
+    /// which holds the only handle that joins it; the task owns `root`, so the
+    /// `Err` arm (every tree handle dropped) does not fire here — it is the
+    /// clean-exit path a daemon driver, holding `root` elsewhere, would use.
     pub async fn run(mut self, root: OpTracker) {
-        let mut last = root.version();
+        let mut rx = root.subscribe();
         self.reconcile(&root.snapshot());
-        loop {
-            root.changed().await;
-            let v = root.version();
-            if v == last {
-                continue;
-            }
-            last = v;
+        while rx.changed().await.is_ok() {
             self.reconcile(&root.snapshot());
         }
+    }
+
+    /// Renders `root` onto this shim's draw target for as long as `fut` is
+    /// pending, then clears the bars and returns `fut`'s output.
+    ///
+    /// Unlike [`run`](Self::run), which renders for the life of the tree, this
+    /// is *scoped* to a single future: it `select!`s repaints (driven by
+    /// [`OpTracker::subscribe`]) against `fut`'s completion. When `fut`
+    /// resolves it clears the bars; dropping `self` afterwards tears down the
+    /// `MultiProgress` (and, for the channel renderer, the byte sink behind it).
+    /// Spinner animation comes from indicatif's own steady-tick threads, so no
+    /// tick is needed in the loop.
+    pub async fn render_while<F: Future>(mut self, root: &OpTracker, fut: F) -> F::Output {
+        let mut rx = root.subscribe();
+        self.reconcile(&root.snapshot());
+        let mut fut = std::pin::pin!(fut);
+        let out = loop {
+            tokio::select! {
+                out = &mut fut => break out,
+                changed = rx.changed() => match changed {
+                    // A mutation landed: repaint from a fresh snapshot.
+                    Ok(()) => self.reconcile(&root.snapshot()),
+                    // Every tree handle was dropped while `fut` is still
+                    // pending; there is nothing left to render, so just await
+                    // the future without touching the (now-static) tree.
+                    Err(_) => break fut.await,
+                },
+            }
+        };
+        // Erase the bars before handing the sink back / dropping it.
+        let _ = self.mp.clear();
+        out
     }
 
     /// Brings the live bars in line with `snap`: create bars for newly active
@@ -270,6 +493,7 @@ impl io::Write for StdoutWriter {
 #[cfg(test)]
 mod tests {
     use indicatif::ProgressDrawTarget;
+    use tokio::io::AsyncReadExt;
 
     use super::*;
     use crate::CheckKind;
@@ -315,6 +539,74 @@ mod tests {
         shim.reconcile(&root.snapshot());
         assert_eq!(shim.bars.len(), 1);
         assert!(shim.bars.contains_key(&id));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn render_operations_while_returns_output_and_paints() {
+        // Read end of the pipe stands in for the SSH channel's far side; the
+        // renderer writes ANSI frames into the write end while the future runs.
+        let (mut read, write) = tokio::io::duplex(64 * 1024);
+
+        let root = OpTracker::new_root();
+        let op_root = root.clone();
+        // A future that, once running, drives some visible progress then
+        // resolves with a value the renderer must hand back untouched.
+        let fut = async move {
+            let child = op_root.new_child();
+            child.set_op(Operation::FetchPkg {
+                name: "demo".into(),
+            });
+            child.set_length(100);
+            for _ in 0..10 {
+                child.increment(10);
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            child.set_done();
+            42usize
+        };
+
+        let out = render_operations_while(&root, write, (80, 24), fut).await;
+        assert_eq!(out, 42, "the wrapped future's output is returned verbatim");
+
+        // The far side received a non-empty ANSI render naming the operation.
+        let mut buf = Vec::new();
+        read.read_to_end(&mut buf).await.expect("read pipe");
+        assert!(!buf.is_empty(), "progress bytes should have been written");
+        let text = String::from_utf8_lossy(&buf);
+        assert!(
+            text.contains("demo"),
+            "rendered frames mention the op: {text:?}"
+        );
+        assert!(text.contains('\x1b'), "frames contain ANSI escapes");
+    }
+
+    #[test]
+    fn channel_term_translates_draw_calls_to_ansi_frame() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let term = ChannelTerm::new(80, 24, tx);
+        assert_eq!(term.width(), 80);
+        assert_eq!(term.height(), 24);
+
+        // A representative draw: move up, return to col 0, clear, write a line.
+        term.move_cursor_up(2).unwrap();
+        term.write_str("\r").unwrap();
+        term.clear_line().unwrap();
+        term.write_line("bar").unwrap();
+        // Nothing is shipped until flush coalesces the frame.
+        assert!(rx.try_recv().is_err(), "no frame before flush");
+        term.flush().unwrap();
+
+        let frame = rx.try_recv().expect("a frame after flush");
+        // The draw bytes, bracketed in a synchronized-update (BSU…ESU) so a
+        // supporting terminal applies the whole frame atomically.
+        assert_eq!(
+            frame,
+            b"\x1b[?2026h\x1b[2A\r\r\x1b[Kbar\r\n\x1b[?2026l".to_vec()
+        );
+        // An empty draw flushes nothing — not even the synchronized-update
+        // wrapper, which would otherwise be an empty atomic frame.
+        term.flush().unwrap();
+        assert!(rx.try_recv().is_err(), "empty draw sends no frame");
     }
 
     #[test]

--- a/crates/ot/src/lib.rs
+++ b/crates/ot/src/lib.rs
@@ -7,12 +7,12 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-use tokio::sync::Notify;
+use tokio::sync::watch;
 
 #[cfg(feature = "indicatif")]
 mod indicatif_shim;
 #[cfg(feature = "indicatif")]
-pub use indicatif_shim::{IndicatifShim, StdoutWriter, render_to_stderr};
+pub use indicatif_shim::{IndicatifShim, StdoutWriter, render_operations_while, render_to_stderr};
 
 #[derive(Debug, Clone)]
 pub enum CheckKind {
@@ -65,26 +65,34 @@ pub struct Progress {
 ///
 /// Created once per root (see [`OpTracker::new_root`]) and cloned into each
 /// child so the whole tree shares one change counter and wakeup primitive.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct RootShared {
-    /// Bumped on every mutation anywhere in the tree. The source of truth a
-    /// driver polls to decide whether a repaint is due.
-    version: AtomicU64,
-    /// Wakeup for the tree's driver awaiting the next change. A tree has a
-    /// single consumer (one renderer per root), so `notify_one` is used: a
-    /// mutation that races ahead of the driver leaves a stored permit rather
-    /// than being lost, and `version` reconciles coalesced bumps.
-    notify: Notify,
+    /// Monotonic change counter, bumped on every mutation anywhere in the tree,
+    /// carried as the value of a [`watch`] channel. `watch` supports any number
+    /// of independent receivers (one per renderer/driver), each woken on change
+    /// and tracking its own last-seen version — so multiple drivers (e.g. a CLI
+    /// stderr renderer plus a logger, or two terminals attached to one daemon
+    /// session) can observe the same root without missed wakeups.
+    version: watch::Sender<u64>,
     /// Allocator for [`OpId`]s within this tree.
     next_id: AtomicU64,
 }
 
+impl Default for RootShared {
+    fn default() -> Self {
+        // The initial receiver is dropped; drivers obtain their own via
+        // `Sender::subscribe`, which works even with no live receivers.
+        Self {
+            version: watch::channel(0).0,
+            next_id: AtomicU64::new(0),
+        }
+    }
+}
+
 impl RootShared {
-    /// Records a mutation: bump the version and wake the driver (or leave a
-    /// permit if it is not currently parked).
+    /// Records a mutation: bump the version, waking every subscribed driver.
     fn bump(&self) {
-        self.version.fetch_add(1, Ordering::Relaxed);
-        self.notify.notify_one();
+        self.version.send_modify(|v| *v += 1);
     }
 
     /// Allocates the next unique [`OpId`] for this tree (root is `0`).
@@ -263,24 +271,20 @@ impl OpTracker {
     /// Returns the tree's current change version. Increases on every mutation
     /// anywhere in the tree; a driver polls this to decide whether to repaint.
     pub fn version(&self) -> u64 {
-        self.inner
-            .lock()
-            .unwrap()
-            .shared
-            .version
-            .load(Ordering::Relaxed)
+        *self.inner.lock().unwrap().shared.version.borrow()
     }
 
-    /// Awaits the next change anywhere in the tree.
+    /// Subscribes to changes anywhere in the tree, returning a [`watch`]
+    /// receiver carrying the change [`version`](Self::version).
     ///
-    /// [`version`](Self::version) is the source of truth; pair the two. The
-    /// tree assumes a single consumer (one renderer per root): a mutation that
-    /// races ahead of an un-parked driver leaves a stored permit, so the next
-    /// `changed()` returns immediately rather than missing the update. Drivers
-    /// render, read the version, `await changed()`, then re-check the version.
-    pub async fn changed(&self) {
-        let shared = self.inner.lock().unwrap().shared.clone();
-        shared.notify.notified().await;
+    /// Each driver owns its own receiver and tracks its own last-seen version,
+    /// so any number of drivers can observe the same root concurrently. The
+    /// typical loop renders, then `rx.changed().await` (which also returns
+    /// immediately if the version advanced since the last `borrow_and_update`),
+    /// then re-snapshots. `changed()` resolves to `Err` once the tree is
+    /// dropped, giving drivers a clean exit.
+    pub fn subscribe(&self) -> watch::Receiver<u64> {
+        self.inner.lock().unwrap().shared.version.subscribe()
     }
 }
 
@@ -550,15 +554,38 @@ mod tests {
     async fn changed_wakes_on_mutation() {
         let root = OpTracker::new_root();
         let child = root.new_child();
-        let waiter = root.clone();
-        // Register the wait, then mutate from another task; the notify must wake.
-        let h = tokio::spawn(async move { waiter.changed().await });
+        let mut rx = root.subscribe();
+        // Register the wait, then mutate from another task; the watch must wake.
+        let h = tokio::spawn(async move { rx.changed().await });
         // Yield so the spawned task reaches the await point before we notify.
         tokio::task::yield_now().await;
         child.set_op(Operation::PackageBuild { name: "x".into() });
         tokio::time::timeout(Duration::from_secs(1), h)
             .await
             .expect("changed() should wake within timeout")
-            .expect("waiter task should not panic");
+            .expect("waiter task should not panic")
+            .expect("watch sender should be alive");
+    }
+
+    #[tokio::test]
+    async fn two_concurrent_watchers_both_wake_on_mutation() {
+        // The multi-consumer guarantee `watch` buys us over `notify_one`: a
+        // single mutation wakes *every* subscribed driver, not just one.
+        let root = OpTracker::new_root();
+        let child = root.new_child();
+        let mut rx1 = root.subscribe();
+        let mut rx2 = root.subscribe();
+        let h1 = tokio::spawn(async move { rx1.changed().await });
+        let h2 = tokio::spawn(async move { rx2.changed().await });
+        // Yield so both watchers are parked before the mutation lands.
+        tokio::task::yield_now().await;
+        child.set_op(Operation::PackageBuild { name: "x".into() });
+        for h in [h1, h2] {
+            tokio::time::timeout(Duration::from_secs(1), h)
+                .await
+                .expect("both watchers should wake within timeout")
+                .expect("watcher task should not panic")
+                .expect("watch sender should be alive");
+        }
     }
 }

--- a/docs/specs/04-spec-ot-render-decoupling/04-spec-ot-render-decoupling.md
+++ b/docs/specs/04-spec-ot-render-decoupling/04-spec-ot-render-decoupling.md
@@ -95,15 +95,19 @@ struct TrackerInner {
 }
 
 struct RootShared {
-    version: AtomicU64,               // bumped on every mutation
-    notify: tokio::sync::Notify,      // wakes async drivers; notify_* is sync-callable
+    version: tokio::sync::watch::Sender<u64>, // bumped on every mutation; the
+                                              // channel value *is* the counter
     next_id: AtomicU64,
 }
 ```
 
 Every mutator (`set_op`, `set_done`, `set_length`, `increment`) bumps `version`
-and notifies — both callable from sync code, so the synchronous build threads in
-`op`/`graph` are unchanged and still wake the async renderer.
+via `send_modify` — callable from sync code, so the synchronous build threads in
+`op`/`graph` are unchanged and still wake the async renderer. `watch` (not
+`Notify`) is used so **any number of drivers** can observe one root: each holds
+its own `watch::Receiver`, every bump wakes all of them, and each tracks its own
+last-seen version with no missed wakeups. (A single `notify_one` would wake only
+one of several waiters.)
 
 `OpTracker`'s public mutation API (`with_op`, `set_op`, `set_done`,
 `set_length`, `increment`, `new_child`, `depth`) stays **identical**, so the
@@ -139,8 +143,8 @@ impl OpTracker {
     pub fn snapshot(&self) -> Vec<OpSnapshot>;
     /// Current change version; cheap to poll.
     pub fn version(&self) -> u64;
-    /// Await the next change (best-effort wake; pair with version()).
-    pub async fn changed(&self);
+    /// Subscribe to changes; each driver owns its own receiver.
+    pub fn subscribe(&self) -> tokio::sync::watch::Receiver<u64>;
 }
 ```
 
@@ -149,10 +153,12 @@ it is already in render order, maps trivially to "rows," and is what both
 indicatif and strides ultimately want. This Vec **is** the slice of progress a
 renderer takes a handle to.
 
-`changed()` is a best-effort wake; `version()` is the source of truth. Drivers
-loop: render, read version, `changed().await`, re-check version. Per root there
-is at most one driver, so missed-wakeup races are bounded and reconciled by the
-version check plus a steady tick (needed anyway for spinners).
+Drivers loop: render, then `rx.changed().await` (which also returns immediately
+if the version advanced since the last observation, so missed wakeups are
+impossible), then re-snapshot. A steady tick is still useful for spinner
+animation. `changed()` resolves to `Err` once every `OpTracker` handle for the
+tree is dropped, giving drivers a clean exit — and multiple receivers are fully
+supported, so a root may have more than one driver.
 
 ## Layer 3 — drivers
 
@@ -166,29 +172,69 @@ paint.
   CLI behavior and the `StdoutWriter`/`suspend` log coordination, with no
   global — the shim owns its `MultiProgress`.
 
-- **Daemon path (no separate writer).** `Binding`
-  (`session_host.rs`) already owns the channel writer and is the single
-  serialized writer via its `select!` loop. `Host` (the surrounding
-  process-management actor) owns the session lifecycle, the vt100 `parser`
-  screen, and the live binding's mailbox. Therefore:
+- **Daemon path — a scoped, exclusive renderer (revised).** The earlier
+  `render_frame` + `BindingMsg::Progress` + `Host` `select!`-arm design (a
+  progress overlay multiplexed into the PTY mainloop) is **superseded** by a
+  simpler model: for the duration of one operation future, a renderer takes
+  **exclusive** ownership of an async sink and paints the live tree onto it with
+  indicatif; when the future resolves it clears the bars and hands the sink
+  back. No second writer, no `Host`/`Binding` changes, no vt100 interaction.
 
-  - Render is a **pure function** in `ot`:
-    `render_frame(&[OpSnapshot], &mut RenderState) -> Vec<u8>` — produces the
-    ANSI diff (cursor moves, clears, repaint) against the previous frame. No
-    I/O.
-  - The **`Host`** drives repaints: it holds the session `OpTracker` root and a
-    persistent `RenderState`; its `mainloop` `select!` gains one arm = the
-    root's `changed()` future plus a steady tick. On fire → `snapshot()` →
-    `render_frame()` → send bytes to the binding.
-  - The **`Binding`** just writes bytes: a new `BindingMsg::Progress(Bytes)`
-    variant is written in the same `select!` family as process stdout, so
-    progress and process output are serialized by construction — zero tearing,
-    no extra lock.
+  Two pieces:
 
-  Render state lives in the `Host`, not the `Binding`, because it must survive
-  detach/re-attach: the `Host` already replays
-  `parser.screen().state_formatted()` on `attach()`, so the progress overlay
-  repaints there alongside it.
+  - **`ot` (indicatif feature): a generic scoped primitive.**
+    ```rust
+    pub async fn render_operations_while<W, F>(
+        root: &OpTracker,
+        sink: W,
+        size: (u16, u16),          // (cols, rows); required — no hardcoded default
+        fut: F,
+    ) -> F::Output
+    where W: tokio::io::AsyncWrite + Unpin + Send + 'static, F: Future;
+    ```
+    Internals: a `ChannelTerm` implementing indicatif's `TermLike` translates
+    indicatif's sync cursor ops into ANSI bytes and pushes them onto an
+    **unbounded** `mpsc` (a sync→async bridge — indicatif draws from its own
+    steady-tick OS threads, which must never block on an async write; unbounded
+    because dropping a frame mid-sequence would corrupt the stateful cursor
+    stream). A pump task drains the `mpsc` into `sink`. The primitive feeds a
+    `MultiProgress::with_draw_target(term_like(..))` into the **reused**
+    `IndicatifShim` and runs a `select!` between `fut` and `root.subscribe()`
+    (reconcile on each change). On `fut` completion: `mp.clear()`, drop the
+    shim (stops tickers, drops the `mpsc` sender), `await` the pump so the clear
+    is flushed, return the output. Generic over `AsyncWrite` so it is unit-
+    testable against a `tokio::io::duplex` pipe.
+
+  - **`minimald`: `ChannelProgress`** — the russh-concrete wrapper (keeps
+    `russh` out of `ot`):
+    ```rust
+    pub struct ChannelProgress { channel: Channel<Msg>, tracker: OpTracker, size: (u16, u16) }
+    impl ChannelProgress {
+        pub fn new(channel: Channel<Msg>, tracker: OpTracker, size: (u16, u16)) -> Self;
+        pub async fn run<F: Future>(self, fut: F) -> (Channel<Msg>, F::Output) {
+            let w = self.channel.make_writer();        // 'static clone of the channel sender
+            let out = ot::render_operations_while(&self.tracker, w, self.size, fut).await;
+            (self.channel, out)                        // writer dropped; channel intact, returned
+        }
+    }
+    ```
+    `make_writer(&self)` clones the channel's internal sender, and the pump only
+    ever `write_all`/`flush`es (never `shutdown`), so dropping the writer does
+    not EOF the channel — handing it back is sound.
+
+  **Exclusive-ownership constraint.** While the future runs, the wrapped
+  operation must **not** write its own text to the same sink: this is a
+  "compute under a progress bar, then print the result" model. It fits
+  `check`/compute-style operations; live build-log streaming (which
+  `run_patched_pkg` does today) is out of scope for v1 and would need the
+  indicatif-`suspend` shared-writer path instead.
+
+  **Wiring is deferred.** This step lands the reusable building block (the `ot`
+  primitive + the `Channel<Msg>` wrapper) and tests it via the generic
+  `AsyncWrite` seam. Which call sites adopt it — and reconciling that the
+  current progress-producing handlers (`run_check`, `run_patched_pkg`) write to
+  a per-request `UnixStream` rather than a `Channel<Msg>`, plus plumbing the real
+  PTY `WinSize` down to supply `size` — is a separate follow-up.
 
 - **`StridesDriver`** (future) — additive, Layers 1–2 untouched.
 
@@ -201,7 +247,7 @@ Each step compiles and keeps tests green.
 | 1 | Add `Progress{pos,len}`, `OpId`, `RootShared` to the core; keep the `ProgressBar` field, feed both. Add `snapshot()`, `version()`, `changed()`. | `ot` only; existing tests pass |
 | 2 | Carve `set_op`'s indicatif templates into an `IndicatifShim` that renders from `snapshot()`. Drop `pg` from `TrackerInner`; move indicatif behind a feature. **Core is now render-dep-free.** | `ot` only |
 | 3 | Replace `static ROOT`/`root()` with `OpTracker::new_root()`. CLI builds one root; `minimald` builds one per session. Audit the `new_with_root(&None)` sites. | `ot` + entry points |
-| 4 | Daemon render: `render_frame` + `RenderState`, a `Host` `select!` arm, and `BindingMsg::Progress`. Thread the session root via existing builders. | `minimald` |
+| 4 | Scoped renderer: `ot::render_operations_while` (generic `AsyncWrite` primitive: `TermLike`→`mpsc`→pump, reusing `IndicatifShim`) + a `minimald` `ChannelProgress` wrapper that consumes a `Channel<Msg>` + `OpTracker` + future and returns the channel + result. Building block only; call-site wiring + `WinSize` plumbing deferred. | `ot` + `minimald` |
 | 5 | *(future)* `StridesDriver`. | new driver only |
 
 ## Decisions
@@ -209,13 +255,24 @@ Each step compiles and keeps tests green.
 - **Defer the CLI side.** indicatif stays as a thin shim over the new core
   (step 2); no effort re-imagining the local TTY UX now. It is an isolated
   later swap touching only Layer 3.
-- **`tokio sync` in the core** for change signalling (above).
+- **`watch` (not `Notify`) in the core** for change signalling (above), so a
+  root supports multiple concurrent drivers with lossless wakeups.
 - **Styling moves wholesale into drivers**; the state core stays semantic.
+- **Daemon progress is scoped + exclusive** (step 4): a renderer owns the sink
+  for one future's duration and returns it, rather than multiplexing a
+  persistent overlay through the `Host`/`Binding` PTY loop. Simpler, no tearing,
+  no `Host` changes; trades away live-log-plus-progress interleaving (deferred).
+- **Step-4 primitive is generic over `AsyncWrite`**; the `russh`-concrete
+  `ChannelProgress` wrapper is the only `Channel<Msg>`-aware piece, keeping
+  `russh` out of `ot` and the core testable via a pipe.
 
 ## Non-Goals
 
 - Re-designing the local CLI progress UX (deferred).
-- The vt100/overlay interaction in the daemon (whether progress renders in a
-  reserved bottom region or is fed through the parser) — resolved in step 4; it
-  affects only the daemon render path, not the `ot` core.
+- Live operation output (build logs) interleaved with progress on the same sink
+  — the step-4 renderer is exclusive-ownership/compute-then-print; interleaving
+  would need the indicatif-`suspend` shared-writer path (deferred).
+- Wiring the step-4 renderer into specific call sites and plumbing the real PTY
+  `WinSize` to supply its `size` (deferred follow-up; step 4 lands the building
+  block only).
 - Adopting `strides` (future, additive).


### PR DESCRIPTION
This will avoid the apparent hang when you first launch a session with packages that need to be downloaded or built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live progress rendering for SSH/channel-based operations while tasks run, including during host startup.
  * Introduced a scoped rendering flow that keeps progress output smooth and supports multiple active viewers.
* **Bug Fixes**
  * Reduced flicker and half-painted updates during live rendering.
  * Improved session/host attach error reporting when startup completes before attachment is possible.
* **Other**
  * Progress output is now properly cleared after rendering completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->