### PR TITLE
chore: add CODEOWNERS for the minimalists team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for this repository.
+# See https://docs.github.com/articles/about-code-owners
+#
+# The minimalists team owns everything in the repo. Later, more specific rules
+# can be added below — the last matching pattern for a path wins.
+
+* @gominimal/minimalists


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with a single catch-all rule so that
`@gominimal/minimalists` owns every path in the repository:

```
* @gominimal/minimalists
```

With this in place GitHub auto-requests the team for review on every pull
request. The rule is a base layer — more specific per-path owners can be added
below it later (CODEOWNERS uses last-match-wins).

Note: for the auto-request and any branch-protection "require review from Code
Owners" rule to take effect, `@gominimal/minimalists` must have write access to
this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6SWKgFLoRffVAUrkAWtz6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository ownership rules to help route code reviews to the appropriate maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->