### PR TITLE
security(actions): SHA-pin the SDD agentic trust chain

### DIFF
--- a/.github/workflows/distillery-sync.yml
+++ b/.github/workflows/distillery-sync.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   distillery-sync:
-    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/distillery-sync.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     # Thread the consumer's DISTILLERY_DOC_GLOBS variable into the reusable
     # workflow as an input. A repo variable cannot be read inside the agent
     # prompt (`vars.*` is not an allowed gh-aw body expression), but a

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -219,7 +219,7 @@ jobs:
             - name: Mint docs-repo token (gominimal-aw-bot)
               id: docs-token
               if: ${{ inputs.dry_run != true }}
-              uses: actions/create-github-app-token@v3
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
               with:
                   app-id: ${{ vars.AW_BOT_APP_ID }}
                   private-key: ${{ secrets.AW_BOT_PRIVATE_KEY }}

--- a/.github/workflows/sdd-derive.yml
+++ b/.github/workflows/sdd-derive.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Decide whether to offer or run, and build the run matrix
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-derive@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-derive@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ github.token }}
           # Net-changed-line floor for the offer; unset falls back to 400
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       max-parallel: ${{ fromJSON(vars.SDD_DERIVE_MAX_PARALLEL || '5') }}
       matrix: ${{ fromJSON(needs.route.outputs.run_matrix) }}
-    uses: norrietaylor/spectacles/.github/workflows/sdd-derive.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-derive.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ matrix.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -168,7 +168,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -178,7 +178,7 @@ jobs:
           permission-pull-requests: write
       - name: Ack the command with 👀
         id: ack
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: ack
@@ -198,7 +198,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -207,7 +207,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
       - name: Replace 👀 with the run outcome
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: terminal

--- a/.github/workflows/sdd-dispatch.yml
+++ b/.github/workflows/sdd-dispatch.yml
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: Decide whether to run, and find the tracking issue
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-dispatch@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           app-id: ${{ vars.APP_ID }}
           github-token: ${{ github.token }}
@@ -138,7 +138,7 @@ jobs:
     steps:
       - name: Compute ready set and precondition state
         id: compute
-        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-dispatch-compute@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           tracking-issue: ${{ needs.route.outputs.tracking_issue }}
           trigger-kind: ${{ needs.route.outputs.trigger_kind }}
@@ -183,7 +183,7 @@ jobs:
       # cascade to its agent.
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -297,7 +297,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -525,7 +525,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -599,7 +599,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -649,7 +649,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -659,7 +659,7 @@ jobs:
           permission-pull-requests: write
       - name: Ack the command with 👀
         id: ack
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: ack
@@ -679,7 +679,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -688,7 +688,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
       - name: Replace 👀 with the run outcome
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: terminal

--- a/.github/workflows/sdd-execute-haiku.yml
+++ b/.github/workflows/sdd-execute-haiku.yml
@@ -190,7 +190,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           tier: haiku
           app-id: ${{ vars.APP_ID }}
@@ -202,7 +202,7 @@ jobs:
   sdd-execute-haiku:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-haiku.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -250,7 +250,7 @@ jobs:
       # issues endpoint.
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -266,7 +266,7 @@ jobs:
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-haiku.outputs.created_pr_number }}
@@ -290,7 +290,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -300,7 +300,7 @@ jobs:
           permission-pull-requests: write
       - name: Ack the command with 👀
         id: ack
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: ack
@@ -320,7 +320,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -329,7 +329,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
       - name: Replace 👀 with the run outcome
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: terminal

--- a/.github/workflows/sdd-execute-opus.yml
+++ b/.github/workflows/sdd-execute-opus.yml
@@ -190,7 +190,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           tier: opus
           app-id: ${{ vars.APP_ID }}
@@ -202,7 +202,7 @@ jobs:
   sdd-execute-opus:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-opus.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -250,7 +250,7 @@ jobs:
       # issues endpoint.
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -266,7 +266,7 @@ jobs:
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-opus.outputs.created_pr_number }}
@@ -315,7 +315,7 @@ jobs:
       # (a GITHUB_TOKEN comment would not).
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -325,7 +325,7 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
       - name: Sweep open sdd/ PRs and refresh those behind base
-        uses: norrietaylor/spectacles/.github/actions/sdd-refresh-siblings@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-refresh-siblings@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           merged-pr-number: ${{ github.event.pull_request.number }}
@@ -348,7 +348,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -358,7 +358,7 @@ jobs:
           permission-pull-requests: write
       - name: Ack the command with 👀
         id: ack
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: ack
@@ -378,7 +378,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -387,7 +387,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
       - name: Replace 👀 with the run outcome
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: terminal

--- a/.github/workflows/sdd-execute-sonnet.yml
+++ b/.github/workflows/sdd-execute-sonnet.yml
@@ -190,7 +190,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-execute@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           tier: sonnet
           app-id: ${{ vars.APP_ID }}
