### PR TITLE
fix(minimald): hide unplumbed --stdlib-dir and -n args from help

### DIFF
--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -139,11 +139,12 @@ pub struct GlobalArgs {
 
     /// Load the minimal standard library from the given path instead
     #[arg(long)]
-    #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
+    #[clap(hide = true)]
     stdlib_dir: Option<CwdRelative<Daemon>>,
 
     /// Configure the number of parallel builds
     #[arg(short, long, global = true)]
+    #[clap(hide = true)]
     num_parallel_builds: Option<usize>,
 }
 


### PR DESCRIPTION
## Summary

`minimald`'s `GlobalArgs` declares `--stdlib-dir` and `-n`/`--num-parallel-builds`, but neither is read anywhere in the daemon — the microVM path hardcodes both to `None` and the server `Config` consumes neither. `--stdlib-dir` was hidden only outside `MINIMAL_SCIENCE_MODE`, while `-n` was fully user-visible dead surface.

This hides both unconditionally with `#[clap(hide = true)]` so they no longer appear in help output. Since neither is plumbed even in science mode, there's no reason to surface them there. The flags still parse and are silently accepted, so any caller already passing them keeps working.

## Change

```rust
     /// Load the minimal standard library from the given path instead
     #[arg(long)]
-    #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
+    #[clap(hide = true)]
     stdlib_dir: Option<CwdRelative<Daemon>>,

     /// Configure the number of parallel builds
     #[arg(short, long, global = true)]
+    #[clap(hide = true)]
     num_parallel_builds: Option<usize>,
```

## Testing

- `cargo build -p minimald`
- `cargo clippy -p minimald --all-targets -- -D warnings`
- `cargo fmt -p minimald`

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * The `--stdlib-dir` command-line option is now consistently hidden from help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->