### PR TITLE
ci: add the nightly test tier

### DIFF
--- a/.github/actions/core-tests/action.yml
+++ b/.github/actions/core-tests/action.yml
@@ -10,6 +10,13 @@ inputs:
     description: rust-cache shared-key, forwarded to setup-rust.
     required: false
     default: tests
+  save-if:
+    description: >
+      Whether this job may write the cache, forwarded to setup-rust. Nightly
+      canaries pass "false" so a throwaway beta/updated-deps build never
+      consumes the shared pool the real lanes restore from.
+    required: false
+    default: ${{ github.ref == 'refs/heads/main' }}
 
 runs:
   using: composite
@@ -18,6 +25,7 @@ runs:
       uses: ./.github/actions/setup-rust
       with:
         shared-key: ${{ inputs.shared-key }}
+        save-if: ${{ inputs.save-if }}
     - name: Install nextest
       uses: taiki-e/install-action@v2
       with:

--- a/.github/workflows/ci-shell-installer.yml
+++ b/.github/workflows/ci-shell-installer.yml
@@ -16,6 +16,9 @@ on:
   push:
     branches: ["main"]
   workflow_dispatch:
+  # Reused by nightly-tests.yml to re-run the suite against a fresh runner
+  # image even when install.sh is untouched (runner-image shell drift).
+  workflow_call:
 
 # Cancel superseded runs on a branch; never cancel a run on main.
 concurrency:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -218,12 +218,17 @@ jobs:
         with:
           tool: cargo-machete,zizmor
       - name: actionlint (workflow lint)
-        # Pinned official image; no toolchain needed and it auto-discovers
-        # .github/workflows. Docker is preinstalled on ubuntu-latest.
+        # `if: always()` so a failed install (or an earlier failing check)
+        # doesn't skip the remaining hygiene checks — each should report on its
+        # own. actionlint itself needs no install (pinned official image; it
+        # auto-discovers .github/workflows; Docker is preinstalled).
+        if: always()
         run: docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.12 -color
       - name: cargo-machete (unused deps)
+        if: always()
         run: cargo machete
       - name: zizmor (workflow security)
+        if: always()
         run: zizmor .github/workflows/
 
   notify:
@@ -260,7 +265,10 @@ jobs:
           # would let back-to-back failing runs open duplicate issues.
           gh label create ci-nightly --repo "$GITHUB_REPOSITORY" \
             --color B60205 --description "Nightly test-tier failure" 2>/dev/null || true
-          body="$(printf 'A nightly-tests run failed.\n\n- advisories: %s\n- session-e2e-soak: %s\n- installer: %s\n\nRun: %s' \
+          # The trigger condition fires on both failure and cancellation (a
+          # timeout reports 'failure'); the per-job lines below carry the exact
+          # result, so keep the lead line accurate for either outcome.
+          body="$(printf 'A nightly-tests run failed or was cancelled.\n\n- advisories: %s\n- session-e2e-soak: %s\n- installer: %s\n\nRun: %s' \
             "$ADV" "$SOAK" "$INSTALLER" "$RUN_URL")"
           existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
             --label ci-nightly --json number --jq '.[0].number // empty')"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,271 @@
