### PR TITLE
feat(installer): implement uninstall, fix update components on MacOS

### DIFF
--- a/docs/specs/07-spec-installer/07-spec-installer.md
+++ b/docs/specs/07-spec-installer/07-spec-installer.md
@@ -204,6 +204,18 @@ already exists **and** its on-disk SHA-256 equals the manifest `sha256`, the
 component is skipped with no download. The on-disk file — not any recorded
 state — is the source of truth for "already installed".
 
+A macOS `bin` file is the one exception: it is ad-hoc code-signed after download
+(R5.4 / Security), which rewrites the Mach-O so its installed bytes no longer
+equal the manifest `sha256`. To keep reruns cheap there, the installer also skips
+a component whose on-disk hash equals the **installed hash it recorded last run
+for the same manifest `sha256`** (R6.1). Keying on the manifest hash is
+load-bearing: a new release changes `sha256`, so the recorded row no longer
+matches the current `want` and the (now stale) signed file is re-downloaded
+instead of being wrongly judged up to date — the signed bytes would otherwise
+still equal the old recorded installed hash forever. The record is only ever a
+positive-match optimization; a deleted or tampered file matches nothing and is
+reinstalled.
+
 **R5.2** — Otherwise the artifact is downloaded from `<BUCKET>/<src>` to a
 temp sibling **in the destination directory** (`<dest>.tmp.$$`), so the final
 rename is same-filesystem and atomic.
@@ -237,13 +249,22 @@ mv -f "$target.tmp.$$" "$target"
   download-count stub).
 - **Test**: A manifest whose `sha256` disagrees with the served artifact exits
   non-zero and leaves no file (and no `.tmp.` file) at the destination.
+- **Test** (macOS staleness): after a signed-`bin` install, a rerun against the
+  *same* manifest performs zero downloads and no re-sign, but a rerun against a
+  manifest whose `sha256` for that component *changed* re-downloads and re-signs
+  it — the recorded installed hash does not mask a new release.
 
 ### Unit 6 — Install record and PATH advisory
 
 **R6.1** — After a successful run the installer writes a record of what it
-installed to `<state>/installed` — the resolved `(component, dest, sha256)`
-rows for this platform. The record enables future uninstall and surfaces
-prefix drift if `XDG_*` variables change between runs.
+installed to `<state>/installed` — the resolved
+`(component, dest, manifest-sha256, installed-sha256)` rows for this platform,
+tab-delimited. `manifest-sha256` is the artifact's `sha256` from the manifest;
+`installed-sha256` is the SHA-256 of the bytes actually on disk, which equals
+`manifest-sha256` except for a macOS-signed `bin` file. Pairing the two is what
+lets the R5.1 signed-file skip stay correct across releases (skip only while the
+manifest still wants that artifact). The record also enables uninstall (Units
+7–8) and surfaces prefix drift if `XDG_*` variables change between runs.
 
 **R6.2** — If the resolved `bin` directory is not on `$PATH`, the installer
 prints an advisory telling the user to add it — it does **not** silently edit
@@ -258,8 +279,10 @@ any shell rc file.
 
 ## Non-Goals
 
