### PR TITLE
feat(installer): setup PATH and shell completions

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -15,7 +15,7 @@ pub mod dirs;
 pub mod loadouts;
 
 #[derive(Parser)]
-#[command(name = "minimal", version = env!("CARGO_PKG_VERSION"), long_version = env!("LONG_VERSION"))]
+#[command(name = "min", version = env!("CARGO_PKG_VERSION"), long_version = env!("LONG_VERSION"))]
 #[command(about = "The Minimal CLI")]
 pub struct Cli {
     #[command(subcommand)]
@@ -98,7 +98,7 @@ pub enum Command {
     Version,
     /// Generate shell completion script
     #[command(
-        long_about = "Generate a shell tab-completion script for the minimal CLI.\nSupported shells include bash, zsh, elvish and fish.\n\n   source <(minimal completions bash)"
+        long_about = "Generate a shell tab-completion script for the minimal CLI.\nSupported shells include bash, zsh, elvish and fish.\n\n   source <(min completions bash)"
     )]
     Completions(CompletionsArgs),
 }

--- a/docs/specs/07-spec-installer/07-spec-installer.md
+++ b/docs/specs/07-spec-installer/07-spec-installer.md
@@ -16,6 +16,10 @@ supersedes:
 `x86_64`/`aarch64`. Users need a way to get those binaries onto a machine without
 a pre-existing package manager.
 
+The user-facing command is **`min`**: the `minimal` CLI component's manifest
+`dest` is `bin/min`, so that is the name written to disk (the component and
+release-artifact names keep the crate name `minimal`).
+
 This spec describes **the fallback installer only**: a single POSIX-sh script
 served for `curl … | sh`. The intended primary paths are native, platform-specific packages —
 Homebrew (`brew`), Debian/Ubuntu (`apt`/`.deb`), Arch (`pacman`/AUR), and
@@ -39,6 +43,12 @@ file is already installed (by hashing the on-disk file) and, if not, downloads,
 checksum-verifies, and atomically installs it. Reruns re-download only
 components whose hash changed.
 
