### PR TITLE
fix(graph): don't panic hashing a spec with a Subset build-dep

### DIFF
--- a/crates/graph/src/spec_hasher.rs
+++ b/crates/graph/src/spec_hasher.rs
@@ -239,9 +239,11 @@ fn build_attrs_hash(spec: &BuildSpec, h: &mut Hasher) {
     }
 
     h.write_all(b"-inputs").unwrap();
+    // Build and Subset deps are hashed as edges (by index) in SpecHasher::hash,
+    // not as inline inputs — build_input_hash treats both as `unreachable!()`.
     spec.build_deps
         .iter()
-        .filter(|i| i.as_build().is_none())
+        .filter(|i| !matches!(i, BuildDep::Build(_) | BuildDep::Subset(_)))
         .for_each(|i| build_input_hash(i, h));
 
     h.write_all(b"-outputs").unwrap();
@@ -364,6 +366,32 @@ mod tests {
                 $arm64
             }
         }};
+    }
+
+    #[test]
+    fn subset_build_dep_does_not_panic() {
+        // Regression: a BuildDep::Subset in build_deps used to reach
+        // build_input_hash's `Build(_) | Subset(_) => unreachable!()` because
+        // build_attrs_hash's filter only excluded the Build variant. process()
+        // already treats Subset build-deps as edges, so this is a real state.
+        use crate::SubsetInput;
+        let mut g = Graph::new();
+        let b = g.insert_build(BuildSpec {
+            name: "b".into(),
+            ..Default::default()
+        });
+        let a = g.insert_build(BuildSpec {
+            name: "a".into(),
+            build_deps: [BuildDep::Subset(SubsetInput {
+                from: b,
+                outputs: ["out".into()].into_iter().collect(),
+            })]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        });
+        // Must not panic.
+        let _ = SpecHasher::hash(&g, &a);
     }
 
     #[test]


### PR DESCRIPTION
A `BuildDep::Subset` in `build_deps` crashes spec-hash computation.

`build_attrs_hash` (spec_hasher.rs:244) filtered build_deps with `.filter(|i| i.as_build().is_none())`, which only excludes the `Build` variant. A `Subset` therefore reached `build_input_hash`, whose first arm is `Build(_) | Subset(_) => unreachable!()` (:167) -> panic.

Subset build-deps are a real state: `loader.rs:116` constructs them and `SpecHasher::process` (:106) already handles them as edges. So hashing any spec with a subset build-dep aborts the process (spec-hash is computed during planning/build, so this is not niche).

**Fix:** exclude `Subset` from the inline-input pass (it is already hashed as an edge by index). **No hash values change** — specs without subset build-deps are byte-identical, and specs with them previously panicked — so there is zero cache invalidation. Regression test included (it panics before the fix, passes after).

Found during an Aeneas/Lean formal-verification scoping pass on the spec hasher; a broader tracking issue (collision/prefix-free rewrite + verification roadmap) is coming separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)