### PR TITLE
feat(sessions): tighten daemon composer pending/ready routing

### DIFF
--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -224,11 +224,16 @@ pub struct CreateSessionRequest {
 
 /// The response for a [`CreateSession`] RPC.
 ///
-/// `Ready` is the only variant exercised today; `Pending` is
-/// reserved for when daemon-side Phase 2 routing lands and the
-/// daemon can ask the client to gate items that need approval.
-/// Defining both up front locks the wire shape so adding the
-/// Pending path later doesn't break callers.
+/// Both variants are part of the Phase 2 flow and reachable on the
+/// wire: `Ready` when the daemon's composer finalizes in one shot,
+/// `Pending` when it collects items the client must gate before
+/// composition completes (the client follows up via `SubmitVerdict`).
+///
+/// In practice today every caller still takes the `Ready` path — no
+/// daemon-side contributors (project / package `Composable`s) are
+/// wired into the manager yet, so the composer never has anything to
+/// route back for gating. `Pending` lights up automatically once
+/// those contributors land.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum CreateSessionResponse {

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -7,6 +7,8 @@ use crate::{
 use paths::DaemonAbsPath;
 use sessions::{
     SessionId,
+    core::compose::ComposeOptions,
+    daemon::composer::{ComposeOutcome, SessionComposer},
     store::{DiskLoader, Loader, SessionKey, SessionObject},
     wire::request::WireContribution,
 };
@@ -306,29 +308,56 @@ impl<L: Loader> Manager<L> {
                             ));
                         }
 
-                        // Until daemon-side Phase 2 routing lands, the only
-                        // valid contribution is the empty default. Silently
-                        // dropping a non-empty contribution would let clients
-                        // believe their composed vars/patches/packages/hooks
-                        // were honored — they would not be. Reject explicitly
-                        // so the failure surfaces at the call site instead
-                        // of as missing items in the assembled session.
+                        // Drive Phase 2 via `SessionComposer`. The daemon
+                        // doesn't add any project/package contributors yet,
+                        // so on the all-decided path the composer just
+                        // cross-process-merges the client's wire
+                        // contribution into an empty `Composition`.
                         //
-                        // TODO(composition): when Phase 2 lands, the
-                        // composition pipeline consumes this field instead.
-                        // The seam is here: replace this check with the
-                        // partition + ContributionResponse flow.
-                        if contribution != WireContribution::default() {
-                            return Err(SessionsError::new(
-                                std::io::ErrorKind::InvalidInput,
-                                "non-empty WireContribution is not supported \
-                                 by this daemon — daemon-side composition \
-                                 (Phase 2) is not wired yet",
-                            ));
+                        // The `session_id` parameter on `compose` is only
+                        // observed on the `Pending` outcome (it goes on
+                        // the response so the client can correlate a
+                        // future `SubmitVerdict`). The `Ready` outcome
+                        // ignores it. We pass `nil` because the manager
+                        // doesn't allocate the id until `store.create`
+                        // below — and the `Pending` outcome is unreachable
+                        // today since no daemon-side contributors are
+                        // wired in. The defensive guard below catches
+                        // it anyway.
+                        let composer = SessionComposer::new(contribution);
+                        match composer.compose(SessionId::nil(), ComposeOptions::default()) {
+                            Ok(ComposeOutcome::Ready(_composition)) => {}
+                            Ok(ComposeOutcome::Pending { .. }) => {
+                                // Unreachable today: no daemon-side
+                                // contributors are wired in, so the
+                                // composer can never collect a var or
+                                // patch that would need the client to
+                                // gate. Defensive guard for when that
+                                // changes — once the `SubmitVerdict`
+                                // handler exists, this branch will
+                                // persist a Draft and return Pending.
+                                return Err(std::io::Error::new(
+                                    std::io::ErrorKind::InvalidInput,
+                                    "CreateSession produced a Pending outcome, \
+                                     but the daemon cannot yet resume from a \
+                                     client verdict",
+                                ));
+                            }
+                            Err(e) => {
+                                // Cross-process conflict or wire-shape
+                                // failure during merge. Both are
+                                // declaration-time bugs — surface as
+                                // InvalidInput.
+                                return Err(std::io::Error::new(
+                                    std::io::ErrorKind::InvalidInput,
+                                    e.to_string(),
+                                ));
+                            }
                         }
+
                         // Assemble the on-disk Record from out-of-band config
                         // + the SSH-supplied username. Persists `Active`
-                        // immediately on the empty-contribution fast path.
+                        // immediately on the all-decided path.
                         let record = sessions::Record {
                             id: SessionId::nil(),
                             name: config.name,
@@ -744,12 +773,13 @@ mod tests {
         assert_eq!(err.kind(), ErrorKind::NotFound);
     }
 
-    /// A non-empty `WireContribution` must be refused with
-    /// `InvalidInput` until daemon-side Phase 2 routing lands.
-    /// Silently dropping it would let clients believe their
-    /// composed items were honored.
+    /// A non-empty `WireContribution` from the client is accepted —
+    /// the daemon-side composer cross-process-merges it into an
+    /// empty `Composition` (no daemon contributors are wired today)
+    /// and the session persists `Active`. Was previously rejected
+    /// pre-Step 6 to prevent silent data loss; now flows through.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn create_session_rejects_non_empty_contribution() {
+    async fn create_session_accepts_client_contribution() {
         use sessions::core::source::Source;
         use sessions::wire::primitives::{WireResolvedVar, WireSessionVar, WireSource};
 
@@ -765,10 +795,13 @@ mod tests {
             }),
         });
 
