### PR TITLE
refactor(rcache): make the index-file wire format public as IndexFile

### DIFF
--- a/crates/rcache/src/index_file.rs
+++ b/crates/rcache/src/index_file.rs
@@ -1,3 +1,26 @@
+//! The on-disk/wire format of the remote cache index (`index.shisha`), and the
+//! in-memory [`IndexFile`] that reads and writes it.
+//!
+//! # Format
+//!
+//! A bare, headerless array of fixed 68-byte records, ordered by ascending
+//! `spec_hash` (an [`IndexFile`] is a `BTreeMap`, and [`IndexFile::write_to`]
+//! drains it in order). There is no magic, no version, and no entry count:
+//!
+//! ```text
+//! byte  0..32   spec_hash   blake3, the key
+//! byte 32..36   flags       reserved; MUST be zero
+//! byte 36..68   sha256      content hash of the build output
+//! ```
+//!
+//! Because the record order is a pure function of the keys, the same set of
+//! entries always serializes to identical bytes. Callers that sign or otherwise
+//! digest an index file depend on that.
+//!
+//! `flags` is the sole forward-compatibility hook: a reader that sees a
+//! non-zero value knows the format moved on and refuses to guess
+//! ([`IndexFile::from_reader`] errors rather than misparse).
+
 use common::SpecHash;
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
@@ -38,9 +61,9 @@ impl<'a, R: Read> Iterator for IndexWireIter<'a, R> {
     }
 }
 
-/// The value of a [RemoteIndex] entry.
+/// The value of a [IndexFile] entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IndexEntry {
+pub(crate) struct IndexEntry {
     sha256: [u8; 32],
 }
 