+name: nightly-tests
+
+# Nightly TEST tier — distinct from nightly.yml (which cuts + blesses the
+# `nightly` release channel). This runs the checks that are too slow, too
+# flaky-adjacent, or not tied to a specific PR: an advisory re-check, a
+# repeated session-e2e soak, toolchain/dependency canaries, and workflow
+# hygiene. A blocking-job failure files (or updates) a tracking issue rather
+# than rotting in the Actions tab.
+on:
+  schedule:
+    - cron: "0 6 * * *" # 06:00 UTC — offset from nightly.yml's 10:00
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never overlap a slow soak with the next night's run.
+concurrency:
+  group: nightly-tests
+  cancel-in-progress: false
+
+jobs:
+  advisories:
+    # cargo-deny advisories, BLOCKING here — the between-PRs counterpart of
+    # the PR-side `cargo-deny` (which stays blocking too). Catches RUSTSEC
+    # advisories published since the last PR touched the tree. Feeds notify.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories
+
+  session-e2e-soak:
+    # Boot a real microVM and round-trip a full session ten times to shake
+    # out the boot / first-connect raciness that a single PR-lane run cannot
+    # surface. Self-contained: builds minvmd + the CLI, materializes the
+    # guest images, then loops scripts/soak-session-e2e.sh.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+    steps:
+      - name: Free Disk Space
+        uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install build dependencies
+        run: |
+          sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends \
+               protobuf-compiler libprotobuf-dev cpio git'
+      - name: Install cross
+        # build-initramfs.sh cross-compiles the guest minimald to static musl;
+        # install the prebuilt cross like the KVM lane so it never falls back
+        # to `cargo install cross` from source inside this blocking job.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+      - name: Enable /dev/kvm access
+        run: |
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm not present on this runner." >&2
+            exit 1
+          fi
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Cache cargo + build artifacts
+        # Shares the KVM lane's build cache key (same minvmd + CLI compile);
+        # a scheduled run on main also writes it back, keeping it warm.
+        id: cargo-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-x86_64-minvmd-kvm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-x86_64-minvmd-kvm-
+      - name: Materialize libkrun prefix (upstream package)
+        uses: ./.github/actions/setup-libkrun-linux
+        with:
+          arch: x86_64
+      - name: Build guest initramfs (minimald as /init)
+        run: ./scripts/build-initramfs.sh "$RUNNER_TEMP/initramfs.cpio" x86_64-unknown-linux-musl
+      - name: Build minvmd + the CLI
+        # Separate invocations: a combined build feature-unifies libkrun into
+        # the CLI (the regression the macOS lane guards).
+        run: |
+          cargo build -p minvmd --bin minvmd --locked
+          cargo build -p minimal --bin minimal --locked
+      - name: Materialize guest kernel (raw Image)
+        uses: ./.github/actions/materialize
+        with:
+          output: virtio-kernel
+          dest: ${{ runner.temp }}/vmlinuz
+          arch: x86_64
+          channel: unstable
+      - name: Materialize guest rootfs (ext4 image)
+        uses: ./.github/actions/materialize
+        with:
+          output: minvmd-rootfs
+          dest: ${{ runner.temp }}/rootfs.img
+          arch: x86_64
+          channel: unstable
+      - name: Soak the session e2e (x10)
+        env:
+          MINVMD_KERNEL_PATH: ${{ runner.temp }}/vmlinuz
+          MINVMD_ROOTFS_PATH: ${{ runner.temp }}/rootfs.img
+          MINVMD_INITRAMFS: ${{ runner.temp }}/initramfs.cpio
+          E2E_VM: "1"
+          E2E_MINIMAL_ARGS: --minvmd
+          E2E_PROJECT_DIR: /tmp
+        run: |
+          export PATH="$PWD/target/debug:$PATH"
+          ./scripts/soak-session-e2e.sh 10 "$RUNNER_TEMP/soak-logs"
+      - name: Save cargo + build artifacts cache (main only)
+        if: github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ steps.cargo-cache.outputs.cache-primary-key }}
+      - name: Upload soak boot logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: soak-boot-logs
+          path: ${{ runner.temp }}/soak-logs
+          if-no-files-found: ignore
+
+  beta-canary:
+    # Run the workspace suite on beta rustc to catch upcoming-toolchain
+    # breakage ahead of the 1.97.0 pin. Non-blocking (the pin is the gate);
+    # RUSTUP_TOOLCHAIN overrides rust-toolchain.toml for this job only.
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    continue-on-error: true
+    env:
+      RUSTUP_TOOLCHAIN: beta
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Beta toolchain
+        uses: dtolnay/rust-toolchain@beta
+      - name: Core workspace tests (beta)
+        uses: ./.github/actions/core-tests
+        with:
+          # Own cache class, and never write (a nightly beta build must not
+          # consume the shared pool the real lanes restore from).
+          shared-key: beta-canary
+          save-if: "false"
+
+  update-canary:
+    # Re-resolve every dependency to its newest semver-compatible version and
+    # run the suite, to catch upstream breakage early. Non-blocking.
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: cargo update (newest compatible deps)
+        run: cargo update
+      - name: Core workspace tests (updated deps)
+        uses: ./.github/actions/core-tests
+        with:
+          shared-key: update-canary
+          save-if: "false"
+
+  installer:
+    # Re-run the curl|sh installer suite (shellcheck + the POSIX-sh matrix,
+    # incl. macOS's frozen /bin/sh) nightly, so runner-image shell drift is
+    # caught even when nobody touches install.sh — the PR lane is path-scoped
+    # to it. Same definition, reused via workflow_call (no duplication).
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci-shell-installer.yml
+
+  hygiene:
+    # Workflow lint + unused-dependency check. Non-blocking; especially handy
+    # during CI surgery. Tool installs are best-effort under continue-on-error.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Install cargo-machete + zizmor
+        # Both are prebuilt binaries in taiki-e's manifest (zizmor is Rust,
+        # from zizmorcore/zizmor). actionlint is NOT — it runs from its
+        # pinned official image below.
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete,zizmor
+      - name: actionlint (workflow lint)
+        # Pinned official image; no toolchain needed and it auto-discovers
+        # .github/workflows. Docker is preinstalled on ubuntu-latest.
+        run: docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.12 -color
+      - name: cargo-machete (unused deps)
+        run: cargo machete
+      - name: zizmor (workflow security)
+        run: zizmor .github/workflows/
+
+  notify:
+    # File (or update) a tracking issue when a BLOCKING nightly job fails, so
+    # a regression doesn't rot in the Actions tab. Canaries are
+    # continue-on-error and deliberately do NOT trip this — read them in the
+    # run itself.
+    needs: [advisories, session-e2e-soak, installer]
+    # Fire on failure OR cancellation of a blocking job (a timeout reports
+    # 'failure', so hangs are covered; this also catches an infra cancel).
+    if: >-
+      always() &&
+      (needs.advisories.result == 'failure' || needs.advisories.result == 'cancelled'
+       || needs.session-e2e-soak.result == 'failure' || needs.session-e2e-soak.result == 'cancelled'
+       || needs.installer.result == 'failure' || needs.installer.result == 'cancelled')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the nightly-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ADV: ${{ needs.advisories.result }}
+          SOAK: ${{ needs.session-e2e-soak.result }}
+          INSTALLER: ${{ needs.installer.result }}
+        run: |
+          set -euo pipefail
+          title="Nightly test tier failing"
+          # Dedup by LABEL, not free-text title search: label filtering is
+          # immediately consistent, whereas the search index lags creation and
+          # would let back-to-back failing runs open duplicate issues.
+          gh label create ci-nightly --repo "$GITHUB_REPOSITORY" \
+            --color B60205 --description "Nightly test-tier failure" 2>/dev/null || true
+          body="$(printf 'A nightly-tests run failed.\n\n- advisories: %s\n- session-e2e-soak: %s\n- installer: %s\n\nRun: %s' \
+            "$ADV" "$SOAK" "$INSTALLER" "$RUN_URL")"
+          existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --label ci-nightly --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body" --label ci-nightly
+          fi

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -152,6 +152,7 @@ jobs:
     promote:
         needs: gate
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         permissions:
             contents: "read"
             id-token: "write"

