### PR TITLE
test: add cargo-mutants minimal task for the graph wire decoder

### DIFF
--- a/.minimal/minimal.toml
+++ b/.minimal/minimal.toml
@@ -103,6 +103,19 @@ inherit_cwd = true
 exec = "cargo clippy --all-targets -- -D warnings"
 inherit_cwd = true
 
+# Mutation-test the graph wire decoder. Runs in the Linux sandbox, where the
+# graph baseline test suite is green (the spec_hasher hash assertions that fail
+# on macOS pass here), which cargo-mutants requires. Scoped to wire.rs to keep
+# the run bounded; widen -f / drop it to cover more.
+[tasks.mutants]
+description = "Mutation-test the graph wire decoder with cargo-mutants"
+inherit_cwd = true
+bash = """
+set -e
+command -v cargo-mutants >/dev/null 2>&1 || cargo install cargo-mutants --locked
+cargo mutants -p graph -f wire.rs --timeout 120
+"""
+
 [tasks.arg-smoketest]
 args = {
     input_str = "string"


### PR DESCRIPTION
Adds a `mutants` task to `.minimal/minimal.toml` that runs `cargo mutants -p graph -f wire.rs` in the Linux sandbox.

Mutation testing requires a green baseline, which `cargo test -p graph` only has under Linux — the `spec_hasher` blake3 hash assertions fail on macOS. The task installs `cargo-mutants` if absent, then runs it scoped to the wire decoder to keep runtime bounded (widen/drop `-f` to cover more). Surviving mutants pinpoint untested encode/decode branches — the concrete round-trip property-test targets.

Run it with `MINIMAL_CPUS=6 MINIMAL_MEMORY=16G minimal run mutants` from a plain terminal (an active Claude session can trip the ~/.claude.json virtiofs stale-handle race).

Companion to the graph wire fuzz harness (#651 stack) and the OOM fix in #653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)