### PR TITLE
fix(release CI): fix 'chmod: cannot access 'artifacts/*-macos-*': No such file or directory'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,10 +249,10 @@ jobs:
             - name: Download artifacts
               uses: actions/download-artifact@v8
               with:
-                  pattern: "*-linux-*"
+                  pattern: "*-*-*"
                   path: artifacts/
             - name: Make binaries executable
-              run: chmod +x artifacts/*-{linux,macos}-*
+              run: chmod +x artifacts/*-*-*
             - name: Generate completions
               run: |
                   mkdir -p artifacts/completions/{bash,zsh,fish}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release artifact handling so all platform builds are downloaded and marked executable correctly during release packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->