### PR TITLE
feat(minimal,minimald): show shared resource pool in session list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3682,6 +3682,7 @@ dependencies = [
  "sessions",
  "stdlib",
  "switch",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -641,6 +641,28 @@ pub fn format_ls(
         return Ok(());
     }
 
+    if !args.raw
+        && let Some(pool) = &resp.resource_pool
+    {
+        let session_count = resp.sessions.len();
+        let core_label = if pool.cpu_cores == 1 { "core" } else { "cores" };
+        let session_label = if session_count == 1 {
+            "session"
+        } else {
+            "sessions"
+        };
+        writeln!(
+            out,
+            "RESOURCE POOL:  {} CPU {} · {} memory · shared by {} {}",
+            pool.cpu_cores,
+            core_label,
+            format_memory(pool.memory_bytes),
+            session_count,
+            session_label,
+        )?;
+        writeln!(out)?;
+    }
+
     if resp.sessions.is_empty() {
         if !args.raw {
             writeln!(out, "No active sessions.")?;
@@ -690,6 +712,22 @@ pub fn format_ls(
     }
 
     Ok(())
+}
+
+fn format_memory(bytes: u64) -> String {
+    const MIB: u64 = 1024 * 1024;
+    const GIB: u64 = 1024 * MIB;
+
+    if bytes >= GIB {
+        let gib = bytes as f64 / GIB as f64;
+        if bytes.is_multiple_of(GIB) {
+            format!("{gib:.0} GiB")
+        } else {
+            format!("{gib:.1} GiB")
+        }
+    } else {
+        format!("{} MiB", bytes / MIB)
+    }
 }
 
 /// Default policy hook for `minimal activate`: auto-approves any

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -9,6 +9,7 @@ mod common;
 
 use common::setup;
 use minimal::*;
+use minimald_rpc::{ListSessionsResponse, ResourcePool};
 use sessions::SessionId;
 
 use minimald::test_harness::unwrap_ready;
@@ -36,6 +37,37 @@ async fn version_succeeds_without_daemon() {
 }
 
 // --- ls ---
+
+#[test]
+fn ls_shows_shared_resource_pool() {
+    let resp = ListSessionsResponse {
+        resource_pool: Some(ResourcePool {
+            cpu_cores: 8,
+            memory_bytes: 16 * 1024 * 1024 * 1024,
+        }),
+        sessions: vec![minimald_rpc::ListSessionsEntry {
+            id: SessionId::nil(),
+            name: None,
+            attrs: None,
+        }],
+    };
+    let mut out = Vec::new();
+
+    format_ls(
+        &mut out,
+        &LsArgs {
+            raw: false,
+            json: false,
+        },
+        &resp,
+    )
+    .unwrap();
+
+    let text = String::from_utf8(out).unwrap();
+    assert!(
+        text.starts_with("RESOURCE POOL:  8 CPU cores · 16 GiB memory · shared by 1 session\n\n")
+    );
+}
 
 #[tokio::test]
 async fn ls_empty() {
@@ -101,6 +133,8 @@ async fn ls_json_empty() {
     .unwrap();
     let text = String::from_utf8(out).unwrap();
     let parsed: Value = serde_json::from_str(&text).expect("json output should be valid JSON");
+    assert!(parsed["resource_pool"]["cpu_cores"].as_u64().unwrap() > 0);
+    assert!(parsed["resource_pool"]["memory_bytes"].as_u64().unwrap() > 0);
     assert!(parsed["sessions"].is_array());
     assert!(parsed["sessions"].as_array().unwrap().is_empty());
 }

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -132,9 +132,20 @@ pub struct ListSessionsEntry {
     pub attrs: Option<RunningSessionAttrs>,
 }
 
+/// Resources shared by every session managed by a minimald instance.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourcePool {
+    pub cpu_cores: u32,
+    pub memory_bytes: u64,
+}
+
 /// The response to the [`ListSessions`] RPC.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListSessionsResponse {
+    /// Provider capacity shared by all sessions. Optional for compatibility
+    /// with minimald versions that predate resource-pool reporting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_pool: Option<ResourcePool>,
     pub sessions: Vec<ListSessionsEntry>,
 }
 
@@ -676,6 +687,14 @@ mod tests {
             id: SessionId::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
         };
         assert_eq!(round_trip(&resp), resp);
+    }
+
+    #[test]
+    fn list_sessions_accepts_response_without_resource_pool() {
+        let resp: ListSessionsResponse =
+            serde_json::from_str(r#"{"sessions":[]}"#).expect("deserialize");
+        assert!(resp.resource_pool.is_none());
+        assert!(resp.sessions.is_empty());
     }
 
     #[test]

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -40,6 +40,7 @@ russh-sftp.workspace = true
 path-absolutize.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sysinfo.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 vt100-ctt.workspace = true

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -5,8 +5,8 @@ use minimald_rpc::{
     Errorable, GetMeshStatus, GetSessionPolicy, GetSessionPolicyRequest, GetSessionRecord,
     GetSessionRecordRequest, GetSessionRecordResponse, GetVersion, GetVersionResponse,
     IssueClientCert, IssueClientCertRequest, ListSessions, ListSessionsEntry, ListSessionsResponse,
-    OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse, Shutdown,
-    ShutdownRequest, ShutdownResponse, SubmitVerdict,
+    OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse, ResourcePool,
+    Shutdown, ShutdownRequest, ShutdownResponse, SubmitVerdict,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
@@ -80,8 +80,12 @@ async fn serve_get_version(c: RuChannel<Msg>) {
 async fn serve_list_sessions(s: ServerStateHandle, c: RuChannel<Msg>) {
     let res = ListSessions
         .handle_channel(c, async |_req| {
+            let resource_pool = tokio::task::spawn_blocking(detect_resource_pool)
+                .await
+                .map_err(|e| ConnectionError::Internal(e.to_string()))?;
             let mngr = s.sessions_manager().await;
             Ok(ListSessionsResponse {
+                resource_pool,
                 sessions: mngr
                     .list()
                     .await
@@ -114,6 +118,22 @@ async fn serve_list_sessions(s: ServerStateHandle, c: RuChannel<Msg>) {
     if let Err(e) = res {
         tracing::warn!("RPC handler for {} failed: {}", ListSessions::NAME, e);
     }
+}
+
+fn detect_resource_pool() -> Option<ResourcePool> {
+    let cpu_cores = std::thread::available_parallelism()
+        .ok()?
+        .get()
+        .try_into()
+        .ok()?;
+    let mut system = sysinfo::System::new();
+    system.refresh_memory();
+    let memory_bytes = system.total_memory();
+
+    (memory_bytes > 0).then_some(ResourcePool {
+        cpu_cores,
+        memory_bytes,
+    })
 }
 
 async fn serve_get_session_record(s: ServerStateHandle, c: RuChannel<Msg>) {
@@ -839,6 +859,7 @@ mod tests {
         );
 
         let list_sessions = client.call::<ListSessions>(&()).await;
+        assert!(list_sessions.resource_pool.is_some());
         assert_eq!(
             list_sessions.sessions,
             vec![ListSessionsEntry {


### PR DESCRIPTION
## Summary

- report the daemon's CPU-core and memory capacity as a shared resource pool
- show the pool once above the `min ls` table instead of implying per-session allocations
- expose the optional pool in `min ls --json` while preserving compatibility with older daemons and leaving `--raw` unchanged

## Example

```text
RESOURCE POOL:  8 CPU cores · 16 GiB memory · shared by 6 sessions
```

## Verification

- `cargo fmt --check`
- `cargo test -p minimald-rpc`
- `cargo clippy -p minimald-rpc --all-targets -- -D warnings`
- `cargo check -p minimal --lib`
- `cargo clippy -p minimal --lib --no-deps -- -D warnings`
- `git diff --check`

The `minimal` CLI integration and `minimald` tests cannot build on macOS because existing `hakoniwa` dependencies compile Linux-only `procfs`; a Linux cross-check additionally requires an unavailable `aarch64-linux-gnu-gcc` toolchain.

(amp-codex-5.5-test-ls-resource-pool)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource pool details to session listings, including available CPU cores, memory, and shared session count.
  * Human-readable listings now show a formatted “RESOURCE POOL” summary.
  * JSON responses include resource pool CPU and memory information when available.
* **Bug Fixes**
  * Preserved compatibility with responses that do not include resource pool data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->