### PR TITLE
fix(common): return an error on malformed JSON in jq::parse_file

### DIFF
--- a/crates/common/src/jq.rs
+++ b/crates/common/src/jq.rs
@@ -29,7 +29,11 @@ pub fn parse_file<P: AsRef<Path>>(path: P, data: Vec<u8>) -> Result<Val, JqError
             relevant_file: Some(path.as_ref().to_str().unwrap().to_string()),
             relevant_jq: None,
         })?),
-        Some(Some("json")) => Ok(jaq_all::fmts::read::json::parse_single(&data).unwrap()),
+        Some(Some("json")) => jaq_all::fmts::read::json::parse_single(&data).map_err(|e| JqError {
+            err: e.to_string(),
+            relevant_file: Some(path.as_ref().to_str().unwrap().to_string()),
+            relevant_jq: None,
+        }),
         _ => Err(JqError {
             err: "cannot handle file extension".to_string(),
             relevant_file: Some(path.as_ref().to_str().unwrap().to_string()),
@@ -84,5 +88,23 @@ impl Expression {
                 relevant_jq: Some(self.raw.clone()),
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_file_rejects_malformed_json_without_panicking() {
+        // Regression for a fuzzer-found panic: `parse_single(..).unwrap()` on
+        // malformed (or empty) JSON. Both must now return a `JqError`.
+        assert!(parse_file("x.json", Vec::new()).is_err());
+        assert!(parse_file("x.json", b"{not json".to_vec()).is_err());
+    }
+
+    #[test]
+    fn parse_file_accepts_valid_json() {
+        assert!(parse_file("x.json", b"{\"a\": 1}".to_vec()).is_ok());
     }
 }


### PR DESCRIPTION
## What

The JSON branch of `jq::parse_file` did `parse_single(&data).unwrap()`, panicking on malformed or empty JSON — even though the sibling TOML branch right above it maps its parse error to `JqError`. `parse_file` is called during config decode on project-supplied `.json` data files (SUPPLY trust, `decode::stacks`), so a broken data file crashed the process instead of surfacing an error.

## How it was found

The new `jq_parse_json` fuzz target (in the fuzzing-infrastructure branch) hit it **immediately** — the crashing input is empty:

```
panicked at crates/common/src/jq.rs:32: called `Result::unwrap()` on an `Err` value: Error(0, Token(Value))
==ERROR: libFuzzer: deadly signal
```

## Fix

Map the JSON parse error into `JqError` exactly like the TOML branch does. Regression tests cover empty, malformed, and valid JSON.

## Validation

`cargo test -p common jq` — passes (malformed/empty → `Err`, valid → `Ok`); `cargo clippy -p common --lib -- -D warnings` clean.

This is the sixth and final bug from the decoder/parser fuzzing campaign — the capstone. The others: tar traversal (#651), two graph-wire OOMs (#653), a graph-wire slice panic + filename traversal (#656).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
