### PR TITLE
feat(sessions): prompt user when shell process exits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-dialog"
+version = "0.0.1"
+dependencies = [
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "async-tar"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3615,6 +3623,7 @@ version = "0.0.1"
 dependencies = [
  "args",
  "async-compression",
+ "async-dialog",
  "async-tar",
  "base64",
  "boringtun",
@@ -6276,7 +6285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/args",
+    "crates/async-dialog",
     "crates/lcache",
     "crates/rcache",
     "crates/check",
@@ -147,6 +148,7 @@ petgraph = "0.8"
 
 # our crates
 args = { version = "0.0.1", path = "crates/args" }
+async-dialog = { version = "0.0.1", path = "crates/async-dialog" }
 graph = { version = "0.0.1", path = "crates/graph" }
 lcache = { version = "0.0.1", path = "crates/lcache" }
 rcache = { version = "0.0.1", path = "crates/rcache" }

--- a/crates/async-dialog/Cargo.toml
+++ b/crates/async-dialog/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "async-dialog"
+version = "0.0.1"
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+thiserror.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/async-dialog/src/error.rs
+++ b/crates/async-dialog/src/error.rs
@@ -1,0 +1,19 @@
+//! Error types for the crate.
+
+/// A specialized [`Result`](std::result::Result) for dialog operations.
+pub type Result<T> = std::result::Result<T, DialogError>;
+
+/// The set of failures a prompt can surface.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DialogError {
+    /// The underlying reader or writer failed.
+    #[error("terminal i/o failed: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A prompt was asked to display an empty set of items. A selection prompt
+    /// over zero items has no valid answer, so this is rejected up front rather
+    /// than rendering an empty menu.
+    #[error("cannot present a selection prompt with no items")]
+    NoItems,
+}

--- a/crates/async-dialog/src/key.rs
+++ b/crates/async-dialog/src/key.rs
@@ -1,0 +1,257 @@
+//! Incremental decoding of raw terminal input into logical [`Key`] events.
+//!
+//! The reader backing a prompt is a raw-mode terminal, so keystrokes arrive as
+//! bytes: a plain key is a single byte, while arrows and other function keys
+//! arrive as multi-byte escape sequences (`ESC [ A`, `ESC O B`, `ESC [ 1 ; 5 A`,
+//! …). Those sequences can also be split across reads. [`KeyStream`] buffers the
+//! byte stream and hands back one decoded [`Key`] at a time, holding any partial
+//! escape sequence until the rest arrives.
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+/// A logical key press decoded from the terminal byte stream.
+///
+/// Only the keys a prompt cares about are given distinct variants; anything
+/// recognized-but-unhandled (function keys, unknown CSI sequences) collapses to
+/// [`Key::Unknown`] so callers can ignore it without inspecting raw bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Key {
+    /// Cursor up (also `Ctrl-P`).
+    Up,
+    /// Cursor down (also `Ctrl-N`).
+    Down,
+    /// Cursor left.
+    Left,
+    /// Cursor right.
+    Right,
+    /// Return / newline.
+    Enter,
+    /// Backspace or delete.
+    Backspace,
+    /// A printable ASCII character.
+    Char(char),
+    /// `Ctrl-C`.
+    CtrlC,
+    /// `Ctrl-D`.
+    CtrlD,
+    /// A bare `Escape` press.
+    Escape,
+    /// A recognized-but-unhandled byte or escape sequence.
+    Unknown,
+}
+
+/// Attempts to decode a single key from the front of `bytes`.
+///
+/// Returns `Some((key, consumed))` when a complete key (or an unhandled but
+/// fully-formed sequence) is at the front, where `consumed` is the number of
+/// bytes it occupied. Returns `None` when `bytes` holds only the prefix of an
+/// escape sequence (or is empty) and more input is required to disambiguate.
+fn decode(bytes: &[u8]) -> Option<(Key, usize)> {
+    let first = *bytes.first()?;
+    match first {
+        0x1b => decode_escape(bytes),
+        b'\r' | b'\n' => Some((Key::Enter, 1)),
+        0x03 => Some((Key::CtrlC, 1)),
+        0x04 => Some((Key::CtrlD, 1)),
+        0x10 => Some((Key::Up, 1)),   // Ctrl-P
+        0x0e => Some((Key::Down, 1)), // Ctrl-N
+        0x08 | 0x7f => Some((Key::Backspace, 1)),
+        0x20..=0x7e => Some((Key::Char(first as char), 1)),
+        _ => Some((Key::Unknown, 1)),
+    }
+}
+
+/// Decodes an escape-introduced sequence. `bytes[0]` is known to be `ESC`.
+fn decode_escape(bytes: &[u8]) -> Option<(Key, usize)> {
+    match bytes.get(1) {
+        // Lone ESC so far — could be the start of a longer sequence.
+        None => None,
+        // CSI: `ESC [ … final`.
+        Some(b'[') => decode_csi(bytes),
+        // SS3: `ESC O final` — cursor keys in application mode.
+        Some(b'O') => bytes.get(2).map(|&f| (map_final(f), 3)),
+        // ESC followed by anything else: treat the ESC as a standalone key. An
+        // Alt-modified key (`ESC x`) thus surfaces as Escape then the key, which
+        // is fine — prompts treat Escape as "cancel" and ignore the rest.
+        Some(_) => Some((Key::Escape, 1)),
+    }
+}
+
+/// Longest CSI sequence we keep buffering while waiting for a final byte. A real
+/// cursor-key or modified-key sequence is only a handful of bytes; anything
+/// longer is malformed. Bounding it stops a stream of parameter bytes with no
+/// final byte from growing the [`KeyStream`] buffer without bound.
+const MAX_CSI_LEN: usize = 32;
+
+/// Decodes a CSI sequence (`ESC [ params… final`). `bytes[0..2]` is `ESC [`.
+///
+/// Scans for the final byte (`0x40..=0x7e`); everything before it is parameter
+/// or intermediate bytes we don't need — the final byte alone selects the key,
+/// so modified arrows like `ESC [ 1 ; 5 A` still decode to [`Key::Up`].
+fn decode_csi(bytes: &[u8]) -> Option<(Key, usize)> {
+    // Skip the `ESC [` prefix, then take the first final byte. Parameter and
+    // intermediate bytes (all below `0x40`) are skipped.
+    match bytes
+        .iter()
+        .enumerate()
+        .skip(2)
+        .find(|&(_, &c)| (0x40..=0x7e).contains(&c))
+    {
+        Some((i, &c)) => Some((map_final(c), i + 1)),
+        // No final byte yet: normally incomplete, so wait for more input. But
+        // once the sequence has outgrown any legitimate length, give up and
+        // consume what's buffered as unknown so the buffer can drain.
+        None if bytes.len() > MAX_CSI_LEN => Some((Key::Unknown, bytes.len())),
+        None => None,
+    }
+}
+
+/// Maps a CSI/SS3 final byte to a cursor key, or [`Key::Unknown`].
+fn map_final(final_byte: u8) -> Key {
+    match final_byte {
+        b'A' => Key::Up,
+        b'B' => Key::Down,
+        b'C' => Key::Right,
+        b'D' => Key::Left,
+        _ => Key::Unknown,
+    }
+}
+
+/// Buffers a raw-mode terminal byte stream and yields decoded [`Key`]s.
+pub struct KeyStream<R> {
+    reader: R,
+    buf: Vec<u8>,
+    /// Offset of the first not-yet-consumed byte in `buf`.
+    pos: usize,
+}
+
+impl<R: AsyncRead + Unpin> KeyStream<R> {
+    /// Wraps `reader`, which should yield raw terminal input bytes.
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            buf: Vec::new(),
+            pos: 0,
+        }
+    }
+
+    /// Reads and decodes the next key.
+    ///
+    /// Resolves to `Ok(None)` at end of input (the reader returned EOF), which a
+    /// prompt should treat as cancellation.
+    pub async fn next(&mut self) -> std::io::Result<Option<Key>> {
+        loop {
+            if let Some((key, consumed)) = decode(&self.buf[self.pos..]) {
+                self.pos += consumed;
+                return Ok(Some(key));
+            }
+
+            // The buffer holds only an incomplete sequence (or nothing). Drop the
+            // already-consumed prefix before pulling more bytes so it can't grow
+            // without bound across many reads.
+            if self.pos > 0 {
+                self.buf.drain(..self.pos);
+                self.pos = 0;
+            }
+
+            let mut chunk = [0u8; 64];
+            let n = self.reader.read(&mut chunk).await?;
+            if n == 0 {
+                return Ok(None);
+            }
+            self.buf.extend_from_slice(&chunk[..n]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_single_byte_keys() {
+        assert_eq!(decode(b"\r"), Some((Key::Enter, 1)));
+        assert_eq!(decode(b"\n"), Some((Key::Enter, 1)));
+        assert_eq!(decode(b"\x03"), Some((Key::CtrlC, 1)));
+        assert_eq!(decode(b"\x04"), Some((Key::CtrlD, 1)));
+        assert_eq!(decode(b"a"), Some((Key::Char('a'), 1)));
+        assert_eq!(decode(b"\x10"), Some((Key::Up, 1)));
+        assert_eq!(decode(b"\x0e"), Some((Key::Down, 1)));
+    }
+
+    #[test]
+    fn decodes_csi_arrows() {
+        assert_eq!(decode(b"\x1b[A"), Some((Key::Up, 3)));
+        assert_eq!(decode(b"\x1b[B"), Some((Key::Down, 3)));
+        assert_eq!(decode(b"\x1b[C"), Some((Key::Right, 3)));
+        assert_eq!(decode(b"\x1b[D"), Some((Key::Left, 3)));
+    }
+
+    #[test]
+    fn decodes_ss3_arrows() {
+        assert_eq!(decode(b"\x1bOA"), Some((Key::Up, 3)));
+        assert_eq!(decode(b"\x1bOB"), Some((Key::Down, 3)));
+    }
+
+    #[test]
+    fn decodes_modified_arrow_by_final_byte() {
+        // Ctrl+Up: ESC [ 1 ; 5 A — parameters ignored, final byte wins.
+        assert_eq!(decode(b"\x1b[1;5A"), Some((Key::Up, 6)));
+    }
+
+    #[test]
+    fn partial_escape_needs_more_input() {
+        assert_eq!(decode(b""), None);
+        assert_eq!(decode(b"\x1b"), None);
+        assert_eq!(decode(b"\x1b["), None);
+        assert_eq!(decode(b"\x1b[1;5"), None);
+    }
+
+    #[test]
+    fn overlong_csi_without_final_is_consumed_as_unknown() {
+        // A parameter-byte flood with no final byte must not buffer forever: once
+        // past the cap it is consumed as unknown so the stream can drain.
+        let mut seq = vec![0x1b, b'['];
+        seq.extend(std::iter::repeat_n(b'1', MAX_CSI_LEN));
+        assert_eq!(decode(&seq), Some((Key::Unknown, seq.len())));
+
+        // A partial sequence still within the cap stays incomplete.
+        assert_eq!(decode(b"\x1b[1111"), None);
+    }
+
+    #[test]
+    fn only_leading_key_is_consumed() {
+        // Down-arrow followed by Enter: decode returns just the arrow.
+        assert_eq!(decode(b"\x1b[B\r"), Some((Key::Down, 3)));
+    }
+
+    #[tokio::test]
+    async fn key_stream_reassembles_split_sequence() {
+        // The arrow sequence is delivered one byte per read via chained slices.
+        // A plain `&[u8]` reader delivers everything at once, so use a duplex
+        // pipe and dribble the bytes in.
+        let (mut client, server) = tokio::io::duplex(64);
+        let mut keys = KeyStream::new(server);
+
+        use tokio::io::AsyncWriteExt;
+        let writer = tokio::spawn(async move {
+            for byte in [0x1b, b'[', b'B', b'\r'] {
+                client.write_all(&[byte]).await.unwrap();
+                client.flush().await.unwrap();
+            }
+        });
+
+        assert_eq!(keys.next().await.unwrap(), Some(Key::Down));
+        assert_eq!(keys.next().await.unwrap(), Some(Key::Enter));
+        writer.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn key_stream_reports_eof() {
+        let reader: &[u8] = b"a";
+        let mut keys = KeyStream::new(reader);
+        assert_eq!(keys.next().await.unwrap(), Some(Key::Char('a')));
+        assert_eq!(keys.next().await.unwrap(), None);
+    }
+}

--- a/crates/async-dialog/src/lib.rs
+++ b/crates/async-dialog/src/lib.rs
@@ -1,0 +1,45 @@
+//! Interactive terminal prompts over any async reader/writer.
+//!
+//! Unlike terminal-prompt libraries built on [`console`]/[`dialoguer`], nothing
+//! here needs a file descriptor or a real TTY: a prompt drives an arbitrary
+//! [`AsyncRead`](tokio::io::AsyncRead) + [`AsyncWrite`](tokio::io::AsyncWrite)
+//! pair. That makes it usable over transports that have no backing `fd` — the
+//! motivating case being an SSH channel (e.g. a `russh` channel split into its
+//! read and write halves).
+//!
+//! The backing terminal is assumed to be in **raw mode**: keystrokes arrive as
+//! raw bytes (arrows as escape sequences), and the prompt owns all rendering via
+//! ANSI escape codes. For an SSH/PTY session the client has already put the
+//! terminal into that state, so no local `termios` handling is required.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use async_dialog::{Select, Selection};
+//!
+//! # async fn demo(
+//! #     reader: impl tokio::io::AsyncRead + Unpin,
+//! #     writer: impl tokio::io::AsyncWrite + Unpin,
+//! # ) {
+//! let choice = Select::new()
+//!     .with_prompt("How do you want to proceed?")
+//!     .items(["Detach", "Terminate"])
+//!     .interact(reader, writer)
+//!     .await
+//!     .unwrap();
+//!
+//! match choice {
+//!     Selection::At(0) => { /* detach */ }
+//!     Selection::At(_) => { /* terminate */ }
+//!     Selection::Cancelled => { /* left as-is */ }
+//! }
+//! # }
+//! ```
+
+mod error;
+mod key;
+mod select;
+
+pub use error::{DialogError, Result};
+pub use key::{Key, KeyStream};
+pub use select::{Select, Selection};

--- a/crates/async-dialog/src/select.rs
+++ b/crates/async-dialog/src/select.rs
@@ -1,0 +1,338 @@
+//! A single-choice selection prompt.
+
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+
+use crate::error::{DialogError, Result};
+use crate::key::{Key, KeyStream};
+
+/// Hide the cursor while the menu is interactive.
+const HIDE_CURSOR: &[u8] = b"\x1b[?25l";
+/// Restore the cursor on teardown.
+const SHOW_CURSOR: &[u8] = b"\x1b[?25h";
+/// Reset all SGR (color / attribute) state.
+const RESET_SGR: &[u8] = b"\x1b[0m";
+/// Erase from the cursor to the end of the screen.
+const CLEAR_DOWN: &[u8] = b"\x1b[0J";
+/// Reverse-video, used to highlight the active row.
+const REVERSE: &[u8] = b"\x1b[7m";
+
+/// The result of running a [`Select`] prompt.
+///
+/// A single-choice prompt has exactly two outcomes — a confirmed index or a
+/// cancellation — so this enum is exhaustive; callers can `match` it without a
+/// wildcard arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Selection {
+    /// The user confirmed the item at this index.
+    At(usize),
+    /// The user dismissed the prompt (`Ctrl-C`, `Ctrl-D`, `q`, `Escape`, or
+    /// end of input) without choosing.
+    Cancelled,
+}
+
+impl Selection {
+    /// The chosen index, or `None` if the prompt was cancelled.
+    #[must_use]
+    pub fn index(self) -> Option<usize> {
+        match self {
+            Selection::At(i) => Some(i),
+            Selection::Cancelled => None,
+        }
+    }
+}
+
+/// A single-choice menu driven over an async terminal.
+///
+/// Arrow keys (or `j`/`k`, `Ctrl-N`/`Ctrl-P`) move the highlight, `Enter`
+/// confirms, and `Ctrl-C`/`Ctrl-D`/`q`/`Escape` cancel. The prompt assumes the
+/// backing terminal is in raw mode (keystrokes arrive unbuffered and unechoed),
+/// which is the state an SSH/PTY client is already in.
+///
+/// Each item is expected to occupy a single terminal line. Set [`Self::width`]
+/// to have over-long items truncated so they don't wrap and desync the
+/// redraw geometry.
+#[derive(Debug, Clone, Default)]
+#[must_use]
+pub struct Select {
+    prompt: Option<String>,
+    items: Vec<String>,
+    default: usize,
+    width: Option<usize>,
+}
+
+impl Select {
+    /// Creates an empty prompt. Add items with [`Self::item`] / [`Self::items`].
+    pub fn new() -> Self {
+        <Self as Default>::default()
+    }
+
+    /// Sets the header line shown above the items.
+    pub fn with_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.prompt = Some(prompt.into());
+        self
+    }
+
+    /// Appends a single selectable item.
+    pub fn item(mut self, item: impl Into<String>) -> Self {
+        self.items.push(item.into());
+        self
+    }
+
+    /// Appends a sequence of selectable items.
+    pub fn items(mut self, items: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.items.extend(items.into_iter().map(Into::into));
+        self
+    }
+
+    /// Sets the initially-highlighted index. Clamped to the item range when the
+    /// prompt runs, so an out-of-range default lands on the last item.
+    pub fn default(mut self, index: usize) -> Self {
+        self.default = index;
+        self
+    }
+
+    /// Sets the terminal width used to truncate over-long item text, keeping
+    /// each rendered row to one physical line.
+    pub fn width(mut self, cols: usize) -> Self {
+        self.width = Some(cols);
+        self
+    }
+
+    /// Runs the prompt to completion, reading keys from `reader` and drawing to
+    /// `writer`.
+    ///
+    /// The `reader`/`writer` are the two halves of the terminal — for an SSH
+    /// channel, that's the channel's read and write halves.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DialogError::NoItems`] if no items were added, or
+    /// [`DialogError::Io`] if reading or writing the terminal fails.
+    pub async fn interact<R, W>(&self, reader: R, mut writer: W) -> Result<Selection>
+    where
+        R: AsyncRead + Unpin,
+        W: AsyncWrite + Unpin,
+    {
+        if self.items.is_empty() {
+            return Err(DialogError::NoItems);
+        }
+
+        let mut selected = self.default.min(self.items.len() - 1);
+        let mut keys = KeyStream::new(reader);
+
+        let mut opening = Vec::from(HIDE_CURSOR);
+        self.render_into(&mut opening, selected, false);
+        writer.write_all(&opening).await?;
+        writer.flush().await?;
+
+        let outcome = loop {
+            let Some(key) = keys.next().await? else {
+                break Selection::Cancelled; // EOF
+            };
+            match key {
+                Key::Up | Key::Char('k') => selected = self.step_back(selected),
+                Key::Down | Key::Char('j') => selected = self.step_forward(selected),
+                Key::Enter => break Selection::At(selected),
+                Key::CtrlC | Key::CtrlD | Key::Escape | Key::Char('q') => {
+                    break Selection::Cancelled;
+                }
+                // Ignore everything else without repainting.
+                _ => continue,
+            }
+
+            let mut frame = Vec::new();
+            self.render_into(&mut frame, selected, true);
+            writer.write_all(&frame).await?;
+            writer.flush().await?;
+        };
+
+        let mut closing = Vec::new();
+        self.move_to_top(&mut closing);
+        closing.extend_from_slice(CLEAR_DOWN);
+        closing.extend_from_slice(RESET_SGR);
+        closing.extend_from_slice(SHOW_CURSOR);
+        writer.write_all(&closing).await?;
+        writer.flush().await?;
+
+        Ok(outcome)
+    }
+
+    /// Total number of terminal lines the menu occupies.
+    fn height(&self) -> usize {
+        usize::from(self.prompt.is_some()) + self.items.len()
+    }
+
+    /// Emits the escape sequence that moves the cursor from the last drawn row
+    /// back to column 1 of the menu's first row.
+    fn move_to_top(&self, out: &mut Vec<u8>) {
+        let up = self.height() - 1;
+        if up > 0 {
+            out.extend_from_slice(format!("\x1b[{up}A").as_bytes());
+        }
+        out.push(b'\r');
+    }
+
+    /// Truncates `text` to fit the configured width (leaving room for the
+    /// 2-column row prefix), or returns it unchanged when no width is set.
+    fn fit<'a>(&self, text: &'a str) -> std::borrow::Cow<'a, str> {
+        match self.width {
+            Some(cols) => {
+                std::borrow::Cow::Owned(text.chars().take(cols.saturating_sub(2)).collect())
+            }
+            None => std::borrow::Cow::Borrowed(text),
+        }
+    }
+
+    /// Renders the full menu into `out`. When `redraw` is set, the cursor is
+    /// first walked back up to the menu's top and the region cleared, so a
+    /// repaint lands exactly over the previous frame.
+    fn render_into(&self, out: &mut Vec<u8>, selected: usize, redraw: bool) {
+        if redraw {
+            self.move_to_top(out);
+        } else {
+            out.push(b'\r');
+        }
+        out.extend_from_slice(CLEAR_DOWN);
+
+        if let Some(prompt) = &self.prompt {
+            out.extend_from_slice(RESET_SGR);
+            out.extend_from_slice(prompt.as_bytes());
+            out.extend_from_slice(b"\r\n");
+        }
+
+        let last = self.items.len() - 1;
+        for (i, item) in self.items.iter().enumerate() {
+            let text = self.fit(item);
+            if i == selected {
+                out.extend_from_slice(REVERSE);
+                out.extend_from_slice(b"> ");
+                out.extend_from_slice(text.as_bytes());
+                out.extend_from_slice(RESET_SGR);
+            } else {
+                out.extend_from_slice(b"  ");
+                out.extend_from_slice(text.as_bytes());
+            }
+            if i != last {
+                out.extend_from_slice(b"\r\n");
+            }
+        }
+    }
+
+    /// Highlight index one row up, wrapping to the bottom.
+    fn step_back(&self, current: usize) -> usize {
+        match current {
+            0 => self.items.len() - 1,
+            n => n - 1,
+        }
+    }
+
+    /// Highlight index one row down, wrapping to the top.
+    fn step_forward(&self, current: usize) -> usize {
+        if current + 1 == self.items.len() {
+            0
+        } else {
+            current + 1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drives a prompt with a canned input byte stream, returning the outcome
+    /// and everything written to the terminal.
+    async fn run(select: &Select, input: &[u8]) -> (Selection, Vec<u8>) {
+        let mut output = Vec::new();
+        let outcome = select
+            .interact(input, &mut output)
+            .await
+            .expect("prompt failed");
+        (outcome, output)
+    }
+
+    fn menu() -> Select {
+        Select::new()
+            .with_prompt("pick one")
+            .items(["alpha", "beta", "gamma"])
+    }
+
+    #[tokio::test]
+    async fn empty_prompt_is_rejected() {
+        let err = Select::new()
+            .interact(&b""[..], Vec::new())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DialogError::NoItems));
+    }
+
+    #[tokio::test]
+    async fn enter_confirms_the_default() {
+        let (outcome, _) = run(&menu(), b"\r").await;
+        assert_eq!(outcome, Selection::At(0));
+    }
+
+    #[tokio::test]
+    async fn arrow_down_then_enter_selects_second() {
+        let (outcome, _) = run(&menu(), b"\x1b[B\r").await;
+        assert_eq!(outcome, Selection::At(1));
+    }
+
+    #[tokio::test]
+    async fn vim_keys_navigate() {
+        let (outcome, _) = run(&menu(), b"jj\r").await;
+        assert_eq!(outcome, Selection::At(2));
+    }
+
+    #[tokio::test]
+    async fn up_wraps_to_last_item() {
+        let (outcome, _) = run(&menu(), b"\x1b[A\r").await;
+        assert_eq!(outcome, Selection::At(2));
+    }
+
+    #[tokio::test]
+    async fn down_wraps_around_to_first() {
+        // Three down presses on a three-item menu returns to the top.
+        let (outcome, _) = run(&menu(), b"\x1b[B\x1b[B\x1b[B\r").await;
+        assert_eq!(outcome, Selection::At(0));
+    }
+
+    #[tokio::test]
+    async fn ctrl_c_cancels() {
+        let (outcome, _) = run(&menu(), b"\x03").await;
+        assert_eq!(outcome, Selection::Cancelled);
+        assert_eq!(outcome.index(), None);
+    }
+
+    #[tokio::test]
+    async fn eof_cancels() {
+        let (outcome, _) = run(&menu(), b"").await;
+        assert_eq!(outcome, Selection::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn default_is_clamped_into_range() {
+        let (outcome, _) = run(&menu().default(99), b"\r").await;
+        assert_eq!(outcome, Selection::At(2));
+    }
+
+    #[tokio::test]
+    async fn restores_cursor_and_clears_on_exit() {
+        let (_, output) = run(&menu(), b"\r").await;
+        // Cursor hidden on entry, shown on exit; menu cleared at teardown.
+        assert!(output.starts_with(HIDE_CURSOR));
+        assert!(output.ends_with(SHOW_CURSOR));
+        let cleared = output.windows(CLEAR_DOWN.len()).any(|w| w == CLEAR_DOWN);
+        assert!(cleared);
+    }
+
+    #[tokio::test]
+    async fn width_truncates_long_items() {
+        let select = Select::new().item("abcdefghij").width(6);
+        let (_, output) = run(&select, b"\r").await;
+        // Row prefix is 2 cols, so at width 6 only 4 chars of text survive.
+        let rendered = String::from_utf8(output).unwrap();
+        assert!(rendered.contains("abcd"));
+        assert!(!rendered.contains("abcde"));
+    }
+}

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -56,6 +56,7 @@ boringtun = { workspace = true, optional = true }
 rand_core = { workspace = true, optional = true }
 
 args.workspace = true
+async-dialog.workspace = true
 check.workspace = true
 common.workspace = true
 graph.workspace = true

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1,4 +1,5 @@
 use crate::channel_progress::ChannelProgress;
+use crate::sessions::{SessionControl, WeakManagerHandle};
 use crate::{
     ChannelConfig,
     session_host::{self, HostAttrs, WinSize},
@@ -123,6 +124,12 @@ pub struct Session<S: SessionObject> {
     /// [`DaemonContext`]: mctx::DaemonContext
     /// [`OpTracker`]: ot::OpTracker
     context: Option<mctx::Context>,
+
+    /// A non-owning handle to the [`Manager`](crate::sessions::Manager), used to
+    /// build the [`SessionControl`] handed to each [`Binding`] so a shell-exit
+    /// "delete" tears this session down through the manager (record removal and
+    /// all). Weak by design — see [`crate::sessions::Manager::weak_self`].
+    manager: WeakManagerHandle,
 }
 
 impl<S: SessionObject> Session<S> {
@@ -140,6 +147,7 @@ impl<S: SessionObject> Session<S> {
         session: S,
         net_switch: Arc<Mutex<crate::net::SwitchClient>>,
         composition: Option<Arc<Composition>>,
+        manager: WeakManagerHandle,
     ) -> Result<SessionHandle, std::io::Error> {
         std::fs::create_dir_all(session.workspace_path())?;
         std::fs::create_dir_all(session.home_path())?;
@@ -156,6 +164,7 @@ impl<S: SessionObject> Session<S> {
             tracker: OpTracker::new_root(),
             composition,
             context: None,
+            manager,
         };
 
         tokio::spawn(mngr.mainloop());
@@ -278,6 +287,10 @@ impl<S: SessionObject> Session<S> {
         // the channel back. The host is spawned without a channel so the
         // renderer has exclusive use of it while building; once the bars are
         // cleared we attach the channel to the now-running host.
+        // The destroy capability handed down to the host's binding: on a
+        // shell-exit "delete", the binding calls back through this to have the
+        // manager tear the whole session (record included) down.
+        let control = SessionControl::new(self.manager.clone(), self.session.record().id);
         let launcher = self.session_launcher(session_hnd)?;
         let progress = ChannelProgress::new(channel, self.tracker.clone(), (sz.cols, sz.rows));
         let (channel, spawned) = progress
@@ -288,6 +301,7 @@ impl<S: SessionObject> Session<S> {
                 self.paths(),
                 sz,
                 None,
+                Some(control),
             )))
             .await;
         let h = spawned.map_err(AttachError::SpawnFailed)?;
@@ -508,9 +522,18 @@ mod tests {
     use russh::ChannelMsg;
     use sessions::SessionId;
 
-    use minimald_rpc::CreateSession;
+    use minimald_rpc::{CreateSession, GetSessionRecord, GetSessionRecordRequest};
 
     use crate::test_harness::{TestClient, TestServer, create_session_req, unwrap_ready};
+
+    /// Reads the session record for `id`, or `None` once it has been deleted.
+    async fn record_exists(client: &mut TestClient, id: SessionId) -> bool {
+        client
+            .call::<GetSessionRecord>(&GetSessionRecordRequest::Id(id))
+            .await
+            .record
+            .is_some()
+    }
 
     /// Creates a fresh session on the server and returns its id.
     async fn create_session(client: &mut TestClient) -> SessionId {
@@ -554,15 +577,34 @@ mod tests {
             }
         }
 
-        // Now ask the mock to exit and confirm the host tears the channel down.
+        // Now ask the mock to exit. The shell exiting raises the session-exit
+        // prompt (see `session_host`), rendered over the channel; answer it by
+        // confirming the first option (Enter -> detach) so teardown proceeds and
+        // the channel closes.
         channel
             .data_bytes(format!("{}\n", crate::session_host::MOCK_EXIT_LINE).into_bytes())
             .await
             .unwrap();
         let mut saw_exit_status = false;
         let mut closed = false;
+        let mut answered_prompt = false;
+        let mut prompt_out = Vec::new();
         while let Ok(msg) = tokio::time::timeout(Duration::from_secs(10), channel.wait()).await {
             match msg {
+                Some(ChannelMsg::Data { data }) => {
+                    // Wait for the prompt to render, then confirm the first
+                    // option. The prompt only appears once the mainloop has
+                    // stopped reading the channel, so this keypress reaches the
+                    // prompt rather than the (now-defunct) stdin path.
+                    prompt_out.extend_from_slice(&data);
+                    if !answered_prompt
+                        && String::from_utf8_lossy(&prompt_out)
+                            .contains(crate::session_host::SHELL_EXIT_PROMPT)
+                    {
+                        channel.data_bytes(b"\r".to_vec()).await.unwrap();
+                        answered_prompt = true;
+                    }
+                }
                 Some(ChannelMsg::ExitStatus { .. }) => saw_exit_status = true,
                 Some(_) => {}
                 None => {
@@ -571,8 +613,90 @@ mod tests {
                 }
             }
         }
+        assert!(
+            answered_prompt,
+            "expected the session-exit prompt to render"
+        );
         assert!(closed, "channel should close once the mock process exits");
         assert!(saw_exit_status, "expected an exit status on teardown");
+
+        // Detach leaves the session alive: its record must still resolve.
+        assert!(
+            record_exists(&mut client, session_id).await,
+            "detach must not delete the session record"
+        );
+    }
+
+    /// Selecting "delete" on the shell-exit prompt must tear the connection down
+    /// *and* destroy the session (record removed), routed through the manager
+    /// via the binding's weak handle.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn terminate_option_deletes_session_and_closes_channel() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        let mut channel = client.open_shell(session_id).await;
+
+        // Confirm the shell is live before exiting it (mock echoes `got:<line>`).
+        channel.data_bytes(b"hello\n".to_vec()).await.unwrap();
+        let mut stdout = Vec::new();
+        loop {
+            match channel.wait().await {
+                Some(ChannelMsg::Data { data }) => {
+                    stdout.extend_from_slice(&data);
+                    if String::from_utf8_lossy(&stdout).contains("got:hello") {
+                        break;
+                    }
+                }
+                Some(_) => {}
+                None => panic!("channel closed before the echo arrived"),
+            }
+        }
+
+        // Exit the shell to raise the prompt, then pick the second option
+        // (delete): a down-arrow to move off the default, then Enter.
+        channel
+            .data_bytes(format!("{}\n", crate::session_host::MOCK_EXIT_LINE).into_bytes())
+            .await
+            .unwrap();
+        let mut closed = false;
+        let mut answered_prompt = false;
+        let mut prompt_out = Vec::new();
+        while let Ok(msg) = tokio::time::timeout(Duration::from_secs(10), channel.wait()).await {
+            match msg {
+                Some(ChannelMsg::Data { data }) => {
+                    prompt_out.extend_from_slice(&data);
+                    if !answered_prompt
+                        && String::from_utf8_lossy(&prompt_out)
+                            .contains(crate::session_host::SHELL_EXIT_PROMPT)
+                    {
+                        channel.data_bytes(b"\x1b[B\r".to_vec()).await.unwrap();
+                        answered_prompt = true;
+                    }
+                }
+                Some(_) => {}
+                None => {
+                    closed = true;
+                    break;
+                }
+            }
+        }
+
+        // Requirement 1: the connection is torn down.
+        assert!(
+            answered_prompt,
+            "expected the session-exit prompt to render"
+        );
+        assert!(closed, "channel should close after the delete completes");
+
+        // Requirement 2: the session is gone. The binding awaits the destroy
+        // before closing the channel, so the record is already removed by the
+        // time we observe the close.
+        assert!(
+            !record_exists(&mut client, session_id).await,
+            "delete must remove the session record"
+        );
     }
 
     /// A second shell request to the same session takes over the running host:

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -5,6 +5,7 @@
 //!
 //! The [`Host`] struct holds the running state of an active session.
 
+use async_dialog::Selection;
 use either::Either;
 use russh::Channel;
 use russh::server::Msg;
@@ -25,6 +26,7 @@ use tokio::task::JoinHandle;
 
 use crate::RequestedPty;
 use crate::session::SessionPaths;
+use crate::sessions::SessionControl;
 #[cfg(not(test))]
 use sessions::NetworkMode;
 
@@ -38,6 +40,12 @@ const CTRL_W_CSI_U: &[u8] = b"\x1b[119;5u";
 ///
 /// Corrsponds to: modifyOtherKeys: CSI 27 ; 5 ; 119 ~
 const CTRL_W_CSI_27: &[u8] = b"\x1b[27;5;119~";
+
+/// Header of the prompt shown over the channel when a session's shell process
+/// exits, offering to detach or delete. Exposed so tests can await its
+/// appearance in the channel output before answering.
+pub(crate) const SHELL_EXIT_PROMPT: &str =
+    "Session shell process exited. What would you like to do with this session?";
 
 /// The dimensions of a terminal.
 ///
@@ -325,6 +333,10 @@ struct Binding {
     stdin_tx: mpsc::Sender<Either<bytes::Bytes, RequestedPty>>,
     /// Channel the [`Host`] uses to communicate with this [`Binding`].
     receiver: mpsc::Receiver<BindingMsg>,
+    /// Capability to destroy the owning session, exercised when the user picks
+    /// "delete" on the shell-exit prompt. `None` for hosts spawned without a
+    /// manager (the test harness), where "delete" degrades to a detach.
+    control: Option<SessionControl>,
 }
 
 impl Binding {
@@ -333,6 +345,7 @@ impl Binding {
     pub(crate) async fn spawn(
         channel: Channel<Msg>,
         stdin_tx: mpsc::Sender<Either<bytes::Bytes, RequestedPty>>,
+        control: Option<SessionControl>,
     ) -> (mpsc::Sender<BindingMsg>, JoinHandle<()>) {
         let (tx, rx) = mpsc::channel(4);
 
@@ -340,6 +353,7 @@ impl Binding {
             channel,
             stdin_tx,
             receiver: rx,
+            control,
         };
 
         (tx, tokio::spawn(binding.run()))
@@ -349,10 +363,18 @@ impl Binding {
         let (mut rs, ws) = self.channel.split();
         let mut w = ws.make_writer();
 
+        #[derive(Debug, PartialEq, Eq)]
+        enum MainloopExitReason {
+            HostGone,
+            Detach,
+            Superceded,
+            StdoutErr,
+        }
+
         // Reading from the remote stops once it sends EOF;
         // the loop lives on to keep forwarding stdout.
         let mut remote_open = true;
-        loop {
+        let exit_reason = loop {
             tokio::select! {
                 // Remote (ssh channel) => session stdin.
                 res = rs.wait(), if remote_open => match res {
@@ -380,11 +402,8 @@ impl Binding {
                             },
                             // Flow-control window updates fire on every
                             // burst of bytes forwarded through the
-                            // channel — routine, not a fault. Debug
-                            // keeps them out of the default log stream.
-                            russh::ChannelMsg::WindowAdjusted { .. } => {
-                                tracing::debug!("skipping msg: {:?}", msg);
-                            }
+                            // channel, v. noisy.
+                            russh::ChannelMsg::WindowAdjusted { .. } => {}
                             _ => tracing::warn!("skipping msg: {:?}", msg),
                         };
                     }
@@ -393,7 +412,7 @@ impl Binding {
                 // A closed channel means the host is gone;
                 // tear the attachment down.
                 msg = self.receiver.recv() => {
-                    let Some(msg) = msg else { break };
+                    let Some(msg) = msg else { break MainloopExitReason::HostGone; };
                     match msg {
                         BindingMsg::Stdin(b) => {
                             let _ = w.write_all(&b).await;
@@ -402,27 +421,69 @@ impl Binding {
                             if e.raw_os_error() != Some(5) {
                                 let _ = w.write_all(format!("Error reading stdout: {e}\n").as_bytes()).await;
                             }
-                            break;
+                            break MainloopExitReason::StdoutErr;
                         }
                         BindingMsg::TeardownDueToSuperceded(unwind_codes) => {
                             let _ = w.write_all(&unwind_codes).await;
                             let _ = w.write_all(b"\r\nDisconnecting - session attached to from a different connection\r\n").await;
-                            break;
+                            break MainloopExitReason::Superceded;
                         }
                         BindingMsg::TeardownDueToDetach(unwind_codes) => {
                             let _ = w.write_all(&unwind_codes).await;
                             let _ = w.write_all(b"\r\nDetaching due to ctrl-w.\r\n").await;
-                            break;
+                            break MainloopExitReason::Detach;
                         }
                     };
 
                 }
             }
+        };
+
+        tracing::debug!("Binding leaving mainloop due to {:?}", exit_reason);
+
+        if exit_reason == MainloopExitReason::StdoutErr {
+            // The shell process exited. For a bash shell, this usually meant someone pressed ctrl-d absent-mindedly.
+            // We presume they didnt want to completely destroy the session, perhaps just detach, but lets prompt
+            // to see where they wanted to go from here.
+            let _ = w.write_all(b"\r\n").await;
+            match async_dialog::Select::new()
+                .with_prompt(SHELL_EXIT_PROMPT)
+                .items([
+                    "Detach, leaving the session running",
+                    "Delete, all in-session files permanently deleted",
+                ])
+                .interact(rs.make_reader(), &mut w)
+                .await
+            {
+                // User selected detach, keep going to disconnect
+                Ok(Selection::At(0)) => {}
+                // User cancelled selection, safest option is to detach
+                Ok(Selection::Cancelled) => {}
+                // User selected delete: ask the manager to tear the whole
+                // session down (kill the host, remove the on-disk record) before
+                // we close the channel. Awaiting is deadlock-free here — the
+                // destroy cascade waits on the host runtime loop (already exiting
+                // after this StdoutErr), never on this binding task.
+                Ok(Selection::At(1)) => match &self.control {
+                    Some(control) => {
+                        let _ = w.write_all(b"\r\nDeleting session...\r\n").await;
+                        if let Err(e) = control.destroy().await {
+                            tracing::warn!(error = %e, "session delete failed");
+                            let _ = w
+                                .write_all(format!("Failed to delete session: {e}\r\n").as_bytes())
+                                .await;
+                        }
+                    }
+                    // No manager wired (test harness): degrade to a detach.
+                    None => tracing::warn!("delete selected but no session control available"),
+                },
+                Ok(Selection::At(_)) => unreachable!(),
+                Err(e) => tracing::warn!(error = %e, "session-exit prompt failed"),
+            }
         }
 
-        tracing::debug!("Binding shutting down");
         let _ = ws.eof().await;
-        let _ = ws.exit_status(0).await; // TODO: Only report this if process terminates
+        let _ = ws.exit_status(0).await;
         let _ = ws.close().await; // needed to release the remote
     }
 }
@@ -646,6 +707,11 @@ pub(crate) struct Host<P: SessionProcess, G: Send + 'static> {
     // down explicitly in `mainloop` when the session ends, before `_guard` (and
     // thus the sandbox files) is dropped. `None` for `HostNet`/`NoNet` and tests.
     net_guard: Option<Box<dyn sandbox2::NetGuard>>,
+
+    // Destroy capability handed to each binding this host spawns, so a
+    // shell-exit "delete" can tear the whole session down. `None` for hosts
+    // built without a manager (the test harness).
+    control: Option<SessionControl>,
 
     // Keeps launcher-owned resources (the session's `Env`, which owns the
     // sandbox files backing the running process's rootfs along with the context
@@ -1167,11 +1233,13 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
         paths: SessionPaths,
         sz: WinSize,
         channel: Option<Channel<Msg>>,
+        control: Option<SessionControl>,
     ) -> Result<(HostHandle, JoinHandle<Result<i32, std::io::Error>>), std::io::Error>
     where
         L: SessionLauncher<Process = P, Guard = G>,
     {
-        let (host, handle) = Self::build(launcher, name, username, paths, sz, channel).await?;
+        let (host, handle) =
+            Self::build(launcher, name, username, paths, sz, channel, control).await?;
         let task = tokio::spawn(host.mainloop());
         Ok((handle, task))
     }
@@ -1186,6 +1254,7 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
         paths: SessionPaths,
         sz: WinSize,
         channel: Option<Channel<Msg>>,
+        control: Option<SessionControl>,
     ) -> Result<(Self, HostHandle), std::io::Error>
     where
         L: SessionLauncher<Process = P, Guard = G>,
@@ -1228,6 +1297,7 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
             stdout_buf: vec![0u8; 8 * 1024],
             stdin_buf: None,
             net_guard,
+            control,
             _guard: guard,
         };
 
@@ -1441,7 +1511,8 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
                 .write_all(&self.parser.screen().state_formatted())
                 .await;
         }
-        let new_binding = Binding::spawn(channel, self.remote_tx.clone()).await;
+        let new_binding =
+            Binding::spawn(channel, self.remote_tx.clone(), self.control.clone()).await;
 
         if let Some((old_tx, old_join_hnd)) = self.remote.replace(new_binding) {
             // If there was a binding we just swapped out, tell it to
@@ -1617,6 +1688,7 @@ mod tests {
             },
             DEFAULT_SIZE,
             None,
+            None,
         )
         .await
         .expect("failed to build host");
@@ -1681,6 +1753,7 @@ mod tests {
                 home: DaemonAbsPath::root(),
             },
             DEFAULT_SIZE,
+            None,
             None,
         )
         .await
@@ -1781,6 +1854,7 @@ mod tests {
             test_paths(),
             DEFAULT_SIZE,
             None,
+            None,
         )
         .await
         .expect("failed to build host");
@@ -1826,6 +1900,7 @@ mod tests {
             "user".to_string(),
             test_paths(),
             DEFAULT_SIZE,
+            None,
             None,
         )
         .await

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -189,6 +189,15 @@ pub struct Manager<L: Loader = DiskLoader> {
     running: BTreeMap<L::Key, SessionHandle>,
     store: L,
 
+    /// A weak handle to this manager, handed down to each session it spawns so
+    /// a session's [`Binding`](crate::session_host) can ask the manager to
+    /// destroy it (the "delete" choice on the shell-exit prompt) without owning
+    /// the manager. It must be weak: a strong self-handle would keep the
+    /// manager's own `recv` loop from ever seeing all senders dropped (wedging
+    /// shutdown) and would close an ownership cycle
+    /// (manager → session → host → binding → manager).
+    weak_self: WeakManagerHandle,
+
     /// Per-session stash for in-flight `CreateSession` flows that
     /// reached [`ComposeOutcome::Pending`]. Keyed by the daemon's
     /// allocated [`SessionId`]; the matching `SubmitVerdict` pops
@@ -271,11 +280,20 @@ impl Manager {
         let hostnames = Arc::new(RwLock::new(crate::net::dns::HostnameRegistry::new(
             crate::net::dns::DEFAULT_HOST_ID,
         )));
+        let handle = ManagerHandle {
+            sender,
+            #[cfg(target_os = "linux")]
+            hostnames: Arc::clone(&hostnames),
+        };
+        // A non-owning path back to this actor, handed to each spawned session
+        // so its binding can request destruction (see `weak_self`).
+        let weak_self = handle.downgrade();
         let mngr = Self {
             in_shutdown: false,
             receiver,
             running,
             store: l,
+            weak_self,
             pending: BTreeMap::new(),
             compositions: BTreeMap::new(),
             daemon_ctx,
@@ -283,15 +301,11 @@ impl Manager {
             minimal_cache_dir,
             net_switch,
             #[cfg(target_os = "linux")]
-            hostnames: Arc::clone(&hostnames),
+            hostnames,
         };
 
         tokio::spawn(mngr.mainloop());
-        Ok(ManagerHandle {
-            sender,
-            #[cfg(target_os = "linux")]
-            hostnames,
-        })
+        Ok(handle)
     }
 }
 
@@ -459,6 +473,7 @@ impl<L: Loader> Manager<L> {
                                         obj,
                                         Arc::clone(&self.net_switch),
                                         composition,
+                                        self.weak_self.clone(),
                                     )
                                     .await?;
                                     // Spawn succeeded — safe to drain the
@@ -928,7 +943,79 @@ pub struct ManagerHandle {
     hostnames: Arc<RwLock<crate::net::dns::HostnameRegistry>>,
 }
 
+/// A non-owning handle to the [`Manager`] actor.
+///
+/// Held by per-session machinery that must be able to reach the manager
+/// (notably a session's [`Binding`](crate::session_host), to request its own
+/// destruction) without keeping the actor alive. See [`Manager::weak_self`] for
+/// why the path back to the manager must be weak.
+#[derive(Debug, Clone)]
+pub struct WeakManagerHandle {
+    sender: mpsc::WeakSender<ManagerMessage>,
+    /// Mirrors [`ManagerHandle::hostnames`]; the registry `Arc` is held so an
+    /// [`upgrade`](Self::upgrade) can reconstruct a full handle. This does not
+    /// keep the actor alive (only live senders do).
+    #[cfg(target_os = "linux")]
+    hostnames: Arc<RwLock<crate::net::dns::HostnameRegistry>>,
+}
+
+impl WeakManagerHandle {
+    /// Promotes to a strong [`ManagerHandle`], or `None` if the manager actor
+    /// has already shut down (all strong senders dropped).
+    #[must_use]
+    pub fn upgrade(&self) -> Option<ManagerHandle> {
+        Some(ManagerHandle {
+            sender: self.sender.upgrade()?,
+            #[cfg(target_os = "linux")]
+            hostnames: Arc::clone(&self.hostnames),
+        })
+    }
+}
+
+/// The capability handed to a session's [`Binding`](crate::session_host) to
+/// tear its own session down — the "delete" choice on the shell-exit prompt.
+///
+/// Bundles a [`WeakManagerHandle`] with the [`SessionId`] to destroy, so the
+/// binding neither owns the manager nor needs to know how destruction is
+/// carried out.
+#[derive(Debug, Clone)]
+pub struct SessionControl {
+    manager: WeakManagerHandle,
+    id: SessionId,
+}
+
+impl SessionControl {
+    /// Binds the destroy capability to a specific session.
+    #[must_use]
+    pub fn new(manager: WeakManagerHandle, id: SessionId) -> Self {
+        Self { manager, id }
+    }
+
+    /// Requests the manager destroy this session: kills the host and removes the
+    /// on-disk record. Errors if the manager has already shut down, or if the
+    /// destroy itself fails (e.g. the manager is mid-shutdown).
+    pub async fn destroy(&self) -> Result<(), SessionsError> {
+        match self.manager.upgrade() {
+            Some(mngr) => mngr.destroy_session(self.id).await,
+            None => Err(SessionsError::new(
+                std::io::ErrorKind::NotConnected,
+                "sessions manager is gone",
+            )),
+        }
+    }
+}
+
 impl ManagerHandle {
+    /// Returns a non-owning handle to this manager.
+    #[must_use]
+    pub fn downgrade(&self) -> WeakManagerHandle {
+        WeakManagerHandle {
+            sender: self.sender.downgrade(),
+            #[cfg(target_os = "linux")]
+            hostnames: Arc::clone(&self.hostnames),
+        }
+    }
+
     /// Returns a shared handle to the in-memory PTask hostname registry, for the
     /// daemon's host-side proxies ([`crate::net::proxy`]) to route by `Host:`
     /// header.


### PR DESCRIPTION
 - New crate `async-dialog` to implement ANSI terminal prompt, such as down an SSH connection.
 - `WeakManagerHandle` counterpart to `ManagerHandle`, used to avoid circular references
 - Prompt for when the shell process exits
 - Tests for teardown when the user selects deletion in the prompt



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an async terminal dialog library with keyboard-driven selection menus (prompt support, default option, width truncation, and confirm/cancel controls).
  * Added a shell-exit prompt that lets users choose to detach or delete the session, with deletion performed through a manager-mediated control path.
* **Bug Fixes**
  * Improved session teardown behavior when shell connections end, including reliable cleanup after choosing “delete”.
  * Restored terminal rendering state cleanly after interactive prompts complete.
* **Tests**
  * Updated/extended session prompt interaction tests to validate delete/detach outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->