### PR TITLE
feat(sessions,minimald,minvmd): session persistence contracts + provider index

### DIFF
--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -834,6 +834,12 @@ pub(crate) async fn handle_exec(
     Ok(())
 }
 
+/// The receive-side git hooks installed for every session push (R3.3).
+/// `pre-receive` gates dirty worktrees behind `git push -o force-checkout`;
+/// `post-receive` checks the pushed branch out into the worktree.
+const GIT_PRE_RECEIVE_HOOK: &str = include_str!("git_hooks/pre-receive.sh");
+const GIT_POST_RECEIVE_HOOK: &str = include_str!("git_hooks/post-receive.sh");
+
 async fn handle_git_receive(
     ident: &str,
     serv: ServerStateHandle,
@@ -900,34 +906,26 @@ async fn handle_git_receive(
             }
         }
         let hooks_tmp = TempDir::new().unwrap();
-        tokio::fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .mode(0o755)
-            .open(hooks_tmp.path().join("post-receive"))
-            .await
-            .unwrap()
-            .write_all(
-                r#"#!/bin/sh
-                GIT_DIR_ABS=$(pwd -P)
-                WORK_TREE=$(dirname "$GIT_DIR_ABS")
-                unset GIT_DIR GIT_WORK_TREE GIT_QUARANTINE_PATH
-                g() { git --git-dir="$GIT_DIR_ABS" --work-tree="$WORK_TREE" "$@"; }
-
-                while read -r old new ref; do
-                    case "$ref" in refs/heads/*) ;; *) continue ;; esac
-                    branch=${ref#refs/heads/}
-
-                    if ! g diff --quiet || ! g diff --cached --quiet; then
-                        echo "remote worktree has uncommitted changes; skipping checkout of $branch" >&2
-                        continue
-                    fi
-                    g checkout -f "$branch"
-                done"#
-                    .as_bytes(),
-            )
-            .await
-            .unwrap();
+        // R3.3: pre-receive rejects a push into a dirty worktree (loudly,
+        // before refs update) unless the client passed `-o force-checkout`;
+        // post-receive then checks the pushed branch out unconditionally.
+        // Push options reach the hooks because the receive-pack invocation
+        // below advertises them.
+        for (name, body) in [
+            ("pre-receive", GIT_PRE_RECEIVE_HOOK),
+            ("post-receive", GIT_POST_RECEIVE_HOOK),
+        ] {
+            tokio::fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .mode(0o755)
+                .open(hooks_tmp.path().join(name))
+                .await
+                .unwrap()
+                .write_all(body.as_bytes())
+                .await
+                .unwrap();
+        }
 
         let exec_task = ExecTask {
             conn,
@@ -935,8 +933,12 @@ async fn handle_git_receive(
             session: session_handle,
             channel_id: id,
             exec: TokioExec {
+                // denyCurrentBranch=ignore: the hook pair owns worktree
+                // consistency, and git's default guard would otherwise refuse
+                // any push to the branch post-receive last checked out.
                 argv: format!(
-                    "git -c core.hooksPath={} receive-pack .",
+                    "git -c core.hooksPath={} -c receive.advertisePushOptions=true \
+                     -c receive.denyCurrentBranch=ignore receive-pack .",
                     hooks_tmp.path().to_str().unwrap()
                 ),
                 cwd: paths.working,
@@ -1103,6 +1105,111 @@ mod tests {
 
     use super::bridge;
     use super::testing::{MockEndpoints, build_mock, build_mock_seq};
+
+    /// R3.3: the production hook pair drives real git — a push into a dirty
+    /// session worktree is rejected loudly by pre-receive; `git push -o
+    /// force-checkout` overrides and post-receive replaces the worktree;
+    /// clean pushes (including re-pushes to the checked-out branch) succeed.
+    #[tokio::test]
+    async fn dirty_worktree_push_rejected_unless_forced() {
+        use std::os::unix::fs::PermissionsExt;
+
+        use tempfile::TempDir;
+        use tokio::process::Command;
+
+        async fn git(cwd: &std::path::Path, args: &[&str]) -> std::process::Output {
+            Command::new("git")
+                .current_dir(cwd)
+                .args(args)
+                .output()
+                .await
+                .expect("git should be invocable")
+        }
+        async fn git_ok(cwd: &std::path::Path, args: &[&str]) {
+            let out = git(cwd, args).await;
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr),
+            );
+        }
+
+        let tmp = TempDir::new().unwrap();
+        let hooks = tmp.path().join("hooks");
+        std::fs::create_dir(&hooks).unwrap();
+        std::fs::write(hooks.join("pre-receive"), super::GIT_PRE_RECEIVE_HOOK).unwrap();
+        std::fs::write(hooks.join("post-receive"), super::GIT_POST_RECEIVE_HOOK).unwrap();
+        for h in ["pre-receive", "post-receive"] {
+            std::fs::set_permissions(hooks.join(h), std::fs::Permissions::from_mode(0o755))
+                .unwrap();
+        }
+
+        // Source repo with one commit on main. (`init -b` needs git ≥ 2.28;
+        // `symbolic-ref` names the unborn branch on anything older too.)
+        let src = tmp.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+        git_ok(&src, &["init", "-q"]).await;
+        git_ok(&src, &["symbolic-ref", "HEAD", "refs/heads/main"]).await;
+        git_ok(&src, &["config", "user.email", "t@example.com"]).await;
+        git_ok(&src, &["config", "user.name", "Test"]).await;
+        std::fs::write(src.join("f.txt"), "v1\n").unwrap();
+        git_ok(&src, &["add", "f.txt"]).await;
+        git_ok(&src, &["commit", "-qm", "v1"]).await;
+
+        // Destination worktree repo, configured the way `handle_git_receive`
+        // invokes receive-pack (there the settings ride the command line;
+        // local config is the file-transport equivalent for this test).
+        let dst = tmp.path().join("dst");
+        std::fs::create_dir(&dst).unwrap();
+        git_ok(&dst, &["init", "-q"]).await;
+        git_ok(&dst, &["config", "receive.advertisePushOptions", "true"]).await;
+        git_ok(&dst, &["config", "receive.denyCurrentBranch", "ignore"]).await;
+        git_ok(&dst, &["config", "core.hooksPath", hooks.to_str().unwrap()]).await;
+        let dst_url = dst.to_str().unwrap();
+
+        // Clean first push checks the branch out into the worktree.
+        git_ok(&src, &["push", "-q", dst_url, "main"]).await;
+        assert_eq!(std::fs::read_to_string(dst.join("f.txt")).unwrap(), "v1\n");
+
+        // Clean re-push (to the now checked-out branch) succeeds and updates
+        // — this is what receive.denyCurrentBranch=ignore buys.
+        std::fs::write(src.join("f.txt"), "v2\n").unwrap();
+        git_ok(&src, &["commit", "-qam", "v2"]).await;
+        git_ok(&src, &["push", "-q", dst_url, "main"]).await;
+        assert_eq!(std::fs::read_to_string(dst.join("f.txt")).unwrap(), "v2\n");
+
+        // Dirty worktree: push without force fails, worktree untouched.
+        std::fs::write(dst.join("f.txt"), "v2\nscratch\n").unwrap();
+        std::fs::write(src.join("f.txt"), "v3\n").unwrap();
+        git_ok(&src, &["commit", "-qam", "v3"]).await;
+        let rejected = git(&src, &["push", dst_url, "main"]).await;
+        let stderr = String::from_utf8_lossy(&rejected.stderr);
+        assert!(
+            !rejected.status.success(),
+            "dirty push must fail; stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("pre-receive hook declined"),
+            "got: {stderr}"
+        );
+        assert!(
+            stderr.contains("force-checkout"),
+            "rejection must name the escape hatch; got: {stderr}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.join("f.txt")).unwrap(),
+            "v2\nscratch\n",
+            "rejected push must not touch the worktree"
+        );
+
+        // `-o force-checkout` discards the dirty state and lands the push.
+        git_ok(
+            &src,
+            &["push", "-q", "-o", "force-checkout", dst_url, "main"],
+        )
+        .await;
+        assert_eq!(std::fs::read_to_string(dst.join("f.txt")).unwrap(), "v3\n");
+    }
 
     /// Bytes flow client→child stdin and child stdout/stderr→client,
     /// and the child's exit code propagates to the bridge's return.

--- a/crates/minimald/src/git_hooks/post-receive.sh
+++ b/crates/minimald/src/git_hooks/post-receive.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Check out each pushed branch into the session worktree. The dirty-worktree
+# gate lives in pre-receive (R3.3): a push that reaches here either had a
+# clean worktree or carried `-o force-checkout`, so `checkout -f` discarding
+# uncommitted tracked-file modifications is the requested semantics. Recovery
+# from a mid-checkout failure is git-level: re-run the push.
+GIT_DIR_ABS=$(pwd -P)
+WORK_TREE=$(dirname "$GIT_DIR_ABS")
+unset GIT_DIR GIT_WORK_TREE GIT_QUARANTINE_PATH
+g() { git --git-dir="$GIT_DIR_ABS" --work-tree="$WORK_TREE" "$@"; }
+
+status=0
+while read -r old new ref; do
+    case "$ref" in refs/heads/*) ;; *) continue ;; esac
+    branch=${ref#refs/heads/}
+    if ! g checkout -f "$branch"; then
+        echo "error: checkout of $branch failed; re-run the push to retry" >&2
+        status=1
+    fi
+done
+exit $status

--- a/crates/minimald/src/git_hooks/pre-receive.sh
+++ b/crates/minimald/src/git_hooks/pre-receive.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Reject a branch push into a dirty session worktree unless the client passed
+# `git push -o force-checkout` (R3.3). Running in pre-receive — before refs
+# update — makes the rejection loud on the client: `! [remote rejected]
+# (pre-receive hook declined)` and a non-zero `git push` exit, instead of the
+# old post-receive silent skip. Requires the server to advertise push options
+# (receive.advertisePushOptions=true).
+#
+# "Dirty" matches the historical gate: uncommitted changes to tracked files
+# (staged or unstaged). Untracked files never block a push, and the eventual
+# `checkout -f` leaves them alone — collisions with untracked files are a
+# pre-existing residual risk, unchanged here.
+GIT_DIR_ABS=$(pwd -P)
+WORK_TREE=$(dirname "$GIT_DIR_ABS")
+unset GIT_DIR GIT_WORK_TREE GIT_QUARANTINE_PATH
+g() { git --git-dir="$GIT_DIR_ABS" --work-tree="$WORK_TREE" "$@"; }
+
+i=0
+while [ "$i" -lt "${GIT_PUSH_OPTION_COUNT:-0}" ]; do
+    eval "opt=\${GIT_PUSH_OPTION_$i}"
+    [ "$opt" = "force-checkout" ] && exit 0
+    i=$((i + 1))
+done
+
+touches_branch=0
+while read -r old new ref; do
+    case "$ref" in refs/heads/*) touches_branch=1 ;; esac
+done
+[ "$touches_branch" -eq 0 ] && exit 0
+
+if ! g diff --quiet || ! g diff --cached --quiet; then
+    echo "error: session worktree has uncommitted changes; push rejected to protect them." >&2
+    echo "hint: commit or stash them in the session, or force the checkout (DISCARDS those changes):" >&2
+    echo "hint:   git push -o force-checkout <remote> <branch>" >&2
+    exit 1
+fi
+exit 0

--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -548,6 +548,41 @@ pub fn quiesce_state_volume(mountpoint: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Reset the boot-ephemeral `providers/` directory under the (now persistent)
+/// state dir, returning the number of entries removed (R3.2).
+///
+/// Provider registrations — per-instance host keys, known_hosts, socket
+/// paths — are ephemeral per boot; before the persistent volume they died
+/// with the tmpfs. `sessions/` and `cache/` are the durable state and are
+/// untouchable by construction here: only entries *inside* `providers/` are
+/// removed, never a glob over the state root. A missing `providers/` is not
+/// an error (first boot).
+pub fn reset_providers_dir(state_dir: &std::path::Path) -> std::io::Result<usize> {
+    let providers = state_dir.join("providers");
+    let entries = match std::fs::read_dir(&providers) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(e),
+    };
+    let mut removed = 0usize;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            std::fs::remove_dir_all(&path)?;
+        } else {
+            std::fs::remove_file(&path)?;
+        }
+        removed += 1;
+    }
+    tracing::info!(
+        dir = %providers.display(),
+        removed,
+        "reset boot-ephemeral directory"
+    );
+    Ok(removed)
+}
+
 /// Enumerate open fds (and cwds) under `mountpoint` across all processes, for
 /// the EBUSY diagnostics in [`quiesce_state_volume`] — an unmountable volume
 /// is invisible without knowing who holds it. Best-effort `/proc` scan.
@@ -945,6 +980,36 @@ mod tests {
             format!("READY\n{expected_openssh}\n"),
             "beacon must be READY\\n<openssh-pubkey>\\n"
         );
+    }
+
+    #[test]
+    fn reset_providers_dir_clears_providers_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path();
+        std::fs::create_dir_all(state.join("providers/local-0")).unwrap();
+        std::fs::write(state.join("providers/local-0/key"), b"k").unwrap();
+        std::fs::write(state.join("providers/stray-file"), b"s").unwrap();
+        std::fs::create_dir_all(state.join("sessions/abcde")).unwrap();
+        std::fs::write(state.join("sessions/abcde/record.json"), b"{}").unwrap();
+        std::fs::create_dir_all(state.join("cache")).unwrap();
+        std::fs::write(state.join("cache/x"), b"x").unwrap();
+
+        let removed = reset_providers_dir(state).unwrap();
+
+        assert_eq!(removed, 2, "one dir + one stray file");
+        assert!(
+            std::fs::read_dir(state.join("providers")).unwrap().count() == 0,
+            "providers/ must be emptied"
+        );
+        assert!(
+            state.join("sessions/abcde/record.json").exists(),
+            "sessions/ must be preserved"
+        );
+        assert!(state.join("cache/x").exists(), "cache/ must be preserved");
+
+        // Missing providers/ (first boot) is not an error.
+        let fresh = tempfile::tempdir().unwrap();
+        assert_eq!(reset_providers_dir(fresh.path()).unwrap(), 0);
     }
 
     #[test]

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -501,6 +501,16 @@ async fn async_main() -> Result<(), MainError> {
                 );
                 state_volume_mounted = true;
                 tracing::info!(device = %dev, "cache + state relocated onto the data volume (/var/lib/minimal)");
+                // R3.2: provider registrations (host keys, known_hosts,
+                // socket paths) are boot-ephemeral; before the persistent
+                // volume they died with the tmpfs. Reset them here — before
+                // `client_instance_dir` below recreates a fresh one — while
+                // `sessions/` and `cache/` stay untouched.
+                if let Err(e) =
+                    guest::reset_providers_dir(std::path::Path::new(guest::STATE_VOLUME_MOUNTPOINT))
+                {
+                    tracing::warn!(error = %e, "resetting providers dir on boot");
+                }
             }
             // The MOUNT_FAILED beacon + park contract only makes sense with a
             // minvmd host watching the marker socket (the vsock transport);

--- a/crates/minvmd/Cargo.toml
+++ b/crates/minvmd/Cargo.toml
@@ -40,9 +40,10 @@ russh.workspace = true
 # Canonical state-dir base + provider-instance dir layout (`state`, `sock`,
 # `volume`).
 paths.workspace = true
+# `SessionId` keys the provider index (session → volume image map, R3.4).
+sessions.workspace = true
 
 [dev-dependencies]
 serial_test.workspace = true
 tempfile.workspace = true
-sessions.workspace = true
 russh-sftp.workspace = true

--- a/crates/minvmd/src/cmd/run.rs
+++ b/crates/minvmd/src/cmd/run.rs
@@ -25,6 +25,19 @@ use anyhow::Context as _;
 /// Default timeout in seconds for `run --detach` to wait for the host UDS.
 pub const DEFAULT_DETACH_TIMEOUT_SECS: u64 = 8;
 
+/// Env var tuning the session-index poll interval in seconds (R3.5).
+/// `0` disables the poller.
+pub const SESSION_POLL_SECS_ENV: &str = "MINVMD_SESSION_POLL_SECS";
+
+/// Default session-index poll interval.
+#[cfg(minvmd_libkrun)]
+const DEFAULT_SESSION_POLL_SECS: u64 = 15;
+
+/// VM identifier recorded in provider-index entries. Single-instance today,
+/// matching the `local-0` naming in known_hosts (see the multi-instance TODO
+/// in `cmd/mod.rs`).
+const LOCAL_VM_ID: &str = "local-0";
+
 /// Run the `run` subcommand.
 ///
 /// - `detach`: if true, spawn the supervisor in the background and poll until
@@ -438,9 +451,20 @@ fn run_foreground() -> Result<()> {
         }
     }
 
+    // R3.5: keep the host-side session → volume-image index current while the
+    // VM runs. Host-initiated polling by design — see the transport note on
+    // `spawn_session_index_poller`.
+    let poller_stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let poller = spawn_session_index_poller(&state_dir, std::sync::Arc::clone(&poller_stop));
+
     // ── Phase 3: Supervise until VMM child exits ─────────────────────────────
     let status = child.wait().context("waiting for VMM child")?;
     tracing::info!(success = status.success(), "VMM child exited");
+
+    poller_stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    if let Some(handle) = poller {
+        let _ = handle.join();
+    }
 
     // ── Phase 4: Running → Stopped (under lock) ─────────────────────────────
     {
@@ -461,6 +485,131 @@ fn run_foreground() -> Result<()> {
     Ok(())
 }
 
+/// Reconcile the provider index against the live session listing (R3.5):
+/// upsert an entry for every live id, remove entries owned by `vm_id` whose
+/// session is gone. Entries owned by other VMs — and every entry once the VM
+/// stops (the poller stops with it) — persist: the index maps sessions to
+/// volume images precisely so a *stopped* VM's sessions stay routable.
+/// Returns whether anything changed (the caller flushes).
+pub(crate) fn reconcile_session_index(
+    index: &mut crate::provider_index::ProviderIndex,
+    live: &[sessions::SessionId],
+    image_path: &std::path::Path,
+    vm_id: &str,
+) -> bool {
+    let mut changed = false;
+    for id in live {
+        let entry = crate::provider_index::VolumeEntry {
+            image_path: image_path.to_path_buf(),
+            vm_id: vm_id.to_string(),
+        };
+        if index.get_by_session(id) != Some(&entry) {
+            index.insert(*id, entry);
+            changed = true;
+        }
+    }
+    let stale: Vec<sessions::SessionId> = index
+        .iter()
+        .filter(|(id, entry)| entry.vm_id == vm_id && !live.contains(id))
+        .map(|(id, _)| *id)
+        .collect();
+    for id in &stale {
+        index.remove(id);
+        changed = true;
+    }
+    changed
+}
+
+/// Spawn the session-index poller thread (R3.5): every
+/// [`SESSION_POLL_SECS_ENV`] seconds (default 15, `0` disables) it lists the
+/// guest's sessions over the host→guest bridge UDS and reconciles the
+/// provider index at `StateDir::session_index_path`.
+///
+/// Transport note: this deliberately replaces the spec's guest→host
+/// `SessionLifecycle` RPC. libkrun's vsock wedges when a guest→host
+/// connection overlaps host→guest traffic (#588 — the same failure that
+/// red-lit autospawn-e2e on #672), and session lifecycle events fire exactly
+/// while the client's own host→guest connection is open, so neither a
+/// held-open stream nor one-shot guest emits can be made wedge-safe.
+/// Host-initiated polling rides the same direction as all existing bridge
+/// traffic; the cost is bounded staleness, acceptable for an index whose
+/// only consumer (#311 multi-VM routing) is future work. Only the `run`
+/// supervisor maintains the index — bare `minvmd boot` leaves no supervisor
+/// behind to poll.
+#[cfg(minvmd_libkrun)]
+fn spawn_session_index_poller(
+    state_dir: &crate::state::StateDir,
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> Option<std::thread::JoinHandle<()>> {
+    use std::sync::atomic::Ordering;
+
+    let interval = match std::env::var(SESSION_POLL_SECS_ENV) {
+        Ok(v) => match v.trim().parse::<u64>() {
+            Ok(0) => {
+                tracing::info!("session-index poller disabled ({SESSION_POLL_SECS_ENV}=0)");
+                return None;
+            }
+            Ok(secs) => Duration::from_secs(secs),
+            Err(e) => {
+                tracing::warn!(error = %e, value = %v, "bad {SESSION_POLL_SECS_ENV}; using default");
+                Duration::from_secs(DEFAULT_SESSION_POLL_SECS)
+            }
+        },
+        Err(_) => Duration::from_secs(DEFAULT_SESSION_POLL_SECS),
+    };
+    let uds = match crate::sock::resolve_uds_path() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, "cannot resolve bridge UDS; session-index poller disabled");
+            return None;
+        }
+    };
+    let index_path = state_dir.session_index_path();
+    let image_path = crate::volume::resolve_data_volume_path();
+
+    Some(std::thread::spawn(move || {
+        // Listing sessions is cheap on the guest side, so one short deadline
+        // covers connect and RPC alike; a slow tick just retries next tick.
+        const POLL_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+        const POLL_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+        // First poll immediately so sessions restored from the volume appear
+        // right after READY; then on the interval.
+        loop {
+            match crate::rpc_client::call_oneshot_blocking::<minimald_rpc::ListSessions>(
+                &uds,
+                (),
+                POLL_CONNECT_TIMEOUT,
+                POLL_RPC_TIMEOUT,
+            ) {
+                Ok(resp) => {
+                    let live: Vec<sessions::SessionId> =
+                        resp.sessions.iter().map(|s| s.id).collect();
+                    match crate::provider_index::ProviderIndex::load(index_path.clone()) {
+                        Ok(mut index) => {
+                            if reconcile_session_index(&mut index, &live, &image_path, LOCAL_VM_ID)
+                                && let Err(e) = index.flush()
+                            {
+                                tracing::warn!(error = %e, "flushing session index");
+                            }
+                        }
+                        Err(e) => tracing::warn!(error = %e, "loading session index"),
+                    }
+                }
+                // Transient: the VM may be mid-boot or shutting down.
+                Err(e) => tracing::debug!(error = %e, "session listing poll failed"),
+            }
+            // Sleep in small steps so a stop is honoured promptly.
+            let deadline = std::time::Instant::now() + interval;
+            while std::time::Instant::now() < deadline {
+                if stop.load(Ordering::Relaxed) {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(250));
+            }
+        }
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(not(minvmd_libkrun))]
@@ -474,5 +623,76 @@ mod tests {
             err.to_string().contains("requires libkrun"),
             "expected libkrun-required message, got: {err}"
         );
+    }
+
+    mod reconcile {
+        use super::super::reconcile_session_index;
+        use crate::provider_index::{ProviderIndex, VolumeEntry};
+        use sessions::SessionId;
+
+        fn sid(n: u8) -> SessionId {
+            SessionId::parse_str(&format!("019f0000-0000-7000-8000-0000000000{n:02x}")).unwrap()
+        }
+
+        fn empty_index(tmp: &tempfile::TempDir) -> ProviderIndex {
+            ProviderIndex::load(tmp.path().join("session_index.json")).unwrap()
+        }
+
+        #[test]
+        fn inserts_live_and_removes_own_stale() {
+            let tmp = tempfile::tempdir().unwrap();
+            let mut index = empty_index(&tmp);
+            let image = std::path::Path::new("/vols/a.raw");
+
+            // First reconcile: two live sessions appear.
+            assert!(reconcile_session_index(
+                &mut index,
+                &[sid(1), sid(2)],
+                image,
+                "local-0"
+            ));
+            assert_eq!(index.iter().count(), 2);
+
+            // Second reconcile with the same listing: no change.
+            assert!(!reconcile_session_index(
+                &mut index,
+                &[sid(1), sid(2)],
+                image,
+                "local-0"
+            ));
+
+            // Session 2 destroyed: its entry goes, session 1 stays.
+            assert!(reconcile_session_index(
+                &mut index,
+                &[sid(1)],
+                image,
+                "local-0"
+            ));
+            assert!(index.get_by_session(&sid(1)).is_some());
+            assert!(index.get_by_session(&sid(2)).is_none());
+        }
+
+        #[test]
+        fn preserves_foreign_vm_entries() {
+            let tmp = tempfile::tempdir().unwrap();
+            let mut index = empty_index(&tmp);
+            index.insert(
+                sid(9),
+                VolumeEntry {
+                    image_path: "/vols/other.raw".into(),
+                    vm_id: "local-1".to_string(),
+                },
+            );
+
+            // Reconciling local-0 with an empty listing must not touch the
+            // foreign VM's entry.
+            assert!(!reconcile_session_index(
+                &mut index,
+                &[],
+                std::path::Path::new("/vols/a.raw"),
+                "local-0"
+            ));
+            assert!(index.get_by_session(&sid(9)).is_some());
+        }
     }
 }

--- a/crates/minvmd/src/lib.rs
+++ b/crates/minvmd/src/lib.rs
@@ -15,6 +15,7 @@ pub mod error;
 pub mod image;
 pub mod lifecycle;
 pub mod net;
+pub mod provider_index;
 pub(crate) mod rpc_client;
 pub mod sock;
 pub mod state;

--- a/crates/minvmd/src/provider_index.rs
+++ b/crates/minvmd/src/provider_index.rs
@@ -1,0 +1,217 @@
+//! Host-side session → volume-image index (spec R3.4).
+//!
+//! Sessions persist on a VM's data volume and outlive the VM process, but
+//! their only record used to live *inside* the ext4 image — invisible to the
+//! host. The `ProviderIndex` maps each `SessionId` (UUIDv7, globally unique —
+//! no two VMs may share one) to the volume image that holds it and the vm id
+//! that last served it, so future multi-VM routing (#311) can dispatch
+//! `attach`/`activate` to the right place. This module only creates and
+//! maintains the map; routing itself is out of scope.
+//!
+//! The index is *derived* state: the volume images remain the source of
+//! truth, and the `run` supervisor's poller rebuilds entries from the live
+//! VM. A missing or corrupt file therefore loads as empty rather than
+//! failing (mirroring the R3.1 posture for the in-guest session index).
+
+use std::collections::BTreeMap;
+use std::io::Write as _;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use sessions::SessionId;
+
+/// Where a session lives: the volume image that holds its state and the VM
+/// that last served it. The session id is the map key only, never repeated
+/// here (R3.4).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VolumeEntry {
+    /// Host path of the raw ext4 volume image holding the session.
+    pub image_path: PathBuf,
+    /// Identifier of the VM instance that last served the session
+    /// (`local-<n>`; single-instance today).
+    pub vm_id: String,
+}
+
+/// Failure modes of [`ProviderIndex`] persistence.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ProviderIndexError {
+    /// The index file exists but could not be read.
+    #[error("reading provider index {path}")]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The index could not be written (tmp create, write, fsync, or rename).
+    #[error("writing provider index {path}")]
+    Write {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The in-memory map could not be serialized (broken invariant —
+    /// `BTreeMap<SessionId, VolumeEntry>` always serializes).
+    #[error("serializing provider index")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// Persistent JSON map of session id → [`VolumeEntry`], stored at
+/// [`crate::state::StateDir::session_index_path`].
+#[derive(Debug)]
+pub struct ProviderIndex {
+    path: PathBuf,
+    sessions: BTreeMap<SessionId, VolumeEntry>,
+}
+
+impl ProviderIndex {
+    /// Load the index at `path`. Missing file → empty index; a corrupt file
+    /// is logged and treated as empty (derived data — the poller rebuilds
+    /// it). Only a genuine read error fails.
+    pub fn load(path: PathBuf) -> Result<Self, ProviderIndexError> {
+        let sessions = match std::fs::read(&path) {
+            Ok(bytes) => match serde_json::from_slice(&bytes) {
+                Ok(map) => map,
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        path = %path.display(),
+                        "corrupt provider index; starting empty (poller rebuilds it)",
+                    );
+                    BTreeMap::new()
+                }
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => BTreeMap::new(),
+            Err(source) => {
+                return Err(ProviderIndexError::Read {
+                    path: path.clone(),
+                    source,
+                });
+            }
+        };
+        Ok(Self { path, sessions })
+    }
+
+    /// Insert (or replace) the entry for `id`, returning the previous entry.
+    /// Replacing an entry that names a *different* VM is logged: session ids
+    /// are globally unique, so ownership moving between VMs is noteworthy.
+    pub fn insert(&mut self, id: SessionId, entry: VolumeEntry) -> Option<VolumeEntry> {
+        let prev = self.sessions.insert(id, entry);
+        if let Some(prev) = &prev
+            && prev.vm_id != self.sessions[&id].vm_id
+        {
+            tracing::warn!(
+                session = %id,
+                from = %prev.vm_id,
+                to = %self.sessions[&id].vm_id,
+                "provider index entry changed owning VM",
+            );
+        }
+        prev
+    }
+
+    /// Look up the entry for `id`.
+    #[must_use]
+    pub fn get_by_session(&self, id: &SessionId) -> Option<&VolumeEntry> {
+        self.sessions.get(id)
+    }
+
+    /// Remove the entry for `id`, returning it if present.
+    pub fn remove(&mut self, id: &SessionId) -> Option<VolumeEntry> {
+        self.sessions.remove(id)
+    }
+
+    /// Iterate over all entries.
+    pub fn iter(&self) -> impl Iterator<Item = (&SessionId, &VolumeEntry)> {
+        self.sessions.iter()
+    }
+
+    /// Write the index atomically (tmp → fsync → rename), matching the
+    /// `StateDir::write_state` pattern.
+    pub fn flush(&self) -> Result<(), ProviderIndexError> {
+        let write_err = |source| ProviderIndexError::Write {
+            path: self.path.clone(),
+            source,
+        };
+        let serialized = serde_json::to_vec_pretty(&self.sessions)?;
+        let tmp = self.path.with_extension("json.tmp");
+        {
+            let mut f = std::fs::File::create(&tmp).map_err(write_err)?;
+            f.write_all(&serialized).map_err(write_err)?;
+            f.sync_all().map_err(write_err)?;
+        }
+        std::fs::rename(&tmp, &self.path).map_err(write_err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(image: &str, vm: &str) -> VolumeEntry {
+        VolumeEntry {
+            image_path: PathBuf::from(image),
+            vm_id: vm.to_string(),
+        }
+    }
+
+    #[test]
+    fn round_trips_through_flush_and_load() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session_index.json");
+
+        let id_a = SessionId::parse_str("019f0000-0000-7000-8000-00000000000a").unwrap();
+        let id_b = SessionId::parse_str("019f0000-0000-7000-8000-00000000000b").unwrap();
+        let mut index = ProviderIndex::load(path.clone()).unwrap();
+        assert!(index.get_by_session(&id_a).is_none());
+
+        index.insert(id_a, entry("/vols/a.raw", "local-0"));
+        index.insert(id_b, entry("/vols/a.raw", "local-0"));
+        index.flush().unwrap();
+
+        let reloaded = ProviderIndex::load(path.clone()).unwrap();
+        assert_eq!(
+            reloaded.get_by_session(&id_a),
+            Some(&entry("/vols/a.raw", "local-0"))
+        );
+        assert_eq!(reloaded.iter().count(), 2);
+        assert!(
+            !path.with_extension("json.tmp").exists(),
+            "atomic flush must leave no tmp residue"
+        );
+    }
+
+    #[test]
+    fn remove_persists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session_index.json");
+        let id = SessionId::parse_str("019f0000-0000-7000-8000-00000000000c").unwrap();
+
+        let mut index = ProviderIndex::load(path.clone()).unwrap();
+        index.insert(id, entry("/vols/a.raw", "local-0"));
+        index.flush().unwrap();
+        assert_eq!(index.remove(&id), Some(entry("/vols/a.raw", "local-0")));
+        index.flush().unwrap();
+
+        let reloaded = ProviderIndex::load(path).unwrap();
+        assert!(reloaded.get_by_session(&id).is_none());
+    }
+
+    #[test]
+    fn missing_and_corrupt_files_load_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("absent.json");
+        assert_eq!(ProviderIndex::load(missing).unwrap().iter().count(), 0);
+
+        let corrupt = tmp.path().join("corrupt.json");
+        std::fs::write(&corrupt, b"{ not json").unwrap();
+        let index = ProviderIndex::load(corrupt.clone()).unwrap();
+        assert_eq!(index.iter().count(), 0);
+
+        // And it recovers: a flush replaces the corrupt file with valid JSON.
+        index.flush().unwrap();
+        let reread: BTreeMap<SessionId, VolumeEntry> =
+            serde_json::from_slice(&std::fs::read(&corrupt).unwrap()).unwrap();
+        assert!(reread.is_empty());
+    }
+}

--- a/crates/minvmd/src/state.rs
+++ b/crates/minvmd/src/state.rs
@@ -130,6 +130,11 @@ impl StateDir {
         self.dir.join(paths::MINVMD_LOCK_FILE)
     }
 
+    /// Path to `session_index.json` (the session → volume image map, R3.4).
+    pub fn session_index_path(&self) -> PathBuf {
+        self.dir.join("session_index.json")
+    }
+
     /// Read the current state from `minvmd.toml`.
     ///
     /// Returns `State { lifecycle: NotProvisioned, .. }` when the file does

--- a/crates/minvmd/tests/session_index_e2e.rs
+++ b/crates/minvmd/tests/session_index_e2e.rs
@@ -1,0 +1,304 @@
+//! Session-index end-to-end test for Unit 3 (spec R3.4/R3.5).
+//!
+//! Boots a VM under the `run` supervisor with a fast poll interval, creates
+//! and destroys sessions in the guest over the bridge UDS, and asserts the
+//! host-side `session_index.json` tracks them — and that entries persist
+//! across `minvmd stop` (the index maps sessions to volume images precisely
+//! so a stopped VM's sessions stay routable).
+//!
+//! Gates match `boot_e2e.rs`: `#[cfg(minvmd_libkrun)]`, `#[ignore]`, and
+//! `MINVMD_E2E=1` with `MINVMD_KERNEL_PATH`/`MINVMD_ROOTFS_PATH`/
+//! `MINVMD_INITRAMFS` set.
+
+#![cfg(minvmd_libkrun)]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use minimald_rpc::OneshotSshRpc;
+use serial_test::serial;
+use sessions::SessionId;
+
+fn e2e_enabled(test: &str) -> bool {
+    if std::env::var("MINVMD_E2E").as_deref() != Ok("1") {
+        eprintln!("{test}: MINVMD_E2E != 1, skipping");
+        return false;
+    }
+    for var in &[
+        "MINVMD_KERNEL_PATH",
+        "MINVMD_ROOTFS_PATH",
+        "MINVMD_INITRAMFS",
+    ] {
+        assert!(
+            std::env::var(var).is_ok(),
+            "{test}: {var} must be set when MINVMD_E2E=1"
+        );
+    }
+    true
+}
+
+/// Isolated per-test environment: a fresh state dir holding everything
+/// (volume image, state file, locks, bridge socket, session index). Short
+/// `/tmp` paths, matching `boot_e2e::short_state_dir` — the bridge UDS lives
+/// inside the state dir and must fit `sun_path`.
+struct TestEnv {
+    _state: tempfile::TempDir,
+    state_home: PathBuf,
+}
+
+impl TestEnv {
+    fn new() -> Self {
+        let state = tempfile::Builder::new()
+            .prefix("mnl")
+            .tempdir_in("/tmp")
+            .expect("state tempdir");
+        Self {
+            state_home: state.path().to_path_buf(),
+            _state: state,
+        }
+    }
+
+    fn command(&self, args: &[&str]) -> Command {
+        let bin =
+            std::env::var_os("MINVMD_BIN").unwrap_or_else(|| env!("CARGO_BIN_EXE_minvmd").into());
+        let mut cmd = Command::new(bin);
+        // HOME too, not just XDG_STATE_HOME, as belt-and-braces: any
+        // `dirs`-based fallback that ignores XDG on macOS must also land in
+        // the tempdir, never the developer's real state dir.
+        cmd.args(args)
+            .env("HOME", &self.state_home)
+            .env("XDG_STATE_HOME", &self.state_home);
+        cmd
+    }
+
+    /// Everything lives in the provider-instance dir under the state base.
+    fn provider_dir(&self) -> PathBuf {
+        self.state_home.join("minimal/providers/local-0")
+    }
+
+    fn bridge_uds(&self) -> PathBuf {
+        self.provider_dir().join("ssh.sock")
+    }
+
+    fn volume_path(&self) -> PathBuf {
+        self.provider_dir().join("data-vol.raw")
+    }
+
+    fn session_index_path(&self) -> PathBuf {
+        self.provider_dir().join("session_index.json")
+    }
+}
+
+fn wait_until_running(env: &TestEnv, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let out = env
+            .command(&["status", "--json"])
+            .output()
+            .expect("running minvmd status");
+        if String::from_utf8_lossy(&out.stdout).contains("running") {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "VM did not reach Running within {timeout:?}"
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+/// Read the on-disk index, empty when absent.
+fn read_index(path: &Path) -> BTreeMap<SessionId, serde_json::Value> {
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).expect("session_index.json must parse"),
+        Err(_) => BTreeMap::new(),
+    }
+}
+
+/// Poll until `pred(index)` holds (or panic with the last state).
+fn wait_for_index(
+    path: &Path,
+    what: &str,
+    pred: impl Fn(&BTreeMap<SessionId, serde_json::Value>) -> bool,
+) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let index = read_index(path);
+        if pred(&index) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "session index never became {what}; last state: {index:?}"
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+struct AnyHostKey;
+
+impl russh::client::Handler for AnyHostKey {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        _key: &russh::keys::ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+/// Minimal oneshot RPC over the bridge UDS (test-local twin of the client in
+/// `minimal`/`minvmd`, which are not visible to integration tests).
+async fn oneshot<R: OneshotSshRpc>(uds: &Path, request: R::Request<'_>) -> R::Response {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let stream = {
+        let mut conn = None;
+        for _ in 0..20 {
+            match tokio::net::UnixStream::connect(uds).await {
+                Ok(s) => {
+                    conn = Some(s);
+                    break;
+                }
+                Err(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+            }
+        }
+        conn.expect("connect to bridge UDS")
+    };
+    let config = Arc::new(russh::client::Config::default());
+    let mut handle = russh::client::connect_stream(config, stream, AnyHostKey)
+        .await
+        .expect("ssh connect");
+    assert!(
+        handle
+            .authenticate_none("session-index-e2e")
+            .await
+            .expect("authenticate")
+            .success()
+    );
+    let channel = handle
+        .channel_open_session()
+        .await
+        .expect("open rpc channel");
+    channel
+        .request_subsystem(false, R::NAME)
+        .await
+        .expect("request subsystem");
+    let body = serde_json::to_vec(&request).expect("serialize request");
+    let mut rpc = channel.into_stream();
+    rpc.write_all(&body).await.expect("write request");
+    rpc.shutdown().await.expect("shutdown write half");
+    let mut resp = Vec::with_capacity(256);
+    rpc.read_to_end(&mut resp).await.expect("read response");
+    serde_json::from_slice(&resp).expect("decode response")
+}
+
+async fn create_session(uds: &Path, name: &str) -> SessionId {
+    let req = minimald_rpc::CreateSessionRequest {
+        config: minimald_rpc::SessionConfig {
+            name: Some(name.to_string()),
+            project_path: paths::HostAbsPath::try_new("/tmp").unwrap(),
+            network: sessions::NetworkMode::default(),
+            policy: Default::default(),
+            attrs: Default::default(),
+        },
+        contribution: Default::default(),
+    };
+    match oneshot::<minimald_rpc::CreateSession>(uds, req)
+        .await
+        .ok()
+        .expect("CreateSession errored")
+    {
+        minimald_rpc::CreateSessionResponse::Ready { id } => id,
+        minimald_rpc::CreateSessionResponse::Pending { .. } => {
+            panic!("CreateSession returned Pending; e2e only handles Ready")
+        }
+    }
+}
+
+/// Panic-safe teardown: stops the VM on drop, so a failed assertion after
+/// `run --detach` never leaks a detached supervisor whose state dir the
+/// `TempDir` then unlinks out from under it. Idempotent — the test's own
+/// asserted `stop` leaves this a no-op. Declared after the [`TestEnv`] it
+/// borrows, so it drops (and stops the VM) before the tempdirs go.
+struct StopOnDrop<'a>(&'a TestEnv);
+
+impl Drop for StopOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.command(&["stop"]).status();
+    }
+}
+
+#[test]
+#[serial]
+#[ignore = "gated MINVMD_E2E=1; requires Mac with libkrun, kernel, rootfs, initramfs"]
+fn session_index_tracks_lifecycle_and_survives_stop() {
+    if !e2e_enabled("session_index_e2e") {
+        return;
+    }
+    let env = TestEnv::new();
+
+    let status = env
+        .command(&["run", "--detach", "--timeout", "120"])
+        .env("MINVMD_VOLUME_BYTES", "1073741824") // 1 GiB
+        .env("MINVMD_SESSION_POLL_SECS", "1")
+        .status()
+        .expect("spawning minvmd run --detach");
+    assert!(status.success(), "minvmd run --detach failed: {status}");
+    let _teardown = StopOnDrop(&env);
+    wait_until_running(&env, Duration::from_secs(60));
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let uds = env.bridge_uds();
+    let index_path = env.session_index_path();
+
+    // Create → the poller records the session against this VM's image.
+    let id_a = rt.block_on(create_session(&uds, "session-index-e2e-a"));
+    wait_for_index(&index_path, "tracking session A", |idx| {
+        idx.contains_key(&id_a)
+    });
+    let entry = &read_index(&index_path)[&id_a];
+    assert_eq!(
+        entry["image_path"],
+        serde_json::json!(env.volume_path()),
+        "entry must name this VM's volume image"
+    );
+    assert_eq!(entry["vm_id"], serde_json::json!("local-0"));
+
+    // Destroy → the entry is removed.
+    rt.block_on(async {
+        oneshot::<minimald_rpc::DestroySession>(
+            &uds,
+            minimald_rpc::DestroySessionRequest { id: id_a },
+        )
+        .await
+        .ok()
+        .expect("DestroySession errored");
+    });
+    wait_for_index(&index_path, "cleared of session A", |idx| {
+        !idx.contains_key(&id_a)
+    });
+
+    // A session live at stop time persists in the index: it still exists on
+    // the volume image, and the mapping is what future routing needs.
+    let id_b = rt.block_on(create_session(&uds, "session-index-e2e-b"));
+    wait_for_index(&index_path, "tracking session B", |idx| {
+        idx.contains_key(&id_b)
+    });
+    let status = env
+        .command(&["stop"])
+        .status()
+        .expect("running minvmd stop");
+    assert!(status.success(), "minvmd stop failed: {status}");
+    assert!(
+        read_index(&index_path).contains_key(&id_b),
+        "index entry must survive VM stop"
+    );
+}

--- a/crates/sessions/src/store.rs
+++ b/crates/sessions/src/store.rs
@@ -349,19 +349,47 @@ impl DiskLoader {
     /// # Errors
     ///
     /// I/O error if the sessions directory can't be created or
-    /// `index.json` can't be read.
+    /// `index.json` can't be read. A *corrupt* `index.json` is not an
+    /// error: the index is derived state, so it is rebuilt from the
+    /// per-session `record.json` files instead of failing startup
+    /// (R3.1 — with the state dir on the persistent volume, a torn
+    /// index write now survives restarts).
     pub fn new(minimal_dir: DaemonAbsPath) -> Result<Self, std::io::Error> {
         std::fs::create_dir_all(minimal_dir.as_utf8_path().join("sessions"))?;
         let index_file = minimal_dir.as_utf8_path().join("sessions/index.json");
+        let mut recovered_from_corrupt = false;
         let index = if std::fs::exists(&index_file)? {
-            serde_json::from_reader(std::fs::File::open(index_file)?)?
+            // Same split as `classify_record_for_reconcile`: an I/O error is
+            // transient (hard-fail, retry next startup); anything else is
+            // data corruption (definitive — rebuild below).
+            match serde_json::from_reader(std::fs::File::open(&index_file)?) {
+                Ok(index) => index,
+                Err(e) if e.is_io() => return Err(e.into()),
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        path = %index_file,
+                        "corrupt sessions index.json; rebuilding from per-session records",
+                    );
+                    recovered_from_corrupt = true;
+                    Index::default()
+                }
+            }
         } else {
             Index::default()
         };
 
         let mut this = Self { minimal_dir, index };
-        if this.self_heal()? {
+        // Flush even when self-heal found nothing to re-index: the corrupt
+        // file itself must be replaced with a valid (possibly empty) index.
+        if this.self_heal()? || recovered_from_corrupt {
             this.flush_index()?;
+        }
+        if recovered_from_corrupt {
+            tracing::warn!(
+                sessions_recovered = this.index.short_to_id.len(),
+                "session index rebuilt after corruption",
+            );
         }
         Ok(this)
     }
@@ -1713,5 +1741,85 @@ mod tests {
         );
         assert_eq!(loader.find_by_id(key_a.id()).unwrap(), None);
         assert_eq!(loader.find_by_id(key_b.id()).unwrap(), None);
+    }
+
+    // =================================================================
+    // corrupt index.json recovery (R3.1)
+    // =================================================================
+
+    fn index_path(loader_root: &DaemonAbsPath) -> std::path::PathBuf {
+        loader_root
+            .as_utf8_path()
+            .join("sessions/index.json")
+            .as_std_path()
+            .to_path_buf()
+    }
+
+    /// A syntactically corrupt index must not fail startup: the index
+    /// is rebuilt from the per-session `record.json` files and a valid
+    /// index is flushed back.
+    #[test]
+    fn corrupt_index_rebuilds_from_records() {
+        let tmp = TempDir::new().unwrap();
+        let root = loader_dir(&tmp);
+
+        let mut loader = DiskLoader::new(root.clone()).unwrap();
+        let key_a = loader.create(sample_record()).unwrap();
+        let key_b = loader
+            .create({
+                let mut r = sample_record();
+                r.name = Some("other".into());
+                r
+            })
+            .unwrap();
+        drop(loader);
+
+        // Simulate a torn index write on the persistent volume.
+        std::fs::write(index_path(&root), b"{ not json").unwrap();
+
+        let loader = DiskLoader::new(root.clone()).unwrap();
+        assert_eq!(loader.find_by_id(key_a.id()).unwrap(), Some(key_a));
+        assert_eq!(loader.find_by_id(key_b.id()).unwrap(), Some(key_b));
+        assert!(loader.find_by_name("my-session").unwrap().is_some());
+        assert!(loader.find_by_name("other").unwrap().is_some());
+
+        // The corrupt file was replaced with a valid one.
+        let reread: serde_json::Value =
+            serde_json::from_slice(&read_index_bytes(&root)).expect("index.json must parse again");
+        drop(reread);
+    }
+
+    /// Valid JSON of the wrong shape is corruption too, not an error.
+    #[test]
+    fn wrong_shape_index_rebuilds_from_records() {
+        let tmp = TempDir::new().unwrap();
+        let root = loader_dir(&tmp);
+
+        let mut loader = DiskLoader::new(root.clone()).unwrap();
+        let key = loader.create(sample_record()).unwrap();
+        drop(loader);
+
+        std::fs::write(index_path(&root), b"[]").unwrap();
+
+        let loader = DiskLoader::new(root).unwrap();
+        assert_eq!(loader.find_by_id(key.id()).unwrap(), Some(key));
+    }
+
+    /// A corrupt index with no session records recovers to an empty
+    /// store and rewrites a valid (empty) index.
+    #[test]
+    fn corrupt_index_with_no_records_recovers_empty() {
+        let tmp = TempDir::new().unwrap();
+        let root = loader_dir(&tmp);
+
+        // Initialize the layout, then corrupt the (empty) index.
+        drop(DiskLoader::new(root.clone()).unwrap());
+        std::fs::write(index_path(&root), b"garbage").unwrap();
+
+        let loader = DiskLoader::new(root.clone()).unwrap();
+        assert_eq!(loader.find_by_name("my-session").unwrap(), None);
+        let reread: serde_json::Value =
+            serde_json::from_slice(&read_index_bytes(&root)).expect("index.json must parse again");
+        drop(reread);
     }
 }

--- a/docs/specs/08-spec-vm-ext4-volume/architecture.md
+++ b/docs/specs/08-spec-vm-ext4-volume/architecture.md
@@ -213,6 +213,22 @@ removed. This makes explicit the behavior already present on branch #573 commit
 
 ### Workspace upload (`crates/minimald/src/rpc.rs`)
 
+> **Rescoped as landed (R3.3):** the tar-receiver semantics below were
+> deferred — `unpack_workspace_files` has no ported client (the
+> `Client::upload_workspace` port past #603 never happened), so the
+> user-reachable upload path is `git push` over the session remote. Unit 3
+> implements the R3.3 contract there instead
+> (`crates/minimald/src/git_hooks/`): a push into a worktree with
+> uncommitted tracked changes is **rejected** by a pre-receive hook (loud:
+> `[remote rejected] (pre-receive hook declined)`, non-zero `git push`
+> exit), and `git push -o force-checkout` overrides, discarding those
+> changes via `checkout -f`. The receive-pack invocation advertises push
+> options and sets `receive.denyCurrentBranch=ignore` (the hook pair owns
+> worktree consistency; git's guard would refuse every re-push to the
+> checked-out branch). Mid-checkout failure recovery is git-level: re-run
+> the push. The staged-swap design below remains valid if the tar receiver
+> ever grows a client.
+
 `unpack_workspace_files` (currently `rpc.rs:384-413`) gains:
 
 - **Non-empty check:** if the target worktree (`paths.working`) contains any
@@ -239,13 +255,22 @@ place; atomicity semantics and the non-empty check are new.
   map key only, not repeated in `VolumeEntry`. Operations: `insert`,
   `get_by_session`, `remove`, `flush` (atomic rename-based JSON write). Stored
   at `<minvmd_state_dir>/session_index.json`.
-- Session lifecycle events: `minimald` emits session-created and
-  session-destroyed events over a persistent guest→host vsock connection (new
-  `SessionLifecycle` RPC direction, using the same vsock guest-outbound
-  mechanism as the boot-marker port — connect, keep open, stream events).
-  `minvmd` receives and updates `ProviderIndex`. Full multi-VM routing
-  (`attach`/`activate` dispatch to the owning VM) is #311 scope; this spec
-  only creates and maintains the index so that routing is not blocked later.
+- **Transport (as implemented — supersedes the guest→host sketch below):**
+  the `run` supervisor polls `ListSessions` over the existing host→guest
+  UDS↔vsock bridge (`MINVMD_SESSION_POLL_SECS`, default 15 s, `0` disables)
+  and reconciles `ProviderIndex`: upsert every live id, remove only entries
+  owned by this `vm_id` whose session is gone. Entries persist across VM stop
+  — the mapping is what future routing needs. The originally sketched
+  guest→host `SessionLifecycle` emit was rejected: a held-open guest→host
+  vsock wedges against host→guest traffic (#588), and one-shot emits fire
+  exactly while the client's own host→guest connection is open, so the guest
+  can never establish the serialization that would make them safe. Bounded
+  staleness (one poll interval) is acceptable for an index whose consumer
+  (#311 multi-VM routing) is future work. Bare `minvmd boot` leaves no
+  supervisor behind and does not maintain the index.
+- Full multi-VM routing (`attach`/`activate` dispatch to the owning VM) is
+  #311 scope; this spec only creates and maintains the index so that routing
+  is not blocked later.
 
 ### Rootfs build
 
@@ -299,7 +324,7 @@ crash-recovery data-loss window. `full` is preserved as a tunable via
 | rename-exchange-ext4 | `renameat2(RENAME_EXCHANGE)` is supported by the ext4 guest filesystem and available in the guest kernel image | settled | Linux kernel: RENAME_EXCHANGE added in Linux 3.15; ext4 documented support; the same virtio-linux guest kernel already enables modern features (user namespaces, hakoniwa sandbox builds) requiring ≥ Linux 3.8 | R3.3 |
 | shutdown-rpc-reachable | The Shutdown RPC is reachable from `minvmd stop` via the existing host UDS ↔ guest vsock bridge | settled | `VmConfig::apply()` registers the host UDS → guest vsock bridge at VSOCK_BRIDGE_PORT; Shutdown RPC handler exists in `server.rs` merged via PR #613 (informed by #613); `stop.rs` reaches the same host UDS via `sock::resolve_uds_path()` | R2.3 |
 | syncfs-bounded-flush | `syncfs(2)` on the `/var/lib/minimal` mount causes the ext4 journal to flush to the block device within a bounded time well under the 10-second quiesce timeout | settled | Linux semantics: `syncfs` is a blocking syscall that waits for all dirty pages and journal entries to reach the underlying block device; ext4 journal is sized (default 128 MiB) to flush quickly at modern I/O rates | R2.1, R2.2 |
-| lifecycle-vsock-persistent | A persistent guest→host vsock connection for `SessionLifecycle` events is feasible using the same mechanism as `BOOT_MARKER_PORT` | needs-spike | Contradicted by #588: libkrun's vsock device wedges when a guest→host connection overlaps a host→guest one. The boot-marker is safe only because it is connect→write→**close** *before* the SSH bridge is used; a connection held open for the VM's lifetime overlaps every host→guest SSH/attach and hits the wedge continuously — not just at boot. This is the same failure mode that red-lit autospawn-e2e on #672 (an awaited best-effort expose serialized vsock use and dodged the wedge; detaching it exposed it as `ssh connect: Disconnected`). The lifecycle channel needs a wedge-safe transport — a one-shot/serialized guest→host emit or a host-initiated poll — not a held-open socket. Spike the transport before R3.5 planning. | R3.5 |
+| lifecycle-vsock-persistent | A persistent guest→host vsock connection for `SessionLifecycle` events is feasible using the same mechanism as `BOOT_MARKER_PORT` | settled-by-avoidance | Contradicted by #588: libkrun's vsock device wedges when a guest→host connection overlaps a host→guest one. The boot-marker is safe only because it is connect→write→**close** *before* the SSH bridge is used; a connection held open for the VM's lifetime overlaps every host→guest SSH/attach and hits the wedge continuously. One-shot emits are equally unsafe: lifecycle events fire exactly while the client's host→guest connection is open, and the guest cannot observe host-side connection state. **Resolution (Unit 3 as landed):** no guest→host channel at all — the `run` supervisor polls `ListSessions` host→guest (the proven direction) and reconciles the index; see "Provider index" above. | R3.5 |
 
 ## Knowledge gaps
 
@@ -313,12 +338,12 @@ codebase for atomic directory swap via `RENAME_EXCHANGE`. The system call is
 well-documented (Linux 3.15+, `man 2 renameat2`); the pattern is standard
 for atomic directory replacement.
 
-**Open spike: `SessionLifecycle` vsock transport (`lifecycle-vsock-persistent`).**
+**Resolved spike: `SessionLifecycle` vsock transport (`lifecycle-vsock-persistent`).**
 The libkrun vsock device wedges under concurrent guest→host and host→guest
-connections (#588). A held-open guest→host lifecycle socket would collide with
-the host→guest SSH/attach bridge continuously — the same failure that broke
-autospawn-e2e on #672. Spike a wedge-safe transport (one-shot/serialized emit,
-or host-initiated poll) before committing R3.5 to a persistent connection.
+connections (#588), and one-shot guest emits fire exactly while a host→guest
+connection is necessarily open. R3.5 landed as a host-initiated
+`ListSessions` poll in the `run` supervisor instead — no guest→host channel
+exists; see "Provider index" above.
 
 **Referenced prior work.** Precursor PR #573 (closed WIP: seeded cache disk +
 workspace upload) is referenced throughout the spec but not available in the


### PR DESCRIPTION
Stacked on #705. Now that session worktrees and the package cache survive a VM restart on the `/dev/vdb` volume, several things that were harmless when all state died with the per-boot tmpfs become persistent traps. This PR closes them.

## Failure modes fixed

**1. A corrupt session index bricks every session — silently, after READY.**
The session store hard-failed to construct if `sessions/index.json` didn't parse. On a tmpfs that was nearly impossible (the file was rewritten every boot); on the persistent volume a torn write survives, and an unclean stop is exactly how you get one. The daemon then reached READY but every session RPC failed against the un-constructable store — a VM that looks healthy and can touch none of its sessions, with no path back short of hand-deleting the file.
*Now:* a parse failure is treated as recoverable (the index is derived state, not the source of truth). The store falls back to an empty index, rebuilds it from the per-session `record.json` files via the self-heal pass that already existed, and writes a valid index back. A read *I/O* error still fails — only corruption self-heals.

**2. Stale provider identity persists across reboots.**
`providers/` holds boot-ephemeral identity — the host SSH key, `known_hosts`, socket paths. On the tmpfs it was regenerated every boot. On the persistent volume it would carry a previous boot's host key forward, so a client that learned the new key mid-session, or any host-key rotation, would silently mismatch.
*Now:* the guest resets `providers/` after mounting the volume and before regenerating its instance dir, while `sessions/` and `cache/` are preserved. The reset only ever touches entries *inside* `providers/` — never a glob over the state root — so persistent user data is untouchable by construction.

**3. A dirty worktree silently swallows every push.**
When a session's checked-out worktree had uncommitted changes, the git `post-receive` hook printed a note to `stderr` and `continue`d — the push exited 0, the refs updated, but the working tree was never checked out. The client believes it deployed new code; the guest keeps running the old code. On a tmpfs the dirty state cleared on the next boot; on the persistent worktree it sticks, so *every* subsequent push to that session is silently ignored until someone manually cleans the tree.
*Now:* a `pre-receive` hook rejects the push loudly — `! [remote rejected] (pre-receive hook declined)` and a non-zero `git push` exit — unless the client passes `git push -o force-checkout`, which discards the uncommitted changes and checks out. receive-pack advertises push options and sets `receive.denyCurrentBranch=ignore` (the hook pair, not git's default guard, owns worktree consistency). Recovery from a mid-checkout failure is a re-push.

**4. The host can't locate a session that outlives its VM.**
Sessions now persist on the volume image after the VM process exits, but nothing on the host recorded which image holds which session — the mapping lived only *inside* the ext4 image, invisible until a VM booted it. Any future routing of `attach`/`activate` to the owning VM (#311) had nothing to route against.
*Now:* a host-side `ProviderIndex` at `<state>/session_index.json` maps each session id to `{ image_path, vm_id }`, written atomically. It's derived state — a corrupt or missing file loads empty and is rebuilt — so it never becomes its own failure mode.

## Transport note (why not the guest→host RPC the design sketched)

Maintaining the index was originally sketched as the guest pushing session-lifecycle events to the host. That's unimplementable safely: libkrun's vsock wedges when a guest→host connection overlaps host→guest traffic (#588 — the failure that red-lit autospawn-e2e on #672), and lifecycle events fire *precisely* while the client's own host→guest SSH connection is open, so even one-shot emits can't be serialized clear of it. Instead the `run` supervisor **polls** `ListSessions` over the existing host→guest bridge (the proven direction) and reconciles the index — `MINVMD_SESSION_POLL_SECS`, default 15 s, `0` disables. Entries persist across VM stop (a stopped VM's sessions stay routable); the cost is bounded staleness, fine for a consumer that's future work. Only the `run` supervisor maintains the index — bare `minvmd boot` leaves nothing behind to poll. `architecture.md` is updated to record this.

## Verification

Gated e2e (`MINVMD_E2E=1`, verified on macOS/HVF): a created session appears in `session_index.json` with the right image path and vm id, a destroyed one is removed, and a session live at `minvmd stop` persists in the index. Unit coverage: corrupt-index recovery (three shapes — bad bytes, wrong-shape JSON, corrupt-with-no-records), providers reset preserving sessions/cache, the git-push hook matrix (clean push, clean re-push, dirty rejection, forced override) driven against real `git`, and ProviderIndex round-trip / atomic-flush / corrupt-load.

Refs: #583. Full multi-VM routing on top of the index is #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)