+After the files are placed, the installer wires up shell integration (Unit 9):
+it generates per-shell init files that put the bin dir on `PATH`, installs tab
+completions for `min` by running the freshly-installed binary, and hooks the
+user's login-shell rc file with an idempotent, marker-fenced block. Uninstall
+(Units 7–8) undoes all of it.
+
 The whole script targets POSIX `sh` (not bash) so it runs identically under
 `dash`, macOS's frozen bash 3.2, busybox, and zsh-invoked-`sh`. It depends only
 on tools present by default on every target: a downloader (`curl` **or**
@@ -58,6 +68,8 @@ on tools present by default on every target: a downloader (`curl` **or**
    half-written binary in place.
 5. A malformed manifest, version string, or destination path is rejected before
    it can cause a path traversal or arbitrary-code execution.
+6. After one install and one new shell, `min` is on `PATH` and tab-completes
+   in bash, zsh, and fish (Unit 9).
 
 ## User Stories
 
@@ -266,9 +278,11 @@ lets the R5.1 signed-file skip stay correct across releases (skip only while the
 manifest still wants that artifact). The record also enables uninstall (Units
 7–8) and surfaces prefix drift if `XDG_*` variables change between runs.
 
-**R6.2** — If the resolved `bin` directory is not on `$PATH`, the installer
-prints an advisory telling the user to add it — it does **not** silently edit
-any shell rc file.
+**R6.2** — If the resolved `bin` directory is not on `$PATH` **in the
+installing session**, the installer prints an advisory: the Unit 9 rc hook only
+takes effect in new shells, so the advisory tells the user to restart their
+shell or export `PATH` now. The installer never *silently* edits an rc file —
+the only rc edit it makes is Unit 9's announced, marker-fenced block (R9.2).
 
 **Proof artifacts**:
 
@@ -276,6 +290,106 @@ any shell rc file.
   exists and lists the installed components with their destinations and hashes.
 - **Test**: With the `bin` prefix absent from `PATH`, the advisory is printed;
   with it present, it is not.
+
+### Unit 9 — Shell integration: PATH, shell-init files, completions
+
+The goal: after one install and one new shell, `min` is on `PATH` and
+tab-completes, in bash, zsh, and fish. Everything this unit writes is either an
+install-record row (so Units 7–8 remove it for free) or a marker-fenced rc
+block (so uninstall can strip it precisely).
+
+**R9.1** — After the component loop, the installer **generates** (never
+downloads) one init file per shell family under `<data>/shell-init/`:
+`bash.sh`, `zsh.sh`, and `fish.fish`. Each file:
+
+- embeds the `bin` directory as resolved **at install time**
+  (`${MINIMAL_BIN:-$HOME/.local/bin}`), and
+- guards at shell startup: only if the dir exists and is not already in
+  `PATH` is it prepended (`case ":$PATH:"` for POSIX shells,
+  `fish_add_path --prepend` for fish) — so sourcing is idempotent and becomes a
+  no-op once the user manages `PATH` themselves.
+
+`zsh.sh` additionally adds the zsh completions dir (R9.3) to `fpath` and runs
+`compinit`. All three files are regenerated on every run and appended to the
+install record (R6.1) with the on-disk digest in **both** hash columns (no
+manifest hash exists for generated content), so reruns replace them and
+uninstall removes them like any component.
+
+**R9.2** — The installer hooks the rc file of the user's login shell
+(`basename "$SHELL"`) with a block sourcing the matching init file, fenced by
+the exact markers `# >>> minimal >>>` / `# <<< minimal <<<`:
+
+| shell   | rc file(s)                                                        |
+|---------|-------------------------------------------------------------------|
+| `bash`  | every existing one of `~/.bashrc`, `~/.bash_profile`; neither exists → create `~/.bashrc` |
+| `zsh`   | `${ZDOTDIR:-$HOME}/.zshrc`, created if missing                     |
+| `fish`  | `${XDG_CONFIG_HOME:-~/.config}/fish/config.fish`, created if missing |
+| other   | `~/.profile` (the POSIX login rc), with the `bash.sh` (POSIX) init |
+
+The edit is idempotent — a file already containing the start marker is never
+touched again — and always announced, never silent. The sourced line itself is
+guarded (`[ -f … ] && . …` / `if test -f …`), so an rc file that outlives an
+uninstall stays harmless.
+
+The hook is **best-effort and non-fatal**: by the time it runs, the binaries
+are already correctly installed, so an rc file that cannot be appended (or a
+config dir that cannot be created) must not turn the run into a failure. The
+installer prints a warning naming the file (`failed to hook minimal shell
+support (… is not writable)`) plus the exact line to add by hand, continues,
+and still exits 0 — and the R6.2 `PATH` advisory still fires.
+
+**R9.3** — Tab completions are generated by **running the just-installed
+binary** — `<bin>/min completions <shell>` — so they always match the installed
+version, and are written atomically (temp sibling + `mv`) to each shell's
+user-level completion dir:
+
+| shell  | completion file                                                        |
+|--------|------------------------------------------------------------------------|
+| bash   | `${XDG_DATA_HOME:-~/.local/share}/bash-completion/completions/min`     |
+| zsh    | `${XDG_DATA_HOME:-~/.local/share}/zsh/completions/_min` (on `fpath` via `zsh.sh`) |
+| fish   | `${XDG_CONFIG_HOME:-~/.config}/fish/completions/min.fish`              |
+
+All three are written regardless of `$SHELL` (covers shell switching), each
+recorded in the install record like the init files. Failure to execute the
+binary (or empty output) is a **warning, not an error**: the binaries are
+already correctly installed, and completions regenerate on the next run. If
+`<bin>/min` was not part of the manifest, the step is skipped with a notice.
+
+**R9.4** — Uninstall (Units 7–8) undoes shell integration completely:
+
+- the generated init and completion files are ordinary record rows, removed by
+  the hash-verified walk (R7.3);
+- the marker-fenced block is stripped from every rc file the installer may
+  have edited (all candidates from the R9.2 table are tried — `$SHELL` may have
+  changed since install; a file without markers is never rewritten), via an
+  awk filter to a temp sibling + atomic `mv` (`sed -i` is not portable);
+- the emptied `shell-init` and completion dirs (and their possibly
+  installer-created parents) are pruned with the same `rmdir`-only discipline
+  as R8.1 — they are shared locations, never `rm -rf`ed;
+- `--dry-run` composes: it announces the would-be rc strip and removals and
+  touches nothing.
+
+**Proof artifacts**:
+
+- **Test**: after an install with `SHELL=/bin/bash`, the three init files exist
+  under `<data>/shell-init/`, embed the resolved bin dir, and are listed in the
+  install record; sourcing `bash.sh` under plain `sh` prepends the bin dir to
+  `PATH` exactly once (a second source does not duplicate it).
+- **Test**: a fresh home gets `~/.bashrc` created with exactly one marker-fenced
+  block; a rerun adds no second block; with both `~/.bashrc` and
+  `~/.bash_profile` pre-existing, both are hooked and user content is preserved.
+- **Test**: `SHELL=…/zsh` hooks (and creates) `.zshrc`; `…/fish` hooks
+  `config.fish`; an unrecognized shell falls back to `~/.profile`.
+- **Test**: with a read-only `~/.bashrc`, the install still exits 0, prints the
+  `failed to hook minimal shell support` warning and the manual line, leaves
+  the rc file untouched, and still prints the R6.2 PATH advisory.
+- **Test**: the bash/zsh/fish completion files exist at their R9.3 paths with
+  content produced by the installed binary; a manifest without the `min`
+  component skips completions non-fatally, and an unrunnable binary degrades to
+  a warning with exit 0.
+- **Test**: `--uninstall` removes the generated files, strips the rc block
+  while preserving the user's own rc content, and prunes the emptied
+  completion/shell-init dirs; `--dry-run` announces the strip without editing.
 
 ## Non-Goals
 
@@ -374,11 +488,13 @@ architecture record; design rationale is captured above.
 1. **Static**: `shellcheck --shell=sh` passes on the installer with no warnings.
 2. **Dash conformance**: the installer's test harness runs the script under
    `dash` (and, where available, macOS `/bin/sh`) — not just `bash` — in CI.
-3. **Unit tests** (Units 1–6) pass against fixture pointer files, manifests, and
-   a stubbed bucket/downloader, asserting: downloader/hasher/platform selection;
-   target and version validation; field extraction; prefix resolution and
-   traversal rejection; skip-on-rerun and checksum-mismatch handling; install
-   record and PATH advisory.
+3. **Unit tests** (Units 1–6, 9) pass against fixture pointer files, manifests,
+   and a stubbed bucket/downloader, asserting: downloader/hasher/platform
+   selection; target and version validation; field extraction; prefix resolution
+   and traversal rejection; skip-on-rerun and checksum-mismatch handling; install
+   record and PATH advisory; shell-init generation, rc hooking, and completion
+   installation (the `min` CLI fixture is a runnable script, so completion
+   generation exercises the real execute-the-binary path).
 4. **End-to-end**: against a real (or local mock) bucket, `curl … | sh` installs
    the current `stable` binaries into temp prefixes; a second run performs zero
    downloads; corrupting one on-disk binary makes the next run re-fetch only that
@@ -401,8 +517,11 @@ manifest `sha256` (see R5.1 and `install.sh`'s signing note). Uninstall reads on
 rerun skip check (R5.1) and is unused here.
 
 That record is a complete, self-contained inventory of the installer's
-footprint. An uninstaller does not need the network, the bucket, the manifest, or
-even to know which version is installed: it walks the record and undoes it. This
+footprint — downloaded components and the generated shell-init/completion files
+alike (Unit 9 records what it writes). An uninstaller does not need the network,
+the bucket, the manifest, or even to know which version is installed: it walks
+the record and undoes it, then strips the marker-fenced rc block (R9.4), the one
+piece of footprint an rc file carries instead of the record. This
 mirrors the installer's guiding principle — **the recorded/on-disk hash is the
 oracle** — applied in reverse: only remove a file the installer wrote and that is
 still byte-for-byte what it wrote.
@@ -545,8 +664,10 @@ what was asked); only an unexpected internal failure is non-zero.
   only authority. If it is missing, uninstall is a no-op — the uninstaller never
   fetches a manifest and deletes by guessing which paths *would have* been
   written, which could clobber unrelated files at those paths.
-- **Removing PATH edits.** The installer never edits shell rc files (R6.2), so
-  there is nothing of that kind to undo.
+- ~~Removing PATH edits.~~ Superseded by Unit 9: the installer hooks rc files
+  with a marker-fenced block (R9.2), and uninstall strips exactly that block
+  from every candidate rc file (R9.4). User content around the markers is never
+  touched.
 - **Cross-prefix drift recovery.** If `XDG_*`/`MINIMAL_BIN` differ between install
   and uninstall, the record's **absolute** `dest` paths are still removed
   correctly, but directory pruning (R8.1) targets the *currently* resolved
@@ -597,7 +718,8 @@ behind explicit `--purge` and confined to the `.../minimal` roots the tool owns.
 2. **Unit tests** (Units 7–8): dispatch and record-absent no-op; hash-verified
    removal; modified-file keep vs `--force`; already-absent idempotency;
    non-regular-file refusal; record teardown and empty-dir pruning; `--dry-run`
-   removing nothing; `--purge` clearing the owned trees.
+   removing nothing; `--purge` clearing the owned trees; rc-block stripping and
+   shell-integration teardown (R9.4).
 3. **End-to-end**: `install` into temp prefixes, then `--uninstall` leaves the
    prefixes free of every recorded file and removes the record; a second
    `--uninstall` is a clean no-op exiting 0.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,6 +21,13 @@
 # --force (remove modified files too), --purge (also delete the minimal data/
 # state/cache trees), and --dry-run. See Units 7–8 of the spec.
 #
+# After the files are placed, the installer wires up shell integration (Unit 9):
+# it generates per-shell init files that prepend the bin dir to PATH, installs
+# tab completions for `min` by running the freshly-installed binary, and adds a
+# marker-fenced source line to the current shell's rc file. Uninstall undoes all
+# of it (the generated files are ordinary install-record rows; the rc block is
+# stripped by its markers).
+#
 # The script targets strict POSIX `sh` (not bash): it runs identically under
 # dash, macOS's frozen bash 3.2, busybox, and zsh-invoked-sh. It depends only on
 # tooling present by default on every target: a downloader (curl or wget), a
@@ -148,6 +155,41 @@ resolve_prefix() {
     esac
 }
 
+# --- Unit 9: shared shell-integration paths and markers ---------------------
+
+# Where the generated (not downloaded) shell-integration files live. Init
+# scripts sit under the minimal-owned data prefix; completions go to each
+# shell's standard user-level lookup dir. Shared by install (write/record) and
+# uninstall (strip/prune). The rc files themselves are the user's; the
+# installer only ever appends/removes one marker-fenced block (R9.2).
+init_dir="$(resolve_prefix data)/shell-init"
+bash_comp_dir="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
+zsh_comp_dir="${XDG_DATA_HOME:-$HOME/.local/share}/zsh/completions"
+fish_comp_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fish/completions"
+fish_config="${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
+zshrc="${ZDOTDIR:-$HOME}/.zshrc"
+
+marker_start='# >>> minimal >>>'
+marker_end='# <<< minimal <<<'
+
+# Remove the marker-fenced block (R9.2) from rc file $1. Rewrites via a temp
+# sibling + atomic mv — `sed -i` is not portable across BSD/GNU. A file without
+# the start marker is never rewritten (or even opened for write).
+strip_rc_block() {
+    [ -f "$1" ] || return 0
+    grep -q '>>> minimal >>>' "$1" 2>/dev/null || return 0
+    if [ "$dry_run" -eq 1 ]; then
+        say "  would remove shell-init block from $1"
+        return 0
+    fi
+    _tmp="$1.tmp.$$"
+    awk -v s="$marker_start" -v e="$marker_end" \
+        '$0==s {skip=1; next} $0==e {skip=0; next} !skip' "$1" >"$_tmp" \
+        || { rm -f "$_tmp"; die "failed to rewrite $1"; }
+    mv -f "$_tmp" "$1"
+    say "  removed shell-init block from $1"
+}
+
 # --- Units 7+8: uninstall (walk the install record and undo it) ------------
 
 # Offline teardown driven solely by the local install record (R6.1). The record
@@ -227,6 +269,15 @@ do_uninstall() {
         rm -f "$record"
     fi
 
+    # R9.4 — strip the marker-fenced shell-init block from every rc file the
+    # installer may have edited (which shell's rc got it depends on $SHELL at
+    # install time, so try them all — a file without markers is untouched).
+    # The generated init/completion files themselves are ordinary record rows,
+    # already handled by the walk above.
+    for _rc in "$HOME/.bashrc" "$HOME/.bash_profile" "$zshrc" "$fish_config" "$HOME/.profile"; do
+        strip_rc_block "$_rc"
+    done
+
     # R8.2 — --purge additionally deletes the minimal-owned trees wholesale (build
     # cache included); they live at fixed .../minimal paths the tool owns. It
     # never removes files outside those roots.
@@ -248,6 +299,18 @@ do_uninstall() {
     # lib (~/.local/lib) is shared like bin, so it is only ever rmdir'd-if-empty,
     # never purged.
     if [ "$dry_run" -eq 0 ]; then
+        # Shell-integration dirs first (R9.4): the init dir must empty out
+        # before the data prefix can, and the completion dirs (plus their
+        # parents, which the installer may have created) are shared with other
+        # tools so, like bin, they are only ever rmdir'd-if-empty.
+        for d in "$init_dir" \
+                 "$bash_comp_dir" "${bash_comp_dir%/*}" \
+                 "$zsh_comp_dir" "${zsh_comp_dir%/*}" \
+                 "$fish_comp_dir"; do
+            if [ -d "$d" ]; then
+                rmdir "$d" 2>/dev/null || true
+            fi
+        done
         for p in bin lib data state cache; do
             d="$(resolve_prefix "$p")"
             if [ -d "$d" ]; then
@@ -410,6 +473,94 @@ while read -r comp _ _ _ want kind dest src; do
     printf '%s\t%s\t%s\t%s\n' "$comp" "$target_file" "$want" "$(sha256 "$target_file")" >>"$records"
 done <"$applicable"
 
+# --- Unit 9a: generated shell-init files and completions -------------------
+
+bindir="$(resolve_prefix bin)"
+
+# Append a generated file to this run's install record so a later run and
+# `--uninstall` treat it exactly like a downloaded component (R9.1/R9.3). No
+# manifest hash exists for generated content, so both hash columns carry the
+# on-disk digest.
+record_generated() {
+    _h="$(sha256 "$2")"
+    printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$_h" "$_h" >>"$records"
+}
+
+# R9.1 — per-shell init files, regenerated on every run. Each embeds the bin
+# dir as resolved NOW and guards at shell startup (dir exists, not already on
+# PATH), so sourcing is idempotent and a no-op once the user manages PATH
+# themselves. Only shell-runtime variables are escaped in the heredocs; the
+# unescaped $bindir/$zsh_comp_dir/$fish_comp_dir expand at generation time.
+mkdir -p "$init_dir"
+
+cat >"$init_dir/bash.sh" <<EOF
+# minimal shell init for bash
+# Completions are auto-loaded from $bash_comp_dir/
+
+if [ -d "$bindir" ]; then
+    case ":\${PATH}:" in
+        *":$bindir:"*) ;;
+        *) export PATH="$bindir:\$PATH" ;;
+    esac
+fi
+EOF
+record_generated shell-init-bash "$init_dir/bash.sh"
+
+cat >"$init_dir/zsh.sh" <<EOF
+# minimal shell init for zsh
+# Adds the completions dir to fpath before compinit.
+
+if [ -d "$bindir" ]; then
+    case ":\${PATH}:" in
+        *":$bindir:"*) ;;
+        *) export PATH="$bindir:\$PATH" ;;
+    esac
+fi
+
+# Completions
+if [ -d "$zsh_comp_dir" ]; then
+    fpath=("$zsh_comp_dir" \$fpath)
+    autoload -Uz compinit
+    compinit
+fi
+EOF
+record_generated shell-init-zsh "$init_dir/zsh.sh"
+
+cat >"$init_dir/fish.fish" <<EOF
+# minimal shell init for fish
+# Completions are auto-loaded from $fish_comp_dir/
+
+if test -d "$bindir"
+    fish_add_path --prepend "$bindir"
+end
+EOF
+record_generated shell-init-fish "$init_dir/fish.fish"
+
+# R9.3 — tab completions, generated by the just-installed binary itself so
+# they always match the installed version, written atomically like any other
+# install. A failure here is a warning, not an error: the binaries are already
+# correctly installed, and completions regenerate on the next run.
+gen_completions() {
+    mkdir -p "${2%/*}"
+    _tmp="$2.tmp.$$"
+    if "$bindir/min" completions "$1" >"$_tmp" 2>/dev/null && [ -s "$_tmp" ]; then
+        mv -f "$_tmp" "$2"
+        record_generated "completions-$1" "$2"
+    else
+        rm -f "$_tmp"
+        say "  completions: warning: could not generate $1 completions (non-fatal)"
+    fi
+}
+
+if [ -x "$bindir/min" ]; then
+    say "  completions: generating for bash, zsh, fish"
+    gen_completions bash "$bash_comp_dir/min"
+    gen_completions zsh  "$zsh_comp_dir/_min"
+    gen_completions fish "$fish_comp_dir/min.fish"
+else
+    say "  completions: skipped ($bindir/min not present)"
+fi
+
 # --- Unit 6: install record and PATH advisory ------------------------------
 
 # R6.1 — persist the resolved (component, dest, installed-hash) rows for this
