### PR TITLE
ci: remove ci.yml's redundant workspace test job

### DIFF
--- a/.github/workflows/ci-linux-native.yml
+++ b/.github/workflows/ci-linux-native.yml
@@ -66,6 +66,11 @@ jobs:
               - "crates/**"
               - "Cargo.toml"
               - "Cargo.lock"
+              # Registry/build config (e.g. the buf codegen registry) affects
+              # what the workspace suite compiles. This lane is the sole per-PR
+              # gate for `core-tests` since ci.yml's redundant `test` job was
+              # removed, so a build-config change must re-run it.
+              - ".cargo/**"
               # The toolchain pin: a rustc bump must re-run the Rust lanes.
               - "rust-toolchain.toml"
               # Nextest profiles change how this lane's tests run.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,23 +86,12 @@ jobs:
             - name: Run Clippy
               run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
-    test:
-        needs: [changes]
-        if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
-        runs-on: ubuntu-latest
-        timeout-minutes: 40
-        steps:
-            - uses: actions/checkout@v7
-              with:
-                  persist-credentials: false
-            - name: Run core workspace tests
-              uses: ./.github/actions/core-tests
-            - name: Run HTTPS/mTLS proxy tests
-              # The mTLS reverse proxy is behind the non-default `networking-proxy`
-              # feature, so the core-tests `--workspace` run does not compile or
-              # run its proofs (mtls_missing_cert_returns_401_with_no_topology,
-              # mtls_valid_cert_routes_to_backend). Exercise them explicitly.
-              run: cargo nextest run -p minimald --features networking-proxy --locked
+    # NOTE: the workspace test job was removed once ci-linux-native.yml's
+    # required `tests` job (the same `core-tests` composite) covered it — the two
+    # ran the identical suite. The mTLS reverse-proxy step it also carried
+    # (`--features networking-proxy`) was mothballed from per-PR CI by owner
+    # decision; that coverage now runs in release.yml. See the note in the
+    # ci-linux-native `tests` job.
 
     dogfood:
         needs: [changes]
@@ -160,7 +149,7 @@ jobs:
     # on failure/cancellation.
     ci-success:
         if: always()
-        needs: [changes, fmt, clippy, test, dogfood, cargo-deny, minimal-check]
+        needs: [changes, fmt, clippy, dogfood, cargo-deny, minimal-check]
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:


### PR DESCRIPTION
## What

Removes `ci.yml`'s `test` job — it ran the `core-tests` composite (workspace
nextest + doctests), the **exact same suite** as `ci-linux-native.yml`'s `tests`
job, which is now a required check after the ruleset flip. Running it twice per
PR was pure duplication.

- Delete the `test` job and drop it from `ci-success`'s `needs`.
- Add `.cargo/**` to the native lane's changes-filter (see below).

## Coverage is preserved

| Was in `ci.yml` `test` | Now |
|---|---|
| `core-tests` (workspace nextest + doctests) | `ci-linux-native.yml` `tests` — identical composite, a required check |
| mTLS reverse-proxy step (`--features networking-proxy`) | mothballed from per-PR CI by owner decision ([#687](https://github.com/gominimal/minimal/issues/687)); still runs in `release.yml` |

## Why `.cargo/**` moves into the native filter

`ci.yml`'s removed `test` job used the **catch-all** `code` filter (every
non-docs path). The native lane's `tests` is scoped to a specific path list that
did not include `.cargo/`. Since the native lane is now the **sole per-PR gate**
for the workspace suite, a change to `.cargo/config.toml` (which sources the
`buf` protobuf-codegen registry — build-affecting) must still re-run it.
Without this line, PR8 would be a silent coverage regression on `.cargo/`-only
PRs. `actionlint` passes both files.

## Note

This is the first PR to merge under the flipped ruleset, so it also validates
the five-aggregator required-check gate on a real change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbXL6jxHTY2YuLPaMxc1yU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated continuous integration checks to ensure native builds are revalidated when Rust registry or build configuration changes.
  - Consolidated core and networking test coverage under the designated testing workflow.
  - Updated overall CI status reporting so successful validation remains accurately reflected in branch checks.

- **Chores**
  - Improved CI workflow documentation and maintenance guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->