### PR TITLE
feat(justfile): present CI's testable surfaces as just recipes (remove dep on previous minimal shim) 

### DIFF
--- a/.minimal/minimal.toml
+++ b/.minimal/minimal.toml
@@ -1,7 +1,7 @@
 [upstream] # Source of software & tooling
 repo = "https://github.com/gominimal/pkgs"
 branch = "main"
-locked_commit = "12f324d8f436bd014e54269b3ff412390d4040d5"
+locked_commit = "4538ab8bf88eebe1fc095241f8bb21e20a9e77eb"
 
 [stack]
 use = "rust"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,16 @@ See [README.md](README.md) for build instructions.
 Before opening a PR:
 
 ```shell
-cargo fmt
-cargo test -- --include-ignored
-cargo clippy --all-targets -- -D warnings
+just ci
 ```
+
+which runs the same gates the PR lanes run (fmt, clippy, cargo-deny, the
+test suite, doctests — plus, on Linux, the locally-runnable `#[ignore]`
+tests via `just test-ignored`, which no CI lane covers), dispatched for your
+OS. On macOS, `just test-cross` additionally covers the Linux-only crates
+(minimald et al.) via `cross`. If your change touches the VM/daemon path,
+also run `just e2e` (the session proof) and/or `just test-vm` (the VM
+integration harnesses).
 
 ## Coding standards
 
@@ -40,11 +46,11 @@ where it lives and what it is named:
 
 | Test kind | Where it goes | How CI runs it | Local command |
 |---|---|---|---|
-| Unit | `#[cfg(test)]` next to the code | every lane's core-tests suite | `cargo nextest run --workspace` |
-| In-process integration | `crates/<crate>/tests/*.rs` | same core-tests suite | `cargo nextest run --workspace` |
-| Doctest | `///` examples in lib code | `cargo test --workspace --doc` | `cargo test --workspace --doc` |
-| **Integration harness** — needs a real VM / kernel / netns | `crates/<crate>/tests/*_integration.rs` (add `_root` → `*_root_integration.rs` if it needs `CAP_NET_ADMIN`) | the KVM / macOS / native lanes **auto-discover it by suffix**, no CI edit: the non-root step runs `binary(/_integration$/) and not binary(/_root_integration$/)` and the `sudo` step runs `binary(/_root_integration$/)` (the `and not` matters — `_root_integration` also ends in `_integration`) | `just up`, then run the harness binary |
-| **End-to-end** — drives the `minimal` CLI through the whole system | a script under `scripts/` (e.g. `session-e2e.sh`) | native / KVM / macOS lanes call the script | `E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd ./scripts/session-e2e.sh` |
+| Unit | `#[cfg(test)]` next to the code | every lane's core-tests suite | `just test` (macOS: `just test-cross` adds the Linux-only crates) |
+| In-process integration | `crates/<crate>/tests/*.rs` | same core-tests suite | `just test` (macOS: `just test-cross` adds the Linux-only crates) |
+| Doctest | `///` examples in lib code | `cargo test --workspace --doc` | `just doctest` |
+| **Integration harness** — needs a real VM / kernel / netns | `crates/<crate>/tests/*_integration.rs` (add `_root` → `*_root_integration.rs` if it needs `CAP_NET_ADMIN`) | the KVM / macOS / native lanes **auto-discover it by suffix**, no CI edit: the non-root step runs `binary(/_integration$/) and not binary(/_root_integration$/)` and the `sudo` step runs `binary(/_root_integration$/)` (the `and not` matters — `_root_integration` also ends in `_integration`) | `just test-vm` (root proofs: `just test-root-integration`) — running a harness binary by hand needs `MINVMD_E2E=1`, the `MINVMD_*` artifact paths, and `--include-ignored`, or every test self-skips green |
+| **End-to-end** — drives the `minimal` CLI through the whole system | a script under `scripts/` (e.g. `session-e2e.sh`) | native / KVM / macOS lanes call the script | `just e2e` (VM-backed; wraps `scripts/session-e2e.sh`) or `just e2e-native` (Linux, no VM) |
 
 The line between the last two rows: **does the test drive the `minimal` CLI
 through a full user workflow across the whole system?** If yes it is an

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,7 +2,11 @@
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:main"
 pre-build = [
     # protoc version in apt is too old and chokes on optional keyword in proto3 fmt
-    "apt-get update && apt-get install --assume-yes wget unzip",
+    # git: the checkouts crate's tests shell out to it (`just test-cross`); CI
+    # runners have a modern one natively, but the image's Ubuntu 20.04 base
+    # ships 2.25, which predates `git init -b` (2.28) — hence the git-core PPA.
+    "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes wget unzip software-properties-common",
+    "add-apt-repository -y ppa:git-core/ppa && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes git",
     "wget https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip -O /tmp/protoc.zip",
     "unzip /tmp/protoc.zip -d /usr/local",
 ]

--- a/docs/ci-strategy.md
+++ b/docs/ci-strategy.md
@@ -441,10 +441,10 @@ map to a binary-name suffix + `just`/`scripts`, per the preamble):
 
 | Test kind | Where it goes | How CI discovers it | Local proof command |
 |---|---|---|---|
-| Unit | `#[cfg(test)]` module next to the code | cargo/nextest target discovery | `cargo nextest run --workspace` |
-| In-process integration | `crates/<crate>/tests/*.rs` | cargo target discovery | `cargo nextest run --workspace` |
-| Integration harness (real VM / kernel / netns) | `crates/<crate>/tests/*_integration.rs` (add `_root` → `*_root_integration.rs` if it needs `CAP_NET_ADMIN`) | the KVM/macOS/native lanes' non-root filterset `-E 'binary(/_integration$/) and not binary(/_root_integration$/)'` (root step: `-E 'binary(/_root_integration$/)'`, run under `sudo`) | `just up`, then run the harness binary |
-| End-to-end (drives the `minimal` CLI through the whole system) | a script under `scripts/` (e.g. `session-e2e.sh`) | the target lane invokes the script | `E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd ./scripts/session-e2e.sh` |
+| Unit | `#[cfg(test)]` module next to the code | cargo/nextest target discovery | `just test` |
+| In-process integration | `crates/<crate>/tests/*.rs` | cargo target discovery | `just test` |
+| Integration harness (real VM / kernel / netns) | `crates/<crate>/tests/*_integration.rs` (add `_root` → `*_root_integration.rs` if it needs `CAP_NET_ADMIN`) | the KVM/macOS/native lanes' non-root filterset `-E 'binary(/_integration$/) and not binary(/_root_integration$/)'` (root step: `-E 'binary(/_root_integration$/)'`, run under `sudo`) | `just test-vm` (root: `just test-root-integration`) |
+| End-to-end (drives the `minimal` CLI through the whole system) | a script under `scripts/` (e.g. `session-e2e.sh`) | the target lane invokes the script | `just e2e` (Linux native daemon: `just e2e-native`) |
 
 The discriminator between the last two rows is whether the test drives the
 `minimal` CLI through a full user workflow: if so it is *end-to-end* and lives as

--- a/docs/ci-strategy.md
+++ b/docs/ci-strategy.md
@@ -373,7 +373,7 @@ steps involve real logic — building the guest for the right arch, wiring the
 is reviewed code, not a command list. This repo keeps that logic in the **justfile +
 `scripts/`** (the role the strategy assigns to `cargo xtask`):
 
-- `just up` / `just dm1` / `just dm3` — build the stack and boot the guest for the arch
+- `just up` / `just up-kvm` — build the stack and bring it up for the host (macOS and `up-kvm` boot the guest VM)
 - `scripts/session-e2e.sh` — the unified CLI session proof every target lane runs
 - `scripts/build-initramfs.sh` — the musl guest (minimald) initramfs build
 

--- a/justfile
+++ b/justfile
@@ -324,9 +324,14 @@ up: minimald-build minimal-cli gvproxy && (_smoke "--minimal-dir" native-dir)
     sock="{{native-dir}}/providers/local-0/ssh.sock"
     pidf="{{scratch}}/minimald.pid"
     mkdir -p "{{native-dir}}"
-    if [ -S "$sock" ] && [ -f "$pidf" ] && kill -0 "$(cat "$pidf")" 2>/dev/null; then
+    # PID files survive reboots and PIDs get reused: only trust the pidfile if
+    # the PID is still THIS checkout's minimald (prefix match tolerates the
+    # "(deleted)" suffix a rebuilt binary leaves on /proc/<pid>/exe).
+    owns() { case "$(readlink "/proc/$1/exe" 2>/dev/null)" in "{{minimald-bin}}"*) return 0 ;; *) return 1 ;; esac; }
+    if [ -S "$sock" ] && [ -f "$pidf" ] && owns "$(cat "$pidf")"; then
       echo "native minimald already up: $sock"
     else
+      rm -f "$sock" "$pidf"
       setsid "{{minimald-bin}}" \
         --minimal-state-dir "{{native-dir}}" --minimal-cache-dir "{{native-dir}}/cache" \
         run --instance-num 0 --gvproxy-bin "{{gvproxy}}" > "{{scratch}}/minimald.log" 2>&1 &
@@ -343,7 +348,7 @@ up: minimald-build minimal-cli gvproxy && (_smoke "--minimal-dir" native-dir)
 # Bring the stack up: native Linux + one Linux VM over KVM (stop with `just stop`).
 [linux]
 up-kvm: _kvm artifacts gvproxy initramfs minvmd-build minimal-cli && (_smoke)
-    MINVMD_GVPROXY_BIN="{{gvproxy}}" "{{minvmd-bin}}" run --detach --timeout 75
+    MINVMD_GVPROXY_BIN="{{gvproxy}}" "{{minvmd-bin}}" run --detach --timeout "$MINVMD_READY_TIMEOUT_SECS"
     @echo "up-kvm: VM booted; minimald reachable at providers/local-0/ssh.sock"
 
 # Stop the stack `just up` started.
@@ -357,7 +362,14 @@ down:
     set -eu
     pidf="{{scratch}}/minimald.pid"
     [ -f "$pidf" ] || { echo "no native minimald running"; exit 0; }
-    pid="$(cat "$pidf")"; kill "$pid" 2>/dev/null || true
+    pid="$(cat "$pidf")"
+    # Never signal a reused PID: the pidfile is only trusted if the process is
+    # still this checkout's minimald (see the matching check in `up`).
+    case "$(readlink "/proc/$pid/exe" 2>/dev/null)" in
+      "{{minimald-bin}}"*) ;;
+      *) rm -f "$pidf"; echo "stale pidfile (pid $pid is not this checkout's minimald); removed"; exit 0 ;;
+    esac
+    kill "$pid" 2>/dev/null || true
     for _ in $(seq 1 30); do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
     kill -9 "$pid" 2>/dev/null || true; rm -f "$pidf"
     echo "native minimald stopped (pid $pid)"

--- a/justfile
+++ b/justfile
@@ -495,6 +495,11 @@ test-lifecycle: artifacts initramfs minvmd-build
       Linux)
         [ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "test-lifecycle needs writable /dev/kvm; try: sg kvm -c 'just test-lifecycle'" >&2; exit 1; }
         export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        # Same boot headroom as dm3/e2e: on slower Linux hosts (nested KVM)
+        # the generic guest kernel can take 40-70s to reach pid-1, past the
+        # script's 30s default and the supervisor's 60s READY default.
+        export MINVMD_READY_TIMEOUT_SECS="${MINVMD_READY_TIMEOUT_SECS:-150}"
+        export MINVMD_LIFECYCLE_BOOT_TIMEOUT_SECS="${MINVMD_LIFECYCLE_BOOT_TIMEOUT_SECS:-150}"
         ;;
     esac
     ./scripts/minvmd-lifecycle.sh

--- a/justfile
+++ b/justfile
@@ -449,6 +449,12 @@ e2e: artifacts gvproxy initramfs minimal-cli minvmd-build
       Linux)
         [ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "e2e (VM) needs writable /dev/kvm; try: sg kvm -c 'just e2e' — or use 'just e2e-native'" >&2; exit 1; }
         export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        # Same boot headroom as dm3: the generic guest kernel can spend 40-70s
+        # probing hardware before pid-1 starts, overrunning both the
+        # supervisor's 60s READY default and the CLI autospawn's 75s wait
+        # (the e2e's post-stop respawn proof autospawns via the CLI).
+        export MINVMD_READY_TIMEOUT_SECS="${MINVMD_READY_TIMEOUT_SECS:-150}"
+        export MINIMAL_SPAWN_TIMEOUT_SECS="${MINIMAL_SPAWN_TIMEOUT_SECS:-150}"
         E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
         ;;
       *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;

--- a/justfile
+++ b/justfile
@@ -1,225 +1,231 @@
-# justfile — repo-wide task runner. Lives at the workspace root.
+# justfile — repo-wide task runner; the local twin of the frozen CI workflows
+# (docs/ci-strategy.md §8: CI YAML schedules, the logic lives here + scripts/).
+# OS-specific recipes carry [linux]/[macos] attributes — `just --list` shows
+# only this host's. The comment line directly above a recipe is its caption.
+
+scratch      := justfile_directory() / ".scratch"
+arch         := arch()
+musl-target  := arch + "-unknown-linux-musl"
+# Flat libkrun link/runtime prefix (Linux; macOS links the Homebrew install).
+krun-prefix  := env('HOME') / ".krun"
+# Guest networking features baked into the initramfs (networking-wg deferred).
+features     := "networking-proxy"
+kernel       := scratch / "vmlinuz"
+rootfs       := scratch / "rootfs.img"
+initramfs    := scratch / "initramfs.cpio"
+gvproxy      := scratch / "gvproxy"
+minvmd-bin   := justfile_directory() / "target/debug/minvmd"
+minimald-bin := justfile_directory() / "target/debug/minimald"
+# The CLI crate is `minimal`; its [[bin]] target is `min`.
+min-bin      := justfile_directory() / "target/debug/min"
+# State dir for the host-native minimald that `just up` runs on Linux.
+native-dir   := scratch / "native-state"
+
+# The workspace doesn't compile natively on macOS (minimald/lcache/mctx are
+# Linux-only): scope to the darwin-capable crates there; `just test-cross`
+# covers the rest. The Linux lanes run nextest's ci profile; macOS has none.
+scope      := if os() == "macos" { "-p minvmd -p sessions" } else { "--workspace" }
+ci-profile := if os() == "macos" { "" } else { "--profile ci" }
+e2e-env    := "E2E_VM=1 E2E_PROJECT_DIR=/tmp" + if os() == "linux" { " E2E_MINIMAL_ARGS=--minvmd" } else { "" }
+
+# Shared dev-stack env: target/debug on PATH so autospawn finds sibling
+# binaries; MINVMD_* are inert outside the VM recipes. 150s timeouts: the
+# generic guest kernel can spend 40-70s probing hardware before pid-1 starts,
+# overrunning the 60s READY / 75s autospawn / 30s lifecycle defaults.
+export PATH := justfile_directory() / "target/debug:" + env('PATH')
+export LD_LIBRARY_PATH := krun-prefix + if env('LD_LIBRARY_PATH', '') == '' { '' } else { ':' + env('LD_LIBRARY_PATH') }
+export MINVMD_KERNEL_PATH := kernel
+export MINVMD_ROOTFS_PATH := rootfs
+export MINVMD_INITRAMFS := initramfs
+export MINVMD_BOOT_LOG := scratch / "boot.log"
+export MINVMD_READY_TIMEOUT_SECS := env('MINVMD_READY_TIMEOUT_SECS', '150')
+export MINIMAL_SPAWN_TIMEOUT_SECS := env('MINIMAL_SPAWN_TIMEOUT_SECS', '150')
+export MINVMD_LIFECYCLE_BOOT_TIMEOUT_SECS := env('MINVMD_LIFECYCLE_BOOT_TIMEOUT_SECS', '150')
+
+[private]
+default:
+    @just --list
+
+# ── build & fetch ────────────────────────────────────────────────────────────
 #
