### PR TITLE
stdlib: accept 'Gitlab source_provenance category (supply-chain#347)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6128,7 +6128,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdlib"
-version = "0.0.16"
+version = "0.0.17"
 
 [[package]]
 name = "streaming-iterator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,4 +169,4 @@ sandbox2 = { version = "0.0.1", path = "crates/sandbox2" }
 sessions = { version = "0.0.1", path = "crates/sessions" }
 switch = { version = "0.0.1", path = "crates/switch" }
 
-stdlib = { version = "0.0.16", path = "crates/stdlib" }
+stdlib = { version = "0.0.17", path = "crates/stdlib" }

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stdlib"
-version = "0.0.16"
+version = "0.0.17"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 edition.workspace = true

--- a/crates/stdlib/minimal-ncl/attr_classes.ncl
+++ b/crates/stdlib/minimal-ncl/attr_classes.ncl
@@ -35,6 +35,13 @@ let source_provenance_website = {
     downloads_page | String | optional | doc "The web page linking to the latest release or enumerating releases.",
 }
 in
+let source_provenance_gitlab = {
+    category = 'Gitlab,
+    host | String | doc "GitLab instance host, e.g. \"gitlab.com\" or \"gitlab.inria.fr\". GitLab is federated, so the host disambiguates the project (the same owner/repo on two instances are different projects).",
+    owner | String | doc "The group/user that owns the project — the path segment before the repo.",
+    repo | String | doc "The project (repository) name.",
+}
+in
 let PURL = std.contract.custom (fun _label value =>
     if std.typeof value != 'String then
         'Error { message = "PURLs must be a string" }
@@ -134,6 +141,7 @@ in
                 {category = 'GithubRepo, ..} => std.contract.check source_provenance_github label value,
                 {category = 'Sourceforge, ..} => std.contract.check source_provenance_sourceforge label value,
                 {category = 'Website, ..} => std.contract.check source_provenance_website label value,
+                {category = 'Gitlab, ..} => std.contract.check source_provenance_gitlab label value,
                     _ => 'Error {
                         message = "source_provenance value had invalid/unknown category",
                     },


### PR DESCRIPTION
Companion to gominimal/minimal-supply-chain#347 / #348.

GitLab-hosted upstreams — the fpottier trio (`menhir`/`visitors`/`unionFind` on
`gitlab.inria.fr`, hard deps of charon-ml/aeneas) and `mesa` — had no honest
`source_provenance` category, so a build.ncl couldn't declare one; they were
pushed onto `gs://` mirrors and `Cpe` workarounds.

This adds a `source_provenance_gitlab` sub-contract and its dispatch arm:

```nickel
source_provenance = {
  category = 'Gitlab,
  host  = "gitlab.inria.fr",   # required — GitLab is federated
  owner = "fpottier",
  repo  = "unionFind",
}
```

`host` is required because the same `owner/repo` on `gitlab.com` vs
`gitlab.inria.fr` are different projects.

Pairs with supply-chain #348, which adds the matching
`Provenance::Gitlab { host, owner, repo }` (parse tiers +
`pkg:generic/{host}/{owner}/{repo}` purl identity that joins OSV GIT-ecosystem
advisories). Verified with `nickel export`: a valid Gitlab block exports, a block
missing `host` is a contract error, and GithubRepo/GnuProject/Sourceforge/Website
still validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
