### PR TITLE
fix(nightly): remove broken verify-ci gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,18 +7,11 @@ on:
                 description: "Build, sign, and assemble everything but publish nothing (no GCS upload, no GitHub release, no installer-bucket write, no channel advance)."
                 type: boolean
                 default: false
-            skip_ci_verify:
-                description: "Bypass the verify-ci gate that requires this commit's five lane aggregators to be green. Admin override for a commit whose checks are known-good but unreported."
-                type: boolean
-                default: false
     # Invoked by nightly.yml, which depends on this run completing before it
     # flips the `nightly` channel. Inputs default to a real, verified release.
     workflow_call:
         inputs:
             dry_run:
-                type: boolean
-                default: false
-            skip_ci_verify:
                 type: boolean
                 default: false
 
@@ -35,49 +28,6 @@ permissions:
     contents: read
 
 jobs:
-    verify-ci:
-        # Gate the release on the required CI checks having passed for the EXACT
-        # commit being released, instead of re-running the workspace suite here
-        # (the old `test` job duplicated ci-linux-native's `core-tests`). The five
-        # lane aggregators are the required checks on `main` (ruleset 14240442);
-        # assert each reported success on HEAD. The job always runs so `release`'s
-        # `needs` is satisfied; `skip_ci_verify` short-circuits it to a pass for a
-        # commit whose checks are green but unreported (admin override).
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        permissions:
-            contents: read
-            checks: read
-        steps:
-            - uses: actions/checkout@v7
-              with:
-                  persist-credentials: false
-            - name: Verify required checks are green on this commit
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  SKIP: ${{ inputs.skip_ci_verify }}
-              run: |
-                  set -euo pipefail
-                  if [ "$SKIP" = "true" ]; then
-                    echo "::warning::skip_ci_verify set — bypassing the required-checks gate"
-                    exit 0
-                  fi
-                  required="ci-success ci-linux-native-success ci-linux-kvm-success ci-macos-success ci-shell-installer-success"
-                  sha="$(git rev-parse HEAD)"
-                  # Latest conclusion per check-run name for this commit.
-                  runs="$(gh api "repos/$GITHUB_REPOSITORY/commits/$sha/check-runs" --paginate \
-                    --jq '.check_runs[] | "\(.name)\t\(.conclusion)"')"
-                  fail=0
-                  for name in $required; do
-                    c="$(printf '%s\n' "$runs" | awk -F'\t' -v n="$name" '$1==n {print $2}' | tail -1)"
-                    if [ "$c" != "success" ]; then
-                      echo "::error::required check '$name' is '${c:-missing}' on $sha (need success)"
-                      fail=1
-                    fi
-                  done
-                  [ "$fail" -eq 0 ] && echo "all five required checks are green on $sha"
-                  exit "$fail"
-
     build-release-linux-amd64:
         runs-on: ubuntu-latest
         # 90m, matching arm64. The build step below links the three binaries one
@@ -629,7 +579,6 @@ jobs:
         timeout-minutes: 30
         needs:
             [
-                verify-ci,
                 build-release-linux-amd64,
                 build-release-linux-arm64,
                 build-release-macos-arm64,


### PR DESCRIPTION
`verify-ci` only worked when the HEAD commit had resulted in all those tests having being launched (they are conditional), otherwise it would fail. Also it broke the release job being called from nightly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Removed the required CI verification gate from the release workflow.
  * Removed the option to bypass required CI checks.
  * Releases now depend only on the remaining configured release steps.
  * Retained support for dry-run releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->