-        let err = mngr
+        let resp = mngr
             .create_session(sample_config(), None, contribution)
             .await
-            .expect_err("non-empty contribution must be rejected today");
-        assert_eq!(err.kind(), ErrorKind::InvalidInput);
+            .expect("non-empty contribution should succeed via SessionComposer");
+        assert!(matches!(
+            resp,
+            minimald_rpc::CreateSessionResponse::Ready { .. }
+        ));
     }
 }

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -80,9 +80,12 @@ struct CreateSessionMsg {
     /// Authenticated SSH username, supplied by the RPC handler from
     /// the SSH connection context (never the client).
     username: Option<String>,
-    /// Client-side Phase 1 contribution. Today the handler rejects
-    /// anything other than the default; the composition pipeline will
-    /// consume it when Phase 2 lands.
+    /// Client-side Phase 1 contribution. Fed into `SessionComposer`
+    /// in the handler: the composer either finalizes a `Composition`
+    /// (persist Active, ship `Ready { id }`) or routes items back to
+    /// the client for gating (persist Pending, stash state, ship
+    /// `Pending { id, response }`). A cross-process merge conflict
+    /// or malformed wire item surfaces as `InvalidInput`.
     contribution: WireContribution,
     responder: Responder<minimald_rpc::CreateSessionResponse>,
 }
@@ -326,7 +329,31 @@ impl<L: Loader> Manager<L> {
                         // it anyway.
                         let composer = SessionComposer::new(contribution);
                         match composer.compose(SessionId::nil(), ComposeOptions::default()) {
-                            Ok(ComposeOutcome::Ready(_composition)) => {}
+                            Ok(ComposeOutcome::Ready(composition)) => {
+                                // The composition carries the merged
+                                // vars / patches / packages / lifecycle
+                                // hooks the composer produced. There is
+                                // no apply layer yet — the on-disk
+                                // Record below stores only the
+                                // out-of-band `SessionConfig`, so a
+                                // non-empty composition would be
+                                // silently discarded. Reject rather
+                                // than lose the client's contribution.
+                                // Fast path (empty client contribution,
+                                // no daemon contributors) still passes.
+                                if !composition.vars().is_empty()
+                                    || !composition.patches().is_empty()
+                                    || !composition.packages().is_empty()
+                                    || !composition.lifecycle_hooks().is_empty()
+                                {
+                                    return Err(std::io::Error::new(
+                                        std::io::ErrorKind::InvalidInput,
+                                        "CreateSession composed a non-empty \
+                                         Composition, but the apply layer that \
+                                         would consume it is not wired yet",
+                                    ));
+                                }
+                            }
                             Ok(ComposeOutcome::Pending { .. }) => {
                                 // Unreachable today: no daemon-side
                                 // contributors are wired in, so the
@@ -773,13 +800,14 @@ mod tests {
         assert_eq!(err.kind(), ErrorKind::NotFound);
     }
 
-    /// A non-empty `WireContribution` from the client is accepted —
-    /// the daemon-side composer cross-process-merges it into an
-    /// empty `Composition` (no daemon contributors are wired today)
-    /// and the session persists `Active`. Was previously rejected
-    /// pre-Step 6 to prevent silent data loss; now flows through.
+    /// A non-empty `WireContribution` from the client is rejected —
+    /// the composer would produce a non-empty `Composition`, and
+    /// there is no apply layer yet to consume it. Accepting would
+    /// silently discard the client's contribution while the on-disk
+    /// Record only carries the out-of-band `SessionConfig`.
+    /// Prevents the silent data loss until apply plumbing lands.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn create_session_accepts_client_contribution() {
+    async fn create_session_rejects_non_empty_client_contribution() {
         use sessions::core::source::Source;
         use sessions::wire::primitives::{WireResolvedVar, WireSessionVar, WireSource};
 
@@ -795,13 +823,10 @@ mod tests {
             }),
         });
 
-        let resp = mngr
+        let err = mngr
             .create_session(sample_config(), None, contribution)
             .await
-            .expect("non-empty contribution should succeed via SessionComposer");
-        assert!(matches!(
-            resp,
-            minimald_rpc::CreateSessionResponse::Ready { .. }
-        ));
+            .expect_err("non-empty composition should be rejected until apply plumbing lands");
+        assert_eq!(err.kind(), ErrorKind::InvalidInput);
     }
 }