-- **Uninstall.** The install record (R6.1) is written to enable it later; the
-  uninstall command itself is out of scope.
+- **Uninstall.** ~~The install record (R6.1) is written to enable it later; the
+  uninstall command itself is out of scope.~~ Now specified below — see
+  [Uninstaller](#uninstaller). The install record (R6.1) is the sole authority
+  for what to remove.
 - **Multi-file / archive components.** v1 handles `kind = file` single files only.
   The `kind` column reserves room for archive kinds without a format break.
 - **Signing/verification beyond TLS + SHA-256.** See Security Considerations for
@@ -360,3 +383,221 @@ architecture record; design rationale is captured above.
    the current `stable` binaries into temp prefixes; a second run performs zero
    downloads; corrupting one on-disk binary makes the next run re-fetch only that
    component.
+
+---
+
+# Uninstaller
+
+## Context
+
+The installer places files (R5) and, after each successful run, records exactly
+what it placed: `<state>/installed` holds one **tab-delimited** row per installed
+component variant, `component<TAB>dest<TAB>manifest-hash<TAB>installed-hash`, where
+`dest` is the **absolute** on-disk path and `installed-hash` is the SHA-256 of the
+bytes actually written there (R6.1). On macOS that hash is the *post-signing*
+digest of an ad-hoc-signed `bin` file, which deliberately diverges from the
+manifest `sha256` (see R5.1 and `install.sh`'s signing note). Uninstall reads only
+`dest` and `installed-hash`; the `manifest-hash` column is for the installer's
+rerun skip check (R5.1) and is unused here.
+
+That record is a complete, self-contained inventory of the installer's
+footprint. An uninstaller does not need the network, the bucket, the manifest, or
+even to know which version is installed: it walks the record and undoes it. This
+mirrors the installer's guiding principle — **the recorded/on-disk hash is the
+oracle** — applied in reverse: only remove a file the installer wrote and that is
+still byte-for-byte what it wrote.
+
+## Introduction/Overview
+
+Uninstall is a **mode of the same `install.sh` script**, entered with
+`--uninstall` as the first argument, so there is one published URL and one script
+to maintain and the two modes share environment probing (SHA-256 tool, prefix
+resolution) and the path-safety discipline. It is offline: no downloader is
+required or invoked.
+
+```sh
+curl --proto '=https' --tlsv1.2 -fsSL <URL>/install.sh | sh -s -- --uninstall
+# or, if the script is already on disk:
+sh install.sh --uninstall [--dry-run] [--force] [--purge]
+```
+
+For each recorded component the uninstaller re-hashes the file at `dest` and,
+**only if it matches the recorded `installed-hash`**, removes it; a file that is
+missing is counted and skipped, and a file whose bytes have changed is left in
+place (the user edited or replaced it) unless `--force` is given. It then removes
+the record itself and prunes now-empty `minimal`-owned directories. The operation
+is idempotent: a second `--uninstall` finds no record and is a clean no-op.
+
+## Goals
+
+1. A single `… | sh -s -- --uninstall` removes every file the installer placed
+   for this host, using only the local install record — no network, no bucket,
+   no manifest.
+2. It never deletes a file the installer did not write, and never a file the user
+   has since modified or replaced (unless `--force`).
+3. It is idempotent and safe to interrupt: a partial or repeated run never errors
+   out and never removes something outside the recorded footprint.
+4. `--dry-run` shows precisely what would be removed without touching anything.
+
+## User Stories
+
+- **As a user who wants minimal gone**, I run the documented `--uninstall` line
+  and every binary and data file the installer placed is removed, with a summary
+  of what went and what was kept.
+- **As a user who hand-patched a binary**, I run `--uninstall` and my modified
+  file is reported as *kept* (its hash no longer matches the record), not silently
+  deleted.
+- **As a user reclaiming disk**, I add `--purge` to also delete the `minimal`
+  data/state/cache trees, not just the recorded files.
+
+## Demoable Units of Work
+
+### Unit 7 — Uninstall dispatch and record walk
+
+**R7.1** — When the first argument is `--uninstall`, the script enters uninstall
+mode **before** target validation (R2.1) — `--uninstall` otherwise passes the
+target charset and would be fetched as a bogus target. In this mode the downloader
+probe (R1.1) is skipped/made lazy: an uninstall must succeed on a host with no
+`curl`/`wget`. The SHA-256 tool (R1.2), platform probe (R1.3), and prefix
+resolution (R4.1) are still required. `--uninstall` is mutually exclusive with a
+target argument.
+
+**R7.2** — The record is located at `<state>/installed` via the same
+`resolve_prefix state` used to write it (R6.1), so an `XDG_STATE_HOME` set at
+uninstall time resolves identically. If the record is absent, the uninstaller
+prints "nothing to uninstall (no install record at …)" and exits **0** — absence
+is success, not an error.
+
+**R7.3** — Each record row is parsed with tab as the field separator
+(`awk -F'\t'` / `read -r … <TAB>`), never default whitespace splitting, because a
+`dest` under a `$HOME` containing spaces is legal. Taking `dest` and
+`installed-hash` from each `(component, dest, manifest-hash, installed-hash)` row:
+
+- `dest` **absent** → counted as *already removed*, skipped.
+- `dest` is **not a regular file** (a symlink or directory now occupies the
+  path) → left in place with a warning; the installer only ever writes regular
+  files, so something else owns this path.
+- `dest` present, a regular file, and `sha256(dest) == installed-hash` → removed.
+- `dest` present but `sha256(dest) != installed-hash` → the file was modified or
+  replaced since install; **left in place** with a warning by default, removed
+  only under `--force`.
+
+**R7.4** — The comparison is against the recorded `installed-hash`, **not** the
+manifest `sha256` (which the uninstaller does not have offline). This is what
+lets a macOS ad-hoc-signed `bin` file — whose on-disk bytes diverge from the
+manifest — still match and be recognized as ours.
+
+**Proof artifacts**:
+
+- **Test**: After an install into temp prefixes, `--uninstall` removes every
+  recorded file and reports the count; the destinations no longer exist.
+- **Test**: A recorded file whose bytes are altered before `--uninstall` is
+  **kept** (reported as modified) and removed only when `--force` is added.
+- **Test**: A record listing a `dest` that has already been deleted causes
+  `--uninstall` to exit 0, counting it as already-removed, with no error.
+
+### Unit 8 — Record teardown, directory pruning, and purge
+
+**R8.1** — After the walk, the record file is removed **only if the footprint is
+fully gone** — every recorded file removed or already absent. If anything was
+kept (a modified file under R7.3, or a foreign path), the record is **retained**
+so a later `--force` or manual cleanup still has the inventory to work from;
+re-running is idempotent because already-removed rows re-classify as
+already-absent. Teardown happens after the walk (not before) for the same reason:
+an interrupted run leaves the inventory intact for the retry. Then each
+`minimal`-owned directory that the installer may have created is removed **only
+if empty**, via `rmdir` (never `rm -rf`): the `data`, `state`, and `cache`
+prefixes resolve to `.../minimal` subdirectories the installer owns, and the
+`bin` prefix (`~/.local/bin`) is shared with other tools so it is `rmdir`ed only
+when empty and otherwise left untouched. Pruning failures (a non-empty dir) are
+ignored, not fatal.
+
+**R8.2** — `--purge` additionally removes the `minimal`-owned trees in full —
+the resolved `data`, `state`, and `cache` directories and everything under them
+(build cache included) — because those live at fixed `.../minimal` paths the tool
+owns exclusively. `--purge` never touches the shared `bin` directory beyond the
+empty-`rmdir` of R8.1, and never removes individual files outside those
+`minimal`-owned roots.
+
+**R8.3** — `--dry-run` (accepted in uninstall mode) prints each planned removal
+and prune, prefixed to make it unmistakable, and touches nothing — no file
+removed, record left intact. It composes with `--force`/`--purge` to preview
+their effect.
+
+**R8.4** — The run prints a summary: counts of *removed*, *already-absent*,
+*kept (modified)*, and *kept (not a regular file)*, plus which directories were
+pruned. A run that kept files because they were modified still exits **0** (it did
+what was asked); only an unexpected internal failure is non-zero.
+
+**Proof artifacts**:
+
+- **Test**: After `--uninstall`, `<state>/installed` is gone and an emptied
+  `data`/`state` dir is `rmdir`ed, while a `bin` dir still holding an unrelated
+  file is left in place.
+- **Test**: `--dry-run` against a populated record removes nothing and leaves the
+  record; a subsequent plain `--uninstall` then removes everything.
+- **Test**: With a stray build artifact under the `cache` prefix, plain
+  `--uninstall` leaves the cache tree; `--purge` removes it.
+
+## Non-Goals (uninstaller)
+
+- **Reconstructing the footprint from the manifest.** The local record is the
+  only authority. If it is missing, uninstall is a no-op — the uninstaller never
+  fetches a manifest and deletes by guessing which paths *would have* been
+  written, which could clobber unrelated files at those paths.
+- **Removing PATH edits.** The installer never edits shell rc files (R6.2), so
+  there is nothing of that kind to undo.
+- **Cross-prefix drift recovery.** If `XDG_*`/`MINIMAL_BIN` differ between install
+  and uninstall, the record's **absolute** `dest` paths are still removed
+  correctly, but directory pruning (R8.1) targets the *currently* resolved
+  prefixes; a stale, differently-resolved empty dir may remain. Surfacing that is
+  out of scope.
+
+## Design Considerations (uninstaller)
+
+**Why a mode of `install.sh`, not a separate script.** One published URL, one
+script to keep POSIX-clean and shellcheck-green, and direct reuse of
+`resolve_prefix`, the SHA-256 wrapper, and the path-safety `case`s. The cost is a
+small dispatch at the top of `main`; the alternative — a second script — would
+duplicate all of environment probing and drift out of sync.
+
+**Hash-verify before delete.** The symmetric counterpart to the install skip
+oracle (R5.1). Removing only files whose current bytes equal what we recorded
+writing means a user who replaced a binary with their own build, or whose file
+was touched by another tool, never loses data to `--uninstall`. `--force` exists
+for the "I know, remove it anyway" case.
+
+**Record deleted last.** Files are removed first, the record last, so an
+interrupted run can be re-run: rows already removed re-classify as
+*already-absent* (R7.3) and the run completes. Deleting the record first would
+strand any not-yet-removed files with no inventory to find them by.
+
+**`rmdir`, never `rm -rf`, for shared paths.** `~/.local/bin` holds other tools'
+binaries; an empty-only `rmdir` can never take them. Full-tree deletion is gated
+behind explicit `--purge` and confined to the `.../minimal` roots the tool owns.
+
+## Security Considerations (uninstaller)
+
+- **Trust boundary is the local record.** The record lives in the user's own
+  `state` dir and lists absolute paths the installer itself wrote through the
+  validated `resolve_prefix` + subpath checks (R4). The uninstaller does not
+  re-derive paths from any network input. As defense in depth it still refuses to
+  remove a `dest` that is not a regular file (R7.3), so a symlink swapped in at a
+  recorded path is not followed into deleting something else.
+- **No privilege escalation.** Like the installer, uninstall runs as the user and
+  writes only under user-owned prefixes; it never invokes `sudo`.
+- **`--force`/`--purge` are opt-in.** The destructive behaviors (removing modified
+  files; deleting whole `minimal` trees) require an explicit flag; the default is
+  the conservative, hash-verified removal of the exact recorded footprint.
+
+## Verification (uninstaller)
+
+1. **Static/conformance**: the same `shellcheck --shell=sh` and `dash` CI gates
+   cover the added uninstall path.
+2. **Unit tests** (Units 7–8): dispatch and record-absent no-op; hash-verified
+   removal; modified-file keep vs `--force`; already-absent idempotency;
+   non-regular-file refusal; record teardown and empty-dir pruning; `--dry-run`
+   removing nothing; `--purge` clearing the owned trees.
+3. **End-to-end**: `install` into temp prefixes, then `--uninstall` leaves the
+   prefixes free of every recorded file and removes the record; a second
+   `--uninstall` is a clean no-op exiting 0.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,12 @@
 # Usage:
 #   curl --proto '=https' --tlsv1.2 -fsSL <URL>/install.sh | sh
 #   curl … | sh -s -- unstable          # pick a non-default target
+#   curl … | sh -s -- --uninstall       # remove what a prior run installed
+#
+# Uninstall walks the local install record (no network) and removes each file
+# whose on-disk bytes still match what the installer recorded writing; it accepts
+# --force (remove modified files too), --purge (also delete the minimal data/
+# state/cache trees), and --dry-run. See Units 7–8 of the spec.
 #
 # The script targets strict POSIX `sh` (not bash): it runs identically under
 # dash, macOS's frozen bash 3.2, busybox, and zsh-invoked-sh. It depends only on
@@ -38,16 +44,42 @@ SUPPORTED_FORMAT=1
 say() { printf '%s\n' "$*" >&2; }
 die() { printf 'install: %s\n' "$*" >&2; exit 1; }
 
+# --- Mode dispatch: install (default) vs uninstall (R7.1) ------------------
+
+# `--uninstall` as the FIRST argument switches to uninstall mode; it is parsed
+# here, before the target charset check (R2.1), because `--uninstall` otherwise
+# validates as a target and would be fetched as one. Uninstall is offline and
+# takes its own flags; install mode's sole positional is the target, left in `$@`
+# for Unit 2. The two modes are mutually exclusive.
+MODE=install
+uninstall_force=0
+uninstall_purge=0
+dry_run=0
+if [ "${1-}" = "--uninstall" ]; then
+    MODE=uninstall
+    shift
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --force)      uninstall_force=1 ;;
+            --purge)      uninstall_purge=1 ;;
+            -n|--dry-run) dry_run=1 ;;
+            *)            die "unknown uninstall option '$1' (allowed: --force, --purge, --dry-run)" ;;
+        esac
+        shift
+    done
+fi
+
 # --- Unit 1: environment probing (downloader, hasher, platform) ------------
 
 # R1.1 — prefer curl, else wget. Both enforce HTTPS + TLS 1.2 and refuse a
