### PR TITLE
feat(sessions): load and apply user policy

### DIFF
--- a/crates/minimal/src/config.rs
+++ b/crates/minimal/src/config.rs
@@ -30,3 +30,15 @@ pub fn read_client_config(
     let cfg_path = resolve_minimal_config_dir(global).join("config.toml");
     sessions::client::config::read_config_or_default(&cfg_path).map_err(|e| anyhow::anyhow!("{e}"))
 }
+
+/// Read the user policy from `<config>/minimal/user_policy.toml`.
+/// A missing file returns [`UserPolicy::empty`] — a fresh install
+/// activates fine without needing the file to exist.
+///
+/// [`UserPolicy::empty`]: sessions::core::policy::UserPolicy::empty
+pub fn read_user_policy(
+    global: &GlobalArgs,
+) -> Result<sessions::core::policy::UserPolicy, anyhow::Error> {
+    let path = resolve_minimal_config_dir(global).join("user_policy.toml");
+    sessions::core::policy::read_user_policy_or_default(&path).map_err(|e| anyhow::anyhow!("{e}"))
+}

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -724,27 +724,26 @@ impl sessions::core::hooks::PolicyHooks for ApproveProjectAndPackage {
 }
 
 /// Phase 3 + final SubmitVerdict round-trip for a `Pending` session.
