### PR TITLE
fix(orchestrator,rcache): offload package extract so the spinner renders 

### DIFF
--- a/crates/orchestrator/src/local_backend.rs
+++ b/crates/orchestrator/src/local_backend.rs
@@ -14,7 +14,6 @@ use op::{Runnable, SourceFetcher};
 use ot::OpTracker;
 use rcache::RemoteCache;
 use tokio::sync::Semaphore;
-use tokio::task::spawn_blocking;
 
 use crate::Error;
 
@@ -183,7 +182,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
         };
 
         let shared_hnd2 = shared_hnd.clone();
-        let artifact = spawn_blocking(async move || {
+        let artifact = async move {
             let shared = shared_hnd2.inner().read().await;
             let permit = shared
                 .backend
@@ -242,9 +241,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
             drop(permit);
             drop(shared);
             res
-        })
-        .await
-        .unwrap()
+        }
         .await?;
 
         {
@@ -281,7 +278,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
         }
 
         let shared_hnd2 = shared_hnd.clone();
-        spawn_blocking(async move || {
+        async move {
             let shared = shared_hnd2.inner().read().await;
             let sema = shared.fetch_semaphore.acquire().await;
             let res = if let Some(remote_cache) = shared.backend.remote_cache.as_ref() {
@@ -320,9 +317,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
             drop(sema);
             drop(shared);
             res
-        })
-        .await
-        .unwrap()
+        }
         .await
     }
 
@@ -355,7 +350,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
 
         let shared_hnd2 = shared_hnd.clone();
         let subset2 = subset.clone();
-        let pending_dir = spawn_blocking(async move || {
+        let pending_dir = async move {
             let shared = shared_hnd2.inner().read().await;
             let res = op::SubsetBuild {
                 from_dir: Some(build_dir),
@@ -370,9 +365,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
             .await;
             drop(shared);
             res
-        })
-        .await
-        .unwrap()
+        }
         .await?;
 
         let shared = shared_hnd.inner().read().await;

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -275,12 +275,20 @@ impl<B: FetchBackend> RemoteCache<B> {
             name: span_name.to_string(),
         });
         let cache_hnd = cache.write_dir(spec_hash).map_err(Error::Cache)?;
-        archive::extract_compressed_tar(
-            tar_file,
-            archive::Compression::Zstd,
-            cache_hnd.path(),
-            None,
-        )
+        // Decompression is synchronous and CPU-bound; run it on the blocking
+        // pool so the async worker stays free. Besides honouring the
+        // no-blocking-in-async rule, this yield point is what lets the progress
+        // renderer task be scheduled between `set_op(ExtractPkg)` and
+        // `set_done()`. Without it the extract runs to completion inline, the two
+        // bracketing version bumps coalesce in the watch channel, and the
+        // renderer never observes the ExtractPkg state — so the extract spinner
+        // is never drawn.
+        let dest = cache_hnd.path().to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            archive::extract_compressed_tar(tar_file, archive::Compression::Zstd, &dest, None)
+        })
+        .await
+        .expect("extract task is awaited immediately and never cancelled")
         .map_err(Error::ArchiveError)?;
 
         materialize_op.set_done();

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -471,6 +471,12 @@ impl<C: Channel> Sandbox<C> {
         Ok(())
     }
 
