### PR TITLE
fix(ot): fix some progress ops not being cleared

### DIFF
--- a/crates/check/src/lib.rs
+++ b/crates/check/src/lib.rs
@@ -589,6 +589,7 @@ async fn check_package(
         let ctx = ctx.clone();
         let pkg = pkg.clone();
         let span = tracing::Span::current();
+        let check_op = check_op.clone();
 
         tokio::task::spawn_blocking(move || {
             let _enter = span.enter();
@@ -615,6 +616,8 @@ async fn check_package(
     };
 
     out.extend(file_based_results);
+
+    check_op.set_done();
 
     Ok(out)
 }

--- a/crates/ot/src/lib.rs
+++ b/crates/ot/src/lib.rs
@@ -154,6 +154,21 @@ impl TrackerInner {
     }
 }
 
+impl Drop for TrackerInner {
+    /// A node disappearing is itself a change the renderer must observe: it has
+    /// to re-snapshot and drop the bar for any operation whose node was dropped
+    /// without an explicit [`set_done`](OpTracker::set_done) — e.g. an early `?`
+    /// return, or a completed operation that simply went out of scope. The
+    /// renderer only repaints on a version bump, so without this wake an
+    /// orphaned spinner would keep animating (via indicatif's steady-tick
+    /// thread) until some unrelated mutation happened to wake it. `shared`
+    /// outlives this body — it is a field, dropped only after `drop` returns —
+    /// so the bump is sound.
+    fn drop(&mut self) {
+        self.shared.bump();
+    }
+}
+
 /// A node in the operation tree, potentially describing an operation.
 ///
 /// Nodes may have a parent (unless they are the root) or children.
@@ -548,6 +563,43 @@ mod tests {
             .set_op(Operation::PackageBuild { name: "x".into() });
         assert!(r1.version() > 0);
         assert_eq!(r2.version(), 0, "mutating one tree must not touch another");
+    }
+
+    #[test]
+    fn dropping_a_node_bumps_version() {
+        // A node vanishing is a change a renderer must see (to clear its bar),
+        // even when the operation was never explicitly marked done.
+        let root = OpTracker::new_root();
+        let child = root.new_child();
+        child.set_op(Operation::ExtractPkg { name: "p".into() });
+        let before = root.version();
+        drop(child);
+        assert!(
+            root.version() > before,
+            "dropping a node must bump the version"
+        );
+    }
+
+    #[tokio::test]
+    async fn changed_wakes_on_node_drop() {
+        // The renderer only repaints on a wake; dropping an op node without
+        // set_done() must still wake it so it can clear the orphaned bar.
+        let root = OpTracker::new_root();
+        let child = root.new_child();
+        child.set_op(Operation::Check {
+            kind: CheckKind::CheckPackages,
+            name: "p".into(),
+        });
+        let mut rx = root.subscribe();
+        rx.borrow_and_update();
+        let h = tokio::spawn(async move { rx.changed().await });
+        tokio::task::yield_now().await;
+        drop(child);
+        tokio::time::timeout(Duration::from_secs(1), h)
+            .await
+            .expect("changed() should wake on node drop")
+            .expect("waiter task should not panic")
+            .expect("watch sender should be alive");
     }
 
     #[tokio::test]

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -283,6 +283,8 @@ impl<B: FetchBackend> RemoteCache<B> {
         )
         .map_err(Error::ArchiveError)?;
 
+        materialize_op.set_done();
+
         Ok((Instant::now().duration_since(start), cache_hnd))
     }
 }


### PR DESCRIPTION
Found this sometimes happening with `mip`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status updates during package checks and cache materialization, so completed work is now marked more reliably.
  * Fixed operation tracking so removed items are reflected promptly in progress views and renderers.
  * Added coverage for these tracking updates to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->