-# redirect that would downgrade the scheme.
+# redirect that would downgrade the scheme. Uninstall never fetches (R7.1), so a
+# missing downloader is fatal only in install mode.
 DL_TOOL=
 if command -v curl >/dev/null 2>&1; then
     DL_TOOL=curl
 elif command -v wget >/dev/null 2>&1; then
     DL_TOOL=wget
-else
+elif [ "$MODE" = install ]; then
     die "need a downloader: neither curl nor wget found on PATH"
 fi
 
@@ -115,6 +147,125 @@ resolve_prefix() {
     esac
 }
 
+# --- Units 7+8: uninstall (walk the install record and undo it) ------------
+
+# Offline teardown driven solely by the local install record (R6.1). The record
+# is a tab-delimited table of `component<TAB>dest<TAB>manifest-hash<TAB>installed-hash`
+# rows, where `dest` is absolute and `installed-hash` is the SHA-256 of the bytes
+# actually written (the post-sign digest for a macOS `bin` file). Uninstall keys
+# off `installed-hash`; the manifest-hash column is unused here. A file is removed
+# only if it is still byte-for-byte what we recorded writing (R7.3/R7.4), so a
+# user's edited or replaced file is kept unless --force. Runs entirely on local
+# state: no network, manifest, or bucket.
+do_uninstall() {
+    state_dir="$(resolve_prefix state)"
+    record="$state_dir/installed"
+
+    # R7.2 — no record means nothing to undo (or it is already gone). Absence is
+    # success, so a second --uninstall is a clean no-op.
+    if [ ! -f "$record" ]; then
+        say "uninstall: nothing to uninstall (no install record at $record)"
+        return 0
+    fi
+    [ "$dry_run" -eq 1 ] && say "uninstall: dry run — nothing will be removed"
+
+    # Tab, computed once, so rows are split on tab alone (R7.3): a dest under a
+    # $HOME containing spaces must still parse as one field.
+    tab="$(printf '\t')"
+    removed=0 absent=0 kept_modified=0 kept_foreign=0
+
+    # `comp` is informational here and the manifest-hash column (`_`) is unused;
+    # `dest`/`want` (the installed hash) drive removal. Read from the record via
+    # redirection so the loop body runs in this shell (counters persist).
+    while IFS="$tab" read -r comp dest _ want; do
+        [ -n "$dest" ] || continue
+
+        # Already gone (not even a dangling symlink) — count and continue, which
+        # is what makes an interrupted run re-runnable (R7.3).
+        if [ ! -e "$dest" ] && [ ! -L "$dest" ]; then
+            say "  $comp: already removed"
+            absent=$((absent + 1))
+            continue
+        fi
+
+        # The installer only ever writes regular files. A symlink or directory
+        # now at this path is something else — never follow it into a delete.
+        if [ -L "$dest" ] || [ ! -f "$dest" ]; then
+            say "  $comp: kept ($dest is not a regular file the installer wrote)"
+            kept_foreign=$((kept_foreign + 1))
+            continue
+        fi
+
+        # R7.3/R7.4 — remove only if the on-disk bytes still equal the recorded
+        # installed-hash (matches a macOS ad-hoc-signed bin), unless --force.
+        if [ "$(sha256 "$dest")" != "$want" ] && [ "$uninstall_force" -eq 0 ]; then
+            say "  $comp: kept (modified since install; pass --force to remove)"
+            kept_modified=$((kept_modified + 1))
+            continue
+        fi
+
+        if [ "$dry_run" -eq 1 ]; then
+            say "  $comp: would remove $dest"
+        else
+            rm -f "$dest" || die "failed to remove $dest"
+            say "  $comp: removed $dest"
+        fi
+        removed=$((removed + 1))
+    done <"$record"
+
+    # R8.1 — teardown AFTER the walk. Remove the record only once the footprint is
+    # fully gone; if anything was kept (modified or foreign), retain it so a later
+    # `--force`/manual cleanup still has the inventory to work from. Re-running is
+    # idempotent: already-removed rows re-classify as already-gone.
+    if [ "$kept_modified" -ne 0 ] || [ "$kept_foreign" -ne 0 ]; then
+        say "  kept install record $record (unremoved entries remain)"
+    elif [ "$dry_run" -eq 1 ]; then
+        say "  would remove install record $record"
+    else
+        rm -f "$record"
+    fi
+
+    # R8.2 — --purge additionally deletes the minimal-owned trees wholesale (build
+    # cache included); they live at fixed .../minimal paths the tool owns. It
+    # never removes files outside those roots.
+    if [ "$uninstall_purge" -eq 1 ]; then
+        for p in data state cache; do
+            d="$(resolve_prefix "$p")"
+            [ -d "$d" ] || continue
+            if [ "$dry_run" -eq 1 ]; then
+                say "  would purge $d"
+            else
+                rm -rf "$d"
+            fi
+        done
+    fi
+
+    # R8.1 — prune now-empty minimal-owned dirs with rmdir only (never rm -rf):
+    # the shared bin dir is removed only if empty, and a non-empty dir fails
+    # rmdir harmlessly. --purge (above) already cleared the data/state/cache trees.
+    if [ "$dry_run" -eq 0 ]; then
+        for p in bin data state cache; do
+            d="$(resolve_prefix "$p")"
+            if [ -d "$d" ]; then
+                rmdir "$d" 2>/dev/null || true
+            fi
+        done
+    fi
+
+    # R8.4 — a run that merely kept modified files still did what was asked; only
+    # an unexpected internal failure (via set -e / die) is non-zero.
+    say "uninstall: $removed removed, $absent already gone, $kept_modified kept (modified), $kept_foreign kept (foreign)"
+    [ "$dry_run" -eq 1 ] && say "uninstall: dry run — nothing was actually removed"
+    return 0
+}
+
+# R7.1 — dispatch uninstall before any target/manifest work. resolve_prefix and
+# the SHA/platform probes above are all it needs; it never reaches Unit 2.
+if [ "$MODE" = uninstall ]; then
+    do_uninstall
+    exit 0
+fi
+
 # --- Unit 2: target -> version -> manifest resolution ----------------------
 
 # R2.1 — optional first argument, the target, defaulting to `stable`. The
