### PR TITLE
chore(fix release ci): split build tasks + boop timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
 
     build-release-linux-arm64:
         runs-on: ubuntu-latest
-        timeout-minutes: 60
+        timeout-minutes: 90
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         steps:
             - uses: actions/checkout@v6
@@ -187,12 +187,21 @@ jobs:
                       target/
                   key: ${{ runner.os }}-arm64-cargo-release-${{ hashFiles('**/Cargo.lock') }}
                   restore-keys: ${{ runner.os }}-arm64-cargo-release-
-            - name: Build static release binaries
+            - name: Build static minimal binary
+              run: |
+                  cross build --release \
+                     --package minimal \
+                     --target aarch64-unknown-linux-musl
+            - name: Upload binary (minimal)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: minimal-linux-arm64
+                  path: target/aarch64-unknown-linux-musl/release/minimal
+                  retention-days: 7
+            - name: Build static mip binary
               run: |
                   cross build --release \
                      --package mip \
-                     --package minimal \
-                     --package minimald \
                      --target aarch64-unknown-linux-musl
             - name: Upload binary (mip)
               uses: actions/upload-artifact@v7
@@ -200,12 +209,11 @@ jobs:
                   name: mip-linux-arm64
                   path: target/aarch64-unknown-linux-musl/release/mip
                   retention-days: 7
-            - name: Upload binary (minimal)
-              uses: actions/upload-artifact@v7
-              with:
-                  name: minimal-linux-arm64
-                  path: target/aarch64-unknown-linux-musl/release/minimal
-                  retention-days: 7
+            - name: Build static minimald binary
+              run: |
+                  cross build --release \
+                     --package minimald \
+                     --target aarch64-unknown-linux-musl
             - name: Upload binary (minimald)
               uses: actions/upload-artifact@v7
               with:


### PR DESCRIPTION
Working theory is that during link time for the three binaries, its using a ton of memory (as ldd does) and committing death-by-swap.

Splitting the build into different execs for the three binaries should have it link one at a time, and hopefully finish this time. Also bumped up the timeout so we get some more signal before it times out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Linux arm64 release pipeline to run longer and handle builds in smaller stages.
  * Split release artifact creation into separate steps, which should make builds more reliable and easier to recover if one step fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->