### PR TITLE
ci(release): dependency-pruned build cache + arm64 timeout headroom

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,16 +105,19 @@ jobs:
                   echo '' >> .cargo/config.toml
                   echo '[target.x86_64-unknown-linux-musl]' >> .cargo/config.toml
                   echo 'linker = "musl-gcc"' >> .cargo/config.toml
-            - uses: actions/cache@v6
+            - name: Cache Rust build artifacts (dependency-pruned)
+              # Was a raw actions/cache of the entire target/ — the largest target
+              # dir in the repo (multi-GB). Cached whole into the 10 GB per-repo
+              # LRU it shares with every PR lane, it was evicted fast, so release
+              # builds kept starting cold. rust-cache prunes target/ to just the
+              # dependency artifacts (the costly aws-lc-sys/crypto compiles),
+              # shrinking the entry so it survives; save-if keeps branch/dry-run
+              # dispatches read-only so they don't churn the budget and evict
+              # main's warm cache. Registry + git caches come for free.
+              uses: Swatinem/rust-cache@v2
               with:
-                  path: |
-                      ~/.cargo/bin/
-                      ~/.cargo/registry/index/
-                      ~/.cargo/registry/cache/
-                      ~/.cargo/git/db/
-                      target/
-                  key: ${{ runner.os }}-amd64-cargo-release-${{ hashFiles('**/Cargo.lock') }}
-                  restore-keys: ${{ runner.os }}-amd64-cargo-release-
+                  shared-key: release-amd64
+                  save-if: ${{ github.ref == 'refs/heads/main' }}
             - name: Build static release binaries
               run: |
                   cargo build --release --locked --target x86_64-unknown-linux-musl \
@@ -179,10 +182,11 @@ jobs:
     build-release-linux-arm64:
         runs-on: ubuntu-latest
         # One combined cross build (was three sequential single-package builds).
-        # Keep the 90m headroom the split had, not the optimistic 60: a dry-run
-        # (run 29375276363) showed the cold-cache cross build (musl +
-        # aws-lc-sys) runs ~65m and hit the 60m cap. The recollapse saves link
-        # time, not the dominant aws-lc-sys compile, so the cap must clear it.
+        # Keep 90m, not the optimistic 60: a dry-run (run 29375276363) showed the
+        # cold cross build (musl + aws-lc-sys) runs ~65m and hit the 60m cap. The
+        # rust-cache below makes the typical run fast, but a cache miss (first
+        # build, Cargo.lock change, or LRU eviction) is still cold, so the cap
+        # must clear the aws-lc-sys compile the recollapse can't shorten.
         timeout-minutes: 90
         steps:
             - uses: actions/checkout@v7
@@ -190,16 +194,17 @@ jobs:
               uses: taiki-e/install-action@v2
               with:
                   tool: cross
-            - uses: actions/cache@v6
+            - name: Cache Rust build artifacts (dependency-pruned)
+              # See the amd64 job: rust-cache replaces a raw multi-GB target/ cache
+              # the 10 GB LRU evicted, which is why this cross build kept running
+              # cold (~65m). Pruned to dependency artifacts so it survives; save-if
+              # keeps branch/dry-run dispatches read-only. cross writes target/ and
+              # reads ~/.cargo on the host, so rust-cache caches them the same as a
+              # native build.
+              uses: Swatinem/rust-cache@v2
               with:
-                  path: |
-                      ~/.cargo/bin/
-                      ~/.cargo/registry/index/
-                      ~/.cargo/registry/cache/
-                      ~/.cargo/git/db/
-                      target/
-                  key: ${{ runner.os }}-arm64-cargo-release-${{ hashFiles('**/Cargo.lock') }}
-                  restore-keys: ${{ runner.os }}-arm64-cargo-release-
+                  shared-key: release-arm64
+                  save-if: ${{ github.ref == 'refs/heads/main' }}
             - name: Build static release binaries
               # One build of all three packages (mirrors the amd64 job) instead of
               # three separate cross invocations resolving the graph three times.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,9 +178,12 @@ jobs:
 
     build-release-linux-arm64:
         runs-on: ubuntu-latest
-        # One combined cross build (was three sequential single-package builds);
-        # right-sized from the padded 90 the split required.
-        timeout-minutes: 60
+        # One combined cross build (was three sequential single-package builds).
+        # Keep the 90m headroom the split had, not the optimistic 60: a dry-run
+        # (run 29375276363) showed the cold-cache cross build (musl +
+        # aws-lc-sys) runs ~65m and hit the 60m cap. The recollapse saves link
+        # time, not the dominant aws-lc-sys compile, so the cap must clear it.
+        timeout-minutes: 90
         steps:
             - uses: actions/checkout@v7
             - name: Install cross


### PR DESCRIPTION
Two related changes to the release build's critical path (the arm64 job — it runs parallel to amd64/macOS, which finish far sooner, so it sets release wall clock).

## 1. `perf`: dependency-pruned build cache (rust-cache)

Both linux release builds already cached `target/` — but via **raw `actions/cache` of the entire target dir**, which the comment on the amd64 job calls out as *the largest target dir in the repo* (multi-GB). Cached whole into the **10 GB per-repo LRU it shares with every PR lane**, the entries get evicted fast, so release builds keep **starting cold** — the post-PR9 arm64 dry-run ([run 29375276363](https://github.com/gominimal/minimal/actions/runs/29375276363)) ran ~65 min from cold, while warm pre-PR9 runs were 19–42 min. The 3× swing was cache hit-vs-evicted, not job structure.

Swap the two linux builds to **`Swatinem/rust-cache@v2`** (already used in `setup-rust`):
- **Prunes `target/`** to just the dependency artifacts (the costly `aws-lc-sys`/crypto compiles) — the entry is small enough to survive the LRU instead of being evicted.
- **`save-if: github.ref == 'refs/heads/main'`** — real releases (dispatch/`nightly.yml` call, both on `main`) warm the cache; branch/`dry_run` dispatches restore **read-only** so they stop churning the budget and evicting main's warm cache.
- `cross` reads `~/.cargo` and writes `target/` on the host, so rust-cache caches the arm64 build the same as a native one.

Expected effect: typical arm64 build drops from cold ~65 min toward warm ~15–20 min. macOS (self-hosted mini, persistent local `target/`) and `build-libkrun` (cached via `vendor/libkrun.lock`, [#694](https://github.com/gominimal/minimal/pull/694)) are deliberately left untouched.

## 2. `ci`: restore arm64 timeout 60 → 90

PR9 ([#757](https://github.com/gominimal/minimal/pull/757)) recollapsed the arm64 build to one `cross build` and cut the timeout 90→60 on the assumption it'd be faster. The dry-run proved a **cold** build exceeds 60 min → cancelled → skipped `initramfs`/`release`/`stage-installer`. The cache above makes the *typical* run fast, but a cache miss (first build, `Cargo.lock` change, LRU eviction) is still cold, so **the cap must still clear the cold case** — 90 stays.

## Validation

actionlint clean (only the pre-existing shellcheck infos in untouched scripts). Full proof is a `dry_run: true` release dispatch on this branch: first run cold (populates the cache from `main` only — so validate warmth via a second dispatch, or note the first dry-run on a *branch* won't save). The correctness net is cargo's own fingerprinting — a stale cache triggers a rebuild, never a bad binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
