### PR TITLE
fix(release): tune production load command for finding libkrun

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,12 +228,37 @@ jobs:
                   fi
             - name: Build release minvmd binary
               run: cargo build --release -p minvmd --bin minvmd
-            - name: Print libkrun load command (informational)
-              # Show the name+path minvmd records for libkrun. For the shipped
-              # bin/libkrun.dylib (next to minvmd) to resolve via @loader_path, this
-              # must be an @rpath entry whose basename matches the staged dylib's
-              # install name (see build-libkrun-macos-arm64). Non-gating.
-              run: otool -L target/release/minvmd | grep -i krun || true
+            - name: Point minvmd's libkrun load command at @rpath
+              # Linking against Homebrew's libkrun bakes its ABSOLUTE install name
+              # (/opt/homebrew/opt/libkrun/lib/libkrun.1.dylib) into minvmd as the
+              # load command. dyld resolves an absolute load command directly and
+              # NEVER consults the rpath, so the shipped bin/libkrun.1.dylib next to
+              # minvmd is ignored and the binary is unloadable on a host without that
+              # exact Homebrew keg. Rewrite the load command to `@rpath/…` so dyld
+              # walks minvmd's rpath instead: `@loader_path` (the adjacent shipped
+              # dylib) first, then `/opt/homebrew/lib` as a fallback (see the minvmd
+              # build.rs rpath ordering). Derive the current path from otool rather
+              # than hardcoding it, so a libkrun version/path bump can't silently
+              # skip the rewrite. install_name_tool invalidates the ad-hoc signature,
+              # so re-sign (the installer re-signs on download too, but keep the
+              # artifact valid in the meantime).
+              run: |
+                  current="$(otool -L target/release/minvmd | awk '/libkrun/ {print $1; exit}')"
+                  if [ -z "$current" ]; then
+                    echo "::error::minvmd has no libkrun load command; did it link the stub?" >&2
+                    exit 1
+                  fi
+                  install_name_tool -change "$current" @rpath/libkrun.1.dylib target/release/minvmd
+                  codesign --sign - --force target/release/minvmd
+            - name: Verify minvmd loads libkrun via @rpath
+              # Gate the release on the rewrite above having stuck: an absolute or
+              # bare load command here would ship an unloadable binary (this bug).
+              run: |
+                  otool -L target/release/minvmd | grep -i krun
+                  if ! otool -L target/release/minvmd | grep -q '@rpath/libkrun\.1\.dylib'; then
+                    echo "::error::minvmd does not reference @rpath/libkrun.1.dylib; the shipped dylib will not be found" >&2
+                    exit 1
+                  fi
             - name: Build release minimal binary
               run: cargo build --release -p minimal --bin minimal
             - name: Rename binaries with platform suffix

--- a/crates/minvmd/build.rs
+++ b/crates/minvmd/build.rs
@@ -5,16 +5,22 @@
 //! Without that cfg the crate compiles to a runtime-bailing stub and never
 //! links libkrun.
 //!
-//! The rpath always includes a binary-relative entry (`$ORIGIN` /
-//! `@loader_path`) so a relocated release binary finds libkrun's shared objects
-//! shipped next to it. The absolute libkrun prefix is also recorded, except for
-//! a Linux `--release` build (its prefix is an ephemeral build path that must
-//! not leak). A macOS release keeps the prefix because it is the stable Homebrew
-//! lib dir (`/opt/homebrew/lib`), letting the shipped binary resolve
-//! libkrun.dylib on any target that has `brew install slp/krun/libkrun`. On
-//! Linux the standard system lib dirs ([`LINUX_LIB_DIRS`]) are added too, so a
-//! target with a system-installed libkrun resolves it without bundling. See
-//! [`emit_rpaths`] for the full ordering.
+//! The rpath leads with a binary-relative entry (`$ORIGIN` / `@loader_path`) so
+//! a relocated release binary prefers libkrun's shared objects shipped next to
+//! it, and only then falls back to the absolute libkrun prefix. The prefix is
+//! recorded except for a Linux `--release` build (its prefix is an ephemeral
+//! build path that must not leak). A macOS release keeps the prefix because it
+//! is the stable Homebrew lib dir (`/opt/homebrew/lib`), so a host that has
+//! `brew install slp/krun/libkrun` but is missing the shipped dylib still
+//! resolves libkrun. On Linux the standard system lib dirs ([`LINUX_LIB_DIRS`])
+//! are added too, so a target with a system-installed libkrun resolves it
+//! without bundling. See [`emit_rpaths`] for the full ordering.
+//!
+//! dyld only consults these rpaths for a load command that begins with
+//! `@rpath/`. macOS links libkrun by its own (absolute Homebrew) install name,
+//! so the release workflow rewrites minvmd's load command to
+//! `@rpath/libkrun.1.dylib` with `install_name_tool` after the build — that is
+//! what activates the `@loader_path`-first search above.
 //!
 //! - **macOS**: libkrun is always linked (Hypervisor.framework backend). The
 //!   prefix defaults to `/opt/homebrew/lib` (the Homebrew tap install location);
@@ -70,35 +76,42 @@ fn main() {
 }
 
 /// Record the runtime library search paths (rpath) baked into the binary. The
