### PR TITLE
refactor: move all session logic into session actor, init loadouts in own RPC

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -804,9 +804,16 @@ fn project_has_mfile(project_path: &camino::Utf8Path) -> bool {
     )
 }
 
-/// Check for a `minimal.toml` at the project path. If missing, prompt
-/// the user to initialize one before proceeding with activation.
-fn ensure_mfile_or_prompt(
+/// Offer to initialize a `minimal.toml` at the project path when it has
+/// none, on the way into an activation.
+///
+/// Purely an offer: a project without one still activates. The daemon never
+/// reads this path — it is a path on the *client's* machine — and fabricates
+/// a default shell-stack `minimal.toml` inside the session's own workspace
+/// instead, so the session comes up either way. Scaffolding here is a
+/// convenience for the interactive case (the project gets a real config it
+/// can grow), not a precondition.
+fn offer_mfile_scaffold(
     project_path: &camino::Utf8Path,
     global: &GlobalArgs,
 ) -> Result<(), anyhow::Error> {
@@ -819,14 +826,14 @@ fn ensure_mfile_or_prompt(
     // `confirm` treats empty/EOF input as "yes", so on non-interactive
     // stdin (CI, pipes, agents) it would silently default this scaffold to
     // "yes" — and, when a config is discovered under `.minimal/`, the init
-    // writer would clobber it. Only prompt on a real terminal; otherwise
-    // bail with the same hint the declined prompt gives.
-    let create = std::io::stdin().is_terminal() && confirm("Would you like to create one?")?;
-    if !create {
-        bail!(
-            "No {} found. Run 'minimal init' to create one.",
-            mfile::MFILE_NAME
+    // writer would clobber it. Only prompt on a real terminal; anywhere else
+    // (and on a declined prompt) carry on without scaffolding.
+    if !std::io::stdin().is_terminal() || !confirm("Would you like to create one?")? {
+        eprintln!(
+            "Continuing without one; the session gets a default environment. \
+             Run 'minimal init' to give the project its own config."
         );
+        return Ok(());
     }
 
     let config = if global.repo_dir.is_some() {
@@ -856,7 +863,7 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
     let abs_path =
         paths::HostAbsPath::try_new(utf8_path.clone()).context("Invalid project path")?;
 
-    ensure_mfile_or_prompt(&utf8_path, global)?;
+    offer_mfile_scaffold(&utf8_path, global)?;
 
     let mut port_mappings = Vec::with_capacity(args.ingress.len());
     for spec in &args.ingress {
@@ -899,13 +906,11 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
 
     let mut client = connect_daemon(global).await?;
 
-    use minimald_rpc::{CreateSession, CreateSessionRequest};
-    let req = CreateSessionRequest {
-        config,
-        contribution,
+    use minimald_rpc::{
+        ConfigureLoadout, ConfigureLoadoutRequest, CreateSession, CreateSessionRequest,
     };
     let resp = client
-        .oneshot_rpc::<CreateSession>(req)
+        .oneshot_rpc::<CreateSession>(CreateSessionRequest { config })
         .await
         .context("CreateSession RPC failed")?;
 
@@ -918,14 +923,29 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
             bail!("CreateSession failed: {error}");
         }
     };
-    // The daemon may finalize immediately (`Ready`) or ask the
-    // client to gate items first (`Pending`).
-    let id = match created {
-        minimald_rpc::CreateSessionResponse::Ready { id } => id,
-        minimald_rpc::CreateSessionResponse::Pending { id: _, response } => {
-            drive_pending_to_active(&mut client, response, user_policy, compose_options).await?
+    let id = created.id;
+
+    // The session exists but has no loadout yet; composing it is a second
+    // round-trip because the daemon's composer reads the project config out
+    // of the session's workspace, not from a path on this machine.
+    let configured = client
+        .oneshot_rpc::<ConfigureLoadout>(ConfigureLoadoutRequest {
+            session_id: id,
+            contribution,
+        })
+        .await
+        .context("ConfigureLoadout RPC failed")?;
+    let configured = match configured {
+        minimald_rpc::Errorable::Ok(r) => r,
+        minimald_rpc::Errorable::Err { error } => {
+            bail!("ConfigureLoadout failed: {error}");
         }
     };
+    // The daemon may finalize immediately (`Ready`) or ask the
+    // client to gate items first (`Pending`).
+    if let minimald_rpc::ConfigureLoadoutResponse::Pending { response } = configured {
+        drive_pending_to_active(&mut client, response, user_policy, compose_options).await?;
+    }
 
     println!("{id}");
 

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -260,10 +260,23 @@ async fn stop_succeeds_when_no_sessions() {
 }
 
 #[tokio::test]
-async fn stop_refuses_with_live_session() {
+async fn stop_succeeds_with_idle_session() {
     let (daemon, args) = setup().await;
-    let session_id = create_session(&daemon, "active").await;
+    let session_id = create_session(&daemon, "idle").await;
     daemon.server.bring_session_up(session_id).await;
+
+    // An idle session (actor up, but no shell hosted and no create flow in
+    // flight) does not block an unforced stop; its record survives for the
+    // next daemon start.
+    cmd_stop(&args, StopArgs { force: false }).await.unwrap();
+}
+
+#[tokio::test]
+async fn stop_refuses_with_pending_session() {
+    let (daemon, args) = setup().await;
+    // A Pending session (mid create flow, awaiting the client's verdict) is
+    // busy: an unforced stop must refuse rather than strand the flow.
+    let _id = create_pending_session(&daemon, "mid-create").await;
 
     let result = cmd_stop(&args, StopArgs { force: false }).await;
     assert!(result.is_err());
@@ -339,7 +352,47 @@ async fn session_policy_succeeds() {
 
 // --- helpers ---
 
-/// Create a session on the daemon via TestClient and return its ID.
+/// Creates a session whose workspace mfile declares a `[session.vars]`
+/// entry, which the daemon must route back to the client for gating — so
+/// configuring its loadout returns `Pending` and the session actor parks in
+/// its Draft state awaiting a verdict. Returns its ID.
+async fn create_pending_session(daemon: &common::TestDaemon, name: &str) -> SessionId {
+    let mut client = daemon.server.connect().await;
+    let project_path =
+        camino::Utf8PathBuf::from_path_buf(std::env::current_dir().unwrap()).unwrap();
+    let config = minimald_rpc::SessionConfig {
+        name: Some(name.to_string()),
+        project_path: paths::HostAbsPath::try_new(project_path).unwrap(),
+        network: sessions::NetworkMode::NoNet,
+        policy: Default::default(),
+        attrs: Default::default(),
+    };
+
+    use minimald_rpc::{
+        ConfigureLoadout, ConfigureLoadoutRequest, ConfigureLoadoutResponse, CreateSession,
+        CreateSessionRequest,
+    };
+    let id = client
+        .call::<CreateSession>(&CreateSessionRequest { config })
+        .await
+        .unwrap()
+        .id;
+    daemon
+        .server
+        .seed_workspace_mfile(id, "[session.vars]\nRUST_LOG = \"info\"\n")
+        .await;
+    let resp = client
+        .call::<ConfigureLoadout>(&ConfigureLoadoutRequest {
+            session_id: id,
+            contribution: Default::default(),
+        })
+        .await;
+    match resp {
+        minimald_rpc::Errorable::Ok(ConfigureLoadoutResponse::Pending { .. }) => id,
+        other => panic!("expected a Pending loadout, got {other:?}"),
+    }
+}
+
 async fn create_session(daemon: &common::TestDaemon, name: &str) -> SessionId {
     let mut client = daemon.server.connect().await;
 
@@ -355,17 +408,31 @@ async fn create_session(daemon: &common::TestDaemon, name: &str) -> SessionId {
         attrs: Default::default(),
     };
 
-    use minimald_rpc::{CreateSession, CreateSessionRequest};
-    let resp = client
-        .call::<CreateSession>(&CreateSessionRequest {
-            config,
-            contribution: Default::default(),
-        })
-        .await;
-    match resp {
-        minimald_rpc::Errorable::Ok(r) => unwrap_ready(r),
+    use minimald_rpc::{
+        ConfigureLoadout, ConfigureLoadoutRequest, CreateSession, CreateSessionRequest,
+    };
+    let id = match client
+        .call::<CreateSession>(&CreateSessionRequest { config })
+        .await
+    {
+        minimald_rpc::Errorable::Ok(r) => r.id,
         minimald_rpc::Errorable::Err { error } => {
             panic!("CreateSession failed: {error}")
         }
+    };
+    // Finalize the session's loadout, as `min activate` does: its workspace
+    // is empty, so this composes to an empty `Ready` in one shot.
+    match client
+        .call::<ConfigureLoadout>(&ConfigureLoadoutRequest {
+            session_id: id,
+            contribution: Default::default(),
+        })
+        .await
+    {
+        minimald_rpc::Errorable::Ok(r) => unwrap_ready(r),
+        minimald_rpc::Errorable::Err { error } => {
+            panic!("ConfigureLoadout failed: {error}")
+        }
     }
+    id
 }

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -174,11 +174,12 @@ impl OneshotSshRpc for GetSessionRecord {
 
 /// An RPC to create a new session.
 ///
-/// Carries two parts: a [`SessionConfig`] (everything that doesn't
-/// fit in a [`WireContribution`] — name, network, policy, attrs)
-/// plus the client's Phase 1 [`WireContribution`]. Callers that
-/// don't go through the composition pipeline (sftp / exec /
-/// session-recovery) send `WireContribution::default()`.
+/// Allocates the session's record and brings its actor up; the
+/// session exists but has no loadout yet. The client follows up with
+/// [`ConfigureLoadout`] once the daemon-side workspace holds the
+/// project files the composer reads — nothing here composes, so a
+/// caller that only needs a session (sftp / exec / session-recovery)
+/// can stop after this RPC.
 pub struct CreateSession;
 
 /// Session configuration that lives outside the composable
@@ -213,51 +214,73 @@ pub struct SessionConfig {
 pub struct CreateSessionRequest {
     /// Out-of-band session config.
     pub config: SessionConfig,
-    /// Client-side Phase 1 contribution. Defaulted (empty) by
-    /// internal callers that aren't composing a session — e.g. sftp,
-    /// exec, session-recovery — so the daemon takes the empty-
-    /// contribution fast path and returns [`CreateSessionResponse::Ready`]
-    /// immediately.
-    #[serde(default)]
-    pub contribution: sessions::wire::request::WireContribution,
 }
 
-/// The response for a [`CreateSession`] RPC.
+/// The response for a [`CreateSession`] RPC: the allocated session.
 ///
-/// Both variants are part of the Phase 2 flow and reachable on the
-/// wire: `Ready` when the daemon's composer finalizes in one shot,
-/// `Pending` when it collects items the client must gate before
-/// composition completes (the client follows up via `SubmitVerdict`).
-///
-/// In practice today every caller still takes the `Ready` path — no
-/// daemon-side contributors (project / package `Composable`s) are
-/// wired into the manager yet, so the composer never has anything to
-/// route back for gating. `Pending` lights up automatically once
-/// those contributors land.
+/// The session's loadout is not composed yet — the returned id is
+/// what the client names it by in the [`ConfigureLoadout`] that
+/// follows.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum CreateSessionResponse {
-    /// No items need user gating. The session id is the finalized
-    /// session — callers can immediately use it.
-    Ready {
-        /// Daemon-assigned session id.
-        id: SessionId,
-    },
-    /// Items need client-side gating. The session id is allocated
-    /// and the session is persisted (status reflects "in flight").
-    /// Client follows up with `SubmitVerdict` carrying the same id.
-    Pending {
-        /// Daemon-assigned session id; also embedded in `response`.
-        id: SessionId,
-        /// Pending items the client must gate.
-        response: sessions::wire::request::ContributionResponse,
-    },
+pub struct CreateSessionResponse {
+    /// Daemon-assigned session id.
+    pub id: SessionId,
 }
 
 impl OneshotSshRpc for CreateSession {
     const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "CreateSession");
     type Request<'a> = CreateSessionRequest;
     type Response = Errorable<CreateSessionResponse>;
+}
+
+/// An RPC to compose a session's loadout, completing its create flow.
+///
+/// Split from [`CreateSession`] because the composer reads the
+/// project config out of the session's *daemon-side workspace*, which
+/// only holds the project files once the client has streamed them up
+/// — the record's `project_path` is a path on the client's machine,
+/// which the daemon generally can't read. So the client creates the
+/// session, populates its workspace, and only then configures the
+/// loadout.
+pub struct ConfigureLoadout;
+
+/// The request for a [`ConfigureLoadout`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfigureLoadoutRequest {
+    /// The session to configure, from [`CreateSessionResponse::id`].
+    pub session_id: SessionId,
+    /// Client-side Phase 1 contribution. Defaulted (empty) by
+    /// callers that aren't composing a session, which take the
+    /// empty-contribution fast path to [`ConfigureLoadoutResponse::Ready`].
+    #[serde(default)]
+    pub contribution: sessions::wire::request::WireContribution,
+}
+
+/// The response for a [`ConfigureLoadout`] RPC.
+///
+/// Both variants are part of the Phase 2 flow and reachable on the
+/// wire: `Ready` when the daemon's composer finalizes in one shot,
+/// `Pending` when it collects items the client must gate before
+/// composition completes (the client follows up via `SubmitVerdict`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConfigureLoadoutResponse {
+    /// No items need user gating; the session is finalized and
+    /// callers can immediately use it.
+    Ready,
+    /// Items need client-side gating. The session stays in flight;
+    /// the client follows up with `SubmitVerdict` carrying the same
+    /// id.
+    Pending {
+        /// Pending items the client must gate.
+        response: sessions::wire::request::ContributionResponse,
+    },
+}
+
+impl OneshotSshRpc for ConfigureLoadout {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "ConfigureLoadout");
+    type Request<'a> = ConfigureLoadoutRequest;
+    type Response = Errorable<ConfigureLoadoutResponse>;
 }
 
 /// An RPC to rename an existing session.
@@ -632,7 +655,7 @@ mod tests {
     }
 
     #[test]
-    fn create_session_request_round_trips_with_explicit_contribution() {
+    fn create_session_request_round_trips() {
         let req = CreateSessionRequest {
             config: SessionConfig {
                 name: Some("my-session".into()),
@@ -643,42 +666,50 @@ mod tests {
                     .into_iter()
                     .collect(),
             },
-            contribution: WireContribution::default(),
         };
         assert_eq!(round_trip(&req), req);
     }
 
     #[test]
-    fn create_session_request_accepts_missing_contribution_field() {
-        // Wire payload from an internal caller that doesn't know about
-        // the composition pipeline: only `config` is set.
+    fn create_session_response_round_trips() {
+        let resp = CreateSessionResponse {
+            id: SessionId::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
+        };
+        assert_eq!(round_trip(&resp), resp);
+    }
+
+    #[test]
+    fn configure_loadout_request_round_trips_with_explicit_contribution() {
+        let req = ConfigureLoadoutRequest {
+            session_id: SessionId::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
+            contribution: WireContribution::default(),
+        };
+        assert_eq!(round_trip(&req), req);
+    }
+
+    /// A caller that doesn't compose a session omits `contribution`
+    /// entirely; it defaults to empty rather than failing to parse.
+    #[test]
+    fn configure_loadout_request_accepts_missing_contribution_field() {
         let raw = serde_json::json!({
-            "config": {
-                "name": null,
-                "project_path": "/proj",
-                "network": "host_net",
-                "policy": { "egress": null, "ingress": null },
-                "attrs": {},
-            },
+            "session_id": "00000000-0000-0000-0000-000000000001",
         });
-        let req: CreateSessionRequest = serde_json::from_value(raw).expect("deserialize");
+        let req: ConfigureLoadoutRequest = serde_json::from_value(raw).expect("deserialize");
         assert_eq!(req.contribution, WireContribution::default());
     }
 
     #[test]
-    fn create_session_response_ready_round_trips() {
-        let id = SessionId::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
-        let resp = CreateSessionResponse::Ready { id };
+    fn configure_loadout_response_ready_round_trips() {
+        let resp = ConfigureLoadoutResponse::Ready;
         assert_eq!(round_trip(&resp), resp);
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains(r#""kind":"ready""#), "got: {json}");
     }
 
     #[test]
-    fn create_session_response_pending_round_trips() {
+    fn configure_loadout_response_pending_round_trips() {
         let id = SessionId::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
-        let resp = CreateSessionResponse::Pending {
-            id,
+        let resp = ConfigureLoadoutResponse::Pending {
             response: ContributionResponse {
                 session_id: id,
                 vars: vec![],

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -179,7 +179,7 @@ async fn task_producer(
         // guest rootfs lacking `ip`/`nsenter`), so an `OwnIp` session's task
         // falls back to `HostNet` here instead of running in an empty,
         // egress-less netns.
-        let network_mode = match session.record().await.network {
+        let network_mode = match session.record().await?.network {
             m @ (sandbox2::NetworkMode::HostNet | sandbox2::NetworkMode::NoNet) => m,
             // OwnIp falls back to HostNet (the per-PTask tap/switch attach for the
             // task producer is a follow-up); `NetworkMode` is #[non_exhaustive],
@@ -880,7 +880,15 @@ async fn handle_git_receive(
     session.channel_success(id)?;
 
     spawn(async move {
-        let paths = session_handle.paths().await;
+        let paths = match session_handle.paths().await {
+            Ok(paths) => paths,
+            // The actor died between resolve and this call (raced an
+            // abort/destroy); the channel was already acked, so just drop it.
+            Err(e) => {
+                tracing::warn!(error = %e, "git-receive-pack aborted: session is gone");
+                return;
+            }
+        };
 
         let dotgit_dir = paths.working.as_utf8_path().join(".git");
         if let Ok(false) = tokio::fs::try_exists(&dotgit_dir).await {
@@ -1361,22 +1369,17 @@ mod tests {
         //! and `handle_exec` request routing.
         use sessions::SessionId;
 
-        use minimald_rpc::CreateSession;
-
         use crate::MINIMAL_SESSION_ID_ENV;
         use crate::sessions::SessionKeyPredicate;
-        use crate::test_harness::{TestClient, TestServer, create_session_req, unwrap_ready};
+        use crate::test_harness::{
+            TestClient, TestServer, create_configured_session, create_session_req,
+        };
 
         /// Creates a fresh session through the public CreateSession RPC
         /// and returns its id, mirroring how a real client sets up state
         /// before running commands against the session.
         async fn fresh_session(client: &mut TestClient) -> SessionId {
-            unwrap_ready(
-                client
-                    .call::<CreateSession>(&create_session_req("exec-test", "/tmp"))
-                    .await
-                    .unwrap(),
-            )
+            create_configured_session(client, "exec-test", "/tmp").await
         }
 
         /// An exec request that isn't `min run <task>` must be refused
@@ -1408,29 +1411,48 @@ mod tests {
         /// serviced straight from the workspace `minimal.toml` — no
         /// package graph, upstream, or sandbox — and its text (plus a
         /// trailing newline) round-trips over the channel with exit 0.
+        ///
+        /// Drives the client's real ordering — create, populate the
+        /// workspace, *then* configure the loadout against it — which is the
+        /// sequence `minvmd`'s libkrun e2e test runs over the bridge. Keeping
+        /// it in-process here means a break in that sequence (e.g. execing a
+        /// session whose loadout was never configured, which has no context
+        /// to resolve a task against) surfaces without needing a VM.
         #[tokio::test]
         async fn exec_runs_echo_task() {
+            use minimald_rpc::{ConfigureLoadout, ConfigureLoadoutRequest, CreateSession};
+
             let server = TestServer::new().await;
             let mut client = server.connect().await;
-            let session_id = fresh_session(&mut client).await;
-            let session_str = session_id.to_string();
-
-            // Drop a task-only `minimal.toml` into the session workspace.
-            // No `[upstream]`: the echo short-circuit never builds a graph,
-            // so nothing here reaches the (network-bound) package machinery.
-            let mngr = server.state.sessions_manager().await;
-            let session_handle = mngr
-                .get_session(SessionKeyPredicate::Id(session_id))
+            let session_id = client
+                .call::<CreateSession>(&create_session_req("exec-test", "/tmp"))
                 .await
                 .unwrap()
-                .expect("freshly-created session should be retrievable");
-            let workspace = session_handle.paths().await.working;
-            tokio::fs::write(
-                workspace.as_utf8_path().join(mfile::MFILE_NAME),
-                "[tasks.echo_ok]\necho = \"MINIMALD_SESSION_OK\"\n",
-            )
-            .await
-            .unwrap();
+                .id;
+            let session_str = session_id.to_string();
+
+            // Drop a task-only `minimal.toml` into the session workspace,
+            // standing in for the e2e test's SFTP upload. No `[upstream]`:
+            // the echo short-circuit never builds a graph, so nothing here
+            // reaches the (network-bound) package machinery.
+            server
+                .seed_workspace_mfile(
+                    session_id,
+                    "[tasks.echo_ok]\necho = \"MINIMALD_SESSION_OK\"\n",
+                )
+                .await;
+
+            // A task-only mfile gates nothing, so the loadout finalizes in
+            // one shot rather than erroring or pending.
+            crate::test_harness::unwrap_ready(
+                client
+                    .call::<ConfigureLoadout>(&ConfigureLoadoutRequest {
+                        session_id,
+                        contribution: Default::default(),
+                    })
+                    .await
+                    .unwrap(),
+            );
 
             let out = client
                 .exec(
@@ -1541,7 +1563,7 @@ mod tests {
                 .await
                 .unwrap()
                 .expect("session should be retrievable");
-            let paths = session_handle.paths().await;
+            let paths = session_handle.paths().await.unwrap();
             let pushed = paths.working.as_utf8_path().join("hello.txt");
             let contents = tokio::fs::read(&pushed)
                 .await

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -137,6 +137,9 @@ async fn serve_get_session_record(s: ServerStateHandle, c: RuChannel<Msg>) {
     }
 }
 
+/// `CreateSession`: allocates the session's record and brings its actor
+/// up, replying with the assigned id. The loadout is composed separately,
+/// by the `ConfigureLoadout` that follows.
 async fn serve_create_session(
     s: ServerStateHandle,
     c: RuChannel<Msg>,
@@ -146,31 +149,19 @@ async fn serve_create_session(
         .handle_channel(c, async |req| {
             let mngr = s.sessions_manager().await;
 
-            Ok(
-                match mngr
-                    .create_session(req.config, ssh_username, req.contribution)
-                    .await
-                {
-                    Ok(resp) => Errorable::Ok(resp),
-                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Errorable::Err {
-                        error: "A session with that name already exists".to_string(),
-                    },
-                    // R2.1: a policy/network-mode mismatch is rejected at
-                    // declaration time and surfaced as a clean typed error rather
-                    // than a transport failure.
-                    Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => Errorable::Err {
-                        error: e.to_string(),
-                    },
-                    // The daemon's in-flight Pending stash is full
-                    // (see `MAX_PENDING_SESSIONS`). Surface as a clean
-                    // typed error so the client can retry rather than
-                    // treat it as a transport failure.
-                    Err(e) if e.kind() == std::io::ErrorKind::ResourceBusy => Errorable::Err {
-                        error: e.to_string(),
-                    },
-                    Err(e) => return Err(ConnectionError::Internal(e.to_string())),
+            Ok(match mngr.create_session(req.config, ssh_username).await {
+                Ok(id) => Errorable::Ok(minimald_rpc::CreateSessionResponse { id }),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Errorable::Err {
+                    error: "A session with that name already exists".to_string(),
                 },
-            )
+                // R2.1: a policy/network-mode mismatch is rejected at
+                // declaration time and surfaced as a clean typed error rather
+                // than a transport failure.
+                Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => Errorable::Err {
+                    error: e.to_string(),
+                },
+                Err(e) => return Err(ConnectionError::Internal(e.to_string())),
+            })
         })
         .await;
     if let Err(e) = res {
@@ -178,37 +169,112 @@ async fn serve_create_session(
     }
 }
 
+/// `ConfigureLoadout`: composes a created session's loadout from the
+/// project config in its workspace plus the client's contribution.
+/// Resolves the session's live actor and routes the contribution to it;
+/// the actor composes and either promotes its record `Pending → Active`
+/// (`Ready`) or parks awaiting a verdict (`Pending`).
+///
+/// A compose failure leaves the session alive and unconfigured, so it
+/// surfaces as an `Errorable::Err` the client can act on (fix the project
+/// and retry, or abort) rather than a transport failure. An unknown id —
+/// including an actor that died between resolve and delivery — is a
+/// `NotFound`-flavoured `Errorable::Err`.
+async fn serve_configure_loadout(s: ServerStateHandle, c: RuChannel<Msg>) {
+    let res = minimald_rpc::ConfigureLoadout
+        .handle_channel(c, async |req: minimald_rpc::ConfigureLoadoutRequest| {
+            let mngr = s.sessions_manager().await;
+            let handle = mngr
+                .get_session(SessionKeyPredicate::Id(req.session_id))
+                .await
+                .map_err(|e| ConnectionError::Internal(e.to_string()))?;
+            let Some(h) = handle else {
+                return Ok(Errorable::Err {
+                    error: format!("no session with ID `{}`", req.session_id.as_ref()),
+                });
+            };
+            Ok(match h.configure_loadout(req.contribution).await {
+                Ok(None) => Errorable::Ok(minimald_rpc::ConfigureLoadoutResponse::Ready),
+                Ok(Some(response)) => {
+                    Errorable::Ok(minimald_rpc::ConfigureLoadoutResponse::Pending { response })
+                }
+                Err(e) => Errorable::Err {
+                    error: e.to_string(),
+                },
+            })
+        })
+        .await;
+    if let Err(e) = res {
+        tracing::warn!(
+            "RPC handler for {} failed: {}",
+            minimald_rpc::ConfigureLoadout::NAME,
+            e
+        );
+    }
+}
+
 /// `SubmitVerdict`: the client's per-item decisions for a `Pending`
-/// session. Delegates to the manager actor, which pops the matching
-/// `PendingComposeState`, runs `resume_from_verdict`, and promotes
-/// the record `Pending → Active`. Replies with `Errorable::Ok(SessionStep)`
+/// session. Resolves the session's live actor and routes the verdict
+/// to it; the actor runs `resume_from_verdict` and promotes its
+/// record `Pending → Active`. Replies with `Errorable::Ok(SessionStep)`
 /// where the `SessionStep` is `Active { id }` on success or
-/// `Fault { error }` for a structured failure (unknown id, wrong
-/// state, or a `ComposeError`-mapped `WireError`). Manager-side
-/// `io::Error`s bubble up as `ConnectionError::Internal`.
+/// `Fault { error }` for a structured failure. A verdict for an id
+/// with no live session — including an actor that died between
+/// resolve and delivery — maps to `Fault { UnknownSessionId }` here;
+/// other `io::Error`s bubble up as `ConnectionError::Internal`.
 async fn serve_submit_verdict(s: ServerStateHandle, c: RuChannel<Msg>) {
     let res = SubmitVerdict
-        .handle_channel(c, async |req| {
-            let mngr = s.sessions_manager().await;
-            match mngr.submit_verdict(req).await {
-                Ok(step) => Ok(Errorable::Ok(step)),
-                Err(e) => Err(ConnectionError::Internal(e.to_string())),
-            }
-        })
+        .handle_channel(
+            c,
+            async |req: sessions::wire::request::ContributionVerdict| {
+                let mngr = s.sessions_manager().await;
+                let unknown = || {
+                    Errorable::Ok(sessions::wire::request::SessionStep::Fault {
+                        error: sessions::wire::errors::WireError::UnknownSessionId,
+                    })
+                };
+                let handle = mngr
+                    .get_session(SessionKeyPredicate::Id(req.session_id))
+                    .await
+                    .map_err(|e| ConnectionError::Internal(e.to_string()))?;
+                match handle {
+                    None => Ok(unknown()),
+                    Some(h) => match h.submit_verdict(req).await {
+                        Ok(step) => Ok(Errorable::Ok(step)),
+                        Err(e) if e.kind() == std::io::ErrorKind::NotConnected => Ok(unknown()),
+                        Err(e) => Err(ConnectionError::Internal(e.to_string())),
+                    },
+                }
+            },
+        )
         .await;
     if let Err(e) = res {
         tracing::warn!("RPC handler for {} failed: {}", SubmitVerdict::NAME, e);
     }
 }
 
+/// `RenameSession`: resolves the session's actor (spinning it up from
+/// disk if needed) and lets it persist the new name and relink its
+/// PTask hostname. A name collision surfaces as the store's
+/// `AlreadyExists` in the `Errorable::Err` text.
 async fn serve_rename_session(s: ServerStateHandle, c: RuChannel<Msg>) {
     let res = RenameSession
         .handle_channel(c, async |req| {
-            let res = s
-                .sessions_manager()
-                .await
-                .rename_session(req.id, req.new_name)
-                .await;
+            let res = async {
+                match s
+                    .sessions_manager()
+                    .await
+                    .get_session(SessionKeyPredicate::Id(req.id))
+                    .await?
+                {
+                    None => Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("no session with ID `{}`", req.id.as_ref()),
+                    )),
+                    Some(h) => h.rename(req.new_name).await,
+                }
+            }
+            .await;
             match res {
                 Ok(()) => Ok(Errorable::Ok(RenameSessionResponse)),
                 Err(e) => Ok(Errorable::Err {
@@ -225,7 +291,7 @@ async fn serve_rename_session(s: ServerStateHandle, c: RuChannel<Msg>) {
 async fn serve_destroy_session(s: ServerStateHandle, c: RuChannel<Msg>) {
     let res = DestroySession
         .handle_channel(c, async |req| {
-            let res = s.sessions_manager().await.destroy_session(req.id).await;
+            let res = s.sessions_manager().await.delete_session(req.id).await;
             match res {
                 Ok(()) => Ok(Errorable::Ok(DestroySessionResponse)),
                 Err(e) => Ok(Errorable::Err {
@@ -300,13 +366,28 @@ async fn quiesce_state_volume_if_mounted(s: &ServerStateHandle) {
 #[cfg(not(target_os = "linux"))]
 async fn quiesce_state_volume_if_mounted(_s: &ServerStateHandle) {}
 
-/// `AbortSession`: drop a `Pending` session's stash entry and delete
-/// its on-disk record. See the manager arm for the actor-side rules
-/// (refuses `Active` records and unknown ids).
+/// `AbortSession`: routes to the session actor, whose state machine
+/// deletes a `Draft` session's record and stops, or refuses an
+/// `Active` session with `InvalidInput` (use `DestroySession`).
+/// Unknown ids are `NotFound`.
 async fn serve_abort_session(s: ServerStateHandle, c: RuChannel<Msg>) {
     let res = AbortSession
         .handle_channel(c, async |req| {
-            let res = s.sessions_manager().await.abort_session(req.id).await;
+            let res = async {
+                match s
+                    .sessions_manager()
+                    .await
+                    .get_session(SessionKeyPredicate::Id(req.id))
+                    .await?
+                {
+                    None => Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("no session with ID `{}`", req.id.as_ref()),
+                    )),
+                    Some(h) => h.abort().await,
+                }
+            }
+            .await;
             match res {
                 Ok(()) => Ok(Errorable::Ok(AbortSessionResponse)),
                 Err(e) => Ok(Errorable::Err {
@@ -438,7 +519,10 @@ async fn unpack_workspace_files(
         .await
         .map_err(|e| format!("session UUID lookup failed: {e}"))?
         .ok_or("unknown session UUID")?;
-    let paths = session_handle.paths().await;
+    let paths = session_handle
+        .paths()
+        .await
+        .map_err(|e| format!("session is gone: {e}"))?;
 
     let reader = async_compression::tokio::bufread::ZstdDecoder::new(tokio::io::BufReader::new(
         c.make_reader(),
@@ -476,6 +560,7 @@ pub async fn handle_ssh_rpc(
         | ListSessions::NAME
         | GetSessionRecord::NAME
         | CreateSession::NAME
+        | minimald_rpc::ConfigureLoadout::NAME
         | SubmitVerdict::NAME
         | RenameSession::NAME
         | DestroySession::NAME
@@ -514,6 +599,7 @@ pub async fn handle_ssh_rpc(
         ListSessions::NAME => drop(spawn(serve_list_sessions(s, channel))),
         GetSessionRecord::NAME => drop(spawn(serve_get_session_record(s, channel))),
         CreateSession::NAME => drop(spawn(serve_create_session(s, channel, ssh_username))),
+        minimald_rpc::ConfigureLoadout::NAME => drop(spawn(serve_configure_loadout(s, channel))),
         SubmitVerdict::NAME => drop(spawn(serve_submit_verdict(s, channel))),
         RenameSession::NAME => drop(spawn(serve_rename_session(s, channel))),
         DestroySession::NAME => drop(spawn(serve_destroy_session(s, channel))),
@@ -576,16 +662,12 @@ mod tests {
         encoder.into_inner()
     }
 
-    use crate::test_harness::{create_session_req as req, unwrap_ready};
+    use crate::test_harness::create_session_req as req;
 
-    /// Creates a session through the public RPC and returns its id.
+    /// Creates a session through the public RPCs and returns its id, ready
+    /// to attach.
     async fn fresh_session(client: &mut TestClient) -> SessionId {
-        unwrap_ready(
-            client
-                .call::<CreateSession>(&req("stream-test", "/tmp"))
-                .await
-                .unwrap(),
-        )
+        crate::test_harness::create_configured_session(client, "stream-test", "/tmp").await
     }
 
     #[tokio::test]
@@ -621,7 +703,7 @@ mod tests {
             .await
             .unwrap()
             .expect("freshly-created session should be retrievable");
-        let paths = handle.paths().await;
+        let paths = handle.paths().await.unwrap();
 
         assert_eq!(
             tokio::fs::read(paths.working.as_utf8_path().join("hello.txt"))
@@ -736,12 +818,11 @@ mod tests {
         let server = TestServer::new().await;
         let mut client = server.connect().await;
 
-        let id = unwrap_ready(
-            client
-                .call::<CreateSession>(&req("my session", "/uwu"))
-                .await
-                .unwrap(),
-        );
+        let id = client
+            .call::<CreateSession>(&req("my session", "/uwu"))
+            .await
+            .unwrap()
+            .id;
         assert!(id != SessionId::nil());
 
         let get_session = client
@@ -781,21 +862,19 @@ mod tests {
             allow_dns_hosts: None,
             allow_protocols: None,
         };
-        let created_id = unwrap_ready(
-            client
-                .call::<CreateSession>(&CreateSessionRequest {
-                    config: minimald_rpc::SessionConfig {
-                        name: Some("policy-session".to_string()),
-                        project_path: HostAbsPath::try_new("/uwu").unwrap(),
-                        network: NetworkMode::OwnIp,
-                        policy: SessionPolicy::new(Some(egress.clone()), None),
-                        attrs: Default::default(),
-                    },
-                    contribution: Default::default(),
-                })
-                .await
-                .unwrap(),
-        );
+        let created_id = client
+            .call::<CreateSession>(&CreateSessionRequest {
+                config: minimald_rpc::SessionConfig {
+                    name: Some("policy-session".to_string()),
+                    project_path: HostAbsPath::try_new("/uwu").unwrap(),
+                    network: NetworkMode::OwnIp,
+                    policy: SessionPolicy::new(Some(egress.clone()), None),
+                    attrs: Default::default(),
+                },
+            })
+            .await
+            .unwrap()
+            .id;
 
         let policy = client
             .call::<GetSessionPolicy>(&GetSessionPolicyRequest::Id(created_id))
@@ -812,12 +891,11 @@ mod tests {
         let server = TestServer::new().await;
         let mut client = server.connect().await;
 
-        let id = unwrap_ready(
-            client
-                .call::<CreateSession>(&req("my session", "/uwu"))
-                .await
-                .unwrap(),
-        );
+        let id = client
+            .call::<CreateSession>(&req("my session", "/uwu"))
+            .await
+            .unwrap()
+            .id;
         assert!(id != SessionId::nil());
 
         assert_eq!(
@@ -851,7 +929,6 @@ mod tests {
                     policy: SessionPolicy::new(Some(egress), None),
                     attrs: Default::default(),
                 },
-                contribution: Default::default(),
             })
             .await;
         assert_eq!(
@@ -890,7 +967,7 @@ mod tests {
         assert_eq!(resp, Errorable::Ok(RenameSessionResponse));
 
         // The record held by the running session reflects the new name...
-        let record = handle.record().await;
+        let record = handle.record().await.unwrap();
         assert_eq!(record.name.as_deref(), Some("renamed"));
         // ...while its id is untouched by the rename.
         assert_eq!(record.id, session_id);
@@ -921,6 +998,30 @@ mod tests {
             matches!(resp, Errorable::Err { error } if error.contains("no session with ID")),
             "expected an unknown-id error",
         );
+    }
+
+    /// A verdict for an id with no live session is a terminal, structured
+    /// `Fault::UnknownSessionId` on the wire — not a transport error. This
+    /// mapping lives in `serve_submit_verdict` now that verdicts route to
+    /// per-session actors.
+    #[tokio::test]
+    async fn submit_verdict_unknown_id_returns_unknown_session_id() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        let resp = client
+            .call::<minimald_rpc::SubmitVerdict>(&sessions::wire::request::ContributionVerdict {
+                session_id: SessionId::nil(),
+                vars: vec![],
+                patches: vec![],
+            })
+            .await;
+        match resp {
+            Errorable::Ok(sessions::wire::request::SessionStep::Fault {
+                error: sessions::wire::errors::WireError::UnknownSessionId,
+            }) => {}
+            other => panic!("expected Fault::UnknownSessionId, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -998,19 +1099,30 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shutdown_without_force_refuses_while_a_session_is_live() {
         let server = TestServer::new().await;
         let mut client = server.connect().await;
         let session_id = fresh_session(&mut client).await;
 
-        // A persisted session isn't "live" until it's brought up; do so, so the
-        // manager has a running actor that an unforced shutdown must protect.
-        let mngr = server.state.sessions_manager().await;
-        mngr.get_session(SessionKeyPredicate::Id(session_id))
-            .await
-            .unwrap()
-            .expect("freshly-created session should be retrievable");
+        // A session is only "busy" once it hosts a live shell (an idle actor
+        // no longer blocks an unforced shutdown). Open one and drive an echo
+        // round trip so the host is provably up before the shutdown request.
+        let mut channel = client.open_shell(session_id).await;
+        channel.data_bytes(b"hello\n".to_vec()).await.unwrap();
+        let mut stdout = Vec::new();
+        loop {
+            match channel.wait().await {
+                Some(russh::ChannelMsg::Data { data }) => {
+                    stdout.extend_from_slice(&data);
+                    if String::from_utf8_lossy(&stdout).contains("got:hello") {
+                        break;
+                    }
+                }
+                Some(_) => {}
+                None => panic!("channel closed before the echo arrived"),
+            }
+        }
 
         let resp = client
             .call::<Shutdown>(&ShutdownRequest { force: false })
@@ -1019,6 +1131,7 @@ mod tests {
 
         // The refusal left the daemon fully operational: the live session is
         // still reachable and no shutdown flag was latched.
+        let mngr = server.state.sessions_manager().await;
         assert!(
             mngr.get_session(SessionKeyPredicate::Id(session_id))
                 .await

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1,5 +1,6 @@
 use crate::channel_progress::ChannelProgress;
-use crate::sessions::{SessionControl, WeakManagerHandle};
+use crate::sessions::{SessionControl, WeakManagerHandle, composables};
+use crate::store::SessionRecordHandle;
 use crate::{
     ChannelConfig,
     session_host::{self, HostAttrs, WinSize},
@@ -8,12 +9,35 @@ use mctx::ConfigBuilder;
 use ot::OpTracker;
 use paths::DaemonAbsPath;
 use russh::{Channel, server::Msg};
-use sessions::{Record, core::compose::Composition, store::SessionObject};
+use sessions::wire::request::ContributionResponse;
+use sessions::{
+    Record, SessionStatus,
+    core::compose::Composition,
+    daemon::composer::{ComposeOutcome, PendingComposeState, resume_from_verdict},
+    store::{DiskSession, SessionObject},
+    wire::request::{ContributionVerdict, SessionStep, WireContribution},
+};
 use std::fmt::{self};
 use std::ops::ControlFlow;
 use std::sync::Arc;
+#[cfg(target_os = "linux")]
+use std::sync::RwLock;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
+
+/// The name a session's PTask hostname is registered under, doubling as the
+/// session host's display name: the session's assigned name, or the project
+/// directory's basename when unnamed.
+pub(crate) fn registry_name(record: &Record) -> String {
+    match &record.name {
+        Some(s) => s.clone(),
+        None => record
+            .project_path
+            .file_name()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "session".to_string()),
+    }
+}
 
 /// An error that occurred when attaching to a running session/its-shell.
 #[derive(Debug)]
@@ -24,12 +48,20 @@ pub enum AttachError {
     /// The session's networking policy is incompatible with its network mode
     /// (R2.1): e.g. an egress section on a non-`OwnIp` PTask.
     InvalidPolicy(sessions::PolicyError),
+    /// Configuring the loadout of an as-yet-unconfigured session, on the way
+    /// into the attach, failed.
+    LoadoutFailed(std::io::Error),
+    /// The session's composition is awaiting the client's contribution
+    /// verdict, so there is nothing to attach to yet. The client has to gate
+    /// the pending items (`SubmitVerdict`) before a shell can be minted.
+    SessionPending,
 }
 
 impl std::error::Error for AttachError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             AttachError::InvalidPolicy(e) => Some(e),
+            AttachError::LoadoutFailed(e) => Some(e),
             _ => None,
         }
     }
@@ -44,14 +76,93 @@ impl fmt::Display for AttachError {
             AttachError::NoPty => write!(f, "SSH channel did not configure a PTY"),
             AttachError::SpawnFailed(e) => write!(f, "session spawn: {e}"),
             AttachError::InvalidPolicy(e) => write!(f, "invalid session policy: {e}"),
+            AttachError::LoadoutFailed(e) => write!(f, "configuring session loadout: {e}"),
+            AttachError::SessionPending => write!(
+                f,
+                "session is awaiting its contribution verdict; cannot attach"
+            ),
         }
     }
 }
 
+/// The paths on the daemon relevant to a session's internals.
+#[derive(Debug)]
 pub struct SessionPaths {
     pub working: DaemonAbsPath,
     pub cache: DaemonAbsPath,
     pub home: DaemonAbsPath,
+}
+
+/// Everything a [`Session`] actor needs at spawn time. Every session actor
+/// is spawned through [`Session::run`] with one of these, whether it is
+/// backed by a freshly allocated record (the `CreateSession` path) or an
+/// existing one being brought up from disk (the `GetSession` path); what the
+/// session *is* comes from its record, not from the spawn site.
+pub(crate) struct SessionConfig {
+    pub minimal_state_dir: DaemonAbsPath,
+    pub minimal_cache_dir: DaemonAbsPath,
+    pub daemon_ctx: Arc<mctx::DaemonContext>,
+
+    /// Handle to this session's record.
+    pub record: SessionRecordHandle,
+    /// Handle to the session manager, powers operations initiated within the session.
+    pub manager: WeakManagerHandle,
+
+    pub net_switch: Arc<Mutex<crate::net::SwitchClient>>,
+    /// The daemon's shared PTask hostname registry; the actor registers its
+    /// route on spawn, relinks on rename, and withdraws on stop/destroy.
+    #[cfg(target_os = "linux")]
+    pub hostnames: Arc<RwLock<crate::net::dns::HostnameRegistry>>,
+}
+
+/// Lifecycle-dependent state of a session actor: the multi-step create flow
+/// as a state machine. Session-lifetime state (record snapshot, dirs,
+/// tracker, handles) lives on [`Session`] itself.
+#[derive(Debug)]
+enum SessionInner {
+    /// Session allocated but is accumulating configuration / not yet started.
+    Draft {
+        /// Daemon-side resume state for [`resume_from_verdict`], stashed by a
+        /// [`ComposeOutcome::Pending`] loadout. `None` before the loadout is
+        /// configured at all, and for an actor spawned from a `Pending`
+        /// record — the state is in-memory only, so it died with whichever
+        /// actor produced it. Either way there is nothing to resume, and
+        /// `SubmitVerdict` faults.
+        pending: Option<Box<PendingComposeState>>,
+    },
+    /// Composition finalized (record status `Active`), or spawned from an
+    /// on-disk `Active` record.
+    Active {
+        /// The finalized [`Composition`] this session was created with.
+        /// `None` after a daemon restart — the composition isn't persisted,
+        /// and the launcher falls back to its baseline set in that case.
+        ///
+        /// The launcher currently consumes only the composition's packages
+        /// and vars. Patches (need file-upload plumbing) and lifecycle hooks
+        /// (need in-sandbox exec plumbing) are held here but not yet applied.
+        composition: Option<Arc<Composition>>,
+        /// The running host, if minted, paired with the `JoinHandle` of its
+        /// runtime loop so teardown can be awaited on destroy.
+        host: Option<(
+            session_host::HostHandle,
+            JoinHandle<Result<i32, std::io::Error>>,
+        )>,
+        /// Lazily-built [`mctx::Context`] rooted at this session's workspace,
+        /// cached so repeated attach / task-exec paths don't re-parse the
+        /// workspace mfile. Boxed to keep the variant's inline size down
+        /// (`Context` runs into the several-hundred-byte range).
+        context: Option<Box<mctx::Context>>,
+    },
+}
+
+/// How a session actor's mainloop ended, deciding whether the actor still
+/// needs to notify the manager to drop its `running` entry. Manager-initiated
+/// terminations (`Stop`, `Destroy`) already removed the entry on the manager
+/// side; actor-initiated ones (`Abort`, a failed verdict resume) must evict
+/// themselves after the mailbox closes.
+enum Teardown {
+    ManagerInitiated,
+    SelfInitiated,
 }
 
 enum SessionMessage {
@@ -65,20 +176,72 @@ enum SessionMessage {
         ChannelConfig,
     ),
     GetHostAttrs(oneshot::Sender<Option<HostAttrs>>),
-    RefreshRecord(Record),
-    Destroy(oneshot::Sender<()>),
+    /// Compose a `Draft` session's loadout from the project config and the
+    /// client's wire contribution. `None` finalizes the session (`Active`);
+    /// `Some(response)` parks it in `Draft` awaiting a verdict. Refused with
+    /// `AlreadyExists` once `Active`; a compose failure is answered as an
+    /// error and leaves the actor `Draft`, ready for another attempt.
+    ConfigureLoadout(
+        WireContribution,
+        oneshot::Sender<Result<Option<ContributionResponse>, std::io::Error>>,
+    ),
+    /// Resume a `Draft` session with the client's verdict, promoting it to
+    /// `Active`. Boxed so the variant doesn't dominate the enum's size.
+    /// Answered with a `WrongState` fault on an `Active` or unconfigured
+    /// session, and with a composer fault on an unresumable verdict — none
+    /// of which are terminal for the actor.
+    SubmitVerdict(
+        Box<(
+            ContributionVerdict,
+            oneshot::Sender<Result<SessionStep, std::io::Error>>,
+        )>,
+    ),
+    /// Abort a `Draft` session: delete its record and stop the actor.
+    /// Refused with `InvalidInput` on an `Active` session (use `Destroy`).
+    Abort(oneshot::Sender<Result<(), std::io::Error>>),
+    /// Rename the session: persist the new name through the record handle,
+    /// refresh the in-memory snapshot, and relink the PTask hostname.
+    Rename(String, oneshot::Sender<Result<(), std::io::Error>>),
+    /// Whether this session blocks an unforced daemon shutdown: a `Draft`
+    /// holding compose state (a client is mid create flow, and stopping
+    /// would strand it) or an `Active` with a minted host. A `Draft` that
+    /// was merely created isn't busy — nothing is in flight to strand.
+    IsBusy(oneshot::Sender<bool>),
+    /// Shutdown-stop: kill the host (if any), withdraw the hostname, and stop
+    /// the actor — the on-disk record is kept.
+    Stop(oneshot::Sender<()>),
+    /// Full teardown: like [`Stop`](Self::Stop), but also deletes the on-disk
+    /// record.
+    Destroy(oneshot::Sender<Result<(), std::io::Error>>),
     GetRecord(oneshot::Sender<Record>),
+    /// Test-only inspection: an `Arc` clone of the held [`Composition`]
+    /// (`None` in `Draft`, or `Active` without one post-restart). Lets tests
+    /// assert composition contents without disturbing the lifecycle.
+    #[cfg(test)]
+    PeekComposition(oneshot::Sender<Option<Arc<Composition>>>),
 }
 
-/// Manages a running session.
+/// Manages one session, from the moment its record is allocated: the create
+/// flow (compose → `Draft` → verdict → `Active`) runs as the
+/// [`SessionInner`] state machine, and the actor owns its record's writes
+/// and deletion, its PTask hostname, its held composition, and its host.
 ///
 /// Follows the actor pattern.
 #[derive(Debug)]
-pub struct Session<S: SessionObject> {
+pub struct Session {
     receiver: mpsc::Receiver<SessionMessage>,
     minimal_state_dir: DaemonAbsPath,
     minimal_cache_dir: DaemonAbsPath,
-    session: S,
+    daemon_ctx: Arc<mctx::DaemonContext>,
+
+    /// Store-backed handle to this session's record.
+    record: SessionRecordHandle,
+
+    /// The daemon's shared PTask hostname registry (see
+    /// [`SessionSeed::hostnames`]). The lock is only ever held for a
+    /// synchronous register/deregister, never across an `.await`.
+    #[cfg(target_os = "linux")]
+    hostnames: Arc<RwLock<crate::net::dns::HostnameRegistry>>,
 
     /// The daemon-scoped gvproxy switch, injected into each `SandboxLauncher`
     /// this session mints so an `OwnIp` PTask attaches to the one per-host
@@ -88,110 +251,191 @@ pub struct Session<S: SessionObject> {
     #[cfg_attr(test, allow(dead_code))]
     net_switch: Arc<Mutex<crate::net::SwitchClient>>,
 
-    /// The running host, if minted, paired with the `JoinHandle` of its runtime
-    /// loop so teardown can be awaited on destroy.
-    host: Option<(
-        session_host::HostHandle,
-        JoinHandle<Result<i32, std::io::Error>>,
-    )>,
-
-    /// The root of this session's operation tree. Created once for the session
-    /// and wired into the context each launch builds against, so package
-    /// fetches/builds report into it; the channel renderer paints it onto the
-    /// SSH channel while a host is being minted.
+    /// The root of this session's operation tree - tracks long-running
+    /// operations for display.
     tracker: OpTracker,
 
-    /// The finalized [`Composition`] this session was created with.
-    /// `None` after a daemon restart — the composition isn't
-    /// persisted, and the launcher falls back to its baseline set
-    /// in that case.
-    ///
-    /// The launcher currently consumes only the composition's
-    /// packages and vars. Patches (need file-upload plumbing) and
-    /// lifecycle hooks (need in-sandbox exec plumbing) are held
-    /// here but not yet applied.
-    #[cfg_attr(test, allow(dead_code))]
-    composition: Option<Arc<Composition>>,
-
-    /// Lazily-built [`mctx::Context`] rooted at this session's
-    /// workspace, cached so repeated attach / task-exec paths don't
-    /// re-parse the workspace mfile.
-    ///
-    /// Each session builds its own [`DaemonContext`] (rather than
-    /// sharing the Manager's `Arc`) so the per-session
-    /// [`OpTracker`] on [`mctx::Config`] stays scoped correctly.
-    ///
-    /// [`DaemonContext`]: mctx::DaemonContext
-    /// [`OpTracker`]: ot::OpTracker
-    context: Option<mctx::Context>,
+    /// Session state machine.
+    inner: SessionInner,
 
     /// A non-owning handle to the [`Manager`](crate::sessions::Manager), used to
     /// build the [`SessionControl`] handed to each [`Binding`] so a shell-exit
     /// "delete" tears this session down through the manager (record removal and
-    /// all). Weak by design — see [`crate::sessions::Manager::weak_self`].
+    /// all), and to self-evict from the manager's running map on
+    /// actor-initiated termination. Weak by design — see
+    /// [`crate::sessions::Manager::weak_self`].
     manager: WeakManagerHandle,
 }
 
-impl<S: SessionObject> Session<S> {
-    /// Launches the actor for the given session.
-    ///
-    /// `composition` is the daemon's Phase 2 output for this session,
-    /// carried in memory from `Manager::CreateSession` (or the
-    /// `SubmitVerdict` handler that promotes a Pending record). `None`
-    /// when the session was minted before the composables pipeline
-    /// existed, or when the actor is spawned from disk after a daemon
-    /// restart — both cases are graceful degradations.
-    pub async fn run(
-        minimal_state_dir: DaemonAbsPath,
-        minimal_cache_dir: DaemonAbsPath,
-        session: S,
-        net_switch: Arc<Mutex<crate::net::SwitchClient>>,
-        composition: Option<Arc<Composition>>,
-        manager: WeakManagerHandle,
-    ) -> Result<SessionHandle, std::io::Error> {
-        std::fs::create_dir_all(session.workspace_path())?;
-        std::fs::create_dir_all(session.home_path())?;
-        std::fs::create_dir_all(session.cache_path())?;
-
-        let (sender, receiver) = mpsc::channel(8);
-        let mngr = Self {
-            host: None,
-            receiver,
-            session,
+impl Session {
+    /// Assembles the actor from its seed, mailbox, and initial state. The
+    /// caller decides when to enter [`Self::mainloop`].
+    fn assemble(
+        seed: SessionConfig,
+        receiver: mpsc::Receiver<SessionMessage>,
+        inner: SessionInner,
+    ) -> Self {
+        let SessionConfig {
             minimal_state_dir,
             minimal_cache_dir,
+            daemon_ctx,
+            record,
+            net_switch,
+            manager,
+            #[cfg(target_os = "linux")]
+            hostnames,
+        } = seed;
+        Self {
+            receiver,
+            record,
+            minimal_state_dir,
+            minimal_cache_dir,
+            daemon_ctx,
             net_switch,
             tracker: OpTracker::new_root(),
-            composition,
-            context: None,
+            inner,
             manager,
+            #[cfg(target_os = "linux")]
+            hostnames,
+        }
+    }
+
+    /// Create the session's backing directories (workspace, home, cache).
+    fn create_dirs(object: &DiskSession) -> Result<(), std::io::Error> {
+        std::fs::create_dir_all(object.workspace_path())?;
+        std::fs::create_dir_all(object.home_path())?;
+        std::fs::create_dir_all(object.cache_path())?;
+        Ok(())
+    }
+
+    /// Launches the actor for a session — the one path onto which every
+    /// session actor is spawned. The initial state machine state is derived
+    /// from the record alone: an `Active` record comes up ready to attach
+    /// (without a composition; it isn't persisted, so the launcher falls back
+    /// to its baseline set), a `Pending` one as an unconfigured `Draft`
+    /// awaiting `ConfigureLoadout`.
+    pub(crate) async fn run(conf: SessionConfig) -> Result<SessionHandle, std::io::Error> {
+        let obj = conf.record.object().await?;
+        Self::create_dirs(&obj)?;
+
+        let inner = match obj.record().status {
+            SessionStatus::Active => SessionInner::Active {
+                composition: None,
+                host: None,
+                context: None,
+            },
+            SessionStatus::Pending => SessionInner::Draft { pending: None },
         };
 
-        tokio::spawn(mngr.mainloop());
+        let (sender, receiver) = mpsc::channel(8);
+        let actor = Self::assemble(conf, receiver, inner);
+
+        // Register the PTask hostname before the actor goes live, so the
+        // route exists by the time the caller can observe the session
+        // (R3.1/R3.6). A `Draft` session has nothing to route to yet, so
+        // `register_hostname` no-ops until its loadout finalizes.
+        #[cfg(target_os = "linux")]
+        actor.register_hostname(obj.record());
+
+        tokio::spawn(actor.mainloop());
         Ok(SessionHandle(sender))
     }
 
-    /// The async task which handles interactions with the
-    /// session.
+    /// Register this session's PTask hostname (R3.1/R3.6). Both HostNet and
+    /// OwnIp resolve to loopback: a HostNet PTask's listeners are on host
+    /// loopback; an OwnIp PTask is reached through a gvproxy-published
+    /// loopback port (#542, the published-loopback model). A NoNet PTask
+    /// exposes no services, so it is not registered — and neither is a
+    /// `Draft` session, which has nothing to route to until its composition
+    /// finalizes.
+    #[cfg(target_os = "linux")]
+    fn register_hostname(&self, record: &Record) {
+        if !self.owns_hostname_route(record) {
+            return;
+        }
+        let name = registry_name(record);
+        let mut reg = self
+            .hostnames
+            .write()
+            .expect("hostname registry lock poisoned");
+        match record.network {
+            sessions::NetworkMode::OwnIp => {
+                reg.register_own_ip(record.id, &name);
+            }
+            sessions::NetworkMode::HostNet => {
+                reg.register_host_net(record.id, &name);
+            }
+            _ => {}
+        }
+    }
+
+    /// Whether this session currently owns a PTask hostname route: `Active`
+    /// with a routable network mode — exactly the condition under which
+    /// [`Self::register_hostname`] registered one.
+    #[cfg(target_os = "linux")]
+    fn owns_hostname_route(&self, record: &Record) -> bool {
+        matches!(self.inner, SessionInner::Active { .. })
+            && matches!(
+                record.network,
+                sessions::NetworkMode::HostNet | sessions::NetworkMode::OwnIp
+            )
+    }
+
+    /// Withdraw this session's PTask hostname (R3.5).
+    ///
+    /// Gated on [`Self::owns_hostname_route`] rather than relying on the
+    /// registry's no-op behavior: the registry is keyed by name alone, so an
+    /// ungated deregister from a session that never registered (`Draft`, or
+    /// a non-routable mode) could withdraw an *unrelated* session's route
+    /// that happens to share the same derived name.
+    #[cfg(target_os = "linux")]
+    async fn deregister_hostname(&self) {
+        let record = self.record.record().await.unwrap();
+        if !self.owns_hostname_route(&record) {
+            return;
+        }
+        self.hostnames
+            .write()
+            .expect("hostname registry lock poisoned")
+            .deregister(&registry_name(&record));
+    }
+
+    /// The async task which handles interactions with the session.
+    ///
+    /// On an actor-initiated termination (abort, failed verdict resume) the
+    /// mailbox is closed *before* the manager is told to drop its `running`
+    /// entry, so a manager concurrently awaiting this actor errors out
+    /// instead of deadlocking against a full manager mailbox.
     async fn mainloop(mut self) {
+        let mut teardown = Teardown::ManagerInitiated;
         while let Some(msg) = self.receiver.recv().await {
-            if self.handle_message(msg).await.is_break() {
+            if let ControlFlow::Break(t) = self.handle_message(msg).await {
+                teardown = t;
                 break;
+            }
+        }
+        if matches!(teardown, Teardown::SelfInitiated) {
+            let session_id = *self.record.id();
+            let manager = self.manager.clone();
+            // Close the mailbox first (see above), then notify the manager.
+            drop(self);
+            if let Some(manager) = manager.upgrade() {
+                manager.evict(session_id).await;
             }
         }
     }
 
     /// Handles a specific message recieved by the session.
     ///
-    /// Returns [`ControlFlow::Break`] when the session has been destroyed and
+    /// Returns [`ControlFlow::Break`] when the session has terminated and
     /// the actor loop should exit.
-    async fn handle_message(&mut self, msg: SessionMessage) -> ControlFlow<()> {
+    async fn handle_message(&mut self, msg: SessionMessage) -> ControlFlow<Teardown> {
         match msg {
             SessionMessage::GetPaths(r) => {
-                let _ = r.send(self.paths());
+                let _ = r.send(self.paths().await);
             }
             SessionMessage::MakeContext(r) => {
-                let _ = r.send(self.context());
+                let _ = r.send(self.context().await);
             }
             SessionMessage::Attach(r, session_hnd, conn_username, channel, config) => {
                 let _ = r.send(
@@ -200,36 +444,252 @@ impl<S: SessionObject> Session<S> {
                 );
             }
             SessionMessage::GetHostAttrs(r) => {
-                let _ = r.send(match self.host.as_ref() {
-                    None => None,
-                    Some((h, _)) => h.get_attrs().await.ok(),
+                let _ = r.send(match &self.inner {
+                    SessionInner::Active {
+                        host: Some((h, _)), ..
+                    } => h.get_attrs().await.ok(),
+                    _ => None,
                 });
             }
-            SessionMessage::RefreshRecord(r) => {
-                self.session.refresh_from_record(r);
+            SessionMessage::ConfigureLoadout(contribution, r) => {
+                let _ = r.send(self.configure_loadout(contribution).await);
+            }
+            SessionMessage::SubmitVerdict(msg) => {
+                let (verdict, r) = *msg;
+                let _ = r.send(self.handle_verdict(verdict).await);
+            }
+            SessionMessage::Abort(r) => match &self.inner {
+                // Abort is Draft-only: delete the record, then stop. The
+                // record delete happens before the reply so a post-reply
+                // store read never sees the aborted session.
+                SessionInner::Draft { .. } => {
+                    let _ = r.send(self.record.clone().delete().await);
+                    return ControlFlow::Break(Teardown::SelfInitiated);
+                }
+                SessionInner::Active { .. } => {
+                    let _ = r.send(Err({
+                        match self.record.record().await {
+                            Ok(record) => std::io::Error::new(
+                                std::io::ErrorKind::InvalidInput,
+                                format!(
+                                    "cannot abort session `{}`: status is {:?}, expected Pending",
+                                    record.id.as_ref(),
+                                    record.status,
+                                ),
+                            ),
+                            Err(e) => e,
+                        }
+                    }));
+                }
+            },
+            SessionMessage::Rename(new_name, r) => {
+                let _ = r.send(self.rename(new_name).await);
+            }
+            SessionMessage::IsBusy(r) => {
+                let _ = r.send(match &self.inner {
+                    // Awaiting a verdict: a client is mid create flow.
+                    SessionInner::Draft { pending } => pending.is_some(),
+                    SessionInner::Active { host, .. } => host.is_some(),
+                });
+            }
+            SessionMessage::Stop(r) => {
+                self.stop_host().await;
+                #[cfg(target_os = "linux")]
+                self.deregister_hostname().await;
+                let _ = r.send(());
+                return ControlFlow::Break(Teardown::ManagerInitiated);
             }
             SessionMessage::Destroy(r) => {
-                self.destroy().await;
-                let _ = r.send(());
-                return ControlFlow::Break(());
+                self.stop_host().await;
+                // Withdraw the hostname before the fallible record delete, so
+                // a delete failure leaves a stale on-disk record (repairable
+                // on restart) but never a stale routing entry pointing at a
+                // destroyed session (R3.5).
+                #[cfg(target_os = "linux")]
+                self.deregister_hostname().await;
+                let _ = r.send(self.record.clone().delete().await);
+                return ControlFlow::Break(Teardown::ManagerInitiated);
             }
             SessionMessage::GetRecord(r) => {
-                let _ = r.send(self.session.record().clone());
+                let _ = r.send(self.record.record().await.unwrap());
+            }
+            #[cfg(test)]
+            SessionMessage::PeekComposition(r) => {
+                let _ = r.send(match &self.inner {
+                    SessionInner::Active { composition, .. } => composition.clone(),
+                    SessionInner::Draft { .. } => None,
+                });
             }
         }
         ControlFlow::Continue(())
     }
 
+    /// Compose this session's loadout from its project config and the
+    /// client's wire contribution, then either finalize it (`Ok(None)`, the
+    /// session is now `Active`) or park it in `Draft` holding the resume
+    /// state until the client gates the returned items (`Ok(Some(response))`).
+    ///
+    /// Every failure leaves the actor alive and `Draft`: the caller decides
+    /// whether to retry with a different contribution or tear the session
+    /// down, so a compose error can't strand a half-built session.
+    async fn configure_loadout(
+        &mut self,
+        contribution: WireContribution,
+    ) -> Result<Option<ContributionResponse>, std::io::Error> {
+        if matches!(self.inner, SessionInner::Active { .. }) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "session loadout is already configured",
+            ));
+        }
+        let object = self.record.object().await?;
+        let workspace_path = object.workspace_path();
+
+        // Deliberately no scaffold here: composing is not the moment to
+        // fabricate a project. `scaffold_default_mfile` resolves the default
+        // package repo's branch head over the network, and the default's
+        // packages reach the sandbox through the launcher's context (built
+        // from the workspace mfile) rather than through the composition —
+        // so paying for it here would buy nothing. A bare workspace composes
+        // to an empty loadout, and the scaffold lands at context-build time.
+
+        // Phase 1+2: resolve the project and drive the composer. Kept fully
+        // synchronous — its non-`Send` intermediaries must not cross an
+        // `.await`.
+        let outcome = composables::run_compose(&self.daemon_ctx, &workspace_path, contribution)?;
+
+        match outcome {
+            // The composition is complete: promote the record
+            // `Pending → Active` and hold the composition for the launcher.
+            ComposeOutcome::Ready(composition) => {
+                let mut record = object.record().clone();
+                record.status = SessionStatus::Active;
+                self.record.write(record.clone()).await?;
+                self.inner = SessionInner::Active {
+                    composition: Some(Arc::new(composition)),
+                    host: None,
+                    context: None,
+                };
+                // The session is Active now — publish its PTask route
+                // (R3.1/R3.6).
+                #[cfg(target_os = "linux")]
+                self.register_hostname(&record);
+                Ok(None)
+            }
+            // The client must gate items before the composition completes.
+            // Park in `Draft` with the daemon-side resume state; the record
+            // is already `Pending` on disk, so nothing to write.
+            ComposeOutcome::Pending {
+                mut response,
+                state,
+            } => {
+                // The composer ran before the allocated id was known to it.
+                response.session_id = *self.record.id();
+                self.inner = SessionInner::Draft {
+                    pending: Some(Box::new(state)),
+                };
+                Ok(Some(response))
+            }
+        }
+    }
+
+    /// Resume a `Draft` session with the client's verdict: finalize the
+    /// composition and transition to `Active`.
+    ///
+    /// Structured refusals — a session that is already `Active` or was never
+    /// configured, and a verdict the composer can't apply — come back as a
+    /// [`SessionStep::Fault`] and leave the session `Draft` and resumable, so
+    /// a client that mis-gated an item can correct it and re-submit rather
+    /// than lose the session.
+    async fn handle_verdict(
+        &mut self,
+        verdict: ContributionVerdict,
+    ) -> Result<SessionStep, std::io::Error> {
+        let wrong_state = |what: &str| {
+            Ok(SessionStep::Fault {
+                error: sessions::wire::errors::WireError::WrongState {
+                    what: what.to_string(),
+                },
+            })
+        };
+        let pending = match &self.inner {
+            SessionInner::Active { .. } => return wrong_state("expected Pending, found Active"),
+            SessionInner::Draft { pending: None } => {
+                return wrong_state(
+                    "expected Pending, found a session with no composition to resume",
+                );
+            }
+            SessionInner::Draft {
+                pending: Some(state),
+            } => state,
+        };
+
+        // Clone rather than take: `resume_from_verdict` consumes the state,
+        // and a rejected verdict has to leave the session resumable.
+        let composition = match resume_from_verdict((**pending).clone(), verdict) {
+            Ok(c) => c,
+            Err(e) => return Ok(SessionStep::Fault { error: e.into() }),
+        };
+
+        // Promote the on-disk record `Pending → Active`. A write failure
+        // leaves both the record and the actor `Draft`, so the client can
+        // re-submit the same verdict once the store recovers.
+        let mut record = self.record.record().await?;
+        record.status = SessionStatus::Active;
+        self.record.write(record.clone()).await?;
+        self.inner = SessionInner::Active {
+            composition: Some(Arc::new(composition)),
+            host: None,
+            context: None,
+        };
+        // The session is Active now — publish its PTask route (R3.1/R3.6).
+        #[cfg(target_os = "linux")]
+        self.register_hostname(&record);
+        Ok(SessionStep::Active { id: record.id })
+    }
+
     /// Tears down the running host, if any, waiting for the process to be reaped
     /// and the sandbox guard to be dropped before returning.
-    async fn destroy(&mut self) {
-        if let Some((host, task)) = self.host.take() {
+    async fn stop_host(&mut self) {
+        let host = match &mut self.inner {
+            SessionInner::Active { host, .. } => host.take(),
+            SessionInner::Draft { .. } => None,
+        };
+        if let Some((host, task)) = host {
             // Signal the process to die, then await the runtime loop so the
             // sandbox files backing its rootfs are released before the caller
             // removes the session's directory tree.
             let _ = host.kill().await;
             let _ = task.await;
         }
+    }
+
+    /// Renames the session: persists the new name through the record handle
+    /// (a name collision surfaces as the store's `AlreadyExists`), relinks
+    /// the PTask hostname so `<new>.local.min.internal` routes and the old name stops (R3.6).
+    async fn rename(&mut self, new_name: String) -> Result<(), std::io::Error> {
+        let record = self.record.record().await?;
+
+        // Withdraw the route under the pre-rename name before the record
+        // mutates; re-register under the new name afterwards. Both calls
+        // gate on this session actually owning a route, so a Draft/NoNet
+        // rename never touches the registry.
+        #[cfg(target_os = "linux")]
+        self.deregister_hostname().await;
+        let mut new_record = record.clone();
+        new_record.name = Some(new_name);
+        let written = self.record.write(new_record.clone()).await;
+
+        // Re-register whichever name stuck (the new one on success, the old
+        // one if the write was refused) so a failed rename never strands the
+        // session without a route.
+        #[cfg(target_os = "linux")]
+        self.register_hostname(match &written {
+            Ok(_) => &new_record,
+            Err(_) => &record,
+        });
+
+        written
     }
 
     async fn attach(
@@ -244,7 +704,25 @@ impl<S: SessionObject> Session<S> {
             None => return Err(AttachError::NoPty),
         });
 
-        match &mut self.host {
+        // A session that was created but never had its loadout configured has
+        // nothing in flight, so attaching to it shouldn't be an error: set it
+        // up now, with an empty contribution, and carry on into the attach.
+        // Composition that comes back `Pending` is the one case we can't
+        // resolve here — items need a client-side gate — and falls through to
+        // the refusal below.
+        if let SessionInner::Draft { pending: None } = &self.inner {
+            self.configure_loadout(WireContribution::default())
+                .await
+                .map_err(AttachError::LoadoutFailed)?;
+        }
+
+        let host = match &mut self.inner {
+            // Awaiting a verdict: a client is mid create flow, and composing
+            // over it here would discard the items it is still gating.
+            SessionInner::Draft { .. } => return Err(AttachError::SessionPending),
+            SessionInner::Active { host, .. } => host,
+        };
+        match host {
             None => {
                 self.mint_session_host(session_hnd, conn_username, channel, sz)
                     .await
@@ -269,36 +747,22 @@ impl<S: SessionObject> Session<S> {
         channel: Channel<Msg>,
         sz: WinSize,
     ) -> Result<(), AttachError> {
-        let name = {
-            let record = self.session.record();
-            match &record.name {
-                Some(s) => s.clone(),
-                None => record
-                    .project_path
-                    .file_name()
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| "session".to_string()),
-            }
-        };
+        let record = self.record.record().await.unwrap();
+        let paths = self.paths().await;
+        let name = registry_name(&record);
 
-        // The launcher's context reports into this session's operation tree (see
-        // `context`). Render that tree onto the channel for the duration of the
-        // launch (graph build + package builds + sandbox assembly), then take
-        // the channel back. The host is spawned without a channel so the
-        // renderer has exclusive use of it while building; once the bars are
-        // cleared we attach the channel to the now-running host.
-        // The destroy capability handed down to the host's binding: on a
-        // shell-exit "delete", the binding calls back through this to have the
-        // manager tear the whole session (record included) down.
-        let control = SessionControl::new(self.manager.clone(), self.session.record().id);
-        let launcher = self.session_launcher(session_hnd)?;
+        // Mint a handle to this session ID in the sessions actor/manager.
+        let control = SessionControl::new(self.manager.clone(), record.id);
+
+        // Spawn/setup the session in a closure that reports progress down the terminal.
+        let launcher = self.session_launcher(session_hnd, &record).await?;
         let progress = ChannelProgress::new(channel, self.tracker.clone(), (sz.cols, sz.rows));
         let (channel, spawned) = progress
             .run(Box::pin(session_host::Host::spawn(
                 launcher,
                 name,
                 conn_username,
-                self.paths(),
+                paths,
                 sz,
                 None,
                 Some(control),
@@ -314,18 +778,31 @@ impl<S: SessionObject> Session<S> {
                 "session host exited before its channel could attach",
             ))
         })?;
-        self.host = Some(h);
+        let SessionInner::Active { host, .. } = &mut self.inner else {
+            unreachable!("mint_session_host is only reachable from the Active state");
+        };
+        *host = Some(h);
         Ok(())
+    }
+
+    /// The held [`Composition`], if any — `None` in `Draft` or for an actor
+    /// spawned from disk after a daemon restart.
+    #[cfg_attr(test, allow(dead_code))]
+    fn composition(&self) -> Option<Arc<Composition>> {
+        match &self.inner {
+            SessionInner::Active { composition, .. } => composition.clone(),
+            SessionInner::Draft { .. } => None,
+        }
     }
 
     /// Builds the session launcher used to mint a session host: the real
     /// sandboxed shell in production.
     #[cfg(not(test))]
-    fn session_launcher(
+    async fn session_launcher(
         &mut self,
         _session: SessionHandle,
+        record: &Record,
     ) -> Result<session_host::SandboxLauncher, AttachError> {
-        let record = self.session.record();
         // R2.1: reject a policy that is incompatible with the network mode
         // (e.g. egress on a non-`OwnIp` PTask) before launching the host.
         record
@@ -337,11 +814,14 @@ impl<S: SessionObject> Session<S> {
         // ingress configured on any other mode.
         let ingress = record.policy.ingress.clone();
         Ok(session_host::SandboxLauncher {
-            ctx: self.context().map_err(AttachError::ContextCreationFailed)?,
+            ctx: self
+                .context()
+                .await
+                .map_err(AttachError::ContextCreationFailed)?,
             network_mode,
             net_switch: Arc::clone(&self.net_switch),
             ingress,
-            composition: self.composition.clone(),
+            composition: self.composition(),
         })
     }
 
@@ -349,14 +829,14 @@ impl<S: SessionObject> Session<S> {
     /// to the pty, exercising the session-host runtime without building a real
     /// sandbox (which needs packages unavailable in the unit-test tempdir).
     #[cfg(test)]
-    fn session_launcher(
+    async fn session_launcher(
         &mut self,
         _session: SessionHandle,
+        record: &Record,
     ) -> Result<session_host::MockLauncher, AttachError> {
         // Mirror the production R2.1 gate so test launches reject a
         // policy/network-mode mismatch the same way production does.
-        self.session
-            .record()
+        record
             .validate_policy()
             .map_err(AttachError::InvalidPolicy)?;
         Ok(session_host::MockLauncher)
@@ -365,25 +845,31 @@ impl<S: SessionObject> Session<S> {
     /// Return this session's workspace-rooted [`mctx::Context`],
     /// building it lazily the first time and cloning the cached
     /// value on every subsequent call. The scaffold pass and mfile
-    /// parse happen once per actor lifetime.
-    fn context(&mut self) -> Result<mctx::Context, String> {
-        if let Some(ctx) = &self.context {
-            return Ok(ctx.clone());
+    /// parse happen once per actor lifetime. A `Draft` session has
+    /// no workspace to root a context in yet.
+    async fn context(&mut self) -> Result<mctx::Context, String> {
+        match &self.inner {
+            SessionInner::Draft { .. } => {
+                return Err("session is pending composition".to_string());
+            }
+            SessionInner::Active {
+                context: Some(ctx), ..
+            } => return Ok((**ctx).clone()),
+            SessionInner::Active { context: None, .. } => {}
         }
-        let ctx = self.build_context()?;
-        self.context = Some(ctx.clone());
+        let ctx = self.build_context().await?;
+        if let SessionInner::Active { context, .. } = &mut self.inner {
+            *context = Some(Box::new(ctx.clone()));
+        }
         Ok(ctx)
     }
 
-    /// Do the actual context construction: scaffold a default
-    /// workspace mfile if missing, then run [`mctx::Context::new`]
-    /// against a session-rooted [`Config`]. Called at most once per
-    /// actor lifetime by [`Self::context`].
+    /// The mctx [`Config`] rooted at this session's workspace, shared by the
+    /// scaffold and context-construction paths so both see one session.
     ///
     /// [`Config`]: mctx::Config
-    fn build_context(&self) -> Result<mctx::Context, String> {
-        let wsp = self.session.workspace_path();
-        let config = ConfigBuilder::new()
+    fn workspace_config(&self, wsp: &DaemonAbsPath) -> Result<mctx::Config, String> {
+        ConfigBuilder::new()
             .with_repo_dir(wsp.as_utf8_path())
             .with_cache_dir(self.minimal_cache_dir.as_utf8_path())
             .with_state_dir(self.minimal_state_dir.as_utf8_path())
@@ -393,38 +879,53 @@ impl<S: SessionObject> Session<S> {
             // surface on the same tracker even though only a mint renders it.
             .with_operation_tracker(self.tracker.clone())
             .build()
-            .map_err(|e| mctx::Error::from(e).to_string())?;
-
-        // TEMPORARY: scaffold a default `minimal.toml` if the
-        // workspace has none, so `Context::new` below can succeed.
-        // Delete this block (and `mctx::scaffold`) once sessions
-        // receive their project files via the workspace-upload path.
-        //
-        // The scaffold performs a blocking network git clone. On a
-        // multi-thread runtime, `block_in_place` moves other futures
-        // off this worker for the duration; on a current-thread
-        // runtime it panics, so fall back to a plain blocking call.
-        if !wsp.as_utf8_path().join(mfile::MFILE_NAME).exists() {
-            let scaffold = || mctx::scaffold_default_mfile(&config, wsp.as_utf8_path());
-            let on_multi_thread = matches!(
-                tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()),
-                Ok(tokio::runtime::RuntimeFlavor::MultiThread)
-            );
-            if on_multi_thread {
-                tokio::task::block_in_place(scaffold)
-            } else {
-                scaffold()
-            }
-            .map_err(|e| e.to_string())?;
-        }
-
-        mctx::Context::new(config).map_err(|e| e.to_string())
+            .map_err(|e| mctx::Error::from(e).to_string())
     }
-    fn paths(&self) -> SessionPaths {
+
+    /// TEMPORARY: write a default shell-stack `minimal.toml` into the
+    /// session's workspace if it has none, so [`mctx::Context::new`] can
+    /// succeed and the session gets a usable set of packages. A workspace
+    /// that already holds an uploaded `minimal.toml` is left alone.
+    ///
+    /// Deliberately on the context-build path rather than the compose path:
+    /// it resolves the default package repo's branch head over the network,
+    /// so it belongs where a session is actually being brought up, and is
+    /// paid once per actor. The packages it declares reach the sandbox
+    /// through the launcher's context, which is built from this file.
+    ///
+    /// Delete this (and `mctx::scaffold`) once sessions receive their project
+    /// files via the workspace-upload path.
+    fn scaffold_mfile_if_missing(&self, wsp: &DaemonAbsPath) -> Result<(), String> {
+        if wsp.as_utf8_path().join(mfile::MFILE_NAME).exists() {
+            return Ok(());
+        }
+        let config = self.workspace_config(wsp)?;
+        mctx::scaffold_default_mfile(&config, wsp.as_utf8_path())
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    /// Do the actual context construction: run [`mctx::Context::new`] against
+    /// a session-rooted [`Config`]. Called at most once per actor lifetime by
+    /// [`Self::context`].
+    ///
+    /// The workspace mfile it parses is either the client's uploaded one or
+    /// a default scaffolded here on the way past.
+    ///
+    /// [`Config`]: mctx::Config
+    async fn build_context(&self) -> Result<mctx::Context, String> {
+        let wsp = self.record.object().await.unwrap().workspace_path();
+        self.scaffold_mfile_if_missing(&wsp)?;
+        mctx::Context::new(self.workspace_config(&wsp)?).map_err(|e| e.to_string())
+    }
+
+    async fn paths(&self) -> SessionPaths {
+        let obj = self.record.object().await.unwrap();
+
         SessionPaths {
-            working: self.session.workspace_path(),
-            cache: self.session.cache_path(),
-            home: self.session.home_path(),
+            working: obj.workspace_path(),
+            cache: obj.cache_path(),
+            home: obj.home_path(),
         }
     }
 }
@@ -435,18 +936,24 @@ pub struct SessionHandle(mpsc::Sender<SessionMessage>);
 
 impl SessionHandle {
     /// Returns paths on the daemon backing various internals of the session.
-    pub async fn paths(&self) -> SessionPaths {
+    /// A dead actor (self-terminated abort/failed-verdict/create-failure, or
+    /// mid-teardown) maps to `NotConnected` — callers race actor death.
+    pub async fn paths(&self) -> Result<SessionPaths, std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(SessionMessage::GetPaths(send)).await;
-        recv.await.expect("corresponding session is dead")
+        recv.await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
+        })
     }
-    /// Returns the host attributes of the running session, if any.
+    /// Returns the host attributes of the running session, if any. A dead
+    /// actor (self-terminated or mid-teardown) reads as `None` rather than a
+    /// panic — the manager polls this while actors come and go.
     pub async fn get_attrs(&self) -> Option<HostAttrs> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(SessionMessage::GetHostAttrs(send)).await;
-        recv.await.expect("corresponding session is dead")
+        recv.await.ok().flatten()
     }
 
     /// Returns a minimal context initialized on this sessions' worktree.
@@ -454,35 +961,139 @@ impl SessionHandle {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(SessionMessage::MakeContext(send)).await;
-        recv.await.expect("corresponding session is dead")
+        recv.await
+            .unwrap_or_else(|_| Err("session actor is gone".to_string()))
     }
 
     /// Returns the session record currently held by the live session actor
     /// (the in-memory copy, not the on-disk record). Used by the task-exec path
     /// to read the session's network mode, and by tests to assert propagation.
-    pub(crate) async fn record(&self) -> Record {
+    /// A dead actor maps to `NotConnected`.
+    pub(crate) async fn record(&self) -> Result<Record, std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(SessionMessage::GetRecord(send)).await;
-        recv.await.expect("corresponding session is dead")
+        recv.await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
+        })
     }
 
-    /// Tell the session that the underlying session record was updated.
-    pub(crate) async fn apply_record(&self, new_record: Record) {
-        self.0
-            .send(SessionMessage::RefreshRecord(new_record))
-            .await
-            .expect("corresponding session is dead");
+    /// Configure the session's loadout from the client's wire contribution:
+    /// `Ok(None)` means the composition finalized and the session is now
+    /// `Active`; `Ok(Some(response))` means the client must gate the returned
+    /// items and come back with a verdict. `AlreadyExists` if the loadout is
+    /// already configured; a dead actor maps to `NotConnected`.
+    pub(crate) async fn configure_loadout(
+        &self,
+        contribution: WireContribution,
+    ) -> Result<Option<ContributionResponse>, std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .0
+            .send(SessionMessage::ConfigureLoadout(contribution, send))
+            .await;
+        recv.await.unwrap_or_else(|_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "session actor is gone",
+            ))
+        })
     }
 
-    /// Tears down the session: kills its host (if any), waits for teardown, and
-    /// stops the actor. The handle is dead once this returns.
-    pub(crate) async fn destroy(&self) {
+    /// Submit the client's contribution verdict against a `Draft` session.
+    /// On success the actor promotes its record to `Active` and replies with
+    /// [`SessionStep::Active`]; structured failures (wrong state, an
+    /// unresumable verdict) come back as [`SessionStep::Fault`]. A dead
+    /// actor maps to `NotConnected` (the caller reads it as unknown-session).
+    pub(crate) async fn submit_verdict(
+        &self,
+        verdict: ContributionVerdict,
+    ) -> Result<SessionStep, std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .0
+            .send(SessionMessage::SubmitVerdict(Box::new((verdict, send))))
+            .await;
+        recv.await.unwrap_or_else(|_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "session actor is gone",
+            ))
+        })
+    }
+
+    /// Abort a `Draft` session: the actor deletes its on-disk record and
+    /// stops. `InvalidInput` if the session is `Active` (use destroy);
+    /// a dead actor maps to `NotConnected`.
+    pub(crate) async fn abort(&self) -> Result<(), std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.0.send(SessionMessage::Abort(send)).await;
+        recv.await.unwrap_or_else(|_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "session actor is gone",
+            ))
+        })
+    }
+
+    /// Whether this session blocks an unforced daemon shutdown: awaiting a
+    /// contribution verdict mid create flow, or hosting a live shell. A dead
+    /// actor is not busy.
+    pub(crate) async fn is_busy(&self) -> bool {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.0.send(SessionMessage::IsBusy(send)).await;
+        recv.await.unwrap_or(false)
+    }
+
+    /// Test-only peek at the actor's held [`Composition`]. Bumps the
+    /// refcount rather than moving it, so the caller can assert on contents
+    /// without disturbing the lifecycle.
+    #[cfg(test)]
+    pub(crate) async fn peek_composition(&self) -> Option<Arc<Composition>> {
+        let (send, recv) = oneshot::channel();
+        let _ = self.0.send(SessionMessage::PeekComposition(send)).await;
+        recv.await.ok().flatten()
+    }
+
+    /// Renames the session: the actor persists the new name through its
+    /// record handle (name collision → `AlreadyExists`) and relinks its PTask
+    /// hostname. A dead actor maps to `NotConnected`.
+    pub(crate) async fn rename(&self, new_name: String) -> Result<(), std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.0.send(SessionMessage::Rename(new_name, send)).await;
+        recv.await.unwrap_or_else(|_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "session actor is gone",
+            ))
+        })
+    }
+
+    /// Shutdown-stop: kills the host (if any), withdraws the hostname, and
+    /// stops the actor — the on-disk record is kept. A dead actor is already
+    /// stopped, so send/recv failures read as success.
+    pub(crate) async fn stop(&self) {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.0.send(SessionMessage::Stop(send)).await;
+        // If the actor died before acking, it is stopped all the same.
+        let _ = recv.await;
+    }
+
+    /// Tears down the session: kills its host (if any), waits for teardown,
+    /// deletes the on-disk record, and stops the actor. The handle is dead
+    /// once this returns. A dead actor reads as `Ok` — whatever terminated it
+    /// already ran its teardown.
+    pub(crate) async fn destroy(&self) -> Result<(), std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(SessionMessage::Destroy(send)).await;
-        // If the actor died before acking, the session is gone all the same.
-        let _ = recv.await;
+        recv.await.unwrap_or(Ok(()))
     }
 
     pub async fn attach(
@@ -522,9 +1133,9 @@ mod tests {
     use russh::ChannelMsg;
     use sessions::SessionId;
 
-    use minimald_rpc::{CreateSession, GetSessionRecord, GetSessionRecordRequest};
+    use minimald_rpc::{GetSessionRecord, GetSessionRecordRequest};
 
-    use crate::test_harness::{TestClient, TestServer, create_session_req, unwrap_ready};
+    use crate::test_harness::{TestClient, TestServer, create_configured_session};
 
     /// Reads the session record for `id`, or `None` once it has been deleted.
     async fn record_exists(client: &mut TestClient, id: SessionId) -> bool {
@@ -535,14 +1146,65 @@ mod tests {
             .is_some()
     }
 
-    /// Creates a fresh session on the server and returns its id.
+    /// Creates a fresh, configured session on the server and returns its id.
     async fn create_session(client: &mut TestClient) -> SessionId {
-        unwrap_ready(
-            client
-                .call::<CreateSession>(&create_session_req("shell-test", "/uwu"))
+        create_configured_session(client, "shell-test", "/uwu").await
+    }
+
+    /// Attaching to a session whose loadout was never configured must not
+    /// blow up: nothing is in flight on a bare `Draft`, so the attach
+    /// configures it with an empty contribution on the way in and mints the
+    /// shell as usual. Guards the `min activate` → `min attach` path against
+    /// a client that skipped `ConfigureLoadout`, and any internal caller that
+    /// only ever wanted a session to run something in.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn attach_to_an_unconfigured_session_configures_it_rather_than_failing() {
+        use crate::test_harness::create_session_req;
+        use minimald_rpc::CreateSession;
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        // Bare `CreateSession` — no `ConfigureLoadout` follow-up.
+        let session_id = client
+            .call::<CreateSession>(&create_session_req("bare-session", "/uwu"))
+            .await
+            .unwrap()
+            .id;
+
+        let mut channel = client.open_shell(session_id).await;
+        channel.data_bytes(b"hello\n".to_vec()).await.unwrap();
+        let mut stdout = Vec::new();
+        loop {
+            match channel.wait().await {
+                Some(ChannelMsg::Data { data }) => {
+                    stdout.extend_from_slice(&data);
+                    if String::from_utf8_lossy(&stdout).contains("got:hello") {
+                        break;
+                    }
+                }
+                Some(_) => {}
+                None => {
+                    let stdout = String::from_utf8_lossy(&stdout);
+                    panic!(
+                        "attaching to an unconfigured session should mint a shell; got: {stdout:?}"
+                    );
+                }
+            }
+        }
+
+        // The attach finalized the session on its way in.
+        assert_eq!(
+            server
+                .state
+                .sessions_manager()
                 .await
-                .unwrap(),
-        )
+                .get_record(crate::sessions::SessionKeyPredicate::Id(session_id))
+                .await
+                .unwrap()
+                .expect("the record should exist")
+                .status,
+            sessions::SessionStatus::Active,
+        );
     }
 
     /// Drives the full SSH path into the session host with the mock launcher:

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -1,26 +1,20 @@
 use std::{collections::BTreeMap, io::ErrorKind::NotFound};
 
 use crate::{
-    session::{Session, SessionHandle},
+    session::{Session, SessionConfig, SessionHandle},
     session_host::HostAttrs,
-    store::{RecordPredicate, Store, StoreHandle},
+    store::{RecordPredicate, SessionRecordHandle, Store, StoreHandle},
 };
 use paths::DaemonAbsPath;
-use sessions::{
-    SessionId,
-    daemon::composer::{ComposeOutcome, PendingComposeState, resume_from_verdict},
-    store::SessionObject,
-    wire::request::{ContributionVerdict, SessionStep, WireContribution},
-};
+use sessions::SessionId;
 use std::sync::Arc;
 #[cfg(target_os = "linux")]
 use std::sync::RwLock;
 use tokio::sync::{Mutex, mpsc, oneshot};
 
-mod composables;
+pub(crate) mod composables;
 #[cfg(test)]
-use composables::ProjectResolution;
-use composables::{build_composables, resolve_project_ctx_and_graph, run_composer};
+use composables::{ProjectResolution, build_composables, run_composer};
 
 /// A short summary of the metadata of a session.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,21 +43,6 @@ impl From<SessionKeyPredicate> for RecordPredicate {
 /// Transport / internal error when communicating with the sessions actor.
 type SessionsError = std::io::Error;
 
-/// The name a PTask hostname is registered under: the session's assigned name,
-/// or the project directory's basename when unnamed (matching how a session
-/// host derives its display name).
-#[cfg(target_os = "linux")]
-fn registry_name(record: &sessions::Record) -> String {
-    match &record.name {
-        Some(s) => s.clone(),
-        None => record
-            .project_path
-            .file_name()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "session".to_string()),
-    }
-}
-
 /// Assemble a [`sessions::Record`] from the out-of-band session
 /// config and the SSH-supplied username, then validate its policy.
 /// Returns `Err(io::InvalidInput)` if the policy is incompatible
@@ -71,9 +50,9 @@ fn registry_name(record: &sessions::Record) -> String {
 /// written to the store. The `id` field is left as `nil`; the store
 /// allocates the real id at `create` time.
 ///
-/// Shared by the `Ready` and `Pending` branches of the
-/// `CreateSession` handler so both paths persist the same record
-/// shape, differing only in their initial `status`.
+/// The `CreateSession` handler always persists the record as
+/// `Pending`; the session actor's create flow promotes it to
+/// `Active` once composition finalizes.
 fn build_record(
     config: minimald_rpc::SessionConfig,
     username: Option<String>,
@@ -97,17 +76,17 @@ fn build_record(
 
 /// Encapsulates the return channel for messages back from the actor.
 #[derive(Debug)]
-struct Responder<T>(oneshot::Sender<Result<T, SessionsError>>);
+pub(crate) struct Responder<T>(oneshot::Sender<Result<T, SessionsError>>);
 
 impl<T> Responder<T> {
     /// Constructs both ends of the return channel.
-    pub fn channel() -> (Self, oneshot::Receiver<Result<T, SessionsError>>) {
+    pub(crate) fn channel() -> (Self, oneshot::Receiver<Result<T, SessionsError>>) {
         let (send, recv) = oneshot::channel();
         (Self(send), recv)
     }
 
     /// Awaits the provided future, transmitting its result to the caller.
-    pub async fn handle<F>(self, fut: F)
+    pub(crate) async fn handle<F>(self, fut: F)
     where
         F: Future<Output = Result<T, SessionsError>>,
     {
@@ -115,49 +94,16 @@ impl<T> Responder<T> {
     }
 }
 
-/// Maximum number of in-flight `Pending` sessions the manager will
-/// stash before refusing further `CreateSession` requests that
-/// produce a [`ComposeOutcome::Pending`].
-///
-/// Each entry holds a [`PendingComposeState`] (a few KB of vectors,
-/// the client's wire contribution, and the by-id pending stash). A
-/// misbehaving or abandoned client could otherwise call
-/// `CreateSession` repeatedly without ever sending `SubmitVerdict`,
-/// growing the stash without bound; the cap exists as a backstop.
-///
-/// `Ready` outcomes never consume stash capacity, so this bound
-/// only matters once daemon-side contributors are wired in.
-const MAX_PENDING_SESSIONS: usize = 1024;
-
 /// CreateSession payload — boxed so it doesn't dominate
 /// `ManagerMessage`'s size (the variant carries a full session
-/// config + an optional contribution; other variants are just a
-/// few words).
+/// config; other variants are just a few words).
 #[derive(Debug)]
 struct CreateSessionMsg {
     config: minimald_rpc::SessionConfig,
     /// Authenticated SSH username, supplied by the RPC handler from
     /// the SSH connection context (never the client).
     username: Option<String>,
-    /// Client-side Phase 1 contribution. Fed into `SessionComposer`
-    /// in the handler: the composer either finalizes a `Composition`
-    /// (persist Active, ship `Ready { id }`) or routes items back to
-    /// the client for gating (persist Pending, stash state, ship
-    /// `Pending { id, response }`). A cross-process merge conflict
-    /// or malformed wire item surfaces as `InvalidInput`.
-    contribution: WireContribution,
-    responder: Responder<minimald_rpc::CreateSessionResponse>,
-}
-
-/// SubmitVerdict payload — boxed for the same size-balance reason as
-/// [`CreateSessionMsg`]. Carries the client's per-item decisions for
-/// a `Pending` session id; the handler pops the matching stash from
-/// `Manager::pending`, calls [`resume_from_verdict`], promotes the
-/// record `Pending → Active`, and replies with [`SessionStep::Active`].
-#[derive(Debug)]
-struct SubmitVerdictMsg {
-    verdict: ContributionVerdict,
-    responder: Responder<SessionStep>,
+    responder: Responder<SessionId>,
 }
 
 enum ManagerMessage {
@@ -165,31 +111,21 @@ enum ManagerMessage {
     GetRecord(SessionKeyPredicate, Responder<Option<sessions::Record>>),
     GetSession(SessionKeyPredicate, Responder<Option<SessionHandle>>),
     CreateSession(Box<CreateSessionMsg>),
-    SubmitVerdict(Box<SubmitVerdictMsg>),
-    RenameSession(SessionId, String, Responder<()>),
-    DestroySession(SessionId, Responder<()>),
-    AbortSession(SessionId, Responder<()>),
+    DeleteSession(SessionId, Responder<()>),
     Shutdown(bool, Responder<Result<(), ()>>),
-    /// Test-only inspection: reply with the current size of the
-    /// `compositions` stash. Used to assert stash lifecycle
-    /// transitions (insert on Ready → drain on GetSession →
-    /// cleanup on Destroy/Abort) without exposing the internal
-    /// map to production callers.
-    #[cfg(test)]
-    CompositionsLen(Responder<usize>),
-    /// Test-only inspection: reply with an [`Arc`] clone of the
-    /// stashed [`Composition`] for a given [`SessionId`], or `None`
-    /// if absent. Used to assert that composables actually reached
-    /// the composition with the expected contents (packages, vars),
-    /// not just that a stash entry exists.
-    #[cfg(test)]
-    PeekComposition(
-        SessionId,
-        Responder<Option<Arc<sessions::core::compose::Composition>>>,
-    ),
+    /// Fire-and-forget: drop the `running` entry for a session whose actor
+    /// terminated on its own (abort, failed verdict resume, create failure).
+    /// A no-op for an id already removed; ids are never reused, so a stale
+    /// evict can't remove a fresh actor.
+    Evict(SessionId),
 }
 
-/// Manages session instances, and session state on disk.
+/// Routes session operations to per-session [`Session`] actors, spawning
+/// them as needed: `CreateSession` allocates a record and spawns the actor
+/// that owns the create flow, `GetSession` brings a known session's actor up
+/// from disk, and `DeleteSession` tears one down. Everything session-
+/// specific (compose state, verdicts, rename, attach) lives on the session
+/// actor behind its [`SessionHandle`].
 ///
 /// Follows the actor pattern.
 #[derive(Debug)]
@@ -204,33 +140,10 @@ pub struct Manager {
     /// to do operations on us.
     weak_self: WeakManagerHandle,
 
-    /// Per-session stash for in-flight `CreateSession` flows that
-    /// reached [`ComposeOutcome::Pending`]. Keyed by the daemon's
-    /// allocated [`SessionId`]; the matching `SubmitVerdict` pops
-    /// the entry and finalizes. The stash is in-memory only — if
-    /// the daemon restarts mid-flow the on-disk
-    /// `SessionStatus::Pending` record loses its match and is
-    /// reaped by [`Manager::reap_orphan_pending`] at startup.
-    pending: BTreeMap<SessionId, PendingComposeState>,
-
-    /// Per-session stash of finalized [`Composition`]s awaiting
-    /// their `Session` actor. Populated on `CreateSession` / post-
-    /// verdict, drained on first `GetSession`. In-memory only; a
-    /// daemon restart drops the stash and post-restart spawns fall
-    /// back to the launcher's baseline.
-    ///
-    /// `DestroySession` / `AbortSession` also drain the stash
-    /// defensively — without those drains a client that activates
-    /// then destroys without ever attaching would leak an entry per
-    /// cycle.
-    ///
-    /// [`Composition`]: sessions::core::compose::Composition
-    compositions: BTreeMap<SessionId, Arc<sessions::core::compose::Composition>>,
-
-    /// Daemon-scoped mctx state (config, stdlib_dir, vcs, cache) shared
-    /// with each per-session `mctx::Context` the manager builds at
-    /// `CreateSession` time. Held behind `Arc` so the daemon-level
-    /// setup work runs once per process rather than per session.
+    /// Daemon-scoped mctx state (config, stdlib_dir, vcs, cache) cloned
+    /// into each session actor, which composes its loadout and builds its
+    /// per-session `mctx::Context` on top. Held behind `Arc` so the
+    /// daemon-level setup work runs once per process rather than per session.
     daemon_ctx: Arc<mctx::DaemonContext>,
 
     minimal_state_dir: DaemonAbsPath,
@@ -259,7 +172,6 @@ impl Manager {
         net_switch: Arc<Mutex<crate::net::SwitchClient>>,
     ) -> Result<ManagerHandle, std::io::Error> {
         let store = Store::init(minimal_state_dir.clone()).await?;
-        Self::reap_orphan_pending(&store).await?;
 
         // Build the daemon-scoped mctx state once at startup. Each
         // `CreateSession` will build a per-session `Context` on top of
@@ -300,8 +212,6 @@ impl Manager {
             running,
             store,
             weak_self,
-            pending: BTreeMap::new(),
-            compositions: BTreeMap::new(),
             daemon_ctx,
             minimal_state_dir,
             minimal_cache_dir,
@@ -316,33 +226,112 @@ impl Manager {
 }
 
 impl Manager {
-    /// Delete any on-disk `Pending` records at startup. Their
-    /// in-memory `PendingComposeState` didn't survive the restart,
-    /// so they can never transition to `Active`.
-    async fn reap_orphan_pending(store: &StoreHandle) -> Result<(), std::io::Error> {
-        let mut reaped = 0u64;
-        for handle in store.handles().await? {
-            if handle.record().await?.status == sessions::SessionStatus::Pending {
-                let id = *handle.id();
-                handle.delete().await?;
-                tracing::info!(
-                    session_id = %id,
-                    "reaped orphan Pending session on startup",
-                );
-                reaped += 1;
-            }
-        }
-        if reaped > 0 {
-            tracing::info!(count = reaped, "orphan Pending reap complete");
-        }
-        Ok(())
-    }
-
     /// The async task which handles interactions with the
     /// manager.
     async fn mainloop(mut self) {
         while let Some(msg) = self.receiver.recv().await {
             self.handle_message(msg).await;
+        }
+    }
+
+    /// Resolves the predicate to a live session actor, spawning one from the
+    /// on-disk record if the session is known but not running. Shared by
+    /// every manager operation that needs a session actor.
+    ///
+    /// The store is consulted *before* the running map so a session mid-
+    /// self-teardown (its actor deleted the record but hasn't been evicted
+    /// yet) resolves to `None` rather than a dying handle. Record status
+    /// doesn't gate resolution: the actor's state machine decides which
+    /// operations are valid, including for a `Pending` record brought up
+    /// without its (in-memory only, so long-gone) compose state — such a
+    /// session resolves to an unconfigured `Draft` that can be re-configured
+    /// or aborted, rather than to an unreachable record.
+    async fn resolve_session(
+        &mut self,
+        pred: SessionKeyPredicate,
+    ) -> Result<Option<SessionHandle>, SessionsError> {
+        if self.in_shutdown {
+            return Err(SessionsError::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "in shutdown",
+            ));
+        }
+        let Some(handle) = self.store.find(pred.into()).await? else {
+            return Ok(None);
+        };
+        let session_id = *handle.id();
+        if let Some(h) = self.running.get(&session_id) {
+            return Ok(Some(h.clone()));
+        }
+        // Not running, start it!
+        let h = Session::run(self.session_config(handle)).await?;
+        self.running.insert(session_id, h.clone());
+        Ok(Some(h))
+    }
+
+    /// The spawn-time config for a session actor backing `record`. The one
+    /// place the daemon-scoped dependencies are gathered, so the create and
+    /// bring-up-from-disk paths can't hand their actors different worlds.
+    fn session_config(&self, record: SessionRecordHandle) -> SessionConfig {
+        SessionConfig {
+            minimal_state_dir: self.minimal_state_dir.clone(),
+            minimal_cache_dir: self.minimal_cache_dir.clone(),
+            daemon_ctx: Arc::clone(&self.daemon_ctx),
+            record,
+            net_switch: Arc::clone(&self.net_switch),
+            manager: self.weak_self.clone(),
+            #[cfg(target_os = "linux")]
+            hostnames: Arc::clone(&self.hostnames),
+        }
+    }
+
+    /// Allocate a session's record and bring its actor up. The session is
+    /// live but unconfigured: `ConfigureLoadout` against the returned id
+    /// composes its loadout and finalizes it.
+    ///
+    /// If the actor can't be spawned the record is rolled back — the caller
+    /// never received an id, so nothing else could ever reach the session to
+    /// abort it, and a `Pending` record left parked would hold its name
+    /// hostage.
+    async fn create_session(
+        &mut self,
+        config: minimald_rpc::SessionConfig,
+        username: Option<String>,
+    ) -> Result<SessionId, SessionsError> {
+        if self.in_shutdown {
+            return Err(SessionsError::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "in shutdown",
+            ));
+        }
+        // Allocate the record up front: `store.create` assigns the id and
+        // catches a name collision (`AlreadyExists`) before any actor exists.
+        let record = build_record(config, username, sessions::SessionStatus::Pending)?;
+        let handle = self.store.create(record).await?;
+        let session_id = *handle.id();
+
+        match Session::run(self.session_config(handle.clone())).await {
+            Ok(session) => {
+                self.running.insert(session_id, session);
+                Ok(session_id)
+            }
+            // The actor never started, so no one else will delete the
+            // record. Best-effort: the spawn error is what the client needs
+            // to see, and a leftover `Pending` record is inert — no actor
+            // holds it, so it only costs a name until it is deleted.
+            Err(e) => {
+                if let Err(del_err) = handle.delete().await
+                    && del_err.kind() != NotFound
+                {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %del_err,
+                        "failed to delete the session record after a create \
+                         failure; it will linger until it is deleted explicitly",
+                    );
+                }
+                Err(e)
+            }
         }
     }
 
@@ -379,440 +368,26 @@ impl Manager {
                 .await;
             }
             // Get the session actor for the predicate, starting it
-            // if the session is known but not running. `Pending`
-            // records return `None` (they have no `Composition`
-            // yet, so attaching would give a half-built session).
+            // if the session is known but not running.
             ManagerMessage::GetSession(pred, r) => {
-                r.handle(async {
-                    if self.in_shutdown {
-                        return Err(SessionsError::new(
-                            std::io::ErrorKind::ConnectionRefused,
-                            "in shutdown",
-                        ));
-                    }
-                    match self.store.find(pred.into()).await? {
-                        None => Ok(None),
-                        Some(handle) => {
-                            let obj = handle.object().await?;
-                            if obj.record().status != sessions::SessionStatus::Active {
-                                tracing::info!(
-                                    session_id = %obj.record().id,
-                                    status = ?obj.record().status,
-                                    "refused GetSession on non-Active session",
-                                );
-                                return Ok(None);
-                            }
-                            let session_id = obj.record().id;
-                            let session_handle = match self.running.get(&session_id) {
-                                Some(h) => h.clone(),
-                                None => {
-                                    // Not running, start it!
-                                    // Register a PTask's hostname on launch so it
-                                    // routes host-side (R3.1/R3.6). Both HostNet and
-                                    // OwnIp resolve to loopback: a HostNet PTask's
-                                    // listeners are on host loopback; an OwnIp PTask
-                                    // is reached through a gvproxy-published loopback
-                                    // port (#542, the published-loopback model). A
-                                    // NoNet PTask exposes no services, so it is not
-                                    // registered. Capture id + name + mode before
-                                    // `obj` moves into `Session::run`.
-                                    #[cfg(target_os = "linux")]
-                                    let ptask_reg = {
-                                        let net = obj.record().network;
-                                        matches!(
-                                            net,
-                                            sessions::NetworkMode::HostNet
-                                                | sessions::NetworkMode::OwnIp
-                                        )
-                                        .then(|| {
-                                            (obj.record().id, registry_name(obj.record()), net)
-                                        })
-                                    };
-                                    // Hand over the finalized composition,
-                                    // if it's still in the manager's stash.
-                                    // Absent after a daemon restart — the
-                                    // actor spawns without one, and the
-                                    // record is still usable.
-                                    //
-                                    // Clone the `Arc` rather than draining
-                                    // now, so that a `Session::run` failure
-                                    // below leaves the stash intact: the
-                                    // next `GetSession` retry will still
-                                    // see the composition and run
-                                    // identically. Drain happens only on
-                                    // the success path just after the
-                                    // spawn returns.
-                                    let composition = self.compositions.get(&session_id).cloned();
-                                    // A spawn failure at this point (only
-                                    // I/O failures on `mkdir` of the
-                                    // workspace / home / cache dirs today)
-                                    // means the session can't be brought
-                                    // up — surface as an `io::Error` to
-                                    // the client rather than panicking the
-                                    // actor. Leaves the record on disk and
-                                    // the composition in the stash; the
-                                    // next GetSession retries the same
-                                    // setup and either succeeds or errors
-                                    // identically.
-                                    let h = Session::run(
-                                        self.minimal_state_dir.clone(),
-                                        self.minimal_cache_dir.clone(),
-                                        obj,
-                                        Arc::clone(&self.net_switch),
-                                        composition,
-                                        self.weak_self.clone(),
-                                    )
-                                    .await?;
-                                    // Spawn succeeded — safe to drain the
-                                    // stash. If the entry is already gone
-                                    // (post-restart spawn with a `None`
-                                    // composition), the remove is a
-                                    // no-op.
-                                    self.compositions.remove(&session_id);
-                                    #[cfg(target_os = "linux")]
-                                    if let Some((id, name, net)) = ptask_reg {
-                                        let mut reg = self
-                                            .hostnames
-                                            .write()
-                                            .expect("hostname registry lock poisoned");
-                                        match net {
-                                            sessions::NetworkMode::OwnIp => {
-                                                reg.register_own_ip(id, &name)
-                                            }
-                                            _ => reg.register_host_net(id, &name),
-                                        };
-                                    }
-                                    self.running.insert(session_id, h.clone());
-                                    h
-                                }
-                            };
-                            Ok(Some(session_handle))
-                        }
-                    }
-                })
-                .await;
+                r.handle(self.resolve_session(pred)).await;
             }
-            // Create a session: resolve the project, build the
-            // composables, and drive the composer. Failures pre-mapped
-            // to `InvalidInput`.
+            // Create a session: allocate the record (as `Pending`) and spawn
+            // the session actor. The rest of the create flow — composing the
+            // loadout, promoting the record — belongs to the actor, driven
+            // by the `ConfigureLoadout` that follows.
             ManagerMessage::CreateSession(msg) => {
                 let CreateSessionMsg {
                     config,
                     username,
-                    contribution,
                     responder,
                 } = *msg;
-                // Capture `in_shutdown` by value before we take
-                // `&mut self` borrows below — the async move needs
-                // to see it without holding a `self` reference.
-                let in_shutdown = self.in_shutdown;
-
-                let outcome = resolve_project_ctx_and_graph(&self.daemon_ctx, &config.project_path)
-                    .and_then(|resolution| {
-                        let (project_composable, package_composables) =
-                            build_composables(&config.project_path, &resolution, &contribution)?;
-                        run_composer(contribution, project_composable, package_composables)
-                    });
-                let pending = &mut self.pending;
-                let compositions = &mut self.compositions;
-                let store = self.store.clone();
-                responder
-                    .handle(async move {
-                        if in_shutdown {
-                            return Err(SessionsError::new(
-                                std::io::ErrorKind::ConnectionRefused,
-                                "in shutdown",
-                            ));
-                        }
-                        // Phase 2: branch on the composer outcome.
-                        //
-                        // `Ready` — composition is complete; persist
-                        // the record as `Active`, stash the
-                        // [`Composition`] against its allocated id so
-                        // the [`Session`] actor picks it up on its
-                        // first spawn, and ship
-                        // `CreateSessionResponse::Ready { id }`.
-                        //
-                        // `Pending` — the client must gate items
-                        // before composition completes. Allocate the
-                        // id by persisting the record as `Pending`,
-                        // stash the daemon-side resume state under
-                        // that id, overwrite the placeholder
-                        // `session_id` on the wire response, and ship
-                        // `CreateSessionResponse::Pending { id, response }`.
-                        //
-                        // `Err` — a composable failed to contribute
-                        // (e.g. an `Inherit`-shaped project var the
-                        // daemon couldn't resolve; malformed package
-                        // state_wiring), a cross-process merge
-                        // conflict, or a malformed wire item. All are
-                        // pre-mapped to [`std::io::ErrorKind::InvalidInput`]
-                        // at the call site above.
-                        match outcome {
-                            Ok(ComposeOutcome::Ready(composition)) => {
-                                let record = build_record(
-                                    config,
-                                    username,
-                                    sessions::SessionStatus::Active,
-                                )?;
-                                let handle = store.create(record).await?;
-                                let id = *handle.id();
-                                compositions.insert(id, Arc::new(composition));
-                                Ok(minimald_rpc::CreateSessionResponse::Ready { id })
-                            }
-                            Ok(ComposeOutcome::Pending {
-                                mut response,
-                                state,
-                            }) => {
-                                // Bound the in-memory stash. Check
-                                // before `store.create` so a refusal
-                                // doesn't leave a half-allocated record
-                                // on disk that the next daemon restart
-                                // would have to reap.
-                                if pending.len() >= MAX_PENDING_SESSIONS {
-                                    return Err(std::io::Error::new(
-                                        std::io::ErrorKind::ResourceBusy,
-                                        format!(
-                                            "daemon pending-session stash is full \
-                                             (cap {MAX_PENDING_SESSIONS}); the daemon \
-                                             will accept new sessions as in-flight ones \
-                                             finalize or are aborted",
-                                        ),
-                                    ));
-                                }
-                                let record = build_record(
-                                    config,
-                                    username,
-                                    sessions::SessionStatus::Pending,
-                                )?;
-                                let handle = store.create(record).await?;
-                                let id = *handle.id();
-                                response.session_id = id;
-                                pending.insert(id, state);
-                                Ok(minimald_rpc::CreateSessionResponse::Pending { id, response })
-                            }
-                            Err(e) => Err(e),
-                        }
-                    })
-                    .await;
+                let created = self.create_session(config, username).await;
+                responder.handle(async move { created }).await;
             }
-            // Resume a `Pending` session with the client's verdict.
-            // Pops the matching `PendingComposeState` from the stash,
-            // resumes composition, promotes the record `Pending →
-            // Active`, and replies with `SessionStep::Active { id }`.
-            // A verdict for an id with no stash → `UnknownSessionId`;
-            // a record present but already `Active` (or otherwise not
-            // `Pending`) → `WrongState`.
-            ManagerMessage::SubmitVerdict(msg) => {
-                let SubmitVerdictMsg { verdict, responder } = *msg;
-                let session_id = verdict.session_id;
-                // Capture by value; async move can't hold `self`.
-                let in_shutdown = self.in_shutdown;
-                // Only pop the stash if we're actually going to resume —
-                // otherwise a shutdown-refused verdict would drop the
-                // stash entry without cleanup.
-                let stash_hit = if in_shutdown {
-                    None
-                } else {
-                    self.pending.remove(&session_id)
-                };
-                let store = self.store.clone();
-                let compositions = &mut self.compositions;
-                responder
-                    .handle(async move {
-                        if in_shutdown {
-                            return Err(SessionsError::new(
-                                std::io::ErrorKind::ConnectionRefused,
-                                "in shutdown",
-                            ));
-                        }
-                        let state = match stash_hit {
-                            Some(s) => s,
-                            None => {
-                                return Ok(SessionStep::Fault {
-                                    error: sessions::wire::errors::WireError::UnknownSessionId,
-                                });
-                            }
-                        };
-                        // Run Phase 4 resume. A verdict that the
-                        // composer can't apply (mismatched
-                        // PendingIds, denied items, etc.) maps to a
-                        // `Fault` via `WireError::from(ComposeError)`.
-                        // On success the composition lands in the
-                        // manager's stash so the Session actor picks
-                        // it up on its first spawn (same path as the
-                        // `CreateSession` Ready branch).
-                        let composition = match resume_from_verdict(state, verdict) {
-                            Ok(c) => c,
-                            Err(e) => {
-                                // Verdict couldn't be applied — the
-                                // session is dead. Destroy the
-                                // matching on-disk Pending record so
-                                // the name is freed, `list()` doesn't
-                                // show a phantom entry, and the next
-                                // reap pass has nothing to clean up.
-                                // A delete failure here is logged but
-                                // doesn't override the verdict-level
-                                // error returned to the client.
-                                if let Some(handle) =
-                                    store.find(RecordPredicate::Id(session_id)).await?
-                                    && let Err(del_err) = handle.delete().await
-                                {
-                                    tracing::warn!(
-                                        session_id = %session_id,
-                                        error = %del_err,
-                                        "failed to delete Pending record after \
-                                         resume failure; record will be reaped on \
-                                         next daemon restart",
-                                    );
-                                }
-                                return Ok(SessionStep::Fault { error: e.into() });
-                            }
-                        };
-                        // Promote the on-disk record `Pending →
-                        // Active`. A mid-flight delete or a status
-                        // already past `Pending` is degenerate but
-                        // surfaces as a structured `WrongState`.
-                        let handle = match store.find(RecordPredicate::Id(session_id)).await? {
-                            Some(h) => h,
-                            None => {
-                                return Ok(SessionStep::Fault {
-                                    error: sessions::wire::errors::WireError::UnknownSessionId,
-                                });
-                            }
-                        };
-                        let mut record = handle.record().await?;
-                        if record.status != sessions::SessionStatus::Pending {
-                            return Ok(SessionStep::Fault {
-                                error: sessions::wire::errors::WireError::WrongState {
-                                    what: format!("expected Pending, found {:?}", record.status,),
-                                },
-                            });
-                        }
-                        record.status = sessions::SessionStatus::Active;
-                        handle.write(record).await?;
-                        compositions.insert(session_id, Arc::new(composition));
-                        Ok(SessionStep::Active { id: session_id })
-                    })
-                    .await;
-            }
-            // Renames an existing session with the given ID.
-            ManagerMessage::RenameSession(id, new_name, r) => {
-                r.handle(async {
-                    if self.in_shutdown {
-                        return Err(SessionsError::new(
-                            std::io::ErrorKind::ConnectionRefused,
-                            "in shutdown",
-                        ));
-                    }
-                    match self.store.find(RecordPredicate::Id(id)).await? {
-                        None => Err(std::io::Error::new(
-                            NotFound,
-                            format!("no session with ID `{}`", id.as_ref()),
-                        )),
-                        Some(handle) => {
-                            let mut record = handle.record().await?;
-                            // Snapshot the live route (id + pre-rename name + mode)
-                            // before the rename mutates the record. Only a running
-                            // session has a route (registered on launch), and both
-                            // HostNet and OwnIp carry one (R3.1/R3.6).
-                            #[cfg(target_os = "linux")]
-                            let relink: Option<(
-                                SessionId,
-                                String,
-                                sessions::NetworkMode,
-                            )> = if self.running.contains_key(&id) {
-                                let net = record.network;
-                                matches!(
-                                    net,
-                                    sessions::NetworkMode::HostNet | sessions::NetworkMode::OwnIp
-                                )
-                                .then(|| (record.id, registry_name(&record), net))
-                            } else {
-                                None
-                            };
-
-                            record.name = Some(new_name.clone());
-                            handle.write(record.clone()).await?;
-                            if let Some(hnd) = self.running.get(&id) {
-                                hnd.apply_record(record.clone()).await;
-                            }
-
-                            // Follow the rename in the hostname registry so
-                            // `<new>.local.min.internal` routes and the old name
-                            // stops (R3.6) — otherwise the route is stranded
-                            // under the launch name.
-                            #[cfg(target_os = "linux")]
-                            if let Some((id, old_name, net)) = relink {
-                                let new_reg = registry_name(&record);
-                                let mut reg = self
-                                    .hostnames
-                                    .write()
-                                    .expect("hostname registry lock poisoned");
-                                reg.deregister(&old_name);
-                                match net {
-                                    sessions::NetworkMode::OwnIp => {
-                                        reg.register_own_ip(id, &new_reg)
-                                    }
-                                    _ => reg.register_host_net(id, &new_reg),
-                                };
-                            }
-                            Ok(())
-                        }
-                    }
-                })
-                .await
-            }
-            // Abort a `Pending` session: drop its stash entry and
-            // delete the on-disk record. Refuses `Active` (use
-            // `DestroySession`) or unknown ids. Never touches
-            // `running`: a Pending record can't be running.
-            ManagerMessage::AbortSession(id, r) => {
-                r.handle(async {
-                    if self.in_shutdown {
-                        return Err(SessionsError::new(
-                            std::io::ErrorKind::ConnectionRefused,
-                            "in shutdown",
-                        ));
-                    }
-                    let handle =
-                        self.store
-                            .find(RecordPredicate::Id(id))
-                            .await?
-                            .ok_or_else(|| {
-                                std::io::Error::new(
-                                    NotFound,
-                                    format!("no session with ID `{}`", id.as_ref()),
-                                )
-                            })?;
-                    let record = handle.record().await?;
-                    if record.status != sessions::SessionStatus::Pending {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidInput,
-                            format!(
-                                "cannot abort session `{}`: status is {:?}, expected Pending",
-                                id.as_ref(),
-                                record.status,
-                            ),
-                        ));
-                    }
-                    // Stash may be absent (post-restart orphan reached
-                    // us before the reap pass, or the pending path was
-                    // never populated). Delete the record either way.
-                    self.pending.remove(&id);
-                    // Called for symmetry with `DestroySession`.
-                    // `compositions` is only populated on the Ready
-                    // (post-Active) path, so a Pending abort always
-                    // finds nothing here; the call is a no-op today.
-                    self.compositions.remove(&id);
-                    handle.delete().await?;
-                    Ok(())
-                })
-                .await
-            }
-            // Destroys a session: tears down its running host and actor (if
+            // Deletes a session: tears down its running host and actor (if
             // any), then removes its on-disk record.
-            ManagerMessage::DestroySession(id, r) => {
+            ManagerMessage::DeleteSession(id, r) => {
                 r.handle(async {
                     if self.in_shutdown {
                         return Err(SessionsError::new(
@@ -830,85 +405,53 @@ impl Manager {
                                     format!("no session with ID `{}`", id.as_ref()),
                                 )
                             })?;
-                    // Derive the hostname registry key from the record up front,
-                    // letting a read error propagate before anything is torn
-                    // down. `deregister` is a no-op for a session that never
-                    // registered one, so it is called unconditionally.
-                    #[cfg(target_os = "linux")]
-                    let host_net_name = registry_name(&handle.record().await?);
-                    // Drain the composition stash before teardown. A
-                    // session that never advanced to `GetSession`
-                    // (created + destroyed without an attach) would
-                    // otherwise leak its `Composition` in the
-                    // manager's in-memory map until daemon shutdown.
-                    self.compositions.remove(&id);
-                    // Stop the live session first (killing its host and waiting
-                    // for the sandbox to be released) so the on-disk tree is
-                    // free to remove.
-                    if let Some(hnd) = self.running.remove(&id) {
-                        hnd.destroy().await;
+                    match self.running.remove(&id) {
+                        // A live actor owns its full teardown.
+                        Some(hnd) => {
+                            hnd.destroy().await?;
+                            // Belt-and-braces: a dead actor (self-terminated
+                            // but not yet evicted) reads as `Ok` above, and
+                            // may have died *without* deleting its record
+                            // (its own delete failed). Remove any leftover;
+                            // `NotFound` is the normal already-deleted case.
+                            if let Err(e) = handle.delete().await
+                                && e.kind() != NotFound
+                            {
+                                return Err(e);
+                            }
+                        }
+                        // Never spawned: no host or hostname registration to
+                        // undo, so just remove the on-disk record.
+                        None => handle.delete().await?,
                     }
-                    // Withdraw the PTask hostname (R3.5) before the fallible
-                    // on-disk delete, so a `delete` failure leaves a stale
-                    // on-disk record (repairable on restart) but never a stale
-                    // routing entry pointing at a destroyed session.
-                    #[cfg(target_os = "linux")]
-                    self.hostnames
-                        .write()
-                        .expect("hostname registry lock poisoned")
-                        .deregister(&host_net_name);
-                    handle.delete().await?;
                     Ok(())
                 })
                 .await
             }
             ManagerMessage::Shutdown(force, r) => {
                 r.handle(async {
-                    // Sessions are live but force not given, send false to signal
-                    // we didnt shutdown and continue.
-                    if !self.running.is_empty() && !force {
-                        return Ok(Err(()));
+                    // Busy sessions (a `Draft` awaiting its verdict, or a
+                    // live host) block an unforced shutdown. Idle actors
+                    // don't: every created session now has one, so mere
+                    // existence can't be the guard or a create-and-
+                    // disconnect client would wedge unforced shutdowns
+                    // forever.
+                    if !force {
+                        for hnd in self.running.values() {
+                            if hnd.is_busy().await {
+                                return Ok(Err(()));
+                            }
+                        }
                     }
 
                     self.in_shutdown = true;
-                    // Withdraw the PTask hostnames (R3.5) for every live session
-                    // before tearing them down, mirroring DestroySession, so the
-                    // shutdown drain never leaves stale routing entries pointing
-                    // at destroyed sessions. Names are read from the store up
-                    // front (best-effort — a read failure just skips that entry)
-                    // so the registry lock is never held across `destroy().await`.
-                    // `deregister` is a no-op for a session that never registered
-                    // a hostname.
-                    #[cfg(target_os = "linux")]
-                    {
-                        let mut names: Vec<String> = Vec::new();
-                        for id in self.running.keys().copied().collect::<Vec<_>>() {
-                            if let Ok(Some(handle)) = self.store.find(RecordPredicate::Id(id)).await
-                                && let Ok(record) = handle.record().await
-                            {
-                                names.push(registry_name(&record));
-                            }
-                        }
-                        let mut reg = self
-                            .hostnames
-                            .write()
-                            .expect("hostname registry lock poisoned");
-                        for name in &names {
-                            reg.deregister(name);
-                        }
-                    }
-                    // Stop live sessions
+                    // Stop live sessions. Each actor kills its host and
+                    // withdraws its own PTask hostname (R3.5) on the way
+                    // down; records are kept — shutdown is not deletion.
                     for hnd in self.running.values() {
-                        hnd.destroy().await;
+                        hnd.stop().await;
                     }
                     self.running.clear();
-                    // Drop any stashed compositions for symmetry with
-                    // `running.clear()`. The process is exiting, so
-                    // the map dies with it either way; the explicit
-                    // clear documents the intent and future-proofs
-                    // against a not-yet-existing "restart in place"
-                    // flow.
-                    self.compositions.clear();
                     // Release the cache's held-open alog fd: it lives on the
                     // state volume, and a surviving write-open fd there makes
                     // the post-drain quiesce (R2.1 syncfs + unmount) fail
@@ -918,15 +461,11 @@ impl Manager {
                 })
                 .await
             }
-            #[cfg(test)]
-            ManagerMessage::CompositionsLen(r) => {
-                let n = self.compositions.len();
-                r.handle(async move { Ok(n) }).await;
-            }
-            #[cfg(test)]
-            ManagerMessage::PeekComposition(id, r) => {
-                let comp = self.compositions.get(&id).cloned();
-                r.handle(async move { Ok(comp) }).await;
+            // Actor-initiated termination: drop the running entry. The
+            // actor already handled its record and hostname; ids are never
+            // reused, so a stale evict can't remove a fresh actor.
+            ManagerMessage::Evict(id) => {
+                self.running.remove(&id);
             }
         }
     }
@@ -989,12 +528,12 @@ impl SessionControl {
         Self { manager, id }
     }
 
-    /// Requests the manager destroy this session: kills the host and removes the
+    /// Requests the manager delete this session: kills the host and removes the
     /// on-disk record. Errors if the manager has already shut down, or if the
-    /// destroy itself fails (e.g. the manager is mid-shutdown).
+    /// delete itself fails (e.g. the manager is mid-shutdown).
     pub async fn destroy(&self) -> Result<(), SessionsError> {
         match self.manager.upgrade() {
-            Some(mngr) => mngr.destroy_session(self.id).await,
+            Some(mngr) => mngr.delete_session(self.id).await,
             None => Err(SessionsError::new(
                 std::io::ErrorKind::NotConnected,
                 "sessions manager is gone",
@@ -1045,16 +584,20 @@ impl ManagerHandle {
         recv.await.expect("corresponding sessions manager is dead")
     }
 
-    /// Creates a session from the given config + client wire
-    /// contribution. `username` is the authenticated SSH user from
-    /// the connection context; pass `None` for non-SSH callers (e.g.
-    /// in-process daemon callers and tests).
+    /// Creates a session from the given config, returning its allocated id.
+    /// The session comes up live but unconfigured — [`configure_loadout`]
+    /// against the returned id composes its loadout and finalizes it.
+    ///
+    /// `username` is the authenticated SSH user from the connection context;
+    /// pass `None` for non-SSH callers (e.g. in-process daemon callers and
+    /// tests).
+    ///
+    /// [`configure_loadout`]: crate::session::SessionHandle::configure_loadout
     pub async fn create_session(
         &self,
         config: minimald_rpc::SessionConfig,
         username: Option<String>,
-        contribution: WireContribution,
-    ) -> Result<minimald_rpc::CreateSessionResponse, SessionsError> {
+    ) -> Result<SessionId, SessionsError> {
         let (send, recv) = Responder::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self
@@ -1062,27 +605,6 @@ impl ManagerHandle {
             .send(ManagerMessage::CreateSession(Box::new(CreateSessionMsg {
                 config,
                 username,
-                contribution,
-                responder: send,
-            })))
-            .await;
-        recv.await.expect("corresponding sessions manager is dead")
-    }
-
-    /// Submit a client verdict against a `Pending` session. On
-    /// success the daemon promotes the record to `Active` and replies
-    /// with [`SessionStep::Active`]. A verdict against an unknown id
-    /// or a non-`Pending` record surfaces as a [`SessionStep::Fault`]
-    /// — see the SubmitVerdict handler arm in [`Self::mainloop`].
-    pub async fn submit_verdict(
-        &self,
-        verdict: ContributionVerdict,
-    ) -> Result<SessionStep, SessionsError> {
-        let (send, recv) = Responder::channel();
-        let _ = self
-            .sender
-            .send(ManagerMessage::SubmitVerdict(Box::new(SubmitVerdictMsg {
-                verdict,
                 responder: send,
             })))
             .await;
@@ -1103,48 +625,16 @@ impl ManagerHandle {
         recv.await.expect("corresponding sessions manager is dead")
     }
 
-    /// Renames the given session to the given name.
-    pub async fn rename_session(
-        &self,
-        id: SessionId,
-        new_name: String,
-    ) -> Result<(), SessionsError> {
-        let (send, recv) = Responder::channel();
-        // Ignore send errors - the recv will also fail.
-        let _ = self
-            .sender
-            .send(ManagerMessage::RenameSession(id, new_name, send))
-            .await;
-        recv.await.expect("corresponding sessions manager is dead")
-    }
-
-    /// Destroys the session with the given ID, cascadingly tearing down its
+    /// Deletes the session with the given ID, cascadingly tearing down its
     /// running host and actor (if any) before removing its on-disk record.
     ///
     /// Returns a `NotFound` error if no session with that ID is known.
-    pub async fn destroy_session(&self, id: SessionId) -> Result<(), SessionsError> {
+    pub async fn delete_session(&self, id: SessionId) -> Result<(), SessionsError> {
         let (send, recv) = Responder::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self
             .sender
-            .send(ManagerMessage::DestroySession(id, send))
-            .await;
-        recv.await.expect("corresponding sessions manager is dead")
-    }
-
-    /// Aborts a `Pending` session: drops the daemon's stash entry and
-    /// deletes the on-disk record. Used by the client when its
-    /// Phase 3 gating produces no verdict (e.g. user cancelled at a
-    /// prompt).
-    ///
-    /// `NotFound` if the id is unknown; `InvalidInput` if the record
-    /// exists but its status isn't `Pending`
-    /// (use [`Self::destroy_session`] on an `Active` session).
-    pub async fn abort_session(&self, id: SessionId) -> Result<(), SessionsError> {
-        let (send, recv) = Responder::channel();
-        let _ = self
-            .sender
-            .send(ManagerMessage::AbortSession(id, send))
+            .send(ManagerMessage::DeleteSession(id, send))
             .await;
         recv.await.expect("corresponding sessions manager is dead")
     }
@@ -1163,40 +653,12 @@ impl ManagerHandle {
             .expect("no SessionError expected from shutdown msg")
     }
 
-    /// Test-only inspection of the manager's in-memory
-    /// `compositions` stash. Used to assert stash lifecycle
-    /// transitions (insert on Ready → drain on GetSession →
-    /// cleanup on Destroy/Abort). Not exposed to production
-    /// callers.
-    #[cfg(test)]
-    pub async fn compositions_len(&self) -> usize {
-        let (send, recv) = Responder::channel();
-        let _ = self
-            .sender
-            .send(ManagerMessage::CompositionsLen(send))
-            .await;
-        recv.await
-            .expect("corresponding sessions manager is dead")
-            .expect("infallible")
-    }
-
-    /// Test-only peek at a stashed [`Composition`] by session id.
-    /// Bumps the refcount rather than draining the entry, so the
-    /// caller can assert on contents without disturbing the
-    /// lifecycle.
-    #[cfg(test)]
-    pub async fn peek_composition(
-        &self,
-        id: SessionId,
-    ) -> Option<Arc<sessions::core::compose::Composition>> {
-        let (send, recv) = Responder::channel();
-        let _ = self
-            .sender
-            .send(ManagerMessage::PeekComposition(id, send))
-            .await;
-        recv.await
-            .expect("corresponding sessions manager is dead")
-            .expect("infallible")
+    /// Drop the `running` entry for a session whose actor terminated on its
+    /// own (abort, failed verdict resume, create failure). Fire-and-forget:
+    /// never awaits a reply, so a self-terminating actor can call it without
+    /// any risk of a cycle with a manager that might be awaiting the actor.
+    pub(crate) async fn evict(&self, id: SessionId) {
+        let _ = self.sender.send(ManagerMessage::Evict(id)).await;
     }
 }
 
@@ -1204,11 +666,121 @@ impl ManagerHandle {
 mod tests {
     use super::*;
     use paths::HostAbsPath;
+    use sessions::daemon::composer::ComposeOutcome;
+    use sessions::wire::request::{ContributionVerdict, SessionStep, WireContribution};
     use std::io::ErrorKind;
     use tempfile::TempDir;
 
     fn daemon_dir(tmp: &TempDir) -> DaemonAbsPath {
         DaemonAbsPath::try_new(tmp.path().to_str().unwrap()).unwrap()
+    }
+
+    /// Resolves the session's live actor and peeks its held
+    /// [`Composition`](sessions::core::compose::Composition).
+    async fn peek_composition(
+        mngr: &ManagerHandle,
+        id: SessionId,
+    ) -> Arc<sessions::core::compose::Composition> {
+        mngr.get_session(SessionKeyPredicate::Id(id))
+            .await
+            .expect("get_session succeeds")
+            .expect("session resolves")
+            .peek_composition()
+            .await
+            .expect("the session actor should hold a composition")
+    }
+
+    /// Resolves the session's live actor.
+    async fn session(mngr: &ManagerHandle, id: SessionId) -> SessionHandle {
+        mngr.get_session(SessionKeyPredicate::Id(id))
+            .await
+            .expect("get_session succeeds")
+            .expect("session resolves")
+    }
+
+    /// Seeds `contents` as the project mfile in the session's daemon-side
+    /// workspace, standing in for the client's workspace upload.
+    ///
+    /// The composer reads a session's project config out of its workspace,
+    /// never from the record's `project_path` — that's a path on the
+    /// *client's* machine, which the daemon generally can't read. So a test
+    /// that wants `configure_loadout` to see a project seeds it here, after
+    /// `create_session` and before configuring, exactly where a real client
+    /// streams its files up.
+    async fn seed_workspace_mfile(mngr: &ManagerHandle, id: SessionId, contents: &str) {
+        let paths = session(mngr, id).await.paths().await.unwrap();
+        tokio::fs::write(
+            paths.working.as_utf8_path().join(mfile::MFILE_NAME),
+            contents,
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Creates a session, seeds `mfile` into its workspace, and configures
+    /// its loadout with an empty client contribution — the whole create flow
+    /// a client drives, in one call. Returns the manager and the id
+    /// alongside the compose outcome.
+    async fn create_and_configure(
+        mfile: &str,
+    ) -> (
+        TempDir,
+        TempDir,
+        ManagerHandle,
+        SessionId,
+        Option<sessions::wire::request::ContributionResponse>,
+    ) {
+        let (state, cache, mngr) = manager().await;
+        let id = mngr.create_session(sample_config(), None).await.unwrap();
+        seed_workspace_mfile(&mngr, id, mfile).await;
+        let response = session(&mngr, id)
+            .await
+            .configure_loadout(WireContribution::default())
+            .await
+            .expect("configuring the loadout should succeed");
+        (state, cache, mngr, id, response)
+    }
+
+    /// A project mfile whose `[session.vars]` entry forces the composer down
+    /// the Pending path: a daemon-collected var must be gated by the client.
+    const PENDING_VAR_MFILE: &str = "[session.vars]\nRUST_LOG = \"info\"\n";
+
+    /// Drives a session to the point of awaiting a verdict: created,
+    /// workspace seeded with [`PENDING_VAR_MFILE`], loadout configured and
+    /// come back `Pending`. Returns the manager, the id, and the wire
+    /// response carrying the pending var.
+    async fn create_pending_session() -> (
+        TempDir,
+        TempDir,
+        ManagerHandle,
+        SessionId,
+        sessions::wire::request::ContributionResponse,
+    ) {
+        let (state, cache, mngr, id, response) = create_and_configure(PENDING_VAR_MFILE).await;
+        let response = response.expect("a daemon-side var should pend, not finalize");
+        (state, cache, mngr, id, response)
+    }
+
+    /// An approve-everything verdict for the given pending response.
+    fn approve_all(
+        id: SessionId,
+        response: &sessions::wire::request::ContributionResponse,
+    ) -> ContributionVerdict {
+        ContributionVerdict {
+            session_id: id,
+            vars: response
+                .vars
+                .iter()
+                .map(|pv| sessions::wire::policy::WireVarVerdict::Approved {
+                    id: pv.id,
+                    value: sessions::wire::primitives::WireResolvedVar {
+                        name: pv.name.clone(),
+                        value: "info".into(),
+                    },
+                })
+                .collect(),
+            patches: vec![],
+        }
     }
 
     fn sample_config() -> minimald_rpc::SessionConfig {
@@ -1221,14 +793,27 @@ mod tests {
         }
     }
 
-    /// Test helper: send via the in-process manager actor (not RPC),
-    /// then unwrap the `Ready` arm via the shared test_harness helper.
-    async fn create_and_unwrap_id(mngr: &ManagerHandle) -> SessionId {
-        crate::test_harness::unwrap_ready(
-            mngr.create_session(sample_config(), None, WireContribution::default())
-                .await
-                .unwrap(),
-        )
+    /// Test helper: create a session via the in-process manager actor (not
+    /// RPC) and configure its loadout against an empty workspace, so it
+    /// lands `Active` with an empty composition — the shape most lifecycle
+    /// tests want.
+    async fn create_active_session(mngr: &ManagerHandle) -> SessionId {
+        create_active_session_with(mngr, sample_config()).await
+    }
+
+    /// [`create_active_session`] with a caller-supplied config.
+    async fn create_active_session_with(
+        mngr: &ManagerHandle,
+        config: minimald_rpc::SessionConfig,
+    ) -> SessionId {
+        let id = mngr.create_session(config, None).await.unwrap();
+        let response = session(mngr, id)
+            .await
+            .configure_loadout(WireContribution::default())
+            .await
+            .expect("configuring an empty loadout should succeed");
+        assert!(response.is_none(), "an empty loadout should finalize");
+        id
     }
 
     async fn manager() -> (TempDir, TempDir, ManagerHandle) {
@@ -1259,9 +844,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn destroy_removes_a_non_running_session() {
         let (_state, _cache, mngr) = manager().await;
-        let id = create_and_unwrap_id(&mngr).await;
+        let id = create_active_session(&mngr).await;
 
-        mngr.destroy_session(id).await.unwrap();
+        mngr.delete_session(id).await.unwrap();
 
         assert!(
             mngr.get_record(SessionKeyPredicate::Id(id))
@@ -1272,7 +857,7 @@ mod tests {
         );
         assert!(mngr.list().await.unwrap().is_empty());
         // The name index entry was dropped, so the name can be taken again.
-        let _ = create_and_unwrap_id(&mngr).await;
+        let _ = create_active_session(&mngr).await;
     }
 
     /// Destroying a session that has been brought up (its actor is running, but
@@ -1280,7 +865,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn destroy_tears_down_a_running_session() {
         let (_state, _cache, mngr) = manager().await;
-        let id = create_and_unwrap_id(&mngr).await;
+        let id = create_active_session(&mngr).await;
 
         // Bring the session actor up (populating the running map) without
         // attaching a host.
@@ -1290,7 +875,7 @@ mod tests {
             .unwrap()
             .expect("session should resolve");
 
-        mngr.destroy_session(id).await.unwrap();
+        mngr.delete_session(id).await.unwrap();
 
         // The destroy cascade completed: the record is gone, and a fresh
         // get_session no longer resolves the (now removed) session.
@@ -1315,23 +900,22 @@ mod tests {
     async fn destroy_unknown_id_errors() {
         let (_state, _cache, mngr) = manager().await;
         let err = mngr
-            .destroy_session(SessionId::nil())
+            .delete_session(SessionId::nil())
             .await
-            .expect_err("destroying an unknown id should error");
+            .expect_err("deleting an unknown id should error");
         assert_eq!(err.kind(), ErrorKind::NotFound);
     }
 
     /// A non-empty `WireContribution` from the client is accepted:
-    /// the composer produces a non-empty [`Composition`], the
-    /// [`Manager`] stashes it against the allocated session id, and
-    /// the record persists as `Active`. The stashed composition is
-    /// handed to the [`Session`] actor the first time
-    /// [`GetSession`] spawns it.
+    /// the composer produces a non-empty
+    /// [`Composition`](sessions::core::compose::Composition), the
+    /// create flow holds it on the live [`Session`] actor, and the
+    /// record persists as `Active`.
     ///
     /// Replaces an earlier test that asserted the opposite while
     /// no apply layer existed to consume the composition; that
-    /// silent-data-loss guard is gone now that the manager keeps
-    /// the composition against a live actor.
+    /// silent-data-loss guard is gone now that the actor keeps
+    /// its composition.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn create_session_accepts_non_empty_client_contribution() {
         use sessions::core::source::Source;
@@ -1349,98 +933,56 @@ mod tests {
             }),
         });
 
-        let resp = mngr
-            .create_session(sample_config(), None, contribution)
+        let id = mngr.create_session(sample_config(), None).await.unwrap();
+        let response = session(&mngr, id)
             .await
-            .expect("non-empty composition should now finalize as Active");
-        assert!(matches!(
-            resp,
-            minimald_rpc::CreateSessionResponse::Ready { .. }
-        ));
-    }
-
-    /// `reap_orphan_pending` deletes `Pending` records on disk —
-    /// they have no in-memory stash post-restart and can't be
-    /// resumed. `Active` records pass through untouched.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn reap_orphan_pending_deletes_pending_records() {
-        let tmp = TempDir::new().unwrap();
-        let store = Store::init(daemon_dir(&tmp)).await.unwrap();
-
-        let pending_id = *store
-            .create(sessions::Record {
-                id: SessionId::nil(),
-                name: Some("pending".into()),
-                username: None,
-                project_path: HostAbsPath::try_new("/p").unwrap(),
-                network: sessions::NetworkMode::default(),
-                policy: Default::default(),
-                status: sessions::SessionStatus::Pending,
-                attrs: Default::default(),
-            })
+            .configure_loadout(contribution)
             .await
-            .unwrap()
-            .id();
-        let active_id = *store
-            .create(sessions::Record {
-                id: SessionId::nil(),
-                name: Some("active".into()),
-                username: None,
-                project_path: HostAbsPath::try_new("/p2").unwrap(),
-                network: sessions::NetworkMode::default(),
-                policy: Default::default(),
-                status: sessions::SessionStatus::Active,
-                attrs: Default::default(),
-            })
-            .await
-            .unwrap()
-            .id();
-
-        Manager::reap_orphan_pending(&store).await.unwrap();
-
+            .expect("a non-empty client contribution should compose");
         assert!(
-            store
-                .find(RecordPredicate::Id(pending_id))
+            response.is_none(),
+            "an already-gated client contribution needs no verdict, so the \
+             loadout should finalize in one shot",
+        );
+        assert_eq!(
+            mngr.get_record(SessionKeyPredicate::Id(id))
                 .await
                 .unwrap()
-                .is_none(),
-            "the Pending record should be reaped from the index",
-        );
-        let active = store
-            .find(RecordPredicate::Id(active_id))
-            .await
-            .unwrap()
-            .expect("Active record's index entry should remain");
-        assert_eq!(
-            active.record().await.unwrap().status,
+                .expect("the record should survive")
+                .status,
             sessions::SessionStatus::Active,
-            "the Active record should remain",
         );
     }
 
-    /// `AbortSession` on an unknown id → `NotFound`, mirrors
-    /// `DestroySession`'s error shape so clients can uniformly
-    /// handle "no such session".
+    /// An unknown id resolves to no session at all — the `NotFound`
+    /// (abort/rename) and `Fault::UnknownSessionId` (verdict) wire
+    /// mappings all hang off this `None`, in the RPC handlers.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn abort_unknown_id_errors() {
+    async fn get_session_unknown_id_resolves_to_none() {
         let (_state, _cache, mngr) = manager().await;
-        let err = mngr
-            .abort_session(SessionId::nil())
-            .await
-            .expect_err("aborting an unknown id should error");
-        assert_eq!(err.kind(), ErrorKind::NotFound);
+        assert!(
+            mngr.get_session(SessionKeyPredicate::Id(SessionId::nil()))
+                .await
+                .expect("get_session succeeds")
+                .is_none(),
+        );
     }
 
-    /// `AbortSession` refuses `Active` records — abort is for
-    /// `Pending` only; `DestroySession` handles `Active`. Guards
-    /// against a client accidentally tearing down a running session
-    /// via the wrong RPC.
+    /// Abort refuses `Active` sessions — abort is for `Pending`
+    /// only; `DeleteSession` handles `Active`. Guards against a
+    /// client accidentally tearing down a running session via the
+    /// wrong RPC.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn abort_refuses_active_session() {
         let (_state, _cache, mngr) = manager().await;
-        let id = create_and_unwrap_id(&mngr).await;
-        let err = mngr
-            .abort_session(id)
+        let id = create_active_session(&mngr).await;
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(id))
+            .await
+            .unwrap()
+            .expect("session resolves");
+        let err = handle
+            .abort()
             .await
             .expect_err("aborting an Active session should error");
         assert_eq!(err.kind(), ErrorKind::InvalidInput);
@@ -1454,17 +996,74 @@ mod tests {
         );
     }
 
-    /// `SubmitVerdict` for an id with no stash entry → terminal
-    /// `Fault::UnknownSessionId`. The stash is the single source of
-    /// truth for in-flight sessions; a verdict for an id that was
-    /// never `Pending` (or has already been resumed) reads as
-    /// "unknown" to the daemon.
+    /// The full Pending → verdict → Active flow through the session
+    /// actor's state machine: a project `[session.vars]` entry pends
+    /// the loadout, `get_session` resolves the live Draft actor, an
+    /// approving verdict promotes the on-disk record to `Active`,
+    /// and the finalized composition (carrying the gated var) stays
+    /// on the actor.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn submit_verdict_unknown_id_returns_unknown_session_id() {
+    async fn pending_session_activates_on_approving_verdict() {
+        let (_state, _cache, mngr, id, response) = create_pending_session().await;
+        assert_eq!(response.vars.len(), 1, "the project var should pend");
+        assert_eq!(
+            response.session_id, id,
+            "the response should carry the allocated id, not the composer's \
+             placeholder",
+        );
+        assert_eq!(
+            mngr.get_record(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .expect("the Pending record should exist")
+                .status,
+            sessions::SessionStatus::Pending,
+        );
+
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(id))
+            .await
+            .expect("get_session succeeds")
+            .expect("a Pending session's live actor should resolve");
+        let step = handle
+            .submit_verdict(approve_all(id, &response))
+            .await
+            .expect("the verdict should be accepted");
+        assert_eq!(step, SessionStep::Active { id });
+
+        assert_eq!(
+            mngr.get_record(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .expect("the record should survive promotion")
+                .status,
+            sessions::SessionStatus::Active,
+        );
+        let comp = handle
+            .peek_composition()
+            .await
+            .expect("the promoted actor should hold the composition");
+        assert!(
+            comp.vars().iter().any(|v| v.var().name() == "RUST_LOG"),
+            "the gated var should reach the composition",
+        );
+    }
+
+    /// A verdict against an `Active` session is answered by the
+    /// actor's state machine with a structured `WrongState` fault —
+    /// not an error, and not silent acceptance.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_verdict_on_active_session_returns_wrong_state() {
         let (_state, _cache, mngr) = manager().await;
-        let step = mngr
+        let id = create_active_session(&mngr).await;
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(id))
+            .await
+            .unwrap()
+            .expect("session resolves");
+        let step = handle
             .submit_verdict(ContributionVerdict {
-                session_id: SessionId::nil(),
+                session_id: id,
                 vars: vec![],
                 patches: vec![],
             })
@@ -1472,10 +1071,210 @@ mod tests {
             .expect("actor reply should succeed");
         match step {
             SessionStep::Fault {
-                error: sessions::wire::errors::WireError::UnknownSessionId,
-            } => {}
-            other => panic!("expected Fault::UnknownSessionId, got {other:?}"),
+                error: sessions::wire::errors::WireError::WrongState { what },
+            } => assert!(what.contains("expected Pending"), "got: {what}"),
+            other => panic!("expected Fault::WrongState, got {other:?}"),
         }
+    }
+
+    /// Aborting a Draft session through its handle deletes the
+    /// record and stops the actor; the session no longer resolves
+    /// (the actor evicted itself from the manager's running map, and
+    /// the record is gone).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn abort_via_handle_deletes_pending_session() {
+        let (_state, _cache, mngr, id, _response) = create_pending_session().await;
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(id))
+            .await
+            .unwrap()
+            .expect("the Draft actor should resolve");
+        handle.abort().await.expect("abort should succeed");
+
+        assert!(
+            mngr.get_record(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .is_none(),
+            "the record should be deleted by the abort",
+        );
+        assert!(
+            mngr.get_session(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .is_none(),
+            "the aborted session should no longer resolve",
+        );
+    }
+
+    /// A verdict the composer can't apply (a denied project item)
+    /// faults, but isn't terminal: the session stays `Pending` and
+    /// resumable, so the client can correct the verdict and re-submit
+    /// rather than lose the session to a mis-gated item.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn denying_verdict_faults_and_leaves_session_resumable() {
+        let (_state, _cache, mngr, id, response) = create_pending_session().await;
+        let handle = session(&mngr, id).await;
+        let verdict = ContributionVerdict {
+            session_id: id,
+            vars: response
+                .vars
+                .iter()
+                .map(|pv| sessions::wire::policy::WireVarVerdict::Denied {
+                    id: pv.id,
+                    name: pv.name.clone(),
+                })
+                .collect(),
+            patches: vec![],
+        };
+        let step = handle
+            .submit_verdict(verdict)
+            .await
+            .expect("actor reply should succeed");
+        assert!(
+            matches!(step, SessionStep::Fault { .. }),
+            "a denied item should fault the resume, got {step:?}",
+        );
+        assert_eq!(
+            mngr.get_record(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .expect("the record should survive a faulted resume")
+                .status,
+            sessions::SessionStatus::Pending,
+        );
+
+        // The compose state survived the fault: a corrected verdict still
+        // finalizes the same session.
+        let step = handle
+            .submit_verdict(approve_all(id, &response))
+            .await
+            .expect("the corrected verdict should be accepted");
+        assert_eq!(step, SessionStep::Active { id });
+    }
+
+    /// Renaming a session that owns no PTask hostname route (NoNet here)
+    /// must not touch the registry: it is keyed by name alone, so an
+    /// ungated deregister would withdraw an unrelated routable session's
+    /// route that shares the same *derived* name (both unnamed, projects
+    /// with the same basename).
+    #[cfg(target_os = "linux")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rename_of_unroutable_session_leaves_other_routes_alone() {
+        let (_state, _cache, mngr) = manager().await;
+
+        // Two unnamed sessions whose projects share the basename "app":
+        // both derive the registry name "app". Only the HostNet one
+        // registers a route when its actor spawns.
+        let routable_project = TempDir::new().unwrap();
+        let routable_dir = routable_project.path().join("app");
+        std::fs::create_dir_all(&routable_dir).unwrap();
+        let unroutable_project = TempDir::new().unwrap();
+        let unroutable_dir = unroutable_project.path().join("app");
+        std::fs::create_dir_all(&unroutable_dir).unwrap();
+
+        let mut config = sample_config();
+        config.name = None;
+        config.network = sessions::NetworkMode::HostNet;
+        config.project_path = HostAbsPath::try_new(routable_dir.to_str().unwrap()).unwrap();
+        // Finalizing the loadout registers the "app" route.
+        let _routable_id = create_active_session_with(&mngr, config).await;
+
+        let mut config = sample_config();
+        config.name = None;
+        config.network = sessions::NetworkMode::NoNet;
+        config.project_path = HostAbsPath::try_new(unroutable_dir.to_str().unwrap()).unwrap();
+        let unroutable_id = create_active_session_with(&mngr, config).await;
+        let handle = session(&mngr, unroutable_id).await;
+
+        handle
+            .rename("renamed".to_string())
+            .await
+            .expect("rename should succeed");
+
+        // The routable session's route survived the other session's rename.
+        assert!(
+            mngr.hostnames()
+                .write()
+                .expect("registry lock")
+                .deregister("app")
+                .is_some(),
+            "the HostNet session's route must survive a NoNet rename \
+             under the same derived name",
+        );
+    }
+
+    /// A handle to a self-terminated actor answers `paths`/`record`/
+    /// `context` with errors, not panics — callers (SFTP, exec, uploads)
+    /// race actor death.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dead_actor_handle_reads_error_instead_of_panicking() {
+        let (_state, _cache, mngr, id, _response) = create_pending_session().await;
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(id))
+            .await
+            .unwrap()
+            .expect("the Draft actor should resolve");
+        handle.abort().await.expect("abort should succeed");
+
+        let err = handle
+            .paths()
+            .await
+            .expect_err("paths on a dead actor should error");
+        assert_eq!(err.kind(), ErrorKind::NotConnected);
+        let err = handle
+            .record()
+            .await
+            .expect_err("record on a dead actor should error");
+        assert_eq!(err.kind(), ErrorKind::NotConnected);
+        assert!(
+            handle
+                .context()
+                .await
+                .expect_err("context on a dead actor should error")
+                .contains("gone"),
+        );
+    }
+
+    /// A Draft session refuses context creation — there is no
+    /// workspace-rooted context to build until composition
+    /// finalizes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn draft_session_refuses_context_creation() {
+        let (_state, _cache, mngr, id, _response) = create_pending_session().await;
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(id))
+            .await
+            .unwrap()
+            .expect("the Draft actor should resolve");
+        let err = handle
+            .context()
+            .await
+            .expect_err("a Draft session should refuse context creation");
+        assert!(err.contains("pending"), "got: {err}");
+    }
+
+    /// An idle `Active` session (created, never attached) does not
+    /// block an unforced shutdown — every created session now has a
+    /// live actor, so mere existence can't be the guard.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn idle_session_does_not_block_unforced_shutdown() {
+        let (_state, _cache, mngr) = manager().await;
+        let _id = create_active_session(&mngr).await;
+        mngr.shutdown(false)
+            .await
+            .expect("an idle session should not block unforced shutdown");
+    }
+
+    /// A Draft session (mid create flow, awaiting its verdict) is
+    /// busy: it blocks an unforced shutdown until the client
+    /// finalizes or aborts.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn draft_session_blocks_unforced_shutdown() {
+        let (_state, _cache, mngr, _id, _response) = create_pending_session().await;
+        mngr.shutdown(false)
+            .await
+            .expect_err("a Draft session should block unforced shutdown");
     }
 
     /// `CreateSession` against a `project_path` that has a real
@@ -1493,59 +1292,39 @@ mod tests {
     /// pipeline breaks creation for real projects. Once composition
     /// consumes the parsed mfile + graph, this test evolves.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn create_session_with_real_project_mfile_succeeds() {
-        use std::io::Write;
-
-        // Set up a temp project directory with a minimal `minimal.toml`.
-        let project = TempDir::new().unwrap();
-        let mfile_path = project.path().join(mfile::MFILE_NAME);
-        let mut f = std::fs::File::create(&mfile_path).unwrap();
-        writeln!(f, "[stack]\nuse = \"empty\"").unwrap();
-        drop(f);
-
-        let (_state, _cache, mngr) = manager().await;
-        let mut config = sample_config();
-        config.project_path = HostAbsPath::try_new(project.path().to_str().unwrap()).unwrap();
-
-        let resp = mngr
-            .create_session(config, None, WireContribution::default())
-            .await
-            .expect("create with valid project mfile should succeed");
-        assert!(matches!(
-            resp,
-            minimald_rpc::CreateSessionResponse::Ready { .. }
-        ));
+    async fn configure_loadout_with_real_project_mfile_succeeds() {
+        let (_state, _cache, _mngr, _id, response) =
+            create_and_configure("[stack]\nuse = \"empty\"\n").await;
+        assert!(
+            response.is_none(),
+            "a stack-only mfile gates nothing, so the loadout should finalize"
+        );
     }
 
-    /// `CreateSession` against a `project_path` with no `minimal.toml`
+    /// Configuring a loadout against a workspace with no `minimal.toml`
     /// still succeeds — the parse fails silently (debug log), the
     /// graph resolve is short-circuited (no `Context` to resolve
     /// against), no project contribution lands, and the
     /// empty-contribution fast path completes as before. Guards the
     /// DM1 / empty-workspace path against regressions.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn create_session_with_missing_mfile_still_succeeds() {
-        let empty_project = TempDir::new().unwrap();
+    async fn configure_loadout_with_missing_mfile_still_succeeds() {
         let (_state, _cache, mngr) = manager().await;
-        let mut config = sample_config();
-        config.project_path = HostAbsPath::try_new(empty_project.path().to_str().unwrap()).unwrap();
-
-        let resp = mngr
-            .create_session(config, None, WireContribution::default())
+        // No `seed_workspace_mfile`: the workspace stays empty.
+        let id = mngr.create_session(sample_config(), None).await.unwrap();
+        let response = session(&mngr, id)
             .await
-            .expect("create with missing mfile should still succeed");
-        assert!(matches!(
-            resp,
-            minimald_rpc::CreateSessionResponse::Ready { .. }
-        ));
+            .configure_loadout(WireContribution::default())
+            .await
+            .expect("configuring against a missing mfile should still succeed");
+        assert!(response.is_none());
     }
 
     /// A `[session]` block that contributes a package is picked up
     /// by [`ProjectComposable`] and lands in the composition. With
     /// the non-empty-composition guard gone, the record now
-    /// persists as `Active` and the composition lands in the
-    /// manager's per-session stash for the [`Session`] actor to
-    /// pick up.
+    /// persists as `Active` and the composition stays on the live
+    /// [`Session`] actor.
     ///
     /// Uses a package contribution rather than a var so no
     /// env-resolution (or graph presence) is needed — the test
@@ -1554,106 +1333,48 @@ mod tests {
     /// [`ProjectComposable`]: mfile::ProjectComposable
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn project_composable_contribution_reaches_composer() {
-        use std::io::Write;
-
-        let project = TempDir::new().unwrap();
-        let mfile_path = project.path().join(mfile::MFILE_NAME);
-        let mut f = std::fs::File::create(&mfile_path).unwrap();
-        writeln!(f, "[session]\npackages = [\"rustc\"]").unwrap();
-        drop(f);
-
-        let (_state, _cache, mngr) = manager().await;
-        let mut config = sample_config();
-        config.project_path = HostAbsPath::try_new(project.path().to_str().unwrap()).unwrap();
-
-        let resp = mngr
-            .create_session(config, None, WireContribution::default())
-            .await
-            .expect(
-                "project composable contributes a package; \
-                 without the non-empty-composition guard, the \
-                 session finalizes as Active",
-            );
-        assert!(matches!(
-            resp,
-            minimald_rpc::CreateSessionResponse::Ready { .. }
-        ));
+        let (_state, _cache, mngr, id, response) =
+            create_and_configure("[session]\npackages = [\"rustc\"]\n").await;
+        assert!(
+            response.is_none(),
+            "a project package needs no client gate, so the loadout finalizes"
+        );
+        assert_eq!(
+            mngr.get_record(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .expect("the record should survive")
+                .status,
+            sessions::SessionStatus::Active,
+        );
     }
 
-    /// A Ready CreateSession stashes the composition against the
-    /// allocated id — `compositions_len` bumps by exactly one.
-    /// Baseline for the drain-and-cleanup tests below.
+    /// A finalized loadout leaves the session's actor live and holding its
+    /// composition — the actor `get_session` resolves is the same one the
+    /// create flow spawned, composition intact.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn compositions_stash_populated_on_ready() {
+    async fn created_session_actor_holds_its_composition() {
         let (_state, _cache, mngr) = manager().await;
-        assert_eq!(mngr.compositions_len().await, 0);
-        let _id = create_and_unwrap_id(&mngr).await;
-        assert_eq!(mngr.compositions_len().await, 1);
+        let id = create_active_session(&mngr).await;
+        assert!(
+            session(&mngr, id).await.peek_composition().await.is_some(),
+            "the create-flow actor should still hold its composition",
+        );
     }
 
-    /// `GetSession` on an Active record drains its composition out
-    /// of the stash and hands it to `Session::run`. The next
-    /// `compositions_len` reads zero — the entry was moved, not
-    /// cloned.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn compositions_stash_drained_on_first_spawn() {
-        let (_state, _cache, mngr) = manager().await;
-        let id = create_and_unwrap_id(&mngr).await;
-        assert_eq!(mngr.compositions_len().await, 1);
-        let _handle = mngr
-            .get_session(SessionKeyPredicate::Id(id))
-            .await
-            .expect("get_session succeeds")
-            .expect("session resolves");
-        assert_eq!(mngr.compositions_len().await, 0);
-    }
-
-    /// `DestroySession` on a session that was never spawned via
-    /// `GetSession` still drops its composition — the entry would
-    /// otherwise leak because the spawn path never ran to drain
-    /// it. Regression guard for the create-and-forget-then-destroy
-    /// case.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn compositions_stash_drained_on_destroy_before_spawn() {
-        let (_state, _cache, mngr) = manager().await;
-        let id = create_and_unwrap_id(&mngr).await;
-        assert_eq!(mngr.compositions_len().await, 1);
-        mngr.destroy_session(id).await.expect("destroy succeeds");
-        assert_eq!(mngr.compositions_len().await, 0);
-    }
-
-    /// The stashed [`Composition`] actually carries the project
+    /// The held [`Composition`] actually carries the project
     /// composable's packages — not just an entry-shaped placeholder.
     /// Guards against a `run_composer` refactor that would produce
     /// a well-shaped-but-empty composition and silently pass the
     /// existing lifecycle tests.
+    ///
+    /// [`Composition`]: sessions::core::compose::Composition
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn stashed_composition_carries_project_packages() {
-        use std::io::Write;
+    async fn created_session_composition_carries_project_packages() {
+        let (_state, _cache, mngr, id, _response) =
+            create_and_configure("[session]\npackages = [\"ripgrep\", \"jq\"]\n").await;
 
-        let project = TempDir::new().unwrap();
-        let mfile_path = project.path().join(mfile::MFILE_NAME);
-        let mut f = std::fs::File::create(&mfile_path).unwrap();
-        writeln!(f, "[session]\npackages = [\"ripgrep\", \"jq\"]").unwrap();
-        drop(f);
-
-        let (_state, _cache, mngr) = manager().await;
-        let mut config = sample_config();
-        config.project_path = HostAbsPath::try_new(project.path().to_str().unwrap()).unwrap();
-
-        let resp = mngr
-            .create_session(config, None, WireContribution::default())
-            .await
-            .expect("create with project mfile should succeed");
-        let id = match resp {
-            minimald_rpc::CreateSessionResponse::Ready { id } => id,
-            other => panic!("expected Ready, got {other:?}"),
-        };
-
-        let comp = mngr
-            .peek_composition(id)
-            .await
-            .expect("stashed composition should be present");
+        let comp = peek_composition(&mngr, id).await;
         let package_names: std::collections::BTreeSet<&str> =
             comp.packages().iter().map(|p| p.package()).collect();
         assert!(
@@ -1671,39 +1392,16 @@ mod tests {
     /// declaring stack extras (or having no `[session]` block at
     /// all) still gets those packages into its sessions.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn stashed_composition_includes_stack_packages() {
-        use std::io::Write;
-
-        let project = TempDir::new().unwrap();
-        let mfile_path = project.path().join(mfile::MFILE_NAME);
-        let mut f = std::fs::File::create(&mfile_path).unwrap();
-        writeln!(
-            f,
+    async fn created_session_composition_includes_stack_packages() {
+        let (_state, _cache, mngr, id, _response) = create_and_configure(
             "[stack]\n\
              use = \"shell\"\n\
              build_packages = [\"cmake\"]\n\
-             runtime_packages = [\"postgres\"]\n"
+             runtime_packages = [\"postgres\"]\n",
         )
-        .unwrap();
-        drop(f);
+        .await;
 
-        let (_state, _cache, mngr) = manager().await;
-        let mut config = sample_config();
-        config.project_path = HostAbsPath::try_new(project.path().to_str().unwrap()).unwrap();
-
-        let resp = mngr
-            .create_session(config, None, WireContribution::default())
-            .await
-            .expect("create with stack-only mfile should succeed");
-        let id = match resp {
-            minimald_rpc::CreateSessionResponse::Ready { id } => id,
-            other => panic!("expected Ready, got {other:?}"),
-        };
-
-        let comp = mngr
-            .peek_composition(id)
-            .await
-            .expect("stashed composition should be present");
+        let comp = peek_composition(&mngr, id).await;
         let package_names: std::collections::BTreeSet<&str> =
             comp.packages().iter().map(|p| p.package()).collect();
         assert!(
@@ -1725,7 +1423,7 @@ mod tests {
     fn build_composables_no_mfile_yields_nothing() {
         use sessions::wire::primitives::{WirePackageRef, WireSource};
 
-        let path = HostAbsPath::try_new("/proj").unwrap();
+        let path = DaemonAbsPath::try_new("/proj").unwrap();
         let mut contribution = WireContribution::default();
         contribution.requested_packages.push(WirePackageRef {
             name: "helix".into(),
@@ -1772,7 +1470,7 @@ mod tests {
             .unwrap();
         let ctx = mctx::Context::from_daemon(daemon, mfile);
 
-        let path = HostAbsPath::try_new(project.path().to_str().unwrap()).unwrap();
+        let path = DaemonAbsPath::try_new(project.path().to_str().unwrap()).unwrap();
         let (project_composable, packages) = build_composables(
             &path,
             &ProjectResolution::MFileOnly(ctx),

--- a/crates/minimald/src/sessions/composables.rs
+++ b/crates/minimald/src/sessions/composables.rs
@@ -21,6 +21,7 @@
 use std::sync::Arc;
 
 use mctx::PackageSelection;
+use paths::DaemonAbsPath;
 use sessions::{
     SessionId,
     core::compose::ComposeOptions,
@@ -213,7 +214,7 @@ pub(crate) enum ProjectResolution {
 /// mfile errors are returned as `InvalidInput`.
 pub(crate) fn resolve_project_ctx_and_graph(
     daemon_ctx: &Arc<mctx::DaemonContext>,
-    project_path: &paths::HostAbsPath,
+    project_path: &DaemonAbsPath,
 ) -> Result<ProjectResolution, std::io::Error> {
     let project_path_std = project_path.as_utf8_path().as_std_path().to_path_buf();
     let mfile = match mctx::MFileSearchStrategy::Override(project_path_std).find_mfile() {
@@ -302,7 +303,7 @@ fn fold_stack_vars_into_session<'a, I>(
 /// package-composables list; the client's wire contribution still
 /// lands.
 pub(crate) fn build_composables(
-    project_path: &paths::HostAbsPath,
+    project_path: &DaemonAbsPath,
     resolution: &ProjectResolution,
     contribution: &WireContribution,
 ) -> Result<
@@ -401,7 +402,10 @@ pub(crate) fn build_composables(
         // `effective` empty despite the pre-check. Rare, but the
         // recheck is cheap.
         (!effective.is_empty()).then(|| {
-            mfile::ProjectComposable::new(paths::HostPath::from(project_path.clone()), effective)
+            mfile::ProjectComposable::new(
+                paths::AbsPath::<paths::Host>::new_unchecked(project_path.as_utf8_path()).into(),
+                effective,
+            )
         })
     };
 
@@ -439,6 +443,23 @@ pub(crate) fn build_composables(
         }
     };
     Ok((project_composable, package_composables))
+}
+
+/// The full compose chain for a create flow: resolve the project,
+/// build its composables, and run the composer. Synchronous and
+/// potentially expensive (nickel evaluation, graph resolution) —
+/// callers on an async runtime should wrap it in a blocking-safe
+/// helper. Kept free of `.await`s so its non-`Send` intermediaries
+/// ([`mctx::Context`], nickel-`Rc`-carrying errors) never cross one.
+pub(crate) fn run_compose(
+    daemon_ctx: &Arc<mctx::DaemonContext>,
+    project_path: &DaemonAbsPath,
+    contribution: WireContribution,
+) -> Result<ComposeOutcome, std::io::Error> {
+    let resolution = resolve_project_ctx_and_graph(daemon_ctx, project_path)?;
+    let (project_composable, package_composables) =
+        build_composables(project_path, &resolution, &contribution)?;
+    run_composer(contribution, project_composable, package_composables)
 }
 
 /// Assemble the [`SessionComposer`], `add()` the daemon-side

--- a/crates/minimald/src/sftp.rs
+++ b/crates/minimald/src/sftp.rs
@@ -448,7 +448,16 @@ pub(crate) async fn handle_sftp_subsystem(
             return Ok(());
         }
     };
-    let paths = session_handle.paths().await;
+    let paths = match session_handle.paths().await {
+        Ok(paths) => paths,
+        // The actor died between resolve and this call (raced an
+        // abort/destroy) — to this channel the session no longer exists.
+        Err(e) => {
+            tracing::warn!(%session_id, error = %e, "sftp subsystem rejected: session is gone");
+            session.channel_failure(id)?;
+            return Ok(());
+        }
+    };
 
     session.channel_success(id)?;
     spawn(russh_sftp::server::run(
@@ -466,21 +475,13 @@ mod tests {
     use sessions::SessionId;
     use tokio::io::AsyncWriteExt;
 
-    use minimald_rpc::CreateSession;
-
     use crate::test_harness::TestServer;
 
     /// Creates a fresh session through the public CreateSession RPC and
     /// returns its uuid, mirroring how a real client would set things up
     /// before opening an SFTP channel.
     async fn fresh_session(client: &mut crate::test_harness::TestClient) -> SessionId {
-        use crate::test_harness::{create_session_req, unwrap_ready};
-        unwrap_ready(
-            client
-                .call::<CreateSession>(&create_session_req("sftp-test", "/tmp"))
-                .await
-                .unwrap(),
-        )
+        crate::test_harness::create_configured_session(client, "sftp-test", "/tmp").await
     }
 
     #[tokio::test]

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -148,6 +148,32 @@ impl TestServer {
             .expect("get_session RPC should succeed")
             .expect("session should be retrievable");
     }
+
+    /// Seed a project mfile into a session's daemon-side workspace,
+    /// standing in for the client's workspace upload.
+    ///
+    /// The composer reads a session's project config out of its workspace,
+    /// never from the record's `project_path` — that's a path on the
+    /// *client's* machine. So a test that wants `ConfigureLoadout` to see a
+    /// project seeds it here, between `CreateSession` and `ConfigureLoadout`,
+    /// exactly where a real client streams its files up.
+    pub async fn seed_workspace_mfile(&self, session_id: sessions::SessionId, contents: &str) {
+        let mngr = self.state.sessions_manager().await;
+        let paths = mngr
+            .get_session(crate::sessions::SessionKeyPredicate::Id(session_id))
+            .await
+            .expect("get_session RPC should succeed")
+            .expect("session should be retrievable")
+            .paths()
+            .await
+            .expect("the session actor should be live");
+        tokio::fs::write(
+            paths.working.as_utf8_path().join(mfile::MFILE_NAME),
+            contents,
+        )
+        .await
+        .expect("seeding the workspace mfile should succeed");
+    }
 }
 
 /// Dials an already-listening minimald UDS and returns an authenticated
@@ -367,16 +393,48 @@ pub fn create_session_req(name: &str, project: &str) -> minimald_rpc::CreateSess
             policy: Default::default(),
             attrs: Default::default(),
         },
-        contribution: Default::default(),
     }
 }
 
-/// Unwrap the `Ready` arm of a [`minimald_rpc::CreateSessionResponse`].
-pub fn unwrap_ready(resp: minimald_rpc::CreateSessionResponse) -> sessions::SessionId {
+/// Unwrap the `Ready` arm of a [`minimald_rpc::ConfigureLoadoutResponse`],
+/// for a caller that expects its contribution to compose in one shot.
+pub fn unwrap_ready(resp: minimald_rpc::ConfigureLoadoutResponse) {
     match resp {
-        minimald_rpc::CreateSessionResponse::Ready { id } => id,
-        minimald_rpc::CreateSessionResponse::Pending { .. } => {
+        minimald_rpc::ConfigureLoadoutResponse::Ready => {}
+        minimald_rpc::ConfigureLoadoutResponse::Pending { .. } => {
             panic!("expected Ready variant, got Pending")
         }
     }
+}
+
+/// Drive the client half of the whole create flow — `CreateSession` plus
+/// the `ConfigureLoadout` that finalizes it — and return the session's id.
+///
+/// A session isn't usable until its loadout is configured (a `Draft` refuses
+/// attach and context creation), so any test that goes on to *use* the
+/// session wants this rather than a bare `CreateSession`. The workspace is
+/// left empty, so the loadout composes to an empty `Ready` in one shot; a
+/// test that wants a project in the mix seeds the workspace in between and
+/// calls the two RPCs itself.
+pub async fn create_configured_session(
+    client: &mut TestClient,
+    name: &str,
+    project: &str,
+) -> SessionId {
+    use minimald_rpc::{ConfigureLoadout, ConfigureLoadoutRequest, CreateSession};
+    let id = client
+        .call::<CreateSession>(&create_session_req(name, project))
+        .await
+        .unwrap()
+        .id;
+    unwrap_ready(
+        client
+            .call::<ConfigureLoadout>(&ConfigureLoadoutRequest {
+                session_id: id,
+                contribution: Default::default(),
+            })
+            .await
+            .unwrap(),
+    );
+    id
 }

--- a/crates/minvmd/examples/exec.rs
+++ b/crates/minvmd/examples/exec.rs
@@ -27,11 +27,17 @@ use std::time::Duration;
 use russh::ChannelMsg;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use minimald_rpc::{CreateSessionRequest, CreateSessionResponse, SessionConfig};
+use minimald_rpc::{
+    ConfigureLoadoutRequest, ConfigureLoadoutResponse, CreateSessionRequest, CreateSessionResponse,
+    Errorable, SessionConfig,
+};
 
 /// SSH subsystem for the CreateSession RPC (mirrors minimald's
 /// `RPC_SUBSYSTEM_PREFIX` + "CreateSession").
 const CREATE_SESSION_SUBSYSTEM: &str = "minimald-v1-CreateSession";
+/// SSH subsystem for the ConfigureLoadout RPC, which finalizes the session
+/// a `CreateSession` allocated.
+const CONFIGURE_LOADOUT_SUBSYSTEM: &str = "minimald-v1-ConfigureLoadout";
 /// Env var minimald reads to scope an exec to a session.
 const MINIMAL_SESSION_ID_ENV: &str = "MINIMAL_SESSION_ID";
 
@@ -164,7 +170,6 @@ async fn run_session_exec(
                 policy: Default::default(),
                 attrs: Default::default(),
             },
-            contribution: Default::default(),
         };
         let body = serde_json::to_vec(&req).map_err(|e| format!("serialize request: {e}"))?;
 
@@ -181,15 +186,55 @@ async fn run_session_exec(
             .map_err(|e| format!("read response: {e}"))?;
         let resp: CreateSessionResponse =
             serde_json::from_slice(&resp_buf).map_err(|e| format!("decode response: {e}"))?;
+        resp.id
+    };
+
+    // ConfigureLoadout: finalize the session the create allocated. Required
+    // before the exec below — a session with an unconfigured loadout has no
+    // context to resolve a task against. This example uploads no project
+    // files, so the loadout composes empty and finalizes in one shot.
+    {
+        let channel = handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("open ConfigureLoadout channel: {e}"))?;
+        channel
+            .request_subsystem(false, CONFIGURE_LOADOUT_SUBSYSTEM)
+            .await
+            .map_err(|e| format!("request_subsystem: {e}"))?;
+
+        let req = ConfigureLoadoutRequest {
+            session_id,
+            contribution: Default::default(),
+        };
+        let body = serde_json::to_vec(&req).map_err(|e| format!("serialize request: {e}"))?;
+
+        let mut rpc = channel.into_stream();
+        rpc.write_all(&body)
+            .await
+            .map_err(|e| format!("write request: {e}"))?;
+        rpc.shutdown()
+            .await
+            .map_err(|e| format!("shutdown write half: {e}"))?;
+        let mut resp_buf = Vec::with_capacity(256);
+        rpc.read_to_end(&mut resp_buf)
+            .await
+            .map_err(|e| format!("read response: {e}"))?;
+        // The RPC's wire type is `Errorable<_>`: decoding the bare response
+        // would turn a daemon-side error into a confusing "missing field
+        // `kind`" decode failure, swallowing the message it carries.
+        let resp: Errorable<ConfigureLoadoutResponse> =
+            serde_json::from_slice(&resp_buf).map_err(|e| format!("decode response: {e}"))?;
         match resp {
-            CreateSessionResponse::Ready { id } => id,
-            CreateSessionResponse::Pending { .. } => {
-                return Err("CreateSession returned Pending; \
+            Errorable::Ok(ConfigureLoadoutResponse::Ready) => {}
+            Errorable::Ok(ConfigureLoadoutResponse::Pending { .. }) => {
+                return Err("ConfigureLoadout returned Pending; \
                             this example only handles Ready"
                     .to_string());
             }
+            Errorable::Err { error } => return Err(format!("ConfigureLoadout failed: {error}")),
         }
-    };
+    }
 
     // Exec the command in that session.
     let mut channel = handle

--- a/crates/minvmd/tests/minimald_session_integration.rs
+++ b/crates/minvmd/tests/minimald_session_integration.rs
@@ -264,7 +264,6 @@ async fn run_session_exec(
                 policy: Default::default(),
                 attrs: Default::default(),
             },
-            contribution: Default::default(),
         };
         let body = serde_json::to_vec(&req).map_err(|e| format!("serialize request: {e}"))?;
 
@@ -281,17 +280,9 @@ async fn run_session_exec(
             .map_err(|e| format!("read response: {e}"))?;
         let resp: <CreateSession as OneshotSshRpc>::Response =
             serde_json::from_slice(&resp_buf).map_err(|e| format!("decode response: {e}"))?;
-        let created = resp
-            .ok()
-            .ok_or_else(|| "CreateSession returned an error".to_string())?;
-        match created {
-            minimald_rpc::CreateSessionResponse::Ready { id } => id,
-            minimald_rpc::CreateSessionResponse::Pending { .. } => {
-                return Err("CreateSession returned Pending; \
-                            e2e test only handles Ready"
-                    .to_string());
-            }
-        }
+        resp.ok()
+            .ok_or_else(|| "CreateSession returned an error".to_string())?
+            .id
     };
 
     // Upload the project's `minimal.toml` into the session workspace over
@@ -328,6 +319,54 @@ async fn run_session_exec(
         sftp.close()
             .await
             .map_err(|e| format!("close sftp session: {e}"))?;
+    }
+
+    // ConfigureLoadout: compose the session's loadout now that its workspace
+    // holds the project files, finalizing it `Pending → Active`. This is the
+    // ordering the create flow is split for, and it has to happen before the
+    // exec below — a session with an unconfigured loadout has no context to
+    // resolve a task against.
+    {
+        use minimald_rpc::{ConfigureLoadout, ConfigureLoadoutRequest, ConfigureLoadoutResponse};
+        let channel = handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("open ConfigureLoadout channel: {e}"))?;
+        channel
+            .request_subsystem(false, ConfigureLoadout::NAME)
+            .await
+            .map_err(|e| format!("request_subsystem: {e}"))?;
+
+        let req = ConfigureLoadoutRequest {
+            session_id,
+            contribution: Default::default(),
+        };
+        let body = serde_json::to_vec(&req).map_err(|e| format!("serialize request: {e}"))?;
+
+        let mut rpc = channel.into_stream();
+        rpc.write_all(&body)
+            .await
+            .map_err(|e| format!("write request: {e}"))?;
+        rpc.shutdown()
+            .await
+            .map_err(|e| format!("shutdown write half: {e}"))?;
+        let mut resp_buf = Vec::with_capacity(256);
+        rpc.read_to_end(&mut resp_buf)
+            .await
+            .map_err(|e| format!("read response: {e}"))?;
+        let resp: <ConfigureLoadout as OneshotSshRpc>::Response =
+            serde_json::from_slice(&resp_buf).map_err(|e| format!("decode response: {e}"))?;
+        match resp.ok() {
+            // The uploaded mfile declares only tasks, so nothing needs a
+            // client gate and the loadout finalizes in one shot.
+            Some(ConfigureLoadoutResponse::Ready) => {}
+            Some(ConfigureLoadoutResponse::Pending { .. }) => {
+                return Err("ConfigureLoadout returned Pending; \
+                            this test's mfile gates nothing"
+                    .to_string());
+            }
+            None => return Err("ConfigureLoadout returned an error".to_string()),
+        }
     }
 
     // Exec the command in that session.


### PR DESCRIPTION
 * All session logic now lives in the session actor.
 * The session activation flow now has another RPC, `ConfigureLoadout`, which is fired between the session creation and the submit verdict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session activation now creates the session first, then separately applies the loadout—making ready vs pending states clearer.
  * Interactive activation can offer to scaffold a missing project configuration, while non-interactive runs continue without blocking.
  * Sessions can attach using a default environment when no configuration is provided.

* **Bug Fixes**
  * Improved behavior when sessions disconnect or vanish during execution, SFTP, and other session control operations.
  * Stop now correctly allows idle sessions and refuses those that are still pending approval.
  * RPC error handling and responses are more consistent and structured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->