### PR TITLE
feat(sessions): SubmitVerdict handler resumes pending sessions

### DIFF
--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -430,6 +430,93 @@ async fn cmd_ls(global: &GlobalArgs, args: LsArgs) -> Result<(), ()> {
     Ok(())
 }
 
+/// [`PolicyHooks`] impl that aborts on every unapproved item.
+///
+/// `minimal2` has no interactive prompt yet, so anything the user's
+/// policy can't auto-decide bubbles into here, and we treat that as
+/// "abort the session creation, surface a clear error." The user can
+/// widen their policy (`allow`/`ignore`) to admit specific items once
+/// the policy-config story lands.
+struct AbortOnUnapproved;
+
+impl sessions::core::hooks::PolicyHooks for AbortOnUnapproved {
+    fn on_var_unapproved(
+        &self,
+        _policy: sessions::core::policy::VarsPolicy,
+        _items: &[sessions::core::hooks::Unapproved<'_, str>],
+    ) -> sessions::core::hooks::HookResult<sessions::core::policy::VarsPolicy> {
+        sessions::core::hooks::HookResult::Abort
+    }
+
+    fn on_patch_unapproved(
+        &self,
+        _policy: sessions::core::policy::PatchPolicy,
+        _items: &[sessions::core::hooks::Unapproved<'_, camino::Utf8Path>],
+    ) -> sessions::core::hooks::HookResult<sessions::core::policy::PatchPolicy> {
+        sessions::core::hooks::HookResult::Abort
+    }
+}
+
+/// Phase 3 + final SubmitVerdict round-trip for a `Pending` session.
+///
+/// Runs `handle_response` over the daemon's `ContributionResponse`
+/// with [`UserPolicy::default`] (today's empty policy — see
+/// [`AbortOnUnapproved`]); sends the resulting [`ContributionVerdict`]
+/// over the [`SubmitVerdict`] RPC; unwraps the daemon's terminal
+/// [`SessionStep::Active`] reply to the finalized session id.
+///
+/// [`UserPolicy::default`]: sessions::core::policy::UserPolicy::default
+/// [`SubmitVerdict`]: minimald_rpc::SubmitVerdict
+async fn drive_pending_to_active(
+    client: &mut client::Client,
+    response: sessions::wire::request::ContributionResponse,
+) -> Result<sessions::SessionId, ()> {
+    use minimald_rpc::SubmitVerdict;
+    use sessions::client::handler::handle_response;
+    use sessions::core::compose::ComposeOptions;
+    use sessions::core::policy::UserPolicy;
+    use sessions::wire::request::SessionStep;
+
+    let hooks = AbortOnUnapproved;
+    let verdict = handle_response(
+        response,
+        &[],
+        UserPolicy::default(),
+        &hooks,
+        ComposeOptions::default(),
+        &|name| std::env::var(name),
+    )
+    .map_err(|e| eprintln!("Composition gating failed: {e}"))?;
+
+    let resp = client
+        .oneshot_rpc::<SubmitVerdict>(verdict)
+        .await
+        .map_err(|e| eprintln!("SubmitVerdict RPC failed: {e}"))?;
+    let step = match resp {
+        minimald_rpc::Errorable::Ok(s) => s,
+        minimald_rpc::Errorable::Err { error } => {
+            eprintln!("SubmitVerdict failed: {error}");
+            return Err(());
+        }
+    };
+    match step {
+        SessionStep::Active { id } => Ok(id),
+        SessionStep::Response { .. } => {
+            // The daemon's terminal reply today is always Active
+            // (single-round flow). Multi-round Response would be a
+            // future extension and the client isn't wired for it.
+            eprintln!(
+                "SubmitVerdict returned a follow-up Response, which this client cannot drive"
+            );
+            Err(())
+        }
+        SessionStep::Fault { error } => {
+            eprintln!("SubmitVerdict faulted: {error}");
+            Err(())
+        }
+    }
+}
+
 /// Create a new session via the `CreateSession` RPC.
 async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), ()> {
     if let Err(e) = autospawn::ensure_daemon_running(global.minvmd, global.minimal_dir.as_deref()) {
@@ -495,17 +582,15 @@ async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), ()>
             return Err(());
         }
     };