@@ -420,11 +571,65 @@ mv -f "$records" "$prev_record"
 
 say "install: $installed installed, $skipped up to date -> record at $prev_record"
 
-# R6.2 — if the bin prefix is not on PATH, advise the user; never edit an rc file.
-bindir="$(resolve_prefix bin)"
+# --- Unit 9b: hook the current shell's rc file ------------------------------
+
+# R9.2 — append one marker-fenced block sourcing the matching init file to the
+# rc of the user's login shell ($SHELL). Idempotent: a file already carrying
+# the markers is never touched again, so reruns and upgrades add nothing. The
+# markers are also what --uninstall strips (strip_rc_block).
+add_rc_block() {
+    if grep -q '>>> minimal >>>' "$1" 2>/dev/null; then
+        return 0
+    fi
+    # Non-fatal: by this point the binaries are correctly installed, so an
+    # unwritable rc file must not turn a successful install into a failure.
+    # Warn, tell the user what to add by hand, and keep going (the R6.2 PATH
+    # advisory below still fires).
+    if ! mkdir -p "${1%/*}" 2>/dev/null \
+        || ! printf '\n%s\n%s\n%s\n' "$marker_start" "$2" "$marker_end" >>"$1" 2>/dev/null; then
+        say "  warning: failed to hook minimal shell support ($1 is not writable)"
+        say "  to enable it yourself, add this line to your shell rc:"
+        say "      $2"
+        return 0
+    fi
+    say "  shell-init: added block to $1"
+}
+
+posix_line="[ -f \"$init_dir/bash.sh\" ] && . \"$init_dir/bash.sh\""
+shell_name="${SHELL:-/bin/sh}"
+shell_name="${shell_name##*/}"
+case "$shell_name" in
+    bash)
+        # Append to whichever bash rc files exist (a login-shell-only
+        # .bash_profile must also see PATH); with neither present, create
+        # .bashrc so a fresh machine still gets wired up.
+        if [ -f "$HOME/.bashrc" ] || [ -f "$HOME/.bash_profile" ]; then
+            for _rc in "$HOME/.bashrc" "$HOME/.bash_profile"; do
+                if [ -f "$_rc" ]; then
+                    add_rc_block "$_rc" "$posix_line"
+                fi
+            done
+        else
+            add_rc_block "$HOME/.bashrc" "$posix_line"
+        fi
+        ;;
+    zsh)
+        add_rc_block "$zshrc" "[ -f \"$init_dir/zsh.sh\" ] && . \"$init_dir/zsh.sh\""
+        ;;
+    fish)
+        add_rc_block "$fish_config" "if test -f \"$init_dir/fish.fish\"; source \"$init_dir/fish.fish\"; end"
+        ;;
+    *)
+        # Unknown or unset shell: .profile is the POSIX login-shell rc.
+        add_rc_block "$HOME/.profile" "$posix_line"
+        ;;
+esac
+
+# R6.2 — if the bin prefix is not on PATH in THIS session, say so: the rc hook
+# above only takes effect in new shells.
 case ":${PATH:-}:" in
     *":$bindir:"*) ;;
     *) say ""
