### PR TITLE
ci: nightly test tier + the CI strategy & test-extension contract

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,6 +21,11 @@ slow-timeout = { period = "60s", terminate-after = 5 }
 leak-timeout = "1s"
 final-status-level = "slow"
 
+[profile.ci.junit]
+# Written to target/nextest/ci/junit.xml; core-tests reads it to publish a
+# pass/fail summary to $GITHUB_STEP_SUMMARY.
+path = "junit.xml"
+
 [profile.vm]
 # Prebuilt-harness VM runs (the KVM lane's archived e2e tests). One VM at a
 # time on a 2-vCPU runner; boots are legitimately slow, so the slow period is

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# The CI/workflow layer is frozen: it is a thin scheduler over the tests,
+# scripts, and the justfile (see docs/ci-strategy.md §10 and CONTRIBUTING.md).
+# Any PR touching it — human or agent — needs a code-owner review. Extension
+# happens through convention-discovered tests and scripts, not YAML edits.
+/.github/ @norrietaylor @twitchyliquid64

--- a/.github/actions/core-tests/action.yml
+++ b/.github/actions/core-tests/action.yml
@@ -10,6 +10,13 @@ inputs:
     description: rust-cache shared-key, forwarded to setup-rust.
     required: false
     default: tests
+  save-if:
+    description: >
+      Whether this job may write the cache, forwarded to setup-rust. Nightly
+      canaries pass "false" so a throwaway beta/updated-deps build never
+      consumes the shared pool the real lanes restore from.
+    required: false
+    default: ${{ github.ref == 'refs/heads/main' }}
 
 runs:
   using: composite
@@ -18,6 +25,7 @@ runs:
       uses: ./.github/actions/setup-rust
       with:
         shared-key: ${{ inputs.shared-key }}
+        save-if: ${{ inputs.save-if }}
     - name: Install nextest
       uses: taiki-e/install-action@v2
       with:
@@ -33,3 +41,21 @@ runs:
     - name: Run doctests
       shell: bash
       run: cargo test --workspace --doc --locked
