### PR TITLE
ci(dogfood): split the cargo-state cache into restore + main-only save

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,10 @@ jobs:
               with:
                   persist-credentials: false
             - name: Cache Cargo state
-              uses: actions/cache@v5
+              # Restore-only; the save half (main only) runs at the end of the
+              # job, matching the KVM lane's cache policy.
+              id: cargo-cache
+              uses: actions/cache/restore@v6
               with:
                   path: ~/.local/state/minimal/state
                   key: dogfood-minimal-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -119,6 +122,14 @@ jobs:
               with:
                   channel: unstable
                   task: build-smoke
+            - name: Save Cargo state cache (main only)
+              # PR branches restore but never write: caches written by every
+              # branch LRU-evict the main entries all PRs restore from.
+              if: github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'
+              uses: actions/cache/save@v6
+              with:
+                  path: ~/.local/state/minimal/state
+                  key: ${{ steps.cargo-cache.outputs.cache-primary-key }}
 
     cargo-deny:
         needs: [changes]


### PR DESCRIPTION
## Summary

Splits the dogfood job's `actions/cache` into an always-run `actions/cache/restore` and an end-of-job `actions/cache/save` guarded to `main`, mirroring the KVM lane's documented cache policy (`ci-linux-kvm.yml`: "PR branches restore but never write: … caches written by every branch LRU-evict the main entries all PRs restore from").

**Failure state:** every PR branch's dogfood run saves its own `dogfood-minimal-cargo-*` entry via the combined action's post step. Under the repo's 10 GB cache quota, those per-branch entries LRU-evict the main-built entries — so the next PR's restore misses (or falls back to a stale prefix match) and dogfood rebuilds from scratch, exactly the churn the KVM lane's split already prevents for its own cache.

**Change:**
- `actions/cache@v5` → `actions/cache/restore@v6` (id: `cargo-cache`), same path/key/restore-keys.
- New `Save Cargo state cache (main only)` step after the smoketest: `actions/cache/save@v6`, `if: github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'`, keyed on `cache-primary-key` — save semantics identical to the KVM lane (runs only on job success, skips when the exact key already exists).

`actionlint` passes.

> Note: `.github/workflows/` is CODEOWNER-gated per [CONTRIBUTING.md](https://github.com/gominimal/minimal/blob/main/CONTRIBUTING.md); this PR needs a CODEOWNER review to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI build-cache handling to restore existing caches efficiently.
  * Added conditional cache saving for builds on the main branch when no matching cache is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->