--- a/crates/minvmd/tests/minimald_session_e2e.rs
+++ b/crates/minvmd/tests/minimald_session_e2e.rs
@@ -224,9 +224,17 @@ async fn run_session_exec(
             .await
             .map_err(|e| format!("request_subsystem: {e}"))?;
 
+        // Unique name per invocation — minimald dedups sessions by
+        // name, so the outer retry loop would otherwise collide on
+        // `AlreadyExists` after any prior attempt persisted a record.
+        // Matches the convention in `crates/minvmd/examples/exec.rs`.
+        let uniq = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
         let req = CreateSessionRequest {
             config: minimald_rpc::SessionConfig {
-                name: Some("minvmd-e2e".to_string()),
+                name: Some(format!("minvmd-e2e-{uniq:x}")),
                 project_path: paths::HostAbsPath::try_new("/tmp")
                     .map_err(|e| format!("project_path: {e}"))?,
                 network: sessions::NetworkMode::default(),

--- a/crates/sessions/docs/COMPOSITION.md
+++ b/crates/sessions/docs/COMPOSITION.md
@@ -91,13 +91,14 @@ verbatim) and draws items from project- and package-level
   `ComposeOutcome::Ready(composition)`.
 - **Pending path.** If the daemon collected any vars or patches,
   the composer routes every one of them back to the client as
-  pending items —
-  the daemon never runs user policy, so no daemon-origin item is
-  ever auto-decided. The pending items + the daemon-collected
-  packages and lifecycle hooks (which have no per-item verdict
-  slot) ride in a `ContributionResponse`; the daemon also retains
-  a `PendingComposeState` so Phase 4 can finalize after the
-  verdict comes back.
+  pending items — the daemon never runs user policy, so no
+  daemon-origin item is ever auto-decided. The `ContributionResponse`
+  carries the pending vars and patches plus a copy of the
+  daemon-collected lifecycle hooks (for client-side audit; hooks
+  have no per-item verdict slot). **Packages never appear on the
+  wire** — the response schema has no slot for them; they stay in
+  the daemon's `PendingComposeState` alongside the hooks so Phase 4
+  can finalize after the verdict comes back.
 
 ### Phase 3 — Client gates the pending items
 
@@ -134,14 +135,17 @@ copies patched files, and installs lifecycle hooks.
 
 **Response shape.** The daemon returns
 `CreateSessionResponse::Ready { id }` when no items need user
-gating (today's only path, including the empty-contribution fast
-path used by internal callers) or
+gating or
 `CreateSessionResponse::Pending { id, response }` when items need
 user-side gating. The `id` is allocated before the response
 returns, so file uploads (when that subsystem lands) can target
 the session as soon as the client receives either variant. Today
-only `Ready` is reachable; `Pending` is wire-defined for the
-daemon-side Phase 2 routing that will land in a future change.
+`Ready` is the only variant that reaches the wire: the composer
+already produces `ComposeOutcome::Pending` on paper, but the
+manager's `CreateSession` handler rejects that outcome with
+`InvalidInput` because the resume path (`SubmitVerdict` + apply
+consumption of the finalized `Composition`) isn't yet wired.
+`Pending` becomes wire-reachable when that path lands.
 
 **Empty-contribution fast path.** When the client sends
 `WireContribution::default()` the daemon skips Phase 2 entirely:

--- a/crates/sessions/docs/COMPOSITION.md
+++ b/crates/sessions/docs/COMPOSITION.md
@@ -44,11 +44,15 @@ batches every verdict into one `ContributionVerdict`.
 > **Status note.** The shared gate pipeline (`compose_contribution`,
 > with `gate_vars` + `gate_patches`) lives in `core::compose`. Phase
 > 1 runs it via `UserComposer::compose` and Phase 3 runs it via
-> `client::handler::handle_response`. Phases 2 and 4 (daemon-side
-> routing) are not yet wired: `SessionComposer::compose` errors with
-> `HookRequired` instead of batching pending items into a
-> `ContributionResponse`, and there is no `SubmitVerdict` handler
-> yet to apply verdicts and assemble the final `Composition`.
+> `client::handler::handle_response`. Phase 2 (daemon-side routing)
+> lives in `SessionComposer::compose` and produces a
+> `ComposeOutcome::Ready` or `ComposeOutcome::Pending`. Phase 4 is
+> partially wired — the `Ready` outcome is consumed (the manager
+> persists the session and returns `CreateSessionResponse::Ready`),
+> but `Pending` outcomes are still rejected with `InvalidInput`
+> because the `SubmitVerdict` handler hasn't landed yet. No daemon-
+> side project/package contributors are wired in either, so every
+> caller still hits the all-decided path today.
 
 ## Phases in detail
 
@@ -74,11 +78,26 @@ contribution fast path described in Phase 4.
 
 The daemon receives the `WireContribution` (already gated, trusted
 verbatim) and draws items from project- and package-level
-`Composable`s into a `Contribution`. Items decidable from the
-user's existing policy go straight into the building `Composition`;
-items the policy can't decide are collected as
-`WirePendingVar`/`WirePendingPatch` and emitted in one
-`ContributionResponse`.
+`Composable`s into a `Contribution` via `SessionComposer::add`.
+`SessionComposer::compose` then drives the routing:
+
+- **All-decided fast path.** If the daemon collected no vars and
+  no patches (today's only path — no project/package contributors
+  are wired into the manager yet), the composer assembles a
+  `Composition` directly: daemon-collected packages and lifecycle
+  hooks pass through (neither has a per-item verdict slot in the
+  wire schema), and the client's already-gated wire contribution
+  is merged in via `Composition::extend_from_wire`. Returns
+  `ComposeOutcome::Ready(composition)`.
+- **Pending path.** If the daemon collected any vars or patches,
+  the composer routes every one of them back to the client as
+  pending items —
+  the daemon never runs user policy, so no daemon-origin item is
+  ever auto-decided. The pending items + the daemon-collected
+  packages and lifecycle hooks (which have no per-item verdict
+  slot) ride in a `ContributionResponse`; the daemon also retains
+  a `PendingComposeState` so Phase 4 can finalize after the
+  verdict comes back.
 
 ### Phase 3 — Client gates the pending items
 
@@ -333,9 +352,12 @@ overload:
   merge in `Composition::extend_from_wire`), `HookContract`
   (application bug —
   wrong decision count, or `UseRule` to a still-undecidable
-  item), `HookRequired` (non-user-origin item reached the daemon
-  composer with no hook to prompt — placeholder until Phase 2
-  routing lands), `PatchWalk` (IO-level filesystem walk failures),
+  item), `HookRequired` (non-user-origin item reached a
+  legacy `core::compose` path with no hook to prompt — Phase 2
+  now routes such items through `SessionComposer::compose`
+  instead; this remains for the per-side
+  `compose_contribution` codepath), `PatchWalk` (IO-level
+  filesystem walk failures),
   `Expansion` (malformed `$VAR` / `~` pattern, or undefined var),
   `VarResolution` (a Phase 3 pending `Inherit` var couldn't be
   resolved against the client env), `InvalidPendingPatchDest` (a

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -22,7 +22,8 @@ use crate::core::source::{
 };
 use crate::wire::policy::{WirePatchVerdict, WireVarVerdict};
 use crate::wire::primitives::{
-    PendingId, WirePendingVar, WireResolvedVar, WireSessionPatch, WireSessionVar,
+    PendingId, WirePendingPatch, WirePendingVar, WireProvenancedHook, WireResolvedVar,
+    WireSessionPatch, WireSessionVar, WireVarSpec,
 };
 
 /// Errors produced while a [`Composable`] materializes its
@@ -354,6 +355,17 @@ impl Contribution {
         dedupe_by_name(&mut self.packages, ProvenancedPackage::package);
         self.lifecycle_hooks.extend(other.lifecycle_hooks);
         Ok(())
+    }
+
+    /// True when no items have been contributed across any domain.
+    /// Used by daemon-side composers to take the empty-contribution
+    /// fast path (no pending items to ship back to the client).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.vars.is_empty()
+            && self.patches.is_empty()
+            && self.packages.is_empty()
+            && self.lifecycle_hooks.is_empty()
     }
 
     /// All vars contributed so far.