-# Recipes are grouped by crate where they're crate-specific.
+# Prereqs — macOS: `brew install slp/krun/libkrun` + the `minimal` shim.
+# Linux: a KVM host with kvm-group membership, Rust + protoc + jq + cpio.
+# See crates/minvmd/README.md for the manual bring-up.
 
-# The -rel twins are repo-relative because the shim-VM materialize (see
-# `artifacts`) can only write outputs back through repo-relative paths; the
-# absolute forms are derived from them so guard, write, and consumers can
-# never disagree.
-scratch-rel := ".scratch"
-scratch     := justfile_directory() / scratch-rel
-# Host CPU arch — drives the materialized guest artifacts and the musl target.
-# aarch64 on Apple Silicon; x86_64 on most Linux hosts.
-arch        := arch()
-musl-target := arch + "-unknown-linux-musl"
-# Flat libkrun link/runtime prefix (Linux only; macOS uses the Homebrew install).
-krun-prefix := env_var('HOME') / ".krun"
-# Guest minimald networking features baked into the initramfs (R4.x): the HTTPS
-# reverse proxy (mTLS). The WireGuard mesh peer (networking-wg) is disabled for
-# now (UC7 / UC2b-A deferred).
-features    := "networking-proxy"
-kernel-rel  := scratch-rel / "vmlinuz"
-rootfs-rel  := scratch-rel / "rootfs.img"
-kernel      := justfile_directory() / kernel-rel
-rootfs      := justfile_directory() / rootfs-rel
-initramfs   := scratch / "initramfs.cpio"
-gvproxy     := scratch / "gvproxy"
-minvmd-bin  := justfile_directory() / "target/debug/minvmd"
-# The CLI's binary target is `min` (crates/minimal/Cargo.toml [[bin]]); the
-# crate it comes from is still `minimal`, hence `cargo build -p minimal`.
-min-bin     := justfile_directory() / "target/debug/min"
-
-# Re-run any time the entitlements file or binary changes. Ad-hoc signing
-# (`-s -`) requires no Apple Developer membership; the binary only runs on the
-# host that signed it, which is correct for dev builds.
-
-# Build a release `minvmd` and code-sign it with the hypervisor entitlement.
-codesign-minvmd:
-    cargo build -p minvmd --release
-    codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - {{justfile_directory()}}/target/release/minvmd
-
-# ── minimal → minvmd → minimald bring-up (macOS/HVF or Linux/KVM) ───────────
-#
-# `just dm1` (macOS/HVF) and `just dm3` (Linux/KVM) bring the whole stack up
-# with full guest networking:
-#   1. materialize the guest kernel + generic rootfs into .scratch
-#   2. cross-compile minimald → initramfs /init WITH the networking features
-#   3. build minvmd (codesign on macOS), build the `min` CLI
-#   4. run `min ls`, which auto-spawns `minvmd run --detach`; minvmd boots
-#      the microVM whose initramfs pid-1 is minimald, which serves the session
-#      over the host UDS bridge.
-#
-# Prereqs:
-#   macOS  — `brew install slp/krun/libkrun`; the `minimal` shim on PATH.
-#   Linux  — a KVM host; durable `kvm` group membership (`sudo usermod -aG kvm
-#            $USER`, then re-login) so the autospawned minvmd can open /dev/kvm;
-#            a Rust toolchain + protoc + jq + cpio. libkrun is fetched by `dm3`.
-# See crates/minvmd/README.md for the manual equivalent.
-
-# macOS: via the `minimal` SHIM (~/.minimal/shim/bin/minimal — runs the CLI in a
-# VM; --output must be a repo-RELATIVE path, see the recipe). Distinct from the
-# `min` binary this repo builds. Linux: via fetch-artifact.sh (builds `mip` from
-# source).
-
-# Materialize the guest kernel + generic rootfs into .scratch. Skips a fetch when
-# the artifact already exists; `just clean` first to force a refresh.
+# Materialize the guest kernel + generic rootfs (`just clean` forces a refresh).
+[macos]
 artifacts:
     #!/usr/bin/env sh
     set -eu
+    [ -f {{kernel}} ] && [ -f {{rootfs}} ] && exit 0
     mkdir -p {{scratch}}
-    # `minimal materialize` runs in a VM via the shim; on a cold cache its
-    # overlay-sync can transiently drop the output ("copying output file I/O
-    # error … No such file or directory"). Retry a few times before failing.
-    #
-    # The --output path MUST be repo-RELATIVE: outputs come back to the host
-    # via the project-dir sync overlay, and an absolute path — even one under
-    # the repo — reliably fails the copy-out with the same I/O error.
+    # Resolve the shim by its install path FIRST: PATH is polluted with this
+    # repo's own target/debug (see the global export), where a stale `minimal`
+    # binary would shadow the shim.
+    if [ -x "$HOME/.minimal/shim/bin/minimal" ]; then shim="$HOME/.minimal/shim/bin/minimal"
+    elif command -v minimal >/dev/null 2>&1; then shim=minimal
+    else echo "the \`minimal\` shim is required (not at ~/.minimal/shim/bin, not on PATH)" >&2; exit 1
+    fi
+    # The shim's --output MUST be repo-RELATIVE (outputs sync back through the
+    # project-dir overlay; absolute paths fail the copy-out), and a cold cache
+    # can transiently drop the output — retry.
     materialize() {
-      n=0
-      until minimal materialize --output "$1" --arch "$2" "$3"; do
-        n=$((n + 1))
-        [ "$n" -ge 3 ] && { echo "materialize $3 failed after $n attempts" >&2; return 1; }
-        echo "materialize $3 failed (attempt $n); retrying…" >&2
-        rm -f "$1"
-        sleep 2
+      for n in 1 2 3; do
+        "$shim" materialize --output "$1" --arch {{arch}} "$2" && return 0
+        echo "materialize $2 failed (attempt $n)" >&2; rm -f "$1"; sleep 2
       done
+      return 1
     }
-    case "$(uname -s)" in
-      Darwin)
-        # Both artifacts present — nothing to fetch, so don't demand the shim.
-        [ -f {{kernel}} ] && [ -f {{rootfs}} ] && exit 0
-        # Resolve the shim: PATH first, then its install location — a dev
-        # shell without ~/.minimal/shim/bin on PATH shouldn't fail here.
-        if command -v minimal >/dev/null 2>&1; then :; elif [ -x "$HOME/.minimal/shim/bin/minimal" ]; then
-          PATH="$HOME/.minimal/shim/bin:$PATH"
-        else
-          echo "the \`minimal\` shim is required (not on PATH, not at ~/.minimal/shim/bin/minimal); see the bring-up prereqs above" >&2
-          exit 1
-        fi
-        [ -f {{kernel}} ] || materialize {{kernel-rel}} {{arch}} virtio-kernel
-        [ -f {{rootfs}} ] || materialize {{rootfs-rel}} {{arch}} minvmd-rootfs
-        ;;
-      Linux)
-        [ -f {{kernel}} ] || scripts/fetch-artifact.sh virtio-kernel {{kernel}} {{arch}}
-        [ -f {{rootfs}} ] || scripts/fetch-artifact.sh minvmd-rootfs {{rootfs}} {{arch}}
-        ;;
-      *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
-    esac
+    [ -f {{kernel}} ] || materialize .scratch/vmlinuz virtio-kernel
+    [ -f {{rootfs}} ] || materialize .scratch/rootfs.img minvmd-rootfs
 
-# macOS uses the Homebrew install, so this is a no-op there.
+# Materialize the guest kernel + generic rootfs (`just clean` forces a refresh).
+[linux]
+artifacts:
+    @mkdir -p {{scratch}}
+    @[ -f {{kernel}} ] || scripts/fetch-artifact.sh virtio-kernel {{kernel}} {{arch}}
+    @[ -f {{rootfs}} ] || scripts/fetch-artifact.sh minvmd-rootfs {{rootfs}} {{arch}}
 
-# Fetch libkrun + libkrunfw into the link/runtime prefix (Linux only).
+# Fetch libkrun + libkrunfw into the link/runtime prefix.
+[linux]
 libkrun:
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Linux) scripts/fetch-libkrun.sh {{krun-prefix}} {{arch}} ;;
-      *) echo "libkrun: macOS uses the Homebrew install; nothing to fetch" ;;
-    esac
+    scripts/fetch-libkrun.sh {{krun-prefix}} {{arch}}
 
-# Uses `cross`/Docker for the musl toolchain.
+# Fetch the pinned gvproxy switch (guest egress + own-IP; missing = switchless boot).
+gvproxy:
+    @mkdir -p {{scratch}}
+    @[ -x {{gvproxy}} ] || scripts/fetch-gvproxy.sh {{gvproxy}}
 
-# Cross-compile minimald → initramfs /init with the networking features baked in.
+# Cross-compile minimald → initramfs /init with the networking features.
 initramfs:
     FEATURES={{features}} scripts/build-initramfs.sh {{initramfs}} {{musl-target}}
 
-# Not yet consumed by `minvmd run`; provided for the netns/relay e2e flows.
+# The ad-hoc (-s -) hypervisor-entitlement codesign must be the LAST touch:
+# any later cargo call that relinks minvmd drops it (EINVAL from krun_start_enter).
+#
+# Build minvmd (debug); codesign is the last touch.
+[macos]
+minvmd-build:
+    cargo build -p minvmd --bin minvmd --locked
+    codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - {{minvmd-bin}}
 
-# Fetch the pinned gvproxy switch binary into .scratch (skips if already present).
-gvproxy:
-    #!/usr/bin/env sh
-    set -eu
-    mkdir -p {{scratch}}
-    [ -x {{gvproxy}} ] || scripts/fetch-gvproxy.sh {{gvproxy}}
-
-# macOS: codesign with the hypervisor entitlement (must be the last thing to
-# touch the binary). Linux: build with the libkrun prefix exported so build.rs
-# links the real (non-stub) implementation.
-
-# Build minvmd (debug).
+# Build minvmd (debug); LIBKRUN_PREFIX links the real (non-stub) libkrun.
+[linux]
 minvmd-build: libkrun
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Darwin)
-        cargo build -p minvmd --bin minvmd --locked
-        codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - {{minvmd-bin}}
-        ;;
-      Linux)
-        export LIBKRUN_PREFIX="{{krun-prefix}}"
-        export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-        cargo build -p minvmd --bin minvmd --locked
-        ;;
-      *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
-    esac
+    LIBKRUN_PREFIX="{{krun-prefix}}" cargo build -p minvmd --bin minvmd --locked
 
-# Build the `min` CLI (from the `minimal` crate; its [[bin]] target is `min`).
+# Build the `min` CLI.
 minimal-cli:
     cargo build -p minimal --locked
 
-# Run the `min` CLI against the workspace's own debug build. Prepends
-# `target/debug/` to `$PATH` so `min`'s auto-spawn can find the sibling
-# daemon binary (it invokes it by name). On Linux that sibling is minimald;
-# on macOS minimald doesn't compile natively (hakoniwa/procfs are Linux-only)
-# and the daemon is minvmd-hosted anyway, so only the CLI is built (use
-# `just up` for the full VM bring-up). Arguments after `just min` are
-# forwarded verbatim.
-#
-# Example:
-#   just min activate --loadout helix --attach
-#   just min loadout list
-#   just min dirs
+# Build a host-native (glibc) minimald with the networking features (for `just up`).
+[linux]
+minimald-build:
+    cargo build -p minimald --features {{features}}
+
+# ── run & inspect ────────────────────────────────────────────────────────────
+
+# Run the dev-built `min` CLI, args forwarded (e.g. `just min loadout list`).
 min *args:
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Darwin) cargo build -p minimal ;;
-      *)      cargo build -p minimal -p minimald ;;
-    esac
-    PATH="{{justfile_directory()}}/target/debug:$PATH" "{{min-bin}}" {{args}}
+    @cargo build {{ if os() == "macos" { "-p minimal" } else { "-p minimal -p minimald" } }}
+    @"{{min-bin}}" {{args}}
 
-# Print `export` lines wiring the dev-built binaries and guest artifacts into
-# the environment — the same setup `dm1`/`dm3` do internally, for running
-# `min`/`minvmd` by hand against the built stack. Load into the current
-# shell with:  eval "$(just env)"
+# Print `export` lines for running the stack by hand: eval "$(just env)".
 env:
-    #!/usr/bin/env sh
-    set -eu
-    printf 'export MINVMD_KERNEL_PATH="%s"\n' '{{kernel}}'
-    printf 'export MINVMD_ROOTFS_PATH="%s"\n' '{{rootfs}}'
-    printf 'export MINVMD_INITRAMFS="%s"\n' '{{initramfs}}'
-    printf 'export MINVMD_BOOT_LOG="%s"\n' '{{scratch}}/boot.log'
-    printf 'export MINVMD_GVPROXY_BIN="%s"\n' '{{gvproxy}}'
-    printf 'export PATH="%s:$PATH"\n' '{{justfile_directory()}}/target/debug'
-    case "$(uname -s)" in
-      Linux) printf 'export LD_LIBRARY_PATH="%s${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"\n' '{{krun-prefix}}' ;;
-    esac
+    @printf 'export %s="%s"\n' \
+      PATH "$PATH" LD_LIBRARY_PATH "$LD_LIBRARY_PATH" \
+      MINVMD_KERNEL_PATH "$MINVMD_KERNEL_PATH" MINVMD_ROOTFS_PATH "$MINVMD_ROOTFS_PATH" \
+      MINVMD_INITRAMFS "$MINVMD_INITRAMFS" MINVMD_BOOT_LOG "$MINVMD_BOOT_LOG" \
+      MINVMD_GVPROXY_BIN "{{gvproxy}}" \
+      MINVMD_READY_TIMEOUT_SECS "$MINVMD_READY_TIMEOUT_SECS" \
+      MINIMAL_SPAWN_TIMEOUT_SECS "$MINIMAL_SPAWN_TIMEOUT_SECS"
 
-# Drop into a subshell with that environment loaded (exit to leave).
+# Subshell with the dev env loaded (exit to leave).
 shell:
-    #!/usr/bin/env sh
-    set -eu
-    eval "$(just env)"
-    echo "minimal dev shell: target/debug on PATH, MINVMD_* set (exit to leave)"
-    exec "${SHELL:-sh}"
+    @echo "minimal dev shell: target/debug on PATH, MINVMD_* set (exit to leave)"
+    @MINVMD_GVPROXY_BIN="{{gvproxy}}" "${SHELL:-sh}"
 
 # Report the supervised minvmd lifecycle state.
 status:
-    "{{minvmd-bin}}" status
+    @"{{minvmd-bin}}" status
 
 # Stop the supervised minvmd (SIGTERM → SIGKILL).
 stop:
-    "{{minvmd-bin}}" stop
+    @"{{minvmd-bin}}" stop
 
-# Remove only the bring-up artifacts this justfile manages (.scratch is a shared
-# scratchpad — do NOT blow the whole directory away).
+# Remove the bring-up artifacts this justfile manages (never all of .scratch).
 clean:
     rm -f {{kernel}} {{rootfs}} {{initramfs}} {{gvproxy}} {{scratch}}/boot.log
 
