### PR TITLE
feat(sessions): loadouts, config, and debug commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,6 +3658,7 @@ dependencies = [
  "tokio-util",
  "tokio-vsock",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "vt100-ctt",
 ]
@@ -5871,6 +5872,7 @@ dependencies = [
  "camino",
  "common",
  "globset",
+ "indoc",
  "nutype",
  "paths",
  "serde",
@@ -6204,6 +6206,12 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 [[package]]
 name = "switch"
 version = "0.0.1"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -6744,6 +6752,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ tonic-prost = "0.14.6"
 tonic-prost-build = "0.14.6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-appender = "0.2"
 thiserror = "2"
 url = "2" # keep in sync with reqwest
 uuid = { version = "1.23", features = ["v4", "v7", "serde"] }

--- a/crates/minimal/src/config.rs
+++ b/crates/minimal/src/config.rs
@@ -1,0 +1,32 @@
+//! Client-side config-dir resolution and `config.toml` loading.
+//!
+//! Both the loadouts and dirs subsystems route through this module so
+//! `--config-dir`, `paths::minimal_config_dir()`, and the on-disk
+//! `config.toml` layout are all resolved in one place.
+
+use std::path::PathBuf;
+
+use crate::GlobalArgs;
+
+/// Resolve `<config>/minimal` on the platform's user config dir,
+/// or the `--config-dir` override if the caller passed one. The
+/// base for both the loadouts subdir and the client config file.
+pub fn resolve_minimal_config_dir(global: &GlobalArgs) -> PathBuf {
+    if let Some(dir) = &global.config_dir {
+        return dir.join("minimal");
+    }
+    paths::minimal_config_dir()
+        .as_utf8_path()
+        .as_std_path()
+        .to_path_buf()
+}
+
+/// Read the client config once, so both loadout resolution and
+/// compose-option handling see the same values without hitting the
+/// disk twice.
+pub fn read_client_config(
+    global: &GlobalArgs,
+) -> Result<sessions::client::config::Config, anyhow::Error> {
+    let cfg_path = resolve_minimal_config_dir(global).join("config.toml");
+    sessions::client::config::read_config_or_default(&cfg_path).map_err(|e| anyhow::anyhow!("{e}"))
+}

--- a/crates/minimal/src/dirs.rs
+++ b/crates/minimal/src/dirs.rs
@@ -1,0 +1,423 @@
+//! `minimal dirs` — print the important directories and files a user
+//! might want to inspect when debugging.
+
+use std::path::PathBuf;
+
+use crate::GlobalArgs;
+use crate::config::resolve_minimal_config_dir;
+use crate::mesh_enrolment_path;
+
+/// Print the important directories and files a user might want to
+/// inspect when debugging. Grouped by role (config / state / cache)
+/// with an "exists?" marker so unused paths don't look identical to
+/// misconfigured ones.
+pub fn cmd_dirs(global: &GlobalArgs) -> Result<(), anyhow::Error> {
+    // Shown in the "Daemon logs" note to point users at today's
+    // rolling log file directly, e.g. `minimald.log.2026-07-08`.
+    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+    let dirs = DirsLookup {
+        config: resolve_minimal_config_dir(global),
+        mesh_enrolment: mesh_enrolment_path(global),
+        // `mesh_enrolment_path` follows `--minimal-dir` when set,
+        // so the row groups with State in that case rather than
+        // Config — otherwise a user reading `minimal dirs` would
+        // find the mesh file under the wrong header.
+        mesh_group: if global.minimal_dir.is_some() {
+            MeshGroup::State
+        } else {
+            MeshGroup::Config
+        },
+        state: match &global.minimal_dir {
+            Some(dir) => dir.clone(),
+            None => paths::minimal_state_dir()
+                .as_utf8_path()
+                .as_std_path()
+                .to_path_buf(),
+        },
+        cache: paths::minimal_cache_dir()
+            .as_utf8_path()
+            .as_std_path()
+            .to_path_buf(),
+        today,
+    };
+    print_dir_rows(&build_dir_rows(&dirs));
+    Ok(())
+}
+
+/// Resolved locations `cmd_dirs` prints, materialized once so
+/// [`build_dir_rows`] stays a pure function of its inputs (easy to
+/// snapshot-test without touching env or the filesystem).
+struct DirsLookup {
+    /// `<config>/minimal` — root for `config.toml`, `loadouts/`,
+    /// mTLS certs.
+    config: PathBuf,
+    /// The specific path `minimal mesh join` writes to. Kept separate
+    /// so a `--minimal-dir` override that redirects the mesh file
+    /// (but not the loadouts subsystem) still shows up correctly.
+    mesh_enrolment: PathBuf,
+    /// Which group heading the mesh row prints under —
+    /// `Config` in the common case, `State` when
+    /// `--minimal-dir` redirected the mesh file to the state tree.
+    mesh_group: MeshGroup,
+    /// `<state>/minimal` (or the `--minimal-dir` override).
+    state: PathBuf,
+    /// `<cache>/minimal`.
+    cache: PathBuf,
+    /// Today's date in `YYYY-MM-DD`, used only in the "Daemon logs"
+    /// note next to the rolling filename suffix.
+    today: String,
+}
+
+/// Which top-level group the mesh-enrolment row prints under. Values
+/// match the row group labels one-to-one via [`Self::as_row_group`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MeshGroup {
+    Config,
+    State,
+}
+
+impl MeshGroup {
+    /// Group label used in [`DirRow::group`] and printed as the
+    /// column header. Kept as a method (not `Display`) so the mapping
+    /// is grep-friendly and callers can't accidentally pass an
+    /// unrelated `&str`.
+    fn as_row_group(self) -> &'static str {
+        match self {
+            Self::Config => "Config",
+            Self::State => "State",
+        }
+    }
+}
+
+/// Build the `cmd_dirs` row list from a resolved [`DirsLookup`].
+/// Pure function of its input — no env reads, no filesystem stat
+/// calls beyond what [`DirRow::existence_marker`] does at print
+/// time.
+fn build_dir_rows(dirs: &DirsLookup) -> Vec<DirRow> {
+    let mesh_row = || {
+        (
+            dirs.mesh_group.as_row_group(),
+            "Mesh enrolment",
+            Some(dirs.mesh_enrolment.clone()),
+            None,
+        )
+            .into_row()
+    };
+
+    let mut rows = vec![
+        ("Config", "Config dir", Some(dirs.config.clone()), None).into_row(),
+        (
+            "Config",
+            "config.toml",
+            Some(dirs.config.join("config.toml")),
+            None,
+        )
+            .into_row(),
+        (
+            "Config",
+            "Loadouts dir",
+            Some(dirs.config.join("loadouts")),
+            None,
+        )
+            .into_row(),
+    ];
+    if dirs.mesh_group == MeshGroup::Config {
+        rows.push(mesh_row());
+    }
+    rows.extend([
+        (
+            "Config",
+            "mTLS client cert",
+            Some(dirs.config.join("client.pem")),
+            None,
+        )
+            .into_row(),
+        (
+            "Config",
+            "mTLS client key",
+            Some(dirs.config.join("client.key")),
+            None,
+        )
+            .into_row(),
+        (
+            "Config",
+            "mTLS CA cert",
+            Some(dirs.config.join("ca.pem")),
+            None,
+        )
+            .into_row(),
+        ("State", "State dir", Some(dirs.state.clone()), None).into_row(),
+        ("State", "Sessions", Some(dirs.state.join("sessions")), None).into_row(),
+        (
+            "State",
+            "Daemon logs",
+            Some(dirs.state.join("logs")),
+            Some(format!("daily-rotated: minimald.log.{}", dirs.today)),
+        )
+            .into_row(),
+        (
+            "State",
+            "SSH socket",
+            Some(dirs.state.join("providers/local-0/ssh.sock")),
+            None,
+        )
+            .into_row(),
+    ]);
+    if dirs.mesh_group == MeshGroup::State {
+        // After the SSH-socket row so the mesh file lands at the
+        // tail of the State group — visually adjacent to the state
+        // dir root it lives under.
+        rows.push(mesh_row());
+    }
+    rows.extend([
+        ("Cache", "Cache dir", Some(dirs.cache.clone()), None).into_row(),
+        (
+            "Cache",
+            "Built artifacts",
+            Some(dirs.cache.join("built")),
+            None,
+        )
+            .into_row(),
+    ]);
+    rows
+}
+
+/// Print the row list produced by [`build_dir_rows`] with per-column
+/// width-alignment and a blank line between groups.
+fn print_dir_rows(rows: &[DirRow]) {
+    let group_w = rows.iter().map(|r| r.group.len()).max().unwrap_or(6);
+    let name_w = rows.iter().map(|r| r.name.len()).max().unwrap_or(4).max(4);
+    let path_w = rows
+        .iter()
+        .map(|r| r.path_display().len())
+        .max()
+        .unwrap_or(4);
+
+    println!(
+        "{group:<group_w$}     {name:<name_w$}  {path:<path_w$}",
+        group = "GROUP",
+        name = "NAME",
+        path = "PATH",
+    );
+
+    let mut current_group = "";
+    for row in rows {
+        if row.group != current_group {
+            if !current_group.is_empty() {
+                println!();
+            }
+            current_group = row.group;
+        }
+        let mark = row.existence_marker();
+        let path = row.path_display();
+        let note = row
+            .note
+            .as_deref()
+            .map(|n| format!("  ({n})"))
+            .unwrap_or_default();
+        println!(
+            "{group:<group_w$}  {mark}  {name:<name_w$}  {path:<path_w$}{note}",
+            group = row.group,
+            name = row.name,
+        );
+    }
+    println!();
+    println!("  * = exists   - = missing   ? = unknown (path unresolved)");
+}
+
+/// One row emitted by [`cmd_dirs`]. Kept as a struct rather than
+/// a tuple so the group / mark / path / note columns can be widened
+/// independently at print time.
+struct DirRow {
+    group: &'static str,
+    name: &'static str,
+    path: Option<PathBuf>,
+    note: Option<String>,
+}
+
+impl DirRow {
+    fn path_display(&self) -> String {
+        match &self.path {
+            Some(p) => p.display().to_string(),
+            None => "<unresolved>".to_string(),
+        }
+    }
+    fn existence_marker(&self) -> char {
+        match &self.path {
+            None => '?',
+            Some(p) if p.exists() => '*',
+            Some(_) => '-',
+        }
+    }
+}
+
+trait IntoDirRow {
+    fn into_row(self) -> DirRow;
+}
+impl IntoDirRow for (&'static str, &'static str, Option<PathBuf>, Option<String>) {
+    fn into_row(self) -> DirRow {
+        DirRow {
+            group: self.0,
+            name: self.1,
+            path: self.2,
+            note: self.3,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `build_dir_rows` produces exactly 13 rows in the fixed order
+    /// [Config × 7, State × 4, Cache × 2] when the mesh row is
+    /// under Config (the common case), each with the right group
+    /// tag, name, and derived path. Guards against a future edit
+    /// that drops a row or shuffles groups without noticing.
+    #[test]
+    fn build_dir_rows_layout_is_stable() {
+        let dirs = DirsLookup {
+            config: PathBuf::from("/home/u/.config/minimal"),
+            mesh_enrolment: PathBuf::from("/home/u/.config/minimal/mesh-enrolment"),
+            mesh_group: MeshGroup::Config,
+            state: PathBuf::from("/home/u/.local/state/minimal"),
+            cache: PathBuf::from("/home/u/.cache/minimal"),
+            today: "2026-07-08".to_string(),
+        };
+        let rows = build_dir_rows(&dirs);
+        let shape: Vec<(&str, &str, String)> = rows
+            .iter()
+            .map(|r| (r.group, r.name, r.path_display()))
+            .collect();
+        assert_eq!(
+            shape,
+            vec![
+                (
+                    "Config",
+                    "Config dir",
+                    "/home/u/.config/minimal".to_string()
+                ),
+                (
+                    "Config",
+                    "config.toml",
+                    "/home/u/.config/minimal/config.toml".to_string()
+                ),
+                (
+                    "Config",
+                    "Loadouts dir",
+                    "/home/u/.config/minimal/loadouts".to_string()
+                ),
+                (
+                    "Config",
+                    "Mesh enrolment",
+                    "/home/u/.config/minimal/mesh-enrolment".to_string()
+                ),
+                (
+                    "Config",
+                    "mTLS client cert",
+                    "/home/u/.config/minimal/client.pem".to_string()
+                ),
+                (
+                    "Config",
+                    "mTLS client key",
+                    "/home/u/.config/minimal/client.key".to_string()
+                ),
+                (
+                    "Config",
+                    "mTLS CA cert",
+                    "/home/u/.config/minimal/ca.pem".to_string()
+                ),
+                (
+                    "State",
+                    "State dir",
+                    "/home/u/.local/state/minimal".to_string()
+                ),
+                (
+                    "State",
+                    "Sessions",
+                    "/home/u/.local/state/minimal/sessions".to_string()
+                ),
+                (
+                    "State",
+                    "Daemon logs",
+                    "/home/u/.local/state/minimal/logs".to_string()
+                ),
+                (
+                    "State",
+                    "SSH socket",
+                    "/home/u/.local/state/minimal/providers/local-0/ssh.sock".to_string()
+                ),
+                ("Cache", "Cache dir", "/home/u/.cache/minimal".to_string()),
+                (
+                    "Cache",
+                    "Built artifacts",
+                    "/home/u/.cache/minimal/built".to_string()
+                ),
+            ],
+        );
+    }
+
+    /// The "Daemon logs" row's note interpolates `today` into the
+    /// rolling-file suffix so operators see the exact filename they
+    /// should look at.
+    #[test]
+    fn build_dir_rows_daemon_logs_note_interpolates_date() {
+        let dirs = DirsLookup {
+            config: PathBuf::from("/c"),
+            mesh_enrolment: PathBuf::from("/c/mesh-enrolment"),
+            mesh_group: MeshGroup::Config,
+            state: PathBuf::from("/s"),
+            cache: PathBuf::from("/x"),
+            today: "2030-01-15".to_string(),
+        };
+        let rows = build_dir_rows(&dirs);
+        let daemon_logs = rows.iter().find(|r| r.name == "Daemon logs").unwrap();
+        assert_eq!(
+            daemon_logs.note.as_deref(),
+            Some("daily-rotated: minimald.log.2030-01-15"),
+        );
+    }
+
+    /// `DirRow::existence_marker` returns `?` when path is `None`,
+    /// `-` for a resolved-but-missing file, `*` for one that exists.
+    #[test]
+    fn dir_row_existence_marker_covers_all_three_states() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("here");
+        std::fs::write(&real, "x").unwrap();
+        let missing = tmp.path().join("gone");
+
+        let row_present = ("_", "_", Some(real), None).into_row();
+        let row_missing = ("_", "_", Some(missing), None).into_row();
+        let row_unresolved = ("_", "_", None, None).into_row();
+
+        assert_eq!(row_present.existence_marker(), '*');
+        assert_eq!(row_missing.existence_marker(), '-');
+        assert_eq!(row_unresolved.existence_marker(), '?');
+    }
+
+    /// When `--minimal-dir` redirects the mesh file to the state
+    /// tree, the Mesh row must render under the State group so the
+    /// output stays semantically honest. Guards the `mesh_group`
+    /// branching added to `build_dir_rows`.
+    #[test]
+    fn build_dir_rows_places_mesh_under_state_when_minimal_dir_overrides() {
+        let dirs = DirsLookup {
+            config: PathBuf::from("/c"),
+            mesh_enrolment: PathBuf::from("/override/mesh-enrolment"),
+            mesh_group: MeshGroup::State,
+            state: PathBuf::from("/override"),
+            cache: PathBuf::from("/x"),
+            today: "_".to_string(),
+        };
+        let rows = build_dir_rows(&dirs);
+        let mesh = rows.iter().find(|r| r.name == "Mesh enrolment").unwrap();
+        assert_eq!(mesh.group, "State");
+        assert_eq!(mesh.path_display(), "/override/mesh-enrolment");
+
+        // And there must be no "Mesh enrolment" row under Config
+        // (bug: the row was duplicated when we introduced the flag).
+        let mesh_count = rows.iter().filter(|r| r.name == "Mesh enrolment").count();
+        assert_eq!(mesh_count, 1, "mesh row must appear exactly once");
+    }
+}

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -10,6 +10,9 @@ use tokio::io::AsyncWriteExt as _;
 
 pub mod autospawn;
 pub mod client;
+pub mod config;
+pub mod dirs;
+pub mod loadouts;
 
 #[derive(Parser)]
 #[command(name = "minimal", version = env!("CARGO_PKG_VERSION"), long_version = env!("LONG_VERSION"))]
@@ -36,6 +39,10 @@ pub enum Command {
     Stop(StopArgs),
     /// Session inspection subcommands
     Session(SessionArgs),
+    /// Loadout management subcommands
+    Loadout(LoadoutArgs),
+    /// Print important directories and file paths for debugging
+    Dirs,
     /// WireGuard mesh: join, leave, and inspect remote-access state
     Mesh(MeshArgs),
     /// Proxy stdio to a daemon UDS socket (used as an SSH ProxyCommand).
@@ -114,6 +121,27 @@ pub struct PolicyArgs {
     pub session: String,
 }
 
+#[derive(Debug, Args)]
+pub struct LoadoutArgs {
+    #[command(subcommand)]
+    pub command: LoadoutCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LoadoutCommand {
+    /// List loadouts from the user's config directory
+    #[command(visible_alias = "ls")]
+    List(LoadoutListArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct LoadoutListArgs {
+    /// Override the loadouts directory (default:
+    /// `<config>/minimal/loadouts` per platform, e.g. `~/.config/minimal/loadouts` on Linux)
+    #[arg(long)]
+    pub dir: Option<PathBuf>,
+}
+
 /// WireGuard mesh subcommands for authenticated remote PTask access (UC7 /
 /// UC2b). The mesh lets a laptop, or another host's PTasks, reach this host's
 /// PTasks over an encrypted tunnel.
@@ -174,6 +202,14 @@ pub struct GlobalArgs {
     /// Override the base directory used for operations (default: ~/.cache/minimal)
     #[arg(long)]
     pub minimal_dir: Option<PathBuf>,
+    /// Override the user config directory. Everything under
+    /// `<config_dir>/minimal/` (config.toml, loadouts/, ...) is
+    /// resolved relative to this. Defaults to the platform's config
+    /// dir — `$XDG_CONFIG_HOME` on Linux (or `$HOME/.config` when
+    /// that's unset). macOS uses `$HOME/.config` for consistency with
+    /// state and cache dirs, not `~/Library/Application Support`.
+    #[arg(long, global = true)]
+    pub config_dir: Option<PathBuf>,
     /// Linux: run minimald inside the minvmd microVM (DM1) instead of natively
     /// on the host (DM2, the default). No effect on macOS, where minvmd is the
     /// only backend.
@@ -196,6 +232,15 @@ pub struct ActivateArgs {
     /// tcp). Repeatable. Requires `--network own-ip`.
     #[arg(long = "ingress", value_name = "EXT:INT[/PROTO]")]
     pub ingress: Vec<String>,
+    /// Apply the named loadout from `<config>/minimal/loadouts/<NAME>.toml`.
+    /// Repeatable. If any `--loadout` is specified, defaults from
+    /// `[loadouts].default_loadouts` in the client config are ignored.
+    #[arg(long = "loadout", value_name = "NAME")]
+    pub loadout: Vec<String>,
+    /// Apply no loadouts at all — overrides both `--loadout` and the
+    /// config's `default_loadouts`.
+    #[arg(long, conflicts_with = "loadout")]
+    pub no_loadouts: bool,
     /// Automatically attach after creation
     #[arg(long)]
     pub attach: bool,
@@ -378,6 +423,10 @@ pub async fn run(cli: Cli) -> Result<(), anyhow::Error> {
         Command::Session(SessionArgs {
             command: SessionCommand::Policy(args),
         }) => cmd_session_policy(&cli.global_args, args).await,
+        Command::Loadout(LoadoutArgs {
+            command: LoadoutCommand::List(args),
+        }) => loadouts::cmd_loadout_list(args, &cli.global_args),
+        Command::Dirs => dirs::cmd_dirs(&cli.global_args),
         Command::Mesh(MeshArgs { command }) => match command {
             MeshCommand::Status => cmd_mesh_status(&cli.global_args).await,
             MeshCommand::Join(args) => cmd_mesh_join(&cli.global_args, args),
@@ -759,12 +808,26 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
         attrs: Default::default(),
     };
 
+    // Resolve and compose the loadouts BEFORE opening the daemon
+    // connection: a missing loadout file or a malformed one should
+    // fail loudly on the client side without ever touching the
+    // daemon.
+    let cfg = config::read_client_config(global)?;
+    let selection = loadouts::LoadoutSelection::from_flags(&args.loadout, args.no_loadouts);
+    let active = loadouts::resolve_active_loadouts(selection, &cfg, global)?;
+    if !active.is_empty() {
+        let names: Vec<&str> = active.iter().map(|l| l.name().as_ref()).collect();
+        eprintln!("Applying loadouts: {}", names.join(", "));
+    }
+    let contribution =
+        loadouts::compose_user_contribution(active, loadouts::compose_options_from_config(&cfg))?;
+
     let mut client = connect_daemon(global).await?;
 
     use minimald_rpc::{CreateSession, CreateSessionRequest};
     let req = CreateSessionRequest {
         config,
-        contribution: Default::default(),
+        contribution,
     };
     let resp = client
         .oneshot_rpc::<CreateSession>(req)
@@ -902,16 +965,17 @@ pub async fn cmd_session_policy(
     }
 }
 
-/// The local mesh-enrolment record path. Honors `--minimal-dir`, else falls
-/// back to the user config dir.
-pub fn mesh_enrolment_path(global: &GlobalArgs) -> Result<PathBuf, anyhow::Error> {
+/// The local mesh-enrolment record path. `--minimal-dir` still wins for
+/// the historical "everything lives under the state dir" workflow;
+/// otherwise falls through to the loadout-subsystem's config dir
+/// so `--config-dir` moves the mesh enrolment along with everything
+/// else.
+pub fn mesh_enrolment_path(global: &GlobalArgs) -> PathBuf {
     let base = match &global.minimal_dir {
         Some(dir) => dir.clone(),
-        None => dirs::config_dir()
-            .map(|c| c.join("minimal"))
-            .context("cannot determine config directory; set --minimal-dir")?,
+        None => config::resolve_minimal_config_dir(global),
     };
-    Ok(base.join("mesh-enrolment"))
+    base.join("mesh-enrolment")
 }
 
 /// Show this minimald's WireGuard mesh status (R4.6): own public key, the
@@ -973,7 +1037,7 @@ pub fn cmd_mesh_join(global: &GlobalArgs, args: MeshJoinArgs) -> Result<(), anyh
         bail!("mesh join address must include a non-empty host and a valid non-zero port");
     }
 
-    let path = mesh_enrolment_path(global)?;
+    let path = mesh_enrolment_path(global);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;
@@ -997,7 +1061,7 @@ pub fn cmd_mesh_join(global: &GlobalArgs, args: MeshJoinArgs) -> Result<(), anyh
 /// Drop this machine's local mesh enrolment (R4.3). Remote peer entries are
 /// removed on the remote host (manual v1).
 pub fn cmd_mesh_leave(global: &GlobalArgs) -> Result<(), anyhow::Error> {
-    let path = mesh_enrolment_path(global)?;
+    let path = mesh_enrolment_path(global);
     match std::fs::remove_file(&path) {
         Ok(()) => {
             println!(
@@ -1200,13 +1264,12 @@ pub async fn cmd_login(global: &GlobalArgs, args: LoginArgs) -> Result<(), anyho
         }
     };
 
-    // Determine the cert directory.
+    // Determine the cert directory. Honors `--cert-dir` first, then
+    // routes through the shared config-dir helper so `--config-dir`
+    // moves the certs alongside `config.toml` and `loadouts/`.
     let cert_dir = match args.cert_dir {
         Some(d) => d,
-        None => {
-            let config_dir = dirs::config_dir().context("cannot determine config directory")?;
-            config_dir.join("minimal")
-        }
+        None => config::resolve_minimal_config_dir(global),
     };
     std::fs::create_dir_all(&cert_dir)
         .with_context(|| format!("cannot create cert dir {}", cert_dir.display()))?;

--- a/crates/minimal/src/loadouts.rs
+++ b/crates/minimal/src/loadouts.rs
@@ -1,0 +1,298 @@
+//! Loadout selection, composition, and the `minimal loadout list`
+//! command. Backed by the on-disk primitives in
+//! [`sessions::client::disk`] and driven from the client `config.toml`
+//! (see [`crate::config`]).
+
+use anyhow::{Context as _, bail};
+use std::path::PathBuf;
+
+use crate::config::{read_client_config, resolve_minimal_config_dir};
+use crate::{GlobalArgs, LoadoutListArgs};
+
+/// The user's choice of which loadouts to apply for a session
+/// activation, resolved from CLI flags before disk I/O begins.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum LoadoutSelection {
+    /// `--no-loadouts` set — apply nothing regardless of config.
+    None,
+    /// `--loadout` set (one or more) — apply exactly these names,
+    /// config defaults ignored.
+    Cli(Vec<String>),
+    /// Neither flag set — apply `[loadouts].default_loadouts` from
+    /// the client config (which may itself be empty).
+    Defaults,
+}
+
+impl LoadoutSelection {
+    /// Fold `--loadout` and `--no-loadouts` into a single value.
+    /// Clap enforces the mutual exclusion via `conflicts_with`, so
+    /// the two flags together never reach here.
+    pub(crate) fn from_flags(cli_loadouts: &[String], no_loadouts: bool) -> Self {
+        if no_loadouts {
+            Self::None
+        } else if cli_loadouts.is_empty() {
+            Self::Defaults
+        } else {
+            Self::Cli(cli_loadouts.to_vec())
+        }
+    }
+}
+
+/// Resolve the loadout names to apply for a session activation
+/// and load each from disk.
+///
+/// Errors out on any missing or malformed loadout so the user
+/// doesn't get a silently-empty session when their config is
+/// broken.
+pub(crate) fn resolve_active_loadouts(
+    selection: LoadoutSelection,
+    cfg: &sessions::client::config::Config,
+    global: &GlobalArgs,
+) -> Result<Vec<sessions::core::loadout::Loadout>, anyhow::Error> {
+    let (names, source): (Vec<String>, &str) = match selection {
+        LoadoutSelection::None => return Ok(Vec::new()),
+        LoadoutSelection::Cli(names) => (names, "--loadout"),
+        LoadoutSelection::Defaults => (cfg.loadouts.default_loadouts.clone(), "default_loadouts"),
+    };
+    let loadouts_dir = resolve_minimal_config_dir(global).join("loadouts");
+    names
+        .iter()
+        .map(|name| {
+            let path = loadouts_dir.join(format!("{name}.toml"));
+            sessions::client::disk::read_loadout_file(&path)
+                .with_context(|| format!("{source} `{name}`"))
+        })
+        .collect()
+}
+
+/// Build the [`ComposeOptions`] the client passes to
+/// `UserComposer::compose`, translating relevant config fields.
+///
+/// [`ComposeOptions`]: sessions::core::compose::ComposeOptions
+pub(crate) fn compose_options_from_config(
+    cfg: &sessions::client::config::Config,
+) -> sessions::core::compose::ComposeOptions {
+    sessions::core::compose::ComposeOptions::default()
+        .with_follow_symlinks(cfg.loadouts.follow_symlinks)
+}
+
+/// Compose the given loadouts into a [`sessions::wire::request::WireContribution`]
+/// under an empty [`UserPolicy`] (user-origin items auto-pass allow
+/// so no rules are needed at this stage).
+pub(crate) fn compose_user_contribution(
+    loadouts: Vec<sessions::core::loadout::Loadout>,
+    options: sessions::core::compose::ComposeOptions,
+) -> Result<sessions::wire::request::WireContribution, anyhow::Error> {
+    let mut composer = sessions::client::composer::UserComposer::new();
+    composer
+        .add_all(loadouts)
+        .map_err(|e| anyhow::anyhow!("composing loadouts: {e}"))?;
+    composer
+        .compose(sessions::core::policy::UserPolicy::empty(), options)
+        .map_err(|e| anyhow::anyhow!("composing loadouts: {e}"))
+}
+
+// =========================================================================
+// `minimal loadout list` — enumerate discovered loadouts.
+// =========================================================================
+
+/// Resolve the loadouts directory. Order of precedence:
+/// `--dir` on the subcommand, then `--config-dir` via
+/// [`resolve_minimal_config_dir`], then the platform default.
+fn resolve_loadouts_dir(args: &LoadoutListArgs, global: &GlobalArgs) -> PathBuf {
+    if let Some(dir) = &args.dir {
+        return dir.clone();
+    }
+    resolve_minimal_config_dir(global).join("loadouts")
+}
+
+/// List loadouts discovered in the loadouts directory. One row per
+/// `.toml` file; malformed entries are shown with their parse error
+/// so an operator can fix them in place. Loadouts named in
+/// `[loadouts].default_loadouts` in the client config are marked
+/// with a leading `*`.
+pub fn cmd_loadout_list(args: LoadoutListArgs, global: &GlobalArgs) -> Result<(), anyhow::Error> {
+    let dir = resolve_loadouts_dir(&args, global);
+    let entries = match sessions::client::disk::list_loadouts(&dir) {
+        Ok(entries) => entries,
+        Err(sessions::client::disk::ListError::NotFound { path }) => {
+            eprintln!("No loadouts directory at {}.", path.display());
+            eprintln!("Create it and drop `<name>.toml` files there to get started.");
+            return Ok(());
+        }
+        Err(e) => bail!("{e}"),
+    };
+
+    // Load `<config>/minimal/config.toml` to discover which
+    // loadouts should be marked as defaults. Missing file → no
+    // defaults; malformed file → error out so the user can see it.
+    // Routes through `read_client_config` so this and `cmd_activate`
+    // share one config-loading path.
+    let defaults: std::collections::HashSet<String> = read_client_config(global)?
+        .loadouts
+        .default_loadouts
+        .into_iter()
+        .collect();
+
+    if entries.is_empty() {
+        println!("No loadouts in {}.", dir.display());
+        return Ok(());
+    }
+
+    // Warn about defaults that don't have a matching file — a
+    // silent typo in `default_loadouts` would otherwise be
+    // invisible until the user wondered why their loadout wasn't
+    // active.
+    let present: std::collections::HashSet<&str> =
+        entries.iter().map(|e| e.file_stem.as_str()).collect();
+    defaults
+        .iter()
+        .filter(|missing| !present.contains(missing.as_str()))
+        .for_each(|missing| {
+            eprintln!(
+                "Warning: `{missing}` listed in default_loadouts but no `{missing}.toml` in {}",
+                dir.display(),
+            );
+        });
+
+    let rows: Vec<LoadoutRow> = entries
+        .iter()
+        .map(|entry| LoadoutRow::from_entry(entry, &defaults))
+        .collect();
+
+    let name_w = rows.iter().map(|r| r.name.len()).max().unwrap_or(4).max(4);
+    let desc_w = rows
+        .iter()
+        .map(|r| r.desc.len())
+        .max()
+        .unwrap_or(11)
+        .max(11);
+    println!(
+        "  {:<name_w$}  {:<desc_w$}  CONTRIBUTES",
+        "NAME", "DESCRIPTION"
+    );
+    rows.into_iter().for_each(
+        |LoadoutRow {
+             marker,
+             name,
+             desc,
+             counts,
+         }| { println!("{marker} {name:<name_w$}  {desc:<desc_w$}  {counts}") },
+    );
+    if !defaults.is_empty() {
+        println!();
+        println!("* default (from `[loadouts].default_loadouts`)");
+    }
+    Ok(())
+}
+
+/// One row of `loadout list` output. Kept as a struct rather than a
+/// tuple so the marker / name / description / counts columns can be
+/// widened independently at print time — mirrors the `DirRow` shape
+/// used by `crate::dirs`.
+struct LoadoutRow {
+    marker: &'static str,
+    name: String,
+    desc: String,
+    counts: String,
+}
+
+impl LoadoutRow {
+    /// Build a row from a discovered [`LoadoutEntry`]. Failures
+    /// collapse into a single "(error: …)" cell in the counts
+    /// column so the layout stays uniform across the whole listing.
+    fn from_entry(
+        entry: &sessions::client::disk::LoadoutEntry,
+        defaults: &std::collections::HashSet<String>,
+    ) -> Self {
+        let marker = if defaults.contains(&entry.file_stem) {
+            "*"
+        } else {
+            " "
+        };
+        match &entry.loadout {
+            Ok(l) => Self {
+                marker,
+                name: entry.file_stem.clone(),
+                desc: l.description().unwrap_or("").to_string(),
+                counts: format!(
+                    "{} pkg / {} var / {} patch / {} hook",
+                    l.packages().len(),
+                    l.vars().len() + l.vars_lenient().len(),
+                    l.patches().iter().count(),
+                    l.lifecycle_hooks().len(),
+                ),
+            },
+            Err(e) => Self {
+                marker,
+                name: entry.file_stem.clone(),
+                desc: String::new(),
+                // Uses `entry.path` for a full-path prefix so a user
+                // running with a `--dir` override (or with symlinks
+                // in the tree) can trace which physical file is
+                // broken even if two entries share a `file_stem`.
+                counts: format!("(error at {}: {e})", entry.path.display()),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `LoadoutSelection::from_flags` — full truth table.
+    #[test]
+    fn loadout_selection_from_flags_truth_table() {
+        assert!(matches!(
+            LoadoutSelection::from_flags(&[], true),
+            LoadoutSelection::None
+        ));
+        assert!(matches!(
+            LoadoutSelection::from_flags(&[], false),
+            LoadoutSelection::Defaults
+        ));
+        let cli = ["helix".to_string(), "fish".to_string()];
+        match LoadoutSelection::from_flags(&cli, false) {
+            LoadoutSelection::Cli(names) => assert_eq!(names, cli),
+            other => panic!("expected Cli, got {other:?}"),
+        }
+    }
+
+    /// `resolve_active_loadouts` on `LoadoutSelection::None` returns
+    /// an empty vec without touching the filesystem. Uses a bogus
+    /// config-dir override so a stray disk read would surface as a
+    /// panic-shaped failure.
+    #[test]
+    fn resolve_active_loadouts_none_short_circuits() {
+        let cfg = sessions::client::config::Config::default();
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(PathBuf::from("/definitely/does/not/exist")),
+            minvmd: false,
+        };
+        let out = resolve_active_loadouts(LoadoutSelection::None, &cfg, &global)
+            .expect("None → Ok(empty), no I/O");
+        assert!(out.is_empty());
+    }
+
+    /// `resolve_active_loadouts` errors when a `--loadout NAME`
+    /// selection names a file that isn't on disk. The concrete
+    /// error goes to stderr via the closure; here we only assert
+    /// the Result is Err.
+    #[test]
+    fn resolve_active_loadouts_cli_missing_file_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("minimal/loadouts")).unwrap();
+        let cfg = sessions::client::config::Config::default();
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(tmp.path().to_path_buf()),
+            minvmd: false,
+        };
+        let selection = LoadoutSelection::Cli(vec!["missing".to_string()]);
+        assert!(resolve_active_loadouts(selection, &cfg, &global).is_err());
+    }
+}

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -28,6 +28,7 @@ async fn version_succeeds_without_daemon() {
     let args = GlobalArgs {
         repo_dir: None,
         minimal_dir: Some(std::path::PathBuf::from("/nonexistent")),
+        config_dir: None,
         minvmd: false,
     };
     // Should print client version and note daemon is unreachable, but return Ok.
@@ -173,6 +174,8 @@ async fn activate_creates_session() {
         path: ".".to_string(),
         network: CliNetworkMode::NoNet,
         ingress: vec![],
+        loadout: vec![],
+        no_loadouts: false,
         attach: false,
     };
     cmd_activate(&args, activate_args).await.unwrap();

--- a/crates/minimal/tests/common/mod.rs
+++ b/crates/minimal/tests/common/mod.rs
@@ -36,6 +36,7 @@ impl TestDaemon {
         GlobalArgs {
             repo_dir: None,
             minimal_dir: Some(self.temp.path().to_path_buf()),
+            config_dir: None,
             minvmd: false,
         }
     }

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -43,6 +43,7 @@ vt100-ctt.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
+tracing-appender.workspace = true
 tracing-subscriber.workspace = true
 
 # WireGuard mesh peer (Unit 4, R4.1/R4.7): compiled only under `networking-wg`.

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -19,6 +19,11 @@ use tokio_vsock::{VMADDR_CID_ANY, VsockAddr, VsockListener};
 #[cfg(target_os = "linux")]
 const DEFAULT_VSOCK_PORT_BASE: u32 = 2222;
 
+/// Env var `spawn_detached` sets on the child so `async_main` knows
+/// its stdio has been redirected to `/dev/null` and needs to swap
+/// the tracing writer over to a rolling log file.
+const DETACHED_ENV: &str = "MINIMALD_DETACHED";
+
 #[derive(Parser)]
 #[command(name = "minimald", version = env!("CARGO_PKG_VERSION"), long_version = env!("LONG_VERSION"))]
 #[command(about = "The Minimal daemon")]
@@ -247,7 +252,10 @@ fn spawn_detached(cli: &Cli) -> Result<(), MainError> {
     cmd.args(&args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
+        .stderr(std::process::Stdio::null())
+        // Mark the child so `async_main` knows its stdio has been
+        // null'd and can route tracing output to a log file instead.
+        .env(DETACHED_ENV, "1");
     // SAFETY: setsid() is async-signal-safe. In the child it starts a new
     // session so the daemon outlives the CLI and is unaffected by SIGHUP when
     // the invoking shell exits.
@@ -313,18 +321,67 @@ fn lock_held(path: &std::path::Path) -> std::io::Result<bool> {
     }
 }
 
-async fn async_main() -> Result<(), MainError> {
+/// Install the tracing subscriber. Foreground processes log to
+/// stdout; detached daemons (marked by [`DETACHED_ENV`]) write to
+/// `<state_dir>/logs/minimald.log`, daily-rotated. The returned
+/// [`WorkerGuard`] must outlive the process — dropping it flushes
+/// pending records and terminates the appender's worker thread.
+///
+/// [`WorkerGuard`]: tracing_appender::non_blocking::WorkerGuard
+fn init_tracing(
+    cli: &Cli,
+) -> Result<Option<tracing_appender::non_blocking::WorkerGuard>, MainError> {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new("info")
             .add_directive("topiary=off".parse().unwrap())
             .add_directive("libcgroups=off".parse().unwrap())
     });
 
+    let detached = std::env::var_os(DETACHED_ENV).is_some();
+    if !detached {
+        tracing_subscriber::registry()
+            .with(fmt::layer().with_writer(ot::StdoutWriter::new))
+            .with(filter)
+            .init();
+        return Ok(None);
+    }
+
+    // Under `<state_dir>/logs/` so `<state_dir>` itself stays
+    // dominated by the sockets, sessions, and providers it already
+    // owns. `create_dir_all` is idempotent — subsequent daemon
+    // starts don't churn.
+    let log_dir = cli
+        .minimal_state_dir()
+        .as_utf8_path()
+        .as_std_path()
+        .join("logs");
+    std::fs::create_dir_all(&log_dir)
+        .map_err(|e| MainError::IO(e, "creating minimald log directory"))?;
+    // Cap retained files so a long-running daemon doesn't accumulate
+    // logs indefinitely. Two weeks is comfortably longer than the
+    // usual "look at what happened yesterday" window and short enough
+    // that the on-disk footprint stays bounded.
+    let appender = tracing_appender::rolling::Builder::new()
+        .rotation(tracing_appender::rolling::Rotation::DAILY)
+        .filename_prefix("minimald.log")
+        .max_log_files(14)
+        .build(&log_dir)
+        .map_err(|e| MainError::IO(std::io::Error::other(e), "building rolling log appender"))?;
+    let (writer, guard) = tracing_appender::non_blocking(appender);
     tracing_subscriber::registry()
-        .with(fmt::layer().with_writer(ot::StdoutWriter::new))
+        // ANSI colors only make sense on a terminal; a file logger
+        // just gets noise from the escape sequences.
+        .with(fmt::layer().with_ansi(false).with_writer(writer))
         .with(filter)
         .init();
+    tracing::info!(
+        log_dir = %log_dir.display(),
+        "detached minimald: routing tracing output to daily-rotated log file",
+    );
+    Ok(Some(guard))
+}
 
+async fn async_main() -> Result<(), MainError> {
     // With `networking-proxy` on, both the `ring` (workspace rustls) and the
     // `aws-lc-rs` (google-cloud) providers are compiled in, so rustls cannot
     // auto-pick one and panics ("no process-level CryptoProvider") the first time
@@ -372,6 +429,16 @@ async fn async_main() -> Result<(), MainError> {
         clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
         return Ok(());
     }
+
+    // Initialize tracing. Foreground runs (or the parent-side of a
+    // `--detach` re-exec) log to stdout. A child spawned by
+    // `spawn_detached` has its stdio null'd — detectable via the
+    // `MINIMALD_DETACHED` env var — so it routes tracing to a daily-
+    // rotated log file under the state directory instead. `_log_guard`
+    // is bound at function scope so the non-blocking appender's
+    // worker survives for the daemon's entire lifetime; dropping it
+    // would flush and terminate the appender prematurely.
+    let _log_guard = init_tracing(&cli)?;
 
     let listen_args = cli.listen_args().unwrap();
 

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -155,6 +155,115 @@ impl Pty {
     }
 }
 
+/// Emit one `tracing::info!` per item the launcher folds into the
+/// session — packages, vars, patches, and lifecycle hooks —
+/// tagging each with its provenance so an operator can trace
+/// "where did `EDITOR=hx` come from?" back to the loadout /
+/// project / package that contributed it.
+///
+/// Baseline items (the launcher-defaults `PS1`, `base`, `coreutils`,
+/// `socat`) log with `source = "launcher-baseline"` so they can be
+/// distinguished from composition contributions. Patches and hooks
+/// still log even though the launcher can't act on them yet — an
+/// operator inspecting a session should see the intent even when
+/// the plumbing is deferred.
+///
+/// Var values are logged at `debug` (separate call) rather than
+/// `info` so an accidentally-inherited secret doesn't sit in the
+/// default log stream.
+#[cfg(not(test))]
+fn log_session_contents(
+    session_name: &str,
+    baseline_packages: &[&str],
+    baseline_var_names: &[&str],
+    composition: Option<&sessions::core::compose::Composition>,
+) {
+    for p in baseline_packages {
+        tracing::info!(
+            session = session_name,
+            domain = "package",
+            name = p,
+            source = "launcher-baseline",
+            "session content",
+        );
+    }
+    for k in baseline_var_names {
+        tracing::info!(
+            session = session_name,
+            domain = "var",
+            name = k,
+            source = "launcher-baseline",
+            "session content",
+        );
+    }
+    let Some(comp) = composition else {
+        return;
+    };
+    for p in comp.packages() {
+        tracing::info!(
+            session = session_name,
+            domain = "package",
+            name = %p.package(),
+            source = ?sessions::core::source::Provenanced::source(p),
+            "session content",
+        );
+    }
+    for v in comp.vars() {
+        let var = v.var();
+        tracing::info!(
+            session = session_name,
+            domain = "var",
+            name = %var.name(),
+            source = ?sessions::core::source::Provenanced::source(v),
+            "session content",
+        );
+        tracing::debug!(
+            session = session_name,
+            name = %var.name(),
+            value = %var.value(),
+            "session var value",
+        );
+    }
+    for sp in comp.patches() {
+        let patch = sp.patch();
+        tracing::info!(
+            session = session_name,
+            domain = "patch",
+            host_source = %patch.host_path(),
+            sandbox_dest = %patch.destination(),
+            source = ?sessions::core::source::Provenanced::source(sp),
+            deferred = true,
+            "session content (patch: file-upload plumbing deferred)",
+        );
+    }
+    for h in comp.lifecycle_hooks() {
+        let src = sessions::core::source::Provenanced::source(h);
+        let hook = h.hook();
+        [
+            ("on_activate", hook.on_activate()),
+            ("on_destroy", hook.on_destroy()),
+            ("on_failure", hook.on_failure()),
+        ]
+        .into_iter()
+        .filter_map(|(event, script)| script.map(|s| (event, s)))
+        .for_each(|(event, script)| {
+            let kind = match script {
+                sessions::core::lifecyclehook::HookScript::Inline(_) => "inline",
+                sessions::core::lifecyclehook::HookScript::External(_) => "external",
+            };
+            tracing::info!(
+                session = session_name,
+                domain = "lifecycle_hook",
+                event = event,
+                script_kind = kind,
+                source = ?src,
+                deferred = true,
+                "session content (lifecycle hook: exec plumbing deferred)",
+            );
+        });
+    }
+}
+
 /// Duplicate `fd` into a new close-on-exec `OwnedFd` via
 /// `F_DUPFD_CLOEXEC`, so a concurrent `fork` can't inherit and hold
 /// the pty open past our child's exit.
@@ -271,6 +380,13 @@ impl Binding {
                                     modes: terminal_modes.to_vec(),
                                 })).await;
                             },
+                            // Flow-control window updates fire on every
+                            // burst of bytes forwarded through the
+                            // channel — routine, not a fault. Debug
+                            // keeps them out of the default log stream.
+                            russh::ChannelMsg::WindowAdjusted { .. } => {
+                                tracing::debug!("skipping msg: {:?}", msg);
+                            }
                             _ => tracing::warn!("skipping msg: {:?}", msg),
                         };
                     }
@@ -591,6 +707,23 @@ impl SessionProcess for SandboxProcess {
     }
 }
 
+/// Packages every session sandbox gets unconditionally, regardless of
+/// the client's contribution: `base` for the shell, `coreutils` for
+/// `ls`/`cat`/etc, and `socat` for the `min` command bridge (the
+/// helper installed at `/usr/bin/min` speaks to `/run/minenv_sock`
+/// via `socat`).
+#[cfg(not(test))]
+const BASELINE_PACKAGES: &[&str] = &["base", "coreutils", "socat"];
+
+/// Env vars every session sandbox gets unconditionally, regardless of
+/// the client's contribution. `PS1` is here so the shell prompt is
+/// styled the same whether a composition sets it or not.
+#[cfg(not(test))]
+const BASELINE_VARS: &[(&str, &str)] = &[(
+    "PS1",
+    r"\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ ",
+)];
+
 /// The real [`SessionLauncher`]: evaluates a minimal context into a graph,
 /// builds a sandboxed `/bin/bash`, and wires it to a freshly opened PTY.
 #[cfg(not(test))]
@@ -759,7 +892,6 @@ impl SessionLauncher for SandboxLauncher {
         // are not applied yet (the file-upload path and in-sandbox
         // exec plumbing that they need aren't wired), so they pass
         // through this stage untouched.
-        let baseline_packages = ["base", "coreutils", "socat"];
         // A shadow set tracks membership so the composition-union
         // pass below stays O(n) instead of the naive
         // `Vec::contains` per iteration (see clippy's O(n²) hint).
@@ -768,13 +900,13 @@ impl SessionLauncher for SandboxLauncher {
         // strings and `String::clone` is a deep copy. Trivial cost
         // for a three-element baseline.
         let mut packages: Vec<String> =
-            baseline_packages.iter().map(|s| (*s).to_string()).collect();
+            BASELINE_PACKAGES.iter().map(|s| (*s).to_string()).collect();
         let mut package_set: std::collections::HashSet<String> =
-            baseline_packages.iter().map(|s| (*s).to_string()).collect();
-        let mut env_vars: HashMap<String, String> = HashMap::from([(
-            "PS1".to_string(),
-            r"\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ ".to_string(),
-        )]);
+            BASELINE_PACKAGES.iter().map(|s| (*s).to_string()).collect();
+        let mut env_vars: HashMap<String, String> = BASELINE_VARS
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
         if let Some(comp) = &composition {
             for p in comp.packages() {
                 let name = p.package();
@@ -787,6 +919,17 @@ impl SessionLauncher for SandboxLauncher {
                 env_vars.insert(var.name().to_string(), var.value().to_string());
             }
         }
+        // Log every item that will (or would) end up in the session,
+        // tagged with its provenance. Patches and lifecycle hooks are
+        // included even though the launcher can't act on them yet —
+        // an operator inspecting logs should see the intent.
+        let baseline_var_names: Vec<&str> = BASELINE_VARS.iter().map(|(k, _)| *k).collect();
+        log_session_contents(
+            &name,
+            BASELINE_PACKAGES,
+            &baseline_var_names,
+            composition.as_deref(),
+        );
 
         // Build the env + container and spawn the process. Any failure here (env
         // build, container build, spawn) leaves no process to reap; the phase-1

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -162,6 +162,34 @@ pub fn provider_instance_dir(state_dir: &DaemonAbsPath, instance: u32) -> Daemon
     sub_path!(state_dir, "providers").sub_path_unchecked(&format!("local-{instance}"))
 }
 
+/// Returns minimal's default config directory, `<config>/minimal`.
+///
+/// The base is `$XDG_CONFIG_HOME` when set to an absolute path, otherwise
+/// `~/.config` on every platform. Deliberately does not use
+/// [`dirs::config_dir`]: on macOS that would produce
+/// `~/Library/Application Support`, diverging from how the rest of minimal's
+/// on-disk state is laid out ([`minimal_state_dir`] already falls through to
+/// `~/.local/state`). One layout everywhere is easier to document, and users
+/// who genuinely want the platform-native location can override with the
+/// CLI's `--config-dir` flag.
+///
+/// # Panics
+///
+/// Panics if neither `$XDG_CONFIG_HOME` nor a home directory can be
+/// resolved, or if the resulting path is not valid UTF-8.
+pub fn minimal_config_dir() -> DaemonAbsPath {
+    default_dir(xdg_config_home, ".config")
+}
+
+/// Return `$XDG_CONFIG_HOME` if it's set to an absolute path. Matches the
+/// spec: [XDG Base Directory Specification, "XDG_CONFIG_HOME"](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+/// says relative paths are invalid and should be ignored.
+fn xdg_config_home() -> Option<std::path::PathBuf> {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .map(std::path::PathBuf::from)
+        .filter(|p| p.is_absolute())
+}
+
 /// Computes `<base>/minimal`, where `base` comes from `base_dir` or, failing
 /// that, `~/<home_fallback>`.
 fn default_dir(
@@ -1483,5 +1511,41 @@ mod tests {
             sub_path!(p, "moose"),
             HostRelPath::try_new("silly/moose").unwrap()
         );
+    }
+
+    /// Shared lock for every test in this file that mutates
+    /// `std::env`. Cargo runs `#[test]`s in parallel, and every
+    /// test in the process shares one process env — a second env-
+    /// touching test added anywhere in this crate must acquire this
+    /// lock too, or the runs will race. `Mutex` (not `PoisonError`-
+    /// aware) is fine because a panicking test would poison it and
+    /// downstream env tests would fail with a clear error, which is
+    /// what we want.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// `xdg_config_home` reflects `$XDG_CONFIG_HOME` when it's an
+    /// absolute path (per the XDG spec) and yields `None` otherwise,
+    /// so the caller can fall through to `$HOME/.config`. Three
+    /// assertions kept in one test to minimize env-lock contention.
+    #[test]
+    fn xdg_config_home_resolution() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        // SAFETY: `ENV_LOCK` serializes every env-touching test in
+        // this crate; the block runs single-threaded w.r.t. any
+        // sibling test that might read or write these vars.
+        unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
+        assert_eq!(xdg_config_home(), None, "unset → None");
+
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", "not/absolute") };
+        assert_eq!(xdg_config_home(), None, "relative → ignored per spec");
+
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", "/some/absolute/xdg") };
+        assert_eq!(
+            xdg_config_home(),
+            Some(std::path::PathBuf::from("/some/absolute/xdg")),
+            "absolute → returned verbatim",
+        );
+
+        unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
     }
 }

--- a/crates/remote-proto/build.rs
+++ b/crates/remote-proto/build.rs
@@ -1,5 +1,13 @@
 use std::io::Result;
+
 fn main() -> Result<()> {
+    let mut includes: Vec<String> = vec!["protos/".into(), "protos/res".into()];
+    if let Ok(dir) = std::env::var("PROTOC_INCLUDE") {
+        includes.push(dir);
+    }
+    println!("cargo:rerun-if-env-changed=PROTOC_INCLUDE");
+    let include_paths: Vec<&str> = includes.iter().map(String::as_str).collect();
+
     prost_build::compile_protos(
         &[
             "protos/streams.proto",
@@ -11,11 +19,14 @@ fn main() -> Result<()> {
             "protos/res/check.proto",
             "protos/res/remote_execution_service.proto",
         ],
-        &["protos/", "protos/res"],
+        &include_paths,
     )?;
 
     tonic_prost_build::configure()
-        .compile_protos(&["protos/res/remote_execution_service.proto"], &["protos"])
+        .compile_protos(
+            &["protos/res/remote_execution_service.proto"],
+            &include_paths,
+        )
         .unwrap();
 
     Ok(())

--- a/crates/sessions/Cargo.toml
+++ b/crates/sessions/Cargo.toml
@@ -13,13 +13,14 @@ paths.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+toml.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 walkdir.workspace = true
 
 [dev-dependencies]
+indoc.workspace = true
 tempfile.workspace = true
-toml.workspace = true
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/sessions/src/client/config.rs
+++ b/crates/sessions/src/client/config.rs
@@ -1,0 +1,198 @@
+//! User-level configuration for the minimal client, read from
+//! `<config>/minimal/config.toml`.
+//!
+//! Small on purpose: today it carries only the default loadouts the
+//! client applies when the user activates a session without naming
+//! any explicit ones. Additional keys can be added as sections
+//! grow, but every new field should start with a
+//! `#[serde(default)]` so an old config keeps parsing after an
+//! upgrade.
+
+use std::path::{Path, PathBuf};
+
+/// Root of the minimal client config.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct Config {
+    /// `[loadouts]` section: preferences that apply across the
+    /// loadout subsystem.
+    #[serde(default)]
+    pub loadouts: LoadoutsConfig,
+}
+
+/// The `[loadouts]` section.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct LoadoutsConfig {
+    /// Loadouts (by filename stem) automatically applied to each
+    /// new session unless the client overrides them.
+    #[serde(default)]
+    pub default_loadouts: Vec<String>,
+    /// When true, the patch walker follows symlinks while
+    /// enumerating loadout patch sources. Off by default — most
+    /// walks want the on-disk file, not a symlink target. Turn on
+    /// when your dotfile tree is a symlink farm (stow / chezmoi /
+    /// hand-linked) and you actually want the walk to descend
+    /// through the links.
+    #[serde(default)]
+    pub follow_symlinks: bool,
+}
+
+/// Failure loading the config file.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConfigError {
+    /// The file couldn't be read.
+    #[error("read `{path}`: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The file wasn't valid TOML or didn't match the [`Config`]
+    /// schema.
+    #[error("parse `{path}`: {source}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+}
+
+/// Parse the config at `path`.
+///
+/// # Errors
+///
+/// See [`ConfigError`]. A missing file returns
+/// [`ConfigError::Io`] — use [`read_config_or_default`] if you
+/// want the default config in that case.
+pub fn read_config_file(path: &Path) -> Result<Config, ConfigError> {
+    let contents = std::fs::read_to_string(path).map_err(|source| ConfigError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Parse the config at `path`, or return [`Config::default`] when
+/// the file doesn't exist. Any other read or parse failure
+/// propagates as [`ConfigError`].
+///
+/// # Errors
+///
+/// See [`ConfigError`]. `NotFound` is folded into `Ok(default)`;
+/// permission or parse failures still surface.
+pub fn read_config_or_default(path: &Path) -> Result<Config, ConfigError> {
+    match read_config_file(path) {
+        Ok(cfg) => Ok(cfg),
+        Err(ConfigError::Io { source, .. }) if source.kind() == std::io::ErrorKind::NotFound => {
+            Ok(Config::default())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &Path, name: &str, contents: &str) -> PathBuf {
+        let path = dir.join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    /// A well-formed config with a populated `default_loadouts`
+    /// list round-trips through the parser.
+    #[test]
+    fn read_config_file_ok() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r#"
+                [loadouts]
+                default_loadouts = ["helix", "fish"]
+            "#},
+        );
+        let cfg = read_config_file(&path).unwrap();
+        assert_eq!(cfg.loadouts.default_loadouts, vec!["helix", "fish"]);
+        // `follow_symlinks` defaults to false when omitted.
+        assert!(!cfg.loadouts.follow_symlinks);
+    }
+
+    /// `follow_symlinks` round-trips when explicitly set.
+    #[test]
+    fn read_config_file_follow_symlinks_opt_in() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r"
+                [loadouts]
+                follow_symlinks = true
+            "},
+        );
+        let cfg = read_config_file(&path).unwrap();
+        assert!(cfg.loadouts.follow_symlinks);
+    }
+
+    /// An empty config file parses to `Config::default()`.
+    #[test]
+    fn read_config_file_empty_is_default() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "config.toml", "");
+        let cfg = read_config_file(&path).unwrap();
+        assert_eq!(cfg, Config::default());
+    }
+
+    /// A missing `[loadouts]` section deserializes to the default
+    /// `LoadoutsConfig` (empty default list) — every subsection is
+    /// optional.
+    #[test]
+    fn read_config_file_missing_section_uses_default() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "config.toml", "# empty");
+        let cfg = read_config_file(&path).unwrap();
+        assert!(cfg.loadouts.default_loadouts.is_empty());
+    }
+
+    /// Unknown top-level keys are rejected so a typo (`loadout`
+    /// vs `loadouts`) fails loudly instead of silently doing
+    /// nothing.
+    #[test]
+    fn read_config_file_unknown_key_errors() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "config.toml", "[loadout]\n");
+        let err = read_config_file(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+
+    /// A missing config file folds into `Config::default()` via
+    /// `read_config_or_default`.
+    #[test]
+    fn read_config_or_default_missing_returns_default() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist.toml");
+        let cfg = read_config_or_default(&missing).unwrap();
+        assert_eq!(cfg, Config::default());
+    }
+
+    /// A malformed config file still errors under
+    /// `read_config_or_default` — only `NotFound` is silenced.
+    #[test]
+    fn read_config_or_default_malformed_still_errors() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "config.toml", "= not = toml =");
+        let err = read_config_or_default(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+}

