### PR TITLE
feat(minimald): implement Shutdown RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,6 +3549,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tokio-vsock",
  "tracing",
  "tracing-subscriber",

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -294,6 +294,38 @@ impl OneshotSshRpc for DestroySession {
     type Response = Errorable<DestroySessionResponse>;
 }
 
+/// An RPC asking the daemon to shut down its session manager so the process
+/// can terminate gracefully.
+pub struct Shutdown;
+
+/// The request for a [`Shutdown`] RPC.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShutdownRequest {
+    /// When `true`, live sessions are destroyed and the daemon shuts down
+    /// regardless. When `false`, the daemon refuses to shut down if any
+    /// session is still live, answering with [`ShutdownResponse::SessionsLive`].
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// The response for a [`Shutdown`] RPC.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ShutdownResponse {
+    /// The daemon accepted the request: the session manager is shutting down
+    /// and rejecting further work.
+    ShuttingDown,
+    /// The daemon refused: live sessions exist and `force` was not set. No
+    /// state changed; the caller may retry with `force = true`.
+    SessionsLive,
+}
+
+impl OneshotSshRpc for Shutdown {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "Shutdown");
+    type Request<'a> = ShutdownRequest;
+    type Response = ShutdownResponse;
+}
+
 // ---------------------------------------------------------------------------
 // Session-creation flow (multi-round contribution composition).
 //

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -36,6 +36,7 @@ thiserror.workspace = true
 vt100-ctt.workspace = true
 
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -5,7 +5,8 @@ use minimald_rpc::{
     GetSessionPolicy, GetSessionPolicyRequest, GetSessionRecord, GetSessionRecordRequest,
     GetSessionRecordResponse, GetVersion, GetVersionResponse, IssueClientCert,
     IssueClientCertRequest, ListSessions, ListSessionsEntry, ListSessionsResponse, OneshotSshRpc,
-    RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse,
+    RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse, Shutdown, ShutdownRequest,
+    ShutdownResponse,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
@@ -208,6 +209,28 @@ async fn serve_destroy_session(s: ServerStateHandle, c: RuChannel<Msg>) {
     }
 }
 