-# Run the curl|sh installer's test harness under every POSIX sh available. The
-# installer targets strict POSIX sh, so dash conformance is checked alongside sh
-# (spec docs/specs/07-spec-installer, Verification §2); shellcheck --shell=sh is
-# run when present.
+# Kill THIS checkout's stranded VM processes (they wedge the next VM's vsock bridge).
+reap:
+    scripts/reap-vms.sh
+
+# ── CI-parity gates ──────────────────────────────────────────────────────────
+
+# Fail fast with an install hint when a required tool is missing.
+_need tool hint:
+    @command -v {{tool}} >/dev/null 2>&1 || { echo "'{{tool}}' not found — install with: {{hint}}" >&2; exit 1; }
+
+_nextest: (_need "cargo-nextest" "cargo install cargo-nextest --locked")
+
+# Apply rustfmt across the workspace (the fixer for a red `just fmt-check`).
+fmt:
+    cargo fmt --all
+
+# CI: ci.yml `fmt`.
+fmt-check:
+    cargo fmt --all -- --check
+
+# CI: ci.yml `clippy` / the ci-macos.yml `unit` scope.
+clippy:
+    cargo clippy {{scope}} --all-targets --locked -- -D warnings
+
+# A local advisories failure may just mean newer RUSTSEC data than CI's last run.
+#
+# CI: ci.yml `cargo-deny` (advisories/bans/licenses/sources).
+deny: (_need "cargo-deny" "cargo install cargo-deny --locked")
+    cargo deny --all-features check
+
+# Unit + in-process integration tests. CI: every lane's core-tests suite.
+test: _nextest
+    cargo nextest run {{scope}} {{ci-profile}} --locked --no-tests=fail
+
+# Doctests — nextest can't run them, so they are their own surface.
+doctest:
+    cargo test {{scope}} --doc --locked
+
+# The old `cargo test -- --include-ignored` pre-PR surface; the env-gated
+# VM/netns harnesses self-skip here (`just test-vm` runs those for real).
+#
+# The #[ignore] tests GitHub runners can't run — NO CI lane covers these.
+[linux]
+test-ignored: _nextest
+    cargo nextest run --workspace --locked --profile ci --run-ignored ignored-only --no-tests=fail
+
+# COST: the first run compiles the workspace under emulation and can take an
+# hour+; later runs are incremental. HOME=/tmp: the container has no HOME.
+#
+# clippy + tests for the Linux-only crates from a Mac (musl in Docker; not minvmd).
+[macos]
+test-cross: (_need "cross" "cargo install cross --locked")
+    @docker info >/dev/null 2>&1 || { echo "docker daemon not running (cross needs it) — start Docker Desktop or OrbStack" >&2; exit 1; }
+    cross clippy --workspace --exclude minvmd --all-targets --target {{musl-target}} --locked -- -D warnings
+    CROSS_CONTAINER_OPTS="--env HOME=/tmp" cross test --workspace --exclude minvmd --target {{musl-target}} --locked
+
+# Not replicated: commitlint, the dogfood jobs, the installer lane (`just test-installer`).
+#
+# The local PR gate set, cheapest first.
+[linux]
+ci: fmt-check clippy deny test doctest test-ignored
+    @echo "ci: local PR gates green"
+
+# The local PR gate set, cheapest first (`just test-cross` covers the Linux-only crates).
+[macos]
+ci: fmt-check clippy deny test doctest
+    @echo "ci: local PR gates green"
+
+# Run the curl|sh installer's tests under every POSIX sh. CI: ci-shell-installer.yml.
 test-installer:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -235,470 +241,160 @@ test-installer:
         SH="$sh" "$sh" scripts/install_test.sh
     done
 
-# ── CI-parity gates & test surfaces ──────────────────────────────────────────
+# ── VM & e2e surfaces ────────────────────────────────────────────────────────
+
+# VM recipes need writable /dev/kvm on Linux; no-op on macOS (HVF).
+[macos]
+_kvm:
+
+[linux]
+_kvm:
+    @[ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "needs writable /dev/kvm — durable: sudo usermod -aG kvm $USER (re-login); one-off: sg kvm -c 'just <recipe>'" >&2; exit 1; }
+
+# minvmd's VM harnesses (tests/*_integration.rs). CI: `test-kvm` / macOS `e2e`.
+[macos]
+test-vm: _nextest artifacts initramfs
+    #!/usr/bin/env sh
+    set -eu
+    export MINVMD_E2E=1 MINVMD_BIN="{{minvmd-bin}}" XDG_STATE_HOME="{{scratch}}/test-state"
+    # CI's archive pattern: build EVERYTHING, codesign minvmd LAST (a later
+    # cargo call would relink it → entitlement lost), run from the archive.
+    cargo nextest archive -p minvmd --locked --archive-file "{{scratch}}/nextest-archive.tar.zst"
+    cargo build -p minvmd --bin minvmd --locked
+    cargo build -p minimal --bin min --locked
+    # Resolve the FFI-smoke binary from cargo itself (an mtime-sorted ls can
+    # pick a stale build config), BEFORE codesign — the last cargo call allowed.
+    testbin="$(cargo test -p minvmd --test krun_smoke_integration --no-run --locked --message-format=json 2>/dev/null \
+      | sed -n 's/.*"executable":"\([^"]*krun_smoke_integration[^"]*\)".*/\1/p' | head -1)"
+    [ -n "$testbin" ] && [ -x "$testbin" ] || { echo "krun_smoke_integration test binary not resolved via cargo" >&2; exit 1; }
+    codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - "{{minvmd-bin}}"
+    # The FFI smoke boots libkrun IN-PROCESS from the unsigned test binary:
+    # run it kernel-less and directly — never via cargo, never from the filterset.
+    env -u MINVMD_KERNEL_PATH -u MINVMD_ROOTFS_PATH -u MINVMD_INITRAMFS \
+      "$testbin" --include-ignored --nocapture
+    cargo-nextest nextest run --archive-file "{{scratch}}/nextest-archive.tar.zst" \
+      --workspace-remap "{{justfile_directory()}}" --profile vm \
+      --run-ignored all --no-tests=fail \
+      -E 'binary(/_integration$/) and not binary(/_root_integration$/) and not binary(krun_smoke_integration)'
+
+# minvmd's VM harnesses (tests/*_integration.rs). CI: ci-linux-kvm.yml `test-kvm`.
+[linux]
+test-vm: _nextest _kvm artifacts initramfs minvmd-build
+    MINVMD_E2E=1 MINVMD_BIN="{{minvmd-bin}}" XDG_STATE_HOME="{{scratch}}/test-state" LIBKRUN_PREFIX="{{krun-prefix}}" \
+      cargo nextest run -p minvmd --profile vm --run-ignored all --no-tests=fail \
+      -E 'binary(/_integration$/) and not binary(/_root_integration$/)'
+
+# minimald's netns/tap proofs (the tests sudo their own netns commands).
+# CI: ci-linux-native.yml `minimald-root-integration`.
+[linux]
+test-root-integration: _nextest gvproxy
+    @[ "$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)" = "0" ] || { echo "unprivileged userns is restricted; run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0" >&2; exit 1; }
+    MINIMALD_NETNS_TEST=1 GVPROXY_BIN="{{gvproxy}}" cargo nextest run -p minimald --profile ci --run-ignored all --no-tests=fail -E 'binary(/_root_integration$/)'
+
+# minvmd-build is LAST so its macOS codesign is the final touch on the binary.
 #
-# Local entry points for the same checks CI runs (docs/ci-strategy.md §8: the
-# workflows are a thin frozen scheduler; the justfile + scripts/ are the
-# reviewed logic). Each recipe's comment names its CI counterpart so parity is
-# reviewable. OS dispatch follows the lanes: Linux gets the native/KVM
-# surfaces, macOS the ci-macos ones plus cross-compiled (Docker) coverage of
-# the Linux-only crates.
+# The unified session e2e against the VM-backed daemon. CI: the session e2e steps.
+e2e: _kvm artifacts gvproxy initramfs minimal-cli minvmd-build
+    {{e2e-env}} MINVMD_GVPROXY_BIN="{{gvproxy}}" ./scripts/session-e2e.sh
 
-# Fail fast with an install hint when a required tool is missing.
-_need tool hint:
-    @command -v {{tool}} >/dev/null 2>&1 || { echo "'{{tool}}' not found — install with: {{hint}}" >&2; exit 1; }
-
-# Apply rustfmt across the workspace (the fixer for a red `just fmt-check`).
-fmt:
-    cargo fmt --all
-
-# CI parity: ci.yml `fmt`.
-fmt-check:
-    cargo fmt --all -- --check
-
-# CI parity: ci.yml `clippy` (Linux, workspace-wide). On macOS the workspace
-# doesn't compile natively (minimald/lcache/mctx are Linux-only), so mirror
-# ci-macos.yml `unit` (-p minvmd); `just test-cross` covers the Linux-only
-# crates from a Mac.
-clippy:
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Darwin) cargo clippy -p minvmd --all-targets --locked -- -D warnings ;;
-      *)      cargo clippy --workspace --all-targets --locked -- -D warnings ;;
-    esac
-
-# CI parity: ci.yml `cargo-deny` (the EmbarkStudios action defaults to
-# `cargo deny --all-features check`: advisories/bans/licenses/sources over the
-# full feature graph, config deny.toml). A local advisories failure may just
-# mean newer RUSTSEC data than CI's last run; nightly re-checks advisories
-# blocking.
-deny: (_need "cargo-deny" "cargo install cargo-deny --locked")
-    cargo deny --all-features check
-
-# Unit + in-process integration tests.
-# CI parity: the core-tests composite on ci-linux-native.yml `tests` — the
-# Linux branch is its exact command (--profile ci: fail-fast off, slow tests
-# killed at 5x60s, junit to target/nextest/ci/junit.xml). On macOS this
-# mirrors ci-macos.yml `unit` (-p minvmd -p sessions via nextest; the
-# workspace is uncompilable there, and that job has no nextest profile) — run
-# `just test-cross` for the Linux-only crates. Locally-runnable #[ignore]
-# tests are a separate surface: `just test-ignored`.
-test: (_need "cargo-nextest" "cargo install cargo-nextest --locked")
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Darwin) cargo nextest run -p minvmd -p sessions --locked --no-tests=fail ;;
-      *)      cargo nextest run --workspace --locked --profile ci --no-tests=fail ;;
-    esac
-
-# The ungated #[ignore] tests — ignored only because GitHub runners can't run
-# them (e.g. mctx's layer-init/build proofs need nested user namespaces,
-# minimald's git_receive_pack proof), i.e. MEANT to be run on a dev machine.
-# This is the surface `cargo test -- --include-ignored` used to cover in the
-# pre-PR flow; no CI lane runs these, so a local run is the only gate. The
-# env-gated VM/netns harnesses also match --run-ignored but self-skip without
-# their MINVMD_E2E / MINIMALD_NETNS_TEST env (use `just test-vm` /
-# `just test-root-integration` to actually run those). Linux-only: the crates
-# carrying these tests don't compile natively on macOS.
-test-ignored:
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Linux) ;;
-      *) echo "test-ignored is Linux-only (mctx/minimald don't compile natively here); SKIP on $(uname -s)"; exit 0 ;;
-    esac
-    command -v cargo-nextest >/dev/null 2>&1 || { echo "'cargo-nextest' not found — install with: cargo install cargo-nextest --locked" >&2; exit 1; }
-    cargo nextest run --workspace --locked --profile ci --run-ignored ignored-only --no-tests=fail
-
-# The Linux-crate surface from a macOS host: clippy + tests for every
-# workspace crate except minvmd (libkrun linkage), cross-compiled to musl in
-# Docker. This is the local stand-in for what the Linux lanes check natively —
-# including minimald, which cannot compile on darwin. The container has no
-# HOME, which breaks env::tests — hence HOME=/tmp.
-#
-# COST WARNING: the first run compiles the whole workspace for {{musl-target}}
-# inside the container, and nickel-lang-parser's LALRPOP build script may run
-# under CPU emulation — that first build can take an hour or more. Later runs
-# reuse target/{{musl-target}} and are incremental. On Linux this is a clean
-# SKIP: the native `just test`/`just clippy` already cover the workspace.
-test-cross:
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Darwin) ;;
-      *) echo "test-cross is for macOS hosts; native 'just test' covers the workspace here. SKIP"; exit 0 ;;
-    esac
-    command -v cross >/dev/null 2>&1 || { echo "'cross' not found — install with: cargo install cross --locked" >&2; exit 1; }
-    docker info >/dev/null 2>&1 || { echo "docker daemon not running (cross needs it) — start Docker Desktop or OrbStack" >&2; exit 1; }
-    cross clippy --workspace --exclude minvmd --all-targets --target {{musl-target}} --locked -- -D warnings
-    CROSS_CONTAINER_OPTS="--env HOME=/tmp" cross test --workspace --exclude minvmd --target {{musl-target}} --locked
-
-# Doctests — nextest can't run them, so they are their own surface, exactly as
-# CI treats them. CI parity: core-tests composite (`cargo test --workspace
-# --doc --locked`); macOS covers the doc tests of the crates its unit lane
-# tests.
-doctest:
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Darwin) cargo test -p minvmd -p sessions --doc --locked ;;
-      *)      cargo test --workspace --doc --locked ;;
-    esac
-
-# The PR gate set, locally: quick gates (ci.yml fmt/clippy/cargo-deny) + core
-# tests (nextest + doctests) + the locally-runnable #[ignore] tests (Linux;
-# clean SKIP on macOS), cheapest first. On macOS add `just test-cross` when
-# touching the Linux-only crates. Deliberately NOT replicated: commitlint
-# (needs node + the PR commit range — docs/commit-conventions.md), the
-# dogfood/minimal-check jobs (released-binary-vs-repo-config checks), and the
-# path-filtered installer lane (`just test-installer` when touching
-# scripts/install*).
-ci: fmt-check clippy deny test doctest test-ignored
-    @echo "ci: local PR gates green"
-
-# minvmd's VM integration harnesses (crates/minvmd/tests/*_integration.rs).
-# CI parity: ci-linux-kvm.yml `test-kvm` / ci-macos.yml `e2e` — the same
-# `-p minvmd` scope those lanes archive, same filtersets, --profile vm,
-# --run-ignored all, --no-tests=fail. The §10 suffix convention selects
-# WITHIN that scope: a `*_integration.rs` harness in another crate is not
-# picked up here or by the CI VM lanes today. XDG_STATE_HOME is isolated to
-# .scratch so harness-spawned daemons can't clobber the real
-# ~/.local/state/minimal. Stranded VMs after a failed run: `just reap`.
-test-vm: (_need "cargo-nextest" "cargo install cargo-nextest --locked") artifacts gvproxy initramfs libkrun
-    #!/usr/bin/env sh
-    set -eu
-    export MINVMD_E2E=1 MINVMD_BIN="{{minvmd-bin}}"
-    export MINVMD_KERNEL_PATH="{{kernel}}" MINVMD_ROOTFS_PATH="{{rootfs}}"
-    export MINVMD_INITRAMFS="{{initramfs}}" MINVMD_BOOT_LOG="{{scratch}}/boot.log"
-    export XDG_STATE_HOME="{{scratch}}/test-state"
-    case "$(uname -s)" in
-      Darwin)
-        # CI's archive pattern, for the same reason CI uses it: build
-        # EVERYTHING first, codesign minvmd as the last touch (any later cargo
-        # invocation with minvmd in its build graph relinks it → entitlement
-        # lost → EINVAL from krun_start_enter), then run from the archive,
-        # which never rebuilds.
-        cargo nextest archive -p minvmd --locked --archive-file "{{scratch}}/nextest-archive.tar.zst"
-        cargo build -p minvmd --bin minvmd --locked
-        cargo build -p minimal --bin min --locked
-        # Resolve the FFI-smoke binary from cargo itself (an mtime-sorted ls
-        # can pick a stale binary from an abandoned build config), and do it
-        # BEFORE codesign — it is the last cargo invocation allowed.
-        testbin="$(cargo test -p minvmd --test krun_smoke_integration --no-run --locked --message-format=json 2>/dev/null \
-          | sed -n 's/.*"executable":"\([^"]*krun_smoke_integration[^"]*\)".*/\1/p' | head -1)"
-        [ -n "$testbin" ] && [ -x "$testbin" ] || { echo "krun_smoke_integration test binary not resolved via cargo" >&2; exit 1; }
-        codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - "{{minvmd-bin}}"
-        # FFI smoke (ci-macos.yml): boots libkrun IN-PROCESS from the
-        # (unsigned) test binary, so it must run kernel-less and be invoked
-        # directly — never via cargo (relink) and never from the filterset.
-        env -u MINVMD_KERNEL_PATH -u MINVMD_ROOTFS_PATH -u MINVMD_INITRAMFS \
-          "$testbin" --include-ignored --nocapture
-        cargo-nextest nextest run --archive-file "{{scratch}}/nextest-archive.tar.zst" \
-          --workspace-remap "{{justfile_directory()}}" --profile vm \
-          --run-ignored all --no-tests=fail \
-          -E 'binary(/_integration$/) and not binary(/_root_integration$/) and not binary(krun_smoke_integration)'
-        ;;
-      Linux)
-        [ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "test-vm needs writable /dev/kvm; try: sg kvm -c 'just test-vm'" >&2; exit 1; }
-        export LIBKRUN_PREFIX="{{krun-prefix}}"
-        export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-        cargo build -p minvmd --bin minvmd --locked
-        cargo nextest run -p minvmd --profile vm --run-ignored all --no-tests=fail \
-          -E 'binary(/_integration$/) and not binary(/_root_integration$/)'
-        ;;
-      *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
-    esac
-
-# minimald root-integration proofs (netns/tap via gvproxy; no KVM needed).
-# CI parity: ci-linux-native.yml `minimald-root-integration` — same env,
-# profile, and filterset; the tests sudo their own tap/netns commands.
-test-root-integration:
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Linux) ;;
-      *) echo "root-integration is Linux-only (netns/CAP_NET_ADMIN); SKIP on $(uname -s)"; exit 0 ;;
-    esac
-    command -v cargo-nextest >/dev/null 2>&1 || { echo "'cargo-nextest' not found — install with: cargo install cargo-nextest --locked" >&2; exit 1; }
-    # Ubuntu 24.04+ gates unprivileged userns behind apparmor; CI flips it too.
-    v="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)"
-    [ "$v" = "0" ] || { echo "unprivileged userns is restricted; run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0" >&2; exit 1; }
-    just gvproxy
-    MINIMALD_NETNS_TEST=1 GVPROXY_BIN="{{gvproxy}}" \
-      cargo nextest run -p minimald --profile ci --run-ignored all --no-tests=fail \
-      -E 'binary(/_root_integration$/)'
-
-# The unified session e2e (scripts/session-e2e.sh) against this host's
-# VM-backed daemon. CI parity: ci-macos.yml session e2e (Darwin: E2E_VM=1, no
-# E2E_MINIMAL_ARGS — macOS is always VM-backed) and ci-linux-kvm.yml session
-# e2e (Linux/DM3: E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd). The script isolates its
-# own XDG state under /tmp. Dep order matters: minvmd-build LAST, so its macOS
-# codesign is the final touch on the binary. Stranded VMs: `just reap`.
-e2e: artifacts gvproxy initramfs minimal-cli minvmd-build
-    #!/usr/bin/env sh
-    set -eu
-    export MINVMD_KERNEL_PATH="{{kernel}}" MINVMD_ROOTFS_PATH="{{rootfs}}"
-    export MINVMD_INITRAMFS="{{initramfs}}" MINVMD_BOOT_LOG="{{scratch}}/e2e-boot.log"
-    export MINVMD_GVPROXY_BIN="{{gvproxy}}"
-    export PATH="{{justfile_directory()}}/target/debug:$PATH"
-    case "$(uname -s)" in
-      Darwin)
-        E2E_VM=1 E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
-        ;;
-      Linux)
-        [ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "e2e (VM) needs writable /dev/kvm; try: sg kvm -c 'just e2e' — or use 'just e2e-native'" >&2; exit 1; }
-        export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-        # Same boot headroom as dm3: the generic guest kernel can spend 40-70s
-        # probing hardware before pid-1 starts, overrunning both the
-        # supervisor's 60s READY default and the CLI autospawn's 75s wait
-        # (the e2e's post-stop respawn proof autospawns via the CLI).
-        export MINVMD_READY_TIMEOUT_SECS="${MINVMD_READY_TIMEOUT_SECS:-150}"
-        export MINIMAL_SPAWN_TIMEOUT_SECS="${MINIMAL_SPAWN_TIMEOUT_SECS:-150}"
-        E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
-        ;;
-      *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
-    esac
-
-# The SAME session e2e against a host-native minimald (no VM; DM2 — the Linux
-# default run mode). CI parity: ci-linux-native.yml `native-daemon-e2e` —
-# combined minimald+min build, PATH prepend, no E2E_* env.
+# The SAME session e2e against a host-native minimald (no VM).
+# CI: ci-linux-native.yml `native-daemon-e2e`.
+[linux]
 e2e-native:
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Linux) ;;
-      *) echo "native-daemon e2e is Linux-only (minimald); SKIP on $(uname -s)"; exit 0 ;;
-    esac
-    # Build before the userns preflight so the advised --path target exists.
     cargo build -p minimald --bin minimald -p minimal --bin min --locked
