### PR TITLE
feat(minvmd): build minvmd for release, tweak libkrun search paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
 
     build-release-linux-amd64:
         runs-on: ubuntu-latest
-        timeout-minutes: 45
+        timeout-minutes: 60
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         steps:
             - name: Free Disk Space
@@ -176,6 +176,29 @@ jobs:
                   name: minimald-linux-amd64
                   path: target/x86_64-unknown-linux-musl/release/minimald-linux-amd64
                   retention-days: 7
+            - name: Materialize libkrun prefix (upstream package)
+              # minvmd links libkrun's KVM backend dynamically, so unlike the three
+              # binaries above it can't join the static-musl cross build — it needs a
+              # native glibc build against a real libkrun. Materialize libkrun (a cache
+              # fetch keyed by the pinned upstream commit, NOT a from-source build) into
+              # a flat prefix that minvmd's build.rs link-searches + rpaths against.
+              run: ./scripts/fetch-libkrun.sh "$HOME/.krun" x86_64
+            - name: Build native minvmd binary
+              # Native host target (x86_64-unknown-linux-gnu), NOT musl: the binary
+              # links libkrun.so (and libkrunfw.so.5 is dlopen'd at runtime), so unlike
+              # the three above it is not self-contained — running it still needs those
+              # .so's reachable via rpath/LD_LIBRARY_PATH. LIBKRUN_PREFIX drives the
+              # build.rs link search and the `minvmd_libkrun` cfg (real, non-stub impl).
+              run: |
+                  LIBKRUN_PREFIX="$HOME/.krun" \
+                    cargo build --release -p minvmd --bin minvmd
+                  mv target/release/minvmd target/release/minvmd-linux-amd64
+            - name: Upload binary (minvmd)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: minvmd-linux-amd64
+                  path: target/release/minvmd-linux-amd64
+                  retention-days: 7
 
     build-release-linux-arm64:
         runs-on: ubuntu-latest
@@ -239,6 +262,53 @@ jobs:
                   path: target/aarch64-unknown-linux-musl/release/minimald-linux-arm64
                   retention-days: 7
 
+    build-release-macos-arm64:
+        # Self-hosted Apple Silicon runner. minvmd links libkrun (Hypervisor.framework
+        # backend) via `#[link(name = "krun")]` and builds the real (non-stub) impl
+        # only on macOS against a provisioned libkrun — it can't join the static-musl
+        # cross builds above, so it's built natively here (mirrors ci-macos.yml's
+        # build-macos). Gated on RUN_MACOS_CI like the other macOS jobs so it's skipped
+        # while the single self-hosted runner is offline — a skip here also skips
+        # `release`, which needs it.
+        runs-on: [self-hosted, macOS, ARM64]
+        timeout-minutes: 45
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.RUN_MACOS_CI != 'false'
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  # Don't leave git credentials on the persistent self-hosted runner.
+                  persist-credentials: false
+            - name: Toolchain
+              uses: dtolnay/rust-toolchain@stable
+            - name: Provision libkrun (slp/krun tap)
+              # Self-install libkrun so the job doesn't depend on hand-provisioned
+              # runner state. Idempotent (a no-op when already present).
+              run: brew install slp/krun/libkrun
+            - name: Verify libkrun is available
+              run: |
+                  if [ ! -f /opt/homebrew/lib/libkrun.dylib ]; then
+                    echo "::error::libkrun.dylib not found under /opt/homebrew/lib. Provision the runner with: brew install slp/krun/libkrun" >&2
+                    exit 1
+                  fi
+            - name: Build release minvmd binary
+              run: cargo build --release -p minvmd --bin minvmd
+            - name: Codesign minvmd (hypervisor entitlement, R1.4)
+              # Codesigning must be the LAST thing to touch the binary: any later relink
+              # (a stray cargo build/test) drops the ad-hoc signature and
+              # krun_start_enter then fails with EINVAL. Renaming + uploading below
+              # preserve the embedded signature (they don't rewrite the Mach-O).
+              run: codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/release/minvmd
+            - name: Rename binary with platform suffix
+              # download-artifact merge-multiple flattens on basename, so the uploaded
+              # file must already carry the platform-suffixed name the release job expects.
+              run: mv target/release/minvmd target/release/minvmd-macos-arm64
+            - name: Upload binary (minvmd)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: minvmd-macos-arm64
+                  path: target/release/minvmd-macos-arm64
+                  retention-days: 7
+
     cargo-deny:
         runs-on: ubuntu-latest
         timeout-minutes: 10
@@ -250,7 +320,12 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         needs:
-            [ci-success, build-release-linux-amd64, build-release-linux-arm64]
+            [
+                ci-success,
+                build-release-linux-amd64,
+                build-release-linux-arm64,
+                build-release-macos-arm64,
+            ]
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         permissions:
             contents: write

--- a/crates/minvmd/build.rs
+++ b/crates/minvmd/build.rs
@@ -5,6 +5,17 @@
 //! Without that cfg the crate compiles to a runtime-bailing stub and never
 //! links libkrun.
 //!
