### PR TITLE
fix(installer): fix completions when legacy minimal was previously installed

### DIFF
--- a/docs/specs/07-spec-installer/07-spec-installer.md
+++ b/docs/specs/07-spec-installer/07-spec-installer.md
@@ -310,7 +310,14 @@ downloads) one init file per shell family under `<data>/shell-init/`:
   no-op once the user manages `PATH` themselves.
 
 `zsh.sh` additionally adds the zsh completions dir (R9.3) to `fpath` and runs
-`compinit`. All three files are regenerated on every run and appended to the
+`compinit` — and then **self-heals a lying dump**: `compinit` trusts its cached
+`.zcompdump` whenever the dump's (zsh version, completion-file count) header
+matches, a check that misses real changes (one completions dir replacing
+another with the same file count). If `min` is still unregistered after
+`compinit` while the `_min` file exists, `zsh.sh` deletes
+`${ZDOTDIR:-$HOME}/.zcompdump` and reruns `compinit`; the file-exists guard
+keeps a home without generated completions from rebuilding the dump on every
+startup. All three files are regenerated on every run and appended to the
 install record (R6.1) with the on-disk digest in **both** hash columns (no
 manifest hash exists for generated content), so reruns replace them and
 uninstall removes them like any component.
@@ -376,6 +383,15 @@ installed, and completions regenerate on the next run. Specifically:
   with stderr nulled — a command-level `2>/dev/null` cannot catch them), so the
   user sees the installer's warning, never a raw `Permission denied` line.
 
+Writing the zsh completion file also **drops a pre-existing
+`${ZDOTDIR:-$HOME}/.zcompdump`** (announced, best-effort like the rest of the
+step): the dump is a pure, regenerable cache, and its staleness check cannot
+see `_min` change when the completion-file count stays equal — the upgrade
+from the pre-rewrite installer hits exactly that, leaving `min` completion
+dead in every new shell until an unrelated `fpath` change. Dropping the cache
+forces a real rescan on the next zsh startup (the `zsh.sh` self-heal in R9.1
+is the belt-and-braces for dumps that go stale later).
+
 **R9.4** — Uninstall (Units 7–8) undoes shell integration completely:
 
 - the generated init and completion files are ordinary record rows, removed by
@@ -390,6 +406,11 @@ installed, and completions regenerate on the next run. Specifically:
 - the emptied `shell-init` and completion dirs (and their possibly
   installer-created parents) are pruned with the same `rmdir`-only discipline
   as R8.1 — they are shared locations, never `rm -rf`ed;
+- `${ZDOTDIR:-$HOME}/.zcompdump` is dropped (announced), but **only when the
+  record shows zsh completions were installed**: the dump is the user's cache,
+  and left behind it keeps a `min` registration whose function file is gone,
+  so the first `min <tab>` in every new zsh fails with `function definition
+  file not found`;
 - `--dry-run` composes: it announces the would-be rc strip and removals and
   touches nothing.
 
@@ -408,7 +429,11 @@ installed, and completions regenerate on the next run. Specifically:
   (sourcing `~/.minimal/shim/shell-init/…`) has it replaced — the run announces
   the replacement, exactly one marker block remains, it sources the current
   init file, no shim reference survives, and user content on both sides of the
-  old block is preserved; a rerun then rewrites nothing.
+  old block is preserved; a rerun then rewrites nothing. A pre-existing
+  `.zcompdump` is dropped by that upgrade (announced), and the rerun — with no
+  dump present — announces no drop.
+- **Test**: the generated `zsh.sh` carries the compinit self-heal (checks
+  `_comps[min]` against the `_min` file).
 - **Test**: an rc file with a start marker but no end marker is left untouched
   by both install and uninstall — each warns naming the file, appends nothing,
   preserves the content after the stray marker, and exits 0.
@@ -423,8 +448,11 @@ installed, and completions regenerate on the next run. Specifically:
   0, warns naming that dir, still installs the other shells' completions, and
   leaks no raw shell `Permission denied` error into the output.
 - **Test**: `--uninstall` removes the generated files, strips the rc block
-  while preserving the user's own rc content, and prunes the emptied
-  completion/shell-init dirs; `--dry-run` announces the strip without editing.
+  while preserving the user's own rc content, prunes the emptied
+  completion/shell-init dirs, and drops the `.zcompdump` cache; `--dry-run`
+  announces the strip and the dump drop without editing either. A data-only
+  install (no zsh completions in the record) leaves the user's `.zcompdump`
+  untouched on uninstall.
 
 ## Non-Goals
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -168,6 +168,12 @@ zsh_comp_dir="${XDG_DATA_HOME:-$HOME/.local/share}/zsh/completions"
 fish_comp_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fish/completions"
 fish_config="${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
 zshrc="${ZDOTDIR:-$HOME}/.zshrc"