-    # Ubuntu 24.04+ gates unprivileged userns behind AppArmor. The sanctioned
-    # fix is the per-binary profile the installer advises end users — it
-    # grants `userns` to minimald alone, where flipping the sysctl hands it
-    # back to everything on the host. Remediated = profile installed AND its
-    # tunables name THIS checkout's dev binary (the installer's own check);
-    # the sysctl stays 1 either way, so it alone can't be the gate.
-    v="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)"
-    bin="{{justfile_directory()}}/target/debug/minimald"
-    if [ "$v" != "0" ] && ! { [ -e /etc/apparmor.d/minimald ] && grep -rqs "$bin" /etc/apparmor.d/tunables 2>/dev/null; }; then
-      {
-        echo "note: this host restricts unprivileged user namespaces (Ubuntu 24.04+);"
-        echo "  minimald's session sandbox cannot start until you install its AppArmor"
-        echo "  profile — a one-time step that needs root:"
-        echo "      sudo scripts/install-apparmor-profile.sh --path $bin"
-        echo "  details: docs/reference/linux-host-setup.md"
-      } >&2
-      exit 1
-    fi
-    export PATH="{{justfile_directory()}}/target/debug:$PATH"
+    @just _userns-check
     ./scripts/session-e2e.sh
 
-# Supervised daemon lifecycle proof (run --detach → status Running → stop →
-# status Stopped). CI parity: ci-linux-kvm.yml `lifecycle`
-# (scripts/minvmd-lifecycle.sh); CI only schedules it on the KVM lane, but the
-# script is target-agnostic, so it runs here on both hosts. Like CI's
-# lifecycle step, this boots the VM switchless: MINVMD_GVPROXY_BIN is
-# deliberately NOT exported (CI's lifecycle runs before that lane fetches
-# gvproxy, so the switchless boot path is what it proves).
-test-lifecycle: artifacts initramfs minvmd-build
-    #!/usr/bin/env sh
-    set -eu
-    command -v jq >/dev/null 2>&1 || { echo "'jq' not found — install with: brew install jq (or apt install jq)" >&2; exit 1; }
-    export MINVMD_KERNEL_PATH="{{kernel}}" MINVMD_ROOTFS_PATH="{{rootfs}}"
-    export MINVMD_INITRAMFS="{{initramfs}}" MINVMD_BOOT_LOG="{{scratch}}/lifecycle-boot.log"
-    export XDG_STATE_HOME="{{scratch}}/test-state"
-    export PATH="{{justfile_directory()}}/target/debug:$PATH"
-    case "$(uname -s)" in
-      Linux)
-        [ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "test-lifecycle needs writable /dev/kvm; try: sg kvm -c 'just test-lifecycle'" >&2; exit 1; }
-        export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-        # Same boot headroom as dm3/e2e: on slower Linux hosts (nested KVM)
-        # the generic guest kernel can take 40-70s to reach pid-1, past the
-        # script's 30s default and the supervisor's 60s READY default.
-        export MINVMD_READY_TIMEOUT_SECS="${MINVMD_READY_TIMEOUT_SECS:-150}"
-        export MINVMD_LIFECYCLE_BOOT_TIMEOUT_SECS="${MINVMD_LIFECYCLE_BOOT_TIMEOUT_SECS:-150}"
-        ;;
-    esac
-    ./scripts/minvmd-lifecycle.sh
-
-# Nightly soak parity: N session-e2e repetitions (nightly-tests.yml
-# `session-e2e-soak` runs 10). The soak script reaps between iterations and on
-# exit via scripts/reap-vms.sh — scoped to this checkout's binaries, but it
-# WILL kill this repo's own live dev stack (e.g. from `just up`) each pass.
-soak n="10": artifacts gvproxy initramfs minimal-cli minvmd-build
-    #!/usr/bin/env sh
-    set -eu
-    export MINVMD_KERNEL_PATH="{{kernel}}" MINVMD_ROOTFS_PATH="{{rootfs}}"
-    export MINVMD_INITRAMFS="{{initramfs}}"
-    export MINVMD_GVPROXY_BIN="{{gvproxy}}"
-    export PATH="{{justfile_directory()}}/target/debug:$PATH"
-    export E2E_VM=1 E2E_PROJECT_DIR=/tmp
-    case "$(uname -s)" in
-      Darwin) ;;
-      Linux)
-        [ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "soak needs writable /dev/kvm; try: sg kvm -c 'just soak'" >&2; exit 1; }
-        export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-        export E2E_MINIMAL_ARGS=--minvmd
-        ;;
-      *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
-    esac
-    ./scripts/soak-session-e2e.sh {{n}} "{{scratch}}/soak-logs"
-
-# Kill stranded VM host processes (minvmd, __krun-vmm, gvproxy) after a failed
-# or interrupted harness run — leftovers wedge the next VM's vsock bridge.
-# Scoped to THIS checkout's binaries (path-anchored pkill), so other checkouts'
-# live VMs and unrelated gvproxies (e.g. podman's) are untouched. Needs
-# passwordless sudo for root-owned relay leftovers; without it, sudo -n fails
-# fast and user-owned processes still die.
-reap:
-    scripts/reap-vms.sh
-
-# ── DM1 / DM2 / DM3 deployment-model bring-up ────────────────────────────────
+# Boots switchless like CI's step — MINVMD_GVPROXY_BIN deliberately not set.
 #
-# DM1: macOS (Apple Silicon) host + Linux VM(s) over Hypervisor.framework. This
-#      is the primary bring-up on macOS; on Linux it is a clean SKIP (use `dm3`
-#      for the native-Linux + VM equivalent over KVM).
-# DM2: native Linux, a host-native `minimald` (no VM), reachable over UDS at
-#      providers/local-0/ssh.sock — the same path the `min` CLI dials, so no
-#      bridge is needed. Own-IP is rootless (hakoniwa RustSlirp builds the tap
-#      inside the sandbox's own user+net namespace — no setcap).
-# DM3: native Linux + one Linux VM (minimald as initramfs pid-1 in libkrun). The
-#      Linux CLI dials providers/local-0/ssh.sock, which minvmd binds directly
-#      (the socket/path coordination fix, #690) — no bridge/symlink needed. Run
-#      under `sg kvm` if the shell lacks the kvm group.
+# Daemon lifecycle proof (run --detach → Running → stop → Stopped). CI: `lifecycle`.
+test-lifecycle: (_need "jq" "brew install jq (or apt install jq)") _kvm artifacts initramfs minvmd-build
+    XDG_STATE_HOME="{{scratch}}/test-state" ./scripts/minvmd-lifecycle.sh
 
-# Bring the stack up for THIS host's DEFAULT run mode — the `just up` the docs
-# reference (CONTRIBUTING.md, docs/ci-strategy.md §8/§10). macOS → dm1 (VM over
-# HVF is the only macOS mode); Linux → dm2 (native minimald is the default run
-# mode on Linux — use `just dm3` explicitly for the VM/KVM stack).
-up:
+# Reaps between iterations — this WILL kill this checkout's live dev stack each pass.
+#
+# Nightly soak parity: N session-e2e reps (nightly-tests.yml runs 10).
+soak n="10": _kvm artifacts gvproxy initramfs minimal-cli minvmd-build
+    {{e2e-env}} MINVMD_GVPROXY_BIN="{{gvproxy}}" ./scripts/soak-session-e2e.sh {{n}} "{{scratch}}/soak-logs"
+
+# ── stack bring-up ───────────────────────────────────────────────────────────
+#
+# `just up` = this host's default run mode; `just down` stops it.
+#   macOS: Linux VM over Hypervisor.framework (the only macOS mode).
+#   Linux: host-native minimald, no VM. `just up-kvm`: Linux + VM over KVM.
+# The CLI dials providers/local-0/ssh.sock in every mode; minvmd binds it
+# directly (#690), so no bridge is needed.
+
+# The daemon can reset the very first connect after boot/bind; retry briefly.
+_smoke *args:
     #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Darwin) exec just dm1 ;;
-      Linux)  exec just dm2 ;;
-      *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
-    esac
-
-# On Linux this is a clean SKIP (use `dm3`). min auto-spawns `minvmd run
-# --detach`, so minvmd must be on PATH and the MINVMD_* artifact paths exported —
-# both are set here and inherited by the detached supervisor.
-
-# DM1 — macOS host + Linux VM over Hypervisor.framework: bring the full stack up.
-dm1:
-    #!/usr/bin/env sh
-    set -eu
-    case "$(uname -s)" in
-      Darwin) ;;
-      *) echo "DM1 needs macOS (Hypervisor.framework). SKIP on $(uname -s); use 'just dm3' for native Linux + VM over KVM." ; exit 0 ;;
-    esac
-    echo "DM1 (macOS + Linux VM over HVF): bringing the stack up."
-    just artifacts gvproxy initramfs minvmd-build minimal-cli
-    export MINVMD_KERNEL_PATH="{{kernel}}"
-    export MINVMD_ROOTFS_PATH="{{rootfs}}"
-    export MINVMD_INITRAMFS="{{initramfs}}"
-    export MINVMD_BOOT_LOG="{{scratch}}/boot.log"
-    # Host gvproxy switch: minvmd spawns it for guest egress (root netns + own-IP
-    # PTasks). Best-effort — skipped if the binary is absent.
-    export MINVMD_GVPROXY_BIN="{{gvproxy}}"
-    export PATH="{{justfile_directory()}}/target/debug:$PATH"
-    "{{min-bin}}" ls
-
-# Build a host-native (glibc) minimald WITH the networking features, for DM2.
-minimald-build:
-    cargo build -p minimald --features {{features}}
-
-# DM3 — native Linux + one Linux VM. Boots the VM; minvmd binds the CLI socket.
-dm3: artifacts gvproxy initramfs minvmd-build minimal-cli
-    #!/usr/bin/env sh
-    set -eu
-    [ -e /dev/kvm ] || { echo "DM3 needs /dev/kvm (KVM host)"; exit 1; }
-    [ -w /dev/kvm ] || { echo "DM3: /dev/kvm not writable here; retry: sg kvm -c 'just dm3'"; exit 1; }
-    export MINVMD_KERNEL_PATH="{{kernel}}" MINVMD_ROOTFS_PATH="{{rootfs}}"
-    export MINVMD_INITRAMFS="{{initramfs}}" MINVMD_BOOT_LOG="{{scratch}}/boot.log"
-    export MINVMD_GVPROXY_BIN="{{gvproxy}}"
-    export PATH="{{justfile_directory()}}/target/debug:$PATH"
-    export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-    # Boot the VM explicitly (the CLI's autospawn would also work, but an
-    # explicit boot keeps ordering clear and lets us raise the READY timeout).
-    # The generic guest kernel can spend 40-50s probing hardware before pid-1
-    # (minimald) even starts, which overruns minvmd's 60s READY default on a
-    # cold boot; give it headroom (overridable by the caller).
-    export MINVMD_READY_TIMEOUT_SECS="${MINVMD_READY_TIMEOUT_SECS:-150}"
-    "{{minvmd-bin}}" run --detach --timeout 75
-    # No socket bridge: since the socket/path coordination fix (#690) minvmd binds
-    # the CLI-facing <state>/providers/local-0/ssh.sock directly — exactly the path
-    # the `minimal` CLI dials. (The old `ln -sf` from a runtime-dir socket clobbered
-    # minvmd's own live socket, so every dial fell through to a failing autospawn.)
-    echo "DM3 up: VM booted; minimald reachable at providers/local-0/ssh.sock"
-    # The guest SSH server can reset the very first connect right after boot, so
-    # retry briefly rather than fail the recipe on that one-shot race.
-    ok=0
-    for _ in $(seq 1 5); do
-      if "{{min-bin}}" ls; then ok=1; break; fi
+    for _ in 1 2 3 4 5; do
+      MINVMD_GVPROXY_BIN="{{gvproxy}}" "{{min-bin}}" {{args}} ls && exit 0
       sleep 2
     done
