### PR TITLE
feat(stdlib): redistributable attr class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6220,7 +6220,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdlib"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "fd-lock",
  "tempfile",

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stdlib"
-version = "0.0.17"
+version = "0.0.18"
 rust-version = "1.91"
 license.workspace = true
 edition.workspace = true

--- a/crates/stdlib/minimal-ncl/attr_classes.ncl
+++ b/crates/stdlib/minimal-ncl/attr_classes.ncl
@@ -154,5 +154,11 @@ in
         name = "build cost multiple",
         desc = "Hint to build infrastructure that this build is much more intensive than the typical, by some factor.",
         validate = Number,
+    },
+
+    redistributable = {
+        name = "redistributable",
+        desc = "Whether built artifacts of this package may be redistributed through a shared binary cache. Absent means true. Set false when the upstream license or terms forbid redistribution: build infrastructure then neither uploads, indexes, nor seals the artifacts, and consumers build the package locally from the upstream source.",
+        validate = Bool,
     }
 }


### PR DESCRIPTION
Adds the `redistributable | Bool` attr class (default-absent = true): declares whether a package's built artifacts may enter a shared binary cache. Set false when the upstream license or terms forbid redistribution — build infrastructure then neither uploads, indexes, nor seals the artifacts, and consumers build the package locally from the upstream source via the planner's existing index-miss fallback.

Schema + docs only — nothing in this repo reads it. Attrs are unhashed, so setting it causes zero rebuilds.

Supersedes #860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)