### PR TITLE
feat(release ci): build minimal-macos-arm64 for release as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,21 +292,25 @@ jobs:
                   fi
             - name: Build release minvmd binary
               run: cargo build --release -p minvmd --bin minvmd
-            - name: Codesign minvmd (hypervisor entitlement, R1.4)
-              # Codesigning must be the LAST thing to touch the binary: any later relink
-              # (a stray cargo build/test) drops the ad-hoc signature and
-              # krun_start_enter then fails with EINVAL. Renaming + uploading below
-              # preserve the embedded signature (they don't rewrite the Mach-O).
-              run: codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/release/minvmd
-            - name: Rename binary with platform suffix
+            - name: Build release minimal binary
+              run: cargo build --release -p minimal --bin minimal
+            - name: Rename binaries with platform suffix
               # download-artifact merge-multiple flattens on basename, so the uploaded
               # file must already carry the platform-suffixed name the release job expects.
-              run: mv target/release/minvmd target/release/minvmd-macos-arm64
+              run: |
+                  mv target/release/minvmd target/release/minvmd-macos-arm64
+                  mv target/release/minimal target/release/minimal-macos-arm64
             - name: Upload binary (minvmd)
               uses: actions/upload-artifact@v7
               with:
                   name: minvmd-macos-arm64
                   path: target/release/minvmd-macos-arm64
+                  retention-days: 7
+            - name: Upload binary (minimal)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: minimal-macos-arm64
+                  path: target/release/minimal-macos-arm64
                   retention-days: 7
 
     cargo-deny:


### PR DESCRIPTION
Also drop the codesign as its worthless - only works on that runner machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS arm64 release build to produce and publish both the standard and minimal binaries.
  * Release artifacts are now renamed with a macOS arm64 suffix for easier identification and download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->