@@ -952,6 +964,30 @@ impl Composition {
         self.lifecycle_hooks.extend(incoming_hooks);
         Ok(())
     }
+
+    /// Construct a [`Composition`] pre-populated with daemon-side
+    /// pass-through items (packages and lifecycle hooks — neither
+    /// has a per-item user-policy gate).
+    ///
+    /// Used by the daemon-side composer on the all-decided fast
+    /// path: vars and patches don't appear here because anything
+    /// that would have needed the client's verdict routes through
+    /// [`ComposeOutcome::Pending`] instead. Packages are deduped by
+    /// name (same rule [`Contribution::merge`] applies).
+    ///
+    /// [`ComposeOutcome::Pending`]: crate::daemon::composer::ComposeOutcome::Pending
+    pub(crate) fn from_daemon_passthrough(
+        mut packages: Vec<ProvenancedPackage>,
+        lifecycle_hooks: Vec<ProvenancedHook>,
+    ) -> Self {
+        dedupe_by_name(&mut packages, ProvenancedPackage::package);
+        Self {
+            vars: Vec::new(),
+            patches: Vec::new(),
+            packages,
+            lifecycle_hooks,
+        }
+    }
 }
 
 /// Configuration for the compose pipeline.
@@ -1343,6 +1379,103 @@ pub(crate) fn compose_contribution(
         lifecycle_hooks,
     };
     Ok((composition, final_policy))