-    [ "$ok" = 1 ] || { echo "DM3: min ls failed after retries" >&2; exit 1; }
+    echo "min ls failed after retries" >&2; exit 1
 
-# DM2 — native Linux, host-native minimald (no VM) over UDS. Runs minimald under
-# a dedicated state dir; the CLI reaches it with `--minimal-dir`, which (via the
-# autospawn gate) connects directly instead of booting a VM.
-dm2: minimald-build minimal-cli gvproxy
+# Bring the stack up: Linux VM over Hypervisor.framework (`min ls` autospawns minvmd).
+[macos]
+up: artifacts gvproxy initramfs minvmd-build minimal-cli && (_smoke)
+
+# Bring the stack up: host-native minimald, no VM (`just up-kvm` for the VM stack).
+[linux]
+up: minimald-build minimal-cli gvproxy && (_smoke "--minimal-dir" native-dir)
     #!/usr/bin/env sh
     set -eu
-    dir="{{scratch}}/dm2-state"
-    sock="$dir/providers/local-0/ssh.sock"
-    pidf="{{scratch}}/dm2-minimald.pid"
-    bin="{{justfile_directory()}}/target/debug/minimald"
-    mkdir -p "$dir"
-    # Own-IP is rootless: hakoniwa's RustSlirp builds each PTask's tap inside the
-    # sandbox's own user+net namespace, so the daemon needs no `setcap` / elevated
-    # privilege. (It does need an unprivileged-user-namespace-capable host.)
+    sock="{{native-dir}}/providers/local-0/ssh.sock"
+    pidf="{{scratch}}/minimald.pid"
+    mkdir -p "{{native-dir}}"
     if [ -S "$sock" ] && [ -f "$pidf" ] && kill -0 "$(cat "$pidf")" 2>/dev/null; then
-      echo "DM2 minimald already up: $sock"
+      echo "native minimald already up: $sock"
     else
-      # --gvproxy-bin points the per-host OwnIp switch at the pinned local gvproxy,
-      # so no system install (/usr/lib/minimal/bin/gvproxy) is required.
-      setsid "$bin" \
-        --minimal-state-dir "$dir" --minimal-cache-dir "$dir/cache" \
-        run --instance-num 0 --gvproxy-bin "{{gvproxy}}" > {{scratch}}/dm2-minimald.log 2>&1 &
+      setsid "{{minimald-bin}}" \
+        --minimal-state-dir "{{native-dir}}" --minimal-cache-dir "{{native-dir}}/cache" \
+        run --instance-num 0 --gvproxy-bin "{{gvproxy}}" > "{{scratch}}/minimald.log" 2>&1 &
       echo $! > "$pidf"
       for _ in $(seq 1 50); do [ -S "$sock" ] && break; sleep 0.1; done
     fi
-    [ -S "$sock" ] || { echo "DM2 minimald failed to bind $sock; see {{scratch}}/dm2-minimald.log" >&2; exit 1; }
-    echo "DM2 up: host-native minimald at $sock (pid $(cat "$pidf"))"
-    echo "  own-IP: {{min-bin}} --minimal-dir $dir activate -n net1 --network own-ip . && \\"
-    echo "          {{min-bin}} --minimal-dir $dir attach net1   # curl http://example.com -> 200"
-    # Warn-only twin of the e2e-native preflight: the daemon runs fine without
-    # it, but every `activate` sandbox will die at uid_map with EPERM until the
-    # profile is in (see that recipe's comment for the remediation logic).
-    v="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)"
-    if [ "$v" != "0" ] && ! { [ -e /etc/apparmor.d/minimald ] && grep -rqs "$bin" /etc/apparmor.d/tunables 2>/dev/null; }; then
-      {
-        echo "note: this host restricts unprivileged user namespaces (Ubuntu 24.04+);"
-        echo "  minimald's session sandbox cannot start until you install its AppArmor"
-        echo "  profile — a one-time step that needs root:"
-        echo "      sudo scripts/install-apparmor-profile.sh --path $bin"
-        echo "  details: docs/reference/linux-host-setup.md"
-      } >&2
-    fi
-    # Same first-connect retry as dm3: minimald can reset the very first SSH
-    # connect right after binding the socket, which trips the CLI's autospawn
-    # (and fails the recipe) even though the daemon is healthy.
-    ok=0
-    for _ in $(seq 1 5); do
-      if "{{min-bin}}" --minimal-dir "$dir" ls; then ok=1; break; fi
-      sleep 2
-    done
-    [ "$ok" = 1 ] || { echo "DM2: min ls failed after retries; see {{scratch}}/dm2-minimald.log" >&2; exit 1; }
+    [ -S "$sock" ] || { echo "minimald failed to bind $sock; see {{scratch}}/minimald.log" >&2; exit 1; }
+    # Warn-only: the daemon runs without the AppArmor profile, but every
+    # `activate` sandbox dies at uid_map EPERM until it's installed.
+    just _userns-check || true
+    echo "up: host-native minimald at $sock (pid $(cat "$pidf"))"
+    echo "  own-IP demo: min --minimal-dir {{native-dir}} activate -n net1 --network own-ip . && min --minimal-dir {{native-dir}} attach net1"
 
-# Stop the DM2 host-native minimald.
-dm2-down:
+# Bring the stack up: native Linux + one Linux VM over KVM (stop with `just stop`).
+[linux]
+up-kvm: _kvm artifacts gvproxy initramfs minvmd-build minimal-cli && (_smoke)
+    MINVMD_GVPROXY_BIN="{{gvproxy}}" "{{minvmd-bin}}" run --detach --timeout 75
+    @echo "up-kvm: VM booted; minimald reachable at providers/local-0/ssh.sock"
+
+# Stop the stack `just up` started.
+[macos]
+down: stop
+
+# Stop the stack `just up` started (the host-native minimald).
+[linux]
+down:
     #!/usr/bin/env sh
     set -eu
-    pidf="{{scratch}}/dm2-minimald.pid"
-    [ -f "$pidf" ] || { echo "no DM2 minimald running"; exit 0; }
+    pidf="{{scratch}}/minimald.pid"
+    [ -f "$pidf" ] || { echo "no native minimald running"; exit 0; }
     pid="$(cat "$pidf")"; kill "$pid" 2>/dev/null || true
     for _ in $(seq 1 30); do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done
     kill -9 "$pid" 2>/dev/null || true; rm -f "$pidf"
-    echo "DM2 minimald stopped (pid $pid)"
+    echo "native minimald stopped (pid $pid)"
+
+# Ubuntu 24.04+ gates unprivileged userns behind AppArmor. The fix is the
+# installer's per-binary profile (grants userns to minimald ALONE — flipping
+# the sysctl hands it to everything). Details: docs/reference/linux-host-setup.md.
+[linux]
+_userns-check:
+    #!/usr/bin/env sh
+    set -eu
+    if [ "$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)" = "0" ]; then exit 0; fi
+    if [ -e /etc/apparmor.d/minimald ] && grep -rqs "{{minimald-bin}}" /etc/apparmor.d/tunables 2>/dev/null; then exit 0; fi
+    echo "note: this host restricts unprivileged user namespaces (Ubuntu 24.04+);" >&2
+    echo "  minimald's session sandbox cannot start until its AppArmor profile is" >&2
+    echo "  installed — a one-time step that needs root:" >&2
+    echo "      sudo scripts/install-apparmor-profile.sh --path {{minimald-bin}}" >&2
+    exit 1

--- a/justfile
+++ b/justfile
@@ -121,13 +121,13 @@ minimal-cli:
 # Build a host-native (glibc) minimald with the networking features (for `just up`).
 [linux]
 minimald-build:
-    cargo build -p minimald --features {{features}}
+    cargo build -p minimald --features {{features}} --locked
 
 # ── run & inspect ────────────────────────────────────────────────────────────
 
 # Run the dev-built `min` CLI, args forwarded (e.g. `just min loadout list`).
 min *args:
-    @cargo build {{ if os() == "macos" { "-p minimal" } else { "-p minimal -p minimald" } }}
+    @cargo build {{ if os() == "macos" { "-p minimal" } else { "-p minimal -p minimald" } }} --locked
     @"{{min-bin}}" {{args}}
 
 # Print `export` lines for running the stack by hand: eval "$(just env)".

--- a/justfile
+++ b/justfile
@@ -470,9 +470,26 @@ e2e-native:
       Linux) ;;
       *) echo "native-daemon e2e is Linux-only (minimald); SKIP on $(uname -s)"; exit 0 ;;
     esac
-    v="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)"
-    [ "$v" = "0" ] || { echo "unprivileged userns is restricted; run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0" >&2; exit 1; }
+    # Build before the userns preflight so the advised --path target exists.
     cargo build -p minimald --bin minimald -p minimal --bin min --locked
+    # Ubuntu 24.04+ gates unprivileged userns behind AppArmor. The sanctioned
+    # fix is the per-binary profile the installer advises end users — it
+    # grants `userns` to minimald alone, where flipping the sysctl hands it
+    # back to everything on the host. Remediated = profile installed AND its
+    # tunables name THIS checkout's dev binary (the installer's own check);
+    # the sysctl stays 1 either way, so it alone can't be the gate.
+    v="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)"
+    bin="{{justfile_directory()}}/target/debug/minimald"
+    if [ "$v" != "0" ] && ! { [ -e /etc/apparmor.d/minimald ] && grep -rqs "$bin" /etc/apparmor.d/tunables 2>/dev/null; }; then
+      {
+        echo "note: this host restricts unprivileged user namespaces (Ubuntu 24.04+);"
+        echo "  minimald's session sandbox cannot start until you install its AppArmor"
+        echo "  profile — a one-time step that needs root:"
+        echo "      sudo scripts/install-apparmor-profile.sh --path $bin"
+        echo "  details: docs/reference/linux-host-setup.md"
+      } >&2
+      exit 1
+    fi
     export PATH="{{justfile_directory()}}/target/debug:$PATH"
     ./scripts/session-e2e.sh
 
@@ -652,6 +669,19 @@ dm2: minimald-build minimal-cli gvproxy
     echo "DM2 up: host-native minimald at $sock (pid $(cat "$pidf"))"
     echo "  own-IP: {{min-bin}} --minimal-dir $dir activate -n net1 --network own-ip . && \\"
     echo "          {{min-bin}} --minimal-dir $dir attach net1   # curl http://example.com -> 200"
+    # Warn-only twin of the e2e-native preflight: the daemon runs fine without
+    # it, but every `activate` sandbox will die at uid_map with EPERM until the
+    # profile is in (see that recipe's comment for the remediation logic).
+    v="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)"
+    if [ "$v" != "0" ] && ! { [ -e /etc/apparmor.d/minimald ] && grep -rqs "$bin" /etc/apparmor.d/tunables 2>/dev/null; }; then
+      {
+        echo "note: this host restricts unprivileged user namespaces (Ubuntu 24.04+);"
+        echo "  minimald's session sandbox cannot start until you install its AppArmor"
+        echo "  profile — a one-time step that needs root:"
+        echo "      sudo scripts/install-apparmor-profile.sh --path $bin"
+        echo "  details: docs/reference/linux-host-setup.md"
+      } >&2
+    fi
     # Same first-connect retry as dm3: minimald can reset the very first SSH
     # connect right after binding the socket, which trips the CLI's autospawn
     # (and fails the recipe) even though the daemon is healthy.

--- a/justfile
+++ b/justfile
@@ -2,7 +2,12 @@
 #
 # Recipes are grouped by crate where they're crate-specific.
 
-scratch     := justfile_directory() / ".scratch"
+# The -rel twins are repo-relative because the shim-VM materialize (see
+# `artifacts`) can only write outputs back through repo-relative paths; the
+# absolute forms are derived from them so guard, write, and consumers can
+# never disagree.
+scratch-rel := ".scratch"
+scratch     := justfile_directory() / scratch-rel
 # Host CPU arch — drives the materialized guest artifacts and the musl target.
 # aarch64 on Apple Silicon; x86_64 on most Linux hosts.
 arch        := arch()
@@ -13,8 +18,10 @@ krun-prefix := env_var('HOME') / ".krun"
 # reverse proxy (mTLS). The WireGuard mesh peer (networking-wg) is disabled for
 # now (UC7 / UC2b-A deferred).
 features    := "networking-proxy"
-kernel      := scratch / "vmlinuz"
-rootfs      := scratch / "rootfs.img"
+kernel-rel  := scratch-rel / "vmlinuz"
+rootfs-rel  := scratch-rel / "rootfs.img"
+kernel      := justfile_directory() / kernel-rel
+rootfs      := justfile_directory() / rootfs-rel
 initramfs   := scratch / "initramfs.cpio"
 gvproxy     := scratch / "gvproxy"
 minvmd-bin  := justfile_directory() / "target/debug/minvmd"
@@ -50,8 +57,9 @@ codesign-minvmd:
 # See crates/minvmd/README.md for the manual equivalent.
 
 # macOS: via the `minimal` SHIM (~/.minimal/shim/bin/minimal — runs the CLI in a
-# VM; --output must stay under the repo). Distinct from the `min` binary this
-# repo builds. Linux: via fetch-artifact.sh (builds `mip` from source).
+# VM; --output must be a repo-RELATIVE path, see the recipe). Distinct from the
+# `min` binary this repo builds. Linux: via fetch-artifact.sh (builds `mip` from
+# source).
 
 # Materialize the guest kernel + generic rootfs into .scratch. Skips a fetch when
 # the artifact already exists; `just clean` first to force a refresh.
@@ -62,6 +70,10 @@ artifacts:
     # `minimal materialize` runs in a VM via the shim; on a cold cache its
     # overlay-sync can transiently drop the output ("copying output file I/O
     # error … No such file or directory"). Retry a few times before failing.
+    #
+    # The --output path MUST be repo-RELATIVE: outputs come back to the host
+    # via the project-dir sync overlay, and an absolute path — even one under
+    # the repo — reliably fails the copy-out with the same I/O error.
     materialize() {
       n=0
       until minimal materialize --output "$1" --arch "$2" "$3"; do
@@ -74,8 +86,18 @@ artifacts:
     }
     case "$(uname -s)" in
       Darwin)
