### PR TITLE
feat(minvmd): add MINVMD_KRUN_LOG to configure krun debug logging

### DIFF
--- a/crates/minvmd/src/error.rs
+++ b/crates/minvmd/src/error.rs
@@ -35,6 +35,12 @@ pub enum VmError {
     /// A required environment variable was unset or empty.
     MissingEnv { var: &'static str },
 
+    /// The `MINVMD_KRUN_LOG` environment variable was set to a value that is
+    /// not a recognised libkrun log level (a name `off`/`error`/`warn`/`info`/
+    /// `debug`/`trace` or the numeric level `0`–`5`). `value` is the offending
+    /// setting.
+    InvalidLogLevel { value: String },
+
     /// A required image could not be located: the override env var was unset or
     /// empty, and no file exists at the default install location. `var` names
     /// the override; `default` is the path that was checked.
@@ -88,6 +94,13 @@ impl fmt::Display for VmError {
             Self::MissingEnv { var } => {
                 write!(f, "required environment variable {var} is unset or empty")
             }
+            Self::InvalidLogLevel { value } => {
+                write!(
+                    f,
+                    "MINVMD_KRUN_LOG value {value:?} is not a valid log level \
+                     (expected off/error/warn/info/debug/trace or 0-5)"
+                )
+            }
             Self::MissingImage { var, default } => {
                 write!(
                     f,
@@ -120,6 +133,7 @@ impl std::error::Error for VmError {
             | Self::NulInString { .. }
             | Self::StartEnterReturnedUnexpectedly { .. }
             | Self::MissingEnv { .. }
+            | Self::InvalidLogLevel { .. }
             | Self::MissingImage { .. }
             | Self::Configuration { .. }
             | Self::InvalidEgressSubnet { .. } => None,

--- a/crates/minvmd/src/krun/ctx.rs
+++ b/crates/minvmd/src/krun/ctx.rs
@@ -13,6 +13,7 @@
 use std::ffi::{CString, c_char};
 use std::path::{Path, PathBuf};
 use std::ptr;
+use std::sync::OnceLock;
 
 use crate::error::VmError;
 use crate::krun::raw;
@@ -29,7 +30,13 @@ pub struct Context {
 
 impl Context {
     /// Create a new libkrun configuration context.
+    ///
+    /// If the `MINVMD_KRUN_LOG` environment variable is set (see
+    /// [`KRUN_LOG_ENV`]), libkrun's logging is configured to stderr at the
+    /// corresponding level before the context is created, so bring-up itself
+    /// is captured.
     pub fn create() -> Result<Self, VmError> {
+        configure_logging_from_env()?;
         // SAFETY: krun_create_ctx takes no arguments and either returns a
         // non-negative ctx_id (owned by the caller until krun_free_ctx) or a
         // negative errno. No pointer or lifetime invariants apply.
@@ -301,6 +308,71 @@ impl Drop for Context {
     }
 }
 
+/// Environment variable that, when set to a non-empty value, configures
+/// libkrun's logging. The value is a level name (`off`, `error`, `warn`,
+/// `info`, `debug`, `trace`; case-insensitive) or the equivalent numeric
+/// level `0`–`5`. Unset or empty leaves libkrun's logging at its default.
+pub const KRUN_LOG_ENV: &str = "MINVMD_KRUN_LOG";
+
+/// Configure libkrun's logging to stderr from [`KRUN_LOG_ENV`], if set.
+///
+/// A no-op when the variable is unset or empty. A set-but-unrecognised value
+/// is a hard error ([`VmError::InvalidLogLevel`]) rather than a silent
+/// fallback, so a typo in the level surfaces at start-up.
+///
+/// `krun_init_log` installs a process-global logger and fails if called more
+/// than once, so the FFI call is memoized through a [`OnceLock`]: the first
+/// configuring `create()` performs it and every caller observes the same
+/// return code. `KRUN_LOG_ENV` is read on each call (it cannot change between
+/// them) so an invalid value is reported consistently even before the logger
+/// would be initialized.
+fn configure_logging_from_env() -> Result<(), VmError> {
+    static LOG_INIT_RET: OnceLock<i32> = OnceLock::new();
+
+    let Some(raw_value) = std::env::var_os(KRUN_LOG_ENV) else {
+        return Ok(());
+    };
+    let value = raw_value.to_string_lossy();
+    if value.trim().is_empty() {
+        return Ok(());
+    }
+    let level = parse_log_level(&value).ok_or_else(|| VmError::InvalidLogLevel {
+        value: value.into_owned(),
+    })?;
+
+    let ret = *LOG_INIT_RET.get_or_init(|| {
+        // SAFETY: krun_init_log takes four values by value (no pointers). The
+        // `target_fd` is libkrun's sentinel for stderr; `level`, `style`, and
+        // `options` are plain integers. Guarded by the enclosing `OnceLock`
+        // so libkrun's install-once logger is initialized at most once.
+        unsafe {
+            raw::krun_init_log(
+                raw::LOG_TARGET_DEFAULT,
+                level as u32,
+                raw::LOG_STYLE_AUTO,
+                raw::LOG_OPTIONS_DEFAULT,
+            )
+        }
+    });
+    raw::check_backend("krun_init_log", ret)?;
+    Ok(())
+}
+
+/// Map a [`KRUN_LOG_ENV`] value to a [`raw::LogLevel`], accepting either a
+/// case-insensitive level name or the numeric level `0`–`5`.
+fn parse_log_level(value: &str) -> Option<raw::LogLevel> {
+    use raw::LogLevel;
+    match value.trim().to_ascii_lowercase().as_str() {
+        "off" | "0" => Some(LogLevel::Off),
+        "error" | "1" => Some(LogLevel::Error),
+        "warn" | "2" => Some(LogLevel::Warn),
+        "info" | "3" => Some(LogLevel::Info),
+        "debug" | "4" => Some(LogLevel::Debug),
+        "trace" | "5" => Some(LogLevel::Trace),
+        _ => None,
+    }
+}
+
 /// Build a `CString` from a path, mapping interior NULs to a typed error.
 fn cstring_from_path(path: &Path, what: &'static str) -> Result<CString, VmError> {
     // Use OsStr bytes on Unix; libkrun only ships on Unix (macOS/Linux) so we
@@ -365,5 +437,31 @@ mod tests {
         let items = ["ok", "ba\0d", "also-ok"];
         let err = cstrings_from_strs(&items, "argv").unwrap_err();
         assert!(matches!(err, VmError::NulInString { what: "argv", .. }));
+    }
+
+    #[test]
+    fn parse_log_level_accepts_names_case_insensitively() {
+        use raw::LogLevel;
+        assert_eq!(parse_log_level("off"), Some(LogLevel::Off));
+        assert_eq!(parse_log_level("Error"), Some(LogLevel::Error));
+        assert_eq!(parse_log_level("WARN"), Some(LogLevel::Warn));
+        assert_eq!(parse_log_level("  info  "), Some(LogLevel::Info));
+        assert_eq!(parse_log_level("debug"), Some(LogLevel::Debug));
+        assert_eq!(parse_log_level("trace"), Some(LogLevel::Trace));
+    }
+
+    #[test]
+    fn parse_log_level_accepts_numeric_levels() {
+        use raw::LogLevel;
+        assert_eq!(parse_log_level("0"), Some(LogLevel::Off));
+        assert_eq!(parse_log_level("3"), Some(LogLevel::Info));
+        assert_eq!(parse_log_level("5"), Some(LogLevel::Trace));
+    }
+
+    #[test]
+    fn parse_log_level_rejects_unknown_values() {
+        assert_eq!(parse_log_level("verbose"), None);
+        assert_eq!(parse_log_level("6"), None);
+        assert_eq!(parse_log_level(""), None);
     }
 }

--- a/crates/minvmd/src/krun/mod.rs
+++ b/crates/minvmd/src/krun/mod.rs
@@ -19,4 +19,4 @@ mod ctx;
 mod raw;
 
 pub use ctx::Context;
-pub use raw::{DiskFormat, KernelFormat};
+pub use raw::{DiskFormat, KernelFormat, LogLevel};

--- a/crates/minvmd/src/krun/raw.rs
+++ b/crates/minvmd/src/krun/raw.rs
@@ -8,7 +8,7 @@
 //! ([`crate::build`]) emits the link-search and rpath; we declare the link
 //! requirement here so it travels with the symbols themselves.
 
-use std::ffi::c_char;
+use std::ffi::{c_char, c_int};
 use std::io;
 
 use crate::error::VmError;
@@ -43,6 +43,32 @@ pub enum DiskFormat {
     Raw = 0,
 }
 
+/// Log verbosity for `krun_init_log`. Values match the `KRUN_LOG_LEVEL_*`
+/// constants in libkrun.h; higher is more verbose.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LogLevel {
+    Off = 0,
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+    Debug = 4,
+    Trace = 5,
+}
+
+/// `KRUN_LOG_TARGET_DEFAULT`: the `target_fd` value directing `krun_init_log`
+/// at libkrun's default sink (stderr).
+pub const LOG_TARGET_DEFAULT: c_int = -1;
+
+/// `KRUN_LOG_STYLE_AUTO`: auto-detect whether the target supports terminal
+/// colour escape sequences.
+pub const LOG_STYLE_AUTO: u32 = 0;
+
+/// Default (empty) `options` bitmask for `krun_init_log`. Notably this leaves
+/// libkrun's own env-var overrides enabled (as opposed to
+/// `KRUN_LOG_OPTION_NO_ENV`).
+pub const LOG_OPTIONS_DEFAULT: u32 = 0;
+
 // SAFETY: every function in this block is an `extern "C"` declaration that
 // inherits its safety contract from libkrun.h. Specifically:
 //
@@ -76,6 +102,15 @@ unsafe extern "C" {
     /// Free a previously created context. Returns 0 on success or a negative
     /// errno on failure. Safe to call exactly once per `krun_create_ctx`.
     pub fn krun_free_ctx(ctx_id: u32) -> i32;
+
+    /// Initialize the library's logging. Global (not per-context) and NOT
+    /// idempotent — the underlying logger can only be installed once per
+    /// process, so a second call fails. `target_fd` selects the sink
+    /// (`KRUN_LOG_TARGET_DEFAULT` = stderr); `level` is one of
+    /// `KRUN_LOG_LEVEL_*` (0=off … 5=trace); `style` is one of
+    /// `KRUN_LOG_STYLE_*`; `options` is a bitmask (`0` = defaults). Returns 0
+    /// on success or a negative errno on failure.
+    pub fn krun_init_log(target_fd: c_int, level: u32, style: u32, options: u32) -> i32;
 
     /// Set the microVM's basic config: vcpu count and RAM in MiB.
     pub fn krun_set_vm_config(ctx_id: u32, num_vcpus: u8, ram_mib: u32) -> i32;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring libkrun logging through an environment variable.
  * Accepted log levels now include both named values and numeric values.
  * Logging initialization is now set up automatically before the runtime context is created.

* **Bug Fixes**
  * Clearer errors are shown when an invalid log level is provided.
  * Empty or unrecognized log values are now rejected consistently.

* **Tests**
  * Added coverage for valid and invalid log level parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->