### PR TITLE
feat!: coalesce default dir computation across crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,7 +3421,6 @@ dependencies = [
  "checkouts",
  "codespan-reporting",
  "common",
- "dirs",
  "futures",
  "google-cloud-auth",
  "google-cloud-storage",
@@ -3433,6 +3432,7 @@ dependencies = [
  "op",
  "orchestrator",
  "ot",
+ "paths",
  "rcache",
  "sandbox2",
  "serial_test",
@@ -3589,7 +3589,6 @@ dependencies = [
  "clap_complete",
  "common",
  "constcat",
- "dirs",
  "either",
  "futures",
  "graph",
@@ -4393,6 +4392,7 @@ name = "paths"
 version = "0.0.1"
 dependencies = [
  "camino",
+ "dirs",
  "serde",
  "thiserror 2.0.18",
  "toml",

--- a/crates/mctx/Cargo.toml
+++ b/crates/mctx/Cargo.toml
@@ -10,7 +10,6 @@ publish.workspace = true
 anyhow.workspace = true
 check.workspace = true
 codespan-reporting.workspace = true
-dirs.workspace = true
 google-cloud-auth.workspace = true
 google-cloud-storage.workspace = true
 toml.workspace = true
@@ -34,6 +33,7 @@ graph.workspace = true
 mfile.workspace = true
 op.workspace = true
 ot.workspace = true
+paths.workspace = true
 orchestrator.workspace = true
 stdlib.workspace = true
 

--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -153,29 +153,17 @@ impl ConfigBuilder {
                 .num_parallel_builds
                 .unwrap_or_else(common::default_parallelism),
 
-            // TODO: Update default to
-            //
-            // dirs::state_dir()
-            //  .unwrap_or_else(|| dirs::home_dir().unwrap().join(".local/state"))
-            //  .join("minimal")
-            //
-            // Once Minimal One is the primary surface.
             minimal_state_dir: self.minimal_state_dir.unwrap_or_else(|| {
-                dirs::cache_dir()
-                    .unwrap_or_else(|| PathBuf::from("~/.cache"))
-                    .join("minimal")
+                paths::minimal_state_dir()
+                    .as_utf8_path()
+                    .as_std_path()
+                    .to_path_buf()
             }),
-            // TODO: Update default to
-            //
-            // dirs::cache_dir()
-            //  .unwrap_or_else(|| dirs::home_dir().unwrap().join(".local/cache"))
-            //  .join("minimal")
-            //
-            // Once Minimal One is the primary surface.
             minimal_cache_dir: self.minimal_cache_dir.unwrap_or_else(|| {
-                dirs::cache_dir()
-                    .unwrap_or_else(|| PathBuf::from("~/.cache"))
-                    .join("minimal")
+                paths::minimal_cache_dir()
+                    .as_utf8_path()
+                    .as_std_path()
+                    .to_path_buf()
             }),
             stdlib_dir: self.stdlib_dir,
             repo_dir: self.repo_dir,

--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -165,15 +165,10 @@ pub fn resolve_socket_path(
         if use_minvmd {
             return minvmd::sock::resolve_uds_path();
         }
-        let state = dirs::state_dir()
-            .or_else(|| dirs::home_dir().map(|h| h.join(".local/state")))
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "cannot determine state directory; set --minimal-dir",
-                )
-            })?;
-        Ok(state.join("minimal/providers/local-0/ssh.sock"))
+        Ok(paths::minimal_state_dir()
+            .as_utf8_path()
+            .as_std_path()
+            .join("providers/local-0/ssh.sock"))
     }
     #[cfg(target_os = "macos")]
     minvmd::sock::resolve_uds_path()

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -21,7 +21,6 @@ camino.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 constcat.workspace = true
-dirs.workspace = true
 either.workspace = true
 futures.workspace = true
 hakoniwa.workspace = true

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -1,7 +1,6 @@
 //! The minimal daemon, an SSH server which hosts sessions and
 //! task/sandbox executions within them.
 
-use camino::Utf8PathBuf;
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 use paths::{CwdRelative, Daemon, DaemonAbsPath, DaemonRelPath, sub_path};
@@ -35,16 +34,10 @@ impl Cli {
     /// based on command-line arguments.
     pub fn minimal_state_dir(&self) -> DaemonAbsPath {
         match &self.global_args.minimal_state_dir {
-            Some(p) => p.resolve().unwrap(),
-            None => DaemonAbsPath::try_new(
-                Utf8PathBuf::from_path_buf(
-                    dirs::state_dir()
-                        .unwrap_or_else(|| dirs::home_dir().unwrap().join(".local/state"))
-                        .join("minimal"),
-                )
-                .unwrap(),
-            )
-            .unwrap(),
+            Some(p) => p
+                .resolve()
+                .expect("could not resolve --minimal-state-dir against the current directory"),
+            None => paths::minimal_state_dir(),
         }
     }
 
@@ -52,16 +45,10 @@ impl Cli {
     /// based on command-line arguments.
     pub fn minimal_cache_dir(&self) -> DaemonAbsPath {
         match &self.global_args.minimal_cache_dir {
-            Some(p) => p.resolve().unwrap(),
-            None => DaemonAbsPath::try_new(
-                Utf8PathBuf::from_path_buf(
-                    dirs::cache_dir()
-                        .unwrap_or_else(|| dirs::home_dir().unwrap().join(".local/cache"))
-                        .join("minimal"),
-                )
-                .unwrap(),
-            )
-            .unwrap(),
+            Some(p) => p
+                .resolve()
+                .expect("could not resolve --minimal-cache-dir against the current directory"),
+            None => paths::minimal_cache_dir(),
         }
     }
 

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -6,6 +6,7 @@ publish.workspace = true
 
 [dependencies]
 camino.workspace = true
+dirs.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -116,6 +116,50 @@ pub type DaemonPath = EitherPath<Daemon>;
 /// [`RelPath::<ConfigRelative>::bind_to_host`].
 pub type ConfigRelPath = RelPath<ConfigRelative>;
 
+/// Returns minimal's default cache directory, `<cache>/minimal`.
+///
+/// The base is the platform cache directory (e.g. `$XDG_CACHE_HOME` or
+/// `~/.cache` on Linux), falling back to `~/.cache` when it cannot be
+/// determined.
+///
+/// # Panics
+///
+/// Panics if neither a cache directory nor a home directory can be resolved,
+/// or if the resulting path is not valid UTF-8.
+pub fn minimal_cache_dir() -> DaemonAbsPath {
+    default_dir(dirs::cache_dir, ".cache")
+}
+
+/// Returns minimal's default state directory, `<state>/minimal`.
+///
+/// The base is the platform state directory (e.g. `$XDG_STATE_HOME` or
+/// `~/.local/state` on Linux), falling back to `~/.local/state` when it cannot
+/// be determined.
+///
+/// # Panics
+///
+/// Panics if neither a state directory nor a home directory can be resolved,
+/// or if the resulting path is not valid UTF-8.
+pub fn minimal_state_dir() -> DaemonAbsPath {
+    default_dir(dirs::state_dir, ".local/state")
+}
+
+/// Computes `<base>/minimal`, where `base` comes from `base_dir` or, failing
+/// that, `~/<home_fallback>`.
+fn default_dir(
+    base_dir: impl FnOnce() -> Option<std::path::PathBuf>,
+    home_fallback: &str,
+) -> DaemonAbsPath {
+    let base = base_dir().unwrap_or_else(|| {
+        dirs::home_dir()
+            .expect("could not determine home directory")
+            .join(home_fallback)
+    });
+    let path = Utf8PathBuf::from_path_buf(base.join("minimal"))
+        .expect("default directory path is not valid UTF-8");
+    DaemonAbsPath::try_new(path).expect("default directory path is not absolute")
+}
+
 /// Errors produced when constructing a path.
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]


### PR DESCRIPTION
 * Minimal cache dir: Use `XDG_CACHE_DIR/minimal` fallback `~/.cache/minimal`
 * Minimal state dir: Use `XDG_STATE_DIR/minimal` fallback `~/.local/state/minimal`

This is technically a behavior change for legacy mip, which would use `~/.cache/minimal` unconditionally, but now respects XDG_CACHE_DIR if set. But given we are doing a pivot to Minimal One, now is the right time for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized default locations for the daemon’s state and cache under dedicated “minimal” directories, improving consistent setup across platforms.
  * Updated both the daemon and client to use these shared defaults for socket and directory resolution.

* **Bug Fixes**
  * Improved robustness when platform directory discovery fails by relying on consistent fallback behavior.
  * Enhanced handling of user-supplied directory paths with clearer error messages instead of less descriptive failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->