+    /// Builds the hakoniwa [`Container`] for this sandbox.
+    ///
+    /// Spawning this container (`Command::spawn`) does a bare in-process `fork()`
+    /// on the calling thread and arms `PR_SET_PDEATHSIG(SIGKILL)`, tying the
+    /// child's lifetime to that thread. See [`run_with_cancel`](Self::run_with_cancel)
+    /// for the thread-affinity constraints this imposes on callers.
     pub fn new_container(&self) -> Result<Container, Error> {
         let mut container = hakoniwa::Container::new();
         container
@@ -779,6 +785,10 @@ impl<C: Channel> Sandbox<C> {
         container.command_inner(self, &program, args, env_vars)
     }
 
+    /// Runs the invocations in the sandbox to completion.
+    ///
+    /// Delegates to [`run_with_cancel`](Self::run_with_cancel) — see its docs for
+    /// the important thread-affinity constraint on the sandbox container.
     pub async fn run<W1, W2>(
         &mut self,
         invocations: Vec<Invocation>,
@@ -798,6 +808,34 @@ impl<C: Channel> Sandbox<C> {
         .await
     }
 
+    /// Runs the invocations in the sandbox, killing the container if `cancel`
+    /// fires.
+    ///
+    /// # Thread-affinity footgun (hakoniwa `PR_SET_PDEATHSIG`)
+    ///
+    /// This forks the sandbox container **in-process, on the calling thread**
+    /// (via [`new_container`](Self::new_container) → hakoniwa's `Command::spawn`,
+    /// a bare `fork()`). The forked container arms `PR_SET_PDEATHSIG(SIGKILL)`
+    /// ("die with parent") — and on Linux that signal is delivered when the
+    /// **parent *thread*** terminates, not the parent *process*. Nothing ever
+    /// clears it, so the container stays bound to the exact thread that forked it
+    /// for its whole life.
+    ///
+    /// Consequences for callers:
+    ///
+    /// * The forking thread MUST outlive the container. This future is fine on a
+    ///   normal multi-thread runtime worker (they're stable), but the container
+    ///   dies with a spurious SIGKILL — surfacing as `InvocationFailed` — if that
+    ///   thread is retired while the container runs.
+    /// * NEVER drive this under [`tokio::task::block_in_place`]: it churns/retires
+    ///   worker threads, which SIGKILLs containers forked on them — including
+    ///   those of *unrelated* concurrent builds.
+    /// * NEVER run this on a [`tokio::task::spawn_blocking`] pool thread: those
+    ///   are reaped after an idle keep-alive, again killing the container.
+    ///
+    /// By contrast, purely-synchronous work that forks no container (e.g. staging
+    /// the rootfs in `Sandbox::new`) carries none of this and could be offloaded
+    /// to the blocking pool if it ever became hot enough to matter.
     pub async fn run_with_cancel<W1, W2>(
         &mut self,
         invocations: Vec<Invocation>,


### PR DESCRIPTION
If you do:

```rust
    spawn_blocking(async move || { ... .await ... }).await.unwrap().await
```

it doesn't actually run the closure in a separate thread. It computes the future in a different thread(basically instant), and then schedules the actual work on the async runtime. Which is the opposite of the point. WHELP.

The extract spinner shown after a remote-cache fetch often never appeared: the extract ran synchronously inline on an async worker, so the progress renderer could not be scheduled between the ExtractPkg set_op and set_done version bumps and the two coalesced in the watch channel, leaving the ExtractPkg state unobserved.

The root cause was an anti-pattern in the orchestrator backend. `spawn_blocking` expects a synchronous FnOnce; passing an async closure means the blocking thread only *constructs* the future and returns it, after which the trailing `.await.unwrap().await` drives the whole body
back on the async worker. The `.await.unwrap().await` double-await is the tell. So nothing was offloaded -- every blocking call inside, including the extract, ran on the runtime.

- rcache: run the synchronous extract in materialize() on a real  spawn_blocking (sync closure). This yield point lets the renderer  observe the ExtractPkg state and animate its steady-tick bar.
- orchestrator: drop the three bogus spawn_blocking(async ...) wrappers;  each deliverable is already its own spawned task, so the async bodies  run directly with no loss of concurrency.

The build path's synchronous sections are deliberately left inline. block_in_place cannot be used there: hakoniwa forks each sandbox container in-process with PR_SET_PDEATHSIG(SIGKILL) bound to the forking tokio worker thread, and block_in_place's thread churn retires that thread, delivering SIGKILL to a still-running container in an unrelated build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress display during archive extraction so the spinner appears reliably instead of skipping straight to completion.
  * Made progress reporting more consistent during local build and cache-related operations by reducing scheduling/coalescing issues.

* **Documentation**
  * Added clearer guidance on thread-affinity and process-lifetime implications when spawning and running the sandbox/container, including recommended calling patterns to avoid pitfalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->