+    - name: Publish test summary
+      # Surface the nextest JUnit counts on the run page so per-PR test
+      # evidence is visible without downloading artifacts. `always()` so a
+      # failing run still reports. Best-effort parse of the testsuites root.
+      if: always()
+      shell: bash
+      run: |
+        junit="target/nextest/ci/junit.xml"
+        [ -f "$junit" ] || exit 0
+        line="$(grep -m1 '<testsuites' "$junit" || true)"
+        attr() { printf '%s' "$line" | grep -oE "$1=\"[0-9.]+\"" | head -1 | grep -oE '[0-9.]+'; }
+        {
+          echo "### Workspace tests (nextest, profile ci)"
+          echo ""
+          echo "| tests | failures | errors | time |"
+          echo "|---|---|---|---|"
+          echo "| $(attr tests) | $(attr failures) | $(attr errors) | $(attr time)s |"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,243 @@
+name: nightly-tests
+
+# Nightly TEST tier — distinct from nightly.yml (which cuts + blesses the
+# `nightly` release channel). This runs the checks that are too slow, too
+# flaky-adjacent, or not tied to a specific PR: an advisory re-check, a
+# repeated session-e2e soak, toolchain/dependency canaries, and workflow
+# hygiene. A blocking-job failure files (or updates) a tracking issue rather
+# than rotting in the Actions tab.
+on:
+  schedule:
+    - cron: "0 6 * * *" # 06:00 UTC — offset from nightly.yml's 10:00
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never overlap a slow soak with the next night's run.
+concurrency:
+  group: nightly-tests
+  cancel-in-progress: false
+
+jobs:
+  advisories:
+    # cargo-deny advisories, BLOCKING here — the between-PRs counterpart of
+    # the PR-side `cargo-deny` (which stays blocking too). Catches RUSTSEC
+    # advisories published since the last PR touched the tree. Feeds notify.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories
+
+  session-e2e-soak:
+    # Boot a real microVM and round-trip a full session ten times to shake
+    # out the boot / first-connect raciness that a single PR-lane run cannot
+    # surface. Self-contained: builds minvmd + the CLI, materializes the
+    # guest images, then loops scripts/soak-session-e2e.sh.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+    steps:
+      - name: Free Disk Space
+        uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install build dependencies
+        run: |
+          sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends \
+               protobuf-compiler libprotobuf-dev cpio git'
+      - name: Enable /dev/kvm access
+        run: |
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm not present on this runner." >&2
+            exit 1
+          fi
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Cache cargo + build artifacts
+        # Shares the KVM lane's build cache key (same minvmd + CLI compile);
+        # a scheduled run on main also writes it back, keeping it warm.
+        id: cargo-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-x86_64-minvmd-kvm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-x86_64-minvmd-kvm-
+      - name: Materialize libkrun prefix (upstream package)
+        uses: ./.github/actions/setup-libkrun-linux
+        with:
+          arch: x86_64
+      - name: Build guest initramfs (minimald as /init)
+        run: ./scripts/build-initramfs.sh "$RUNNER_TEMP/initramfs.cpio" x86_64-unknown-linux-musl
+      - name: Build minvmd + the CLI
+        # Separate invocations: a combined build feature-unifies libkrun into
+        # the CLI (the regression the macOS lane guards).
+        run: |
+          cargo build -p minvmd --bin minvmd --locked
+          cargo build -p minimal --bin minimal --locked
+      - name: Materialize guest kernel (raw Image)
+        uses: ./.github/actions/materialize
+        with:
+          output: virtio-kernel
+          dest: ${{ runner.temp }}/vmlinuz
+          arch: x86_64
+          channel: unstable
+      - name: Materialize guest rootfs (ext4 image)
+        uses: ./.github/actions/materialize
+        with:
+          output: minvmd-rootfs
+          dest: ${{ runner.temp }}/rootfs.img
+          arch: x86_64
+          channel: unstable
+      - name: Soak the session e2e (x10)
+        env:
+          MINVMD_KERNEL_PATH: ${{ runner.temp }}/vmlinuz
+          MINVMD_ROOTFS_PATH: ${{ runner.temp }}/rootfs.img
+          MINVMD_INITRAMFS: ${{ runner.temp }}/initramfs.cpio
+          E2E_VM: "1"
+          E2E_MINIMAL_ARGS: --minvmd
+          E2E_PROJECT_DIR: /tmp
+        run: |
+          export PATH="$PWD/target/debug:$PATH"
+          ./scripts/soak-session-e2e.sh 10 "$RUNNER_TEMP/soak-logs"
+      - name: Save cargo + build artifacts cache (main only)
+        if: github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ steps.cargo-cache.outputs.cache-primary-key }}
+      - name: Upload soak boot logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: soak-boot-logs
+          path: ${{ runner.temp }}/soak-logs
+          if-no-files-found: ignore
+
+  beta-canary:
+    # Run the workspace suite on beta rustc to catch upcoming-toolchain
+    # breakage ahead of the 1.97.0 pin. Non-blocking (the pin is the gate);
+    # RUSTUP_TOOLCHAIN overrides rust-toolchain.toml for this job only.
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    continue-on-error: true
+    env:
+      RUSTUP_TOOLCHAIN: beta
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Beta toolchain
+        uses: dtolnay/rust-toolchain@beta
+      - name: Core workspace tests (beta)
+        uses: ./.github/actions/core-tests
+        with:
+          # Own cache class, and never write (a nightly beta build must not
+          # consume the shared pool the real lanes restore from).
+          shared-key: beta-canary
+          save-if: "false"
+
+  update-canary:
+    # Re-resolve every dependency to its newest semver-compatible version and
+    # run the suite, to catch upstream breakage early. Non-blocking.
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: cargo update (newest compatible deps)
+        run: cargo update
+      - name: Core workspace tests (updated deps)
+        uses: ./.github/actions/core-tests
+        with:
+          shared-key: update-canary
+          save-if: "false"
+
+  hygiene:
+    # Workflow lint + unused-dependency check. Non-blocking; especially handy
+    # during CI surgery. Tool installs are best-effort under continue-on-error.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Install cargo-machete + zizmor
+        # Both are prebuilt binaries in taiki-e's manifest (zizmor is Rust,
+        # from zizmorcore/zizmor). actionlint is NOT — it runs from its
+        # pinned official image below.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete,zizmor
+      - name: actionlint (workflow lint)
+        # Pinned official image; no toolchain needed and it auto-discovers
+        # .github/workflows. Docker is preinstalled on ubuntu-latest.
+        run: docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.12 -color
+      - name: cargo-machete (unused deps)
+        run: cargo machete
+      - name: zizmor (workflow security)
+        run: zizmor .github/workflows/
+
+  notify:
+    # File (or update) a tracking issue when a BLOCKING nightly job fails, so
+    # a regression doesn't rot in the Actions tab. Canaries are
+    # continue-on-error and deliberately do NOT trip this — read them in the
+    # run itself.
+    needs: [advisories, session-e2e-soak]
+    if: always() && (needs.advisories.result == 'failure' || needs.session-e2e-soak.result == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the nightly-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ADV: ${{ needs.advisories.result }}
+          SOAK: ${{ needs.session-e2e-soak.result }}
+        run: |
+          set -euo pipefail
+          title="Nightly test tier failing"
+          body="$(printf 'A nightly-tests run failed.\n\n- advisories: %s\n- session-e2e-soak: %s\n\nRun: %s' \
+            "$ADV" "$SOAK" "$RUN_URL")"
+          existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "in:title \"$title\"" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body"
+          fi

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -152,6 +152,7 @@ jobs:
     promote:
         needs: gate
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         permissions:
             contents: "read"
             id-token: "write"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,10 @@ This repository follows Conventional Commits. Every commit message must conform.
 ## Rust Coding Standards
 
 @docs/rust-coding-standards.md
+
+## CI
+
+Do NOT edit `.github/workflows/` — the CI layer is frozen and CODEOWNER-gated.
+Extend coverage through convention-discovered tests, `scripts/`, and the
+`justfile`, per the contract in [CONTRIBUTING.md](CONTRIBUTING.md) and the
+design in [docs/ci-strategy.md](docs/ci-strategy.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,31 @@ cargo clippy --all-targets -- -D warnings
 ## Coding standards
 
 Rust coding standards are documented in [docs/rust-coding-standards.md](docs/rust-coding-standards.md).
+
+## CI and the test-extension contract
+
+The CI layer is **frozen**: do not edit `.github/workflows/`. It is a thin
+scheduler over the tests, `scripts/`, and the `justfile` — all reviewed like
+any other code. `/.github/` is CODEOWNER-gated, so workflow edits need an owner
+review no matter who authored them. The full rationale and the CI design are in
+[docs/ci-strategy.md](docs/ci-strategy.md) (§10 is this contract).
+
+**Adding a test never requires a CI change** — the matching lane discovers it
+by where it lives and what it is named:
+
+| Test kind | Where it goes | How CI runs it | Local command |
+|---|---|---|---|
+| Unit | `#[cfg(test)]` next to the code | nextest target discovery (`ci` / native lane) | `cargo nextest run --workspace` |
+| Integration | `crates/<crate>/tests/*.rs` | same | `cargo nextest run --workspace` |
+| Doctest | `///` examples in lib code | `cargo test --workspace --doc` | `cargo test --doc` |
+| VM boot / session e2e | `crates/minvmd/tests/` (env-gated `#[ignore]` harnesses) | the KVM / macOS lanes build and run them | `just up` then run locally |
+| Session scenario | driven by `scripts/session-e2e.sh` across every target | native / KVM / macOS lanes | `E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd ./scripts/session-e2e.sh` |
+
+When a genuinely new *kind* of check is needed, add it to `scripts/` or the
+`justfile` (reviewed code) and let the lane call it — never by growing the YAML.
+
+> The VM e2e harnesses are moving to a name-based convention (`*_e2e` /
+> `*_root_e2e`) so a lane runs every matching harness by filterset and a new
+> one needs no CI edit at all. Until that lands, a genuinely new VM harness is
+> the one test kind that still needs a one-line lane change (reviewed as a
+> workflow edit).

--- a/docs/ci-strategy.md
+++ b/docs/ci-strategy.md
@@ -1,0 +1,550 @@
+# CI Strategy: Rust client / host-daemon / guest-daemon system (libkrun + KVM)
+
+> **How this maps to gominimal/minimal.** This is the design the CI refactor
+> ([#687](https://github.com/gominimal/minimal/issues/687)) implements — adopted
+> policy, not aspiration. A few terms map to this repo's shape:
+>
+> - The strategy's single-workflow + `preflight` is realised as **five
+>   always-triggered lane workflows** (`ci`, `ci-linux-native`, `ci-linux-kvm`,
+>   `ci-macos`, `ci-shell-installer`), each with an in-workflow `changes` job
+>   (dorny/paths-filter) and an `if: always()` aggregator; the five aggregators
+>   are the required checks.
+> - The "compile once per triple, fan out" archive pattern lives in the KVM
+>   lane (`cargo nextest archive` → toolchain-free test job); the same unified
+>   proof (`scripts/session-e2e.sh`) runs on all three targets.
+> - The strategy's `cargo xtask` is this repo's **justfile + `scripts/`** — the
+>   same "logic in reviewed code, YAML stays a thin scheduler" property (§10).
+> - Guest kernel/rootfs come prebuilt from the GCS channel via the
+>   `materialize` composite; the initramfs cross-compiles minimald to musl.
+> - The nightly TEST tier is `nightly-tests.yml` (distinct from `nightly.yml`,
+>   which cuts the release channel).
+>
+> The test-extension contract (§10) is the load-bearing part for contributors —
+> see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+---
+
+Research document — optimal CI shape on GitHub Actions for a Rust workspace targeting
+**x86_64 Linux** and **arm64 macOS**, with three components:
+
+| Component | Runs on | Notes |
+|---|---|---|
+| `client` | host (Linux, macOS) | user-facing |
+| host daemon | host (Linux, macOS) | spawns/supervises libkrun VMs, provides vsock proxy |
+| guest daemon | **inside the VM (always Linux)** | talks to client via vsock proxy; on Linux without KVM can connect to the client directly as a plain process |
+
+Goals: fast PR feedback, no redundant compilation, cached builds, cargo tests, e2e smoke
+tests, and a defensible PR-vs-nightly split.
+
+---
+
+## 1. Executive summary
+
+The pipeline is a **tiered fan-out**: cheap gates first, then **one compile per target
+triple** whose outputs (nextest archives, static guest binaries) are shared as artifacts
+with every downstream test job — no job ever recompiles the workspace. E2E runs at two
+levels: a **process-mode suite** (guest daemon as a plain process, no VM — runs anywhere)
+and a **real-VM smoke suite** (libkrun boot + vsock round-trip) that runs on stock
+`ubuntu-latest` runners because **all x86_64 Linux hosted runners expose `/dev/kvm`**.
+macOS VM smoke requires a **self-hosted Apple Silicon machine** (hosted macOS runners
+cannot nest virtualization); it is gated to trusted refs. Everything expensive,
+matrix-expanding, or advisory-flavored moves to a nightly cron that doubles as a
+cache-primer for main.
+
+Target: **≤ ~10 min PR wall-clock** on the common path (quick gates ~2 min, build ~4–6 min
+warm, tests and VM smoke overlapping in parallel).
+
+```mermaid
+graph LR
+  subgraph gates [Quick gates ~2 min]
+    fmt[fmt]
+    clippy[clippy]
+    deny[cargo-deny]
+  end
+  pre[preflight: classify changed paths] --> buildL & buildG & buildM
+  buildL[build-linux x86_64<br/>workspace + nextest archive<br/>+ x86_64-musl guest] --> testL[test-linux<br/>nextest + doctests<br/>+ process-mode e2e]
+  buildL --> vmL[vm-smoke-linux<br/>KVM + libkrun boot<br/>vsock round-trip]
+  buildG[build-guest-arm64<br/>ubuntu-24.04-arm<br/>aarch64-musl guest] --> vmM
+  buildM[build-test-macos<br/>hosted macos arm64<br/>build + unit tests] --> vmM[vm-smoke-macos<br/>self-hosted Mac<br/>trusted refs only]
+  fmt & clippy & deny --> ok((ci-ok))
+  testL & vmL & buildM --> ok
+  vmM -.gated.-> ok
+```
+
+---
+
+## 2. Platform facts that constrain the design
+
+These five facts, all verified against primary sources, dictate the shape:
+
+1. **`/dev/kvm` is available on every x86_64 Linux hosted runner** — larger runners since
+   Feb 2023, the standard 2-vCPU `ubuntu-latest` since Apr 2024
+   ([changelog](https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/)).
+   One permissions step is required (udev rule, §5). Live proof: **libkrun's own CI boots
+   real microVMs with a guest agent over vsock on plain hosted runners, on every PR**
+   ([integration_tests.yml](https://github.com/libkrun/libkrun/blob/main/.github/workflows/integration_tests.yml)).
+   Caveat: GitHub has declined to document nested virt as supported
+   ([runner-images#12933](https://github.com/actions/runner-images/issues/12933)) —
+   the Android-emulator ecosystem depends on it so regression risk is low, but nonzero.
+
+2. **arm64 Linux hosted runners (`ubuntu-24.04-arm`) have no `/dev/kvm`**
+   ([community discussion](https://github.com/orgs/community/discussions/148648)). Linux
+   arm64 is out of scope for this project's targets, but these runners are still useful:
+   they build the aarch64 guest binary natively (fact 5).
+
+3. **Hosted macOS runners cannot create VMs.** They are themselves M1/M2 VMs under Apple's
+   Virtualization framework; Hypervisor.framework calls fail with `HV_UNSUPPORTED`
+   ([runner-images#9460](https://github.com/actions/runner-images/issues/9460)). Apple's
+   nested-virt support (macOS 15+) requires M3/M4 hosts and only covers Linux guests;
+   GitHub's request to enable it was **closed "not planned"**
+   ([runner-images#13505](https://github.com/actions/runner-images/issues/13505)).
+   → Exercising libkrun/HVF on macOS in CI requires **bare-metal Apple Silicon**
+   (self-hosted). This holds for *every* VM-based macOS provider (Tart, Orka, Anka,
+   GitLab, Cirrus hosted) — bare metal is the only way.
+
+4. **libkrun's vsock needs nothing from the CI host kernel.** libkrun implements
+   virtio-vsock in userspace; the host side of every guest vsock port is a plain
+   **AF_UNIX socket** (`krun_add_vsock_port`), and TSI networking rides the same device
+   ([libkrun.h](https://github.com/libkrun/libkrun/blob/main/include/libkrun.h)).
+   No `vhost-vsock` module, no `modprobe`, no host AF_VSOCK support. The only host
+   requirements are `/dev/kvm` (Linux) or the HVF entitlement (macOS). This is the same
+   "hybrid vsock" design as
+   [Firecracker](https://github.com/firecracker-microvm/firecracker/blob/main/docs/vsock.md),
+   and it is what makes VM smoke tests viable on hosted runners at all.
+
+5. **The guest daemon is always a Linux binary**, even for macOS hosts (libkrun boots a
+   Linux microVM there). Build it as a static musl binary per host arch:
+   - `x86_64-unknown-linux-musl` — natively on `ubuntu-latest` with `musl-tools`.
+   - `aarch64-unknown-linux-musl` — natively on `ubuntu-24.04-arm` (free for public
+     repos since Aug 2025, private standard runners since Jan 2026;
+     [GA changelog](https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/)).
+     No cross toolchain, no Docker/`cross`, no zigbuild needed in CI.
+   musl-static guest agents are the ecosystem norm (kata-containers' `kata-agent`,
+   libkrun's own test `guest-agent`).
+
+---
+
+## 3. Test taxonomy
+
+Order tests by cost; push each test into the cheapest tier that can catch its failure.
+
+| Tier | What | Where | Cost |
+|---|---|---|---|
+| 1 | `cargo fmt --check`, `cargo clippy --all-targets`, `cargo-deny` | any runner, no VM | seconds–2 min |
+| 2 | unit + integration tests (`cargo nextest run`), `cargo test --doc` | Linux + macOS runners | minutes, warm-cached |
+| 3 | **process-mode e2e** — guest daemon as a plain process, direct client connection | Linux runners, no KVM needed | minutes |
+| 4 | **VM smoke e2e** — boot real libkrun VM, client → vsock proxy → guest daemon round-trip, handful of scenarios | `ubuntu-latest` (KVM) + self-hosted Mac | ~5–10 min |
+| 5 | extended e2e — long scenarios, supervision/restart paths, stress, larger matrix | nightly | tens of minutes |
+
+**Tier 3 is this project's structural advantage.** The Linux no-KVM fallback (guest daemon
+connects directly to the client) means the full client↔guest protocol, lifecycle, and
+supervision logic can be tested with zero virtualization — deterministic, fast, runnable
+on any runner. This is exactly gVisor's platform strategy (`systrap` everywhere, `kvm`
+where hardware allows: [platform guide](https://gvisor.dev/docs/architecture_guide/platforms/)).
+Firecracker and cloud-hypervisor have no such mode and carry permanent bare-metal fleets
+just to gate PRs; the process mode avoids that fate.
+
+**Write the e2e suite once, parametrized over transport** (process-direct vs VM+vsock) —
+gVisor-style target duplication — rather than maintaining two suites. Tier 4 then only
+needs to prove the VM/vsock/boot path itself, so a *handful* of smoke scenarios suffices
+on PR; behavioral breadth lives in tier 3.
+
+**Tagging:** keep VM tests out of default `cargo test` runs with nextest's
+`default-filter` (e.g. `default-filter = 'not test(vm_e2e)'`) and select them explicitly
+in the VM jobs with filtersets (`-E 'test(vm_e2e)'`)
+([nextest filtersets](https://nexte.st/docs/filtersets/)). Reference nextest CI profile
+(cloud-hypervisor uses `retries = 3` for flaky VM boots,
+[.config/nextest.toml](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/.config/nextest.toml)):
+
+```toml
+# .config/nextest.toml
+[profile.ci]
+retries = 2
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 5 }   # hard kill hung VM boots
+
+[profile.ci.junit]
+path = "junit.xml"
+```
+
+Harness rules (firecracker/lima consensus): every VM test times out, expects a clean
+environment, and leaves one behind (kill leaked VMs in teardown; nextest's `leak-timeout`
+flags leaked child processes); always capture guest console/serial output and upload as
+a workflow artifact with `if: always()`.
+
+---
+
+## 4. Build & cache strategy
+
+### Cache: `Swatinem/rust-cache@v2`, not sccache
+
+The consensus across corrode.dev, rustprojectprimer, and independent measurements: on
+hosted runners, [rust-cache](https://github.com/Swatinem/rust-cache) wins. sccache's GHA
+backend **never caches bin/dylib/proc-macro crates** (anything that links), is slower
+than a warm target-dir hit, and regresses cold builds (Depot measured −16.8% cold,
+−27.7% on release builds). Revisit sccache only if moving to runner providers with
+co-located object storage (Depot, Namespace).
+
+Configuration rules:
+
+- **`shared-key` per (target-triple × job class)** — rust-cache does not key on
+  `--target` automatically; jobs building different triples or feature sets must not
+  share a key, and jobs building identically should (e.g. `build-linux` and
+  `vm-smoke-linux` share, if the latter compiles anything at all).
+- **`save-if: ${{ github.ref == 'refs/heads/main' }}`** — PRs restore but never write.
+  GitHub cache is branch-scoped (PRs read own branch + default branch only) and
+  LRU-evicts at 10 GB (raisable since Nov 2025, but stay under it). PR churn writing
+  caches evicts the main caches every PR actually wants.
+- `CARGO_INCREMENTAL=0` (rust-cache sets it automatically; incremental is pure overhead
+  and bloat in CI).
+- Dedicated CI profile to shrink `target/` and speed linking, without touching dev builds:
+
+```toml
+# Cargo.toml
+[profile.ci]
+inherits = "dev"
+debug = "line-tables-only"   # or 0; usable backtraces vs smallest cache
+incremental = false
+```
+
+### Compile once per target, fan out
+
+The workspace compiles **exactly once per target triple**; everything downstream consumes
+artifacts:
+
+1. **`cargo nextest archive --archive-file tests.tar.zst`** in the build job →
+   `actions/upload-artifact` → test jobs download and
+   `cargo nextest run --archive-file ...` with **no toolchain-warm-cache rebuild at all**
+   ([canonical example](https://github.com/nextest-rs/reuse-build-partition-example/blob/main/.github/workflows/ci.yml)).
+   Test jobs need a same-revision checkout for fixtures, nothing else.
+2. **Guest musl binaries** built once per arch → artifact → consumed by VM-smoke jobs
+   and the host-daemon packaging step.
+3. Doctests are the one thing nextest can't run — keep a cheap `cargo test --doc` step
+   in the build job (compiles against the already-built lib).
+
+Avoid the classic redundancy traps:
+
+- Don't run `cargo build` then `cargo test` as separate compilations — test artifacts
+  differ (`#[cfg(test)]`, dev-deps). The archive pattern sidesteps this.
+- **Identical flags everywhere**: `--locked` on every cargo invocation; uniform
+  `RUSTFLAGS` (or prefer `CARGO_BUILD_WARNINGS: deny` over `RUSTFLAGS: -Dwarnings` —
+  RUSTFLAGS participates in fingerprints and forks caches when it drifts between jobs).
+- **Feature unification**: always drive CI with the same feature set (`--workspace`
+  with a fixed feature list). `cargo build -p foo` resolves different unified features
+  than `--workspace` → same deps rebuilt twice. If per-crate builds are ever needed,
+  [cargo-hakari](https://crates.io/crates/cargo-hakari)'s workspace-hack is the escape hatch.
+- Install CI tools (nextest, cargo-deny) via
+  [taiki-e/install-action](https://github.com/taiki-e/install-action) (prebuilt
+  binaries) — never `cargo install` in CI.
+- Toolchain: pin with `rust-toolchain.toml` + `dtolnay/rust-toolchain`.
+
+### Embedding the guest binary
+
+Cargo's proper mechanism (artifact dependencies / `bindeps`,
+[RFC 3028](https://rust-lang.github.io/rfcs/3028-cargo-binary-dependencies.html)) is
+**still nightly-only with open musl cross-compile bugs** — not usable on a stable
+toolchain. The pattern every VMM project uses instead is *guest assets as external
+artifacts with a local-build fallback*:
+
+- build.rs on the host daemon reads an env var pointing at the guest binary
+  (`GUEST_DAEMON_PATH`), `include_bytes!`s it (or packages it beside the binary);
+  `cargo:rerun-if-env-changed` keeps it correct.
+- In CI the env var points at the downloaded artifact; locally, an `xtask` builds the
+  guest for the current arch first and sets the var. (Firecracker downloads guest
+  artifacts from S3; crosvm from GCS; propolis via an artifact TOML with
+  remote/local/CI-output sources — same shape.)
+
+---
+
+## 5. PR pipeline
+
+All jobs carry `timeout-minutes` (default job timeout is 6 h) and the workflow carries:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+```
+
+**Jobs** (see diagram in §1):
+
+| Job | Runner | Does | Est. (warm) |
+|---|---|---|---|
+| `fmt` | ubuntu-latest | `cargo fmt --check` — no cache, no deps | <1 min |
+| `clippy` | ubuntu-latest | `cargo clippy --workspace --all-targets --locked` (own cache key; clippy shares artifacts with `check`, not `build`) | 2–4 min |
+| `deny` | ubuntu-latest | `cargo-deny check` — **licenses/bans blocking; advisories `continue-on-error`** (Embark's own recommendation: a newly published advisory must not break unrelated PRs) | 1 min |
+| `preflight` | ubuntu-latest | classify changed paths (cloud-hypervisor pattern); docs-only changes skip everything below | seconds |
+| `build-linux` | ubuntu-latest | workspace build, `nextest archive`, `cargo test --doc`, x86_64-musl guest → upload artifacts | 4–6 min |
+| `build-guest-arm64` | ubuntu-24.04-arm | aarch64-musl guest → artifact | 2–3 min |
+| `test-linux` | ubuntu-latest | nextest from archive (tier 2) + **process-mode e2e** (tier 3) | 2–4 min |
+| `vm-smoke-linux` | ubuntu-latest | KVM perms step → boot libkrun VM with real guest daemon → client→vsock→guest round-trip smoke; console logs uploaded `if: always()` | 3–6 min |
+| `build-test-macos` | macos-15 (arm64) | build + unit tests, **no VM** | 4–6 min |
+| `vm-smoke-macos` | self-hosted Mac | download client/host-daemon (from macOS build) + aarch64 guest artifacts → libkrun/HVF smoke. **Gated** (§7): same-repo PRs via label, always on main/merge-queue | 3–6 min |
+| `ci-ok` | ubuntu-latest | join job, `needs:` everything, `if: always()` + fail-on-any-failure | seconds |
+
+The KVM permissions step (used by GitHub's own changelog, android-emulator-runner, and
+libkrun):
+
+```yaml
+- name: Enable KVM group perms
+  run: |
+    echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+      | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger --name-match=kvm
+```
+
+**Why `ci-ok` and `preflight` instead of workflow-level `paths:` filters:** a
+`paths:`-filtered workflow that is also a required check leaves PRs stuck at *"Waiting
+for status to be reported"*. A single always-running join job as the only required check,
+with an in-workflow preflight deciding what to skip, avoids the deadlock entirely — and
+makes adding/removing jobs a workflow-only change, not a branch-protection change.
+
+**Merge queue (optional but recommended once the team grows):** add `merge_group:` as a
+trigger; run the *full* set (including `vm-smoke-macos` unconditionally) in the queue,
+wasmtime-style, and consider trimming PR runs further (wasmtime PRs default to smoke-only
+with `prtest:full` opt-in).
+
+---
+
+## 6. Nightly pipeline (cron on main)
+
+Everything here is valuable but either too slow, too flaky-adjacent, or not tied to a
+specific PR:
+
+| Task | Rationale / precedent |
+|---|---|
+| **Extended e2e** (tier 5): long-running scenarios, VM supervision/restart/kill paths, stress, both platforms | rustls daily-tests rule: move out of PR CI what is "too long or relies on flaky externals" |
+| **Toolchain canaries**: full test run on `beta` and `nightly` rustc, `continue-on-error: true` | catch upcoming rustc breakage without blocking merges (official Cargo CI guide) |
+| **`cargo-deny` advisories** (blocking here, non-blocking on PR) | tokio/wasmtime run advisories daily; wasmtime keeps it non-blocking because the advisory DB fetch itself flakes |
+| **Latest-deps canary**: `cargo update` then test, `continue-on-error` | Cargo CI guide pattern; catches semver-compatible breakage early |
+| **MSRV**: `cargo hack check --rust-version --workspace --all-targets` | cheap enough for PR too, if an MSRV is declared; official Cargo guide method |
+| **miri** on pure protocol/logic crates (vsock framing, supervision state machines) | expensive; high value on unsafe/protocol code |
+| **Hygiene**: `cargo-machete` (unused deps), `actionlint` + `zizmor` (workflow lint/security) | low cost, low urgency |
+| **Cache priming**: the nightly run itself writes fresh caches on main | wasmtime runs a daily cron explicitly to "prime caches for GitHub Actions and the merge queue" |
+
+Nightly failures should notify (issue-on-failure or Slack), not just rot in the Actions tab.
+
+---
+
+## 7. Self-hosted Mac runner
+
+- **Hardware**: bare-metal Apple Silicon — a Mac mini in a closet, Scaleway/MacStadium
+  bare metal, or Cirrus persistent workers. EC2 Mac works but has a 24-hour minimum host
+  allocation (poor fit for CI economics). Any macOS *VM* product cannot nest HVF (§2.3).
+- **Security — the critical one**: a self-hosted runner on a public repo must **never run
+  fork PRs** (arbitrary code execution on your hardware, runner token theft). Gate
+  `vm-smoke-macos` to trusted events: `push` to main, `merge_group`,
+  `workflow_dispatch`, and same-repo PRs (`github.event.pull_request.head.repo.full_name
+  == github.repository`) optionally behind a label + GitHub environment with required
+  approval. Podman's `mac-pool` job group is the working precedent.
+- **Serialize** VM jobs on the machine with a concurrency group sized to the hardware
+  (`group: mac-vm-tests`), since libkrun VMs contend for HVF/memory.
+- **Cleanup as a contract**: persistent runners accumulate state; run a cleanup script in
+  a `post`/`if: always()` step killing leaked VMs and scrubbing temp dirs (podman ships
+  `gha_mac_cleanup.sh` pre *and* post).
+- **darwin gotcha**: Unix socket paths (the host side of libkrun vsock ports) hit macOS's
+  104-byte `sun_path` limit — podman rejects `TMPDIR` ≥ 22 chars on darwin for exactly
+  this reason. Keep the harness's socket dir short (`/tmp/x`), never under the default
+  runner workspace path.
+- Build nothing on this machine: hosted `macos-15` builds the darwin binaries, the arm
+  Linux runner builds the guest; the Mac only downloads artifacts and runs the smoke
+  suite (podman pattern). Keeps the trusted machine's job simple and short.
+
+---
+
+## 8. Local/CI parity: `cargo xtask`
+
+The failure mode to avoid is CI YAML drifting from what developers run. This project's CI
+steps involve real logic — building the guest for the right arch, wiring the
+`GUEST_DAEMON_PATH` env var, orchestrating VM smoke runs, collecting console logs — which
+is Rust code, not a command list. Use the
+[cargo-xtask pattern](https://github.com/matklad/cargo-xtask):
+
+- `cargo xtask build-guest [--arch aarch64]` — musl guest build + env wiring
+- `cargo xtask e2e --transport process|vm` — the exact suite CI runs
+- `cargo xtask ci` — the full PR-equivalent locally
+
+CI YAML stays a thin scheduler over the same commands (bevy runs `cargo run -p ci` in CI
+and tells contributors to run the identical command; propolis wraps its VM test runner in
+`cargo xtask phd`). A justfile is a fine lighter-weight alternative if the logic stays
+trivial, but VM orchestration rarely does.
+
+---
+
+## 9. What runs where
+
+| Task | PR | main / merge queue | Nightly |
+|---|:---:|:---:|:---:|
+| fmt, clippy, cargo-deny (licenses/bans) | ✅ | ✅ | ✅ |
+| cargo-deny advisories | ⚠️ non-blocking | ⚠️ | ✅ blocking |
+| Workspace build + unit/integration tests (Linux x86_64, macOS arm64) | ✅ | ✅ | ✅ |
+| Doctests | ✅ | ✅ | ✅ |
+| Process-mode e2e (Linux) | ✅ | ✅ | ✅ |
+| VM smoke e2e — Linux/KVM (hosted) | ✅ | ✅ | ✅ |
+| VM smoke e2e — macOS/HVF (self-hosted) | label / same-repo only | ✅ | ✅ |
+| Extended e2e, stress, supervision/restart | — | — | ✅ |
+| beta/nightly rustc canaries | — | — | ✅ non-blocking |
+| MSRV (`cargo hack check --rust-version`) | optional | — | ✅ |
+| `cargo update` latest-deps canary | — | — | ✅ non-blocking |
+| miri (protocol crates), cargo-machete, actionlint/zizmor | — | — | ✅ |
+| Cache write (`save-if`) | ❌ restore-only | ✅ | ✅ (primes caches) |
+
+---
+
+## 10. Extending CI without editing workflows — the agent & developer contract
+
+Contributors (human or agent) are required to ship tests and proofs with their work, but
+must never modify `.github/workflows/`. The industry answer is **not** appendable stub
+scripts — it is two mechanisms working together: freeze the workflow layer mechanically,
+and make every test **discovered by convention, never registered**.
+
+### 10.1 Freeze the workflow layer mechanically
+
+Instructions alone ("don't touch GitHub Actions") are policy; enforce them structurally:
+
+- **CODEOWNERS**: `/.github/ @norrie` plus branch protection "require code owner
+  review" — any PR touching workflows is un-mergeable without human sign-off, no matter
+  who or what authored it. This is the standard control; GitHub already treats workflow
+  edits as privileged (fork PRs modifying workflows don't run with secrets).
+- **Preflight guard**: the existing `preflight` job fails fast if a PR from an
+  agent-labeled branch modifies `.github/**` — cheap belt-and-suspenders, and it gives
+  agents an immediate, legible error instead of a review-time rejection.
+- When humans *do* edit workflows: `actionlint` + `zizmor` (already in nightly) and
+  SHA-pinned actions.
+
+The reason the YAML can stay frozen at all is §8: workflows are thin schedulers over
+`cargo xtask` commands. All logic that evolves — harness code, scenario wiring, artifact
+handling — lives in the `xtask` crate, which is ordinary Rust reviewed like any other
+code. Agents *may* modify the harness; they may not modify the scheduler.
+
+### 10.2 Every test is auto-discovered
+
+The contract: **adding a test never requires a CI change.** Choose the tier by where the
+test lives and what it's named; the matching CI job picks it up automatically.
+
+| Test kind | Where it goes | How CI discovers it | Local proof command |
+|---|---|---|---|
+| Unit | `#[cfg(test)]` module next to the code | cargo/nextest target discovery | `cargo xtask test` |
+| Integration | `crates/<crate>/tests/*.rs` | cargo target discovery | `cargo xtask test` |
+| E2E (transport-agnostic) | e2e test crate, written against the transport-parametrized harness (§3) | nextest filterset, e.g. `-E 'test(e2e_)'` — runs under *both* process and VM transports | `cargo xtask e2e --transport process` |
+| VM-only e2e | same crate, `vm_e2e_` name prefix (or a nextest per-test override) | VM jobs' filterset `-E 'test(vm_e2e_)'` | `cargo xtask e2e --transport vm` |
+| CLI smoke scenario | **one file per scenario** in `tests/smoke/` — [`trycmd`](https://github.com/assert-rs/trycmd) `.toml`/`.trycmd` case files, or a directory the xtask harness globs | harness globs the directory | `cargo xtask smoke` |
+
+Naming conventions are load-bearing here, so guard them: run nextest with
+`--no-tests=fail` in every job, so a filterset that matches nothing (typo'd prefix,
+renamed module) fails loudly instead of green-washing the PR. A tiny meta-test in the
+harness can additionally assert that every test in the e2e crate matches one of the
+known filtersets — nothing silently falls out of CI.
+
+### 10.3 Why one-file-per-scenario beats append-to-script stubs
+
+The tempting design — `scripts/e2e.sh` with a `# agents: append tests below` marker — is
+an anti-pattern:
+
+- **Merge conflicts by construction**: parallel agents all append to the same tail of the
+  same file. One scenario per file means N agents produce N independent, conflict-free
+  diffs; reverting one test is deleting one file.
+- **Ordering coupling**: appended script blocks inherit shell state from everything above
+  them; failures become position-dependent and unreproducible in isolation.
+- **No compiler in the loop**: shell appended by an agent gets reviewed by nobody but the
+  reviewer; a Rust test or a trycmd case file is checked by the toolchain and runs under
+  the harness's timeouts, retries, and log capture for free.
+
+This is the pattern every discovery-based test system uses (cargo's target discovery,
+pytest collection, LLVM `lit`, rustc's `run-make` — a directory of self-contained cases,
+globbed by the runner). The stable extension points to advertise to agents are therefore:
+(a) cargo test locations — automatic; (b) the `tests/smoke/` scenario directory —
+globbed; (c) `xtask` subcommands — code-reviewed Rust, for when a genuinely new *kind* of
+check is needed. That last one is the escape hatch that keeps the first two honest: new
+capabilities go through the harness as reviewed code, never through YAML.
+
+### 10.4 Proofs
+
+"Provide proofs" becomes cheap when local and CI runs are identical (§8):
+
+- `cargo xtask ci` produces the same artifacts CI does — nextest JUnit XML, VM console
+  logs, smoke-scenario transcripts. An agent's proof-of-work is that output attached to
+  the PR; the reviewer re-derives it by reading the CI run, not by trusting the claim.
+- CI publishes the JUnit summary to `$GITHUB_STEP_SUMMARY` (libkrun's `--github-summary`
+  flag is precedent), so per-PR test evidence is visible without downloading artifacts.
+- Optional soft gate: `preflight` warns (labels, doesn't fail) when a PR touches `src/`
+  without touching any test path — a nudge, with the real enforcement left to review.
+
+Document this contract in `CONTRIBUTING.md` / the agents' instruction file as a short
+table (test kind → location → local command), and point CI failure messages at it.
+
+---
+
+## Appendix A — prior art (what named projects actually do)
+
+- **libkrun** — full VM integration tests **on every PR** on hosted `ubuntu-26.04`
+  (udev KVM step, musl-static `guest-agent` inside the VM, host/guest test halves over
+  vsock, `--keep-all` log artifacts on `always()`); aarch64 on self-hosted; **no macOS VM
+  job at all** (krunkit does build+unit only on `macos-latest`).
+  [integration_tests.yml](https://github.com/libkrun/libkrun/blob/main/.github/workflows/integration_tests.yml)
+- **podman (libkrun provider)** — the best macOS answer: binaries built on hosted
+  `macos-26`, artifacts downloaded by a self-hosted `mac-pool` runner group, matrix over
+  `provider: [applehv, libkrun]`, pre/post cleanup scripts, path-filtered.
+  [ci.yml](https://github.com/podman-container-tools/podman/blob/main/.github/workflows/ci.yml)
+- **cloud-hypervisor** — nextest-driven integration tests (retries=3, hard per-test
+  kill) in containers with `/dev/kvm` passed in, on self-hosted bare metal; `preflight`
+  change-classification job; everything PR/merge-queue gated.
+  [ci.yaml](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/.github/workflows/ci.yaml),
+  [nextest.toml](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/.config/nextest.toml)
+- **firecracker** — pytest harness on AWS bare metal (Buildkite): layered VM fixtures,
+  always-collect-cheap-artifacts, `nonci` markers exclude heavy tests from PR, perf/
+  sanitizers scheduled. [tests/README](https://github.com/firecracker-microvm/firecracker/blob/main/tests/README.md)
+- **wasmtime** — PRs run smoke-only by default with `prtest:full` opt-in; **full CI in
+  the merge queue**; daily cron exists to prime caches; cargo-audit daily, non-blocking.
+  [main.yml](https://github.com/bytecodealliance/wasmtime/blob/main/.github/workflows/main.yml)
+- **tokio** — cheap `basics` job gates all expensive jobs via `needs:`; loom
+  model-checking label-gated on PRs, full on master; cargo-deny daily + on lockfile-touching PRs.
+  [ci.yml](https://github.com/tokio-rs/tokio/blob/master/.github/workflows/ci.yml)
+- **rustls** — MSRV + cargo-deny blocking on PR; daily cron for internet-touching,
+  post-quantum, and feature-powerset tests.
+  [build.yml](https://github.com/rustls/rustls/blob/main/.github/workflows/build.yml),
+  [daily-tests.yml](https://github.com/rustls/rustls/blob/main/.github/workflows/daily-tests.yml)
+- **gVisor** — same behavioral suite duplicated across `systrap` (no virt) and `kvm`
+  platforms — the precedent for this project's process-mode/VM-mode transport split.
+  [platforms](https://gvisor.dev/docs/architecture_guide/platforms/)
+
+## Appendix B — key sources
+
+**Runner capabilities**
+- KVM on all Linux x64 runners: https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/
+- No KVM on arm64 runners: https://github.com/orgs/community/discussions/148648
+- macOS nested virt unsupported / closed not-planned: https://github.com/actions/runner-images/issues/9460 , https://github.com/actions/runner-images/issues/13505
+- Nested virt "experimental" stance: https://github.com/actions/runner-images/issues/12933
+- arm64 Linux runners GA: https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/
+
+**libkrun / vsock**
+- https://github.com/libkrun/libkrun (README, include/libkrun.h)
+- https://github.com/libkrun/libkrun/blob/main/.github/workflows/integration_tests.yml
+- https://github.com/firecracker-microvm/firecracker/blob/main/docs/vsock.md
+
+**Caching / build speed**
+- https://github.com/Swatinem/rust-cache
+- https://corrode.dev/blog/tips-for-faster-ci-builds/
+- https://blog.arriven.wtf/posts/rust-ci-cache/ (rust-cache vs sccache measurements)
+- https://depot.dev/blog/sccache-in-github-actions (sccache cold-cache regressions)
+- https://doc.rust-lang.org/cargo/guide/continuous-integration.html
+- https://doc.rust-lang.org/cargo/guide/build-performance.html
+- https://nickb.dev/blog/cargo-workspace-and-the-feature-unification-pitfall/
+- Cache >10 GB purchasable: https://github.blog/changelog/2025-11-20-github-actions-cache-size-can-now-exceed-10-gb-per-repository/
+
+**nextest**
+- Archives (build once, run anywhere): https://nexte.st/docs/ci-features/archiving/
+- Filtersets / default-filter: https://nexte.st/docs/filtersets/ , https://nexte.st/docs/selecting/
+- Example workflow: https://github.com/nextest-rs/reuse-build-partition-example/blob/main/.github/workflows/ci.yml
+
+**Guest binary building / embedding**
+- Embedding a binary in a binary: https://zameermanji.com/blog/2021/6/17/embedding-a-rust-binary-in-another-rust-binary/
+- bindeps still nightly, musl bugs: https://github.com/rust-lang/cargo/issues/9096 , https://github.com/rust-lang/cargo/issues/15095
+- kata-agent musl/rootfs: https://github.com/kata-containers/kata-containers/blob/main/tools/osbuilder/rootfs-builder/README.md
+
+**Conventions**
+- cargo-deny advisories non-blocking: https://github.com/EmbarkStudios/cargo-deny-action
+- xtask pattern: https://github.com/matklad/cargo-xtask
+- Task-runner comparison: https://rustprojectprimer.com/tools/tasks.html
+- Required-check paths-filter deadlock: https://github.com/orgs/community/discussions/44490

--- a/scripts/soak-session-e2e.sh
+++ b/scripts/soak-session-e2e.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Soak harness: run the unified session e2e (scripts/session-e2e.sh) N times
+# back-to-back against a VM-backed target, reaping leftover VM processes
+# between iterations, to shake out the boot / first-connect raciness (the
+# vsock-bridge wedge class) that a single PR-lane run cannot surface. Reports
+# a pass/fail tally and exits non-zero if ANY iteration failed.
+#
+# The caller sets the VM up exactly as the KVM lane does — minvmd + minimal
+# on PATH, MINVMD_KERNEL_PATH / MINVMD_ROOTFS_PATH / MINVMD_INITRAMFS set,
+# libkrun on the loader path — and passes the VM knobs through the
+# environment (E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd E2E_PROJECT_DIR=/tmp),
+# same as the lane invocation. Each iteration runs session-e2e.sh, which
+# creates its own fresh XDG state, so every pass is a clean cold start.
+#
+# Usage: scripts/soak-session-e2e.sh [iterations] [boot-log-dir]
+set -uo pipefail
+
+ITER="${1:-10}"
+LOGDIR="${2:-$(mktemp -d /tmp/mnl-soak.XXXXXX)}"
+mkdir -p "$LOGDIR"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Reap leftovers a failed boot may strand (Guest::drop kills only its own
+# minvmd; the detached __krun-vmm grandchild and the gvproxy switch can
+# linger and wedge the next iteration's bridge). sudo: relay leftovers can
+# be root-owned.
+reap() {
+  sudo pkill -x minvmd 2>/dev/null || true
+  sudo pkill -f __krun-vmm 2>/dev/null || true
+  sudo pkill -f gvproxy 2>/dev/null || true
+}
+
+pass=0
+fail=0
+for i in $(seq 1 "$ITER"); do
+  echo "::group::soak iteration $i/$ITER"
+  reap
+  if MINVMD_BOOT_LOG="$LOGDIR/boot-$i.log" "$ROOT/scripts/session-e2e.sh"; then
+    pass=$((pass + 1))
+    echo "iteration $i: OK"
+  else
+    fail=$((fail + 1))
+    echo "::warning::soak iteration $i FAILED"
+  fi
+  echo "::endgroup::"
+done
+reap
+
+echo "soak complete: $pass passed, $fail failed (of $ITER)"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Two mid-soak additions that touch no lane workflow.

Nightly test tier (nightly-tests.yml, 06:00 UTC — distinct from nightly.yml's release-channel cut):
- advisories: cargo-deny check advisories, BLOCKING (the between-PRs counterpart of the PR-side check);
- session-e2e-soak: builds minvmd + the CLI, then loops the unified session e2e x10 with an inter-iteration reap (scripts/soak-session- e2e.sh) to shake out the boot/first-connect wedge class a single PR-lane run can't surface;
- beta-canary + update-canary: workspace suite on beta rustc and on freshly-updated deps, continue-on-error (the pin/lock are the gate);
- hygiene: actionlint + zizmor + cargo-machete, non-blocking;
- notify: files/updates a tracking issue when a blocking job fails.
- drive-by: the missing timeout-minutes on promote.yml's promote job.

core-tests gains a save-if passthrough (canaries never write the shared pool) and publishes the nextest JUnit counts to the step summary; the ci profile now emits junit.xml.

Docs / freeze (the agent & developer contract, ci-strategy.md §10):
- docs/ci-strategy.md: the strategy doc with a repo-specific preamble (retires the untracked root copy);
- CONTRIBUTING.md: the test-extension contract table (test kind ->
  location -> how CI runs it -> local command) and the do-not-edit- workflows rule;
- CLAUDE.md: a pointer so agents inherit it;
- .github/CODEOWNERS: freeze /.github/ so workflow edits need an owner review (pair with 'require code owner review' at the ruleset flip).

Refs: #687