### PR TITLE
feat(minimal): support configuring the file sync during activate

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -235,6 +235,9 @@ pub struct ActivateArgs {
     /// Project path to activate (defaults to current directory)
     #[arg(default_value = ".")]
     pub path: String,
+    /// How to load project files into the session.
+    #[arg(long, value_enum, default_value_t = SyncMode::Tarball)]
+    pub sync: SyncMode,
     /// Network mode: no-net, host-net (default), or own-ip.
     #[arg(long, value_enum, default_value_t = CliNetworkMode::HostNet)]
     pub network: CliNetworkMode,
@@ -254,6 +257,15 @@ pub struct ActivateArgs {
     /// Automatically attach after creation
     #[arg(long)]
     pub attach: bool,
+}
+
+/// Configuration for file sync during activation.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum SyncMode {
+    /// Stream a tarball of your project and unpack it into the session.
+    Tarball,
+    /// Do not populate the worktree of the session.
+    None,
 }
 
 /// CLI surface for [`sessions::NetworkMode`]. A local `ValueEnum` keeps the
@@ -956,11 +968,16 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
 
     // Upload the project directory to the daemon so the session
     // sandbox has the user's files available.
-    eprintln!("Uploading project files...");
-    client
-        .upload_workspace_files(id, utf8_path.as_std_path())
-        .await
-        .context("Failed to upload project files")?;
+    match args.sync {
+        SyncMode::None => {}
+        SyncMode::Tarball => {
+            eprintln!("Uploading project files...");
+            client
+                .upload_workspace_files(id, utf8_path.as_std_path())
+                .await
+                .context("Failed to upload project files")?;
+        }
+    };
 
     println!("{id}");
 

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -181,6 +181,7 @@ async fn activate_creates_session() {
     let activate_args = ActivateArgs {
         name: Some("test-session".to_string()),
         path: project.path().to_string_lossy().to_string(),
+        sync: SyncMode::Tarball,
         network: CliNetworkMode::NoNet,
         ingress: vec![],
         loadout: vec![],
@@ -217,6 +218,7 @@ async fn activate_uploads_project_files() {
     let activate_args = ActivateArgs {
         name: Some("upload-test".to_string()),
         path: project.path().to_string_lossy().to_string(),
+        sync: SyncMode::Tarball,
         network: CliNetworkMode::NoNet,
         ingress: vec![],
         loadout: vec![],


### PR DESCRIPTION
Also need this so i can experiment with `git push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--sync` option to the `activate` command.
  * Projects can now be synchronized using a tarball or activated without uploading workspace files.
  * Tarball synchronization remains the default behavior.

* **Tests**
  * Updated activation coverage to explicitly verify tarball-based synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->