### PR TITLE
ci(nightly): add dry_run and skip_ci_verify dispatch inputs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,15 @@ on:
     schedule:
         - cron: "0 10 * * *" # 10:00 UTC = 02:00 PST
     workflow_dispatch:
+        inputs:
+            dry_run:
+                description: "Build, sign, assemble, and smoke everything but publish nothing (no GCS upload, no GitHub release, no installer-bucket write, no nightly channel advance). Forces the build even when HEAD is already staged."
+                type: boolean
+                default: false
+            skip_ci_verify:
+                description: "Bypass release.yml's verify-ci gate that requires this commit's five lane aggregators to be green. Admin override for a commit whose checks are known-good but unreported."
+                type: boolean
+                default: false
 
 permissions:
     contents: write # release job cuts a GitHub release
@@ -51,8 +60,15 @@ jobs:
 
     release:
         needs: check
-        if: ${{ needs.check.outputs.should_release == 'true' }}
+        # A dry_run dispatch forces the build even when HEAD is already staged
+        # (a rehearsal that skips itself proves nothing). On schedule the
+        # inputs context is empty, so both expressions fall back to the
+        # unforced/real-release path.
+        if: ${{ needs.check.outputs.should_release == 'true' || inputs.dry_run == true }}
         uses: ./.github/workflows/release.yml
+        with:
+            dry_run: ${{ inputs.dry_run || false }}
+            skip_ci_verify: ${{ inputs.skip_ci_verify || false }}
         secrets: inherit
 
     # --- Smoke: prove the artifacts release.yml just built actually run before
@@ -386,8 +402,10 @@ jobs:
         # Run whether release executed (success) or was skipped as a no-op;
         # bail only if it actually failed or was cancelled, or if the smoke
         # gate reds. always() is needed so a skipped `release` doesn't
-        # auto-skip this job.
-        if: ${{ always() && needs.check.result == 'success' && needs.release.result != 'failure' && needs.release.result != 'cancelled' && needs.smoke-success.result == 'success' }}
+        # auto-skip this job. A dry_run dispatch never advances the channel —
+        # a dry-run release stages nothing, and re-pointing nightly at a
+        # previously staged HEAD would make the rehearsal publish.
+        if: ${{ always() && needs.check.result == 'success' && needs.release.result != 'failure' && needs.release.result != 'cancelled' && needs.smoke-success.result == 'success' && !inputs.dry_run }}
         runs-on: ubuntu-latest
         timeout-minutes: 20
         permissions:


### PR DESCRIPTION
## What

Mirrors release.yml's `workflow_dispatch` inputs on nightly.yml and passes them through the `workflow_call`:

- **`dry_run`** — build, sign, assemble, and smoke everything, publish nothing. Two nightly-specific behaviors:
  - **Forces the build even when HEAD is already staged** (`should_release == 'true' || inputs.dry_run == true`) — a rehearsal that skips itself proves nothing. The smoke jobs then run against the fresh artifacts.
  - **Never advances the channel** — `promote-nightly` gains `&& !inputs.dry_run`. A dry-run release stages nothing, and re-pointing `nightly` at a previously staged HEAD would make the rehearsal publish.
- **`skip_ci_verify`** — straight pass-through to release.yml's verify-ci gate (admin override for a commit whose checks are known-good but unreported).

Scheduled runs see an empty `inputs` context, so every expression falls back to today's behavior.

This makes `gh workflow run nightly.yml -f dry_run=true` the safe end-to-end rehearsal of the whole nightly pipeline — including the smoke jobs added in [#759](https://github.com/gominimal/minimal/pull/759) — which #759's description noted wasn't previously possible.

## Authorization (workflow freeze)

Editing `.github/workflows/` is normally frozen and CODEOWNER-gated (see `CLAUDE.md`). Owner-directed follow-up to [#759](https://github.com/gominimal/minimal/pull/759), opened for code-owner review.

## Validation

`actionlint` (1.7.12) runs clean. Scheduled-path behavior is unchanged by construction (empty `inputs` context); the dispatch path gets its first proof from a `dry_run=true` dispatch once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual nightly workflow options for dry runs and skipping CI verification.
  * Dry runs can now execute release preparation without advancing the release channel.
  * Workflow inputs are forwarded automatically, with safe defaults when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->