@@ -174,20 +325,29 @@ records="$tmpdir/installed"
 installed=0 skipped=0
 
 # The prior run's install record (R6.1) maps each component to the hash of the
-# file it actually placed on disk. On macOS a `bin` file is ad-hoc code-signed
-# after download (see below), so its installed bytes — and hash — differ from
-# the manifest `sha256`; this lets a signed component be recognized as already
-# installed without re-downloading. It is only a positive-match optimization: a
-# deleted or tampered file matches neither hash and is reinstalled, so the
-# on-disk file remains the source of truth (R5.1). Read before the new record is
-# written into place at the end of the run.
+# file it actually placed on disk, paired with the manifest `sha256` that file
+# was built from. On macOS a `bin` file is ad-hoc code-signed after download (see
+# below), so its installed bytes — and hash — differ from the manifest `sha256`;
+# the pairing lets a signed component be recognized as already installed without
+# re-downloading. It is keyed on the manifest hash for exactly that reason: the
+# recorded installed hash only means "up to date" while the manifest still wants
+# the SAME artifact. A new release changes the manifest `sha256`, so the recorded
+# row no longer matches the current `want` and the component is re-downloaded
+# rather than wrongly judged current (the signed on-disk bytes would otherwise
+# still equal the old recorded installed hash). It is only a positive-match
+# optimization: a deleted or tampered file matches nothing and is reinstalled, so
+# the on-disk file remains the source of truth (R5.1). Read before the new record
+# is written into place at the end of the run.
 state_dir="$(resolve_prefix state)"
 prev_record="$state_dir/installed"
