### PR TITLE
feat(gha): use released mip to fetch pkgs artifacts for CI

### DIFF
--- a/.github/actions/materialize/action.yml
+++ b/.github/actions/materialize/action.yml
@@ -1,0 +1,99 @@
+name: 'Materialize minimal output'
+description: >-
+  Download the `mip` binary from a release channel and materialize an output
+  declared in the repo's `.minimal/minimal.toml` (e.g. the guest kernel or
+  rootfs). Replaces scripts/fetch-artifact.sh: instead of building the CLI from
+  source, it pulls a prebuilt `mip`. Like that script this is a cache fetch, so
+  a prebuilt guest artifact of any arch pulls fine on any Linux runner.
+inputs:
+  output:
+    description: 'Name of the output to materialize (e.g. virtio-kernel)'
+    required: true
+  dest:
+    description: 'Destination path to write the materialized output to'
+    required: true
+  arch:
+    description: >-
+      Target (guest) arch of the output, kernel-style: x86_64 or aarch64. This
+      is the artifact arch, independent of the runner arch that selects `mip`.
+    required: false
+    default: 'aarch64'
+  channel:
+    description: 'The release channel to fetch `mip` from'
+    required: false
+    default: 'stable'
+outputs:
+  version:
+    description: 'The specific `mip` version that was resolved and run'
+    value: ${{ steps.materialize.outputs.version }}
+runs:
+  using: 'composite'
+  steps:
+    - id: materialize
+      shell: bash
+      env:
+        BASE: https://storage.googleapis.com/minimal-one
+        INPUT_OUTPUT: ${{ inputs.output }}      # via env, not inline — injection-safe
+        INPUT_DEST: ${{ inputs.dest }}
+        INPUT_ARCH: ${{ inputs.arch }}
+        INPUT_CHANNEL: ${{ inputs.channel }}
+      run: |
+        # ---- platform guard: bail before any bash-4+ syntax appears ----
+        if [ "${RUNNER_OS:-$(uname -s)}" != "Linux" ]; then
+          echo "::error::materialize supports Linux only (got ${RUNNER_OS:-$(uname -s)}); see crates/minvmd/README.md"
+          exit 1
+        fi
+
+        set -euo pipefail   # everything below is free to use modern bash
+
+        case "$INPUT_ARCH" in
+          x86_64|aarch64) ;;
+          *) echo "::error::unsupported target arch '$INPUT_ARCH' (want x86_64 or aarch64)"; exit 1 ;;
+        esac
+
+        # ---- ensure unprivileged user namespaces are usable (idempotent) ----
+        userns_knob=/proc/sys/kernel/apparmor_restrict_unprivileged_userns
+        if [[ -e "$userns_knob" ]]; then
+          if [[ "$(cat "$userns_knob")" != "0" ]]; then
+            echo "Lifting AppArmor unprivileged-userns restriction for mip"
+            if ! sudo -n sysctl -w kernel.apparmor_restrict_unprivileged_userns=0; then
+              echo "::error::passwordless sudo unavailable; set 'kernel.apparmor_restrict_unprivileged_userns=0' on this runner yourself"
+              exit 1
+            fi
+          else
+            echo "Unprivileged user namespaces already permitted"
+          fi
+        else
+          echo "No AppArmor userns restriction on this kernel; nothing to do"
+        fi
+
+        # hardened fetch: $1 = URL, $2 = output file
+        fetch() {
+          curl --proto '=https' --proto-redir '=https' --tlsv1.2 --retry 3 -fsSL "$1" -o "$2"
+        }
+
+        # ---- select the mip binary for THIS runner's arch (not the target arch) ----
+        runner_arch="$(uname -m)"
+        case "$runner_arch" in
+          x86_64|amd64)  runner_arch="amd64" ;;
+          aarch64|arm64) runner_arch="arm64" ;;
+          *) echo "::error::unsupported runner arch: $runner_arch"; exit 1 ;;
+        esac
+
+        # ---- resolve version from the channel pointer ----
+        ptr="$RUNNER_TEMP/channel-pointer"
+        fetch "$BASE/$INPUT_CHANNEL" "$ptr"
+        version="$(tr -d '[:space:]' < "$ptr")"
+        [[ -n "$version" ]] || { echo "::error::empty version from channel '$INPUT_CHANNEL'"; exit 1; }
+        echo "Resolved minimal version: $version (channel: $INPUT_CHANNEL)"
+
+        # ---- fetch mip ----
+        bin="$RUNNER_TEMP/mip"
+        fetch "$BASE/versions/$version/mip-linux-$runner_arch" "$bin"
+        chmod +x "$bin"
+
+        # ---- materialize ----
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        mkdir -p "$(dirname "$INPUT_DEST")"
+        "$bin" materialize --output "$INPUT_DEST" --arch "$INPUT_ARCH" "$INPUT_OUTPUT"
+        echo "materialized $INPUT_OUTPUT -> $INPUT_DEST ($(wc -c < "$INPUT_DEST" | tr -d ' ') bytes, $INPUT_ARCH)"

