### PR TITLE
feat(minimal): make socket arg for proxy command optional

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -399,7 +399,7 @@ pub struct UpdateArgs {}
 pub struct ProxyArgs {
     /// UDS socket path to connect to
     #[arg(long)]
-    pub socket: String,
+    pub socket: Option<String>,
 }
 
 /// Arguments for `minimal ssh-forward`.
@@ -452,7 +452,7 @@ pub async fn run(cli: Cli) -> Result<(), anyhow::Error> {
             MeshCommand::Join(args) => cmd_mesh_join(&cli.global_args, args),
             MeshCommand::Leave => cmd_mesh_leave(&cli.global_args),
         },
-        Command::Proxy(args) => cmd_proxy(args).await,
+        Command::Proxy(args) => cmd_proxy(&cli.global_args, args).await,
         #[cfg(feature = "remote-access")]
         Command::SshForward(args) => cmd_ssh_forward(&cli.global_args, args).await,
         Command::Login(args) => cmd_login(&cli.global_args, args).await,
@@ -548,10 +548,22 @@ async fn resolve_session(
 ///
 /// Intended for use as an SSH `ProxyCommand`: ssh writes to our stdin and
 /// reads from our stdout, while we bridge both directions to the UDS.
-pub async fn cmd_proxy(args: ProxyArgs) -> Result<(), anyhow::Error> {
-    let stream = tokio::net::UnixStream::connect(&args.socket)
+pub async fn cmd_proxy(global: &GlobalArgs, args: ProxyArgs) -> Result<(), anyhow::Error> {
+    let socket_path = match args.socket {
+        Some(socket_path) => socket_path,
+        None => {
+            ensure_daemon(global)?;
+            client::resolve_socket_path(global.minimal_dir.as_deref())
+                .context("Failed to resolve daemon socket path")?
+                .to_str()
+                .unwrap()
+                .to_string()
+        }
+    };
+
+    let stream = tokio::net::UnixStream::connect(&socket_path)
         .await
-        .with_context(|| format!("connect to {}", args.socket))?;
+        .with_context(|| format!("connect to {}", socket_path))?;
 
     let (mut rx, mut tx) = stream.into_split();
     let mut stdin = tokio::io::stdin();


### PR DESCRIPTION
Uses global args / default-to-local when socket not specified. Helpful when im trying to get the pipe from the IDE (Zed) working so I dont have to figure out the socket path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `proxy` command can now automatically connect to the managed daemon when no socket path is specified.
  * Added support for connecting directly to a custom socket using the optional `--socket` argument.

* **Bug Fixes**
  * Improved proxy connection handling and error context for the selected socket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->