-    // Today the daemon only ever produces `Ready` (the empty-
-    // contribution fast path). `Pending` lights up when Phase 2
-    // routing lands.
+    // The daemon may finalize immediately (`Ready`) or ask the
+    // client to gate items first (`Pending`). On `Pending`: run
+    // Phase 3 (`handle_response`) against the user's policy, then
+    // send the resulting verdict over `SubmitVerdict` and wait for
+    // the daemon's terminal `SessionStep::Active`.
     let id = match created {
         minimald_rpc::CreateSessionResponse::Ready { id } => id,
-        minimald_rpc::CreateSessionResponse::Pending { .. } => {
-            eprintln!(
-                "CreateSession returned Pending, but the composition pipeline \
-                 is not wired in this client yet",
-            );
-            return Err(());
+        minimald_rpc::CreateSessionResponse::Pending { id: _, response } => {
+            drive_pending_to_active(&mut client, response).await?
         }
     };
 

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -6,7 +6,7 @@ use minimald_rpc::{
     GetSessionRecordResponse, GetVersion, GetVersionResponse, IssueClientCert,
     IssueClientCertRequest, ListSessions, ListSessionsEntry, ListSessionsResponse, OneshotSshRpc,
     RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse, Shutdown, ShutdownRequest,
-    ShutdownResponse,
+    ShutdownResponse, SubmitVerdict,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
@@ -161,6 +161,13 @@ async fn serve_create_session(
                     Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => Errorable::Err {
                         error: e.to_string(),
                     },
+                    // The daemon's in-flight Pending stash is full
+                    // (see `MAX_PENDING_SESSIONS`). Surface as a clean
+                    // typed error so the client can retry rather than
+                    // treat it as a transport failure.
+                    Err(e) if e.kind() == std::io::ErrorKind::ResourceBusy => Errorable::Err {
+                        error: e.to_string(),
+                    },
                     Err(e) => return Err(ConnectionError::Internal(e.to_string())),
                 },
             )
@@ -168,6 +175,29 @@ async fn serve_create_session(
         .await;
     if let Err(e) = res {
         tracing::warn!("RPC handler for {} failed: {}", CreateSession::NAME, e);
+    }
+}
+
+/// `SubmitVerdict`: the client's per-item decisions for a `Pending`
+/// session. Delegates to the manager actor, which pops the matching
+/// `PendingComposeState`, runs `resume_from_verdict`, and promotes
+/// the record `Pending → Active`. Replies with `Errorable::Ok(SessionStep)`
+/// where the `SessionStep` is `Active { id }` on success or
+/// `Fault { error }` for a structured failure (unknown id, wrong
+/// state, or a `ComposeError`-mapped `WireError`). Manager-side
+/// `io::Error`s bubble up as `ConnectionError::Internal`.
+async fn serve_submit_verdict(s: ServerStateHandle, c: RuChannel<Msg>) {
+    let res = SubmitVerdict
+        .handle_channel(c, async |req| {
+            let mngr = s.sessions_manager().await;
+            match mngr.submit_verdict(req).await {
+                Ok(step) => Ok(Errorable::Ok(step)),
+                Err(e) => Err(ConnectionError::Internal(e.to_string())),
+            }
+        })
+        .await;
+    if let Err(e) = res {
+        tracing::warn!("RPC handler for {} failed: {}", SubmitVerdict::NAME, e);
     }
 }
 
@@ -387,6 +417,7 @@ pub async fn handle_ssh_rpc(
         | ListSessions::NAME
         | GetSessionRecord::NAME
         | CreateSession::NAME
+        | SubmitVerdict::NAME
         | RenameSession::NAME
         | DestroySession::NAME
         | Shutdown::NAME
@@ -423,6 +454,7 @@ pub async fn handle_ssh_rpc(
         ListSessions::NAME => drop(spawn(serve_list_sessions(s, channel))),
         GetSessionRecord::NAME => drop(spawn(serve_get_session_record(s, channel))),
         CreateSession::NAME => drop(spawn(serve_create_session(s, channel, ssh_username))),
+        SubmitVerdict::NAME => drop(spawn(serve_submit_verdict(s, channel))),
         RenameSession::NAME => drop(spawn(serve_rename_session(s, channel))),
         DestroySession::NAME => drop(spawn(serve_destroy_session(s, channel))),
         Shutdown::NAME => drop(spawn(serve_shutdown(s, channel))),

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -8,9 +8,9 @@ use paths::DaemonAbsPath;
 use sessions::{
     SessionId,
     core::compose::ComposeOptions,
-    daemon::composer::{ComposeOutcome, SessionComposer},
+    daemon::composer::{ComposeOutcome, PendingComposeState, SessionComposer, resume_from_verdict},
     store::{DiskLoader, Loader, SessionKey, SessionObject},
-    wire::request::WireContribution,
+    wire::request::{ContributionVerdict, SessionStep, WireContribution},
 };
 use std::sync::Arc;
 #[cfg(target_os = "linux")]
@@ -50,6 +50,37 @@ fn registry_name(record: &sessions::Record) -> String {
     }
 }
 
+/// Assemble a [`sessions::Record`] from the out-of-band session
+/// config and the SSH-supplied username, then validate its policy.
+/// Returns `Err(io::InvalidInput)` if the policy is incompatible
+/// with the network mode (R2.1) — so an invalid session is never
+/// written to the store. The `id` field is left as `nil`; the store
+/// allocates the real id at `create` time.
+///
+/// Shared by the `Ready` and `Pending` branches of the
+/// `CreateSession` handler so both paths persist the same record
+/// shape, differing only in their initial `status`.
+fn build_record(
+    config: minimald_rpc::SessionConfig,
+    username: Option<String>,
+    status: sessions::SessionStatus,
+) -> Result<sessions::Record, std::io::Error> {
+    let record = sessions::Record {
+        id: SessionId::nil(),
+        name: config.name,
+        username,
+        project_path: config.project_path,
+        network: config.network,
+        policy: config.policy,
+        status,
+        attrs: config.attrs,
+    };
+    record
+        .validate_policy()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+    Ok(record)
+}
+
 /// Encapsulates the return channel for messages back from the actor.
 #[derive(Debug)]
 struct Responder<T>(oneshot::Sender<Result<T, SessionsError>>);
@@ -69,6 +100,20 @@ impl<T> Responder<T> {
         let _ = self.0.send(fut.await);
     }
 }
+
+/// Maximum number of in-flight `Pending` sessions the manager will
+/// stash before refusing further `CreateSession` requests that
+/// produce a [`ComposeOutcome::Pending`].
+///
+/// Each entry holds a [`PendingComposeState`] (a few KB of vectors,
+/// the client's wire contribution, and the by-id pending stash). A
+/// misbehaving or abandoned client could otherwise call
+/// `CreateSession` repeatedly without ever sending `SubmitVerdict`,
+/// growing the stash without bound; the cap exists as a backstop.
+///
+/// `Ready` outcomes never consume stash capacity, so this bound
+/// only matters once daemon-side contributors are wired in.
+const MAX_PENDING_SESSIONS: usize = 1024;
 
 /// CreateSession payload — boxed so it doesn't dominate
 /// `ManagerMessage`'s size (the variant carries a full session
@@ -90,11 +135,23 @@ struct CreateSessionMsg {
     responder: Responder<minimald_rpc::CreateSessionResponse>,
 }
 
+/// SubmitVerdict payload — boxed for the same size-balance reason as
+/// [`CreateSessionMsg`]. Carries the client's per-item decisions for
+/// a `Pending` session id; the handler pops the matching stash from
+/// `Manager::pending`, calls [`resume_from_verdict`], promotes the
+/// record `Pending → Active`, and replies with [`SessionStep::Active`].
+#[derive(Debug)]
+struct SubmitVerdictMsg {
+    verdict: ContributionVerdict,
+    responder: Responder<SessionStep>,
+}
+
 enum ManagerMessage {
     List(Responder<Vec<SessionInfo>>),
     GetRecord(SessionKeyPredicate, Responder<Option<sessions::Record>>),
     GetSession(SessionKeyPredicate, Responder<Option<SessionHandle>>),
     CreateSession(Box<CreateSessionMsg>),
+    SubmitVerdict(Box<SubmitVerdictMsg>),
     RenameSession(SessionId, String, Responder<()>),
     DestroySession(SessionId, Responder<()>),
     Shutdown(bool, Responder<Result<(), ()>>),
@@ -109,6 +166,15 @@ pub struct Manager<L: Loader = DiskLoader> {
     receiver: mpsc::Receiver<ManagerMessage>,
     running: BTreeMap<L::Key, SessionHandle>,
     store: L,
+
+    /// Per-session stash for in-flight `CreateSession` flows that
+    /// reached [`ComposeOutcome::Pending`]. Keyed by the daemon's
+    /// allocated [`SessionId`]; the matching `SubmitVerdict` pops
+    /// the entry and finalizes. The stash is in-memory only — if
+    /// the daemon restarts mid-flow the on-disk
+    /// `SessionStatus::Pending` record loses its match and is
+    /// reaped by [`Manager::reap_orphan_pending`] at startup.
+    pending: BTreeMap<SessionId, PendingComposeState>,
 
     minimal_state_dir: DaemonAbsPath,
     minimal_cache_dir: DaemonAbsPath,
@@ -134,7 +200,11 @@ impl Manager {
         minimal_cache_dir: DaemonAbsPath,
         net_switch: Arc<Mutex<crate::net::SwitchClient>>,
     ) -> Result<ManagerHandle, std::io::Error> {
-        let l = DiskLoader::new(minimal_state_dir.clone())?;
+        let mut l = DiskLoader::new(minimal_state_dir.clone())?;
+        // Reap any on-disk `SessionStatus::Pending` records left over
+        // from a previous daemon process — the in-memory stash that
+        // would have let them resume is gone, so they're unresumable.
+        Self::reap_orphan_pending(&mut l)?;
         let running = BTreeMap::new();
         let (sender, receiver) = mpsc::channel(8);
         // Shared so the host-side proxies can resolve `Host:` headers directly;
@@ -149,6 +219,7 @@ impl Manager {
             receiver,
             running,
             store: l,
+            pending: BTreeMap::new(),
             minimal_state_dir,
             minimal_cache_dir,
             net_switch,
@@ -171,6 +242,34 @@ impl<L: Loader> Manager<L> {
             SessionKeyPredicate::Id(id) => self.store.find_by_id(id),
             SessionKeyPredicate::Name(name) => self.store.find_by_name(name),
         }
+    }
+
+    /// Delete any on-disk record whose status is
+    /// [`sessions::SessionStatus::Pending`]. Run once at startup —
+    /// the matching in-memory `PendingComposeState` lives only on
+    /// the previous daemon process, so a `Pending` record post-restart
+    /// has no path to `Active` and a client waiting on `SubmitVerdict`
+    /// would hang. Cheap correctness floor; daemon-restart-survives-
+    /// pending is a separate concern.
+    fn reap_orphan_pending(store: &mut L) -> Result<(), std::io::Error> {
+        let mut reaped = 0u64;
+        let keys: Vec<L::Key> = store.keys().collect();
+        for k in keys {
+            let obj = store.get(&k)?;
+            if obj.record().status == sessions::SessionStatus::Pending {
+                let id = obj.record().id;
+                store.delete(&k)?;
+                tracing::info!(
+                    session_id = %id,
+                    "reaped orphan Pending session on startup",
+                );
+                reaped += 1;
+            }
+        }
+        if reaped > 0 {
+            tracing::info!(count = reaped, "orphan Pending reap complete");
+        }
+        Ok(())
     }
 
     /// The async task which handles interactions with the
@@ -225,6 +324,15 @@ impl<L: Loader> Manager<L> {
             // Gets the session actor corresponding to the predicate.
             //
             // If the session is known but not running, it is started.
+            //
+            // `SessionStatus::Pending` records are filtered out here —
+            // they have no composed `Composition` yet, so spinning up
+            // the session host would attach a client to a half-built
+            // session. The filter returns `None` (caller sees the
+            // same shape as "unknown id") and logs the reason at info
+            // level. exec/sftp call sites surface the `None` as a
+            // channel failure, which is the correct user-facing
+            // behavior in either case.
             ManagerMessage::GetSession(pred, r) => {
                 r.handle(async {
                     if self.in_shutdown {
@@ -236,6 +344,15 @@ impl<L: Loader> Manager<L> {
                     match self.key_for(&pred)? {
                         None => Ok(None),
                         Some(k) => {
+                            let obj = self.store.get(&k)?;
+                            if obj.record().status != sessions::SessionStatus::Active {
+                                tracing::info!(
+                                    session_id = %obj.record().id,
+                                    status = ?obj.record().status,
+                                    "refused GetSession on non-Active session",
+                                );
+                                return Ok(None);
+                            }
                             let session_handle = match self.running.get(&k) {
                                 Some(h) => h.clone(),
                                 None => {
@@ -302,45 +419,47 @@ impl<L: Loader> Manager<L> {
                     contribution,
                     responder,
                 } = *msg;
+                // Capture `in_shutdown` by value before we take
+                // `&mut self` borrows below — the async move needs
+                // to see it without holding a `self` reference.
+                let in_shutdown = self.in_shutdown;
+                let outcome = SessionComposer::new(contribution)
+                    .compose(SessionId::nil(), ComposeOptions::default());
+                let pending = &mut self.pending;
+                let store = &mut self.store;
                 responder
-                    .handle(async {
-                        if self.in_shutdown {
+                    .handle(async move {
+                        if in_shutdown {
                             return Err(SessionsError::new(
                                 std::io::ErrorKind::ConnectionRefused,
                                 "in shutdown",
                             ));
                         }
-
-                        // Drive Phase 2 via `SessionComposer`. The daemon
-                        // doesn't add any project/package contributors yet,
-                        // so on the all-decided path the composer just
-                        // cross-process-merges the client's wire
-                        // contribution into an empty `Composition`.
+                        // Phase 2: branch on the composer outcome.
                         //
-                        // The `session_id` parameter on `compose` is only
-                        // observed on the `Pending` outcome (it goes on
-                        // the response so the client can correlate a
-                        // future `SubmitVerdict`). The `Ready` outcome
-                        // ignores it. We pass `nil` because the manager
-                        // doesn't allocate the id until `store.create`
-                        // below — and the `Pending` outcome is unreachable
-                        // today since no daemon-side contributors are
-                        // wired in. The defensive guard below catches
-                        // it anyway.
-                        let composer = SessionComposer::new(contribution);
-                        match composer.compose(SessionId::nil(), ComposeOptions::default()) {
+                        // `Ready` — composition is complete; persist
+                        // the record as `Active` in one write and ship
+                        // `CreateSessionResponse::Ready { id }`. Guard
+                        // against silent data loss: no apply layer
+                        // yet consumes the `Composition`, so a
+                        // non-empty one would be discarded. Reject
+                        // until apply plumbing lands — the fast path
+                        // (empty client contribution, no daemon
+                        // contributors) still passes.
+                        //
+                        // `Pending` — the client must gate items
+                        // before composition completes. Allocate the
+                        // id by persisting the record as `Pending`,
+                        // stash the daemon-side resume state under
+                        // that id, overwrite the placeholder
+                        // `session_id` on the wire response, and ship
+                        // `CreateSessionResponse::Pending { id, response }`.
+                        //
+                        // `Err` — a cross-process merge conflict or a
+                        // malformed wire item. Both are
+                        // declaration-time bugs — `InvalidInput`.
+                        match outcome {
                             Ok(ComposeOutcome::Ready(composition)) => {
-                                // The composition carries the merged
-                                // vars / patches / packages / lifecycle
-                                // hooks the composer produced. There is
-                                // no apply layer yet — the on-disk
-                                // Record below stores only the
-                                // out-of-band `SessionConfig`, so a
-                                // non-empty composition would be
-                                // silently discarded. Reject rather
-                                // than lose the client's contribution.
-                                // Fast path (empty client contribution,
-                                // no daemon contributors) still passes.
                                 if !composition.vars().is_empty()
                                     || !composition.patches().is_empty()
                                     || !composition.packages().is_empty()
@@ -353,58 +472,145 @@ impl<L: Loader> Manager<L> {
                                          would consume it is not wired yet",
                                     ));
                                 }
+                                let record = build_record(
+                                    config,
+                                    username,
+                                    sessions::SessionStatus::Active,
+                                )?;
+                                let k = store.create(record)?;
+                                Ok(minimald_rpc::CreateSessionResponse::Ready { id: *k.id() })
                             }
-                            Ok(ComposeOutcome::Pending { .. }) => {
-                                // Unreachable today: no daemon-side
-                                // contributors are wired in, so the
-                                // composer can never collect a var or
-                                // patch that would need the client to
-                                // gate. Defensive guard for when that
-                                // changes — once the `SubmitVerdict`
-                                // handler exists, this branch will
-                                // persist a Draft and return Pending.
-                                return Err(std::io::Error::new(
-                                    std::io::ErrorKind::InvalidInput,
-                                    "CreateSession produced a Pending outcome, \
-                                     but the daemon cannot yet resume from a \
-                                     client verdict",
-                                ));
+                            Ok(ComposeOutcome::Pending {
+                                mut response,
+                                state,
+                            }) => {
+                                // Bound the in-memory stash. Check
+                                // before `store.create` so a refusal
+                                // doesn't leave a half-allocated record
+                                // on disk that the next daemon restart
+                                // would have to reap.
+                                if pending.len() >= MAX_PENDING_SESSIONS {
+                                    return Err(std::io::Error::new(
+                                        std::io::ErrorKind::ResourceBusy,
+                                        format!(
+                                            "daemon pending-session stash is full \
+                                             (cap {MAX_PENDING_SESSIONS}); the daemon \
+                                             will accept new sessions as in-flight ones \
+                                             finalize or are aborted",
+                                        ),
+                                    ));
+                                }
+                                let record = build_record(
+                                    config,
+                                    username,
+                                    sessions::SessionStatus::Pending,
+                                )?;
+                                let k = store.create(record)?;
+                                let id = *k.id();
+                                response.session_id = id;
+                                pending.insert(id, state);
+                                Ok(minimald_rpc::CreateSessionResponse::Pending { id, response })
                             }
-                            Err(e) => {
-                                // Cross-process conflict or wire-shape
-                                // failure during merge. Both are
-                                // declaration-time bugs — surface as
-                                // InvalidInput.
-                                return Err(std::io::Error::new(
-                                    std::io::ErrorKind::InvalidInput,
-                                    e.to_string(),
-                                ));
-                            }
+                            Err(e) => Err(std::io::Error::new(
+                                std::io::ErrorKind::InvalidInput,
+                                e.to_string(),
+                            )),
                         }
-
-                        // Assemble the on-disk Record from out-of-band config
-                        // + the SSH-supplied username. Persists `Active`
-                        // immediately on the all-decided path.
-                        let record = sessions::Record {
-                            id: SessionId::nil(),
-                            name: config.name,
-                            username,
-                            project_path: config.project_path,
-                            network: config.network,
-                            policy: config.policy,
-                            status: sessions::SessionStatus::Active,
-                            attrs: config.attrs,
+                    })
+                    .await;
+            }
+            // Resume a `Pending` session with the client's verdict.
+            // Pops the matching `PendingComposeState` from the stash,
+            // resumes composition, promotes the record `Pending →
+            // Active`, and replies with `SessionStep::Active { id }`.
+            // A verdict for an id with no stash → `UnknownSessionId`;
+            // a record present but already `Active` (or otherwise not
+            // `Pending`) → `WrongState`.
+            ManagerMessage::SubmitVerdict(msg) => {
+                let SubmitVerdictMsg { verdict, responder } = *msg;
+                let session_id = verdict.session_id;
+                // Capture by value; async move can't hold `self`.
+                let in_shutdown = self.in_shutdown;
+                // Only pop the stash if we're actually going to resume —
+                // otherwise a shutdown-refused verdict would drop the
+                // stash entry without cleanup.
+                let stash_hit = if in_shutdown {
+                    None
+                } else {
+                    self.pending.remove(&session_id)
+                };
+                let store = &mut self.store;
+                responder
+                    .handle(async move {
+                        if in_shutdown {
+                            return Err(SessionsError::new(
+                                std::io::ErrorKind::ConnectionRefused,
+                                "in shutdown",
+                            ));
+                        }
+                        let state = match stash_hit {
+                            Some(s) => s,
+                            None => {
+                                return Ok(SessionStep::Fault {
+                                    error: sessions::wire::errors::WireError::UnknownSessionId,
+                                });
+                            }
                         };
-                        // R2.1: reject a policy incompatible with the network
-                        // mode (e.g. egress on a non-`OwnIp` PTask) at
-                        // declaration time, so an invalid session is never
-                        // written to the store rather than only failing when
-                        // a client later attaches.
-                        record.validate_policy().map_err(|e| {
-                            std::io::Error::new(std::io::ErrorKind::InvalidInput, e)
-                        })?;
-                        let k = self.store.create(record)?;
-                        Ok(minimald_rpc::CreateSessionResponse::Ready { id: *k.id() })
+                        // Run Phase 4 resume. A verdict that the
+                        // composer can't apply (mismatched
+                        // PendingIds, denied items, etc.) maps to a
+                        // `Fault` via `WireError::from(ComposeError)`.
+                        // The resumed composition is dropped today:
+                        // session activation doesn't yet consume it.
+                        let _composition = match resume_from_verdict(state, verdict) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                // Verdict couldn't be applied — the
+                                // session is dead. Destroy the
+                                // matching on-disk Pending record so
+                                // the name is freed, `list()` doesn't
+                                // show a phantom entry, and the next
+                                // reap pass has nothing to clean up.
+                                // A delete failure here is logged but
+                                // doesn't override the verdict-level
+                                // error returned to the client.
+                                if let Some(k) = store.find_by_id(&session_id)?
+                                    && let Err(del_err) = store.delete(&k)
+                                {
+                                    tracing::warn!(
+                                        session_id = %session_id,
+                                        error = %del_err,
+                                        "failed to delete Pending record after \
+                                         resume failure; record will be reaped on \
+                                         next daemon restart",
+                                    );
+                                }
+                                return Ok(SessionStep::Fault { error: e.into() });
+                            }
+                        };
+                        // Promote the on-disk record `Pending →
+                        // Active`. A mid-flight delete or a status
+                        // already past `Pending` is degenerate but
+                        // surfaces as a structured `WrongState`.
+                        let k = match store.find_by_id(&session_id)? {
+                            Some(k) => k,
+                            None => {
+                                return Ok(SessionStep::Fault {
+                                    error: sessions::wire::errors::WireError::UnknownSessionId,
+                                });
+                            }
+                        };
+                        let mut record = store.get(&k)?.record().clone();
+                        if record.status != sessions::SessionStatus::Pending {
+                            return Ok(SessionStep::Fault {
+                                error: sessions::wire::errors::WireError::WrongState {
+                                    what: format!("expected Pending, found {:?}", record.status,),
+                                },
+                            });
+                        }
+                        record.status = sessions::SessionStatus::Active;
+                        store.save(&k, &record)?;
+                        Ok(SessionStep::Active { id: session_id })
                     })
                     .await;
             }
@@ -628,6 +834,26 @@ impl ManagerHandle {
         recv.await.expect("corresponding sessions manager is dead")
     }
 
+    /// Submit a client verdict against a `Pending` session. On
+    /// success the daemon promotes the record to `Active` and replies
+    /// with [`SessionStep::Active`]. A verdict against an unknown id
+    /// or a non-`Pending` record surfaces as a [`SessionStep::Fault`]
+    /// — see the SubmitVerdict handler arm in [`Self::mainloop`].
+    pub async fn submit_verdict(
+        &self,
+        verdict: ContributionVerdict,
+    ) -> Result<SessionStep, SessionsError> {
+        let (send, recv) = Responder::channel();
+        let _ = self
+            .sender
+            .send(ManagerMessage::SubmitVerdict(Box::new(SubmitVerdictMsg {
+                verdict,
+                responder: send,
+            })))
+            .await;
+        recv.await.expect("corresponding sessions manager is dead")
+    }
+
     /// Gets a handle to the session corresponding with the given predicate.
     pub async fn get_session(
         &self,
@@ -828,5 +1054,81 @@ mod tests {
             .await
             .expect_err("non-empty composition should be rejected until apply plumbing lands");
         assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    }
+
+    /// `reap_orphan_pending` deletes `Pending` records on disk —
+    /// they have no in-memory stash post-restart and can't be
+    /// resumed. `Active` records pass through untouched.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reap_orphan_pending_deletes_pending_records() {
+        let tmp = TempDir::new().unwrap();
+        let mut loader = DiskLoader::new(daemon_dir(&tmp)).unwrap();
+
+        let pending_key = loader
+            .create(sessions::Record {
+                id: SessionId::nil(),
+                name: Some("pending".into()),
+                username: None,
+                project_path: HostAbsPath::try_new("/p").unwrap(),
+                network: sessions::NetworkMode::default(),
+                policy: Default::default(),
+                status: sessions::SessionStatus::Pending,
+                attrs: Default::default(),
+            })
+            .unwrap();
+        let active_key = loader
+            .create(sessions::Record {
+                id: SessionId::nil(),
+                name: Some("active".into()),
+                username: None,
+                project_path: HostAbsPath::try_new("/p2").unwrap(),
+                network: sessions::NetworkMode::default(),
+                policy: Default::default(),
+                status: sessions::SessionStatus::Active,
+                attrs: Default::default(),
+            })
+            .unwrap();
+
+        let pending_id = *pending_key.id();
+        let active_id = *active_key.id();
+        Manager::<DiskLoader>::reap_orphan_pending(&mut loader).unwrap();
+
+        assert!(
+            loader.find_by_id(&pending_id).unwrap().is_none(),
+            "the Pending record should be reaped from the index",
+        );
+        let active_key_again = loader
+            .find_by_id(&active_id)
+            .unwrap()
+            .expect("Active record's index entry should remain");
+        assert_eq!(
+            loader.get(&active_key_again).unwrap().record().status,
+            sessions::SessionStatus::Active,
+            "the Active record should remain",
+        );
+    }
+
+    /// `SubmitVerdict` for an id with no stash entry → terminal
+    /// `Fault::UnknownSessionId`. The stash is the single source of
+    /// truth for in-flight sessions; a verdict for an id that was
+    /// never `Pending` (or has already been resumed) reads as
+    /// "unknown" to the daemon.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_verdict_unknown_id_returns_unknown_session_id() {
+        let (_state, _cache, mngr) = manager().await;
+        let step = mngr
+            .submit_verdict(ContributionVerdict {
+                session_id: SessionId::nil(),
+                vars: vec![],
+                patches: vec![],
+            })
+            .await
+            .expect("actor reply should succeed");
+        match step {
+            SessionStep::Fault {
+                error: sessions::wire::errors::WireError::UnknownSessionId,
+            } => {}
+            other => panic!("expected Fault::UnknownSessionId, got {other:?}"),
+        }
     }
 }

--- a/crates/sessions/docs/COMPOSITION.md
+++ b/crates/sessions/docs/COMPOSITION.md
@@ -121,31 +121,69 @@ correlate by `id`, not slice position.
 
 ### Phase 4 — Daemon assembles and hands off
 
-The daemon applies the verdicts: allowed items enter the
-`Composition`, denied items abort the session. The client's
-already-gated wire contribution is then merged in via
-`Composition::extend_from_wire`, which runs the same conflict
-checks as `Contribution::merge` (see the merge invariant
-below) — a cross-process disagreement (e.g. the daemon's
-package set declares `EDITOR=hx` and the client's loadout
-declares `EDITOR=vim`) surfaces here as
-`ComposeError::Conflict`. The final `Composition` is handed to
-the apply layer, which builds the sandbox, materializes vars,
-copies patched files, and installs lifecycle hooks.
+**Ready path.** On `ComposeOutcome::Ready`, the daemon already
+holds a finalized `Composition` (built directly inside
+`SessionComposer::compose`). The record persists as `Active` in
+one write, `CreateSessionResponse::Ready { id }` ships, and the
+flow is done.
+
+**Pending path.** On `ComposeOutcome::Pending`, the daemon
+persists the record as `SessionStatus::Pending` (which
+allocates the real id), stashes the matching
+`PendingComposeState` in-memory keyed by that id, overwrites the
+placeholder `session_id` on the `ContributionResponse`, and ships
+`CreateSessionResponse::Pending { id, response }`. The client
+then runs Phase 3 and sends a `ContributionVerdict` over the
+`SubmitVerdict` RPC. The daemon's `SubmitVerdict` handler:
+
+1. Pops the matching stash entry (missing → `WireError::UnknownSessionId`).
+2. Runs `resume_from_verdict`: per-item verdicts walked,
+   `Approved` items take the verdict's value + the stashed source
+   provenance, `Ignored` items drop silently, `Denied` items
+   surface as `ComposeError::Denied` (project- or package-declared
+   items the user policy rejected — the session can't finalize
+   in a state inconsistent with what was declared).
+3. Merges the stashed `client_contribution` via
+   `Composition::extend_from_wire` — same cross-process conflict
+   checks as the Ready path.
+4. Promotes the record `Pending → Active` via `store.save`.
+5. Replies with `SessionStep::Active { id }`.
+
+**Resume stash is in-memory only.** Daemon restart loses the
+stash. Any `SessionStatus::Pending` record on disk after restart
+is unresumable, so the daemon reaps it at startup
+(`Manager::reap_orphan_pending`) and the would-be-resuming client
+receives `WireError::UnknownSessionId` on its next
+`SubmitVerdict`. Survival across restarts is a separate concern.
+
+**Final assembly.** Whichever path produced the `Composition`,
+the apply layer takes over: builds the sandbox, materializes
+vars, copies patched files, installs lifecycle hooks. (Today the
+finalized `Composition` is dropped — apply isn't yet consuming
+it; the on-disk record carries enough state for the existing
+session-host stack.)
 
 **Response shape.** The daemon returns
-`CreateSessionResponse::Ready { id }` when no items need user
-gating or
-`CreateSessionResponse::Pending { id, response }` when items need
-user-side gating. The `id` is allocated before the response
-returns, so file uploads (when that subsystem lands) can target
-the session as soon as the client receives either variant. Today
-`Ready` is the only variant that reaches the wire: the composer
-already produces `ComposeOutcome::Pending` on paper, but the
-manager's `CreateSession` handler rejects that outcome with
-`InvalidInput` because the resume path (`SubmitVerdict` + apply
-consumption of the finalized `Composition`) isn't yet wired.
-`Pending` becomes wire-reachable when that path lands.
+`CreateSessionResponse::Ready { id }` (composition finalized in
+one shot) or `CreateSessionResponse::Pending { id, response }`
+(client must gate before the session activates). The `id` is
+allocated before either response returns, so file uploads (when
+that subsystem lands) can target the session as soon as the
+client receives either variant.
+
+**Ready-path silent-drop guard.** No apply layer yet consumes the
+finalized `Composition` on the Ready path. Until that lands, the
+manager rejects a non-empty `Composition` with `InvalidInput`
+rather than silently discard the client's contribution — the
+empty-composition fast path (no daemon contributors, empty client
+contribution) still succeeds.
+
+**State guards.** A session in `SessionStatus::Pending` is not
+attachable: the manager's `GetSession` handler returns `None` for
+non-`Active` records, so exec/sftp surface as channel failures.
+Metadata-only RPCs (`GetSessionRecord`, `ListSessions`,
+`RenameSession`, `DestroySession`) keep working over a Pending
+session.
 
 **Empty-contribution fast path.** When the client sends
 `WireContribution::default()` the daemon skips Phase 2 entirely:

--- a/crates/sessions/docs/COMPOSITION.md
+++ b/crates/sessions/docs/COMPOSITION.md
@@ -47,12 +47,16 @@ batches every verdict into one `ContributionVerdict`.
 > `client::handler::handle_response`. Phase 2 (daemon-side routing)
 > lives in `SessionComposer::compose` and produces a
 > `ComposeOutcome::Ready` or `ComposeOutcome::Pending`. Phase 4 is
-> partially wired — the `Ready` outcome is consumed (the manager
-> persists the session and returns `CreateSessionResponse::Ready`),
-> but `Pending` outcomes are still rejected with `InvalidInput`
-> because the `SubmitVerdict` handler hasn't landed yet. No daemon-
-> side project/package contributors are wired in either, so every
-> caller still hits the all-decided path today.
+> wired end-to-end: `Ready` outcomes persist an `Active` record and
+> return `CreateSessionResponse::Ready`, and `Pending` outcomes
+> persist a `Pending` record + stash a `PendingComposeState`,
+> returning `CreateSessionResponse::Pending`. The client then ships
+> a verdict via `SubmitVerdict`, which the daemon resumes via
+> `resume_from_verdict` and promotes the record to `Active`. See
+> the Phase 4 section below for the full state-machine and error
+> shapes. No daemon-side project/package contributors are wired in
+> yet, so in practice every caller still hits the all-decided
+> `Ready` path today.
 
 ## Phases in detail
 

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -959,16 +959,7 @@ impl Composition {
         // Run conflict checks against the chained union before
         // touching `self`. `Conflict` propagates through
         // `ComposeError::Conflict` via the `#[from]` impl.
-        check_var_mismatches(
-            self.vars.iter().chain(incoming_vars.iter()),
-            |v| v.var().name(),
-            |v| v.var().value(),
-        )?;
-        check_patch_mismatches(
-            self.patches.iter().chain(incoming_patches.iter()),
-            |p| p.patch().destination(),
-            |p| p.patch().host_path().as_str(),
-        )?;
+        self.check_incoming_conflicts(&incoming_vars, &incoming_patches)?;
 
         // Checks passed — commit.
         self.vars.extend(incoming_vars);
@@ -1023,18 +1014,31 @@ impl Composition {
         vars: Vec<SessionVar>,
         patches: Vec<SessionPatch>,
     ) -> Result<(), ComposeError> {
+        self.check_incoming_conflicts(&vars, &patches)?;
+        self.vars.extend(vars);
+        self.patches.extend(patches);
+        Ok(())
+    }
+
+    /// Run the cross-set var- and patch-mismatch checks against the
+    /// union of `self` and the incoming items. Shared by
+    /// [`Self::extend_from_wire`] and [`Self::extend_with`] so both
+    /// atomic-precheck paths run the exact same conflict semantics.
+    fn check_incoming_conflicts(
+        &self,
+        incoming_vars: &[SessionVar],
+        incoming_patches: &[SessionPatch],
+    ) -> Result<(), ComposeError> {
         check_var_mismatches(
-            self.vars.iter().chain(vars.iter()),
+            self.vars.iter().chain(incoming_vars.iter()),
             |v| v.var().name(),
             |v| v.var().value(),
         )?;
         check_patch_mismatches(
-            self.patches.iter().chain(patches.iter()),
+            self.patches.iter().chain(incoming_patches.iter()),
             |p| p.patch().destination(),
             |p| p.patch().host_path().as_str(),
         )?;
-        self.vars.extend(vars);
-        self.patches.extend(patches);
         Ok(())
     }
 }

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -11,6 +11,7 @@
 //! gate functions in this module.
 
 use core::fmt;
+use std::collections::BTreeMap;
 
 use crate::core::decision::{CheckOutcome, Decision, ItemDecision};
 use crate::core::enumerate::{ExpandedProvenancedPatch, PatchFile, enumerate_patch_files};
@@ -658,6 +659,19 @@ pub struct SessionPatch {
 }
 
 impl SessionPatch {
+    /// Direct construction. Crate-internal because outside callers
+    /// should obtain `SessionPatch`s by going through the gate or by
+    /// reconstructing one from a [`WireSessionPatch`] via the `From`
+    /// impl — both of which guarantee provenance is truthful.
+    /// `pub(crate)` exposes it for in-crate handlers (e.g.
+    /// `daemon::composer::resume_from_verdict`) that build session
+    /// patches from already-gated verdict payloads + stashed source
+    /// provenance.
+    #[must_use]
+    pub(crate) fn new(patch: ResolvedPatch, source: Source) -> Self {
+        Self { patch, source }
+    }
+
     /// The resolved patch — host source path plus the destination
     /// relative to the sandbox user's home directory.
     #[must_use]
@@ -987,6 +1001,41 @@ impl Composition {
             packages,
             lifecycle_hooks,
         }
+    }
+
+    /// Append already-gated domain-typed vars and patches. Used by
+    /// [`resume_from_verdict`] to land items reassembled from a
+    /// client verdict (the verdict carries domain values, not wire
+    /// shapes, after the source provenance is rejoined from the
+    /// daemon stash).
+    ///
+    /// Atomic: conflict checks run against the chained union before
+    /// any mutation; on `Err`, `self` is untouched.
+    ///
+    /// [`resume_from_verdict`]: crate::daemon::composer::resume_from_verdict
+    ///
+    /// # Errors
+    ///
+    /// [`ComposeError::Conflict`] if an incoming var or patch
+    /// disagrees with one already in `self`.
+    pub(crate) fn extend_with(
+        &mut self,
+        vars: Vec<SessionVar>,
+        patches: Vec<SessionPatch>,
+    ) -> Result<(), ComposeError> {
+        check_var_mismatches(
+            self.vars.iter().chain(vars.iter()),
+            |v| v.var().name(),
+            |v| v.var().value(),
+        )?;
+        check_patch_mismatches(
+            self.patches.iter().chain(patches.iter()),
+            |p| p.patch().destination(),
+            |p| p.patch().host_path().as_str(),
+        )?;
+        self.vars.extend(vars);
+        self.patches.extend(patches);
+        Ok(())
     }
 }
 
@@ -1382,15 +1431,38 @@ pub(crate) fn compose_contribution(
 }
 
 /// Output of [`contribution_to_pending`]: the daemon-collected vars,
-/// patches, and lifecycle hooks in their daemon→client wire shape.
+/// patches, and lifecycle hooks in their daemon→client wire shape,
+/// **plus** the original domain items keyed by their assigned
+/// [`PendingId`] for the daemon-side stash to hand back to
+/// [`resume_from_verdict`].
 ///
-/// Packages are deliberately not included — the wire schema's
-/// [`ContributionResponse`] has no slot for them, and the daemon
-/// stashes them separately for Phase 4 to install. Lifecycle hooks
-/// have no per-item verdict on the wire either, but the response
-/// does carry a copy for client-side audit, so they're included here.
+/// Packages aren't carried on the wire — the schema's
+/// [`ContributionResponse`] has no slot for them — and the daemon
+/// stashes them separately. Lifecycle hooks have no per-item verdict
+/// either, but the response does carry them for client-side audit.
 ///
 /// [`ContributionResponse`]: crate::wire::request::ContributionResponse
+/// [`resume_from_verdict`]: crate::daemon::composer::resume_from_verdict
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PendingTransform {
+    /// Wire-shaped pending payload destined for [`ContributionResponse`].
+    ///
+    /// [`ContributionResponse`]: crate::wire::request::ContributionResponse
+    pub(crate) wire: WirePending,
+    /// Daemon-side stash: original [`ProvenancedVar`]s keyed by the
+    /// [`PendingId`] they were assigned in `wire.vars`. The verdict
+    /// only carries the resolved value; the source comes from here.
+    pub(crate) pending_vars: BTreeMap<PendingId, ProvenancedVar>,
+    /// Daemon-side stash: original [`ProvenancedPatch`]s keyed by
+    /// [`PendingId`]. The verdict only carries the resolved
+    /// `host_path` per file; destination + source come from here.
+    pub(crate) pending_patches: BTreeMap<PendingId, ProvenancedPatch>,
+}
+
+/// Wire-shaped pending payload — the subset of [`PendingTransform`]
+/// that crosses the RPC boundary. Carried as a field inside
+/// `PendingTransform` so the daemon-side stash can be built from one
+/// canonical traversal.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct WirePending {
     /// Pending vars (id-tagged for verdict correlation).
@@ -1405,15 +1477,14 @@ pub(crate) struct WirePending {
 }
 
 /// Convert daemon-collected vars, patches, and lifecycle hooks into
-/// their wire pending shape. Pure: no policy is consulted (the daemon
-/// never runs user policy), no env is touched (clients resolve
-/// `Inherit` shapes).
+/// their wire pending shape **and** the matching daemon-side stash
+/// keyed by [`PendingId`]. Pure: no policy consulted, no env touched.
 ///
 /// Every var and patch becomes a pending item with a fresh
-/// `PendingId` so the client's verdict can correlate per-item.
-/// Lifecycle hooks pass through unchanged — there's no per-item
-/// policy gate for them, the wire response just carries them for
-/// audit and the daemon installs the originals from its stash.
+/// [`PendingId`] so the client's verdict can correlate per-item.
+/// Lifecycle hooks pass through unchanged on the wire and aren't
+/// stashed — there's no per-item policy gate and the daemon's own
+/// original copy already lives in [`PendingComposeState::daemon_lifecycle_hooks`].
 ///
 /// Packages aren't transformed here. The wire response has no
 /// packages slot, so daemon-collected packages stay in domain
@@ -1424,6 +1495,8 @@ pub(crate) struct WirePending {
 /// different domains may share the integer; correlation is per
 /// `(domain, id)` from the daemon's perspective.
 ///
+/// [`PendingComposeState::daemon_lifecycle_hooks`]: crate::daemon::composer::PendingComposeState::daemon_lifecycle_hooks
+///
 /// # Panics
 ///
 /// Panics if a single domain holds more than `u32::MAX + 1` items,
@@ -1433,48 +1506,51 @@ pub(crate) fn contribution_to_pending(
     vars: Vec<ProvenancedVar>,
     patches: Vec<ProvenancedPatch>,
     lifecycle_hooks: Vec<ProvenancedHook>,
-) -> WirePending {
-    let vars: Vec<WirePendingVar> = vars
-        .into_iter()
-        .enumerate()
-        .map(|(i, pv)| {
-            let (resolved, source) = pv.into_parts();
-            let (name, value) = resolved.into_parts();
-            WirePendingVar {
-                // Items reach this transform already resolved (the
-                // composer's input is `ResolvedVar`); ship as a
-                // `Specified` spec so the client treats the value
-                // verbatim instead of re-resolving against its env.
-                id: PendingId::new(u32::try_from(i).expect("pending var index fits in u32")),
-                name,
-                spec: WireVarSpec::Specified { value },
-                source: source.into(),
-            }
-        })
-        .collect();
+) -> PendingTransform {
+    let mut pending_vars: BTreeMap<PendingId, ProvenancedVar> = BTreeMap::new();
+    let mut wire_vars: Vec<WirePendingVar> = Vec::with_capacity(vars.len());
+    for (i, pv) in vars.into_iter().enumerate() {
+        let id = PendingId::new(u32::try_from(i).expect("pending var index fits in u32"));
+        // Items reach this transform already resolved (the composer's
+        // input is `ResolvedVar`); ship as a `Specified` spec so the
+        // client treats the value verbatim instead of re-resolving
+        // against its env.
+        wire_vars.push(WirePendingVar {
+            id,
+            name: pv.var().name().to_string(),
+            spec: WireVarSpec::Specified {
+                value: pv.var().value().to_string(),
+            },
+            source: pv.source().clone().into(),
+        });
+        pending_vars.insert(id, pv);
+    }
 
-    let patches: Vec<WirePendingPatch> = patches
-        .into_iter()
-        .enumerate()
-        .map(|(i, pp)| {
-            let (patch, source) = pp.into_parts();
-            WirePendingPatch {
-                id: PendingId::new(u32::try_from(i).expect("pending patch index fits in u32")),
-                source_pattern: patch.source().to_string(),
-                destination: patch.dest().as_sandbox_path().clone(),
-                description: None,
-                source: source.into(),
-            }
-        })
-        .collect();
+    let mut pending_patches: BTreeMap<PendingId, ProvenancedPatch> = BTreeMap::new();
+    let mut wire_patches: Vec<WirePendingPatch> = Vec::with_capacity(patches.len());
+    for (i, pp) in patches.into_iter().enumerate() {
+        let id = PendingId::new(u32::try_from(i).expect("pending patch index fits in u32"));
+        wire_patches.push(WirePendingPatch {
+            id,
+            source_pattern: pp.patch().source().to_string(),
+            destination: pp.patch().dest().as_sandbox_path().clone(),
+            description: None,
+            source: pp.source().clone().into(),
+        });
+        pending_patches.insert(id, pp);
+    }
 
-    let lifecycle_hooks: Vec<WireProvenancedHook> =
+    let wire_hooks: Vec<WireProvenancedHook> =
         lifecycle_hooks.into_iter().map(Into::into).collect();
 
-    WirePending {
-        vars,
-        patches,
-        lifecycle_hooks,
+    PendingTransform {
+        wire: WirePending {
+            vars: wire_vars,
+            patches: wire_patches,
+            lifecycle_hooks: wire_hooks,
+        },
+        pending_vars,
+        pending_patches,
     }
 }
 

--- a/crates/sessions/src/daemon/composer.rs
+++ b/crates/sessions/src/daemon/composer.rs
@@ -2,13 +2,20 @@
 //! project and package contributions, and produces a final
 //! [`Composition`].
 
+use std::collections::BTreeMap;
+
 use crate::SessionId;
 use crate::core::compose::{
-    Composable, ComposeError, ComposeOptions, Composition, Contribution, Error, StoredEnv,
-    contribution_to_pending, default_env,
+    Composable, ComposeError, ComposeOptions, Composition, Contribution, Error, SessionPatch,
+    SessionVar, StoredEnv, contribution_to_pending, default_env,
 };
-use crate::core::source::{ProvenancedHook, ProvenancedPackage};
-use crate::wire::request::{ContributionResponse, WireContribution};
+use crate::core::primitives::ResolvedPatch;
+use crate::core::source::{
+    Provenanced, ProvenancedHook, ProvenancedPackage, ProvenancedPatch, ProvenancedVar, Source,
+};
+use crate::wire::policy::{WirePatchVerdict, WireVarVerdict};
+use crate::wire::primitives::PendingId;
+use crate::wire::request::{ContributionResponse, ContributionVerdict, WireContribution};
 
 /// Daemon-side state that survives a `Pending` outcome and feeds
 /// into Phase 4 once the client's verdict comes back.
@@ -30,6 +37,16 @@ pub struct PendingComposeState {
     /// response for client-side audit; the daemon also retains this
     /// copy for Phase 4 install.
     pub daemon_lifecycle_hooks: Vec<ProvenancedHook>,
+    /// Original daemon-collected vars keyed by the [`PendingId`] the
+    /// wire response shipped. [`resume_from_verdict`] looks each one
+    /// up to attach provenance to the verdict-approved value — the
+    /// wire verdict only carries the resolved name/value pair, not
+    /// the source.
+    pub pending_vars: BTreeMap<PendingId, ProvenancedVar>,
+    /// Original daemon-collected patches keyed by [`PendingId`]. The
+    /// wire verdict only carries the resolved `host_path`; the
+    /// destination and source provenance come from the stash entry.
+    pub pending_patches: BTreeMap<PendingId, ProvenancedPatch>,
     /// Client's already-gated wire contribution, untouched.
     pub client_contribution: WireContribution,
 }
@@ -223,23 +240,254 @@ impl SessionComposer {
         // client for gating. Lifecycle hooks ride in the response
         // for audit; a separate copy is retained on the stash for
         // Phase 4 to install. Packages aren't on the wire at all —
-        // they only live on the stash.
-        let pending = contribution_to_pending(vars, patches, lifecycle_hooks.clone());
+        // they only live on the stash. Vars and patches are stashed
+        // by `PendingId` so `resume_from_verdict` can reattach
+        // provenance to whatever the client approves.
+        let transform = contribution_to_pending(vars, patches, lifecycle_hooks.clone());
         let response = ContributionResponse {
             session_id,
-            vars: pending.vars,
-            patches: pending.patches,
-            lifecycle_hooks: pending.lifecycle_hooks,
+            vars: transform.wire.vars,
+            patches: transform.wire.patches,
+            lifecycle_hooks: transform.wire.lifecycle_hooks,
         };
         Ok(ComposeOutcome::Pending {
             response,
             state: PendingComposeState {
                 daemon_packages: packages,
                 daemon_lifecycle_hooks: lifecycle_hooks,
+                pending_vars: transform.pending_vars,
+                pending_patches: transform.pending_patches,
                 client_contribution: client,
             },
         })
     }
+}
+
+/// Phase 4: assemble the final [`Composition`] from a daemon-side
+/// stash plus the client's verdict.
+///
+/// **Where this fits in the pipeline.** The daemon called
+/// [`SessionComposer::compose`] and got back
+/// [`ComposeOutcome::Pending`]; it stashed the
+/// [`PendingComposeState`] and shipped the [`ContributionResponse`]
+/// to the client. The client ran Phase 3 (`client::handler::handle_response`),
+/// produced a [`ContributionVerdict`], and sent it back. This function
+/// closes the loop: it walks the verdict, reattaches provenance from
+/// the stash, and merges everything into a finalized `Composition`.
+///
+/// **What it does, per verdict variant.**
+///
+/// - [`WireVarVerdict::Approved`] / [`WirePatchVerdict::Approved`]:
+///   include in the assembled composition. The verdict carries the
+///   client-resolved value (var) or matched file path (patch); the
+///   stash supplies source provenance the wire schema doesn't carry.
+/// - [`WireVarVerdict::Ignored`] / [`WirePatchVerdict::Ignored`]:
+///   silently dropped per the user policy's `ignore` rule.
+/// - [`WireVarVerdict::Denied`] / [`WirePatchVerdict::Denied`]:
+///   abort the resume with [`ComposeError::Denied`]. A `Denied`
+///   verdict means the user policy explicitly rejected a
+///   project- or package-declared item — finalizing would produce a
+///   session inconsistent with what was declared.
+///
+/// **Determinism.** This function reads no env and consults no
+/// policy. The values and decisions arrive embedded in the verdict;
+/// resume is pure type-shape assembly.
+///
+/// # Errors
+///
+/// - [`ComposeError::InvalidWireItem`] if the verdict references a
+///   `PendingId` that wasn't in the stash, or omits one that was.
+/// - [`ComposeError::Denied`] if any verdict entry is `Denied`.
+/// - [`ComposeError::Conflict`] / [`ComposeError::InvalidWireItem`]
+///   from `extend_from_wire` while merging the client's already-gated
+///   wire contribution back in.
+pub fn resume_from_verdict(
+    state: PendingComposeState,
+    verdict: ContributionVerdict,
+) -> Result<Composition, ComposeError> {
+    let PendingComposeState {
+        daemon_packages,
+        daemon_lifecycle_hooks,
+        pending_vars,
+        pending_patches,
+        client_contribution,
+    } = state;
+
+    let mut composition =
+        Composition::from_daemon_passthrough(daemon_packages, daemon_lifecycle_hooks);
+
+    let accepted_vars = apply_var_verdicts(pending_vars, verdict.vars)?;
+    let accepted_patches = apply_patch_verdicts(&pending_patches, verdict.patches)?;
+    composition.extend_with(accepted_vars, accepted_patches)?;
+    composition.extend_from_wire(client_contribution)?;
+    Ok(composition)
+}
+
+/// Walk the var verdict, draining `pending_vars` as items are
+/// addressed. Returns the [`SessionVar`]s that survived (Approved
+/// items reattached to their stashed source) or surfaces a structured
+/// error for: missing/unknown `PendingId`s, omitted stash entries,
+/// or a `Denied` verdict (which terminates the resume).
+fn apply_var_verdicts(
+    mut pending_vars: BTreeMap<PendingId, ProvenancedVar>,
+    var_verdicts: Vec<WireVarVerdict>,
+) -> Result<Vec<SessionVar>, ComposeError> {
+    // Snapshot every stashed var's source before walking the
+    // verdict. The walk drains `pending_vars` via `take_pending`,
+    // so a duplicate-id verdict (Approved then Denied for the same
+    // id, or two Denieds for the same id) would otherwise see an
+    // already-drained stash and need to fall back to a placeholder
+    // for the `Denied` provenance. The snapshot makes the lookup
+    // order-independent and lets a duplicate id surface as a
+    // structured `InvalidWireItem` instead.
+    let pending_var_sources: BTreeMap<PendingId, Source> = pending_vars
+        .iter()
+        .map(|(id, pv)| (*id, pv.source().clone()))
+        .collect();
+
+    let mut accepted: Vec<SessionVar> = Vec::new();
+    for v in var_verdicts {
+        match v {
+            WireVarVerdict::Approved { id, value } => {
+                let pv = take_pending(&mut pending_vars, id, "var")?;
+                // The verdict's `value` is the client-resolved
+                // (possibly user-edited at prompt) value; the
+                // stashed `pv` supplies the source the wire schema
+                // doesn't echo.
+                let (_, source) = pv.into_parts();
+                accepted.push(SessionVar::new(value.into(), source));
+            }
+            WireVarVerdict::Ignored { id, name: _ } => {
+                take_pending(&mut pending_vars, id, "var")?;
+            }
+            WireVarVerdict::Denied { id, name } => {
+                let from =
+                    pending_var_sources
+                        .get(&id)
+                        .cloned()
+                        .ok_or(ComposeError::InvalidWireItem {
+                            what: "verdict references unknown pending var id",
+                            context: format!("denied var id {id:?} (`{name}`)"),
+                        })?;
+                return Err(ComposeError::Denied { what: name, from });
+            }
+        }
+    }
+    if let Some((id, pv)) = pending_vars.into_iter().next() {
+        return Err(ComposeError::InvalidWireItem {
+            what: "verdict missing entry for pending var",
+            context: format!("pending id {id:?} (`{}`)", pv.var().name()),
+        });
+    }
+    Ok(accepted)
+}
+
+/// Walk the patch verdict against the stash without consuming
+/// entries — a single stashed `PendingId` backs many verdicts (one
+/// per glob match). Returns the [`SessionPatch`]es that survived or
+/// surfaces a structured error for: duplicate `(id, host_path)`
+/// entries, missing/unknown `PendingId`s, stash entries the verdict
+/// never mentioned, or a `Denied` verdict.
+fn apply_patch_verdicts(
+    pending_patches: &BTreeMap<PendingId, ProvenancedPatch>,
+    patch_verdicts: Vec<WirePatchVerdict>,
+) -> Result<Vec<SessionPatch>, ComposeError> {
+    let mut accepted: Vec<SessionPatch> = Vec::new();
+    let mut touched_ids: std::collections::BTreeSet<PendingId> = std::collections::BTreeSet::new();
+    // Verdicts are deduped by `(PendingId, host_path)` — a client
+    // bug that submits two decisions for the same matched file
+    // (e.g. Approved then Ignored) would otherwise silently land
+    // one of them in the composition; instead, the duplicate
+    // surfaces as a structured error.
+    let mut seen_entries: std::collections::BTreeSet<(PendingId, paths::HostAbsPath)> =
+        std::collections::BTreeSet::new();
+    for p in patch_verdicts {
+        let (id, host_path_for_dedupe) = match &p {
+            WirePatchVerdict::Approved { id, host_path }
+            | WirePatchVerdict::Ignored { id, host_path }
+            | WirePatchVerdict::Denied { id, host_path } => (*id, host_path.clone()),
+        };
+        if !seen_entries.insert((id, host_path_for_dedupe.clone())) {
+            return Err(ComposeError::InvalidWireItem {
+                what: "verdict contains duplicate patch entry",
+                context: format!(
+                    "pending id {id:?}, host_path `{}`",
+                    host_path_for_dedupe.as_str(),
+                ),
+            });
+        }
+
+        match p {
+            WirePatchVerdict::Approved { id, host_path } => {
+                let pp = lookup_patch(pending_patches, id)?;
+                touched_ids.insert(id);
+                let destination = pp.patch().dest().as_sandbox_path().clone();
+                let source = pp.source().clone();
+                accepted.push(SessionPatch::new(
+                    ResolvedPatch::new(host_path, destination),
+                    source,
+                ));
+            }
+            WirePatchVerdict::Ignored { id, host_path: _ } => {
+                lookup_patch(pending_patches, id)?;
+                touched_ids.insert(id);
+            }
+            WirePatchVerdict::Denied { id, host_path } => {
+                let pp = lookup_patch(pending_patches, id)?;
+                let from = pp.source().clone();
+                return Err(ComposeError::Denied {
+                    what: host_path.as_str().to_string(),
+                    from,
+                });
+            }
+        }
+    }
+    // Every stashed pending patch must have been mentioned at least
+    // once by the verdict — a glob that matched zero files on the
+    // client should still emit an `Ignored` entry per file, or, if
+    // truly zero, a synthetic `Ignored { id, host_path: <glob> }`.
+    // The client today does this; missing means a malformed verdict.
+    if let Some((id, pp)) = pending_patches
+        .iter()
+        .find(|(id, _)| !touched_ids.contains(id))
+    {
+        return Err(ComposeError::InvalidWireItem {
+            what: "verdict missing entry for pending patch",
+            context: format!(
+                "pending id {id:?} (source pattern `{}`)",
+                pp.patch().source(),
+            ),
+        });
+    }
+    Ok(accepted)
+}
+
+/// Pop a stashed pending item by id, returning a structured error if
+/// the verdict referenced an id that isn't on the stash. Shared by
+/// the var branches of [`resume_from_verdict`].
+fn take_pending<T>(
+    map: &mut BTreeMap<PendingId, T>,
+    id: PendingId,
+    domain: &'static str,
+) -> Result<T, ComposeError> {
+    map.remove(&id).ok_or(ComposeError::InvalidWireItem {
+        what: "verdict references unknown pending id",
+        context: format!("{domain} id {id:?}"),
+    })
+}
+
+/// Look up a stashed pending patch by id without consuming the entry —
+/// a single stashed [`ProvenancedPatch`] backs many wire verdicts (one
+/// per expanded glob match), so the stash entry must outlive any single
+/// lookup. Returns a structured error if the id isn't on the stash.
+fn lookup_patch(
+    map: &BTreeMap<PendingId, ProvenancedPatch>,
+    id: PendingId,
+) -> Result<&ProvenancedPatch, ComposeError> {
+    map.get(&id).ok_or(ComposeError::InvalidWireItem {
+        what: "verdict references unknown pending patch id",
+        context: format!("pending id {id:?}"),
+    })
 }
 
 #[cfg(test)]
@@ -393,6 +641,229 @@ mod tests {
         assert_eq!(res.packages().len(), 1);
         assert_eq!(res.packages()[0].package(), "ripgrep");
         assert_eq!(res.lifecycle_hooks().len(), 1);
+    }
+
+    // ============================================================
+    // resume_from_verdict
+    // ============================================================
+
+    /// Build a `PendingComposeState` with a single daemon-collected
+    /// `PROJECT_VAR` keyed at `PendingId(0)`. Mirrors what
+    /// `SessionComposer::compose` would have stashed.
+    fn stash_with_one_var(value: &str) -> (PendingComposeState, SessionId) {
+        use crate::core::primitives::{ResolvedVar, VarValue};
+        let id = SessionId::parse_str("00000000-0000-0000-0000-000000000042").unwrap();
+        let resolved =
+            ResolvedVar::resolve_with("PROJECT_VAR".into(), VarValue::specified(value), |_| {
+                Err(std::env::VarError::NotPresent)
+            })
+            .unwrap();
+        let pv = ProvenancedVar::new(
+            resolved,
+            Source::Project {
+                path: paths::HostPath::new("/proj"),
+            },
+        );
+        let mut pending_vars = BTreeMap::new();
+        pending_vars.insert(PendingId::new(0), pv);
+        let state = PendingComposeState {
+            daemon_packages: Vec::new(),
+            daemon_lifecycle_hooks: Vec::new(),
+            pending_vars,
+            pending_patches: BTreeMap::new(),
+            client_contribution: WireContribution::default(),
+        };
+        (state, id)
+    }
+
+    /// An `Approved` verdict lands the var on the `Composition` with
+    /// the verdict's value and the stashed source — provenance is
+    /// reattached.
+    #[test]
+    fn resume_from_verdict_keeps_approved_var() {
+        let (state, id) = stash_with_one_var("from-project");
+        let verdict = ContributionVerdict {
+            session_id: id,
+            vars: vec![WireVarVerdict::Approved {
+                id: PendingId::new(0),
+                value: WireResolvedVar {
+                    name: "PROJECT_VAR".into(),
+                    value: "approved-value".into(),
+                },
+            }],
+            patches: vec![],
+        };
+        let comp = resume_from_verdict(state, verdict).unwrap();
+        assert_eq!(comp.vars().len(), 1);
+        assert_eq!(comp.vars()[0].var().name(), "PROJECT_VAR");
+        assert_eq!(comp.vars()[0].var().value(), "approved-value");
+        assert!(matches!(comp.vars()[0].source(), Source::Project { .. },));
+    }
+
+    /// An `Ignored` verdict drops the item silently.
+    #[test]
+    fn resume_from_verdict_drops_ignored_var() {
+        let (state, id) = stash_with_one_var("v");
+        let verdict = ContributionVerdict {
+            session_id: id,
+            vars: vec![WireVarVerdict::Ignored {
+                id: PendingId::new(0),
+                name: "PROJECT_VAR".into(),
+            }],
+            patches: vec![],
+        };
+        let comp = resume_from_verdict(state, verdict).unwrap();
+        assert!(comp.vars().is_empty());
+    }
+
+    /// A `Denied` verdict aborts with `ComposeError::Denied`.
+    #[test]
+    fn resume_from_verdict_denied_var_aborts() {
+        let (state, id) = stash_with_one_var("v");
+        let verdict = ContributionVerdict {
+            session_id: id,
+            vars: vec![WireVarVerdict::Denied {
+                id: PendingId::new(0),
+                name: "PROJECT_VAR".into(),
+            }],
+            patches: vec![],
+        };
+        let err = resume_from_verdict(state, verdict).unwrap_err();
+        match err {
+            ComposeError::Denied { what, from } => {
+                assert_eq!(what, "PROJECT_VAR");
+                assert!(matches!(from, Source::Project { .. }));
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+
+    /// A verdict referencing a `PendingId` the stash doesn't have →
+    /// `InvalidWireItem`. Catches mis-correlated verdicts.
+    #[test]
+    fn resume_from_verdict_unknown_pending_id_errors() {
+        let (state, id) = stash_with_one_var("v");
+        let verdict = ContributionVerdict {
+            session_id: id,
+            vars: vec![WireVarVerdict::Approved {
+                id: PendingId::new(99),
+                value: WireResolvedVar {
+                    name: "PROJECT_VAR".into(),
+                    value: "v".into(),
+                },
+            }],
+            patches: vec![],
+        };
+        let err = resume_from_verdict(state, verdict).unwrap_err();
+        assert!(
+            matches!(err, ComposeError::InvalidWireItem { what, .. } if what.contains("unknown")),
+            "expected InvalidWireItem(unknown), got {err:?}",
+        );
+    }
+
+    /// A verdict that omits an entry the stash holds → `InvalidWireItem`.
+    /// Catches under-specified verdicts that would leave items
+    /// silently in limbo.
+    #[test]
+    fn resume_from_verdict_missing_entry_errors() {
+        let (state, id) = stash_with_one_var("v");
+        let verdict = ContributionVerdict {
+            session_id: id,
+            vars: vec![],
+            patches: vec![],
+        };
+        let err = resume_from_verdict(state, verdict).unwrap_err();
+        assert!(
+            matches!(err, ComposeError::InvalidWireItem { what, .. } if what.contains("missing")),
+            "expected InvalidWireItem(missing), got {err:?}",
+        );
+    }
+
+    /// A stash with zero pending items + an empty verdict still
+    /// works — the path is degenerate (the composer wouldn't have
+    /// produced a Pending outcome from no pending items) but the
+    /// fn shouldn't error.
+    #[test]
+    fn resume_from_verdict_empty_inputs_yields_empty_composition() {
+        let state = PendingComposeState {
+            daemon_packages: Vec::new(),
+            daemon_lifecycle_hooks: Vec::new(),
+            pending_vars: BTreeMap::new(),
+            pending_patches: BTreeMap::new(),
+            client_contribution: WireContribution::default(),
+        };
+        let verdict = ContributionVerdict {
+            session_id: SessionId::nil(),
+            vars: vec![],
+            patches: vec![],
+        };
+        let comp = resume_from_verdict(state, verdict).unwrap();
+        assert!(comp.vars().is_empty());
+        assert!(comp.patches().is_empty());
+        assert!(comp.packages().is_empty());
+        assert!(comp.lifecycle_hooks().is_empty());
+    }
+
+    /// Daemon-stashed packages and lifecycle hooks pass through the
+    /// resume into the assembled `Composition` (they have no
+    /// per-item verdict and are never on the wire round-trip).
+    #[test]
+    fn resume_from_verdict_passes_through_packages_and_hooks() {
+        use crate::core::lifecyclehook::{HookScript, LifecycleHook};
+        let src = Source::Project {
+            path: paths::HostPath::new("/proj"),
+        };
+        let hook = LifecycleHook::builder()
+            .with_on_activate(HookScript::inline("echo hi"))
+            .build()
+            .unwrap();
+        let state = PendingComposeState {
+            daemon_packages: vec![ProvenancedPackage::new("ripgrep", src.clone())],
+            daemon_lifecycle_hooks: vec![ProvenancedHook::new(hook, src)],
+            pending_vars: BTreeMap::new(),
+            pending_patches: BTreeMap::new(),
+            client_contribution: WireContribution::default(),
+        };
+        let verdict = ContributionVerdict {
+            session_id: SessionId::nil(),
+            vars: vec![],
+            patches: vec![],
+        };
+        let comp = resume_from_verdict(state, verdict).unwrap();
+        assert_eq!(comp.packages().len(), 1);
+        assert_eq!(comp.packages()[0].package(), "ripgrep");
+        assert_eq!(comp.lifecycle_hooks().len(), 1);
+    }
+
+    /// The client's stashed wire contribution merges in on top of
+    /// the verdict-derived vars/patches.
+    #[test]
+    fn resume_from_verdict_merges_client_wire_contribution() {
+        let client = WireContribution {
+            vars: vec![WireSessionVar {
+                var: WireResolvedVar {
+                    name: "EDITOR".into(),
+                    value: "hx".into(),
+                },
+                source: WireSource::UserLoadout { name: "dev".into() },
+            }],
+            ..Default::default()
+        };
+        let state = PendingComposeState {
+            daemon_packages: Vec::new(),
+            daemon_lifecycle_hooks: Vec::new(),
+            pending_vars: BTreeMap::new(),
+            pending_patches: BTreeMap::new(),
+            client_contribution: client,
+        };
+        let verdict = ContributionVerdict {
+            session_id: SessionId::nil(),
+            vars: vec![],
+            patches: vec![],
+        };
+        let comp = resume_from_verdict(state, verdict).unwrap();
+        assert_eq!(comp.vars().len(), 1);
+        assert_eq!(comp.vars()[0].var().name(), "EDITOR");
     }
 
     /// Client-contributed vars survive into the merged composition.

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -266,10 +266,13 @@ impl fmt::Display for SessionId {
 
 /// Lifecycle status of a [`Record`].
 ///
-/// `Draft` covers a session whose composition is still in flight —
+/// `Pending` covers a session whose composition is still in flight —
 /// an id has been allocated and a stub record persisted, but the
 /// composition pipeline hasn't yet produced a finalized
-/// `Composition`. `Active` is the finalized, ready-to-use state.
+/// `Composition`. Mirrors the wire word
+/// [`CreateSessionResponse::Pending`] the daemon returns when the
+/// client must gate items before composition completes. `Active`
+/// is the finalized, ready-to-use state.
 ///
 /// Defaults to `Active` so on-disk records predating this field
 /// (which were always finalized at create time) deserialize
@@ -277,7 +280,7 @@ impl fmt::Display for SessionId {
 ///
 /// The store layer doesn't enforce transitions between states — it
 /// records the status verbatim. State-machine rules (e.g. "only
-/// the composition pipeline can promote `Draft` → `Active`") live
+/// the composition pipeline can promote `Pending` → `Active`") live
 /// in the manager actor.
 ///
 /// **Forward compatibility.** This enum is binary today but will
@@ -289,12 +292,17 @@ impl fmt::Display for SessionId {
 /// variant arrives. `#[non_exhaustive]` will be added at the same
 /// time; we omit it today because every match site is in-tree and
 /// the extra noise buys nothing yet.
+///
+/// [`CreateSessionResponse::Pending`]: ../minimald_rpc/enum.CreateSessionResponse.html#variant.Pending
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionStatus {
     /// Composition is in flight; the record is a stub awaiting the
-    /// `SubmitVerdict` round-trip to finalize.
-    Draft,
+    /// `SubmitVerdict` round-trip to finalize. Accepts the legacy
+    /// on-disk spelling `"draft"` so records written before the
+    /// rename continue to load.
+    #[serde(alias = "draft")]
+    Pending,
     /// Composition complete; the record is ready to apply.
     #[default]
     Active,
@@ -738,5 +746,24 @@ mod tests {
     #[test]
     fn session_status_default_is_active() {
         assert_eq!(SessionStatus::default(), SessionStatus::Active);
+    }
+
+    /// Records persisted before the `Draft` → `Pending` rename used
+    /// the string `"draft"`. The serde alias keeps those records
+    /// readable; regression guard for accidentally dropping the
+    /// alias on a future rename.
+    #[test]
+    fn legacy_draft_string_deserializes_as_pending() {
+        let parsed: SessionStatus =
+            serde_json::from_value(serde_json::json!("draft")).expect("deserialize");
+        assert_eq!(parsed, SessionStatus::Pending);
+    }
+
+    /// The canonical serialized form is `"pending"`; the alias is
+    /// read-only.
+    #[test]
+    fn pending_serializes_as_pending_not_draft() {
+        let s = serde_json::to_string(&SessionStatus::Pending).expect("serialize");
+        assert_eq!(s, "\"pending\"");
     }
 }

--- a/crates/sessions/src/store.rs
+++ b/crates/sessions/src/store.rs
@@ -83,7 +83,7 @@ pub trait Loader {
     /// key, never changes after [`Self::create`]. Other fields
     /// (`name`, `status`, `policy`, `attrs`, …) are written verbatim;
     /// the store does not enforce state-machine transitions (e.g.
-    /// `Draft` → `Active`), that policy belongs in higher layers.
+    /// `Pending` → `Active`), that policy belongs in higher layers.
     ///
     /// If `record.name` differs from the on-disk name, the name
     /// index is remapped; a name collision with a *different* session
@@ -1208,14 +1208,14 @@ mod tests {
     }
 
     #[test]
-    fn save_promotes_draft_to_active() {
+    fn save_promotes_pending_to_active() {
         let tmp = TempDir::new().unwrap();
         let mut loader = DiskLoader::new(loader_dir(&tmp)).unwrap();
 
         let key = loader
             .create({
                 let mut r = sample_record();
-                r.status = SessionStatus::Draft;
+                r.status = SessionStatus::Pending;
                 r
             })
             .unwrap();

--- a/crates/sessions/src/wire/errors.rs
+++ b/crates/sessions/src/wire/errors.rs
@@ -39,6 +39,19 @@ pub enum WireError {
     /// before this message arrived.
     #[error("unknown session id")]
     UnknownSessionId,
+    /// The operation isn't valid for the session's current state —
+    /// for example, attempting to attach an SSH channel to a session
+    /// still in `Pending` composition, or submitting a verdict for a
+    /// session that's already been promoted to `Active`. Distinct
+    /// from [`Self::UnknownSessionId`] (the id exists; the state
+    /// doesn't permit this operation).
+    #[error("wrong session state: {what}")]
+    WrongState {
+        /// Short human-readable description of why the operation
+        /// isn't valid in the current state. Used by clients for log
+        /// surfaces; not parsed.
+        what: String,
+    },
     /// Anything else — daemon-internal bug, transient infrastructure
     /// failure, etc. Clients should surface as a generic failure and
     /// not retry blindly.
@@ -92,6 +105,9 @@ mod tests {
                 supported: 1,
             },
             WireError::UnknownSessionId,
+            WireError::WrongState {
+                what: "session is pending; cannot exec".into(),
+            },
             WireError::Internal {
                 message: "fs walk failed".into(),
             },

--- a/crates/sessions/src/wire/request.rs
+++ b/crates/sessions/src/wire/request.rs
@@ -123,12 +123,21 @@ pub enum AbortReason {
     },
 }
 
-/// Daemon's reply to a session-creation RPC: either the batch of
-/// pending items needing client-side gating, or a protocol-level
-/// fault the transport layer didn't catch.
+/// Daemon's reply to a session-creation RPC: a terminal "session
+/// ready" signal, the next batch of pending items needing
+/// client-side gating, or a protocol-level fault the transport layer
+/// didn't catch.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SessionStep {
+    /// Composition complete; the session record has been promoted to
+    /// [`Active`](crate::SessionStatus::Active) and is ready to use.
+    /// Terminal — the client doesn't follow up after receiving this.
+    Active {
+        /// Daemon-assigned session id. Matches the id returned by
+        /// the originating `CreateSessionResponse::Pending`.
+        id: SessionId,
+    },
     /// Pending items awaiting client verdicts.
     Response {
         /// The pending-items payload.
@@ -286,7 +295,8 @@ mod tests {
     }
 
     #[test]
-    fn session_step_round_trips_both_variants() {
+    fn session_step_round_trips_all_variants() {
+        let active = SessionStep::Active { id: session_id() };
         let response = SessionStep::Response {
             response: ContributionResponse {
                 session_id: session_id(),
@@ -298,6 +308,7 @@ mod tests {
         let fault = SessionStep::Fault {
             error: WireError::UnknownSessionId,
         };
+        assert_eq!(round_trip(&active), active);
         assert_eq!(round_trip(&response), response);
         assert_eq!(round_trip(&fault), fault);
     }


### PR DESCRIPTION
Depends on #602 

Wires up the `SubmitVerdict` RPC end-to-end so a `Pending` session can be resumed after the client returns its per-item verdict. Manager pops the stashed `PendingComposeState`, runs `resume_from_verdict`, promotes the record `Pending → Active`, replies with `SessionStep::Active { id }`.

- `sessions`: `resume_from_verdict` (walks verdict → reattaches provenance → assembles `Composition`); `WireError::WrongState`, `SessionStep::Active` wire additions; `Draft → Pending` status rename (serde alias keeps old records loading).
- `minimald`: `Manager.pending` in-memory stash (cap `MAX_PENDING_SESSIONS`, `ResourceBusy` on overflow); `SubmitVerdict` handler; `CreateSession` Pending branch actually returns Pending now; `GetSession` refuses non-`Active`; startup reap of orphan `Pending` records; failed resume destroys the on-disk record.
- `minimal`: `cmd_activate` drives Phase 3 (`handle_response`) → `SubmitVerdict` → unwrap `SessionStep::Active` instead of erroring on Pending. Deny-all `PolicyHooks` stub until interactive prompts land.
- `minimald-rpc`: `SubmitVerdict` RPC dispatch.

Stash is in-memory only — restart-survives-pending is out of scope; the reap pass is the correctness floor. Ready-path composition is still dropped (apply-layer plumbing separate work); guard on non-empty `Composition` prevents silent data loss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session creation can now return a pending session that later becomes active after verdict submission.
  * Added a new “session active” response in the session protocol and support for submitting verdicts to advance sessions.
  * Pending session behavior now includes resume/merge of approved items.

* **Bug Fixes**
  * Pending/orphaned sessions are cleaned up on startup, and non-active sessions are refused for attachment.
  * Legacy serialized state names continue to load correctly.

* **Documentation**
  * Updated composition documentation to describe the new pending-to-active lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->