### PR TITLE
feat(orchestrator): keep track of which build failed

### DIFF
--- a/crates/mctx/src/error.rs
+++ b/crates/mctx/src/error.rs
@@ -241,6 +241,9 @@ impl From<orchestrator::Error> for Error {
             orchestrator::Error::IO(e) => Self::IO("vcs", PathBuf::new(), e),
             orchestrator::Error::Other(e) => Self::Other(anyhow::anyhow!(e)),
             orchestrator::Error::Cache(e) => Self::Other(anyhow::anyhow!(e)), // TODO: better error
+            orchestrator::Error::BuildFailed(build, e) => {
+                Self::Other(anyhow::anyhow!("`{build}` failed to build: {e}"))
+            } // TODO: better error
             orchestrator::Error::Sandbox(e) => Self::Other(anyhow::anyhow!(e)), // TODO: better error
             orchestrator::Error::Plan(graph, e) => Self::Plan(Box::new((graph, e))),
         }

--- a/crates/orchestrator/src/error.rs
+++ b/crates/orchestrator/src/error.rs
@@ -15,7 +15,9 @@ pub enum Error {
     Cache(CacheErr),
     /// An error during planning occurred.
     Plan(Graph, PlanErr),
-    /// An error occurred during the setup or execution of a sandbox.
+    /// An error occurred building a specific package.
+    BuildFailed(String, op::Error),
+    /// A generic error occurred during the setup or execution of a sandbox.
     Sandbox(sandbox2::Error),
     /// Other errors.
     Other(anyhow::Error),
@@ -63,6 +65,7 @@ impl fmt::Display for Error {
             Error::IO(e) => write!(f, "i/o error: {}", e),
             Error::Cache(e) => write!(f, "cache error: {}", e),
             Error::Plan(_, e) => write!(f, "plan error: {:?}", e),
+            Error::BuildFailed(name, e) => write!(f, "`{name}` failed to build: {e}"),
             Error::Sandbox(e) => write!(f, "sandbox error: {}", e),
             Error::Other(e) => write!(f, "other: {}", e),
         }
@@ -75,6 +78,7 @@ impl std::error::Error for Error {
             Error::IO(e) => Some(e),
             Error::Cache(e) => Some(e),
             Error::Plan(_, e) => Some(e),
+            Error::BuildFailed(_, e) => Some(e),
             Error::Sandbox(e) => Some(e),
             _ => None,
         }

--- a/crates/orchestrator/src/local_backend.rs
+++ b/crates/orchestrator/src/local_backend.rs
@@ -240,7 +240,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
             });
             drop(permit);
             drop(shared);
-            res
+            res.map_err(|e| Error::BuildFailed(name, e))
         }
         .await?;
 


### PR DESCRIPTION
Should help when buildbot bubbles up errors like

```
11:04:28 AM [amd64] Build failed: Other(orchestration failed: other: strip prefix error: prefix not found)
11:04:29 AM [arm64] Build failed: Other(orchestration failed: other: strip prefix error: prefix not found)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build failure reporting by identifying the package that failed to build.
  * Preserved the underlying error details to provide clearer diagnostic information.
  * Updated error messages to clearly indicate which build failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->