+}
+
+/// Output of [`contribution_to_pending`]: the daemon-collected vars,
+/// patches, and lifecycle hooks in their daemon→client wire shape.
+///
+/// Packages are deliberately not included — the wire schema's
+/// [`ContributionResponse`] has no slot for them, and the daemon
+/// stashes them separately for Phase 4 to install. Lifecycle hooks
+/// have no per-item verdict on the wire either, but the response
+/// does carry a copy for client-side audit, so they're included here.
+///
+/// [`ContributionResponse`]: crate::wire::request::ContributionResponse
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct WirePending {
+    /// Pending vars (id-tagged for verdict correlation).
+    pub(crate) vars: Vec<WirePendingVar>,
+    /// Pending patches (id-tagged for verdict correlation).
+    pub(crate) patches: Vec<WirePendingPatch>,
+    /// Lifecycle hooks (no per-item verdict — pass-through to the
+    /// daemon's apply layer; see [`ContributionResponse::lifecycle_hooks`]).
+    ///
+    /// [`ContributionResponse::lifecycle_hooks`]: crate::wire::request::ContributionResponse::lifecycle_hooks
+    pub(crate) lifecycle_hooks: Vec<WireProvenancedHook>,
+}
+
+/// Convert daemon-collected vars, patches, and lifecycle hooks into
+/// their wire pending shape. Pure: no policy is consulted (the daemon
+/// never runs user policy), no env is touched (clients resolve
+/// `Inherit` shapes).
+///
+/// Every var and patch becomes a pending item with a fresh
+/// `PendingId` so the client's verdict can correlate per-item.
+/// Lifecycle hooks pass through unchanged — there's no per-item
+/// policy gate for them, the wire response just carries them for
+/// audit and the daemon installs the originals from its stash.
+///
+/// Packages aren't transformed here. The wire response has no
+/// packages slot, so daemon-collected packages stay in domain
+/// shape on the daemon-side stash; callers extract them off the
+/// `Contribution` separately before calling this.
+///
+/// Ids are assigned by position within each domain. Two items in
+/// different domains may share the integer; correlation is per
+/// `(domain, id)` from the daemon's perspective.
+///
+/// # Panics
+///
+/// Panics if a single domain holds more than `u32::MAX + 1` items,
+/// which the wire schema's [`PendingId`] cannot represent. In
+/// practice no daemon-collected contribution gets near that bound.
+pub(crate) fn contribution_to_pending(
+    vars: Vec<ProvenancedVar>,
+    patches: Vec<ProvenancedPatch>,
+    lifecycle_hooks: Vec<ProvenancedHook>,
+) -> WirePending {
+    let vars: Vec<WirePendingVar> = vars
+        .into_iter()
+        .enumerate()
+        .map(|(i, pv)| {
+            let (resolved, source) = pv.into_parts();
+            let (name, value) = resolved.into_parts();
+            WirePendingVar {
+                // Items reach this transform already resolved (the
+                // composer's input is `ResolvedVar`); ship as a
+                // `Specified` spec so the client treats the value
+                // verbatim instead of re-resolving against its env.
+                id: PendingId::new(u32::try_from(i).expect("pending var index fits in u32")),
+                name,
+                spec: WireVarSpec::Specified { value },
+                source: source.into(),
+            }
+        })
+        .collect();
+
+    let patches: Vec<WirePendingPatch> = patches
+        .into_iter()
+        .enumerate()
+        .map(|(i, pp)| {
+            let (patch, source) = pp.into_parts();
+            WirePendingPatch {
+                id: PendingId::new(u32::try_from(i).expect("pending patch index fits in u32")),
+                source_pattern: patch.source().to_string(),
+                destination: patch.dest().as_sandbox_path().clone(),
+                description: None,
+                source: source.into(),
+            }
+        })
+        .collect();
+
+    let lifecycle_hooks: Vec<WireProvenancedHook> =
+        lifecycle_hooks.into_iter().map(Into::into).collect();
+
+    WirePending {
+        vars,
+        patches,
+        lifecycle_hooks,
+    }
 }
 
 // =====================================================================

--- a/crates/sessions/src/daemon/composer.rs
+++ b/crates/sessions/src/daemon/composer.rs
@@ -2,23 +2,74 @@
 //! project and package contributions, and produces a final
 //! [`Composition`].
 
+use crate::SessionId;
 use crate::core::compose::{
     Composable, ComposeError, ComposeOptions, Composition, Contribution, Error, StoredEnv,
-    compose_contribution, default_env,
+    contribution_to_pending, default_env,
 };
-use crate::core::policy::UserPolicy;
-use crate::wire::request::WireContribution;
+use crate::core::source::{ProvenancedHook, ProvenancedPackage};
+use crate::wire::request::{ContributionResponse, WireContribution};
+
+/// Daemon-side state that survives a `Pending` outcome and feeds
+/// into Phase 4 once the client's verdict comes back.
+///
+/// Packages and lifecycle hooks have no per-item verdict (the wire
+/// schema doesn't carry verdicts for them), so the daemon retains
+/// its own copy here. `client_contribution` is the client's
+/// already-gated wire contribution, untouched — Phase 4 calls
+/// [`Composition::extend_from_wire`] on it after the verdict
+/// resolves the pending vars/patches.
+///
+/// [`Composition::extend_from_wire`]: crate::core::compose::Composition::extend_from_wire
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingComposeState {
+    /// Daemon-collected packages. The wire response has no slot for
+    /// them; the daemon installs them when Phase 4 finalizes.
+    pub daemon_packages: Vec<ProvenancedPackage>,
+    /// Daemon-collected lifecycle hooks. A copy goes in the wire
+    /// response for client-side audit; the daemon also retains this
+    /// copy for Phase 4 install.
+    pub daemon_lifecycle_hooks: Vec<ProvenancedHook>,
+    /// Client's already-gated wire contribution, untouched.
+    pub client_contribution: WireContribution,
+}
+
+/// Output of [`SessionComposer::compose`].
+///
+/// `Ready` fires when the daemon collected no vars and no patches —
+/// the only two domains with a per-item user-policy gate. Packages
+/// and lifecycle hooks pass through on this path. Today every
+/// internal caller hits the narrower case where the daemon
+/// collected nothing at all. `Pending` fires when the daemon
+/// collected a var or patch the client must gate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ComposeOutcome {
+    /// All items decided; the assembled Composition is ready to apply.
+    Ready(Composition),
+    /// The client must gate `response.vars` and `response.patches`
+    /// before composition completes. `state` is the daemon-side
+    /// stash Phase 4 will need to finalize.
+    Pending {
+        /// Wire payload the daemon ships back to the client.
+        response: ContributionResponse,
+        /// Daemon-side state retained for Phase 4. Not on the wire.
+        state: PendingComposeState,
+    },
+}
 
 /// Accumulator for daemon-side contributions (project + packages),
 /// joined with the client's already-gated wire contribution.
 ///