+# Emit the installed hash recorded for component $1, but only if the manifest
+# hash recorded alongside it ($3) equals the manifest's current want ($2) — so a
+# signed macOS bin is skipped only when this release wants the same artifact.
 prev_installed_hash() {
     [ -f "$prev_record" ] || return 0
     # Records are tab-delimited; split on tab so a dest containing spaces (e.g. a
-    # $HOME with a space) still parses.
-    awk -F'\t' -v c="$1" '$1==c {print $3; exit}' "$prev_record"
+    # $HOME with a space) still parses. Columns: comp, dest, manifest-sha, installed-sha.
+    awk -F'\t' -v c="$1" -v w="$2" '$1==c && $3==w {print $4; exit}' "$prev_record"
 }
 
 # No field ever contains whitespace (R3.2), so default IFS splitting is exact.
@@ -216,14 +376,16 @@ while read -r comp _ _ _ want kind dest src; do
     target_file="$dir/$subpath"
 
     # R5.1 — the on-disk file is the skip oracle. It is up to date if its hash
-    # matches the manifest `sha256` OR (for a macOS `bin` file we signed last
-    # run) the installed hash recorded then, since signing diverges the bytes.
+    # matches the manifest `sha256` OR (for a macOS `bin` file we signed last run)
+    # the installed hash recorded against THIS manifest hash, since signing
+    # diverges the bytes. Passing `$want` to the lookup is what stops a new
+    # release — whose `want` changed — from matching the old signed file.
     if [ -f "$target_file" ]; then
         on_disk="$(sha256 "$target_file")"