-       say "note: $bindir is not on your PATH."
-       say "  add it, e.g.:  export PATH=\"$bindir:\$PATH\"" ;;
+       say "note: $bindir is not on your PATH yet."
+       say "  restart your shell, or add it now:  export PATH=\"$bindir:\$PATH\"" ;;
 esac

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -2,7 +2,7 @@
 #
 # install_test.sh — POSIX-sh test harness for scripts/install.sh.
 #
-# Exercises Units 1–6 of docs/specs/07-spec-installer against a local mock
+# Exercises Units 1–9 of docs/specs/07-spec-installer against a local mock
 # bucket and a stubbed downloader, then asserts the spec's proof artifacts.
 #
 # The downloader is stubbed by prepending a temp dir to PATH containing a fake
@@ -60,11 +60,26 @@ BUCKET_HOST="https://mock.invalid/minimal-one"
 mock="$root/bucket"
 mkdir -p "$mock/versions/v1"
 
-# Two platform-diverse artifacts with padded columns and comment/blank lines, to
-# prove awk field-splitting survives padding (R3.1/R3.3).
+# Platform-diverse artifacts with padded columns and comment/blank lines, to
+# prove awk field-splitting survives padding (R3.1/R3.3). The `minimal` CLI
+# artifacts are runnable sh scripts that answer `completions <shell>`, because
+# the installer generates completions by executing the installed bin/min
+# (R9.3); the other artifacts stay opaque bodies.
 printf 'linux-amd64-minimald-body\n'  >"$mock/versions/v1/minimald-linux-amd64"