+async fn serve_shutdown(s: ServerStateHandle, c: RuChannel<Msg>) {
+    let res = Shutdown
+        .handle_channel(c, async |req: ShutdownRequest| {
+            let mngr = s.sessions_manager().await;
+            Ok(match mngr.shutdown(req.force).await {
+                Ok(()) => {
+                    // Manager is down; tell the accept loop to stop and drain
+                    // so the process can exit. Firing before the response is
+                    // written is safe: the drain waits out the grace period,
+                    // so this reply still flushes to the client.
+                    s.trigger_shutdown().await;
+                    ShutdownResponse::ShuttingDown
+                }
+                Err(()) => ShutdownResponse::SessionsLive,
+            })
+        })
+        .await;
+    if let Err(e) = res {
+        tracing::warn!("RPC handler for {} failed: {}", Shutdown::NAME, e);
+    }
+}
+
 async fn serve_get_session_policy(s: ServerStateHandle, c: RuChannel<Msg>) {
     let res = GetSessionPolicy
         .handle_channel(c, async |req| {
@@ -366,6 +389,7 @@ pub async fn handle_ssh_rpc(
         | CreateSession::NAME
         | RenameSession::NAME
         | DestroySession::NAME
+        | Shutdown::NAME
         | GetSessionPolicy::NAME
         | GetMeshStatus::NAME
         | STREAM_WORKSPACE_FILES
@@ -401,6 +425,7 @@ pub async fn handle_ssh_rpc(
         CreateSession::NAME => drop(spawn(serve_create_session(s, channel, ssh_username))),
         RenameSession::NAME => drop(spawn(serve_rename_session(s, channel))),
         DestroySession::NAME => drop(spawn(serve_destroy_session(s, channel))),
+        Shutdown::NAME => drop(spawn(serve_shutdown(s, channel))),
         GetSessionPolicy::NAME => drop(spawn(serve_get_session_policy(s, channel))),
         GetMeshStatus::NAME => drop(spawn(serve_get_mesh_status(s, channel))),
         STREAM_WORKSPACE_FILES => drop(spawn(serve_stream_workspace_files(s, config, channel))),
@@ -427,7 +452,8 @@ pub async fn handle_ssh_rpc(
 mod tests {
     use minimald_rpc::{
         CreateSession, CreateSessionRequest, DestroySessionRequest, EgressPolicy, GetSessionPolicy,
-        GetSessionPolicyRequest, RenameSessionRequest, SessionPolicy,
+        GetSessionPolicyRequest, RenameSessionRequest, SessionPolicy, Shutdown, ShutdownRequest,
+        ShutdownResponse,
     };
     use paths::HostAbsPath;
     use sessions::{NetworkMode, SessionId};
@@ -844,6 +870,95 @@ mod tests {
         assert!(
             matches!(resp, Errorable::Err { error } if error.contains("no session with ID")),
             "expected an unknown-id error",
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_reports_shutting_down_when_no_sessions_are_live() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        let resp = client
+            .call::<Shutdown>(&ShutdownRequest { force: false })
+            .await;
+        assert_eq!(resp, ShutdownResponse::ShuttingDown);
+    }
+
+    #[tokio::test]
+    async fn shutdown_rejects_further_session_work_once_shut_down() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        let resp = client
+            .call::<Shutdown>(&ShutdownRequest { force: false })
+            .await;
+        assert_eq!(resp, ShutdownResponse::ShuttingDown);
+
+        // After shutdown the manager refuses to bring sessions up, so even a
+        // lookup for a well-formed id is rejected rather than answered.
+        let mngr = server.state.sessions_manager().await;
+        assert!(
+            mngr.get_session(SessionKeyPredicate::Id(SessionId::nil()))
+                .await
+                .is_err(),
+            "manager should reject session work while shutting down",
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_without_force_refuses_while_a_session_is_live() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        // A persisted session isn't "live" until it's brought up; do so, so the
+        // manager has a running actor that an unforced shutdown must protect.
+        let mngr = server.state.sessions_manager().await;
+        mngr.get_session(SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("freshly-created session should be retrievable");
+
+        let resp = client
+            .call::<Shutdown>(&ShutdownRequest { force: false })
+            .await;
+        assert_eq!(resp, ShutdownResponse::SessionsLive);
+
+        // The refusal left the daemon fully operational: the live session is
+        // still reachable and no shutdown flag was latched.
+        assert!(
+            mngr.get_session(SessionKeyPredicate::Id(session_id))
+                .await
+                .unwrap()
+                .is_some(),
+            "an unforced, refused shutdown must not tear down live sessions",
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_with_force_tears_down_live_sessions() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let mngr = server.state.sessions_manager().await;
+        mngr.get_session(SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("freshly-created session should be retrievable");
+
+        // `force` overrides the live-session guard: the daemon shuts down...
+        let resp = client
+            .call::<Shutdown>(&ShutdownRequest { force: true })
+            .await;
+        assert_eq!(resp, ShutdownResponse::ShuttingDown);
+
+        // ...and, being in shutdown, refuses to hand out sessions afterwards.
+        assert!(
+            mngr.get_session(SessionKeyPredicate::Id(session_id))
+                .await
+                .is_err(),
+            "a forced shutdown should leave the manager rejecting session work",
         );
     }
 

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -8,6 +8,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
 
 use crate::connection::Connection;
 use crate::sessions;
@@ -98,6 +99,11 @@ pub struct ServerState {
     config: Config,
     sessions: sessions::ManagerHandle,
 
+    /// Fired by the `Shutdown` RPC handler once the session manager has been
+    /// torn down, telling [`Server::run`]'s accept loop to stop accepting,
+    /// drain in-flight connections, and return so the process can exit.
+    shutdown: CancellationToken,
+
     /// Memoized SSH host key, after first successful load.
     host_key: Option<PrivateKey>,
 
@@ -155,6 +161,7 @@ impl ServerState {
             sessions: sessions::Manager::init(minimal_state_dir, minimal_cache_dir, net_switch)
                 .await?,
             config,
+            shutdown: CancellationToken::new(),
             host_key: None,
             #[cfg(feature = "networking-proxy")]
             cert_authority,
@@ -192,6 +199,19 @@ impl ServerStateHandle {
     /// Returns a handle to the sessions manager.
     pub async fn sessions_manager(&self) -> sessions::ManagerHandle {
         self.0.lock().await.sessions.clone()
+    }
+
+    /// Returns a clone of the server shutdown token. [`Server::run`]'s accept
+    /// loop awaits [`CancellationToken::cancelled`] on it to leave the loop.
+    pub(crate) async fn shutdown_token(&self) -> CancellationToken {
+        self.0.lock().await.shutdown.clone()
+    }
+
+    /// Signals [`Server::run`] to stop accepting connections and drain. Called
+    /// by the `Shutdown` RPC handler after the session manager has shut down.
+    /// Idempotent: repeated calls (e.g. two `Shutdown` RPCs) are harmless.
+    pub(crate) async fn trigger_shutdown(&self) {
+        self.0.lock().await.shutdown.cancel();
     }
 
     /// Returns the daemon's TLS certificate authority (only with
@@ -288,6 +308,12 @@ impl Listener for tokio_vsock::VsockListener {
     }
 }
 
+/// How long [`Server::run`] waits for in-flight connections to drain after a
+/// [`Shutdown`](minimald_rpc::Shutdown) RPC before aborting the stragglers. The
+/// shutdown-initiating client's own connection stays open until it disconnects,
+/// so an unbounded wait could hang the process; this bounds it.
+const SHUTDOWN_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// A listening minimald server.
 #[derive(Debug)]
 pub struct Server;
@@ -313,6 +339,9 @@ impl Server {
             .await
             .map_err(std::io::Error::other)?;
         let mut session_set = JoinSet::new();
+        // Fired by the `Shutdown` RPC handler once the session manager is torn
+        // down; ends the accept loop below so the daemon can exit gracefully.
+        let shutdown = state.shutdown_token().await;
 
         loop {
             // Drain any completed sessions to prevent unbounded growth.
@@ -322,7 +351,13 @@ impl Server {
                 }
             }
 
-            let (stream, peer) = listener.accept().await?;
+            // A pending shutdown wins over a ready accept (`biased`), so we
+            // never take on a new connection once shutdown has been requested.
+            let (stream, peer) = tokio::select! {
+                biased;
+                () = shutdown.cancelled() => break,
+                accepted = listener.accept() => accepted?,
+            };
             tracing::info!(?peer, transport = L::TRANSPORT, "accepted connection");
             let (_conn_hnd, session_fut) = match Connection::from_stream(
                 stream,
@@ -349,6 +384,38 @@ impl Server {
                 }
             });
         }
+
+        // Shutdown requested: stop accepting (done — loop exited) and drain
+        // in-flight connections. The initiating client's own connection stays
+        // open until it disconnects, so bound the wait: after `SHUTDOWN_GRACE`,
+        // abort whatever is left so `run` always returns and the process exits.
+        tracing::info!(
+            live = session_set.len(),
+            "draining connections for shutdown"
+        );
+        let grace = tokio::time::sleep(SHUTDOWN_GRACE);
+        tokio::pin!(grace);
+        loop {
+            tokio::select! {
+                res = session_set.join_next() => match res {
+                    None => break,
+                    Some(Err(e)) => {
+                        tracing::warn!(error = %e, "session task panicked while draining")
+                    }
+                    Some(Ok(())) => {}
+                },
+                () = &mut grace => {
+                    tracing::warn!(
+                        live = session_set.len(),
+                        "shutdown grace elapsed; aborting remaining connections"
+                    );
+                    session_set.abort_all();
+                    while session_set.join_next().await.is_some() {}
+                    break;
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -470,5 +537,86 @@ async fn expose_proxy_on_host(daemon_ip: std::net::Ipv4Addr, port: u16) {
             %error,
             "could not publish host-side proxy on the host loopback via gvproxy forwarder"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use camino::Utf8PathBuf;
+    use minimald_rpc::{Shutdown, ShutdownRequest, ShutdownResponse};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::test_harness::connect_uds;
+
+    /// A `Config` backed by a fresh tempdir, mirroring `TestServer::new`.
+    fn test_config(dir: &TempDir) -> Config {
+        let path = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        Config {
+            host_key: HostKey::Ephemeral,
+            minimal_state_dir: DaemonAbsPath::try_new(path.clone()).unwrap(),
+            minimal_cache_dir: DaemonAbsPath::try_new(path).unwrap(),
+            gvproxy_bin: None,
+            in_microvm: false,
+        }
+    }
+
+    /// Binds a UDS in `dir` and spawns `Server::run` against it, returning the
+    /// run task's join handle alongside the socket path clients dial.
+    fn spawn_server(
+        dir: &TempDir,
+    ) -> (
+        tokio::task::JoinHandle<Result<(), std::io::Error>>,
+        std::path::PathBuf,
+    ) {
+        let sock = dir.path().join("minimald.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let run = tokio::spawn(Server::run(test_config(dir), listener));
+        (run, sock)
+    }
+
+    #[tokio::test]
+    async fn shutdown_rpc_drives_run_to_return_once_the_client_disconnects() {
+        let dir = TempDir::new().unwrap();
+        let (run, sock) = spawn_server(&dir);
+
+        {
+            let mut client = connect_uds(&sock).await;
+            let resp = client
+                .call::<Shutdown>(&ShutdownRequest { force: false })
+                .await;
+            assert_eq!(resp, ShutdownResponse::ShuttingDown);
+            // Dropping `client` closes the connection, so the drain sees the
+            // last in-flight session finish and `run` returns without waiting
+            // out the grace period.
+        }
+
+        let res = tokio::time::timeout(Duration::from_secs(5), run)
+            .await
+            .expect("run should return promptly once the client disconnects");
+        assert!(res.unwrap().is_ok(), "run should return Ok after shutdown");
+    }
+
+    #[tokio::test]
+    async fn shutdown_rpc_returns_even_if_the_initiating_client_lingers() {
+        let dir = TempDir::new().unwrap();
+        let (run, sock) = spawn_server(&dir);
+
+        // Keep the client — and thus its connection — open past the shutdown.
+        // The drain can't complete gracefully, so the grace period must elapse
+        // and abort the straggler, guaranteeing `run` still returns.
+        let mut client = connect_uds(&sock).await;
+        let resp = client
+            .call::<Shutdown>(&ShutdownRequest { force: false })
+            .await;
+        assert_eq!(resp, ShutdownResponse::ShuttingDown);
+
+        let res = tokio::time::timeout(SHUTDOWN_GRACE + Duration::from_secs(3), run)
+            .await
+            .expect("run must return after the grace period aborts lingering connections");
+        assert!(res.unwrap().is_ok(), "run should return Ok after shutdown");
+        drop(client);
     }
 }

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -92,6 +92,7 @@ enum ManagerMessage {
     CreateSession(Box<CreateSessionMsg>),
     RenameSession(SessionId, String, Responder<()>),
     DestroySession(SessionId, Responder<()>),
+    Shutdown(bool, Responder<Result<(), ()>>),
 }
 
 /// Manages session instances, and session state on disk.
@@ -99,6 +100,7 @@ enum ManagerMessage {
 /// Follows the actor pattern.
 #[derive(Debug)]
 pub struct Manager<L: Loader = DiskLoader> {
+    in_shutdown: bool,
     receiver: mpsc::Receiver<ManagerMessage>,
     running: BTreeMap<L::Key, SessionHandle>,
     store: L,
@@ -138,6 +140,7 @@ impl Manager {
             crate::net::dns::DEFAULT_HOST_ID,
         )));
         let mngr = Self {
+            in_shutdown: false,
             receiver,
             running,
             store: l,
@@ -219,6 +222,12 @@ impl<L: Loader> Manager<L> {
             // If the session is known but not running, it is started.
             ManagerMessage::GetSession(pred, r) => {
                 r.handle(async {
+                    if self.in_shutdown {
+                        return Err(SessionsError::new(
+                            std::io::ErrorKind::ConnectionRefused,
+                            "in shutdown",
+                        ));
+                    }
                     match self.key_for(&pred)? {
                         None => Ok(None),
                         Some(k) => {
@@ -272,6 +281,13 @@ impl<L: Loader> Manager<L> {
                 } = *msg;
                 responder
                     .handle(async {
+                        if self.in_shutdown {
+                            return Err(SessionsError::new(
+                                std::io::ErrorKind::ConnectionRefused,
+                                "in shutdown",
+                            ));
+                        }
+
                         // Until daemon-side Phase 2 routing lands, the only
                         // valid contribution is the empty default. Silently
                         // dropping a non-empty contribution would let clients
@@ -285,7 +301,7 @@ impl<L: Loader> Manager<L> {
                         // The seam is here: replace this check with the
                         // partition + ContributionResponse flow.
                         if contribution != WireContribution::default() {
-                            return Err(std::io::Error::new(
+                            return Err(SessionsError::new(
                                 std::io::ErrorKind::InvalidInput,
                                 "non-empty WireContribution is not supported \
                                  by this daemon — daemon-side composition \
@@ -321,6 +337,12 @@ impl<L: Loader> Manager<L> {
             // Renames an existing session with the given ID.
             ManagerMessage::RenameSession(id, new_name, r) => {
                 r.handle(async {
+                    if self.in_shutdown {
+                        return Err(SessionsError::new(
+                            std::io::ErrorKind::ConnectionRefused,
+                            "in shutdown",
+                        ));
+                    }
                     match self.store.find_by_id(&id)? {
                         None => Err(std::io::Error::new(
                             NotFound,
@@ -369,6 +391,12 @@ impl<L: Loader> Manager<L> {
             // any), then removes its on-disk record.
             ManagerMessage::DestroySession(id, r) => {
                 r.handle(async {
+                    if self.in_shutdown {
+                        return Err(SessionsError::new(
+                            std::io::ErrorKind::ConnectionRefused,
+                            "in shutdown",
+                        ));
+                    }
                     let k = self.store.find_by_id(&id)?.ok_or_else(|| {
                         std::io::Error::new(
                             NotFound,
@@ -398,6 +426,47 @@ impl<L: Loader> Manager<L> {
                         .deregister(&host_net_name);
                     self.store.delete(&k)?;
                     Ok(())
+                })
+                .await
+            }
+            ManagerMessage::Shutdown(force, r) => {
+                r.handle(async {
+                    // Sessions are live but force not given, send false to signal
+                    // we didnt shutdown and continue.
+                    if !self.running.is_empty() && !force {
+                        return Ok(Err(()));
+                    }
+
+                    self.in_shutdown = true;
+                    // Withdraw the PTask hostnames (R3.5) for every live session
+                    // before tearing them down, mirroring DestroySession, so the
+                    // shutdown drain never leaves stale routing entries pointing
+                    // at destroyed sessions. Names are derived up front via
+                    // synchronous store reads so the registry lock is never held
+                    // across `destroy().await`. `deregister` is a no-op for a
+                    // session that never registered a hostname.
+                    #[cfg(target_os = "linux")]
+                    {
+                        let names: Vec<String> = self
+                            .running
+                            .keys()
+                            .filter_map(|k| self.store.get(k).ok())
+                            .map(|obj| registry_name(obj.record()))
+                            .collect();
+                        let mut reg = self
+                            .hostnames
+                            .write()
+                            .expect("hostname registry lock poisoned");
+                        for name in &names {
+                            reg.deregister(name);
+                        }
+                    }
+                    // Stop live sessions
+                    for hnd in self.running.values() {
+                        hnd.destroy().await;
+                    }
+                    self.running.clear();
+                    Ok(Ok(()))
                 })
                 .await
             }
@@ -513,6 +582,20 @@ impl ManagerHandle {
             .send(ManagerMessage::DestroySession(id, send))
             .await;
         recv.await.expect("corresponding sessions manager is dead")
+    }
+
+    /// Shuts down all sessions for process termination. If force is true, live sessions are killed.
+    /// If force is false but there are live sessions, an error is returned.
+    pub async fn shutdown(&self, force: bool) -> Result<(), ()> {
+        let (send, recv) = Responder::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .sender
+            .send(ManagerMessage::Shutdown(force, send))
+            .await;
+        recv.await
+            .expect("corresponding sessions manager is dead")
+            .expect("no SessionError expected from shutdown msg")
     }
 }
 

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -138,6 +138,24 @@ impl TestServer {
     }
 }
 
+/// Dials an already-listening minimald UDS and returns an authenticated
+/// [`TestClient`].
+///
+/// Unlike [`TestServer::connect`], which bridges an in-memory pair straight
+/// into `Connection::from_stream`, this drives a real `UnixStream` against a
+/// server's `UnixListener` — so it exercises the actual `Server::run` accept
+/// loop, which is what the shutdown-drain tests need.
+pub(crate) async fn connect_uds(sock: &Path) -> TestClient {
+    let stream = UnixStream::connect(sock).await.unwrap();
+    let client_config = Arc::new(russh::client::Config::default());
+    let mut handle = russh::client::connect_stream(client_config, stream, TestClientHandler)
+        .await
+        .unwrap();
+    let auth = handle.authenticate_none("test").await.unwrap();
+    assert!(auth.success(), "auth_none should succeed on local UDS");
+    TestClient { handle }
+}
+
 /// An authenticated client connection against a [`TestServer`].
 pub(crate) struct TestClient {
     handle: russh::client::Handle<TestClientHandler>,


### PR DESCRIPTION
Tells the minimald to shutdown.

`force=false` - will error if there are active sessions.
`force=true` - will kill active sessions/connections, drain them, then exit.

```shell
$> echo "{\"force\": true}" | ssh -s  \
    -o ProxyCommand='socat - UNIX-CONNECT:/home/xxx/.local/state/minimal/providers/local-0/ssh.sock' \
    -o 'UserKnownHostsFile=/home/xxx/.local/state/minimal/providers/local-0/known_hosts' \
    local-0 minimald-v1-Shutdown
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SSH-based one-shot `Shutdown` RPC with a `force` option.
  * Server now stops accepting new connections and performs shutdown with a short grace period before terminating remaining session work.
  * Shutdown responses indicate whether termination started or was refused due to active sessions.

* **Bug Fixes**
  * New session operations are blocked once shutdown begins.
  * Non-forced shutdown is refused when sessions are live; forced shutdown proceeds and then rejects further session work.

* **Tests**
  * Added coverage for the above shutdown scenarios.

* **Chores**
  * Added a Unix-domain socket test client helper and updated workspace dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->