### PR TITLE
fix(ci): grant the nightly installer job pull-requests: read

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -198,6 +198,11 @@ jobs:
     # to it. Same definition, reused via workflow_call (no duplication).
     permissions:
       contents: read
+      # ci-shell-installer.yml declares pull-requests: read at the workflow
+      # level (dorny/paths-filter on its PR runs); a called reusable workflow
+      # cannot request a permission the caller withheld, so grant it here too
+      # or the whole nightly fails at startup. It is unused on this non-PR call.
+      pull-requests: read
     uses: ./.github/workflows/ci-shell-installer.yml
 
   hygiene:


### PR DESCRIPTION
## Problem

The nightly test tier has **never run** — every scheduled run (and a
`workflow_dispatch` reproduction) dies at **`startup_failure`**: zero jobs, no
logs, nothing in `actionlint`. So the soak signal it exists to provide
(`session-e2e-soak` ×10, the #588 vsock-wedge hunt) has been silently absent.

## Root cause

The `installer` job calls `ci-shell-installer.yml` via `workflow_call` but
granted only `permissions: contents: read`. That reusable workflow declares
`pull-requests: read` at the **workflow level** (for `dorny/paths-filter` on its
PR runs). A called reusable workflow **cannot request a permission the caller
withheld**, so GitHub rejects the entire workflow before scheduling any job.

## Fix

Grant the union on the `installer` job. The permission is unused on this non-PR
call (dorny only runs on `pull_request`), but must be granted for the reusable
call to validate.

## How it was verified

Bisected on a throwaway branch:
- neutralize the reusable call → the nightly **starts** (jobs run);
- restore it with `contents: read` + `pull-requests: read` → the nightly
  **starts** again.

## After merge

Re-dispatch `nightly-tests.yml` once to confirm a clean full run, so the soak
starts producing data (the ruleset flip is gated on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbXL6jxHTY2YuLPaMxc1yU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly test workflow permissions to ensure required checks run successfully.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->