### PR TITLE
feat(ci): script to prune old auto-releases

### DIFF
--- a/.github/workflows/prune-releases.yml
+++ b/.github/workflows/prune-releases.yml
@@ -1,0 +1,93 @@
+name: Prune old releases
+
+# Deletes the auto-cut `release-<sha>` GitHub Releases once they age out, so they
+# don't accumulate forever. Wholly a housekeeping job: the installer serves from
+# the GCS buckets, not GitHub Releases, and `scripts/prune-releases.sh` will NEVER
+# touch a vMAJOR.MINOR.PATCH release (hard guard, independent of --match).
+#
+# All the logic lives in scripts/prune-releases.sh so it can be run and tested
+# outside CI; this workflow is just the schedule + the on-demand button.
+
+on:
+    workflow_dispatch:
+        inputs:
+            execute:
+                description: "Actually delete (unchecked = dry-run preview in the logs)"
+                type: boolean
+                default: false
+            older_than:
+                description: "Age cutoff (any GNU `date -d` spec)"
+                type: string
+                default: "2 months"
+            keep_latest:
+                description: "Always retain this many newest release-* releases"
+                type: string
+                default: "10"
+            verify_permissions:
+                description: "Self-test only: create + delete a throwaway release/tag to prove the token can, then stop (no pruning)"
+                type: boolean
+                default: false
+    schedule:
+        # Nightly at 04:17 UTC Monday and Friday.
+        - cron: "17 4 * * 1,5"
+
+# Deleting releases/tags needs write on contents; nothing else.
+permissions:
+    contents: write
+
+# Never let two prune runs (e.g. a manual dispatch during the nightly) race.
+concurrency:
+    group: prune-releases
+    cancel-in-progress: false
+
+jobs:
+    prune:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        # Don't run the scheduled deletion on forks; a manual dispatch on a fork is
+        # still allowed (it'll act on that fork's own releases).
+        if: github.event_name != 'schedule' || github.repository == 'gominimal/minimal'
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  # The script authenticates via GH_TOKEN and deletes tags through the
+                  # API, so no git credentials need to persist on the runner.
+                  persist-credentials: false
+            - name: Verify GITHUB_TOKEN can delete a release + tag (opt-in self-test)
+              # Proves the *workflow token's* effective permissions in-context — the
+              # only faithful check, since an external PAT has different scopes. Creates
+              # a throwaway release/tag and deletes it, isolating the two failure modes:
+              # missing contents:write vs. a tag-protection ruleset blocking --cleanup-tag.
+              if: github.event_name == 'workflow_dispatch' && inputs.verify_permissions
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  TAG: prune-perms-check-${{ github.run_id }}
+              run: |
+                  set -euo pipefail
+                  echo "Creating throwaway release $TAG at $GITHUB_SHA ..."
+                  gh release create "$TAG" --target "$GITHUB_SHA" --title "$TAG" \
+                      --notes "Permission self-test; safe to ignore, auto-deleted." >/dev/null
+                  echo "Deleting it with --cleanup-tag ..."
+                  if gh release delete "$TAG" --yes --cleanup-tag; then
+                      echo "::notice::OK — token can delete releases AND tags; --cleanup-tags will work."
+                  else
+                      echo "::warning::release+tag delete failed; retrying release-only to isolate the cause"
+                      gh release delete "$TAG" --yes \
+                          && echo "::error::Release deletion works but TAG deletion is blocked (likely a tag ruleset). Run without --cleanup-tags, or exempt release-* tags." \
+                          || echo "::error::Even release deletion failed — the token lacks effective contents:write."
+                      exit 1
+                  fi
+            - name: Prune release-* older than the cutoff
+              # Skipped when running the self-test above.
+              if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.verify_permissions) }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  # The nightly run always executes; a manual dispatch honors the
+                  # checkbox (defaulting to a safe dry-run preview).
+                  EXECUTE: ${{ github.event_name == 'schedule' || inputs.execute }}
+                  OLDER_THAN: ${{ inputs.older_than || '2 months' }}
+                  KEEP_LATEST: ${{ inputs.keep_latest || '10' }}
+              run: |
+                  args=(--older-than "$OLDER_THAN" --keep-latest "$KEEP_LATEST" --cleanup-tags)
+                  [ "$EXECUTE" = "true" ] && args+=(--execute)
+                  scripts/prune-releases.sh "${args[@]}"

