### PR TITLE
fix(installer): better handle case where shell dir is not writeable

### DIFF
--- a/docs/specs/07-spec-installer/07-spec-installer.md
+++ b/docs/specs/07-spec-installer/07-spec-installer.md
@@ -350,10 +350,19 @@ user-level completion dir:
 | fish   | `${XDG_CONFIG_HOME:-~/.config}/fish/completions/min.fish`              |
 
 All three are written regardless of `$SHELL` (covers shell switching), each
-recorded in the install record like the init files. Failure to execute the
-binary (or empty output) is a **warning, not an error**: the binaries are
-already correctly installed, and completions regenerate on the next run. If
-`<bin>/min` was not part of the manifest, the step is skipped with a notice.
+recorded in the install record like the init files. The whole step is
+**best-effort, warning-not-error**: the binaries are already correctly
+installed, and completions regenerate on the next run. Specifically:
+
+- an unwritable completion dir (these are shared, user-owned locations that can
+  pre-exist unwritable — e.g. a root-owned `~/.config/fish/completions`) is
+  probed before generating and skipped with a warning naming the dir;
+- failure to execute the binary (or empty output) warns and moves on;
+- if `<bin>/min` was not part of the manifest, the step is skipped with a
+  notice;
+- the shell's own redirection errors are suppressed (writes run in a subshell
+  with stderr nulled — a command-level `2>/dev/null` cannot catch them), so the
+  user sees the installer's warning, never a raw `Permission denied` line.
 
 **R9.4** — Uninstall (Units 7–8) undoes shell integration completely:
 
@@ -387,6 +396,9 @@ already correctly installed, and completions regenerate on the next run. If
   content produced by the installed binary; a manifest without the `min`
   component skips completions non-fatally, and an unrunnable binary degrades to
   a warning with exit 0.
+- **Test**: with one completion dir pre-existing unwritable, the install exits
+  0, warns naming that dir, still installs the other shells' completions, and
+  leaks no raw shell `Permission denied` error into the output.
 - **Test**: `--uninstall` removes the generated files, strips the rc block
   while preserving the user's own rc content, and prunes the emptied
   completion/shell-init dirs; `--dry-run` announces the strip without editing.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -541,13 +541,25 @@ record_generated shell-init-fish "$init_dir/fish.fish"
 # install. A failure here is a warning, not an error: the binaries are already
 # correctly installed, and completions regenerate on the next run.
 gen_completions() {
-    mkdir -p "${2%/*}"
+    _dir="${2%/*}"
     _tmp="$2.tmp.$$"
-    if "$bindir/min" completions "$1" >"$_tmp" 2>/dev/null && [ -s "$_tmp" ]; then
-        mv -f "$_tmp" "$2"
+    # Probe that the dir exists and is writable BEFORE generating, inside a
+    # subshell with stderr nulled: the completion dirs are shared, user-owned
+    # locations that can pre-exist unwritable (e.g. a root-owned
+    # ~/.config/fish/completions), and a redirection error is reported by the
+    # shell itself — a plain `2>/dev/null` on the command cannot silence it,
+    # only the subshell wrapper can. Non-fatal either way: the binaries are
+    # already correctly installed.
+    if ! ( mkdir -p "$_dir" && : >"$_tmp" ) 2>/dev/null; then
+        say "  completions: warning: failed to install $1 completions ($_dir is not writable)"
+        return 0
+    fi
+    if ( "$bindir/min" completions "$1" >"$_tmp" ) 2>/dev/null \
+        && [ -s "$_tmp" ] \
+        && mv -f "$_tmp" "$2" 2>/dev/null; then
         record_generated "completions-$1" "$2"
     else
-        rm -f "$_tmp"
+        rm -f "$_tmp" 2>/dev/null || true
         say "  completions: warning: could not generate $1 completions (non-fatal)"
     fi
 }
@@ -585,8 +597,11 @@ add_rc_block() {
     # unwritable rc file must not turn a successful install into a failure.
     # Warn, tell the user what to add by hand, and keep going (the R6.2 PATH
     # advisory below still fires).
-    if ! mkdir -p "${1%/*}" 2>/dev/null \
-        || ! printf '\n%s\n%s\n%s\n' "$marker_start" "$2" "$marker_end" >>"$1" 2>/dev/null; then
+    # The subshell wrapper (not just 2>/dev/null on the command) is what keeps
+    # a redirection failure quiet: that error is printed by the shell itself,
+    # before the command-level stderr redirect is in effect.
+    if ! ( mkdir -p "${1%/*}" \
+            && printf '\n%s\n%s\n%s\n' "$marker_start" "$2" "$marker_end" >>"$1" ) 2>/dev/null; then
         say "  warning: failed to hook minimal shell support ($1 is not writable)"
         say "  to enable it yourself, add this line to your shell rc:"
         say "      $2"

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -438,7 +438,27 @@ if [ "$(id -u)" -ne 0 ]; then
     want_ok "binaries still installed despite rc failure (R9.2)" test -x "$H12/bin/min"
     want_ok "PATH advisory still printed after rc failure (R6.2)" \
         grep -q "is not on your PATH" "$OUT"
+    want_err "no raw shell error leaks on rc failure (R9.2)" \
+        grep -qi "permission denied" "$OUT"
     TEST_SHELL=
+
+    # An unwritable completion dir (e.g. a root-owned ~/.config/fish/completions
+    # left by another tool) degrades to a warning naming the dir: the install
+    # still exits 0, the other shells' completions still land, and the shell's
+    # own redirection error is not leaked to the user.
+    H13="$root/h13"; mkdir -p "$H13/xdg-config/fish/completions"
+    chmod 555 "$H13/xdg-config/fish/completions"
+    run compreadonly "$H13"
+    chmod 755 "$H13/xdg-config/fish/completions"   # restore for later cleanup
+    check 0 "$rc" "unwritable completion dir is non-fatal (R9.3)"
+    want_ok "warning names the unwritable completion dir (R9.3)" \
+        grep -q "failed to install fish completions" "$OUT"
+    want_err "no raw shell error leaks on completion failure (R9.3)" \
+        grep -qi "permission denied" "$OUT"
+    want_ok "other shells' completions still installed (R9.3)" \
+        test -f "$H13/xdg-data/bash-completion/completions/min"
+    want_err "nothing written into the unwritable dir (R9.3)" \
+        ls "$H13/xdg-config/fish/completions/"* 2>/dev/null
 fi
 
 # --- Unit 5 (darwin): dequarantine Mach-O bin/lib components ---------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell completion installation now handles unwritable or shared completion directories gracefully.
  * Installations continue successfully with a clear warning when a completion directory cannot be written.
  * Completion files for other supported shells are still generated when one directory is unavailable.
  * Raw permission-denied errors are suppressed during completion and shell configuration setup.
  * Shell initialization setup now continues non-fatally when configuration files cannot be updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->