--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -168,10 +168,20 @@ jobs:
           echo "MINVMD_GVPROXY_BIN=$RUNNER_TEMP/gvproxy" >> "$GITHUB_ENV"
 
       - name: Materialize guest kernel (raw Image)
-        run: ./scripts/fetch-artifact.sh virtio-kernel "$RUNNER_TEMP/vmlinuz" x86_64
+        uses: ./.github/actions/materialize
+        with:
+          output: virtio-kernel
+          dest: ${{ runner.temp }}/vmlinuz
+          arch: x86_64
+          channel: unstable
 
       - name: Materialize guest rootfs (ext4 image)
-        run: ./scripts/fetch-artifact.sh minvmd-rootfs "$RUNNER_TEMP/rootfs.img" x86_64
+        uses: ./.github/actions/materialize
+        with:
+          output: minvmd-rootfs
+          dest: ${{ runner.temp }}/rootfs.img
+          arch: x86_64
+          channel: unstable
 
       - name: Build guest initramfs (minimald as /init)
         run: ./scripts/build-initramfs.sh "$RUNNER_TEMP/initramfs.cpio" x86_64-unknown-linux-musl

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -77,9 +77,19 @@ jobs:
                   key: ${{ runner.os }}-stage2-artifacts-${{ hashFiles('**/Cargo.lock') }}
                   restore-keys: ${{ runner.os }}-stage2-artifacts-
             - name: Materialize guest kernel (raw Image)
-              run: ./scripts/fetch-artifact.sh virtio-kernel "$RUNNER_TEMP/vmlinuz" aarch64
+              uses: ./.github/actions/materialize
+              with:
+                  output: virtio-kernel
+                  dest: ${{ runner.temp }}/vmlinuz
+                  arch: aarch64
+                  channel: unstable
             - name: Materialize guest rootfs (ext4 image)
-              run: ./scripts/fetch-artifact.sh minvmd-rootfs "$RUNNER_TEMP/rootfs.img" aarch64
+              uses: ./.github/actions/materialize
+              with:
+                  output: minvmd-rootfs
+                  dest: ${{ runner.temp }}/rootfs.img
+                  arch: aarch64
+                  channel: unstable
             - name: Install cross
               uses: taiki-e/install-action@v2
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -479,8 +479,8 @@ jobs:
         # build-release-initramfs, which reuses the minimald-linux-* binaries.
         #
         # None require the target host's arch to produce: the kernel and rootfs are
-        # cache pulls keyed by the pinned upstream commit (fetch-artifact.sh pulls
-        # any guest arch on an x86_64 runner), and gvproxy is a pin-verified
+        # cache pulls keyed by the pinned upstream commit (the materialize action
+        # pulls any guest arch on an x86_64 runner), and gvproxy is a pin-verified
         # download of the upstream release binary. So a single x86_64 runner emits
         # both the amd64 and arm64 variants, covering every release host
         # (linux-amd64/arm64, macos-arm64). Files are arch-suffixed so