@@ -202,7 +202,7 @@ jobs:
   sdd-execute-sonnet:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-execute-sonnet.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -250,7 +250,7 @@ jobs:
       # issues endpoint.
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -266,7 +266,7 @@ jobs:
       # the PR is UNSTABLE with every required check green (issue #135). The
       # mechanics live in the sdd-auto-merge composite action.
       - name: Enable auto-merge when protection requires a check
-        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-auto-merge@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           pr-number: ${{ needs.sdd-execute-sonnet.outputs.created_pr_number }}
@@ -290,7 +290,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -300,7 +300,7 @@ jobs:
           permission-pull-requests: write
       - name: Ack the command with 👀
         id: ack
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: ack
@@ -320,7 +320,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -329,7 +329,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
       - name: Replace 👀 with the run outcome
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: terminal

--- a/.github/workflows/sdd-monitor.yml
+++ b/.github/workflows/sdd-monitor.yml
@@ -139,7 +139,7 @@ jobs:
       # already drives the cascade fan-out in sdd-dispatch (ADR 0014).
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -168,7 +168,7 @@ jobs:
           permission-pull-requests: read
           permission-issues: write
       - name: Nudge armed-but-idle trackers
-        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-monitor@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           # App token: PR/issue reads + the /dispatch comment (App-authored so
           # the dispatch wrapper's carve-out admits it).

--- a/.github/workflows/sdd-pr-sanitize.yml
+++ b/.github/workflows/sdd-pr-sanitize.yml
@@ -63,6 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Correct the issue references in the pull request body
-        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-pr-sanitize@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-review.yml
+++ b/.github/workflows/sdd-review.yml
@@ -52,14 +52,14 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-review@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ github.token }}
 
   sdd-review:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-review.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets
@@ -112,7 +112,7 @@ jobs:
       # resolve.
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -120,7 +120,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-pull-requests: write
       - name: Resolve App-bot advisory review threads
-        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-resolve-review-threads@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           bot-login: ${{ steps.app.outputs.app-slug }}[bot]

--- a/.github/workflows/sdd-spec.yml
+++ b/.github/workflows/sdd-spec.yml
@@ -101,7 +101,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-spec@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ github.token }}
 
@@ -135,14 +135,14 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Record approval or dispatch sdd-execute-{tier}
-        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           tracking: ${{ needs.route.outputs.fastpath_tracking }}
@@ -166,14 +166,14 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Dispatch sdd-execute-{tier} for the approved merged spec PR
-        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           tracking: ${{ needs.route.outputs.approved_tracking }}
@@ -193,14 +193,14 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Clear the stale sdd:approved marker
-        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-fastpath-approve@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           tracking: ${{ needs.route.outputs.approved_tracking }}
@@ -209,7 +209,7 @@ jobs:
   sdd-spec:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-spec.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
       # Single-PR classifier diff ceiling (ADR 0024). Maps the consumer's
@@ -271,14 +271,14 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
       - name: Post failure hand-off to tracking issue
-        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-spec-failure-handoff@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           aw-context: ${{ needs.route.outputs.aw_context }}
@@ -300,7 +300,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -310,7 +310,7 @@ jobs:
           permission-pull-requests: write
       - name: Ack the command with 👀
         id: ack
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: ack
@@ -330,7 +330,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -339,7 +339,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
       - name: Replace 👀 with the run outcome
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: terminal

--- a/.github/workflows/sdd-spike-actuator.yml
+++ b/.github/workflows/sdd-spike-actuator.yml
@@ -66,7 +66,7 @@ jobs:
       # walk errored) means this is not a spike-wave member to actuate.
       - name: Resolve the parent tracking issue
         id: tree
-        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           mode: actuator
           spike-issue: ${{ github.event.issue.number }}
@@ -79,7 +79,7 @@ jobs:
       - name: Mint App token
         id: app
         if: steps.tree.outputs.armed == 'true'
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/sdd-spike-reentry.yml
+++ b/.github/workflows/sdd-spike-reentry.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Resolve the tracking issue and the drain state
         id: tree
-        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-spike-tree@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           mode: reentry
           spike-issue: ${{ github.event.issue.number }}
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Build the phase-B re-entry context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ github.token }}
           reentry-tracking-issue: ${{ needs.walk.outputs.tracking_issue }}
@@ -108,7 +108,7 @@ jobs:
   sdd-triage:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-plan.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-plan.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
       min_task: ${{ vars.SDD_TRIAGE_MIN_TASK }}