-        [ -f {{kernel}} ] || materialize {{kernel}} {{arch}} virtio-kernel
-        [ -f {{rootfs}} ] || materialize {{rootfs}} {{arch}} minvmd-rootfs
+        # Both artifacts present — nothing to fetch, so don't demand the shim.
+        [ -f {{kernel}} ] && [ -f {{rootfs}} ] && exit 0
+        # Resolve the shim: PATH first, then its install location — a dev
+        # shell without ~/.minimal/shim/bin on PATH shouldn't fail here.
+        if command -v minimal >/dev/null 2>&1; then :; elif [ -x "$HOME/.minimal/shim/bin/minimal" ]; then
+          PATH="$HOME/.minimal/shim/bin:$PATH"
+        else
+          echo "the \`minimal\` shim is required (not on PATH, not at ~/.minimal/shim/bin/minimal); see the bring-up prereqs above" >&2
+          exit 1
+        fi
+        [ -f {{kernel}} ] || materialize {{kernel-rel}} {{arch}} virtio-kernel
+        [ -f {{rootfs}} ] || materialize {{rootfs-rel}} {{arch}} minvmd-rootfs
         ;;
       Linux)
         [ -f {{kernel}} ] || scripts/fetch-artifact.sh virtio-kernel {{kernel}} {{arch}}
@@ -120,24 +142,27 @@ minvmd-build: libkrun
     set -eu
     case "$(uname -s)" in
       Darwin)
-        cargo build -p minvmd --bin minvmd
+        cargo build -p minvmd --bin minvmd --locked
         codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - {{minvmd-bin}}
         ;;
       Linux)
         export LIBKRUN_PREFIX="{{krun-prefix}}"
         export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-        cargo build -p minvmd --bin minvmd
+        cargo build -p minvmd --bin minvmd --locked
         ;;
       *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
     esac
 
 # Build the `min` CLI (from the `minimal` crate; its [[bin]] target is `min`).
 minimal-cli:
-    cargo build -p minimal
+    cargo build -p minimal --locked
 
 # Run the `min` CLI against the workspace's own debug build. Prepends
 # `target/debug/` to `$PATH` so `min`'s auto-spawn can find the sibling
-# `minimald` binary (it invokes it by name). Arguments after `just min` are
+# daemon binary (it invokes it by name). On Linux that sibling is minimald;
+# on macOS minimald doesn't compile natively (hakoniwa/procfs are Linux-only)
+# and the daemon is minvmd-hosted anyway, so only the CLI is built (use
+# `just up` for the full VM bring-up). Arguments after `just min` are
 # forwarded verbatim.
 #
 # Example:
@@ -145,7 +170,12 @@ minimal-cli:
 #   just min loadout list
 #   just min dirs
 min *args:
-    cargo build -p minimal -p minimald
+    #!/usr/bin/env sh
+    set -eu
+    case "$(uname -s)" in
+      Darwin) cargo build -p minimal ;;
+      *)      cargo build -p minimal -p minimald ;;
+    esac
     PATH="{{justfile_directory()}}/target/debug:$PATH" "{{min-bin}}" {{args}}
 
 # Print `export` lines wiring the dev-built binaries and guest artifacts into
@@ -205,6 +235,296 @@ test-installer:
         SH="$sh" "$sh" scripts/install_test.sh
     done
 
+# ── CI-parity gates & test surfaces ──────────────────────────────────────────
+#
+# Local entry points for the same checks CI runs (docs/ci-strategy.md §8: the
+# workflows are a thin frozen scheduler; the justfile + scripts/ are the
+# reviewed logic). Each recipe's comment names its CI counterpart so parity is
+# reviewable. OS dispatch follows the lanes: Linux gets the native/KVM
+# surfaces, macOS the ci-macos ones plus cross-compiled (Docker) coverage of
+# the Linux-only crates.
+
+# Fail fast with an install hint when a required tool is missing.
+_need tool hint:
+    @command -v {{tool}} >/dev/null 2>&1 || { echo "'{{tool}}' not found — install with: {{hint}}" >&2; exit 1; }
+
+# Apply rustfmt across the workspace (the fixer for a red `just fmt-check`).
+fmt:
+    cargo fmt --all
+
+# CI parity: ci.yml `fmt`.
+fmt-check:
+    cargo fmt --all -- --check
+
+# CI parity: ci.yml `clippy` (Linux, workspace-wide). On macOS the workspace
+# doesn't compile natively (minimald/lcache/mctx are Linux-only), so mirror
+# ci-macos.yml `unit` (-p minvmd); `just test-cross` covers the Linux-only
+# crates from a Mac.
+clippy:
+    #!/usr/bin/env sh
+    set -eu
+    case "$(uname -s)" in
+      Darwin) cargo clippy -p minvmd --all-targets --locked -- -D warnings ;;
+      *)      cargo clippy --workspace --all-targets --locked -- -D warnings ;;
+    esac
+
+# CI parity: ci.yml `cargo-deny` (the EmbarkStudios action defaults to
+# `cargo deny --all-features check`: advisories/bans/licenses/sources over the
+# full feature graph, config deny.toml). A local advisories failure may just
+# mean newer RUSTSEC data than CI's last run; nightly re-checks advisories
+# blocking.
+deny: (_need "cargo-deny" "cargo install cargo-deny --locked")
+    cargo deny --all-features check
+
+# Unit + in-process integration tests.
+# CI parity: the core-tests composite on ci-linux-native.yml `tests` — the
+# Linux branch is its exact command (--profile ci: fail-fast off, slow tests
+# killed at 5x60s, junit to target/nextest/ci/junit.xml). On macOS this
+# mirrors ci-macos.yml `unit` (-p minvmd -p sessions via nextest; the
+# workspace is uncompilable there, and that job has no nextest profile) — run
+# `just test-cross` for the Linux-only crates. Locally-runnable #[ignore]
+# tests are a separate surface: `just test-ignored`.
+test: (_need "cargo-nextest" "cargo install cargo-nextest --locked")
+    #!/usr/bin/env sh
+    set -eu
+    case "$(uname -s)" in
+      Darwin) cargo nextest run -p minvmd -p sessions --locked --no-tests=fail ;;
+      *)      cargo nextest run --workspace --locked --profile ci --no-tests=fail ;;
+    esac
+
+# The ungated #[ignore] tests — ignored only because GitHub runners can't run
+# them (e.g. mctx's layer-init/build proofs need nested user namespaces,
+# minimald's git_receive_pack proof), i.e. MEANT to be run on a dev machine.
+# This is the surface `cargo test -- --include-ignored` used to cover in the
+# pre-PR flow; no CI lane runs these, so a local run is the only gate. The
+# env-gated VM/netns harnesses also match --run-ignored but self-skip without
+# their MINVMD_E2E / MINIMALD_NETNS_TEST env (use `just test-vm` /
+# `just test-root-integration` to actually run those). Linux-only: the crates
+# carrying these tests don't compile natively on macOS.
+test-ignored:
+    #!/usr/bin/env sh
+    set -eu
+    case "$(uname -s)" in
+      Linux) ;;
+      *) echo "test-ignored is Linux-only (mctx/minimald don't compile natively here); SKIP on $(uname -s)"; exit 0 ;;
+    esac
+    command -v cargo-nextest >/dev/null 2>&1 || { echo "'cargo-nextest' not found — install with: cargo install cargo-nextest --locked" >&2; exit 1; }
+    cargo nextest run --workspace --locked --profile ci --run-ignored ignored-only --no-tests=fail
+
+# The Linux-crate surface from a macOS host: clippy + tests for every
+# workspace crate except minvmd (libkrun linkage), cross-compiled to musl in
+# Docker. This is the local stand-in for what the Linux lanes check natively —
+# including minimald, which cannot compile on darwin. The container has no
+# HOME, which breaks env::tests — hence HOME=/tmp.
+#
+# COST WARNING: the first run compiles the whole workspace for {{musl-target}}
+# inside the container, and nickel-lang-parser's LALRPOP build script may run
+# under CPU emulation — that first build can take an hour or more. Later runs
+# reuse target/{{musl-target}} and are incremental. On Linux this is a clean
+# SKIP: the native `just test`/`just clippy` already cover the workspace.
+test-cross:
+    #!/usr/bin/env sh
+    set -eu
+    case "$(uname -s)" in
+      Darwin) ;;
+      *) echo "test-cross is for macOS hosts; native 'just test' covers the workspace here. SKIP"; exit 0 ;;
+    esac
+    command -v cross >/dev/null 2>&1 || { echo "'cross' not found — install with: cargo install cross --locked" >&2; exit 1; }
+    docker info >/dev/null 2>&1 || { echo "docker daemon not running (cross needs it) — start Docker Desktop or OrbStack" >&2; exit 1; }
+    cross clippy --workspace --exclude minvmd --all-targets --target {{musl-target}} --locked -- -D warnings
+    CROSS_CONTAINER_OPTS="--env HOME=/tmp" cross test --workspace --exclude minvmd --target {{musl-target}} --locked
+
+# Doctests — nextest can't run them, so they are their own surface, exactly as
+# CI treats them. CI parity: core-tests composite (`cargo test --workspace
+# --doc --locked`); macOS covers the doc tests of the crates its unit lane
+# tests.
+doctest:
+    #!/usr/bin/env sh
+    set -eu
+    case "$(uname -s)" in
+      Darwin) cargo test -p minvmd -p sessions --doc --locked ;;
+      *)      cargo test --workspace --doc --locked ;;
+    esac
+
+# The PR gate set, locally: quick gates (ci.yml fmt/clippy/cargo-deny) + core
+# tests (nextest + doctests) + the locally-runnable #[ignore] tests (Linux;
+# clean SKIP on macOS), cheapest first. On macOS add `just test-cross` when
+# touching the Linux-only crates. Deliberately NOT replicated: commitlint
+# (needs node + the PR commit range — docs/commit-conventions.md), the
+# dogfood/minimal-check jobs (released-binary-vs-repo-config checks), and the
+# path-filtered installer lane (`just test-installer` when touching
+# scripts/install*).
+ci: fmt-check clippy deny test doctest test-ignored
+    @echo "ci: local PR gates green"
+
+# minvmd's VM integration harnesses (crates/minvmd/tests/*_integration.rs).
+# CI parity: ci-linux-kvm.yml `test-kvm` / ci-macos.yml `e2e` — the same
+# `-p minvmd` scope those lanes archive, same filtersets, --profile vm,
+# --run-ignored all, --no-tests=fail. The §10 suffix convention selects
+# WITHIN that scope: a `*_integration.rs` harness in another crate is not
+# picked up here or by the CI VM lanes today. XDG_STATE_HOME is isolated to
+# .scratch so harness-spawned daemons can't clobber the real
+# ~/.local/state/minimal. Stranded VMs after a failed run: `just reap`.
+test-vm: (_need "cargo-nextest" "cargo install cargo-nextest --locked") artifacts gvproxy initramfs libkrun
+    #!/usr/bin/env sh
+    set -eu
+    export MINVMD_E2E=1 MINVMD_BIN="{{minvmd-bin}}"
+    export MINVMD_KERNEL_PATH="{{kernel}}" MINVMD_ROOTFS_PATH="{{rootfs}}"
+    export MINVMD_INITRAMFS="{{initramfs}}" MINVMD_BOOT_LOG="{{scratch}}/boot.log"
+    export XDG_STATE_HOME="{{scratch}}/test-state"
+    case "$(uname -s)" in
+      Darwin)
+        # CI's archive pattern, for the same reason CI uses it: build
+        # EVERYTHING first, codesign minvmd as the last touch (any later cargo
+        # invocation with minvmd in its build graph relinks it → entitlement
+        # lost → EINVAL from krun_start_enter), then run from the archive,
+        # which never rebuilds.
+        cargo nextest archive -p minvmd --locked --archive-file "{{scratch}}/nextest-archive.tar.zst"
+        cargo build -p minvmd --bin minvmd --locked
+        cargo build -p minimal --bin min --locked
+        # Resolve the FFI-smoke binary from cargo itself (an mtime-sorted ls
+        # can pick a stale binary from an abandoned build config), and do it
+        # BEFORE codesign — it is the last cargo invocation allowed.
+        testbin="$(cargo test -p minvmd --test krun_smoke_integration --no-run --locked --message-format=json 2>/dev/null \
+          | sed -n 's/.*"executable":"\([^"]*krun_smoke_integration[^"]*\)".*/\1/p' | head -1)"
+        [ -n "$testbin" ] && [ -x "$testbin" ] || { echo "krun_smoke_integration test binary not resolved via cargo" >&2; exit 1; }
+        codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - "{{minvmd-bin}}"
+        # FFI smoke (ci-macos.yml): boots libkrun IN-PROCESS from the
+        # (unsigned) test binary, so it must run kernel-less and be invoked
+        # directly — never via cargo (relink) and never from the filterset.
+        env -u MINVMD_KERNEL_PATH -u MINVMD_ROOTFS_PATH -u MINVMD_INITRAMFS \
+          "$testbin" --include-ignored --nocapture
+        cargo-nextest nextest run --archive-file "{{scratch}}/nextest-archive.tar.zst" \
+          --workspace-remap "{{justfile_directory()}}" --profile vm \
+          --run-ignored all --no-tests=fail \
+          -E 'binary(/_integration$/) and not binary(/_root_integration$/) and not binary(krun_smoke_integration)'
+        ;;
+      Linux)
+        [ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "test-vm needs writable /dev/kvm; try: sg kvm -c 'just test-vm'" >&2; exit 1; }
+        export LIBKRUN_PREFIX="{{krun-prefix}}"
+        export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        cargo build -p minvmd --bin minvmd --locked
+        cargo nextest run -p minvmd --profile vm --run-ignored all --no-tests=fail \
+          -E 'binary(/_integration$/) and not binary(/_root_integration$/)'
+        ;;
+      *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
+    esac
+
+# minimald root-integration proofs (netns/tap via gvproxy; no KVM needed).
+# CI parity: ci-linux-native.yml `minimald-root-integration` — same env,
+# profile, and filterset; the tests sudo their own tap/netns commands.
+test-root-integration:
+    #!/usr/bin/env sh
+    set -eu
+    case "$(uname -s)" in
+      Linux) ;;
+      *) echo "root-integration is Linux-only (netns/CAP_NET_ADMIN); SKIP on $(uname -s)"; exit 0 ;;
+    esac
+    command -v cargo-nextest >/dev/null 2>&1 || { echo "'cargo-nextest' not found — install with: cargo install cargo-nextest --locked" >&2; exit 1; }
+    # Ubuntu 24.04+ gates unprivileged userns behind apparmor; CI flips it too.
+    v="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)"
+    [ "$v" = "0" ] || { echo "unprivileged userns is restricted; run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0" >&2; exit 1; }
+    just gvproxy
+    MINIMALD_NETNS_TEST=1 GVPROXY_BIN="{{gvproxy}}" \
+      cargo nextest run -p minimald --profile ci --run-ignored all --no-tests=fail \
+      -E 'binary(/_root_integration$/)'
+
+# The unified session e2e (scripts/session-e2e.sh) against this host's
+# VM-backed daemon. CI parity: ci-macos.yml session e2e (Darwin: E2E_VM=1, no
+# E2E_MINIMAL_ARGS — macOS is always VM-backed) and ci-linux-kvm.yml session
+# e2e (Linux/DM3: E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd). The script isolates its
+# own XDG state under /tmp. Dep order matters: minvmd-build LAST, so its macOS
+# codesign is the final touch on the binary. Stranded VMs: `just reap`.
+e2e: artifacts gvproxy initramfs minimal-cli minvmd-build
+    #!/usr/bin/env sh
+    set -eu
+    export MINVMD_KERNEL_PATH="{{kernel}}" MINVMD_ROOTFS_PATH="{{rootfs}}"
+    export MINVMD_INITRAMFS="{{initramfs}}" MINVMD_BOOT_LOG="{{scratch}}/e2e-boot.log"
+    export MINVMD_GVPROXY_BIN="{{gvproxy}}"
+    export PATH="{{justfile_directory()}}/target/debug:$PATH"
+    case "$(uname -s)" in
+      Darwin)
+        E2E_VM=1 E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
+        ;;
+      Linux)
+        [ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "e2e (VM) needs writable /dev/kvm; try: sg kvm -c 'just e2e' — or use 'just e2e-native'" >&2; exit 1; }
+        export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
+        ;;
+      *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
+    esac
+
+# The SAME session e2e against a host-native minimald (no VM; DM2 — the Linux
+# default run mode). CI parity: ci-linux-native.yml `native-daemon-e2e` —
+# combined minimald+min build, PATH prepend, no E2E_* env.
+e2e-native:
+    #!/usr/bin/env sh
+    set -eu
+    case "$(uname -s)" in
+      Linux) ;;
+      *) echo "native-daemon e2e is Linux-only (minimald); SKIP on $(uname -s)"; exit 0 ;;
+    esac
+    v="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)"
+    [ "$v" = "0" ] || { echo "unprivileged userns is restricted; run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0" >&2; exit 1; }
+    cargo build -p minimald --bin minimald -p minimal --bin min --locked
+    export PATH="{{justfile_directory()}}/target/debug:$PATH"
+    ./scripts/session-e2e.sh
+
+# Supervised daemon lifecycle proof (run --detach → status Running → stop →
+# status Stopped). CI parity: ci-linux-kvm.yml `lifecycle`
+# (scripts/minvmd-lifecycle.sh); CI only schedules it on the KVM lane, but the
+# script is target-agnostic, so it runs here on both hosts. Like CI's
+# lifecycle step, this boots the VM switchless: MINVMD_GVPROXY_BIN is
+# deliberately NOT exported (CI's lifecycle runs before that lane fetches
+# gvproxy, so the switchless boot path is what it proves).
+test-lifecycle: artifacts initramfs minvmd-build
+    #!/usr/bin/env sh
+    set -eu
+    command -v jq >/dev/null 2>&1 || { echo "'jq' not found — install with: brew install jq (or apt install jq)" >&2; exit 1; }
+    export MINVMD_KERNEL_PATH="{{kernel}}" MINVMD_ROOTFS_PATH="{{rootfs}}"
+    export MINVMD_INITRAMFS="{{initramfs}}" MINVMD_BOOT_LOG="{{scratch}}/lifecycle-boot.log"
+    export XDG_STATE_HOME="{{scratch}}/test-state"
+    export PATH="{{justfile_directory()}}/target/debug:$PATH"
+    case "$(uname -s)" in
+      Linux)
+        [ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "test-lifecycle needs writable /dev/kvm; try: sg kvm -c 'just test-lifecycle'" >&2; exit 1; }
+        export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        ;;
+    esac
+    ./scripts/minvmd-lifecycle.sh
+
+# Nightly soak parity: N session-e2e repetitions (nightly-tests.yml
+# `session-e2e-soak` runs 10). The soak script reaps between iterations and on
+# exit via scripts/reap-vms.sh — scoped to this checkout's binaries, but it
+# WILL kill this repo's own live dev stack (e.g. from `just up`) each pass.
+soak n="10": artifacts gvproxy initramfs minimal-cli minvmd-build
+    #!/usr/bin/env sh
+    set -eu
+    export MINVMD_KERNEL_PATH="{{kernel}}" MINVMD_ROOTFS_PATH="{{rootfs}}"
+    export MINVMD_INITRAMFS="{{initramfs}}"
+    export MINVMD_GVPROXY_BIN="{{gvproxy}}"
+    export PATH="{{justfile_directory()}}/target/debug:$PATH"
+    export E2E_VM=1 E2E_PROJECT_DIR=/tmp
+    case "$(uname -s)" in
+      Darwin) ;;
+      Linux)
+        [ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "soak needs writable /dev/kvm; try: sg kvm -c 'just soak'" >&2; exit 1; }
+        export LD_LIBRARY_PATH="{{krun-prefix}}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        export E2E_MINIMAL_ARGS=--minvmd
+        ;;
+      *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
+    esac
+    ./scripts/soak-session-e2e.sh {{n}} "{{scratch}}/soak-logs"
+
+# Kill stranded VM host processes (minvmd, __krun-vmm, gvproxy) after a failed
+# or interrupted harness run — leftovers wedge the next VM's vsock bridge.
+# Scoped to THIS checkout's binaries (path-anchored pkill), so other checkouts'
+# live VMs and unrelated gvproxies (e.g. podman's) are untouched. Needs
+# passwordless sudo for root-owned relay leftovers; without it, sudo -n fails
+# fast and user-owned processes still die.
+reap:
+    scripts/reap-vms.sh
+
 # ── DM1 / DM2 / DM3 deployment-model bring-up ────────────────────────────────
 #
 # DM1: macOS (Apple Silicon) host + Linux VM(s) over Hypervisor.framework. This
