### PR TITLE
fix(minvmd): resource-surface hardening from post-merge review of #775

### DIFF
--- a/crates/minvmd/src/cmd/boot.rs
+++ b/crates/minvmd/src/cmd/boot.rs
@@ -106,6 +106,10 @@ fn run_boot(foreground: bool) -> Result<()> {
     let volume_preexisted = crate::cmd::volume_preexists(&volume_path);
 
     // Spawn `minvmd __krun-vmm` — the VMM child that calls krun_start_enter.
+    // The child boots with the pre-spawn resource snapshot handed to it here
+    // (`MINVMD_BOOTED_*`), not its own config read, so a concurrent `config
+    // set` cannot change what this boot uses (R2.6).
+    let (booted_vcpus, booted_ram_mib) = crate::cmd::effective_resources();
     let exe = std::env::current_exe().context("resolving current executable path")?;
     let mut cmd = std::process::Command::new(&exe);
     cmd.arg("__krun-vmm");
@@ -115,6 +119,8 @@ fn run_boot(foreground: bool) -> Result<()> {
     alive_lock.inherit_into(&mut cmd);
     let mut child = cmd
         .env(MARKER_SOCK_ENV, &marker_sock_path)
+        .env(crate::cmd::BOOTED_VCPUS_ENV, booted_vcpus.to_string())
+        .env(crate::cmd::BOOTED_RAM_MIB_ENV, booted_ram_mib.to_string())
         // Inherit MINVMD_KERNEL_PATH and MINVMD_ROOTFS_PATH from environment.
         .spawn()
         .with_context(|| format!("spawning VMM child: {}", exe.display()))?;

--- a/crates/minvmd/src/cmd/config.rs
+++ b/crates/minvmd/src/cmd/config.rs
@@ -8,7 +8,7 @@
 
 use anyhow::{Context as _, Result, bail};
 
-use crate::cmd::{DEFAULT_VM_RAM_MIB, DEFAULT_VM_VCPUS, env_ram_mib, env_vcpus};
+use crate::cmd::{DEFAULT_VM_RAM_MIB, DEFAULT_VM_VCPUS};
 use crate::config::ResourceConfig;
 use crate::state::provider_dir;
 
@@ -142,25 +142,34 @@ pub fn run_set(vcpus: Option<u8>, ram_mib: Option<u32>) -> Result<()> {
 }
 
 /// Run `minvmd config show`: print the effective configuration and each value's
-/// source (`env` / `config` / `default`).
+/// source (`env` / `config` / `default`). Values and sources come from the one
+/// resolution pass boot itself uses ([`crate::cmd::resolve_resources`]) — a
+/// single persisted-config read, so the labels cannot describe a different
+/// `config.toml` version than the values, and a malformed file falls back to
+/// the defaults (as boot would) instead of failing the one command that could
+/// report the fallback.
 pub fn run_show(json: bool) -> Result<()> {
-    let cfg = ResourceConfig::read(&provider_dir()).context("reading resource config")?;
-    let vcpus = crate::cmd::effective_vcpus();
-    let ram_mib = crate::cmd::effective_ram_mib();
-    let vcpus_source = source(env_vcpus().is_some(), cfg.vcpus.is_some());
-    let ram_source = source(env_ram_mib().is_some(), cfg.ram_mib.is_some());
+    let resolved = crate::cmd::resolve_resources();
 
     if json {
         let out = serde_json::json!({
-            "vcpus": vcpus,
-            "ram_mib": ram_mib,
-            "vcpus_source": vcpus_source,
-            "ram_mib_source": ram_source,
+            "vcpus": resolved.vcpus,
+            "ram_mib": resolved.ram_mib,
+            "vcpus_source": resolved.vcpus_source.label(),
+            "ram_mib_source": resolved.ram_mib_source.label(),
         });
         println!("{out}");
     } else {
-        println!("vcpus   = {vcpus} ({vcpus_source})");
-        println!("ram_mib = {ram_mib} ({ram_source})");
+        println!(
+            "vcpus   = {} ({})",
+            resolved.vcpus,
+            resolved.vcpus_source.label()
+        );
+        println!(
+            "ram_mib = {} ({})",
+            resolved.ram_mib,
+            resolved.ram_mib_source.label()
+        );
     }
     Ok(())
 }
@@ -168,18 +177,6 @@ pub fn run_show(json: bool) -> Result<()> {
 /// Render a persisted-or-default value for the confirmation line.
 fn describe<T: std::fmt::Display>(value: Option<T>, default: impl std::fmt::Display) -> String {
     value.map_or_else(|| format!("{default} (default)"), |v| v.to_string())
-}
-
-/// Which layer supplied the effective value: env override, persisted config, or
-/// the built-in default (matching [`crate::cmd::effective_ram_mib`] precedence).
-fn source(from_env: bool, from_config: bool) -> &'static str {
-    if from_env {
-        "env"
-    } else if from_config {
-        "config"
-    } else {
-        "default"
-    }
 }
 
 #[cfg(test)]
@@ -252,8 +249,31 @@ mod tests {
 
     #[test]
     fn source_precedence_is_env_then_config_then_default() {
-        assert_eq!(source(true, true), "env");
-        assert_eq!(source(false, true), "config");
-        assert_eq!(source(false, false), "default");
+        use crate::cmd::ValueSource;
+
+        // Env beats a persisted value; a persisted value beats the default.
+        let cfg = ResourceConfig {
+            vcpus: Some(2),
+            ram_mib: Some(1024),
+        };
+        let r = crate::cmd::resolve_from(Some(1), None, &cfg);
+        assert_eq!(r.vcpus_source, ValueSource::Env);
+        assert_eq!(r.vcpus, 1);
+        assert_eq!(r.ram_mib_source, ValueSource::Config);
+        assert_eq!(r.ram_mib, 1024);
+
+        let r = crate::cmd::resolve_from(None, None, &ResourceConfig::default());
+        assert_eq!(r.vcpus_source, ValueSource::Default);
+        assert_eq!(r.vcpus, DEFAULT_VM_VCPUS);
+        assert_eq!(r.ram_mib_source, ValueSource::Default);
+        assert_eq!(r.ram_mib, DEFAULT_VM_RAM_MIB);
+    }
+
+    #[test]
+    fn source_labels_match_the_show_schema() {
+        use crate::cmd::ValueSource;
+        assert_eq!(ValueSource::Env.label(), "env");
+        assert_eq!(ValueSource::Config.label(), "config");
+        assert_eq!(ValueSource::Default.label(), "default");
     }
 }

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -71,12 +71,24 @@ pub fn ready_timeout() -> std::time::Duration {
 /// Environment variable overriding the [`DEFAULT_VM_RAM_MIB`] guest RAM size.
 pub const VM_RAM_MIB_ENV: &str = "MINVMD_VM_RAM_MIB";
 
+/// Environment variable carrying the parent supervisor's pre-spawn vcpu
+/// snapshot to the VMM child (with [`BOOTED_RAM_MIB_ENV`]). The child boots
+/// with exactly the pair the parent records as `State.booted_*` at the Running
+/// transition, so a `config set` landing inside the boot window cannot make
+/// `status` report resources the VM did not boot with (R2.6). Internal — set
+/// by `boot`/`run` alongside [`MARKER_SOCK_ENV`], not a user knob.
+pub const BOOTED_VCPUS_ENV: &str = "MINVMD_BOOTED_VCPUS";
+
+/// Environment variable carrying the parent supervisor's pre-spawn RAM-MiB
+/// snapshot to the VMM child. See [`BOOTED_VCPUS_ENV`].
+pub const BOOTED_RAM_MIB_ENV: &str = "MINVMD_BOOTED_RAM_MIB";
+
 /// Environment variable overriding the [`DEFAULT_VM_VCPUS`] guest vcpu count.
 pub const VM_VCPUS_ENV: &str = "MINVMD_VM_VCPUS";
 
 /// Default guest vcpu count. 2 is the v0.1 baseline; stay below the guest
 /// kernel's `CONFIG_NR_CPUS`. Overridable via [`VM_VCPUS_ENV`] or persisted
-/// resource config (see [`effective_vcpus`]).
+/// resource config (see [`effective_resources`]).
 pub const DEFAULT_VM_VCPUS: u8 = 2;
 
 /// Logical cores backed off from the vcpu ceiling for the host side: the VMM
@@ -149,15 +161,41 @@ pub(crate) fn env_vcpus() -> Option<u8> {
 /// The persisted resource config from the provider dir. A missing file yields
 /// the all-`None` default; a malformed file is logged — so a boot that silently
 /// falls back to built-in defaults is at least diagnosable — and also treated as
-/// the default, so an unreadable file never blocks boot (R9.7).
+/// the default, so an unreadable file never blocks boot (R9.7). Values `config
+/// set` would reject are sanitized out (see [`sanitize_persisted`]).
 pub(crate) fn persisted_resource_config() -> crate::config::ResourceConfig {
-    match crate::config::ResourceConfig::read(&crate::state::provider_dir()) {
+    let cfg = match crate::config::ResourceConfig::read(&crate::state::provider_dir()) {
         Ok(cfg) => cfg,
         Err(e) => {
             tracing::warn!(error = %e, "failed to read persisted resource config; using defaults");
             crate::config::ResourceConfig::default()
         }
+    };
+    sanitize_persisted(cfg)
+}
+
+/// Drop persisted values that `config set` would reject — it validates only
+/// the write path, so a hand-edited `config.toml` can carry `vcpus = 0` or a
+/// sub-floor `ram_mib` that boot resolution would otherwise hand straight to
+/// the VMM (a 0-vcpu VmConfig, or a guest that cannot reach userspace). Each
+/// offending field is warned about and treated as unset, falling back to the
+/// built-in default.
+fn sanitize_persisted(mut cfg: crate::config::ResourceConfig) -> crate::config::ResourceConfig {
+    if cfg.vcpus == Some(0) {
+        tracing::warn!("persisted vcpus = 0 is invalid; falling back to the default");
+        cfg.vcpus = None;
     }
+    if let Some(m) = cfg.ram_mib
+        && m < config::MIN_RAM_MIB
+    {
+        tracing::warn!(
+            ram_mib = m,
+            min = config::MIN_RAM_MIB,
+            "persisted ram_mib is below the boot floor; falling back to the default"
+        );
+        cfg.ram_mib = None;
+    }
+    cfg
 }
 
 /// Clamp a resolved vcpu count to this host's [`max_vm_vcpus`]. Warns when it
@@ -177,51 +215,109 @@ fn clamp_vcpus(vcpus: u8) -> u8 {
     }
 }
 
-/// The effective guest RAM in MiB, resolved as
-/// `env override ?? persisted config ?? default` (R9.7). The
-/// [`VM_RAM_MIB_ENV`] override still wins so power users keep a per-boot escape
-/// hatch; `minvmd config set --ram-mib` supplies the persisted layer beneath it.
+/// Which layer supplied an effective resource value (R9.5), matching the
+/// `env override ?? persisted config ?? default` precedence (R9.7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ValueSource {
+    /// A `MINVMD_VM_*` environment override.
+    Env,
+    /// The persisted `config.toml` (`minvmd config set`).
+    Config,
+    /// The built-in default.
+    Default,
+}
+
+impl ValueSource {
+    /// The label reported by `config show` (`env` / `config` / `default`).
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Env => "env",
+            Self::Config => "config",
+            Self::Default => "default",
+        }
+    }
+}
+
+/// The effective resource pair plus each value's source, resolved in one pass
+/// (see [`resolve_resources`]).
+pub(crate) struct ResolvedResources {
+    pub vcpus: u8,
+    pub ram_mib: u32,
+    pub vcpus_source: ValueSource,
+    pub ram_mib_source: ValueSource,
+}
+
+/// Resolve values and sources from one `(env, config)` snapshot. Pure — inputs
+/// are injected so precedence is testable without touching the process env or
+/// a real state dir. vcpus is clamped to this host's [`max_vm_vcpus`].
 ///
-/// Note: the RAM stop-gap is *not* reduced when the cache moves to the writable
-/// volume. A reduced baseline is only safe once a failed volume mount is fatal
-/// (no silent tmpfs fallback) and the floor is measured against real in-VM build
-/// memory pressure; reducing it here would leave a mount-failed VM at half RAM
-/// with the cache still on the tmpfs. Out of scope for this feature — deferred to
-/// a separate memory-pressure spec.
-#[must_use]
-pub fn effective_ram_mib() -> u32 {
-    env_ram_mib()
-        .or_else(|| persisted_resource_config().ram_mib)
-        .unwrap_or(DEFAULT_VM_RAM_MIB)
+/// Note: the RAM stop-gap default is *not* reduced when the cache moves to the
+/// writable volume. A reduced baseline is only safe once a failed volume mount
+/// is fatal (no silent tmpfs fallback) and the floor is measured against real
+/// in-VM build memory pressure; reducing it here would leave a mount-failed VM
+/// at half RAM with the cache still on the tmpfs. Out of scope for this
+/// feature — deferred to a separate memory-pressure spec.
+fn resolve_from(
+    env_vcpus: Option<u8>,
+    env_ram_mib: Option<u32>,
+    cfg: &crate::config::ResourceConfig,
+) -> ResolvedResources {
+    let (vcpus, vcpus_source) = match (env_vcpus, cfg.vcpus) {
+        (Some(v), _) => (v, ValueSource::Env),
+        (None, Some(v)) => (v, ValueSource::Config),
+        (None, None) => (DEFAULT_VM_VCPUS, ValueSource::Default),
+    };
+    let (ram_mib, ram_mib_source) = match (env_ram_mib, cfg.ram_mib) {
+        (Some(m), _) => (m, ValueSource::Env),
+        (None, Some(m)) => (m, ValueSource::Config),
+        (None, None) => (DEFAULT_VM_RAM_MIB, ValueSource::Default),
+    };
+    ResolvedResources {
+        vcpus: clamp_vcpus(vcpus),
+        ram_mib,
+        vcpus_source,
+        ram_mib_source,
+    }
 }
 
-/// The effective guest vcpu count, resolved as
-/// `env override ?? persisted config ?? default` (R9.7) and clamped to this
-/// host's [`max_vm_vcpus`] so an over-large env/config value cannot brick the
-/// boot.
-#[must_use]
-pub fn effective_vcpus() -> u8 {
-    clamp_vcpus(
-        env_vcpus()
-            .or_else(|| persisted_resource_config().vcpus)
-            .unwrap_or(DEFAULT_VM_VCPUS),
-    )
+/// Resolve the effective resources — and each value's source — from a
+/// **single** read of the persisted config, so neither the `(vcpus, ram_mib)`
+/// pair nor its source labels can tear when `config.toml` changes between two
+/// separate reads. The `MINVMD_VM_*` overrides still win so power users keep a
+/// per-boot escape hatch; `minvmd config set` supplies the persisted layer
+/// beneath them (R9.7). Shared by boot resolution and `config show`, so both
+/// see the same malformed-file fallback (defaults, with a warning).
+pub(crate) fn resolve_resources() -> ResolvedResources {
+    resolve_from(env_vcpus(), env_ram_mib(), &persisted_resource_config())
 }
 
-/// Resolve `(vcpus, ram_mib)` from a **single** read of the persisted config, so
-/// the pair cannot tear when `config.toml` changes between two separate
-/// `effective_*` calls (e.g. the two `booted_*` fields recorded at the Running
-/// transition). Per-field env overrides still take precedence; vcpus is clamped
-/// to this host's [`max_vm_vcpus`].
+/// The effective `(vcpus, ram_mib)` pair — [`resolve_resources`] without the
+/// source labels.
 #[must_use]
 pub fn effective_resources() -> (u8, u32) {
-    let env_v = env_vcpus();
-    let env_r = env_ram_mib();
-    let cfg = persisted_resource_config();
-    (
-        clamp_vcpus(env_v.or(cfg.vcpus).unwrap_or(DEFAULT_VM_VCPUS)),
-        env_r.or(cfg.ram_mib).unwrap_or(DEFAULT_VM_RAM_MIB),
+    let resolved = resolve_resources();
+    (resolved.vcpus, resolved.ram_mib)
+}
+
+/// The parent supervisor's pre-spawn resource snapshot from the environment
+/// ([`BOOTED_VCPUS_ENV`] / [`BOOTED_RAM_MIB_ENV`]), if both halves are present
+/// and valid.
+#[cfg(any(minvmd_libkrun, test))]
+pub(crate) fn booted_resources_from_env() -> Option<(u8, u32)> {
+    parse_booted_snapshot(
+        std::env::var(BOOTED_VCPUS_ENV).ok().as_deref(),
+        std::env::var(BOOTED_RAM_MIB_ENV).ok().as_deref(),
     )
+}
+
+/// Parse the two snapshot halves; `None` unless both are positive integers, so
+/// a half-set or corrupted snapshot falls back to local resolution rather than
+/// booting a 0-vcpu VM.
+#[cfg(any(minvmd_libkrun, test))]
+fn parse_booted_snapshot(vcpus: Option<&str>, ram_mib: Option<&str>) -> Option<(u8, u32)> {
+    let vcpus = vcpus?.trim().parse::<u8>().ok().filter(|&v| v > 0)?;
+    let ram_mib = ram_mib?.trim().parse::<u32>().ok().filter(|&m| m > 0)?;
+    Some((vcpus, ram_mib))
 }
 
 /// Verify the host hypervisor backend is accessible before booting a VM (R2.4).
@@ -485,6 +581,47 @@ mod tests {
         let msg = kvm_access_error(&Error::from(ErrorKind::PermissionDenied)).to_string();
         assert!(msg.contains("permission denied"), "got: {msg}");
         assert!(msg.contains("`kvm` group"), "got: {msg}");
+    }
+}
+
+#[cfg(test)]
+mod resource_resolution_tests {
+    use super::*;
+    use crate::config::ResourceConfig;
+
+    #[test]
+    fn sanitize_drops_zero_vcpus_and_sub_floor_ram() {
+        let cfg = sanitize_persisted(ResourceConfig {
+            vcpus: Some(0),
+            ram_mib: Some(config::MIN_RAM_MIB - 1),
+        });
+        assert_eq!(cfg.vcpus, None, "vcpus = 0 must fall back to the default");
+        assert_eq!(
+            cfg.ram_mib, None,
+            "sub-floor ram_mib must fall back to the default"
+        );
+    }
+
+    #[test]
+    fn sanitize_keeps_valid_persisted_values() {
+        let cfg = ResourceConfig {
+            vcpus: Some(2),
+            ram_mib: Some(config::MIN_RAM_MIB),
+        };
+        assert_eq!(sanitize_persisted(cfg.clone()), cfg);
+    }
+
+    #[test]
+    fn snapshot_parses_only_when_both_halves_are_positive_integers() {
+        assert_eq!(
+            parse_booted_snapshot(Some("2"), Some("3072")),
+            Some((2, 3072))
+        );
+        assert_eq!(parse_booted_snapshot(None, Some("3072")), None);
+        assert_eq!(parse_booted_snapshot(Some("2"), None), None);
+        assert_eq!(parse_booted_snapshot(Some("0"), Some("3072")), None);
+        assert_eq!(parse_booted_snapshot(Some("two"), Some("3072")), None);
+        assert_eq!(parse_booted_snapshot(Some("2"), Some("")), None);
     }
 }
 

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -301,8 +301,9 @@ pub fn effective_resources() -> (u8, u32) {
 
 /// The parent supervisor's pre-spawn resource snapshot from the environment
 /// ([`BOOTED_VCPUS_ENV`] / [`BOOTED_RAM_MIB_ENV`]), if both halves are present
-/// and valid.
-#[cfg(any(minvmd_libkrun, test))]
+/// and valid. Only the libkrun VMM child calls this; the stub build has no
+/// boot path (`parse_booted_snapshot` stays test-visible for coverage).
+#[cfg(minvmd_libkrun)]
 pub(crate) fn booted_resources_from_env() -> Option<(u8, u32)> {
     parse_booted_snapshot(
         std::env::var(BOOTED_VCPUS_ENV).ok().as_deref(),

--- a/crates/minvmd/src/cmd/run.rs
+++ b/crates/minvmd/src/cmd/run.rs
@@ -312,6 +312,13 @@ fn run_foreground() -> Result<()> {
     let volume_path = crate::volume::resolve_data_volume_path();
     let volume_preexisted = crate::cmd::volume_preexists(&volume_path);
 
+    // Resolve the boot resources ONCE, pre-spawn, and hand the snapshot to the
+    // child: the child boots with exactly this pair, and the Running transition
+    // below records the same pair as `booted_*` — a `config set` landing inside
+    // the boot window cannot make `status` report resources the VM did not boot
+    // with (R2.6).
+    let (booted_vcpus, booted_ram_mib) = crate::cmd::effective_resources();
+
     let exe = std::env::current_exe().context("resolving current executable path")?;
     let mut cmd = std::process::Command::new(&exe);
     cmd.arg("__krun-vmm");
@@ -321,6 +328,8 @@ fn run_foreground() -> Result<()> {
     alive_lock.inherit_into(&mut cmd);
     let mut child = cmd
         .env(MARKER_SOCK_ENV, &marker_sock_path)
+        .env(crate::cmd::BOOTED_VCPUS_ENV, booted_vcpus.to_string())
+        .env(crate::cmd::BOOTED_RAM_MIB_ENV, booted_ram_mib.to_string())
         .spawn()
         .with_context(|| format!("spawning VMM child: {}", exe.display()))?;
 
@@ -407,13 +416,9 @@ fn run_foreground() -> Result<()> {
         let state = state_dir.read_state().context("reading state")?;
         let running = next_state(state.lifecycle, Action::MarkRunning)
             .map_err(|e| anyhow::anyhow!("lifecycle transition error: {e}"))?;
-        // Record the resources the running VM was booted with (R2.6), resolved
-        // from a single config read so the (vcpus, ram_mib) pair cannot tear. The
-        // VMM child resolves the same effective values from the inherited env +
-        // shared config.toml; a `config set` landing inside the brief boot window
-        // could still make this parent read diverge from the child's, but the
-        // recorded pair itself is always self-consistent.
-        let (booted_vcpus, booted_ram_mib) = crate::cmd::effective_resources();
+        // Record the pre-spawn snapshot the VMM child was handed via
+        // `MINVMD_BOOTED_*` — by construction the exact resources the running
+        // VM booted with (R2.6).
         state_dir
             .write_state(&State {
                 lifecycle: running,

--- a/crates/minvmd/src/cmd/vmm_child.rs
+++ b/crates/minvmd/src/cmd/vmm_child.rs
@@ -49,18 +49,22 @@ fn run_vmm() -> Result<()> {
     })?;
 
     let mut ctx = Context::create().context("krun_create_ctx")?;
-    // vcpus and guest RAM are the *effective* values: env override ?? persisted
-    // `minvmd config` ?? default (R9.7). RAM keeps its tmpfs-headroom default and
-    // x86_64 hole-safe rule (see `DEFAULT_VM_RAM_MIB`); vcpus stay below the
-    // kernel's CONFIG_NR_CPUS. `apply` configures the kernel + initramfs, the
-    // ext4 root disk, the writable data volume, and the vsock bridge.
-    let mut cfg = VmConfig::new(
-        crate::cmd::effective_vcpus(),
-        crate::cmd::effective_ram_mib(),
-        kernel,
-        rootfs,
-        initramfs,
-    );
+    // vcpus and guest RAM come from the parent's pre-spawn snapshot
+    // (`MINVMD_BOOTED_*`), so this child boots with exactly the pair the parent
+    // records as `State.booted_*` — a `config set` landing between the parent's
+    // resolution and this point cannot make the two diverge (R2.6). A missing
+    // snapshot (a child spawned by an older parent binary mid-upgrade) falls
+    // back to local resolution: env override ?? persisted `minvmd config` ??
+    // default (R9.7). `apply` configures the kernel + initramfs, the ext4 root
+    // disk, the writable data volume, and the vsock bridge.
+    let (vcpus, ram_mib) = crate::cmd::booted_resources_from_env().unwrap_or_else(|| {
+        tracing::warn!(
+            "no booted-resource snapshot in the environment; resolving locally \
+             (VMM child spawned by an older parent?)"
+        );
+        crate::cmd::effective_resources()
+    });
+    let mut cfg = VmConfig::new(vcpus, ram_mib, kernel, rootfs, initramfs);
     // An own-IP VM registers the per-PTask gvproxy shuttle vsock
     // bridge in `apply`; the host gvproxy is spawned by the parent supervisor.
     // The env var keeps the parent's gvproxy-spawn decision and this child's VM

--- a/crates/minvmd/src/config.rs
+++ b/crates/minvmd/src/config.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 /// Persisted resource parameters. A `None` field means "unset — use the
 /// built-in default"; an explicit value overrides the default (but is itself
 /// overridden by the matching environment variable at resolution time, see
-/// [`crate::cmd::effective_ram_mib`]).
+/// [`crate::cmd::effective_resources`]).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ResourceConfig {

--- a/crates/minvmd/src/main.rs
+++ b/crates/minvmd/src/main.rs
@@ -82,8 +82,12 @@ enum ConfigAction {
 
 fn main() -> Result<()> {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    // Diagnostics go to stderr: stdout is a machine-readable surface (`status
+    // --json`, `config show --json`), so a warning on stdout corrupts piped
+    // JSON; and the detached supervisor captures *stderr* into run.log — on
+    // stdout its diagnostics would vanish into /dev/null instead.
     tracing_subscriber::registry()
-        .with(fmt::layer())
+        .with(fmt::layer().with_writer(std::io::stderr))
         .with(filter)
         .init();
 

--- a/crates/minvmd/src/state.rs
+++ b/crates/minvmd/src/state.rs
@@ -231,10 +231,10 @@ impl StateDir {
     }
 }
 
-/// Serialise `value` to TOML and write it to `target` atomically: content is
-/// written to a `.toml.tmp` sibling, `fsync`'d, then renamed over the target
-/// (R4.1). Shared by [`StateDir::write_state`] and
-/// [`crate::config::ResourceConfig::write`].
+/// Serialise `value` to TOML and write it to `target` atomically and durably:
+/// content is written to a `.toml.tmp` sibling, `fsync`'d, renamed over the
+/// target, and the parent directory `fsync`'d (R4.1). Shared by
+/// [`StateDir::write_state`] and [`crate::config::ResourceConfig::write`].
 pub(crate) fn atomic_write_toml<T: Serialize>(target: &Path, value: &T) -> io::Result<()> {
     let tmp = target.with_extension("toml.tmp");
     let serialised =
@@ -244,7 +244,14 @@ pub(crate) fn atomic_write_toml<T: Serialize>(target: &Path, value: &T) -> io::R
         f.write_all(serialised.as_bytes())?;
         f.sync_all()?;
     }
-    fs::rename(&tmp, target)
+    fs::rename(&tmp, target)?;
+    // The file fsync above only persists the tmp file's *contents*; the rename
+    // lives in the directory, so without a parent-dir fsync a crash here can
+    // resurface the old file after the caller was told the write succeeded.
+    if let Some(parent) = target.parent() {
+        File::open(parent)?.sync_all()?;
+    }
+    Ok(())
 }
 
 /// Whether some process holds an exclusive advisory lock on `path`.

--- a/crates/minvmd/tests/config_cli_integration.rs
+++ b/crates/minvmd/tests/config_cli_integration.rs
@@ -5,10 +5,23 @@
 //! need no VM, so — unlike the boot harness — they are neither `#[ignore]`d nor
 //! `MINVMD_E2E`-gated and run on every lane. They prove the config surface and
 //! the `status --json` schema through the actual CLI, including that a persisted
-//! value is what the boot path's `effective_ram_mib()` would read (surfaced as
-//! `ram_mib_source: "config"` by `config show`).
+//! value is what boot resolution (`effective_resources()`) would read (surfaced
+//! as `ram_mib_source: "config"` by `config show`).
 
 use std::process::Command;
+
+/// The provider-instance `config.toml` under an isolated `XDG_STATE_HOME`, for
+/// tests that plant hand-edited (i.e. never `config set`-validated) content.
+fn config_toml_path(state_home: &std::path::Path) -> std::path::PathBuf {
+    state_home.join("minimal/providers/local-0/config.toml")
+}
+
+/// Write raw `content` as the provider's `config.toml`, creating the dir tree.
+fn plant_config_toml(state_home: &std::path::Path, content: &str) {
+    let path = config_toml_path(state_home);
+    std::fs::create_dir_all(path.parent().expect("provider dir")).expect("create provider dir");
+    std::fs::write(path, content).expect("write config.toml");
+}
 
 /// The minvmd binary under test: `MINVMD_BIN` when set (CI's split build/test
 /// runners), else the compile-time cargo-built path.
@@ -77,6 +90,42 @@ fn set_merges_without_clobbering_the_other_field() {
         "earlier ram_mib must survive a later set"
     );
     assert_eq!(v["vcpus"], 1);
+}
+
+#[test]
+fn show_survives_a_malformed_config_toml() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    plant_config_toml(tmp.path(), "vcpus = \"not-a-number\"");
+
+    // Boot resolution falls back to defaults on a malformed file; `config show`
+    // must do the same — not fail — or the one command that could report the
+    // fallback is the one command the malformed file breaks.
+    let (ok, out, err) = run(tmp.path(), &["config", "show", "--json"]);
+    assert!(
+        ok,
+        "config show must not fail on malformed TOML; stderr: {err}"
+    );
+    let v: serde_json::Value = serde_json::from_str(out.trim()).expect("valid JSON");
+    assert_eq!(v["vcpus_source"], "default");
+    assert_eq!(v["ram_mib_source"], "default");
+}
+
+#[test]
+fn hand_edited_invalid_values_fall_back_to_defaults() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // `config set` rejects both of these; a hand-edited file is the only way
+    // they reach disk. Resolution must treat them as unset rather than hand a
+    // 0-vcpu / 64 MiB VmConfig to the VMM.
+    plant_config_toml(tmp.path(), "vcpus = 0\nram_mib = 64\n");
+
+    let (ok, out, err) = run(tmp.path(), &["config", "show", "--json"]);
+    assert!(ok, "config show must succeed; stderr: {err}");
+    let v: serde_json::Value = serde_json::from_str(out.trim()).expect("valid JSON");
+    assert_eq!(v["vcpus_source"], "default", "vcpus = 0 must be ignored");
+    assert_eq!(
+        v["ram_mib_source"], "default",
+        "sub-floor ram_mib must be ignored"
+    );
 }
 
 #[test]

--- a/docs/specs/09-spec-minvmd-resource-monitoring/09-spec-minvmd-resource-monitoring.md
+++ b/docs/specs/09-spec-minvmd-resource-monitoring/09-spec-minvmd-resource-monitoring.md
@@ -36,8 +36,8 @@ in-guest, post-mortem — OOM via `/sys/fs/cgroup/memory.events` and disk-full v
 `df … ≥95%`, each pointing the user at the knob to raise. This spec ports those
 ideas to a host-side, typed, tested implementation.
 
-`vcpus`/`ram_mib` are read at boot from `crate::cmd::effective_*` and are static
-for the VM's lifetime. This work monitors the *current* allocation and persists
+`vcpus`/`ram_mib` are resolved once per boot (`crate::cmd::resolve_resources`)
+and are static for the VM's lifetime. This work monitors the *current* allocation and persists
 config for the *next* boot; live hot-add / resize of a running VM is explicitly a
 non-goal, per the host-daemon spec's deferral of "RAM resizing, vcpu hot-add"
 (`docs/specs/01-spec-minvmd-host-daemon/01-spec-minvmd-host-daemon.md:335`).
@@ -166,8 +166,9 @@ process in `status --json` and `status` human output.
 - `crates/minvmd/src/state.rs` — extract `atomic_write_toml` helper; add
   `booted_vcpus`/`booted_ram_mib` runtime snapshot fields
 - `crates/minvmd/src/cmd/config.rs` (new) — `show`/`set` + validation
-- `crates/minvmd/src/cmd/mod.rs` — `effective_vcpus`/`effective_ram_mib`
-- `crates/minvmd/src/cmd/vmm_child.rs` — boot from effective values
+- `crates/minvmd/src/cmd/mod.rs` — `resolve_resources`/`effective_resources`
+- `crates/minvmd/src/cmd/vmm_child.rs` — boot from the parent's pre-spawn
+  snapshot
 - `crates/minvmd/src/cmd/run.rs` — stamp booted snapshot into `Running` state
 - `crates/minvmd/src/main.rs` — `config` subcommand
 - `crates/minvmd/src/lib.rs` — `pub mod config;`
@@ -185,12 +186,16 @@ process in `status --json` and `status` human output.
   provider-instance dir — **separate from `State`**, so a stop/crash reset cannot
   wipe it. `read` treats a missing file as the all-`None` default; `write` is
   atomic via the shared `crate::state::atomic_write_toml`.
-- **R2.2**: `crates/minvmd/src/cmd/mod.rs` shall provide `effective_vcpus() -> u8`
-  and `effective_ram_mib() -> u32`, each resolving
+- **R2.2**: `crates/minvmd/src/cmd/mod.rs` shall provide a single-pass
+  resolution (`resolve_resources()`, with `effective_resources() -> (u8, u32)`
+  as the value-only view) resolving
   `environment override ?? persisted config ?? built-in default`
   (`MINVMD_VM_VCPUS`/`MINVMD_VM_RAM_MIB`; defaults `DEFAULT_VM_VCPUS = 2` and the
-  existing arch-conditional `DEFAULT_VM_RAM_MIB`). `status` (R1.3) and
-  `vmm_child` shall report/boot from these.
+  existing arch-conditional `DEFAULT_VM_RAM_MIB`) from one persisted-config
+  read, so neither the pair nor its source labels can tear. Persisted values
+  `config set` would reject (zero vcpus, sub-floor RAM) are treated as unset
+  with a warning. `status` (R1.3) and `vmm_child` shall report/boot from this
+  resolution.
 - **R2.3**: `minvmd config set [--vcpus N] [--ram-mib M]` shall validate, merge
   into the existing persisted config, and write it atomically. Validation rejects
   `vcpus == 0` and `ram_mib < 512` (the userspace floor). With neither flag it is
@@ -198,14 +203,17 @@ process in `status --json` and `status` human output.
 - **R2.4**: `minvmd config show [--json]` shall print the effective `vcpus`/`ram_mib`
   and each value's source (`env`/`config`/`default`).
 - **R2.5**: `crates/minvmd/src/cmd/vmm_child.rs` shall construct its `VmConfig`
-  from `effective_vcpus()`/`effective_ram_mib()`, so a persisted config takes
-  effect on the next boot.
-- **R2.6**: The `Running` state shall record the resolved boot-time `vcpus`/`ram_mib`
-  as `State.booted_vcpus`/`booted_ram_mib` (runtime facts like `vmm_pid`, cleared
-  on stop, `#[serde(default)]` for backward compatibility). `status` shall report
-  and warn against these live values for a running VM — **not** a later
-  `config set`'s next-boot resolution — falling back to `effective_*` only when
-  stopped or when reading a pre-#747 state file with no snapshot.
+  from the parent's pre-spawn resource snapshot (`MINVMD_BOOTED_VCPUS`/
+  `MINVMD_BOOTED_RAM_MIB`), so a persisted config takes effect on the next boot
+  and a `config set` racing the boot window cannot change what that boot uses;
+  a missing snapshot (older parent binary) falls back to local resolution.
+- **R2.6**: The `Running` state shall record the pre-spawn snapshot handed to
+  the VMM child as `State.booted_vcpus`/`booted_ram_mib` (runtime facts like
+  `vmm_pid`, cleared on stop, `#[serde(default)]` for backward compatibility).
+  `status` shall report and warn against these live values for a running VM —
+  **not** a later `config set`'s next-boot resolution — falling back to the
+  effective (next-boot) resolution only when stopped or when reading a pre-#747
+  state file with no snapshot.
 
 **Proof Artifacts:**
 1. **Test:** `config::tests::round_trips_through_toml` and

--- a/docs/specs/09-spec-minvmd-resource-monitoring/architecture.md
+++ b/docs/specs/09-spec-minvmd-resource-monitoring/architecture.md
@@ -23,11 +23,13 @@ the next launch).
 
 2. **Config** (`config.rs` + `cmd/config.rs`) — `ResourceConfig { vcpus, ram_mib }`
    persists to `config.toml` in the provider-instance dir, **separate from the
-   runtime `State`** so a stop/crash reset cannot wipe it. `effective_vcpus()` /
-   `effective_ram_mib()` resolve `env ?? config ?? default`; `vmm_child` boots
-   from them and `config show` reports them. The `Running` state additionally
-   records the resolved boot-time values (`State.booted_*`), and `status` reports
-   *those* for a live VM.
+   runtime `State`** so a stop/crash reset cannot wipe it. `resolve_resources()`
+   resolves `env ?? config ?? default` (values + sources) in one pass from a
+   single config read; `boot`/`run` snapshot it once pre-spawn and hand the pair
+   to `vmm_child` via `MINVMD_BOOTED_*`, and `config show` reports the same
+   resolution. The `Running` state records that pre-spawn snapshot
+   (`State.booted_*`) — by construction what the VM booted with — and `status`
+   reports *those* for a live VM.
 
 3. **Warnings** — proactive only: over-allocation vs host cores/memory, the
    x86_64 MMIO hole, and a host-derived vCPU ceiling (logical cores minus a
@@ -59,11 +61,14 @@ are motivated below.
   value)`; `write_state` delegates to it (behaviour unchanged). Shared with
   `ResourceConfig::write`.
 - `cmd/mod.rs` — `DEFAULT_VM_VCPUS`, `VM_VCPUS_ENV`, `env_ram_mib`/`env_vcpus`
-  (private), `persisted_resource_config`, `effective_ram_mib`/`effective_vcpus`.
-  `vm_ram_mib()` is removed (its two callers move to `effective_ram_mib`).
+  (private), `persisted_resource_config` (sanitizing hand-edited invalid
+  values), `resolve_resources`/`effective_resources`, and the `MINVMD_BOOTED_*`
+  parent→child snapshot env vars. `vm_ram_mib()` is removed (its two callers
+  move to the effective resolution).
 - `cmd/status.rs` — inline `json!` → `#[derive(Serialize)] StatusReport { …,
   metrics }`; pure `build_report`; metrics sampled only when running.
-- `cmd/vmm_child.rs` — `VmConfig::new(effective_vcpus(), effective_ram_mib(), …)`.
+- `cmd/vmm_child.rs` — `VmConfig::new` from the parent's `MINVMD_BOOTED_*`
+  snapshot (local resolution only as a fallback).
 - `cmd/run.rs` — abnormal-exit resource hint before the existing `bail!`.
 - `main.rs` — `Command::Config { action: ConfigAction::{Show, Set} }`.
 - `Cargo.toml` (workspace + crate) — `sysinfo` dependency.

--- a/scripts/minvmd-lifecycle.sh
+++ b/scripts/minvmd-lifecycle.sh
@@ -25,14 +25,34 @@ command -v jq >/dev/null || { echo "::error::jq is required"; exit 1; }
 # Scratch dir for status captures; EXIT-trap teardown so a failed assert
 # can't strand a running daemon on the runner.
 WORK="$(mktemp -d /tmp/mnl-lifecycle.XXXXXX)"
+
+# This proof mutates the default provider's config.toml. Back up any
+# pre-existing file so a local run restores the user's real resource settings
+# instead of erasing them; CI runners have none, so teardown just drops the
+# proof's own config (either way the session-e2e boot that runs next on the
+# same default state dir sees the pre-proof state).
+CFG_PATH="${XDG_STATE_HOME:-$HOME/.local/state}/minimal/providers/local-0/config.toml"
+CFG_BACKUP=""
+if [ -f "$CFG_PATH" ]; then
+  CFG_BACKUP="$WORK/config.toml.pre-proof"
+  cp "$CFG_PATH" "$CFG_BACKUP"
+fi
+
 teardown() {
   minvmd stop >/dev/null 2>&1 || true
-  # Drop the resource config this proof persisted so it cannot alter the
-  # session-e2e boot that runs next on the same default state dir.
-  rm -f "${XDG_STATE_HOME:-$HOME/.local/state}/minimal/providers/local-0/config.toml"
+  if [ -n "$CFG_BACKUP" ] && [ -f "$CFG_BACKUP" ]; then
+    cp "$CFG_BACKUP" "$CFG_PATH"
+  else
+    rm -f "$CFG_PATH"
+  fi
   rm -rf "$WORK"
 }
 trap teardown EXIT
+
+# Ambient overrides out-rank the persisted layer (env ?? config ?? default),
+# so a caller-exported MINVMD_VM_* would fail the `ram_mib_source == "config"`
+# assertion below for reasons unrelated to the code under proof.
+unset MINVMD_VM_RAM_MIB MINVMD_VM_VCPUS
 
 # Persist a resource config BEFORE boot so the running VM demonstrably
 # consumes it (R2.3/R2.4/R2.5). 3072 MiB differs from the x86_64 default


### PR DESCRIPTION
## Summary

Follow-up to [#775](https://github.com/gominimal/minimal/pull/775): fixes the four confirmed findings from CodeRabbit's post-merge review of the `minvmd` resource surface, plus one adjacent bug the new tests exposed. Each section below states the failure as *state + action → observed wrong outcome*.

### 1. `status` could report resources the VM did not boot with

**Failure state:** A VM is booting (the ~30–60 s window between VMM-child spawn and the guest's READY marker). A user runs `minvmd config set --ram-mib 8192` inside that window. → The child boots the VM with the *old* RAM value, but the parent re-resolves the config after READY and records the *new* value as `State.booted_ram_mib`; `minvmd status` then reports a RAM size the running VM does not have, silencing or fabricating any reasoning built on the booted values (R2.6).

**Also:** the child resolved `vcpus` and `ram_mib` as two separate `config.toml` reads — a `config set` between them boots a VM with vcpus from one config version and RAM from another.

**Fix:** the parent resolves the pair once, pre-spawn, hands it to the child via `MINVMD_BOOTED_VCPUS`/`MINVMD_BOOTED_RAM_MIB`, and persists that same snapshot at the Running transition. The child boots from the snapshot (local resolution only as a mixed-version fallback). Both spawn sites (`run`, `boot`) pass it.

### 2. A malformed `config.toml` broke the one command that could diagnose it

**Failure state:** `config.toml` contains invalid TOML (hand edit, partial write). → Boot silently falls back to defaults, but `minvmd config show` — the command a user would run to see what boot will use — exits with an error instead. Additionally, `run_show`'s three independent config reads could label values with sources from a *different* file version under a concurrent `config set`.

**Fix:** `config show` now uses the same single-read resolution pass as boot (`resolve_resources()`): one snapshot supplies values *and* source labels, and a malformed file reports the same default fallback boot would use (with a warning on stderr).

### 3. Hand-edited invalid values rode straight into the VMM

**Failure state:** `config.toml` contains `vcpus = 0` or `ram_mib = 64` (values `config set` rejects — only the write path validated). → Boot resolution hands a 0-vcpu `VmConfig` to libkrun, or boots a guest with too little RAM to reach userspace, which then fails as an opaque READY timeout.

**Fix:** persisted values that `config set` would reject are treated as unset with a warning; boot falls back to the built-in defaults. Covered by new CLI integration tests driving the real binary against planted `config.toml` files.

### 4. `atomic_write_toml` was atomic but not durable

**Failure state:** A state/config write completes (`config set` prints `saved:`), then the host crashes before the directory entry reaches disk. → The rename lives in the parent directory, which was never fsynced, so the *old* file resurfaces after reboot — an acknowledged write is lost.

**Fix:** fsync the parent directory after the rename.

### 5. Lifecycle proof erased the developer's real config (script)

**Failure state:** A developer with persisted VM settings runs `scripts/minvmd-lifecycle.sh` locally. → The EXIT-trap teardown `rm -f`s the default provider's `config.toml` unconditionally, permanently deleting their real resource configuration. Separately, an ambient `MINVMD_VM_RAM_MIB` in the caller's shell out-ranks the persisted layer and fails the proof's `ram_mib_source == "config"` assertion for reasons unrelated to the code under proof.

**Fix:** back up any pre-existing `config.toml` into the proof's scratch dir and restore it on exit (CI runners have none, so teardown still just drops the proof's own file); `unset MINVMD_VM_RAM_MIB MINVMD_VM_VCPUS` before the assertions.

### Bonus: tracing diagnostics corrupted piped JSON

**Failure state (exposed by the new tests):** any code path emits a `tracing` warning while `minvmd config show --json` or `minvmd status --json` runs (e.g. the malformed-config fallback). → `fmt::layer()` wrote to **stdout**, so the warning lands in front of the JSON document and `minvmd … --json | jq` fails to parse. In `run --detach`, diagnostics went to `/dev/null` (stdout) instead of the `run.log` that captures stderr as the documented boot-failure diagnosis channel.

**Fix:** route the tracing subscriber to stderr.

## Not addressed (from the same review)

- The suggestion to lower the CLI test's RAM value to 512 MiB rests on a wrong premise — over-allocation *warns*, it never rejects, so 3072 passes on any runner.
- The standalone doc findings (stale reactive-warning user story, undefined `R9.1` anchors) are left for a separate docs pass; this PR only updates spec prose the code changes made stale.

## Testing

- `cargo test -p minvmd` — 127 lib + 6 CLI-integration tests pass (3 new resolution/sanitize unit tests; 2 new CLI tests for malformed / hand-edited-invalid `config.toml`).
- `cargo clippy -p minvmd --all-targets -- -D warnings` clean; `cargo fmt` applied; `bash -n` on the script.
- The snapshot handoff on a real boot needs the gated VM lanes (`MINVMD_E2E=1` / `scripts/minvmd-lifecycle.sh`), which CI exercises on the KVM lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - VM boots now use a consistent snapshot of configured CPU and memory resources throughout startup.
  - `config show` reports the resolved resource values and whether they come from environment settings, saved configuration, or defaults.

- **Bug Fixes**
  - Invalid or malformed saved resource settings now safely fall back to defaults.
  - Runtime status remains aligned with the resources used at boot.
  - Diagnostic output no longer interferes with JSON command results.

- **Reliability**
  - Configuration state is written more durably to reduce data loss after interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->