### PR TITLE
test: prove the in-sandbox min add path via interactive PTY attach on every lane

### DIFF
--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -335,17 +335,26 @@ jobs:
           MINVMD_BOOT_LOG: ${{ runner.temp }}/boot-daemon.log
         run: ./scripts/minvmd-lifecycle.sh
 
+      - name: Fetch pinned gvproxy switch binary
+        # minvmd spawns this as the per-host-VM switch that provides the guest's
+        # egress (NAT + DNS). Without it minvmd boots the VM switchless
+        # (gvproxy resolution is best-effort and never errors), so the guest's
+        # overlay has no other end and every egress — including the in-guest
+        # `pkgs` clone during session mint — dies with "Could not resolve host".
+        run: ./scripts/fetch-gvproxy.sh "$RUNNER_TEMP/gvproxy"
+
       - name: Session e2e via the CLI (activate/exec/destroy; autospawns minvmd)
         # The SAME unified proof every target lane runs (scripts/session-e2e.sh)
         # against Deployment Model 3 (native Linux + VM — the target this
         # lane owns; see docs/specs/03-spec-networking): from a clean state
         # `minimal --minvmd activate` must auto-spawn minvmd, boot the microVM,
         # and round-trip a session exec over the vsock bridge — the Linux/KVM
-        # counterpart of the macOS lane's CLI gate. E2E_PROJECT_DIR=/tmp: no
-        # project sync into the guest yet, so activate a path that exists in
-        # the guest image. minimal/minvmd resolve from the testbed on PATH.
+        # counterpart of the macOS lane's CLI gate. Since #748 activate uploads
+        # the project into the guest; E2E_PROJECT_DIR=/tmp still names a guest
+        # path. minimal/minvmd resolve from the testbed on PATH.
         env:
           MINVMD_BOOT_LOG: ${{ runner.temp }}/cli-e2e-boot.log
+          MINVMD_GVPROXY_BIN: ${{ runner.temp }}/gvproxy
         run: E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
 
       - name: Upload guest boot console logs

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -328,6 +328,14 @@ jobs:
                   pkill -f '__krun-vmm' 2>/dev/null || true
                   pkill -f gvproxy 2>/dev/null || true
                   sleep 1
+            - name: Fetch pinned gvproxy switch binary
+              # minvmd spawns this (gvproxy-darwin) as the host-side switch that
+              # provides the guest's egress (NAT + DNS). Without it minvmd boots
+              # the VM switchless (gvproxy resolution is best-effort and never
+              # errors), so the guest overlay has no other end and every egress —
+              # including the in-guest `pkgs` clone during session mint — dies
+              # with "Could not resolve host".
+              run: ./scripts/fetch-gvproxy.sh "$RUNNER_TEMP/gvproxy"
             - name: Session e2e via the CLI (activate/exec/destroy; autospawns minvmd)
               # The unified session e2e (scripts/session-e2e.sh — the SAME
               # proof every target lane runs), here against the VM-backed
@@ -340,14 +348,15 @@ jobs:
               # full user path and subsumes it (the cold activate IS the
               # autospawn). Runs the prebuilt binaries directly (never
               # `cargo run`, which would relink and unsign minvmd).
-              # E2E_PROJECT_DIR=/tmp: the guest sees no host project dir yet
-              # (no project sync), and /tmp exists in the guest image.
+              # Since #748 activate uploads the project into the guest;
+              # E2E_PROJECT_DIR=/tmp still names a guest path.
               run: |
                   export PATH="$PWD/target/debug:$PATH"
                   export MINVMD_KERNEL_PATH="$RUNNER_TEMP/kernel/vmlinuz"
                   export MINVMD_ROOTFS_PATH="$RUNNER_TEMP/rootfs/rootfs.img"
                   export MINVMD_INITRAMFS="$RUNNER_TEMP/initramfs/initramfs.cpio"
                   export MINVMD_BOOT_LOG="$RUNNER_TEMP/cli-e2e-boot.log"
+                  export MINVMD_GVPROXY_BIN="$RUNNER_TEMP/gvproxy"
                   E2E_VM=1 E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
             - name: Upload guest boot console logs
               # Capture hvc0 output for diagnosing a stuck/failed boot (e.g. a missing

