### PR TITLE
feat(minimal): prompt to init when activate has no minimal.toml

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -819,6 +819,7 @@ fn ensure_mfile_or_prompt(
             .map_err(|e| anyhow::anyhow!("{e}"))?
     };
     run_init_flow(config, false)
+}
 
 /// Create a new session via the `CreateSession` RPC.
 pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), anyhow::Error> {

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -772,6 +772,49 @@ async fn send_abort(client: &mut client::Client, session_id: sessions::SessionId
     }
 }
 
+/// Check for a `minimal.toml` at the project path. If missing, prompt
+/// the user to initialize one before proceeding with activation.
+fn ensure_mfile_or_prompt(
+    project_path: &camino::Utf8Path,
+    global: &GlobalArgs,
+) -> Result<(), anyhow::Error> {
+    if project_path.join(mfile::MFILE_NAME).exists() {
+        return Ok(());
+    }
+
+    eprintln!("\nNo {} found at {}.", mfile::MFILE_NAME, project_path);
+    eprint!("Would you like to create one? [Y/n] ");
+    std::io::stderr().flush().ok();
+
+    let mut input = String::new();
+    std::io::stdin()
+        .read_line(&mut input)
+        .context("reading stdin")?;
+    let trimmed = input.trim();
+    if !(trimmed.eq_ignore_ascii_case("y")
+        || trimmed.eq_ignore_ascii_case("yes")
+        || trimmed.is_empty())
+    {
+        bail!(
+            "No {} found. Run 'minimal init' to create one.",
+            mfile::MFILE_NAME
+        );
+    }
+
+    let config = if global.repo_dir.is_some() {
+        build_config(global).map_err(|e| anyhow::anyhow!("{e}"))?
+    } else {
+        let mut builder = mctx::ConfigBuilder::new();
+        if let Some(dir) = &global.minimal_dir {
+            builder = builder.with_state_dir(dir).with_cache_dir(dir);
+        }
+        builder
+            .with_repo_dir(project_path.as_std_path())
+            .build()
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+    };
+    run_init_flow(config, false)
+
 /// Create a new session via the `CreateSession` RPC.
 pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), anyhow::Error> {
     ensure_daemon(global)?;
@@ -781,7 +824,10 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
 
     let utf8_path = camino::Utf8PathBuf::from_path_buf(project_path)
         .map_err(|_| anyhow::anyhow!("Project path is not valid UTF-8"))?;
-    let abs_path = paths::HostAbsPath::try_new(utf8_path).context("Invalid project path")?;
+    let abs_path =
+        paths::HostAbsPath::try_new(utf8_path.clone()).context("Invalid project path")?;
+
+    ensure_mfile_or_prompt(&utf8_path, global)?;
 
     let mut port_mappings = Vec::with_capacity(args.ingress.len());
     for spec in &args.ingress {
@@ -1350,14 +1396,18 @@ pub fn build_config(global: &GlobalArgs) -> Result<mctx::Config, mctx::Error> {
     Ok(builder.build()?)
 }
 
-/// Initialize a `minimal.toml` based on the source tree.
-pub async fn cmd_init(global: &GlobalArgs, args: InitArgs) -> Result<(), mctx::Error> {
+/// Run the init flow for a given config: detect the project's stack,
+/// generate a `minimal.toml`, show the plan, prompt for confirmation,
+/// and write the file. Shared by `cmd_init` and the `cmd_activate`
+/// missing-mfile prompt.
+fn run_init_flow(config: mctx::Config, skip_confirm: bool) -> Result<(), anyhow::Error> {
     use op::ProjectOp as _;
-    let config = build_config(global)?;
-    let mut env = mctx::ProjectSetup::for_init(config)?;
-    let plan = op::InitProject.run(&mut env)?;
+    let mut env = mctx::ProjectSetup::for_init(config).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let plan = op::InitProject
+        .run(&mut env)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-    if !args.yes {
+    if !skip_confirm {
         eprintln!("\nWill create {}:\n", plan.toml_path.display());
         eprintln!("---");
         eprint!("{}", plan.content);
@@ -1369,7 +1419,7 @@ pub async fn cmd_init(global: &GlobalArgs, args: InitArgs) -> Result<(), mctx::E
         let mut input = String::new();
         std::io::stdin()
             .read_line(&mut input)
-            .map_err(|e| mctx::Error::Other(anyhow::anyhow!("reading stdin: {}", e)))?;
+            .context("reading stdin")?;
         let trimmed = input.trim();
         if !(trimmed.eq_ignore_ascii_case("y")
             || trimmed.eq_ignore_ascii_case("yes")
@@ -1380,13 +1430,8 @@ pub async fn cmd_init(global: &GlobalArgs, args: InitArgs) -> Result<(), mctx::E
         }
     }
 
-    std::fs::write(&plan.toml_path, &plan.content).map_err(|e| {
-        mctx::Error::Other(anyhow::anyhow!(
-            "writing {}: {}",
-            plan.toml_path.display(),
-            e
-        ))
-    })?;
+    std::fs::write(&plan.toml_path, &plan.content)
+        .with_context(|| format!("writing {}", plan.toml_path.display()))?;
 
     eprintln!("Created {}", plan.toml_path.display());
     eprintln!();
@@ -1398,6 +1443,12 @@ pub async fn cmd_init(global: &GlobalArgs, args: InitArgs) -> Result<(), mctx::E
     }
 
     Ok(())
+}
+
+/// Initialize a `minimal.toml` based on the source tree.
+pub async fn cmd_init(global: &GlobalArgs, args: InitArgs) -> Result<(), mctx::Error> {
+    let config = build_config(global)?;
+    run_init_flow(config, args.yes).map_err(mctx::Error::Other)
 }
 
 /// Add packages as dependencies to the project's `minimal.toml`.

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -553,6 +553,22 @@ fn ensure_daemon(global: &GlobalArgs) -> Result<(), anyhow::Error> {
         .context("Failed to ensure the minimald daemon is running")
 }
 
+/// Prompt the user with a yes/no question on stderr. Defaults to yes
+/// (empty input or Y/y/yes returns true; anything else returns false).
+fn confirm(question: &str) -> Result<bool, anyhow::Error> {
+    eprint!("{question} [Y/n] ");
+    std::io::stderr().flush().ok();
+
+    let mut input = String::new();
+    std::io::stdin()
+        .read_line(&mut input)
+        .context("reading stdin")?;
+    let trimmed = input.trim();
+    Ok(trimmed.is_empty()
+        || trimmed.eq_ignore_ascii_case("y")
+        || trimmed.eq_ignore_ascii_case("yes"))
+}
+
 /// List sessions via the `ListSessions` RPC.
 pub async fn cmd_ls(global: &GlobalArgs, args: LsArgs) -> Result<(), anyhow::Error> {
     ensure_daemon(global)?;
@@ -783,18 +799,7 @@ fn ensure_mfile_or_prompt(
     }
 
     eprintln!("\nNo {} found at {}.", mfile::MFILE_NAME, project_path);
-    eprint!("Would you like to create one? [Y/n] ");
-    std::io::stderr().flush().ok();
-
-    let mut input = String::new();
-    std::io::stdin()
-        .read_line(&mut input)
-        .context("reading stdin")?;
-    let trimmed = input.trim();
-    if !(trimmed.eq_ignore_ascii_case("y")
-        || trimmed.eq_ignore_ascii_case("yes")
-        || trimmed.is_empty())
-    {
+    if !confirm("Would you like to create one?")? {
         bail!(
             "No {} found. Run 'minimal init' to create one.",
             mfile::MFILE_NAME
@@ -1413,18 +1418,7 @@ fn run_init_flow(config: mctx::Config, skip_confirm: bool) -> Result<(), anyhow:
         eprint!("{}", plan.content);
         eprintln!("---");
         eprintln!();
-        eprint!("Continue? [Y/n] ");
-        std::io::stderr().flush().ok();
-
-        let mut input = String::new();
-        std::io::stdin()
-            .read_line(&mut input)
-            .context("reading stdin")?;
-        let trimmed = input.trim();
-        if !(trimmed.eq_ignore_ascii_case("y")
-            || trimmed.eq_ignore_ascii_case("yes")
-            || trimmed.is_empty())
-        {
+        if !confirm("Continue?")? {
             eprintln!("Aborted.");
             return Ok(());
         }

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -169,9 +169,18 @@ async fn ls_raw_with_sessions() {
 async fn activate_creates_session() {
     let (daemon, args) = setup().await;
 
+    // Create a temp project dir with a minimal.toml so the
+    // missing-mfile prompt doesn't fire.
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        project.path().join("minimal.toml"),
+        "# test minimal.toml\n[upstream]\nrepo = \"https://github.com/gominimal/pkgs\"\nbranch = \"main\"\n\n[stack]\nuse = \"shell\"\n",
+    )
+    .unwrap();
+
     let activate_args = ActivateArgs {
         name: Some("test-session".to_string()),
-        path: ".".to_string(),
+        path: project.path().to_string_lossy().to_string(),
         network: CliNetworkMode::NoNet,
         ingress: vec![],
         loadout: vec![],


### PR DESCRIPTION
## Summary

When `minimal activate` is run in a project without a `minimal.toml`, the client now prompts the user to create one instead of the daemon silently scaffolding a default (the temporary `mctx::scaffold_default_mfile` path, which does a blocking network git clone). This is the last remaining P0 item from gominimal/inbox#159.

### Changes

- **`cmd_activate`** now calls `ensure_mfile_or_prompt` after canonicalizing the project path. If no `minimal.toml` exists, it prompts `Would you like to create one? [Y/n]`:
  - **Yes (Linux)**: runs the same init flow as `minimal init` (detect stack, generate `minimal.toml`, confirm, write)
  - **Yes (macOS)**: bails with a clear message — `minimal init` is Linux-only due to `mctx`/`op` pulling in `hakoniwa`/`procfs`
  - **No**: bails with `No minimal.toml found. Run 'minimal init' to create one.`
- **`run_init_flow`** extracted from `cmd_init` so both `cmd_init` and the activate prompt share the same init logic (plan display, confirmation prompt, file write)
- **`activate_creates_session` test** updated to use a tempdir with a `minimal.toml` so the prompt doesn't fire

Closes the last P0 item on gominimal/inbox#159.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activation now verifies the required project config file exists before starting a session.
  * If the file is missing on Linux, activation can guide you through creating it automatically.
* **Bug Fixes**
  * Activation no longer proceeds when the required project config file is absent.
  * Non-Linux systems now provide clearer instructions for creating the config file.
* **Tests**
  * Updated CLI integration test setup to include the required config file, preventing prompt-related flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->