+///
+/// `policy` is the user's own [`UserPolicy`](sessions::core::policy::UserPolicy)
+/// loaded from `user_policy.toml`; daemon-side pending items
+/// (packages, projects) are gated against it here on the client.
 async fn drive_pending_to_active(
     client: &mut client::Client,
     response: sessions::wire::request::ContributionResponse,
+    policy: sessions::core::policy::UserPolicy,
+    options: sessions::core::compose::ComposeOptions,
 ) -> Result<sessions::SessionId, anyhow::Error> {
     use minimald_rpc::SubmitVerdict;
     use sessions::client::handler::handle_response;
-    use sessions::core::compose::ComposeOptions;
-    use sessions::core::policy::UserPolicy;
     use sessions::wire::request::SessionStep;
 
     let session_id = response.session_id;
 
     let hooks = ApproveProjectAndPackage;
-    let verdict = match handle_response(
-        response,
-        &[],
-        UserPolicy::default(),
-        &hooks,
-        ComposeOptions::default(),
-        &|name| std::env::var(name),
-    ) {
+    let verdict = match handle_response(response, &[], policy, &hooks, options, &|name| {
+        std::env::var(name)
+    }) {
         Ok(v) => v,
         Err(e) => {
             send_abort(client, session_id).await;
@@ -863,6 +862,8 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
     // fail loudly on the client side without ever touching the
     // daemon.
     let cfg = config::read_client_config(global)?;
+    let user_policy = config::read_user_policy(global)?;
+    let compose_options = loadouts::compose_options_from_config(&cfg);
     let selection = loadouts::LoadoutSelection::from_flags(&args.loadout, args.no_loadouts);
     let active = loadouts::resolve_active_loadouts(selection, &cfg, global)?;
     if !active.is_empty() {
@@ -870,7 +871,7 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
         eprintln!("Applying loadouts: {}", names.join(", "));
     }
     let contribution =
-        loadouts::compose_user_contribution(active, loadouts::compose_options_from_config(&cfg))?;
+        loadouts::compose_user_contribution(active, user_policy.clone(), compose_options)?;
 
     let mut client = connect_daemon(global).await?;
 
@@ -898,7 +899,7 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
     let id = match created {
         minimald_rpc::CreateSessionResponse::Ready { id } => id,
         minimald_rpc::CreateSessionResponse::Pending { id: _, response } => {
-            drive_pending_to_active(&mut client, response).await?
+            drive_pending_to_active(&mut client, response, user_policy, compose_options).await?
         }
     };
 

--- a/crates/minimal/src/loadouts.rs
+++ b/crates/minimal/src/loadouts.rs
@@ -77,10 +77,15 @@ pub(crate) fn compose_options_from_config(
 }
 
 /// Compose the given loadouts into a [`sessions::wire::request::WireContribution`]
-/// under an empty [`UserPolicy`] (user-origin items auto-pass allow
-/// so no rules are needed at this stage).
+/// under the user's [`UserPolicy`] loaded from `user_policy.toml`.
+/// User-origin items auto-pass the allow step but the policy's
+/// `deny` / `ignore` rules still apply, so a loadout patch matching
+/// a deny rule fails the composition here rather than at the daemon.
+///
+/// [`UserPolicy`]: sessions::core::policy::UserPolicy
 pub(crate) fn compose_user_contribution(
     loadouts: Vec<sessions::core::loadout::Loadout>,
+    policy: sessions::core::policy::UserPolicy,
     options: sessions::core::compose::ComposeOptions,
 ) -> Result<sessions::wire::request::WireContribution, anyhow::Error> {
     let mut composer = sessions::client::composer::UserComposer::new();
@@ -88,7 +93,7 @@ pub(crate) fn compose_user_contribution(
         .add_all(loadouts)
         .map_err(|e| anyhow::anyhow!("composing loadouts: {e}"))?;
     composer
-        .compose(sessions::core::policy::UserPolicy::empty(), options)
+        .compose(policy, options)
         .map_err(|e| anyhow::anyhow!("composing loadouts: {e}"))
 }
 

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -2219,8 +2219,11 @@ mod tests {
             );
         }
 
+        /// `~someuser/…` (per-user tilde) is rejected at expansion —
+        /// only bare `~` and `~/…` are supported. Silent noop
+        /// otherwise: the pattern would be literal and never match.
         #[test]
-        fn user_prefixed_tilde_is_rejected_as_relative() {
+        fn user_prefixed_tilde_is_rejected() {
             let (_tmp, patch) = single_file_patch("conf.toml", "conf");
             let pp = ProvenancedPatch::new(patch, user_source());
             let policy = PatchPolicy::empty().with_deny(["~someuser/.ssh/**"]);
@@ -2237,7 +2240,7 @@ mod tests {
                 matches!(
                     err,
                     ComposeError::Expansion(
-                        crate::core::expansion::ExpandError::NotAbsolute { .. }
+                        crate::core::expansion::ExpandError::UnsupportedTildeUser { .. }
                     )
                 ),
                 "got: {err:?}",

--- a/crates/sessions/src/core/expansion.rs
+++ b/crates/sessions/src/core/expansion.rs
@@ -96,14 +96,33 @@ pub enum ExpandError {
          use `~/...` or an explicit `$HOME` reference for home-relative paths"
     )]
     NotAbsolute { pattern: String },
+
+    /// A leading `~name/...` form (per-user tilde) was used. Only
+    /// bare `~` and `~/…` (the current user's home) are expanded;
+    /// `~someuser/` would silently be treated as literal, producing
+    /// an inert pattern that never matches an absolute path.
+    /// Rejecting it up front turns a silent-noop policy rule into a
+    /// loud error, since that's almost never what the user intended.
+    #[error(
+        "pattern `{pattern}` uses `~name/` form; only `~/...` is expanded — \
+         use `$HOME/...` or an explicit path"
+    )]
+    UnsupportedTildeUser { pattern: String },
 }
 
 /// Expand `raw` against `resolved_vars` and parse the result as a
-/// [`FileSet`].
+/// [`FileSet`] intended as a **patch source pattern** — the input
+/// to the walker. The result must be absolute so the walker has a
+/// concrete starting point.
 ///
 /// `home_fallback` applies only to the `~` / `~/…` prefix when
 /// `HOME` isn't in `resolved_vars`. Explicit `$HOME` / `${HOME}`
 /// references stay strict.
+///
+/// See [`expand_policy_pattern`] for the matcher-side variant that
+/// drops the "must be absolute" requirement — policy patterns are
+/// used to check paths, not to seed a walk, so a pattern like
+/// `**/*.pem` is meaningful there.
 ///
 /// # Errors
 ///
@@ -117,6 +136,45 @@ pub fn expand_source(
     raw: &str,
     resolved_vars: &(impl VarLookup + ?Sized),
     home_fallback: Option<&str>,
+) -> Result<FileSet, ExpandError> {
+    expand_pattern(raw, resolved_vars, home_fallback, RequireAbsolute::Yes)
+}
+
+/// Expand `raw` against `resolved_vars` and parse the result as a
+/// [`FileSet`] intended as a **policy pattern** — checked against
+/// paths that other patches produce.
+///
+/// Same substitution and normalization as [`expand_source`], but
+/// the result does not have to be absolute: a policy pattern like
+/// `**/*.pem` is a legitimate matcher for "any `.pem` at any depth"
+/// and doesn't need to point at a walk root.
+///
+/// # Errors
+///
+/// See [`ExpandError`]. [`ExpandError::NotAbsolute`] cannot be
+/// returned from this function.
+pub fn expand_policy_pattern(
+    raw: &str,
+    resolved_vars: &(impl VarLookup + ?Sized),
+    home_fallback: Option<&str>,
+) -> Result<FileSet, ExpandError> {
+    expand_pattern(raw, resolved_vars, home_fallback, RequireAbsolute::No)
+}
+
+/// Whether the expander enforces "result must be absolute." Kept
+/// internal so the two public entry points expose their intent via
+/// their name rather than a caller-visible bool.
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum RequireAbsolute {
+    Yes,
+    No,
+}
+
+fn expand_pattern(
+    raw: &str,
+    resolved_vars: &(impl VarLookup + ?Sized),
+    home_fallback: Option<&str>,
+    require_absolute: RequireAbsolute,
 ) -> Result<FileSet, ExpandError> {
     let mut out = String::with_capacity(raw.len());
     let bytes = raw.as_bytes();
@@ -133,6 +191,14 @@ pub fn expand_source(
             })?;
         escape_glob_metas(home, &mut out);
         i = 1;
+    } else if bytes.first() == Some(&b'~') {
+        // `~name/...`: we don't support per-user tilde expansion.
+        // Left literal, it would be an inert pattern that silently
+        // never matches — a footgun. Reject it here so both the
+        // walker and policy paths surface the mistake loudly.
+        return Err(ExpandError::UnsupportedTildeUser {
+            pattern: raw.to_owned(),
+        });
     }
 
     while i < bytes.len() {
@@ -169,7 +235,7 @@ pub fn expand_source(
     }
 
     let normalized = normalize_path(&out)?;
-    if !normalized.starts_with('/') {
+    if require_absolute == RequireAbsolute::Yes && !normalized.starts_with('/') {
         return Err(ExpandError::NotAbsolute {
             pattern: normalized,
         });
@@ -401,15 +467,17 @@ mod tests {
         assert_eq!(expand("~", &vars).unwrap(), "/home/u");
     }
 
+    /// `~foo` isn't `~/`, so it's not tilde-expanded. Left literal,
+    /// it would be an inert glob that never matches an absolute
+    /// path (the walker's inputs) and never matches a real host
+    /// path (a policy's inputs). Reject up front — this is almost
+    /// always a user mistake for `~/foo` or an explicit path.
     #[test]
-    fn tilde_user_passes_through_literally_but_rejected_as_relative() {
-        // `~foo` isn't `~/` so it stays as-is. The glob parser would
-        // treat it as a literal directory name — but the absoluteness
-        // check rejects it first since it doesn't start with `/`.
+    fn tilde_user_form_is_rejected_up_front() {
         let vars = [];
         let err = expand("~root/x", &vars).unwrap_err();
         assert!(
-            matches!(err, ExpandError::NotAbsolute { ref pattern } if pattern == "~root/x"),
+            matches!(err, ExpandError::UnsupportedTildeUser { ref pattern } if pattern == "~root/x"),
             "got: {err:?}",
         );
     }
@@ -710,6 +778,40 @@ mod tests {
         let err = expand("~/foo", &vars).unwrap_err();
         assert!(
             matches!(err, ExpandError::NotAbsolute { .. }),
+            "got: {err:?}",
+        );
+    }
+
+    // ---- expand_policy_pattern ----
+
+    /// `expand_policy_pattern` accepts a non-absolute pattern — the
+    /// whole point of the split from `expand_source`. `**/*.pem`
+    /// means "any `.pem` at any depth" for matching purposes and
+    /// never gets walked, so it doesn't need a root.
+    #[test]
+    fn policy_pattern_accepts_non_absolute_glob() {
+        let vars: [ResolvedVar; 0] = [];
+        let fs = expand_policy_pattern("**/*.pem", vars.as_slice(), None).unwrap();
+        assert_eq!(fs.pattern(), "**/*.pem");
+    }
+
+    /// A `~/…` policy pattern still tilde-expands normally — matching
+    /// user-owned paths is the common case.
+    #[test]
+    fn policy_pattern_expands_tilde() {
+        let vars = [sv("HOME", "/home/u")];
+        let fs = expand_policy_pattern("~/.ssh/**", vars.as_slice(), None).unwrap();
+        assert_eq!(fs.pattern(), "/home/u/.ssh/**");
+    }
+
+    /// Substitution and `..` normalization still apply — dropping
+    /// the absoluteness check is the only relaxation.
+    #[test]
+    fn policy_pattern_still_rejects_parent_traversal() {
+        let vars: [ResolvedVar; 0] = [];
+        let err = expand_policy_pattern("a/../b/*.pem", vars.as_slice(), None).unwrap_err();
+        assert!(
+            matches!(err, ExpandError::PathTraversal { .. }),
             "got: {err:?}",
         );
     }

--- a/crates/sessions/src/core/policy.rs
+++ b/crates/sessions/src/core/policy.rs
@@ -191,14 +191,16 @@ impl<'de> serde::Deserialize<'de> for VarNameGlobs {
 /// Policy gating which variable declarations are honored.
 ///
 /// Applied at the session-construction layer. Precedence is the same
-/// for every origin: `ignore` first (silent), then `deny` (reject),
-/// then origin-aware allow (auto-allow for user-origin, otherwise
-/// require an `allow` match or prompt).
+/// for every origin: `deny` first (reject, emergency-stop), then
+/// `ignore` (silent drop), then origin-aware allow (auto-allow for
+/// user-origin, otherwise require an `allow` match or prompt).
+/// Overlapping deny+ignore rules resolve as denied so a would-be
+/// rejection isn't hidden behind an ignore glob.
 ///
 /// - **User-origin** (variables coming from a [`Loadout`]):
-///   `ignore` drops, `deny` rejects, otherwise auto-allowed. The
+///   `deny` rejects, `ignore` drops, otherwise auto-allowed. The
 ///   user doesn't need to `allow`-list their own loadout items.
-/// - **Project- and Package-origin**: `ignore` drops, `deny` rejects,
+/// - **Project- and Package-origin**: `deny` rejects, `ignore` drops,
 ///   then `allow` must match or the item prompts.
 ///
 /// [`Loadout`]: crate::core::loadout::Loadout
@@ -308,12 +310,14 @@ impl VarsPolicy {
 
     /// Categorize a single variable against this policy.
     ///
-    /// Precedence: `ignore` first (silent drop), then `deny` (reject
-    /// regardless of origin), then the origin-aware allow step. For
-    /// user-origin items ([`Source::UserLoadout`]), the allow step
-    /// auto-passes — the user doesn't need to allow-list their own
-    /// loadout entries. For every other source, `allow` must match
-    /// or the item routes to `NeedsApproval`.
+    /// Precedence: `deny` first (reject regardless of origin, the
+    /// emergency stop), then `ignore` (silent drop), then the
+    /// origin-aware allow step. Overlapping deny+ignore rules
+    /// resolve as denied. For user-origin items
+    /// ([`Source::UserLoadout`]), the allow step auto-passes — the
+    /// user doesn't need to allow-list their own loadout entries.
+    /// For every other source, `allow` must match or the item routes
+    /// to `NeedsApproval`.
     ///
     /// `item` reports its provenance via [`Provenanced`]; the composer
     /// constructs `T` types that carry their own source, so the caller
@@ -326,11 +330,17 @@ impl VarsPolicy {
     /// [`Provenanced`]: crate::core::source::Provenanced
     #[must_use]
     pub fn check<T: Provenanced>(&self, name: &str, item: T) -> CheckOutcome<T> {
-        if self.ignore.is_match(name) {
-            return CheckOutcome::Decided(Decision::Ignored);
-        }
+        // Deny wins over everything, including ignore. `deny` is the
+        // user's emergency stop: if a rule matches, the composition
+        // must fail loudly, not silently drop the item. Overlapping
+        // deny+ignore rules resolve as denied so an operator can't
+        // accidentally hide a would-be-rejected value behind an
+        // ignore glob.
         if self.deny.is_match(name) {
             return CheckOutcome::Decided(Decision::Denied(item));
+        }
+        if self.ignore.is_match(name) {
+            return CheckOutcome::Decided(Decision::Ignored);
         }
         if matches!(item.source(), Source::UserLoadout { .. }) {
             return CheckOutcome::Decided(Decision::Allowed(item));
@@ -351,17 +361,19 @@ impl VarsPolicy {
 /// after the patch's [`FileSet`] is walked. The patch's `dest` is
 /// not matched; only the enumerated source paths are.
 ///
-/// - **User-origin patches** (from a [`Loadout`]): `ignore` drops,
-///   `deny` rejects, otherwise auto-allowed.
-/// - **Project- and Package-origin patches**: `ignore` drops, `deny`
-///   rejects, then `allow` must match — otherwise routes to a
+/// - **User-origin patches** (from a [`Loadout`]): `deny` rejects,
+///   `ignore` drops, otherwise auto-allowed.
+/// - **Project- and Package-origin patches**: `deny` rejects,
+///   `ignore` drops, then `allow` must match — otherwise routes to a
 ///   prompt via [`PolicyHooks`](crate::core::hooks::PolicyHooks).
 ///
-/// Precedence: `ignore` first, then `deny`, then origin-aware
-/// `allow`. Patterns may contain `~/` or `$VAR`; expansion happens
-/// at session construction (see [`crate::core::expansion`]) and
-/// stored patterns retain their raw form so the policy round-trips
-/// losslessly.
+/// Precedence: `deny` first (emergency stop), then `ignore` (silent
+/// drop), then origin-aware `allow`. Overlapping deny+ignore rules
+/// resolve as denied so a would-be rejection isn't hidden behind an
+/// ignore glob. Patterns may contain `~/` or `$VAR`; expansion
+/// happens at session construction (see [`crate::core::expansion`])
+/// and stored patterns retain their raw form so the policy
+/// round-trips losslessly.
 ///
 /// [`Loadout`]: crate::core::loadout::Loadout
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -491,8 +503,19 @@ impl PatchPolicy {
     ) -> Result<ExpandedPatchPolicy, crate::core::expansion::ExpandError> {
         let expand_one =
             |raws: &[String]| -> Result<Vec<FileSet>, crate::core::expansion::ExpandError> {
+                // Policy patterns are matchers, not walk seeds — they
+                // check paths another patch produced. A bare glob
+                // like `**/*.pem` should mean "any `.pem` anywhere,"
+                // so we skip the "must be absolute" check that
+                // `expand_source` enforces for walker inputs.
                 raws.iter()
-                    .map(|r| crate::core::expansion::expand_source(r, resolved_vars, home_fallback))
+                    .map(|r| {
+                        crate::core::expansion::expand_policy_pattern(
+                            r,
+                            resolved_vars,
+                            home_fallback,
+                        )
+                    })
                     .collect()
             };
         let allow = expand_one(&self.allow)?;
@@ -638,9 +661,10 @@ impl ExpandedPatchPolicy {
     /// traversed an actual symlink. Both forms are checked
     /// independently and the outcomes are combined.
     ///
-    /// **Precedence within one path:** `ignore` first (silent drop),
-    /// then `deny` (reject regardless of origin), then the
-    /// origin-aware allow step. For user-origin items
+    /// **Precedence within one path:** `deny` first (reject
+    /// regardless of origin, the emergency stop), then `ignore`
+    /// (silent drop), then the origin-aware allow step. Overlapping
+    /// deny+ignore rules resolve as denied. For user-origin items
     /// ([`Source::UserLoadout`]) the allow step auto-passes; for
     /// every other source `allow` must match or the path routes to
     /// `NeedsApproval`.
@@ -675,11 +699,15 @@ impl ExpandedPatchPolicy {
     /// helper used by both [`check`](Self::check) and
     /// [`check_dual`](Self::check_dual).
     fn decide(&self, path: &camino::Utf8Path, source: &Source) -> PathDecision {
-        if filesets_match(&self.ignore, path) {
-            return PathDecision::Ignored;
-        }
+        // Deny wins over everything, including ignore. `deny` is the
+        // user's emergency stop: overlapping deny+ignore rules must
+        // resolve as denied so an operator can't accidentally hide a
+        // would-be-rejected patch behind an ignore glob.
         if filesets_match(&self.deny, path) {
             return PathDecision::Denied;
+        }
+        if filesets_match(&self.ignore, path) {
+            return PathDecision::Ignored;
         }
         if matches!(source, Source::UserLoadout { .. }) {
             return PathDecision::Allowed;
@@ -734,6 +762,75 @@ fn attach_decision<T>(decision: PathDecision, item: T) -> CheckOutcome<T> {
 
 fn filesets_match(sets: &[FileSet], path: &camino::Utf8Path) -> bool {
     sets.iter().any(|fs| fs.is_match(path))
+}
+
+// =====================================================================
+// user_policy.toml loading
+// =====================================================================
+
+/// Failure loading `user_policy.toml`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum UserPolicyError {
+    /// The file couldn't be read.
+    #[error("read `{path}`: {source}")]
+    Io {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The file wasn't valid TOML or didn't match the [`UserPolicy`]
+    /// schema.
+    #[error("parse `{path}`: {source}")]
+    Parse {
+        path: std::path::PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+}
+
+/// Parse the user policy at `path`.
+///
+/// The file sits beside `config.toml` at
+/// `<config>/minimal/user_policy.toml` and deserializes into
+/// [`UserPolicy`] — the same type the composer consumes at gate
+/// time.
+///
+/// # Errors
+///
+/// See [`UserPolicyError`]. A missing file returns
+/// [`UserPolicyError::Io`] — use [`read_user_policy_or_default`] if
+/// you want an empty policy in that case.
+pub fn read_user_policy_file(path: &std::path::Path) -> Result<UserPolicy, UserPolicyError> {
+    let contents = std::fs::read_to_string(path).map_err(|source| UserPolicyError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    toml::from_str(&contents).map_err(|source| UserPolicyError::Parse {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Parse the user policy at `path`, or return [`UserPolicy::empty`]
+/// when the file doesn't exist. Any other read or parse failure
+/// propagates as [`UserPolicyError`].
+///
+/// # Errors
+///
+/// See [`UserPolicyError`]. `NotFound` is folded into
+/// `Ok(UserPolicy::empty())`; permission or parse failures still
+/// surface.
+pub fn read_user_policy_or_default(path: &std::path::Path) -> Result<UserPolicy, UserPolicyError> {
+    match read_user_policy_file(path) {
+        Ok(p) => Ok(p),
+        Err(UserPolicyError::Io { source, .. })
+            if source.kind() == std::io::ErrorKind::NotFound =>
+        {
+            Ok(UserPolicy::empty())
+        }
+        Err(e) => Err(e),
+    }
 }
 
 // =====================================================================
@@ -853,6 +950,36 @@ mod tests {
     fn vars_policy_try_with_allow_propagates_invalid_glob() {
         let err = VarsPolicy::empty().try_with_allow(["[bad"]).unwrap_err();
         assert!(matches!(err, VarError::InvalidGlob { .. }), "got: {err:?}");
+    }
+
+    /// Deny wins when a name matches both `deny` and `ignore`. The
+    /// user's intent with `deny` is an emergency stop; an ignore
+    /// glob must never silently hide a would-be rejection.
+    #[test]
+    fn vars_policy_check_deny_wins_over_ignore_on_overlap() {
+        struct Item {
+            source: Source,
+        }
+        impl Provenanced for Item {
+            fn source(&self) -> &Source {
+                &self.source
+            }
+        }
+        let policy = VarsPolicy::empty()
+            .try_with_deny(["DIAGRAM"])
+            .unwrap()
+            .try_with_ignore(["DIAGRAM"])
+            .unwrap();
+        let item = Item {
+            source: Source::UserLoadout {
+                name: "test".to_string(),
+            },
+        };
+        let outcome = policy.check("DIAGRAM", item);
+        assert!(
+            matches!(outcome, CheckOutcome::Decided(Decision::Denied(_))),
+            "overlapping deny+ignore must resolve as denied",
+        );
     }
 
     // =================================================================
@@ -984,6 +1111,69 @@ mod tests {
         assert_eq!(expanded.ignore().len(), 1);
     }
 
+    /// Deny wins when a path matches both `deny` and `ignore`. Same
+    /// invariant as [`vars_policy_check_deny_wins_over_ignore_on_overlap`],
+    /// on the patch-side gate. Goes through
+    /// [`ExpandedPatchPolicy::check`] with a `link` of `None` so only
+    /// the single-path `decide` codepath is exercised.
+    #[test]
+    fn patch_policy_check_deny_wins_over_ignore_on_overlap() {
+        struct Item {
+            source: Source,
+        }
+        impl Provenanced for Item {
+            fn source(&self) -> &Source {
+                &self.source
+            }
+        }
+        let policy = PatchPolicy::empty()
+            .with_deny(["/etc/secret/**"])
+            .with_ignore(["/etc/secret/**"]);
+        let vars: [crate::core::primitives::ResolvedVar; 0] = [];
+        let expanded = policy.expand_with(vars.as_slice(), None).unwrap();
+        let target = camino::Utf8Path::new("/etc/secret/token");
+        let item = Item {
+            source: Source::UserLoadout {
+                name: "test".to_string(),
+            },
+        };
+        let outcome = expanded.check(None, target, item);
+        assert!(
+            matches!(outcome, CheckOutcome::Decided(Decision::Denied(_))),
+            "overlapping deny+ignore must resolve as denied",
+        );
+    }
+
+    /// Non-absolute policy patterns are legal now — they're matchers,
+    /// not walk seeds. `**/*.pem` should expand cleanly and actually
+    /// deny a real `.pem` path at check time.
+    #[test]
+    fn patch_policy_expand_accepts_non_absolute_glob_and_matches() {
+        struct Item {
+            source: Source,
+        }
+        impl Provenanced for Item {
+            fn source(&self) -> &Source {
+                &self.source
+            }
+        }
+        let policy = PatchPolicy::empty().with_deny(["**/*.pem"]);
+        let vars: [crate::core::primitives::ResolvedVar; 0] = [];
+        let expanded = policy
+            .expand_with(vars.as_slice(), None)
+            .expect("non-absolute policy pattern must expand");
+        let item = Item {
+            source: Source::UserLoadout {
+                name: "dev".to_string(),
+            },
+        };
+        let outcome = expanded.check(None, camino::Utf8Path::new("/etc/ssl/private.pem"), item);
+        assert!(
+            matches!(outcome, CheckOutcome::Decided(Decision::Denied(_))),
+            "non-absolute deny pattern must still match at check time",
+        );
+    }
+
     // =================================================================
     // UserPolicy tests
     // =================================================================
@@ -1075,6 +1265,94 @@ mod tests {
         #[test]
         fn both_allowed_is_allowed() {
             assert_eq!(Allowed.combine(Allowed), Allowed);
+        }
+    }
+
+    // =================================================================
+    // user_policy.toml loading
+    // =================================================================
+
+    mod user_policy_toml {
+        use super::*;
+        use std::io::Write;
+        use std::path::{Path, PathBuf};
+        use tempfile::TempDir;
+
+        fn write_file(dir: &Path, name: &str, contents: &str) -> PathBuf {
+            let path = dir.join(name);
+            let mut f = std::fs::File::create(&path).unwrap();
+            f.write_all(contents.as_bytes()).unwrap();
+            path
+        }
+
+        /// A well-formed policy with a vars allow list round-trips
+        /// through the parser.
+        #[test]
+        fn read_user_policy_file_ok() {
+            let dir = TempDir::new().unwrap();
+            let path = write_file(
+                dir.path(),
+                "user_policy.toml",
+                indoc::indoc! {r#"
+                    [vars]
+                    allow = ["MY_APP_*"]
+                "#},
+            );
+            let policy = read_user_policy_file(&path).unwrap();
+            assert_eq!(policy.vars().allow().raw_patterns(), &["MY_APP_*"]);
+        }
+
+        /// An empty file parses to `UserPolicy::empty()`.
+        #[test]
+        fn read_user_policy_file_empty_is_empty_policy() {
+            let dir = TempDir::new().unwrap();
+            let path = write_file(dir.path(), "user_policy.toml", "");
+            let policy = read_user_policy_file(&path).unwrap();
+            assert_eq!(policy, UserPolicy::empty());
+        }
+
+        /// A missing file folds into `UserPolicy::empty()` via
+        /// `read_user_policy_or_default`.
+        #[test]
+        fn read_user_policy_or_default_missing_returns_empty() {
+            let dir = TempDir::new().unwrap();
+            let missing = dir.path().join("does-not-exist.toml");
+            let policy = read_user_policy_or_default(&missing).unwrap();
+            assert_eq!(policy, UserPolicy::empty());
+        }
+
+        /// A malformed file still errors under
+        /// `read_user_policy_or_default` — only `NotFound` is silenced.
+        #[test]
+        fn read_user_policy_or_default_malformed_still_errors() {
+            let dir = TempDir::new().unwrap();
+            let path = write_file(dir.path(), "user_policy.toml", "= not = toml =");
+            let err = read_user_policy_or_default(&path).unwrap_err();
+            assert!(matches!(err, UserPolicyError::Parse { .. }));
+        }
+
+        /// Both narrow policies round-trip together — the shape an
+        /// operator would actually write.
+        #[test]
+        fn read_user_policy_file_both_sections() {
+            let dir = TempDir::new().unwrap();
+            let path = write_file(
+                dir.path(),
+                "user_policy.toml",
+                indoc::indoc! {r#"
+                    [vars]
+                    allow = ["MY_APP_*"]
+                    deny  = ["SECRET_*"]
+
+                    [patches]
+                    allow = ["~/dotfiles/**"]
+                "#},
+            );
+            let policy = read_user_policy_file(&path).unwrap();
+            let expected_vars = VarsPolicy::empty()
+                .with_allow(VarNameGlobs::try_new(["MY_APP_*"]).unwrap())
+                .with_deny(VarNameGlobs::try_new(["SECRET_*"]).unwrap());
+            assert_eq!(policy.vars(), &expected_vars);
         }
     }
 }


### PR DESCRIPTION
Load `user_policy.toml` from `<config>/minimal/` and thread it through
activation. Fills in the placeholder `UserPolicy::empty()` /
`UserPolicy::default()` sites that were shipping unenforced.

- `sessions::core::policy` — `read_user_policy_file` / `_or_default`
  loaders (empty policy on `NotFound`).
- `minimal::config::read_user_policy` — helper mirroring
  `read_client_config`. Loaded once in `cmd_activate`, passed into
  both `compose_user_contribution` and `drive_pending_to_active`.
- `drive_pending_to_active` now takes `UserPolicy` + `ComposeOptions`
  (was defaults) — daemon-response pending items get gated against
  the real policy.

## Policy semantics fixes

Two behavior corrections uncovered while wiring this up:

- **Deny beats ignore** on single-path check in both `VarsPolicy` and
  `ExpandedPatchPolicy`. Deny is the emergency stop — it can't be
  silently hidden behind an overlapping ignore glob. `PathDecision::combine`
  was already correct; single-path `decide` / `check` were inverted.
- **Policy patterns don't need to be absolute.** Split
  `expand_source` (patch-source, must-be-absolute walker input) from
  `expand_policy_pattern` (matcher against real paths). `deny =
  ["**/*.pem"]` in `user_policy.toml` now works. `~name/` tilde-user
  form still rejected loudly (was previously caught by the absolute
  check; now has its own `ExpandError::UnsupportedTildeUser` variant
  so both code paths surface the footgun).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading user policy rules from `user_policy.toml`, with missing files defaulting to an empty policy.
  * User-defined variable and patch rules are now used during session composition/activation.
  * Policy pattern matching now supports non-absolute globs while still expanding home-directory paths.
* **Bug Fixes**
  * `deny` rules now consistently take precedence over `ignore` for both variables and patch matching, including overlapping rules.
  * Per-user tilde patterns (for example `~name/...`) are rejected earlier with a clearer error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->