--- a/crates/checkouts/src/error.rs
+++ b/crates/checkouts/src/error.rs
@@ -14,6 +14,12 @@ pub enum Error {
         command: String,
         /// The stderr output from the failed command
         stderr: String,
+        /// How the process terminated (`std::process::ExitStatus`, rendered):
+        /// an exit code (`exit status: N`) or a signal (`signal: 9 (SIGKILL)`).
+        /// Distinguishes a git-reported failure from an externally killed
+        /// process — a signal kill leaves only whatever git wrote before dying,
+        /// which can be a misleadingly benign line (e.g. a templates warning).
+        status: String,
     },
 
     /// The repository path is invalid (e.g., contains invalid UTF-8) or for a different remote.
@@ -48,8 +54,12 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::IO(e) => write!(f, "I/O error: {}", e),
-            Error::GitCommandFailed { command, stderr } => {
-                write!(f, "git command  {} failed: {}", command, stderr)
+            Error::GitCommandFailed {
+                command,
+                stderr,
+                status,
+            } => {
+                write!(f, "git command '{command}' failed ({status}): {stderr}")
             }
             Error::InvalidPath => write!(f, "invalid path"),
             Error::Other(e) => write!(f, "other: {}", e),

--- a/crates/checkouts/src/repo.rs
+++ b/crates/checkouts/src/repo.rs
@@ -56,6 +56,7 @@ impl Repo {
             return Err(Error::GitCommandFailed {
                 command: "clone".to_string(),
                 stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                status: output.status.to_string(),
             });
         }
 
@@ -209,6 +210,7 @@ impl Repo {
             return Err(Error::GitCommandFailed {
                 command: args.join(" "),
                 stderr,
+                status: output.status.to_string(),
             });
         }
         Ok(output)
@@ -232,6 +234,7 @@ impl Repo {
             return Err(Error::GitCommandFailed {
                 command: args.join(" "),
                 stderr,
+                status: output.status.to_string(),
             });
         }
         Ok(output)

--- a/crates/mctx/src/error.rs
+++ b/crates/mctx/src/error.rs
@@ -191,10 +191,12 @@ impl From<checkouts::Error> for Error {
         match value {
             checkouts::Error::IO(e) => Self::IO("vcs", PathBuf::new(), e),
             checkouts::Error::Other(e) => Self::Other(anyhow::anyhow!(e)),
-            checkouts::Error::GitCommandFailed { command, stderr } => Self::Other(anyhow::anyhow!(
-                "unexpected: git command '{}' failed: {}",
+            checkouts::Error::GitCommandFailed {
                 command,
-                stderr
+                stderr,
+                status,
+            } => Self::Other(anyhow::anyhow!(
+                "unexpected: git command '{command}' failed ({status}): {stderr}"
             )),
             checkouts::Error::InvalidPath => {
                 Self::Other(anyhow::anyhow!("vcs: invalid remote path"))

--- a/scripts/e2e-attach-pty.py
+++ b/scripts/e2e-attach-pty.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Drive an interactive `min attach` over a REAL pty, like a user at a terminal.
+
+The session-exit path shows a Detach/Delete prompt (`async_dialog::Select`) and
+reads the answer as keystrokes from the channel. A piped stdin cannot answer it
+(and is not a real tty), so the session e2e drives the attach through a pty here
+instead: pump the sandbox-proof command stream, wait for the exit prompt, then
+send the arrow-key + Enter that selects "Delete" — exercising the genuine
+interactive teardown a user performs.
+
+Usage: e2e-attach-pty.py <add_tool> <argv...>
+  <add_tool>  package to `min add` (also its binary + `--version` subject)
+  <argv...>   the command to spawn under the pty, e.g. `min --minvmd attach <sid>`
+
+Prints the full captured terminal output on stdout. Exits 0 iff the attach
+process exited 0.
+"""
+
+import os
+import pty
+import select
+import signal
+import sys
+import time
+
+add_tool = sys.argv[1]
+attach_argv = sys.argv[2:]
+if not attach_argv:
+    sys.stderr.write("e2e-attach-pty: missing attach argv\n")
+    sys.exit(2)
+
+# Built so the absence marker `TOOL_ABSENT_BEFORE` appears ONLY as executed
+# output, never as echoed input (the pty echoes what we type).
+commands = [
+    f"if command -v {add_tool} >/dev/null 2>&1; then "
+    f"printf 'TOOL_%s_BEFORE\\n' PRESENT; else printf 'TOOL_%s_BEFORE\\n' ABSENT; fi",
+    f"min add {add_tool}",
+    "hash -r",
+    f"{add_tool} --version",
+    "exit",
+]
+
+EXIT_PROMPT = b"would you like to do with this session"  # SHELL_EXIT_PROMPT, lowercased
+DELETE_KEY = b"\x1b[B\r"  # Down arrow -> "Delete", Enter to confirm
+DEADLINE = time.monotonic() + 240  # overall safety cap
+
+pid, fd = pty.fork()
+if pid == 0:  # child
+    os.execvp(attach_argv[0], attach_argv)
+    os._exit(127)
+
+buf = bytearray()
+answered = False
+
+
+def drain_ready(timeout):
+    if select.select([fd], [], [], timeout)[0]:
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            return None
+        return chunk or None
+    return b""
+
+
+try:
+    # The shell only starts once the sandbox is minted (seconds, more on a VM);
+    # bytes we write buffer in the pty until then, so pump the whole stream up
+    # front. The shell runs the commands in order and `exit` ends it.
+    time.sleep(1.5)
+    os.write(fd, ("\n".join(commands) + "\n").encode())
+
+    while time.monotonic() < DEADLINE:
+        chunk = drain_ready(1.0)
+        if chunk is None:
+            break  # EOF / closed
+        buf.extend(chunk)
+        if not answered and EXIT_PROMPT in bytes(buf).lower():
+            os.write(fd, DELETE_KEY)  # answer the prompt like a user
+            answered = True
+finally:
+    # Don't let a hung attach wedge the lane.
+    try:
+        wpid, status = os.waitpid(pid, os.WNOHANG)
+        if wpid == 0:
+            time.sleep(2)
+            wpid, status = os.waitpid(pid, os.WNOHANG)
+        if wpid == 0:
+            os.kill(pid, signal.SIGKILL)
+            _, status = os.waitpid(pid, 0)
+    except ChildProcessError:
+        status = 0
+
+sys.stdout.buffer.write(bytes(buf))
+sys.stdout.flush()
+ok = os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0
+sys.exit(0 if ok else 1)

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -1,36 +1,59 @@
 #!/usr/bin/env bash
 # The ONE session e2e, invoked by every target lane. Drives the real user
 # path through the `min` CLI — which abstracts where the daemon lives —
-# so the identical proof runs against all three deployment targets:
+# so the IDENTICAL proof runs against all three deployment targets:
 #
 #   Linux native (DM2)   minimald on the host          (no extra env)
 #   Linux KVM    (DM3)   minimald in a minvmd microVM  E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd
 #   macOS HVF    (DM1)   minimald in a minvmd microVM  E2E_VM=1 (macOS is always VM-backed)
 # (DM numbers are the deployment models in docs/specs/03-spec-networking.)
 #
-# Flow: from a guaranteed-clean state, `min activate` must auto-spawn the
-# target's daemon and create a session; then list, warm-call, destroy
-# (verified delisted), and a clean `min stop`. Timing is reported but NOT
-# asserted.
+# Two proofs, in order, on EVERY lane:
 #
-# In-session exec over the daemon's SSH surface is NOT exercised here: only
-# `min run <task>` is accepted (arbitrary exec was removed), and a task needs
-# a `minimal.toml` in the otherwise-empty session workspace — which this shell
-# harness cannot seed on the VM lanes (the workspace lives inside the guest).
-# That path is proven in Rust instead: `exec::tests::end_to_end::exec_runs_echo_task`
-# (host daemon) and `minimald_exec_over_bridge` (over the libkrun bridge).
+#  1. Lifecycle: from a guaranteed-clean state, `min activate` must auto-spawn
+#     the target's daemon and create a session; then list, warm-call, destroy
+#     (verified delisted), and a clean `min stop` that the next command
+#     auto-respawns from.
+#
+#  2. Session sandbox: with the session live, attach an INTERACTIVE shell —
+#     which forks a real hakoniwa sandbox (on a VM lane, inside the guest, over
+#     the vsock bridge) — and prove the in-sandbox `min` helper. Inside the
+#     sandbox we `min add <tool>` a package that is NOT in the launcher
+#     baseline (base/coreutils/socat), then run it: the tool being absent
+#     before and runnable after proves `min add` reached the daemon over the
+#     in-sandbox `/run/minenv_sock` relay and hardlinked the package into the
+#     live rootfs. This is lane-agnostic: it operates on the session workspace,
+#     not the host project, so the identical attach+add+run runs everywhere.
+#     Timing is reported but NOT asserted.
+#
+#     A session is interactive by design, so we drive it like a real user
+#     through a REAL pty (scripts/e2e-attach-pty.py) rather than a pipe: pump
+#     the command stream, then, when the shell exits and the daemon shows its
+#     Detach/Delete prompt, answer it with keystrokes (Down + Enter => Delete).
+#     A pipe is not a tty and could not answer that prompt. Selecting Delete
+#     tears the session down, so it must be delisted afterwards. The same daemon
+#     prompt runs whether local or in-guest, so the pty driver covers every lane.
+#
+# Host-side project seed: `min activate` runs client-side and, since #758,
+# BAILS (rather than scaffolding over an existing config) when the target dir
+# has no `minimal.toml` and stdin is non-interactive; and since #748 it UPLOADS
+# the project dir into the session. So we activate a small, self-seeded dir
+# carrying the repo's own pinned `[upstream]` + a light `shell` stack — never
+# the repo root (uploading the whole tree, and scaffolding over its
+# `.minimal/minimal.toml`, is the clobber #758 prevents). On the VM lanes the
+# caller passes E2E_PROJECT_DIR=/tmp; we seed a small subdir under it so the
+# upload stays small. Every seed we create is removed on teardown.
 #
 # VM targets (E2E_VM=1) additionally need, from the caller:
 #   - a codesigned/linkable `minvmd` on PATH (min spawns it by name)
 #   - MINVMD_KERNEL_PATH / MINVMD_ROOTFS_PATH / MINVMD_INITRAMFS
 #     (propagate through the `minvmd run --detach` re-exec)
 #   - MINVMD_BOOT_LOG (optional) to capture the guest console
-#   The guest sees no host project dir yet (no project sync), so VM lanes
-#   pass E2E_PROJECT_DIR=/tmp — a path that exists in the guest image.
 #
 # Environment:
 #   E2E_MINIMAL_ARGS    global args for every `min` call (e.g. --minvmd)
-#   E2E_PROJECT_DIR     project to activate (default: repo root)
+#   E2E_PROJECT_DIR     project to activate (default: a self-seeded throwaway
+#                       dir; VM lanes pass /tmp)
 #   E2E_ACTIVATE_ARGS   extra args for `min activate` (e.g. a future
 #                       `--loadout dev` once the loadouts CLI lands, #686)
 #   E2E_VM              set to 1 for VM-backed targets (extra teardown +
@@ -40,23 +63,66 @@
 set -uo pipefail # not -e: capture failures so we can dump diagnostics
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PROJECT_DIR="${E2E_PROJECT_DIR:-$ROOT}"
 E2E_VM="${E2E_VM:-}"
 
-# On VM lanes the project dir is /tmp (a path that exists in the guest
-# image), but uploading all of /tmp is impractical. Create a minimal
-# project subdir with a minimal.toml so the file upload stays small.
-if [ -n "$E2E_VM" ] && [ "$PROJECT_DIR" = "/tmp" ]; then
-  PROJECT_DIR="/tmp/mnl-e2e-project"
-  mkdir -p "$PROJECT_DIR"
-  cat > "$PROJECT_DIR/minimal.toml" <<'TOML'
-[upstream]
-repo = "https://github.com/gominimal/pkgs"
-branch = "main"
+# The non-baseline package the sandbox proof adds and then runs. It must be a
+# real upstream package that is genuinely ABSENT from a fresh shell-stack
+# sandbox — the `shell` stack composes `base` (bash, coreutils, tar, gzip, …)
+# plus `curl`, so anything in that set (tar included, which an earlier revision
+# used and which is a `base` runtime dep) would already be present and prove
+# nothing. `jq` is a standalone upstream package pulled in by none of them, and
+# its `--version` banner (`jq-1.x`) is a distinctive, greppable marker that
+# never appears in the echoed command stream.
+ADD_TOOL="jq"
+ADD_TOOL_MARKER="jq-1"
 
-[stack]
-use = "shell"
-TOML
+# Resolve + seed the project to activate. Since #748, `min activate` UPLOADS the
+# project dir into the session, so the target must (a) carry a `minimal.toml`
+# (also what the #758 client pre-flight requires) and (b) stay SMALL, as the
+# whole dir is uploaded. SEED_DIR is a throwaway we created and remove wholesale
+# on teardown; SEEDED_MFILE is a lone minimal.toml dropped into a caller's dir.
+SEED_DIR=""
+SEEDED_MFILE=""
+if [ -z "${E2E_PROJECT_DIR:-}" ]; then
+  # Native: self-seed a small throwaway — never $ROOT (uploading the whole repo,
+  # and scaffolding over its `.minimal/`, is the very clobber #758 prevents).
+  SEED_DIR="$(mktemp -d /tmp/mnl-e2e-proj.XXXXXX)"
+  PROJECT_DIR="$SEED_DIR"
+elif [ -n "$E2E_VM" ] && [ "$E2E_PROJECT_DIR" = "/tmp" ]; then
+  # VM lanes pass /tmp; uploading all of /tmp is impractical, so seed a small
+  # subdir under it and upload that instead. Use a UNIQUE mktemp dir (like the
+  # native branch), never a fixed name: a persistent/self-hosted runner may run
+  # VM lanes concurrently, and a fixed dir would let them clobber each other's
+  # seed; a fresh dir also sidesteps any stale/unpinned leftover. Removed on
+  # teardown.
+  SEED_DIR="$(mktemp -d /tmp/mnl-e2e-project.XXXXXX)"
+  PROJECT_DIR="$SEED_DIR"
+else
+  PROJECT_DIR="$E2E_PROJECT_DIR"
+fi
+
+# Seed a pinned minimal.toml: the repo's `[upstream]` verbatim (same
+# locked_commit → same warmed cache keys, zero pin drift) plus a light `shell`
+# stack. A dir we own (SEED_DIR) always gets a fresh one — never trust a
+# leftover; a caller-provided dir is seeded only if it has none (never clobber).
+if [ -n "$SEED_DIR" ] || { [ ! -e "$PROJECT_DIR/minimal.toml" ] && [ ! -e "$PROJECT_DIR/.minimal/minimal.toml" ]; }; then
+  {
+    awk '
+      /^\[upstream\]/            { grab = 1; print; next }
+      grab && (/^$/ || /^\[/)    { exit }
+      grab                       { print }
+    ' "$ROOT/.minimal/minimal.toml"
+    printf '\n[stack]\nuse = "shell"\n'
+  } > "$PROJECT_DIR/minimal.toml"
+  # The upstream MUST be pinned — `min activate` uploads this and the graph
+  # loader rejects an unpinned upstream.
+  if ! grep -q '^\[upstream\]' "$PROJECT_DIR/minimal.toml" \
+     || ! grep -q '^locked_commit' "$PROJECT_DIR/minimal.toml"; then
+    echo "::error::seeded minimal.toml lacks a pinned [upstream] (need repo + locked_commit) from $ROOT/.minimal/minimal.toml"
+    exit 1
+  fi
+  # A dir we own is cleaned wholesale; otherwise track the lone file we dropped.
+  [ -n "$SEED_DIR" ] || SEEDED_MFILE="$PROJECT_DIR/minimal.toml"
 fi
 
 # Fresh state under /tmp — NOT $TMPDIR: macOS's deep $TMPDIR would push
@@ -97,6 +163,8 @@ teardown() {
   if [ -n "$E2E_VM" ]; then
     minvmd stop >/dev/null 2>&1 || true
   fi
+  [ -n "$SEED_DIR" ] && rm -rf "$SEED_DIR"
+  [ -n "$SEEDED_MFILE" ] && rm -f "$SEEDED_MFILE"
 }
 trap teardown EXIT
 
@@ -147,11 +215,61 @@ mnl ls >/dev/null 2>&1 || { echo "::error::warm 'min ls' failed"; fail; }
 t1=$(now_ms)
 echo "warm 'min ls': $((t1 - t0))ms"
 
-# Destroy the session; it must drop out of the listing.
-mnl destroy "$sid" >/dev/null 2>&1 \
-  || { echo "::error::'min destroy $sid' failed"; fail; }
+# ---------------------------------------------------------------------------
+# Session-sandbox proof (every lane). Everything above proves the lifecycle;
+# this forks a real sandbox and proves the in-sandbox `min add`. A session is
+# interactive by design, so we drive it like a real user through a REAL pty
+# (scripts/e2e-attach-pty.py), NOT a pipe — a pipe is not a tty and cannot
+# answer the session-exit prompt. The driver:
+#   1. records that $ADD_TOOL is ABSENT before the add (a baseline tool would
+#      already be present, so the add would prove nothing),
+#   2. `min add`s it into this session,
+#   3. `hash -r` so bash re-scans PATH for the freshly hardlinked binary,
+#   4. runs it — its version banner round-tripping proves it is now runnable,
+#   5. `exit`s, then answers the Detach/Delete prompt with keystrokes (Down +
+#      Enter => "Delete"), the genuine interactive teardown — which destroys the
+#      session, so it must then be delisted.
+echo "::group::sandbox proof (interactive attach via pty: min add $ADD_TOOL + run)"
+t0=$(now_ms)
+# shellcheck disable=SC2086
+attach_out="$(python3 "$ROOT/scripts/e2e-attach-pty.py" "$ADD_TOOL" \
+  min ${E2E_MINIMAL_ARGS:-} attach "$sid" 2>"$WORK/exec.err")"
+rc=$?
+t1=$(now_ms)
+if [ "$rc" -ne 0 ]; then
+  echo "::error::interactive 'min attach $sid' (pty) exited $rc (expected 0)"
+  echo "--- attach output ---"; printf '%s\n' "$attach_out"
+  echo "--- driver stderr ---"; cat "$WORK/exec.err" 2>/dev/null || true
+  fail
+fi
+# Match with a bash glob, NOT `printf ... | grep -q`: `min add`'s pty progress
+# bars can flood `$attach_out` to megabytes, and `grep -q` exits on the first
+# match while `printf` is still writing — that SIGPIPE, under `pipefail`,
+# becomes the pipeline's non-zero exit and a FALSE "not found". A glob on the
+# variable touches no pipe, so it is immune.
+#
+# Must have been absent before the add — otherwise the add proves nothing.
+if [[ "$attach_out" != *TOOL_ABSENT_BEFORE* ]]; then
+  echo "::error::'$ADD_TOOL' was already present before 'min add' (pick a non-baseline tool)"
+  echo "--- attach output ---"; printf '%s\n' "$attach_out"
+  fail
+fi
+# And runnable after — its version banner must round-trip on stdout.
+if [[ "$attach_out" != *"$ADD_TOOL_MARKER"* ]]; then
+  echo "::error::in-sandbox 'min add $ADD_TOOL' did not make it runnable (no '$ADD_TOOL_MARKER')"
+  echo "--- attach output ---"; printf '%s\n' "$attach_out"
+  echo "--- driver stderr ---"; cat "$WORK/exec.err" 2>/dev/null || true
+  fail
+fi
+echo "sandbox proof: in-sandbox 'min add $ADD_TOOL' + run OK ($((t1 - t0))ms)"
+echo "::endgroup::"
+
+# We answered the exit prompt with "Delete", so the session was destroyed and
+# must have dropped out of the listing — this doubles as the interactive
+# delete/lifecycle-teardown proof.
 if mnl ls --raw 2>/dev/null | grep -Fqx "$sid"; then
-  echo "::error::session $sid still listed after destroy"; fail
+  echo "::error::session $sid still listed after answering 'Delete' at the exit prompt"
+  fail
 fi
 
 # Shut the daemon down; it must not survive.


### PR DESCRIPTION
## What

Deepens the shared session e2e (`scripts/session-e2e.sh`) so that, on **every**
deployment lane (native DM2, KVM DM3, macOS DM1), it forks a real session
sandbox and proves the in-sandbox `min` helper end to end — not just the session
lifecycle. Also fixes the CI gap that prevented the VM lanes from running an
in-guest session at all, and improves git-command error reporting.

Three commits.

## `test: exercise the session sandbox via interactive attach`

Attaches an interactive shell to a live session (which forks a real hakoniwa
sandbox — on a VM lane, inside the guest over the vsock bridge) and proves
`min add`: a genuinely-absent tool (`jq` — the `shell` stack composes `base` +
`curl`, and `jq` is pulled in by neither) is recorded absent, `min add`ed, then
run; its version banner round-tripping proves `min add` reached the daemon over
the `/run/minenv_sock` relay and hardlinked the package into the live rootfs.

A session is **interactive by design**, so the proof drives it like a real user
through a **real PTY** (`scripts/e2e-attach-pty.py`), not a pipe: it pumps the
command stream, then answers the session-exit Detach/Delete prompt with
keystrokes (Down + Enter → Delete). A pipe is not a tty and cannot answer that
prompt. Selecting Delete tears the session down, so it must then be delisted —
doubling as the interactive-teardown proof. Output is matched with a bash glob,
not `printf | grep -q`: `min add`'s progress-bar flood can make `grep -q`
short-circuit and SIGPIPE the feeding `printf`, which under `pipefail` becomes a
false negative.

Host-side seed: since [#748](https://github.com/gominimal/minimal/pull/748)
`min activate` uploads the project into the session, so the e2e seeds a small,
**pinned** `minimal.toml` (the repo's `[upstream]` verbatim, incl.
`locked_commit`, plus a light `shell` stack) in a dir it owns and cleans
(`rm -rf` first — a persistent/self-hosted runner can carry a stale *unpinned*
leftover that the graph loader rejects). This also satisfies the
[#758](https://github.com/gominimal/minimal/pull/758) non-interactive `min
activate` pre-flight. Every seed is removed on teardown.

## `ci: provision gvproxy for the KVM/macOS session-e2e lanes`

The VM lanes boot a microVM whose guest daemon clones the upstream `pkgs` repo
during session mint — which needs the guest's egress (NAT + DNS), provided by
the gvproxy switch `minvmd` spawns. Neither VM lane provisioned the gvproxy
binary, and its resolution is best-effort (never errors), so `minvmd` booted the
VM **switchless**: the guest overlay had no other end and every egress died with
`Could not resolve host: github.com`. It looks like DNS but is dead L3 egress —
raw TCP to literal public IPs returns `EHOSTUNREACH`, and even the gateway is
silent.

Fetches the pinned gvproxy (`scripts/fetch-gvproxy.sh` +
`vendor/gvproxy/gvproxy.lock`, already used by the native
`minimald-root-integration` job) and points `minvmd` at it via
`MINVMD_GVPROXY_BIN` on each VM lane's session-e2e step. The macOS lane
auto-selects the `gvproxy-darwin` asset. Native lanes never needed it (`minimald`
runs on the host with real internet; no overlay).

## `fix(checkouts): report exit status on git command failure`

A failed git command surfaced only its stderr, which for a signal-killed process
can be a misleadingly benign line (e.g. a "templates not found" warning that
masks that the process was killed). Includes the rendered `ExitStatus` (exit code
or signal) in `GitCommandFailed` and its `mctx` wrapper.

## Validated

All three e2e lanes green — native, KVM, and macOS: the in-sandbox `min add jq` +
run + interactive Delete-teardown round-trips on each. Rebased onto `main`
(post-[#748](https://github.com/gominimal/minimal/pull/748)); `cargo`/`clippy`
clean via cross; `shellcheck`/`bash -n`/`py_compile`/`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git command errors now display the process termination status alongside the failed command and error output.
  * Added interactive end-to-end coverage for installing and running tools inside an attached session.
* **Bug Fixes**
  * Improved session teardown verification when users choose to delete a session.
* **Tests**
  * Enhanced Linux and macOS session testing with pinned networking support.
  * Added validation for project setup, tool installation, session lifecycle, and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->