### PR TITLE
fix(minimal): don't scaffold over an existing config on non-interactive activate

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context as _, bail};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
+use std::io::IsTerminal as _;
 use std::io::Write as _;
 use std::os::unix::process::CommandExt as _;
 use std::path::PathBuf;
@@ -787,18 +788,41 @@ async fn send_abort(client: &mut client::Client, session_id: sessions::SessionId
     }
 }
 
+/// Whether the project already has a `minimal.toml`, in either the root
+/// (`<project>/minimal.toml`) or `.minimal/`
+/// (`<project>/.minimal/minimal.toml`) layout.
+///
+/// Uses [`mfile::File::from_dir`] — the same resolver the CLI loads config
+/// with — rather than a naive `join(MFILE_NAME)`, so detection matches the
+/// path the init writer would target and we never scaffold over a config
+/// living under `.minimal/`. Any outcome other than [`mfile::Error::NotFound`]
+/// (including a present-but-malformed file) counts as "exists".
+fn project_has_mfile(project_path: &camino::Utf8Path) -> bool {
+    !matches!(
+        mfile::File::from_dir(project_path.as_std_path()),
+        Err(mfile::Error::NotFound)
+    )
+}
+
 /// Check for a `minimal.toml` at the project path. If missing, prompt
 /// the user to initialize one before proceeding with activation.
 fn ensure_mfile_or_prompt(
     project_path: &camino::Utf8Path,
     global: &GlobalArgs,
 ) -> Result<(), anyhow::Error> {
-    if project_path.join(mfile::MFILE_NAME).exists() {
+    if project_has_mfile(project_path) {
         return Ok(());
     }
 
     eprintln!("\nNo {} found at {}.", mfile::MFILE_NAME, project_path);
-    if !confirm("Would you like to create one?")? {
+
+    // `confirm` treats empty/EOF input as "yes", so on non-interactive
+    // stdin (CI, pipes, agents) it would silently default this scaffold to
+    // "yes" — and, when a config is discovered under `.minimal/`, the init
+    // writer would clobber it. Only prompt on a real terminal; otherwise
+    // bail with the same hint the declined prompt gives.
+    let create = std::io::stdin().is_terminal() && confirm("Would you like to create one?")?;
+    if !create {
         bail!(
             "No {} found. Run 'minimal init' to create one.",
             mfile::MFILE_NAME
@@ -1671,5 +1695,36 @@ mod tests {
         let sources: [sessions::core::source::Source; 0] = [];
         let d = decisions_for_trusted_sources(sources.iter()).expect("empty → Some(empty)");
         assert!(d.is_empty());
+    }
+
+    /// Regression: a config in the `.minimal/` layout must be detected so
+    /// `activate` returns without prompting and never scaffolds over it.
+    /// The old naive `join(MFILE_NAME)` check missed this path.
+    #[test]
+    fn project_has_mfile_detects_dot_minimal_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        let mfile_dir = dir.path().join(".minimal");
+        std::fs::create_dir(&mfile_dir).unwrap();
+        std::fs::write(
+            mfile_dir.join(mfile::MFILE_NAME),
+            "[upstream]\nrepo = \"https://github.com/gominimal/pkgs\"\n",
+        )
+        .unwrap();
+
+        let path = camino::Utf8Path::from_path(dir.path()).expect("temp path is UTF-8");
+        assert!(
+            project_has_mfile(path),
+            "config under .minimal/ must be detected",
+        );
+    }
+
+    /// A project with no config in either layout is genuinely missing an
+    /// mfile, so detection reports false and the caller falls through to
+    /// the (tty-gated) prompt.
+    #[test]
+    fn project_has_mfile_false_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = camino::Utf8Path::from_path(dir.path()).expect("temp path is UTF-8");
+        assert!(!project_has_mfile(path));
     }
 }


### PR DESCRIPTION
## The bug

`min activate .` on a project whose config lives at `.minimal/minimal.toml`
would, in any **non-interactive** context (CI, piped/EOF stdin, an agent),
**overwrite that config with a generated template** — destroying the user's
tasks and package lists. It was also silently regenerating this repo's own
`.minimal/minimal.toml` on every native e2e run (`scripts/session-e2e.sh` runs
`min activate .` with non-tty stdin).


## The fixes

**Fix A — `.minimal/`-aware detection.** Detection now goes through
`mfile::File::from_dir` — the same resolver the CLI loads config with. In the
activate path the config always carries a `repo_dir` override, so
`ProjectSetup::for_init` resolves via `MFileSearchStrategy::Override` →
`mfile::File::from_dir` (`crates/mctx/src/mfile_search_strategy.rs:21`), which
understands **both** the root and `.minimal/` layouts. Reusing it makes
detection match the exact path the init writer would target. Any outcome other
than `mfile::Error::NotFound` (including a present-but-malformed file) counts as
"exists", so we never scaffold over it.

**Fix B — never default-YES a scaffold on non-interactive stdin.** The prompt is
now gated on `std::io::stdin().is_terminal()`. On non-tty stdin we skip the
prompt entirely and `bail!` with the existing
`"No {MFILE_NAME} found. Run 'minimal init' to create one."` hint instead of
default-YES-ing a destructive create.

**Where I gated the tty check:** at the `ensure_mfile_or_prompt` call site, not
in the shared `confirm()`. `confirm()` has one other caller — the
`run_init_flow` "Continue?" prompt — which legitimately wants
empty-input-defaults-yes and is only reached once we're already committed to a
non-destructive init flow. Changing `confirm()` globally would be a wider blast
radius for no benefit, so gating only the destructive path is the surgical
choice.

## Invariants after the fix

- `min activate .` with non-tty stdin over a project that **has** a config
  (root or `.minimal/`) → proceeds, config untouched.
- `min activate .` with non-tty stdin over a project with **no** config →
  errors telling the user to run `minimal init`; writes nothing.
- Interactive behavior (real tty) is unchanged.

## Test

Added focused, behavior-level tests in the `minimal` crate's existing `tests`
module:

- `project_has_mfile_detects_dot_minimal_layout` — the core regression: a temp
  dir containing `.minimal/minimal.toml` is detected (so activate returns
  without prompting and never scaffolds over it). This is exactly what the old
  naive `join(MFILE_NAME)` check missed.
- `project_has_mfile_false_when_absent` — a project with no config in either
  layout reports false, so the caller falls through to the (tty-gated) prompt.

Detection was factored into a small pure `project_has_mfile` helper to make it
directly testable; the stdin/tty branch is environment-dependent and left to
manual/CI coverage.

## Validation

- `cargo fmt` — clean (no reformatting of the change).
- `cargo test -p minimal` / `cargo clippy -p minimal --all-targets -- -D warnings`
  can't run natively on the macOS dev host: the `minimal` crate transitively
  depends on `procfs` (via `minvmd`/`switch`), which is Linux-only. A Linux
  `cross` build compiled the full dependency tree and reached the `minimal`
  package, failing only in `crates/minimal/build.rs` (a `git rev-parse` for the
  version string returns empty inside the container because this is a git
  worktree whose gitdir isn't mounted) — a pre-existing, environment-specific
  build-script issue unrelated to this change. Definitive `cargo test -p minimal`
  + clippy run on the Linux CI lanes. The change is confined to CLI logic +
  tests in one crate with no platform-specific surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activation behavior when projects use either supported configuration layout.
  * Prevented automatic configuration prompts in non-interactive environments.
  * Added clearer guidance to run `minimal init` when configuration is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->