### PR TITLE
chore(release ci): boop timeout for build-release-linux-arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
 
     build-release-linux-arm64:
         runs-on: ubuntu-latest
-        timeout-minutes: 45
+        timeout-minutes: 60
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         steps:
             - uses: actions/checkout@v6


### PR DESCRIPTION
Last PR timed out at 45 mins just as it was linking the final binaries, for the cross build I think we need more like 1 hr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the Linux ARM64 release build timeout to help prevent workflow failures during longer runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->