### PR TITLE
fix(minimald): bound the boot-path gvproxy expose so it can't stall SSH accept

### DIFF
--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -529,10 +529,21 @@ async fn start_host_proxies(state: &ServerStateHandle, in_microvm: bool) {
     }
 }
 
+/// Upper bound on the best-effort host-loopback publish in
+/// [`expose_proxy_on_host`]. Deliberately far below `post_json`'s gvproxy
+/// control timeout: the publish is awaited on [`Server::run`]'s boot path
+/// *before* the SSH accept loop starts serving, so when no host gvproxy answers
+/// (e.g. none is configured) it must not hold that loop for the full control
+/// timeout — the cold `minimal ls` connect-retry deadline would expire first and
+/// the first list fails (`ssh connect: Disconnected`). A present gvproxy answers
+/// in well under this.
+#[cfg(target_os = "linux")]
+const HOST_EXPOSE_PUBLISH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Publishes a guest-side proxy bound on `daemon_ip:port` onto the macOS host's
 /// loopback (`127.0.0.1:port`) via the host gvproxy forwarder, reached over the
 /// vsock shuttle (DM1). Best-effort: warns and returns on failure, since the
-/// host gvproxy may be absent.
+/// host gvproxy may be absent. Capped at [`HOST_EXPOSE_PUBLISH_TIMEOUT`].
 #[cfg(target_os = "linux")]
 async fn expose_proxy_on_host(daemon_ip: std::net::Ipv4Addr, port: u16) {
     use crate::net::policy::{ControlChannel, ExposeRequest, post_json};
@@ -546,12 +557,23 @@ async fn expose_proxy_on_host(daemon_ip: std::net::Ipv4Addr, port: u16) {
         remote: format!("{daemon_ip}:{port}"),
         protocol: "tcp".to_string(),
     };
-    if let Err(error) = post_json(&control, "/services/forwarder/expose", &request).await {
-        tracing::warn!(
+    match tokio::time::timeout(
+        HOST_EXPOSE_PUBLISH_TIMEOUT,
+        post_json(&control, "/services/forwarder/expose", &request),
+    )
+    .await
+    {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => tracing::warn!(
             %port,
             %error,
             "could not publish host-side proxy on the host loopback via gvproxy forwarder"
-        );
+        ),
+        Err(_) => tracing::warn!(
+            %port,
+            timeout = ?HOST_EXPOSE_PUBLISH_TIMEOUT,
+            "host-side proxy publish did not complete in time; continuing (best-effort)"
+        ),
     }
 }
 


### PR DESCRIPTION
## Problem

`autospawn-e2e` is green on `main` but only by a **~40 ms margin**, and it's a pre-existing latent flake — surfaced while working the volume PR (#672), whose extra ~60 ms first-boot cost tips it red.

Root cause (from the green-main boot log): `start_host_proxies` **awaits** `expose_proxy_on_host` on `Server::run`'s boot path, *before* the SSH accept loop serves. When no host gvproxy answers — which is always the case in the `autospawn-e2e` job (no `MINVMD_GVPROXY_BIN`) — that await runs to the full 5 s `GVPROXY_CONTROL_TIMEOUT`, holding the accept loop closed:

```
16:21:55.511  host-side egress proxy :7654 bindable       ← awaited expose begins
16:22:00.517  WARN expose timed out after 5s              ← accept loop blocked this whole 5s
16:22:00.518  accepted connection … SSH handshake failed: Broken pipe   ← client's 1st retry, gap
16:22:00.607  accepted connection … (a later retry succeeds → cold ls = 6196ms)
```

The cold `minimal ls` clears it only because the CLI **retries** and one retry lands the instant the loop unblocks at ~5 s. Any perturbation past that edge (CI load, or #672's mkfs) flips it to `ssh connect: Disconnected`.

In **production this never happens** — a host gvproxy is present, so the expose returns in <100 ms and the accept loop is never delayed.

## Fix

Cap the best-effort publish at `HOST_EXPOSE_PUBLISH_TIMEOUT` (1 s), so a missing/slow gvproxy can't hold the accept loop near the CLI's retry deadline. The accept loop now resumes at ~1.6 s (vs ~5 s) — a multi-second margin instead of 40 ms. Best-effort semantics unchanged (timeout warns and continues); when a gvproxy is present the 1 s cap never triggers.

## Validation

- `cross clippy -p minimald --features networking-proxy,networking-wg --target aarch64-unknown-linux-musl -- -D warnings` → clean.
- De-flakes `autospawn-e2e` on `main`; also unblocks #672's `autospawn-e2e` once #672 rebases onto this.

Refs: #588


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Host-side proxy publication no longer waits indefinitely when the host forwarder is unavailable or unresponsive.
  * Added a bounded wait time for proxy exposure and improved warning messages for timeout versus connection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->