### PR TITLE
feat(sessions): per-loadout follow symlinks setting

### DIFF
--- a/crates/sessions/src/client/composer.rs
+++ b/crates/sessions/src/client/composer.rs
@@ -21,6 +21,15 @@ use crate::wire::request::WireContribution;
 /// [`PolicyHooks`]: crate::core::hooks::PolicyHooks
 pub struct UserComposer {
     contribution: Contribution,
+    /// Names of every loadout already accepted via [`Self::add`].
+    /// Duplicates are rejected up-front: `Loadout::follow_symlinks`
+    /// is now stamped onto each patch's [`ProvenancedPatch`] and
+    /// keyed by loadout name in the [`Source::UserLoadout`]
+    /// provenance, so two loadouts sharing a name would produce
+    /// patches that couldn't be attributed unambiguously.
+    ///
+    /// [`Source::UserLoadout`]: crate::core::source::Source::UserLoadout
+    seen_names: std::collections::HashSet<crate::core::loadout::LoadoutName>,
     env: StoredEnv,
 }
 
@@ -28,6 +37,7 @@ impl core::fmt::Debug for UserComposer {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("UserComposer")
             .field("contribution", &self.contribution)
+            .field("seen_names", &self.seen_names)
             .field("env", &"<closure>")
             .finish()
     }