+# zsh's compinit caches completion registrations here, and its staleness check
+# is only (zsh version, completion-file count) — it cannot see `_min` appear,
+# change, or vanish when the count happens to stay equal. The dump is a pure,
+# regenerable cache: both install and uninstall drop it when they change the
+# zsh completions, forcing a real rescan on the next zsh startup.
+zcompdump="${ZDOTDIR:-$HOME}/.zcompdump"
 
 marker_start='# >>> minimal >>>'
 marker_end='# <<< minimal <<<'
@@ -227,13 +233,18 @@ do_uninstall() {
     # Tab, computed once, so rows are split on tab alone (R7.3): a dest under a
     # $HOME containing spaces must still parse as one field.
     tab="$(printf '\t')"
-    removed=0 absent=0 kept_modified=0 kept_foreign=0
+    removed=0 absent=0 kept_modified=0 kept_foreign=0 had_zsh_completions=0
 
     # `comp` is informational here and the manifest-hash column (`_`) is unused;
     # `dest`/`want` (the installed hash) drive removal. Read from the record via
     # redirection so the loop body runs in this shell (counters persist).
     while IFS="$tab" read -r comp dest _ want; do
         [ -n "$dest" ] || continue
+
+        # A completions-zsh row (whatever the file's fate below) means a
+        # compinit dump may hold a `min` registration; noted for the cache
+        # drop after the walk.
+        [ "$comp" = completions-zsh ] && had_zsh_completions=1
 
         # Already gone (not even a dangling symlink) — count and continue, which
         # is what makes an interrupted run re-runnable (R7.3).
@@ -290,6 +301,22 @@ do_uninstall() {
         # that must not abort the walk over the remaining rc candidates.
         strip_rc_block "$_rc" || true
     done
+
+    # R9.4 — the `min` registration also lives on inside zsh's compinit dump
+    # (see zcompdump above); left behind, the first `min <tab>` in every new
+    # zsh fails with "function definition file not found". Dropped only when
+    # the record shows zsh completions were installed: the dump belongs to
+    # the user, and an install that never touched zsh completions has no
+    # business clearing their cache.
+    if [ "$had_zsh_completions" -eq 1 ] && [ -f "$zcompdump" ]; then
+        if [ "$dry_run" -eq 1 ]; then
+            say "  would remove compinit dump cache $zcompdump"
+        elif rm -f "$zcompdump" 2>/dev/null; then
+            say "  removed compinit dump cache $zcompdump"
+        else
+            say "  warning: could not remove compinit dump cache $zcompdump"
+        fi
+    fi
 
     # R8.2 — --purge additionally deletes the minimal-owned trees wholesale (build
     # cache included); they live at fixed .../minimal paths the tool owns. It
@@ -535,6 +562,17 @@ if [ -d "$zsh_comp_dir" ]; then
     fpath=("$zsh_comp_dir" \$fpath)
     autoload -Uz compinit
     compinit
+    # compinit trusts a cached dump whenever its (zsh version, completion-file
+    # count) header matches — a check that misses real changes, e.g. one
+    # completions dir replacing another with the same file count. If min is
+    # still unregistered while its completion file exists, the dump lied:
+    # drop it and scan for real. The file-exists guard keeps this from
+    # rebuilding the dump on every startup when completions were never
+    # generated.
+    if [ -f "$zsh_comp_dir/_min" ] && [ -z "\${_comps[min]:-}" ]; then
+        rm -f "\${ZDOTDIR:-\$HOME}/.zcompdump"
+        compinit
+    fi
 fi
 EOF
 record_generated shell-init-zsh "$init_dir/zsh.sh"
@@ -571,6 +609,16 @@ gen_completions() {
         && [ -s "$_tmp" ] \
         && mv -f "$_tmp" "$2" 2>/dev/null; then
         record_generated "completions-$1" "$2"
+        # A pre-existing compinit dump can keep trusting its stale contents
+        # after the zsh completion file changes (see zcompdump above) — the
+        # upgrade path from the pre-rewrite installer hits exactly that, and
+        # "restart your shell" cannot fix it. Cheap rm, so unconditional on
+        # every (re)generation; failure is as non-fatal as the rest of R9.3.
+        if [ "$1" = zsh ] && [ -f "$zcompdump" ]; then
+            if rm -f "$zcompdump" 2>/dev/null; then
+                say "  completions: cleared compinit dump cache $zcompdump"
+            fi
+        fi
     else
         rm -f "$_tmp" 2>/dev/null || true
         say "  completions: warning: could not generate $1 completions (non-fatal)"

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -405,6 +405,8 @@ run zshinit "$H9"
 want_ok ".zshrc created and hooked (R9.2)" grep -q "shell-init/zsh.sh" "$H9/.zshrc"
 want_ok "zsh init wires fpath completions (R9.1)" \
     grep -q "fpath=" "$H9/xdg-data/minimal/shell-init/zsh.sh"
+want_ok "zsh init self-heals a stale compinit dump (R9.1)" \
+    grep -q '_comps\[min\]' "$H9/xdg-data/minimal/shell-init/zsh.sh"
 H10="$root/h10"; mkdir -p "$H10"
 TEST_SHELL=/usr/bin/fish
 run fishinit "$H10"
@@ -431,9 +433,16 @@ H14="$root/h14"; mkdir -p "$H14"
     printf '# <<< minimal <<<\n'
     printf '\n# added after the old install\n'
 } >"$H14/.zshrc"
+# A compinit dump from the old install: its (version, file count) header can
+# keep matching after the completions-dir swap, so compinit would trust it and
+# never see the new _min. The install must drop it when it (re)writes the zsh
+# completions.
+printf '#files: 1 version: 5.9\n' >"$H14/.zcompdump"
 TEST_SHELL=/usr/bin/zsh
 run oldblock "$H14"
 check 0 "$rc" "upgrade over old rc block exits 0"
+want_err "stale compinit dump dropped on upgrade (R9.3)" test -e "$H14/.zcompdump"
+want_ok "dump drop announced (R9.3)" grep -q "cleared compinit dump cache" "$OUT"
 want_ok "stale block replacement announced (R9.2)" grep -q "replaced stale block" "$OUT"
 check 1 "$(grep -c '>>> minimal >>>' "$H14/.zshrc")" "exactly one marker block after upgrade (R9.2)"
 want_ok "block now sources the current zsh init (R9.2)" grep -q "shell-init/zsh.sh" "$H14/.zshrc"
@@ -445,6 +454,8 @@ run oldblock2 "$H14"
 check 0 "$rc" "rerun after replacement exits 0"
 want_err "rerun rewrites nothing (R9.2)" grep -qE "shell-init: (added|replaced)" "$OUT"
 check 1 "$(grep -c '>>> minimal >>>' "$H14/.zshrc")" "rerun keeps a single marker block (R9.2)"
+want_err "no dump means no drop announcement on rerun (R9.3)" \
+    grep -q "cleared compinit dump cache" "$OUT"
 TEST_SHELL=
 
 # A start marker whose end marker was lost to a hand edit must never cost the
@@ -679,12 +690,19 @@ printf '# keep me\n' >"$HU7/.bashrc"
 TEST_SHELL=/bin/bash
 run u7_install "$HU7"
 check 0 "$rc" "shell-integration seed install exits 0"
+# A dump written after the install (by the user's shells) still holds the min
+# registration; uninstall must drop it or the next `min <tab>` autoload fails.
+printf '#files: 1 version: 5.9\n' >"$HU7/.zcompdump"
 run u7_dry "$HU7" --uninstall --dry-run
 want_ok "dry-run announces the rc strip without editing (R9.4/R8.3)" \
     grep -q "would remove shell-init block" "$OUT"
 want_ok "dry-run leaves the rc block (R8.3)" grep -q '>>> minimal >>>' "$HU7/.bashrc"
+want_ok "dry-run announces the compinit dump drop (R9.4/R8.3)" \
+    grep -q "would remove compinit dump cache" "$OUT"
+want_ok "dry-run leaves the compinit dump (R8.3)" test -f "$HU7/.zcompdump"
 run u7_un "$HU7" --uninstall
 check 0 "$rc" "uninstall with shell integration exits 0"
+want_err "compinit dump dropped (R9.4)" test -e "$HU7/.zcompdump"
 want_err "completions removed (R9.4)" test -e "$HU7/xdg-data/bash-completion/completions/min"
 want_err "init files removed (R9.4)" test -e "$HU7/xdg-data/minimal/shell-init"
 want_err "emptied completion dirs pruned (R9.4)" test -d "$HU7/xdg-data/bash-completion"
@@ -692,6 +710,15 @@ want_err "emptied data dir pruned (R9.4)" test -d "$HU7/xdg-data/minimal"
 want_err "rc block stripped (R9.4)" grep -q '>>> minimal >>>' "$HU7/.bashrc"
 want_ok "user rc content survives the strip (R9.4)" grep -q '# keep me' "$HU7/.bashrc"
 TEST_SHELL=
+
+# R9.4 — a record without a completions-zsh row (the data-only install above)
+# must NOT cost the user their compinit dump: the cache is only cleared when
+# the installer actually put min into it.
+printf '# untouched user cache\n' >"$H5/.zcompdump"
+run u_datadump "$H5" --uninstall
+check 0 "$rc" "data-only uninstall exits 0"
+want_ok "dump kept when no zsh completions were installed (R9.4)" \
+    grep -q '# untouched user cache' "$H5/.zcompdump"
 
 # ===========================================================================
 echo "# ---"


### PR DESCRIPTION
I think i was the only one hitting this lol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved zsh completion reliability by detecting and recovering from stale completion caches.
  - Zsh completion updates now refresh outdated cache data automatically.
  - Uninstall removes the zsh completion cache only when it was created by the installer, preserving unrelated user data.
  - Dry-run mode now accurately reports cache cleanup without modifying files.

- **Tests**
  - Added coverage for stale-cache recovery, upgrades, reruns, uninstall behavior, and dry-run handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->