### PR TITLE
feat(release): build/upload gvproxy/initramfs/rootfs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,148 @@ jobs:
                   path: target/release/minimal-macos-arm64
                   retention-days: 7
 
+    build-release-guest-artifacts:
+        # Guest microVM artifacts shipped in the release: the raw guest kernel
+        # Image, the ext4 rootfs image, the initramfs (minimald as pid-1 /init),
+        # and the pinned gvproxy switch binary. These are already produced
+        # piecemeal in the CI lanes (ci-macos.yml, ci-linux-kvm.yml,
+        # ci-gvproxy.yml); this job gathers them into the release.
+        #
+        # None require the target host's arch to produce: the kernel and rootfs are
+        # cache pulls keyed by the pinned upstream commit (fetch-artifact.sh pulls
+        # any guest arch on an x86_64 runner), the initramfs cross-compiles minimald
+        # to static musl for the target arch, and gvproxy is a pin-verified download
+        # of the upstream release binary. So a single x86_64 runner emits both the
+        # amd64 and arm64 variants, covering every release host
+        # (linux-amd64/arm64, macos-arm64). Files are arch-suffixed so
+        # download-artifact's merge-multiple basename-flatten in the release job
+        # doesn't collide.
+        runs-on: ubuntu-latest
+        timeout-minutes: 45
+        steps:
+            - name: Free Disk Space
+              # Two cross (Docker) initramfs builds plus the CLI build that drives
+              # the rootfs cache pulls; reclaim the tool cache for headroom.
+              uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
+              with:
+                  remove_android: true
+                  remove_dotnet: true
+                  remove_haskell: true
+                  remove_tool_cache: true
+            - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
+            - name: Toolchain
+              uses: dtolnay/rust-toolchain@stable
+            - name: Install build dependencies
+              # protoc + libprotobuf-dev: the `mip` CLI build that drives the rootfs
+              # cache pull (the well-known protos live in libprotobuf-dev, only a
+              # `recommends` of protobuf-compiler, so name it under
+              # --no-install-recommends). cpio: packs the initramfs.
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y --no-install-recommends \
+                    protobuf-compiler libprotobuf-dev cpio
+            - name: Install cross
+              uses: taiki-e/install-action@v2
+              with:
+                  tool: cross
+            - uses: actions/cache@v6
+              with:
+                  path: |
+                      ~/.cargo/bin/
+                      ~/.cargo/registry/index/
+                      ~/.cargo/registry/cache/
+                      ~/.cargo/git/db/
+                      target/
+                  key: ${{ runner.os }}-guest-artifacts-release-${{ hashFiles('**/Cargo.lock') }}
+                  restore-keys: ${{ runner.os }}-guest-artifacts-release-
+            # NOTE: fetch-artifact.sh takes the kernel-style arch (x86_64/aarch64)
+            # and build-initramfs.sh takes a rust target triple; only the emitted
+            # file/artifact names use the amd64/arm64 suffixes the release binaries
+            # already use.
+            - name: Materialize guest kernel (raw Image, amd64)
+              run: ./scripts/fetch-artifact.sh virtio-kernel "$RUNNER_TEMP/vmlinuz-amd64" x86_64
+            - name: Materialize guest kernel (raw Image, arm64)
+              run: ./scripts/fetch-artifact.sh virtio-kernel "$RUNNER_TEMP/vmlinuz-arm64" aarch64
+            - name: Materialize guest rootfs (ext4 image, amd64)
+              run: ./scripts/fetch-artifact.sh minvmd-rootfs "$RUNNER_TEMP/rootfs-amd64.img" x86_64
+            - name: Materialize guest rootfs (ext4 image, arm64)
+              run: ./scripts/fetch-artifact.sh minvmd-rootfs "$RUNNER_TEMP/rootfs-arm64.img" aarch64
+            - name: Build guest initramfs (amd64)
+              run: ./scripts/build-initramfs.sh "$RUNNER_TEMP/initramfs-amd64.cpio" x86_64-unknown-linux-musl
+            - name: Build guest initramfs (arm64)
+              run: ./scripts/build-initramfs.sh "$RUNNER_TEMP/initramfs-arm64.cpio" aarch64-unknown-linux-musl
+            - name: Fetch pinned gvproxy (linux-amd64)
+              run: ./scripts/fetch-gvproxy.sh "$RUNNER_TEMP/gvproxy-linux-amd64" gvproxy-linux-amd64
+            - name: Fetch pinned gvproxy (linux-arm64)
+              run: ./scripts/fetch-gvproxy.sh "$RUNNER_TEMP/gvproxy-linux-arm64" gvproxy-linux-arm64
+            - name: Fetch pinned gvproxy (darwin-arm64)
+              run: ./scripts/fetch-gvproxy.sh "$RUNNER_TEMP/gvproxy-darwin-arm64" gvproxy-darwin
+            - name: Upload kernel (amd64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: virtio-kernel-amd64
+                  path: ${{ runner.temp }}/vmlinuz-amd64
+                  if-no-files-found: error
+                  retention-days: 7
+            - name: Upload kernel (arm64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: virtio-kernel-arm64
+                  path: ${{ runner.temp }}/vmlinuz-arm64
+                  if-no-files-found: error
+                  retention-days: 7
+            - name: Upload rootfs (amd64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: minvmd-rootfs-amd64
+                  path: ${{ runner.temp }}/rootfs-amd64.img
+                  if-no-files-found: error
+                  retention-days: 7
+            - name: Upload rootfs (arm64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: minvmd-rootfs-arm64
+                  path: ${{ runner.temp }}/rootfs-arm64.img
+                  if-no-files-found: error
+                  retention-days: 7
+            - name: Upload initramfs (amd64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: minimald-initramfs-amd64
+                  path: ${{ runner.temp }}/initramfs-amd64.cpio
+                  if-no-files-found: error
+                  retention-days: 7
+            - name: Upload initramfs (arm64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: minimald-initramfs-arm64
+                  path: ${{ runner.temp }}/initramfs-arm64.cpio
+                  if-no-files-found: error
+                  retention-days: 7
+            - name: Upload gvproxy (linux-amd64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: gvproxy-linux-amd64
+                  path: ${{ runner.temp }}/gvproxy-linux-amd64
+                  if-no-files-found: error
+                  retention-days: 7
+            - name: Upload gvproxy (linux-arm64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: gvproxy-linux-arm64
+                  path: ${{ runner.temp }}/gvproxy-linux-arm64
+                  if-no-files-found: error
+                  retention-days: 7
+            - name: Upload gvproxy (darwin-arm64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: gvproxy-darwin-arm64
+                  path: ${{ runner.temp }}/gvproxy-darwin-arm64
+                  if-no-files-found: error
+                  retention-days: 7
+
     release:
         runs-on: ubuntu-latest
         timeout-minutes: 30
@@ -253,6 +395,7 @@ jobs:
                 build-release-linux-amd64,
                 build-release-linux-arm64,
                 build-release-macos-arm64,
+                build-release-guest-artifacts,
             ]
         permissions:
             contents: write

--- a/scripts/fetch-gvproxy.sh
+++ b/scripts/fetch-gvproxy.sh
@@ -1,20 +1,29 @@
 #!/usr/bin/env bash
-# Download the pinned gvproxy (gvisor-tap-vsock) release binary for the host
-# platform and verify its SHA-256 against vendor/gvproxy/gvproxy.lock.
-# No build, no Go toolchain. minimald spawns this binary as the per-host switch.
+# Download the pinned gvproxy (gvisor-tap-vsock) release binary and verify its
+# SHA-256 against vendor/gvproxy/gvproxy.lock. No build, no Go toolchain.
+# minimald spawns this binary as the per-host switch.
+#
+# The asset defaults to the host platform's binary; pass an explicit asset name
+# (2nd arg) to fetch a different platform's binary regardless of the host arch —
+# the release job uses this to pack every platform's gvproxy from one runner.
+#
+# Usage: scripts/fetch-gvproxy.sh [dest-path] [asset]
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 lock="${here}/../vendor/gvproxy/gvproxy.lock"
 out="${1:-./gvproxy}"
+asset="${2:-}"
 
 ver="$(sed -n 's/^version=//p' "$lock")"
-case "$(uname -s)-$(uname -m)" in
-  Linux-x86_64)  asset=gvproxy-linux-amd64 ;;
-  Linux-aarch64) asset=gvproxy-linux-arm64 ;;
-  Darwin-*)      asset=gvproxy-darwin ;;
-  *) echo "fetch-gvproxy: unsupported platform $(uname -s)-$(uname -m)" >&2; exit 1 ;;
-esac
+if [ -z "$asset" ]; then
+  case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64)  asset=gvproxy-linux-amd64 ;;
+    Linux-aarch64) asset=gvproxy-linux-arm64 ;;
+    Darwin-*)      asset=gvproxy-darwin ;;
+    *) echo "fetch-gvproxy: unsupported platform $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+  esac
+fi
 want="$(sed -n "s/^${asset}=//p" "$lock")"
 [ -n "$want" ] || { echo "fetch-gvproxy: no pinned digest for ${asset}" >&2; exit 1; }
 


### PR DESCRIPTION
Builds:

- virtio-kernel-amd64 / virtio-kernel-arm64 (vmlinuz-amd64 / vmlinuz-arm64)
- minvmd-rootfs-amd64 / minvmd-rootfs-arm64 (rootfs-amd64.img / rootfs-arm64.img)
- minimald-initramfs-amd64 / minimald-initramfs-arm64 (initramfs-amd64.cpio / initramfs-arm64.cpio)
- gvproxy-linux-amd64 / gvproxy-linux-arm64 / gvproxy-darwin-arm64 (already amd64/arm64)

The x86_64/aarch64 strings that remain are only script arguments — fetch-artifact.sh's --arch value and build-initramfs.sh's rust target triples, which must stay in that form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds now include prepackaged guest artifacts for both x86_64 and arm64 targets, helping ensure complete release assets are available.
  * Release uploads now cover additional platform-specific binaries, including Linux and macOS variants.

* **Bug Fixes**
  * Improved download handling so a specific release asset can be chosen directly instead of relying only on the current machine’s platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->