### PR TITLE
refactor(op): move init and update code into op crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,6 +4016,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "toml_edit",
  "tracing",
  "url",
  "walkdir",

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -34,7 +34,7 @@ pub use profiles::Profile;
 mod decl_tests;
 pub use decl_tests::Test;
 mod stacks;
-pub use stacks::{Stack, StackMatcher};
+pub use stacks::{PackageMatcherPredicate, Stack, StackMatcher};
 
 // Increment for any big change to the format of build specs / stacks, so that hash
 // keys get invalidated.

--- a/crates/mctx/src/error.rs
+++ b/crates/mctx/src/error.rs
@@ -217,6 +217,16 @@ impl From<graph::Error> for Error {
     }
 }
 
+impl From<op::Error> for Error {
+    fn from(value: op::Error) -> Self {
+        match value {
+            op::Error::IO(e) => Self::IO("op", PathBuf::new(), e),
+            op::Error::Plan(graph, e) => Self::Plan(Box::new((graph, e))),
+            other => Self::Other(anyhow::anyhow!("{}", other)),
+        }
+    }
+}
+
 impl From<super::ConfigError> for Error {
     fn from(value: super::ConfigError) -> Self {
         Error::Config(value)

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -34,6 +34,9 @@ pub use mfile_search_strategy::MFileSearchStrategy;
 mod scaffold;
 pub use scaffold::scaffold_default_mfile;
 
+mod project_setup;
+pub use project_setup::ProjectSetup;
+
 pub use env::Env;
 use tokio::sync::Semaphore;
 use toml_edit::{Array, DocumentMut, Item, TableLike, Value};
@@ -299,6 +302,18 @@ impl Context {
     /// to be used after the minimal file has been mutated.
     pub fn cloned_reinit(&self) -> Result<Self, Error> {
         Self::new(self.config.clone())
+    }
+
+    /// Builds a [`ProjectSetup`] from this context, for running project-setup
+    /// operations (e.g. [`op::UpdateProject`]) that refresh the `minimal.toml`.
+    pub fn project_setup(&self) -> ProjectSetup {
+        ProjectSetup::from_parts(
+            self.config.clone(),
+            self.vcs.clone(),
+            self.stdlib_dir.clone(),
+            self.mfile.clone(),
+            self.repo_dir().to_path_buf(),
+        )
     }
 
     /// Returns a handle to the local cache.

--- a/crates/mctx/src/project_setup.rs
+++ b/crates/mctx/src/project_setup.rs
@@ -1,0 +1,115 @@
+//! [`ProjectSetup`]: the `mctx` adapter implementing [`op::ProjectEnv`].
+
+use std::path::{Path, PathBuf};
+
+use checkouts::{GitRef, ManagerHandle as VcsManagerHandle};
+use common::Target;
+use graph::Graph;
+use mfile::LinkConfig;
+
+use crate::{Config, Context, Error, MFileSearchStrategy};
+
+/// The environment project-setup operations ([`op::InitProject`],
+/// [`op::UpdateProject`]) run against.
+///
+/// Unlike [`Context`], this can be constructed without a `minimal.toml` on disk,
+/// which `init` requires when bootstrapping a fresh project.
+pub struct ProjectSetup {
+    config: Config,
+    vcs: VcsManagerHandle,
+    stdlib_dir: PathBuf,
+    mfile: Option<mfile::File>,
+    repo_dir: PathBuf,
+}
+
+impl ProjectSetup {
+    /// Builds an environment for `init`, loading a `minimal.toml` if one is
+    /// already present (the user may be re-initializing).
+    pub fn for_init(config: Config) -> Result<Self, Error> {
+        let (vcs, _cache, stdlib_dir) = Context::sub_setup(&config)?;
+        let strategy = match config.repo_dir_override() {
+            Some(path) => MFileSearchStrategy::Override(path.to_path_buf()),
+            None => MFileSearchStrategy::CurrentDirOnly,
+        };
+        let mfile = match strategy.find_mfile() {
+            Ok(m) => Some(m),
+            Err(Error::MFile(mfile::Error::NotFound)) => None,
+            Err(e) => return Err(e),
+        };
+        let repo_dir = resolve_repo_dir(&config, mfile.as_ref())?;
+        Ok(Self {
+            config,
+            vcs,
+            stdlib_dir,
+            mfile,
+            repo_dir,
+        })
+    }
+
+    /// Builds an environment from the parts of an existing [`Context`].
+    pub(crate) fn from_parts(
+        config: Config,
+        vcs: VcsManagerHandle,
+        stdlib_dir: PathBuf,
+        mfile: mfile::File,
+        repo_dir: PathBuf,
+    ) -> Self {
+        Self {
+            config,
+            vcs,
+            stdlib_dir,
+            mfile: Some(mfile),
+            repo_dir,
+        }
+    }
+}
+
+/// Resolves the project root: the minimal file's repo, else the configured
+/// override, else the current directory.
+fn resolve_repo_dir(config: &Config, mfile: Option<&mfile::File>) -> Result<PathBuf, Error> {
+    if let Some(p) = mfile.and_then(|m| m.repo_path()) {
+        return Ok(p.to_path_buf());
+    }
+    if let Some(p) = config.repo_dir_override() {
+        return Ok(p.to_path_buf());
+    }
+    std::env::current_dir().map_err(|e| Error::IO("Getting current directory", PathBuf::new(), e))
+}
+
+impl op::ProjectEnv for ProjectSetup {
+    fn repo_dir(&self) -> &Path {
+        &self.repo_dir
+    }
+
+    fn minimal_file(&self) -> Option<&mfile::File> {
+        self.mfile.as_ref()
+    }
+
+    fn checkout_branch(&mut self, repo: &str, branch: &str) -> Result<String, op::Error> {
+        self.vcs
+            .checkout_of(repo, GitRef::Branch(branch.to_string()))
+            .map(|(_dir, rev)| rev)
+            .map_err(|e| op::Error::Other(anyhow::Error::from(e)))
+    }
+
+    fn update_checkouts(&mut self) -> Result<(), op::Error> {
+        self.vcs
+            .update()
+            .map_err(|e| op::Error::Other(anyhow::Error::from(e)))
+    }
+
+    fn graph_from_chain(&mut self, link: LinkConfig, target: Target) -> Result<Graph, op::Error> {
+        Graph::new_from_chain(
+            self.vcs.clone(),
+            &mut graph::LayerCacheDir(self.config.layer_cache_dir()),
+            link,
+            self.stdlib_dir.clone(),
+            target,
+        )
+        .map_err(|e| op::Error::Other(anyhow::anyhow!("loading package graph: {e:?}")))
+    }
+
+    fn invalidate_remote_index(&mut self) {
+        std::fs::remove_file(self.config.index_dir().join(rcache::INDEX_FILENAME)).ok();
+    }
+}

--- a/crates/minimal/src/cmd_init.rs
+++ b/crates/minimal/src/cmd_init.rs
@@ -30,7 +30,11 @@ pub async fn cmd_init(args: InitArgs, config: Config) -> Result<(), Error> {
         std::io::stdin()
             .read_line(&mut input)
             .map_err(|e| Error::Other(anyhow::anyhow!("reading stdin: {}", e)))?;
-        if !(input.trim().eq_ignore_ascii_case("y") || input.trim().is_empty()) {
+        let trimmed = input.trim();
+        if !(trimmed.eq_ignore_ascii_case("y")
+            || trimmed.eq_ignore_ascii_case("yes")
+            || trimmed.is_empty())
+        {
             eprintln!("Aborted.");
             return Ok(());
         }

--- a/crates/minimal/src/cmd_init.rs
+++ b/crates/minimal/src/cmd_init.rs
@@ -1,13 +1,9 @@
 //! Command to initialize a minimal file based on matching the source tree to a valid harness.
 
 use std::io::Write;
-use std::path::PathBuf;
 
-use anyhow::anyhow;
-use common::{SpecOrigin, Target, repo_spec::Repo};
-use graph::Graph;
-use mctx::{Config, Context, Error};
-use mfile::LinkConfig;
+use mctx::{Config, Error, ProjectSetup};
+use op::{InitProject, ProjectOp};
 
 #[derive(clap::Args)]
 pub struct InitArgs {
@@ -16,139 +12,15 @@ pub struct InitArgs {
     yes: bool,
 }
 
-const DEFAULT_PKGS: &str = "https://github.com/gominimal/pkgs";
-const DEFAULT_PKGS_BRANCH: &str = "main";
-const FALLBACK_STACK: &str = "shell";
-
 pub async fn cmd_init(args: InitArgs, config: Config) -> Result<(), Error> {
-    let mfile_strategy = match config.repo_dir_override() {
-        Some(path) => mctx::MFileSearchStrategy::Override(path.to_path_buf()),
-        _ => mctx::MFileSearchStrategy::CurrentDirOnly,
-    };
-    // Stacks have the match rules, so we need a graph, either from the repo
-    // minimal file or some default based on the MPPR.
-    let (upstream_origin, repo_dir, toml_path, graph) =
-        match Context::new_with_strategy(config.clone(), mfile_strategy) {
-            // We are in a repo where theres a minimal file, and the minimal file has an upstream.
-            // Lets use that upstream. Maybe the user is re-initializing?
-            Ok(mut ctx) if ctx.minimal_file().upstream.is_some() => {
-                let upstream = ctx.minimal_file().upstream.clone().unwrap();
-                let origin = upstream.as_ref().as_spec_origin().ok_or_else(|| {
-                    Error::Other(anyhow!(
-                        "Could not use upstream{} as a spec origin",
-                        ctx.minimal_file()
-                            .file_path()
-                            .map(|p| format!(" from minimal file at {}", p.to_string_lossy()))
-                            .unwrap_or("".into())
-                    ))
-                })?;
-                (
-                    origin,
-                    ctx.repo_dir().to_path_buf(),
-                    ctx.minimal_file().file_path().cloned(),
-                    ctx.graph_from_all_packages()?,
-                )
-            }
-            // Unsurprisingly, theres no minimal file yet, or theres no upstream so theres no
-            // useful information. We need the stacks though for auto-detection, so lets
-            // wire up a default graph.
-            Err(Error::MFile(mfile::Error::NotFound)) | Ok(_) => {
-                let (mut vcs, _cache, stdlib_dir) = Context::sub_setup(&config)?;
-                let (_dir, rev) = vcs.checkout_of(
-                    DEFAULT_PKGS,
-                    checkouts::GitRef::Branch(DEFAULT_PKGS_BRANCH.to_string()),
-                )?;
-
-                let repo_dir = match config.repo_dir_override() {
-                    Some(path) => path.to_path_buf(),
-                    _ => std::env::current_dir()
-                        .map_err(|e| Error::IO("Getting current directory", PathBuf::new(), e))?,
-                };
-
-                (
-                    SpecOrigin::Repo(common::repo_spec::Repo::Git {
-                        url: DEFAULT_PKGS.to_string(),
-                        rev: rev.clone(),
-                        tracking: Some(common::repo_spec::GitRef::Branch(
-                            DEFAULT_PKGS_BRANCH.to_string(),
-                        )),
-                    }),
-                    repo_dir,
-                    None,
-                    Graph::new_from_chain(
-                        vcs,
-                        &mut (),
-                        LinkConfig::Git {
-                            repo: DEFAULT_PKGS.to_string(),
-                            branch: Some(DEFAULT_PKGS_BRANCH.to_string()),
-                            locked_commit: Some(rev),
-                        },
-                        stdlib_dir,
-                        Target::host(),
-                    )?,
-                )
-            }
-            Err(e) => {
-                return Err(e);
-            }
-        };
-    let toml_path = toml_path.unwrap_or_else(|| repo_dir.join(mfile::MFILE_NAME));
-
-    // Apply all predicates, collecting the stacks name, any additional build packages, and any additional runtime packages.
-    let stacks = {
-        let mut h = graph.iter_stacks().collect::<Vec<_>>();
-        // Sort stacks so those with a higher priority are iterated first.
-        h.sort_by(|a, b| {
-            a.1.matches_project_priority
-                .cmp(&b.1.matches_project_priority)
-                .reverse()
-        });
-        h
-    };
-    let matched_stack: Option<(String, Vec<String>, Vec<String>)> =
-        stacks.into_iter().find_map(|(name, stack)| {
-            stack.matches_project_if_any.as_ref().and_then(|matchers| {
-                matchers
-                    .iter()
-                    .find(|m| m.match_dir(&repo_dir).unwrap_or(false))
-                    .map(|stack| {
-                        (
-                            name.clone(),
-                            stack
-                                .build_package_matchers
-                                .iter()
-                                .filter_map(|(pkg, if_any)| {
-                                    if_any
-                                        .iter()
-                                        .any(|c| c.match_dir(&repo_dir).unwrap_or(false))
-                                        .then_some(pkg)
-                                })
-                                .cloned()
-                                .collect::<Vec<_>>(),
-                            stack
-                                .runtime_package_matchers
-                                .iter()
-                                .filter_map(|(pkg, if_any)| {
-                                    if_any
-                                        .iter()
-                                        .any(|c| c.match_dir(&repo_dir).unwrap_or(false))
-                                        .then_some(pkg)
-                                })
-                                .cloned()
-                                .collect::<Vec<_>>(),
-                        )
-                    })
-            })
-        });
-
-    let has_matched = matched_stack.is_some();
-    let content = generate_mfile(matched_stack, &upstream_origin);
+    let mut env = ProjectSetup::for_init(config)?;
+    let plan = InitProject.run(&mut env)?;
 
     // -- Confirmation prompt (unless --yes) --
     if !args.yes {
-        eprintln!("\nWill create {}:\n", toml_path.display());
+        eprintln!("\nWill create {}:\n", plan.toml_path.display());
         eprintln!("---");
-        eprint!("{}", content);
+        eprint!("{}", plan.content);
         eprintln!("---");
         eprintln!();
         eprint!("Continue? [Y/n] ");
@@ -158,87 +30,28 @@ pub async fn cmd_init(args: InitArgs, config: Config) -> Result<(), Error> {
         std::io::stdin()
             .read_line(&mut input)
             .map_err(|e| Error::Other(anyhow::anyhow!("reading stdin: {}", e)))?;
-        if !(input.trim().eq_ignore_ascii_case("y") || input.trim() == "") {
+        if !(input.trim().eq_ignore_ascii_case("y") || input.trim().is_empty()) {
             eprintln!("Aborted.");
             return Ok(());
         }
     }
 
-    std::fs::write(&toml_path, &content)
-        .map_err(|e| Error::Other(anyhow::anyhow!("writing {}: {}", toml_path.display(), e)))?;
+    std::fs::write(&plan.toml_path, &plan.content).map_err(|e| {
+        Error::Other(anyhow::anyhow!(
+            "writing {}: {}",
+            plan.toml_path.display(),
+            e
+        ))
+    })?;
 
-    eprintln!("Created {}", toml_path.display());
+    eprintln!("Created {}", plan.toml_path.display());
     eprintln!();
     eprintln!("Next steps:");
     eprintln!("  minimal update      # pin package versions");
     eprintln!("  minimal run shell   # enter development shell");
-    if has_matched {
+    if plan.matched {
         eprintln!("  minimal build       # build the project");
     }
 
     Ok(())
-}
-
-fn generate_mfile(
-    matched_stack: Option<(String, Vec<String>, Vec<String>)>,
-    origin: &SpecOrigin,
-) -> String {
-    // Fall back to the "shell" stack if no project-specific matcher hit.
-    let (stack_name, build_packages, runtime_packages) = matched_stack
-        .map(|h| (h.0, h.1, h.2))
-        .unwrap_or_else(|| (FALLBACK_STACK.to_string(), vec![], vec![]));
-
-    let mut content = String::new();
-    content.push_str("# Generated by `minimal init`\n\n");
-
-    // [upstream]
-    content.push_str("[upstream] # Source of software & tooling\n");
-    match &origin {
-        SpecOrigin::Repo(Repo::Git { url, rev, tracking }) => {
-            content.push_str(&format!("repo = \"{}\"\n", url));
-            if let Some(common::repo_spec::GitRef::Branch(b)) = tracking {
-                content.push_str(&format!("branch = \"{}\"\n", b));
-            }
-            content.push_str(&format!("locked_commit = \"{}\"\n", rev,));
-        }
-        SpecOrigin::LocalDir { given, .. } => {
-            content.push_str(&format!("dir = \"{}\"\n", given.to_str().unwrap()))
-        }
-        SpecOrigin::Inline => unreachable!(),
-    }
-    content.push('\n');
-
-    content.push_str("[stack]\n");
-    content.push_str(&format!("use = \"{}\"\n", stack_name));
-    if !build_packages.is_empty() {
-        content.push_str(&format!(
-            "build_packages = [{}]\n",
-            build_packages
-                .into_iter()
-                .map(|s| format!("\"{}\"", s))
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
-    }
-    if !runtime_packages.is_empty() {
-        content.push_str(&format!(
-            "runtime_packages = [{}]\n",
-            runtime_packages
-                .into_iter()
-                .map(|s| format!("\"{}\"", s))
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
-    }
-
-    content.push('\n');
-
-    content.push_str("[defaults]\n");
-    content.push_str("state_key = \"dev\"\n");
-    content.push('\n');
-    content.push_str("[tasks.shell]\n");
-    content.push_str("interactive = true\n");
-    content.push_str("packages = [\"base\"]\n");
-    content.push_str("exec = \"bash --noprofile -l\"\n");
-    content
 }

--- a/crates/minimal/src/cmd_update.rs
+++ b/crates/minimal/src/cmd_update.rs
@@ -9,9 +9,6 @@ pub async fn cmd_update(_args: UpdateArgs, ctx: &mut Context) -> Result<(), Erro
     let mut env = ctx.project_setup();
     let report = UpdateProject.run(&mut env)?;
 
-    if report.migrated_harness {
-        println!("Renamed `[harness]` to its new name `[stack]`");
-    }
     if let Some(c) = &report.upstream {
         println!(
             "Upstream {}:{} updated from {} to {}",

--- a/crates/minimal/src/cmd_update.rs
+++ b/crates/minimal/src/cmd_update.rs
@@ -1,133 +1,39 @@
 use crate::{Context, Error};
+use op::{ProjectOp, UpdateProject};
 
 #[derive(clap::Args)]
 pub struct UpdateArgs {}
 
 pub async fn cmd_update(_args: UpdateArgs, ctx: &mut Context) -> Result<(), Error> {
-    let mfile = ctx.minimal_file();
-    let mfile_path = mfile.file_path().cloned();
+    // Refresh upstream/sideload checkouts and re-pin them in the minimal file.
+    let mut env = ctx.project_setup();
+    let report = UpdateProject.run(&mut env)?;
 
-    let upstream: Option<(String, Option<String>, Option<String>)> =
-        match mfile.upstream.as_ref().map(|u| &u.link) {
-            Some(mfile::LinkConfig::Git {
-                repo,
-                branch,
-                locked_commit,
-            }) => Some((repo.clone(), branch.clone(), locked_commit.clone())),
-            Some(mfile::LinkConfig::Dir { .. }) => None,
-            None => None,
-        };
-
-    // best effort, yeet any cached remote index so a fresh fetch occurs
-    std::fs::remove_file(ctx.index_dir().join(rcache::INDEX_FILENAME)).ok();
-
-    let mut vcs = ctx.vcs_manager();
-    vcs.update()
-        .map_err(|e| Error::Other(anyhow::Error::from(e)))?;
-
-    // If tracking branch for upstream is specified, check out the new commit
-    let new_up_rev = if let Some((repo, Some(b), commit)) = &upstream {
-        let new_git_ref = vcs
-            .checkout_of(repo, checkouts::GitRef::Branch(b.clone()))?
-            .1;
-        if Some(&new_git_ref) != commit.as_ref() {
-            Some(new_git_ref)
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-
-    // Update all the sideloads, if present
-    let sideload_updates = if let Some(sideloads) = mfile.upstream.as_ref().map(|u| u.sideloads()) {
-        sideloads
-            .iter()
-            .map(|s| match s.link() {
-                mfile::LinkConfig::Git {
-                    repo,
-                    branch: Some(branch),
-                    locked_commit,
-                } => {
-                    let new_git_ref = vcs
-                        .checkout_of(repo, checkouts::GitRef::Branch(branch.clone()))?
-                        .1;
-                    if Some(&new_git_ref) != locked_commit.as_ref() {
-                        Ok(Some(new_git_ref))
-                    } else {
-                        Ok(None)
-                    }
-                }
-                _ => Ok(None),
-            })
-            .collect::<Result<Vec<_>, Error>>()?
-    } else {
-        vec![]
-    };
-
-    // If theres a minimal file on disk, and:
-    //  - theres at least one new rev, or
-    //  - we need to migrate the 'harness' name to 'stack'
-    //
-    // write the revs to the minimal file.
-    if let Some(p) = mfile_path {
-        use toml_edit::{DocumentMut, value};
-        let toml = std::fs::read_to_string(&p)
-            .map_err(|e| Error::IO("reading minimal.toml for update", p.to_path_buf(), e))?;
-        let mut doc = toml
-            .parse::<DocumentMut>()
-            .map_err(|e| Error::Other(anyhow::Error::from(e)))?;
-
-        let mut did_upgrade_fmt = false;
-        // TODO: Remove after June 2026.
-        if let Some(t) = doc.remove("harness") {
-            println!("Renamed `[harness]` to its new name `[stack]`");
-            doc.insert("stack", t);
-            did_upgrade_fmt = true;
-        }
-
-        if new_up_rev.is_some() || sideload_updates.iter().any(|u| u.is_some()) || did_upgrade_fmt {
-            // Update upstream
-            if let Some(new_rev) = new_up_rev {
-                doc["upstream"]["locked_commit"] = value(new_rev.clone());
-
-                println!(
-                    "Upstream {}:{} updated from {} to {}",
-                    upstream.as_ref().unwrap().0,
-                    upstream.as_ref().unwrap().1.as_ref().unwrap(),
-                    match upstream.as_ref().unwrap().2.clone() {
-                        Some(r) => r,
-                        None => "<unpinned>".to_string(),
-                    },
-                    new_rev
-                )
-            }
-
-            // Update sideloads
-            for (i, rev) in sideload_updates.into_iter().enumerate() {
-                if let Some(new_rev) = rev {
-                    println!(
-                        "Sideload {}:{} updated from {} to {}",
-                        doc["upstream"]["sideload"][i]["repo"].as_str().unwrap(),
-                        doc["upstream"]["sideload"][i]["branch"].as_str().unwrap(),
-                        doc["upstream"]["sideload"][i]
-                            .get("locked_commit")
-                            .and_then(|s| s.as_str())
-                            .unwrap_or("<unpinned>"),
-                        new_rev
-                    );
-
-                    doc["upstream"]["sideload"][i]["locked_commit"] = value(new_rev.clone());
-                }
-            }
-
-            std::fs::write(p, doc.to_string()).map_err(|e| Error::Other(anyhow::Error::from(e)))?;
-        }
+    if report.migrated_harness {
+        println!("Renamed `[harness]` to its new name `[stack]`");
+    }
+    if let Some(c) = &report.upstream {
+        println!(
+            "Upstream {}:{} updated from {} to {}",
+            c.repo,
+            c.branch,
+            c.from.as_deref().unwrap_or("<unpinned>"),
+            c.to,
+        );
+    }
+    for c in &report.sideloads {
+        println!(
+            "Sideload {}:{} updated from {} to {}",
+            c.repo,
+            c.branch,
+            c.from.as_deref().unwrap_or("<unpinned>"),
+            c.to,
+        );
     }
 
-    // Enumerate all the reachable transitive packages and
-    // make sure we download any we are missing but are available
-    // remotely.
+    // Enumerate all the reachable transitive packages and make sure we download
+    // any we are missing but are available remotely. This is a separate step
+    // from the minimal-file refresh above.
     *ctx = ctx.cloned_reinit()?;
     let graph = ctx.graph_from_all_packages()?;
     let ensure_pkgs = ctx.scaffolding_packages()?;

--- a/crates/op/Cargo.toml
+++ b/crates/op/Cargo.toml
@@ -25,6 +25,7 @@ shlex.workspace = true
 size.workspace = true
 tar.workspace = true
 tempfile.workspace = true
+toml_edit.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true

--- a/crates/op/src/lib.rs
+++ b/crates/op/src/lib.rs
@@ -54,3 +54,8 @@ pub use standalone_test::{StandaloneTest, StandaloneTestError};
 
 mod task_env;
 pub use task_env::{CaptureWriter, TaskEnv};
+
+mod project;
+pub use project::{
+    InitPlan, InitProject, ProjectEnv, ProjectOp, RevChange, UpdateProject, UpdateReport,
+};

--- a/crates/op/src/project/init.rs
+++ b/crates/op/src/project/init.rs
@@ -1,0 +1,341 @@
+//! The `init` operation: detect a project's stack and produce the `minimal.toml`
+//! it should be initialized with.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::anyhow;
+use common::{SpecOrigin, Target, repo_spec::Repo};
+use decode::Stack;
+use mfile::LinkConfig;
+
+use super::{ProjectEnv, ProjectOp};
+use crate::Error;
+
+const DEFAULT_PKGS: &str = "https://github.com/gominimal/pkgs";
+const DEFAULT_PKGS_BRANCH: &str = "main";
+const FALLBACK_STACK: &str = "shell";
+
+/// Detects the stack matching an existing codebase and produces the
+/// `minimal.toml` it should be initialized with.
+///
+/// The operation does not touch the filesystem beyond what the [`ProjectEnv`]
+/// performs (checkouts, graph loading); writing the file and confirming with the
+/// user are left to the caller, which inspects the returned [`InitPlan`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct InitProject;
+
+/// The result of running [`InitProject`]: the `minimal.toml` to write and where.
+#[derive(Debug, Clone)]
+pub struct InitPlan {
+    /// Path the `minimal.toml` should be written to.
+    pub toml_path: PathBuf,
+    /// The generated file contents.
+    pub content: String,
+    /// Whether a project-specific stack matched (as opposed to the fallback).
+    pub matched: bool,
+}
+
+/// A matched stack: its name, plus the additional build and runtime packages
+/// detected for the project.
+type MatchedStack = (String, Vec<String>, Vec<String>);
+
+impl ProjectOp for InitProject {
+    type Result = InitPlan;
+
+    fn run<E: ProjectEnv>(&mut self, env: &mut E) -> Result<InitPlan, Error> {
+        // Stacks carry the match rules, so we need a graph: either from the
+        // existing minimal file's upstream (the user may be re-initializing) or
+        // from a default packages repo we check out for the occasion.
+        let existing = env
+            .minimal_file()
+            .and_then(|m| m.upstream.clone().map(|up| (up, m.file_path().cloned())));
+
+        let (origin, link, toml_path) = match existing {
+            Some((upstream, file_path)) => {
+                let origin = upstream.as_ref().as_spec_origin().ok_or_else(|| {
+                    Error::Other(anyhow!("Could not use upstream as a spec origin"))
+                })?;
+                let link = LinkConfig::Dir {
+                    dir: env.repo_dir().to_string_lossy().into_owned(),
+                };
+                (origin, link, file_path)
+            }
+            None => {
+                let rev = env.checkout_branch(DEFAULT_PKGS, DEFAULT_PKGS_BRANCH)?;
+                let origin = SpecOrigin::Repo(Repo::Git {
+                    url: DEFAULT_PKGS.to_string(),
+                    rev: rev.clone(),
+                    tracking: Some(common::repo_spec::GitRef::Branch(
+                        DEFAULT_PKGS_BRANCH.to_string(),
+                    )),
+                });
+                let link = LinkConfig::Git {
+                    repo: DEFAULT_PKGS.to_string(),
+                    branch: Some(DEFAULT_PKGS_BRANCH.to_string()),
+                    locked_commit: Some(rev),
+                };
+                (origin, link, None)
+            }
+        };
+
+        let graph = env.graph_from_chain(link, Target::host())?;
+        let repo_dir = env.repo_dir().to_path_buf();
+        let toml_path = toml_path.unwrap_or_else(|| repo_dir.join(mfile::MFILE_NAME));
+
+        let matched_stack = match_stack(graph.iter_stacks(), &repo_dir);
+        let matched = matched_stack.is_some();
+        let content = generate_mfile(matched_stack, &origin);
+
+        Ok(InitPlan {
+            toml_path,
+            content,
+            matched,
+        })
+    }
+}
+
+/// Applies every stack's match rules against `repo_dir`, returning the
+/// highest-priority match along with any additional build and runtime packages.
+fn match_stack<'a>(
+    stacks: impl IntoIterator<Item = (&'a String, &'a Stack)>,
+    repo_dir: &Path,
+) -> Option<MatchedStack> {
+    let mut stacks = stacks.into_iter().collect::<Vec<_>>();
+    // Sort stacks so those with a higher priority are iterated first.
+    stacks.sort_by(|a, b| {
+        a.1.matches_project_priority
+            .cmp(&b.1.matches_project_priority)
+            .reverse()
+    });
+
+    stacks.into_iter().find_map(|(name, stack)| {
+        stack.matches_project_if_any.as_ref().and_then(|matchers| {
+            matchers
+                .iter()
+                .find(|m| m.match_dir(repo_dir).unwrap_or(false))
+                .map(|matcher| {
+                    (
+                        name.clone(),
+                        matcher
+                            .build_package_matchers
+                            .iter()
+                            .filter_map(|(pkg, if_any)| {
+                                if_any
+                                    .iter()
+                                    .any(|c| c.match_dir(repo_dir).unwrap_or(false))
+                                    .then_some(pkg)
+                            })
+                            .cloned()
+                            .collect::<Vec<_>>(),
+                        matcher
+                            .runtime_package_matchers
+                            .iter()
+                            .filter_map(|(pkg, if_any)| {
+                                if_any
+                                    .iter()
+                                    .any(|c| c.match_dir(repo_dir).unwrap_or(false))
+                                    .then_some(pkg)
+                            })
+                            .cloned()
+                            .collect::<Vec<_>>(),
+                    )
+                })
+        })
+    })
+}
+
+/// Renders the `minimal.toml` contents for the (optional) matched stack and the
+/// resolved upstream `origin`.
+fn generate_mfile(matched_stack: Option<MatchedStack>, origin: &SpecOrigin) -> String {
+    // Fall back to the "shell" stack if no project-specific matcher hit.
+    let (stack_name, build_packages, runtime_packages) =
+        matched_stack.unwrap_or_else(|| (FALLBACK_STACK.to_string(), vec![], vec![]));
+
+    let mut content = String::new();
+    content.push_str("# Generated by `minimal init`\n\n");
+
+    // [upstream]
+    content.push_str("[upstream] # Source of software & tooling\n");
+    match &origin {
+        SpecOrigin::Repo(Repo::Git { url, rev, tracking }) => {
+            content.push_str(&format!("repo = \"{url}\"\n"));
+            if let Some(common::repo_spec::GitRef::Branch(b)) = tracking {
+                content.push_str(&format!("branch = \"{b}\"\n"));
+            }
+            content.push_str(&format!("locked_commit = \"{rev}\"\n"));
+        }
+        SpecOrigin::LocalDir { given, .. } => {
+            content.push_str(&format!("dir = \"{}\"\n", given.to_str().unwrap()))
+        }
+        SpecOrigin::Inline => unreachable!(),
+    }
+    content.push('\n');
+
+    content.push_str("[stack]\n");
+    content.push_str(&format!("use = \"{stack_name}\"\n"));
+    if !build_packages.is_empty() {
+        content.push_str(&format!(
+            "build_packages = [{}]\n",
+            build_packages
+                .into_iter()
+                .map(|s| format!("\"{s}\""))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !runtime_packages.is_empty() {
+        content.push_str(&format!(
+            "runtime_packages = [{}]\n",
+            runtime_packages
+                .into_iter()
+                .map(|s| format!("\"{s}\""))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    content.push('\n');
+
+    content.push_str("[defaults]\n");
+    content.push_str("state_key = \"dev\"\n");
+    content.push('\n');
+    content.push_str("[tasks.shell]\n");
+    content.push_str("interactive = true\n");
+    content.push_str("packages = [\"base\"]\n");
+    content.push_str("exec = \"bash --noprofile -l\"\n");
+    content
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::repo_spec::GitRef;
+    use decode::{PackageMatcherPredicate, StackMatcher};
+    use tempfile::TempDir;
+
+    /// A predicate that matches when `file` merely exists in the project.
+    fn exists(file: &str) -> PackageMatcherPredicate {
+        PackageMatcherPredicate {
+            file_regexes: [(file.to_string(), "*".to_string())].into_iter().collect(),
+            ..Default::default()
+        }
+    }
+
+    /// A stack that applies when `file` exists, at the given match priority.
+    fn stack_for(name: &str, priority: i32, file: &str) -> Stack {
+        Stack {
+            name: name.to_string(),
+            matches_project_priority: priority,
+            matches_project_if_any: Some(vec![StackMatcher {
+                file_regexes: [(file.to_string(), "*".to_string())].into_iter().collect(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn match_stack_picks_highest_priority_that_actually_matches() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "[package]").unwrap();
+        std::fs::write(dir.path().join("go.mod"), "module x").unwrap();
+
+        // `python` has the highest priority but does not match (no
+        // requirements.txt); `rust` outranks `go` among the matching stacks.
+        let stacks = [
+            ("go".to_string(), stack_for("go", 5, "go.mod")),
+            (
+                "python".to_string(),
+                stack_for("python", 100, "requirements.txt"),
+            ),
+            ("rust".to_string(), stack_for("rust", 10, "Cargo.toml")),
+        ];
+
+        let matched = match_stack(stacks.iter().map(|(n, s)| (n, s)), dir.path());
+        assert_eq!(matched.map(|m| m.0), Some("rust".to_string()));
+    }
+
+    #[test]
+    fn match_stack_returns_none_when_nothing_matches() {
+        let dir = TempDir::new().unwrap();
+        let stacks = [("rust".to_string(), stack_for("rust", 0, "Cargo.toml"))];
+
+        assert!(match_stack(stacks.iter().map(|(n, s)| (n, s)), dir.path()).is_none());
+    }
+
+    #[test]
+    fn match_stack_collects_only_matching_build_and_runtime_packages() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "x").unwrap();
+        std::fs::write(dir.path().join("build.rs"), "x").unwrap();
+
+        let stack = Stack {
+            name: "rust".to_string(),
+            matches_project_if_any: Some(vec![StackMatcher {
+                file_regexes: [("Cargo.toml".to_string(), "*".to_string())]
+                    .into_iter()
+                    .collect(),
+                build_package_matchers: [("cc".to_string(), vec![exists("build.rs")])]
+                    .into_iter()
+                    .collect(),
+                runtime_package_matchers: [
+                    ("openssl".to_string(), vec![exists("Cargo.toml")]),
+                    // No matching file, so this package must be excluded.
+                    ("absent".to_string(), vec![exists("nonexistent")]),
+                ]
+                .into_iter()
+                .collect(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+
+        let stacks = [("rust".to_string(), stack)];
+        let (name, build, runtime) =
+            match_stack(stacks.iter().map(|(n, s)| (n, s)), dir.path()).unwrap();
+
+        assert_eq!(name, "rust");
+        assert_eq!(build, vec!["cc".to_string()]);
+        assert_eq!(runtime, vec!["openssl".to_string()]);
+    }
+
+    #[test]
+    fn generate_mfile_renders_git_origin_and_matched_stack() {
+        let origin = SpecOrigin::Repo(Repo::Git {
+            url: "https://github.com/gominimal/pkgs".to_string(),
+            rev: "abc123".to_string(),
+            tracking: Some(GitRef::Branch("main".to_string())),
+        });
+        let matched = Some((
+            "rust".to_string(),
+            vec!["cc".to_string()],
+            vec!["openssl".to_string()],
+        ));
+
+        let out = generate_mfile(matched, &origin);
+
+        assert!(out.contains("repo = \"https://github.com/gominimal/pkgs\""));
+        assert!(out.contains("branch = \"main\""));
+        assert!(out.contains("locked_commit = \"abc123\""));
+        assert!(out.contains("use = \"rust\""));
+        assert!(out.contains("build_packages = [\"cc\"]"));
+        assert!(out.contains("runtime_packages = [\"openssl\"]"));
+    }
+
+    #[test]
+    fn generate_mfile_falls_back_to_shell_without_match() {
+        let origin = SpecOrigin::Repo(Repo::Git {
+            url: "u".to_string(),
+            rev: "r".to_string(),
+            tracking: None,
+        });
+
+        let out = generate_mfile(None, &origin);
+
+        assert!(out.contains("use = \"shell\""));
+        // No tracking branch and no detected packages.
+        assert!(!out.contains("branch ="));
+        assert!(!out.contains("build_packages"));
+        assert!(!out.contains("runtime_packages"));
+    }
+}

--- a/crates/op/src/project/mod.rs
+++ b/crates/op/src/project/mod.rs
@@ -1,0 +1,66 @@
+//! Operations that create or refresh a project's `minimal.toml` and its
+//! checkouts, based on an existing codebase.
+//!
+//! Unlike a [`crate::Runnable`], which builds cache artifacts against the
+//! package [`Graph`], these operations inspect and mutate the project checkout
+//! itself. The capabilities they need from the surrounding tooling (VCS
+//! checkouts, graph construction, the on-disk `minimal.toml`) are abstracted
+//! behind the [`ProjectEnv`] port, which `mctx` implements.
+
+use std::path::Path;
+
+use common::Target;
+use graph::Graph;
+use mfile::LinkConfig;
+
+use crate::Error;
+
+mod init;
+mod update;
+
+pub use init::{InitPlan, InitProject};
+pub use update::{RevChange, UpdateProject, UpdateReport};
+
+/// The environment a [`ProjectOp`] runs against: an existing (or to-be-created)
+/// project checkout, its `minimal.toml`, and the VCS + graph machinery needed
+/// to inspect it.
+///
+/// This is the project-setup counterpart to [`crate::Options`]. It is
+/// implemented outside this crate (by `mctx`) so that `op` need not depend on
+/// the higher-level context, VCS, or remote-cache machinery.
+pub trait ProjectEnv {
+    /// Root of the project checkout being configured.
+    fn repo_dir(&self) -> &Path;
+
+    /// The project's `minimal.toml`, if one exists yet.
+    ///
+    /// Returns `None` during a fresh `init`, before any `minimal.toml` has been
+    /// written.
+    fn minimal_file(&self) -> Option<&mfile::File>;
+
+    /// Resolve `branch` of `repo` to its current commit, performing a
+    /// checkout/fetch as needed.
+    fn checkout_branch(&mut self, repo: &str, branch: &str) -> Result<String, Error>;
+
+    /// Fetch/update every known checkout.
+    fn update_checkouts(&mut self) -> Result<(), Error>;
+
+    /// Build the full package graph from the given upstream `link`.
+    fn graph_from_chain(&mut self, link: LinkConfig, target: Target) -> Result<Graph, Error>;
+
+    /// Best-effort invalidation of any cached remote index, so the next
+    /// operation performs a fresh fetch.
+    fn invalidate_remote_index(&mut self);
+}
+
+/// An operation that creates or refreshes a project's `minimal.toml` and its
+/// checkouts from an existing codebase.
+///
+/// This is the project-setup counterpart to [`crate::Runnable`].
+pub trait ProjectOp {
+    /// The value produced by running the operation.
+    type Result: Sized;
+
+    /// Run the operation against the given [`ProjectEnv`].
+    fn run<E: ProjectEnv>(&mut self, env: &mut E) -> Result<Self::Result, Error>;
+}

--- a/crates/op/src/project/update.rs
+++ b/crates/op/src/project/update.rs
@@ -1,0 +1,168 @@
+//! The `update` operation: refresh upstream/sideload checkouts and re-pin them
+//! in the project's `minimal.toml`.
+
+use anyhow::anyhow;
+use mfile::LinkConfig;
+use toml_edit::{DocumentMut, value};
+
+use super::{ProjectEnv, ProjectOp};
+use crate::Error;
+
+/// Refreshes a project's upstream and sideload checkouts to the head of their
+/// tracking branches and re-pins the new commits in `minimal.toml`.
+///
+/// Downloading any newly-reachable packages is deliberately left to the caller:
+/// this operation only concerns the `minimal.toml` and its checkouts.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UpdateProject;
+
+/// A single pin that moved during an update.
+#[derive(Debug, Clone)]
+pub struct RevChange {
+    /// The repository whose pin changed.
+    pub repo: String,
+    /// The tracking branch the new commit was taken from.
+    pub branch: String,
+    /// The previously pinned commit, if any (`None` when previously unpinned).
+    pub from: Option<String>,
+    /// The newly pinned commit.
+    pub to: String,
+}
+
+/// A summary of what [`UpdateProject`] changed, for the caller to report.
+#[derive(Debug, Default, Clone)]
+pub struct UpdateReport {
+    /// The upstream pin, if it moved.
+    pub upstream: Option<RevChange>,
+    /// Any sideload pins that moved.
+    pub sideloads: Vec<RevChange>,
+    /// Whether a legacy `[harness]` table was migrated to `[stack]`.
+    pub migrated_harness: bool,
+}
+
+impl ProjectOp for UpdateProject {
+    type Result = UpdateReport;
+
+    fn run<E: ProjectEnv>(&mut self, env: &mut E) -> Result<UpdateReport, Error> {
+        // Snapshot everything we need from the minimal file before taking the
+        // mutable borrows the checkout/update calls require.
+        let Some(mfile) = env.minimal_file() else {
+            // No minimal file to re-pin; still refresh checkouts best-effort.
+            env.invalidate_remote_index();
+            env.update_checkouts()?;
+            return Ok(UpdateReport::default());
+        };
+        let mfile_path = mfile.file_path().cloned();
+
+        let upstream: Option<(String, Option<String>, Option<String>)> =
+            match mfile.upstream.as_ref().map(|u| &u.link) {
+                Some(LinkConfig::Git {
+                    repo,
+                    branch,
+                    locked_commit,
+                }) => Some((repo.clone(), branch.clone(), locked_commit.clone())),
+                Some(LinkConfig::Dir { .. }) | None => None,
+            };
+
+        // Preserve index alignment with the on-disk `[[upstream.sideload]]`
+        // array: non-git / branchless sideloads stay as `None`.
+        let sideloads: Vec<Option<(String, String, Option<String>)>> = mfile
+            .upstream
+            .as_ref()
+            .map(|u| u.sideloads())
+            .unwrap_or_default()
+            .iter()
+            .map(|s| match s.link() {
+                LinkConfig::Git {
+                    repo,
+                    branch: Some(branch),
+                    locked_commit,
+                } => Some((repo.clone(), branch.clone(), locked_commit.clone())),
+                _ => None,
+            })
+            .collect();
+
+        // best effort, yeet any cached remote index so a fresh fetch occurs
+        env.invalidate_remote_index();
+        env.update_checkouts()?;
+
+        // If a tracking branch is specified for the upstream, check out its head.
+        let new_up_rev = if let Some((repo, Some(b), commit)) = &upstream {
+            let new_git_ref = env.checkout_branch(repo, b)?;
+            (Some(&new_git_ref) != commit.as_ref()).then_some(new_git_ref)
+        } else {
+            None
+        };
+
+        // Update all the sideloads, if present.
+        let sideload_updates = sideloads
+            .iter()
+            .map(|s| match s {
+                Some((repo, branch, locked_commit)) => {
+                    let new_git_ref = env.checkout_branch(repo, branch)?;
+                    Ok((Some(&new_git_ref) != locked_commit.as_ref()).then_some(new_git_ref))
+                }
+                None => Ok(None),
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        let mut report = UpdateReport::default();
+
+        // If theres a minimal file on disk, and:
+        //  - theres at least one new rev, or
+        //  - we need to migrate the 'harness' name to 'stack'
+        //
+        // write the revs to the minimal file.
+        let Some(p) = mfile_path else {
+            return Ok(report);
+        };
+
+        let toml = std::fs::read_to_string(&p)
+            .map_err(|e| Error::Other(anyhow!("reading {} for update: {e}", p.display())))?;
+        let mut doc = toml
+            .parse::<DocumentMut>()
+            .map_err(|e| Error::Other(anyhow::Error::from(e)))?;
+
+        // TODO: Remove after June 2026.
+        if let Some(t) = doc.remove("harness") {
+            doc.insert("stack", t);
+            report.migrated_harness = true;
+        }
+
+        if new_up_rev.is_some()
+            || sideload_updates.iter().any(|u| u.is_some())
+            || report.migrated_harness
+        {
+            if let Some(new_rev) = new_up_rev {
+                doc["upstream"]["locked_commit"] = value(new_rev.clone());
+                // `new_up_rev` is only set when the upstream has a tracking branch.
+                let (repo, branch, from) = upstream.expect("upstream present for new rev");
+                report.upstream = Some(RevChange {
+                    repo,
+                    branch: branch.expect("tracking branch present for new rev"),
+                    from,
+                    to: new_rev,
+                });
+            }
+
+            for (i, rev) in sideload_updates.into_iter().enumerate() {
+                if let Some(new_rev) = rev {
+                    if let Some((repo, branch, from)) = &sideloads[i] {
+                        report.sideloads.push(RevChange {
+                            repo: repo.clone(),
+                            branch: branch.clone(),
+                            from: from.clone(),
+                            to: new_rev.clone(),
+                        });
+                    }
+                    doc["upstream"]["sideload"][i]["locked_commit"] = value(new_rev);
+                }
+            }
+
+            std::fs::write(&p, doc.to_string())
+                .map_err(|e| Error::Other(anyhow!("writing {}: {e}", p.display())))?;
+        }
+
+        Ok(report)
+    }
+}

--- a/crates/op/src/project/update.rs
+++ b/crates/op/src/project/update.rs
@@ -36,8 +36,6 @@ pub struct UpdateReport {
     pub upstream: Option<RevChange>,
     /// Any sideload pins that moved.
     pub sideloads: Vec<RevChange>,
-    /// Whether a legacy `[harness]` table was migrated to `[stack]`.
-    pub migrated_harness: bool,
 }
 
 impl ProjectOp for UpdateProject {
@@ -108,11 +106,8 @@ impl ProjectOp for UpdateProject {
 
         let mut report = UpdateReport::default();
 
-        // If theres a minimal file on disk, and:
-        //  - theres at least one new rev, or
-        //  - we need to migrate the 'harness' name to 'stack'
-        //
-        // write the revs to the minimal file.
+        // If theres a minimal file on disk with at least one new rev, write the
+        // revs to the minimal file.
         let Some(p) = mfile_path else {
             return Ok(report);
         };
@@ -123,16 +118,7 @@ impl ProjectOp for UpdateProject {
             .parse::<DocumentMut>()
             .map_err(|e| Error::Other(anyhow::Error::from(e)))?;
 
-        // TODO: Remove after June 2026.
-        if let Some(t) = doc.remove("harness") {
-            doc.insert("stack", t);
-            report.migrated_harness = true;
-        }
-
-        if new_up_rev.is_some()
-            || sideload_updates.iter().any(|u| u.is_some())
-            || report.migrated_harness
-        {
+        if new_up_rev.is_some() || sideload_updates.iter().any(|u| u.is_some()) {
             if let Some(new_rev) = new_up_rev {
                 doc["upstream"]["locked_commit"] = value(new_rev.clone());
                 // `new_up_rev` is only set when the upstream has a tracking branch.


### PR DESCRIPTION
Moves the logic for `minimal init` and `minimal update` into the op crate, generalized by the `ProjectOp` trait.

This enables:

1. Tests
2. Being able to do these operations in minimald

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined project setup for creating and updating `minimal.toml`.
  * Initialization now auto-detects the project stack and generates the configuration and output path.
  * Updates now refresh upstream/sideload pins and return a structured report of changes.
* **Refactor**
  * Initialization and update commands were refactored to share centralized project setup and operations.
  * Init confirmation preview now reflects the generated TOML content; accepts `yes` in addition to `y`.
* **Bug Fixes**
  * Improved error handling for project operations with clearer error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->