@@ -492,38 +492,37 @@ jobs:
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false
-            - name: Toolchain
-              uses: dtolnay/rust-toolchain@stable
-            - name: Install build dependencies
-              # protoc + libprotobuf-dev: the `mip` CLI build that drives the rootfs
-              # cache pull (the well-known protos live in libprotobuf-dev, only a
-              # `recommends` of protobuf-compiler, so name it under
-              # --no-install-recommends).
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install -y --no-install-recommends \
-                    protobuf-compiler libprotobuf-dev
-            - uses: actions/cache@v6
-              with:
-                  path: |
-                      ~/.cargo/bin/
-                      ~/.cargo/registry/index/
-                      ~/.cargo/registry/cache/
-                      ~/.cargo/git/db/
-                      target/
-                  key: ${{ runner.os }}-guest-artifacts-release-${{ hashFiles('**/Cargo.lock') }}
-                  restore-keys: ${{ runner.os }}-guest-artifacts-release-
-            # NOTE: fetch-artifact.sh takes the kernel-style arch (x86_64/aarch64);
-            # only the emitted file/artifact names use the amd64/arm64 suffixes the
-            # release binaries already use.
+            # NOTE: the `arch` input is the kernel-style target arch
+            # (x86_64/aarch64); only the emitted file/artifact names use the
+            # amd64/arm64 suffixes the release binaries already use.
             - name: Materialize guest kernel (raw Image, amd64)
-              run: ./scripts/fetch-artifact.sh virtio-kernel "$RUNNER_TEMP/vmlinuz-amd64" x86_64
+              uses: ./.github/actions/materialize
+              with:
+                  output: virtio-kernel
+                  dest: ${{ runner.temp }}/vmlinuz-amd64
+                  arch: x86_64
+                  channel: unstable
             - name: Materialize guest kernel (raw Image, arm64)
-              run: ./scripts/fetch-artifact.sh virtio-kernel "$RUNNER_TEMP/vmlinuz-arm64" aarch64
+              uses: ./.github/actions/materialize
+              with:
+                  output: virtio-kernel
+                  dest: ${{ runner.temp }}/vmlinuz-arm64
+                  arch: aarch64
+                  channel: unstable
             - name: Materialize guest rootfs (ext4 image, amd64)
-              run: ./scripts/fetch-artifact.sh minvmd-rootfs "$RUNNER_TEMP/rootfs-amd64.img" x86_64
+              uses: ./.github/actions/materialize
+              with:
+                  output: minvmd-rootfs
+                  dest: ${{ runner.temp }}/rootfs-amd64.img
+                  arch: x86_64
+                  channel: unstable
             - name: Materialize guest rootfs (ext4 image, arm64)
-              run: ./scripts/fetch-artifact.sh minvmd-rootfs "$RUNNER_TEMP/rootfs-arm64.img" aarch64
+              uses: ./.github/actions/materialize
+              with:
+                  output: minvmd-rootfs
+                  dest: ${{ runner.temp }}/rootfs-arm64.img
+                  arch: aarch64
+                  channel: unstable
             - name: Fetch pinned gvproxy (linux-amd64)
               run: ./scripts/fetch-gvproxy.sh "$RUNNER_TEMP/gvproxy-linux-amd64" gvproxy-linux-amd64
             - name: Fetch pinned gvproxy (linux-arm64)


### PR DESCRIPTION
Hopefully this will shave 20 mins off our CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable action for materializing prebuilt guest artifacts.
  * Workflows now use this action to fetch kernel and root filesystem images for Linux, macOS, and release jobs.

* **Bug Fixes**
  * Added checks for supported runner OS and architecture to prevent unsupported runs.
  * Improved handling of environments that require relaxed user-namespace settings before materialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->