### PR TITLE
feat(minvmd,minimald): per-VM writable /dev/vdb ext4 volume (#583 Unit 1)

### DIFF
--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -149,6 +149,17 @@ jobs:
         # `minimal` CLI build it drives is incremental.
         run: ./scripts/fetch-libkrun.sh "$KRUN_PREFIX" x86_64
 
+      - name: Assert libkrun exports krun_add_disk3 (>= 1.19.0)
+        # krun_add_disk3 (this PR's /dev/vdb attach) needs libkrun >= 1.19.0. Fail
+        # loudly here rather than with a cryptic runtime error at VM boot if the
+        # materialized upstream libkrun is too old.
+        run: |
+          so="$(ls "$KRUN_PREFIX"/libkrun.so* 2>/dev/null | head -1)"
+          test -n "$so" || { echo "::error::no libkrun.so under $KRUN_PREFIX"; exit 1; }
+          nm -D "$so" 2>/dev/null | grep -q krun_add_disk3 \
+            || { echo "::error::materialized libkrun ($so) does not export krun_add_disk3; need >= 1.19.0"; exit 1; }
+          echo "libkrun OK: $so exports krun_add_disk3"
+
       - name: Materialize gvproxy switch binary (DM1 relay)
         # The DM1 gvproxy relay e2e (vsock_relay_e2e) spawns this per-host switch
         # binary; pin-verified, no Go toolchain. Publish its path for the gated

--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -174,6 +174,34 @@ jobs:
           MINVMD_BOOT_LOG: ${{ runner.temp }}/boot.log
         run: cargo test -p minvmd --test boot_e2e -- --include-ignored --nocapture
 
+      - name: Volume E2E (R1.4/R1.5/R1.6 — /dev/vdb mount, relocation, persistence)
+        # Boot with a writable data volume attached and assert the guest formats +
+        # mounts /dev/vdb at /var/lib/minimal and relocates cache/state onto it.
+        # READY alone is insufficient — Unit 1 falls back to tmpfs on mount
+        # failure — so assert the guest boot log. A second boot on the same image
+        # must reuse it (no reformat, no ext4 `bad geometry`), guarding superblock
+        # idempotency + the mkfs margin that absorbs libkrun's backing-file trailer
+        # shave. The provisioned image must stay sparse (allocate-on-write).
+        env:
+          MINVMD_DATA_VOLUME_PATH: ${{ runner.temp }}/data-vol.raw
+          MINVMD_VOLUME_BYTES: "2147483648"
+        run: |
+          img="$MINVMD_DATA_VOLUME_PATH"; rm -f "$img"
+          echo "=== boot 1 (fresh volume: format + mount) ==="
+          MINVMD_BOOT_LOG="$RUNNER_TEMP/vol1.log" cargo test -p minvmd --test boot_e2e -- --include-ignored --nocapture
+          grep -q "formatting data volume" "$RUNNER_TEMP/vol1.log" || { echo "::error::boot 1 did not format /dev/vdb"; tail -60 "$RUNNER_TEMP/vol1.log"; exit 1; }
+          grep -q "mounted writable state volume" "$RUNNER_TEMP/vol1.log" || { echo "::error::R1.5: /dev/vdb was not mounted"; tail -60 "$RUNNER_TEMP/vol1.log"; exit 1; }
+          grep -q "relocated onto /dev/vdb" "$RUNNER_TEMP/vol1.log" || { echo "::error::R1.6: cache/state not relocated"; tail -60 "$RUNNER_TEMP/vol1.log"; exit 1; }
+          echo "=== boot 2 (reuse volume: no reformat, no bad geometry) ==="
+          MINVMD_BOOT_LOG="$RUNNER_TEMP/vol2.log" cargo test -p minvmd --test boot_e2e -- --include-ignored --nocapture
+          grep -q "mounted writable state volume" "$RUNNER_TEMP/vol2.log" || { echo "::error::boot 2 failed to mount the existing volume"; tail -60 "$RUNNER_TEMP/vol2.log"; exit 1; }
+          ! grep -q "formatting data volume" "$RUNNER_TEMP/vol2.log" || { echo "::error::boot 2 reformatted (superblock idempotency broken)"; exit 1; }
+          ! grep -qi "bad geometry" "$RUNNER_TEMP/vol2.log" || { echo "::error::ext4 bad geometry on reboot (mkfs margin regressed)"; tail -60 "$RUNNER_TEMP/vol2.log"; exit 1; }
+          echo "=== allocate-on-write sparsity ==="
+          logical=$(stat -c %s "$img"); allocated=$(( $(stat -c %b "$img") * $(stat -c %B "$img") ))
+          echo "data volume: logical=$logical allocated=$allocated"
+          [ "$allocated" -lt $(( logical / 4 )) ] || { echo "::error::image not sparse: $allocated of $logical bytes allocated"; exit 1; }
+
       - name: Session E2E (full minimald session over the bridge)
         run: cargo test -p minvmd --test minimald_session_e2e -- --include-ignored --nocapture --exact minimald_exec_over_bridge
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -193,6 +193,39 @@ jobs:
                   MINVMD_ROOTFS_PATH="$RUNNER_TEMP/rootfs/rootfs.img" \
                   MINVMD_INITRAMFS="$RUNNER_TEMP/initramfs/initramfs.cpio" \
                     "$testbin" --include-ignored --nocapture --exact minimald_exec_over_bridge
+            - name: Volume E2E (R1.4/R1.5/R1.6 — /dev/vdb mount, relocation, persistence)
+              # Boot with a writable data volume attached and assert the guest
+              # formats + mounts /dev/vdb at /var/lib/minimal and relocates
+              # cache/state onto it. READY alone is insufficient — Unit 1 falls
+              # back to tmpfs on mount failure — so we assert the guest boot log.
+              # A second boot on the same image must reuse it (no reformat, no ext4
+              # `bad geometry`), guarding superblock idempotency + the mkfs margin
+              # that absorbs libkrun's backing-file trailer shave. The provisioned
+              # image must stay sparse (allocate-on-write, Proof Artifact 3).
+              run: |
+                  testbin="$(ls -1t target/debug/deps/boot_e2e-* | grep -v '\.d$' | head -1)"
+                  test -x "$testbin" || { echo "::error::boot_e2e test binary not found"; exit 1; }
+                  img="$RUNNER_TEMP/data-vol.raw"; rm -f "$img"
+                  benv=(MINVMD_E2E=1
+                    MINVMD_KERNEL_PATH="$RUNNER_TEMP/kernel/vmlinuz"
+                    MINVMD_ROOTFS_PATH="$RUNNER_TEMP/rootfs/rootfs.img"
+                    MINVMD_INITRAMFS="$RUNNER_TEMP/initramfs/initramfs.cpio"
+                    MINVMD_DATA_VOLUME_PATH="$img"
+                    MINVMD_VOLUME_BYTES=2147483648)
+                  echo "=== boot 1 (fresh volume: format + mount) ==="
+                  env "${benv[@]}" MINVMD_BOOT_LOG="$RUNNER_TEMP/vol1.log" "$testbin" --include-ignored --nocapture
+                  grep -q "formatting data volume" "$RUNNER_TEMP/vol1.log" || { echo "::error::boot 1 did not format /dev/vdb"; tail -60 "$RUNNER_TEMP/vol1.log"; exit 1; }
+                  grep -q "mounted writable state volume" "$RUNNER_TEMP/vol1.log" || { echo "::error::R1.5: /dev/vdb was not mounted"; tail -60 "$RUNNER_TEMP/vol1.log"; exit 1; }
+                  grep -q "relocated onto /dev/vdb" "$RUNNER_TEMP/vol1.log" || { echo "::error::R1.6: cache/state not relocated"; tail -60 "$RUNNER_TEMP/vol1.log"; exit 1; }
+                  echo "=== boot 2 (reuse volume: no reformat, no bad geometry) ==="
+                  env "${benv[@]}" MINVMD_BOOT_LOG="$RUNNER_TEMP/vol2.log" "$testbin" --include-ignored --nocapture
+                  grep -q "mounted writable state volume" "$RUNNER_TEMP/vol2.log" || { echo "::error::boot 2 failed to mount the existing volume"; tail -60 "$RUNNER_TEMP/vol2.log"; exit 1; }
+                  ! grep -q "formatting data volume" "$RUNNER_TEMP/vol2.log" || { echo "::error::boot 2 reformatted (superblock idempotency broken)"; exit 1; }
+                  ! grep -qi "bad geometry" "$RUNNER_TEMP/vol2.log" || { echo "::error::ext4 bad geometry on reboot (mkfs margin regressed)"; tail -60 "$RUNNER_TEMP/vol2.log"; exit 1; }
+                  echo "=== allocate-on-write sparsity ==="
+                  logical=$(stat -f %z "$img"); allocated=$(( $(stat -f %b "$img") * 512 ))
+                  echo "data volume: logical=$logical allocated=$allocated"
+                  [ "$allocated" -lt $(( logical / 4 )) ] || { echo "::error::image not sparse: $allocated of $logical bytes allocated"; exit 1; }
             - name: Boot latency benchmark (informational)
               # Report boot-to-READY min/median/max on the runner. Uses the already
               # codesigned minvmd; non-gating (boot correctness is gated by the e2e

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -106,6 +106,74 @@ jobs:
                   path: ${{ runner.temp }}/initramfs.cpio
                   if-no-files-found: error
 
+    libkrun-macos:
+        # Self-provision libkrun >= 1.19.0 for the boot-e2e VM path. `krun_add_disk3`
+        # (this PR's /dev/vdb attach) landed in libkrun 1.19.0, but the self-hosted
+        # boot-e2e runner's brew libkrun is stale (1.18.1) and its /opt/homebrew is
+        # not writable, so it can't self-upgrade. Build a self-contained libkrun from
+        # source on a GitHub-hosted Apple Silicon runner (mirrors release.yml's
+        # build-libkrun-macos-arm64) and hand it to boot-e2e as an artifact. Cached
+        # by LIBKRUN_REF so the from-source build is paid once.
+        runs-on: macos-latest
+        timeout-minutes: 50
+        env:
+            # The version the slp/krun tap ships (kept in step with release.yml).
+            LIBKRUN_REF: v1.19.4
+        steps:
+            - name: Cache built libkrun prefix
+              id: krun-cache
+              uses: actions/cache@v6
+              with:
+                  path: ${{ runner.temp }}/krun
+                  key: libkrun-macos-arm64-${{ env.LIBKRUN_REF }}
+            - name: Checkout libkrun (${{ env.LIBKRUN_REF }})
+              if: steps.krun-cache.outputs.cache-hit != 'true'
+              uses: actions/checkout@v7
+              with:
+                  repository: containers/libkrun
+                  ref: ${{ env.LIBKRUN_REF }}
+                  persist-credentials: false
+            - name: Toolchain
+              if: steps.krun-cache.outputs.cache-hit != 'true'
+              uses: dtolnay/rust-toolchain@stable
+            - name: Install build dependencies
+              if: steps.krun-cache.outputs.cache-hit != 'true'
+              # Mirrors upstream's cross-compile-macos job: the default init-blob
+              # feature needs the LLVM linker (lld) and xz.
+              run: brew install lld xz
+            - name: Build trimmed libkrun (BLK + NET, no GPU) + install
+              if: steps.krun-cache.outputs.cache-hit != 'true'
+              run: |
+                  make BLK=1 NET=1
+                  make PREFIX="$RUNNER_TEMP/krun" install
+            - name: Assert self-contained + exports krun_add_disk3 (>= 1.19.0)
+              # A trimmed build must link only system libs; any /opt/homebrew ref means
+              # a dependency leaked and the dylib would not load on the target runner.
+              # And it MUST export krun_add_disk3 — the whole point of provisioning it.
+              run: |
+                  dylib="$RUNNER_TEMP/krun/lib/libkrun.dylib"
+                  test -f "$dylib" || { echo "::error::libkrun build produced no $dylib"; exit 1; }
+                  if otool -L "$dylib" | grep -E '/opt/homebrew|/usr/local'; then
+                    echo "::error::built libkrun links a non-system (Homebrew) dylib; see otool -L above" >&2
+                    exit 1
+                  fi
+                  if ! nm -gU "$dylib" 2>/dev/null | grep -q '_krun_add_disk3'; then
+                    echo "::error::libkrun $LIBKRUN_REF does not export krun_add_disk3 (need >= 1.19.0)" >&2
+                    exit 1
+                  fi
+            - name: Ad-hoc codesign
+              # make install leaves the signature stale; arm64 macOS refuses to load a
+              # dylib with an invalid signature. Sign the real versioned file.
+              run: codesign --sign - --force "$(readlink -f "$RUNNER_TEMP/krun/lib/libkrun.dylib")"
+            - name: Pack prefix (tar preserves the versioned-dylib symlinks)
+              run: tar -C "$RUNNER_TEMP" -czf "$RUNNER_TEMP/krun-prefix.tgz" krun
+            - name: Upload libkrun prefix
+              uses: actions/upload-artifact@v7
+              with:
+                  name: libkrun-macos-arm64-prefix
+                  path: ${{ runner.temp }}/krun-prefix.tgz
+                  if-no-files-found: error
+
     boot-e2e:
         # Boot E2E (R2.4 READY round-trip) on real hardware, using the cache-pulled
         # kernel + rootfs ext4 image (both from the `artifacts` job).
@@ -119,7 +187,7 @@ jobs:
         # guest both 7350). The full vsock session round-trip is gated by the Session
         # E2E step below (direct run_on_vsock; needs libkrun >= 1.19.0).
         if: ${{ vars.RUN_MACOS_CI != 'false' }}
-        needs: [artifacts]
+        needs: [artifacts, libkrun-macos]
         runs-on: [self-hosted, macOS, ARM64]
         timeout-minutes: 20
         steps:
@@ -155,12 +223,38 @@ jobs:
               with:
                   name: minimald-initramfs-aarch64
                   path: ${{ runner.temp }}/initramfs
+            - name: Download self-provisioned libkrun (>= 1.19.0)
+              # The self-hosted runner's brew libkrun is stale (1.18.1) and lacks
+              # krun_add_disk3 (this PR's /dev/vdb attach). Use the from-source
+              # >= 1.19.0 built by the libkrun-macos job instead.
+              uses: actions/download-artifact@v8
+              with:
+                  name: libkrun-macos-arm64-prefix
+                  path: ${{ runner.temp }}/krun-dl
+            - name: Stage libkrun + assert krun_add_disk3 (>= 1.19.0)
+              # Point minvmd's build.rs (LIBKRUN_PREFIX -> link + rpath) and the running
+              # VMM (DYLD_FALLBACK_LIBRARY_PATH) at the staged libkrun, keeping the
+              # runner's libkrunfw as the dlopen fallback. Explicit gate: fail loudly
+              # (not a cryptic dyld symbol-not-found at VM boot) if it lacks the symbol.
+              run: |
+                  tar -C "$RUNNER_TEMP" -xzf "$RUNNER_TEMP/krun-dl/krun-prefix.tgz"
+                  dylib="$RUNNER_TEMP/krun/lib/libkrun.dylib"
+                  if ! nm -gU "$dylib" 2>/dev/null | grep -q '_krun_add_disk3'; then
+                    echo "::error::staged libkrun does not export krun_add_disk3; need >= 1.19.0" >&2
+                    exit 1
+                  fi
+                  echo "staged libkrun: $(readlink "$dylib" 2>/dev/null || basename "$dylib")"
+                  {
+                    echo "LIBKRUN_PREFIX=$RUNNER_TEMP/krun/lib"
+                    echo "DYLD_FALLBACK_LIBRARY_PATH=$RUNNER_TEMP/krun/lib:/opt/homebrew/lib"
+                  } >> "$GITHUB_ENV"
             - name: Build E2E harnesses + minvmd (no run)
               # Build the test harnesses + the minvmd bin, then codesign, then run the
               # test BINARIES DIRECTLY (below). Invoking `cargo test` again after
               # signing relinks (and unsigns) target/debug/minvmd, so krun_start_enter
               # fails with EINVAL. A direct-binary run never touches the signature, so
               # the binaries must be built here before the single codesign.
+              # LIBKRUN_PREFIX (set above) makes this link the staged >= 1.19.0 libkrun.
               run: cargo test -p minvmd --test boot_e2e --test minimald_session_e2e --no-run
             - name: Codesign minvmd (hypervisor entitlement, R1.4)
               run: codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - target/debug/minvmd

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -144,6 +144,9 @@ jobs:
             - name: Build trimmed libkrun (BLK + NET, no GPU) + install
               if: steps.krun-cache.outputs.cache-hit != 'true'
               run: |
+                  # krun-input's build.rs runs bindgen, which needs libclang from the
+                  # llvm keg that `brew install lld` pulls in; point it there.
+                  export LIBCLANG_PATH="$(brew --prefix llvm)/lib"
                   make BLK=1 NET=1
                   make PREFIX="$RUNNER_TEMP/krun" install
             - name: Assert self-contained + exports krun_add_disk3 (>= 1.19.0)

--- a/.minimal/minimal.toml
+++ b/.minimal/minimal.toml
@@ -1,7 +1,7 @@
 [upstream] # Source of software & tooling
 repo = "https://github.com/gominimal/pkgs"
 branch = "main"
-locked_commit = "23193970569b93e5e7a980aa598c3342c386d33f"
+locked_commit = "12f324d8f436bd014e54269b3ff412390d4040d5"
 
 [stack]
 use = "rust"

--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -332,18 +332,21 @@ fn run_mkfs_ext4(device: &str) -> std::io::Result<()> {
 /// the caller keeps the tmpfs state dir. Unit 2 (R2.4/R2.5) makes an *attached*
 /// volume that fails to mount fatal; this Unit-1 form only reports the outcome.
 pub fn mount_state_volume(device: &str, mountpoint: &str) -> std::io::Result<bool> {
-    if !std::path::Path::new(device).exists() {
+    // `try_exists` distinguishes "absent" (Ok(false)) from a stat error (Err):
+    // a plain `exists()` reports a transiently-unstattable but attached device as
+    // absent, silently dropping to the ephemeral tmpfs and losing the volume.
+    if !std::path::Path::new(device).try_exists()? {
         tracing::info!(device, "no data volume attached; keeping tmpfs state dir");
         return Ok(false);
     }
+    // Ensure the mountpoint exists before formatting: it must be present on the
+    // read-only rootfs (spec R1.7), so on a rootfs that predates R1.7 this fails
+    // with EROFS — better to surface that here than after a needless mkfs.
+    std::fs::create_dir_all(mountpoint)?;
     if !has_ext4_superblock(device)? {
         tracing::info!(device, "no ext4 superblock; formatting data volume");
         run_mkfs_ext4(device)?;
     }
-    // The mountpoint must exist on the read-only rootfs (spec R1.7); on a rootfs
-    // that predates R1.7 this create fails with EROFS, surfacing the missing
-    // mountpoint rather than mounting somewhere unexpected.
-    std::fs::create_dir_all(mountpoint)?;
     raw_mount(device, mountpoint, "ext4", libc::MS_NOATIME)?;
     tracing::info!(device, mountpoint, "mounted writable state volume");
     Ok(true)

--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -239,6 +239,116 @@ pub fn enter_rootfs(device: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+/// ext4 superblock magic (`0xEF53`), stored little-endian at byte offset 1080
+/// (superblock starts at 1024; `s_magic` is at offset 56 within it).
+const EXT4_MAGIC_OFFSET: u64 = 1080;
+const EXT4_MAGIC_LE: [u8; 2] = [0x53, 0xEF];
+
+/// Whether `device` already carries an ext4 filesystem, probed by reading the
+/// superblock magic. This is the idempotency gate for [`mount_state_volume`]:
+/// `mkfs` runs only when the magic is absent, so a VM restart after a partial
+/// format re-formats cleanly and a formatted volume is reused untouched.
+fn has_ext4_superblock(device: &str) -> std::io::Result<bool> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut f = std::fs::File::open(device)?;
+    f.seek(SeekFrom::Start(EXT4_MAGIC_OFFSET))?;
+    let mut buf = [0u8; 2];
+    match f.read_exact(&mut buf) {
+        Ok(()) => Ok(buf == EXT4_MAGIC_LE),
+        // A device smaller than the superblock offset cannot hold ext4.
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+/// The device block size ext4 is formatted with (4 KiB).
+const EXT4_BLOCK_BYTES: u64 = 4096;
+
+/// Safety margin left below the device size when formatting (spec R1.5).
+///
+/// libkrun reserves a small trailer on the raw backing file and shaves it off
+/// between boots (observed: 64 KiB), so the block device the guest sees can
+/// shrink slightly after the first boot. Formatting to the *exact* device size
+/// then fails on the next boot with `EXT4-fs: bad geometry: block count exceeds
+/// device`. Sizing the filesystem 1 MiB below the device (16× the observed shave)
+/// keeps the ext4 geometry valid across reboots; 1 MiB on a multi-GiB volume is
+/// negligible.
+const MKFS_MARGIN_BYTES: u64 = 1024 * 1024;
+
+/// The size of `device` in bytes, read from `/sys/block/<name>/size` (which is
+/// in 512-byte sectors).
+fn device_size_bytes(device: &str) -> std::io::Result<u64> {
+    let name = std::path::Path::new(device)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "device has no basename")
+        })?;
+    let sectors: u64 = std::fs::read_to_string(format!("/sys/block/{name}/size"))?
+        .trim()
+        .parse()
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("bad block size: {e}"),
+            )
+        })?;
+    Ok(sectors * 512)
+}
+
+/// Format `device` as ext4 via `mkfs.ext4 -F` (non-interactive). Resolves from
+/// `PATH` (`/usr/sbin`, set post-chroot in [`enter_rootfs`]); requires
+/// `e2fsprogs` in the rootfs closure (spec R1.7).
+///
+/// The filesystem is sized [`MKFS_MARGIN_BYTES`] below the device so it survives
+/// libkrun's backing-file trailer shave across reboots.
+fn run_mkfs_ext4(device: &str) -> std::io::Result<()> {
+    let fs_blocks = device_size_bytes(device)?.saturating_sub(MKFS_MARGIN_BYTES) / EXT4_BLOCK_BYTES;
+    let status = std::process::Command::new("mkfs.ext4")
+        .arg("-F")
+        .arg("-q")
+        .args(["-b", &EXT4_BLOCK_BYTES.to_string()])
+        .arg(device)
+        .arg(fs_blocks.to_string())
+        .status()?;
+    if !status.success() {
+        return Err(std::io::Error::other(format!(
+            "mkfs.ext4 -F {device} ({fs_blocks} blocks) failed: {status}"
+        )));
+    }
+    Ok(())
+}
+
+/// Mount the per-VM writable data volume (spec R1.5).
+///
+/// Runs **after** [`enter_rootfs`] has chrooted into the rootfs, so `mkfs.ext4`
+/// resolves against the rootfs userland (the initramfs has no e2fsprogs) and the
+/// mount joins the live root mount namespace. Formats `device` on first boot
+/// (superblock-gated, idempotent) and mounts it read-write at `mountpoint` with
+/// `MS_NOATIME`.
+///
+/// Returns `Ok(true)` when the volume was mounted, `Ok(false)` when `device` is
+/// absent — the transitional legacy case where no data volume is attached and
+/// the caller keeps the tmpfs state dir. Unit 2 (R2.4/R2.5) makes an *attached*
+/// volume that fails to mount fatal; this Unit-1 form only reports the outcome.
+pub fn mount_state_volume(device: &str, mountpoint: &str) -> std::io::Result<bool> {
+    if !std::path::Path::new(device).exists() {
+        tracing::info!(device, "no data volume attached; keeping tmpfs state dir");
+        return Ok(false);
+    }
+    if !has_ext4_superblock(device)? {
+        tracing::info!(device, "no ext4 superblock; formatting data volume");
+        run_mkfs_ext4(device)?;
+    }
+    // The mountpoint must exist on the read-only rootfs (spec R1.7); on a rootfs
+    // that predates R1.7 this create fails with EROFS, surfacing the missing
+    // mountpoint rather than mounting somewhere unexpected.
+    std::fs::create_dir_all(mountpoint)?;
+    raw_mount(device, mountpoint, "ext4", libc::MS_NOATIME)?;
+    tracing::info!(device, mountpoint, "mounted writable state volume");
+    Ok(true)
+}
+
 /// Mounts `/proc` and `/sys` if they are not already present.
 ///
 /// The kernel auto-mounts devtmpfs on `/dev`, but not these pseudo