-/// dynamic loader tries them in the order emitted here.
+/// dynamic loader tries them in the order emitted here, so binary-relative comes
+/// FIRST: a libkrun shipped next to the binary must win over any system or
+/// Homebrew copy.
 fn emit_rpaths(target_os: &str, prefix: &str) {
     let is_release = std::env::var("PROFILE").as_deref() == Ok("release");
 
-    // 1. Absolute `{prefix}` — recorded EXCEPT for a Linux `--release` build:
-    //   - Non-release (dev + every e2e CI run use `target/debug/minvmd`): resolve
-    //     libkrun where it was materialized, no LD_LIBRARY_PATH needed.
-    //   - macOS release: KEEP it. On Apple Silicon the prefix is the canonical
-    //     Homebrew lib dir (`/opt/homebrew/lib`) — a stable system path identical
-    //     on any target with `brew install slp/krun/libkrun`, so the shipped binary
-    //     resolves libkrun.dylib directly with no bundling. dyld consults this
-    //     rpath when the dylib's install name is `@rpath/...`, and ignores it
-    //     harmlessly when the install name is already absolute.
-    //   - Linux release: DROP it — the prefix is an ephemeral build path (e.g.
-    //     `$HOME/.krun`) that must not leak into the artifact; entries 2 and 3
-    //     below cover that binary instead.
-    if !is_release || target_os == "macos" {
-        rpath(prefix);
-    }
-
-    // 2. Binary-relative (`$ORIGIN` on Linux, `@loader_path` on macOS) — lets a
-    //    RELOCATED binary find libkrun's shared objects shipped alongside it. It
-    //    reaches the linker as a literal argv token (no shell expansion here), so
-    //    it is recorded verbatim.
+    // 1. Binary-relative (`@loader_path` on macOS, `$ORIGIN` on Linux) — FIRST,
+    //    so a RELOCATED binary prefers libkrun's shared objects shipped alongside
+    //    it (e.g. the release-staged `bin/libkrun.1.dylib` next to minvmd). dyld
+    //    honours this only for an `@rpath/...` load command; on macOS the release
+    //    workflow rewrites minvmd's absolute Homebrew load command to
+    //    `@rpath/libkrun.1.dylib` (install_name_tool) precisely so this entry
+    //    takes effect. Reaches the linker as a literal argv token (no shell
+    //    expansion here), so it is recorded verbatim.
     rpath(if target_os == "macos" {
         "@loader_path"
     } else {
         "$ORIGIN"
     });
+
+    // 2. Absolute `{prefix}` — a FALLBACK consulted only when the binary-relative
+    //    lookup above misses. Recorded EXCEPT for a Linux `--release` build:
+    //   - Non-release (dev + every e2e CI run use `target/debug/minvmd`): resolve
+    //     libkrun where it was materialized, no LD_LIBRARY_PATH needed.
+    //   - macOS release: KEEP it. On Apple Silicon the prefix is the canonical
+    //     Homebrew lib dir (`/opt/homebrew/lib`) — a stable system path identical
+    //     on any target with `brew install slp/krun/libkrun`, so a host missing
+    //     the shipped dylib still resolves libkrun. dyld consults this rpath when
+    //     the load command is `@rpath/...` (see entry 1), and ignores it
+    //     harmlessly when the install name is already absolute.
+    //   - Linux release: DROP it — the prefix is an ephemeral build path (e.g.
+    //     `$HOME/.krun`) that must not leak into the artifact; entries 1 and 3
+    //     cover that binary instead.
+    if !is_release || target_os == "macos" {
+        rpath(prefix);
+    }
 
     // 3. Standard system lib dirs on Linux — lets a target with a system-installed
     //    libkrun resolve it without bundling (the counterpart to macOS reusing the

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -113,11 +113,14 @@ COMPONENTS=(
     # macOS arm64 (darwin)
     "minimal|darwin|arm64|file|bin/minimal|minimal-macos-arm64"
     "minvmd|darwin|arm64|file|bin/minvmd|minvmd-macos-arm64"
-    # The trimmed libkrun.dylib minvmd links against (built from source by the
-    # release workflow's build-release-libkrun-macos-arm64 job). Stamped into
-    # bin/ next to minvmd for now — weird for a dylib, but it puts it on a known
-    # user-owned path the loader can be pointed at; the +x bit bin/ adds is inert.
-    "libkrun|darwin|arm64|file|bin/libkrun.dylib|libkrun-macos-arm64.dylib"
+    # The trimmed libkrun minvmd links against (built from source by the release
+    # workflow's build-libkrun-macos-arm64 job). Stamped into bin/ next to minvmd
+    # for now — weird for a dylib, but it puts it on a known user-owned path the
+    # loader can be pointed at; the +x bit bin/ adds is inert. The basename MUST
+    # be libkrun.1.dylib: minvmd's load command is rewritten to
+    # `@rpath/libkrun.1.dylib` and `@loader_path` (bin/, next to minvmd) is its
+    # first rpath, so the loader looks for exactly this name beside the binary.
+    "libkrun|darwin|arm64|file|bin/libkrun.1.dylib|libkrun-macos-arm64.dylib"
     "gvproxy|darwin|arm64|file|bin/gvproxy|gvproxy-darwin-arm64"
     "initramfs|darwin|arm64|file|data/initramfs.cpio|initramfs-arm64.cpio"
     "rootfs|darwin|arm64|file|data/rootfs.img|rootfs-arm64.img"


### PR DESCRIPTION
More tweaking, trying to get minvmd to find _our_ libkrun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS arm64 release validation so the app now checks that the bundled library reference is correct before publishing.
  * Updated the runtime library path handling to use a more reliable loader-friendly path, reducing launch-time dependency issues.
  * Adjusted the packaged library name and placement to match the expected macOS runtime lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->