--- a/crates/sessions/src/client/disk.rs
+++ b/crates/sessions/src/client/disk.rs
@@ -1,0 +1,309 @@
+//! On-disk loadout discovery.
+//!
+//! A user's loadouts live at `<config>/minimal/loadouts/<name>.toml`
+//! (where `<config>` is the platform-standard user config dir; the
+//! caller resolves that path and hands it in here). The filename
+//! stem is the loadout's identifier: it must match the loadout's
+//! declared `name` field, otherwise loading errors out — divergent
+//! references between the filename and the internal name would be a
+//! confusing source of "which one gets picked up" bugs.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::loadout::Loadout;
+
+/// Failure loading a single loadout file.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum LoadError {
+    /// The file couldn't be read.
+    #[error("read `{path}`: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The file wasn't valid TOML or didn't match the [`Loadout`]
+    /// schema.
+    #[error("parse `{path}`: {source}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    /// The loadout's declared `name` field disagrees with the file
+    /// stem it was loaded from.
+    #[error(
+        "loadout at `{path}` declares name `{declared_name}` but the filename \
+         stem is `{file_stem}`; rename the file or fix the `name` field"
+    )]
+    NameMismatch {
+        path: PathBuf,
+        /// The filename stem the file was found under — the
+        /// user-facing loadout identifier that must match `name`.
+        file_stem: String,
+        /// The value inside the file's `name = "..."` field, which
+        /// disagreed with `file_stem`.
+        declared_name: String,
+    },
+    /// The filename stem itself isn't a valid loadout name (e.g.
+    /// contains a path separator or NUL). Caught before parsing the
+    /// TOML so the operator gets the concrete "your filename is bad"
+    /// message instead of a downstream "name mismatch" one.
+    #[error("loadout file `{path}` has an invalid stem: {source}")]
+    InvalidStem {
+        path: PathBuf,
+        #[source]
+        source: crate::core::loadout::LoadoutNameError,
+    },
+}
+
+/// A directory entry produced by [`list_loadouts`]: the filename
+/// stem this entry was found under, and either the parsed
+/// [`Loadout`] or the error that prevented parsing.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct LoadoutEntry {
+    /// The filename stem (without `.toml`). This is what the user
+    /// interacts with as the loadout identifier — [`read_loadout_file`]
+    /// enforces that it matches the loadout's internal `name` field.
+    pub file_stem: String,
+    /// Path to the loadout file. Absolute when `list_loadouts`
+    /// canonicalized the input directory (its normal path); may be
+    /// relative if the caller invoked `read_loadout_file` directly
+    /// with a relative argument.
+    pub path: PathBuf,
+    /// The parsed loadout, or the error explaining why it couldn't
+    /// be loaded. Listing surfaces malformed entries so an operator
+    /// can fix them; consumers that need only usable loadouts should
+    /// filter on `Ok`.
+    pub loadout: Result<Loadout, LoadError>,
+}
+
+/// Failure enumerating the loadouts directory itself. Distinct from
+/// per-entry [`LoadError`]s, which are folded into [`LoadoutEntry`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ListError {
+    /// The directory doesn't exist.
+    #[error("loadouts directory `{path}` does not exist")]
+    NotFound { path: PathBuf },
+    /// The path exists but isn't a directory.
+    #[error("`{path}` is not a directory")]
+    NotADirectory { path: PathBuf },
+    /// Reading the directory failed for some other reason (permissions,
+    /// I/O error, etc.).
+    #[error("read directory `{path}`: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Parse a single loadout file. The file stem must be a valid
+/// [`LoadoutName`] (rejects path separators, NUL, empty) and must
+/// match the loadout's declared `name` field.
+///
+/// # Errors
+///
+/// See [`LoadError`].
+pub fn read_loadout_file(path: &Path) -> Result<Loadout, LoadError> {
+    // Validate the stem *before* reading the file so an operator
+    // renaming to `~/foo/bar.toml` gets the specific "your filename
+    // is bad" message instead of a confusing name-mismatch error
+    // downstream.
+    let file_stem_str = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    let file_stem =
+        crate::core::loadout::LoadoutName::try_new(file_stem_str).map_err(|source| {
+            LoadError::InvalidStem {
+                path: path.to_path_buf(),
+                source,
+            }
+        })?;
+
+    let contents = std::fs::read_to_string(path).map_err(|source| LoadError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let loadout: Loadout = toml::from_str(&contents).map_err(|source| LoadError::Parse {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if loadout.name() != &file_stem {
+        return Err(LoadError::NameMismatch {
+            path: path.to_path_buf(),
+            file_stem: file_stem.into_inner(),
+            declared_name: loadout.name().as_ref().to_string(),
+        });
+    }
+    Ok(loadout)
+}
+
+/// Enumerate every `*.toml` file in `dir` and try to parse each as a
+/// [`Loadout`]. Returns one [`LoadoutEntry`] per file, sorted by
+/// stem; parse and name-mismatch failures are folded into the
+/// entry's `loadout` field so the caller can surface them in the
+/// listing rather than aborting the whole scan.
+///
+/// Non-`.toml` files and subdirectories are silently ignored.
+///
+/// # Errors
+///
+/// See [`ListError`].
+pub fn list_loadouts(dir: &Path) -> Result<Vec<LoadoutEntry>, ListError> {
+    // Canonicalize once up front so every `LoadoutEntry.path` is
+    // absolute (matches the docstring on that field) and so any
+    // downstream logging or error message names the real path
+    // instead of a `-r ./foo`-shaped relative one. Absence is
+    // reported below as `ListError::NotFound` uniformly.
+    let dir = std::fs::canonicalize(dir).map_err(|source| match source.kind() {
+        std::io::ErrorKind::NotFound => ListError::NotFound {
+            path: dir.to_path_buf(),
+        },
+        _ => ListError::Io {
+            path: dir.to_path_buf(),
+            source,
+        },
+    })?;
+    let read_dir = match std::fs::read_dir(&dir) {
+        Ok(rd) => rd,
+        Err(source) if source.kind() == std::io::ErrorKind::NotADirectory => {
+            return Err(ListError::NotADirectory { path: dir });
+        }
+        Err(source) => {
+            return Err(ListError::Io { path: dir, source });
+        }
+    };
+
+    let mut entries: Vec<LoadoutEntry> = read_dir
+        .filter_map(|res| match res {
+            Ok(entry) => Some(entry),
+            Err(e) => {
+                // Per-dirent errors are typically transient
+                // (permission-denied on a specific entry, a race
+                // where the file vanished between opendir/readdir).
+                // Surface via a warn instead of silently swallowing;
+                // the module's convention is to make errors visible.
+                tracing::warn!(
+                    dir = %dir.display(),
+                    error = %e,
+                    "skipping loadouts directory entry: read failed",
+                );
+                None
+            }
+        })
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_file() {
+                return None;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+                return None;
+            }
+            let file_stem = path.file_stem().and_then(|s| s.to_str())?.to_string();
+            let loadout = read_loadout_file(&path);
+            Some(LoadoutEntry {
+                file_stem,
+                path,
+                loadout,
+            })
+        })
+        .collect();
+    entries.sort_by(|a, b| a.file_stem.cmp(&b.file_stem));
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &Path, name: &str, contents: &str) -> PathBuf {
+        let path = dir.join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    /// A well-formed loadout file loads and its name field matches
+    /// the file stem.
+    #[test]
+    fn read_loadout_file_ok() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "dev.toml", r#"name = "dev""#);
+        let loadout = read_loadout_file(&path).expect("valid loadout should load");
+        assert_eq!(loadout.name().as_ref(), "dev");
+    }
+
+    /// A loadout whose declared `name` disagrees with its filename
+    /// stem is rejected with a descriptive error.
+    #[test]
+    fn read_loadout_file_name_mismatch_errors() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "dev.toml", r#"name = "other""#);
+        let err = read_loadout_file(&path).expect_err("mismatched name should error");
+        match err {
+            LoadError::NameMismatch {
+                file_stem,
+                declared_name,
+                ..
+            } => {
+                assert_eq!(file_stem, "dev");
+                assert_eq!(declared_name, "other");
+            }
+            other => panic!("expected NameMismatch, got {other:?}"),
+        }
+    }
+
+    /// Malformed TOML is reported as a `Parse` error, not swallowed.
+    #[test]
+    fn read_loadout_file_parse_error() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "bad.toml", "= not = toml =");
+        let err = read_loadout_file(&path).expect_err("malformed toml should error");
+        assert!(matches!(err, LoadError::Parse { .. }));
+    }
+
+    /// `list_loadouts` enumerates `.toml` files in stem order,
+    /// ignores non-`.toml` entries and subdirectories, and folds
+    /// per-entry errors into the returned list rather than aborting.
+    #[test]
+    fn list_loadouts_enumerates_and_sorts() {
+        let dir = TempDir::new().unwrap();
+        write_file(dir.path(), "beta.toml", r#"name = "beta""#);
+        write_file(dir.path(), "alpha.toml", r#"name = "alpha""#);
+        write_file(dir.path(), "readme.txt", "not a loadout");
+        std::fs::create_dir(dir.path().join("nested")).unwrap();
+        // Malformed but present — should show up as an entry with
+        // a `Parse` error, not skip the file entirely.
+        write_file(dir.path(), "broken.toml", "= bad =");
+        // Name-mismatch — also surfaces as an entry with an error.
+        write_file(dir.path(), "renamed.toml", r#"name = "different""#);
+
+        let entries = list_loadouts(dir.path()).expect("should list");
+        let stems: Vec<&str> = entries.iter().map(|e| e.file_stem.as_str()).collect();
+        assert_eq!(stems, vec!["alpha", "beta", "broken", "renamed"]);
+
+        assert!(entries[0].loadout.is_ok());
+        assert!(entries[1].loadout.is_ok());
+        assert!(matches!(entries[2].loadout, Err(LoadError::Parse { .. })));
+        assert!(matches!(
+            entries[3].loadout,
+            Err(LoadError::NameMismatch { .. })
+        ));
+    }
+
+    /// A missing directory returns `NotFound`, not a generic I/O error.
+    #[test]
+    fn list_loadouts_missing_dir_returns_not_found() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("nope");
+        let err = list_loadouts(&missing).expect_err("missing dir should error");
+        assert!(matches!(err, ListError::NotFound { .. }));
+    }
+}

--- a/crates/sessions/src/client/mod.rs
+++ b/crates/sessions/src/client/mod.rs
@@ -1,2 +1,4 @@
 pub mod composer;
+pub mod config;
+pub mod disk;
 pub mod handler;

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -522,7 +522,7 @@ pub enum ComposeError {
     /// errors (permission denied, non-UTF-8 paths, etc.). All errors
     /// surfaced by every `FileSet::resolve` invocation are accumulated
     /// — none are discarded.
-    #[error("patch enumeration failed ({} error(s)):{}", sources.len(), DisplayJoin(sources))]
+    #[error("patch enumeration produced {} error{}:{}", sources.len(), if sources.len() == 1 { "" } else { "s" }, DisplayJoin(sources))]
     PatchWalk {
         sources: Vec<crate::core::primitives::PatchError>,
     },
@@ -1075,10 +1075,22 @@ impl Composition {
 /// dotfile trees where a symlink may legitimately point outside the
 /// patch source.
 #[derive(Clone, Copy, Debug, Default)]
+#[non_exhaustive]
 pub struct ComposeOptions {
     /// If `true`, [`FileSet::resolve`](crate::core::primitives::FileSet::resolve)
     /// follows symlinks while walking patch sources. Off by default.
     pub follow_symlinks: bool,
+}
+
+impl ComposeOptions {
+    /// Owned-builder setter for [`Self::follow_symlinks`]. Prefer
+    /// this over struct-literal syntax so external callers keep
+    /// compiling when new fields are added.
+    #[must_use]
+    pub fn with_follow_symlinks(mut self, follow: bool) -> Self {
+        self.follow_symlinks = follow;
+        self
+    }
 }
 
 // =====================================================================
@@ -2007,15 +2019,20 @@ mod tests {
             assert_eq!(dests, ["nvim/a.lua", "nvim/sub/b.lua"]);
         }
 
+        /// A patch whose walk root doesn't exist on the host is
+        /// silently dropped with a `tracing::warn!`, not surfaced as
+        /// [`ComposeError::PatchWalk`]. A user activating a loadout
+        /// that opportunistically patches something absent (e.g. a
+        /// missing dotfile tree) shouldn't have activation fail.
         #[test]
-        fn walk_failure_surfaces_as_patch_walk() {
+        fn missing_patch_source_is_dropped_not_error() {
             let patch = Patch::new(
                 "/definitely/does/not/exist/*",
                 PatchDest::try_new("x").unwrap(),
             );
             let pp = ProvenancedPatch::new(patch, user_source());
             let policy = PatchPolicy::empty();
-            let err = gate_patches(
+            let (patches, _policy) = gate_patches(
                 vec![pp],
                 policy,
                 Some(&PanicHook),
@@ -2023,11 +2040,49 @@ mod tests {
                 &[],
                 None,
             )
-            .unwrap_err();
+            .expect("missing walk root should not error");
             assert!(
-                matches!(err, ComposeError::PatchWalk { ref sources } if !sources.is_empty()),
-                "got: {err:?}",
+                patches.is_empty(),
+                "missing source should yield no patches, got {patches:?}",
             );
+        }
+
+        /// A batch mixing missing and present patch sources keeps
+        /// the present ones through and warn-drops the missing —
+        /// one bad path doesn't sink the whole activation.
+        #[test]
+        fn missing_and_present_patches_partition_cleanly() {
+            let tmp = tempfile::tempdir().unwrap();
+            let root = Utf8Path::from_path(tmp.path()).unwrap().to_path_buf();
+            std::fs::write(root.join("real.txt").as_std_path(), "x").unwrap();
+            let real_pattern = format!("{root}/real.txt");
+
+            let present = ProvenancedPatch::new(
+                Patch::new(&real_pattern, PatchDest::try_new("real.txt").unwrap()),
+                user_source(),
+            );
+            let missing = ProvenancedPatch::new(
+                Patch::new(
+                    "/definitely/does/not/exist/*",
+                    PatchDest::try_new("m").unwrap(),
+                ),
+                user_source(),
+            );
+            let policy = PatchPolicy::empty();
+            let (patches, _) = gate_patches(
+                vec![present, missing],
+                policy,
+                Some(&PanicHook),
+                ComposeOptions::default(),
+                &[],
+                None,
+            )
+            .expect("mixed batch should not error");
+            let dests: Vec<&str> = patches
+                .iter()
+                .map(|sp| sp.patch().destination().as_str())
+                .collect();
+            assert_eq!(dests, ["real.txt"]);
         }
 
         #[test]

--- a/crates/sessions/src/core/enumerate.rs
+++ b/crates/sessions/src/core/enumerate.rs
@@ -73,11 +73,13 @@ pub(crate) struct ExpandedProvenancedPatch {
 /// can't appear in the walk root or yielded paths. A non-existent
 /// walk root surfaces as a walkdir error on first iteration.
 ///
-/// All errors across every patch are accumulated — a permission-denied
-/// subtree under one patch doesn't hide an unwalkable pattern in
-/// another. If any error occurred, they surface together as
-/// [`ComposeError::PatchWalk`]; otherwise the file list is returned
-/// cleanly.
+/// A patch whose walk root doesn't exist is *not* a hard error —
+/// a `tracing::warn!` names the missing path and the patch is
+/// dropped, so a loadout that opportunistically patches something
+/// like `~/dotfiles/helix/` doesn't fail activation on a host that
+/// doesn't have that dotfile tree. Other walk failures (permission
+/// denied, non-UTF-8 paths, etc.) still accumulate and surface as
+/// [`ComposeError::PatchWalk`].
 pub(crate) fn enumerate_patch_files(
     items: Vec<ExpandedProvenancedPatch>,
     follow_symlinks: bool,
@@ -99,6 +101,28 @@ pub(crate) fn enumerate_patch_files(
             let entry = match entry_result {
                 Ok(entry) => entry,
                 Err(source) => {
+                    // `NotFound` is treated as "user doesn't have
+                    // this on their host" — warn and move on.
+                    // `walkdir::Error::path()` reports the specific
+                    // item that failed, which is either the walk
+                    // root itself (the common case) or a subitem
+                    // that vanished mid-walk (the race). Log both
+                    // the pattern's declared root and the failing
+                    // path so operators can distinguish. `.io_error()`
+                    // returns `None` for the loop-detection variant;
+                    // those still fail hard.
+                    if source
+                        .io_error()
+                        .is_some_and(|e| e.kind() == std::io::ErrorKind::NotFound)
+                    {
+                        tracing::warn!(
+                            source_pattern = %pp.source.pattern(),
+                            walk_root = %walk_root_path,
+                            missing_path = ?source.path(),
+                            "patch source not found on host filesystem; dropping"
+                        );
+                        continue;
+                    }
                     accumulated_errors.push(PatchError::WalkFailure {
                         root: walk_root_path.clone(),
                         source,

--- a/crates/sessions/src/core/loadout.rs
+++ b/crates/sessions/src/core/loadout.rs
@@ -237,26 +237,106 @@ impl crate::core::compose::Composable for Loadout {
     /// Materialize the loadout as a [`Contribution`](crate::core::compose::Contribution),
     /// tagging every primitive with [`Source::UserLoadout`].
     ///
-    /// Inherited / default-bearing var values are resolved via `env`
-    /// at this point.
+    /// Inherited / default-bearing var values are resolved via the
+    /// `env` closure at this point. A pure `Inherit` var whose name
+    /// isn't defined in `env` is *not* an error: the var is dropped
+    /// from the contribution and a `tracing::warn!` is emitted, so a
+    /// loadout that opportunistically inherits things like `TERM` or
+    /// `COLORTERM` doesn't fail the whole activation when the host
+    /// happens not to have them set. `InheritWithDefault` already
+    /// handles absence gracefully via its `default`; only bare
+    /// `Inherit` gets this treatment.
     ///
     /// [`Source::UserLoadout`]: crate::core::source::Source::UserLoadout
     fn contribute(
         self,
         env: &dyn Fn(&str) -> Result<String, std::env::VarError>,
     ) -> Result<crate::core::compose::Contribution, crate::core::compose::Error> {
+        let loadout_name = self.name.as_ref().to_string();
         let source = crate::core::source::Source::UserLoadout {
             name: self.name.into_inner(),
         };
+
+        // Resolve bare `Inherit` vars once here so downstream doesn't
+        // re-query `env` — makes the compose stateless w.r.t. the env
+        // closure. `InheritWithDefault` still hits `env` in
+        // `contribute_primitives`, since its default handling is
+        // where the whole point of that variant lives.
+        let vars = self
+            .vars
+            .into_iter()
+            .filter_map(|(name, value)| {
+                match resolve_inherit(&loadout_name, name.as_ref(), value, env) {
+                    Ok(Some(v)) => Some(Ok((name, v))),
+                    Ok(None) => None,
+                    Err(e) => Some(Err(e)),
+                }
+            })
+            .collect::<Result<_, _>>()?;
+        let vars_lenient = self
+            .vars_lenient
+            .into_iter()
+            .filter_map(|entry| {
+                let (name, value) = entry.into_parts();
+                match resolve_inherit(&loadout_name, name.as_ref(), value, env) {
+                    Ok(Some(v)) => Some(Ok(LenientVarEntry::new(name, v))),
+                    Ok(None) => None,
+                    Err(e) => Some(Err(e)),
+                }
+            })
+            .collect::<Result<_, _>>()?;
+
         crate::core::compose::contribute_primitives(
             &source,
             self.packages,
-            self.vars,
-            self.vars_lenient,
+            vars,
+            vars_lenient,
             self.patches,
             self.lifecycle_hooks,
             env,
         )
+    }
+}
+
+/// Resolve a bare `Inherit` value against `env` once. Returns:
+///
+/// - `Ok(Some(Specified(v)))` when the env lookup succeeds — the
+///   caller inserts a resolved value, and downstream never
+///   re-queries `env` for this var.
+/// - `Ok(None)` on `NotPresent`, with a `tracing::warn!` naming the
+///   loadout and var. Drops the entry from the contribution — a
+///   loadout opportunistically inheriting `TERM`/`COLORTERM` doesn't
+///   fail activation when the host doesn't have them set.
+/// - `Err(VarError::ResolutionFailure)` on other errors
+///   (`NotUnicode`), which bubbles to `ComposeError::VarResolution`
+///   at the caller — matches the shape `ResolvedVar::resolve_with`
+///   produces for the same env failure.
+///
+/// Non-`Inherit` values (`Specified`, `InheritWithDefault`) pass
+/// through unchanged.
+fn resolve_inherit(
+    loadout: &str,
+    name: &str,
+    value: VarValue,
+    env: &dyn Fn(&str) -> Result<String, std::env::VarError>,
+) -> Result<Option<VarValue>, crate::core::primitives::VarError> {
+    match value {
+        VarValue::Inherit => match env(name) {
+            Ok(v) => Ok(Some(VarValue::specified(v))),
+            Err(std::env::VarError::NotPresent) => {
+                tracing::warn!(
+                    loadout = %loadout,
+                    var = %name,
+                    "loadout inherits `{name}` but it isn't set in the host env; dropping"
+                );
+                Ok(None)
+            }
+            Err(source) => Err(crate::core::primitives::VarError::ResolutionFailure {
+                name: name.to_string(),
+                source,
+            }),
+        },
+        other => Ok(Some(other)),
     }
 }
 
@@ -447,5 +527,62 @@ mod tests {
         // creep.
         let reserialized = toml::to_string(&parsed).unwrap();
         assert_eq!(serialized, reserialized);
+    }
+
+    /// A bare `Inherit` var whose name is missing from the env is
+    /// dropped from the contribution instead of aborting the whole
+    /// `contribute` call — user loadouts opportunistically inherit
+    /// things like `TERM`, and a host that doesn't set them
+    /// shouldn't be a fatal error.
+    #[test]
+    fn inherit_var_missing_from_env_is_dropped_not_error() {
+        use crate::core::compose::Composable;
+        let loadout = Loadout::new(LoadoutName::try_new("test").unwrap())
+            .with_var(
+                StrictVarName::try_new("PRESENT").unwrap(),
+                VarValue::Inherit,
+            )
+            .with_var(
+                StrictVarName::try_new("MISSING").unwrap(),
+                VarValue::Inherit,
+            );
+
+        // Env has PRESENT but not MISSING.
+        let env: &dyn Fn(&str) -> Result<String, std::env::VarError> = &|k: &str| match k {
+            "PRESENT" => Ok("hello".to_string()),
+            _ => Err(std::env::VarError::NotPresent),
+        };
+
+        let contribution = loadout
+            .contribute(env)
+            .expect("missing inherit var should not error");
+        let names: Vec<&str> = contribution
+            .vars()
+            .iter()
+            .map(|pv| pv.var().name())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["PRESENT"],
+            "MISSING should be silently dropped, PRESENT preserved"
+        );
+    }
+
+    /// An `InheritWithDefault` var whose name is missing from the
+    /// env falls back to its `default` (existing behavior, not
+    /// affected by the bare-Inherit skip).
+    #[test]
+    fn inherit_with_default_still_uses_default_on_missing() {
+        use crate::core::compose::Composable;
+        let loadout = Loadout::new(LoadoutName::try_new("test").unwrap()).with_var(
+            StrictVarName::try_new("TERM").unwrap(),
+            VarValue::inherit_with_default("xterm-256color"),
+        );
+
+        let env: &dyn Fn(&str) -> Result<String, std::env::VarError> =
+            &|_| Err(std::env::VarError::NotPresent);
+        let contribution = loadout.contribute(env).unwrap();
+        assert_eq!(contribution.vars().len(), 1);
+        assert_eq!(contribution.vars()[0].var().value(), "xterm-256color");
     }
 }

--- a/justfile
+++ b/justfile
@@ -117,6 +117,19 @@ minvmd-build: libkrun
 minimal-cli:
     cargo build -p minimal
 
+# Run the `minimal` CLI against the workspace's own debug build. Prepends
+# `target/debug/` to `$PATH` so `minimal`'s auto-spawn can find the sibling
+# `minimald` binary (it invokes it by name). Arguments after `just min` are
+# forwarded verbatim.
+#
+# Example:
+#   just min activate --loadout helix --attach
+#   just min loadout list
+#   just min dirs
+min *args:
+    cargo build -p minimal -p minimald
+    PATH="{{justfile_directory()}}/target/debug:$PATH" "{{minimal}}" {{args}}
+
 # minimal auto-spawns `minvmd run --detach`, so minvmd must be on PATH and the
 # MINVMD_* artifact paths exported; both are set here and inherited by the
 # detached supervisor. On Linux LD_LIBRARY_PATH is also inherited so libkrun can


### PR DESCRIPTION
Resolves https://github.com/gominimal/inbox/issues/202 and resolves https://github.com/gominimal/inbox/issues/203

## Summary

Ships end-to-end loadout support, a user client config file, and two debug
commands (`minimal dirs`, `minimal loadout list`). Adds a rolling
file-based daemon log for detached mode and per-session content logging.

**User-facing (`minimal`):**
- `--config-dir` global flag (routes through the new
  `paths::minimal_config_dir()`, XDG on Linux, `~/.config/minimal` on
  macOS for consistency with the state/cache dirs)
- `minimal loadout list` — enumerate loadouts from
  `<config>/minimal/loadouts/*.toml`, mark defaults from
  `[loadouts].default_loadouts` in `config.toml`
- `minimal dirs` — print all Config/State/Cache paths with existence
  markers (`*` = exists, `-` = missing, `?` = unresolved)
- `minimal activate --loadout NAME` (repeatable) / `--no-loadouts` to
  select which loadouts to apply; otherwise `[loadouts].default_loadouts`
  is used

**Library side (`sessions`):**
- New `sessions::client::config` — TOML with `deny_unknown_fields`,
  `[loadouts]` block for `default_loadouts` and `follow_symlinks`
- New `sessions::client::disk` — `list_loadouts` / `read_loadout_file`
  with per-entry `LoadoutEntry` results so listing tolerates malformed
  files without aborting
- Loadout `Inherit` vars pre-resolve from the process env;
  `NotPresent` → warn+drop rather than error
- Patch enumeration treats walkdir `NotFound` as warn+drop, so a
  loadout that opportunistically patches `~/dotfiles/helix/` doesn't
  fail activation on a host without that tree
- `ComposeOptions::with_follow_symlinks` owned builder

**Daemon (`minimald`):**
- `MINIMALD_DETACHED=1` routes tracing to a daily-rotated log file
  under `<state>/logs/minimald.log.YYYY-MM-DD`
- Per-session content logging: packages, vars, patches, hooks with
  their `Source` provenance
- `WindowAdjusted` SSH flow-control messages downgraded from warn to
  debug (they were spamming the log)

**Structure:**
- `crates/minimal/src/lib.rs` (2313 → 1613 lines) with the new logic
  split into `config`, `dirs`, `loadouts` modules
- `paths::minimal_config_dir()` alongside the existing `state`/`cache`
  helpers
- `just min *args` recipe for quick local invocations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added `loadout` and `dirs` commands to list loadouts and inspect resolved config/state/cache directories.
  * Added `--config-dir` plus loadout activation controls (`--loadout`, `--no-loadouts`), and `minimald` rotation-backed logging in detached mode.
  * Added `min` convenience command to build and run with the daemon available automatically.

* **Bug Fixes**
  * Improved robustness when optional paths or referenced loadouts/patch sources are missing, with clearer warnings.
  * In loadouts, inherited variables now safely drop when the target value is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->