### PR TITLE
 chore(sessions): loadouts flow cleanup

### DIFF
--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -465,6 +465,13 @@ impl sessions::core::hooks::PolicyHooks for AbortOnUnapproved {
 /// over the [`SubmitVerdict`] RPC; unwraps the daemon's terminal
 /// [`SessionStep::Active`] reply to the finalized session id.
 ///
+/// If Phase 3 gating fails (user cancels, policy hook aborts, var
+/// resolution fails, etc.), the client owes the daemon an
+/// `AbortSession` — otherwise the on-disk `Pending` record and its
+/// stash slot leak until daemon restart. Fires it as a
+/// fire-and-report step: the abort's own failure is logged but
+/// doesn't override the original gating error surfaced to the user.
+///
 /// [`UserPolicy::default`]: sessions::core::policy::UserPolicy::default
 /// [`SubmitVerdict`]: minimald_rpc::SubmitVerdict
 async fn drive_pending_to_active(
@@ -477,16 +484,26 @@ async fn drive_pending_to_active(
     use sessions::core::policy::UserPolicy;
     use sessions::wire::request::SessionStep;
 
+    // Capture the session id before consuming `response` — we need it
+    // to send AbortSession on any Phase 3 failure below.
+    let session_id = response.session_id;
+
     let hooks = AbortOnUnapproved;
-    let verdict = handle_response(
+    let verdict = match handle_response(
         response,
         &[],
         UserPolicy::default(),
         &hooks,
         ComposeOptions::default(),
         &|name| std::env::var(name),
-    )
-    .map_err(|e| eprintln!("Composition gating failed: {e}"))?;
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Composition gating failed: {e}");
+            send_abort(client, session_id).await;
+            return Err(());
+        }
+    };
 
     let resp = client
         .oneshot_rpc::<SubmitVerdict>(verdict)
@@ -501,18 +518,34 @@ async fn drive_pending_to_active(
     };
     match step {
         SessionStep::Active { id } => Ok(id),
-        SessionStep::Response { .. } => {
-            // The daemon's terminal reply today is always Active
-            // (single-round flow). Multi-round Response would be a
-            // future extension and the client isn't wired for it.
-            eprintln!(
-                "SubmitVerdict returned a follow-up Response, which this client cannot drive"
-            );
-            Err(())
-        }
         SessionStep::Fault { error } => {
+            // `Fault` means the daemon already tore down its side
+            // (`resume_from_verdict` failure destroys the record;
+            // `UnknownSessionId`/`WrongState` means there was nothing
+            // for us to abort). No AbortSession needed here.
             eprintln!("SubmitVerdict faulted: {error}");
             Err(())
+        }
+    }
+}
+
+/// Fire an `AbortSession` at the daemon for a `Pending` session the
+/// client has decided not to finalize. A best-effort teardown: if
+/// the abort itself fails (network, daemon crash, or a state race)
+/// we log and move on — the daemon's startup reap pass is the
+/// backstop for the leaked `Pending` record.
+async fn send_abort(client: &mut client::Client, session_id: sessions::SessionId) {
+    use minimald_rpc::AbortSession;
+    match client
+        .oneshot_rpc::<AbortSession>(minimald_rpc::AbortSessionRequest { id: session_id })
+        .await
+    {
+        Ok(minimald_rpc::Errorable::Ok(_)) => {}
+        Ok(minimald_rpc::Errorable::Err { error }) => {
+            eprintln!("AbortSession failed: {error}");
+        }
+        Err(e) => {
+            eprintln!("AbortSession RPC failed: {e}");
         }
     }
 }

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -331,34 +331,16 @@ impl OneshotSshRpc for Shutdown {
     type Response = ShutdownResponse;
 }
 
-// ---------------------------------------------------------------------------
-// Session-creation flow (multi-round contribution composition).
-//
-// Distinct from the simpler [`CreateSession`] above: that one takes a
-// fully-formed [`sessions::Record`]; the flow below composes the record
-// by walking client contributions and daemon-side closures across one or
-// more rounds. Each call returns a [`SessionStep`]: either the next round
-// of pending items or a protocol-level fault.
-//
-// TODO: these three RPCs are the building blocks for what is eventually
-// going to subsume `CreateSession` — once the multi-round flow lands on
-// the daemon, the terminal `SessionStep` will assemble a `sessions::Record`
-// and the single-shot `CreateSession` becomes redundant. Keeping them
-// separate for now so the existing `CreateSession` callers stay working
-// while the contribution flow is built out.
-
-/// An RPC to open a new session and receive the first round of items
-/// the client must resolve.
-pub struct SessionCreate;
-
-impl OneshotSshRpc for SessionCreate {
-    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "SessionCreate");
-    type Request<'a> = sessions::wire::request::SessionCreateRequest;
-    type Response = Errorable<sessions::wire::request::SessionStep>;
-}
-
-/// An RPC to submit the client's verdicts for one round and receive the
-/// next round (or a `complete` signal in [`sessions::wire::request::ContributionResponse`]).
+/// Resume a `Pending` session with the client's per-item
+/// [`ContributionVerdict`]. Terminal — the daemon promotes the
+/// record `Pending → Active` and replies with
+/// [`SessionStep::Active`](sessions::wire::request::SessionStep::Active).
+/// A `Fault` reply carries a structured
+/// [`WireError`](sessions::wire::errors::WireError) —
+/// `UnknownSessionId` for a verdict against no stashed session,
+/// `WrongState` if the record isn't `Pending`, or an
+/// `InvalidContribution` / `Internal` reflecting a failed
+/// `resume_from_verdict`.
 pub struct SubmitVerdict;
 
 impl OneshotSshRpc for SubmitVerdict {
@@ -367,13 +349,33 @@ impl OneshotSshRpc for SubmitVerdict {
     type Response = Errorable<sessions::wire::request::SessionStep>;
 }
 
-/// An RPC to abort an in-flight session-creation flow.
-pub struct SessionAbort;
+/// Abort a `Pending` session before its `SubmitVerdict`.
+///
+/// Called by the client when its Phase 3 gating produces no verdict —
+/// user cancelled at a prompt, policy hooks returned `Abort`, or an
+/// upstream resolution / expansion failed. Drops the daemon's stash
+/// entry and deletes the on-disk `Pending` record so the session name
+/// is freed and the stash slot isn't burned.
+///
+/// Refuses non-`Pending` records: an unknown id or a record already
+/// promoted to `Active` (destroy that via [`DestroySession`]) surfaces
+/// as an `Errorable::Err`.
+pub struct AbortSession;
 
-impl OneshotSshRpc for SessionAbort {
-    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "SessionAbort");
-    type Request<'a> = sessions::wire::request::Abort;
-    type Response = Errorable<()>;
+/// The request for an [`AbortSession`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AbortSessionRequest {
+    pub id: SessionId,
+}
+
+/// The response for an [`AbortSession`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AbortSessionResponse;
+
+impl OneshotSshRpc for AbortSession {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "AbortSession");
+    type Request<'a> = AbortSessionRequest;
+    type Response = Errorable<AbortSessionResponse>;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -1,12 +1,12 @@
 #[cfg(feature = "networking-proxy")]
 use minimald_rpc::IssueClientCertResponse;
 use minimald_rpc::{
-    CreateSession, DestroySession, DestroySessionResponse, Errorable, GetMeshStatus,
-    GetSessionPolicy, GetSessionPolicyRequest, GetSessionRecord, GetSessionRecordRequest,
-    GetSessionRecordResponse, GetVersion, GetVersionResponse, IssueClientCert,
-    IssueClientCertRequest, ListSessions, ListSessionsEntry, ListSessionsResponse, OneshotSshRpc,
-    RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse, Shutdown, ShutdownRequest,
-    ShutdownResponse, SubmitVerdict,
+    AbortSession, AbortSessionResponse, CreateSession, DestroySession, DestroySessionResponse,
+    Errorable, GetMeshStatus, GetSessionPolicy, GetSessionPolicyRequest, GetSessionRecord,
+    GetSessionRecordRequest, GetSessionRecordResponse, GetVersion, GetVersionResponse,
+    IssueClientCert, IssueClientCertRequest, ListSessions, ListSessionsEntry, ListSessionsResponse,
+    OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse, Shutdown,
+    ShutdownRequest, ShutdownResponse, SubmitVerdict,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
@@ -261,6 +261,26 @@ async fn serve_shutdown(s: ServerStateHandle, c: RuChannel<Msg>) {
     }
 }
 
