### PR TITLE
feat(minimald): rip out arbitrary session exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,6 +3696,7 @@ dependencies = [
  "minimald-rpc",
  "paths",
  "russh",
+ "russh-sftp",
  "serde",
  "serde_json",
  "serial_test",

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -290,6 +290,36 @@ impl EnvChannel<'_> {
             Err(e) => return EnvChannel::write_error(e, stream),
             Ok(ctx) => ctx,
         };
+
+        // An `echo` task carries its whole output in its declaration, so it
+        // needs no package graph or sandbox — service it straight from the
+        // mfile. Only mfile-local tasks are matched here; a stack-provided
+        // echo task falls through to the normal (sandboxed) path below.
+        if let Some(task) = build_ctx.minimal_file().task(task_name)
+            && task.action.as_echo().is_some()
+        {
+            let parsed_args = if task.args.is_empty() {
+                None
+            } else {
+                match task.args.parse(args) {
+                    Err(e) => {
+                        for line in format!("{}", e.render().ansi()).lines() {
+                            writeln!(stream, "msg:{}", line).ok();
+                        }
+                        writeln!(stream, "error: failed parsing arguments for task").ok();
+                        return;
+                    }
+                    Ok(args) => Some(args),
+                }
+            };
+            match crate::interpolate_task_strings(&task, parsed_args.as_ref()) {
+                Err(e) => return EnvChannel::write_error(e, stream),
+                // `msg:` framing matches how task stdout lines reach the client.
+                Ok(t) => writeln!(stream, "msg:{}", t.action.as_echo().unwrap_or_default()).ok(),
+            };
+            return;
+        }
+
         let graph = match build_ctx.graph_from_all_packages() {
             Err(e) => return EnvChannel::write_error(e, stream),
             Ok(g) => g,
@@ -499,6 +529,42 @@ pub struct EnvArgs<'a> {
     pub ot: Option<OpTracker>,
 }
 
+/// Returns a clone of `task` with every action string interpolated against
+/// the task's parameters — `task_packages` plus any `parsed_args` — so that
+/// `%{name}`-style placeholders are resolved.
+///
+/// Shared by the invocation path ([`Env::task_invocations`]) and the
+/// sandbox-free `echo` short-circuits, so an echoed string is interpolated
+/// the same way an `exec`/`bash` action would be.
+pub fn interpolate_task_strings(
+    task: &mfile::Task,
+    parsed_args: Option<&args::ArgsSet>,
+) -> Result<mfile::Task, Error> {
+    let base = [(
+        "task_packages",
+        args::Arg::Array(
+            task.packages
+                .iter()
+                .map(|s| args::ScalarArg::String(s.clone()))
+                .collect(),
+        ),
+    )]
+    .into_iter();
+    let var_ctx = if let Some(args) = parsed_args {
+        common::ncl_eval::VarCtx::from_iter(
+            base.chain(args.iter().map(|(k, v)| (k.as_str(), v.clone()))),
+        )
+    } else {
+        common::ncl_eval::VarCtx::from_iter(base)
+    };
+    task.map_exec_strings(|s| {
+        var_ctx
+            .eval_string(s)
+            .map_err(|_| anyhow::anyhow!("nickel eval failed for string: {}", s))
+    })
+    .map_err(Error::Other)
+}
+
 /// A successfully-configured runtime environment.
 pub struct Env<'a> {
     sandbox: sandbox2::Sandbox<EnvChannel<'a>>,
