### PR TITLE
fix(minimal): drop the "Next steps" hint printed after init writes the mfile

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -1564,13 +1564,6 @@ fn run_init_flow(config: mctx::Config, skip_confirm: bool) -> Result<(), anyhow:
         .with_context(|| format!("writing {}", plan.toml_path.display()))?;
 
     eprintln!("Created {}", plan.toml_path.display());
-    eprintln!();
-    eprintln!("Next steps:");
-    eprintln!("  minimal update      # pin package versions");
-    eprintln!("  minimal activate .  # create a session");
-    if plan.matched {
-        eprintln!("  minimal attach      # attach to the session");
-    }
 
     Ok(())
 }


### PR DESCRIPTION
Closes #771. Supersedes #781 (closed — wrong root cause).

## Problem

`minimal activate` on a project with no `minimal.toml` auto-scaffolds one and then printed a "Next steps" block telling the user to run `minimal activate .  # create a session` — while `activate` is already running and creates the session in the same command:

```
Created …/minimal.toml

Next steps:
  minimal update      # pin package versions
  minimal activate .  # create a session      ← nonsensical: you just ran activate
```

The block lives in `run_init_flow`, which is shared by `minimal init` and `activate`'s auto-scaffold (`offer_mfile_scaffold`).

(The bot-generated #781 misread this as an "inside an active session" bug and gated on `MINIMAL_SESSION_ID` — a channel-routing var never set in this host-side flow; the session UUID in the report was the one `activate` had *just created*. See the [#781 discussion](https://github.com/gominimal/minimal/pull/781).)

## Change

Just drop the "Next steps" block. `init` still prints the created path; the next action is clear from context (activate proceeds to create the session; a standalone `init` leaves the toml ready). No behavior worth keeping is lost, and there's no caller-conditional logic to maintain.

Net diff: 7-line deletion in `crates/minimal/src/lib.rs`.

_Note: the `minimal` crate doesn't build on macOS (transitive Linux-only `procfs`), so I relied on the Linux CI lanes to compile._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the interactive “Next steps” guidance displayed after initialization.
  * Initialization now completes with the existing success output without additional follow-up prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->