### PR TITLE
chore(deps): fix pointer-deref advisory on crossbeam-epoch 0.9.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279b0f31df31b4add8aeae57d40f3b5e53aad2b531e89b982bd75ed1898851d"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
```
error[vulnerability]: Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
    ┌─ /github/workspace/Cargo.lock:111:1
    │
111 │ crossbeam-epoch 0.9.19 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
    │
    ├ ID: RUSTSEC-2026-0204
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0204
    ├ Affected versions of `fmt::Display` dereference the underlying pointer. This causes a invalid pointer dereference e.g., when a pointer created with `Atomic::null` or `Shared::null`. `fmt::Debug` impls and pre-0.9 `fmt::Display` impls, which do not dereference pointers, are not affected by this issue.
    ├ Announcement: https://github.com/crossbeam-rs/crossbeam/pull/1276
    ├ Solution: Upgrade to >=0.9.20 (try `cargo update -p crossbeam-epoch`)
    ├ crossbeam-epoch v0.9.19
      ├── crossbeam-deque v0.8.7
      │   └── rayon-core v1.13.0
      │       └── rayon v1.12.0
      │           ├── mip v0.4.1
      │           ├── op v0.0.1
      │           │   ├── check v0.0.1
      │           │   │   ├── mctx v0.0.1
      │           │   │   │   ├── minimald v0.0.1
      │           │   │   │   └── mip v0.4.1 (*)
      │           │   │   ├── minimald v0.0.1 (*)
      │           │   │   ├── mip v0.4.1 (*)
      │           │   │   └── remote-client v0.0.1
      │           │   │       └── mip v0.4.1 (*)
      │           │   ├── mctx v0.0.1 (*)
      │           │   ├── minimald v0.0.1 (*)
      │           │   ├── mip v0.4.1 (*)
      │           │   └── orchestrator v0.0.1
      │           │       ├── mctx v0.0.1 (*)
      │           │       ├── mip v0.4.1 (*)
      │           │       └── remote-client v0.0.1 (*)
      │           └── topiary-core v0.7.3
      │               └── nickel-lang-core v0.17.0
      │                   ├── args v0.0.1
      │                   │   ├── common v0.0.1
      │                   │   │   ├── check v0.0.1 (*)
      │                   │   │   ├── checkouts v0.0.1
      │                   │   │   │   ├── graph v0.0.1
      │                   │   │   │   │   ├── check v0.0.1 (*)
      │                   │   │   │   │   ├── lcache v0.0.1
      │                   │   │   │   │   │   ├── check v0.0.1 (*)
      │                   │   │   │   │   │   ├── mctx v0.0.1 (*)
      │                   │   │   │   │   │   ├── mip v0.4.1 (*)
      │                   │   │   │   │   │   ├── op v0.0.1 (*)
      │                   │   │   │   │   │   ├── orchestrator v0.0.1 (*)
      │                   │   │   │   │   │   └── rcache v0.0.1
      │                   │   │   │   │   │       ├── mctx v0.0.1 (*)
      │                   │   │   │   │   │       ├── mip v0.4.1 (*)
      │                   │   │   │   │   │       └── orchestrator v0.0.1 (*)
      │                   │   │   │   │   ├── mctx v0.0.1 (*)
      │                   │   │   │   │   ├── minimald v0.0.1 (*)
      │                   │   │   │   │   ├── mip v0.4.1 (*)
      │                   │   │   │   │   ├── op v0.0.1 (*)
      │                   │   │   │   │   ├── orchestrator v0.0.1 (*)
      │                   │   │   │   │   ├── rcache v0.0.1 (*)
      │                   │   │   │   │   └── remote-client v0.0.1 (*)
      │                   │   │   │   ├── mctx v0.0.1 (*)
      │                   │   │   │   └── mip v0.4.1 (*)
      │                   │   │   ├── decode v0.0.1
      │                   │   │   │   ├── check v0.0.1 (*)
      │                   │   │   │   ├── graph v0.0.1 (*)
      │                   │   │   │   ├── mip v0.4.1 (*)
      │                   │   │   │   ├── op v0.0.1 (*)
      │                   │   │   │   └── orchestrator v0.0.1 (*)
      │                   │   │   ├── graph v0.0.1 (*)
      │                   │   │   ├── lcache v0.0.1 (*)
      │                   │   │   ├── mctx v0.0.1 (*)
      │                   │   │   ├── mfile v0.0.1
      │                   │   │   │   ├── checkouts v0.0.1 (*)
      │                   │   │   │   ├── decode v0.0.1 (*)
      │                   │   │   │   ├── graph v0.0.1 (*)
      │                   │   │   │   ├── mctx v0.0.1 (*)
      │                   │   │   │   ├── minimald v0.0.1 (*)
      │                   │   │   │   ├── mip v0.4.1 (*)
      │                   │   │   │   └── op v0.0.1 (*)
      │                   │   │   ├── minimald v0.0.1 (*)
      │                   │   │   ├── mip v0.4.1 (*)
      │                   │   │   ├── op v0.0.1 (*)
      │                   │   │   ├── orchestrator v0.0.1 (*)
      │                   │   │   ├── rcache v0.0.1 (*)
      │                   │   │   ├── remote-client v0.0.1 (*)
      │                   │   │   ├── sandbox2 v0.0.1
      │                   │   │   │   ├── mctx v0.0.1 (*)
      │                   │   │   │   ├── minimald v0.0.1 (*)
      │                   │   │   │   ├── op v0.0.1 (*)
      │                   │   │   │   └── orchestrator v0.0.1 (*)
      │                   │   │   └── sessions v0.0.1
      │                   │   │       ├── minimal v0.0.1
      │                   │   │       ├── minimald v0.0.1 (*)
      │                   │   │       ├── minimald-rpc v0.0.1
      │                   │   │       │   ├── minimal v0.0.1 (*)
      │                   │   │       │   ├── minimald v0.0.1 (*)
      │                   │   │       │   └── minvmd v0.0.1
      │                   │   │       │       └── minimal v0.0.1 (*)
      │                   │   │       ├── (dev) minvmd v0.0.1 (*)
      │                   │   │       └── sandbox2 v0.0.1 (*)
      │                   │   ├── decode v0.0.1 (*)
      │                   │   ├── graph v0.0.1 (*)
      │                   │   ├── mctx v0.0.1 (*)
      │                   │   ├── mfile v0.0.1 (*)
      │                   │   ├── minimald v0.0.1 (*)
      │                   │   └── mip v0.4.1 (*)
      │                   ├── check v0.0.1 (*)
      │                   ├── common v0.0.1 (*)
      │                   ├── decode v0.0.1 (*)
      │                   ├── graph v0.0.1 (*)
      │                   └── mip v0.4.1 (*)
      └── moka v0.12.15
          └── check v0.0.1 (*)
```