-printf 'linux-amd64-minimal-body\n'   >"$mock/versions/v1/minimal-linux-amd64"
-printf 'darwin-arm64-minimal-body\n'  >"$mock/versions/v1/minimal-darwin-arm64"
+cat >"$mock/versions/v1/minimal-linux-amd64" <<'EOF'
+#!/bin/sh
+# mock min (linux-amd64)
+case "${1:-}" in
+    completions) printf '# mock min completions for %s\n' "$2" ;;
+esac
+EOF
+cat >"$mock/versions/v1/minimal-darwin-arm64" <<'EOF'
+#!/bin/sh
+# mock min (darwin-arm64)
+case "${1:-}" in
+    completions) printf '# mock min completions for %s\n' "$2" ;;
+esac
+EOF
 printf 'darwin-arm64-rootfs-body\n'   >"$mock/versions/v1/rootfs-arm64.img"
 
 h_minimald="$(hash_file "$mock/versions/v1/minimald-linux-amd64")"
@@ -83,9 +98,9 @@ write_manifest() {
         printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
             minimald linux amd64 v1 "$h_minimald" file bin/minimald versions/v1/minimald-linux-amd64
         printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
-            minimal linux amd64 v1 "$h_minimal" file bin/minimal versions/v1/minimal-linux-amd64
+            minimal linux amd64 v1 "$h_minimal" file bin/min versions/v1/minimal-linux-amd64
         printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
-            minimal darwin arm64 v1 "$h_dmin" file bin/minimal versions/v1/minimal-darwin-arm64
+            minimal darwin arm64 v1 "$h_dmin" file bin/min versions/v1/minimal-darwin-arm64
         printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
             rootfs darwin arm64 v1 "$h_rootfs" file data/rootfs.img versions/v1/rootfs-arm64.img
     } >"$mock/versions/v1/components"
