### PR TITLE
fix(release): fix warning about dirty workspace during arm64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,20 +206,19 @@ jobs:
         env:
             CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
         steps:
-            - uses: actions/checkout@v7
             - name: Free Disk Space
               # Static release build of the full workspace; the cargo target dir
-              # is the largest in any of the linux jobs. `remove_tool_cache: true`
-              # is safe even without a `dtolnay/rust-toolchain` step — the
-              # pre-installed Rust toolchain on ubuntu-latest lives in
-              # `~/.rustup` + `~/.cargo`, not `/opt/hostedtoolcache`, so
-              # `rustup target add` below still resolves.
+              # is the largest in any of the linux jobs.
+              #
+              # Runs BEFORE checkout: the action copies a `bc` binary into its
+              # working dir, which dirty's the checkout.
               uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
               with:
                   remove_android: true
                   remove_dotnet: true
                   remove_haskell: true
                   remove_tool_cache: true
+            - uses: actions/checkout@v7
             - name: Install dependencies
               run: sudo apt-get update && sudo apt-get install -y musl-tools protobuf-compiler
             - name: Add Rust target


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Linux ARM64 release build workflow by performing disk-space cleanup before checking out the repository.
  * Prevented the cleanup step from leaving unintended changes in the checked-out workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->