### PR TITLE
build: pin the Rust toolchain via rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -61,6 +61,8 @@ jobs:
               - "scripts/**"
               - "Cargo.toml"
               - "Cargo.lock"
+              # The toolchain pin: a rustc bump must re-run the Rust lanes.
+              - "rust-toolchain.toml"
               - ".minimal/minimal.toml"
               - ".github/workflows/ci-linux-kvm.yml"
               # Composite actions this lane's setup runs through — without

--- a/.github/workflows/ci-linux-native.yml
+++ b/.github/workflows/ci-linux-native.yml
@@ -57,6 +57,8 @@ jobs:
               - "crates/**"
               - "Cargo.toml"
               - "Cargo.lock"
+              # The toolchain pin: a rustc bump must re-run the Rust lanes.
+              - "rust-toolchain.toml"
               - "scripts/**"
               - ".minimal/**"
               - ".github/actions/setup-rust/**"

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -14,6 +14,8 @@ on:
             - "crates/sessions/**" # platform-sensitive: canonicalization, symlinks
             - "Cargo.toml"
             - "Cargo.lock"
+            # The toolchain pin: a rustc bump must re-run the Rust lanes.
+            - "rust-toolchain.toml"
             - ".github/workflows/ci-macos.yml"
             - "scripts/**"
             # Composite actions this lane's setup runs through — without these,
@@ -31,6 +33,8 @@ on:
             - "crates/sessions/**" # platform-sensitive: canonicalization, symlinks
             - "Cargo.toml"
             - "Cargo.lock"
+            # The toolchain pin: a rustc bump must re-run the Rust lanes.
+            - "rust-toolchain.toml"
             - ".github/workflows/ci-macos.yml"
             - "scripts/**"
             # Composite actions this lane's setup runs through — without these,

--- a/crates/check/src/naming.rs
+++ b/crates/check/src/naming.rs
@@ -117,7 +117,7 @@ impl crate::GraphBasedChecker for CycleBreakerNaming {
 
         result.verdict = if let Some(replace_on_cycle) = build.replace_on_cycle {
             let cycle_breaker = graph.get(&replace_on_cycle).unwrap();
-            if cycle_breaker.name != format!("{} (prebuilt)", &pkg) {
+            if cycle_breaker.name != format!("{pkg} (prebuilt)") {
                 result.err.push(format!(
                     "cycle breaker should be named '{} (prebuilt)' instead if '{}'",
                     pkg, cycle_breaker.name

--- a/crates/checkouts/src/lib.rs
+++ b/crates/checkouts/src/lib.rs
@@ -284,7 +284,7 @@ impl Manager {
             return Err(Error::OfflineCacheMiss { remote });
         }
         let checkouts_dir = self.git_checkouts_dir();
-        for (_remote, id) in self.state.git_remotes.iter_mut() {
+        for id in self.state.git_remotes.values_mut() {
             let repo = self.repos.get_mut(id).unwrap();
             trace!("updating repo {}", repo.url());
             repo.fetch()?;

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -898,7 +898,7 @@ impl Context {
         let mut out = std::collections::HashSet::new();
         let mut graph = self.graph_from_all_packages()?;
         let mfile = self.minimal_file().clone();
-        for (name, _) in mfile.tasks.iter() {
+        for name in mfile.tasks.keys() {
             let res = self.task(graph, name)?.unwrap();
             let task = res.0;
             graph = res.1;

--- a/crates/mip/src/cmd_status.rs
+++ b/crates/mip/src/cmd_status.rs
@@ -64,7 +64,7 @@ fn print_tasks(
                     .replace("\n", "\n    ");
                 writeln!(writer, "{}", usage).unwrap();
             } else {
-                writeln!(writer, "{}", &name).unwrap();
+                writeln!(writer, "{name}").unwrap();
             }
 
             writer.set_color(ColorSpec::new().set_fg(None)).unwrap();

--- a/crates/op/src/specs.rs
+++ b/crates/op/src/specs.rs
@@ -227,7 +227,7 @@ impl<'a, SF: crate::SourceFetcher> SpecBuild<'a, SF> {
                 );
             }
         } else {
-            panic!("prebuilt input was not source: {:?}", &build.build_deps[0]);
+            panic!("prebuilt input was not source: {:?}", build.build_deps[0]);
         }
     }
 }

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -779,7 +779,7 @@ impl<C: Channel> Sandbox<C> {
             .unwrap()
             && fs::exists(rootfs.join("usr/bin").join(&program)).unwrap()
         {
-            program = format!("/usr/bin/{}", &program);
+            program = format!("/usr/bin/{program}");
         }
 
         container.command_inner(self, &program, args, env_vars)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Pinned toolchain for CI and local builds (bumped by PR, not by runner-image
+# rolls). The nightly beta canary floats ahead of this pin.
+[toolchain]
+channel = "1.97.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What

Adds `rust-toolchain.toml` pinning **stable 1.97.0** (current stable) with `rustfmt` + `clippy` components.

## Why

CI currently mixes `dtolnay/rust-toolchain@stable` (mac/KVM/release lanes) with runner-preinstalled stable (the `setup-rust` composite installs no toolchain). Both float: a rustc release day can shift clippy lints, codegen, and `Swatinem/rust-cache` keys under in-flight PRs — or mid-soak once the lane ruleset flip starts. rustup's directory-based resolution makes the checked-in file govern every cargo invocation (CI **and** dev machines), overriding both floating defaults with no workflow edits.

- Bump cadence: explicit PR (like any dependency).
- The planned nightly beta canary floats ahead of the pin, so upcoming-rustc breakage is still caught.
- Sequenced before the cache-discipline PR so rust-cache keys (which embed the rustc version) stabilize once.

Part of the CI end-state migration ([#687](https://github.com/gominimal/minimal/issues/687)).

## Impact

- One-time toolchain download in CI jobs until runner images roll to 1.97.0 (released 2026-07-07), and on dev machines/the mini on next build.
- Workspace `rust-version = "1.91"` (where declared) remains satisfied.

## Verification

- All lanes green on this PR = the pinned toolchain builds and tests the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the Rust toolchain to version 1.97.0 and ensured rustfmt/clippy are included for local development and CI.
* **CI**
  * Updated Linux and macOS CI so changes to the Rust toolchain pin re-trigger the relevant Rust build/test jobs.
* **Bug Fixes**
  * Refined naming and task status output formatting; updated an internal panic message without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->