### PR TITLE
feat(release): stage artifacts for the bash installer, re-setup promote flow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,14 +4,17 @@ on:
     workflow_dispatch:
         inputs:
             sha:
-                description: "Short SHA to promote (leave empty for latest in bucket)"
+                description: "Staged version (short SHA) to promote (leave empty for latest staged in bucket)"
                 required: false
                 type: string
-            platforms:
-                description: "Comma-separated platform list or 'all'"
-                required: false
-                default: "amd64-linux,arm64-linux"
-                type: string
+            target:
+                description: "Channel to point at the version"
+                required: true
+                default: "stable"
+                type: choice
+                options:
+                    - stable
+                    - unstable
             dry_run:
                 description: "Dry run — open issue + wait for approval but skip the GCS write"
                 required: false
@@ -47,7 +50,7 @@ jobs:
                   SERVER_URL: ${{ github.server_url }}
                   RUN_ID: ${{ github.run_id }}
                   SHA_INPUT: ${{ inputs.sha }}
-                  PLATFORMS_INPUT: ${{ inputs.platforms }}
+                  TARGET_INPUT: ${{ inputs.target }}
                   DRY_RUN: ${{ inputs.dry_run }}
               run: |
                   set -euo pipefail
@@ -55,8 +58,8 @@ jobs:
                   **Workflow:** \`${WORKFLOW}\`
                   **Requested by:** @${ACTOR}
                   **Run:** ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}
-                  **SHA input:** \`${SHA_INPUT:-<latest>}\`
-                  **Platforms:** \`${PLATFORMS_INPUT}\`
+                  **SHA input:** \`${SHA_INPUT:-<latest staged>}\`
+                  **Target channel:** \`${TARGET_INPUT}\`
                   **Dry run:** \`${DRY_RUN}\`
 
                   Comment **\`approved\`** to proceed or **\`denied\`** to cancel.
@@ -153,46 +156,57 @@ jobs:
             contents: "read"
             id-token: "write"
         steps:
+            - uses: actions/checkout@v7
             - name: Authenticate to Google Cloud
               uses: google-github-actions/auth@v3
               with:
-                  project_id: "289724348228"
-                  workload_identity_provider: "projects/289724348228/locations/global/workloadIdentityPools/github/providers/gominimal"
+                  project_id: "524228262772"
+                  workload_identity_provider: "projects/524228262772/locations/global/workloadIdentityPools/github/providers/gominimal"
 
-            - name: Promote CLI version
+            - name: Point channel at staged version
               id: promote
               env:
                   DRY_RUN: ${{ inputs.dry_run }}
                   # Pass dispatch inputs via env (NOT inline ${{ inputs.* }} in `run:`)
                   # to avoid shell template injection — see GitHub's hardening guide.
                   INPUT_SHA: ${{ inputs.sha }}
-                  INPUT_PLATFORMS: ${{ inputs.platforms }}
+                  INPUT_TARGET: ${{ inputs.target }}
               run: |
+                  set -euo pipefail
                   # Trim leading/trailing whitespace; users often paste SHAs with stray spaces.
                   SHA="$(printf '%s' "$INPUT_SHA" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-                  PLATFORMS="$(printf '%s' "$INPUT_PLATFORMS" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-
-                  if [ "$PLATFORMS" = "all" ]; then
-                    PLATFORMS="amd64-linux,arm64-linux"
-                  fi
+                  TARGET="$(printf '%s' "$INPUT_TARGET" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 
                   if [ -z "$SHA" ]; then
-                    echo "No SHA provided, finding latest archive in bucket..."
-                    LATEST=$(gcloud storage ls -l "gs://minimal-shim/archives/minimalone-*.tar.zst" \
+                    echo "No SHA provided; finding the most recently staged version in gs://minimal-one..."
+                    # Each staged version has a versions/<sha>/components manifest;
+                    # sort those by creation time (col 2 of `ls -l`) and take the newest.
+                    # `|| true`: on an empty match `gcloud` errors and/or the
+                    # `grep -v` emits nothing (exit 1), which under `pipefail`
+                    # would abort via `set -e` before the emptiness check below.
+                    LATEST=$(gcloud storage ls -l "gs://minimal-one/versions/*/components" \
                       | grep -v "^TOTAL:" \
                       | sort -k2 \
                       | tail -1 \
-                      | awk '{print $NF}')
+                      | awk '{print $NF}' || true)
                     if [ -z "$LATEST" ]; then
-                      echo "ERROR: No archive found in bucket"
+                      echo "ERROR: no staged versions found under gs://minimal-one/versions/"
                       exit 1
                     fi
-                    # Extract SHA: archives/minimalone-<sha>.tar.zst → <sha>
-                    SHA="$(basename "$LATEST" | sed 's/^minimalone-//;s/\.tar\.zst$//')"
-                    echo "Latest SHA: ${SHA}"
+                    # gs://minimal-one/versions/<sha>/components → <sha>
+                    SHA="$(basename "$(dirname "$LATEST")")"
+                    echo "Latest staged SHA: ${SHA}"
                   fi
 
-                  # TODO: implement minimal-one-specific promotion process!!
+                  # set-channel.sh verifies the version is actually staged before it
+                  # flips the pointer, and validates the target/version charset.
+                  DRY_FLAG=""
+                  [ "$DRY_RUN" = "true" ] && DRY_FLAG="--dry-run"
+                  scripts/set-channel.sh \
+                    --channel "$TARGET" \
+                    --version "$SHA" \
+                    --bucket gs://minimal-one \
+                    $DRY_FLAG
 
                   # Export resolved SHA for the docs-rebuild dispatch step below.
                   echo "sha=${SHA}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,3 +478,51 @@ jobs:
                     $(find . -maxdepth 1 -type f) \
                     --repo="${GITHUB_REPOSITORY}" \
                     --title="${{ steps.release_info.outputs.name }}"
+
+    stage-installer:
+        # Publish the release into gs://minimal-one in the layout the curl|bash
+        # installer reads (docs/specs/07-spec-installer). It re-fetches the same
+        # build artifacts and touches only gs://minimal-one.
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        needs: [release]
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            - uses: actions/checkout@v7
+            - name: Generate release info
+              id: release_info
+              run: |
+                  SHORT_SHA=$(git rev-parse --short=8 HEAD)
+                  echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+            - name: Download artifacts
+              uses: actions/download-artifact@v8
+              with:
+                  pattern: "*-*-*"
+                  path: artifacts/
+                  merge-multiple: true
+            - name: Authenticate to Google Cloud (installer bucket)
+              # Distinct project + workload-identity pool from the release job's
+              # minimal-shim auth; this one grants write to gs://minimal-one.
+              uses: google-github-actions/auth@v3
+              with:
+                  project_id: "524228262772"
+                  workload_identity_provider: "projects/524228262772/locations/global/workloadIdentityPools/github/providers/gominimal"
+            - name: Stage release into installer bucket
+              # Upload versions/<sha>/{components,<artifacts>}. Inert on its own:
+              # changes nothing users receive until a channel points at it.
+              run: |
+                  scripts/stage-release.sh \
+                    --artifacts-dir artifacts \
+                    --version "${{ steps.release_info.outputs.short_sha }}" \
+                    --bucket gs://minimal-one
+            - name: Point unstable channel at this release
+              # `unstable` auto-advances to every fresh build — it is the
+              # bleeding-edge channel, so no approval gate. Promotion to `stable`
+              # is the manual, gated promote-cli workflow.
+              run: |
+                  scripts/set-channel.sh \
+                    --channel unstable \
+                    --version "${{ steps.release_info.outputs.short_sha }}" \
+                    --bucket gs://minimal-one

--- a/scripts/set-channel.sh
+++ b/scripts/set-channel.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# set-channel.sh — point a distribution channel at an already-staged version.
+#
+# The curl|bash installer (docs/specs/07-spec-installer) resolves a channel to a
+# version by fetching a mutable pointer file at the bucket root (`stable`,
+# `unstable`, …) whose sole contents are a version string. This script writes
+# that pointer.
+#
+# It is deliberately separate from `stage-release.sh`: staging uploads immutable
+# `versions/<VERSION>/…` artifacts and changes nothing users receive; flipping a
+# channel is the single mutating action that actually ships a version. Keeping
+# them apart means a version can be staged and smoke-tested (via its immutable
+# URL) before it is promoted, and promotion — including rollback to a prior
+# already-staged version — is one cheap, reversible command.
+#
+# Usage:
+#   scripts/set-channel.sh --channel NAME --version VER [options]
+#
+# Options (env var in parens overrides the default; flags win over env):
+#   --channel NAME   Channel/pointer to write, e.g. stable   (CHANNEL)
+#   --version VER    Version the channel should point at      (VERSION)
+#   --bucket URL     gs:// bucket URL                         (BUCKET, default: gs://minimal-one)
+#   --dry-run        Print what would be written; touch nothing
+#   -h, --help       Show this help
+#
+# Requires: bash and (unless --dry-run) an authenticated `gcloud`.
+
+set -euo pipefail
+
+die() {
+    printf 'set-channel: %s\n' "$1" >&2
+    exit 1
+}
+
+usage() {
+    sed -n '2,/^set -euo/{/^set -euo/!p;}' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+CHANNEL="${CHANNEL:-}"
+VERSION="${VERSION:-}"
+BUCKET="${BUCKET:-gs://minimal-one}"
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --channel) CHANNEL="$2"; shift 2 ;;
+        --version) VERSION="$2"; shift 2 ;;
+        --bucket)  BUCKET="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) usage 0 ;;
+        *)         die "unknown argument: $1 (try --help)" ;;
+    esac
+done
+
+[ -n "$CHANNEL" ] || die "missing --channel"
+[ -n "$VERSION" ] || die "missing --version"
+
+# Both land in a URL/path and the pointer body; hold them to the charset the
+# installer validates (spec R2.1/R2.2) so a channel can never smuggle a path
+# segment or a newline into the version string.
+case "$CHANNEL" in
+    *[!A-Za-z0-9._-]*) die "channel '$CHANNEL' contains characters outside [A-Za-z0-9._-]" ;;
+esac
+case "$VERSION" in
+    *[!A-Za-z0-9._-]*) die "version '$VERSION' contains characters outside [A-Za-z0-9._-]" ;;
+esac
+
+# A channel must only ever point at a version that is actually staged; otherwise
+# the installer resolves the pointer and then 404s on the components manifest.
+manifest_url="$BUCKET/versions/$VERSION/components"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    printf 'set-channel: would point %s/%s -> %s (after verifying %s exists)\n' \
+        "$BUCKET" "$CHANNEL" "$VERSION" "$manifest_url" >&2
+    exit 0
+fi
+
+command -v gcloud >/dev/null 2>&1 || die "gcloud not found (use --dry-run to skip)"
+
+gcloud storage objects describe "$manifest_url" >/dev/null 2>&1 \
+    || die "version '$VERSION' is not staged ($manifest_url not found); run stage-release.sh first"
+
+workdir="$(mktemp -d 2>/dev/null || mktemp -d -t minimal-channel)"
+trap 'rm -rf "$workdir"' EXIT
+pointer="$workdir/pointer"
+printf '%s\n' "$VERSION" >"$pointer"
+
+# Mutable pointer: barely cache (30s) so a promotion propagates promptly while
+# still shielding the bucket from per-install request storms.
+gcloud storage cp \
+    --cache-control="public, max-age=30" \
+    "$pointer" "$BUCKET/$CHANNEL"
+
+printf 'set-channel: %s now points to %s\n' "$CHANNEL" "$VERSION" >&2

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# stage-release.sh — publish a release into the distribution GCS bucket in the
+# layout the curl|bash installer expects (docs/specs/07-spec-installer).
+#
+# Given a directory of built release artifacts (the flattened output of the
+# release workflow's download-artifact step), this script:
+#
+#   1. Computes the SHA-256 of every artifact that applies to some platform.
+#   2. Writes a `components` manifest — a flat, whitespace-delimited table with
+#      one row per (component, os, arch) variant — describing what the installer
+#      must download and where to place it.
+#   3. Uploads the artifacts and the manifest under `versions/<VERSION>/` with
+#      immutable cache headers.
+#
+# Staging is inert: it never changes which version users get. Publishing a
+# version to a channel (making `stable`/`unstable` point at it) is a separate,
+# reversible step — see `scripts/set-channel.sh`. The installer resolves
+# <channel> -> <version> -> versions/<version>/components and, for each row
+# matching the host os/arch, downloads `src`, checksum-checks it against
+# `sha256`, and installs it at `dest`. `src` is bucket-root-relative; here every
+# artifact lives at `versions/<VERSION>/<basename>`.
+#
+# Usage:
+#   scripts/stage-release.sh [options]
+#
+# Options (env var in parens overrides the default; flags win over env):
+#   --artifacts-dir DIR   Directory of built artifacts   (ARTIFACTS_DIR, default: artifacts)
+#   --version VER         Release version / folder name   (VERSION, default: git short sha)
+#   --bucket URL          gs:// bucket URL                 (BUCKET, default: gs://minimal-one)
+#   --allow-missing       Warn and omit rows whose artifact is absent (default: hard error)
+#   --dry-run             Print the manifest and planned uploads; touch nothing
+#   -h, --help            Show this help
+#
+# Requires: bash, sha256sum, and (unless --dry-run) an authenticated `gcloud`.
+
+set -euo pipefail
+
+die() {
+    printf 'stage-release: %s\n' "$1" >&2
+    exit 1
+}
+
+usage() {
+    sed -n '2,/^set -euo/{/^set -euo/!p;}' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+# --- Configuration ---------------------------------------------------------
+
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-artifacts}"
+BUCKET="${BUCKET:-gs://minimal-one}"
+VERSION="${VERSION:-}"
+ALLOW_MISSING=0
+DRY_RUN=0
+
+# Manifest format version. Bump only on a breaking change to the column layout;
+# the installer reads the `# format:` header (spec R2.4) and refuses an
+# unsupported value rather than misparsing.
+FORMAT_VERSION=1
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --artifacts-dir) ARTIFACTS_DIR="$2"; shift 2 ;;
+        --version)       VERSION="$2"; shift 2 ;;
+        --bucket)        BUCKET="$2"; shift 2 ;;
+        --allow-missing) ALLOW_MISSING=1; shift ;;
+        --dry-run)       DRY_RUN=1; shift ;;
+        -h|--help)       usage 0 ;;
+        *)               die "unknown argument: $1 (try --help)" ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    VERSION="$(git rev-parse --short=8 HEAD)" \
+        || die "no --version given and 'git rev-parse' failed"
+fi
+# The version becomes a bucket path segment and the pointer-file contents; keep
+# it to the same safe charset the installer validates (spec R2.2).
+case "$VERSION" in
+    *[!A-Za-z0-9._-]*) die "version '$VERSION' contains characters outside [A-Za-z0-9._-]" ;;
+esac
+
+[ -d "$ARTIFACTS_DIR" ] || die "artifacts dir not found: $ARTIFACTS_DIR"
+command -v sha256sum >/dev/null 2>&1 || die "sha256sum not found"
+if [ "$DRY_RUN" -eq 0 ]; then
+    command -v gcloud >/dev/null 2>&1 || die "gcloud not found (use --dry-run to skip uploads)"
+fi
+
+# --- Component table -------------------------------------------------------
+
+# One entry per (component, os, arch) variant the installer should place, as
+# `component|os|arch|kind|dest|artifact-basename`:
+#   - os/arch use the installer's normalized names (linux|darwin, amd64|arm64).
+#   - dest is `<prefix-token>/<subpath>`; the installer maps `bin`  -> ~/.local/bin
+#     and `data` -> ~/.local/share/minimal, and marks anything under `bin` +x.
+#   - artifact-basename is the file's name inside ARTIFACTS_DIR (the release
+#     workflow's merge-multiple flattens every upload to its basename).
+#
+# Linux hosts install just the three self-contained musl binaries. macOS hosts
+# additionally need minvmd + gvproxy and the guest microVM payload (kernel,
+# rootfs, initramfs) to boot Linux workloads under libkrun; macOS is arm64-only
+# here, and its guest is arm64, so it consumes the arm64 guest artifacts.
+COMPONENTS=(
+    # Linux amd64
+    "minimald|linux|amd64|file|bin/minimald|minimald-linux-amd64"
+    "mip|linux|amd64|file|bin/mip|mip-linux-amd64"
+    "minimal|linux|amd64|file|bin/minimal|minimal-linux-amd64"
+    # Linux arm64
+    "minimald|linux|arm64|file|bin/minimald|minimald-linux-arm64"
+    "mip|linux|arm64|file|bin/mip|mip-linux-arm64"
+    "minimal|linux|arm64|file|bin/minimal|minimal-linux-arm64"
+    # macOS arm64 (darwin)
+    "minimal|darwin|arm64|file|bin/minimal|minimal-macos-arm64"
+    "minvmd|darwin|arm64|file|bin/minvmd|minvmd-macos-arm64"
+    "gvproxy|darwin|arm64|file|bin/gvproxy|gvproxy-darwin-arm64"
+    "initramfs|darwin|arm64|file|data/initramfs.cpio|initramfs-arm64.cpio"
+    "rootfs|darwin|arm64|file|data/rootfs.img|rootfs-arm64.img"
+    "vmlinuz|darwin|arm64|file|data/vmlinuz|vmlinuz-arm64"
+)
+
+# --- Build the manifest ----------------------------------------------------
+
+workdir="$(mktemp -d 2>/dev/null || mktemp -d -t minimal-stage)"
+trap 'rm -rf "$workdir"' EXIT
+manifest="$workdir/components"
+
+{
+    printf '# format: %s\n' "$FORMAT_VERSION"
+    printf '# component   os      arch    version   sha256%*s   kind   dest                 src\n' 58 ''
+} >"$manifest"
+
+# Files to upload, deduped (a basename may back more than one row).
+declare -A upload_seen=()
+upload_list=()
+
+for entry in "${COMPONENTS[@]}"; do
+    IFS='|' read -r comp os arch kind dest basename <<<"$entry"
+    file="$ARTIFACTS_DIR/$basename"
+
+    if [ ! -f "$file" ]; then
+        if [ "$ALLOW_MISSING" -eq 1 ]; then
+            printf 'stage-release: warning: missing artifact, omitting %s/%s/%s: %s\n' \
+                "$comp" "$os" "$arch" "$file" >&2
+            continue
+        fi
+        die "missing artifact for $comp/$os/$arch: $file (use --allow-missing to skip)"
+    fi
+
+    sha="$(sha256sum "$file" | cut -d' ' -f1)"
+    src="versions/$VERSION/$basename"
+
+    printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
+        "$comp" "$os" "$arch" "$VERSION" "$sha" "$kind" "$dest" "$src" >>"$manifest"
+
+    if [ -z "${upload_seen[$basename]:-}" ]; then
+        upload_seen[$basename]=1
+        upload_list+=("$file")
+    fi
+done
+
+[ "${#upload_list[@]}" -gt 0 ] || die "no artifacts matched the component table in $ARTIFACTS_DIR"
+
+# --- Report / upload -------------------------------------------------------
+
+version_prefix="$BUCKET/versions/$VERSION"
+
+printf '=== components manifest (%s/components) ===\n' "$version_prefix" >&2
+cat "$manifest" >&2
+printf '=== %d artifact(s) -> %s/ ===\n' "${#upload_list[@]}" "$version_prefix" >&2
+printf '  %s\n' "${upload_list[@]}" >&2
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    printf 'stage-release: dry run, nothing uploaded\n' >&2
+    exit 0
+fi
+
+# Immutable version artifacts: cache aggressively. Content is addressed by the
+# version segment, so a given URL never changes payload.
+IMMUTABLE_CACHE="public, max-age=31536000, immutable"
+
+gcloud storage cp \
+    --cache-control="$IMMUTABLE_CACHE" \
+    "${upload_list[@]}" "$version_prefix/"
+
+gcloud storage cp \
+    --cache-control="$IMMUTABLE_CACHE" \
+    "$manifest" "$version_prefix/components"
+
+printf 'stage-release: staged %s at %s (no channel updated; see set-channel.sh)\n' \
+    "$VERSION" "$version_prefix" >&2


### PR DESCRIPTION
 * `Release` workflow now stages artifacts ready for consumption by bash installer
 * `Promote` workflow now sets pointer file for bash installer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release staging and channel-switching support for installer builds.
  * Release workflows can now promote a staged version to either the stable or unstable channel.
  * The latest staged version can be selected automatically when no version is specified.

* **Bug Fixes**
  * Improved validation and safety checks before moving a channel pointer.
  * Updated release handling to ensure installer artifacts and manifests are published in the expected layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->