### PR TITLE
fix(ci): run the path filter only on pull_request events

### DIFF
--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -50,8 +50,13 @@ jobs:
           persist-credentials: false
       - name: Detect relevant changes
         id: filter
-        # v3.0.2, SHA-pinned. On workflow_dispatch there is no diff to filter;
-        # the downstream `if` treats dispatch as "run everything".
+        # v3.0.2, SHA-pinned. Runs ONLY on pull_request, where dorny reads
+        # the PR file list via the API. On push it would need a local diff
+        # against event.before, which our shallow, credential-free checkout
+        # (persist-credentials: false) cannot provide — and pushes to main
+        # SHOULD run everything anyway: they write the main-only caches and
+        # provide the soak signal. Dispatch likewise runs everything.
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         with:
           filters: |
@@ -76,7 +81,7 @@ jobs:
     # artifact, so a flaky e2e rerun replays only the ~15-minute test job
     # instead of this full build. No /dev/kvm needed here.
     needs: [changes]
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.kvm == 'true'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.kvm == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -204,7 +209,7 @@ jobs:
     # standalone cargo-nextest binary. A flake rerun of this job alone costs
     # ~15 minutes instead of the old 60-minute build+test monolith.
     needs: [changes, build-linux]
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.kvm == 'true'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.kvm == 'true'
     runs-on: ubuntu-latest # x86_64; KVM-capable
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci-linux-native.yml
+++ b/.github/workflows/ci-linux-native.yml
@@ -48,8 +48,13 @@ jobs:
           persist-credentials: false
       - name: Detect relevant changes
         id: filter
-        # v3.0.2, SHA-pinned. On workflow_dispatch there is no diff to filter;
-        # the downstream `if` treats dispatch as "run everything".
+        # v3.0.2, SHA-pinned. Runs ONLY on pull_request, where dorny reads
+        # the PR file list via the API. On push it would need a local diff
+        # against event.before, which our shallow, credential-free checkout
+        # (persist-credentials: false) cannot provide — and pushes to main
+        # SHOULD run everything anyway: they write the main-only caches and
+        # provide the soak signal. Dispatch likewise runs everything.
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         with:
           filters: |
@@ -79,7 +84,7 @@ jobs:
     # ran (crates/minimald/tests/netns.rs, mesh_uc7.rs). The code and tests
     # stay in-tree and runnable locally; they are just not CI-covered.
     needs: [changes]
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.native == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -98,7 +103,7 @@ jobs:
     # ran the daemon natively at all. The native target needs no E2E_* knobs:
     # host daemon, repo as the project.
     needs: [changes]
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.native == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
## What / Why

The `changes` jobs in the native and KVM lanes **failed on every push to main** since the lanes landed (three commits: [#702](https://github.com/gominimal/minimal/pull/702)'s merge, #686, [#703](https://github.com/gominimal/minimal/pull/703)'s merge), reddening the advisory lane aggregators while every PR run stayed green.

Mechanism: on a `push` event, dorny/paths-filter diffs locally against `event.before`. Our checkouts are shallow (depth 1) — the before-commit isn't a valid object — and `persist-credentials: false` means its fetch fallback dies with `could not read Username`, so the step exits 128:

```
fatal: Not a valid object name 96548e29…^{commit}
fatal: could not read Username for 'https://github.com'
```

On `pull_request` events dorny reads the file list via the API, which is why the bug stayed invisible until main pushes started mattering.

## Fix

- The filter step runs only on `pull_request`.
- Downstream conditions become `github.event_name != 'pull_request' || <filter matched>`: pushes to main and manual dispatches run everything.

That's the semantics main wants anyway: main runs are what write the main-only caches (#703's `save-if` discipline) and provide the soak signal ([#687](https://github.com/gominimal/minimal/issues/687)) — path economy is only meaningful on PRs.

## Notes

- #703's cache-priming on main was partial (native/KVM lanes died at `changes` before building) — this PR's merge push completes it, since post-fix main pushes run all lanes.
- The upcoming trigger-flip PR applies the identical pattern to the three `changes` jobs it introduces (ci.yml, ci-macos, ci-shell-installer).

## Verification

- This PR's own run exercises the `pull_request` path (filter active, lanes triggered by the workflow-file edits).
- The definitive proof is the merge push: both lane aggregators must go green on main for the first time since #702, with all jobs running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Linux CI workflows to reliably run native and KVM builds and tests on pushes and manually triggered runs.
  * Pull requests continue to run only when relevant Linux-related files change, reducing unnecessary checks while preserving coverage for affected changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->