-        if [ "$on_disk" = "$want" ] || [ "$on_disk" = "$(prev_installed_hash "$comp")" ]; then
+        if [ "$on_disk" = "$want" ] || [ "$on_disk" = "$(prev_installed_hash "$comp" "$want")" ]; then
             say "  $comp: up to date"
             skipped=$((skipped + 1))
-            printf '%s\t%s\t%s\n' "$comp" "$target_file" "$on_disk" >>"$records"
+            printf '%s\t%s\t%s\t%s\n' "$comp" "$target_file" "$want" "$on_disk" >>"$records"
             continue
         fi
     fi
@@ -260,9 +422,10 @@ while read -r comp _ _ _ want kind dest src; do
 
     mv -f "$tmp" "$target_file"
     installed=$((installed + 1))
-    # Record the hash of what is actually on disk now (== manifest hash except
-    # for a signed macOS bin file), so a later run recognizes it (R5.1/R6.1).
-    printf '%s\t%s\t%s\n' "$comp" "$target_file" "$(sha256 "$target_file")" >>"$records"
+    # Record the manifest hash paired with the hash actually on disk now (the
+    # latter == manifest hash except for a signed macOS bin file), so a later run
+    # recognizes it only while the manifest still wants this artifact (R5.1/R6.1).
+    printf '%s\t%s\t%s\t%s\n' "$comp" "$target_file" "$want" "$(sha256 "$target_file")" >>"$records"
 done <"$applicable"
 
 # --- Unit 6: install record and PATH advisory ------------------------------

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -345,8 +345,111 @@ run darwin2 "$HD"
 check 0 "$rc" "darwin rerun exits 0"
 check 0 "$(downloads)" "signed darwin bin: rerun downloads nothing"
 want_err "signed darwin bin: not re-codesigned on rerun" grep -q "/bin/minimal" "$root/codesign.calls"