--- a/scripts/reap-vms.sh
+++ b/scripts/reap-vms.sh
@@ -3,10 +3,12 @@
 # minvmd, its detached __krun-vmm grandchild, and the gvproxy switch. Any of
 # them wedges the next VM's host->guest vsock bridge (the leftover-wedge
 # class). Best-effort, and sudo because a relay leftover can be root-owned.
-# The proper fix is harness-side process-group reaping, tracked separately.
+# `sudo -n` keeps it non-interactive: without passwordless sudo it fails fast
+# instead of blocking on a password prompt in CI. The proper fix is
+# harness-side process-group reaping, tracked separately.
 #
 # Usage: scripts/reap-vms.sh
 set -u
-sudo pkill -x minvmd 2>/dev/null || true
-sudo pkill -f __krun-vmm 2>/dev/null || true
-sudo pkill -f gvproxy 2>/dev/null || true
+sudo -n pkill -x minvmd 2>/dev/null || true
+sudo -n pkill -f __krun-vmm 2>/dev/null || true
+sudo -n pkill -f gvproxy 2>/dev/null || true

--- a/scripts/reap-vms.sh
+++ b/scripts/reap-vms.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Kill leftover microVM host processes a failed or killed session can strand:
+# minvmd, its detached __krun-vmm grandchild, and the gvproxy switch. Any of
+# them wedges the next VM's host->guest vsock bridge (the leftover-wedge
+# class). Best-effort, and sudo because a relay leftover can be root-owned.
+# The proper fix is harness-side process-group reaping, tracked separately.
+#
+# Usage: scripts/reap-vms.sh
+set -u
+sudo pkill -x minvmd 2>/dev/null || true
+sudo pkill -f __krun-vmm 2>/dev/null || true
+sudo pkill -f gvproxy 2>/dev/null || true