@@ -628,31 +694,7 @@ impl<'a> Env<'a> {
         task: &mfile::Task,
         parsed_args: Option<&args::ArgsSet>,
     ) -> Result<(bool, Vec<Invocation>), Error> {
-        let base = [(
-            "task_packages",
-            args::Arg::Array(
-                task.packages
-                    .iter()
-                    .map(|s| args::ScalarArg::String(s.clone()))
-                    .collect(),
-            ),
-        )]
-        .into_iter();
-        let mapped_task = {
-            let var_ctx = if let Some(args) = parsed_args {
-                common::ncl_eval::VarCtx::from_iter(
-                    base.chain(args.iter().map(|(k, v)| (k.as_str(), v.clone()))),
-                )
-            } else {
-                common::ncl_eval::VarCtx::from_iter(base)
-            };
-            task.map_exec_strings(|s| {
-                var_ctx
-                    .eval_string(s)
-                    .map_err(|_| anyhow::anyhow!("nickel eval failed for string: {}", s))
-            })
-            .map_err(Error::Other)?
-        };
+        let mapped_task = interpolate_task_strings(task, parsed_args)?;
 
         Ok((
             task.interactive,

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -38,7 +38,7 @@ pub use scaffold::scaffold_default_mfile;
 mod project_setup;
 pub use project_setup::ProjectSetup;
 
-pub use env::Env;
+pub use env::{Env, interpolate_task_strings};
 use tokio::sync::Semaphore;
 use toml_edit::{Array, DocumentMut, Item, TableLike, Value};
 

--- a/crates/mfile/src/tasks.rs
+++ b/crates/mfile/src/tasks.rs
@@ -60,6 +60,7 @@ impl Task {
                 v.iter().map(|s| f(s)).collect::<Result<Vec<_>, _>>()?,
             )),
             TaskAction::Bash(cmd) => TaskAction::Bash(f(cmd)?),
+            TaskAction::Echo(s) => TaskAction::Echo(f(s)?),
             TaskAction::CmdCmd(argv) => {
                 TaskAction::CmdCmd(argv.iter().map(|s| f(s)).collect::<Result<Vec<_>, _>>()?)
             }
@@ -101,6 +102,7 @@ impl Task {
             TaskAction::Bash(cmd) => {
                 Some(("/bin/bash".to_string(), vec!["-c".to_string(), cmd.clone()]))
             }
+            TaskAction::Echo(s) => Some(("/bin/echo".to_string(), vec![s.clone()])),
             TaskAction::CmdCmd(_) => None,
         }
     }
@@ -120,6 +122,8 @@ pub enum TaskAction {
     /// The invoked program should return each command to run on stdout,
     /// one invocation per line.
     CmdCmd(Vec<String>),
+    /// Echo's the given string.
+    Echo(String),
 }
 
 impl Default for TaskAction {
@@ -132,6 +136,19 @@ impl TaskAction {
     /// Constructs a [TaskAction] that represents the execve of the given string.
     pub fn exec_from_str(s: &str) -> Self {
         Self::Exec(StrOrList::Single(s.to_string()))
+    }
+
+    /// Returns the text to emit if this is an [TaskAction::Echo], else `None`.
+    ///
+    /// Callers that can service an echo without a sandbox (the ssh and
+    /// env-socket `min run` paths) branch on this to short-circuit the
+    /// package/graph machinery entirely. The returned string may still
+    /// contain interpolations that need resolving.
+    pub fn as_echo(&self) -> Option<&str> {
+        match self {
+            TaskAction::Echo(s) => Some(s),
+            _ => None,
+        }
     }
 }
 
@@ -188,6 +205,18 @@ mod tests {
                 vec!["-c".to_string(), "go test ./... || echo failed".to_string()]
             ))
         );