+
+# A NEW release of a signed darwin bin (its manifest sha256 changes) must
+# re-download and re-sign — NOT be judged up to date because the old signed
+# bytes still equal the previously-recorded installed hash. The skip-by-record
+# path is keyed on the manifest hash for exactly this staleness case.
+printf 'darwin-arm64-minimal-body-v2\n' >"$mock/versions/v1/minimal-darwin-arm64-v2"
+h_dmin2="$(hash_file "$mock/versions/v1/minimal-darwin-arm64-v2")"
+awk -v h="$h_dmin2" \
+    '$1=="minimal" && $2=="darwin" {$5=h; $8="versions/v1/minimal-darwin-arm64-v2"} {print}' \
+    "$root/good-components" >"$mock/versions/v1/components"
+reset_dl
+: >"$root/codesign.calls"
+run darwin3 "$HD"
+check 0 "$rc" "darwin new-version rerun exits 0"
+check 1 "$(downloads)" "new manifest hash re-downloads the signed darwin bin (staleness fix)"
+want_ok "new darwin bin is re-codesigned" grep -q "/bin/minimal" "$root/codesign.calls"
+cp "$root/good-components" "$mock/versions/v1/components"   # restore
 PLAT_S=Linux
 PLAT_M=x86_64
+
+# --- Units 7-8: uninstall (walk the install record and undo it) ------------
+# Uninstall is offline and driven solely by the record the install wrote (R6.1).
+# Each scenario seeds a fresh home with a normal linux/amd64 install (placing
+# bin/minimald + bin/minimal and the record), then exercises one uninstall path.
+
+# R7.3/R8.1 — basic uninstall removes every recorded file, the record, and prunes
+# the now-empty owned dirs.
+HU="$root/hu"; mkdir -p "$HU"
+run u_install "$HU"
+check 0 "$rc" "uninstall: seed install exits 0"
+urec="$HU/xdg-state/minimal/installed"
+want_ok "uninstall: seed wrote the record" test -f "$urec"
+run u_basic "$HU" --uninstall
+check 0 "$rc" "uninstall exits 0 (R8.4)"
+want_err "uninstall removed minimald (R7.3)" test -e "$HU/bin/minimald"
+want_err "uninstall removed minimal (R7.3)" test -e "$HU/bin/minimal"
+want_err "uninstall removed the record (R8.1)" test -e "$urec"
+want_ok "uninstall prints a summary" grep -q "uninstall:" "$OUT"
+want_err "empty bin dir pruned (R8.1)" test -d "$HU/bin"
+want_err "empty state dir pruned (R8.1)" test -d "$HU/xdg-state/minimal"
+# R7.2 — a second uninstall (record now gone) is a clean no-op.
+run u_again "$HU" --uninstall
+check 0 "$rc" "second uninstall is a clean no-op (R7.2)"
+want_ok "no-op names the missing record (R7.2)" grep -q "nothing to uninstall" "$OUT"
+
+# R7.3/R7.4 — a file modified since install is KEPT (its bytes no longer match the
+# recorded hash), and the record is retained so --force can still reach it.
+HU2="$root/hu2"; mkdir -p "$HU2"
+run u2_install "$HU2"
+urec2="$HU2/xdg-state/minimal/installed"
+printf 'my own build\n' >"$HU2/bin/minimald"      # user replaced a binary
+run u2_keep "$HU2" --uninstall
+check 0 "$rc" "uninstall with a modified file exits 0 (R8.4)"
+want_ok "modified file kept (R7.3)" test -f "$HU2/bin/minimald"
+want_ok "keep is reported (R7.3)" grep -q "kept (modified" "$OUT"
+want_err "unmodified sibling still removed (R7.3)" test -e "$HU2/bin/minimal"
+want_ok "record retained while entries remain (R8.1)" test -f "$urec2"
+# --force then removes the modified file and, footprint clear, drops the record.
+run u2_force "$HU2" --uninstall --force
+check 0 "$rc" "uninstall --force exits 0"
+want_err "modified file removed under --force (R7.3)" test -e "$HU2/bin/minimald"
+want_err "record removed once footprint is gone (R8.1)" test -e "$urec2"
+
+# R7.2 — uninstall on a home that never installed anything exits 0, does nothing.
+HU3="$root/hu3"; mkdir -p "$HU3"
+run u3_noop "$HU3" --uninstall
+check 0 "$rc" "uninstall with no record exits 0 (R7.2)"
+want_ok "no-op names the missing record" grep -q "nothing to uninstall" "$OUT"
+
+# R8.3 — --dry-run removes nothing and leaves the record; a real run still cleans.
+HU4="$root/hu4"; mkdir -p "$HU4"
+run u4_install "$HU4"
+urec4="$HU4/xdg-state/minimal/installed"
+run u4_dry "$HU4" --uninstall --dry-run
+check 0 "$rc" "uninstall --dry-run exits 0 (R8.3)"
+want_ok "dry-run keeps minimald (R8.3)" test -f "$HU4/bin/minimald"
+want_ok "dry-run keeps the record (R8.3)" test -f "$urec4"
+want_ok "dry-run announces itself (R8.3)" grep -q "dry run" "$OUT"
+run u4_real "$HU4" --uninstall
+want_err "real uninstall after dry-run removes minimald" test -e "$HU4/bin/minimald"
+
+# R8.2 — plain uninstall leaves an unrelated build artifact in the cache tree;
+# --purge removes the whole minimal-owned cache tree.
+HU5="$root/hu5"; mkdir -p "$HU5"
+run u5_install "$HU5"
+stray="$HU5/xdg-cache/minimal/built/deadbeef"
+mkdir -p "$HU5/xdg-cache/minimal/built"; printf 'artifact\n' >"$stray"
+run u5_plain "$HU5" --uninstall
+want_ok "plain uninstall leaves the build cache (R8.2)" test -f "$stray"
+run u5_reinstall "$HU5"
+run u5_purge "$HU5" --uninstall --purge
+check 0 "$rc" "uninstall --purge exits 0"
+want_err "purge removes the cache tree (R8.2)" test -e "$HU5/xdg-cache/minimal"
+
+# R7.3 — a non-regular file now occupying a recorded path is never removed, even
+# with --force (the installer only ever wrote regular files there).
+HU6="$root/hu6"; mkdir -p "$HU6"
+run u6_install "$HU6"
+urec6="$HU6/xdg-state/minimal/installed"
+rm -f "$HU6/bin/minimald"; mkdir -p "$HU6/bin/minimald"   # a dir now sits there
+run u6_foreign "$HU6" --uninstall --force
+check 0 "$rc" "uninstall over a non-regular path exits 0 (R7.3)"
+want_ok "directory at a recorded path is left alone (R7.3)" test -d "$HU6/bin/minimald"
+want_ok "foreign entry is reported (R7.3)" grep -q "not a regular file" "$OUT"
+want_ok "record retained due to the foreign entry (R8.1)" test -f "$urec6"
 
 # ===========================================================================
 echo "# ---"


### PR DESCRIPTION
 * Implement `--uninstall`
 * Fix bug where components with updates were not updated on OSX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline `--uninstall` mode to the installer.
  * Added support for `--force`, `--purge`, and `--dry-run` during uninstall.

* **Bug Fixes**
  * Improved reinstall behavior on macOS so signed binaries are re-downloaded when the installed bytes no longer match the expected release.
  * Uninstall now safely skips modified files unless forced, and handles repeated or empty uninstalls cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->