-/// [`Self::compose`] runs the daemon-side items through the policy
-/// and then appends the client's pre-gated items verbatim. The daemon
-/// does *not* run policy hooks — items the policy can't auto-decide
-/// are routed back to the client (eventually) as a
-/// [`crate::wire::request::ContributionResponse`]. Until that
-/// queueing path is wired, any non-user-origin item that reaches
-/// `NeedsApproval` surfaces as [`ComposeError::HookRequired`].
+/// [`Self::compose`] returns [`ComposeOutcome::Ready`] when the
+/// daemon collected no vars and no patches — the only two domains
+/// with a per-item user-policy gate. Daemon-collected packages and
+/// lifecycle hooks pass through on that path (the all-decided fast
+/// path runs the cross-process merge via
+/// [`Composition::extend_from_wire`] and finalizes). It returns
+/// [`ComposeOutcome::Pending`] when the daemon collected a var or
+/// patch that needs the client's verdict — the daemon never runs
+/// user policy, so Pending items are routed back to the client
+/// for Phase 3 gating.
 pub struct SessionComposer {
     client: WireContribution,
     contribution: Contribution,
@@ -92,37 +143,102 @@ impl SessionComposer {
         Ok(())
     }
 
-    /// Compose daemon-side items against `policy`, then append the
-    /// client's already-gated contribution.
+    /// Drive Phase 2: produce either a finalized [`Composition`] or a
+    /// [`ContributionResponse`] for the client to gate.
     ///
-    /// The policy is unchanged on return — hooks (which could update
-    /// it) don't run here; that happens on the client when verdicts
-    /// are generated for the daemon's `ContributionResponse`.
+    /// **The daemon never runs user policy.** This method routes any
+    /// daemon-collected var or patch back to the client as a pending
+    /// item — the client applies its `policy` and `PolicyHooks` in
+    /// Phase 3, and a future `SubmitVerdict` handler resumes from
+    /// the returned [`PendingComposeState`].
+    ///
+    /// The branching is on `vars + patches` — those are the only
+    /// items with a per-item policy gate. A daemon contribution
+    /// that only carries packages and/or lifecycle hooks takes the
+    /// all-decided path: packages and hooks have no verdict slot in
+    /// the wire schema, the daemon installs them as declared. On
+    /// that path the daemon-collected packages and hooks land in
+    /// the assembled `Composition` and are merged with the client's
+    /// already-gated wire contribution via
+    /// [`Composition::extend_from_wire`].
+    ///
+    /// When the daemon collected nothing (today's only path — every
+    /// internal caller sends `WireContribution::default()`), the
+    /// fast-path body collapses to a single `extend_from_wire` call
+    /// against an empty `Composition`.
+    ///
+    /// **Compared to the pre-Phase-2 single-shot path**, the new
+    /// signature drops the `UserPolicy` parameter the old `compose`
+    /// took — the daemon never runs user policy, so threading it
+    /// here was always misleading. For the empty-contribution case
+    /// (which is what every existing caller exercises today), the
+    /// observable behavior is byte-equivalent.
+    ///
+    /// `session_id` is the daemon-allocated id; it goes on the
+    /// `Pending` response so the client can correlate a future
+    /// `SubmitVerdict`. It's accepted as a parameter rather than
+    /// generated here because the manager allocates ids at
+    /// `Loader::create` time.
+    ///
+    /// `_options` is reserved for the future composition pipeline
+    /// (e.g. symlink-following on patch walks). Today's daemon-side
+    /// path doesn't run the gate, so the parameter is ignored;
+    /// kept on the signature so the call site is forward-compatible.
     ///
     /// # Errors
     ///
-    /// See [`ComposeError`]. In particular, [`ComposeError::HookRequired`]
-    /// fires when a non-user-origin item reaches `NeedsApproval` — the
-    /// daemon has no way to prompt and the multi-phase routing to the
-    /// client isn't wired yet.
+    /// See [`ComposeError`]. The daemon path produces
+    /// [`ComposeError::InvalidWireItem`] (from wire→domain
+    /// conversion in `extend_from_wire`) or [`ComposeError::Conflict`]
+    /// (cross-process disagreement) on the all-decided branch.
     pub fn compose(
         self,
-        policy: UserPolicy,
-        options: ComposeOptions,
-    ) -> Result<Composition, ComposeError> {
-        // Reconstruct the client's already-gated vars as expansion
-        // context so daemon-side patches can resolve `$VAR` / `~`
-        // references against them. The daemon must NEVER use its own
-        // process environment for expansion — that's exclusively the
-        // client's job. `home_fallback` is therefore `None` here:
-        // either `HOME` is in the client's wire vars or `~/...`
-        // patterns in daemon patches fail.
-        let client_vars: Vec<crate::core::compose::SessionVar> =
-            self.client.vars.iter().cloned().map(Into::into).collect();
-        let (mut composition, _final_policy) =
-            compose_contribution(self.contribution, &client_vars, policy, None, options, None)?;
-        composition.extend_from_wire(self.client)?;
-        Ok(composition)
+        session_id: SessionId,
+        _options: ComposeOptions,
+    ) -> Result<ComposeOutcome, ComposeError> {
+        let Self {
+            client,
+            contribution,
+            env: _,
+        } = self;
+        let Contribution {
+            vars,
+            patches,
+            packages,
+            lifecycle_hooks,
+        } = contribution;
+
+        // All-decided fast path: only items the client must gate are
+        // vars and patches. Packages and lifecycle hooks have no
+        // per-item verdict in the wire schema, so a daemon
+        // contribution carrying only those (or carrying nothing)
+        // assembles directly into the Composition.
+        if vars.is_empty() && patches.is_empty() {
+            let mut composition = Composition::from_daemon_passthrough(packages, lifecycle_hooks);
+            composition.extend_from_wire(client)?;
+            return Ok(ComposeOutcome::Ready(composition));
+        }
+
+        // Daemon-collected vars or patches: route them back to the
+        // client for gating. Lifecycle hooks ride in the response
+        // for audit; a separate copy is retained on the stash for
+        // Phase 4 to install. Packages aren't on the wire at all —
+        // they only live on the stash.
+        let pending = contribution_to_pending(vars, patches, lifecycle_hooks.clone());
+        let response = ContributionResponse {
+            session_id,
+            vars: pending.vars,
+            patches: pending.patches,
+            lifecycle_hooks: pending.lifecycle_hooks,
+        };
+        Ok(ComposeOutcome::Pending {
+            response,
+            state: PendingComposeState {
+                daemon_packages: packages,
+                daemon_lifecycle_hooks: lifecycle_hooks,
+                client_contribution: client,
+            },
+        })
     }
 }
 
