### PR TITLE
fix(installer): take ownership of minimal shell init marker

### DIFF
--- a/docs/specs/07-spec-installer/07-spec-installer.md
+++ b/docs/specs/07-spec-installer/07-spec-installer.md
@@ -326,10 +326,22 @@ the exact markers `# >>> minimal >>>` / `# <<< minimal <<<`:
 | `fish`  | `${XDG_CONFIG_HOME:-~/.config}/fish/config.fish`, created if missing |
 | other   | `~/.profile` (the POSIX login rc), with the `bash.sh` (POSIX) init |
 
-The edit is idempotent — a file already containing the start marker is never
-touched again — and always announced, never silent. The sourced line itself is
-guarded (`[ -f … ] && . …` / `if test -f …`), so an rc file that outlives an
-uninstall stays harmless.
+The markers are the installer's to **own**, not merely to detect: a file whose
+marker block already sources the current init file is never touched again
+(reruns add nothing), but a marker block with any other content is *stale* —
+notably the pre-rewrite installer's, which used the same markers around a line
+sourcing `~/.minimal/shim/shell-init/…` — and is replaced (stripped via the
+R9.4 filter, then re-appended), or PATH and completions silently break on every
+upgraded machine. Either edit is always announced, never silent, and the result
+always carries exactly one marker block. The sourced line itself is guarded
+(`[ -f … ] && . …` / `if test -f …`), so an rc file that outlives an uninstall
+stays harmless.
+
+A *malformed* block — a start marker with no matching end marker, i.e. a hand
+edit — is never repaired by force: stripping it would truncate everything from
+the marker to end-of-file, and appending after it would set up exactly that
+truncation for a later strip. The file is left byte-for-byte untouched and the
+installer warns, naming the file and printing the line to add by hand.
 
 The hook is **best-effort and non-fatal**: by the time it runs, the binaries
 are already correctly installed, so an rc file that cannot be appended (or a
@@ -371,7 +383,10 @@ installed, and completions regenerate on the next run. Specifically:
 - the marker-fenced block is stripped from every rc file the installer may
   have edited (all candidates from the R9.2 table are tried — `$SHELL` may have
   changed since install; a file without markers is never rewritten), via an
-  awk filter to a temp sibling + atomic `mv` (`sed -i` is not portable);
+  awk filter to a temp sibling + atomic `mv` (`sed -i` is not portable); a file
+  whose start marker lacks its end marker is kept untouched with a warning
+  (the filter would otherwise drop everything from the marker to end-of-file),
+  and the walk continues to the remaining candidates;
 - the emptied `shell-init` and completion dirs (and their possibly
   installer-created parents) are pruned with the same `rmdir`-only discipline
   as R8.1 — they are shared locations, never `rm -rf`ed;
@@ -389,6 +404,14 @@ installed, and completions regenerate on the next run. Specifically:
   `~/.bash_profile` pre-existing, both are hooked and user content is preserved.
 - **Test**: `SHELL=…/zsh` hooks (and creates) `.zshrc`; `…/fish` hooks
   `config.fish`; an unrecognized shell falls back to `~/.profile`.
+- **Test**: an rc file carrying the pre-rewrite installer's marker block
+  (sourcing `~/.minimal/shim/shell-init/…`) has it replaced — the run announces
+  the replacement, exactly one marker block remains, it sources the current
+  init file, no shim reference survives, and user content on both sides of the
+  old block is preserved; a rerun then rewrites nothing.
+- **Test**: an rc file with a start marker but no end marker is left untouched
+  by both install and uninstall — each warns naming the file, appends nothing,
+  preserves the content after the stray marker, and exits 0.
 - **Test**: with a read-only `~/.bashrc`, the install still exits 0, prints the
   `failed to hook minimal shell support` warning and the manual line, leaves
   the rc file untouched, and still prints the R6.2 PATH advisory.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -178,6 +178,17 @@ marker_end='# <<< minimal <<<'
 strip_rc_block() {
     [ -f "$1" ] || return 0
     grep -q '>>> minimal >>>' "$1" 2>/dev/null || return 0
+    # Refuse a file whose start marker has no matching end marker (hand edits
+    # happen): the filter below would otherwise silently drop everything from
+    # that marker to EOF — the strip must never cost the user their rc tail.
+    # Distinct exit code so add_rc_block can tell "markers are broken" from
+    # "file not writable". Checked before the dry-run branch so a dry run
+    # predicts the real outcome.
+    if ! awk -v s="$marker_start" -v e="$marker_end" \
+            '$0==s {open=1} $0==e {open=0} END {exit open}' "$1"; then
+        say "  warning: unterminated minimal block in $1, left untouched"
+        return 2
+    fi
     if [ "$dry_run" -eq 1 ]; then
         say "  would remove shell-init block from $1"
         return 0
@@ -275,7 +286,9 @@ do_uninstall() {
     # The generated init/completion files themselves are ordinary record rows,
     # already handled by the walk above.
     for _rc in "$HOME/.bashrc" "$HOME/.bash_profile" "$zshrc" "$fish_config" "$HOME/.profile"; do
-        strip_rc_block "$_rc"
+        # An unterminated block returns non-zero (file kept, warning printed);
+        # that must not abort the walk over the remaining rc candidates.
+        strip_rc_block "$_rc" || true
     done
 
     # R8.2 — --purge additionally deletes the minimal-owned trees wholesale (build
@@ -586,12 +599,34 @@ say "install: $installed installed, $skipped up to date -> record at $prev_recor
 # --- Unit 9b: hook the current shell's rc file ------------------------------
 
 # R9.2 — append one marker-fenced block sourcing the matching init file to the
-# rc of the user's login shell ($SHELL). Idempotent: a file already carrying
-# the markers is never touched again, so reruns and upgrades add nothing. The
-# markers are also what --uninstall strips (strip_rc_block).
+# rc of the user's login shell ($SHELL). The markers are ours to own: a block
+# already sourcing the current init file is left alone (reruns add nothing),
+# but a marker block with any other content is stale — e.g. the pre-rewrite
+# installer's, sourcing ~/.minimal/shim/shell-init — and is replaced, or PATH
+# and completions silently break on upgraded machines. The markers are also
+# what --uninstall strips (strip_rc_block).
 add_rc_block() {
+    _verb="added block to"
+    _hook_ok=1
     if grep -q '>>> minimal >>>' "$1" 2>/dev/null; then
-        return 0
+        if grep -qxF "$2" "$1" 2>/dev/null; then
+            return 0
+        fi
+        # Subshell: strip_rc_block dies on a failed rewrite, which must stay
+        # non-fatal (and quiet) here; only the subshell exits. Exit 2 means an
+        # unterminated marker block: never append after a stray start marker —
+        # a later strip would then eat everything between it and our end
+        # marker, the exact truncation the strip guard exists to prevent.
+        _strip_rc=0
+        ( strip_rc_block "$1" ) >/dev/null 2>&1 || _strip_rc=$?
+        if [ "$_strip_rc" -eq 2 ]; then
+            say "  warning: cannot hook minimal shell support: unterminated minimal block in $1"
+            say "  fix or remove its '# >>> minimal >>>' block, or add this line yourself:"
+            say "      $2"
+            return 0
+        fi
+        [ "$_strip_rc" -eq 0 ] || _hook_ok=0
+        _verb="replaced stale block in"
     fi
     # Non-fatal: by this point the binaries are correctly installed, so an
     # unwritable rc file must not turn a successful install into a failure.
@@ -600,14 +635,18 @@ add_rc_block() {
     # The subshell wrapper (not just 2>/dev/null on the command) is what keeps
     # a redirection failure quiet: that error is printed by the shell itself,
     # before the command-level stderr redirect is in effect.
-    if ! ( mkdir -p "${1%/*}" \
-            && printf '\n%s\n%s\n%s\n' "$marker_start" "$2" "$marker_end" >>"$1" ) 2>/dev/null; then
+    if [ "$_hook_ok" -eq 1 ]; then
+        ( mkdir -p "${1%/*}" \
+            && printf '\n%s\n%s\n%s\n' "$marker_start" "$2" "$marker_end" >>"$1" ) 2>/dev/null \
+            || _hook_ok=0
+    fi
+    if [ "$_hook_ok" -eq 0 ]; then
         say "  warning: failed to hook minimal shell support ($1 is not writable)"
         say "  to enable it yourself, add this line to your shell rc:"
         say "      $2"
         return 0
     fi
-    say "  shell-init: added block to $1"
+    say "  shell-init: $_verb $1"
 }
 
 posix_line="[ -f \"$init_dir/bash.sh\" ] && . \"$init_dir/bash.sh\""

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -416,6 +416,65 @@ run kshinit "$H11"
 want_ok "unknown shell falls back to .profile (R9.2)" grep -q "shell-init/bash.sh" "$H11/.profile"
 TEST_SHELL=
 
+# Upgrade from the pre-rewrite installer: its rc block used the same markers
+# but sources ~/.minimal/shim/shell-init, so an unreplaced block leaves PATH
+# and completions silently dead. The markers are ours to own (R9.2): a stale
+# block is swapped for the current one, exactly once, preserving the user's
+# own rc content on both sides of it.
+H14="$root/h14"; mkdir -p "$H14"
+{
+    printf '# my zshrc\n'
+    printf '\n# >>> minimal >>>\n'
+    # The old installer wrote a literal $HOME, hence the single quotes.
+    # shellcheck disable=SC2016
+    printf '[ -f "$HOME/.minimal/shim/shell-init/zsh.sh" ] && . "$HOME/.minimal/shim/shell-init/zsh.sh"\n'
+    printf '# <<< minimal <<<\n'
+    printf '\n# added after the old install\n'
+} >"$H14/.zshrc"
+TEST_SHELL=/usr/bin/zsh
+run oldblock "$H14"
+check 0 "$rc" "upgrade over old rc block exits 0"
+want_ok "stale block replacement announced (R9.2)" grep -q "replaced stale block" "$OUT"
+check 1 "$(grep -c '>>> minimal >>>' "$H14/.zshrc")" "exactly one marker block after upgrade (R9.2)"
+want_ok "block now sources the current zsh init (R9.2)" grep -q "shell-init/zsh.sh" "$H14/.zshrc"
+want_err "no reference to the old shim path remains (R9.2)" grep -q '\.minimal/shim' "$H14/.zshrc"
+want_ok "user content before the old block preserved (R9.2)" grep -q '# my zshrc' "$H14/.zshrc"
+want_ok "user content after the old block preserved (R9.2)" \
+    grep -q '# added after the old install' "$H14/.zshrc"
+run oldblock2 "$H14"
+check 0 "$rc" "rerun after replacement exits 0"
+want_err "rerun rewrites nothing (R9.2)" grep -qE "shell-init: (added|replaced)" "$OUT"
+check 1 "$(grep -c '>>> minimal >>>' "$H14/.zshrc")" "rerun keeps a single marker block (R9.2)"
+TEST_SHELL=
+
+# A start marker whose end marker was lost to a hand edit must never cost the
+# user the tail of their rc file: the strip refuses (the naive filter would
+# drop everything from the marker to EOF), the install warns with the manual
+# line, appends nothing, and still exits 0. Uninstall likewise keeps the file.
+H15="$root/h15"; mkdir -p "$H15"
+{
+    printf '# my zshrc\n'
+    printf '# >>> minimal >>>\n'
+    printf '# end marker lost in a hand edit\n'
+    printf 'alias important=stuff\n'
+} >"$H15/.zshrc"
+TEST_SHELL=/usr/bin/zsh
+run unterminated "$H15"
+check 0 "$rc" "unterminated marker block is non-fatal on install (R9.2)"
+want_ok "warning names the broken block (R9.2)" \
+    grep -q "unterminated minimal block" "$OUT"
+want_ok "manual line still offered (R9.2)" grep -q "shell-init/zsh.sh" "$OUT"
+want_err "nothing appended after the stray marker (R9.2)" \
+    grep -q "shell-init/zsh.sh" "$H15/.zshrc"
+want_ok "rc tail survives (R9.2)" grep -q "alias important=stuff" "$H15/.zshrc"
+want_ok "binaries still installed (R9.2)" test -x "$H15/bin/min"
+run untermuninst "$H15" --uninstall
+check 0 "$rc" "uninstall over unterminated block exits 0 (R9.4)"
+want_ok "uninstall warns about the broken block (R9.4)" \
+    grep -q "unterminated minimal block" "$OUT"
+want_ok "uninstall keeps the rc tail (R9.4)" grep -q "alias important=stuff" "$H15/.zshrc"
+TEST_SHELL=
+
 # A manifest without the min CLI (data-only) skips completions, non-fatally.
 want_ok "completions skipped when min absent (R9.3)" \
     grep -q "completions: skipped" "$root/out.datadest"


### PR DESCRIPTION
If you had installed legacy minimal, the installer would see the existing `>>> minimal >>>` block and think you already had wiring installed.

We now take ownership of blocks of this name, so the installer rewrites it for the new install. This also allows us to tweak shell sections in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shell integration now correctly replaces stale installer-managed blocks with the current configuration.
  * Managed-block handling is more robust: malformed (unterminated) blocks are left unchanged, with a warning, and installation/uninstallation still complete successfully.
  * Installer reruns remain idempotent and preserve all user content outside managed blocks.
* **Tests**
  * Added Zsh regression tests covering stale marker replacement (including “rerun rewrites nothing” behavior) and the unterminated marker case for both install and uninstall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->