@@ -51,6 +61,7 @@ impl UserComposer {
     pub fn new() -> Self {
         Self {
             contribution: Contribution::new(),
+            seen_names: std::collections::HashSet::new(),
             env: default_env(),
         }
     }
@@ -70,10 +81,23 @@ impl UserComposer {
     /// Returns any error the loadout surfaces while resolving inherit
     /// or `InheritWithDefault` variables against `env`.
     pub fn add(&mut self, loadout: Loadout) -> Result<(), Error> {
+        // Loadout names must be unique within a composer instance.
+        // Two loadouts sharing a name would produce patches under the
+        // same `Source::UserLoadout { name }`, and their
+        // `follow_symlinks` overrides — stamped onto each patch's
+        // `ProvenancedPatch` at contribute time — couldn't be
+        // attributed unambiguously downstream.
+        if self.seen_names.contains(loadout.name()) {
+            return Err(Error::DuplicateLoadout {
+                name: loadout.name().as_ref().to_string(),
+            });
+        }
+        let name = loadout.name().clone();
         let incoming = loadout.contribute(&*self.env)?;
         // `merge` is internally atomic — on `Err`, `self.contribution`
         // is untouched.
         self.contribution.merge(incoming)?;
+        self.seen_names.insert(name);
         Ok(())
     }
 
@@ -139,6 +163,7 @@ fn composition_to_wire(composition: Composition) -> WireContribution {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::compose::Composable;
     use crate::core::lifecyclehook::{HookScript, LifecycleHook};
     use crate::core::loadout::LoadoutName;
     use crate::core::policy::VarsPolicy;
@@ -217,6 +242,49 @@ mod tests {
         assert_eq!(wire.requested_packages.len(), 1);
         assert_eq!(wire.requested_packages[0].name, "helix");
         assert_eq!(wire.lifecycle_hooks.len(), 1);
+    }
+
+    /// Adding two loadouts with the same name is rejected. This is
+    /// the invariant that lets each patch's `follow_symlinks`
+    /// override be attributed unambiguously to its source loadout.
+    #[test]
+    fn add_rejects_duplicate_loadout_names() {
+        let l1 = loadout_named("dev");
+        let l2 = loadout_named("dev");
+        let mut composer = UserComposer::new();
+        composer.add(l1).unwrap();
+        let err = composer.add(l2).unwrap_err();
+        assert!(
+            matches!(err, Error::DuplicateLoadout { ref name } if name == "dev"),
+            "got: {err:?}",
+        );
+    }
+
+    /// Per-loadout `follow_symlinks` is stamped onto every patch the
+    /// loadout contributes; a loadout that doesn't set it leaves
+    /// patches with `follow_symlinks = None`, which falls through to
+    /// the compose default at expand time.
+    #[test]
+    fn per_loadout_follow_symlinks_stamps_onto_contributed_patches() {
+        use crate::core::primitives::{Patch, PatchDest};
+
+        let patch = Patch::new("/tmp/whatever", PatchDest::try_new("etc/whatever").unwrap());
+        let opted_in = loadout_named("follow")
+            .with_patch(patch.clone())
+            .with_follow_symlinks(true);
+        let inherit = loadout_named("inherit").with_patch(patch);
+
+        let contrib_in = opted_in
+            .contribute(&|_| Err(std::env::VarError::NotPresent))
+            .unwrap();
+        assert_eq!(contrib_in.patches.len(), 1);
+        assert_eq!(contrib_in.patches[0].follow_symlinks(), Some(true));
+
+        let contrib_none = inherit
+            .contribute(&|_| Err(std::env::VarError::NotPresent))
+            .unwrap();
+        assert_eq!(contrib_none.patches.len(), 1);
+        assert_eq!(contrib_none.patches[0].follow_symlinks(), None);
     }
 
     /// `add_all` runs a sequence of loadouts. Multiple loadouts

--- a/crates/sessions/src/client/handler.rs
+++ b/crates/sessions/src/client/handler.rs
@@ -309,9 +309,16 @@ fn enumerate_and_classify_patches(
         let provenance: Source = p.source.into();
         let dest = PatchDest::try_new(p.destination.as_utf8_path().to_path_buf())
             .map_err(|source| ComposeError::InvalidPendingPatchDest { source })?;
+        // Client-response path handles daemon-side patches (Package /
+        // Project) — user loadouts never reach this path (see
+        // `daemon::composer`, which only accepts non-loadout
+        // Composables). `ProvenancedPatch::new` stamps
+        // `follow_symlinks: None`, which resolves to the compose
+        // default at expand time.
         let pp = ProvenancedPatch::new(Patch::new(p.source_pattern, dest), provenance);
-        let expanded = expand_patch_sources(vec![pp], combined_vars, home_fallback)?;
-        let files = enumerate_patch_files(expanded, follow_symlinks)?;
+        let expanded =
+            expand_patch_sources(vec![pp], combined_vars, home_fallback, follow_symlinks)?;
+        let files = enumerate_patch_files(expanded)?;
         for pf in files {
             match classify_patch_file(policy, PendingPatchFile::new(id, pf)) {
                 PatchClassification::Decided(verdict) => verdicts.push(verdict),

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -57,6 +57,13 @@ pub enum Error {
         #[from]
         source: Conflict,
     },
+    /// A loadout with this name was already added to the composer.
+    /// Loadout names must be unique within a composer instance so
+    /// per-loadout settings (like `follow_symlinks`) can be attributed
+    /// unambiguously; a duplicate would silently overwrite an earlier
+    /// setting on the map keyed by name.
+    #[error("loadout name `{name}` was already added to this composer")]
+    DuplicateLoadout { name: String },
 }
 
 /// Conflicts surfaced when two contributions disagree on a value.
@@ -326,6 +333,20 @@ impl Contribution {
     /// Append a lifecycle hook in place.
     pub fn push_hook(&mut self, h: ProvenancedHook) {
         self.lifecycle_hooks.push(h);
+    }
+
+    /// Overwrite the `follow_symlinks` override on every currently
+    /// accumulated patch. Used by
+    /// [`Loadout::contribute`](crate::core::loadout::Loadout::contribute)
+    /// to stamp the loadout's per-source override after
+    /// `contribute_primitives` produced patches with the default
+    /// `None`.
+    pub fn set_follow_symlinks_on_patches(&mut self, follow: Option<bool>) {
+        for p in std::mem::take(&mut self.patches) {
+            let (patch, source, _) = p.into_parts();
+            self.patches
+                .push(ProvenancedPatch::new(patch, source).with_follow_symlinks(follow));
+        }
     }
 
     /// Merge `other` into `self`: concatenate vars/patches/hooks and
@@ -1263,21 +1284,30 @@ pub(crate) fn gate_vars(
 /// first [`ExpandError`](crate::core::expansion::ExpandError); a partial
 /// expansion would let some patches reach the walker with their
 /// references intact, which silently matches wrong paths.
+///
+/// Per-patch `follow_symlinks` is resolved here: any `Some(v)` carried
+/// on the [`ProvenancedPatch`] wins; `None` inherits
+/// `default_follow_symlinks`. The resolved bool is stamped onto the
+/// emitted [`ExpandedProvenancedPatch`] so downstream code doesn't
+/// have to re-consult a sidecar map.
 pub(crate) fn expand_patch_sources(
     patches: Vec<ProvenancedPatch>,
     gated_vars: &[SessionVar],
     home_fallback: Option<&str>,
+    default_follow_symlinks: bool,
 ) -> Result<Vec<ExpandedProvenancedPatch>, ComposeError> {
     patches
         .into_iter()
         .map(|pp| {
-            let (patch, provenance) = pp.into_parts();
+            let (patch, provenance, follow_override) = pp.into_parts();
             let source =
                 crate::core::expansion::expand_source(patch.source(), gated_vars, home_fallback)?;
+            let follow_symlinks = follow_override.unwrap_or(default_follow_symlinks);
             Ok(ExpandedProvenancedPatch {
                 source,
                 dest: patch.dest().clone(),
                 provenance,
+                follow_symlinks,
             })
         })
         .collect()
@@ -1313,8 +1343,9 @@ pub(crate) fn gate_patches(
     // no IO context for.
     let mut expanded = policy.expand_with(gated_vars, home_fallback)?;
 
-    let expanded_patches = expand_patch_sources(items, gated_vars, home_fallback)?;
-    let files = enumerate_patch_files(expanded_patches, options.follow_symlinks)?;
+    let expanded_patches =
+        expand_patch_sources(items, gated_vars, home_fallback, options.follow_symlinks)?;
+    let files = enumerate_patch_files(expanded_patches)?;
 
     // Pass 1: categorize per file.
     let mut allowed: Vec<PatchFile> = Vec::new();

--- a/crates/sessions/src/core/enumerate.rs
+++ b/crates/sessions/src/core/enumerate.rs
@@ -56,18 +56,32 @@ pub(crate) struct ExpandedProvenancedPatch {
     pub(crate) source: FileSet,
     pub(crate) dest: PatchDest,
     pub(crate) provenance: Source,
+    /// Whether the walker should follow symlinks for this patch.
+    /// Resolved by [`expand_patch_sources`] from the compose default
+    /// and any per-patch override carried on [`ProvenancedPatch`], so
+    /// `enumerate_patch_files` reads it per-item and doesn't need to
+    /// consult any sidecar map.
+    ///
+    /// [`expand_patch_sources`]: crate::core::compose::expand_patch_sources
+    /// [`ProvenancedPatch`]: crate::core::source::ProvenancedPatch
+    pub(crate) follow_symlinks: bool,
 }
 
 /// Walk each pre-expanded patch's `FileSet` and produce one
 /// [`PatchFile`] per matched host file.
 ///
+/// **Per-item follow behavior.** Each [`ExpandedProvenancedPatch`]
+/// carries its own resolved `follow_symlinks` bool — the walker
+/// reads it per iteration, so two patches in the same call can
+/// drive different follow behavior.
+///
 /// **Path safety:** every yielded file is canonicalized via
-/// [`std::fs::canonicalize`] — so when `follow_symlinks` is true the
-/// symlink target is known, and dual-path policy checks become
-/// possible downstream. The walk itself starts from the un-canonical
-/// `walk_root` so the yielded link paths preserve the user's
-/// structural intent (matching against the original glob pattern and
-/// driving dest computation).
+/// [`std::fs::canonicalize`] when the item's `follow_symlinks` is
+/// true, so the symlink target is known and dual-path policy checks
+/// become possible downstream. The walk itself starts from the
+/// un-canonical `walk_root` so the yielded link paths preserve the
+/// user's structural intent (matching against the original glob
+/// pattern and driving dest computation).
 ///
 /// `..` and `.` components are rejected at expansion time, so they
 /// can't appear in the walk root or yielded paths. A non-existent
@@ -82,11 +96,11 @@ pub(crate) struct ExpandedProvenancedPatch {
 /// [`ComposeError::PatchWalk`].
 pub(crate) fn enumerate_patch_files(
     items: Vec<ExpandedProvenancedPatch>,
-    follow_symlinks: bool,
 ) -> Result<Vec<PatchFile>, ComposeError> {
     let mut out = Vec::new();
     let mut accumulated_errors = Vec::new();
     for pp in items {
+        let follow_symlinks = pp.follow_symlinks;
         let Some(walk_root) = pp.source.walk_root() else {
             accumulated_errors.push(PatchError::NoWalkRoot {
                 pattern: pp.source.pattern().to_owned(),
@@ -319,5 +333,106 @@ mod tests {
             "got: {:?}",
             errors[0],
         );
+    }
+
+    // =================================================================
+    // Per-patch `follow_symlinks` — each item drives its own walker
+    // =================================================================
+
+    /// Two patches in a single `enumerate_patch_files` call: one
+    /// follows a symlink, the other doesn't. Verifies the walker
+    /// reads the bool per-item rather than from a call-level arg.
+    #[test]
+    fn per_patch_follow_symlinks_drives_each_walker_independently() {
+        use crate::core::primitives::{FileSet, PatchDest};
+        use crate::core::source::Source;
+
+        let tmp = tempfile::tempdir().unwrap();
+        // Canonicalize upfront to sidestep macOS's `/tmp -> /private/tmp`
+        // prefix symlink. Without this, `canonicalize_utf8` inside
+        // `enumerate_patch_files` returns the `/private/tmp/...`
+        // form for every file — including the plain files — so
+        // `target != walker_path` fires spuriously and the assertion
+        // "at least one entry has link_path = None" fails. Two
+        // sibling symlink tests in compose.rs do the same thing for
+        // the same reason.
+        let root = Utf8PathBuf::from_path_buf(std::fs::canonicalize(tmp.path()).unwrap()).unwrap();
+        // Two sibling dirs, each with one real file. Each dir also
+        // contains a symlink named `link` pointing at a third dir's
+        // real file. When follow_symlinks is on, we get 2 files
+        // (target + link); when off, we get 1 (just the real file).
+        let target_dir = root.join("target");
+        std::fs::create_dir(target_dir.as_std_path()).unwrap();
+        std::fs::write(target_dir.join("real.conf").as_std_path(), "t").unwrap();
+
+        let follow_dir = root.join("follow");
+        std::fs::create_dir(follow_dir.as_std_path()).unwrap();
+        std::fs::write(follow_dir.join("real.conf").as_std_path(), "f").unwrap();
+        std::os::unix::fs::symlink(
+            target_dir.join("real.conf").as_std_path(),
+            follow_dir.join("link.conf").as_std_path(),
+        )
+        .unwrap();
+
+        let nofollow_dir = root.join("nofollow");
+        std::fs::create_dir(nofollow_dir.as_std_path()).unwrap();
+        std::fs::write(nofollow_dir.join("real.conf").as_std_path(), "n").unwrap();
+        std::os::unix::fs::symlink(
+            target_dir.join("real.conf").as_std_path(),
+            nofollow_dir.join("link.conf").as_std_path(),
+        )
+        .unwrap();
+
+        let items = vec![
+            ExpandedProvenancedPatch {
+                source: FileSet::try_new(format!("{}/*.conf", follow_dir.as_str())).unwrap(),
+                dest: PatchDest::try_new("dest_follow").unwrap(),
+                provenance: Source::UserLoadout {
+                    name: "follow".to_string(),
+                },
+                follow_symlinks: true,
+            },
+            ExpandedProvenancedPatch {
+                source: FileSet::try_new(format!("{}/*.conf", nofollow_dir.as_str())).unwrap(),
+                dest: PatchDest::try_new("dest_nofollow").unwrap(),
+                provenance: Source::UserLoadout {
+                    name: "nofollow".to_string(),
+                },
+                follow_symlinks: false,
+            },
+        ];
+
+        let files = enumerate_patch_files(items).unwrap();
+
+        // Bucket by dest to identify which patch produced which.
+        let follow_files: Vec<_> = files
+            .iter()
+            .filter(|f| f.dest.as_str().starts_with("dest_follow"))
+            .collect();
+        let nofollow_files: Vec<_> = files
+            .iter()
+            .filter(|f| f.dest.as_str().starts_with("dest_nofollow"))
+            .collect();
+
+        // Follow: two files (real.conf + link.conf as symlink to target).
+        assert_eq!(
+            follow_files.len(),
+            2,
+            "follow patch should yield real + link entries",
+        );
+        // A followed symlink populates `link_path`; the plain file
+        // has `link_path = None`.
+        assert!(follow_files.iter().any(|f| f.link_path.is_some()));
+        assert!(follow_files.iter().any(|f| f.link_path.is_none()));
+
+        // No-follow: just the single real file (walkdir skips the
+        // symlink because `is_file()` on a symlink entry is false
+        // when follow_links is off).
+        assert_eq!(
+            nofollow_files.len(),
+            1,
+            "no-follow patch should yield the real file only",
+        );
+        assert!(nofollow_files[0].link_path.is_none());
     }
 }

--- a/crates/sessions/src/core/loadout.rs
+++ b/crates/sessions/src/core/loadout.rs
@@ -88,6 +88,11 @@ pub struct Loadout {
     /// Scripts run at session-level transition points.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     lifecycle_hooks: Vec<LifecycleHook>,
+    /// Override the composer's default follow-symlinks behavior for
+    /// this loadout's patches. `None` falls through to
+    /// `ComposeOptions::follow_symlinks`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    follow_symlinks: Option<bool>,
 }
 
 impl Loadout {
@@ -114,6 +119,7 @@ impl Loadout {
             vars_lenient: Vec::new(),
             patches: Patches::empty(),
             lifecycle_hooks: Vec::new(),
+            follow_symlinks: None,
         }
     }
 
@@ -177,6 +183,24 @@ impl Loadout {
         let mut new = self;
         new.lifecycle_hooks.push(hook);
         new
+    }
+
+    /// Override the composer's default follow-symlinks behavior for
+    /// this loadout's patches.
+    #[must_use]
+    pub fn with_follow_symlinks(mut self, v: bool) -> Self {
+        self.follow_symlinks = Some(v);
+        self
+    }
+
+    /// The per-loadout `follow_symlinks` override, if any. Consumed
+    /// by [`UserComposer`](crate::client::composer::UserComposer);
+    /// falls through to [`ComposeOptions::follow_symlinks`] when `None`.
+    ///
+    /// [`ComposeOptions::follow_symlinks`]: crate::core::compose::ComposeOptions::follow_symlinks
+    #[must_use]
+    pub fn follow_symlinks(&self) -> Option<bool> {
+        self.follow_symlinks
     }
 
     /// Packages this loadout requires.
@@ -286,7 +310,7 @@ impl crate::core::compose::Composable for Loadout {
             })
             .collect::<Result<_, _>>()?;
 
-        crate::core::compose::contribute_primitives(
+        let mut contribution = crate::core::compose::contribute_primitives(
             &source,
             self.packages,
             vars,
@@ -294,7 +318,16 @@ impl crate::core::compose::Composable for Loadout {
             self.patches,
             self.lifecycle_hooks,
             env,
-        )
+        )?;
+        // Stamp the loadout's per-source `follow_symlinks` override
+        // onto every patch it contributes. `None` is a no-op — patches
+        // inherit `ComposeOptions::follow_symlinks` at expand time.
+        // `Some(v)` overrides the default for this loadout's patches
+        // specifically.
+        if let Some(follow) = self.follow_symlinks {
+            contribution.set_follow_symlinks_on_patches(Some(follow));
+        }
+        Ok(contribution)
     }
 }
 
@@ -345,6 +378,48 @@ mod tests {
     use super::*;
     use crate::core::lifecyclehook::HookScript;
     use crate::core::primitives::{LenientVarName, PatchDest};
+
+    /// `follow_symlinks` is optional: omitted → `None`, explicit
+    /// bool → `Some(bool)`. Round-trip verifies the field is
+    /// exposed to the composer without leaking into the wire form
+    /// when unset.
+    #[test]
+    fn follow_symlinks_round_trips_from_toml() {
+        let bare = toml::from_str::<Loadout>(r#"name = "d""#).unwrap();
+        assert_eq!(bare.follow_symlinks(), None);
+
+        let opted_in: Loadout = toml::from_str("name = \"d\"\nfollow_symlinks = true\n").unwrap();
+        assert_eq!(opted_in.follow_symlinks(), Some(true));
+
+        let opted_out: Loadout = toml::from_str("name = \"d\"\nfollow_symlinks = false\n").unwrap();
+        assert_eq!(opted_out.follow_symlinks(), Some(false));
+
+        // Serializing a bare loadout omits the field via
+        // `skip_serializing_if`, so we don't broadcast a `false`
+        // that was actually "unset".
+        let serialized = toml::to_string(&bare).unwrap();
+        assert!(!serialized.contains("follow_symlinks"), "got: {serialized}");
+
+        // `Some(false)` is not the same as `None` — serializing an
+        // explicit opt-out must retain the field so a subsequent
+        // deserialize round-trips back to `Some(false)`. Guards
+        // against a future `skip_serializing_if` predicate that
+        // accidentally treats a falsy `Some(false)` as unset.
+        let opt_out_toml = toml::to_string(&opted_out).unwrap();
+        assert!(
+            opt_out_toml.contains("follow_symlinks"),
+            "got: {opt_out_toml}"
+        );
+        let reparsed: Loadout = toml::from_str(&opt_out_toml).unwrap();
+        assert_eq!(reparsed.follow_symlinks(), Some(false));
+    }
+
+    /// `with_follow_symlinks` sets the field via the builder.
+    #[test]
+    fn with_follow_symlinks_builder_sets_the_field() {
+        let l = Loadout::new(LoadoutName::try_new("d").unwrap()).with_follow_symlinks(true);
+        assert_eq!(l.follow_symlinks(), Some(true));
+    }
 
     #[test]
     fn all_vars_yields_strict_then_lenient() {

--- a/crates/sessions/src/core/source.rs
+++ b/crates/sessions/src/core/source.rs
@@ -87,18 +87,41 @@ impl Provenanced for ProvenancedVar {
 }
 
 /// A [`Patch`] tagged with its [`Source`] for the composer.
+///
+/// `follow_symlinks` overrides the compose-level default for this
+/// specific patch's walk. `None` means "use the compose default";
+/// `Some(v)` wins. Populated by [`Loadout::contribute`] from
+/// [`Loadout::follow_symlinks`]; non-loadout contributors emit
+/// `None` and inherit the default.
+///
+/// [`Loadout::contribute`]: crate::core::loadout::Loadout::contribute
+/// [`Loadout::follow_symlinks`]: crate::core::loadout::Loadout::follow_symlinks
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ProvenancedPatch {
     patch: Patch,
     source: Source,
+    follow_symlinks: Option<bool>,
 }
 
 impl ProvenancedPatch {
-    /// Construct a [`ProvenancedPatch`] from a patch declaration and
-    /// its origin.
+    /// Construct a [`ProvenancedPatch`] with no per-item
+    /// follow-symlinks override; the walker uses the compose default.
     #[must_use]
     pub fn new(patch: Patch, source: Source) -> Self {
-        Self { patch, source }
+        Self {
+            patch,
+            source,
+            follow_symlinks: None,
+        }
+    }
+
+    /// Set the per-patch follow-symlinks override. Owned-builder
+    /// form so a caller building `ProvenancedPatch` inline reads
+    /// linearly.
+    #[must_use]
+    pub fn with_follow_symlinks(mut self, follow_symlinks: Option<bool>) -> Self {
+        self.follow_symlinks = follow_symlinks;
+        self
     }
 
     /// The wrapped [`Patch`].
@@ -107,10 +130,17 @@ impl ProvenancedPatch {
         &self.patch
     }
 
-    /// Consume and return the inner patch and source.
+    /// The per-patch follow-symlinks override (`None` = inherit
+    /// the compose default).
     #[must_use]
-    pub fn into_parts(self) -> (Patch, Source) {
-        (self.patch, self.source)
+    pub fn follow_symlinks(&self) -> Option<bool> {
+        self.follow_symlinks
+    }
+
+    /// Consume and return the inner patch, source, and follow-symlinks override.
+    #[must_use]
+    pub fn into_parts(self) -> (Patch, Source, Option<bool>) {
+        (self.patch, self.source, self.follow_symlinks)
     }
 }
 


### PR DESCRIPTION
Adds a per-loadout `follow_symlinks` field to loadout TOML that overrides
the client config's `[loadouts].follow_symlinks` default for one loadout's
patches. `None` (the default) inherits the global setting; `Some(bool)`
wins.

```toml
name = "dotfiles"
follow_symlinks = true    # optional; falls through to config default
```

The override travels through the compose pipeline as a field on
ProvenancedPatch (Option<bool>), stamped by Loadout::contribute and
read once by expand_patch_sources (follow_override.unwrap_or(default)).
Non-loadout contributors (packages, projects) leave it None and inherit
the default. enumerate_patch_files reads the field per-item, so a single
call can walk two patches with different follow behavior. No wire-format
change — the setting resolves to a walk decision on the client before the
wire contribution is built.

Also in this PR: UserComposer::add rejects duplicate loadout names so
Source::UserLoadout { name } unambiguously identifies one loadout in
logs and conflict messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-loadout control over whether patch processing follows symbolic links.
  * Individual patches can now use different symbolic-link handling settings within the same composition.
* **Bug Fixes**
  * Duplicate loadout names are now rejected with a clear error instead of being added multiple times.
  * Symbolic-link behavior is consistently applied during patch expansion and file enumeration.
* **Tests**
  * Added coverage for duplicate loadouts, configuration round-tripping, and mixed symbolic-link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->