--- a/scripts/soak-session-e2e.sh
+++ b/scripts/soak-session-e2e.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Soak harness: run the unified session e2e (scripts/session-e2e.sh) N times
+# back-to-back against a VM-backed target, reaping leftover VM processes
+# between iterations, to shake out the boot / first-connect raciness (the
+# vsock-bridge wedge class) that a single PR-lane run cannot surface. Reports
+# a pass/fail tally and exits non-zero if ANY iteration failed.
+#
+# The caller sets the VM up exactly as the KVM lane does — minvmd + minimal
+# on PATH, MINVMD_KERNEL_PATH / MINVMD_ROOTFS_PATH / MINVMD_INITRAMFS set,
+# libkrun on the loader path — and passes the VM knobs through the
+# environment (E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd E2E_PROJECT_DIR=/tmp),
+# same as the lane invocation. Each iteration runs session-e2e.sh, which
+# creates its own fresh XDG state, so every pass is a clean cold start.
+#
+# Usage: scripts/soak-session-e2e.sh [iterations] [boot-log-dir]
+set -uo pipefail
+
+ITER="${1:-10}"
+case "$ITER" in
+  '' | *[!0-9]*) echo "iterations must be a positive integer, got: '$ITER'" >&2; exit 2 ;;
+esac
+[ "$ITER" -ge 1 ] || { echo "iterations must be >= 1, got: $ITER" >&2; exit 2; }
+
+LOGDIR="${2:-$(mktemp -d /tmp/mnl-soak.XXXXXX)}"
+mkdir -p "$LOGDIR"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Reap leftovers a failed boot may strand (the detached __krun-vmm grandchild
+# and the gvproxy switch can linger and wedge the next iteration's bridge).
+reap() { "$ROOT/scripts/reap-vms.sh"; }
+
+pass=0
+fail=0
+for i in $(seq 1 "$ITER"); do
+  echo "::group::soak iteration $i/$ITER"
+  reap
+  if MINVMD_BOOT_LOG="$LOGDIR/boot-$i.log" "$ROOT/scripts/session-e2e.sh"; then
+    pass=$((pass + 1))
+    echo "iteration $i: OK"
+  else
+    fail=$((fail + 1))
+    echo "::warning::soak iteration $i FAILED"
+  fi
+  echo "::endgroup::"
+done
+reap
+
+echo "soak complete: $pass passed, $fail failed (of $ITER)"
+# Require every iteration to have run AND passed — a short-circuited loop that
+# ran zero iterations must not report success.
+[ "$fail" -eq 0 ] && [ "$pass" -eq "$ITER" ]

--- a/scripts/soak-session-e2e.sh
+++ b/scripts/soak-session-e2e.sh
@@ -28,6 +28,12 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # Reap leftovers a failed boot may strand (the detached __krun-vmm grandchild
 # and the gvproxy switch can linger and wedge the next iteration's bridge).
 reap() { "$ROOT/scripts/reap-vms.sh"; }
+# Reap on any exit, including a mid-run cancel (a cancelled CI job sends TERM,
+# an interactive Ctrl-C sends INT), so orphaned VM processes never outlive the
+# harness. The EXIT trap preserves the script's own exit status.
+trap 'reap' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 pass=0
 fail=0
@@ -43,7 +49,7 @@ for i in $(seq 1 "$ITER"); do
   fi
   echo "::endgroup::"
 done
-reap
+# Final reap is handled by the EXIT trap.
 
 echo "soak complete: $pass passed, $fail failed (of $ITER)"
 # Require every iteration to have run AND passed — a short-circuited loop that


### PR DESCRIPTION
Part of the CI end-state migration ([#687](https://github.com/gominimal/minimal/issues/687)) — the mid-soak nightly tier. Touches no lane workflow (soak-safe).

## What

New `.github/workflows/nightly-tests.yml` at 06:00 UTC — distinct from `nightly.yml`, which cuts the release channel at 10:00:

- **`advisories`** — cargo-deny `check advisories`, **blocking**. The between-PRs counterpart of the PR-side check; catches RUSTSEC advisories published since the last PR touched the tree, and feeds `notify`.
- **`session-e2e-soak`** — builds minvmd + the CLI, materializes the guest images, then loops the unified session e2e **×10** via `scripts/soak-session-e2e.sh` (reap between iterations) to shake out the boot / first-connect wedge class a single PR-lane run can't surface. Shares (and re-warms) the KVM lane's build cache.
- **`beta-canary` + `update-canary`** — the workspace suite on beta rustc and on freshly-`cargo update`d deps, both `continue-on-error` (the 1.97 pin and the lockfile are the gate); both pass `save-if: false` so a throwaway build never consumes the shared cache pool.
- **`hygiene`** — actionlint (pinned `rhysd/actionlint` image) + zizmor + cargo-machete, non-blocking.
- **`notify`** — files or updates a single `ci-nightly`-labelled tracking issue when a blocking job fails or is cancelled, so a regression doesn't rot in the Actions tab.

Supporting:
- `scripts/reap-vms.sh` — the leaked-`__krun-vmm`/gvproxy reap extracted to one place, used by the soak (the frozen lanes can adopt it later).
- `core-tests` gains a `save-if` passthrough (the canaries need it).
- `promote.yml` — the last missing `timeout-minutes` in the repo.

The CI-strategy doc + test-extension contract (and the junit step-summary proof) are **deferred to a follow-up** — they document the convention-based auto-discovery that isn't built yet.

## Review

This branch already went through a max-effort `/code-review`; the mechanical findings are fixed here (prebuilt `cross` instead of `cargo install`, `ITER` validated + `pass == ITER` assertion, `notify` covers cancellation and dedups by label). The documentation-accuracy findings travel with the deferred docs branch.

## Verification

- Scripts shellcheck-clean; workflows parse; the `ITER` guard rejects `0`/non-numeric.
- The nightly tier is `workflow_dispatch`-able — the definitive proof is one manual dispatch (soak survives ×10; `notify` wiring exercised by a forced failure). The `zizmor`/`actionlint` installs get their first-dispatch confirmation there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced nightly CI to include an additional installer verification stage, with notifications and failure tracking updated accordingly.
  * Added automated issue creation for failures in key nightly tests.
  * Added an e2e soak harness to repeatedly run session end-to-end tests and collect boot logs.
* **Bug Fixes**
  * Improved cleanup of leftover VM processes after failed or interrupted tests.
  * Limited promotion jobs to 20 minutes.
  * Restricted Rust cache writes to the main branch by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->