+    }
+
+    #[test]
+    fn echo_str() {
+        let t: Task = toml::from_str(indoc! {
+            r#"
+            echo = "hello world"
+            "#
+        })
+        .unwrap();
+        assert_eq!(t.action, TaskAction::Echo("hello world".to_string()));
+        assert_eq!(t.action.as_echo(), Some("hello world"));
     }
 
     #[test]

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -88,7 +88,7 @@ pub struct TaskExec {
 }
 
 impl Exec for TaskExec {
-    type Process = HakoniwaProcess;
+    type Process = TaskProcess;
 
     fn exec(self, session: SessionHandle) -> BoxStream<'static, io::Result<Self::Process>> {
         // 1-slot request/response channels: the producer only spawns
@@ -96,7 +96,7 @@ impl Exec for TaskExec {
         // `HakoniwaProcess` orphans the child, so we don't want to
         // spawn one we may never deliver.
         let (req_tx, req_rx) = mpsc::channel::<()>(1);
-        let (proc_tx, proc_rx) = mpsc::channel::<io::Result<HakoniwaProcess>>(1);
+        let (proc_tx, proc_rx) = mpsc::channel::<io::Result<TaskProcess>>(1);
 
         // Producer task: holds `env`, `container`, and the invocation
         // list on its stack frame. `env` owns the temp dirs and the
@@ -126,13 +126,35 @@ async fn task_producer(
     exec: TaskExec,
     session: SessionHandle,
     mut req_rx: mpsc::Receiver<()>,
-    proc_tx: mpsc::Sender<io::Result<HakoniwaProcess>>,
+    proc_tx: mpsc::Sender<io::Result<TaskProcess>>,
 ) {
     // Wrap the whole body in a fallible async block so setup errors
     // short-circuit with `?`. An `Err` outcome triggers the
     // "wait for the first request, deliver error, exit" branch below.
     let outcome: io::Result<()> = async {
         let mut ctx = session.context().await.map_err(io::Error::other)?;
+
+        // An `echo` task's output lives entirely in its declaration, so it
+        // needs no package graph or sandbox: emit it straight from the
+        // daemon and skip the heavy path below. Only mfile-local tasks are
+        // matched; a stack-provided echo task falls through to the sandbox.
+        if let Some(task) = ctx.minimal_file().task(&exec.task)
+            && task.action.as_echo().is_some()
+        {
+            let task = mctx::interpolate_task_strings(&task, exec.args.as_ref())
+                .map_err(|e| io::Error::other(e.to_string()))?;
+            let text = task.action.as_echo().unwrap_or_default().to_string();
+            if req_rx.recv().await.is_some() {
+                let _ = proc_tx
+                    .send(Ok(TaskProcess::Echo(EchoProcess::new(&text))))
+                    .await;
+            }
+            // Park until the consumer drops the stream, mirroring the
+            // sandbox path's tail so the bridge sees a clean end-of-stream.
+            let _ = req_rx.recv().await;
+            return Ok(());
+        }
+
         // `graph_from_all_packages` is CPU-heavy (nickel evaluation,
         // graph construction) — run it on the blocking pool so it
         // doesn't stall the async executor.
@@ -191,7 +213,7 @@ async fn task_producer(
             if req_rx.recv().await.is_none() {
                 return Ok(());
             }
-            let result = (|| -> io::Result<HakoniwaProcess> {
+            let result = (|| -> io::Result<TaskProcess> {
                 let mut cmd = env
                     .command(&container, &inv.executable, inv.args.iter())
                     .map_err(|e| io::Error::other(format!("building command failed: {}", e)))?;
@@ -201,7 +223,7 @@ async fn task_producer(
                 let child = cmd
                     .spawn()
                     .map_err(|e| io::Error::other(format!("command launch failed: {}", e)))?;
-                Ok(HakoniwaProcess::new(child))
+                Ok(TaskProcess::Sandbox(HakoniwaProcess::new(child)))
             })();
             if let Err(send_err) = proc_tx.send(result).await {
                 // Receiver dropped between our `recv` returning `Some`
@@ -336,9 +358,92 @@ impl Process for HakoniwaProcess {
     }
 }
 
-/// Production [`Exec`]: runs the SSH `exec_request` argv through
-/// `/bin/sh -c`, matching what OpenSSH would do for the same request.
-/// Always produces a single process.
+/// The [`Process`] produced by a [`TaskExec`]: either a real sandboxed child
+/// ([`HakoniwaProcess`]) or a synthetic [`EchoProcess`] for `echo` tasks.
+///
+/// Stdio is boxed so the two variants' differing handle types unify behind
+/// one associated type; the bridge only ever sees `dyn AsyncRead`/`AsyncWrite`.
+pub enum TaskProcess {
+    Sandbox(HakoniwaProcess),
+    Echo(EchoProcess),
+}
+
+impl Process for TaskProcess {
+    type Stdin = std::pin::Pin<Box<dyn AsyncWrite + Send + Unpin>>;
+    type Stdout = std::pin::Pin<Box<dyn AsyncRead + Send + Unpin>>;
+    type Stderr = std::pin::Pin<Box<dyn AsyncRead + Send + Unpin>>;
+
+    fn take_stdio(&mut self) -> Option<(Self::Stdin, Self::Stdout, Self::Stderr)> {
+        match self {
+            TaskProcess::Sandbox(p) => {
+                let (i, o, e) = p.take_stdio()?;
+                Some((Box::pin(i), Box::pin(o), Box::pin(e)))
+            }
+            TaskProcess::Echo(p) => p.take_stdio(),
+        }
+    }
+
+    async fn wait(&mut self) -> io::Result<Option<i32>> {
+        match self {
+            TaskProcess::Sandbox(p) => p.wait().await,
+            TaskProcess::Echo(p) => p.wait().await,
+        }
+    }
+
+    fn start_kill(&mut self) -> io::Result<()> {
+        match self {
+            TaskProcess::Sandbox(p) => p.start_kill(),
+            TaskProcess::Echo(p) => p.start_kill(),
+        }
+    }
+}
+
+/// A synthetic [`Process`] that emits a fixed string on stdout and exits 0,
+/// without spawning anything. Backs `echo` tasks, whose entire output is
+/// known from the task declaration — so no package graph or sandbox is built.
+///
+/// The stdout carries `text` plus a trailing newline, matching what
+/// `/bin/echo "text"` would produce.
+pub struct EchoProcess {
+    /// `Some` until `take_stdio` hands the streams out; `None` thereafter.
+    stdout: Option<Vec<u8>>,
+}
+
+impl EchoProcess {
+    fn new(text: &str) -> Self {
+        Self {
+            stdout: Some(format!("{text}\n").into_bytes()),
+        }
+    }
+}
+
+impl Process for EchoProcess {
+    type Stdin = std::pin::Pin<Box<dyn AsyncWrite + Send + Unpin>>;
+    type Stdout = std::pin::Pin<Box<dyn AsyncRead + Send + Unpin>>;
+    type Stderr = std::pin::Pin<Box<dyn AsyncRead + Send + Unpin>>;
+
+    fn take_stdio(&mut self) -> Option<(Self::Stdin, Self::Stdout, Self::Stderr)> {
+        let bytes = self.stdout.take()?;
+        Some((
+            // Client stdin is accepted and discarded, as a real fast-exiting
+            // process would leave it unread.
+            Box::pin(tokio::io::sink()),
+            Box::pin(std::io::Cursor::new(bytes)),
+            Box::pin(tokio::io::empty()),
+        ))
+    }
+
+    async fn wait(&mut self) -> io::Result<Option<i32>> {
+        Ok(Some(0))
+    }
+
+    fn start_kill(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Runs an unsandboxed process to service an ssh execution. See [`TaskExec`],
+/// this must only be used to service specific safe invocations like `git recieve-pack`.
 #[derive(Debug, Clone)]
 pub struct TokioExec {
     pub argv: String,
@@ -702,36 +807,28 @@ pub(crate) async fn handle_exec(
         }
     };
 
+    let task = match argv.strip_prefix("min run ") {
+        None => {
+            tracing::warn!(%session_id, "execution request rejected: expected `min run <task name>`");
+            session.channel_failure(id)?;
+            return Ok(());
+        }
+        Some(t) => t,
+    }.to_string();
     session.channel_success(id)?;
 
     spawn(async move {
-        if let Some(task) = argv.strip_prefix("min run ") {
-            let exec_task = ExecTask {
-                conn,
-                serv,
-                session: session_handle,
-                channel_id: id,
-                exec: TaskExec {
-                    args: None,
-                    task: task.to_string(),
-                },
-            };
-            exec_task.run(channel).await;
-        } else {
-            let paths = session_handle.paths().await;
-            let exec_task = ExecTask {
-                conn,
-                serv,
-                session: session_handle,
-                channel_id: id,
-                exec: TokioExec {
-                    argv,
-                    cwd: paths.working,
-                    env: config.env_vars,
-                },
-            };
-            exec_task.run(channel).await;
+        let exec_task = ExecTask {
+            conn,
+            serv,
+            session: session_handle,
+            channel_id: id,
+            exec: TaskExec {
+                args: None,
+                task: task.to_string(),
+            },
         };
+        exec_task.run(channel).await;
     });
 
     Ok(())
@@ -1216,10 +1313,52 @@ mod tests {
         assert_eq!(out, b"AAABBB");
     }
 
+    /// An `EchoProcess` drives through the bridge as a zero-cost stand-in
+    /// for a spawned child: its text (plus a trailing newline, matching
+    /// `/bin/echo`) reaches the SSH stdout stream, stderr stays empty, and
+    /// it reports exit 0 — no sandbox involved.
+    #[tokio::test]
+    async fn echo_process_writes_text_and_exits_zero() {
+        use futures::stream::{self, StreamExt};
+
+        use super::{EchoProcess, TaskProcess};
+
+        let echo = TaskProcess::Echo(EchoProcess::new("MINIMALD_SESSION_OK"));
+        let mut echo_stream = stream::iter(vec![Ok(echo)]).boxed();
+
+        // SSH stdin closed: bridge sees EOF immediately.
+        let (closed_stdin_w, mut bridge_stdin) = duplex(64);
+        drop(closed_stdin_w);
+        let (mut client_stdout, mut bridge_stdout) = duplex(64 * 1024);
+        let (mut client_stderr, mut bridge_stderr) = duplex(64 * 1024);
+
+        let bridge_task = tokio::spawn(async move {
+            bridge(
+                "test",
+                &mut echo_stream,
+                &mut bridge_stdin,
+                &mut bridge_stdout,
+                &mut bridge_stderr,
+            )
+            .await
+        });
+
+        let exit = bridge_task.await.unwrap();
+        assert_eq!(exit, 0);
+
+        let mut out = Vec::new();
+        client_stdout.read_to_end(&mut out).await.unwrap();
+        assert_eq!(out, b"MINIMALD_SESSION_OK\n");
+
+        let mut err = Vec::new();
+        client_stderr.read_to_end(&mut err).await.unwrap();
+        assert!(err.is_empty(), "echo should produce no stderr: {err:?}");
+    }
+
     mod end_to_end {
         //! Tests that exercise the full ssh-exec stack against a real
         //! `TestServer`: russh transport, `ConnectionHandler` dispatch,
-        //! `handle_exec`, and a real `/bin/sh -c` child.
+        //! and `handle_exec` request routing.
         use sessions::SessionId;
 
         use minimald_rpc::CreateSession;
@@ -1240,90 +1379,76 @@ mod tests {
             )
         }
 
+        /// An exec request that isn't `min run <task>` must be refused
+        /// before any process starts: the daemon only services specific
+        /// safe invocations, never arbitrary client-supplied commands.
         #[tokio::test]
-        async fn exec_round_trips_stdout_stderr_and_exit_code() {
+        async fn exec_rejects_arbitrary_command() {
             let server = TestServer::new().await;
             let mut client = server.connect().await;
             let session_id = fresh_session(&mut client).await;
             let session_str = session_id.to_string();
 
-            let out = client
+            let result = client
                 .exec(
                     &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
                     false,
-                    "printf out; printf err 1>&2; exit 7",
+                    "printf pwned",
                     &[],
                 )
-                .await
-                .expect("exec request should be accepted");
+                .await;
 
-            assert_eq!(out.stdout, b"out");
-            assert_eq!(out.stderr, b"err");
-            assert_eq!(out.exit_status, Some(7));
-        }
-
-        #[tokio::test]
-        async fn exec_pipes_stdin_to_child() {
-            let server = TestServer::new().await;
-            let mut client = server.connect().await;
-            let session_id = fresh_session(&mut client).await;
-            let session_str = session_id.to_string();
-
-            let payload: &[u8] = b"hello from stdin\n";
-            let out = client
-                .exec(
-                    &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
-                    false,
-                    "cat",
-                    payload,
-                )
-                .await
-                .expect("exec request should be accepted");
-
-            assert_eq!(out.stdout, payload);
-            assert_eq!(out.exit_status, Some(0));
             assert!(
-                out.stderr.is_empty(),
-                "unexpected stderr from cat: {:?}",
-                out.stderr,
+                result.is_err(),
+                "arbitrary command should be rejected, got {result:?}",
             );
         }
 
+        /// End-to-end happy path for `min run <task>`: an `echo` task is
+        /// serviced straight from the workspace `minimal.toml` — no
+        /// package graph, upstream, or sandbox — and its text (plus a
+        /// trailing newline) round-trips over the channel with exit 0.
         #[tokio::test]
-        async fn exec_runs_in_session_workspace() {
+        async fn exec_runs_echo_task() {
             let server = TestServer::new().await;
             let mut client = server.connect().await;
             let session_id = fresh_session(&mut client).await;
             let session_str = session_id.to_string();
 
-            // Fetch the workspace path the server will hand to the
-            // child, so we can compare with what `pwd` reports.
+            // Drop a task-only `minimal.toml` into the session workspace.
+            // No `[upstream]`: the echo short-circuit never builds a graph,
+            // so nothing here reaches the (network-bound) package machinery.
             let mngr = server.state.sessions_manager().await;
             let session_handle = mngr
                 .get_session(SessionKeyPredicate::Id(session_id))
                 .await
                 .unwrap()
                 .expect("freshly-created session should be retrievable");
-            let paths = session_handle.paths().await;
-            // getcwd resolves symlinks (e.g. /tmp -> /private/tmp on some
-            // platforms); canonicalize both sides so the comparison is
-            // about the same inode rather than spelling.
-            let expected = std::fs::canonicalize(paths.working.as_str()).unwrap();
+            let workspace = session_handle.paths().await.working;
+            tokio::fs::write(
+                workspace.as_utf8_path().join(mfile::MFILE_NAME),
+                "[tasks.echo_ok]\necho = \"MINIMALD_SESSION_OK\"\n",
+            )
+            .await
+            .unwrap();
 
             let out = client
                 .exec(
                     &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
                     false,
-                    "pwd",
+                    "min run echo_ok",
                     &[],
                 )
                 .await
-                .expect("exec request should be accepted");
+                .expect("min run echo_ok should be accepted");
 
+            assert_eq!(out.stdout, b"MINIMALD_SESSION_OK\n");
             assert_eq!(out.exit_status, Some(0));
-            let observed = String::from_utf8(out.stdout).unwrap();
-            let observed = std::path::PathBuf::from(observed.trim_end());
-            assert_eq!(observed, expected);
+            assert!(
+                out.stderr.is_empty(),
+                "echo task should produce no stderr: {:?}",
+                out.stderr,
+            );
         }
 
         /// End-to-end: `git push min://<session-id>` driven by an

--- a/crates/minvmd/Cargo.toml
+++ b/crates/minvmd/Cargo.toml
@@ -45,3 +45,4 @@ paths.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 sessions.workspace = true
+russh-sftp.workspace = true

--- a/crates/minvmd/tests/minimald_session_e2e.rs
+++ b/crates/minvmd/tests/minimald_session_e2e.rs
@@ -6,10 +6,13 @@
 //!
 //! `minimald_exec_over_bridge` drives a real russh client over a `UnixStream`
 //! to the bridge UDS: it authenticates, creates a session (`CreateSession` RPC
-//! over an SSH subsystem), execs a command in that session, and asserts the
+//! over an SSH subsystem), uploads a task-only `minimal.toml` into the session
+//! workspace over SFTP, runs `min run echo_ok` in that session, and asserts the
 //! stdout + exit status that come back — proving the full path host UDS →
 //! libkrun bridge → guest vsock → minimald SSH (`run_on_vsock`, direct, no socat
-//! relay) → session exec. Requires libkrun >= 1.19.0 on the host.
+//! relay) → session task exec. The `echo` task is serviced without a package
+//! graph or sandbox, so the guest needs no network. Requires libkrun >= 1.19.0
+//! on the host.
 //!
 //! Gates:
 //! - `#[cfg(minvmd_libkrun)]`: needs libkrun (macOS, or Linux with libkrun).
@@ -161,12 +164,17 @@ async fn minimald_exec_over_bridge() {
     }
     let guest = Guest::boot();
     let sentinel = "MINIMALD_SESSION_OK";
+    // A task-only `minimal.toml` uploaded into the session workspace over
+    // SFTP. `min run echo_ok` is serviced straight from this declaration —
+    // no `[upstream]`, package graph, or sandbox — so the guest needs no
+    // network and nothing baked into the rootfs beyond minimald itself.
+    let mfile = format!("[tasks.echo_ok]\necho = \"{sentinel}\"\n");
 
     // Retry the whole session to absorb the post-READY startup race.
     tokio::time::sleep(Duration::from_millis(500)).await;
     let mut result = Err("not attempted".to_string());
     for attempt in 1..=6 {
-        result = run_session_exec(&guest.sock_path, &format!("echo {sentinel}")).await;
+        result = run_session_exec(&guest.sock_path, Some(&mfile), "min run echo_ok").await;
         if result.is_ok() {
             break;
         }
@@ -184,9 +192,11 @@ async fn minimald_exec_over_bridge() {
 }
 
 /// Open a russh client over the bridge UDS, authenticate, create a session,
-/// and exec `command` in it. Returns `(stdout, exit_status)`.
+/// optionally upload a `minimal.toml` into its workspace over SFTP, then exec
+/// `command` in it. Returns `(stdout, exit_status)`.
 async fn run_session_exec(
     sock_path: &Path,
+    mfile: Option<&str>,
     command: &str,
 ) -> Result<(String, Option<u32>), String> {
     use minimald_rpc::{CreateSession, CreateSessionRequest, OneshotSshRpc};
@@ -283,6 +293,42 @@ async fn run_session_exec(
             }
         }
     };
+
+    // Upload the project's `minimal.toml` into the session workspace over
+    // SFTP (the subsystem scopes the client's `/` to the workspace root and
+    // reads the same session-id env the exec path does).
+    if let Some(contents) = mfile {
+        let channel = handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("open sftp channel: {e}"))?;
+        channel
+            .set_env(true, MINIMAL_SESSION_ID_ENV, session_id.to_string())
+            .await
+            .map_err(|e| format!("sftp set_env: {e}"))?;
+        channel
+            .request_subsystem(true, "sftp")
+            .await
+            .map_err(|e| format!("request sftp subsystem: {e}"))?;
+        let sftp = russh_sftp::client::SftpSession::new(channel.into_stream())
+            .await
+            .map_err(|e| format!("open sftp session: {e}"))?;
+        // `create` (CREATE|WRITE|TRUNCATE), not the high-level `write` helper —
+        // the latter opens WRITE-only and so fails on a not-yet-existing file.
+        let mut file = sftp
+            .create("/minimal.toml")
+            .await
+            .map_err(|e| format!("sftp create minimal.toml: {e}"))?;
+        file.write_all(contents.as_bytes())
+            .await
+            .map_err(|e| format!("sftp write minimal.toml: {e}"))?;
+        file.shutdown()
+            .await
+            .map_err(|e| format!("sftp close minimal.toml: {e}"))?;
+        sftp.close()
+            .await
+            .map_err(|e| format!("close sftp session: {e}"))?;
+    }
 
     // Exec the command in that session.
     let mut channel = handle

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -9,10 +9,16 @@
 # (DM numbers are the deployment models in docs/specs/03-spec-networking.)
 #
 # Flow: from a guaranteed-clean state, `minimal activate` must auto-spawn the
-# target's daemon and create a session; `minimal attach --command` execs in
-# the session over the daemon's SSH surface (native UDS / vsock bridge),
-# asserting stdout + exit status; then list, warm-call, destroy (verified
-# delisted), and a clean `minimal stop`. Timing is reported but NOT asserted.
+# target's daemon and create a session; then list, warm-call, destroy
+# (verified delisted), and a clean `minimal stop`. Timing is reported but NOT
+# asserted.
+#
+# In-session exec over the daemon's SSH surface is NOT exercised here: only
+# `min run <task>` is accepted (arbitrary exec was removed), and a task needs
+# a `minimal.toml` in the otherwise-empty session workspace — which this shell
+# harness cannot seed on the VM lanes (the workspace lives inside the guest).
+# That path is proven in Rust instead: `exec::tests::end_to_end::exec_runs_echo_task`
+# (host daemon) and `minimald_exec_over_bridge` (over the libkrun bridge).
 #
 # VM targets (E2E_VM=1) additionally need, from the caller:
 #   - a codesigned/linkable `minvmd` on PATH (minimal spawns it by name)
@@ -20,9 +26,7 @@
 #     (propagate through the `minvmd run --detach` re-exec)
 #   - MINVMD_BOOT_LOG (optional) to capture the guest console
 #   The guest sees no host project dir yet (no project sync), so VM lanes
-#   pass E2E_PROJECT_DIR=/tmp — a path that exists in the guest image. In
-#   every target the session runs in a Linux environment, so the in-session
-#   `uname -s` assertion is `Linux` everywhere, including macOS hosts.
+#   pass E2E_PROJECT_DIR=/tmp — a path that exists in the guest image.
 #
 # Environment:
 #   E2E_MINIMAL_ARGS    global args for every `minimal` call (e.g. --minvmd)
@@ -86,7 +90,6 @@ trap teardown EXIT
 fail() {
   echo "::group::session-e2e diagnostics"
   echo "--- activate stderr ---"; cat "$WORK/activate.err" 2>/dev/null || true
-  echo "--- attach stderr ---"; cat "$WORK/attach.err" 2>/dev/null || true
   echo "--- minimal ls ---"; mnl ls 2>&1 || true
   echo "--- state dir ---"; find "$XDG_STATE_HOME" -type f 2>/dev/null | head -50
   find "$XDG_STATE_HOME" -type f \( -name '*.log' -o -name '*.toml' -o -name '*.json' \) 2>/dev/null \
@@ -121,25 +124,6 @@ echo "::endgroup::"
 # The session must be listed.
 mnl ls --raw 2>/dev/null | grep -Fqx "$sid" \
   || { echo "::error::'minimal ls --raw' does not list new session $sid"; fail; }
-
-# Exec a command in the session (non-interactive attach) and assert its
-# stdout and exit status — the full CLI -> daemon -> session path (UDS to a
-# native minimald; the vsock bridge into the guest on VM targets). Sessions
-# are Linux environments on every target, macOS hosts included.
-echo "::group::exec in session"
-marker="session-e2e-$$"
-out="$(mnl attach "$sid" --command "echo $marker && uname -s" 2>"$WORK/attach.err")" \
-  || { echo "::error::'minimal attach --command' exited non-zero"; fail; }
-echo "$out"
-case "$out" in
-  *"$marker"*) ;;
-  *) echo "::error::session exec output missing marker '$marker'"; fail ;;
-esac
-case "$out" in
-  *Linux*) ;;
-  *) echo "::error::session exec output missing 'Linux' (uname -s inside the session)"; fail ;;
-esac
-echo "::endgroup::"
 
 # Warm: the daemon is up; a second CLI call must succeed without respawning.
 t0=$(now_ms)


### PR DESCRIPTION
 - New, mostly-internal task type `echo` so we can tests tasks without needing the graph machinery
 - Rip out arbitrary exec of commands 
 - Fix tests that were using that
 - Unit tests for task exec over minimald

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added task-based `echo` actions with argument interpolation and newline-terminated stdout.
  * Echo tasks execute as synthetic in-process outputs, skipping package graph/sandbox setup.
  * Public helper added to interpolate task action strings, reused across task invocation reporting.
* **Bug Fixes**
  * Remote execution now only accepts `min run <task>` requests; other exec forms are rejected.
* **Tests**
  * Added/updated unit and end-to-end coverage for echo parsing, execution, and request restrictions.
* **Documentation**
  * Updated session E2E harness notes to reflect removal of arbitrary in-session command execution coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->