+//! The rpath always includes a binary-relative entry (`$ORIGIN` /
+//! `@loader_path`) so a relocated release binary finds libkrun's shared objects
+//! shipped next to it. The absolute libkrun prefix is also recorded, except for
+//! a Linux `--release` build (its prefix is an ephemeral build path that must
+//! not leak). A macOS release keeps the prefix because it is the stable Homebrew
+//! lib dir (`/opt/homebrew/lib`), letting the shipped binary resolve
+//! libkrun.dylib on any target that has `brew install slp/krun/libkrun`. On
+//! Linux the standard system lib dirs ([`LINUX_LIB_DIRS`]) are added too, so a
+//! target with a system-installed libkrun resolves it without bundling. See
+//! [`emit_rpaths`] for the full ordering.
+//!
 //! - **macOS**: libkrun is always linked (Hypervisor.framework backend). The
 //!   prefix defaults to `/opt/homebrew/lib` (the Homebrew tap install location);
 //!   override with `LIBKRUN_PREFIX`.
@@ -16,6 +27,20 @@
 //! - **Other targets**: stub only; never links libkrun.
 
 use std::path::Path;
+
+/// Standard system directories that may hold `libkrun.so` on Linux. Used both to
+/// detect libkrun at build time (`find_libkrun_prefix`) and to seed a release
+/// binary's rpath, so a target with a system-installed libkrun resolves it (and
+/// its `libkrunfw.so.5` sibling, via the loader's default search) without any
+/// bundling. Entries that don't exist on a given host are skipped harmlessly by
+/// both the build-time scan and the runtime loader.
+const LINUX_LIB_DIRS: &[&str] = &[
+    "/usr/local/lib",
+    "/usr/lib",
+    "/usr/lib64",
+    "/usr/lib/x86_64-linux-gnu",
+    "/usr/lib/aarch64-linux-gnu",
+];
 
 fn main() {
     println!("cargo:rerun-if-env-changed=LIBKRUN_PREFIX");
@@ -39,9 +64,54 @@ fn main() {
 
     if let Some(prefix) = prefix {
         println!("cargo:rustc-link-search=native={prefix}");
-        println!("cargo:rustc-link-arg=-Wl,-rpath,{prefix}");
+        emit_rpaths(&target_os, &prefix);
         println!("cargo::rustc-cfg=minvmd_libkrun");
     }
+}
+
+/// Record the runtime library search paths (rpath) baked into the binary. The
+/// dynamic loader tries them in the order emitted here.
+fn emit_rpaths(target_os: &str, prefix: &str) {
+    let is_release = std::env::var("PROFILE").as_deref() == Ok("release");
+
+    // 1. Absolute `{prefix}` — recorded EXCEPT for a Linux `--release` build:
+    //   - Non-release (dev + every e2e CI run use `target/debug/minvmd`): resolve
+    //     libkrun where it was materialized, no LD_LIBRARY_PATH needed.
+    //   - macOS release: KEEP it. On Apple Silicon the prefix is the canonical
+    //     Homebrew lib dir (`/opt/homebrew/lib`) — a stable system path identical
+    //     on any target with `brew install slp/krun/libkrun`, so the shipped binary
+    //     resolves libkrun.dylib directly with no bundling. dyld consults this
+    //     rpath when the dylib's install name is `@rpath/...`, and ignores it
+    //     harmlessly when the install name is already absolute.
+    //   - Linux release: DROP it — the prefix is an ephemeral build path (e.g.
+    //     `$HOME/.krun`) that must not leak into the artifact; entries 2 and 3
+    //     below cover that binary instead.
+    if !is_release || target_os == "macos" {
+        rpath(prefix);
+    }
+
+    // 2. Binary-relative (`$ORIGIN` on Linux, `@loader_path` on macOS) — lets a
+    //    RELOCATED binary find libkrun's shared objects shipped alongside it. It
+    //    reaches the linker as a literal argv token (no shell expansion here), so
+    //    it is recorded verbatim.
+    rpath(if target_os == "macos" {
+        "@loader_path"
+    } else {
+        "$ORIGIN"
+    });
+
+    // 3. Standard system lib dirs on Linux — lets a target with a system-installed
+    //    libkrun resolve it without bundling (the counterpart to macOS reusing the
+    //    Homebrew prefix in entry 1). Stable absolute paths, so safe in a release
+    //    artifact; nonexistent dirs are skipped by the loader.
+    if target_os == "linux" {
+        LINUX_LIB_DIRS.iter().for_each(|dir| rpath(dir));
+    }
+}
+
+/// Emit a single rpath entry via the linker.
+fn rpath(path: &str) {
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{path}");
 }
 
 /// Locate the directory holding `libkrun.so` on Linux.
@@ -56,15 +126,7 @@ fn find_libkrun_prefix() -> Option<String> {
         return Some(prefix);
     }
 
-    const CANDIDATES: &[&str] = &[
-        "/usr/local/lib",
-        "/usr/lib",
-        "/usr/lib64",
-        "/usr/lib/x86_64-linux-gnu",
-        "/usr/lib/aarch64-linux-gnu",
-    ];
-
-    CANDIDATES
+    LINUX_LIB_DIRS
         .iter()
         .find(|dir| dir_has_libkrun(dir))
         .map(|dir| (*dir).to_string())


### PR DESCRIPTION
An attempt to build `minvmd` for distribution. We cannot build static as libkrun needs libc unfortunately.

 * On amd64 linux, we just try a regular build and ship that. We might need to do this on an older ubuntu, but lets start here.
 * On MacOS, we use our self-hosted runner to build.
 * Ive tweaked the rpaths to standard locations libkrun is likely to be, as well as adjacent to the binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS Apple Silicon release builds and artifacts.
  * Added a native Linux amd64 release artifact for `minvmd`.

* **Bug Fixes**
  * Improved runtime library lookup so packaged binaries can find required shared libraries after being moved or distributed.
  * Increased the Linux release build timeout to reduce build failures.

* **Chores**
  * Release automation now waits for the new macOS build before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->