@@ -161,6 +176,11 @@ reset_dl()  { : >"$dlcount"; }
 PLAT_S=Linux
 PLAT_M=x86_64
 
+# The login shell the installer sees ($SHELL drives the rc-hook branch, R9.2).
+# Scenarios set TEST_SHELL around their runs; empty means /bin/sh (the
+# unknown-shell fallback branch).
+TEST_SHELL=
+
 # run <label> <homeprefix> [args...] ; sets rc, captures combined output in $OUT.
 OUT=
 run() {
@@ -170,10 +190,12 @@ run() {
     env -i \
         PATH="$stubbin:/usr/bin:/bin" \
         HOME="$hp" \
+        SHELL="${TEST_SHELL:-/bin/sh}" \
         MINIMAL_BIN="$hp/bin" \
         XDG_DATA_HOME="$hp/xdg-data" \
         XDG_STATE_HOME="$hp/xdg-state" \
         XDG_CACHE_HOME="$hp/xdg-cache" \
+        XDG_CONFIG_HOME="$hp/xdg-config" \
         MINIMAL_OVERRIDE_INSTALLER_BUCKET="$BUCKET_HOST" \
         STUB_UNAME_S="$PLAT_S" \
         STUB_UNAME_M="$PLAT_M" \
@@ -220,8 +242,8 @@ reset_dl
 run mismatch "$H2"
 check 1 "$rc" "checksum mismatch exits non-zero (R5.3)"
 want_ok "mismatch names the failure" grep -q "checksum mismatch" "$OUT"
-want_err "no file installed on mismatch" test -e "$H2/bin/minimal"
-if ls "$H2/bin/"minimal.tmp.* >/dev/null 2>&1
+want_err "no file installed on mismatch" test -e "$H2/bin/min"
+if ls "$H2/bin/"min.tmp.* >/dev/null 2>&1
 then bad "temp file left behind"; else ok "no .tmp file left (R5.3)"; fi
 cp "$root/good-components" "$mock/versions/v1/components"   # restore
 
@@ -326,6 +348,99 @@ env -i PATH="$stubbin:$H1/bin:/usr/bin:/bin" HOME="$H1" MINIMAL_BIN="$H1/bin" \
 set -e
 want_err "PATH advisory suppressed when bin present (R6.2)" grep -q "is not on your PATH" "$OUT"
 
+# --- Unit 9: shell-init files, rc hook, completions (R9.1-R9.3) -------------
+# A bash-login-shell install generates the three init files, hooks .bashrc
+# (creating it, since none exists in the fresh home), and produces completions
+# by running the installed bin/min itself.
+H7="$root/h7"; mkdir -p "$H7"
+TEST_SHELL=/bin/bash
+run shellinit "$H7"
+check 0 "$rc" "shell-init install exits 0"
+init7="$H7/xdg-data/minimal/shell-init"
+for f in bash.sh zsh.sh fish.fish; do
+    want_ok "init file $f generated (R9.1)" test -f "$init7/$f"
+done
+want_ok "init embeds the resolved bin dir (R9.1)" grep -q "$H7/bin" "$init7/bash.sh"
+want_ok "record lists the generated init files (R9.1/R6.1)" \
+    grep -q "shell-init-bash" "$H7/xdg-state/minimal/installed"
+
+# Sourcing the init under plain sh prepends bin to PATH exactly once.
+p1="$(env -i PATH=/usr/bin:/bin HOME="$H7" sh -c ". '$init7/bash.sh'; printf %s \"\$PATH\"")"
+check "$H7/bin:/usr/bin:/bin" "$p1" "sourcing the init prepends bin to PATH (R9.1)"
+p2="$(env -i PATH="$H7/bin:/usr/bin:/bin" HOME="$H7" sh -c ". '$init7/bash.sh'; printf %s \"\$PATH\"")"
+check "$H7/bin:/usr/bin:/bin" "$p2" "init never duplicates an existing PATH entry (R9.1)"
+
+# rc hook: created .bashrc carries exactly one marker-fenced block sourcing the
+# bash init; a rerun adds nothing (R9.2 idempotence).
+want_ok ".bashrc created with the marker block (R9.2)" grep -q '>>> minimal >>>' "$H7/.bashrc"
+want_ok "rc block sources the bash init (R9.2)" grep -q "shell-init/bash.sh" "$H7/.bashrc"
+run shellinit2 "$H7"
+check 0 "$rc" "shell-init rerun exits 0"
+check 1 "$(grep -c '>>> minimal >>>' "$H7/.bashrc")" "rerun adds no second rc block (R9.2)"
+
+# Completions, generated by executing the installed mock min (R9.3).
+want_ok "bash completions written for min (R9.3)" \
+    grep -q "mock min completions for bash" "$H7/xdg-data/bash-completion/completions/min"
+want_ok "zsh completions written as _min (R9.3)" \
+    grep -q "mock min completions for zsh" "$H7/xdg-data/zsh/completions/_min"
+want_ok "fish completions written (R9.3)" \
+    grep -q "mock min completions for fish" "$H7/xdg-config/fish/completions/min.fish"
+want_ok "record lists the generated completions (R9.3/R6.1)" \
+    grep -q "completions-zsh" "$H7/xdg-state/minimal/installed"
+
+# Both existing bash rc files are hooked, and user content is preserved.
+H8="$root/h8"; mkdir -p "$H8"
+printf '# my bashrc\n' >"$H8/.bashrc"
+printf '# my bash_profile\n' >"$H8/.bash_profile"
+run bashboth "$H8"
+want_ok "existing .bashrc hooked (R9.2)" grep -q '>>> minimal >>>' "$H8/.bashrc"
+want_ok "existing .bash_profile hooked too (R9.2)" grep -q '>>> minimal >>>' "$H8/.bash_profile"
+want_ok "user rc content preserved (R9.2)" grep -q '# my bashrc' "$H8/.bashrc"
+
+# zsh and fish get their own rc files (created when missing); an unknown shell
+# falls back to .profile with the POSIX init.
+H9="$root/h9"; mkdir -p "$H9"
+TEST_SHELL=/usr/bin/zsh
+run zshinit "$H9"
+want_ok ".zshrc created and hooked (R9.2)" grep -q "shell-init/zsh.sh" "$H9/.zshrc"
+want_ok "zsh init wires fpath completions (R9.1)" \
+    grep -q "fpath=" "$H9/xdg-data/minimal/shell-init/zsh.sh"
+H10="$root/h10"; mkdir -p "$H10"
+TEST_SHELL=/usr/bin/fish
+run fishinit "$H10"
+want_ok "config.fish created and hooked (R9.2)" \
+    grep -q "shell-init/fish.fish" "$H10/xdg-config/fish/config.fish"
+H11="$root/h11"; mkdir -p "$H11"
+TEST_SHELL=/bin/ksh
+run kshinit "$H11"
+want_ok "unknown shell falls back to .profile (R9.2)" grep -q "shell-init/bash.sh" "$H11/.profile"
+TEST_SHELL=
+
+# A manifest without the min CLI (data-only) skips completions, non-fatally.
+want_ok "completions skipped when min absent (R9.3)" \
+    grep -q "completions: skipped" "$root/out.datadest"
+
+# A read-only rc file degrades to a warning: the install itself already
+# succeeded and must still exit 0, with the PATH advisory still printed.
+# (Root ignores file modes, so the scenario can't be staged there.)
+if [ "$(id -u)" -ne 0 ]; then
+    H12="$root/h12"; mkdir -p "$H12"
+    printf '# locked down\n' >"$H12/.bashrc"
+    chmod 444 "$H12/.bashrc"
+    TEST_SHELL=/bin/bash
+    run rcreadonly "$H12"
+    check 0 "$rc" "unwritable rc is non-fatal (R9.2)"
+    want_ok "warning names the unwritable rc (R9.2)" \
+        grep -q "failed to hook minimal shell support" "$OUT"
+    want_ok "warning shows the line to add by hand (R9.2)" \
+        grep -q "shell-init/bash.sh" "$OUT"
+    want_err "read-only rc left untouched (R9.2)" grep -q '>>> minimal >>>' "$H12/.bashrc"
+    want_ok "binaries still installed despite rc failure (R9.2)" test -x "$H12/bin/min"
+    want_ok "PATH advisory still printed after rc failure (R6.2)" \
+        grep -q "is not on your PATH" "$OUT"
+    TEST_SHELL=
+fi
+
 # --- Unit 5 (darwin): dequarantine Mach-O bin/lib components ---------------
 # Force a darwin/arm64 platform (via the uname stub) so this runs on every lane.
 # The applicable rows are then `minimal` (bin) and `rootfs` (data). A bin file
