### PR TITLE
fix(sdd): gate pull_request_review_comment to write-access authors

### DIFF
--- a/.github/workflows/sdd-execute-haiku.yml
+++ b/.github/workflows/sdd-execute-haiku.yml
@@ -134,7 +134,16 @@ jobs:
   route:
     if: |
       (github.event_name != 'issue_comment' && github.event_name != 'issues'
-        && github.event_name != 'check_suite')
+        && github.event_name != 'check_suite'
+        && github.event_name != 'pull_request_review_comment')
+      || (
+        github.event_name == 'pull_request_review_comment'
+        && (
+          github.event.comment.author_association == 'OWNER'
+          || github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
       || (
         github.event_name == 'issue_comment'
         && (

--- a/.github/workflows/sdd-execute-opus.yml
+++ b/.github/workflows/sdd-execute-opus.yml
@@ -134,7 +134,16 @@ jobs:
   route:
     if: |
       (github.event_name != 'issue_comment' && github.event_name != 'issues'
-        && github.event_name != 'check_suite')
+        && github.event_name != 'check_suite'
+        && github.event_name != 'pull_request_review_comment')
+      || (
+        github.event_name == 'pull_request_review_comment'
+        && (
+          github.event.comment.author_association == 'OWNER'
+          || github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
       || (
         github.event_name == 'issue_comment'
         && (

--- a/.github/workflows/sdd-execute-sonnet.yml
+++ b/.github/workflows/sdd-execute-sonnet.yml
@@ -134,7 +134,16 @@ jobs:
   route:
     if: |
       (github.event_name != 'issue_comment' && github.event_name != 'issues'
-        && github.event_name != 'check_suite')
+        && github.event_name != 'check_suite'
+        && github.event_name != 'pull_request_review_comment')
+      || (
+        github.event_name == 'pull_request_review_comment'
+        && (
+          github.event.comment.author_association == 'OWNER'
+          || github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
       || (
         github.event_name == 'issue_comment'
         && (


### PR DESCRIPTION
Closes the one live path from the SDD security review (#708).

## The problem

`sdd-execute-{haiku,sonnet,opus}.yml` gate `/execute` and `/revise` behind a real write-access check, but **`pull_request_review_comment` fell through the route `if:` unconditionally** (it's not `issue_comment`/`issues`/`check_suite`, so it hit the catch-all), and the upstream `sdd-route-execute` action doesn't gate it either — asymmetric with the `pull_request_review` handler right beside it that *does*. So **any GitHub user with no write access (including from a fork) could leave an inline review comment on an open `sdd/` PR and reach the agent**, whose runtime reads the comment body.

Impact is bounded by the gh-aw secretless build + egress firewall (it's not a secret-dump), but the agent can be steered into an authorized write on the `sdd/` branch it owns — and with `SDD_AUTO_MERGE` on, that can land.

## The fix

Add a consumer-side `author_association` gate (`OWNER`/`MEMBER`/`COLLABORATOR`) on the `pull_request_review_comment` path in all three execute wrappers. Write-access reviewers still trigger revises; anonymous/fork commenters no longer reach the agent. No other trigger path changes.

## Caveats (why this is a stopgap, not the last word)

- `author_association` is a cheap proxy for write access, not the precise `getCollaboratorPermissionLevel` check the other paths use inside the route action. The **durable fix is upstream** in `norrietaylor/spectacles` (one-line-shaped: reuse the `pull_request_review` handler's check). See #708 for the fix-location decision (recommended: this stopgap now, upstream to close it properly).
- This **intentionally diverges the wrapper from the "installed unchanged" upstream template.** If a drift check enforces wrapper-immutability, that's itself the signal that the fix *must* go upstream — flagged in #708.
- Complements #707 (SHA-pinning the trust chain); independent change, no overlapping lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted pull request review comment-triggered workflows to comments from authorized repository contributors.
  * Prevented workflow execution routing for review comments from unauthorized accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->