### PR TITLE
fix(minvmd): look in installed paths for data files & gvproxy

### DIFF
--- a/crates/minvmd/src/error.rs
+++ b/crates/minvmd/src/error.rs
@@ -35,6 +35,11 @@ pub enum VmError {
     /// A required environment variable was unset or empty.
     MissingEnv { var: &'static str },
 
+    /// A required image could not be located: the override env var was unset or
+    /// empty, and no file exists at the default install location. `var` names
+    /// the override; `default` is the path that was checked.
+    MissingImage { var: &'static str, default: PathBuf },
+
     /// An I/O error outside the libkrun FFI boundary (e.g. creating or
     /// checking the socket directory, R3.2).
     Io { source: io::Error },
@@ -83,6 +88,13 @@ impl fmt::Display for VmError {
             Self::MissingEnv { var } => {
                 write!(f, "required environment variable {var} is unset or empty")
             }
+            Self::MissingImage { var, default } => {
+                write!(
+                    f,
+                    "{var} is unset and no file exists at the default location {}",
+                    default.display()
+                )
+            }
             Self::Io { source } => {
                 write!(f, "I/O error: {source}")
             }
@@ -108,6 +120,7 @@ impl std::error::Error for VmError {
             | Self::NulInString { .. }
             | Self::StartEnterReturnedUnexpectedly { .. }
             | Self::MissingEnv { .. }
+            | Self::MissingImage { .. }
             | Self::Configuration { .. }
             | Self::InvalidEgressSubnet { .. } => None,
             Self::Io { source } => Some(source),

--- a/crates/minvmd/src/image.rs
+++ b/crates/minvmd/src/image.rs
@@ -1,11 +1,60 @@
 //! Kernel and rootfs image resolution.
 //!
-//! Paths are supplied at runtime via environment variables so the binary is
-//! not tied to a fixed install layout.
+//! Paths are supplied at runtime via environment variables. When an override is
+//! unset, each resolver falls back to the file the installer stamps into the
+//! minimal data directory (`$XDG_DATA_HOME/minimal`, else
+//! `$HOME/.local/share/minimal`) — but only when that file actually exists, so
+//! a default install works with no env setup while a genuinely missing image
+//! still errors rather than silently returning a non-existent path.
 
 use std::path::PathBuf;
 
 use crate::error::VmError;
+
+/// Filenames the installer stamps into the `data/` prefix. Kept in sync with
+/// `scripts/stage-release.sh` (`data/vmlinuz`, `data/rootfs.img`,
+/// `data/initramfs.cpio`).
+const DEFAULT_KERNEL_FILE: &str = "vmlinuz";
+const DEFAULT_ROOTFS_FILE: &str = "rootfs.img";
+const DEFAULT_INITRAMFS_FILE: &str = "initramfs.cpio";
+
+/// The minimal data directory: `$XDG_DATA_HOME/minimal`, else
+/// `$HOME/.local/share/minimal`. Mirrors the installer's `data` prefix
+/// resolution in `scripts/install.sh`. `None` when neither `XDG_DATA_HOME` nor
+/// `HOME` is set, so no default location can be computed.
+fn data_dir() -> Option<PathBuf> {
+    if let Some(xdg) = std::env::var("XDG_DATA_HOME")
+        .ok()
+        .filter(|v| !v.is_empty())
+    {
+        return Some(PathBuf::from(xdg).join("minimal"));
+    }
+    std::env::var("HOME")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(|home| PathBuf::from(home).join(".local/share/minimal"))
+}
+
+/// Return the override in `var` when set and non-empty (used verbatim, without
+/// an existence check — the caller owns an explicit path). Otherwise fall back
+/// to `<data-dir>/default_file`, but only when that file exists.
+///
+/// Errors with `VmError::MissingEnv` when the override is unset and no data
+/// directory can be resolved, and `VmError::MissingImage` when the default path
+/// is resolvable but no file is present there.
+fn resolve_or_default(var: &'static str, default_file: &str) -> Result<PathBuf, VmError> {
+    if let Some(val) = std::env::var(var).ok().filter(|v| !v.is_empty()) {
+        return Ok(PathBuf::from(val));
+    }
+    let default = data_dir()
+        .map(|dir| dir.join(default_file))
+        .ok_or(VmError::MissingEnv { var })?;
+    if default.exists() {
+        Ok(default)
+    } else {
+        Err(VmError::MissingImage { var, default })
+    }
+}
 
 /// Arch-appropriate libkrun kernel format.
 ///
@@ -32,71 +81,86 @@ pub fn kernel_format() -> crate::krun::KernelFormat {
     }
 }
 
-/// Resolve the kernel path from `MINVMD_KERNEL_PATH`.
+/// Resolve the kernel path from `MINVMD_KERNEL_PATH`, falling back to an
+/// existing `<data-dir>/vmlinuz` when the override is unset or empty.
 ///
-/// Returns `VmError::MissingEnv` when the variable is unset or empty.
+/// Errors with `VmError::MissingImage` when the override is unset and no file
+/// exists at the default location, or `VmError::MissingEnv` when no data
+/// directory can be resolved (neither `XDG_DATA_HOME` nor `HOME` is set).
 pub fn resolve_kernel_path() -> Result<PathBuf, VmError> {
-    let val = std::env::var("MINVMD_KERNEL_PATH").map_err(|_| VmError::MissingEnv {
-        var: "MINVMD_KERNEL_PATH",
-    })?;
-    if val.is_empty() {
-        return Err(VmError::MissingEnv {
-            var: "MINVMD_KERNEL_PATH",
-        });
-    }
-    Ok(PathBuf::from(val))
+    resolve_or_default("MINVMD_KERNEL_PATH", DEFAULT_KERNEL_FILE)
 }
 
-/// Resolve the rootfs path from `MINVMD_ROOTFS_PATH`.
+/// Resolve the rootfs path from `MINVMD_ROOTFS_PATH`, falling back to an
+/// existing `<data-dir>/rootfs.img` when the override is unset or empty.
 ///
 /// This is the path to a read-only ext4 root disk image (loaded via
-/// `krun_add_disk2`), not a directory. Returns `VmError::MissingEnv` when the
-/// variable is unset or empty.
+/// `krun_add_disk2`), not a directory. Errors with `VmError::MissingImage` when
+/// the override is unset and no file exists at the default location, or
+/// `VmError::MissingEnv` when no data directory can be resolved.
 pub fn resolve_rootfs_path() -> Result<PathBuf, VmError> {
-    let val = std::env::var("MINVMD_ROOTFS_PATH").map_err(|_| VmError::MissingEnv {
-        var: "MINVMD_ROOTFS_PATH",
-    })?;
-    if val.is_empty() {
-        return Err(VmError::MissingEnv {
-            var: "MINVMD_ROOTFS_PATH",
-        });
-    }
-    Ok(PathBuf::from(val))
+    resolve_or_default("MINVMD_ROOTFS_PATH", DEFAULT_ROOTFS_FILE)
 }
 
-/// Resolve the initramfs path from `MINVMD_INITRAMFS`.
+/// Resolve the initramfs path from `MINVMD_INITRAMFS`, falling back to an
+/// existing `<data-dir>/initramfs.cpio` when the override is unset or empty.
 ///
 /// This is the cpio initramfs whose `/init` is minimald (booted as pid-1).
-/// Returns `VmError::MissingEnv` when the variable is unset or empty.
+/// Errors with `VmError::MissingImage` when the override is unset and no file
+/// exists at the default location, or `VmError::MissingEnv` when no data
+/// directory can be resolved.
 pub fn resolve_initramfs_path() -> Result<PathBuf, VmError> {
-    let val = std::env::var("MINVMD_INITRAMFS").map_err(|_| VmError::MissingEnv {
-        var: "MINVMD_INITRAMFS",
-    })?;
-    if val.is_empty() {
-        return Err(VmError::MissingEnv {
-            var: "MINVMD_INITRAMFS",
-        });
-    }
-    Ok(PathBuf::from(val))
+    resolve_or_default("MINVMD_INITRAMFS", DEFAULT_INITRAMFS_FILE)
 }
 
-/// Default install path for the host gvproxy ("gvisor-tap-vsock") binary, used
-/// when `MINVMD_GVPROXY_BIN` is unset. Fetched + SHA-256-verified by
+/// System-wide install path for the host gvproxy ("gvisor-tap-vsock") binary,
+/// used as the final fallback when `MINVMD_GVPROXY_BIN` is unset and no
+/// user-local install exists. Fetched + SHA-256-verified by
 /// `scripts/fetch-gvproxy.sh` (issue #495).
 pub const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy";
 
-/// Resolve the host gvproxy binary path from `MINVMD_GVPROXY_BIN`, falling back
-/// to [`DEFAULT_GVPROXY_BIN`] when unset or empty.
+/// Filename the installer stamps into the `bin/` prefix (see
+/// `scripts/stage-release.sh`: `bin/gvproxy`).
+const GVPROXY_FILE: &str = "gvproxy";
+
+/// The user-local bin directory the installer stamps into: `$MINIMAL_BIN`, else
+/// `$HOME/.local/bin`. Mirrors the installer's `bin` prefix resolution in
+/// `scripts/install.sh`. `None` when neither is set.
+fn installer_bin_dir() -> Option<PathBuf> {
+    if let Some(bin) = std::env::var("MINIMAL_BIN").ok().filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(bin));
+    }
+    std::env::var("HOME")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(|home| PathBuf::from(home).join(".local/bin"))
+}
+
+/// Resolve the host gvproxy binary path in three tiers: the `MINVMD_GVPROXY_BIN`
+/// override, then an existing user-local install (`<bin-dir>/gvproxy`, where the
+/// installer stamps it), then the system-wide [`DEFAULT_GVPROXY_BIN`].
 ///
-/// Unlike the kernel/rootfs/initramfs resolvers this never errors on a missing
-/// env var: gvproxy is only spawned for an own-IP VM, so an absent
-/// override is the common case and the fixed install path is the default.
+/// Unlike the kernel/rootfs/initramfs resolvers this never errors: gvproxy is
+/// only spawned for an own-IP VM, so an absent override is the common case, and
+/// the system path is returned as a last resort even if nothing exists there
+/// (the caller surfaces a spawn failure with that concrete path).
 #[must_use]
 pub fn resolve_gvproxy_path() -> PathBuf {
-    match std::env::var("MINVMD_GVPROXY_BIN") {
-        Ok(val) if !val.is_empty() => PathBuf::from(val),
-        _ => PathBuf::from(DEFAULT_GVPROXY_BIN),
+    // Tier 1: explicit override, honoured verbatim.
+    if let Some(val) = std::env::var("MINVMD_GVPROXY_BIN")
+        .ok()
+        .filter(|v| !v.is_empty())
+    {
+        return PathBuf::from(val);
     }
+    // Tier 2: user-local install from the curl|sh installer, if present.
+    if let Some(local) = installer_bin_dir().map(|dir| dir.join(GVPROXY_FILE))
+        && local.exists()
+    {
+        return local;
+    }
+    // Tier 3: system-wide install path (hardcoded fallback).
+    PathBuf::from(DEFAULT_GVPROXY_BIN)
 }
 
 #[cfg(test)]
@@ -105,65 +169,128 @@ mod tests {
 
     use super::*;
 
-    // Serialise all tests that mutate MINVMD_KERNEL_PATH so they don't race
+    // Resolver tests mutate process-global env (the MINVMD_* overrides and
+    // XDG_DATA_HOME, which feeds `data_dir`), so serialise them to avoid races
     // when `cargo test` runs them in parallel.
-    static KERNEL_PATH_LOCK: Mutex<()> = Mutex::new(());
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    #[test]
-    fn resolve_kernel_path_errors_on_missing_env() {
-        let _g = KERNEL_PATH_LOCK.lock().unwrap();
-        unsafe { std::env::remove_var("MINVMD_KERNEL_PATH") };
-        let err = resolve_kernel_path().unwrap_err();
-        assert!(
-            matches!(
-                err,
-                VmError::MissingEnv {
-                    var: "MINVMD_KERNEL_PATH"
-                }
-            ),
-            "expected MissingEnv, got {err:?}"
-        );
+    // Point the data dir at an isolated temp dir by setting XDG_DATA_HOME (so
+    // `data_dir` never consults the real HOME) and clearing the override var.
+    fn scoped_data_dir(var: &str, xdg: &std::path::Path) {
+        unsafe {
+            std::env::remove_var(var);
+            std::env::set_var("XDG_DATA_HOME", xdg);
+        }
+    }
+
+    fn clear_env(var: &str) {
+        unsafe {
+            std::env::remove_var(var);
+            std::env::remove_var("XDG_DATA_HOME");
+        }
     }
 
     #[test]
-    fn resolve_kernel_path_returns_path_when_set() {
-        let _g = KERNEL_PATH_LOCK.lock().unwrap();
+    fn returns_override_verbatim_without_existence_check() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // A non-existent explicit path is still honoured: the caller owns it.
         unsafe { std::env::set_var("MINVMD_KERNEL_PATH", "/boot/Image.gz") };
         let path = resolve_kernel_path().unwrap();
-        assert_eq!(path, std::path::PathBuf::from("/boot/Image.gz"));
-        unsafe { std::env::remove_var("MINVMD_KERNEL_PATH") };
+        assert_eq!(path, PathBuf::from("/boot/Image.gz"));
+        clear_env("MINVMD_KERNEL_PATH");
     }
 
     #[test]
-    fn resolve_kernel_path_errors_on_empty_env() {
-        let _g = KERNEL_PATH_LOCK.lock().unwrap();
-        unsafe { std::env::set_var("MINVMD_KERNEL_PATH", "") };
-        let err = resolve_kernel_path().unwrap_err();
-        assert!(
-            matches!(
-                err,
-                VmError::MissingEnv {
-                    var: "MINVMD_KERNEL_PATH"
-                }
-            ),
-            "expected MissingEnv, got {err:?}"
-        );
-        unsafe { std::env::remove_var("MINVMD_KERNEL_PATH") };
+    fn falls_back_to_default_when_file_exists() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let want = tmp.path().join("minimal").join(DEFAULT_KERNEL_FILE);
+        std::fs::create_dir_all(want.parent().unwrap()).unwrap();
+        std::fs::write(&want, b"kernel").unwrap();
+
+        scoped_data_dir("MINVMD_KERNEL_PATH", tmp.path());
+        let path = resolve_kernel_path().unwrap();
+        assert_eq!(path, want);
+        clear_env("MINVMD_KERNEL_PATH");
     }
 
     #[test]
-    fn resolve_rootfs_path_errors_on_missing_env() {
-        unsafe { std::env::remove_var("MINVMD_ROOTFS_PATH") };
+    fn errors_with_missing_image_when_default_absent() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // XDG_DATA_HOME points at an empty temp dir: default is resolvable but
+        // no file is present there.
+        let tmp = tempfile::tempdir().unwrap();
+        scoped_data_dir("MINVMD_ROOTFS_PATH", tmp.path());
         let err = resolve_rootfs_path().unwrap_err();
-        assert!(
-            matches!(
-                err,
-                VmError::MissingEnv {
-                    var: "MINVMD_ROOTFS_PATH"
-                }
-            ),
-            "expected MissingEnv, got {err:?}"
+        let VmError::MissingImage { var, default } = &err else {
+            panic!("expected MissingImage, got {err:?}");
+        };
+        assert_eq!(*var, "MINVMD_ROOTFS_PATH");
+        assert_eq!(
+            *default,
+            tmp.path().join("minimal").join(DEFAULT_ROOTFS_FILE)
         );
+        clear_env("MINVMD_ROOTFS_PATH");
+    }
+
+    #[test]
+    fn empty_override_is_treated_as_unset() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let want = tmp.path().join("minimal").join(DEFAULT_INITRAMFS_FILE);
+        std::fs::create_dir_all(want.parent().unwrap()).unwrap();
+        std::fs::write(&want, b"initramfs").unwrap();
+
+        // Empty string must not be used as a path; it falls through to default.
+        unsafe {
+            std::env::set_var("MINVMD_INITRAMFS", "");
+            std::env::set_var("XDG_DATA_HOME", tmp.path());
+        }
+        let path = resolve_initramfs_path().unwrap();
+        assert_eq!(path, want);
+        clear_env("MINVMD_INITRAMFS");
+    }
+
+    // Remove every env var the gvproxy resolver consults, so a tier is only
+    // exercised by what the test sets explicitly.
+    fn clear_gvproxy_env() {
+        unsafe {
+            std::env::remove_var("MINVMD_GVPROXY_BIN");
+            std::env::remove_var("MINIMAL_BIN");
+        }
+    }
+
+    #[test]
+    fn gvproxy_tier1_override_wins() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_gvproxy_env();
+        unsafe { std::env::set_var("MINVMD_GVPROXY_BIN", "/custom/gvproxy") };
+        assert_eq!(resolve_gvproxy_path(), PathBuf::from("/custom/gvproxy"));
+        clear_gvproxy_env();
+    }
+
+    #[test]
+    fn gvproxy_tier2_installer_bin_when_present() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_gvproxy_env();
+        let tmp = tempfile::tempdir().unwrap();
+        let want = tmp.path().join(GVPROXY_FILE);
+        std::fs::write(&want, b"gvproxy").unwrap();
+        // MINIMAL_BIN steers installer_bin_dir without touching HOME.
+        unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
+        assert_eq!(resolve_gvproxy_path(), want);
+        clear_gvproxy_env();
+    }
+
+    #[test]
+    fn gvproxy_tier3_system_path_when_no_local() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_gvproxy_env();
+        // MINIMAL_BIN points at an empty dir: no user-local gvproxy present.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
+        assert_eq!(resolve_gvproxy_path(), PathBuf::from(DEFAULT_GVPROXY_BIN));
+        clear_gvproxy_env();
     }
 
     #[cfg(minvmd_libkrun)]


### PR DESCRIPTION
Should fix the issue with the installed `minvmd` not being able to find its requisite files with a default install on MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image path resolution with clearer fallback behavior for kernel, rootfs, and initramfs files.
  * Added a more specific error when no usable image can be found.

* **Bug Fixes**
  * Environment-based image overrides are now treated as authoritative when set.
  * Empty override values are handled as unset, reducing unexpected startup failures.
  * gvproxy lookup now follows a clearer precedence order: explicit override, user-local install, then system default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->