@@ -218,6 +538,19 @@ test-installer:
 #      Linux CLI dials providers/local-0/ssh.sock, which minvmd binds directly
 #      (the socket/path coordination fix, #690) — no bridge/symlink needed. Run
 #      under `sg kvm` if the shell lacks the kvm group.
+
+# Bring the stack up for THIS host's DEFAULT run mode — the `just up` the docs
+# reference (CONTRIBUTING.md, docs/ci-strategy.md §8/§10). macOS → dm1 (VM over
+# HVF is the only macOS mode); Linux → dm2 (native minimald is the default run
+# mode on Linux — use `just dm3` explicitly for the VM/KVM stack).
+up:
+    #!/usr/bin/env sh
+    set -eu
+    case "$(uname -s)" in
+      Darwin) exec just dm1 ;;
+      Linux)  exec just dm2 ;;
+      *) echo "unsupported host $(uname -s)" >&2; exit 1 ;;
+    esac
 
 # On Linux this is a clean SKIP (use `dm3`). min auto-spawns `minvmd run
 # --detach`, so minvmd must be on PATH and the MINVMD_* artifact paths exported —

--- a/justfile
+++ b/justfile
@@ -249,7 +249,7 @@ _kvm:
 
 [linux]
 _kvm:
-    @[ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "needs writable /dev/kvm — durable: sudo usermod -aG kvm $USER (re-login); one-off: sg kvm -c 'just <recipe>'" >&2; exit 1; }
+    @[ -e /dev/kvm ] && [ -w /dev/kvm ] || { echo "needs writable /dev/kvm (kvm group membership); one-off: sg kvm -c 'just <recipe>'" >&2; exit 1; }
 
 # minvmd's VM harnesses (tests/*_integration.rs). CI: `test-kvm` / macOS `e2e`.
 [macos]
@@ -285,10 +285,12 @@ test-vm: _nextest _kvm artifacts initramfs minvmd-build
       -E 'binary(/_integration$/) and not binary(/_root_integration$/)'
 
 # minimald's netns/tap proofs (the tests sudo their own netns commands).
-# CI: ci-linux-native.yml `minimald-root-integration`.
+# CI: ci-linux-native.yml `minimald-root-integration`. The AppArmor policy
+# can't unlock this surface — its namespaces come from hashed-path test
+# binaries and /usr/bin/unshare, which a per-binary profile can't cover.
 [linux]
 test-root-integration: _nextest gvproxy
-    @[ "$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)" = "0" ] || { echo "unprivileged userns is restricted; run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0" >&2; exit 1; }
+    @[ "$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)" = "0" ] || { echo "this host restricts unprivileged user namespaces, which this surface needs from hashed-path test binaries (the AppArmor policy can't cover those); leave this lane to CI, or see docs/reference/linux-host-setup.md before relaxing the restriction host-wide" >&2; exit 1; }
     MINIMALD_NETNS_TEST=1 GVPROXY_BIN="{{gvproxy}}" cargo nextest run -p minimald --profile ci --run-ignored all --no-tests=fail -E 'binary(/_root_integration$/)'
 
 # minvmd-build is LAST so its macOS codesign is the final touch on the binary.

--- a/justfile
+++ b/justfile
@@ -641,7 +641,15 @@ dm2: minimald-build minimal-cli gvproxy
     echo "DM2 up: host-native minimald at $sock (pid $(cat "$pidf"))"
     echo "  own-IP: {{min-bin}} --minimal-dir $dir activate -n net1 --network own-ip . && \\"
     echo "          {{min-bin}} --minimal-dir $dir attach net1   # curl http://example.com -> 200"
-    "{{min-bin}}" --minimal-dir "$dir" ls
+    # Same first-connect retry as dm3: minimald can reset the very first SSH
+    # connect right after binding the socket, which trips the CLI's autospawn
+    # (and fails the recipe) even though the daemon is healthy.
+    ok=0
+    for _ in $(seq 1 5); do
+      if "{{min-bin}}" --minimal-dir "$dir" ls; then ok=1; break; fi
+      sleep 2
+    done
+    [ "$ok" = 1 ] || { echo "DM2: min ls failed after retries; see {{scratch}}/dm2-minimald.log" >&2; exit 1; }
 
 # Stop the DM2 host-native minimald.
 dm2-down:

--- a/justfile
+++ b/justfile
@@ -48,48 +48,24 @@ default:
 
 # ── build & fetch ────────────────────────────────────────────────────────────
 #
-# Prereqs — macOS: `brew install slp/krun/libkrun` + the `minimal` shim.
-# Linux: a KVM host with kvm-group membership, Rust + protoc + jq + cpio.
+# Prereqs — macOS: `brew install slp/krun/libkrun zstd jq`.
+# Linux: a KVM host with kvm-group membership, Rust + protoc + jq + cpio + zstd.
 # See crates/minvmd/README.md for the manual bring-up.
 
-# Materialize the guest kernel + generic rootfs (`just clean` forces a refresh).
-[macos]
-artifacts:
-    #!/usr/bin/env sh
-    set -eu
-    [ -f {{kernel}} ] && [ -f {{rootfs}} ] && exit 0
-    mkdir -p {{scratch}}
-    # Resolve the shim by its install path FIRST: PATH is polluted with this
-    # repo's own target/debug (see the global export), where a stale `minimal`
-    # binary would shadow the shim.
-    if [ -x "$HOME/.minimal/shim/bin/minimal" ]; then shim="$HOME/.minimal/shim/bin/minimal"
-    elif command -v minimal >/dev/null 2>&1; then shim=minimal
-    else echo "the \`minimal\` shim is required (not at ~/.minimal/shim/bin, not on PATH)" >&2; exit 1
-    fi
-    # The shim's --output MUST be repo-RELATIVE (outputs sync back through the
-    # project-dir overlay; absolute paths fail the copy-out), and a cold cache
-    # can transiently drop the output — retry.
-    materialize() {
-      for n in 1 2 3; do
-        "$shim" materialize --output "$1" --arch {{arch}} "$2" && return 0
-        echo "materialize $2 failed (attempt $n)" >&2; rm -f "$1"; sleep 2
-      done
-      return 1
-    }
-    [ -f {{kernel}} ] || materialize .scratch/vmlinuz virtio-kernel
-    [ -f {{rootfs}} ] || materialize .scratch/rootfs.img minvmd-rootfs
-
-# Materialize the guest kernel + generic rootfs (`just clean` forces a refresh).
-[linux]
+# Prebuilt from the public cache via the per-commit package index — nothing is
+# built or materialized locally (scripts/fetch-prebuilt.sh; pkgs commit pinned
+# in .minimal/minimal.toml).
+#
+# Fetch the prebuilt guest kernel + generic rootfs (`just clean` forces a refresh).
 artifacts:
     @mkdir -p {{scratch}}
-    @[ -f {{kernel}} ] || scripts/fetch-artifact.sh virtio-kernel {{kernel}} {{arch}}
-    @[ -f {{rootfs}} ] || scripts/fetch-artifact.sh minvmd-rootfs {{rootfs}} {{arch}}
+    @[ -f {{kernel}} ] || scripts/fetch-prebuilt.sh kernel {{kernel}} {{arch}}
+    @[ -f {{rootfs}} ] || scripts/fetch-prebuilt.sh rootfs {{rootfs}} {{arch}}
 
-# Fetch libkrun + libkrunfw into the link/runtime prefix.
+# Fetch prebuilt libkrun + libkrunfw into the link/runtime prefix.
 [linux]
 libkrun:
-    scripts/fetch-libkrun.sh {{krun-prefix}} {{arch}}
+    scripts/fetch-prebuilt.sh krun {{krun-prefix}} {{arch}}
 
 # Fetch the pinned gvproxy switch (guest egress + own-IP; missing = switchless boot).
 gvproxy:

--- a/scripts/fetch-prebuilt.sh
+++ b/scripts/fetch-prebuilt.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Fetch a prebuilt guest artifact straight from the public artifact cache — no
+# toolchain, no shim, no graph evaluation.
+#
+# Resolution goes through the per-commit package map buildbot publishes next to
+# the cache (build-servers crates/buildbot/src/commit_index.rs): for the pkgs
+# commit pinned in .minimal/minimal.toml,
+#
+#   https://cache.minimal.farm/github.com/gominimal/pkgs/<commit>.map.json
+#
+# maps arch -> package name -> {spec_hash, sha256}, and the artifact itself is
+# the content-addressed zstd tarball https://cache.minimal.farm/<sha256>.zst.
+# The map only exists for commits built since the writer landed; a 404 means
+# the pinned commit predates it — bump locked_commit.
+#
+# What we extract per artifact (paths per .minimal/minimal.toml [outputs]):
+#   kernel  package virtio-kernel-raw  -> usr/share/virtio-linux/Image      (file)
+#   rootfs  package microvm-rootfs     -> usr/share/microvm-rootfs/rootfs.img (file)
+#   krun    packages libkrun+libkrunfw -> usr/lib/libkrun*.so*, flattened into
+#           the destination PREFIX dir (Linux hosts; macOS links Homebrew's)
+#
+# Usage: scripts/fetch-prebuilt.sh <kernel|rootfs|krun> <dest> [arch]
+#   dest: file path for kernel/rootfs, prefix DIR for krun
+#   arch: aarch64 (default) or x86_64 (host names; mapped to the index's
+#         arm64/amd64 keys)
+# Env:   MINIMAL_PKGS_COMMIT overrides the pinned commit.
+set -euo pipefail
+
+WHAT="${1:?usage: fetch-prebuilt.sh <kernel|rootfs|krun> <dest> [arch]}"
+DEST="${2:?usage: fetch-prebuilt.sh <kernel|rootfs|krun> <dest> [arch]}"
+ARCH="${3:-aarch64}"
+
+CACHE_URL="${MINIMAL_CACHE_URL:-https://cache.minimal.farm}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+for tool in curl jq zstd tar; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "'$tool' not found — install it (macOS: brew install $tool)" >&2; exit 1; }
+done
+
+case "$ARCH" in
+  aarch64|arm64) MAP_ARCH=arm64 ;;
+  x86_64|amd64)  MAP_ARCH=amd64 ;;
+  *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+COMMIT="${MINIMAL_PKGS_COMMIT:-$(sed -n 's/^locked_commit *= *"\(.*\)"/\1/p' "$ROOT/.minimal/minimal.toml")}"
+[ -n "$COMMIT" ] || { echo "no locked_commit in .minimal/minimal.toml and MINIMAL_PKGS_COMMIT unset" >&2; exit 1; }
+
+case "$WHAT" in
+  kernel) PKGS="virtio-kernel-raw" ;;
+  rootfs) PKGS="microvm-rootfs" ;;
+  krun)   PKGS="libkrun libkrunfw" ;;
+  *) echo "unknown artifact '$WHAT' (kernel|rootfs|krun)" >&2; exit 1 ;;
+esac
+
+MAP_URL="$CACHE_URL/github.com/gominimal/pkgs/$COMMIT.map.json"
+MAP="$(curl -sf --max-time 30 "$MAP_URL")" || {
+  echo "no package map for pkgs commit $COMMIT ($MAP_URL)" >&2
+  echo "the pinned commit likely predates the per-commit index; bump locked_commit in .minimal/minimal.toml" >&2
+  exit 1
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+for pkg in $PKGS; do
+  sha256="$(jq -re --arg a "$MAP_ARCH" --arg p "$pkg" '.arches[$a][$p].sha256' <<<"$MAP")" || {
+    echo "package '$pkg' not in the $MAP_ARCH index for commit $COMMIT" >&2; exit 1; }
+  curl -sf --max-time 300 "$CACHE_URL/$sha256.zst" -o "$TMP/$pkg.zst" || {
+    echo "artifact fetch failed: $CACHE_URL/$sha256.zst ($pkg)" >&2; exit 1; }
+  mkdir -p "$TMP/$pkg"
+  zstd -dc "$TMP/$pkg.zst" | tar -xf - -C "$TMP/$pkg"
+done
+
+case "$WHAT" in
+  kernel)
+    mkdir -p "$(dirname "$DEST")"
+    install -m 0644 "$TMP/virtio-kernel-raw/usr/share/virtio-linux/Image" "$DEST"
+    ;;
+  rootfs)
+    mkdir -p "$(dirname "$DEST")"
+    install -m 0644 "$TMP/microvm-rootfs/usr/share/microvm-rootfs/rootfs.img" "$DEST"
+    ;;
+  krun)
+    # Only the libkrun/libkrunfw libs: the packages' libc closure would shadow
+    # the host's via LD_LIBRARY_PATH and break host binaries.
+    mkdir -p "$DEST"
+    find "$TMP/libkrun/usr/lib" "$TMP/libkrunfw/usr/lib" \
+      \( -name 'libkrun*.so*' -o -name 'libkrunfw*.so*' \) \
+      -exec cp -P {} "$DEST/" \;
+    ;;
+esac
+
+echo "fetched $WHAT (pkgs @${COMMIT:0:12}, $MAP_ARCH) -> $DEST"