@@ -136,17 +252,147 @@ mod tests {
         Source::UserLoadout { name: "dev".into() }
     }
 
-    /// Empty wire contribution + no daemon items → empty composition.
+    fn nil_id() -> SessionId {
+        SessionId::nil()
+    }
+
+    fn unwrap_ready(outcome: ComposeOutcome) -> Composition {
+        match outcome {
+            ComposeOutcome::Ready(c) => c,
+            ComposeOutcome::Pending { .. } => panic!("expected Ready, got Pending"),
+        }
+    }
+
+    /// Empty wire contribution + no daemon items → empty composition
+    /// via the all-decided fast path.
     #[test]
     fn empty_inputs_produce_empty_composition() {
         let composer = SessionComposer::new(WireContribution::default());
-        let res = composer
-            .compose(UserPolicy::empty(), ComposeOptions::default())
-            .unwrap();
+        let res = unwrap_ready(
+            composer
+                .compose(nil_id(), ComposeOptions::default())
+                .unwrap(),
+        );
         assert!(res.vars().is_empty());
         assert!(res.patches().is_empty());
         assert!(res.packages().is_empty());
         assert!(res.lifecycle_hooks().is_empty());
+    }
+
+    /// A daemon-collected var becomes a `Pending` outcome with the
+    /// item in `response.vars` and the original session id on the
+    /// response. No policy is applied on the daemon side — the var
+    /// is routed back for the client to gate.
+    #[test]
+    fn daemon_collected_var_routes_to_pending() {
+        use crate::core::compose::{Composable, Contribution, Error};
+        use crate::core::primitives::{LenientVarEntry, LenientVarName, ResolvedVar, VarValue};
+        use crate::core::source::ProvenancedVar;
+        use crate::wire::primitives::WireVarSpec;
+
+        /// Test-only composable that emits a single project-origin var.
+        struct ProjectVar;
+        impl Composable for ProjectVar {
+            fn contribute(
+                self,
+                _env: &dyn Fn(&str) -> Result<String, std::env::VarError>,
+            ) -> Result<Contribution, Error> {
+                let entry = LenientVarEntry::new(
+                    LenientVarName::try_new("PROJECT_VAR")?,
+                    VarValue::specified("from-project"),
+                );
+                let (name, value) = entry.into_parts();
+                let resolved = ResolvedVar::resolve_with(name.into_inner(), value, |_| {
+                    Err(std::env::VarError::NotPresent)
+                })?;
+                let mut c = Contribution::new();
+                c.push_var(ProvenancedVar::new(
+                    resolved,
+                    Source::Project {
+                        path: paths::HostPath::new("/proj"),
+                    },
+                ));
+                Ok(c)
+            }
+        }
+
+        let mut composer = SessionComposer::new(WireContribution::default());
+        composer.add(ProjectVar).unwrap();
+
+        let id = SessionId::parse_str("00000000-0000-0000-0000-000000000007").unwrap();
+        let outcome = composer.compose(id, ComposeOptions::default()).unwrap();
+        match outcome {
+            ComposeOutcome::Pending { response, state } => {
+                assert_eq!(response.session_id, id);
+                assert_eq!(response.vars.len(), 1);
+                let v = &response.vars[0];
+                assert_eq!(v.name, "PROJECT_VAR");
+                // Already-resolved → ships as Specified so the client
+                // doesn't re-resolve against its env.
+                assert!(
+                    matches!(&v.spec, WireVarSpec::Specified { value } if value == "from-project")
+                );
+                assert!(response.patches.is_empty());
+                assert!(response.lifecycle_hooks.is_empty());
+                // Stash is empty (no packages or hooks collected); the
+                // client's wire contribution is the default we passed.
+                assert!(state.daemon_packages.is_empty());
+                assert!(state.daemon_lifecycle_hooks.is_empty());
+                assert_eq!(state.client_contribution, WireContribution::default());
+            }
+            ComposeOutcome::Ready(_) => panic!("expected Pending, got Ready"),
+        }
+    }
+
+    /// A daemon contribution carrying packages and lifecycle hooks
+    /// (but no vars or patches) takes the all-decided fast path —
+    /// neither domain has a per-item verdict slot, so they pass
+    /// through verbatim into the assembled [`Composition`].
+    /// Regression guard for branching on `vars + patches` (not
+    /// `Contribution::is_empty()`).
+    #[test]
+    fn daemon_collected_packages_and_hooks_route_to_ready() {
+        use crate::core::compose::{Composable, Contribution, Error};
+        use crate::core::lifecyclehook::{HookScript, LifecycleHook};
+        use crate::core::source::ProvenancedHook;
+
+        /// Test-only composable that emits one package and one hook,
+        /// both with project provenance, and no vars or patches.
+        struct ProjectPkgAndHook;
+        impl Composable for ProjectPkgAndHook {
+            fn contribute(
+                self,
+                _env: &dyn Fn(&str) -> Result<String, std::env::VarError>,
+            ) -> Result<Contribution, Error> {
+                let src = Source::Project {
+                    path: paths::HostPath::new("/proj"),
+                };
+                let hook = LifecycleHook::builder()
+                    .with_on_activate(HookScript::inline("echo go"))
+                    .build()
+                    .expect("hook has at least one callback");
+                let mut c = Contribution::new();
+                c.push_package(ProvenancedPackage::new("ripgrep", src.clone()));
+                c.push_hook(ProvenancedHook::new(hook, src));
+                Ok(c)
+            }
+        }
+
+        let mut composer = SessionComposer::new(WireContribution::default());
+        composer.add(ProjectPkgAndHook).unwrap();
+
+        let res = unwrap_ready(
+            composer
+                .compose(nil_id(), ComposeOptions::default())
+                .unwrap(),
+        );
+        // Vars and patches are untouched; pkg and hook passed
+        // through onto the Composition.
+        assert!(res.vars().is_empty());
+        assert!(res.patches().is_empty());
+        assert_eq!(res.packages().len(), 1);
+        assert_eq!(res.packages()[0].package(), "ripgrep");
+        assert_eq!(res.lifecycle_hooks().len(), 1);
     }
 
     /// Client-contributed vars survive into the merged composition.
