### PR TITLE
feat(installer): implement install.sh per 07-spec-installer

### DIFF
--- a/.github/workflows/ci-shell-installer.yml
+++ b/.github/workflows/ci-shell-installer.yml
@@ -1,0 +1,73 @@
+name: CI shell installer
+
+# Static-analyses and tests the curl|sh fallback installer
+# (docs/specs/07-spec-installer). The installer targets strict POSIX sh, so this
+# gate enforces its Verification section: shellcheck --shell=sh with no warnings
+# (§1), and the unit-test harness run under dash and — critically — macOS's
+# frozen /bin/sh (§2/§3), where the installer takes its BSD mktemp and `shasum`
+# (no sha256sum) code paths. No network: the harness stubs the bucket.
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "scripts/install.sh"
+      - "scripts/install_test.sh"
+      - ".github/workflows/ci-shell-installer.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "scripts/install.sh"
+      - "scripts/install_test.sh"
+      - ".github/workflows/ci-shell-installer.yml"
+  workflow_dispatch:
+
+# Cancel superseded runs on a branch; never cancel a run on main.
+concurrency:
+  group: ci-shell-installer-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - name: shellcheck --shell=sh (no warnings)
+        # shellcheck is preinstalled on the ubuntu-latest runner image.
+        run: shellcheck --shell=sh scripts/install.sh scripts/install_test.sh
+
+  test:
+    name: test (${{ matrix.os }} / ${{ matrix.shell }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      # One shell/OS lane failing should not mask the others' results.
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            shell: sh # dash-backed /bin/sh on Ubuntu
+          - os: ubuntu-latest
+            shell: dash # explicit dash conformance (spec Verification §2)
+          - os: macos-latest
+            shell: sh # macOS frozen bash 3.2 as /bin/sh
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run installer test harness under ${{ matrix.shell }}
+        run: SH='${{ matrix.shell }}' '${{ matrix.shell }}' scripts/install_test.sh
+
+  # Single stable status for branch protection: green only when shellcheck and
+  # every test lane succeed (the matrix lanes have dynamic names).
+  ci-shell-installer-success:
+    if: always()
+    needs: [shellcheck, test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify all gating jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+      - run: echo "installer shellcheck + tests passed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,6 +517,17 @@ jobs:
                     --artifacts-dir artifacts \
                     --version "${{ steps.release_info.outputs.short_sha }}" \
                     --bucket gs://minimal-one
+            - name: Stage the installer script into the versioned folder
+              # Keep a version-pinned copy of the curl|sh installer next to the
+              # components it reads, so each version's install path is immutable
+              # and self-contained. Same immutable cache header as the other
+              # versions/<sha>/ artifacts. Done before the channel advances so the
+              # versioned folder is complete when anything points at it.
+              run: |
+                  gcloud storage cp \
+                    --cache-control="public, max-age=31536000, immutable" \
+                    scripts/install.sh \
+                    "gs://minimal-one/versions/${{ steps.release_info.outputs.short_sha }}/install.sh"
             - name: Point unstable channel at this release
               # `unstable` auto-advances to every fresh build — it is the
               # bleeding-edge channel, so no approval gate. Promotion to `stable`

--- a/justfile
+++ b/justfile
@@ -152,6 +152,25 @@ stop:
 clean:
     rm -f {{kernel}} {{rootfs}} {{initramfs}} {{gvproxy}} {{scratch}}/boot.log
 
+# Run the curl|sh installer's test harness under every POSIX sh available. The
+# installer targets strict POSIX sh, so dash conformance is checked alongside sh
+# (spec docs/specs/07-spec-installer, Verification §2); shellcheck --shell=sh is
+# run when present.
+test-installer:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v shellcheck >/dev/null 2>&1; then
+        echo "== shellcheck --shell=sh =="
+        shellcheck --shell=sh scripts/install.sh scripts/install_test.sh
+    else
+        echo "== shellcheck not found, skipping static check =="
+    fi
+    for sh in sh dash; do
+        command -v "$sh" >/dev/null 2>&1 || { echo "== $sh not found, skipping =="; continue; }
+        echo "== running install_test.sh under $sh =="
+        SH="$sh" "$sh" scripts/install_test.sh
+    done
+
 # ── DM1 / DM2 / DM3 deployment-model bring-up ────────────────────────────────
 #
 # DM1: macOS (Apple Silicon) host + Linux VM(s) over Hypervisor.framework. This

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,285 @@
+#!/bin/sh
+#
+# install.sh — the minimal curl|sh fallback installer.
+#
+# A single POSIX-sh script served for `curl … | sh`. It resolves a target
+# (default `stable`) to a version via a pointer file, fetches that version's
+# components manifest, and for each component that applies to the host OS/arch
+# it verifies whether the correct file is already installed (by hashing the
+# on-disk file) and, if not, downloads, checksum-verifies, and atomically
+# installs it. Reruns re-download only components whose hash changed.
+#
+# See docs/specs/07-spec-installer/07-spec-installer.md.
+#
+# Usage:
+#   curl --proto '=https' --tlsv1.2 -fsSL <URL>/install.sh | sh
+#   curl … | sh -s -- unstable          # pick a non-default target
+#
+# The script targets strict POSIX `sh` (not bash): it runs identically under
+# dash, macOS's frozen bash 3.2, busybox, and zsh-invoked-sh. It depends only on
+# tooling present by default on every target: a downloader (curl or wget), a
+# SHA-256 tool (sha256sum, shasum, or openssl), and awk/uname/mkdir/mv/chmod.
+
+set -eu
+
+# --- Configuration ---------------------------------------------------------
+
+# Bucket root. Hardcoded, overridable for staging/tests. Must be HTTPS: the
+# downloader wrappers enforce a TLS 1.2 floor and refuse redirect downgrades.
+BUCKET="${MINIMAL_OVERRIDE_INSTALLER_BUCKET:-https://storage.googleapis.com/minimal-one}"
+
+# Manifest column layout this installer understands. The manifest carries a
+# `# format:` header (spec R2.4); a mismatch is a hard error, not a misparse.
+SUPPORTED_FORMAT=1
+
+# --- Output helpers --------------------------------------------------------
+
+# All diagnostics go to stderr so a future machine-readable stdout stays clean.
+say() { printf '%s\n' "$*" >&2; }
+die() { printf 'install: %s\n' "$*" >&2; exit 1; }
+
+# --- Unit 1: environment probing (downloader, hasher, platform) ------------
+
+# R1.1 — prefer curl, else wget. Both enforce HTTPS + TLS 1.2 and refuse a
+# redirect that would downgrade the scheme.
+DL_TOOL=
+if command -v curl >/dev/null 2>&1; then
+    DL_TOOL=curl
+elif command -v wget >/dev/null 2>&1; then
+    DL_TOOL=wget
+else
+    die "need a downloader: neither curl nor wget found on PATH"
+fi
+
+# Download $1 (url) to $2 (path). Fails non-zero on any HTTP/transport error.
+fetch() {
+    case "$DL_TOOL" in
+        curl) curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL "$1" -o "$2" ;;
+        wget) wget --https-only --secure-protocol=TLSv1_2 -qO "$2" "$1" ;;
+    esac
+}
+
+# R1.2 — prefer sha256sum, else `shasum -a 256`, else `openssl dgst -sha256`.
+# Each wrapper prints the bare lowercase hex digest, nothing else.
+SHA_TOOL=
+if command -v sha256sum >/dev/null 2>&1; then
+    SHA_TOOL=sha256sum
+elif command -v shasum >/dev/null 2>&1; then
+    SHA_TOOL=shasum
+elif command -v openssl >/dev/null 2>&1; then
+    SHA_TOOL=openssl
+else
+    die "need a SHA-256 tool: none of sha256sum, shasum, openssl found on PATH"
+fi
+
+# Emit the lowercase hex digest of file $1 on stdout.
+sha256() {
+    case "$SHA_TOOL" in
+        sha256sum) sha256sum "$1" | awk '{print $1}' ;;
+        shasum)    shasum -a 256 "$1" | awk '{print $1}' ;;
+        openssl)   openssl dgst -sha256 "$1" | awk '{print $NF}' ;;
+    esac
+}
+
+# R1.3 — normalize OS/arch so one CPU has one name across platforms. R1.4 — tool
+# discovery uses `command -v`, never `which` (see above).
+os=
+case "$(uname -s)" in
+    Linux)  os=linux ;;
+    Darwin) os=darwin ;;
+    *)      die "unsupported OS: $(uname -s) (installer covers Linux and macOS)" ;;
+esac
+
+arch=
+case "$(uname -m)" in
+    amd64|x86_64)  arch=amd64 ;;
+    arm64|aarch64) arch=arm64 ;;
+    *)             die "unsupported architecture: $(uname -m)" ;;
+esac
+
+[ -n "${HOME:-}" ] || die "HOME is not set; cannot resolve install prefixes"
+
+# --- Unit 4: destination prefix resolution ---------------------------------
+
+# R4.1 — map a prefix token to an absolute directory through a fixed case.
+# The manifest string is NEVER shell-expanded or eval'ed; an unknown token is a
+# hard error. Note the XDG variable names and that ~/.local/bin has no XDG var
+# (hence MINIMAL_BIN).
+resolve_prefix() {
+    case "$1" in
+        bin)   printf '%s\n' "${MINIMAL_BIN:-$HOME/.local/bin}" ;;
+        data)  printf '%s\n' "${XDG_DATA_HOME:-$HOME/.local/share}/minimal" ;;
+        state) printf '%s\n' "${XDG_STATE_HOME:-$HOME/.local/state}/minimal" ;;
+        cache) printf '%s\n' "${XDG_CACHE_HOME:-$HOME/.cache}/minimal" ;;
+        *)     die "unknown dest prefix token: $1" ;;
+    esac
+}
+
+# --- Unit 2: target -> version -> manifest resolution ----------------------
+
+# R2.1 — optional first argument, the target, defaulting to `stable`. The
+# default applies only when no argument is given (`${1-…}`, not `${1:-…}`): an
+# explicitly-passed empty string is a malformed target and must be rejected, not
+# silently turned into `stable`. Validated against the safe charset before use.
+# The charset forbids `/`, so a value is always a single path segment; `.` and
+# `..` are rejected outright because curl normalizes `$BUCKET/..` back past the
+# bucket prefix (RFC 3986 dot-segment removal) before the request is sent.
+target="${1-stable}"
+case "$target" in
+    ''|.|..|*[!A-Za-z0-9._-]*) die "invalid target '$target' (allowed: A-Za-z0-9._-, not '.'/'..')" ;;
+esac
+
+# A trap-cleaned temp dir for the pointer and manifest. The BSD/GNU mktemp
+# template split is bridged the portable way.
+tmpdir="$(mktemp -d 2>/dev/null || mktemp -d -t minimal)" || die "mktemp failed"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# R2.2 — resolve the target to a version via the pointer file. Command
+# substitution strips the trailing newline; the charset check catches any
+# internal whitespace or smuggled path segment.
+fetch "$BUCKET/$target" "$tmpdir/pointer" \
+    || die "could not fetch target pointer '$target' from $BUCKET/$target"
+VERSION="$(cat "$tmpdir/pointer")"
+# Same guard as the target: reject `.`/`..` so a compromised pointer cannot make
+# `versions/$VERSION/components` normalize outside the versioned prefix.
+case "$VERSION" in
+    ''|.|..|*[!A-Za-z0-9._-]*) die "target '$target' resolved to a malformed version" ;;
+esac
+say "install: target '$target' -> version $VERSION"
+
+# R2.3 — fetch that version's immutable components manifest.
+manifest="$tmpdir/components"
+fetch "$BUCKET/versions/$VERSION/components" "$manifest" \
+    || die "could not fetch components manifest for version $VERSION"
+
+# R2.4 — refuse a manifest whose format this installer does not understand.
+fmt="$(awk '/^#[ \t]*format:/ {print $3; exit}' "$manifest")"
+[ -n "$fmt" ] || die "manifest has no '# format:' header"
+[ "$fmt" = "$SUPPORTED_FORMAT" ] \
+    || die "unsupported manifest format '$fmt' (this installer supports $SUPPORTED_FORMAT); upgrade the installer"
+
+# --- Units 3+5: field extraction, skip/download/verify/install -------------
+
+# R3.1/R3.2/R3.3 — select every data row that applies to this host by EXACT
+# field equality on awk-split columns. Comment and blank lines are dropped.
+# The rows are written to a file and consumed by a `while read` fed via redirection
+# so the loop body runs in this shell: its `die` exits the whole script and its counters persist.
+applicable="$tmpdir/applicable"
+awk -v o="$os" -v a="$arch" \
+    '!/^#/ && NF && $2==o && $3==a {print}' "$manifest" >"$applicable"
+[ -s "$applicable" ] || die "manifest lists no components for $os/$arch at version $VERSION"
+
+records="$tmpdir/installed"
+: >"$records"
+installed=0 skipped=0
+
+# The prior run's install record (R6.1) maps each component to the hash of the
+# file it actually placed on disk. On macOS a `bin` file is ad-hoc code-signed
+# after download (see below), so its installed bytes — and hash — differ from
+# the manifest `sha256`; this lets a signed component be recognized as already
+# installed without re-downloading. It is only a positive-match optimization: a
+# deleted or tampered file matches neither hash and is reinstalled, so the
+# on-disk file remains the source of truth (R5.1). Read before the new record is
+# written into place at the end of the run.
+state_dir="$(resolve_prefix state)"
+prev_record="$state_dir/installed"
+prev_installed_hash() {
+    [ -f "$prev_record" ] || return 0
+    # Records are tab-delimited; split on tab so a dest containing spaces (e.g. a
+    # $HOME with a space) still parses.
+    awk -F'\t' -v c="$1" '$1==c {print $3; exit}' "$prev_record"
+}
+
+# No field ever contains whitespace (R3.2), so default IFS splitting is exact.
+# The os/arch/version columns are consumed into `_` (already matched in awk, or
+# informational); comp/want/kind/dest/src are what drive the install.
+while read -r comp _ _ _ want kind dest src; do
+    # v1 handles single files only; an unknown kind is a hard error, not a
+    # silent skip (the column reserves room for archive kinds later).
+    [ "$kind" = file ] || die "component $comp has unsupported kind '$kind'"
+
+    # dest is `<prefix-token>/<subpath>`. Require both halves.
+    case "$dest" in
+        */*) ;;
+        *)   die "component $comp has malformed dest '$dest' (no subpath)" ;;
+    esac
+    prefix="${dest%%/*}"
+    subpath="${dest#*/}"
+
+    # R4.2 — reject an absolute subpath or any `..` component before it is used
+    # to build a path, closing the traversal vector.
+    case "$subpath" in
+        ''|/*|..|../*|*/..|*/../*) die "component $comp has unsafe dest subpath '$subpath'" ;;
+    esac
+
+    dir="$(resolve_prefix "$prefix")"
+    target_file="$dir/$subpath"
+
+    # R5.1 — the on-disk file is the skip oracle. It is up to date if its hash
+    # matches the manifest `sha256` OR (for a macOS `bin` file we signed last
+    # run) the installed hash recorded then, since signing diverges the bytes.
+    if [ -f "$target_file" ]; then
+        on_disk="$(sha256 "$target_file")"
+        if [ "$on_disk" = "$want" ] || [ "$on_disk" = "$(prev_installed_hash "$comp")" ]; then
+            say "  $comp: up to date"
+            skipped=$((skipped + 1))
+            printf '%s\t%s\t%s\n' "$comp" "$target_file" "$on_disk" >>"$records"
+            continue
+        fi
+    fi
+
+    # R4.3/R5.2 — create the destination dir, then download to a temp sibling
+    # IN that dir so the final rename is a same-filesystem atomic swap.
+    mkdir -p "$dir"
+    tmp="$target_file.tmp.$$"
+    say "  $comp: downloading"
+    fetch "$BUCKET/$src" "$tmp" || { rm -f "$tmp"; die "download failed: $comp ($src)"; }
+
+    # R5.3 — verify the DOWNLOAD against the manifest before any local
+    # post-processing modifies it; a mismatch removes the temp file and aborts,
+    # so a truncated/corrupt artifact is never placed.
+    got="$(sha256 "$tmp")"
+    [ "$got" = "$want" ] || { rm -f "$tmp"; die "checksum mismatch for $comp (want $want, got $got)"; }
+
+    # R5.4 — bin components appear executable at their final path atomically:
+    # chmod the temp file, then rename.
+    [ "$prefix" = bin ] && chmod +x "$tmp"
+
+    # macOS: make a freshly-downloaded bin executable actually runnable before it
+    # is placed. Strip the Gatekeeper quarantine attribute (metadata, so it never
+    # affected the hash above; a no-op if absent — hence the swallowed error),
+    # then ad-hoc self-sign: arm64 macOS refuses to exec an unsigned or
+    # transfer-invalidated Mach-O, and our release binaries are not yet signed
+    # with a developer identity. Signing rewrites the Mach-O, so the installed
+    # bytes deliberately diverge from the manifest hash — the skip oracle and the
+    # installed-hash record both account for this.
+    if [ "$os" = darwin ] && [ "$prefix" = bin ]; then
+        xattr -d com.apple.quarantine "$tmp" 2>/dev/null || true
+        codesign --sign - --force "$tmp" || { rm -f "$tmp"; die "codesign failed: $comp"; }
+    fi
+
+    mv -f "$tmp" "$target_file"
+    installed=$((installed + 1))
+    # Record the hash of what is actually on disk now (== manifest hash except
+    # for a signed macOS bin file), so a later run recognizes it (R5.1/R6.1).
+    printf '%s\t%s\t%s\n' "$comp" "$target_file" "$(sha256 "$target_file")" >>"$records"
+done <"$applicable"
+
+# --- Unit 6: install record and PATH advisory ------------------------------
+
+# R6.1 — persist the resolved (component, dest, installed-hash) rows for this
+# platform, replacing the prior record read during the loop. Enables a future
+# uninstall and surfaces prefix drift across XDG changes.
+mkdir -p "$state_dir"
+mv -f "$records" "$prev_record"
+
+say "install: $installed installed, $skipped up to date -> record at $prev_record"
+
+# R6.2 — if the bin prefix is not on PATH, advise the user; never edit an rc file.
+bindir="$(resolve_prefix bin)"
+case ":${PATH:-}:" in
+    *":$bindir:"*) ;;
+    *) say ""
+       say "note: $bindir is not on your PATH."
+       say "  add it, e.g.:  export PATH=\"$bindir:\$PATH\"" ;;
+esac

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1,0 +1,354 @@
+#!/bin/sh
+#
+# install_test.sh — POSIX-sh test harness for scripts/install.sh.
+#
+# Exercises Units 1–6 of docs/specs/07-spec-installer against a local mock
+# bucket and a stubbed downloader, then asserts the spec's proof artifacts.
+#
+# The downloader is stubbed by prepending a temp dir to PATH containing a fake
+# `curl` that maps `<BUCKET>/<path>` to `<mock>/<path>`, copies the file, and
+# bumps a per-run download counter — so "zero downloads on rerun" is checkable
+# without a network. The installer's own HTTPS/TLS wrapper flags are passed to
+# the stub and ignored; real transport security is covered by the end-to-end
+# run against the real bucket, not here.
+#
+# Usage:
+#   scripts/install_test.sh            # runs under `sh`
+#   sh scripts/install_test.sh         # ditto
+# CI additionally runs it under dash (and macOS /bin/sh where available).
+
+set -eu
+
+here="$(cd "$(dirname "$0")" && pwd)"
+installer="$here/install.sh"
+[ -f "$installer" ] || { echo "cannot find install.sh next to test" >&2; exit 1; }
+
+# The shell the installer-under-test runs in (default sh; CI overrides to dash).
+SH="${SH:-sh}"
+
+root="$(mktemp -d 2>/dev/null || mktemp -d -t minimal-installtest)"
+trap 'rm -rf "$root"' EXIT
+
+pass=0 fail=0
+ok()   { pass=$((pass + 1)); printf 'ok   - %s\n' "$*"; }
+bad()  { fail=$((fail + 1)); printf 'FAIL - %s\n' "$*"; }
+check(){ if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (want [$1] got [$2])"; fi; }
+
+# Assertion wrappers over a command: the message is first, the command follows.
+# Written as an explicit if/else, not `cmd && ok || bad` (which shellcheck flags
+# SC2015 and which silently runs `bad` if `ok` ever returned non-zero).
+want_ok()  { _m="$1"; shift; if "$@"; then ok "$_m"; else bad "$_m"; fi; }
+want_err() { _m="$1"; shift; if "$@"; then bad "$_m"; else ok "$_m"; fi; }
+
+# The harness computes expected hashes with whatever SHA-256 tool the host has.
+# macOS ships `shasum`, not `sha256sum`, so pick portably (same order the
+# installer under test uses) — otherwise the macOS lane fails in the harness
+# rather than exercising the installer.
+if command -v sha256sum >/dev/null 2>&1; then
+    hash_file() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+    hash_file() { shasum -a 256 "$1" | awk '{print $1}'; }
+elif command -v openssl >/dev/null 2>&1; then
+    hash_file() { openssl dgst -sha256 "$1" | awk '{print $NF}'; }
+else
+    echo "install_test: no SHA-256 tool available for the harness" >&2; exit 1
+fi
+
+# --- Mock bucket -----------------------------------------------------------
+
+BUCKET_HOST="https://mock.invalid/minimal-one"
+mock="$root/bucket"
+mkdir -p "$mock/versions/v1"
+
+# Two platform-diverse artifacts with padded columns and comment/blank lines, to
+# prove awk field-splitting survives padding (R3.1/R3.3).
+printf 'linux-amd64-minimald-body\n'  >"$mock/versions/v1/minimald-linux-amd64"
+printf 'linux-amd64-minimal-body\n'   >"$mock/versions/v1/minimal-linux-amd64"
+printf 'darwin-arm64-minimal-body\n'  >"$mock/versions/v1/minimal-darwin-arm64"
+printf 'darwin-arm64-rootfs-body\n'   >"$mock/versions/v1/rootfs-arm64.img"
+
+h_minimald="$(hash_file "$mock/versions/v1/minimald-linux-amd64")"
+h_minimal="$(hash_file "$mock/versions/v1/minimal-linux-amd64")"
+h_dmin="$(hash_file "$mock/versions/v1/minimal-darwin-arm64")"
+h_rootfs="$(hash_file "$mock/versions/v1/rootfs-arm64.img")"
+
+printf 'v1\n' >"$mock/stable"
+
+write_manifest() {
+    fmt="${1:-1}"
+    {
+        printf '# format: %s\n' "$fmt"
+        printf '# component   os      arch    version   sha256   kind   dest   src\n'
+        printf '\n'
+        printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
+            minimald linux amd64 v1 "$h_minimald" file bin/minimald versions/v1/minimald-linux-amd64
+        printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
+            minimal linux amd64 v1 "$h_minimal" file bin/minimal versions/v1/minimal-linux-amd64
+        printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
+            minimal darwin arm64 v1 "$h_dmin" file bin/minimal versions/v1/minimal-darwin-arm64
+        printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
+            rootfs darwin arm64 v1 "$h_rootfs" file data/rootfs.img versions/v1/rootfs-arm64.img
+    } >"$mock/versions/v1/components"
+}
+write_manifest 1
+
+# --- Stubbed downloader (fake curl on PATH) --------------------------------
+
+stubbin="$root/stubbin"
+mkdir -p "$stubbin"
+dlcount="$root/dlcount"
+: >"$dlcount"
+
+cat >"$stubbin/curl" <<STUB
+#!/bin/sh
+# Fake curl: find the -o OUT and the URL among the installer's flags, map the
+# URL to the mock bucket, copy, and count the download.
+out= url=
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -o) out="\$2"; shift 2 ;;
+    https://*|http://*) url="\$1"; shift ;;
+    *) shift ;;
+  esac
+done
+[ -n "\$url" ] || { echo "stub curl: no url" >&2; exit 2; }
+rel="\${url#$BUCKET_HOST/}"
+src="$mock/\$rel"
+[ -f "\$src" ] || { echo "stub curl: 404 \$url" >&2; exit 22; }
+# Count artifact fetches only, not the pointer or the manifest, so "zero
+# downloads on rerun" means "no component re-downloaded" (spec R5.1).
+case "\$rel" in
+  versions/*/components) : ;;
+  versions/*)            printf 'x\n' >>"$dlcount" ;;
+esac
+if [ -n "\$out" ]; then cp "\$src" "\$out"; else cat "\$src"; fi
+STUB
+chmod +x "$stubbin/curl"
+# Force the wget path off so selection is deterministic across hosts.
+cat >"$stubbin/wget" <<'STUB'
+#!/bin/sh
+echo "stub wget should not be used in tests" >&2
+exit 1
+STUB
+chmod +x "$stubbin/wget"
+
+# Stub `uname` so the host platform the installer sees is fixed by the STUB_UNAME
+# env, not the CI runner — the same assertions then hold under Linux and macOS,
+# and the darwin-only code path (below) is exercised on every lane.
+cat >"$stubbin/uname" <<'STUB'
+#!/bin/sh
+case "$1" in
+  -m) printf '%s\n' "${STUB_UNAME_M:-x86_64}" ;;
+  *)  printf '%s\n' "${STUB_UNAME_S:-Linux}" ;;
+esac
+STUB
+chmod +x "$stubbin/uname"
+
+# Stub `codesign`: the real tool needs a valid Mach-O (our mock artifacts are
+# plain files) and is macOS-only. It records the signed path and APPENDS to the
+# file, emulating how signing rewrites the binary so its hash diverges from the
+# manifest — which is exactly what the skip oracle must tolerate.
+cat >"$stubbin/codesign" <<STUB
+#!/bin/sh
+f=
+for a in "\$@"; do f="\$a"; done   # target is the last argument
+printf '%s\n' "\$f" >>"$root/codesign.calls"
+printf 'adhoc-signature\n' >>"\$f"
+STUB
+chmod +x "$stubbin/codesign"
+
+# Stub `xattr`: record the invocation; exit 0 (the installer swallows failure).
+cat >"$stubbin/xattr" <<STUB
+#!/bin/sh
+printf '%s\n' "\$*" >>"$root/xattr.calls"
+STUB
+chmod +x "$stubbin/xattr"
+
+downloads() { wc -l <"$dlcount" | tr -d ' '; }
+reset_dl()  { : >"$dlcount"; }
+
+# --- Run helper ------------------------------------------------------------
+
+# Host platform the installer sees, via the uname stub. Default to linux/amd64;
+# the darwin scenario flips these around its run and restores them after.
+PLAT_S=Linux
+PLAT_M=x86_64
+
+# run <label> <homeprefix> [args...] ; sets rc, captures combined output in $OUT.
+OUT=
+run() {
+    label="$1"; hp="$2"; shift 2
+    OUT="$root/out.$label"
+    set +e
+    env -i \
+        PATH="$stubbin:/usr/bin:/bin" \
+        HOME="$hp" \
+        MINIMAL_BIN="$hp/bin" \
+        XDG_DATA_HOME="$hp/xdg-data" \
+        XDG_STATE_HOME="$hp/xdg-state" \
+        XDG_CACHE_HOME="$hp/xdg-cache" \
+        MINIMAL_OVERRIDE_INSTALLER_BUCKET="$BUCKET_HOST" \
+        STUB_UNAME_S="$PLAT_S" \
+        STUB_UNAME_M="$PLAT_M" \
+        "$SH" "$installer" "$@" >"$OUT" 2>&1
+    rc=$?
+    set -e
+}
+
+# ===========================================================================
+echo "# install.sh tests (SH=$SH)"
+
+# --- Unit 5: install, skip-on-rerun (R5.1), atomic + exec (R5.4) -----------
+H1="$root/h1"; mkdir -p "$H1"
+reset_dl
+run first "$H1"
+check 0 "$rc" "fresh install exits 0"
+want_ok "minimald installed to bin" test -f "$H1/bin/minimald"
+want_ok "bin component is executable (R5.4)" test -x "$H1/bin/minimald"
+check "$h_minimald" "$(hash_file "$H1/bin/minimald")" "installed content matches manifest hash"
+# Only linux/amd64 rows apply on this host: darwin row must not be installed.
+want_err "darwin-only component skipped on linux host" test -e "$H1/data/rootfs.img"
+n1="$(downloads)"; want_ok "first run downloaded ($n1)" test "$n1" -gt 0
+
+reset_dl
+run second "$H1"
+check 0 "$rc" "rerun exits 0"
+check 0 "$(downloads)" "rerun performs zero downloads (R5.1/R2 reruns cheap)"
+
+# Corrupt one on-disk binary -> only that component re-fetches.
+printf 'tampered\n' >"$H1/bin/minimald"
+reset_dl
+run third "$H1"
+check 0 "$rc" "rerun after tamper exits 0"
+check 1 "$(downloads)" "only the changed component re-downloads"
+check "$h_minimald" "$(hash_file "$H1/bin/minimald")" "tampered binary restored"
+
+# --- Unit 5: checksum mismatch (R5.3) --------------------------------------
+# Point the manifest's minimal hash at a wrong value; artifact stays as-is.
+cp "$mock/versions/v1/components" "$root/good-components"
+awk '$1=="minimal" && $2=="linux" {$5="deadbeef"} {print}' "$root/good-components" \
+    >"$mock/versions/v1/components"
+H2="$root/h2"; mkdir -p "$H2"
+reset_dl
+run mismatch "$H2"
+check 1 "$rc" "checksum mismatch exits non-zero (R5.3)"
+want_ok "mismatch names the failure" grep -q "checksum mismatch" "$OUT"
+want_err "no file installed on mismatch" test -e "$H2/bin/minimal"
+if ls "$H2/bin/"minimal.tmp.* >/dev/null 2>&1
+then bad "temp file left behind"; else ok "no .tmp file left (R5.3)"; fi
+cp "$root/good-components" "$mock/versions/v1/components"   # restore
+
+# --- Unit 2: target / version / format validation --------------------------
+H3="$root/h3"; mkdir -p "$H3"
+reset_dl
+run traversal "$H3" "../evil"
+check 1 "$rc" "path-like target exits non-zero (R2.1)"
+check 0 "$(downloads)" "invalid target fetches nothing (R2.1)"
+
+run emptytarget "$H3" ""
+check 1 "$rc" "empty target exits non-zero (R2.1)"
+
+# Dot-segment targets pass the charset but would let curl normalize the URL past
+# the bucket prefix; reject them outright, before any fetch.
+for dot in . ..; do
+    reset_dl
+    run "dottarget" "$H3" "$dot"
+    check 1 "$rc" "dot-segment target '$dot' exits non-zero (R2.1)"
+    check 0 "$(downloads)" "dot-segment target '$dot' fetches nothing"
+done
+
+# A compromised pointer resolving to a dot-segment version must also be rejected
+# (before the manifest fetch), not just the char whitelist.
+printf '..\n' >"$mock/dotversion"
+run dotversion "$H3" dotversion
+check 1 "$rc" "dot-segment version from pointer exits non-zero (R2.2)"
+
+write_manifest 999
+run badformat "$H3"
+check 1 "$rc" "unsupported manifest format exits non-zero (R2.4)"
+want_ok "format error names supported version (R2.4)" grep -q "supports 1" "$OUT"
+write_manifest 1
+
+# --- Unit 4: prefix resolution + traversal rejection (R4.1/R4.2) -----------
+# A dest with a `..` component must be rejected, writing nothing.
+awk '$1=="minimal" && $2=="linux" {$7="bin/../../etc/x"} {print}' "$root/good-components" \
+    >"$mock/versions/v1/components"
+H4="$root/h4"; mkdir -p "$H4"
+run unsafedest "$H4"
+check 1 "$rc" "unsafe .. dest exits non-zero (R4.2)"
+want_err "traversal wrote nothing (R4.2)" test -e "$H4/etc/x"
+# Absolute subpath likewise.
+awk '$1=="minimal" && $2=="linux" {$7="bin//etc/x"} {print}' "$root/good-components" \
+    >"$mock/versions/v1/components"
+run absdest "$H4"
+check 1 "$rc" "absolute dest subpath exits non-zero (R4.2)"
+cp "$root/good-components" "$mock/versions/v1/components"
+
+# XDG_DATA_HOME steers the `data` prefix (R4.1): a one-off manifest with a
+# single data-prefixed row that applies to this host, asserting where it lands.
+{
+    printf '# format: 1\n'
+    printf '# c o a v s k d s\n'
+    printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
+        rootfs linux amd64 v1 "$h_rootfs" file data/rootfs.img versions/v1/rootfs-arm64.img
+} >"$mock/versions/v1/components"
+H5="$root/h5"; mkdir -p "$H5"
+run datadest "$H5"
+check 0 "$rc" "data-prefixed component installs (R4.1)"
+want_ok "data resolves under XDG_DATA_HOME/minimal (R4.1)" \
+    test -f "$H5/xdg-data/minimal/rootfs.img"
+cp "$root/good-components" "$mock/versions/v1/components"
+
+# --- Unit 6: install record (R6.1) + PATH advisory (R6.2) ------------------
+record="$H1/xdg-state/minimal/installed"
+want_ok "install record lists components (R6.1)" grep -q "minimald" "$record"
+want_ok "install record lists resolved dest (R6.1)" grep -q "$H1/bin/minimald" "$record"
+want_ok "install record lists hash (R6.1)" grep -q "$h_minimald" "$record"
+
+# bin not on PATH -> advisory printed.
+run advise_off "$H1"
+want_ok "PATH advisory printed when bin absent (R6.2)" grep -q "is not on your PATH" "$OUT"
+# bin on PATH -> advisory suppressed. Re-run with bin on PATH via a wrapper env.
+OUT="$root/out.advise_on"
+set +e
+env -i PATH="$stubbin:$H1/bin:/usr/bin:/bin" HOME="$H1" MINIMAL_BIN="$H1/bin" \
+    XDG_STATE_HOME="$H1/xdg-state" XDG_DATA_HOME="$H1/xdg-data" XDG_CACHE_HOME="$H1/xdg-cache" \
+    MINIMAL_OVERRIDE_INSTALLER_BUCKET="$BUCKET_HOST" \
+    STUB_UNAME_S="$PLAT_S" STUB_UNAME_M="$PLAT_M" \
+    "$SH" "$installer" >"$OUT" 2>&1
+set -e
+want_err "PATH advisory suppressed when bin present (R6.2)" grep -q "is not on your PATH" "$OUT"
+
+# --- Unit 5 (darwin): dequarantine + ad-hoc codesign for bin files ---------
+# Force a darwin/arm64 platform (via the uname stub) so this runs on every lane.
+# The applicable rows are then `minimal` (bin) and `rootfs` (data). A bin file
+# must be quarantine-stripped and ad-hoc codesigned; a data file must not be.
+PLAT_S=Darwin
+PLAT_M=arm64
+: >"$root/codesign.calls"
+: >"$root/xattr.calls"
+HD="$root/hd"; mkdir -p "$HD"
+reset_dl
+run darwin1 "$HD"
+check 0 "$rc" "darwin install exits 0"
+want_ok "darwin bin component installed" test -f "$HD/bin/minimal"
+want_ok "quarantine stripped from bin (xattr)" grep -q "com.apple.quarantine" "$root/xattr.calls"
+want_ok "bin file ad-hoc codesigned" grep -q "/bin/minimal" "$root/codesign.calls"
+want_err "data component not codesigned" grep -q "rootfs" "$root/codesign.calls"
+
+# Signing diverged the on-disk bytes from the manifest hash. A rerun must still
+# recognize the component as installed (via the recorded hash) and not download
+# or re-sign it — otherwise macOS reruns would never be cheap (Goal 2).
+reset_dl
+: >"$root/codesign.calls"
+run darwin2 "$HD"
+check 0 "$rc" "darwin rerun exits 0"
+check 0 "$(downloads)" "signed darwin bin: rerun downloads nothing"
+want_err "signed darwin bin: not re-codesigned on rerun" grep -q "/bin/minimal" "$root/codesign.calls"
+PLAT_S=Linux
+PLAT_M=x86_64
+
+# ===========================================================================
+echo "# ---"
+printf '# %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
 * Implements the shell-based installer as per `docs/specs/07-spec-installer`.
 * Linux: Tested in an `exe.dev` fresh VM
 * MacOS: TODO test
 * Temporarily strips the quarantine bit + selfsigns on MacOS
 * Implements CI for the shell installer, including `shellcheck` for posix compat + a medium-rare shit test suite.
 * Stamps the `install.sh` into the `minimal-one/<version` bucket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a portable POSIX installer (curl|sh) with OS/arch filtering, SHA-256 verified downloads, atomic installs, and XDG-aware paths.
  * Added a gated CI workflow that shell-checks and runs installer tests across shells/OSes.
  * Added release staging to publish a versioned installer artifact before advancing the stable channel.
  * Added a `just` target to run installer conformance tests.
* **Bug Fixes**
  * Strengthened destination/path safety checks and improved rerun/tamper recovery behavior.
* **Tests**
  * Added a POSIX test harness covering reruns, checksum failures, manifest validation, and macOS-specific signing/quarantine handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->