--- a/scripts/fetch-prebuilt.sh
+++ b/scripts/fetch-prebuilt.sh
@@ -61,25 +61,46 @@ MAP="$(curl -sf --max-time 30 "$MAP_URL")" || {
 }
 
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+PARTIAL=""
+trap 'rm -rf "$TMP" ${PARTIAL:+"$PARTIAL"}' EXIT
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+  else shasum -a 256 "$1" | cut -d' ' -f1; fi
+}
 
 for pkg in $PKGS; do
   sha256="$(jq -re --arg a "$MAP_ARCH" --arg p "$pkg" '.arches[$a][$p].sha256' <<<"$MAP")" || {
     echo "package '$pkg' not in the $MAP_ARCH index for commit $COMMIT" >&2; exit 1; }
+  [[ "$sha256" =~ ^[0-9a-f]{64}$ ]] || {
+    echo "malformed sha256 for '$pkg' in the index: $sha256" >&2; exit 1; }
   curl -sf --max-time 300 "$CACHE_URL/$sha256.zst" -o "$TMP/$pkg.zst" || {
     echo "artifact fetch failed: $CACHE_URL/$sha256.zst ($pkg)" >&2; exit 1; }
+  # The key is the content address — verify the bytes actually match it before
+  # anything gets extracted.
+  got="$(sha256_of "$TMP/$pkg.zst")"
+  [ "$got" = "$sha256" ] || {
+    echo "checksum mismatch for '$pkg': expected $sha256, got $got" >&2; exit 1; }
   mkdir -p "$TMP/$pkg"
   zstd -dc "$TMP/$pkg.zst" | tar -xf - -C "$TMP/$pkg"
 done
 
+# File artifacts publish atomically: write beside DEST, rename into place, so
+# an interrupted run can't leave a partial file that later guards trust.
+publish() {
+  mkdir -p "$(dirname "$DEST")"
+  PARTIAL="$DEST.partial"
+  install -m 0644 "$1" "$PARTIAL"
+  mv -f "$PARTIAL" "$DEST"
+  PARTIAL=""
+}
+
 case "$WHAT" in
   kernel)
-    mkdir -p "$(dirname "$DEST")"
-    install -m 0644 "$TMP/virtio-kernel-raw/usr/share/virtio-linux/Image" "$DEST"
+    publish "$TMP/virtio-kernel-raw/usr/share/virtio-linux/Image"
     ;;
   rootfs)
-    mkdir -p "$(dirname "$DEST")"
-    install -m 0644 "$TMP/microvm-rootfs/usr/share/microvm-rootfs/rootfs.img" "$DEST"
+    publish "$TMP/microvm-rootfs/usr/share/microvm-rootfs/rootfs.img"
     ;;
   krun)
     # Only the libkrun/libkrunfw libs: the packages' libc closure would shadow

--- a/scripts/minvmd-lifecycle.sh
+++ b/scripts/minvmd-lifecycle.sh
@@ -46,18 +46,24 @@ cat "$WORK/config.json"
 jq -e '.ram_mib == 3072 and .ram_mib_source == "config"' "$WORK/config.json"
 echo "::endgroup::"
 
+# Boot window: how long `run --detach` may wait for the host socket, and how
+# long the Running poll below may keep checking. CI's guests boot well inside
+# the 30s default; slower dev hosts (e.g. nested KVM, where the generic guest
+# kernel spends 40-70s probing hardware) override via the env.
+BOOT_TIMEOUT="${MINVMD_LIFECYCLE_BOOT_TIMEOUT_SECS:-30}"
+
 echo "::group::run --detach"
-minvmd run --detach --timeout 30
+minvmd run --detach --timeout "$BOOT_TIMEOUT"
 echo "::endgroup::"
 
 echo "::group::status (expect running)"
 # `run --detach` returns once the host UDS accepts connections, which
 # libkrun opens early in VM setup — slightly ahead of the supervisor's
 # Starting->Running transition (set after the guest READY marker). Poll
-# status (up to ~15s) for Running rather than asserting immediately. jq
-# parses structurally so the check doesn't break on harmless JSON
-# formatting changes.
-for _ in $(seq 1 75); do
+# status (up to the boot window) for Running rather than asserting
+# immediately. jq parses structurally so the check doesn't break on harmless
+# JSON formatting changes.
+for _ in $(seq 1 $((BOOT_TIMEOUT * 5))); do
   minvmd status --json > "$WORK/status.json" || true
   if jq -e '.state == "running" and (.vmm_pid | type == "number")' "$WORK/status.json" >/dev/null; then
     break

--- a/scripts/reap-vms.sh
+++ b/scripts/reap-vms.sh
@@ -7,8 +7,14 @@
 # instead of blocking on a password prompt in CI. The proper fix is
 # harness-side process-group reaping, tracked separately.
 #
+# Matching is scoped to THIS checkout's binaries: the persistent leftovers all
+# carry the absolute repo path in their cmdline (minvmd's supervisor and
+# __krun-vmm re-exec via current_exe(); gvproxy is spawned from the full
+# MINVMD_GVPROXY_BIN path), so a bare-name pkill would only add collateral —
+# an unrelated checkout's live VM, or podman's gvproxy.
+#
 # Usage: scripts/reap-vms.sh
 set -u
-sudo -n pkill -x minvmd 2>/dev/null || true
-sudo -n pkill -f __krun-vmm 2>/dev/null || true
-sudo -n pkill -f gvproxy 2>/dev/null || true
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+sudo -n pkill -f "$ROOT/.*minvmd" 2>/dev/null || true
+sudo -n pkill -f "$ROOT/.*gvproxy" 2>/dev/null || true

--- a/scripts/reap-vms.sh
+++ b/scripts/reap-vms.sh
@@ -16,5 +16,9 @@
 # Usage: scripts/reap-vms.sh
 set -u
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# User-owned leftovers first — this must not depend on sudo succeeding.
+pkill -f "$ROOT/.*minvmd" 2>/dev/null || true
+pkill -f "$ROOT/.*gvproxy" 2>/dev/null || true
+# Root-owned relay leftovers need sudo; -n fails fast without passwordless sudo.
 sudo -n pkill -f "$ROOT/.*minvmd" 2>/dev/null || true
 sudo -n pkill -f "$ROOT/.*gvproxy" 2>/dev/null || true

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -86,7 +86,9 @@ SEEDED_MFILE=""
 if [ -z "${E2E_PROJECT_DIR:-}" ]; then
   # Native: self-seed a small throwaway — never $ROOT (uploading the whole repo,
   # and scaffolding over its `.minimal/`, is the very clobber #758 prevents).
-  SEED_DIR="$(mktemp -d /tmp/mnl-e2e-proj.XXXXXX)"
+  # Short template on purpose: the basename is embedded in the task dir under
+  # the state root, inside the sun_path budget (see the workdir comment below).
+  SEED_DIR="$(mktemp -d /tmp/mnlp.XXXXXX)"
   PROJECT_DIR="$SEED_DIR"
 elif [ -n "$E2E_VM" ] && [ "$E2E_PROJECT_DIR" = "/tmp" ]; then
   # VM lanes pass /tmp; uploading all of /tmp is impractical, so seed a small
@@ -125,16 +127,32 @@ if [ -n "$SEED_DIR" ] || { [ ! -e "$PROJECT_DIR/minimal.toml" ] && [ ! -e "$PROJ
   [ -n "$SEED_DIR" ] || SEEDED_MFILE="$PROJECT_DIR/minimal.toml"
 fi
 
-# Fresh state under /tmp — NOT $TMPDIR: macOS's deep $TMPDIR would push
-# `.../minimal/providers/local-0/*.sock` past the 104-byte sun_path limit.
-# Post-#690, all daemon state (minvmd.toml, locks, the bridge socket) lives
-# under $XDG_STATE_HOME/minimal/providers/local-0 on every platform, so a
-# fresh dir guarantees the clean (no-daemon) cold-start on persistent
-# runners. XDG_CACHE_HOME is deliberately left alone so package pulls reuse
-# the host/CI cache across runs.
-WORK="$(mktemp -d /tmp/mnl-e2e.XXXXXX)"
+# Fresh state dir — a clean (no-daemon) cold-start on persistent runners:
+# post-#690, all daemon state (minvmd.toml, locks, the bridge socket) lives
+# under $XDG_STATE_HOME/minimal/providers/local-0 on every platform.
+# XDG_CACHE_HOME is deliberately left alone so package pulls reuse the
+# host/CI cache across runs — which pins where the state dir may live on a
+# native (DM2) lane: minimald HARDLINKS built packages from the cache into
+# each session rootfs under the state dir, and hardlinks cannot cross
+# filesystems ("Invalid cross-device link" at session spawn on hosts with a
+# tmpfs /tmp). So on Linux the workdir lives under $HOME (same device as the
+# cache, like production's ~/.local/state), and doubles as the state root
+# directly — the extra /state hop is sun_path budget we cannot spare: the
+# deepest socket, tasks/<seed>-<ts>-<n>-<pid>/run/minenv_sock, fits 108 only
+# from a production-depth root. macOS stays on /tmp — NOT $TMPDIR, whose deep
+# paths overflow its 104-byte limit ($HOME-based paths do too; its lanes are
+# VM-backed, so the daemon and its hardlinks live inside the guest anyway).
+case "$(uname -s)" in
+  Darwin)
+    WORK="$(mktemp -d /tmp/mnl-e2e.XXXXXX)"
+    export XDG_STATE_HOME="$WORK/state"
+    ;;
+  *)
+    WORK="$(mktemp -d "$HOME/.mnl-e2e.XXXXXX")"
+    export XDG_STATE_HOME="$WORK"
+    ;;
+esac
 export XDG_RUNTIME_DIR="$WORK/runtime"
-export XDG_STATE_HOME="$WORK/state"
 mkdir -p "$XDG_RUNTIME_DIR" "$XDG_STATE_HOME"
 chmod 700 "$XDG_RUNTIME_DIR"
 

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -3,10 +3,9 @@
 # path through the `min` CLI — which abstracts where the daemon lives —
 # so the IDENTICAL proof runs against all three deployment targets:
 #
-#   Linux native (DM2)   minimald on the host          (no extra env)
-#   Linux KVM    (DM3)   minimald in a minvmd microVM  E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd
-#   macOS HVF    (DM1)   minimald in a minvmd microVM  E2E_VM=1 (macOS is always VM-backed)
-# (DM numbers are the deployment models in docs/specs/03-spec-networking.)
+#   Linux native   minimald on the host          (no extra env)
+#   Linux KVM      minimald in a minvmd microVM  E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd
+#   macOS HVF      minimald in a minvmd microVM  E2E_VM=1 (macOS is always VM-backed)
 #
 # Two proofs, in order, on EVERY lane:
 #
@@ -132,7 +131,7 @@ fi
 # under $XDG_STATE_HOME/minimal/providers/local-0 on every platform.
 # XDG_CACHE_HOME is deliberately left alone so package pulls reuse the
 # host/CI cache across runs — which pins where the state dir may live on a
-# native (DM2) lane: minimald HARDLINKS built packages from the cache into
+# Linux-native lane: minimald HARDLINKS built packages from the cache into
 # each session rootfs under the state dir, and hardlinks cannot cross
 # filesystems ("Invalid cross-device link" at session spawn on hosts with a
 # tmpfs /tmp). So on Linux the workdir lives under $HOME (same device as the


### PR DESCRIPTION
## Goals

Make the justfile the single local entry point for the promise in docs/ci-strategy.md §8 — the frozen CI workflows stay a thin scheduler, and everything they check can be built, tested, and executed locally:

- **Build** — `artifacts` / `initramfs` / `gvproxy` / `minvmd-build` / … fetch and build the full stack on either host; recipes are `[linux]`/`[macos]`-dispatched like the lanes, so `just --list` shows exactly what your machine can run.
- **Test** — `just ci` is the PR gate set (fmt, clippy, cargo-deny, nextest, doctests, plus the `#[ignore]` surface no CI lane can run). `test-vm`, `test-root-integration`, `e2e` / `e2e-native`, `test-lifecycle`, and `soak` mirror their CI lanes one-for-one; each recipe's comment names its counterpart.
- **Execute** — `just up` brings up this host's default stack (macOS: Linux VM over Hypervisor.framework; Linux: host-native minimald), `just up-kvm` the Linux VM mode, `just down` stops it. The DM1/2/3 nomenclature is retired.
- **Stay small** — OS attributes replace `uname` dispatch, top-level `export` replaces per-recipe env stanzas, shared helpers replace copy-pasted preflights, and comments carry captions plus landmines only.

En-route fixes: checkout-scoped `reap-vms.sh`, overridable boot windows for slow/nested-KVM hosts, the installer's AppArmor remediation surfaced in the native lanes, and the e2e workdir pinned to the cache filesystem (hardlinks can't cross devices).

## Verification

After the final rewrite, on macOS: `just ci` (493 tests), `just e2e` (full VM session proof incl. in-sandbox `min add`), and a forced shim re-materialize — all green. Every Linux lane ran green earlier on a native Ubuntu/KVM host; the fixes that run surfaced are the last commits before the rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added standardized commands for formatting, linting, testing, VM integration, end-to-end, lifecycle, and soak testing.
  - Added simplified cross-platform environment controls for starting, stopping, and launching VM-backed development environments.
  - Added automatic retrieval of required guest artifacts for supported architectures.

- **Bug Fixes**
  - Improved startup reliability with connection retries and environment checks.
  - Made lifecycle boot and status polling timeouts configurable.
  - Restricted cleanup to resources belonging to the current checkout.

- **Documentation**
  - Updated contribution and CI guidance with the new local testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->