@@ -163,9 +409,11 @@ mod tests {
             ..Default::default()
         };
         let composer = SessionComposer::new(client);
-        let res = composer
-            .compose(UserPolicy::empty(), ComposeOptions::default())
-            .unwrap();
+        let res = unwrap_ready(
+            composer
+                .compose(nil_id(), ComposeOptions::default())
+                .unwrap(),
+        );
         assert_eq!(res.vars().len(), 1);
         let merged = &res.vars()[0];
         assert_eq!(merged.var().name(), "EDITOR");


### PR DESCRIPTION
Depends on https://github.com/gominimal/minimal/pull/600

- Wires up daemon-side Phase 2 composition routing: `SessionComposer::compose` now returns a `ComposeOutcome::{Ready, Pending}` instead of a finalized `Composition`, and the manager handler in `minimald` consumes the new shape.
- Daemon-collected vars and patches route back to the client as a `ContributionResponse` so the client's `policy` and `PolicyHooks` gate them — the daemon never runs user policy. Daemon-collected packages and lifecycle hooks have no per-item verdict slot in the wire schema, so they pass through into the assembled `Composition` on the all-decided path.
- Today every internal `CreateSession` caller still sends an empty `WireContribution`, so the manager hits the Ready fast path. The Pending branch is guarded with a defensive `InvalidInput` error in the manager until the `SubmitVerdict` handler lands (next step).
- New `PendingComposeState` retains the daemon-side packages, hooks, and the client's wire contribution across a Pending outcome so Phase 4 can finalize after the client's verdict comes back.
- Doc + test coverage: `crates/sessions/docs/COMPOSITION.md` describes the new 4-phase flow; tests cover the empty-input fast path, the packages/hooks-only fast path, the var → Pending routing, and that the client's wire contribution merges into the composition byte-for-byte on the all-decided path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session creation handling for client-supplied contributions, preventing submitted details from being silently ignored.
  * Clearer rejection of unsupported in-progress/pending session outcomes with an explicit input error.
  * Reduced session name collisions in repeated end-to-end runs by generating a unique session name each time.
* **Documentation**
  * Updated session composition documentation to clarify phase responsibilities and the current on-wire behavior for session responses (with `Pending` not reachable yet).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->