@@ -69,11 +92,11 @@ impl IndexEntry {
 
 /// An in-memory index of build outputs accessible remotely.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct RemoteIndex {
+pub struct IndexFile {
     idx: BTreeMap<SpecHash, IndexEntry>,
 }
 
-impl RemoteIndex {
+impl IndexFile {
     /// Loads a remote index that was previously serialized with [Self::write_to].
     pub fn from_reader<R: Read>(reader: &mut R) -> std::io::Result<Self> {
         let mut err = None;
@@ -114,7 +137,7 @@ impl RemoteIndex {
     }
 }
 
-impl Extend<(SpecHash, [u8; 32])> for RemoteIndex {
+impl Extend<(SpecHash, [u8; 32])> for IndexFile {
     #[inline]
     fn extend<T: IntoIterator<Item = (SpecHash, [u8; 32])>>(&mut self, iter: T) {
         self.idx.extend(
@@ -168,7 +191,7 @@ mod tests {
         }
 
         let mut curs = Cursor::new(buf);
-        let ri = RemoteIndex::from_reader(&mut curs).unwrap();
+        let ri = IndexFile::from_reader(&mut curs).unwrap();
         assert_eq!(ri.idx.len(), 2);
         assert_eq!(
             ri.idx.first_key_value(),

--- a/crates/rcache/src/lib.rs
+++ b/crates/rcache/src/lib.rs
@@ -6,7 +6,8 @@ pub use remote::{Error, INDEX_FILENAME, RemoteCache};
 mod remote_writer;
 pub use remote_writer::RemoteCacheWriter;
 
-mod remote_index;
+pub mod index_file;
+pub use index_file::IndexFile;
 
 /// An adapter that lets you use a [RemoteCache] as a [graph::BinProvider].
 #[derive(Debug, Clone)]

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -1,4 +1,4 @@
-use crate::remote_index::RemoteIndex;
+use crate::index_file::IndexFile;
 use common::{SpecHash, archive};
 use lcache::{Cache, LocalDir, PendingDir};
 use ot::{OpTracker, Operation};
@@ -56,7 +56,7 @@ impl<BE: std::fmt::Debug> From<BE> for Error<BE> {
 pub struct RemoteCache<B: FetchBackend> {
     backend: B,
     base: B::Url,
-    index: RemoteIndex,
+    index: IndexFile,
 
     #[allow(dead_code)]
     dir: Option<PathBuf>,
@@ -192,7 +192,7 @@ impl<B: FetchBackend> RemoteCache<B> {
                 tracing::debug!("Re-using remote index (fetched {}s ago)", elapsed.as_secs());
                 return Ok(Self {
                     backend,
-                    index: RemoteIndex::from_reader(
+                    index: IndexFile::from_reader(
                         &mut std::fs::File::open(&l_idx_path).map_err(Error::IO)?,
                     )
                     .map_err(Error::IO)?,
@@ -211,14 +211,14 @@ impl<B: FetchBackend> RemoteCache<B> {
 
         let fetch_op = OpTracker::new_with_root(&ot).with_op(Operation::FetchIndex);
 
-        // TODO: Gotta be a better way to stream it into [RemoteIndex].
+        // TODO: Gotta be a better way to stream it into [IndexFile].
         let mut index_resp = backend.execute(index_req).await?;
         // Capture the GCS generation, if the backend exposes one. Reads
         // need to do this before consuming chunks because the response
         // metadata may not survive the body read in some impls.
         let gcs_generation = index_resp.generation();
         let index = match index_resp.status_code() {
-            404 => RemoteIndex::default(),
+            404 => IndexFile::default(),
             _ => {
                 // Progress total only; a plain-HTTPS backend may omit
                 // Content-Length (chunked transfer), so don't panic on None.
@@ -232,8 +232,8 @@ impl<B: FetchBackend> RemoteCache<B> {
                 }
                 fetch_op.set_done();
 
-                let index = RemoteIndex::from_reader(&mut std::io::Cursor::new(buffer))
-                    .map_err(Error::IO)?;
+                let index =
+                    IndexFile::from_reader(&mut std::io::Cursor::new(buffer)).map_err(Error::IO)?;
 
                 if let Some(index_dir) = index_dir.as_ref() {
                     let l_idx_path = index_dir.join(INDEX_FILENAME);
@@ -421,7 +421,7 @@ mod tests {
         let claimed_sha256: [u8; 32] = [0xBB; 32];
 
         // Build an index that maps spec_hash -> claimed_sha256.
-        let mut index = RemoteIndex::default();
+        let mut index = IndexFile::default();
         index.extend(std::iter::once((spec_hash.clone(), claimed_sha256)));
         let mut index_bytes = Vec::new();
         index.write_to(&mut index_bytes).unwrap();
@@ -461,7 +461,7 @@ mod tests {
         let sha256: [u8; 32] = [0xCD; 32];
 
         // Index maps spec_hash -> sha256.
-        let mut index = RemoteIndex::default();
+        let mut index = IndexFile::default();
         index.extend(std::iter::once((spec_hash.clone(), sha256)));
         let mut index_bytes = Vec::new();
         index.write_to(&mut index_bytes).unwrap();
@@ -519,7 +519,7 @@ mod tests {
     async fn new_any_https_fetches_and_parses_index_over_real_http() {
         let spec_hash = SpecHash::from_bytes([0x07; 32]);
         let sha256: [u8; 32] = [0x42; 32];
-        let mut index = RemoteIndex::default();
+        let mut index = IndexFile::default();
         index.extend(std::iter::once((spec_hash.clone(), sha256)));
         let mut index_bytes = Vec::new();
         index.write_to(&mut index_bytes).unwrap();

--- a/crates/rcache/src/remote_writer.rs
+++ b/crates/rcache/src/remote_writer.rs
@@ -7,8 +7,8 @@
 //! raced.
 
 use crate::INDEX_FILENAME;
+use crate::index_file::IndexFile;
 use crate::remote::Error;
-use crate::remote_index::RemoteIndex;
 use common::SpecHash;
 use common::fetchers::{FetchUrl, GcsUrl};
 use google_cloud_storage::Error as GcsError;
@@ -65,7 +65,7 @@ pub struct RemoteCacheWriter<S: StubStorage + 'static = DefaultStorage> {
     /// The index as it was when we last fetched it from GCS. Used both as the
     /// base to merge `pending` into, and as a dedup check in [Self::upload]
     /// to skip uploads of artifacts already present.
-    fetched_index: RemoteIndex,
+    fetched_index: IndexFile,
 
     /// The GCS object generation that `fetched_index` was loaded from.
     /// `0` means the index file did not exist at fetch time, which
@@ -115,7 +115,7 @@ impl<S: StubStorage + 'static> RemoteCacheWriter<S> {
     pub(crate) fn from_parts(
         backend: Storage<S>,
         base: GcsUrl,
-        fetched_index: RemoteIndex,
+        fetched_index: IndexFile,
         fetched_generation: i64,
         ot: Option<OpTracker>,
     ) -> Self {
@@ -300,7 +300,7 @@ fn decide_retry_after_failure(status_code: Option<u16>, attempts_so_far: u32) ->
 /// Build the index that will be written for this attempt: fetched + pending.
 /// Extracted so the merge invariant ("no entries lost across retries") can
 /// be exercised at the data-structure level without going through GCS.
-fn merge_for_commit(fetched: &RemoteIndex, pending: &[(SpecHash, [u8; 32])]) -> RemoteIndex {
+fn merge_for_commit(fetched: &IndexFile, pending: &[(SpecHash, [u8; 32])]) -> IndexFile {
     let mut merged = fetched.clone();
     merged.extend(pending.iter().cloned());
     merged
@@ -317,13 +317,13 @@ fn merge_for_commit(fetched: &RemoteIndex, pending: &[(SpecHash, [u8; 32])]) -> 
 pub(crate) async fn fetch_gcs_index<S: StubStorage + 'static>(
     backend: &Storage<S>,
     base: &GcsUrl,
-) -> Result<(RemoteIndex, i64), Error<GcsError>> {
+) -> Result<(IndexFile, i64), Error<GcsError>> {
     let url = base.join(INDEX_FILENAME).unwrap();
     let mut response = match backend.read_object(url.bucket, url.object).send().await {
         Ok(r) => r,
         Err(e) => {
             if e.http_status_code() == Some(NOT_FOUND) {
-                return Ok((RemoteIndex::default(), 0));
+                return Ok((IndexFile::default(), 0));
             }
             return Err(Error::Backend(e));
         }
@@ -338,7 +338,7 @@ pub(crate) async fn fetch_gcs_index<S: StubStorage + 'static>(
         buffer.extend_from_slice(&chunk);
     }
 
-    let index = RemoteIndex::from_reader(&mut std::io::Cursor::new(buffer)).map_err(Error::IO)?;
+    let index = IndexFile::from_reader(&mut std::io::Cursor::new(buffer)).map_err(Error::IO)?;
 
     Ok((index, generation))
 }
@@ -415,7 +415,7 @@ mod tests {
 
     fn writer_from_mock(
         mock: MockStorage,
-        fetched_index: RemoteIndex,
+        fetched_index: IndexFile,
         fetched_generation: i64,
     ) -> RemoteCacheWriter<MockStorage> {
         let storage = gcs::client::Storage::from_stub(mock);
@@ -428,9 +428,9 @@ mod tests {
         )
     }
 
-    /// Serialize a RemoteIndex to bytes and return as a ReadObjectResponse
+    /// Serialize a IndexFile to bytes and return as a ReadObjectResponse
     /// with the given generation, the way GCS would return it on a fetch.
-    fn read_response_for(index: &RemoteIndex, generation: i64) -> ReadObjectResponse {
+    fn read_response_for(index: &IndexFile, generation: i64) -> ReadObjectResponse {
         let mut bytes = Vec::with_capacity(2048);
         index.write_to(&mut bytes).unwrap();
         let mut highlights = ObjectHighlights::default();
@@ -458,7 +458,7 @@ mod tests {
             .withf(|_p: &Payload<BytesSource>, req, _| req.spec.if_generation_match == Some(42))
             .return_once(|_p: Payload<BytesSource>, _, _| Ok(Object::default()));
 
-        let writer = writer_from_mock(mock, RemoteIndex::default(), 42);
+        let writer = writer_from_mock(mock, IndexFile::default(), 42);
         writer.finish_uploads().await.expect("expected Ok");
     }
 
@@ -481,7 +481,7 @@ mod tests {
         mock.expect_read_object()
             .times(1)
             .in_sequence(&mut seq)
-            .return_once(|_, _| Ok(read_response_for(&RemoteIndex::default(), 100)));
+            .return_once(|_, _| Ok(read_response_for(&IndexFile::default(), 100)));
 
         // Second write uses the refetched generation, succeeds.
         mock.expect_write_object_buffered()
@@ -490,7 +490,7 @@ mod tests {
             .withf(|_p: &Payload<BytesSource>, req, _| req.spec.if_generation_match == Some(100))
             .return_once(|_p: Payload<BytesSource>, _, _| Ok(Object::default()));
 
-        let writer = writer_from_mock(mock, RemoteIndex::default(), 50);
+        let writer = writer_from_mock(mock, IndexFile::default(), 50);
         writer
             .finish_uploads()
             .await
@@ -514,9 +514,9 @@ mod tests {
         // initial attempt skips the refetch).
         mock.expect_read_object()
             .times(MAX_INDEX_WRITE_RETRIES as usize)
-            .returning(|_, _| Ok(read_response_for(&RemoteIndex::default(), 0)));
+            .returning(|_, _| Ok(read_response_for(&IndexFile::default(), 0)));
 
-        let writer = writer_from_mock(mock, RemoteIndex::default(), 0);
+        let writer = writer_from_mock(mock, IndexFile::default(), 0);
         let err = writer
             .finish_uploads()
             .await
@@ -536,7 +536,7 @@ mod tests {
             .times(1)
             .return_once(|_p: Payload<BytesSource>, _, _| Err(http_500_error()));
 
-        let writer = writer_from_mock(mock, RemoteIndex::default(), 1);
+        let writer = writer_from_mock(mock, IndexFile::default(), 1);
         let err = writer
             .finish_uploads()
             .await


### PR DESCRIPTION
Requested by @twitchyliquid64 on [build-servers#153](https://github.com/gominimal/build-servers/pull/153): build-bot now writes per-commit `index.shisha` snapshots and had to restate the 68-byte record layout by hand, because `remote_index` is a private module. That duplication is a silent-drift hazard — if this format ever changes, an out-of-tree writer keeps emitting the old bytes.

Export it, and name it for what it is (per Tom's steer: "probably with a better name, like wire or index file"). `RemoteIndex` named the in-memory map; what consumers need is **the file**.

- `remote_index` → `index_file`; `RemoteIndex` → `IndexFile`
- `IndexEntry` → `pub(crate)`: it appears in no public signature, so making the module public shouldn't leak it
- module doc states the format as a contract — headerless array of 68-byte records (32-byte blake3 key, 4 zero flag bytes, 32-byte sha256), ascending `spec_hash`

The ordering guarantee is called out deliberately: because record order is a pure function of the keys, the same entry set always serializes to identical bytes. Callers that **sign** an index file (build-servers#86) depend on that, and it's the kind of property that's easy to break by accident once it isn't written down.

Consumers then get `IndexFile::default()` + `Extend<(SpecHash, [u8; 32])>` + `write_to()`, which is byte-identical to the hand-rolled writer it replaces.

**No behaviour change** — rename plus visibility only. Verified in-sandbox: `cargo check -p rcache`, `cargo fmt --check -p rcache`, `cargo test -p rcache` (11 passed).

I went with `index_file`/`IndexFile` over `wire` since the thing has one canonical on-disk home; happy to switch to `wire` if you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer public index type for remote cache data, with updated API exposure and serialization support.
  * Improved documentation for the index format and forward-compatibility fields.

* **Bug Fixes**
  * Updated remote cache read/write paths to use the new index type consistently, including empty-index handling and fetched index parsing.
  * Adjusted tests and fixtures to match the updated index behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->