### PR TITLE
refactor(sessions): Part 1 - store actor & plumbing

### DIFF
--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -14,6 +14,7 @@ mod session;
 pub mod session_host;
 mod sessions;
 mod sftp;
+mod store;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_harness;
 

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -3,12 +3,13 @@ use std::{collections::BTreeMap, io::ErrorKind::NotFound};
 use crate::{
     session::{Session, SessionHandle},
     session_host::HostAttrs,
+    store::{RecordPredicate, Store, StoreHandle},
 };
 use paths::DaemonAbsPath;
 use sessions::{
     SessionId,
     daemon::composer::{ComposeOutcome, PendingComposeState, resume_from_verdict},
-    store::{DiskLoader, Loader, SessionKey, SessionObject},
+    store::SessionObject,
     wire::request::{ContributionVerdict, SessionStep, WireContribution},
 };
 use std::sync::Arc;
@@ -34,6 +35,15 @@ pub struct SessionInfo {
 pub enum SessionKeyPredicate {
     Id(SessionId),
     Name(String),
+}
+
+impl From<SessionKeyPredicate> for RecordPredicate {
+    fn from(pred: SessionKeyPredicate) -> Self {
+        match pred {
+            SessionKeyPredicate::Id(id) => RecordPredicate::Id(id),
+            SessionKeyPredicate::Name(name) => RecordPredicate::Name(name),
+        }
+    }
 }
 
 /// Transport / internal error when communicating with the sessions actor.
@@ -183,19 +193,15 @@ enum ManagerMessage {
 ///
 /// Follows the actor pattern.
 #[derive(Debug)]
-pub struct Manager<L: Loader = DiskLoader> {
+pub struct Manager {
     in_shutdown: bool,
     receiver: mpsc::Receiver<ManagerMessage>,
-    running: BTreeMap<L::Key, SessionHandle>,
-    store: L,
+    running: BTreeMap<SessionId, SessionHandle>,
+    store: StoreHandle,
 
-    /// A weak handle to this manager, handed down to each session it spawns so
-    /// a session's [`Binding`](crate::session_host) can ask the manager to
-    /// destroy it (the "delete" choice on the shell-exit prompt) without owning
-    /// the manager. It must be weak: a strong self-handle would keep the
-    /// manager's own `recv` loop from ever seeing all senders dropped (wedging
-    /// shutdown) and would close an ownership cycle
-    /// (manager → session → host → binding → manager).
+    /// A weak handle to this manager, which can be duplicated so
+    /// that downstream actors (session, session host) have a handle
+    /// to do operations on us.
     weak_self: WeakManagerHandle,
 
     /// Per-session stash for in-flight `CreateSession` flows that
@@ -252,8 +258,8 @@ impl Manager {
         mctx_config: mctx::Config,
         net_switch: Arc<Mutex<crate::net::SwitchClient>>,
     ) -> Result<ManagerHandle, std::io::Error> {
-        let mut l = DiskLoader::new(minimal_state_dir.clone())?;
-        Self::reap_orphan_pending(&mut l)?;
+        let store = Store::init(minimal_state_dir.clone()).await?;
+        Self::reap_orphan_pending(&store).await?;
 
         // Build the daemon-scoped mctx state once at startup. Each
         // `CreateSession` will build a per-session `Context` on top of
@@ -292,7 +298,7 @@ impl Manager {
             in_shutdown: false,
             receiver,
             running,
-            store: l,
+            store,
             weak_self,
             pending: BTreeMap::new(),
             compositions: BTreeMap::new(),
@@ -309,25 +315,16 @@ impl Manager {
     }
 }
 
-impl<L: Loader> Manager<L> {
-    fn key_for(&self, pred: &SessionKeyPredicate) -> Result<Option<L::Key>, std::io::Error> {
-        match pred {
-            SessionKeyPredicate::Id(id) => self.store.find_by_id(id),
-            SessionKeyPredicate::Name(name) => self.store.find_by_name(name),
-        }
-    }
-
+impl Manager {
     /// Delete any on-disk `Pending` records at startup. Their
     /// in-memory `PendingComposeState` didn't survive the restart,
     /// so they can never transition to `Active`.
-    fn reap_orphan_pending(store: &mut L) -> Result<(), std::io::Error> {
+    async fn reap_orphan_pending(store: &StoreHandle) -> Result<(), std::io::Error> {
         let mut reaped = 0u64;
-        let keys: Vec<L::Key> = store.keys().collect();
-        for k in keys {
-            let obj = store.get(&k)?;
-            if obj.record().status == sessions::SessionStatus::Pending {
-                let id = obj.record().id;
-                store.delete(&k)?;
+        for handle in store.handles().await? {
+            if handle.record().await?.status == sessions::SessionStatus::Pending {
+                let id = *handle.id();
+                handle.delete().await?;
                 tracing::info!(
                     session_id = %id,
                     "reaped orphan Pending session on startup",
@@ -356,18 +353,15 @@ impl<L: Loader> Manager<L> {
             ManagerMessage::List(r) => {
                 r.handle(async {
                     let mut out = Vec::with_capacity(32);
-                    for k in self.store.keys() {
-                        out.push({
-                            let s = self.store.get(&k)?;
-                            let r = s.record();
-                            SessionInfo {
-                                id: r.id,
-                                name: r.name.clone(),
-                                attrs: match self.running.get(&k) {
-                                    Some(h) => h.get_attrs().await,
-                                    None => None,
-                                },
-                            }
+                    for handle in self.store.handles().await? {
+                        let record = handle.record().await?;
+                        out.push(SessionInfo {
+                            id: record.id,
+                            name: record.name.clone(),
+                            attrs: match self.running.get(&record.id) {
+                                Some(h) => h.get_attrs().await,
+                                None => None,
+                            },
                         });
                     }
                     Ok(out)
@@ -377,15 +371,9 @@ impl<L: Loader> Manager<L> {
             // Gets the record for a specific session.
             ManagerMessage::GetRecord(pred, r) => {
                 r.handle(async {
-                    Ok::<_, SessionsError>(match pred {
-                        SessionKeyPredicate::Id(id) => self
-                            .store
-                            .find_by_id(&id)?
-                            .map(|k| self.store.get(&k).unwrap().record().clone()),
-                        SessionKeyPredicate::Name(name) => self
-                            .store
-                            .find_by_name(&name)?
-                            .map(|k| self.store.get(&k).unwrap().record().clone()),
+                    Ok::<_, SessionsError>(match self.store.find(pred.into()).await? {
+                        Some(handle) => Some(handle.record().await?),
+                        None => None,
                     })
                 })
                 .await;
@@ -402,10 +390,10 @@ impl<L: Loader> Manager<L> {
                             "in shutdown",
                         ));
                     }
-                    match self.key_for(&pred)? {
+                    match self.store.find(pred.into()).await? {
                         None => Ok(None),
-                        Some(k) => {
-                            let obj = self.store.get(&k)?;
+                        Some(handle) => {
+                            let obj = handle.object().await?;
                             if obj.record().status != sessions::SessionStatus::Active {
                                 tracing::info!(
                                     session_id = %obj.record().id,
@@ -414,11 +402,11 @@ impl<L: Loader> Manager<L> {
                                 );
                                 return Ok(None);
                             }
-                            let session_handle = match self.running.get(&k) {
+                            let session_id = obj.record().id;
+                            let session_handle = match self.running.get(&session_id) {
                                 Some(h) => h.clone(),
                                 None => {
                                     // Not running, start it!
-                                    let obj = self.store.get(&k)?;
                                     // Register a PTask's hostname on launch so it
                                     // routes host-side (R3.1/R3.6). Both HostNet and
                                     // OwnIp resolve to loopback: a HostNet PTask's
@@ -454,7 +442,6 @@ impl<L: Loader> Manager<L> {
                                     // identically. Drain happens only on
                                     // the success path just after the
                                     // spawn returns.
-                                    let session_id = obj.record().id;
                                     let composition = self.compositions.get(&session_id).cloned();
                                     // A spawn failure at this point (only
                                     // I/O failures on `mkdir` of the
@@ -495,7 +482,7 @@ impl<L: Loader> Manager<L> {
                                             _ => reg.register_host_net(id, &name),
                                         };
                                     }
-                                    self.running.insert(k, h.clone());
+                                    self.running.insert(session_id, h.clone());
                                     h
                                 }
                             };
@@ -528,7 +515,7 @@ impl<L: Loader> Manager<L> {
                     });
                 let pending = &mut self.pending;
                 let compositions = &mut self.compositions;
-                let store = &mut self.store;
+                let store = self.store.clone();
                 responder
                     .handle(async move {
                         if in_shutdown {
@@ -568,8 +555,8 @@ impl<L: Loader> Manager<L> {
                                     username,
                                     sessions::SessionStatus::Active,
                                 )?;
-                                let k = store.create(record)?;
-                                let id = *k.id();
+                                let handle = store.create(record).await?;
+                                let id = *handle.id();
                                 compositions.insert(id, Arc::new(composition));
                                 Ok(minimald_rpc::CreateSessionResponse::Ready { id })
                             }
@@ -598,8 +585,8 @@ impl<L: Loader> Manager<L> {
                                     username,
                                     sessions::SessionStatus::Pending,
                                 )?;
-                                let k = store.create(record)?;
-                                let id = *k.id();
+                                let handle = store.create(record).await?;
+                                let id = *handle.id();
                                 response.session_id = id;
                                 pending.insert(id, state);
                                 Ok(minimald_rpc::CreateSessionResponse::Pending { id, response })
@@ -629,7 +616,7 @@ impl<L: Loader> Manager<L> {
                 } else {
                     self.pending.remove(&session_id)
                 };
-                let store = &mut self.store;
+                let store = self.store.clone();
                 let compositions = &mut self.compositions;
                 responder
                     .handle(async move {
@@ -667,8 +654,9 @@ impl<L: Loader> Manager<L> {
                                 // A delete failure here is logged but
                                 // doesn't override the verdict-level
                                 // error returned to the client.
-                                if let Some(k) = store.find_by_id(&session_id)?
-                                    && let Err(del_err) = store.delete(&k)
+                                if let Some(handle) =
+                                    store.find(RecordPredicate::Id(session_id)).await?
+                                    && let Err(del_err) = handle.delete().await
                                 {
                                     tracing::warn!(
                                         session_id = %session_id,
@@ -685,15 +673,15 @@ impl<L: Loader> Manager<L> {
                         // Active`. A mid-flight delete or a status
                         // already past `Pending` is degenerate but
                         // surfaces as a structured `WrongState`.
-                        let k = match store.find_by_id(&session_id)? {
-                            Some(k) => k,
+                        let handle = match store.find(RecordPredicate::Id(session_id)).await? {
+                            Some(h) => h,
                             None => {
                                 return Ok(SessionStep::Fault {
                                     error: sessions::wire::errors::WireError::UnknownSessionId,
                                 });
                             }
                         };
-                        let mut record = store.get(&k)?.record().clone();
+                        let mut record = handle.record().await?;
                         if record.status != sessions::SessionStatus::Pending {
                             return Ok(SessionStep::Fault {
                                 error: sessions::wire::errors::WireError::WrongState {
@@ -702,7 +690,7 @@ impl<L: Loader> Manager<L> {
                             });
                         }
                         record.status = sessions::SessionStatus::Active;
-                        store.save(&k, &record)?;
+                        handle.write(record).await?;
                         compositions.insert(session_id, Arc::new(composition));
                         Ok(SessionStep::Active { id: session_id })
                     })
@@ -717,12 +705,13 @@ impl<L: Loader> Manager<L> {
                             "in shutdown",
                         ));
                     }
-                    match self.store.find_by_id(&id)? {
+                    match self.store.find(RecordPredicate::Id(id)).await? {
                         None => Err(std::io::Error::new(
                             NotFound,
                             format!("no session with ID `{}`", id.as_ref()),
                         )),
-                        Some(k) => {
+                        Some(handle) => {
+                            let mut record = handle.record().await?;
                             // Snapshot the live route (id + pre-rename name + mode)
                             // before the rename mutates the record. Only a running
                             // session has a route (registered on launch), and both
@@ -732,21 +721,21 @@ impl<L: Loader> Manager<L> {
                                 SessionId,
                                 String,
                                 sessions::NetworkMode,
-                            )> = if self.running.contains_key(&k) {
-                                let rec = self.store.get(&k)?;
-                                let net = rec.record().network;
+                            )> = if self.running.contains_key(&id) {
+                                let net = record.network;
                                 matches!(
                                     net,
                                     sessions::NetworkMode::HostNet | sessions::NetworkMode::OwnIp
                                 )
-                                .then(|| (rec.record().id, registry_name(rec.record()), net))
+                                .then(|| (record.id, registry_name(&record), net))
                             } else {
                                 None
                             };
 
-                            self.store.rename(&k, new_name.clone())?;
-                            if let Some(hnd) = self.running.get(&k) {
-                                hnd.apply_record(self.store.get(&k)?.record().clone()).await;
+                            record.name = Some(new_name.clone());
+                            handle.write(record.clone()).await?;
+                            if let Some(hnd) = self.running.get(&id) {
+                                hnd.apply_record(record.clone()).await;
                             }
 
                             // Follow the rename in the hostname registry so
@@ -755,7 +744,7 @@ impl<L: Loader> Manager<L> {
                             // under the launch name.
                             #[cfg(target_os = "linux")]
                             if let Some((id, old_name, net)) = relink {
-                                let new_reg = registry_name(self.store.get(&k)?.record());
+                                let new_reg = registry_name(&record);
                                 let mut reg = self
                                     .hostnames
                                     .write()
@@ -786,13 +775,17 @@ impl<L: Loader> Manager<L> {
                             "in shutdown",
                         ));
                     }
-                    let k = self.store.find_by_id(&id)?.ok_or_else(|| {
-                        std::io::Error::new(
-                            NotFound,
-                            format!("no session with ID `{}`", id.as_ref()),
-                        )
-                    })?;
-                    let record = self.store.get(&k)?.record().clone();
+                    let handle =
+                        self.store
+                            .find(RecordPredicate::Id(id))
+                            .await?
+                            .ok_or_else(|| {
+                                std::io::Error::new(
+                                    NotFound,
+                                    format!("no session with ID `{}`", id.as_ref()),
+                                )
+                            })?;
+                    let record = handle.record().await?;
                     if record.status != sessions::SessionStatus::Pending {
                         return Err(std::io::Error::new(
                             std::io::ErrorKind::InvalidInput,
@@ -812,7 +805,7 @@ impl<L: Loader> Manager<L> {
                     // (post-Active) path, so a Pending abort always
                     // finds nothing here; the call is a no-op today.
                     self.compositions.remove(&id);
-                    self.store.delete(&k)?;
+                    handle.delete().await?;
                     Ok(())
                 })
                 .await
@@ -827,18 +820,22 @@ impl<L: Loader> Manager<L> {
                             "in shutdown",
                         ));
                     }
-                    let k = self.store.find_by_id(&id)?.ok_or_else(|| {
-                        std::io::Error::new(
-                            NotFound,
-                            format!("no session with ID `{}`", id.as_ref()),
-                        )
-                    })?;
+                    let handle =
+                        self.store
+                            .find(RecordPredicate::Id(id))
+                            .await?
+                            .ok_or_else(|| {
+                                std::io::Error::new(
+                                    NotFound,
+                                    format!("no session with ID `{}`", id.as_ref()),
+                                )
+                            })?;
                     // Derive the hostname registry key from the record up front,
                     // letting a read error propagate before anything is torn
                     // down. `deregister` is a no-op for a session that never
                     // registered one, so it is called unconditionally.
                     #[cfg(target_os = "linux")]
-                    let host_net_name = registry_name(self.store.get(&k)?.record());
+                    let host_net_name = registry_name(&handle.record().await?);
                     // Drain the composition stash before teardown. A
                     // session that never advanced to `GetSession`
                     // (created + destroyed without an attach) would
@@ -848,7 +845,7 @@ impl<L: Loader> Manager<L> {
                     // Stop the live session first (killing its host and waiting
                     // for the sandbox to be released) so the on-disk tree is
                     // free to remove.
-                    if let Some(hnd) = self.running.remove(&k) {
+                    if let Some(hnd) = self.running.remove(&id) {
                         hnd.destroy().await;
                     }
                     // Withdraw the PTask hostname (R3.5) before the fallible
@@ -860,7 +857,7 @@ impl<L: Loader> Manager<L> {
                         .write()
                         .expect("hostname registry lock poisoned")
                         .deregister(&host_net_name);
-                    self.store.delete(&k)?;
+                    handle.delete().await?;
                     Ok(())
                 })
                 .await
@@ -877,18 +874,21 @@ impl<L: Loader> Manager<L> {
                     // Withdraw the PTask hostnames (R3.5) for every live session
                     // before tearing them down, mirroring DestroySession, so the
                     // shutdown drain never leaves stale routing entries pointing
-                    // at destroyed sessions. Names are derived up front via
-                    // synchronous store reads so the registry lock is never held
-                    // across `destroy().await`. `deregister` is a no-op for a
-                    // session that never registered a hostname.
+                    // at destroyed sessions. Names are read from the store up
+                    // front (best-effort — a read failure just skips that entry)
+                    // so the registry lock is never held across `destroy().await`.
+                    // `deregister` is a no-op for a session that never registered
+                    // a hostname.
                     #[cfg(target_os = "linux")]
                     {
-                        let names: Vec<String> = self
-                            .running
-                            .keys()
-                            .filter_map(|k| self.store.get(k).ok())
-                            .map(|obj| registry_name(obj.record()))
-                            .collect();
+                        let mut names: Vec<String> = Vec::new();
+                        for id in self.running.keys().copied().collect::<Vec<_>>() {
+                            if let Ok(Some(handle)) = self.store.find(RecordPredicate::Id(id)).await
+                                && let Ok(record) = handle.record().await
+                            {
+                                names.push(registry_name(&record));
+                            }
+                        }
                         let mut reg = self
                             .hostnames
                             .write()
@@ -972,12 +972,10 @@ impl WeakManagerHandle {
     }
 }
 
-/// The capability handed to a session's [`Binding`](crate::session_host) to
-/// tear its own session down — the "delete" choice on the shell-exit prompt.
+/// A non-owning handle to manipulate a specific session on a sessions actor.
 ///
-/// Bundles a [`WeakManagerHandle`] with the [`SessionId`] to destroy, so the
-/// binding neither owns the manager nor needs to know how destruction is
-/// carried out.
+/// Used by downstream actors (i.e. [`Binding`](crate::session_host)) to
+/// manipulate the session itself, such as deletion.
 #[derive(Debug, Clone)]
 pub struct SessionControl {
     manager: WeakManagerHandle,
@@ -1367,9 +1365,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reap_orphan_pending_deletes_pending_records() {
         let tmp = TempDir::new().unwrap();
-        let mut loader = DiskLoader::new(daemon_dir(&tmp)).unwrap();
+        let store = Store::init(daemon_dir(&tmp)).await.unwrap();
 
-        let pending_key = loader
+        let pending_id = *store
             .create(sessions::Record {
                 id: SessionId::nil(),
                 name: Some("pending".into()),
@@ -1380,8 +1378,10 @@ mod tests {
                 status: sessions::SessionStatus::Pending,
                 attrs: Default::default(),
             })
-            .unwrap();
-        let active_key = loader
+            .await
+            .unwrap()
+            .id();
+        let active_id = *store
             .create(sessions::Record {
                 id: SessionId::nil(),
                 name: Some("active".into()),
@@ -1392,22 +1392,27 @@ mod tests {
                 status: sessions::SessionStatus::Active,
                 attrs: Default::default(),
             })
-            .unwrap();
+            .await
+            .unwrap()
+            .id();
 
-        let pending_id = *pending_key.id();
-        let active_id = *active_key.id();
-        Manager::<DiskLoader>::reap_orphan_pending(&mut loader).unwrap();
+        Manager::reap_orphan_pending(&store).await.unwrap();
 
         assert!(
-            loader.find_by_id(&pending_id).unwrap().is_none(),
+            store
+                .find(RecordPredicate::Id(pending_id))
+                .await
+                .unwrap()
+                .is_none(),
             "the Pending record should be reaped from the index",
         );
-        let active_key_again = loader
-            .find_by_id(&active_id)
+        let active = store
+            .find(RecordPredicate::Id(active_id))
+            .await
             .unwrap()
             .expect("Active record's index entry should remain");
         assert_eq!(
-            loader.get(&active_key_again).unwrap().record().status,
+            active.record().await.unwrap().status,
             sessions::SessionStatus::Active,
             "the Active record should remain",
         );

--- a/crates/minimald/src/sessions/composables.rs
+++ b/crates/minimald/src/sessions/composables.rs
@@ -1,7 +1,7 @@
 //! Free helpers that assemble the daemon-side composables for a
 //! `CreateSession` request.
 //!
-//! The three pipeline stages sit here rather than on `Manager<L>`
+//! The three pipeline stages sit here rather than on `Manager`
 //! so each can be unit-tested in isolation without spinning the
 //! actor mainloop:
 //! - [`resolve_project_ctx_and_graph`] parses the client's project

--- a/crates/minimald/src/store.rs
+++ b/crates/minimald/src/store.rs
@@ -1,0 +1,602 @@
+use paths::DaemonAbsPath;
+use sessions::{
+    Record, SessionId,
+    store::{DiskLoader, DiskSession, DiskSessionKey, Loader as _, SessionKey, SessionObject},
+};
+
+use std::fmt;
+use tokio::sync::{mpsc, oneshot};
+
+/// The different ways to identify a session record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordPredicate {
+    Id(SessionId),
+    Name(String),
+}
+
+impl fmt::Display for RecordPredicate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RecordPredicate::Id(id) => write!(f, "id={id}"),
+            RecordPredicate::Name(name) => write!(f, "name={name}"),
+        }
+    }
+}
+
+enum StoreMessage {
+    Handles(oneshot::Sender<Result<Vec<SessionRecordHandle>, std::io::Error>>),
+    Create(
+        Box<Record>,
+        oneshot::Sender<Result<SessionRecordHandle, std::io::Error>>,
+    ),
+    Find(
+        RecordPredicate,
+        oneshot::Sender<Result<Option<SessionRecordHandle>, std::io::Error>>,
+    ),
+    SessionGet(
+        DiskSessionKey,
+        oneshot::Sender<Result<Record, std::io::Error>>,
+    ),
+    SessionObject(
+        DiskSessionKey,
+        oneshot::Sender<Result<DiskSession, std::io::Error>>,
+    ),
+    SessionWrite(
+        DiskSessionKey,
+        Box<Record>,
+        oneshot::Sender<Result<(), std::io::Error>>,
+    ),
+    SessionDelete(DiskSessionKey, oneshot::Sender<Result<(), std::io::Error>>),
+}
+
+/// The session store actor. Mediates reading, writing, and enumerating
+/// session records.
+pub struct Store {
+    receiver: mpsc::Receiver<StoreMessage>,
+    weak_self: WeakStoreHandle,
+    store: DiskLoader,
+}
+
+impl Store {
+    /// Launches the session store actor, managing session records in
+    /// the given minimal state dir.
+    pub async fn init(minimal_state_dir: DaemonAbsPath) -> Result<StoreHandle, std::io::Error> {
+        let l = DiskLoader::new(minimal_state_dir.clone())?;
+
+        let (sender, receiver) = mpsc::channel(8);
+        let handle = StoreHandle { sender };
+        let weak_self = handle.downgrade();
+        let store = Self {
+            receiver,
+            weak_self,
+            store: l,
+        };
+
+        tokio::spawn(store.mainloop());
+        Ok(handle)
+    }
+}
+
+impl Store {
+    async fn mainloop(mut self) {
+        while let Some(msg) = self.receiver.recv().await {
+            self.handle_message(msg).await;
+        }
+    }
+
+    /// Resolves a predicate to a key, if a matching record exists.
+    fn resolve(&self, pred: &RecordPredicate) -> Result<Option<DiskSessionKey>, std::io::Error> {
+        match pred {
+            RecordPredicate::Id(id) => self.store.find_by_id(id),
+            RecordPredicate::Name(name) => self.store.find_by_name(name),
+        }
+    }
+
+    /// Wraps a key in a record handle. The caller awaiting this message holds a
+    /// strong [`StoreHandle`], so the upgrade always succeeds.
+    fn handle_for(&self, k: DiskSessionKey) -> SessionRecordHandle {
+        SessionRecordHandle {
+            h: self
+                .weak_self
+                .upgrade()
+                .expect("store handle is live while its message is being handled"),
+            k,
+        }
+    }
+
+    /// Handles a specific message recieved by the store.
+    async fn handle_message(&mut self, msg: StoreMessage) {
+        match msg {
+            StoreMessage::Handles(r) => {
+                let _ = r.send(Ok(self.store.keys().map(|k| self.handle_for(k)).collect()));
+            }
+            StoreMessage::Create(record, r) => {
+                let created = self.store.create(*record);
+                let _ = r.send(created.map(|k| self.handle_for(k)));
+            }
+            StoreMessage::Find(pred, r) => {
+                let _ = r.send(
+                    self.resolve(&pred)
+                        .map(|opt| opt.map(|k| self.handle_for(k))),
+                );
+            }
+            StoreMessage::SessionGet(k, r) => {
+                let _ = r.send(self.store.get(&k).map(|o| o.record().clone()));
+            }
+            StoreMessage::SessionObject(k, r) => {
+                let _ = r.send(self.store.get(&k));
+            }
+            StoreMessage::SessionWrite(k, v, r) => {
+                let _ = r.send(self.store.save(&k, &v));
+            }
+            StoreMessage::SessionDelete(k, r) => {
+                let _ = r.send(self.store.delete(&k));
+            }
+        }
+    }
+}
+
+/// The handle to the session store.
+#[derive(Debug, Clone)]
+pub struct StoreHandle {
+    sender: mpsc::Sender<StoreMessage>,
+}
+
+impl StoreHandle {
+    /// Returns a non-owning handle to this manager.
+    #[must_use]
+    pub fn downgrade(&self) -> WeakStoreHandle {
+        WeakStoreHandle {
+            sender: self.sender.downgrade(),
+        }
+    }
+
+    /// Returns a handle to every session record known to this store.
+    pub async fn handles(&self) -> Result<Vec<SessionRecordHandle>, std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.sender.send(StoreMessage::Handles(send)).await;
+        recv.await.expect("corresponding store is dead")
+    }
+
+    /// Creates a record, returning a handle to it. The record's `id` is
+    /// ignored — the store allocates the real one.
+    pub async fn create(&self, record: Record) -> Result<SessionRecordHandle, std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .sender
+            .send(StoreMessage::Create(Box::new(record), send))
+            .await;
+        recv.await.expect("corresponding store is dead")
+    }
+
+    /// Returns a handle to the given record, or `None` if none matches.
+    pub async fn find(
+        &self,
+        record: RecordPredicate,
+    ) -> Result<Option<SessionRecordHandle>, std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.sender.send(StoreMessage::Find(record, send)).await;
+        recv.await.expect("corresponding store is dead")
+    }
+}
+
+/// A handle to read or write a specific session record. All mutations to
+/// a specific record are mediated through one of these handles.
+#[derive(Debug, Clone)]
+pub struct SessionRecordHandle {
+    h: StoreHandle,
+    k: DiskSessionKey,
+}
+
+impl SessionRecordHandle {
+    /// Returns the session ID this handle corresponds to.
+    pub fn id(&self) -> &SessionId {
+        self.k.id()
+    }
+
+    /// Returns the full session object (record plus its on-disk paths), for
+    /// callers that need the workspace/home/cache layout to spawn a session.
+    pub async fn object(&self) -> Result<DiskSession, std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .h
+            .sender
+            .send(StoreMessage::SessionObject(self.k.clone(), send))
+            .await;
+        recv.await.expect("corresponding store is dead")
+    }
+
+    /// Returns the current state of the session record.
+    pub async fn record(&self) -> Result<Record, std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .h
+            .sender
+            .send(StoreMessage::SessionGet(self.k.clone(), send))
+            .await;
+        recv.await.expect("corresponding store is dead")
+    }
+
+    /// Overwrites the contents of the session record with the given value.
+    pub async fn write(&self, new: Record) -> Result<(), std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .h
+            .sender
+            .send(StoreMessage::SessionWrite(
+                self.k.clone(),
+                Box::new(new),
+                send,
+            ))
+            .await;
+        recv.await.expect("corresponding store is dead")
+    }
+
+    /// Deletes the record.
+    pub async fn delete(self) -> Result<(), std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .h
+            .sender
+            .send(StoreMessage::SessionDelete(self.k.clone(), send))
+            .await;
+        recv.await.expect("corresponding store is dead")
+    }
+}
+
+/// A non-owning handle to the [`Store`] actor.
+#[derive(Debug, Clone)]
+pub struct WeakStoreHandle {
+    sender: mpsc::WeakSender<StoreMessage>,
+}
+
+impl WeakStoreHandle {
+    /// Promotes to a strong [`StoreHandle`], or `None` if the manager actor
+    /// has already shut down (all strong senders dropped).
+    #[must_use]
+    pub fn upgrade(&self) -> Option<StoreHandle> {
+        Some(StoreHandle {
+            sender: self.sender.upgrade()?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paths::HostAbsPath;
+    use sessions::{NetworkMode, SessionStatus};
+    use std::collections::BTreeSet;
+    use std::io::ErrorKind;
+    use tempfile::TempDir;
+
+    fn daemon_dir(tmp: &TempDir) -> DaemonAbsPath {
+        DaemonAbsPath::try_new(tmp.path().to_str().unwrap()).unwrap()
+    }
+
+    /// A minimal session record carrying the given name.
+    fn record_named(name: &str) -> Record {
+        Record {
+            id: SessionId::nil(),
+            name: Some(name.to_string()),
+            username: Some("alice".to_string()),
+            project_path: HostAbsPath::try_new("/home/alice/proj").unwrap(),
+            network: NetworkMode::default(),
+            policy: Default::default(),
+            status: SessionStatus::default(),
+            attrs: Default::default(),
+        }
+    }
+
+    /// Launch a [`Store`] actor over a fresh directory rooted at `dir`, seeded
+    /// with `records`. Returns the handle alongside the ids the store assigned,
+    /// in creation order.
+    async fn store_seeded_with(
+        dir: &TempDir,
+        records: impl IntoIterator<Item = Record>,
+    ) -> (StoreHandle, Vec<SessionId>) {
+        let handle = Store::init(daemon_dir(dir)).await.unwrap();
+        let mut ids = Vec::new();
+        for r in records {
+            ids.push(*handle.create(r).await.unwrap().id());
+        }
+        (handle, ids)
+    }
+
+    /// Resolve a handle to a record expected to exist.
+    async fn open(store: &StoreHandle, pred: RecordPredicate) -> SessionRecordHandle {
+        store
+            .find(pred)
+            .await
+            .unwrap()
+            .expect("record should resolve")
+    }
+
+    /// The set of session ids the store currently holds, read via `handles`.
+    async fn stored_ids(store: &StoreHandle) -> BTreeSet<SessionId> {
+        store
+            .handles()
+            .await
+            .unwrap()
+            .iter()
+            .map(|h| *h.id())
+            .collect()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handles_is_empty_for_a_fresh_store() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::init(daemon_dir(&tmp)).await.unwrap();
+        assert!(store.handles().await.unwrap().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handles_yield_one_per_seeded_session() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) =
+            store_seeded_with(&tmp, (0..3).map(|i| record_named(&format!("s{i}")))).await;
+
+        assert_eq!(stored_ids(&store).await, ids.into_iter().collect());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn find_by_id_resolves_a_handle_to_the_record() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) = store_seeded_with(&tmp, [record_named("solo")]).await;
+
+        let handle = open(&store, RecordPredicate::Id(ids[0])).await;
+        // The handle names the session it resolved...
+        assert_eq!(*handle.id(), ids[0]);
+        // ...and reads back the seeded record contents.
+        let record = handle.record().await.unwrap();
+        assert_eq!(record.id, ids[0]);
+        assert_eq!(record.name.as_deref(), Some("solo"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn find_by_name_resolves_a_handle_to_the_record() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) = store_seeded_with(&tmp, [record_named("named")]).await;
+
+        let handle = open(&store, RecordPredicate::Name("named".to_string())).await;
+        assert_eq!(*handle.id(), ids[0]);
+        assert_eq!(
+            handle.record().await.unwrap().name.as_deref(),
+            Some("named")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn write_is_reflected_when_the_record_is_read_back() {
+        let tmp = TempDir::new().unwrap();
+        let (store, _ids) = store_seeded_with(&tmp, [record_named("mut")]).await;
+
+        let handle = open(&store, RecordPredicate::Name("mut".to_string())).await;
+        let mut record = handle.record().await.unwrap();
+        record.username = Some("bob".to_string());
+        record.attrs.insert("color".to_string(), "red".to_string());
+        handle.write(record).await.unwrap();
+
+        let reread = handle.record().await.unwrap();
+        assert_eq!(reread.username.as_deref(), Some("bob"));
+        assert_eq!(reread.attrs.get("color").map(String::as_str), Some("red"));
+    }
+
+    /// A rename issued through the handle remaps the name index: the new name
+    /// resolves and the old one stops. This drives the actor's `SessionWrite`
+    /// path all the way through the loader's index bookkeeping.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn write_that_renames_remaps_the_name_index() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) = store_seeded_with(&tmp, [record_named("before")]).await;
+
+        let handle = open(&store, RecordPredicate::Id(ids[0])).await;
+        let mut record = handle.record().await.unwrap();
+        record.name = Some("after".to_string());
+        handle.write(record).await.unwrap();
+
+        let by_new = open(&store, RecordPredicate::Name("after".to_string())).await;
+        assert_eq!(*by_new.id(), ids[0]);
+
+        assert!(
+            store
+                .find(RecordPredicate::Name("before".to_string()))
+                .await
+                .unwrap()
+                .is_none(),
+            "the old name should no longer resolve",
+        );
+    }
+
+    /// The actor is the single owner of the record, so a write through one
+    /// handle is visible through an independently obtained handle for the same
+    /// session — there is no per-handle cached state to go stale.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn writes_are_visible_through_an_independently_obtained_handle() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) = store_seeded_with(&tmp, [record_named("shared")]).await;
+
+        let writer = open(&store, RecordPredicate::Id(ids[0])).await;
+        let reader = open(&store, RecordPredicate::Id(ids[0])).await;
+
+        let mut record = writer.record().await.unwrap();
+        record.username = Some("changed".to_string());
+        writer.write(record).await.unwrap();
+
+        assert_eq!(
+            reader.record().await.unwrap().username.as_deref(),
+            Some("changed"),
+        );
+    }
+
+    /// The loader rejects a write whose record id doesn't match the key (id is
+    /// the immutable primary key); the actor surfaces that error to the caller
+    /// rather than swallowing it. Uses a second session's id as the mismatch so
+    /// the test needs no direct uuid construction.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn write_with_a_mismatched_id_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) =
+            store_seeded_with(&tmp, [record_named("first"), record_named("second")]).await;
+
+        let handle = open(&store, RecordPredicate::Id(ids[0])).await;
+        let mut record = handle.record().await.unwrap();
+        record.id = ids[1];
+
+        let err = handle
+            .write(record)
+            .await
+            .expect_err("a record id that doesn't match the key must be refused");
+        assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    }
+
+    /// Deleting through the handle removes the record: it no longer lists, and
+    /// neither its id nor its name resolves afterwards.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_removes_the_record() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) = store_seeded_with(&tmp, [record_named("doomed")]).await;
+
+        let handle = open(&store, RecordPredicate::Id(ids[0])).await;
+        handle.delete().await.unwrap();
+
+        assert!(store.handles().await.unwrap().is_empty());
+        assert!(
+            store
+                .find(RecordPredicate::Id(ids[0]))
+                .await
+                .unwrap()
+                .is_none(),
+            "the id should no longer resolve",
+        );
+        assert!(
+            store
+                .find(RecordPredicate::Name("doomed".to_string()))
+                .await
+                .unwrap()
+                .is_none(),
+            "the name should no longer resolve",
+        );
+    }
+
+    /// Deleting one session leaves the others untouched — only the targeted
+    /// record is dropped from the store.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_leaves_other_sessions_intact() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) =
+            store_seeded_with(&tmp, [record_named("keep"), record_named("drop")]).await;
+
+        let doomed = open(&store, RecordPredicate::Id(ids[1])).await;
+        doomed.delete().await.unwrap();
+
+        assert_eq!(stored_ids(&store).await, BTreeSet::from([ids[0]]));
+
+        // The survivor still resolves and reads back its own record.
+        let survivor = open(&store, RecordPredicate::Name("keep".to_string())).await;
+        assert_eq!(*survivor.id(), ids[0]);
+    }
+
+    /// Two handles can name the same session; once one deletes it, a read
+    /// through the other (now stale) handle fails cleanly with `NotFound`
+    /// rather than resurrecting — or panicking the actor over — the removed
+    /// record. Guards the store's reliance on the loader's id-strict lookup.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reads_through_a_stale_handle_fail_after_delete() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) = store_seeded_with(&tmp, [record_named("solo")]).await;
+
+        let deleter = open(&store, RecordPredicate::Id(ids[0])).await;
+        let stale = open(&store, RecordPredicate::Id(ids[0])).await;
+
+        deleter.delete().await.unwrap();
+
+        let err = stale
+            .record()
+            .await
+            .expect_err("reading a deleted record through a stale handle must fail");
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+    }
+
+    /// `create` allocates a record and returns a handle that reads it back;
+    /// the store assigns a fresh id regardless of the input record's id.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_allocates_a_record_and_returns_a_working_handle() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::init(daemon_dir(&tmp)).await.unwrap();
+
+        let handle = store.create(record_named("fresh")).await.unwrap();
+        assert_ne!(*handle.id(), SessionId::nil(), "id must be allocated");
+
+        let record = handle.record().await.unwrap();
+        assert_eq!(record.id, *handle.id());
+        assert_eq!(record.name.as_deref(), Some("fresh"));
+        // The record is discoverable through an independent lookup.
+        let by_name = open(&store, RecordPredicate::Name("fresh".to_string())).await;
+        assert_eq!(*by_name.id(), *handle.id());
+    }
+
+    /// A name collision on `create` surfaces the loader's `AlreadyExists`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_rejects_a_duplicate_name() {
+        let tmp = TempDir::new().unwrap();
+        let store = Store::init(daemon_dir(&tmp)).await.unwrap();
+
+        store.create(record_named("dup")).await.unwrap();
+        let err = store
+            .create(record_named("dup"))
+            .await
+            .expect_err("a duplicate name must be refused");
+        assert_eq!(err.kind(), ErrorKind::AlreadyExists);
+    }
+
+    /// `find` resolves an existing record and yields `None` for a miss.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn find_resolves_existing_and_is_none_for_unknown() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) = store_seeded_with(&tmp, [record_named("here")]).await;
+
+        let hit = store
+            .find(RecordPredicate::Id(ids[0]))
+            .await
+            .unwrap()
+            .expect("an existing id should resolve");
+        assert_eq!(*hit.id(), ids[0]);
+
+        assert!(
+            store
+                .find(RecordPredicate::Name("ghost".to_string()))
+                .await
+                .unwrap()
+                .is_none(),
+            "an unknown name should resolve to None, not an error",
+        );
+    }
+
+    /// `object` exposes the on-disk layout: workspace/home/cache all sit under
+    /// the session's dir, and the object carries the record.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn object_exposes_paths_and_record() {
+        let tmp = TempDir::new().unwrap();
+        let (store, ids) = store_seeded_with(&tmp, [record_named("laid-out")]).await;
+
+        let handle = open(&store, RecordPredicate::Id(ids[0])).await;
+        let obj = handle.object().await.unwrap();
+
+        assert_eq!(obj.record().id, ids[0]);
+        let sessions_root = daemon_dir(&tmp).as_utf8_path().join("sessions");
+        for path in [obj.workspace_path(), obj.home_path(), obj.cache_path()] {
+            assert!(
+                path.as_utf8_path().starts_with(&sessions_root),
+                "{path:?} should live under {sessions_root:?}",
+            );
+        }
+    }
+}

--- a/crates/sessions/src/store.rs
+++ b/crates/sessions/src/store.rs
@@ -44,8 +44,10 @@ pub trait Loader {
     ///
     /// # Errors
     ///
-    /// Returns an I/O error if the backing record cannot be read or
-    /// deserialized.
+    /// - `NotFound` if `key` is stale — its short is gone from the index, or
+    ///   has been re-allocated to a different session (same semantics as
+    ///   [`Self::save`]). Prevents reading an unrelated session's record.
+    /// - Other I/O errors if the backing record cannot be read or deserialized.
     fn get(&self, key: &Self::Key) -> Result<Self::Object, std::io::Error>;
 
     /// Returns a lookup key corresponding to the given session ID, if
@@ -126,8 +128,12 @@ pub trait Loader {
     ///
     /// # Errors
     ///
-    /// Returns an I/O error if the record cannot be read or the index cannot be
-    /// flushed. A missing directory tree is not an error.
+    /// - `NotFound` if `key` is stale — its short is gone from the index, or
+    ///   has been re-allocated to a different session (same semantics as
+    ///   [`Self::save`]). Prevents destroying an unrelated session. A missing
+    ///   *directory tree* for a still-indexed key is not an error.
+    /// - Other I/O errors if the record cannot be read or the index cannot be
+    ///   flushed.
     fn delete(&mut self, key: &Self::Key) -> Result<(), std::io::Error>;
 }
 
@@ -635,6 +641,39 @@ impl DiskLoader {
 
         Ok(())
     }
+
+    /// Resolve `key` to its live short directory name, or `NotFound` if the
+    /// key is stale.
+    ///
+    /// A [`DiskSessionKey`] can outlive the session it names — a caller may
+    /// hold a key (or a `SessionRecordHandle`) across a concurrent delete. A
+    /// stale key is refused two ways:
+    ///
+    /// - its short is no longer in the index (the session was deleted), or
+    /// - its short is present but now maps to a *different* id. The short is
+    ///   the UUID's last 5 hex chars (20 bits) and is re-allocatable after a
+    ///   delete, so a freed short can be handed to a new session.
+    ///
+    /// The id-strict second check is what stops a stale key from addressing
+    /// the unrelated session that inherited its short — without it, [`get`]
+    /// would read, and [`delete`] would destroy, the wrong session.
+    ///
+    /// [`get`]: Loader::get
+    /// [`delete`]: Loader::delete
+    fn live_short(&self, key: &DiskSessionKey) -> Result<String, std::io::Error> {
+        let short = key.dir_key.to_string();
+        match self.index.short_to_id.get(&short) {
+            Some(stored_id) if stored_id == key.id() => Ok(short),
+            _ => Err(std::io::Error::new(
+                NotFound,
+                format!(
+                    "no session with key (short `{short}`, id `{}`) \
+                     is present in the index",
+                    key.id(),
+                ),
+            )),
+        }
+    }
 }
 
 impl Loader for DiskLoader {
@@ -698,16 +737,15 @@ impl Loader for DiskLoader {
     }
 
     fn get(&self, key: &Self::Key) -> Result<Self::Object, std::io::Error> {
-        assert!(
-            self.index.find_by_short(&key.dir_key).is_some(),
-            "key {:?} not present in index — Keys are only handed out for sessions that exist",
-            key.dir_key,
-        );
+        // Refuse a stale key (session deleted, or its short re-allocated to a
+        // different session) with `NotFound` rather than reading the wrong
+        // record. See `live_short`.
+        let short = self.live_short(key)?;
         let record_file = self
             .minimal_dir
             .as_utf8_path()
             .join("sessions")
-            .join(&key.dir_key)
+            .join(&short)
             .join("record.json");
         let record: Record = serde_json::from_reader(std::fs::File::open(record_file)?)?;
         Ok(DiskSession {
@@ -731,27 +769,12 @@ impl Loader for DiskLoader {
             ));
         }
 
-        let short = key.dir_key.to_string();
+        // Refuse to save against a stale key — one the index has dropped, or
+        // whose short has since been re-allocated to a different session — so
+        // a stale caller can't overwrite the session that inherited the short.
+        // See `live_short`.
+        let short = self.live_short(key)?;
         let id = *key.id();
-
-        // Refuse to save against a key the index has dropped *or* whose
-        // short has since been reused by a different session. The short
-        // is derived from the UUID's last 5 hex chars (20 bits) and is
-        // re-allocatable after `delete`, so a stale key whose original
-        // session was deleted could otherwise overwrite the unrelated
-        // session that inherited the short.
-        match self.index.short_to_id.get(&short) {
-            Some(stored_id) if *stored_id == id => {}
-            _ => {
-                return Err(std::io::Error::new(
-                    NotFound,
-                    format!(
-                        "no session with key (short `{short}`, id `{id}`) \
-                         is present in the index",
-                    ),
-                ));
-            }
-        }
 
         let old_name = self.index.name_by_id(&id).cloned();
         let new_name = record.name.clone();
@@ -792,7 +815,11 @@ impl Loader for DiskLoader {
     }
 
     fn delete(&mut self, key: &Self::Key) -> Result<(), std::io::Error> {
-        let short = key.dir_key.to_string();
+        // Refuse a stale key up front: without the id-strict check, a key
+        // whose short was re-allocated after its own session was deleted would
+        // deindex and `remove_dir_all` the *unrelated* session that inherited
+        // the short. `live_short` returns `NotFound` in that case.
+        let short = self.live_short(key)?;
         // Discover the name index entry from the index itself, not by reading
         // the record: index cleanup must not depend on the on-disk tree still
         // existing, or a half-deleted session (dir gone, index entries left)
@@ -1365,6 +1392,103 @@ mod tests {
         assert_eq!(loader.find_by_name("my-session").unwrap(), None);
         // Session still reachable by id.
         assert_eq!(loader.find_by_id(key.id()).unwrap(), Some(key));
+    }
+
+    // =================================================================
+    // Stale-key rejection on get / delete (id-strict, mirrors save)
+    // =================================================================
+
+    /// `get` against a stale key — for a session that's been deleted — must
+    /// refuse with `NotFound` rather than trying to read a now-absent record.
+    #[test]
+    fn get_against_stale_key_after_delete_errors_with_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let mut loader = DiskLoader::new(loader_dir(&tmp)).unwrap();
+
+        let key = loader.create(sample_record()).unwrap();
+        loader.delete(&key).unwrap();
+
+        let err = loader.get(&key).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+    }
+
+    /// Plant the "reused short" scenario: create a session, delete it (freeing
+    /// its short), then write a *different* session (distinct id, name
+    /// "squatter") straight onto disk at the freed short and re-open the loader
+    /// so self-heal indexes it as an orphan. Returns the reopened loader, the
+    /// now-stale key of the deleted session, and the new session's id + short.
+    fn reused_short_scenario(tmp: &TempDir) -> (DiskLoader, DiskSessionKey, SessionId, String) {
+        let mut loader = DiskLoader::new(loader_dir(tmp)).unwrap();
+        let stale_key = loader.create(sample_record()).unwrap();
+        let stale_short = stale_key.dir_key.to_string();
+        loader.delete(&stale_key).unwrap();
+        drop(loader);
+
+        // We can't make `create` reliably collide on the 20-bit short, so we
+        // craft the on-disk state directly at the freed short.
+        let new_id = SessionId(uuid::Uuid::from_u128(0xFACE_FEED));
+        assert_ne!(new_id, *stale_key.id(), "test setup: ids must differ");
+        let dir = loader_dir(tmp)
+            .as_utf8_path()
+            .join("sessions")
+            .join(&stale_short);
+        std::fs::create_dir_all(dir.as_std_path()).unwrap();
+        let mut new_record = sample_record();
+        new_record.id = new_id;
+        new_record.name = Some("squatter".into());
+        std::fs::write(
+            dir.join("record.json").as_std_path(),
+            serde_json::to_vec(&new_record).unwrap(),
+        )
+        .unwrap();
+
+        let loader = DiskLoader::new(loader_dir(tmp)).unwrap();
+        assert_eq!(
+            loader.index.short_to_id.get(&stale_short).copied(),
+            Some(new_id),
+            "test setup: the new session should own the reused short",
+        );
+        (loader, stale_key, new_id, stale_short)
+    }
+
+    /// `get` against a stale key whose short has been *reused* by a different
+    /// session must refuse — otherwise a stale caller reads the unrelated
+    /// session's record. The check is id-strict, not just short-presence.
+    #[test]
+    fn get_against_stale_key_with_reused_short_errors_with_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let (loader, stale_key, _new_id, _short) = reused_short_scenario(&tmp);
+
+        let err = loader.get(&stale_key).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+    }
+
+    /// `delete` against a stale key whose short was reused must refuse and
+    /// leave the session that inherited the short fully intact — its index
+    /// entry, its `record.json`, and its dir. Without the id-strict guard the
+    /// stale delete would deindex and `remove_dir_all` the wrong session.
+    #[test]
+    fn delete_against_stale_key_with_reused_short_leaves_new_session_intact() {
+        let tmp = TempDir::new().unwrap();
+        let (mut loader, stale_key, new_id, stale_short) = reused_short_scenario(&tmp);
+
+        let err = loader.delete(&stale_key).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+
+        // The squatting session is untouched: still indexed, record readable,
+        // dir on disk.
+        let new_key = loader
+            .find_by_id(&new_id)
+            .unwrap()
+            .expect("the reused-short session must remain indexed");
+        assert_eq!(
+            loader.get(&new_key).unwrap().record().name.as_deref(),
+            Some("squatter"),
+        );
+        assert!(
+            session_dir_path(&loader_dir(&tmp), &stale_short).exists(),
+            "the reused-short session's dir must not be removed",
+        );
     }
 
     // =================================================================


### PR DESCRIPTION
 - `sessions::store` handles `get()` of a deleted key gracefully
 - Implement `minimald::Store` actor to mediate read/write of session records
 - Implement `SessionRecordHandle` to drive the store actor to read/write/delete a _specific_ session record
 - Refactor `sessions` actor to initialize and use new `store` actor.

Part 2 will refactor the `session` actor to own everything about a specific session, including implementing a state machine for when the session is being built. Hopefullly this will make `sessions` a dumb router again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an asynchronous session store for creating, finding, listing, updating, and deleting sessions.
  * Added session record handles for reading session data and managing individual records.

* **Bug Fixes**
  * Improved protection against stale session references when identifiers are reused.
  * Prevented stale operations from reading, modifying, or deleting unrelated sessions.
  * Added safer handling for orphaned pending sessions during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->