+/// `AbortSession`: drop a `Pending` session's stash entry and delete
+/// its on-disk record. See the manager arm for the actor-side rules
+/// (refuses `Active` records and unknown ids).
+async fn serve_abort_session(s: ServerStateHandle, c: RuChannel<Msg>) {
+    let res = AbortSession
+        .handle_channel(c, async |req| {
+            let res = s.sessions_manager().await.abort_session(req.id).await;
+            match res {
+                Ok(()) => Ok(Errorable::Ok(AbortSessionResponse)),
+                Err(e) => Ok(Errorable::Err {
+                    error: e.to_string(),
+                }),
+            }
+        })
+        .await;
+    if let Err(e) = res {
+        tracing::warn!("RPC handler for {} failed: {}", AbortSession::NAME, e);
+    }
+}
+
 async fn serve_get_session_policy(s: ServerStateHandle, c: RuChannel<Msg>) {
     let res = GetSessionPolicy
         .handle_channel(c, async |req| {
@@ -421,6 +441,7 @@ pub async fn handle_ssh_rpc(
         | RenameSession::NAME
         | DestroySession::NAME
         | Shutdown::NAME
+        | AbortSession::NAME
         | GetSessionPolicy::NAME
         | GetMeshStatus::NAME
         | STREAM_WORKSPACE_FILES
@@ -458,6 +479,7 @@ pub async fn handle_ssh_rpc(
         RenameSession::NAME => drop(spawn(serve_rename_session(s, channel))),
         DestroySession::NAME => drop(spawn(serve_destroy_session(s, channel))),
         Shutdown::NAME => drop(spawn(serve_shutdown(s, channel))),
+        AbortSession::NAME => drop(spawn(serve_abort_session(s, channel))),
         GetSessionPolicy::NAME => drop(spawn(serve_get_session_policy(s, channel))),
         GetMeshStatus::NAME => drop(spawn(serve_get_mesh_status(s, channel))),
         STREAM_WORKSPACE_FILES => drop(spawn(serve_stream_workspace_files(s, config, channel))),

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -154,6 +154,7 @@ enum ManagerMessage {
     SubmitVerdict(Box<SubmitVerdictMsg>),
     RenameSession(SessionId, String, Responder<()>),
     DestroySession(SessionId, Responder<()>),
+    AbortSession(SessionId, Responder<()>),
     Shutdown(bool, Responder<Result<(), ()>>),
 }
 
@@ -680,6 +681,44 @@ impl<L: Loader> Manager<L> {
                 })
                 .await
             }
+            // Abort a `Pending` session: drop its stash entry and
+            // delete the on-disk record. Refuses `Active` (use
+            // `DestroySession`) or unknown ids. Never touches
+            // `running`: a Pending record can't be running.
+            ManagerMessage::AbortSession(id, r) => {
+                r.handle(async {
+                    if self.in_shutdown {
+                        return Err(SessionsError::new(
+                            std::io::ErrorKind::ConnectionRefused,
+                            "in shutdown",
+                        ));
+                    }
+                    let k = self.store.find_by_id(&id)?.ok_or_else(|| {
+                        std::io::Error::new(
+                            NotFound,
+                            format!("no session with ID `{}`", id.as_ref()),
+                        )
+                    })?;
+                    let record = self.store.get(&k)?.record().clone();
+                    if record.status != sessions::SessionStatus::Pending {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            format!(
+                                "cannot abort session `{}`: status is {:?}, expected Pending",
+                                id.as_ref(),
+                                record.status,
+                            ),
+                        ));
+                    }
+                    // Stash may be absent (post-restart orphan reached
+                    // us before the reap pass, or the pending path was
+                    // never populated). Delete the record either way.
+                    self.pending.remove(&id);
+                    self.store.delete(&k)?;
+                    Ok(())
+                })
+                .await
+            }
             // Destroys a session: tears down its running host and actor (if
             // any), then removes its on-disk record.
             ManagerMessage::DestroySession(id, r) => {
@@ -897,6 +936,23 @@ impl ManagerHandle {
         recv.await.expect("corresponding sessions manager is dead")
     }
 
+    /// Aborts a `Pending` session: drops the daemon's stash entry and
+    /// deletes the on-disk record. Used by the client when its
+    /// Phase 3 gating produces no verdict (e.g. user cancelled at a
+    /// prompt).
+    ///
+    /// `NotFound` if the id is unknown; `InvalidInput` if the record
+    /// exists but its status isn't `Pending`
+    /// (use [`Self::destroy_session`] on an `Active` session).
+    pub async fn abort_session(&self, id: SessionId) -> Result<(), SessionsError> {
+        let (send, recv) = Responder::channel();
+        let _ = self
+            .sender
+            .send(ManagerMessage::AbortSession(id, send))
+            .await;
+        recv.await.expect("corresponding sessions manager is dead")
+    }
+
     /// Shuts down all sessions for process termination. If force is true, live sessions are killed.
     /// If force is false but there are live sessions, an error is returned.
     pub async fn shutdown(&self, force: bool) -> Result<(), ()> {
@@ -1105,6 +1161,42 @@ mod tests {
             loader.get(&active_key_again).unwrap().record().status,
             sessions::SessionStatus::Active,
             "the Active record should remain",
+        );
+    }
+
+    /// `AbortSession` on an unknown id → `NotFound`, mirrors
+    /// `DestroySession`'s error shape so clients can uniformly
+    /// handle "no such session".
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn abort_unknown_id_errors() {
+        let (_state, _cache, mngr) = manager().await;
+        let err = mngr
+            .abort_session(SessionId::nil())
+            .await
+            .expect_err("aborting an unknown id should error");
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+    }
+
+    /// `AbortSession` refuses `Active` records — abort is for
+    /// `Pending` only; `DestroySession` handles `Active`. Guards
+    /// against a client accidentally tearing down a running session
+    /// via the wrong RPC.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn abort_refuses_active_session() {
+        let (_state, _cache, mngr) = manager().await;
+        let id = create_and_unwrap_id(&mngr).await;
+        let err = mngr
+            .abort_session(id)
+            .await
+            .expect_err("aborting an Active session should error");
+        assert_eq!(err.kind(), ErrorKind::InvalidInput);
+        // Record is untouched.
+        assert!(
+            mngr.get_record(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .is_some(),
+            "the Active record should survive a refused abort"
         );
     }
 

--- a/crates/sessions/docs/COMPOSITION.md
+++ b/crates/sessions/docs/COMPOSITION.md
@@ -28,11 +28,12 @@ sequenceDiagram
     Note over C: Loadout → Contribution (Loadout::contribute, resolve vars, tag provenance)
     Note over C: Contribution → Composition (UserComposer::compose runs the policy gate)
     Note over C: Composition → WireContribution (composition_to_wire)
-    C->>D: SessionCreate carrying WireContribution
+    C->>D: CreateSession carrying WireContribution
     Note over D: Phase 2 — collect project + package contributions, collect pending items
-    D-->>C: SessionStep::Response carrying ContributionResponse
+    D-->>C: CreateSessionResponse::Pending carrying ContributionResponse
     Note over C: Phase 3 — policy gate pending items, produce verdicts
     C->>D: SubmitVerdict carrying ContributionVerdict
+    D-->>C: SessionStep::Active { id }
     Note over D: Phase 4 — apply verdicts, assemble Composition, hand to apply layer
 ```
 

--- a/crates/sessions/src/client/handler.rs
+++ b/crates/sessions/src/client/handler.rs
@@ -57,8 +57,16 @@ use crate::wire::request::{ContributionResponse, ContributionVerdict};
 ///
 /// See [`ComposeError`]. In particular:
 /// - [`ComposeError::Aborted`] when a hook returns
-///   [`HookResult::Abort`]; the caller should send a `SessionAbort`
-///   RPC with [`AbortReason::UserCancelled`](crate::wire::request::AbortReason::UserCancelled).
+///   [`HookResult::Abort`]. The caller should surface the abort to
+///   the user, skip `SubmitVerdict`, and instead send `AbortSession`
+///   (`minimald_rpc::AbortSession`) so the daemon drops its stash
+///   entry and deletes the on-disk `Pending` record. Without that,
+///   the record and stash slot leak until the next daemon restart:
+///   the in-memory stash is cleared by the restart itself, and the
+///   on-disk record is cleared by `reap_orphan_pending` at startup.
+///   The stash is bounded by `MAX_PENDING_SESSIONS`; further
+///   `CreateSession` requests that would produce a Pending outcome
+///   are refused with `ResourceBusy` once the cap is reached.
 /// - [`ComposeError::VarResolution`] when an `Inherit`-shaped
 ///   pending var can't be resolved against the env.
 /// - [`ComposeError::Expansion`] / [`ComposeError::PatchWalk`] for

--- a/crates/sessions/src/wire/request.rs
+++ b/crates/sessions/src/wire/request.rs
@@ -2,36 +2,20 @@
 //!
 //! Flow:
 //!
-//! 1. Client → daemon: [`SessionCreateRequest`] containing the
-//!    [`WireContribution`] composed from the user's loadouts.
-//! 2. Daemon → client: a single [`ContributionResponse`] with the
+//! 1. Client → daemon: [`WireContribution`] composed from the user's
+//!    loadouts, shipped inside `CreateSessionRequest` in `minimald-rpc`.
+//! 2. Daemon → client: a [`ContributionResponse`] with the
 //!    package- and project-sourced items that need client-side
 //!    policy gating.
-//! 3. Client → daemon: [`ContributionVerdict`] with per-item
-//!    decisions, OR [`Abort`] to bail.
+//! 3. Client → daemon: [`ContributionVerdict`] with per-item decisions.
 
 use super::errors::WireError;
 use super::policy::{WirePatchVerdict, WireVarVerdict};
 use super::primitives::{
     WirePackageRef, WirePendingPatch, WirePendingVar, WireProvenancedHook, WireSessionPatch,
-    WireSessionVar, WireSource,
+    WireSessionVar,
 };
 use crate::SessionId;
-
-/// Client → Daemon: open a new session.
-///
-/// Carries everything the client can resolve on its own — the
-/// composited user loadouts. No session id (the daemon issues one),
-/// no user policy (it's a client-side concern).
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct SessionCreateRequest {
-    /// Wire protocol version. Daemon rejects unrecognized versions.
-    pub protocol_version: u32,
-    /// Absolute host path to the project directory.
-    pub project_path: paths::HostAbsPath,
-    /// The user's already-gated contribution.
-    pub contribution: WireContribution,
-}
 
 /// The client's composed contribution, wire-shaped: var values
 /// resolved, patch sources expanded to concrete files, every item
@@ -52,8 +36,7 @@ pub struct WireContribution {
 /// project config) that need client-side policy + prompts.
 ///
 /// Sent once per session. After receiving the matching
-/// [`ContributionVerdict`] (or an [`Abort`]), the daemon assembles
-/// the session.
+/// [`ContributionVerdict`] the daemon assembles the session.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ContributionResponse {
     /// Session id assigned by the daemon.
@@ -78,55 +61,9 @@ pub struct ContributionVerdict {
     pub patches: Vec<WirePatchVerdict>,
 }
 
-/// Client → Daemon: bail mid-flow.
-///
-/// Distinct from a `ContributionVerdict` because aborts are
-/// terminal — the daemon should tear down session state — and they
-/// carry structured reasons for telemetry / user-facing messages.
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct Abort {
-    /// Session being aborted.
-    pub session_id: SessionId,
-    /// Why.
-    pub reason: AbortReason,
-}
-
-/// Why the client aborted.
-#[non_exhaustive]
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum AbortReason {
-    /// User policy explicitly denied a contributed item. The daemon
-    /// can use `what` + `from` for telemetry without re-running the
-    /// policy itself.
-    PolicyDenied {
-        /// Human-readable identifier of the denied item (var name or
-        /// patch source path).
-        what: String,
-        /// Where the denied item came from.
-        from: WireSource,
-    },
-    /// User cancelled at a prompt.
-    UserCancelled,
-    /// A `PolicyHooks` callback violated its contract. Diagnostic
-    /// only — the message is for telemetry, not the user.
-    HookContract {
-        /// Short categorical label for the contract violation.
-        category: String,
-        /// Free-form context naming the offending item or batch.
-        context: String,
-    },
-    /// Anything else; the daemon should treat as opaque.
-    Other {
-        /// Free-form message.
-        message: String,
-    },
-}
-
-/// Daemon's reply to a session-creation RPC: a terminal "session
-/// ready" signal, the next batch of pending items needing
-/// client-side gating, or a protocol-level fault the transport layer
-/// didn't catch.
+/// Daemon's reply to a `SubmitVerdict`: a terminal "session ready"
+/// signal or a protocol-level fault the transport layer didn't
+/// catch.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SessionStep {
@@ -138,13 +75,9 @@ pub enum SessionStep {
         /// the originating `CreateSessionResponse::Pending`.
         id: SessionId,
     },
-    /// Pending items awaiting client verdicts.
-    Response {
-        /// The pending-items payload.
-        response: ContributionResponse,
-    },
-    /// Protocol-level failure detected by the daemon (e.g. unknown
-    /// session id, version mismatch). Distinct from a transport error.
+    /// Protocol-level failure detected by the daemon (unknown
+    /// session id, wrong state, or a `resume_from_verdict` failure).
+    /// Distinct from a transport error.
     Fault {
         /// Structured fault detail. Nested under a field so its own
         /// `kind` discriminator doesn't collide with this enum's tag.
@@ -155,10 +88,7 @@ pub enum SessionStep {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::wire::primitives::{
-        PendingId, WireHookScript, WireLifecycleHook, WireResolvedPatch, WireResolvedVar,
-        WireVarSpec,
-    };
+    use crate::wire::primitives::{PendingId, WireResolvedVar, WireSource, WireVarSpec};
 
     fn round_trip<T>(value: &T) -> T
     where
@@ -170,48 +100,6 @@ mod tests {
 
     fn session_id() -> SessionId {
         SessionId::parse_str("00000000-0000-0000-0000-000000000001").unwrap()
-    }
-
-    fn user_source() -> WireSource {
-        WireSource::UserLoadout { name: "dev".into() }
-    }
-
-    #[test]
-    fn session_create_request_round_trips() {
-        let req = SessionCreateRequest {
-            protocol_version: 1,
-            project_path: paths::HostAbsPath::try_new("/repo").unwrap(),
-            contribution: WireContribution {
-                vars: vec![WireSessionVar {
-                    var: WireResolvedVar {
-                        name: "EDITOR".into(),
-                        value: "hx".into(),
-                    },
-                    source: user_source(),
-                }],
-                patches: vec![WireSessionPatch {
-                    patch: WireResolvedPatch {
-                        host_path: paths::HostAbsPath::try_new("/home/u/.gitconfig").unwrap(),
-                        destination: paths::SandboxRelPath::try_new(".gitconfig").unwrap(),
-                    },
-                    source: user_source(),
-                }],
-                lifecycle_hooks: vec![WireProvenancedHook {
-                    hook: WireLifecycleHook {
-                        on_activate: Some(WireHookScript::Inline {
-                            body: "echo hi".into(),
-                        }),
-                        ..Default::default()
-                    },
-                    source: user_source(),
-                }],
-                requested_packages: vec![WirePackageRef {
-                    name: "helix".into(),
-                    source: user_source(),
-                }],
-            },
-        };
-        assert_eq!(round_trip(&req), req);
     }
 
     #[test]
@@ -258,58 +146,12 @@ mod tests {
     }
 
     #[test]
-    fn abort_round_trips_all_reasons() {
-        let cases = [
-            AbortReason::PolicyDenied {
-                what: "AWS_SECRET_KEY".into(),
-                from: WireSource::Package {
-                    name: "evil".into(),
-                },
-            },
-            AbortReason::UserCancelled,
-            AbortReason::HookContract {
-                category: "decision count mismatch".into(),
-                context: "expected 3, got 2".into(),
-            },
-            AbortReason::Other {
-                message: "fs walk panicked".into(),
-            },
-        ];
-        for reason in cases {
-            let a = Abort {
-                session_id: session_id(),
-                reason,
-            };
-            assert_eq!(round_trip(&a), a);
-        }
-    }
-
-    #[test]
-    fn abort_reason_uses_explicit_kind_tag() {
-        let a = AbortReason::UserCancelled;
-        let json = serde_json::to_string(&a).unwrap();
-        assert!(
-            json.contains(r#""kind":"user_cancelled""#),
-            "expected `kind` tag, got: {json}"
-        );
-    }
-
-    #[test]
     fn session_step_round_trips_all_variants() {
         let active = SessionStep::Active { id: session_id() };
-        let response = SessionStep::Response {
-            response: ContributionResponse {
-                session_id: session_id(),
-                vars: vec![],
-                patches: vec![],
-                lifecycle_hooks: vec![],
-            },
-        };
         let fault = SessionStep::Fault {
             error: WireError::UnknownSessionId,
         };
         assert_eq!(round_trip(&active), active);
-        assert_eq!(round_trip(&response), response);
         assert_eq!(round_trip(&fault), fault);
     }
 

--- a/crates/sessions/tests/client_flow1.rs
+++ b/crates/sessions/tests/client_flow1.rs
@@ -1,6 +1,5 @@
 //! Integration tests for the client side of session creation, flow 1:
-//! TOML loadout → [`UserComposer`] → [`WireContribution`] →
-//! [`SessionCreateRequest`].
+//! TOML loadout → [`UserComposer`] → `WireContribution`.
 //!
 //! Each test exercises the crate's public surface only (this lives in
 //! `tests/`, not `src/`, so visibility leaks here mean we broke the
@@ -15,7 +14,6 @@ use sessions::core::loadout::Loadout;
 use sessions::core::policy::{PatchPolicy, UserPolicy, VarsPolicy};
 use sessions::core::source::Source;
 use sessions::wire::primitives::WireSource;
-use sessions::wire::request::SessionCreateRequest;
 
 // =====================================================================
 // Support
@@ -468,11 +466,12 @@ AWS_KEY = "leaked"
     }
 }
 
-/// The full `SessionCreateRequest` round-trips through JSON. Catches
-/// drift in any wire-form type without snapshotting against a fragile
-/// byte-for-byte fixture.
+/// The full `WireContribution` — the payload the client ships to
+/// the daemon inside `CreateSessionRequest` — round-trips through
+/// JSON. Catches drift in any wire-form type without snapshotting
+/// against a fragile byte-for-byte fixture.
 #[test]
-fn session_create_request_round_trips_through_json() {
+fn wire_contribution_round_trips_through_json() {
     let tmp = tempfile::tempdir().unwrap();
     let root = Utf8Path::from_path(tmp.path()).unwrap();
     fixture_tree(root, [("dotfiles/helix/config.toml", "theme = 'nord'\n")]);
@@ -498,20 +497,13 @@ on_activate = {{ type = "inline", value = "echo activated" }}
     let contribution = composer
         .compose(UserPolicy::empty(), ComposeOptions::default())
         .unwrap();
-    let req = SessionCreateRequest {
-        protocol_version: 1,
-        project_path: paths::HostAbsPath::try_new("/repo").unwrap(),
-        contribution,
-    };
 
-    let json = serde_json::to_string(&req).unwrap();
-    let decoded: SessionCreateRequest = serde_json::from_str(&json).unwrap();
+    let json = serde_json::to_string(&contribution).unwrap();
+    let decoded: sessions::wire::request::WireContribution = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(decoded.protocol_version, 1);
-    assert_eq!(decoded.project_path.as_str(), "/repo");
-    assert_eq!(decoded.contribution.vars.len(), 1);
-    assert_eq!(decoded.contribution.vars[0].var.value, "sjn_IV");
-    assert_eq!(decoded.contribution.patches.len(), 1);
-    assert_eq!(decoded.contribution.lifecycle_hooks.len(), 1);
-    assert_eq!(decoded.contribution.requested_packages.len(), 1);
+    assert_eq!(decoded.vars.len(), 1);
+    assert_eq!(decoded.vars[0].var.value, "sjn_IV");
+    assert_eq!(decoded.patches.len(), 1);
+    assert_eq!(decoded.lifecycle_hooks.len(), 1);
+    assert_eq!(decoded.requested_packages.len(), 1);
 }


### PR DESCRIPTION
Depends on https://github.com/gominimal/minimal/pull/618

Cleans up the multi-round contribution-composition scaffolding that we ended up not building out, and replaces the removed abort path with a properly-scoped single-round `AbortSession` RPC for the flow we actually shipped.

- **Removes dead multi-round scaffolding.** `SessionCreate` and `SessionAbort` RPCs plus their wire types (`SessionCreateRequest`, `Abort`, `AbortReason`) are gone — the multi-round design that was going to subsume `CreateSession` was abandoned in favor of the `CreateSession` + `SubmitVerdict` flow that landed in wire2/wire3. `SessionStep::Response` variant is also removed; no daemon-side producer exists post-simplification, and the client's defensive arm went with it.
- **Adds `AbortSession`.** Needed to close an actual gap: when Phase 3 gating aborts (user cancels, policy hook returns `Abort`, resolution / expansion fails), the client has to tell the daemon to drop its stash entry and delete the on-disk `Pending` record. Otherwise a client-side abort silently leaks a `Pending` session (name held, stash slot burned) until the next daemon restart's reap pass. Wire type is minimal: `AbortSessionRequest { id }` → `Errorable<AbortSessionResponse>`. Manager arm pops the stash + deletes the record; refuses non-`Pending` (`InvalidInput`) and unknown ids (`NotFound`). Client sends it from `drive_pending_to_active` on any `handle_response` failure.
- **Tightens `handle_response` docstring.** Now names the actual `AbortSession` call as the required cleanup step (not "planned"), documents the `MAX_PENDING_SESSIONS` cap + `ResourceBusy` semantics, and is precise about restart cleanup (in-memory stash cleared by restart; on-disk `Pending` cleared by `reap_orphan_pending` at next startup).
- **Wire schema tidying.** `SessionStep` retargeted to describe `SubmitVerdict`'s reply specifically (two variants: `Active` terminal, `Fault`). `wire::request` module docstring loses references to the deleted types. Client `client_flow1` integration test renamed and rescoped to `wire_contribution_round_trips_through_json` (the round-trip essence, without the deleted wrapper).
- **COMPOSITION.md.** Mermaid diagram updated: `SessionCreate` → `CreateSession`, terminal `SessionStep::Active` reply arrow added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pending session activation, including completion after verdict submission.
  * Introduced a new session abort flow that can cancel pending sessions and clear stored state.

* **Bug Fixes**
  * Improved handling when session gating is not approved, with clearer failure behavior.
  * Session lifecycle responses now distinguish between finalized active sessions and terminal faults.

* **Documentation**
  * Updated session flow diagrams and protocol notes to reflect the new pending-to-active lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->