### PR TITLE
fix(minimald): make git push min:// land on the checked-out workspace branch

### DIFF
--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -925,16 +925,31 @@ async fn handle_git_receive(
                 zero=0000000000000000000000000000000000000000
                 while read -r old new ref; do
                     case "$ref" in refs/heads/*) ;; *) continue ;; esac
+                    # A deleted branch (new = zeros) has nothing to check out.
+                    # Deleting the CURRENT branch never reaches here: git's own
+                    # receive.denyDeleteCurrent refuses it during receive-pack.
+                    [ "$new" = "$zero" ] && continue
                     branch=${ref#refs/heads/}
+
+                    if [ "$old" = "$zero" ]; then
+                        # Previously-unborn branch: nothing tracked, so tracked
+                        # dirtiness cannot exist — but uploaded/untracked files
+                        # may collide with the pushed tree, and -f would
+                        # silently clobber them. -B pins the branch at the
+                        # pushed tip and checks it out; WITHOUT -f, git refuses
+                        # to overwrite untracked files (its stderr names them),
+                        # and we surface the skip like the dirty case below.
+                        if ! g checkout -q -B "$branch" "$new"; then
+                            echo "remote worktree has local files the push would overwrite; skipping checkout of $branch" >&2
+                        fi
+                        continue
+                    fi
 
                     # Dirtiness is measured against the PRE-push tip ($old):
                     # post-receive runs after the ref has already moved, so a
                     # plain `diff --cached` (index vs the NEW tip) would flag
-                    # the pushed delta itself and skip every checkout. An
-                    # all-zeros $old is a previously-unborn branch — nothing
-                    # was tracked, so nothing can be locally modified.
-                    if [ "$old" != "$zero" ] \
-                        && { ! g diff --quiet "$old" || ! g diff --cached --quiet "$old"; }; then
+                    # the pushed delta itself and skip every checkout.
+                    if ! g diff --quiet "$old" || ! g diff --cached --quiet "$old"; then
                         echo "remote worktree has uncommitted changes; skipping checkout of $branch" >&2
                         continue
                     fi

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -922,15 +922,23 @@ async fn handle_git_receive(
                 unset GIT_DIR GIT_WORK_TREE GIT_QUARANTINE_PATH
                 g() { git --git-dir="$GIT_DIR_ABS" --work-tree="$WORK_TREE" "$@"; }
 
+                zero=0000000000000000000000000000000000000000
                 while read -r old new ref; do
                     case "$ref" in refs/heads/*) ;; *) continue ;; esac
                     branch=${ref#refs/heads/}
 
-                    if ! g diff --quiet || ! g diff --cached --quiet; then
+                    # Dirtiness is measured against the PRE-push tip ($old):
+                    # post-receive runs after the ref has already moved, so a
+                    # plain `diff --cached` (index vs the NEW tip) would flag
+                    # the pushed delta itself and skip every checkout. An
+                    # all-zeros $old is a previously-unborn branch — nothing
+                    # was tracked, so nothing can be locally modified.
+                    if [ "$old" != "$zero" ] \
+                        && { ! g diff --quiet "$old" || ! g diff --cached --quiet "$old"; }; then
                         echo "remote worktree has uncommitted changes; skipping checkout of $branch" >&2
                         continue
                     fi
-                    g checkout -f "$branch"
+                    g checkout -qf "$branch"
                 done"#
                     .as_bytes(),
             )
@@ -943,8 +951,16 @@ async fn handle_git_receive(
             session: session_handle,
             channel_id: id,
             exec: TokioExec {
+                // receive.denyCurrentBranch=ignore: the workspace is a
+                // non-bare repo with the pushed branch typically checked
+                // out, and stock git refuses that ref update outright —
+                // before any hook runs. `ignore` accepts it silently; the
+                // post-receive hook above then syncs the worktree (or
+                // warns and skips when it is dirty). NOT `updateInstead`:
+                // that rejects the whole push on a dirty worktree, while
+                // the hook's contract is "ref lands, checkout best-effort".
                 argv: format!(
-                    "git -c core.hooksPath={} receive-pack .",
+                    "git -c core.hooksPath={} -c receive.denyCurrentBranch=ignore receive-pack .",
                     hooks_tmp.path().to_str().unwrap()
                 ),
                 cwd: paths.working,


### PR DESCRIPTION
Fixes two stacked defects in #772's receive-pack path that left every `git push min://<session>` either rejected or inert, depending on the host's git defaults:

1. **Refused before any hook ran.** The workspace is a non-bare repo with the pushed branch typically checked out, and `receive-pack` ran with stock `receive.denyCurrentBranch=refuse` — on hosts where `init.defaultBranch=main`, pushing `main` was rejected outright (`! [remote rejected] main -> main (branch is currently checked out)`). Now passed `-c receive.denyCurrentBranch=ignore`: the ref update is accepted silently and worktree sync remains the post-receive hook's job. Deliberately **not** `updateInstead`, which hard-rejects the whole push on a dirty worktree — the hook's contract is "ref lands, checkout best-effort".

2. **Checkout skipped even on a pristine worktree.** The hook measured dirtiness with `diff --cached` *after* receive-pack had moved the ref, so it compared the stale index against the freshly pushed tip — flagging the pushed delta itself as "uncommitted changes" and skipping the checkout every time. It now measures against the pre-push tip (`$old`); an all-zeros `$old` (previously unborn branch) has nothing tracked, so nothing can be dirty.

## Why CI didn't catch it

The `git_remote` integration test only fails where git checks out `main` on init (`init.defaultBranch` set); on the CI runner's stock config the workspace initializes on `master` while the test pushes `main`, so the deny rule never triggered — and defect 2 was masked behind defect 1.

## Verification

- `cargo test -p minimal --test git_remote` — previously failing on an `init.defaultBranch=main` host with the rejection above, now passes.
- Standalone receive-pack harness (same argv + hook as the daemon) confirms all three behaviors: an unborn-branch push checks out, a clean-worktree push updates the worktree, and a dirty-worktree push preserves the local edit while the ref still lands with the skip warning.
- `cargo test -p minimald`, `clippy -D warnings`, `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic worktree synchronization after pushes by more accurately detecting whether the local worktree is “dirty” relative to the pre-push commit.
  - Reduced unnecessary branch checkouts when local uncommitted or untracked changes are present.
  - Correctly handles branches that are created for the first time during a push.
  - Ensures ref updates proceed smoothly so post-push synchronization can run using best-effort checkout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->