@@ -339,8 +454,8 @@ HD="$root/hd"; mkdir -p "$HD"
 reset_dl
 run darwin1 "$HD"
 check 0 "$rc" "darwin install exits 0"
-want_ok "darwin bin component installed" test -f "$HD/bin/minimal"
-want_ok "quarantine stripped from bin (xattr)" grep -q "/bin/minimal" "$root/xattr.calls"
+want_ok "darwin bin component installed" test -f "$HD/bin/min"
+want_ok "quarantine stripped from bin (xattr)" grep -q "/bin/min\.tmp" "$root/xattr.calls"
 want_err "data component not dequarantined" grep -q "rootfs" "$root/xattr.calls"
 
 # A darwin `lib` dylib gets the SAME dequarantine treatment as a bin file so the
@@ -383,6 +498,10 @@ reset_dl
 run darwin3 "$HD"
 check 0 "$rc" "darwin new-version rerun exits 0"
 check 1 "$(downloads)" "new manifest hash re-downloads the darwin bin"
+# The v2 artifact is an opaque body, not a runnable script: completion
+# generation must degrade to a warning, not fail the install (R9.3).
+want_ok "unrunnable min degrades to a completions warning (R9.3)" \
+    grep -q "could not generate" "$OUT"
 cp "$root/good-components" "$mock/versions/v1/components"   # restore
 PLAT_S=Linux
 PLAT_M=x86_64
@@ -402,7 +521,7 @@ want_ok "uninstall: seed wrote the record" test -f "$urec"
 run u_basic "$HU" --uninstall
 check 0 "$rc" "uninstall exits 0 (R8.4)"
 want_err "uninstall removed minimald (R7.3)" test -e "$HU/bin/minimald"
