### PR TITLE
feat(minimal): avoid host key warning but using known_hosts

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -981,6 +981,42 @@ fn shell_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\"'\"'"))
 }
 
+/// Quote a path for use as an `ssh -o` option value.
+///
+/// ssh re-parses the value as a config line, splitting on whitespace to allow a
+/// file list and honouring `\` escapes inside quotes. So the quotes carry a path
+/// with spaces, and `\`/`"` must be escaped within them — unescaped, a `"`
+/// resolves the option to the wrong file and a trailing `\` swallows the closing
+/// quote, both of which make ssh reject the line outright.
+fn ssh_opt_quote(path: &std::path::Path) -> String {
+    // Backslashes first: escaping quotes introduces backslashes of its own.
+    let escaped = path
+        .display()
+        .to_string()
+        .replace('\\', r"\\")
+        .replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+/// The `ssh` host-key options for attaching, given the `known_hosts` sitting
+/// next to the daemon socket.
+///
+/// minvmd records the guest's host key there from the boot beacon, so when the
+/// file is present we pin against it. A native minimald also writes this.
+fn host_key_opts(known_hosts: &std::path::Path) -> [String; 2] {
+    if known_hosts.is_file() {
+        [
+            "StrictHostKeyChecking=yes".to_string(),
+            format!("UserKnownHostsFile={}", ssh_opt_quote(known_hosts)),
+        ]
+    } else {
+        [
+            "StrictHostKeyChecking=no".to_string(),
+            "UserKnownHostsFile=/dev/null".to_string(),
+        ]
+    }
+}
+
 /// Attach to an existing session. Both interactive and `--command` paths
 /// shell out to `ssh` — the daemon's shell_request handler mints a PTY-backed
 /// session shell, and ssh handles termios/PTY management for us.
@@ -1012,6 +1048,8 @@ pub async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), any
         shell_quote(&sock.display().to_string()),
     );
 
+    let [strict, known_hosts_file] = host_key_opts(&sock.with_file_name(paths::KNOWN_HOSTS_FILE));
+
     let mut ssh = std::process::Command::new("ssh");
     ssh.env("MINIMAL_SESSION_ID", record.id.to_string()).args([
         "-o",
@@ -1019,9 +1057,9 @@ pub async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), any
         "-o",
         &format!("ProxyCommand={proxy_cmd}"),
         "-o",
-        "StrictHostKeyChecking=no",
+        &strict,
         "-o",
-        "UserKnownHostsFile=/dev/null",
+        &known_hosts_file,
     ]);
 
     // The interactive path opens the in-sandbox session shell via the daemon's
@@ -1641,6 +1679,56 @@ pub async fn cmd_version(global: &GlobalArgs) -> Result<(), anyhow::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A VM-backed provider dir carries the guest's recorded host key, so
+    /// attach must verify against it rather than waive the check.
+    #[test]
+    fn host_key_opts_pin_to_an_adjacent_known_hosts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let known_hosts = tmp.path().join(paths::KNOWN_HOSTS_FILE);
+        std::fs::write(&known_hosts, "local-0 ssh-ed25519 AAAA...\n").unwrap();
+
+        let [strict, hosts_file] = host_key_opts(&known_hosts);
+        assert_eq!(strict, "StrictHostKeyChecking=yes");
+        assert_eq!(
+            hosts_file,
+            format!("UserKnownHostsFile=\"{}\"", known_hosts.display())
+        );
+    }
+
+    /// ssh re-parses the option value as a config line, so the path must survive
+    /// its quote and backslash handling intact. These expectations were checked
+    /// against OpenSSH's own parser with `ssh -G`.
+    #[test]
+    fn ssh_opt_quote_escapes_backslashes_and_quotes() {
+        let q = |s: &str| ssh_opt_quote(std::path::Path::new(s));
+
+        assert_eq!(q("/state/known_hosts"), r#""/state/known_hosts""#);
+        // A space is why we quote at all: ssh would otherwise read a file list.
+        assert_eq!(q("/st ate/known_hosts"), r#""/st ate/known_hosts""#);
+        assert_eq!(q(r#"/st"ate/known_hosts"#), r#""/st\"ate/known_hosts""#);
+        assert_eq!(q(r"/st\ate/known_hosts"), r#""/st\\ate/known_hosts""#);
+        // A trailing backslash must not escape the closing quote.
+        assert_eq!(q(r"/state\"), r#""/state\\""#);
+    }
+
+    /// The assembled option for a state dir carrying every character ssh's
+    /// parser treats specially.
+    #[test]
+    fn host_key_opts_pin_to_a_path_needing_escapes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(r#"sp ace q"uote back\slash"#);
+        std::fs::create_dir_all(&dir).unwrap();
+        let known_hosts = dir.join(paths::KNOWN_HOSTS_FILE);
+        std::fs::write(&known_hosts, "local-0 ssh-ed25519 AAAA...\n").unwrap();
+
+        let [strict, hosts_file] = host_key_opts(&known_hosts);
+        assert_eq!(strict, "StrictHostKeyChecking=yes");
+        assert!(
+            hosts_file.contains(r#"q\"uote"#) && hosts_file.contains(r"back\\slash"),
+            "path must reach ssh escaped, got: {hosts_file}"
+        );
+    }
 
     #[test]
     fn ingress_spec_defaults_to_tcp() {

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -159,7 +159,7 @@ fn kvm_access_error(err: &std::io::Error) -> anyhow::Error {
 /// `<provider dir>/known_hosts`.
 #[cfg(minvmd_libkrun)]
 pub(crate) fn default_vm_known_hosts_path() -> std::path::PathBuf {
-    crate::state::provider_dir().join("known_hosts")
+    crate::state::provider_dir().join(paths::KNOWN_HOSTS_FILE)
 }
 
 /// Outcome of the guest boot beacon (R2.4/R2.5): the guest either reached

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -150,6 +150,10 @@ pub fn minimal_state_dir() -> DaemonAbsPath {
 /// File name of the daemon SSH socket in a provider instance dir. Served by
 /// native minimald or by the minvmd host↔guest bridge — one endpoint either way.
 pub const SSH_SOCK_FILE: &str = "ssh.sock";
+/// File name of the SSH `known_hosts` in a provider instance dir, recording the
+/// daemon's host key under the `local-<instance>` hostname. Written at startup
+/// by native minimald, and by minvmd from the guest's boot beacon.
+pub const KNOWN_HOSTS_FILE: &str = "known_hosts";
 /// Native minimald's single-instance lock, held for the daemon's lifetime.
 pub const MINIMALD_LOCK_FILE: &str = "minimald.lock";
 /// The minvmd supervisor's alive lock, held for the daemon's lifetime.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * SSH attachments now verify the daemon’s host key using the appropriate `StrictHostKeyChecking` and `UserKnownHostsFile` settings when a known-hosts file is available.
  * When no known-hosts file is present, connections automatically fall back to a compatibility mode for smoother operation.
  * VM host-key storage now uses a consistent, documented known-hosts filename.
  * Improved handling of SSH option quoting to prevent issues with paths containing special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->