--- a/.github/workflows/sdd-status.yml
+++ b/.github/workflows/sdd-status.yml
@@ -129,6 +129,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Refresh the status comment
-        uses: norrietaylor/spectacles/.github/actions/sdd-status@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-status@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage-dedupe-tasks.yml
+++ b/.github/workflows/sdd-triage-dedupe-tasks.yml
@@ -37,6 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close a duplicate phase-C task sub-issue
-        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-dedupe-tasks@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage-promote-ready.yml
+++ b/.github/workflows/sdd-triage-promote-ready.yml
@@ -57,6 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Promote tasks whose last blocker just closed
-        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-triage-promote-ready@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/sdd-triage.yml
+++ b/.github/workflows/sdd-triage.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-triage@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ github.token }}
 
@@ -102,7 +102,7 @@ jobs:
   arch:
     needs: route
     if: needs.route.outputs.should_run == 'true' && needs.route.outputs.target == 'arch'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-arch.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-arch.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
       min_task: ${{ vars.SDD_TRIAGE_MIN_TASK }}
@@ -128,7 +128,7 @@ jobs:
   plan:
     needs: route
     if: needs.route.outputs.should_run == 'true' && needs.route.outputs.target == 'plan'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-plan.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-plan.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
       min_task: ${{ vars.SDD_TRIAGE_MIN_TASK }}
@@ -152,7 +152,7 @@ jobs:
   materialize:
     needs: route
     if: needs.route.outputs.should_run == 'true' && needs.route.outputs.target == 'materialize'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-materialize.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-triage-materialize.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
       # Task-bundling diff floor (ADR 0022). Maps the consumer's optional
@@ -204,7 +204,7 @@ jobs:
     steps:
       - name: Detect a dependency cycle in the materialized tree
         id: detect
-        uses: norrietaylor/spectacles/.github/actions/sdd-cycle-detect@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-cycle-detect@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           tracking-issue: ${{ needs.route.outputs.item_number }}
           github-token: ${{ github.token }}
@@ -215,7 +215,7 @@ jobs:
       - name: Mint App token
         id: app
         if: steps.detect.outputs.cycle == 'true' || steps.detect.outputs.tree_incomplete == 'true'
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -293,7 +293,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -303,7 +303,7 @@ jobs:
           permission-pull-requests: write
       - name: Ack the command with 👀
         id: ack
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: ack
@@ -323,7 +323,7 @@ jobs:
     steps:
       - name: Mint App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -332,7 +332,7 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
       - name: Replace 👀 with the run outcome
-        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-ack-reaction@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ steps.app.outputs.token }}
           mode: terminal

--- a/.github/workflows/sdd-validate.yml
+++ b/.github/workflows/sdd-validate.yml
@@ -81,14 +81,14 @@ jobs:
     steps:
       - name: Decide whether to run and build aw_context
         id: decide
-        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@v0.3.0
+        uses: norrietaylor/spectacles/.github/actions/sdd-route-validate@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
         with:
           github-token: ${{ github.token }}
 
   sdd-validate:
     needs: route
     if: needs.route.outputs.should_run == 'true'
-    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@v0.3.0
+    uses: norrietaylor/spectacles/.github/workflows/sdd-validate.lock.yml@d928c5f2b9bb6de73f80e5742799eb5e02387652 # v0.3.0
     with:
       aw_context: ${{ needs.route.outputs.aw_context }}
     # Mapped explicitly, not `secrets: inherit`: inherit does not pass secrets


### PR DESCRIPTION
## What

SHA-pin the third-party action refs in the SDD (`sdd-*`) agentic pipeline to full commit SHAs:

- `norrietaylor/spectacles/**@v0.3.0` → `@d928c5f2b9bb6de73f80e5742799eb5e02387652` (both the composite actions **and** the `*.lock.yml` reusable agents)
- `actions/create-github-app-token@v3` → `@bcd2ba49218906704ab6c1aa796996da409d3eb1`

Version tags are kept as trailing `# v0.3.0` / `# v3` comments so Renovate/Dependabot can still track and bump them deliberately. **No behavior change** — same code, pinned. 18 workflow files, 86 refs.

## Why

From a security review of the SDD workflows (the AI-agent CI pipeline). These are the refs that run with the **App private key + Claude token + `contents: write`**, and they were pinned to a **mutable git tag in a third-party repo**. Because `norrietaylor/spectacles@v0.3.0` ships the pipeline's *own* write-access gate, agent, and input sanitizer, a moved `v0.3.0` tag (or an upstream compromise) would silently swap the security control itself — the same failure shape as the March 2025 `tj-actions/changed-files` supply-chain incident, applied to the thing that's supposed to stop the attack. `actions/github-script` in these workflows is already SHA-pinned; this brings the rest of the high-privilege chain to the same bar (OpenSSF Scorecard `Pinned-Dependencies`, GitHub Actions hardening guide).

This is the mechanical, zero-behavior-change slice. The **design decisions** surfaced by the review — the one ungated trigger path, `SDD_AUTO_MERGE` posture, the third-party trust-root adoption policy, and pinning the remaining CI-workflow actions — are written up in the companion issue with options rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
