### PR TITLE
feat(rcache,mctx): read cache over HTTPS via MINIMAL_REMOTE_CACHE_URL (R2 read path)

### DIFF
--- a/crates/common/src/fetchers.rs
+++ b/crates/common/src/fetchers.rs
@@ -264,3 +264,254 @@ impl FetchBackend for Storage {
         req.send().map(Ok)
     }
 }
+
+// --- Runtime-selectable backend --------------------------------------------
+//
+// The remote-cache *reader* needs to target either the GCS bucket (default) or
+// a plain-HTTPS mirror (e.g. a Cloudflare R2 custom domain, to avoid GCS egress
+// cost) chosen at runtime from config. Rather than thread a backend type
+// parameter through every consumer of `RemoteCache`, `AnyBackend` selects the
+// backend at construction and forwards each call to the chosen one. Writers
+// keep using the concrete `Storage` backend (compare-and-swap needs GCS
+// object generations, which plain HTTPS doesn't expose).
+
+/// A [FetchUrl] over either a GCS bucket URL or a plain HTTPS URL.
+#[derive(Clone, Debug)]
+pub enum AnyUrl {
+    Https(ReqwestUrl),
+    Gcs(GcsUrl),
+}
+
+/// Join error for [AnyUrl].
+#[derive(Debug)]
+pub enum AnyJoinError {
+    Https(url::ParseError),
+    Gcs(()),
+}
+
+impl FetchUrl for AnyUrl {
+    type JoinError = AnyJoinError;
+
+    fn join(&self, input: &str) -> Result<Self, Self::JoinError> {
+        match self {
+            AnyUrl::Https(u) => u
+                .join(input)
+                .map(AnyUrl::Https)
+                .map_err(AnyJoinError::Https),
+            AnyUrl::Gcs(u) => u.join(input).map(AnyUrl::Gcs).map_err(AnyJoinError::Gcs),
+        }
+    }
+
+    fn filename(&self) -> String {
+        match self {
+            AnyUrl::Https(u) => u.filename(),
+            AnyUrl::Gcs(u) => u.filename(),
+        }
+    }
+}
+
+/// A [FetchResponse] from either backend.
+#[derive(Debug)]
+pub enum AnyResponse {
+    Https(Response),
+    Gcs(Result<google_cloud_storage::read_object::ReadObjectResponse, GcsError>),
+}
+
+/// Error from an [AnyResponse] (or from constructing an [AnyBackend]).
+#[derive(Debug)]
+pub enum AnyRespError {
+    Https(ReqwestError),
+    Gcs(GcsError),
+    /// The configured plain-HTTPS read URL could not be parsed.
+    InvalidUrl(url::ParseError),
+}
+
+impl FetchResponse for AnyResponse {
+    type Error = AnyRespError;
+
+    fn error_for_status(self) -> Result<Self, Self::Error> {
+        match self {
+            AnyResponse::Https(r) => FetchResponse::error_for_status(r)
+                .map(AnyResponse::Https)
+                .map_err(AnyRespError::Https),
+            AnyResponse::Gcs(r) => FetchResponse::error_for_status(r)
+                .map(AnyResponse::Gcs)
+                .map_err(AnyRespError::Gcs),
+        }
+    }
+
+    fn is_success(&self) -> bool {
+        match self {
+            AnyResponse::Https(r) => FetchResponse::is_success(r),
+            AnyResponse::Gcs(r) => FetchResponse::is_success(r),
+        }
+    }
+
+    fn status_code(&self) -> usize {
+        match self {
+            AnyResponse::Https(r) => FetchResponse::status_code(r),
+            AnyResponse::Gcs(r) => FetchResponse::status_code(r),
+        }
+    }
+
+    fn content_length(&self) -> Option<u64> {
+        match self {
+            AnyResponse::Https(r) => FetchResponse::content_length(r),
+            AnyResponse::Gcs(r) => FetchResponse::content_length(r),
+        }
+    }
+
+    async fn bytes(self) -> Result<Bytes, Self::Error> {
+        match self {
+            AnyResponse::Https(r) => FetchResponse::bytes(r).await.map_err(AnyRespError::Https),
+            AnyResponse::Gcs(r) => FetchResponse::bytes(r).await.map_err(AnyRespError::Gcs),
+        }
+    }
+
+    async fn chunk(&mut self) -> Result<Option<Bytes>, Self::Error> {
+        match self {
+            AnyResponse::Https(r) => FetchResponse::chunk(r).await.map_err(AnyRespError::Https),
+            AnyResponse::Gcs(r) => FetchResponse::chunk(r).await.map_err(AnyRespError::Gcs),
+        }
+    }
+
+    fn generation(&self) -> Option<i64> {
+        match self {
+            AnyResponse::Https(r) => FetchResponse::generation(r),
+            AnyResponse::Gcs(r) => FetchResponse::generation(r),
+        }
+    }
+}
+
+/// A request for either backend.
+#[derive(Debug)]
+pub enum AnyRequest {
+    Https(Request),
+    Gcs(google_cloud_storage::builder::storage::ReadObject),
+}
+
+/// A [FetchBackend] that is either the GCS client or a reqwest HTTPS client,
+/// selected at construction. See the module note above.
+#[derive(Clone, Debug)]
+pub enum AnyBackend {
+    Https(Client),
+    Gcs(Storage),
+}
+
+impl FetchBackend for AnyBackend {
+    type Url = AnyUrl;
+    type Request = AnyRequest;
+    type Response = AnyResponse;
+
+    fn get(
+        &self,
+        url: Self::Url,
+    ) -> Result<Self::Request, <Self::Response as FetchResponse>::Error> {
+        match (self, url) {
+            (AnyBackend::Https(c), AnyUrl::Https(u)) => FetchBackend::get(c, u)
+                .map(AnyRequest::Https)
+                .map_err(AnyRespError::Https),
+            (AnyBackend::Gcs(s), AnyUrl::Gcs(u)) => FetchBackend::get(s, u)
+                .map(AnyRequest::Gcs)
+                .map_err(AnyRespError::Gcs),
+            // A RemoteCache is always built with a matching backend+url pair
+            // (see RemoteCache::new_any_*), so a mismatch is a construction bug.
+            _ => unreachable!("AnyBackend: url does not match backend variant"),
+        }
+    }
+
+    async fn execute(
+        &self,
+        req: Self::Request,
+    ) -> Result<Self::Response, <Self::Response as FetchResponse>::Error> {
+        match (self, req) {
+            (AnyBackend::Https(c), AnyRequest::Https(r)) => FetchBackend::execute(c, r)
+                .await
+                .map(AnyResponse::Https)
+                .map_err(AnyRespError::Https),
+            (AnyBackend::Gcs(s), AnyRequest::Gcs(r)) => FetchBackend::execute(s, r)
+                .await
+                .map(AnyResponse::Gcs)
+                .map_err(AnyRespError::Gcs),
+            _ => unreachable!("AnyBackend: request does not match backend variant"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod any_backend_tests {
+    use super::*;
+
+    fn https(base: &str) -> AnyUrl {
+        AnyUrl::Https(ReqwestUrl::try_from(base).unwrap())
+    }
+    fn gcs(object: &str) -> AnyUrl {
+        AnyUrl::Gcs(GcsUrl {
+            bucket: "projects/_/buckets/b".into(),
+            object: object.into(),
+        })
+    }
+
+    #[test]
+    fn any_url_https_join_appends_segment() {
+        let joined = https("https://cache.example.com/")
+            .join("index.shisha")
+            .unwrap();
+        match &joined {
+            AnyUrl::Https(u) => assert_eq!(u.0.as_str(), "https://cache.example.com/index.shisha"),
+            other => panic!("expected Https, got {other:?}"),
+        }
+        assert_eq!(joined.filename(), "index.shisha");
+    }
+
+    #[test]
+    fn any_url_https_join_requires_trailing_slash() {
+        // Footgun: without a trailing slash on the base, Url::join replaces the
+        // last path segment instead of appending under it. This is exactly why
+        // the R2 / mirror base URL must end in `/`.
+        let no_slash = https("https://cache.example.com/prefix")
+            .join("a.zst")
+            .unwrap();
+        match &no_slash {
+            AnyUrl::Https(u) => assert_eq!(u.0.as_str(), "https://cache.example.com/a.zst"),
+            other => panic!("expected Https, got {other:?}"),
+        }
+        let with_slash = https("https://cache.example.com/prefix/")
+            .join("a.zst")
+            .unwrap();
+        match &with_slash {
+            AnyUrl::Https(u) => assert_eq!(u.0.as_str(), "https://cache.example.com/prefix/a.zst"),
+            other => panic!("expected Https, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn any_url_gcs_join_and_filename() {
+        let joined = gcs("").join("abc.zst").unwrap();
+        match &joined {
+            AnyUrl::Gcs(u) => assert_eq!(u.object, "abc.zst"),
+            other => panic!("expected Gcs, got {other:?}"),
+        }
+        assert_eq!(joined.filename(), "abc.zst");
+        // A nested join uses `/` separators; filename() returns the last segment.
+        assert_eq!(gcs("dir").join("file.zst").unwrap().filename(), "file.zst");
+    }
+
+    #[test]
+    fn any_backend_get_dispatches_to_https() {
+        let backend = AnyBackend::Https(Client::new());
+        let req = backend
+            .get(https("https://cache.example.com/index.shisha"))
+            .unwrap();
+        assert!(matches!(req, AnyRequest::Https(_)));
+    }
+
+    #[test]
+    #[should_panic(expected = "does not match backend")]
+    fn any_backend_get_rejects_url_backend_mismatch() {
+        // An HTTPS backend handed a GCS url is a construction bug -> panic,
+        // never a silent wrong fetch.
+        let backend = AnyBackend::Https(Client::new());
+        let _ = backend.get(gcs("o"));
+    }
+}

--- a/crates/common/src/fetchers.rs
+++ b/crates/common/src/fetchers.rs
@@ -383,19 +383,22 @@ impl FetchResponse for AnyResponse {
     }
 }
 
-/// A request for either backend.
+/// A request for either backend. Both variants are boxed so the enum stays
+/// small regardless of which backend's request type is larger
+/// (clippy::large_enum_variant); a request is a transient per-fetch value.
 #[derive(Debug)]
 pub enum AnyRequest {
-    Https(Request),
-    Gcs(google_cloud_storage::builder::storage::ReadObject),
+    Https(Box<Request>),
+    Gcs(Box<google_cloud_storage::builder::storage::ReadObject>),
 }
 
 /// A [FetchBackend] that is either the GCS client or a reqwest HTTPS client,
-/// selected at construction. See the module note above.
+/// selected at construction. See the module note above. The GCS `Storage`
+/// handle is boxed (it's far larger than a reqwest `Client`).
 #[derive(Clone, Debug)]
 pub enum AnyBackend {
     Https(Client),
-    Gcs(Storage),
+    Gcs(Box<Storage>),
 }
 
 impl FetchBackend for AnyBackend {
@@ -409,10 +412,10 @@ impl FetchBackend for AnyBackend {
     ) -> Result<Self::Request, <Self::Response as FetchResponse>::Error> {
         match (self, url) {
             (AnyBackend::Https(c), AnyUrl::Https(u)) => FetchBackend::get(c, u)
-                .map(AnyRequest::Https)
+                .map(|r| AnyRequest::Https(Box::new(r)))
                 .map_err(AnyRespError::Https),
-            (AnyBackend::Gcs(s), AnyUrl::Gcs(u)) => FetchBackend::get(s, u)
-                .map(AnyRequest::Gcs)
+            (AnyBackend::Gcs(s), AnyUrl::Gcs(u)) => FetchBackend::get(&**s, u)
+                .map(|r| AnyRequest::Gcs(Box::new(r)))
                 .map_err(AnyRespError::Gcs),
             // A RemoteCache is always built with a matching backend+url pair
             // (see RemoteCache::new_any_*), so a mismatch is a construction bug.
@@ -425,11 +428,11 @@ impl FetchBackend for AnyBackend {
         req: Self::Request,
     ) -> Result<Self::Response, <Self::Response as FetchResponse>::Error> {
         match (self, req) {
-            (AnyBackend::Https(c), AnyRequest::Https(r)) => FetchBackend::execute(c, r)
+            (AnyBackend::Https(c), AnyRequest::Https(r)) => FetchBackend::execute(c, *r)
                 .await
                 .map(AnyResponse::Https)
                 .map_err(AnyRespError::Https),
-            (AnyBackend::Gcs(s), AnyRequest::Gcs(r)) => FetchBackend::execute(s, r)
+            (AnyBackend::Gcs(s), AnyRequest::Gcs(r)) => FetchBackend::execute(&**s, *r)
                 .await
                 .map(AnyResponse::Gcs)
                 .map_err(AnyRespError::Gcs),

--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -4,15 +4,16 @@ use std::{
 };
 
 use checkouts::ManagerHandle;
+use common::fetchers::{AnyUrl, GcsUrl, ReqwestUrl};
 use ot::OpTracker;
 
 /// The errors possible in configuration or building a configuration.
 #[derive(Debug)]
 pub enum ConfigError {
     IO(&'static str, PathBuf, std::io::Error),
-    /// Configured remote cache bucket name is empty or whitespace-only.
+    /// Configured remote cache location (`remote_cache_url`) is empty or unparseable.
     /// Carries the offending value for diagnostics.
-    InvalidRemoteCacheBucket(String),
+    InvalidRemoteCacheUrl(String),
 }
 
 impl fmt::Display for ConfigError {
@@ -21,8 +22,8 @@ impl fmt::Display for ConfigError {
             ConfigError::IO(ctx, path, e) => {
                 write!(f, "{} I/O error at path {}: {}", ctx, path.display(), e)
             }
-            ConfigError::InvalidRemoteCacheBucket(bucket) => {
-                write!(f, "invalid remote cache bucket: {:?}", bucket)
+            ConfigError::InvalidRemoteCacheUrl(url) => {
+                write!(f, "invalid remote_cache_url: {:?}", url)
             }
         }
     }
@@ -32,24 +33,41 @@ impl std::error::Error for ConfigError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ConfigError::IO(_, _, e) => Some(e),
-            ConfigError::InvalidRemoteCacheBucket(_) => None,
+            ConfigError::InvalidRemoteCacheUrl(_) => None,
         }
     }
 }
 
-/// Default GCS bucket name used when the caller does not configure one
-/// via [ConfigBuilder::with_remote_cache_bucket].
+/// Default remote cache location when none is configured — the shared GCS
+/// bucket. A bare name (no scheme) is treated as a GCS bucket.
 pub const DEFAULT_REMOTE_CACHE_BUCKET: &str = "minimal-staging-cache";
 
-/// Resolves the remote-cache reader URL override: a non-empty explicit builder
-/// value wins; otherwise a non-empty `MINIMAL_REMOTE_CACHE_URL`; else `None`
-/// (reads go through the GCS client). Empty / whitespace-only values in either
-/// source are treated as unset. Pure so the precedence is unit-testable without
-/// touching process env.
-fn resolve_remote_cache_read_url(builder: Option<String>, env: Option<String>) -> Option<String> {
-    builder
-        .filter(|s| !s.trim().is_empty())
-        .or_else(|| env.filter(|s| !s.trim().is_empty()))
+/// Parses a remote-cache location string into (a) the resolved [`AnyUrl`] a
+/// reader fetches from and (b) the GCS bucket name a *writer* would use
+/// (`None` for an HTTPS mirror — you can't write to a read mirror). Accepted:
+/// `https://…` / `http://…` → an HTTPS mirror; `gs://bucket[/…]` or a bare
+/// `bucket` name → the GCS bucket. Pure, so it's unit-testable.
+fn parse_remote_cache_url(raw: &str) -> Result<(AnyUrl, Option<String>), ConfigError> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(ConfigError::InvalidRemoteCacheUrl(raw.to_string()));
+    }
+    if raw.starts_with("https://") || raw.starts_with("http://") {
+        let url = ReqwestUrl::try_from(raw)
+            .map_err(|_| ConfigError::InvalidRemoteCacheUrl(raw.to_string()))?;
+        return Ok((AnyUrl::Https(url), None));
+    }
+    // gs://bucket[/path] or a bare bucket name -> GCS.
+    let bucket = raw.strip_prefix("gs://").unwrap_or(raw);
+    let bucket = bucket.split('/').next().unwrap_or("");
+    if bucket.is_empty() {
+        return Err(ConfigError::InvalidRemoteCacheUrl(raw.to_string()));
+    }
+    let any = AnyUrl::Gcs(GcsUrl {
+        bucket: format!("projects/_/buckets/{bucket}"),
+        object: String::new(),
+    });
+    Ok((any, Some(bucket.to_string())))
 }
 
 /// Builder for [Config].
@@ -67,8 +85,7 @@ pub struct ConfigBuilder {
 
     vcs_manager: Option<ManagerHandle>,
     ot: Option<OpTracker>,
-    remote_cache_bucket: Option<String>,
-    remote_cache_read_url: Option<String>,
+    remote_cache_url: Option<String>,
 }
 
 impl ConfigBuilder {
@@ -139,21 +156,16 @@ impl ConfigBuilder {
         self.ot = Some(ot);
         self
     }
-    /// Override the GCS bucket name used by the remote cache reader and
-    /// writer. Defaults to [DEFAULT_REMOTE_CACHE_BUCKET] when unset.
-    pub fn with_remote_cache_bucket(mut self, bucket: String) -> Self {
-        self.remote_cache_bucket = Some(bucket);
-        self
-    }
-    /// Override the base URL the remote cache *reader* fetches from, bypassing
-    /// the GCS client in favour of plain unauthenticated HTTPS GETs. Point this
-    /// at an S3-compatible mirror (e.g. a Cloudflare R2 custom domain) to avoid
-    /// GCS egress cost. The URL MUST end in `/`. Takes precedence over the
-    /// `MINIMAL_REMOTE_CACHE_URL` environment variable; when neither is set,
-    /// reads go through the GCS client against the configured bucket. The
-    /// *writer* is unaffected (writes always use GCS).
-    pub fn with_remote_cache_read_url(mut self, url: String) -> Self {
-        self.remote_cache_read_url = Some(url);
+    /// Override where the remote cache lives. One value serves both reader and
+    /// writer: a `gs://bucket` (or bare bucket name) uses the GCS client;
+    /// an `https://…` value reads over plain unauthenticated HTTPS (e.g. a
+    /// Cloudflare R2 custom domain, to avoid GCS egress cost) — an HTTPS value
+    /// is read-only (writes require a `gs://` bucket). Defaults to
+    /// [DEFAULT_REMOTE_CACHE_BUCKET]. For read-only consumers, the
+    /// `MINIMAL_REMOTE_CACHE_URL` env var overrides the *reader* only (the
+    /// writer still uses this value). An HTTPS value MUST end in `/`.
+    pub fn with_remote_cache_url(mut self, url: String) -> Self {
+        self.remote_cache_url = Some(url);
         self
     }
 }
@@ -161,20 +173,22 @@ impl ConfigBuilder {
 impl ConfigBuilder {
     /// Constructs a config object using the given builder.
     pub fn build(self) -> Result<Config, ConfigError> {
-        let remote_cache_bucket = self
-            .remote_cache_bucket
+        // The one configured cache location (default: the shared GCS bucket).
+        let remote_cache_url = self
+            .remote_cache_url
             .unwrap_or_else(|| DEFAULT_REMOTE_CACHE_BUCKET.to_string());
-        if remote_cache_bucket.trim().is_empty() {
-            return Err(ConfigError::InvalidRemoteCacheBucket(remote_cache_bucket));
-        }
-
-        // An explicit builder value wins; otherwise honour the
-        // `MINIMAL_REMOTE_CACHE_URL` env var, so CI / deployments can repoint
-        // cache reads at an R2 mirror without a code change.
-        let remote_cache_read_url = resolve_remote_cache_read_url(
-            self.remote_cache_read_url,
-            std::env::var("MINIMAL_REMOTE_CACHE_URL").ok(),
-        );
+        // The writer always uses the configured location's GCS bucket (`None`
+        // when it's an HTTPS mirror -> writes error, since you can't write to a
+        // read mirror). This also validates the configured value.
+        let (_, remote_cache_write_bucket) = parse_remote_cache_url(&remote_cache_url)?;
+        // Reads honour the `MINIMAL_REMOTE_CACHE_URL` env override (for read-only
+        // consumers pointing at an R2 mirror to avoid GCS egress); otherwise the
+        // configured location.
+        let read_raw = std::env::var("MINIMAL_REMOTE_CACHE_URL")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| remote_cache_url.clone());
+        let (remote_cache_read, _) = parse_remote_cache_url(&read_raw)?;
 
         Ok(Config {
             no_cache: self.no_cache.unwrap_or(false),
@@ -200,8 +214,9 @@ impl ConfigBuilder {
             repo_dir: self.repo_dir,
             vcs_manager: self.vcs_manager,
             ot: self.ot,
-            remote_cache_bucket,
-            remote_cache_read_url,
+            remote_cache_url,
+            remote_cache_read,
+            remote_cache_write_bucket,
         })
     }
 }
@@ -221,8 +236,7 @@ impl Config {
             repo_dir: self.repo_dir,
             vcs_manager: self.vcs_manager,
             ot: self.ot,
-            remote_cache_bucket: Some(self.remote_cache_bucket),
-            remote_cache_read_url: self.remote_cache_read_url,
+            remote_cache_url: Some(self.remote_cache_url),
         }
     }
 }
@@ -253,14 +267,15 @@ pub struct Config {
     vcs_manager: Option<ManagerHandle>,
     /// The [OpTracker] to use instead of the root.
     pub(crate) ot: Option<OpTracker>,
-    /// GCS bucket name for the remote cache reader/writer. Always set —
-    /// defaults to [DEFAULT_REMOTE_CACHE_BUCKET] when the builder did
-    /// not specify one.
-    remote_cache_bucket: String,
-    /// Optional base URL for the remote cache *reader* — plain HTTPS instead of
-    /// the GCS client (e.g. a Cloudflare R2 mirror). `None` reads via GCS. See
-    /// [ConfigBuilder::with_remote_cache_read_url].
-    remote_cache_read_url: Option<String>,
+    /// The one configured cache location (raw), retained for round-tripping via
+    /// [Self::into_builder]. See [ConfigBuilder::with_remote_cache_url].
+    remote_cache_url: String,
+    /// The resolved location the *reader* fetches from (GCS bucket or HTTPS
+    /// mirror), honouring the `MINIMAL_REMOTE_CACHE_URL` env override.
+    remote_cache_read: AnyUrl,
+    /// The GCS bucket a *writer* uses; `None` when the configured location is an
+    /// HTTPS mirror (writes then error — you can't write to a read mirror).
+    remote_cache_write_bucket: Option<String>,
 }
 
 impl Config {
@@ -298,15 +313,16 @@ impl Config {
     pub fn num_parallel_builds(&self) -> usize {
         self.num_parallel_builds
     }
-    /// Returns the GCS bucket name for the remote cache.
-    pub fn remote_cache_bucket(&self) -> &str {
-        &self.remote_cache_bucket
+    /// The resolved location the remote-cache *reader* fetches artifacts from —
+    /// a GCS bucket or an HTTPS mirror — ready to hand to the cache backend.
+    /// Honours the `MINIMAL_REMOTE_CACHE_URL` env override.
+    pub fn remote_cache_url(&self) -> AnyUrl {
+        self.remote_cache_read.clone()
     }
-    /// Returns the remote-cache *reader* base URL override (plain HTTPS), if set
-    /// via the builder or `MINIMAL_REMOTE_CACHE_URL`. `None` reads via the GCS
-    /// client against [Self::remote_cache_bucket].
-    pub fn remote_cache_read_url(&self) -> Option<&str> {
-        self.remote_cache_read_url.as_deref()
+    /// The GCS bucket the remote-cache *writer* uploads to; `None` when the
+    /// configured location is an HTTPS read mirror (writes then error).
+    pub fn remote_cache_write_bucket(&self) -> Option<&str> {
+        self.remote_cache_write_bucket.as_deref()
     }
 
     pub(crate) fn built_cache_dir(&self) -> PathBuf {
@@ -343,95 +359,87 @@ mod tests {
     use super::*;
 
     #[test]
-    fn remote_cache_bucket_defaults_when_unset() {
+    fn parse_bare_bucket_is_gcs() {
+        let (url, wb) = parse_remote_cache_url("my-bucket").unwrap();
+        assert!(matches!(url, AnyUrl::Gcs(ref g) if g.bucket == "projects/_/buckets/my-bucket"));
+        assert_eq!(wb.as_deref(), Some("my-bucket"));
+    }
+
+    #[test]
+    fn parse_gs_scheme_is_gcs() {
+        let (url, wb) = parse_remote_cache_url("gs://b/ignored/path").unwrap();
+        assert!(matches!(url, AnyUrl::Gcs(ref g) if g.bucket == "projects/_/buckets/b"));
+        assert_eq!(wb.as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn parse_https_is_mirror_with_no_write_bucket() {
+        let (url, wb) = parse_remote_cache_url("https://cache.example.com/").unwrap();
+        assert!(matches!(url, AnyUrl::Https(_)));
+        assert_eq!(wb, None);
+    }
+
+    #[test]
+    fn parse_rejects_empty_and_bad_url() {
+        for bad in ["", "   ", "https://"] {
+            assert!(
+                matches!(
+                    parse_remote_cache_url(bad).unwrap_err(),
+                    ConfigError::InvalidRemoteCacheUrl(_)
+                ),
+                "expected error for {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn default_config_writer_uses_default_bucket() {
+        // write bucket is derived from the configured value (not the env
+        // override), so this is free of MINIMAL_REMOTE_CACHE_URL flakiness.
         let cfg = ConfigBuilder::new().build().unwrap();
-        assert_eq!(cfg.remote_cache_bucket(), DEFAULT_REMOTE_CACHE_BUCKET);
+        assert_eq!(
+            cfg.remote_cache_write_bucket(),
+            Some(DEFAULT_REMOTE_CACHE_BUCKET)
+        );
     }
 
     #[test]
-    fn remote_cache_bucket_honors_override() {
+    fn builder_gs_value_sets_reader_and_writer() {
         let cfg = ConfigBuilder::new()
-            .with_remote_cache_bucket("my-bucket".into())
+            .with_remote_cache_url("gs://my-bucket".into())
             .build()
             .unwrap();
-        assert_eq!(cfg.remote_cache_bucket(), "my-bucket");
+        assert_eq!(cfg.remote_cache_write_bucket(), Some("my-bucket"));
+        // Guard the reader assertion: a non-empty MINIMAL_REMOTE_CACHE_URL in
+        // the test process would override the reader.
+        if std::env::var("MINIMAL_REMOTE_CACHE_URL")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .is_none()
+        {
+            assert!(matches!(
+                cfg.remote_cache_url(),
+                AnyUrl::Gcs(g) if g.bucket == "projects/_/buckets/my-bucket"
+            ));
+        }
     }
 
     #[test]
-    fn remote_cache_bucket_rejects_empty() {
-        let err = ConfigBuilder::new()
-            .with_remote_cache_bucket(String::new())
-            .build()
-            .unwrap_err();
-        assert!(matches!(err, ConfigError::InvalidRemoteCacheBucket(_)));
-    }
-
-    #[test]
-    fn remote_cache_bucket_rejects_whitespace_only() {
-        let err = ConfigBuilder::new()
-            .with_remote_cache_bucket("   \t\n".into())
-            .build()
-            .unwrap_err();
-        assert!(matches!(err, ConfigError::InvalidRemoteCacheBucket(_)));
-    }
-
-    #[test]
-    fn read_url_none_when_neither_set() {
-        assert_eq!(resolve_remote_cache_read_url(None, None), None);
-    }
-
-    #[test]
-    fn read_url_builder_wins_over_env() {
-        assert_eq!(
-            resolve_remote_cache_read_url(
-                Some("https://builder/".into()),
-                Some("https://env/".into())
-            ),
-            Some("https://builder/".to_string())
-        );
-    }
-
-    #[test]
-    fn read_url_falls_back_to_env() {
-        assert_eq!(
-            resolve_remote_cache_read_url(None, Some("https://env/".into())),
-            Some("https://env/".to_string())
-        );
-    }
-
-    #[test]
-    fn read_url_ignores_empty_and_whitespace() {
-        // Empty/whitespace builder value falls through to a non-empty env var.
-        assert_eq!(
-            resolve_remote_cache_read_url(Some("  ".into()), Some("https://env/".into())),
-            Some("https://env/".to_string())
-        );
-        // Empty/whitespace in both -> None (read via GCS).
-        assert_eq!(
-            resolve_remote_cache_read_url(Some(String::new()), None),
-            None
-        );
-        assert_eq!(
-            resolve_remote_cache_read_url(None, Some("\t\n".into())),
-            None
-        );
-        assert_eq!(
-            resolve_remote_cache_read_url(Some("".into()), Some(" ".into())),
-            None
-        );
-    }
-
-    #[test]
-    fn read_url_builder_round_trips_through_config() {
-        // The builder value is non-empty, so it wins regardless of any ambient
-        // MINIMAL_REMOTE_CACHE_URL in the test process -> no env flakiness.
+    fn builder_https_value_is_read_only() {
         let cfg = ConfigBuilder::new()
-            .with_remote_cache_read_url("https://cache.example.com/".into())
+            .with_remote_cache_url("https://cache.example.com/".into())
             .build()
             .unwrap();
-        assert_eq!(
-            cfg.remote_cache_read_url(),
-            Some("https://cache.example.com/")
-        );
+        // HTTPS location -> the writer has no bucket (writes will error).
+        assert_eq!(cfg.remote_cache_write_bucket(), None);
+    }
+
+    #[test]
+    fn builder_rejects_empty() {
+        let err = ConfigBuilder::new()
+            .with_remote_cache_url(String::new())
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidRemoteCacheUrl(_)));
     }
 }

--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -41,6 +41,17 @@ impl std::error::Error for ConfigError {
 /// via [ConfigBuilder::with_remote_cache_bucket].
 pub const DEFAULT_REMOTE_CACHE_BUCKET: &str = "minimal-staging-cache";
 
+/// Resolves the remote-cache reader URL override: a non-empty explicit builder
+/// value wins; otherwise a non-empty `MINIMAL_REMOTE_CACHE_URL`; else `None`
+/// (reads go through the GCS client). Empty / whitespace-only values in either
+/// source are treated as unset. Pure so the precedence is unit-testable without
+/// touching process env.
+fn resolve_remote_cache_read_url(builder: Option<String>, env: Option<String>) -> Option<String> {
+    builder
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| env.filter(|s| !s.trim().is_empty()))
+}
+
 /// Builder for [Config].
 #[derive(Debug, Default, Clone)]
 pub struct ConfigBuilder {
@@ -57,6 +68,7 @@ pub struct ConfigBuilder {
     vcs_manager: Option<ManagerHandle>,
     ot: Option<OpTracker>,
     remote_cache_bucket: Option<String>,
+    remote_cache_read_url: Option<String>,
 }
 
 impl ConfigBuilder {
@@ -133,6 +145,17 @@ impl ConfigBuilder {
         self.remote_cache_bucket = Some(bucket);
         self
     }
+    /// Override the base URL the remote cache *reader* fetches from, bypassing
+    /// the GCS client in favour of plain unauthenticated HTTPS GETs. Point this
+    /// at an S3-compatible mirror (e.g. a Cloudflare R2 custom domain) to avoid
+    /// GCS egress cost. The URL MUST end in `/`. Takes precedence over the
+    /// `MINIMAL_REMOTE_CACHE_URL` environment variable; when neither is set,
+    /// reads go through the GCS client against the configured bucket. The
+    /// *writer* is unaffected (writes always use GCS).
+    pub fn with_remote_cache_read_url(mut self, url: String) -> Self {
+        self.remote_cache_read_url = Some(url);
+        self
+    }
 }
 
 impl ConfigBuilder {
@@ -144,6 +167,14 @@ impl ConfigBuilder {
         if remote_cache_bucket.trim().is_empty() {
             return Err(ConfigError::InvalidRemoteCacheBucket(remote_cache_bucket));
         }
+
+        // An explicit builder value wins; otherwise honour the
+        // `MINIMAL_REMOTE_CACHE_URL` env var, so CI / deployments can repoint
+        // cache reads at an R2 mirror without a code change.
+        let remote_cache_read_url = resolve_remote_cache_read_url(
+            self.remote_cache_read_url,
+            std::env::var("MINIMAL_REMOTE_CACHE_URL").ok(),
+        );
 
         Ok(Config {
             no_cache: self.no_cache.unwrap_or(false),
@@ -170,6 +201,7 @@ impl ConfigBuilder {
             vcs_manager: self.vcs_manager,
             ot: self.ot,
             remote_cache_bucket,
+            remote_cache_read_url,
         })
     }
 }
@@ -190,6 +222,7 @@ impl Config {
             vcs_manager: self.vcs_manager,
             ot: self.ot,
             remote_cache_bucket: Some(self.remote_cache_bucket),
+            remote_cache_read_url: self.remote_cache_read_url,
         }
     }
 }
@@ -224,6 +257,10 @@ pub struct Config {
     /// defaults to [DEFAULT_REMOTE_CACHE_BUCKET] when the builder did
     /// not specify one.
     remote_cache_bucket: String,
+    /// Optional base URL for the remote cache *reader* — plain HTTPS instead of
+    /// the GCS client (e.g. a Cloudflare R2 mirror). `None` reads via GCS. See
+    /// [ConfigBuilder::with_remote_cache_read_url].
+    remote_cache_read_url: Option<String>,
 }
 
 impl Config {
@@ -264,6 +301,12 @@ impl Config {
     /// Returns the GCS bucket name for the remote cache.
     pub fn remote_cache_bucket(&self) -> &str {
         &self.remote_cache_bucket
+    }
+    /// Returns the remote-cache *reader* base URL override (plain HTTPS), if set
+    /// via the builder or `MINIMAL_REMOTE_CACHE_URL`. `None` reads via the GCS
+    /// client against [Self::remote_cache_bucket].
+    pub fn remote_cache_read_url(&self) -> Option<&str> {
+        self.remote_cache_read_url.as_deref()
     }
 
     pub(crate) fn built_cache_dir(&self) -> PathBuf {
@@ -330,5 +373,65 @@ mod tests {
             .build()
             .unwrap_err();
         assert!(matches!(err, ConfigError::InvalidRemoteCacheBucket(_)));
+    }
+
+    #[test]
+    fn read_url_none_when_neither_set() {
+        assert_eq!(resolve_remote_cache_read_url(None, None), None);
+    }
+
+    #[test]
+    fn read_url_builder_wins_over_env() {
+        assert_eq!(
+            resolve_remote_cache_read_url(
+                Some("https://builder/".into()),
+                Some("https://env/".into())
+            ),
+            Some("https://builder/".to_string())
+        );
+    }
+
+    #[test]
+    fn read_url_falls_back_to_env() {
+        assert_eq!(
+            resolve_remote_cache_read_url(None, Some("https://env/".into())),
+            Some("https://env/".to_string())
+        );
+    }
+
+    #[test]
+    fn read_url_ignores_empty_and_whitespace() {
+        // Empty/whitespace builder value falls through to a non-empty env var.
+        assert_eq!(
+            resolve_remote_cache_read_url(Some("  ".into()), Some("https://env/".into())),
+            Some("https://env/".to_string())
+        );
+        // Empty/whitespace in both -> None (read via GCS).
+        assert_eq!(
+            resolve_remote_cache_read_url(Some(String::new()), None),
+            None
+        );
+        assert_eq!(
+            resolve_remote_cache_read_url(None, Some("\t\n".into())),
+            None
+        );
+        assert_eq!(
+            resolve_remote_cache_read_url(Some("".into()), Some(" ".into())),
+            None
+        );
+    }
+
+    #[test]
+    fn read_url_builder_round_trips_through_config() {
+        // The builder value is non-empty, so it wins regardless of any ambient
+        // MINIMAL_REMOTE_CACHE_URL in the test process -> no env flakiness.
+        let cfg = ConfigBuilder::new()
+            .with_remote_cache_read_url("https://cache.example.com/".into())
+            .build()
+            .unwrap();
+        assert_eq!(
+            cfg.remote_cache_read_url(),
+            Some("https://cache.example.com/")
+        );
     }
 }

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
 
 use anyhow::anyhow;
 use checkouts::{Manager as VcsManager, ManagerHandle as VcsManagerHandle};
+use common::fetchers::{AnyBackend, AnyRespError};
 use common::{SpecOrigin, Target};
 use google_cloud_storage::{Error as GcsError, client::Storage as GcsStorage};
 use lcache::CacheBinProvider;
@@ -386,29 +387,40 @@ impl Context {
         &self,
         auth: bool,
         force_fresh: bool,
-    ) -> Result<RemoteCache<GcsStorage>, RemoteError<GcsError>> {
+    ) -> Result<RemoteCache<AnyBackend>, RemoteError<AnyRespError>> {
         let start = SystemTime::now();
-        let backend = if auth {
-            GcsStorage::builder().build().await.unwrap()
+        let index_dir = if force_fresh {
+            None
         } else {
-            GcsStorage::builder()
-                .with_credentials(google_cloud_auth::credentials::anonymous::Builder::new().build())
-                .build()
-                .await
-                .unwrap()
+            Some(self.config.index_dir())
         };
 
-        let res = RemoteCache::new_with_gcs_bucket(
-            backend,
-            self.config.remote_cache_bucket(),
-            if force_fresh {
-                None
+        // When a read URL is configured (e.g. a Cloudflare R2 custom domain via
+        // MINIMAL_REMOTE_CACHE_URL), fetch artifacts over plain HTTPS to avoid
+        // GCS egress cost; otherwise read through the GCS client (the default,
+        // unchanged). Writes always use GCS regardless (see remote_cache_writer).
+        let res = if let Some(url) = self.config.remote_cache_read_url() {
+            RemoteCache::new_any_https(url, index_dir, self.config.ot.clone()).await
+        } else {
+            let backend = if auth {
+                GcsStorage::builder().build().await.unwrap()
             } else {
-                Some(self.config.index_dir())
-            },
-            self.config.ot.clone(),
-        )
-        .await;
+                GcsStorage::builder()
+                    .with_credentials(
+                        google_cloud_auth::credentials::anonymous::Builder::new().build(),
+                    )
+                    .build()
+                    .await
+                    .unwrap()
+            };
+            RemoteCache::new_any_gcs(
+                backend,
+                self.config.remote_cache_bucket(),
+                index_dir,
+                self.config.ot.clone(),
+            )
+            .await
+        };
         tracing::trace!("remote cache init took {:?}", start.elapsed());
         res
     }

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -10,9 +10,9 @@ use std::{
 
 use anyhow::anyhow;
 use checkouts::{Manager as VcsManager, ManagerHandle as VcsManagerHandle};
-use common::fetchers::{AnyBackend, AnyRespError};
+use common::fetchers::{AnyBackend, AnyRespError, AnyUrl};
 use common::{SpecOrigin, Target};
-use google_cloud_storage::{Error as GcsError, client::Storage as GcsStorage};
+use google_cloud_storage::client::Storage as GcsStorage;
 use lcache::CacheBinProvider;
 use ot::OpTracker;
 use rcache::{Error as RemoteError, RemoteBinProvider, RemoteCache, RemoteCacheWriter};
@@ -382,7 +382,15 @@ impl Context {
         &self.mfile
     }
 
-    /// Builds and returns a remote cache with default configurations.
+    /// Builds and returns a remote cache reader for the configured cache
+    /// location. [Config] has already resolved where artifacts come from — a GCS
+    /// bucket (the default) or an HTTPS mirror (honouring
+    /// `MINIMAL_REMOTE_CACHE_URL`) — so this just wires up the matching backend.
+    ///
+    /// `auth` selects authenticated vs. anonymous GCS access (the buildbot / mip
+    /// upload path reads authed; anonymous CI reads use the public path). It's
+    /// ignored for an HTTPS mirror, whose objects are fetched with unauthenticated
+    /// public GETs.
     pub async fn remote_cache(
         &self,
         auth: bool,
@@ -395,13 +403,13 @@ impl Context {
             Some(self.config.index_dir())
         };
 
-        // When a read URL is configured (e.g. a Cloudflare R2 custom domain via
-        // MINIMAL_REMOTE_CACHE_URL), fetch artifacts over plain HTTPS to avoid
-        // GCS egress cost; otherwise read through the GCS client (the default,
-        // unchanged). Writes always use GCS regardless (see remote_cache_writer).
-        let res = if let Some(url) = self.config.remote_cache_read_url() {
-            RemoteCache::new_any_https(url, index_dir, self.config.ot.clone()).await
-        } else {
+        // A GCS location needs a Storage client (authed or anonymous per `auth`);
+        // an HTTPS mirror (e.g. a Cloudflare R2 custom domain) needs none —
+        // new_any builds a reqwest client internally. Note it's reading from R2
+        // that avoids GCS egress cost: an https:// URL still pointed at GCS would
+        // egress just the same.
+        let url = self.config.remote_cache_url();
+        let gcs_storage = if matches!(url, AnyUrl::Gcs(_)) {
             let backend = if auth {
                 GcsStorage::builder().build().await.unwrap()
             } else {
@@ -413,14 +421,11 @@ impl Context {
                     .await
                     .unwrap()
             };
-            RemoteCache::new_any_gcs(
-                backend,
-                self.config.remote_cache_bucket(),
-                index_dir,
-                self.config.ot.clone(),
-            )
-            .await
+            Some(backend)
+        } else {
+            None
         };
+        let res = RemoteCache::new_any(url, gcs_storage, index_dir, self.config.ot.clone()).await;
         tracing::trace!("remote cache init took {:?}", start.elapsed());
         res
     }
@@ -429,17 +434,23 @@ impl Context {
     /// access and always fetches the index fresh (no local-cache fast path) —
     /// the writer's compare-and-swap on commit requires the GCS generation
     /// it observed, which a stale local index can't provide.
-    pub async fn remote_cache_writer(&self) -> Result<RemoteCacheWriter, RemoteError<GcsError>> {
+    ///
+    /// Errors if the cache is configured as an HTTPS read mirror: a mirror (e.g.
+    /// R2 via a custom domain) has no writable bucket, so there's nowhere to
+    /// upload. Writes require a `gs://` bucket location.
+    pub async fn remote_cache_writer(&self) -> anyhow::Result<RemoteCacheWriter> {
         let start = SystemTime::now();
+        let bucket = self.config.remote_cache_write_bucket().ok_or_else(|| {
+            anyhow!(
+                "remote cache is configured as an HTTPS read mirror; writes \
+                 require a gs:// bucket — set the cache location to a gs:// URL \
+                 or a bare bucket name"
+            )
+        })?;
         let backend = GcsStorage::builder().build().await.unwrap();
-        let res = RemoteCacheWriter::new(
-            backend,
-            self.config.remote_cache_bucket(),
-            self.config.ot.clone(),
-        )
-        .await;
+        let res = RemoteCacheWriter::new(backend, bucket, self.config.ot.clone()).await?;
         tracing::trace!("remote cache writer init took {:?}", start.elapsed());
-        res
+        Ok(res)
     }
     pub async fn remote_storage(&self) -> Result<common::RemoteStorage, Error> {
         let start = SystemTime::now();

--- a/crates/orchestrator/src/local_backend.rs
+++ b/crates/orchestrator/src/local_backend.rs
@@ -5,9 +5,9 @@ use crate::{
     SharedHandle, StateHandle,
 };
 use common::SpecHash;
+use common::fetchers::AnyBackend;
 use either::Either;
 use futures::channel::mpsc;
-use google_cloud_storage::client::Storage as GcsStorage;
 use graph::{BinProvider, BuildSpecRef, Graph, SubsetInput};
 use lcache::{Cache, CacheErr, DirCacheEntry, EntryMeta, LocalDir, MetaInner, PendingDir};
 use op::{Runnable, SourceFetcher};
@@ -131,7 +131,7 @@ impl Drop for SinkWriter {
 pub struct LocalBackend<SF: SourceFetcher + 'static> {
     pub(crate) sf: SF,
     pub(crate) output_base: PathBuf,
-    pub(crate) remote_cache: Option<RemoteCache<GcsStorage>>,
+    pub(crate) remote_cache: Option<RemoteCache<AnyBackend>>,
     pub(crate) build_semaphore: Semaphore,
     pub(crate) num_concurrent_builds: usize,
     pub(crate) log_sink: Option<mpsc::UnboundedSender<BuildEvent>>,
@@ -389,7 +389,7 @@ impl<SF: SourceFetcher> LocalBackend<SF> {
     #[allow(clippy::too_many_arguments)]
     pub fn new_orchestrator(
         output_base: PathBuf,
-        remote_cache: Option<RemoteCache<GcsStorage>>,
+        remote_cache: Option<RemoteCache<AnyBackend>>,
         sf: SF,
         num_concurrent_builds: usize,
         graph: Graph,

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -131,6 +131,45 @@ impl RemoteCache<Storage> {
     }
 }
 
+impl RemoteCache<AnyBackend> {
+    /// Reader over a plain-HTTPS base URL — a public GCS bucket URL
+    /// (`https://storage.googleapis.com/<bucket>/`) or an S3-compatible mirror
+    /// such as a Cloudflare R2 custom domain (to avoid GCS egress cost).
+    /// Objects are fetched with unauthenticated GETs, so they must be publicly
+    /// readable. `url` MUST end in `/`, or [`url::Url::join`] drops its last
+    /// path segment when resolving object names against it.
+    #[tracing::instrument(skip_all, fields(url = %url), err)]
+    pub async fn new_any_https(
+        url: &str,
+        index_dir: Option<PathBuf>,
+        ot: Option<OpTracker>,
+    ) -> Result<Self, Error<AnyRespError>> {
+        let parsed = reqwest::Url::parse(url).map_err(AnyRespError::InvalidUrl)?;
+        let client = Client::builder()
+            .user_agent("minimal/remote-cache")
+            .build()
+            .map_err(AnyRespError::Https)?;
+        let base = AnyUrl::Https(ReqwestUrl::from(parsed));
+        Self::new(AnyBackend::Https(client), base, index_dir, ot).await
+    }
+
+    /// Reader over the GCS client + bucket — the default read path, preserving
+    /// the exact behaviour of [`RemoteCache::new_with_gcs_bucket`].
+    #[tracing::instrument(skip_all, fields(bucket_id = %bucket_id), err)]
+    pub async fn new_any_gcs(
+        storage: Storage,
+        bucket_id: &str,
+        index_dir: Option<PathBuf>,
+        ot: Option<OpTracker>,
+    ) -> Result<Self, Error<AnyRespError>> {
+        let base = AnyUrl::Gcs(GcsUrl {
+            bucket: format!("projects/_/buckets/{bucket_id}"),
+            object: String::new(),
+        });
+        Self::new(AnyBackend::Gcs(storage), base, index_dir, ot).await
+    }
+}
+
 impl<B: FetchBackend> RemoteCache<B> {
     /// Creates a new remote cache based on the given backend and URL.
     pub async fn new(
@@ -178,7 +217,9 @@ impl<B: FetchBackend> RemoteCache<B> {
         let index = match index_resp.status_code() {
             404 => RemoteIndex::default(),
             _ => {
-                fetch_op.set_length(index_resp.content_length().unwrap());
+                // Progress total only; a plain-HTTPS backend may omit
+                // Content-Length (chunked transfer), so don't panic on None.
+                fetch_op.set_length(index_resp.content_length().unwrap_or(0));
 
                 let mut buffer =
                     Vec::with_capacity(index_resp.content_length().unwrap_or(1024 * 1024) as usize);
@@ -249,7 +290,8 @@ impl<B: FetchBackend> RemoteCache<B> {
 
         // Fetch the remote archive into a temporary file and seek to the beginning for decoding.
         let mut resp = self.backend.execute(req).await?;
-        materialize_op.set_length(resp.content_length().unwrap());
+        // Progress total only; tolerate a missing Content-Length (see above).
+        materialize_op.set_length(resp.content_length().unwrap_or(0));
 
         let mut w = common::Tee::new(
             tempfile::tempfile().map_err(Error::IO)?,
@@ -436,5 +478,75 @@ mod tests {
         // Present spec hash -> its indexed sha256; absent -> None.
         assert_eq!(rc.sha256(&spec_hash), Some(sha256));
         assert_eq!(rc.sha256(&SpecHash::from_bytes([0x11; 32])), None);
+    }
+
+    /// A throwaway single-purpose HTTP/1.1 server that answers `GET
+    /// /index.shisha` with `index` (200) or 404s it when `index` is `None`, and
+    /// 404s everything else. Returns the base URL (with the required trailing
+    /// `/`). Used to exercise the real reqwest transport behind
+    /// `AnyBackend::Https` end-to-end (not a mock backend).
+    fn serve_index(index: Option<Vec<u8>>) -> String {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut buf = [0u8; 2048];
+                let _ = stream.read(&mut buf);
+                let req = String::from_utf8_lossy(&buf);
+                let wants_index = req.starts_with("GET /index.shisha ");
+                let (status, body): (&str, &[u8]) = match (&index, wants_index) {
+                    (Some(bytes), true) => ("200 OK", bytes),
+                    _ => ("404 Not Found", b""),
+                };
+                let head = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(head.as_bytes());
+                let _ = stream.write_all(body);
+                let _ = stream.flush();
+            }
+        });
+        format!("http://{addr}/")
+    }
+
+    #[tokio::test]
+    async fn new_any_https_fetches_and_parses_index_over_real_http() {
+        let spec_hash = SpecHash::from_bytes([0x07; 32]);
+        let sha256: [u8; 32] = [0x42; 32];
+        let mut index = RemoteIndex::default();
+        index.extend(std::iter::once((spec_hash.clone(), sha256)));
+        let mut index_bytes = Vec::new();
+        index.write_to(&mut index_bytes).unwrap();
+
+        let base = serve_index(Some(index_bytes));
+
+        // Reads the index over real HTTPS-shaped transport (AnyBackend::Https ->
+        // reqwest get/execute/chunk/content_length), then parses it.
+        let rc = RemoteCache::new_any_https(&base, None, None).await.unwrap();
+        assert_eq!(rc.sha256(&spec_hash), Some(sha256));
+        assert_eq!(rc.sha256(&SpecHash::from_bytes([0x99; 32])), None);
+    }
+
+    #[tokio::test]
+    async fn new_any_https_treats_404_index_as_empty() {
+        // A 404 on the index must yield an empty (not errored) cache, matching
+        // the GCS path — a fresh bucket/mirror has no index yet.
+        let base = serve_index(None);
+        let rc = RemoteCache::new_any_https(&base, None, None).await.unwrap();
+        assert_eq!(rc.sha256(&SpecHash::from_bytes([0x07; 32])), None);
+    }
+
+    #[tokio::test]
+    async fn new_any_https_rejects_malformed_url() {
+        let err = RemoteCache::new_any_https("not a url", None, None)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::Backend(AnyRespError::InvalidUrl(_))),
+            "expected InvalidUrl, got {err:?}"
+        );
     }
 }

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -166,7 +166,7 @@ impl RemoteCache<AnyBackend> {
             bucket: format!("projects/_/buckets/{bucket_id}"),
             object: String::new(),
         });
-        Self::new(AnyBackend::Gcs(storage), base, index_dir, ot).await
+        Self::new(AnyBackend::Gcs(Box::new(storage)), base, index_dir, ot).await
     }
 }
 

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -132,12 +132,36 @@ impl RemoteCache<Storage> {
 }
 
 impl RemoteCache<AnyBackend> {
-    /// Reader over a plain-HTTPS base URL — a public GCS bucket URL
-    /// (`https://storage.googleapis.com/<bucket>/`) or an S3-compatible mirror
-    /// such as a Cloudflare R2 custom domain (to avoid GCS egress cost).
-    /// Objects are fetched with unauthenticated GETs, so they must be publicly
-    /// readable. `url` MUST end in `/`, or [`url::Url::join`] drops its last
-    /// path segment when resolving object names against it.
+    /// Reader from an already-resolved [`AnyUrl`] — the "where to get artifacts"
+    /// location. For a GCS url the caller supplies the (authed or anonymous)
+    /// `Storage` client; for an HTTPS url a reqwest client is built internally
+    /// and `gcs_storage` is ignored. Objects on the HTTPS path are fetched with
+    /// unauthenticated GETs, so the mirror must serve them publicly.
+    pub async fn new_any(
+        url: AnyUrl,
+        gcs_storage: Option<Storage>,
+        index_dir: Option<PathBuf>,
+        ot: Option<OpTracker>,
+    ) -> Result<Self, Error<AnyRespError>> {
+        let backend = match &url {
+            AnyUrl::Gcs(_) => AnyBackend::Gcs(Box::new(
+                gcs_storage.expect("new_any: a GCS url requires a Storage client"),
+            )),
+            AnyUrl::Https(_) => {
+                let client = Client::builder()
+                    .user_agent("minimal/remote-cache")
+                    .build()
+                    .map_err(AnyRespError::Https)?;
+                AnyBackend::Https(client)
+            }
+        };
+        Self::new(backend, url, index_dir, ot).await
+    }
+
+    /// Convenience reader over a plain-HTTPS base-URL string (public GCS bucket
+    /// URL, or an S3-compatible mirror such as a Cloudflare R2 custom domain).
+    /// `url` MUST end in `/`, or [`url::Url::join`] drops its last path segment
+    /// when resolving object names against it.
     #[tracing::instrument(skip_all, fields(url = %url), err)]
     pub async fn new_any_https(
         url: &str,
@@ -145,28 +169,7 @@ impl RemoteCache<AnyBackend> {
         ot: Option<OpTracker>,
     ) -> Result<Self, Error<AnyRespError>> {
         let parsed = reqwest::Url::parse(url).map_err(AnyRespError::InvalidUrl)?;
-        let client = Client::builder()
-            .user_agent("minimal/remote-cache")
-            .build()
-            .map_err(AnyRespError::Https)?;
-        let base = AnyUrl::Https(ReqwestUrl::from(parsed));
-        Self::new(AnyBackend::Https(client), base, index_dir, ot).await
-    }
-
-    /// Reader over the GCS client + bucket — the default read path, preserving
-    /// the exact behaviour of [`RemoteCache::new_with_gcs_bucket`].
-    #[tracing::instrument(skip_all, fields(bucket_id = %bucket_id), err)]
-    pub async fn new_any_gcs(
-        storage: Storage,
-        bucket_id: &str,
-        index_dir: Option<PathBuf>,
-        ot: Option<OpTracker>,
-    ) -> Result<Self, Error<AnyRespError>> {
-        let base = AnyUrl::Gcs(GcsUrl {
-            bucket: format!("projects/_/buckets/{bucket_id}"),
-            object: String::new(),
-        });
-        Self::new(AnyBackend::Gcs(Box::new(storage)), base, index_dir, ot).await
+        Self::new_any(AnyUrl::Https(ReqwestUrl::from(parsed)), None, index_dir, ot).await
     }
 }
 


### PR DESCRIPTION
## Why

First code step of the GCS→R2 cache migration ([build-servers#145](https://github.com/gominimal/build-servers/issues/145)): let the cache **reader** fetch artifacts over plain unauthenticated **HTTPS** (from a Cloudflare R2 custom domain, or a GCS public URL) instead of the GCS client — so CI reads stop incurring GCS egress (~$460/mo, ~99% of the bill). This is the **read path only**; writes are unchanged (they stay on GCS, per the read-first plan).

## What

Reads are gated on a new **`MINIMAL_REMOTE_CACHE_URL`** env var (or `ConfigBuilder::with_remote_cache_read_url`). When set, the reader does plain HTTPS GETs against that base; when unset, it reads through the GCS client exactly as before (**default behaviour unchanged**).

- **`common/fetchers`** — new `AnyBackend`: a runtime-selectable `FetchBackend` that is *either* the GCS `Storage` client or a reqwest HTTPS `Client`, chosen at construction. This keeps a single `RemoteCache<AnyBackend>` type so the backend choice doesn't thread a type parameter through every consumer (orchestrator, bin-provider, materialize). A url/backend mismatch is a construction bug and panics rather than fetching the wrong thing.
- **`rcache/remote`** — `RemoteCache<AnyBackend>` constructors `new_any_https(url)` / `new_any_gcs(storage, bucket)`; hardened two progress-bar `content_length().unwrap()`s to `unwrap_or(0)` (a plain-HTTPS backend may omit `Content-Length`).
- **`mctx/config`** — `remote_cache_read_url` field + builder + a **pure** `resolve_remote_cache_read_url` (builder value wins, else `MINIMAL_REMOTE_CACHE_URL`, empties ignored) + getter.
- **`mctx/lib`** — `remote_cache()` returns `RemoteCache<AnyBackend>`: HTTPS when a read URL is configured, else the GCS client.
- **`orchestrator`** — `RemoteCache<GcsStorage>` → `RemoteCache<AnyBackend>`.

Verified that `auth=true` is unused anywhere (all callers read the public bucket anonymously) and that `remote_cache()` isn't called from build-servers, so this is self-contained.

## Correctness note

The base URL **must end in `/`** — otherwise `Url::join` replaces the last path segment instead of appending object names under it. There's a dedicated test for this footgun.

## Tests

- **`common`** (unit): `AnyUrl` join/filename for both variants incl. the trailing-slash footgun; `AnyBackend` get-dispatch happy path; and the url/backend **mismatch panics** (never a silent wrong fetch). *(5 tests, pass on host.)*
- **`mctx`** (unit): the pure read-URL resolver — builder-over-env precedence, env fallback, empty/whitespace ignored — plus a builder→config→getter round-trip. *(No process-env flakiness.)*
- **`rcache`** (integration): a real local HTTP server proving `new_any_https` **fetches + parses the index over the actual reqwest transport** (`AnyBackend::Https` → get/execute/chunk/content_length), that a **404 index yields an empty (not errored) cache** like the GCS path, and that a **malformed URL is rejected** cleanly.

*On property tests:* the risk here is I/O-forwarding + URL edge cases, not algebraic invariants, so targeted edge-case units + the end-to-end integration test give better signal than a proptest over a match arm.

## Not in scope

Writes (the `remote_writer.rs` S3 port) — deferred / folded into the signed-index work, per #145. This lands the read cutover that captures the egress savings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote cache access now supports both GCS buckets and HTTPS mirrors.
  * Configuration can now use a unified remote-cache location, with separate read and write behavior.
  * Added backend-aware cache creation for flexible remote cache setup.

* **Bug Fixes**
  * Improved handling for remote cache reads when response sizes are unavailable.
  * Writing now clearly fails when configured with a read-only HTTPS mirror.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->