-want_err "uninstall removed minimal (R7.3)" test -e "$HU/bin/minimal"
+want_err "uninstall removed min (R7.3)" test -e "$HU/bin/min"
 want_err "uninstall removed the record (R8.1)" test -e "$urec"
 want_ok "uninstall prints a summary" grep -q "uninstall:" "$OUT"
 want_err "empty bin dir pruned (R8.1)" test -d "$HU/bin"
@@ -422,7 +541,7 @@ run u2_keep "$HU2" --uninstall
 check 0 "$rc" "uninstall with a modified file exits 0 (R8.4)"
 want_ok "modified file kept (R7.3)" test -f "$HU2/bin/minimald"
 want_ok "keep is reported (R7.3)" grep -q "kept (modified" "$OUT"
-want_err "unmodified sibling still removed (R7.3)" test -e "$HU2/bin/minimal"
+want_err "unmodified sibling still removed (R7.3)" test -e "$HU2/bin/min"
 want_ok "record retained while entries remain (R8.1)" test -f "$urec2"
 # --force then removes the modified file and, footprint clear, drops the record.
 run u2_force "$HU2" --uninstall --force
@@ -472,6 +591,28 @@ check 0 "$rc" "uninstall over a non-regular path exits 0 (R7.3)"
 want_ok "directory at a recorded path is left alone (R7.3)" test -d "$HU6/bin/minimald"
 want_ok "foreign entry is reported (R7.3)" grep -q "not a regular file" "$OUT"
 want_ok "record retained due to the foreign entry (R8.1)" test -f "$urec6"
+
+# R9.4 — uninstall removes the generated init/completion files (they are plain
+# record rows), strips the marker block from the rc file, prunes the emptied
+# completion dirs, and leaves the user's own rc content untouched.
+HU7="$root/hu7"; mkdir -p "$HU7"
+printf '# keep me\n' >"$HU7/.bashrc"
+TEST_SHELL=/bin/bash
+run u7_install "$HU7"
+check 0 "$rc" "shell-integration seed install exits 0"
+run u7_dry "$HU7" --uninstall --dry-run
+want_ok "dry-run announces the rc strip without editing (R9.4/R8.3)" \
+    grep -q "would remove shell-init block" "$OUT"
+want_ok "dry-run leaves the rc block (R8.3)" grep -q '>>> minimal >>>' "$HU7/.bashrc"
+run u7_un "$HU7" --uninstall
+check 0 "$rc" "uninstall with shell integration exits 0"
+want_err "completions removed (R9.4)" test -e "$HU7/xdg-data/bash-completion/completions/min"
+want_err "init files removed (R9.4)" test -e "$HU7/xdg-data/minimal/shell-init"
+want_err "emptied completion dirs pruned (R9.4)" test -d "$HU7/xdg-data/bash-completion"
+want_err "emptied data dir pruned (R9.4)" test -d "$HU7/xdg-data/minimal"
+want_err "rc block stripped (R9.4)" grep -q '>>> minimal >>>' "$HU7/.bashrc"
+want_ok "user rc content survives the strip (R9.4)" grep -q '# keep me' "$HU7/.bashrc"
+TEST_SHELL=
 
 # ===========================================================================
 echo "# ---"

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -97,6 +97,9 @@ fi
 #     ~/.local/share/minimal, and marks anything under `bin` +x.
 #   - artifact-basename is the file's name inside ARTIFACTS_DIR (the release
 #     workflow's merge-multiple flattens every upload to its basename).
+#   - the `minimal` CLI installs as `bin/min`: the user-facing command is `min`
+#     (the installer's completion generation runs `<bin>/min`, spec R9.3), while
+#     the component and artifact names keep the crate name.
 #
 # Linux hosts install just the three self-contained musl binaries. macOS hosts
 # additionally need minvmd + gvproxy and the guest microVM payload (kernel,
@@ -106,13 +109,13 @@ COMPONENTS=(
     # Linux amd64
     "minimald|linux|amd64|file|bin/minimald|minimald-linux-amd64"
     "mip|linux|amd64|file|bin/mip|mip-linux-amd64"
-    "minimal|linux|amd64|file|bin/minimal|minimal-linux-amd64"
+    "minimal|linux|amd64|file|bin/min|minimal-linux-amd64"
     # Linux arm64
     "minimald|linux|arm64|file|bin/minimald|minimald-linux-arm64"
     "mip|linux|arm64|file|bin/mip|mip-linux-arm64"
-    "minimal|linux|arm64|file|bin/minimal|minimal-linux-arm64"
+    "minimal|linux|arm64|file|bin/min|minimal-linux-arm64"
     # macOS arm64 (darwin)
-    "minimal|darwin|arm64|file|bin/minimal|minimal-macos-arm64"
+    "minimal|darwin|arm64|file|bin/min|minimal-macos-arm64"
     "minvmd|darwin|arm64|file|bin/minvmd|minvmd-macos-arm64"
     # The trimmed libkrun minvmd links against (built by the release workflow's
     # build-libkrun-macos-arm64 job), staged into lib/ (ie: minvmd/../lib).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI is now invoked as `min` (including shell completion/help text).
  * The installer sets up PATH integration and tab completion for Bash, Zsh, Fish, and POSIX shells.

* **Bug Fixes**
  * Shell integration and completions are now generated post-install and are removed cleanly on uninstall, preserving unrelated shell rc content.
  * If completion generation can’t run, the installer warns instead of failing.

* **Documentation**
  * Expanded documentation covers shell integration, completion generation, and uninstall cleanup behavior (including idempotent rc changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->