@@ -537,6 +647,38 @@ fn mount_if_absent(target: &str, source: &str, fstype: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ext4_superblock_probe_detects_magic() {
+        use std::io::{Seek, SeekFrom, Write};
+        let dir = std::env::temp_dir().join(format!("guest-sb-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // A file with the ext4 magic at offset 1080 probes positive.
+        let ext4 = dir.join("ext4.img");
+        {
+            let mut f = std::fs::File::create(&ext4).unwrap();
+            f.set_len(2048).unwrap();
+            f.seek(SeekFrom::Start(EXT4_MAGIC_OFFSET)).unwrap();
+            f.write_all(&EXT4_MAGIC_LE).unwrap();
+        }
+        assert!(has_ext4_superblock(ext4.to_str().unwrap()).unwrap());
+
+        // A zeroed image (freshly provisioned, unformatted) probes negative.
+        let blank = dir.join("blank.img");
+        std::fs::File::create(&blank)
+            .unwrap()
+            .set_len(2048)
+            .unwrap();
+        assert!(!has_ext4_superblock(blank.to_str().unwrap()).unwrap());
+
+        // A device too small to hold a superblock probes negative, not error.
+        let tiny = dir.join("tiny.img");
+        std::fs::File::create(&tiny).unwrap().set_len(64).unwrap();
+        assert!(!has_ext4_superblock(tiny.to_str().unwrap()).unwrap());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[tokio::test]
     async fn write_ready_beacon_formats_two_lines() {

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -286,7 +286,7 @@ async fn async_main() -> Result<(), MainError> {
     // would indicate we are operating in a single-purpose micro-vm.
     //
     // If we are not the init process, we load our config from CLI args.
-    let cli = if is_minimal_microvm() {
+    let mut cli = if is_minimal_microvm() {
         Cli {
             command: Command::Run(ListenArgs {
                 instance_num: 0,
@@ -353,6 +353,28 @@ async fn async_main() -> Result<(), MainError> {
         }
     }
 
+    // R1.5/R1.6: mount the per-VM writable data volume (/dev/vdb) and, when it
+    // mounts, relocate cache + state onto it so builds hardlinking from the cache
+    // stay on one filesystem (the EXDEV fix). When no volume is attached (the
+    // transitional case), state stays on the tmpfs default. Unit 2 (R2.4/R2.5)
+    // gates READY on this and removes the silent-fallback path.
+    if is_minimal_microvm() {
+        match guest::mount_state_volume("/dev/vdb", "/var/lib/minimal") {
+            Ok(true) => {
+                cli.global_args.minimal_state_dir =
+                    Some(DaemonAbsPath::try_new("/var/lib/minimal").unwrap().into());
+                cli.global_args.minimal_cache_dir = Some(
+                    DaemonAbsPath::try_new("/var/lib/minimal/cache")
+                        .unwrap()
+                        .into(),
+                );
+                tracing::info!("cache + state relocated onto /dev/vdb (/var/lib/minimal)");
+            }
+            Ok(false) => {}
+            Err(e) => tracing::error!(error = %e, "mounting /dev/vdb state volume"),
+        }
+    }
+
     if let Err(e) = std::fs::create_dir_all(cli.minimal_state_dir())
         && e.kind() != std::io::ErrorKind::AlreadyExists
     {
@@ -377,11 +399,14 @@ async fn async_main() -> Result<(), MainError> {
         },
         minimal_state_dir: cli.minimal_state_dir(),
         minimal_cache_dir: cli.minimal_cache_dir(),
-        gvproxy_bin: listen_args.gvproxy_bin.clone(),
+        // Re-borrow `listen_args` fresh here (as the vsock branch below does):
+        // the R1.6 relocation above takes `&mut cli`, which ends the original
+        // `listen_args` borrow, so it cannot be held across that mutation.
+        gvproxy_bin: cli.listen_args().unwrap().gvproxy_bin.clone(),
         // The vsock listen path is exactly the libkrun-VM (DM1/3/4) case: an
         // `OwnIp` PTask must attach to the host gvproxy over the vsock shuttle,
         // not spawn gvproxy in-guest. The UDS path is DM2.
-        in_microvm: listen_args.vsock,
+        in_microvm: cli.listen_args().unwrap().vsock,
     };
     // Ensure the SSH host key is accessible in a instance-specific known_hosts file.
     // R1.2: load once and reuse in the vsock beacon so there is no redundant disk read.
@@ -443,7 +468,7 @@ async fn async_main() -> Result<(), MainError> {
             }
         };
 
-        let port_num = DEFAULT_VSOCK_PORT_BASE + listen_args.instance_num;
+        let port_num = DEFAULT_VSOCK_PORT_BASE + cli.listen_args().unwrap().instance_num;
         let listener = VsockListener::bind(VsockAddr::new(VMADDR_CID_ANY, port_num))
             .map_err(|e| MainError::IO(e, "binding vsock port"))?;
 

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -93,10 +93,11 @@ pub const DEFAULT_VM_RAM_MIB: u32 = 4096;
 /// empty, or zero value falls back to [`DEFAULT_VM_RAM_MIB`].
 ///
 /// Note: the RAM stop-gap is *not* reduced when the cache moves to the writable
-/// volume in this unit — a reduced baseline is only safe once a failed volume
-/// mount is fatal (no silent tmpfs fallback), which is Unit 2 (R2.4). Reducing
-/// RAM here would leave a mount-failed VM at half RAM with the cache still on the
-/// tmpfs. The reduction is deferred to Unit 2, alongside a measured floor.
+/// volume. A reduced baseline is only safe once a failed volume mount is fatal
+/// (no silent tmpfs fallback) and the floor is measured against real in-VM build
+/// memory pressure; reducing it here would leave a mount-failed VM at half RAM
+/// with the cache still on the tmpfs. Out of scope for this feature — deferred to
+/// a separate memory-pressure spec.
 #[must_use]
 pub fn vm_ram_mib() -> u32 {
     std::env::var(VM_RAM_MIB_ENV)

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -89,37 +89,21 @@ pub const DEFAULT_VM_RAM_MIB: u32 = 2048;
 #[cfg(not(target_arch = "x86_64"))]
 pub const DEFAULT_VM_RAM_MIB: u32 = 4096;
 
-/// Reduced guest RAM (MiB) once the package cache lives on the writable data
-/// volume (`/dev/vdb`) rather than the RAM-backed tmpfs (spec R1.8). The
-/// `DEFAULT_VM_RAM_MIB` headroom exists only to size the tmpfs cache; with the
-/// cache off RAM the guest needs to cover the build working set, not the cache.
-/// 2048 MiB is a conservative first cut (hole-safe on x86_64) — the true floor
-/// needs an in-VM build measurement (spec Open Question) and can be lowered via
-/// [`VM_RAM_MIB_ENV`].
-pub const VOLUME_BACKED_VM_RAM_MIB: u32 = 2048;
-
 /// The guest RAM size in MiB, overridable via [`VM_RAM_MIB_ENV`]. A non-numeric,
 /// empty, or zero value falls back to [`DEFAULT_VM_RAM_MIB`].
+///
+/// Note: the RAM stop-gap is *not* reduced when the cache moves to the writable
+/// volume in this unit — a reduced baseline is only safe once a failed volume
+/// mount is fatal (no silent tmpfs fallback), which is Unit 2 (R2.4). Reducing
+/// RAM here would leave a mount-failed VM at half RAM with the cache still on the
+/// tmpfs. The reduction is deferred to Unit 2, alongside a measured floor.
 #[must_use]
 pub fn vm_ram_mib() -> u32 {
-    vm_ram_mib_for(false)
-}
-
-/// The guest RAM size in MiB (spec R1.8). When `data_volume_attached`, the cache
-/// is off the tmpfs so the reduced [`VOLUME_BACKED_VM_RAM_MIB`] baseline applies;
-/// otherwise the tmpfs-headroom [`DEFAULT_VM_RAM_MIB`]. [`VM_RAM_MIB_ENV`]
-/// overrides either. A non-numeric, empty, or zero override is ignored.
-#[must_use]
-pub fn vm_ram_mib_for(data_volume_attached: bool) -> u32 {
     std::env::var(VM_RAM_MIB_ENV)
         .ok()
         .and_then(|v| v.trim().parse::<u32>().ok())
         .filter(|&mib| mib > 0)
-        .unwrap_or(if data_volume_attached {
-            VOLUME_BACKED_VM_RAM_MIB
-        } else {
-            DEFAULT_VM_RAM_MIB
-        })
+        .unwrap_or(DEFAULT_VM_RAM_MIB)
 }
 
 /// Verify the host hypervisor backend is accessible before booting a VM (R2.4).

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -89,15 +89,37 @@ pub const DEFAULT_VM_RAM_MIB: u32 = 2048;
 #[cfg(not(target_arch = "x86_64"))]
 pub const DEFAULT_VM_RAM_MIB: u32 = 4096;
 
+/// Reduced guest RAM (MiB) once the package cache lives on the writable data
+/// volume (`/dev/vdb`) rather than the RAM-backed tmpfs (spec R1.8). The
+/// `DEFAULT_VM_RAM_MIB` headroom exists only to size the tmpfs cache; with the
+/// cache off RAM the guest needs to cover the build working set, not the cache.
+/// 2048 MiB is a conservative first cut (hole-safe on x86_64) — the true floor
+/// needs an in-VM build measurement (spec Open Question) and can be lowered via
+/// [`VM_RAM_MIB_ENV`].
+pub const VOLUME_BACKED_VM_RAM_MIB: u32 = 2048;
+
 /// The guest RAM size in MiB, overridable via [`VM_RAM_MIB_ENV`]. A non-numeric,
 /// empty, or zero value falls back to [`DEFAULT_VM_RAM_MIB`].
 #[must_use]
 pub fn vm_ram_mib() -> u32 {
+    vm_ram_mib_for(false)
+}
+
+/// The guest RAM size in MiB (spec R1.8). When `data_volume_attached`, the cache
+/// is off the tmpfs so the reduced [`VOLUME_BACKED_VM_RAM_MIB`] baseline applies;
+/// otherwise the tmpfs-headroom [`DEFAULT_VM_RAM_MIB`]. [`VM_RAM_MIB_ENV`]
+/// overrides either. A non-numeric, empty, or zero override is ignored.
+#[must_use]
+pub fn vm_ram_mib_for(data_volume_attached: bool) -> u32 {
     std::env::var(VM_RAM_MIB_ENV)
         .ok()
         .and_then(|v| v.trim().parse::<u32>().ok())
         .filter(|&mib| mib > 0)
-        .unwrap_or(DEFAULT_VM_RAM_MIB)
+        .unwrap_or(if data_volume_attached {
+            VOLUME_BACKED_VM_RAM_MIB
+        } else {
+            DEFAULT_VM_RAM_MIB
+        })
 }
 
 /// Verify the host hypervisor backend is accessible before booting a VM (R2.4).

--- a/crates/minvmd/src/cmd/vmm_child.rs
+++ b/crates/minvmd/src/cmd/vmm_child.rs
@@ -48,13 +48,19 @@ fn run_vmm() -> Result<()> {
         format!("reading {MARKER_SOCK_ENV}: VMM child must be spawned by `minvmd boot`")
     })?;
 
+    // A data volume moves the package cache off the RAM-backed tmpfs, so the
+    // guest RAM can drop to the reduced baseline (R1.8). Resolve its presence
+    // first, before sizing RAM.
+    let data_volume_path = std::env::var_os(crate::volume::DATA_VOLUME_PATH_ENV);
+
     let mut ctx = Context::create().context("krun_create_ctx")?;
-    // 2 vCPU; guest RAM from `crate::cmd::vm_ram_mib()` (env-overridable,
-    // default 4096 MiB) — the headroom feeds the in-VM session build's tmpfs
-    // package cache, but x86_64 needs a hole-safe size (see `DEFAULT_VM_RAM_MIB`).
-    // (Stay below the kernel's CONFIG_NR_CPUS.) `apply` configures the kernel +
-    // initramfs, the ext4 root disk, and the vsock bridge.
-    let mut cfg = VmConfig::new(2, crate::cmd::vm_ram_mib(), kernel, rootfs, initramfs);
+    // 2 vCPU; guest RAM from `vm_ram_mib_for` (env-overridable) — reduced when the
+    // cache lives on `/dev/vdb`, else the tmpfs-headroom default; x86_64 needs a
+    // hole-safe size (see `DEFAULT_VM_RAM_MIB`). (Stay below the kernel's
+    // CONFIG_NR_CPUS.) `apply` configures the kernel + initramfs, the ext4 root
+    // disk, the writable data volume, and the vsock bridge.
+    let ram_mib = crate::cmd::vm_ram_mib_for(data_volume_path.is_some());
+    let mut cfg = VmConfig::new(2, ram_mib, kernel, rootfs, initramfs);
     // An own-IP VM registers the per-PTask gvproxy shuttle vsock
     // bridge in `apply`; the host gvproxy is spawned by the parent supervisor.
     // The env var keeps the parent's gvproxy-spawn decision and this child's VM
@@ -62,6 +68,28 @@ fn run_vmm() -> Result<()> {
     if crate::cmd::own_ip_requested() {
         cfg = cfg.with_network_mode(minimald_rpc::NetworkMode::OwnIp);
     }
+
+    // Attach the per-VM writable data volume (/dev/vdb) when
+    // MINVMD_DATA_VOLUME_PATH is set (spec R1.4). Provision a blank sparse image
+    // there if it does not yet exist, keyed off the requested path's file stem so
+    // the parent (which stats the image) and this child agree on the location.
+    if let Some(raw) = data_volume_path {
+        use crate::volume::{BlankRawProvisioner, VolumeProvisioner, volume_bytes};
+        let path = std::path::PathBuf::from(raw);
+        let dir = path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| std::path::Path::new("."));
+        let vm_id = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .context("MINVMD_DATA_VOLUME_PATH has no usable file stem")?;
+        let image = BlankRawProvisioner::new(dir)
+            .ensure(vm_id, volume_bytes())
+            .context("provisioning writable data volume")?;
+        cfg = cfg.with_data_volume(image);
+    }
+
     cfg.apply(&mut ctx)
         .context("applying VmConfig to krun context")?;
 

--- a/crates/minvmd/src/cmd/vmm_child.rs
+++ b/crates/minvmd/src/cmd/vmm_child.rs
@@ -48,19 +48,13 @@ fn run_vmm() -> Result<()> {
         format!("reading {MARKER_SOCK_ENV}: VMM child must be spawned by `minvmd boot`")
     })?;
 
-    // A data volume moves the package cache off the RAM-backed tmpfs, so the
-    // guest RAM can drop to the reduced baseline (R1.8). Resolve its presence
-    // first, before sizing RAM.
-    let data_volume_path = std::env::var_os(crate::volume::DATA_VOLUME_PATH_ENV);
-
     let mut ctx = Context::create().context("krun_create_ctx")?;
-    // 2 vCPU; guest RAM from `vm_ram_mib_for` (env-overridable) — reduced when the
-    // cache lives on `/dev/vdb`, else the tmpfs-headroom default; x86_64 needs a
-    // hole-safe size (see `DEFAULT_VM_RAM_MIB`). (Stay below the kernel's
-    // CONFIG_NR_CPUS.) `apply` configures the kernel + initramfs, the ext4 root
-    // disk, the writable data volume, and the vsock bridge.
-    let ram_mib = crate::cmd::vm_ram_mib_for(data_volume_path.is_some());
-    let mut cfg = VmConfig::new(2, ram_mib, kernel, rootfs, initramfs);
+    // 2 vCPU; guest RAM from `vm_ram_mib()` (env-overridable, tmpfs-headroom
+    // default; x86_64 needs a hole-safe size — see `DEFAULT_VM_RAM_MIB`). Stay
+    // below the kernel's CONFIG_NR_CPUS. `apply` configures the kernel +
+    // initramfs, the ext4 root disk, the writable data volume, and the vsock
+    // bridge.
+    let mut cfg = VmConfig::new(2, crate::cmd::vm_ram_mib(), kernel, rootfs, initramfs);
     // An own-IP VM registers the per-PTask gvproxy shuttle vsock
     // bridge in `apply`; the host gvproxy is spawned by the parent supervisor.
     // The env var keeps the parent's gvproxy-spawn decision and this child's VM
@@ -69,26 +63,15 @@ fn run_vmm() -> Result<()> {
         cfg = cfg.with_network_mode(minimald_rpc::NetworkMode::OwnIp);
     }
 
-    // Attach the per-VM writable data volume (/dev/vdb) when
-    // MINVMD_DATA_VOLUME_PATH is set (spec R1.4). Provision a blank sparse image
-    // there if it does not yet exist, keyed off the requested path's file stem so
-    // the parent (which stats the image) and this child agree on the location.
-    if let Some(raw) = data_volume_path {
-        use crate::volume::{BlankRawProvisioner, VolumeProvisioner, volume_bytes};
-        let path = std::path::PathBuf::from(raw);
-        let dir = path
-            .parent()
-            .filter(|p| !p.as_os_str().is_empty())
-            .unwrap_or_else(|| std::path::Path::new("."));
-        let vm_id = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .context("MINVMD_DATA_VOLUME_PATH has no usable file stem")?;
-        let image = BlankRawProvisioner::new(dir)
-            .ensure(vm_id, volume_bytes())
-            .context("provisioning writable data volume")?;
-        cfg = cfg.with_data_volume(image);
-    }
+    // Provision + attach the per-VM writable data volume as /dev/vdb (spec R1.4).
+    // On by default: the image lives at the resolved path (MINVMD_DATA_VOLUME_PATH
+    // override, else `<state>/data-vol.raw`) and is created sparse if missing.
+    // Provisioning at the literal path — not a stem-reconstructed one — so an
+    // explicit override is honoured verbatim.
+    let data_volume_path = crate::volume::resolve_data_volume_path();
+    crate::volume::ensure_sparse_raw(&data_volume_path, crate::volume::volume_bytes())
+        .context("provisioning writable data volume")?;
+    cfg = cfg.with_data_volume(data_volume_path);
 
     cfg.apply(&mut ctx)
         .context("applying VmConfig to krun context")?;

--- a/crates/minvmd/src/krun/ctx.rs
+++ b/crates/minvmd/src/krun/ctx.rs
@@ -250,6 +250,45 @@ impl Context {
         Ok(())
     }
 
+    /// Add a disk image as a virtio-blk device with cache/sync control
+    /// (`krun_add_disk3`). Unlike [`add_disk`][Self::add_disk], the caller
+    /// selects `direct_io` (bypass host page cache) and `sync_mode` (how
+    /// `VIRTIO_BLK_F_FLUSH` is honoured). Used for the writable data volume,
+    /// which is attached `read_only=false` with a durability-bounding
+    /// [`SyncMode`][raw::SyncMode].
+    pub fn add_disk_with_sync(
+        &mut self,
+        block_id: &str,
+        disk_path: impl AsRef<Path>,
+        disk_format: raw::DiskFormat,
+        read_only: bool,
+        direct_io: bool,
+        sync_mode: raw::SyncMode,
+    ) -> Result<(), VmError> {
+        let id_cstr = cstring_from_str(block_id, "block_id")?;
+        let path_cstr = cstring_from_path(disk_path.as_ref(), "disk")?;
+        // SAFETY: `id_cstr` and `path_cstr` are CStrings owned by this stack
+        // frame; their pointers are NUL-terminated and valid until after the
+        // FFI returns. `disk_format`, `read_only`, `direct_io`, and `sync_mode`
+        // are passed by value (the enums are `#[repr(u32)]`). `ctx_id` is owned
+        // by `self` and refers to a context not yet freed.
+        let ret = unsafe {
+            raw::krun_add_disk3(
+                self.ctx_id,
+                id_cstr.as_ptr(),
+                path_cstr.as_ptr(),
+                disk_format as u32,
+                read_only,
+                direct_io,
+                sync_mode as u32,
+            )
+        };
+        drop(id_cstr);
+        drop(path_cstr);
+        raw::check_backend("krun_add_disk3", ret)?;
+        Ok(())
+    }
+
     /// Redirect implicit-console output to a host file.
     pub fn set_console_output(&mut self, path: impl AsRef<Path>) -> Result<(), VmError> {
         let cstr = cstring_from_path(path.as_ref(), "console_output")?;

--- a/crates/minvmd/src/krun/mod.rs
+++ b/crates/minvmd/src/krun/mod.rs
@@ -19,4 +19,4 @@ mod ctx;
 mod raw;
 
 pub use ctx::Context;
-pub use raw::{DiskFormat, KernelFormat, LogLevel};
+pub use raw::{DiskFormat, KernelFormat, LogLevel, SyncMode};

--- a/crates/minvmd/src/krun/raw.rs
+++ b/crates/minvmd/src/krun/raw.rs
@@ -34,9 +34,9 @@ pub enum KernelFormat {
     ImageGz = 4,
 }
 
-/// Disk image format for `krun_add_disk2`. A squashfs or ext4 rootfs image is a
-/// `Raw` block device (the filesystem lives inside it; no partition table).
-/// QCOW2=1, VMDK=2 are not used by minvmd.
+/// Disk image format for `krun_add_disk2`/`krun_add_disk3`. A squashfs or ext4
+/// image is a `Raw` block device (the filesystem lives inside it; no partition
+/// table). QCOW2=1, VMDK=2 are not used by minvmd (see spec Non-Goals).
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DiskFormat {
@@ -68,6 +68,26 @@ pub const LOG_STYLE_AUTO: u32 = 0;
 /// libkrun's own env-var overrides enabled (as opposed to
 /// `KRUN_LOG_OPTION_NO_ENV`).
 pub const LOG_OPTIONS_DEFAULT: u32 = 0;
+
+/// Flush/sync behaviour for `krun_add_disk3`'s `sync_mode` argument.
+///
+/// Mirrors `KRUN_SYNC_{NONE,RELAXED,FULL}` in libkrun.h. **Note:** the header
+/// types this argument as `uint32_t`, a tri-state — *not* the `bool` the
+/// original spec (R1.1) described. The three modes trade durability against
+/// throughput:
+/// - [`None`][Self::None] (0) — ignore `VIRTIO_BLK_F_FLUSH`; fastest, may lose
+///   data on host crash.
+/// - [`Relaxed`][Self::Relaxed] (1) — honour flush but, on macOS, flush only the
+///   OS buffers (not the drive's). libkrun documents this as the recommended
+///   mode; on Linux it is identical to `Full`.
+/// - [`Full`][Self::Full] (2) — honour flush and force buffers to physical disk.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SyncMode {
+    None = 0,
+    Relaxed = 1,
+    Full = 2,
+}
 
 // SAFETY: every function in this block is an `extern "C"` declaration that
 // inherits its safety contract from libkrun.h. Specifically:
@@ -181,6 +201,21 @@ unsafe extern "C" {
         disk_path: *const c_char,
         disk_format: u32,
         read_only: bool,
+    ) -> i32;
+
+    /// Add a disk image as a virtio-blk device with cache/sync control.
+    /// `direct_io` bypasses the host page cache; `sync_mode` is one of
+    /// `KRUN_SYNC_{NONE,RELAXED,FULL}` ([`SyncMode`]) and governs how
+    /// `VIRTIO_BLK_F_FLUSH` is honoured. Used to attach the per-VM writable
+    /// data volume (`/dev/vdb`) with a bounded crash data-loss window.
+    pub fn krun_add_disk3(
+        ctx_id: u32,
+        block_id: *const c_char,
+        disk_path: *const c_char,
+        disk_format: u32,
+        read_only: bool,
+        direct_io: bool,
+        sync_mode: u32,
     ) -> i32;
 }
 

--- a/crates/minvmd/src/lib.rs
+++ b/crates/minvmd/src/lib.rs
@@ -18,6 +18,7 @@ pub mod net;
 pub mod sock;
 pub mod state;
 pub mod vm;
+pub mod volume;
 
 #[cfg(minvmd_libkrun)]
 pub mod krun;

--- a/crates/minvmd/src/vm.rs
+++ b/crates/minvmd/src/vm.rs
@@ -11,6 +11,20 @@ use minimald_rpc::{EgressPolicy, NetworkMode};
 
 use crate::error::VmError;
 
+/// Environment variable selecting the data volume's `sync_mode` (spec R1.9).
+/// Accepts `none` / `relaxed` / `full` (case-insensitive), the legacy booleans
+/// `false` → none and `true` → relaxed, or the raw libkrun codes `0` / `1` / `2`.
+/// Defaults to `relaxed` — libkrun's recommended mode: it honours flush but, on
+/// macOS, skips the drive-level sync, bounding the crash data-loss window
+/// without the throughput cost of full sync.
+pub const DISK_SYNC_ENV: &str = "MINVMD_DISK_SYNC";
+
+/// Environment variable toggling `direct_io` (bypass the host page cache) on the
+/// data volume (spec R1.9). Accepts `true` / `1` (any other value is false).
+/// Defaults to `false`, correct for guest ext4 (the guest journal and page cache
+/// interact poorly with host `O_DIRECT`).
+pub const DISK_DIRECT_IO_ENV: &str = "MINVMD_DISK_DIRECT_IO";
+
 /// Which of the spec's deployment models (DM1–DM5) a minvmd host runs under.
 ///
 /// minvmd manages libkrun VMs, which only exist on DM1/DM3/DM4; DM2 is native
@@ -62,6 +76,11 @@ pub struct VmConfig {
     /// boundary (DM1/DM3/DM4); rejected on DM2 by [`VmConfig::validate_for`].
     /// `None` means no VM-wide egress restriction.
     pub vm_egress: Option<EgressPolicy>,
+    /// Path to the per-VM writable data volume image, attached as `/dev/vdb`
+    /// via `krun_add_disk3` (spec R1.4). `None` means no data volume is attached
+    /// (legacy tmpfs-only boot). Provision the image with
+    /// [`crate::volume::VolumeProvisioner`] before setting this.
+    pub data_volume_path: Option<PathBuf>,
 }
 
 impl VmConfig {
@@ -82,6 +101,7 @@ impl VmConfig {
             initramfs,
             network_mode: NetworkMode::default(),
             vm_egress: None,
+            data_volume_path: None,
         }
     }
 
@@ -89,6 +109,15 @@ impl VmConfig {
     #[must_use]
     pub fn with_network_mode(mut self, network_mode: NetworkMode) -> Self {
         self.network_mode = network_mode;
+        self
+    }
+
+    /// Attach a per-VM writable data volume image as `/dev/vdb` (spec R1.4),
+    /// consuming and returning `self`. The image must already be provisioned
+    /// (see [`crate::volume::VolumeProvisioner`]).
+    #[must_use]
+    pub fn with_data_volume(mut self, data_volume_path: PathBuf) -> Self {
+        self.data_volume_path = Some(data_volume_path);
         self
     }
 
@@ -194,6 +223,28 @@ impl VmConfig {
             crate::krun::DiskFormat::Raw,
             true,
         )?;
+        // Attach the per-VM writable data volume as /dev/vdb (spec R1.4). Disks
+        // are enumerated vd{a,b,…} in registration order, so this follows the
+        // read-only root. The sync/cache posture is resolved from the R1.9
+        // tunables rather than hardcoded, so its throughput cost can be measured
+        // (Proof Artifact 4) and tuned per platform.
+        if let Some(data_path) = &self.data_volume_path {
+            let (direct_io, sync_mode) = resolve_disk_flags();
+            tracing::info!(
+                data_path = %data_path.display(),
+                direct_io,
+                ?sync_mode,
+                "attaching writable data volume as /dev/vdb",
+            );
+            ctx.add_disk_with_sync(
+                "data",
+                data_path,
+                crate::krun::DiskFormat::Raw,
+                false,
+                direct_io,
+                sync_mode,
+            )?;
+        }
         // Network attachment (R1.5): the VM joins the per-host gvproxy switch
         // supervised by `crate::net` according to `network_mode`. The libkrun
         // device wiring (tap fd handed to gvproxy over the per-PTask vsock
@@ -238,6 +289,30 @@ impl VmConfig {
         );
         Ok(())
     }
+}
+
+/// Resolve the data-volume `(direct_io, sync_mode)` from the R1.9 environment
+/// tunables ([`DISK_DIRECT_IO_ENV`], [`DISK_SYNC_ENV`]). Defaults: `direct_io =
+/// false`, `sync_mode = Relaxed`.
+#[cfg(minvmd_libkrun)]
+fn resolve_disk_flags() -> (bool, crate::krun::SyncMode) {
+    use crate::krun::SyncMode;
+
+    let direct_io = std::env::var(DISK_DIRECT_IO_ENV)
+        .ok()
+        .is_some_and(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1"));
+
+    let sync_mode = std::env::var(DISK_SYNC_ENV)
+        .ok()
+        .and_then(|v| match v.trim().to_ascii_lowercase().as_str() {
+            "none" | "false" | "0" => Some(SyncMode::None),
+            "relaxed" | "true" | "1" => Some(SyncMode::Relaxed),
+            "full" | "2" => Some(SyncMode::Full),
+            _ => None,
+        })
+        .unwrap_or(SyncMode::Relaxed);
+
+    (direct_io, sync_mode)
 }
 
 #[cfg(test)]

--- a/crates/minvmd/src/vm.rs
+++ b/crates/minvmd/src/vm.rs
@@ -79,7 +79,7 @@ pub struct VmConfig {
     /// Path to the per-VM writable data volume image, attached as `/dev/vdb`
     /// via `krun_add_disk3` (spec R1.4). `None` means no data volume is attached
     /// (legacy tmpfs-only boot). Provision the image with
-    /// [`crate::volume::VolumeProvisioner`] before setting this.
+    /// [`crate::volume::ensure_sparse_raw`] before setting this.
     pub data_volume_path: Option<PathBuf>,
 }
 
@@ -114,7 +114,7 @@ impl VmConfig {
 
     /// Attach a per-VM writable data volume image as `/dev/vdb` (spec R1.4),
     /// consuming and returning `self`. The image must already be provisioned
-    /// (see [`crate::volume::VolumeProvisioner`]).
+    /// (see [`crate::volume::ensure_sparse_raw`]).
     #[must_use]
     pub fn with_data_volume(mut self, data_volume_path: PathBuf) -> Self {
         self.data_volume_path = Some(data_volume_path);

--- a/crates/minvmd/src/volume.rs
+++ b/crates/minvmd/src/volume.rs
@@ -169,16 +169,19 @@ mod tests {
     use super::*;
     use std::os::unix::fs::MetadataExt;
 
-    fn tmpdir() -> PathBuf {
+    /// A unique temp dir per test. Keyed by `tag` as well as the pid so
+    /// concurrently-running tests (cargo's default) never share a directory —
+    /// otherwise one test's `remove_dir_all` cleanup races another's files.
+    fn tmpdir(tag: &str) -> PathBuf {
         let base = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".into());
-        let p = PathBuf::from(base).join(format!("minvmd-vol-test-{}", std::process::id()));
+        let p = PathBuf::from(base).join(format!("minvmd-vol-test-{}-{tag}", std::process::id()));
         let _ = std::fs::remove_dir_all(&p);
         p
     }
 
     #[test]
     fn ensure_creates_sparse_image_of_requested_len() {
-        let dir = tmpdir();
+        let dir = tmpdir("sparse");
         let prov = BlankRawProvisioner::new(dir.join("volumes"));
         let size = 8 * 1024 * 1024 * 1024; // 8 GiB
         let path = prov.ensure("vm-abc", size).unwrap();
@@ -198,7 +201,7 @@ mod tests {
 
     #[test]
     fn ensure_is_idempotent_and_does_not_resize() {
-        let dir = tmpdir();
+        let dir = tmpdir("idempotent");
         let prov = BlankRawProvisioner::new(dir.join("volumes"));
         let path = prov.ensure("vm-xyz", 4 * 1024 * 1024 * 1024).unwrap();
         // A second call at a *different* size must return the same untouched

--- a/crates/minvmd/src/volume.rs
+++ b/crates/minvmd/src/volume.rs
@@ -1,12 +1,10 @@
 //! Host-side provisioning of the per-VM writable data volume (`/dev/vdb`).
 //!
-//! The [`VolumeProvisioner`] trait isolates *how* the backing image is
-//! materialized (the host-side strategy) from the guest boot path, which keys
-//! exclusively off ext4 superblock detection (spec R1.3 / R1.5) and never off a
-//! "disk is blank" assumption. [`BlankRawProvisioner`] is the Phase-1
-//! implementation: a sparse raw file the guest formats with `mkfs.ext4` on first
-//! boot. Replacing it with a reflink/qcow2 provisioner later is a pure host-side
-//! swap with no guest or boot-path change.
+//! The image is a sparse raw file the guest formats with `mkfs.ext4` on first
+//! boot (spec R1.3 / R1.5); the guest keys exclusively off ext4 superblock
+//! detection, never off a "disk is blank" assumption. [`ensure_sparse_raw`]
+//! materializes it at the exact path it is asked for and is idempotent — an
+//! already-provisioned (and possibly guest-formatted) image is left untouched.
 
 use std::fs::OpenOptions;
 use std::io;
@@ -21,10 +19,9 @@ pub const DEFAULT_VOLUME_BYTES: u64 = 32 * 1024 * 1024 * 1024;
 /// Environment variable overriding [`DEFAULT_VOLUME_BYTES`] (spec R1.3).
 pub const VOLUME_BYTES_ENV: &str = "MINVMD_VOLUME_BYTES";
 
-/// Environment variable selecting the data-volume image path. When set, the
-/// VMM child provisions a blank sparse image there (if absent) and attaches it
-/// as `/dev/vdb`. The path's file stem is used as the `vm_id`. Must end in
-/// `.raw`. Unset means no data volume is attached (legacy tmpfs-only boot).
+/// Environment variable overriding the data-volume image path. Unset uses the
+/// default under the minvmd state dir (see [`resolve_data_volume_path`]); the
+/// volume is provisioned and attached as `/dev/vdb` on every boot either way.
 pub const DATA_VOLUME_PATH_ENV: &str = "MINVMD_DATA_VOLUME_PATH";
 
 /// Resolve the configured volume size. A non-numeric, empty, or zero value in
@@ -38,14 +35,41 @@ pub fn volume_bytes() -> u64 {
         .unwrap_or(DEFAULT_VOLUME_BYTES)
 }
 
-/// Failure modes of [`VolumeProvisioner::ensure`].
+/// Resolve the per-VM data-volume image path.
+///
+/// [`DATA_VOLUME_PATH_ENV`] overrides it explicitly (used verbatim); otherwise
+/// the image lives beside minvmd's persistent state as `<state>/data-vol.raw`,
+/// so it survives clean restarts. `XDG_STATE_HOME` is honoured directly rather
+/// than via [`crate::state::StateDir::default_path`] because the `dirs` crate
+/// ignores `XDG_STATE_HOME` on macOS — honouring it keeps the volume isolable in
+/// tests (and beside the state dir) on every platform.
+#[must_use]
+pub fn resolve_data_volume_path() -> PathBuf {
+    if let Some(explicit) = std::env::var_os(DATA_VOLUME_PATH_ENV).filter(|v| !v.is_empty()) {
+        return PathBuf::from(explicit);
+    }
+    let state_dir = std::env::var_os("XDG_STATE_HOME")
+        .filter(|v| !v.is_empty())
+        .map(|x| PathBuf::from(x).join("minimal/minvmd"))
+        .unwrap_or_else(crate::state::StateDir::default_path);
+    state_dir.join("data-vol.raw")
+}
+
+/// Failure modes of [`ensure_sparse_raw`].
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum VolumeError {
-    /// The volumes directory could not be created.
-    #[error("creating volumes directory {dir}")]
+    /// The parent directory could not be created.
+    #[error("creating volume directory {dir}")]
     CreateDir {
         dir: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    /// The image file could not be stat'd.
+    #[error("stat volume image {path}")]
+    Stat {
+        path: PathBuf,
         #[source]
         source: io::Error,
     },
@@ -66,54 +90,18 @@ pub enum VolumeError {
     },
 }
 
-/// Materializes the backing image for a VM's writable data volume.
+/// Ensure a sparse raw data-volume image exists at `path`, creating a blank one
+/// of `size_bytes` if it is missing.
 ///
-/// `ensure` is idempotent: repeated calls for the same `vm_id` return the same
-/// image path without disturbing an already-provisioned (and possibly
-/// guest-formatted) volume.
-pub trait VolumeProvisioner {
-    /// Return the path to `vm_id`'s data-volume image, creating a blank one of
-    /// `size_bytes` if it does not yet exist.
-    fn ensure(&self, vm_id: &str, size_bytes: u64) -> Result<PathBuf, VolumeError>;
-}
-
-/// Provisions a blank sparse raw file per VM under a fixed volumes directory.
-///
-/// The image lives at `<volumes_dir>/<vm_id>.raw`, sized with `ftruncate`
-/// (`File::set_len`) — which yields a sparse/thin file on both APFS (macOS) and
-/// ext4 (Linux), so the host never pays the full size up front. The guest runs
+/// Idempotent: an existing image is never resized in place — shrinking would
+/// truncate a guest-formatted ext4 and growing the file does not grow the
+/// filesystem (that needs `resize2fs`) — so a prior image is left untouched.
+/// The file is created with `ftruncate` (`File::set_len`), which yields a
+/// sparse/thin file on both APFS (macOS) and ext4 (Linux); the guest runs
 /// first-boot `mkfs.ext4` against it (spec R1.5).
-#[derive(Debug, Clone)]
-pub struct BlankRawProvisioner {
-    volumes_dir: PathBuf,
-}
-
-impl BlankRawProvisioner {
-    /// Construct a provisioner rooted at `volumes_dir` (e.g.
-    /// `<state_dir>/volumes`).
-    #[must_use]
-    pub fn new(volumes_dir: impl Into<PathBuf>) -> Self {
-        Self {
-            volumes_dir: volumes_dir.into(),
-        }
-    }
-
-    /// Deterministic image path for `vm_id`.
-    #[must_use]
-    pub fn image_path(&self, vm_id: &str) -> PathBuf {
-        self.volumes_dir.join(format!("{vm_id}.raw"))
-    }
-}
-
-impl VolumeProvisioner for BlankRawProvisioner {
-    fn ensure(&self, vm_id: &str, size_bytes: u64) -> Result<PathBuf, VolumeError> {
-        let path = self.image_path(vm_id);
-
-        // Idempotent: an already-provisioned image is never resized in place —
-        // shrinking would truncate a guest-formatted ext4 and growing the file
-        // does not grow the filesystem (that needs `resize2fs`). If a prior
-        // image exists we return it untouched; only a missing image is created.
-        if let Ok(meta) = std::fs::metadata(&path) {
+pub fn ensure_sparse_raw(path: &Path, size_bytes: u64) -> Result<(), VolumeError> {
+    match std::fs::metadata(path) {
+        Ok(meta) => {
             if meta.len() != size_bytes {
                 tracing::warn!(
                     path = %path.display(),
@@ -122,25 +110,32 @@ impl VolumeProvisioner for BlankRawProvisioner {
                     "existing data volume differs from requested size; keeping as-is",
                 );
             }
-            return Ok(path);
+            Ok(())
         }
-
-        create_sparse_raw(&self.volumes_dir, &path, size_bytes)?;
-        tracing::info!(
-            path = %path.display(),
-            size_bytes,
-            "provisioned blank sparse data volume",
-        );
-        Ok(path)
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            create_sparse_raw(path, size_bytes)?;
+            tracing::info!(
+                path = %path.display(),
+                size_bytes,
+                "provisioned blank sparse data volume",
+            );
+            Ok(())
+        }
+        Err(source) => Err(VolumeError::Stat {
+            path: path.to_path_buf(),
+            source,
+        }),
     }
 }
 
-/// Create a sparse raw file of `size_bytes` at `path`, creating `dir` first.
-fn create_sparse_raw(dir: &Path, path: &Path, size_bytes: u64) -> Result<(), VolumeError> {
-    std::fs::create_dir_all(dir).map_err(|source| VolumeError::CreateDir {
-        dir: dir.to_path_buf(),
-        source,
-    })?;
+/// Create a sparse raw file of `size_bytes` at `path`, creating parents first.
+fn create_sparse_raw(path: &Path, size_bytes: u64) -> Result<(), VolumeError> {
+    if let Some(dir) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(dir).map_err(|source| VolumeError::CreateDir {
+            dir: dir.to_path_buf(),
+            source,
+        })?;
+    }
     let file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -182,9 +177,9 @@ mod tests {
     #[test]
     fn ensure_creates_sparse_image_of_requested_len() {
         let dir = tmpdir("sparse");
-        let prov = BlankRawProvisioner::new(dir.join("volumes"));
+        let path = dir.join("data-vol.raw");
         let size = 8 * 1024 * 1024 * 1024; // 8 GiB
-        let path = prov.ensure("vm-abc", size).unwrap();
+        ensure_sparse_raw(&path, size).unwrap();
 
         let meta = std::fs::metadata(&path).unwrap();
         assert_eq!(meta.len(), size, "logical length must match requested size");
@@ -196,23 +191,24 @@ mod tests {
             allocated < size / 100,
             "expected a sparse file, but {allocated} bytes are allocated for a {size}-byte image",
         );
+        // Best-effort cleanup; a leftover temp dir must not fail the test.
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn ensure_is_idempotent_and_does_not_resize() {
         let dir = tmpdir("idempotent");
-        let prov = BlankRawProvisioner::new(dir.join("volumes"));
-        let path = prov.ensure("vm-xyz", 4 * 1024 * 1024 * 1024).unwrap();
-        // A second call at a *different* size must return the same untouched
-        // image rather than truncating it (which would corrupt a formatted FS).
-        let path2 = prov.ensure("vm-xyz", 1024 * 1024 * 1024).unwrap();
-        assert_eq!(path, path2);
+        let path = dir.join("data-vol.raw");
+        ensure_sparse_raw(&path, 4 * 1024 * 1024 * 1024).unwrap();
+        // A second call at a *different* size must leave the existing image
+        // untouched rather than truncating it (which would corrupt a formatted FS).
+        ensure_sparse_raw(&path, 1024 * 1024 * 1024).unwrap();
         assert_eq!(
             std::fs::metadata(&path).unwrap().len(),
             4 * 1024 * 1024 * 1024,
             "existing image must not be resized",
         );
+        // Best-effort cleanup; a leftover temp dir must not fail the test.
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/minvmd/src/volume.rs
+++ b/crates/minvmd/src/volume.rs
@@ -1,0 +1,221 @@
+//! Host-side provisioning of the per-VM writable data volume (`/dev/vdb`).
+//!
+//! The [`VolumeProvisioner`] trait isolates *how* the backing image is
+//! materialized (the host-side strategy) from the guest boot path, which keys
+//! exclusively off ext4 superblock detection (spec R1.3 / R1.5) and never off a
+//! "disk is blank" assumption. [`BlankRawProvisioner`] is the Phase-1
+//! implementation: a sparse raw file the guest formats with `mkfs.ext4` on first
+//! boot. Replacing it with a reflink/qcow2 provisioner later is a pure host-side
+//! swap with no guest or boot-path change.
+
+use std::fs::OpenOptions;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Default size of a freshly provisioned data volume: 32 GiB. The image is a
+/// sparse raw file, so the host allocates only the blocks the guest actually
+/// writes (allocate-on-write, verified by the sparsity proof gate); this value
+/// is the ceiling, not an up-front cost.
+pub const DEFAULT_VOLUME_BYTES: u64 = 32 * 1024 * 1024 * 1024;
+
+/// Environment variable overriding [`DEFAULT_VOLUME_BYTES`] (spec R1.3).
+pub const VOLUME_BYTES_ENV: &str = "MINVMD_VOLUME_BYTES";
+
+/// Environment variable selecting the data-volume image path. When set, the
+/// VMM child provisions a blank sparse image there (if absent) and attaches it
+/// as `/dev/vdb`. The path's file stem is used as the `vm_id`. Must end in
+/// `.raw`. Unset means no data volume is attached (legacy tmpfs-only boot).
+pub const DATA_VOLUME_PATH_ENV: &str = "MINVMD_DATA_VOLUME_PATH";
+
+/// Resolve the configured volume size. A non-numeric, empty, or zero value in
+/// [`VOLUME_BYTES_ENV`] falls back to [`DEFAULT_VOLUME_BYTES`].
+#[must_use]
+pub fn volume_bytes() -> u64 {
+    std::env::var(VOLUME_BYTES_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&b| b > 0)
+        .unwrap_or(DEFAULT_VOLUME_BYTES)
+}
+
+/// Failure modes of [`VolumeProvisioner::ensure`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum VolumeError {
+    /// The volumes directory could not be created.
+    #[error("creating volumes directory {dir}")]
+    CreateDir {
+        dir: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    /// The image file could not be created.
+    #[error("creating volume image {path}")]
+    Create {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    /// The image file could not be sized (sparse `ftruncate`).
+    #[error("sizing volume image {path} to {size} bytes")]
+    Resize {
+        path: PathBuf,
+        size: u64,
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// Materializes the backing image for a VM's writable data volume.
+///
+/// `ensure` is idempotent: repeated calls for the same `vm_id` return the same
+/// image path without disturbing an already-provisioned (and possibly
+/// guest-formatted) volume.
+pub trait VolumeProvisioner {
+    /// Return the path to `vm_id`'s data-volume image, creating a blank one of
+    /// `size_bytes` if it does not yet exist.
+    fn ensure(&self, vm_id: &str, size_bytes: u64) -> Result<PathBuf, VolumeError>;
+}
+
+/// Provisions a blank sparse raw file per VM under a fixed volumes directory.
+///
+/// The image lives at `<volumes_dir>/<vm_id>.raw`, sized with `ftruncate`
+/// (`File::set_len`) — which yields a sparse/thin file on both APFS (macOS) and
+/// ext4 (Linux), so the host never pays the full size up front. The guest runs
+/// first-boot `mkfs.ext4` against it (spec R1.5).
+#[derive(Debug, Clone)]
+pub struct BlankRawProvisioner {
+    volumes_dir: PathBuf,
+}
+
+impl BlankRawProvisioner {
+    /// Construct a provisioner rooted at `volumes_dir` (e.g.
+    /// `<state_dir>/volumes`).
+    #[must_use]
+    pub fn new(volumes_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            volumes_dir: volumes_dir.into(),
+        }
+    }
+
+    /// Deterministic image path for `vm_id`.
+    #[must_use]
+    pub fn image_path(&self, vm_id: &str) -> PathBuf {
+        self.volumes_dir.join(format!("{vm_id}.raw"))
+    }
+}
+
+impl VolumeProvisioner for BlankRawProvisioner {
+    fn ensure(&self, vm_id: &str, size_bytes: u64) -> Result<PathBuf, VolumeError> {
+        let path = self.image_path(vm_id);
+
+        // Idempotent: an already-provisioned image is never resized in place —
+        // shrinking would truncate a guest-formatted ext4 and growing the file
+        // does not grow the filesystem (that needs `resize2fs`). If a prior
+        // image exists we return it untouched; only a missing image is created.
+        if let Ok(meta) = std::fs::metadata(&path) {
+            if meta.len() != size_bytes {
+                tracing::warn!(
+                    path = %path.display(),
+                    have = meta.len(),
+                    want = size_bytes,
+                    "existing data volume differs from requested size; keeping as-is",
+                );
+            }
+            return Ok(path);
+        }
+
+        create_sparse_raw(&self.volumes_dir, &path, size_bytes)?;
+        tracing::info!(
+            path = %path.display(),
+            size_bytes,
+            "provisioned blank sparse data volume",
+        );
+        Ok(path)
+    }
+}
+
+/// Create a sparse raw file of `size_bytes` at `path`, creating `dir` first.
+fn create_sparse_raw(dir: &Path, path: &Path, size_bytes: u64) -> Result<(), VolumeError> {
+    std::fs::create_dir_all(dir).map_err(|source| VolumeError::CreateDir {
+        dir: dir.to_path_buf(),
+        source,
+    })?;
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|source| VolumeError::Create {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    // `set_len` == `ftruncate(2)`: extends the file to `size_bytes` without
+    // writing any data, leaving it sparse (host `st_blocks` stays ~0 until the
+    // guest writes). This is the allocate-on-write substrate the sparsity gate
+    // measures — `fallocate` *without* `KEEP_SIZE` would defeat it by allocating
+    // eagerly.
+    file.set_len(size_bytes)
+        .map_err(|source| VolumeError::Resize {
+            path: path.to_path_buf(),
+            size: size_bytes,
+            source,
+        })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::MetadataExt;
+
+    fn tmpdir() -> PathBuf {
+        let base = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".into());
+        let p = PathBuf::from(base).join(format!("minvmd-vol-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&p);
+        p
+    }
+
+    #[test]
+    fn ensure_creates_sparse_image_of_requested_len() {
+        let dir = tmpdir();
+        let prov = BlankRawProvisioner::new(dir.join("volumes"));
+        let size = 8 * 1024 * 1024 * 1024; // 8 GiB
+        let path = prov.ensure("vm-abc", size).unwrap();
+
+        let meta = std::fs::metadata(&path).unwrap();
+        assert_eq!(meta.len(), size, "logical length must match requested size");
+        // Allocate-on-write at the host-FS level: a freshly `ftruncate`d file
+        // occupies far fewer blocks than its length (512-byte blocks). Allow
+        // slack for FS metadata but reject anything near full allocation.
+        let allocated = meta.blocks() * 512;
+        assert!(
+            allocated < size / 100,
+            "expected a sparse file, but {allocated} bytes are allocated for a {size}-byte image",
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn ensure_is_idempotent_and_does_not_resize() {
+        let dir = tmpdir();
+        let prov = BlankRawProvisioner::new(dir.join("volumes"));
+        let path = prov.ensure("vm-xyz", 4 * 1024 * 1024 * 1024).unwrap();
+        // A second call at a *different* size must return the same untouched
+        // image rather than truncating it (which would corrupt a formatted FS).
+        let path2 = prov.ensure("vm-xyz", 1024 * 1024 * 1024).unwrap();
+        assert_eq!(path, path2);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().len(),
+            4 * 1024 * 1024 * 1024,
+            "existing image must not be resized",
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn volume_bytes_defaults_when_unset() {
+        // Not asserting on the env (tests share a process); just the default.
+        assert_eq!(DEFAULT_VOLUME_BYTES, 32 * 1024 * 1024 * 1024);
+    }
+}


### PR DESCRIPTION
## per-VM writable ext4 `/dev/vdb` volume

Implements first stage of the [spec](https://github.com/gominimal/minimal/pull/658) for [#583](https://github.com/gominimal/minimal/issues/583): a per-VM writable ext4 volume that carries the package cache, rootfs-staging trees, and session state on one filesystem — resolving the `EXDEV` hardlink constraint and moving session state off RAM onto durable storage.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional writable data volume that can be attached to a VM and reused across boots.
  * Guest state can now be relocated onto the attached volume, with idempotent first-boot and reboot behavior.
  * VM startup now adjusts memory settings based on whether a data volume is present.

* **Bug Fixes**
  * Improved disk handling to avoid unnecessary reformatting and geometry-related boot errors.
  * Added checks to keep provisioned volume images sparse and space-efficient.

* **Tests**
  * Expanded end-to-end coverage on Linux and macOS for volume attachment, persistence, and sparsity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->