--- a/scripts/prune-releases.sh
+++ b/scripts/prune-releases.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# prune-releases.sh — delete GitHub Releases older than a cutoff age.
+#
+# Every release build publishes a `release-<sha>` GitHub Release (see
+# release.yml). These accumulate indefinitely; this script prunes the old ones.
+#
+# It is decoupled from what users actually install: the curl|bash installer
+# resolves versions from the GCS buckets (gs://minimal-shim, gs://minimal-one),
+# not from GitHub Releases, so deleting an old Release removes a redundant
+# artifact copy, not a live install target. It is also decoupled from the
+# version scheme: `crates/version` derives versions via `git describe --match
+# 'v*'`, which ignores `release-<sha>` tags.
+#
+# SAFETY:
+#   * DRY-RUN BY DEFAULT — prints what it would delete; changes nothing until
+#     you pass --execute.
+#   * --keep-latest N always retains the N newest matching releases regardless of
+#     age, so a lull in releases can never empty out the list.
+#   * EXACT vMAJOR.MINOR.PATCH releases are NEVER deleted, whatever --match is set
+#     to — a hard, unconditional guard. Pre-releases (v0.5.0-rc1) and other
+#     suffixed tags are NOT protected and remain prunable.
+#
+# Usage:
+#   scripts/prune-releases.sh [options]
+#
+# Options (env var in parens overrides the default; flags win over env):
+#   --older-than SPEC  Age cutoff, any GNU `date -d` spec   (OLDER_THAN, default: 2 months)
+#   --keep-latest N    Always retain the N newest matches    (KEEP_LATEST, default: 10)
+#   --match GLOB       Only delete releases whose tag matches (MATCH, default: release-*)
+#   --repo OWNER/NAME  Target repo                            (REPO, default: inferred from cwd)
+#   --cleanup-tags     Also delete the underlying git tag, not just the Release
+#   --execute          Actually delete (otherwise dry-run)
+#   -h, --help         Show this help
+#
+# Requires: bash, GNU date, and `gh` authenticated with write access to the repo.
+
+set -euo pipefail
+
+die() {
+    printf 'prune-releases: %s\n' "$1" >&2
+    exit 1
+}
+
+usage() {
+    sed -n '2,/^set -euo/{/^set -euo/!p;}' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+OLDER_THAN="${OLDER_THAN:-2 months}"
+KEEP_LATEST="${KEEP_LATEST:-10}"
+MATCH="${MATCH:-release-*}"
+REPO="${REPO:-}"
+CLEANUP_TAGS=0
+EXECUTE=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --older-than)   OLDER_THAN="$2"; shift 2 ;;
+        --keep-latest)  KEEP_LATEST="$2"; shift 2 ;;
+        --match)        MATCH="$2"; shift 2 ;;
+        --repo)         REPO="$2"; shift 2 ;;
+        --cleanup-tags) CLEANUP_TAGS=1; shift ;;
+        --execute)      EXECUTE=1; shift ;;
+        -h|--help)      usage 0 ;;
+        *)              die "unknown argument: $1 (try --help)" ;;
+    esac
+done
+
+command -v gh >/dev/null 2>&1 || die "gh not found"
+case "$KEEP_LATEST" in
+    '' | *[!0-9]*) die "--keep-latest must be a non-negative integer, got '$KEEP_LATEST'" ;;
+esac
+
+# Cutoff as a Unix epoch. `date -d` handles relative specs like "2 months ago".
+CUTOFF="$(date -u -d "$OLDER_THAN ago" +%s)" \
+    || die "could not parse --older-than '$OLDER_THAN' (needs GNU date)"
+
+# gh's {owner}/{repo} template infers from cwd; an explicit --repo overrides both
+# the API path and `gh release delete`.
+api_repo="{owner}/{repo}"
+repo_flag=()
+if [ -n "$REPO" ]; then
+    api_repo="$REPO"
+    repo_flag=(--repo "$REPO")
+fi
+
+cleanup_flag=()
+[ "$CLEANUP_TAGS" -eq 1 ] && cleanup_flag=(--cleanup-tag)
+
+# Every release as `tag<TAB>epoch`, newest first. Drafts have a null
+# published_at, so fall back to created_at; fromdateiso8601 turns the GitHub UTC
+# timestamp into an epoch. --paginate walks every page; sort descending so
+# --keep-latest can retain the newest N regardless of age.
+mapfile -t rows < <(
+    gh api --paginate "repos/$api_repo/releases" \
+        --jq '.[] | [.tag_name, ((.published_at // .created_at) | fromdateiso8601)] | @tsv' \
+        | sort -t"$(printf '\t')" -k2 -nr
+)
+
+deleted=0
+kept_recent=0
+kept_fresh=0
+skipped=0
+protected=0
+rank=0
+for row in "${rows[@]}"; do
+    tag="${row%%$'\t'*}"
+    epoch="${row##*$'\t'}"
+
+    # HARD GUARD: never delete an EXACT vMAJOR.MINOR.PATCH release, whatever
+    # --match says — these are the hand-cut version releases the installer and
+    # `git describe` depend on. Anchored so only a bare `v1.2.3` is protected;
+    # pre-releases (`v0.5.0-rc1`) and any other suffixed tag remain prunable.
+    if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        protected=$((protected + 1))
+        continue
+    fi
+
+    # Only consider tags the caller asked for (default: the auto-cut release-*).
+    case "$tag" in
+        $MATCH) ;;
+        *) skipped=$((skipped + 1)); continue ;;
+    esac
+
+    # Rank among matching releases; always retain the newest KEEP_LATEST.
+    rank=$((rank + 1))
+    if [ "$rank" -le "$KEEP_LATEST" ]; then
+        kept_recent=$((kept_recent + 1))
+        continue
+    fi
+
+    # Past the keep-window: delete only if also older than the age cutoff.
+    if [ "$epoch" -ge "$CUTOFF" ]; then
+        kept_fresh=$((kept_fresh + 1))
+        continue
+    fi
+
+    if [ "$EXECUTE" -eq 0 ]; then
+        printf 'would delete: %s\n' "$tag"
+        deleted=$((deleted + 1))
+        continue
+    fi
+    if gh release delete "$tag" --yes "${cleanup_flag[@]}" "${repo_flag[@]}"; then
+        printf 'deleted: %s\n' "$tag"
+        deleted=$((deleted + 1))
+    else
+        die "failed to delete release '$tag'"
+    fi
+done
+
+verb="would delete"
+[ "$EXECUTE" -eq 1 ] && verb="deleted"
+printf 'prune-releases: %s %d release(s); kept %d newest + %d within age; protected %d vX.Y.Z; skipped %d non-matching\n' \
+    "$verb" "$deleted" "$kept_recent" "$kept_fresh" "$protected" "$skipped" >&2
+[ "$EXECUTE" -eq 0 ] && printf 'prune-releases: dry-run — re-run with --execute to delete\n' >&2
+exit 0


### PR DESCRIPTION
This will delete releases which are **NOT** point releases (i.e. `v<major>.<minor>.<patch>` will stay forever). Non-point releases are deleted when they are 1) older than 2 months, and 2) not in the last 10 releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated cleanup for older generated releases and their tags.
  * Supports scheduled execution and optional manual runs.
  * Manual runs provide a dry-run preview by default, with configurable age and retention limits.
  * Protects the latest releases and exact semantic-version tags from deletion.
  * Includes an optional permission verification test for release and tag removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->