### PR TITLE
docs(reference): add CLI command reference and config/spec pages

### DIFF
--- a/docs/reference/build-specs.md
+++ b/docs/reference/build-specs.md
@@ -1,6 +1,6 @@
 ---
 title: Build specs
-description: Build spec schema for defining Minimal packages in Nickel — build_deps, runtime_deps, commands, outputs, tests, and metadata.
+description: Build spec schema for defining Minimal packages in Nickel: build_deps, runtime_deps, commands, outputs, tests, and metadata.
 ---
 
 # Build specs

--- a/docs/reference/build-specs.md
+++ b/docs/reference/build-specs.md
@@ -1,10 +1,11 @@
 ---
+title: Build specs
 description: Build spec schema for defining Minimal packages in Nickel — build_deps, runtime_deps, commands, outputs, tests, and metadata.
 ---
 
 # Build specs
 
-Build specs declare everything about a [package](/concepts/packages), the fundamental unit of software
+Build specs declare everything about a [package](https://docs.minimal.dev/concepts/packages), the fundamental unit of software
 in Minimal.
 
 This declaration includes:
@@ -15,8 +16,8 @@ This declaration includes:
    directories used at runtime for state, and a number of other data points.
 
 Build specs are defined in a [Nickel](https://nickel-lang.org/) file located at `packages/<package name>/build.ncl`, either in your codebase
-or any layer in your [software supply chain](/concepts/software-supply-chain). The `packages/` directory in a layer is always adjacent to
-the [`minimal.toml`](/reference/minimal-dot-toml) file at its base. The directory can be omitted if the layer does not define any packages.
+or any layer in your [software supply chain](https://docs.minimal.dev/concepts/software-supply-chain). The `packages/` directory in a layer is always adjacent to
+the [`minimal.toml`](./minimal-dot-toml.md) file at its base. The directory can be omitted if the layer does not define any packages.
 
 ## Example
 
@@ -67,8 +68,9 @@ More examples are maintained in the [Minimal Public Package Registry](https://gi
 ## Schema
 
 The canonical typing of a Build-spec is defined using [Nickel](https://nickel-lang.org/) in Minimal's
-embedded standard library, located
-[here](https://github.com/gominimal/minimal/blob/main/crates/stdlib/minimal-ncl/minimal.ncl#L10).
+embedded standard library, in
+[`crates/stdlib/minimal-ncl/minimal.ncl`](https://github.com/gominimal/minimal/blob/main/crates/stdlib/minimal-ncl/minimal.ncl)
+(the `BuildSpec` contract).
 
 | **Field name** | **Type** | **Usage** |
 |---|---|---|
@@ -80,6 +82,6 @@ embedded standard library, located
 | `outputs` | Map&lt;String, Output> | The named set of output files that are captured from a build. If no files match a named output, it's a build error.   |
 | `attrs` | Attrs | The typed set of metadata attached to a given package. |
 | `needs` | Needs | Any abstract needs declared on a given package. |
-| `tests` | Map&lt;String, Test> | A list of tests that are run by `minimal check`. |
+| `tests` | Map&lt;String, Test> | A list of tests that are run by [`mip check`](./cli-mip.md#check). |
 | `target` | String | The target string this package supports. Defaults to the current target. |
 | `prebuilt` | Bool | Indicates that a package is not built, but just the unpacked files from the first `Source` object in `build_deps`. |

--- a/docs/reference/build-specs.md
+++ b/docs/reference/build-specs.md
@@ -1,6 +1,6 @@
 ---
 title: Build specs
-description: Build spec schema for defining Minimal packages in Nickel: build_deps, runtime_deps, commands, outputs, tests, and metadata.
+description: "Build spec schema for defining Minimal packages in Nickel: build_deps, runtime_deps, commands, outputs, tests, and metadata."
 ---
 
 # Build specs

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -1,6 +1,6 @@
 ---
 title: min CLI
-description: Reference for the min session CLI: create, attach to, and manage sandboxed development sessions, plus the git-remote-min helper.
+description: "Reference for the min session CLI: create, attach to, and manage sandboxed development sessions, plus the git-remote-min helper."
 ---
 
 # `min` - session CLI
@@ -8,11 +8,13 @@ description: Reference for the min session CLI: create, attach to, and manage sa
 `min` is the Minimal session CLI. It talks to the `minimald` daemon (see
 [minimald](./cli-minimald.md)) to create, attach to, and manage sandboxed
 development sessions. Most commands start the daemon automatically when it
-isn't running (`bug` is the exception): natively on Linux, or inside the
-[`minvmd`](./cli-minvmd.md) microVM host daemon on macOS (and on Linux
-under `--minvmd`).
+isn't running (`bug`, `stop`, and `version` are the exceptions): natively on
+Linux, or inside the [`minvmd`](./cli-minvmd.md) microVM host daemon on macOS
+(and on Linux under `--provider local-minvmd`). Running bare `min` with no
+subcommand resolves a session for the current directory (activating one if
+needed) and attaches to it.
 
-Generated from `--help` at `60e19f60`.
+Generated from `--help` at `3a05252c`.
 
 ## Global flags
 
@@ -23,7 +25,8 @@ These apply to every subcommand.
 | `--repo-dir <PATH>` | `-C` | Use the given directory as the repository root, instead of the current working directory |
 | `--minimal-dir <PATH>` | | Override the base directory used for operations (default: `~/.cache/minimal`) |
 | `--config-dir <PATH>` | | Override the user config directory; everything under `<config_dir>/minimal/` (`config.toml`, `loadouts/`, ...) resolves relative to it. Defaults to `$XDG_CONFIG_HOME` on Linux (or `$HOME/.config`); macOS also uses `$HOME/.config` |
-| `--minvmd` | | Linux: run `minimald` inside the `minvmd` microVM instead of natively on the host (the default). No effect on macOS, where `minvmd` is the only backend |
+| `--provider <PROVIDER>` | | Daemon backend that hosts sessions: `local-minimald` (Linux default, `minimald` natively on the host) or `local-minvmd` (`minimald` inside the `minvmd` microVM). No effect on macOS, where `minvmd` is the only backend |
+| `--no-input` | | Skip interactive prompts that need a terminal (such as the session picker); ambiguous choices error with a list of candidates instead. Implied when stdin/stdout is not a terminal |
 
 ## Commands
 
@@ -62,12 +65,16 @@ the current directory).
 ### `attach`
 
 ```
-min attach [-c <COMMAND>] <SESSION>
+min attach [-c <COMMAND>] [SESSION]
 ```
 
-Attaches to an existing session, identified by UUID or session name.
+Attaches to an existing session, identified by UUID or session name. When
+`SESSION` is omitted, `min attach` resolves a session from the current
+working directory (or the only existing session) and opens an interactive
+picker if the choice is ambiguous (`--no-input` errors instead).
 `-c/--command` execs a command in the session context non-interactively
-instead of opening an interactive shell.
+instead of opening an interactive shell; the daemon accepts only
+`min run <task name>` invocations on this channel, not arbitrary commands.
 
 ### `destroy`
 
@@ -165,7 +172,7 @@ Prints CLI and daemon version information.
 min completions <SHELL>
 ```
 
-Generates a shell tab-completion script. Supported shells: `bash`, `zsh`,
+Generates a shell tab-completion script. Supported shells include `bash`, `zsh`,
 `elvish`, `fish`. Usage: `source <(min completions bash)`.
 
 ## `git push min://` - the git remote helper

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -1,0 +1,226 @@
+---
+title: min CLI
+description: Reference for the min session CLI — create, attach to, and manage sandboxed development sessions, plus the git-remote-min helper.
+---
+
+# `min` — session CLI
+
+`min` is the Minimal session CLI. It talks to the `minimald` daemon (see
+[minimald](./cli-minimald.md)) to create, attach to, and manage sandboxed
+development sessions. If the daemon is not running, `min` starts it
+automatically.
+
+Generated from `--help` at `60e19f60`.
+
+## Global flags
+
+These apply to every subcommand.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--repo-dir <PATH>` | `-C` | Use the given directory as the repository root, instead of the current working directory |
+| `--minimal-dir <PATH>` | | Override the base directory used for operations (default: `~/.cache/minimal`) |
+| `--config-dir <PATH>` | | Override the user config directory; everything under `<config_dir>/minimal/` (`config.toml`, `loadouts/`, ...) resolves relative to it. Defaults to `$XDG_CONFIG_HOME` on Linux (or `$HOME/.config`); macOS also uses `$HOME/.config` |
+| `--minvmd` | | Linux: run `minimald` inside the `minvmd` microVM instead of natively on the host (the default). No effect on macOS, where `minvmd` is the only backend |
+
+## Commands
+
+### `ls`
+
+```
+min ls [--raw] [--json]
+```
+
+Lists sessions. `--raw` prints raw session IDs one per line for piping
+into scripts; `--json` prints the full session list as pretty-printed
+JSON. When the daemon reports a shared resource pool, the table is headed
+by a `RESOURCE POOL:` line (CPU cores, memory, and the number of sessions
+sharing them); `--raw` omits it.
+
+### `activate`
+
+```
+min activate [OPTIONS] [PATH]
+```
+
+Activates (creates) a new session for the project at `PATH` (defaults to
+the current directory).
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--name <NAME>` | `-n` | Optional session name |
+| `--sync <MODE>` | | How to load project files into the session: `tarball` (default — stream a tarball of your project and unpack it) or `none` (do not populate the worktree) |
+| `--network <MODE>` | | Network mode: `no-net`, `host-net` (default), or `own-ip` |
+| `--ingress <EXT:INT[/PROTO]>` | | Static ingress port mapping (`PROTO` = `tcp`\|`udp`, default `tcp`). Repeatable. Requires `--network own-ip` |
+| `--loadout <NAME>` | | Apply the named loadout from `<config>/minimal/loadouts/<NAME>.toml`. Repeatable; if given, config-file `default_loadouts` are ignored |
+| `--no-loadouts` | | Apply no loadouts at all (also skips the config's `default_loadouts`). Conflicts with `--loadout` |
+| `--attach` | | Automatically attach after creation |
+
+### `attach`
+
+```
+min attach [-c <COMMAND>] <SESSION>
+```
+
+Attaches to an existing session, identified by UUID or session name.
+`-c/--command` execs a command in the session context non-interactively
+instead of opening an interactive shell.
+
+### `destroy`
+
+```
+min destroy [--all] [-f|--force] [SESSION]
+```
+
+Destroys (terminates) a session. `--all` destroys all sessions;
+`-f/--force` skips the confirmation when destroying all sessions.
+
+### `stop`
+
+```
+min stop [-f|--force]
+```
+
+Shuts down the `minimald` daemon. `--force` shuts down even if active
+sessions exist.
+
+### `session policy`
+
+```
+min session policy <SESSION>
+```
+
+Prints the effective networking policy for a session as JSON.
+
+### `loadout list` (alias: `ls`)
+
+```
+min loadout list [--dir <DIR>]
+```
+
+Lists loadouts from the user's config directory. `--dir` overrides the
+loadouts directory (default: `<config>/minimal/loadouts`, e.g.
+`~/.config/minimal/loadouts` on Linux).
+
+### `dirs`
+
+```
+min dirs
+```
+
+Prints important directories and file paths for debugging.
+
+### `bug`
+
+```
+min bug [-o <OUTPUT>]
+```
+
+Collects a diagnostic bundle (logs, state, config) to send to the minimal
+dev team. Writes `minimal-diag-<timestamp>.tar.zst` to the current
+directory; `-o/--output` overrides the path. The archive contains host
+system facts, log tails, redacted config, and state listings, plus a
+`manifest.json` recording any collector that failed or timed out — a
+broken install still yields a valid archive that explains what is
+missing.
+
+Diagnosing a wedged system must not change it: `bug` mutates no state and
+never starts a daemon; it works even when none is running.
+
+Secret-shaped values (env vars, tokens) are redacted before they enter
+the archive: only a small allowlist of env names (`RUST_LOG`, `HOME`,
+`SHELL`, `TERM`, `PATH`, and the `XDG_*` / `MINIMAL_*` / `MINVMD_*` /
+`MINIMALD_*` prefixes) has values captured verbatim — a sensitive-shaped
+name always loses to the allowlist — and every other env var is reported
+by name only. Session and project file contents are never included, only
+name/size listings. Review the archive before sharing.
+
+### `login`
+
+```
+min login [--cert-dir <DIR>]
+```
+
+Obtains an mTLS client certificate from `minimald` for use with the HTTPS
+reverse proxy. Generates a fresh client certificate signed by the
+daemon's internal CA and writes `client.pem`, `client.key`, and the CA's
+`ca.pem` to `~/.config/minimal/` (override with `--cert-dir`), so tools
+like `curl` can authenticate to and trust the proxy:
+
+```
+min login
+curl --cacert ~/.config/minimal/ca.pem \
+     --cert ~/.config/minimal/client.pem \
+     --key  ~/.config/minimal/client.key \
+     https://localhost:7655/
+```
+
+### `rename`
+
+```
+min rename <SESSION> <NEW_NAME>
+```
+
+Renames an existing session.
+
+### `init`, `add`, `update`
+
+```
+min init [-y|--yes]
+min add <--runtime|--build|--task <TASK>> [PACKAGES]...
+min update
+```
+
+Project-configuration conveniences mirroring the corresponding `mip`
+commands: initialize minimal configuration from your source tree, add a
+tool or dependency, and refresh local checkouts of upstream packages and
+the standard library. See the [mip reference](./cli-mip.md) for details.
+
+### `version`
+
+```
+min version
+```
+
+Prints CLI and daemon version information.
+
+### `completions`
+
+```
+min completions <SHELL>
+```
+
+Generates a shell tab-completion script. Supported shells: `bash`, `zsh`,
+`elvish`, `fish`. Usage: `source <(min completions bash)`.
+
+## `git push min://` — the git remote helper
+
+Installs of `min` lay down a `bin/git-remote-min` symlink pointing at the
+`min` binary. The binary dispatches on `argv[0]`: when invoked with the
+basename `git-remote-min` — which is how git invokes remote helpers for
+`min://` URLs — it speaks the
+[gitremote-helpers](https://git-scm.com/docs/gitremote-helpers) line
+protocol on stdio instead of the normal CLI.
+
+This lets you add a session's workspace as a git remote and push to or
+fetch from it directly:
+
+```
+git remote add session min://<session>
+git push session
+```
+
+Only the `connect` capability is implemented: on `connect`, the helper
+opens an exec channel to `minimald` over its Unix domain socket (the same
+transport the rest of the CLI uses) and bridges git's pack-protocol
+conversation across it — no external `ssh` or `socat` involved. Only the
+two pack services (`git-upload-pack`, `git-receive-pack`) are accepted.
+If the daemon is not running, the helper starts it, using default global
+flags (git invokes helpers without any of `min`'s own flags).
+
+## Feature-gated commands: `mesh`, `ssh-forward`
+
+The `mesh` (WireGuard mesh enrolment) and `ssh-forward` (SSH
+port-forward) subcommands exist only in builds compiled with the
+off-by-default `remote-access` cargo feature. They are not present in
+shipped binaries and are not documented here.

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -7,8 +7,10 @@ description: Reference for the min session CLI: create, attach to, and manage sa
 
 `min` is the Minimal session CLI. It talks to the `minimald` daemon (see
 [minimald](./cli-minimald.md)) to create, attach to, and manage sandboxed
-development sessions. If the daemon is not running, `min` starts it
-automatically.
+development sessions. Most commands start the daemon automatically when it
+isn't running (`bug` is the exception): natively on Linux, or inside the
+[`minvmd`](./cli-minvmd.md) microVM host daemon on macOS (and on Linux
+under `--minvmd`).
 
 Generated from `--help` at `60e19f60`.
 
@@ -85,14 +87,6 @@ min stop [-f|--force]
 Shuts down the `minimald` daemon. `--force` shuts down even if active
 sessions exist.
 
-### `session policy`
-
-```
-min session policy <SESSION>
-```
-
-Prints the effective networking policy for a session as JSON.
-
 ### `loadout list` (alias: `ls`)
 
 ```
@@ -136,26 +130,6 @@ name always loses to the allowlist), and every other env var is reported
 by name only. Session and project file contents are never included, only
 name/size listings. Review the archive before sharing.
 
-### `login`
-
-```
-min login [--cert-dir <DIR>]
-```
-
-Obtains an mTLS client certificate from `minimald` for use with the HTTPS
-reverse proxy. Generates a fresh client certificate signed by the
-daemon's internal CA and writes `client.pem`, `client.key`, and the CA's
-`ca.pem` to `~/.config/minimal/` (override with `--cert-dir`), so tools
-like `curl` can authenticate to and trust the proxy:
-
-```
-min login
-curl --cacert ~/.config/minimal/ca.pem \
-     --cert ~/.config/minimal/client.pem \
-     --key  ~/.config/minimal/client.key \
-     https://localhost:7655/
-```
-
 ### `rename`
 
 ```
@@ -168,7 +142,7 @@ Renames an existing session.
 
 ```
 min init [-y|--yes]
-min add <--runtime|--build|--task <TASK>> [PACKAGES]...
+min add <--runtime|--build|--task <TASK>> <PACKAGES>...
 min update
 ```
 
@@ -218,10 +192,3 @@ conversation across it; no external `ssh` or `socat` involved. Only the
 two pack services (`git-upload-pack`, `git-receive-pack`) are accepted.
 If the daemon is not running, the helper starts it, using default global
 flags (git invokes helpers without any of `min`'s own flags).
-
-## Feature-gated commands: `mesh`, `ssh-forward`
-
-The `mesh` (WireGuard mesh enrolment) and `ssh-forward` (SSH
-port-forward) subcommands exist only in builds compiled with the
-off-by-default `remote-access` cargo feature. They are not present in
-shipped binaries and are not documented here.

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -1,9 +1,9 @@
 ---
 title: min CLI
-description: Reference for the min session CLI — create, attach to, and manage sandboxed development sessions, plus the git-remote-min helper.
+description: Reference for the min session CLI: create, attach to, and manage sandboxed development sessions, plus the git-remote-min helper.
 ---
 
-# `min` — session CLI
+# `min` - session CLI
 
 `min` is the Minimal session CLI. It talks to the `minimald` daemon (see
 [minimald](./cli-minimald.md)) to create, attach to, and manage sandboxed
@@ -49,11 +49,12 @@ the current directory).
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--name <NAME>` | `-n` | Optional session name |
-| `--sync <MODE>` | | How to load project files into the session: `tarball` (default — stream a tarball of your project and unpack it) or `none` (do not populate the worktree) |
+| `--sync <MODE>` | | How to load project files into the session: `tarball` (default: stream a tarball of your project and unpack it) or `none` (do not populate the worktree) |
 | `--network <MODE>` | | Network mode: `no-net`, `host-net` (default), or `own-ip` |
 | `--ingress <EXT:INT[/PROTO]>` | | Static ingress port mapping (`PROTO` = `tcp`\|`udp`, default `tcp`). Repeatable. Requires `--network own-ip` |
 | `--loadout <NAME>` | | Apply the named loadout from `<config>/minimal/loadouts/<NAME>.toml`. Repeatable; if given, config-file `default_loadouts` are ignored |
 | `--no-loadouts` | | Apply no loadouts at all (also skips the config's `default_loadouts`). Conflicts with `--loadout` |
+| `--no-prompt` | | Fail instead of prompting when the daemon surfaces items user policy can't auto-decide; implied when stdin/stderr isn't a TTY |
 | `--attach` | | Automatically attach after creation |
 
 ### `attach`
@@ -120,7 +121,7 @@ Collects a diagnostic bundle (logs, state, config) to send to the minimal
 dev team. Writes `minimal-diag-<timestamp>.tar.zst` to the current
 directory; `-o/--output` overrides the path. The archive contains host
 system facts, log tails, redacted config, and state listings, plus a
-`manifest.json` recording any collector that failed or timed out — a
+`manifest.json` recording any collector that failed or timed out; a
 broken install still yields a valid archive that explains what is
 missing.
 
@@ -130,8 +131,8 @@ never starts a daemon; it works even when none is running.
 Secret-shaped values (env vars, tokens) are redacted before they enter
 the archive: only a small allowlist of env names (`RUST_LOG`, `HOME`,
 `SHELL`, `TERM`, `PATH`, and the `XDG_*` / `MINIMAL_*` / `MINVMD_*` /
-`MINIMALD_*` prefixes) has values captured verbatim — a sensitive-shaped
-name always loses to the allowlist — and every other env var is reported
+`MINIMALD_*` prefixes) has values captured verbatim (a sensitive-shaped
+name always loses to the allowlist), and every other env var is reported
 by name only. Session and project file contents are never included, only
 name/size listings. Review the archive before sharing.
 
@@ -193,12 +194,12 @@ min completions <SHELL>
 Generates a shell tab-completion script. Supported shells: `bash`, `zsh`,
 `elvish`, `fish`. Usage: `source <(min completions bash)`.
 
-## `git push min://` — the git remote helper
+## `git push min://` - the git remote helper
 
 Installs of `min` lay down a `bin/git-remote-min` symlink pointing at the
 `min` binary. The binary dispatches on `argv[0]`: when invoked with the
-basename `git-remote-min` — which is how git invokes remote helpers for
-`min://` URLs — it speaks the
+basename `git-remote-min` (which is how git invokes remote helpers for
+`min://` URLs), it speaks the
 [gitremote-helpers](https://git-scm.com/docs/gitremote-helpers) line
 protocol on stdio instead of the normal CLI.
 
@@ -213,7 +214,7 @@ git push session
 Only the `connect` capability is implemented: on `connect`, the helper
 opens an exec channel to `minimald` over its Unix domain socket (the same
 transport the rest of the CLI uses) and bridges git's pack-protocol
-conversation across it — no external `ssh` or `socat` involved. Only the
+conversation across it; no external `ssh` or `socat` involved. Only the
 two pack services (`git-upload-pack`, `git-receive-pack`) are accepted.
 If the daemon is not running, the helper starts it, using default global
 flags (git invokes helpers without any of `min`'s own flags).

--- a/docs/reference/cli-minimald.md
+++ b/docs/reference/cli-minimald.md
@@ -1,9 +1,9 @@
 ---
 title: minimald daemon
-description: Ops reference for the minimald host daemon — serves sandboxed sessions to the min CLI over SSH-on-UDS.
+description: Ops reference for the minimald host daemon: serves sandboxed sessions to the min CLI over SSH-on-UDS.
 ---
 
-# `minimald` — host daemon
+# `minimald` - host daemon
 
 `minimald` is the Minimal host daemon. It creates and supervises the
 sandboxed sessions that the [min CLI](./cli-min.md) connects to, speaking
@@ -20,7 +20,7 @@ Generated from `--help` at `e5ce5fb8`.
 |------|-------|-------------|
 | `--minimal-state-dir <PATH>` | | Override the directory where state is stored (default: `$XDG_STATE_DIR/minimal`) |
 | `--minimal-cache-dir <PATH>` | | Override the directory where artifacts are cached (default: `$XDG_CACHE_DIR/minimal`) |
-| `--num-parallel-builds <N>` | `-n` | Configure the number of parallel builds (currently accepted but ignored — see [Known issues](#known-issues)) |
+| `--num-parallel-builds <N>` | `-n` | Configure the number of parallel builds (currently accepted but ignored; see [Known issues](#known-issues)) |
 
 ## Commands
 
@@ -51,5 +51,5 @@ Generates a shell tab-completion script for `minimald`. Supported shells:
 
 ## Known issues
 
-- [#820](https://github.com/gominimal/minimal/issues/820) — `minimald`
+- [#820](https://github.com/gominimal/minimal/issues/820): `minimald`
   accepts but ignores `-n`/`--num-parallel-builds` and `--stdlib-dir`.

--- a/docs/reference/cli-minimald.md
+++ b/docs/reference/cli-minimald.md
@@ -1,0 +1,55 @@
+---
+title: minimald daemon
+description: Ops reference for the minimald host daemon — serves sandboxed sessions to the min CLI over SSH-on-UDS.
+---
+
+# `minimald` — host daemon
+
+`minimald` is the Minimal host daemon. It creates and supervises the
+sandboxed sessions that the [min CLI](./cli-min.md) connects to, speaking
+SSH over a Unix domain socket (or vsock when hosted inside the `minvmd`
+microVM). End users normally never run it by hand: `min` auto-starts a
+native daemon on Linux, and [minvmd](./cli-minvmd.md) supervises it
+inside the microVM.
+
+Generated from `--help` at `e5ce5fb8`.
+
+## Global flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--minimal-state-dir <PATH>` | | Override the directory where state is stored (default: `$XDG_STATE_DIR/minimal`) |
+| `--minimal-cache-dir <PATH>` | | Override the directory where artifacts are cached (default: `$XDG_CACHE_DIR/minimal`) |
+| `--num-parallel-builds <N>` | `-n` | Configure the number of parallel builds (currently accepted but ignored — see [Known issues](#known-issues)) |
+
+## Commands
+
+### `run`
+
+```
+minimald run [OPTIONS]
+```
+
+Runs the minimald server in the foreground.
+
+| Flag | Description |
+|------|-------------|
+| `--instance-num <N>` | Instance number for this minimald; determines client-relevant paths under `<minimal_state_dir>/providers/local-<N>`. The SSH socket is accessible as `ssh.sock`. Default: `0` |
+| `--vsock` | Host the SSH socket over vsock instead of UDS; the vsock port is the default port base plus `instance_num` |
+| `--detach` | Daemonize: spawn minimald in a new session (setsid) and return once the SSH socket accepts connections, or an 8s timeout elapses. Used by the `min` CLI to auto-start a native daemon on Linux |
+| `--gvproxy-bin <PATH>` | Path to the gvproxy ("gvisor-tap-vsock") binary backing the per-host own-IP switch. Defaults to the fixed system install path; point it at a local build to run own-IP networking without a system install |
+
+### `completions`
+
+```
+minimald completions <SHELL>
+```
+
+Generates a shell tab-completion script for `minimald`. Supported shells:
+`bash`, `zsh`, `elvish`, `fish`. Usage:
+`source <(minimald completions bash)`.
+
+## Known issues
+
+- [#820](https://github.com/gominimal/minimal/issues/820) — `minimald`
+  accepts but ignores `-n`/`--num-parallel-builds` and `--stdlib-dir`.

--- a/docs/reference/cli-minimald.md
+++ b/docs/reference/cli-minimald.md
@@ -1,6 +1,6 @@
 ---
 title: minimald daemon
-description: Ops reference for the minimald host daemon: serves sandboxed sessions to the min CLI over SSH-on-UDS.
+description: "Ops reference for the minimald host daemon: serves sandboxed sessions to the min CLI over SSH-on-UDS."
 ---
 
 # `minimald` - host daemon
@@ -12,7 +12,7 @@ microVM). End users normally never run it by hand: `min` auto-starts a
 native daemon on Linux, and [minvmd](./cli-minvmd.md) supervises it
 inside the microVM.
 
-Generated from `--help` at `e5ce5fb8`.
+Generated from `--help` at `3a05252c`.
 
 ## Global flags
 
@@ -33,7 +33,7 @@ Runs the minimald server in the foreground.
 
 | Flag | Description |
 |------|-------------|
-| `--instance-num <N>` | Instance number for this minimald; determines client-relevant paths under `<minimal_state_dir>/providers/local-<N>`. The SSH socket is accessible as `ssh.sock`. Default: `0` |
+| `--instance-num <N>` | Instance number for this minimald; determines client-relevant paths under `<minimal_state_dir>/providers/local-minimald<N>`. The SSH socket is accessible as `ssh.sock`. Default: `0` |
 | `--vsock` | Host the SSH socket over vsock instead of UDS; the vsock port is the default port base plus `instance_num` |
 | `--detach` | Daemonize: spawn minimald in a new session (setsid) and return once the SSH socket accepts connections, or an 8s timeout elapses. Used by the `min` CLI to auto-start a native daemon on Linux |
 | `--gvproxy-bin <PATH>` | Path to the gvproxy ("gvisor-tap-vsock") binary used for networking. Defaults to a typical system install path. |
@@ -44,11 +44,10 @@ Runs the minimald server in the foreground.
 minimald completions <SHELL>
 ```
 
-Generates a shell tab-completion script for `minimald`. Supported shells:
+Generates a shell tab-completion script for `minimald`. Supported shells include
 `bash`, `zsh`, `elvish`, `fish`. Usage:
 `source <(minimald completions bash)`.
 
 ## Known issues
 
-- [#820](https://github.com/gominimal/minimal/issues/820): `minimald`
-  accepts but ignores `--stdlib-dir`.
+- `minimald` accepts but ignores the hidden `--stdlib-dir` flag.

--- a/docs/reference/cli-minimald.md
+++ b/docs/reference/cli-minimald.md
@@ -18,9 +18,8 @@ Generated from `--help` at `e5ce5fb8`.
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--minimal-state-dir <PATH>` | | Override the directory where state is stored (default: `$XDG_STATE_DIR/minimal`) |
-| `--minimal-cache-dir <PATH>` | | Override the directory where artifacts are cached (default: `$XDG_CACHE_DIR/minimal`) |
-| `--num-parallel-builds <N>` | `-n` | Configure the number of parallel builds (currently accepted but ignored; see [Known issues](#known-issues)) |
+| `--minimal-state-dir <PATH>` | | Override the directory where state is stored (default: `$XDG_STATE_HOME/minimal`) |
+| `--minimal-cache-dir <PATH>` | | Override the directory where artifacts are cached (default: `$XDG_CACHE_HOME/minimal`) |
 
 ## Commands
 
@@ -52,4 +51,4 @@ Generates a shell tab-completion script for `minimald`. Supported shells:
 ## Known issues
 
 - [#820](https://github.com/gominimal/minimal/issues/820): `minimald`
-  accepts but ignores `-n`/`--num-parallel-builds` and `--stdlib-dir`.
+  accepts but ignores `--stdlib-dir`.

--- a/docs/reference/cli-minimald.md
+++ b/docs/reference/cli-minimald.md
@@ -36,7 +36,7 @@ Runs the minimald server in the foreground.
 | `--instance-num <N>` | Instance number for this minimald; determines client-relevant paths under `<minimal_state_dir>/providers/local-<N>`. The SSH socket is accessible as `ssh.sock`. Default: `0` |
 | `--vsock` | Host the SSH socket over vsock instead of UDS; the vsock port is the default port base plus `instance_num` |
 | `--detach` | Daemonize: spawn minimald in a new session (setsid) and return once the SSH socket accepts connections, or an 8s timeout elapses. Used by the `min` CLI to auto-start a native daemon on Linux |
-| `--gvproxy-bin <PATH>` | Path to the gvproxy ("gvisor-tap-vsock") binary backing the per-host own-IP switch. Defaults to the fixed system install path; point it at a local build to run own-IP networking without a system install |
+| `--gvproxy-bin <PATH>` | Path to the gvproxy ("gvisor-tap-vsock") binary used for networking. Defaults to a typical system install path. |
 
 ### `completions`
 

--- a/docs/reference/cli-minvmd.md
+++ b/docs/reference/cli-minvmd.md
@@ -21,6 +21,12 @@ Generated from `--help` at `e5ce5fb8`.
 
 ## Commands
 
+Two commands bring the VM up. `run` (alias `start`) is the
+lifecycle-managed supervisor: it drives the daemon's state transitions and
+supports `--detach` for background operation, so it is the usual entry
+point. `boot` is a lower-level bring-up that skips lifecycle state, used
+mainly for diagnostics.
+
 ### `boot`
 
 ```
@@ -30,7 +36,7 @@ minvmd boot [--foreground]
 Boots the microVM and waits until the guest is up. `--foreground` stays
 in the foreground until the VMM child exits.
 
-### `run`
+### `run` (alias: `start`)
 
 ```
 minvmd run [--detach] [--timeout <SECONDS>]

--- a/docs/reference/cli-minvmd.md
+++ b/docs/reference/cli-minvmd.md
@@ -1,6 +1,6 @@
 ---
 title: minvmd daemon
-description: Ops reference for the minvmd VM daemon: boots and supervises the Linux microVM that hosts minimald.
+description: "Ops reference for the minvmd VM daemon: boots and supervises the Linux microVM that hosts minimald."
 ---
 
 # `minvmd` - VM daemon
@@ -8,16 +8,16 @@ description: Ops reference for the minvmd VM daemon: boots and supervises the Li
 `minvmd` is the host daemon that brings up a Linux microVM via libkrun
 (macOS/HVF or Linux/KVM) and supervises the
 [minimald](./cli-minimald.md) instance running inside it. On macOS it is
-the only session backend; on Linux it is selected with `min --minvmd`
+the only session backend; on Linux it is selected with `min --provider local-minvmd`
 (see [min](./cli-min.md)).
 
-Generated from `--help` at `e5ce5fb8`.
+Generated from `--help` at `3a05252c`.
 
 ## Global flags
 
 | Flag | Description |
 |------|-------------|
-| `--minimal-state-dir <PATH>` | Override the state dir base (default: `$XDG_STATE_HOME/minimal`). Runtime files live under `<dir>/providers/local-0/` |
+| `--minimal-state-dir <PATH>` | Override the state dir base (default: `$XDG_STATE_HOME/minimal`). Runtime files live under `<dir>/providers/local-minvmd0/` |
 
 ## Commands
 
@@ -94,10 +94,6 @@ Stops the running daemon gracefully.
 minvmd completions <SHELL>
 ```
 
-Generates a shell tab-completion script. Supported shells: `bash`, `zsh`,
+Generates a shell tab-completion script. Supported shells include `bash`, `zsh`,
 `elvish`, `fish`.
 
-## Known issues
-
-- [#823](https://github.com/gominimal/minimal/issues/823):
-  `minvmd run --timeout` is silently ignored without `--detach`.

--- a/docs/reference/cli-minvmd.md
+++ b/docs/reference/cli-minvmd.md
@@ -1,9 +1,9 @@
 ---
 title: minvmd daemon
-description: Ops reference for the minvmd VM daemon — boots and supervises the Linux microVM that hosts minimald.
+description: Ops reference for the minvmd VM daemon: boots and supervises the Linux microVM that hosts minimald.
 ---
 
-# `minvmd` — VM daemon
+# `minvmd` - VM daemon
 
 `minvmd` is the host daemon that brings up a Linux microVM via libkrun
 (macOS/HVF or Linux/KVM) and supervises the
@@ -93,5 +93,5 @@ Generates a shell tab-completion script. Supported shells: `bash`, `zsh`,
 
 ## Known issues
 
-- [#823](https://github.com/gominimal/minimal/issues/823) —
+- [#823](https://github.com/gominimal/minimal/issues/823):
   `minvmd run --timeout` is silently ignored without `--detach`.

--- a/docs/reference/cli-minvmd.md
+++ b/docs/reference/cli-minvmd.md
@@ -1,0 +1,97 @@
+---
+title: minvmd daemon
+description: Ops reference for the minvmd VM daemon — boots and supervises the Linux microVM that hosts minimald.
+---
+
+# `minvmd` — VM daemon
+
+`minvmd` is the host daemon that brings up a Linux microVM via libkrun
+(macOS/HVF or Linux/KVM) and supervises the
+[minimald](./cli-minimald.md) instance running inside it. On macOS it is
+the only session backend; on Linux it is selected with `min --minvmd`
+(see [min](./cli-min.md)).
+
+Generated from `--help` at `e5ce5fb8`.
+
+## Global flags
+
+| Flag | Description |
+|------|-------------|
+| `--minimal-state-dir <PATH>` | Override the state dir base (default: `$XDG_STATE_HOME/minimal`). Runtime files live under `<dir>/providers/local-0/` |
+
+## Commands
+
+### `boot`
+
+```
+minvmd boot [--foreground]
+```
+
+Boots the microVM and waits until the guest is up. `--foreground` stays
+in the foreground until the VMM child exits.
+
+### `run`
+
+```
+minvmd run [--detach] [--timeout <SECONDS>]
+```
+
+Starts the microVM supervisor (foreground by default).
+
+| Flag | Description |
+|------|-------------|
+| `--detach` | Spawn the supervisor in the background and return once the host UDS is accepting connections |
+| `--timeout <SECONDS>` | Timeout in seconds to wait for the host UDS when using `--detach` (default: `8`) |
+
+### `status`
+
+```
+minvmd status [--json]
+```
+
+Prints daemon status. Exit code: `0` if running, `1` if stopped, `2` on
+lock contention. `--json` prints status as a JSON object.
+
+### `config show`
+
+```
+minvmd config show [--json]
+```
+
+Prints the effective per-VM resource configuration and each value's
+source. `--json` prints it as a JSON object.
+
+### `config set`
+
+```
+minvmd config set [--vcpus <N>] [--ram-mib <N>]
+```
+
+Validates and persists resource parameters, applied on the next boot.
+
+| Flag | Description |
+|------|-------------|
+| `--vcpus <N>` | Number of virtual CPUs |
+| `--ram-mib <N>` | Guest RAM in MiB |
+
+### `stop`
+
+```
+minvmd stop
+```
+
+Stops the running daemon gracefully.
+
+### `completions`
+
+```
+minvmd completions <SHELL>
+```
+
+Generates a shell tab-completion script. Supported shells: `bash`, `zsh`,
+`elvish`, `fish`.
+
+## Known issues
+
+- [#823](https://github.com/gominimal/minimal/issues/823) —
+  `minvmd run --timeout` is silently ignored without `--detach`.

--- a/docs/reference/cli-mip.md
+++ b/docs/reference/cli-mip.md
@@ -1,9 +1,9 @@
 ---
 title: mip CLI
-description: Reference for the mip package/build CLI — build packages, run tasks, materialize outputs, and manage the local cache.
+description: Reference for the mip package/build CLI: build packages, run tasks, materialize outputs, and manage the local cache.
 ---
 
-# `mip` — package/build CLI
+# `mip` - package/build CLI
 
 `mip` is the Minimal package/build CLI. It reads a project's
 [`minimal.toml`](./minimal-dot-toml.md), builds packages in clean rooms,
@@ -72,8 +72,8 @@ Add a new tool or dependency. Exactly one placement flag is required:
 
 | Flag | Description |
 |------|-------------|
-| `--runtime` | Add as a runtime dependency — your program needs this package anywhere it runs |
-| `--build` | Add as a build dependency — your program needs this package to build |
+| `--runtime` | Add as a runtime dependency: your program needs this package anywhere it runs |
+| `--build` | Add as a build dependency: your program needs this package to build |
 | `--task <TASK>` | Add to a task's package list |
 
 ### `init`
@@ -109,7 +109,7 @@ Materializes an output specified in an
 | `--output <PATH>` | `-o` | **(required)** The output file to write |
 | `--arch <ARCH>` | | Override the architecture used when building the output (e.g. `amd64`, `arm64`); takes precedence over the `arch` field in `minimal.toml` and the host default |
 
-Supported output types include `oci-image` — a Linux OCI image archive
+Supported output types include `oci-image`, a Linux OCI image archive
 containing the configured packages, suitable for `docker load` or pushing
 to a registry.
 
@@ -176,7 +176,6 @@ Generates Graphviz source code of the dependency graph, e.g.
 | `--build-spec-deps <BOOL>` | | `true` | Include build spec `build_deps` (does not affect runtime deps) |
 | `--source-deps <BOOL>` | | `false` | Include source code `build_deps` |
 | `--local-deps <BOOL>` | | `false` | Include local (`build.sh`) input deps |
-| `--hostpath-deps <BOOL>` | | `false` | Include host path `build_deps` |
 | `--needs <BOOL>` | | `false` | Include "Needs" nodes and edges |
 | `--provides <BOOL>` | | `false` | Include "Provides" edges and "Needs" nodes |
 | `--bootstrap <BOOL>` | | `false` | Include replace-on-cycle/prebuilts/bootstrap |

--- a/docs/reference/cli-mip.md
+++ b/docs/reference/cli-mip.md
@@ -5,10 +5,14 @@ description: Reference for the mip package/build CLI: build packages, run tasks,
 
 # `mip` - package/build CLI
 
-`mip` is the Minimal package/build CLI. It reads a project's
-[`minimal.toml`](./minimal-dot-toml.md), builds packages in clean rooms,
-runs [tasks](./tasks.md) in sandboxes, and manages the content-addressed
-local cache.
+`mip` (short for "Minimal in-process") is the Minimal package/build CLI. It
+reads a project's [`minimal.toml`](./minimal-dot-toml.md), builds packages in
+clean rooms, runs [tasks](./tasks.md) in sandboxes, and manages the
+content-addressed local cache.
+
+> **Advanced tool.** `mip` is Linux-only and aimed at advanced users driving
+> the package/build plane directly. Most workflows are better served by the
+> [`min` session CLI](./cli-min.md).
 
 Generated from `--help` at `d9f20165`.
 

--- a/docs/reference/cli-mip.md
+++ b/docs/reference/cli-mip.md
@@ -1,0 +1,208 @@
+---
+title: mip CLI
+description: Reference for the mip package/build CLI — build packages, run tasks, materialize outputs, and manage the local cache.
+---
+
+# `mip` — package/build CLI
+
+`mip` is the Minimal package/build CLI. It reads a project's
+[`minimal.toml`](./minimal-dot-toml.md), builds packages in clean rooms,
+runs [tasks](./tasks.md) in sandboxes, and manages the content-addressed
+local cache.
+
+Generated from `--help` at `d9f20165`.
+
+## Global flags
+
+These apply to every subcommand.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--repo-dir <PATH>` | `-C` | Use the given directory as the repository root instead of searching from the current working directory |
+| `--minimal-dir <PATH>` | | Override the base directory used for operations (default: `~/.cache/minimal`) |
+| `--no-cache` | | Ignore locally-available binary artifacts (results in rebuilds unless present in a remote cache) |
+| `--no-fetch` | | Do not fetch binary artifacts from the internet |
+| `--offline` | | Use only what's already in the local cache for sources, VCS checkouts, and the remote artifact cache; fail with a clear error on cache miss instead of attempting any network call. Implies the remote-artifact-cache half of `--no-fetch`; orthogonal to `--no-cache`/`--rebuild` |
+| `--num-parallel-builds <N>` | `-n` | Configure the number of parallel builds |
+
+## Commands
+
+### `run` {#run}
+
+Runs a task, such as one specified in `minimal.toml`. *(Linux only)*
+
+```
+mip run [OPTIONS] <task_name> [task_args]...
+mip run [OPTIONS] --upstream <upstream> --task-spec <task_spec> [task_args]...
+```
+
+| Argument / flag | Description |
+|-----------------|-------------|
+| `<task_name>` | Name of the task to run (from `minimal.toml`) |
+| `[task_args]...` | Additional arguments to pass to the task |
+| `--upstream <JSON>` | JSON stanza specifying the software supply chain; must be used with `--task-spec` |
+| `--task-spec <JSON>` | JSON stanza specifying a task inline; must be used with `--upstream` |
+
+### `shell`, `build`, `test`
+
+```
+mip shell
+mip build
+mip test
+```
+
+Shorthands for `mip run shell`, `mip run build`, and `mip run test`
+respectively. `shell` launches a development shell. *(Linux only)*
+
+### `update`
+
+```
+mip update
+```
+
+Refreshes local checkouts of upstream packages and the standard library.
+
+### `add` {#add}
+
+```
+mip add <--runtime|--build|--task <TASK>> [PACKAGES]...
+```
+
+Add a new tool or dependency. Exactly one placement flag is required:
+
+| Flag | Description |
+|------|-------------|
+| `--runtime` | Add as a runtime dependency — your program needs this package anywhere it runs |
+| `--build` | Add as a build dependency — your program needs this package to build |
+| `--task <TASK>` | Add to a task's package list |
+
+### `init`
+
+```
+mip init [-y|--yes]
+```
+
+Automatically initialize minimal configuration based on your source tree.
+`--yes` skips confirmation and writes configuration based on
+auto-detection.
+
+### `status`
+
+```
+mip status
+```
+
+Shows the status of Minimal in this codebase.
+
+### `materialize` {#materialize}
+
+```
+mip materialize --output <OUTPUT> [--arch <ARCH>] <OUTPUT_NAME>
+```
+
+Materializes an output specified in an
+[`[outputs.<name>]`](./minimal-dot-toml.md#outputs) section of
+`minimal.toml`.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output <PATH>` | `-o` | **(required)** The output file to write |
+| `--arch <ARCH>` | | Override the architecture used when building the output (e.g. `amd64`, `arm64`); takes precedence over the `arch` field in `minimal.toml` and the host default |
+
+Supported output types include `oci-image` — a Linux OCI image archive
+containing the configured packages, suitable for `docker load` or pushing
+to a registry.
+
+### `package` (alias: `pkg`)
+
+```
+mip package [OPTIONS] [PACKAGES]...
+```
+
+Builds the specified package(s) in a clean room, making them available in
+the local cache.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--verbose` | `-v` | Log stdout/stderr during the build |
+| `--rebuild` | | Always build the specified packages, even if they are already available |
+
+### `cache clean`
+
+```
+mip cache clean [--older-than <DURATION>]
+```
+
+Removes stale entries from the local cache: cached build artifacts whose
+last recorded use is older than the cutoff, or that have no recorded use
+at all. Packages needed by the current project's tasks and stack are
+always kept. Also removes sandbox, task, and temporary build directories
+whose owning process is no longer running.
+
+`--older-than` takes a whole number of days, hours, or minutes (e.g.
+`30d`, `12h`, `45m`); the default is `14d`.
+
+### `check` {#check}
+
+```
+mip check [OPTIONS] [FILTER_NAMES]...
+```
+
+Validates minimal configuration including packages, stacks, and profiles.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--fix` | `-f` | Attempt to fix any issues |
+| `--packages` | | Check packages defined in the codebase |
+| `--stacks` | | Check stacks defined in the codebase |
+| `--profiles` | | Check profiles defined in the codebase |
+| `--skip-checkers <NAMES>` | `-s` | Checker names to skip, comma-separated |
+
+If no type flags are specified, all types are checked. If filter names
+are given, any package, stack, or profile matching a name is checked.
+
+### `dep`
+
+```
+mip dep [OPTIONS] [PACKAGES]...
+```
+
+Generates Graphviz source code of the dependency graph, e.g.
+`mip dep --input-deps-depth=0 | dot -Tpng > deps.png`.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--excludes <PKGS>` | `-e` | | Packages left out of the graph and not traversed |
+| `--build-spec-deps <BOOL>` | | `true` | Include build spec `build_deps` (does not affect runtime deps) |
+| `--source-deps <BOOL>` | | `false` | Include source code `build_deps` |
+| `--local-deps <BOOL>` | | `false` | Include local (`build.sh`) input deps |
+| `--hostpath-deps <BOOL>` | | `false` | Include host path `build_deps` |
+| `--needs <BOOL>` | | `false` | Include "Needs" nodes and edges |
+| `--provides <BOOL>` | | `false` | Include "Provides" edges and "Needs" nodes |
+| `--bootstrap <BOOL>` | | `false` | Include replace-on-cycle/prebuilts/bootstrap |
+| `--subtrees-only <BOOL>` | | `false` | Require non-zero subtree deps for runtime/input deps |
+| `--input-deps-depth <N>` | | `-1` | How deeply input dependencies are followed (`-1` = all) |
+| `--runtime-deps-depth <N>` | | `-1` | How deeply runtime dependencies are followed (`-1` = all) |
+| `--prune-edgeless <BOOL>` | | `false` | Discard graph nodes with no edges |
+| `--output-format <FMT>` | | `dot` | Output format: `dot` or `mermaid` |
+
+### `completions`
+
+```
+mip completions <SHELL>
+```
+
+Generates a shell tab-completion script for `mip`. Supported shells:
+`bash`, `zsh`, `elvish`, `fish`. Usage: `source <(mip completions bash)`.
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `RUST_LOG` | Controls logging level (default: `info`) |
+
+## Hidden commands
+
+Additional unsupported/internal commands are hidden behind the
+`MINIMAL_SCIENCE_MODE` environment variable. They are experimental, carry
+no stability or consistency guarantees, and are not documented here.

--- a/docs/reference/cli-mip.md
+++ b/docs/reference/cli-mip.md
@@ -1,6 +1,6 @@
 ---
 title: mip CLI
-description: Reference for the mip package/build CLI: build packages, run tasks, materialize outputs, and manage the local cache.
+description: "Reference for the mip package/build CLI: build packages, run tasks, materialize outputs, and manage the local cache."
 ---
 
 # `mip` - package/build CLI

--- a/docs/reference/cli-mip.md
+++ b/docs/reference/cli-mip.md
@@ -65,7 +65,7 @@ Refreshes local checkouts of upstream packages and the standard library.
 ### `add` {#add}
 
 ```
-mip add <--runtime|--build|--task <TASK>> [PACKAGES]...
+mip add <--runtime|--build|--task <TASK>> <PACKAGES>...
 ```
 
 Add a new tool or dependency. Exactly one placement flag is required:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,7 +29,7 @@ drive it directly with the **`mip`** CLI.
 ## Platform availability
 
 - **Linux**: installs ship `min`, `mip`, and `minimald`. `minimald` runs
-  natively by default; `min --minvmd` routes sessions through the `minvmd`
+  natively by default; `min --provider local-minvmd` routes sessions through the `minvmd`
   microVM instead, which needs a separately obtained `minvmd` binary (a
   prebuilt Linux amd64 `minvmd` is attached to each GitHub Release; arm64
   must build from source).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,138 +1,45 @@
 ---
-description: Complete CLI reference for all Minimal commands (run, build, test, shell, add, init, update, check, package, dep) and global flags.
+title: CLI Reference
+description: Overview of the Minimal command-line binaries — min, mip, minimald, and minvmd — and where each is documented.
 ---
 
-# Minimal CLI Reference
+# CLI Reference
 
-## Global Flags
+Minimal ships as a small set of binaries split across two planes:
 
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--repo-dir <PATH>` | `-C` | Use the given directory as the repository root instead of searching from cwd |
-| `--minimal-dir <PATH>` | | Override the base directory used for operations (default: `~/.cache/minimal`) |
-| `--no-cache` | | Ignore locally-available binary artifacts (forces rebuilds unless present in remote cache) |
-| `--no-fetch` | | Do not fetch binary artifacts from the internet |
-| `--offline` | | Use only what's already in the local cache; fail on any network call. Useful for builds in network-isolated environments. |
-| `--num-parallel-builds <N>` | `-n` | Configure the number of parallel builds |
+- **The session plane** manages sandboxed development sessions. The `min`
+  CLI talks to the `minimald` host daemon, which creates and supervises
+  sessions. On macOS (and optionally on Linux), `minimald` runs inside a
+  Linux microVM managed by the `minvmd` daemon.
+- **The package/build plane** evaluates declarative package configuration
+  (`minimal.toml` plus Nickel files), builds packages in clean rooms,
+  runs tasks in sandboxes, and manages the content-addressed artifact
+  cache. This is the `mip` CLI.
 
-## Commands
+## Binaries
 
-### `run <TASK_NAME> [<args>]` {#run}
+| Binary | Role | Reference |
+|--------|------|-----------|
+| `min` | Session CLI — create, attach to, and manage sandboxed dev sessions | [min](./cli-min.md) |
+| `mip` | Package/build CLI — build packages, run tasks, manage the cache | [mip](./cli-mip.md) |
+| `minimald` | Host daemon — serves sessions to `min` over SSH-on-UDS | [minimald](./cli-minimald.md) |
+| `minvmd` | VM daemon — boots the Linux microVM that hosts `minimald` | [minvmd](./cli-minvmd.md) |
 
-Runs a task specified in [`minimal.toml`](/reference/tasks). *(Linux only)*
+## Platform availability
 
-### `shell`
+- **Linux**: installs ship `min`, `mip`, and `minimald`. `minimald` runs
+  natively by default; `min --minvmd` routes sessions through the `minvmd`
+  microVM instead, which needs a separately obtained `minvmd` binary (a
+  prebuilt Linux amd64 `minvmd` is attached to each GitHub Release; arm64
+  must build from source).
+- **macOS**: installs ship `min` and `minvmd` only. `minimald` always runs
+  inside the microVM, and the package/build plane runs there with it —
+  there is no native macOS `mip`.
+- `mip run` (and its `shell`/`build`/`test` shorthands) executes tasks in
+  Linux sandboxes and is available on Linux only.
 
-Launches a development shell. Shorthand for `minimal run shell`.
+## In-sandbox helper commands
 
-### `build`
-
-Runs the build task. Shorthand for `minimal run build`.
-
-### `test`
-
-Runs the test task. Shorthand for `minimal run test`.
-
-### `update`
-
-Refreshes local checkouts of upstream packages and the standard library.
-
-### `add <PACKAGES...>` {#add}
-
-Add a new tool or dependency. Requires exactly one of:
-
-| Flag | Description |
-|------|-------------|
-| `--runtime` | Add as a runtime dependency |
-| `--build` | Add as a build dependency |
-| `--task <TASK_NAME>` | Add to a task's package list |
-
-### `init`
-
-Automatically initialize Minimal configuration based on your source tree.
-
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--yes` | `-y` | Skip confirmation, write configuration based on auto-detection |
-
-### `status`
-
-Shows the status of Minimal in this codebase.
-
-### `package <PACKAGES...>` (alias: `pkg`)
-
-Builds specified package(s) in a clean room, making them available in the local cache. If no packages are specified, Minimal will build packages from local origin.
-
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--verbose` | `-v` | Log stdout/stderr during the build |
-
-### `materialize <OUTPUT_NAME>` {#materialize}
-
-Materializes an output defined in an [`[outputs.<name>]`](/reference/minimal-dot-toml#outputs) section of `minimal.toml`.
-
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--output <PATH>` | `-o` | **(required)** The output file to write |
-| `--arch <ARCH>` | | Target architecture for OCI images (e.g. `amd64`, `arm64`). Overrides the `arch` field in `minimal.toml` and the host default |
-
-Supported output types:
-
-- `oci-image` — a Linux OCI image archive containing the configured packages, suitable for `docker load` or pushing to a registry.
-
-See [`[outputs.*]`](/reference/minimal-dot-toml#outputs) for the full configuration schema.
-
-### `check [FILTER_NAMES...]` {#check}
-
-Validates Minimal's configuration including packages, stacks, and profiles.
-
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--fix` | `-f` | Attempt to fix any issues |
-| `--skip-checkers <NAMES>` | `-s` | Comma-delimited checker names to skip |
-| `--packages` | | Check packages defined in the codebase |
-| `--stacks` | | Check stacks defined in the codebase |
-| `--profiles` | | Check profiles defined in the codebase |
-
-If no type flags are specified, all types are checked by default.
-
-If filter names are specified, any package, stack, or profile matching a specified name is checked.
-
-### `dep [PACKAGES...]`
-
-Generates a dependency graph visualization.
-
-| Flag | Short | Default | Description |
-|------|-------|---------|-------------|
-| `--excludes <PKGS>` | `-e` | | Comma-delimited packages to exclude |
-| `--build-spec-deps` | | `true` | Include build spec "build_deps" |
-| `--source-deps` | | `false` | Include source code "build_deps" |
-| `--local-deps` | | `false` | Include local (build.sh) "input" deps |
-| `--needs` | | `false` | Include "Needs" nodes and edges |
-| `--provides` | | `false` | Include "Provides" edges and "Needs" nodes |
-| `--bootstrap` | | `false` | Include replace-on-cycle/prebuilts/bootstrap |
-| `--subtrees-only` | | `false` | Require non-zero subtree deps for runtime/input deps |
-| `--input-deps-depth <N>` | | `-1` | How deeply input dependencies are followed (-1 = all) |
-| `--runtime-deps-depth <N>` | | `-1` | How deeply runtime dependencies are followed (-1 = all) |
-| `--prune-edgeless` | | `false` | Discard graph nodes with no edges |
-| `--output-format <FMT>` | | `dot` | Output format: `dot` or `mermaid` |
-
-### `cache clean`
-
-Remove cache entries that haven't been used recently.
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--older-than <DURATION>` | `14d` | Duration string (e.g. `7d`, `24h`, `30m`) |
-
-### `completions <SHELL>`
-
-Generate shell completion script. Supported shells: `bash`, `zsh`, `elvish`, `fish`.
-
-Usage: `source <(minimal completions bash)`
-
-## Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `RUST_LOG` | Controls logging level (default: `info`) |
+Task sandboxes expose a small set of helper commands (`add`, `search`,
+`check`, `run`) for use from inside a running sandbox. Those are
+documented separately in [sandbox operations](./sandbox-operations.md).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: Overview of the Minimal command-line binaries — min, mip, minimald, and minvmd — and where each is documented.
+description: Overview of the Minimal command-line binaries (min, mip, minimald, and minvmd) and where each is documented.
 ---
 
 # CLI Reference
@@ -20,10 +20,10 @@ Minimal ships as a small set of binaries split across two planes:
 
 | Binary | Role | Reference |
 |--------|------|-----------|
-| `min` | Session CLI — create, attach to, and manage sandboxed dev sessions | [min](./cli-min.md) |
-| `mip` | Package/build CLI — build packages, run tasks, manage the cache | [mip](./cli-mip.md) |
-| `minimald` | Host daemon — serves sessions to `min` over SSH-on-UDS | [minimald](./cli-minimald.md) |
-| `minvmd` | VM daemon — boots the Linux microVM that hosts `minimald` | [minvmd](./cli-minvmd.md) |
+| `min` | Session CLI: create, attach to, and manage sandboxed dev sessions | [min](./cli-min.md) |
+| `mip` | Package/build CLI: build packages, run tasks, manage the cache | [mip](./cli-mip.md) |
+| `minimald` | Host daemon: serves sessions to `min` over SSH-on-UDS | [minimald](./cli-minimald.md) |
+| `minvmd` | VM daemon: boots the Linux microVM that hosts `minimald` | [minvmd](./cli-minvmd.md) |
 
 ## Platform availability
 
@@ -33,7 +33,7 @@ Minimal ships as a small set of binaries split across two planes:
   prebuilt Linux amd64 `minvmd` is attached to each GitHub Release; arm64
   must build from source).
 - **macOS**: installs ship `min` and `minvmd` only. `minimald` always runs
-  inside the microVM, and the package/build plane runs there with it —
+  inside the microVM, and the package/build plane runs there with it;
   there is no native macOS `mip`.
 - `mip run` (and its `shell`/`build`/`test` shorthands) executes tasks in
   Linux sandboxes and is available on Linux only.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5,23 +5,24 @@ description: Overview of the Minimal command-line binaries (min, mip, minimald, 
 
 # CLI Reference
 
-Minimal ships as a small set of binaries split across two planes:
+Minimal's primary command-line tool is **`min`**, the session CLI: it creates,
+attaches to, and manages sandboxed development sessions. `min` talks to the
+`minimald` host daemon, which creates and supervises sessions. On macOS (and
+optionally on Linux), `minimald` runs inside a Linux microVM managed by the
+`minvmd` daemon.
 
-- **The session plane** manages sandboxed development sessions. The `min`
-  CLI talks to the `minimald` host daemon, which creates and supervises
-  sessions. On macOS (and optionally on Linux), `minimald` runs inside a
-  Linux microVM managed by the `minvmd` daemon.
-- **The package/build plane** evaluates declarative package configuration
-  (`minimal.toml` plus Nickel files), builds packages in clean rooms,
-  runs tasks in sandboxes, and manages the content-addressed artifact
-  cache. This is the `mip` CLI.
+Underneath, Minimal has a declarative package/build engine that evaluates
+`minimal.toml` plus Nickel files, builds packages in clean rooms, runs tasks in
+sandboxes, and manages a content-addressed artifact cache. Most users interact
+with it only through `min` and their `minimal.toml`. Advanced users on Linux can
+drive it directly with the **`mip`** CLI.
 
 ## Binaries
 
 | Binary | Role | Reference |
 |--------|------|-----------|
 | `min` | Session CLI: create, attach to, and manage sandboxed dev sessions | [min](./cli-min.md) |
-| `mip` | Package/build CLI: build packages, run tasks, manage the cache | [mip](./cli-mip.md) |
+| `mip` | Package/build CLI (advanced, Linux-only): build packages, run tasks, manage the cache directly | [mip](./cli-mip.md) |
 | `minimald` | Host daemon: serves sessions to `min` over SSH-on-UDS | [minimald](./cli-minimald.md) |
 | `minvmd` | VM daemon: boots the Linux microVM that hosts `minimald` | [minvmd](./cli-minvmd.md) |
 

--- a/docs/reference/linux-host-setup.md
+++ b/docs/reference/linux-host-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Linux host setup
-description: Preparing a Linux host to run minimald: the unprivileged user namespace the session sandbox needs, and the AppArmor profile that grants it on Ubuntu 24.04+.
+description: "Preparing a Linux host to run minimald: the unprivileged user namespace the session sandbox needs, and the AppArmor profile that grants it on Ubuntu 24.04+."
 ---
 
 # Linux host setup
@@ -101,3 +101,11 @@ Only the host-native daemon (**DM2**) is affected. When minimald runs inside a
 minimal-managed microVM (**DM1** on macOS, **DM3** on Linux/KVM) the sandbox's
 user namespace is created in the guest, whose kernel carries no such
 restriction; the host's setting is irrelevant.
+
+## User namespaces disabled entirely
+
+Separately from the AppArmor restriction, a kernel built without
+`CONFIG_USER_NS`, or a host with `user.max_user_namespaces` set to `0`, cannot
+create user namespaces at all. The daemon's preflight reports this as its own
+error. The fix is distribution-specific: raise `user.max_user_namespaces` via
+sysctl, or use a kernel with user namespaces enabled.

--- a/docs/reference/linux-host-setup.md
+++ b/docs/reference/linux-host-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Linux host setup
-description: Preparing a Linux host to run minimald — the unprivileged user namespace the session sandbox needs, and the AppArmor profile that grants it on Ubuntu 24.04+.
+description: Preparing a Linux host to run minimald: the unprivileged user namespace the session sandbox needs, and the AppArmor profile that grants it on Ubuntu 24.04+.
 ---
 
 # Linux host setup
@@ -8,7 +8,7 @@ description: Preparing a Linux host to run minimald — the unprivileged user na
 `minimald` runs every session and task inside a sandbox (hakoniwa), and every
 sandbox is an **unprivileged user namespace**: the daemon forks, the child calls
 `unshare(CLONE_NEWUSER)` and writes `/proc/self/uid_map`. No `setcap`, no root,
-no setuid helper — but the host has to permit unprivileged user namespaces.
+no setuid helper, but the host has to permit unprivileged user namespaces.
 
 Most distributions do. **Ubuntu 24.04 and later do not**, by default.
 
@@ -26,7 +26,7 @@ DIAG hakoniwa container/process exited non-zero code=125 exit_code=None
 `min attach` shows this as a session that closes immediately. The daemon
 also preflights this at startup: on a host that will refuse the namespace it
 logs a `sessions will fail to start` warning naming the restriction and this
-fix, so check the daemon log first. Confirm the host is the cause — this needs
+fix, so check the daemon log first. Confirm the host is the cause; this needs
 no minimal code at all:
 
 ```console
@@ -39,7 +39,7 @@ unshare: write failed /proc/self/uid_map: Operation not permitted
 ## The fix: install minimald's AppArmor profile
 
 Ubuntu's intended accommodation is a profile that grants the binary the `userns`
-permission — the same thing the distro ships for `rootlesskit`, `runc`, and
+permission, the same thing the distro ships for `rootlesskit`, `runc`, and
 `podman`. minimal ships one in `packaging/apparmor/`:
 
 ```console
@@ -51,7 +51,7 @@ That is all. Sessions work; nothing else on the host gains the ability to create
 user namespaces.
 
 If you installed minimal with the `curl … | sh` installer rather than from a
-checkout, the same loader ships alongside the binaries — run it with root:
+checkout, the same loader ships alongside the binaries; run it with root:
 
 ```console
 $ sudo bash ~/.local/share/minimal/apparmor/install-apparmor-profile.sh
@@ -61,15 +61,15 @@ loaded the minimald AppArmor profile (/etc/apparmor.d/minimald)
 The installer prints this exact hint on its own when it detects the restriction
 on the host, so you do not have to know to look for it.
 
-The profile **confines nothing** — it is declared `flags=(unconfined)`, so it
+The profile **confines nothing**: it is declared `flags=(unconfined)`, so it
 does not restrict what minimald may do. It exists only to give minimald a named
 AppArmor label, because on Ubuntu only a *labelled* program can be granted
 `userns`. Installing it neither sandboxes minimald nor weakens the host.
 
-It attaches to minimald at the paths it is normally installed to — `/usr/bin`,
+It attaches to minimald at the paths it is normally installed to: `/usr/bin`,
 `/usr/local/bin`, and `~/.local/bin` (where the installer puts
-it). A binary somewhere else — a dev build in `target/debug`, or a custom
-`MINIMAL_BIN` — needs that path named explicitly, because AppArmor matches
+it). A binary somewhere else (a dev build in `target/debug`, or a custom
+`MINIMAL_BIN`) needs that path named explicitly, because AppArmor matches
 profiles by executable path:
 
 ```console
@@ -80,7 +80,7 @@ Re-run the installer after moving or reinstalling the binary. To remove the
 profile: `sudo scripts/install-apparmor-profile.sh --uninstall` (from a
 checkout) or `sudo bash ~/.local/share/minimal/apparmor/install-apparmor-profile.sh --uninstall`
 (curl-installed). `minimal`'s own uninstaller
-(`curl … | sh -s -- --uninstall`) also offers to remove this system profile —
+(`curl … | sh -s -- --uninstall`) also offers to remove this system profile,
 prompting on a terminal, or printing the root command otherwise.
 
 ## Alternative: lift the restriction host-wide
@@ -100,4 +100,4 @@ the profile exists to avoid. It is what CI does, for a throwaway runner.
 Only the host-native daemon (**DM2**) is affected. When minimald runs inside a
 minimal-managed microVM (**DM1** on macOS, **DM3** on Linux/KVM) the sandbox's
 user namespace is created in the guest, whose kernel carries no such
-restriction — the host's setting is irrelevant.
+restriction; the host's setting is irrelevant.

--- a/docs/reference/linux-host-setup.md
+++ b/docs/reference/linux-host-setup.md
@@ -1,4 +1,5 @@
 ---
+title: Linux host setup
 description: Preparing a Linux host to run minimald — the unprivileged user namespace the session sandbox needs, and the AppArmor profile that grants it on Ubuntu 24.04+.
 ---
 
@@ -22,7 +23,7 @@ DIAG hakoniwa container/process exited non-zero code=125 exit_code=None
   reason=write("/proc/self/uid_map", ..) => Operation not permitted (os error 1)
 ```
 
-`minimal attach` shows this as a session that closes immediately. The daemon
+`min attach` shows this as a session that closes immediately. The daemon
 also preflights this at startup: on a host that will refuse the namespace it
 logs a `sessions will fail to start` warning naming the restriction and this
 fix, so check the daemon log first. Confirm the host is the cause — this needs
@@ -66,7 +67,7 @@ AppArmor label, because on Ubuntu only a *labelled* program can be granted
 `userns`. Installing it neither sandboxes minimald nor weakens the host.
 
 It attaches to minimald at the paths it is normally installed to — `/usr/bin`,
-`/usr/local/bin`, and `~/.local/bin` (where [the installer](/reference/cli) puts
+`/usr/local/bin`, and `~/.local/bin` (where the installer puts
 it). A binary somewhere else — a dev build in `target/debug`, or a custom
 `MINIMAL_BIN` — needs that path named explicitly, because AppArmor matches
 profiles by executable path:

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -1,0 +1,361 @@
+---
+title: Loadouts
+description: "Per-developer loadout reference: the loadout TOML schema, config-directory layout, min CLI flags, client config, and how loadouts compose into sessions."
+---
+
+# Loadouts
+
+A loadout is a per-developer bundle of packages, environment variables, file
+patches, and lifecycle hooks that the [`min` session CLI](./cli-min.md) layers
+into the sessions it activates. The project's
+[`minimal.toml`](./minimal-dot-toml.md) describes what every contributor's
+session needs; a loadout carries what *you* want on top (your editor,
+terminal multiplexer, shell config, and dotfiles) so each development
+environment comes up matching your muscle memory.
+
+Loadouts apply to sessions (`min activate`); they are not used by task
+sandboxes, which have their own `packages`/`env_vars`/`patches` schema
+described in [Tasks](./tasks.md).
+
+## Where loadouts live
+
+Each loadout is a single TOML file at:
+
+```
+<config>/minimal/loadouts/<name>.toml
+```
+
+`<config>` is the platform user config directory: `$XDG_CONFIG_HOME` on Linux
+(or `$HOME/.config` when unset); macOS also uses `$HOME/.config` for
+consistency with Minimal's state and cache dirs. The global
+[`--config-dir`](./cli-min.md#global-flags) flag overrides the base, and
+`min dirs` prints the resolved loadouts directory.
+
+The filename stem **is** the loadout's identifier:
+
+- It must match the `name` field declared inside the file, or loading fails
+  with a `NameMismatch` error naming both the file stem and the declared
+  `name`.
+- Names are trimmed and must be non-empty, with no `/`, `\`, or NUL
+  characters.
+
+The directory is not created automatically; create it and drop
+`<name>.toml` files there to get started.
+
+## Example
+
+A loadout that brings in the helix editor and zellij multiplexer, wired up
+with the user's dotfiles:
+
+```toml
+name        = "dev"
+description = "helix + zellij with my dotfiles"
+packages    = ["helix", "zellij"]
+
+patches = [
+    # Helix: single config files plus a themes directory.
+    { dest = ".config/helix/config.toml", source = "~/dotfiles/helix/config.toml" },
+    { dest = ".config/helix/languages.toml", source = "~/dotfiles/helix/languages.toml" },
+    { dest = ".config/helix/themes/", source = "~/dotfiles/helix/themes/**/*.toml" },
+
+    # Zellij: single config file plus a layouts directory.
+    { dest = ".config/zellij/config.kdl", source = "~/dotfiles/zellij/config.kdl" },
+    { dest = ".config/zellij/layouts/", source = "~/dotfiles/zellij/layouts/**/*.kdl" },
+]
+
+[vars]
+EDITOR    = "hx"
+VISUAL    = "hx"
+TERM      = { inherit = true, default = "xterm-256color" }
+COLORTERM = { inherit = true }
+
+# Declared to warm helix's tree-sitter grammar cache when the session
+# comes up. Best-effort; failures don't tank activation.
+[[lifecycle_hooks]]
+on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || true" }
+```
+
+Saved as `<config>/minimal/loadouts/dev.toml`, this is applied with
+`min activate --loadout dev`, or automatically via
+[`default_loadouts`](#client-config).
+
+## Loadout schema
+
+### `name` - The loadout's identifier
+
+_Required_
+
+Must match the filename stem. Shown in selection and error messages.
+
+```toml
+name = "dev"
+```
+
+### `description` - Describe the loadout
+
+_Optional_
+
+Free-form text, shown alongside the name in `min loadout list`.
+
+```toml
+description = "Editor + terminal multiplexer"
+```
+
+### `packages` - Packages to bring into the session
+
+_Optional_
+
+Package names installed into the session, in addition to the session's
+baseline packages and anything the project contributes. Duplicates across
+contributors are deduplicated.
+
+```toml
+packages = ["helix", "zellij"]
+```
+
+Names are not checked at activation: an unknown package composes cleanly
+and fails later, when the session first spawns, with
+`no such package: <name>`.
+
+### `[vars]` - Environment variables
+
+_Optional_
+
+Variables set in the session environment. Names must be POSIX-shaped
+(`[A-Z_][A-Z0-9_]*`); for other names, see
+[`[[vars_lenient]]`](#vars_lenient). Each value takes one of three forms:
+
+```toml
+[vars]
+EDITOR = "hx"                                # literal value
+TERM   = { inherit = true, default = "xterm-256color" }  # inherit, with fallback
+COLORTERM = { inherit = true }               # inherit from the host env
+```
+
+- A **literal** string sets the variable to that value.
+- `{ inherit = true }` passes the variable through from the environment of
+  the `min` process on the host. If the host doesn't have it set, the
+  variable is dropped from the session (with a warning) rather than failing
+  activation, so opportunistically inheriting things like `TERM` is safe.
+- `{ inherit = true, default = "..." }` inherits, falling back to `default`
+  when the host doesn't have the variable set.
+
+`inherit = false` is rejected; omit the variable instead.
+
+### `[[vars_lenient]]` - Environment variables with non-POSIX names {#vars_lenient}
+
+_Optional_
+
+An explicit opt-in for the rare variable whose name is not POSIX-shaped.
+Anything the Linux kernel accepts is allowed (no `=`, no NUL). Values use
+the same three forms as `[vars]`.
+
+```toml
+[[vars_lenient]]
+name  = "weird-thing"
+value = "x"
+```
+
+### `patches` - Files copied from the host into the session
+
+_Optional_
+
+Each row names a `source` on the host and a `dest` inside the session,
+with an optional `description`.
+
+```toml
+patches = [
+    { dest = ".psqlrc", source = "~/dotfiles/psqlrc" },
+    { dest = "certs/",    source = "~/ca/*.pem" },
+    { dest = ".config/nvim/", source = "~/dotfiles/nvim/**/*.lua" },
+]
+```
+
+**`source`** is a host path or glob pattern, or a list of them (a list
+fans out into one independent patch per entry, each sharing the `dest` --
+so list entries only make sense with per-entry dests or glob entries):
+
+- A leading `~` expands to the host home directory. `$NAME` / `${NAME}`
+  references (including `$HOME`) resolve against the session's
+  already-resolved variables (declared in `[vars]`); referencing an
+  undefined name is an error. `$$` is a literal `$`.
+- After expansion the path must be absolute; anchor home-relative sources
+  with `~/`.
+- Glob patterns must have a literal directory prefix to walk from:
+  `~/dotfiles/**/*.lua` is fine, a bare `**/*.pem` is rejected.
+- `..` components are rejected wherever they appear.
+- A source path that does not exist on the host is dropped with a warning
+  at activation rather than failing it, so opportunistically patching a
+  dotfile tree the host may not have is safe. Other enumeration failures
+  (permission denied, unreadable entries) still fail the composition.
+
+**`dest`** is interpreted relative to the session user's home directory.
+Absolute paths and `..` components are rejected. For a literal (non-glob)
+source, `dest` is used verbatim as the destination file path; for glob
+sources, `dest` is the destination directory and each match's path under
+the walk root is appended to it.
+
+By default the walker does not follow symlinks while enumerating glob
+matches; see [`follow_symlinks`](#follow_symlinks) and the
+[client config](#client-config).
+
+### `[[lifecycle_hooks]]` - Scripts at session transition points
+
+_Optional_
+
+Each hook groups up to three scripts (`on_activate`, `on_destroy`, and
+`on_failure`), and at least one must be present. An optional `description`
+labels the hook. Scripts are either inline or a path to a file:
+
+```toml
+[[lifecycle_hooks]]
+description = "warm caches"
+on_activate = { type = "inline",   value = "cargo fetch || true" }
+on_failure  = { type = "external", value = "./cleanup.sh" }
+```
+
+External script paths must be relative (absolute paths are rejected at
+parse time) and are anchored to the configuration directory the file was
+loaded from. Hooks from multiple contributors concatenate in declaration
+order. Note: in the current release hooks are composed and recorded with
+the session, but executing them is not yet wired up.
+
+### `follow_symlinks` - Symlink handling for patch sources {#follow_symlinks}
+
+_Optional_
+
+Overrides the client-wide `[loadouts].follow_symlinks` setting (see
+[client config](#client-config)) for this loadout's patches only. When
+unset, the client-wide setting applies.
+
+```toml
+follow_symlinks = true
+```
+
+## Selecting loadouts at activation
+
+[`min activate`](./cli-min.md#activate) decides which loadouts to apply
+from two flags:
+
+| Flag | Description |
+|------|-------------|
+| `--loadout <NAME>` | Apply `<config>/minimal/loadouts/<NAME>.toml`. Repeatable. If given, the config file's `default_loadouts` are ignored |
+| `--no-loadouts` | Apply no loadouts at all. Conflicts with `--loadout` |
+
+Resolution order:
+
+1. `--no-loadouts`: nothing is applied, regardless of configuration.
+2. One or more `--loadout NAME`: exactly the named loadouts are applied.
+3. Neither flag: the `[loadouts].default_loadouts` list from the
+   [client config](#client-config) is applied (which may be empty).
+
+Loadouts are resolved and composed **before** the CLI contacts the daemon:
+a missing or malformed loadout file fails the activation loudly on the
+client rather than producing a silently-empty session. When loadouts are
+applied, the CLI prints `Applying loadouts: <names>` to stderr.
+
+Activation is also when loadout contents are captured: the files are read
+once, inherited vars are resolved against the host environment, and the
+composed result is what the session runs with. Editing a loadout file
+does not change sessions that already exist; destroy and re-activate to
+pick up the edit.
+
+## Client config {#client-config}
+
+Client-wide loadout preferences live in `<config>/minimal/config.toml`,
+under a `[loadouts]` section:
+
+```toml
+[loadouts]
+default_loadouts = ["helix", "fish"]
+follow_symlinks  = false
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `default_loadouts` | `[]` | Loadouts (by filename stem) applied to each new session when no `--loadout`/`--no-loadouts` flag is given |
+| `follow_symlinks` | `false` | Follow symlinks while enumerating loadout patch sources. Turn on when your dotfile tree is a symlink farm (stow, chezmoi) and you want the walk to descend through the links |
+
+A missing file is equivalent to the defaults; unknown keys are rejected so
+a typo (`[loadout]` for `[loadouts]`) fails loudly.
+
+## Listing loadouts
+
+[`min loadout list`](./cli-min.md#loadout-list-alias-ls) (alias:
+`min loadout ls`) enumerates every `*.toml` file in the loadouts
+directory, one row per file:
+
+```
+  NAME   DESCRIPTION                     CONTRIBUTES
+* dev    helix + zellij with my dotfiles 2 pkg / 4 var / 5 patch / 1 hook
+  extra                                  1 pkg / 0 var / 0 patch / 0 hook
+
+* default (from `[loadouts].default_loadouts`)
+```
+
+- Loadouts named in `default_loadouts` are marked with a leading `*`.
+- Malformed entries are listed with their parse error so they can be fixed
+  in place; a `default_loadouts` entry with no matching file produces a
+  warning.
+- `--dir <DIR>` overrides the loadouts directory.
+
+## Composition, conflicts, and policy
+
+At activation, the client composes the selected loadouts into a single
+contribution and ships it to the daemon, where it is merged with the
+project's contribution (the `[session]` block of the project's
+`minimal.toml`, plus per-package contributions) into the session's final
+configuration. Merge semantics across all contributors:
+
+- **Packages** deduplicate: set semantics, there is no value to disagree
+  on.
+- **Vars** with the same name and the same resolved value deduplicate.
+  The same name with *different* values is a hard conflict that fails the
+  composition; there is no override precedence between loadouts and the
+  project. The error's hint applies: add the name to your policy's
+  `ignore` list to drop all contributors of that variable.
+- **Patches** with the same destination and different sources are likewise
+  a conflict.
+- **Lifecycle hooks** concatenate in declaration order (execution is not
+  yet wired up in the current release).
+
+Two loadouts with the same name cannot be applied together.
+
+Loadout contributions are gated by the user's policy
+(`<config>/minimal/user_policy.toml`): items you declare yourself
+automatically pass the `allow` check, but the policy's `deny` and `ignore`
+rules still apply: a loadout patch matching a `deny` pattern fails the
+composition on the client, before the daemon is involved. A missing policy
+file means an empty policy; a fresh install activates fine without it.
+
+## Vars in the attach shell
+
+The interactive shell minted by [`min attach`](./cli-min.md#attach) is
+`bash --noprofile -l`, a login shell that sources **no** startup files
+(not `/etc/profile`, `~/.bash_profile`, or `~/.bashrc`), so rc-file
+patches cannot influence it. Interactive setup travels through the
+environment instead, i.e. through `[vars]`:
+
+- **Prompt**: the session launcher seeds a baseline environment
+  (currently a stock `PS1`) before merging in the composed vars, and a
+  composed var overwrites a baseline entry with the same name. Setting
+  `PS1` in `[vars]` therefore replaces the stock prompt. This baseline is
+  a layer *beneath* composition, not a contributor: the no-override
+  conflict rule above arbitrates between contributors and does not apply
+  to the launcher's defaults.
+- **Banner / MOTD**: bash evaluates `PROMPT_COMMAND` from the
+  environment before the first interactive prompt, so a once-only banner
+  can ship as a payload var plus a self-unsetting trigger:
+
+  ```toml
+  [vars]
+  PROMPT_COMMAND = 'eval "$MINIMAL_MOTD"; unset PROMPT_COMMAND MINIMAL_MOTD'
+  MINIMAL_MOTD   = '''
+  [ -t 1 ] && printf '%s\n' '' '  Welcome to the dev session.' ''
+  '''
+  ```
+
+  The trigger unsets both variables, so the banner prints exactly once
+  and never runs for non-interactive commands; the `[ -t 1 ]` guard keeps
+  redirected output clean. Multi-line literal values survive composition
+  intact.

--- a/docs/reference/manifest.json
+++ b/docs/reference/manifest.json
@@ -1,0 +1,15 @@
+{
+  "pages": [
+    "cli.md",
+    "cli-mip.md",
+    "cli-min.md",
+    "cli-minimald.md",
+    "cli-minvmd.md",
+    "minimal-dot-toml.md",
+    "tasks.md",
+    "build-specs.md",
+    "stack-specs.md",
+    "sandbox-operations.md",
+    "linux-host-setup.md"
+  ]
+}

--- a/docs/reference/manifest.json
+++ b/docs/reference/manifest.json
@@ -7,6 +7,7 @@
     "cli-minvmd.md",
     "minimal-dot-toml.md",
     "tasks.md",
+    "loadouts.md",
     "build-specs.md",
     "stack-specs.md",
     "sandbox-operations.md",

--- a/docs/reference/minimal-dot-toml.md
+++ b/docs/reference/minimal-dot-toml.md
@@ -1,4 +1,5 @@
 ---
+title: minimal.toml
 description: Schema reference for the minimal.toml configuration file — upstream, stack, defaults, tasks, and outputs sections.
 ---
 
@@ -9,7 +10,7 @@ The `minimal.toml` file defines the configuration for Minimal in a codebase.
 This file must be present at the base of the repository (i.e. `./minimal.toml`), or
 in a `.minimal` directory at the base of the repository.
 
-Unless [`-C`](/reference/cli#global-flags) is specified, the [Minimal CLI](/reference/cli) searches the directory tree backwards from
+Unless [`-C`](./cli-mip.md#global-flags) is specified, the [mip CLI](./cli-mip.md) searches the directory tree backwards from
 the current directory till a `minimal.toml` file is found. This behavior allows minimal to be invoked in project directories.
 
 ## Example
@@ -48,8 +49,8 @@ exec = "bash -l"
 
 ### `[upstream]` - Where software comes from {#upstream}
 
-The `[upstream]` section defines the precise source of packages, harnesses, and profiles. This represents the
-preceding link in the [software supply chain](/concepts/software-supply-chain).
+The `[upstream]` section defines the precise source of packages, stacks, and profiles. This represents the
+preceding link in the [software supply chain](https://docs.minimal.dev/concepts/software-supply-chain).
 
 ```toml
 [upstream]
@@ -58,11 +59,14 @@ branch = "<branch>"
 locked_commit = "<commit hash>"
 ```
 
-`locked_commit` is automatically updated when `minimal update` is run.
+`locked_commit` is automatically updated when [`mip update`](./cli-mip.md) is
+run: it re-resolves `branch` to its current HEAD and rewrites the
+`locked_commit` of the upstream (and of every sideload) in `minimal.toml` in
+place — expect a diff on these fields after running it.
 
 #### `[[upstream.sideload]]` - Additional software sideloaded into your supply chain {#sideload}
 
-Sideload entries let you load in additional packages, harnesses, and profiles from a separate repository, but those packages
+Sideload entries let you load in additional packages, stacks, and profiles from a separate repository, but those packages
 are built using the version of packages from your upstream.
 
 Each sideload entry is loaded in order from the specified repository, and follows the same schema as `[upstream]`:
@@ -71,27 +75,28 @@ Each sideload entry is loaded in order from the specified repository, and follow
 [[upstream.sideload]]
 repo = "<git URL>"
 branch = "<branch>"
-locked_commit = "<commit hash>" # Updated via `minimal update`
+locked_commit = "<commit hash>" # Updated via `mip update`
 ```
 
-Sideload repositories have the same layout as an upstream: that is having a `minimal.toml` file, and `packages/` / `harnesses/` / `profiles/`
+Sideload repositories have the same layout as an upstream: that is having a `minimal.toml` file, and `packages/` / `stacks/` / `profiles/`
 directories as needed.
 
 ### `[stack]` - How to build code in your repo {#harness}
 
 ```toml
 [stack]
-use = "<harness name>"
+use = "<stack name>"
 build_packages = ["<additional build package>"]     # optional
 runtime_packages = ["<additional runtime package>"] # optional
 ```
 
-The `[stack]` section configures the [harness](/concepts/harnesses) to use for building code, if any.
+The `[stack]` section configures the [stack](https://docs.minimal.dev/concepts/harnesses) to use for building code, if any.
+See [stack specs](./stack-specs.md) for how stacks themselves are defined.
 
 `[harness]` is accepted as a deprecated alias for `[stack]`, pending removal after
 July 2026; prefer `[stack]` in new configs.
 
-The environment variables and packages configured on a harness are inherited on all tasks in this repository.
+The environment variables and packages configured on a stack are inherited on all tasks in this repository.
 
 `build_packages` and `runtime_packages` are optional fields that allow you to declare
 additional package dependencies for build time or run time respectively.
@@ -106,7 +111,7 @@ profile = "<profile name>" # optional
 state_key = "<state key>"  # optional
 ```
 
-When set, `defaults.profile` will set a [profile](/concepts/profiles) on all tasks which do not set a profile.
+When set, `defaults.profile` will set a [profile](https://docs.minimal.dev/concepts/profiles) on all tasks which do not set a profile.
 
 When set, `defaults.state_key` will set a state key on all tasks which do not set `state_key`.
 
@@ -114,14 +119,14 @@ When set, `defaults.state_key` will set a state key on all tasks which do not se
 
 ### `[tasks.*]` - Run tasks, scripts, & dev tooling {#tasks}
 
-See: [tasks](/reference/tasks).
+See: [tasks](./tasks.md).
 
 
 
-### `[outputs.*]` - Artifacts produced by `minimal materialize` {#outputs}
+### `[outputs.*]` - Artifacts produced by `mip materialize` {#outputs}
 
 Each `[outputs.<name>]` section defines an artifact that can be produced with
-[`minimal materialize <name> -o <path>`](/reference/cli#materialize).
+[`mip materialize <name> -o <path>`](./cli-mip.md#materialize).
 
 ```toml
 [outputs.<name>]
@@ -145,7 +150,7 @@ vars = { KEY = "value" }        # oci-image only; alias: `env_vars`
 
 - **`type`** (alias: `ty`) — The output kind, either `oci-image` or `raw-file`. Defaults to `oci-image` when omitted.
 - **`packages`** — Packages to include in the materialized output. When omitted or empty, defaults to `["base"]`.
-- **`arch`** — Target architecture for OCI images. Common values: `amd64`, `arm64`. The CLI flag [`--arch`](/reference/cli#materialize) overrides this; if neither is set, the host architecture is used.
+- **`arch`** — Target architecture for OCI images. Common values: `amd64`, `arm64`. The CLI flag [`--arch`](./cli-mip.md#materialize) overrides this; if neither is set, the host architecture is used.
 - **`path`** — _(`raw-file` only)_ Path, relative to the package file tree, of the single file to extract. Required for `raw-file` outputs; supplying it on an `oci-image` output is an error.
 - **`entrypoint`** — _(`oci-image` only)_ OCI image entrypoint. May be a string (`"/app/server"`) or a list (`["/bin/sh", "-c"]`).
 - **`cmd`** — _(`oci-image` only)_ OCI image default command. Same string-or-list shape as `entrypoint`.
@@ -163,7 +168,7 @@ type = "oci-image"
 ```
 
 ```sh
-minimal materialize base-image -o ./base.tar
+mip materialize base-image -o ./base.tar
 ```
 
 A server image with extra packages, an entrypoint, and an env var:
@@ -178,13 +183,13 @@ vars = { PORT = "8080" }
 ```
 
 ```sh
-minimal materialize app -o ./app.tar
+mip materialize app -o ./app.tar
 ```
 
 Override the architecture at the command line:
 
 ```sh
-minimal materialize app --arch amd64 -o ./app-amd64.tar
+mip materialize app --arch amd64 -o ./app-amd64.tar
 ```
 
 A `raw-file` output extracts a single file from a package. Here the kernel
@@ -198,5 +203,5 @@ path = "usr/share/virtio-linux/Image"
 ```
 
 ```sh
-minimal materialize virtio-kernel -o ./Image
+mip materialize virtio-kernel -o ./Image
 ```

--- a/docs/reference/minimal-dot-toml.md
+++ b/docs/reference/minimal-dot-toml.md
@@ -1,6 +1,6 @@
 ---
 title: minimal.toml
-description: Schema reference for the minimal.toml configuration file: upstream, stack, defaults, tasks, and outputs sections.
+description: "Schema reference for the minimal.toml configuration file: upstream, stack, defaults, tasks, and outputs sections."
 ---
 
 # `minimal.toml`
@@ -27,6 +27,9 @@ build_packages = ["railway"]
 
 [defaults]
 state_key = "dev"
+
+[session]
+packages = ["base", "git", "nano"]
 
 [tasks.dev]
 exec = "pnpm run dev"
@@ -69,7 +72,7 @@ place; expect a diff on these fields after running it.
 Sideload entries let you load in additional packages, stacks, and profiles from a separate repository, but those packages
 are built using the version of packages from your upstream.
 
-Each sideload entry is loaded in order from the specified repository, and follows the same schema as `[upstream]`:
+Each sideload entry is loaded in order from the specified repository, and follows the same schema as `[upstream]` (the canonical table name is `sideloads`; `sideload` is an accepted alias):
 
 ```toml
 [[upstream.sideload]]
@@ -81,7 +84,7 @@ locked_commit = "<commit hash>" # Updated via `mip update`
 Sideload repositories have the same layout as an upstream: that is having a `minimal.toml` file, and `packages/` / `stacks/` / `profiles/`
 directories as needed.
 
-### `[stack]` - How to build code in your repo {#harness}
+### `[stack]` - How to build code in your repo {#stack}
 
 ```toml
 [stack]
@@ -90,10 +93,11 @@ build_packages = ["<additional build package>"]     # optional
 runtime_packages = ["<additional runtime package>"] # optional
 ```
 
-The `[stack]` section configures the [stack](https://docs.minimal.dev/concepts/harnesses) to use for building code, if any.
+The `[stack]` section configures the [stack](https://docs.minimal.dev/concepts/stacks) to use for building code, if any.
 See [stack specs](./stack-specs.md) for how stacks themselves are defined.
 
-`[harness]` is accepted as a deprecated alias for `[stack]`, pending removal after
+`use` is an accepted alias for the canonical `name` key; both parse. `[harness]`
+is accepted as a deprecated alias for `[stack]`, pending removal after
 July 2026; prefer `[stack]` in new configs.
 
 The environment variables and packages configured on a stack are inherited on all tasks in this repository.
@@ -117,6 +121,57 @@ When set, `defaults.state_key` will set a state key on all tasks which do not se
 
 
 
+### `[session]` - What every contributor's session gets {#session}
+
+Contributes to [sessions](https://docs.minimal.dev/concepts/sessions) activated
+on this project (`min activate`). It carries the same primitives as a
+[loadout](./loadouts.md) (packages, vars, patches, lifecycle hooks), scoped to
+the project rather than the developer: where a loadout says "what this
+developer wants everywhere", the session block says "what every session
+working on this codebase needs". There is at most one per `minimal.toml`, and
+it has no name or description.
+
+```toml
+[session]
+# Toolchain every contributor's session gets.
+packages = ["rustc", "cargo", "postgresql-client"]
+
+# Config that lives in the repo, patched into the session's home.
+patches = [
+    { dest = ".cargo/config.toml", source = "config/cargo.toml" },
+    { dest = ".psqlrc",            source = "config/psqlrc" },
+]
+
+[session.vars]
+# Applies uniformly to every developer's session.
+RUST_LOG         = "info"
+CARGO_TERM_COLOR = "always"
+# Inherit from the developer's environment if set, else the default.
+DATABASE_URL     = { inherit = true, default = "postgres://localhost/dev" }
+
+# Declared to warm the compile cache when a session comes up.
+[[session.lifecycle_hooks]]
+on_activate = { type = "inline", value = "cargo check --workspace >/dev/null 2>&1 || true" }
+```
+
+- **`packages`**: Packages brought into every session on this project,
+  alongside whatever the developer's loadouts contribute.
+- **`vars`**: Environment variables. A string sets a fixed value;
+  `{ inherit = true }` passes the developer's own value through (add
+  `default = "..."` for a fallback when it is unset).
+- **`patches`**: `{ source, dest }` rows copying files into the session.
+  `dest` is relative to the session user's home directory; `source` resolves
+  on the host, typically inside the repo.
+- **`lifecycle_hooks`**: Scripts declared for session transition points
+  (`on_activate`, `on_destroy`, `on_failure`). Composed and recorded today;
+  execution is not yet wired up in the current release.
+
+The field shapes and composition semantics (conflicts, policy gating) are the
+same as loadouts; see the [loadout reference](./loadouts.md) for the exact
+rules.
+
+
+
 ### `[tasks.*]` - Run tasks, scripts, & dev tooling {#tasks}
 
 See: [tasks](./tasks.md).
@@ -130,7 +185,7 @@ Each `[outputs.<name>]` section defines an artifact that can be produced with
 
 ```toml
 [outputs.<name>]
-type = "<output type>"          # required; alias: `ty`
+type = "<output type>"          # optional; defaults to "oci-image"
 packages = ["<package>", ...]   # optional; defaults to ["base"] when empty
 arch = "<arch>"                 # optional; e.g. "amd64", "arm64"
 path = "<path>"                 # raw-file only; required there, invalid for oci-image
@@ -148,7 +203,7 @@ vars = { KEY = "value" }        # oci-image only; alias: `env_vars`
 
 #### Fields
 
-- **`type`** (alias: `ty`): The output kind, either `oci-image` or `raw-file`. Defaults to `oci-image` when omitted.
+- **`type`**: The output kind, either `oci-image` or `raw-file`. Defaults to `oci-image` when omitted.
 - **`packages`**: Packages to include in the materialized output. When omitted or empty, defaults to `["base"]`.
 - **`arch`**: Target architecture for OCI images. Common values: `amd64`, `arm64`. The CLI flag [`--arch`](./cli-mip.md#materialize) overrides this; if neither is set, the host architecture is used.
 - **`path`**: _(`raw-file` only)_ Path, relative to the package file tree, of the single file to extract. Required for `raw-file` outputs; supplying it on an `oci-image` output is an error.
@@ -205,3 +260,27 @@ path = "usr/share/virtio-linux/Image"
 ```sh
 mip materialize virtio-kernel -o ./Image
 ```
+
+### `[params]` - Repo-wide parameters {#params}
+
+Declares named parameters available to tasks across the repository, using the
+same `{type, help, default}` shape as per-task [`args`](./tasks.md). Every
+`[params]` entry must declare a `default`.
+
+### `[cache]` - Artifact cache behavior {#cache}
+
+```toml
+[cache]
+index_source = "auto"  # optional: "auto" (default), "pinned", or "root"
+fetch_retries = 2      # optional: retry count for remote fetches
+```
+
+### `[stdlib]` - Standard library requirements {#stdlib}
+
+```toml
+[stdlib]
+minimum_version = "<version>"  # optional; alias: min_version
+```
+
+Refuses to operate when the upstream's standard library is older than the
+declared minimum.

--- a/docs/reference/minimal-dot-toml.md
+++ b/docs/reference/minimal-dot-toml.md
@@ -1,6 +1,6 @@
 ---
 title: minimal.toml
-description: Schema reference for the minimal.toml configuration file — upstream, stack, defaults, tasks, and outputs sections.
+description: Schema reference for the minimal.toml configuration file: upstream, stack, defaults, tasks, and outputs sections.
 ---
 
 # `minimal.toml`
@@ -62,7 +62,7 @@ locked_commit = "<commit hash>"
 `locked_commit` is automatically updated when [`mip update`](./cli-mip.md) is
 run: it re-resolves `branch` to its current HEAD and rewrites the
 `locked_commit` of the upstream (and of every sideload) in `minimal.toml` in
-place — expect a diff on these fields after running it.
+place; expect a diff on these fields after running it.
 
 #### `[[upstream.sideload]]` - Additional software sideloaded into your supply chain {#sideload}
 
@@ -148,15 +148,15 @@ vars = { KEY = "value" }        # oci-image only; alias: `env_vars`
 
 #### Fields
 
-- **`type`** (alias: `ty`) — The output kind, either `oci-image` or `raw-file`. Defaults to `oci-image` when omitted.
-- **`packages`** — Packages to include in the materialized output. When omitted or empty, defaults to `["base"]`.
-- **`arch`** — Target architecture for OCI images. Common values: `amd64`, `arm64`. The CLI flag [`--arch`](./cli-mip.md#materialize) overrides this; if neither is set, the host architecture is used.
-- **`path`** — _(`raw-file` only)_ Path, relative to the package file tree, of the single file to extract. Required for `raw-file` outputs; supplying it on an `oci-image` output is an error.
-- **`entrypoint`** — _(`oci-image` only)_ OCI image entrypoint. May be a string (`"/app/server"`) or a list (`["/bin/sh", "-c"]`).
-- **`cmd`** — _(`oci-image` only)_ OCI image default command. Same string-or-list shape as `entrypoint`.
-- **`vars`** (alias: `env_vars`) — _(`oci-image` only)_ Environment variables baked into the image as a `KEY = "value"` table.
+- **`type`** (alias: `ty`): The output kind, either `oci-image` or `raw-file`. Defaults to `oci-image` when omitted.
+- **`packages`**: Packages to include in the materialized output. When omitted or empty, defaults to `["base"]`.
+- **`arch`**: Target architecture for OCI images. Common values: `amd64`, `arm64`. The CLI flag [`--arch`](./cli-mip.md#materialize) overrides this; if neither is set, the host architecture is used.
+- **`path`**: _(`raw-file` only)_ Path, relative to the package file tree, of the single file to extract. Required for `raw-file` outputs; supplying it on an `oci-image` output is an error.
+- **`entrypoint`**: _(`oci-image` only)_ OCI image entrypoint. May be a string (`"/app/server"`) or a list (`["/bin/sh", "-c"]`).
+- **`cmd`**: _(`oci-image` only)_ OCI image default command. Same string-or-list shape as `entrypoint`.
+- **`vars`** (alias: `env_vars`): _(`oci-image` only)_ Environment variables baked into the image as a `KEY = "value"` table.
 
-Setting an `oci-image`-only field (`entrypoint`, `cmd`, `vars`) on a `raw-file` output — or setting `path` on an `oci-image` output — is rejected when the `minimal.toml` is parsed.
+Setting an `oci-image`-only field (`entrypoint`, `cmd`, `vars`) on a `raw-file` output, or setting `path` on an `oci-image` output, is rejected when the `minimal.toml` is parsed.
 
 #### Examples
 

--- a/docs/reference/sandbox-operations.md
+++ b/docs/reference/sandbox-operations.md
@@ -1,25 +1,35 @@
 ---
+title: Sandbox operations
 description: In-sandbox min helper commands — add packages, search, check configuration, and run tasks from within a sandbox.
 ---
 
 # `min` commands
 
-`min` helper commands are available within all task sandboxes.
+`min` helper commands are available within all task sandboxes. Task sandboxes
+(and therefore these commands) are Linux-only.
+
+> **Naming note**: the in-sandbox `min` helper is a different tool from the
+> [`min` session CLI](./cli-min.md) that happens to share its name. Inside a
+> task sandbox, `min` always refers to the helper documented here; the session
+> CLI is not available there.
 
 ## Commands
 
-### `add <PACKAGES...>` {#add}
+### `add [FLAG] <PACKAGES...>` {#add}
 
-Installs tools & dependencies into the running sandbox. If flags are provided, the named packages
-are also configured as a build, runtime, or task dependency in `minimal.toml`.
+Installs tools & dependencies into the running sandbox. With no flag, packages
+are installed for the current sandbox session only — `minimal.toml` is not
+modified. With a flag, the named packages are also recorded as a build,
+runtime, or task dependency in `minimal.toml`.
 
 | Flag | Description |
 |------|-------------|
-| `--runtime` | Add packages to `harness.runtime_packages` |
-| `--build` | Add packages to `harness.build_packages` |
-| `--task <TASK_NAME>` | Add packages to `tasks.<TASK_NAME>.packages` |
+| `--session` | Install for this sandbox session only, without editing `minimal.toml` (the default when no flag is given) |
+| `--runtime` | Also add packages to `stack.runtime_packages` |
+| `--build` | Also add packages to `stack.build_packages` |
+| `--task` | Also add packages to the current task's `packages` list |
 
-`min add` is the in-sandbox equivalent of the [`minimal add`](/reference/cli#add) command.
+`min add` is the in-sandbox equivalent of the [`mip add`](./cli-mip.md#add) command.
 
 ### `search <TERM>`
 
@@ -27,24 +37,36 @@ Searches for and lists packages related to the search term.
 
 ### `check [<OPTIONS>] [FILTER_NAMES...]`
 
-Validates minimal configuration including packages, harnesses, and profiles.
+Validates minimal configuration including packages, stacks, and profiles.
 
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--fix` | `-f` | Attempt to fix any issues |
-| `--skip-checkers <NAMES>` | `-s` | Comma-delimited checker names to skip |
-| `--packages` | | Check packages defined in the codebase |
-| `--harnesses` | | Check harnesses defined in the codebase |
-| `--profiles` | | Check profiles defined in the codebase |
+| Flag | Description |
+|------|-------------|
+| `--fix` | Attempt to fix any issues |
+| `--packages` | Check packages defined in the codebase |
+| `--stacks` | Check stacks defined in the codebase |
+| `--profiles` | Check profiles defined in the codebase |
 
 If no type flags are specified, all types are checked by default.
 
-If filter names are specified, any package, harness, or profile matching a specified name is checked.
+If filter names are specified, any package, stack, or profile matching a specified name is checked.
 
-`min check` is the in-sandbox equivalent of the [`minimal check`](/reference/cli#check) command.
+`min check` is the in-sandbox equivalent of the [`mip check`](./cli-mip.md#check)
+command, with a reduced flag set (no `--skip-checkers`, and no short flag
+aliases).
 
 ### `run <TASK_NAME> [<ARGS>...]`
 
 Runs the specified task in a new Minimal sandbox. Interactive tasks are not supported.
 
-`min run` is the in-sandbox equivalent of the [`minimal run`](/reference/cli#run) command.
+`min run` is the in-sandbox equivalent of the [`mip run`](./cli-mip.md#run) command.
+
+### `build`, `test`
+
+Shorthands for `min run build` and `min run test` respectively.
+
+### `patched-pkg <PACKAGE>`
+
+Builds the named package in a clean room using potentially-stale dependencies
+(the already-cached builds of its dependencies, without rebuilding them first),
+and commits the result to the local cache. Useful for quickly iterating on a
+single package's build.

--- a/docs/reference/sandbox-operations.md
+++ b/docs/reference/sandbox-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Sandbox operations
-description: In-sandbox min helper commands — add packages, search, check configuration, and run tasks from within a sandbox.
+description: In-sandbox min helper commands: add packages, search, check configuration, and run tasks from within a sandbox.
 ---
 
 # `min` commands
@@ -18,7 +18,7 @@ description: In-sandbox min helper commands — add packages, search, check conf
 ### `add [FLAG] <PACKAGES...>` {#add}
 
 Installs tools & dependencies into the running sandbox. With no flag, packages
-are installed for the current sandbox session only — `minimal.toml` is not
+are installed for the current sandbox session only; `minimal.toml` is not
 modified. With a flag, the named packages are also recorded as a build,
 runtime, or task dependency in `minimal.toml`.
 

--- a/docs/reference/sandbox-operations.md
+++ b/docs/reference/sandbox-operations.md
@@ -1,12 +1,13 @@
 ---
 title: Sandbox operations
-description: In-sandbox min helper commands: add packages, search, check configuration, and run tasks from within a sandbox.
+description: "In-sandbox min helper commands: add packages, search, check configuration, and run tasks from within a sandbox."
 ---
 
 # `min` commands
 
-`min` helper commands are available within all task sandboxes. Task sandboxes
-(and therefore these commands) are Linux-only.
+`min` helper commands are available within task sandboxes (Linux-only) and
+inside [sessions](./cli-min.md), which install the same helper as
+`/usr/bin/min`.
 
 > **Naming note**: the in-sandbox `min` helper is a different tool from the
 > [`min` session CLI](./cli-min.md) that happens to share its name. Inside a
@@ -17,10 +18,13 @@ description: In-sandbox min helper commands: add packages, search, check configu
 
 ### `add [FLAG] <PACKAGES...>` {#add}
 
-Installs tools & dependencies into the running sandbox. With no flag, packages
-are installed for the current sandbox session only; `minimal.toml` is not
-modified. With a flag, the named packages are also recorded as a session,
-runtime, or build dependency in `minimal.toml`.
+Installs tools & dependencies into the running sandbox. The default differs
+by sandbox type: in a **session**, `min add <pkg>` with no flag defaults to
+`--session`, installing the package live and recording it in the `[session]`
+`packages` list of the project's `minimal.toml`; in a **task sandbox**, no
+flag installs for the current sandbox only and `minimal.toml` is not
+modified. With a flag, the named packages are recorded as a session, runtime,
+or build dependency in `minimal.toml`.
 
 | Flag | Description |
 |------|-------------|
@@ -28,7 +32,7 @@ runtime, or build dependency in `minimal.toml`.
 | `--runtime` | Also add packages to `stack.runtime_packages` |
 | `--build` | Also add packages to `stack.build_packages` |
 
-`min add` is the in-sandbox equivalent of the [`mip add`](./cli-mip.md#add) command.
+`min add` is the in-sandbox counterpart of [`mip add`](./cli-mip.md#add); note the flag surfaces differ (`mip add` requires one of `--runtime`, `--build`, or `--task <TASK>`).
 
 ### `search <TERM>`
 

--- a/docs/reference/sandbox-operations.md
+++ b/docs/reference/sandbox-operations.md
@@ -19,15 +19,14 @@ description: In-sandbox min helper commands: add packages, search, check configu
 
 Installs tools & dependencies into the running sandbox. With no flag, packages
 are installed for the current sandbox session only; `minimal.toml` is not
-modified. With a flag, the named packages are also recorded as a build,
-runtime, or task dependency in `minimal.toml`.
+modified. With a flag, the named packages are also recorded as a session,
+runtime, or build dependency in `minimal.toml`.
 
 | Flag | Description |
 |------|-------------|
-| `--session` | Install for this sandbox session only, without editing `minimal.toml` (the default when no flag is given) |
+| `--session` | Also add packages to the `[session]` `packages` list in `minimal.toml` |
 | `--runtime` | Also add packages to `stack.runtime_packages` |
 | `--build` | Also add packages to `stack.build_packages` |
-| `--task` | Also add packages to the current task's `packages` list |
 
 `min add` is the in-sandbox equivalent of the [`mip add`](./cli-mip.md#add) command.
 

--- a/docs/reference/stack-specs.md
+++ b/docs/reference/stack-specs.md
@@ -1,20 +1,21 @@
 ---
-description: Harness spec schema for defining build system harnesses in Nickel — packages, build commands, env vars, and project detection rules.
+title: Stacks
+description: Stack spec schema for defining build system stacks in Nickel — packages, build commands, env vars, and project detection rules.
 ---
 
-# Harnesses
+# Stacks
 
-Harnesses specify a set of tools and how to use them in a codebase. They encapsulate a common pattern for building software.
+Stacks specify a set of tools and how to use them in a codebase. They encapsulate a common pattern for building software.
 
-Harnesses are defined in a [Nickel](https://nickel-lang.org/) file located at `harnesses/<harness name>/harness.ncl`, either in your codebase
-or any layer in your [software supply chain](/concepts/software-supply-chain). The `harnesses/` directory in a layer is always adjacent to
-the [`minimal.toml`](/reference/minimal-dot-toml) file at the base of the layer. The directory can be omitted if the layer does not define any harnesses.
+Stacks are defined in a [Nickel](https://nickel-lang.org/) file located at `stacks/<stack name>/stack.ncl`, either in your codebase
+or any layer in your [software supply chain](https://docs.minimal.dev/concepts/software-supply-chain). The `stacks/` directory in a layer is always adjacent to
+the [`minimal.toml`](./minimal-dot-toml.md) file at the base of the layer. The directory can be omitted if the layer does not define any stacks.
 
 ## Examples
 
-A number of harnesses are defined and maintained in the [Minimal Public Package Registry](https://github.com/gominimal/pkgs/tree/main/harnesses), which serves as the canonical reference for defining harnesses.
+A number of stacks are defined and maintained in the [Minimal Public Package Registry](https://github.com/gominimal/pkgs/tree/main/stacks), which serves as the canonical reference for defining stacks.
 
-Here is a harness for code that uses `pnpm`:
+Here is a stack for code that uses `pnpm`:
 
 ```ncl
 let { stack, .. } = import "minimal.ncl" in
@@ -24,7 +25,7 @@ stack {
   runtime_packages = ["node"],
   build_packages = ["pnpm", "base"],
 
-  # A command that generates the build command, i.e. commands executed by `minimal build`.
+  # A command that generates the build command, i.e. commands executed by `mip build`.
   build_cmds_cmd = [
     "/bin/bash",
     "-c",
@@ -35,7 +36,7 @@ stack {
   "%
   ],
 
-  # Rules to detect when the harness is applicable to a codebase.
+  # Rules to detect when the stack is applicable to a codebase.
   matches_project_if_any = [
     {
       file_regexes = {
@@ -53,7 +54,7 @@ stack {
 
 _String_
 
-The name of the harness. Must match the name of the containing directory.
+The name of the stack. Must match the name of the containing directory.
 
 ### `runtime_packages`
 
@@ -74,7 +75,7 @@ build-time tools such as pkg-config or compilers.
 _Dictionary of String's, optional_
 
 Pairs of environment-variable names and their values that should be set for a build. These are inherited
-by all tasks in a codebase that uses the harness, unless the task sets the environment variable itself.
+by all tasks in a codebase that uses the stack, unless the task sets the environment variable itself.
 
 ### `build_cmd` or `build_cmds_cmd`
 
@@ -83,9 +84,9 @@ _`build_cmd`: String or array of strings for the build command_
 _`build_cmds_cmd`: String or array of strings for a command that generates the build command_
 
 `build_cmd` and `build_cmds_cmd` are mutually exclusive fields that declare the command for
-building software which uses this harness.
+building software which uses this stack.
 
-`build_cmd` defines the command to run when `minimal build` is invoked. It can be a shell-style
+`build_cmd` defines the command to run when [`mip build`](./cli-mip.md) is invoked. It can be a shell-style
 string or an array containing the executable followed by its arguments.
 
 ```ncl
@@ -125,10 +126,10 @@ stack {
 
 _Array of ProjectMatcher objects, optional_
 
-Defines a list of rules which detect when a harness is applicable to some codebase. This
-is the mechanism underlying `minimal init`.
+Defines a list of rules which detect when a stack is applicable to some codebase. This
+is the mechanism underlying [`mip init`](./cli-mip.md).
 
-A harness is considered applicable if any ProjectMatcher in the array matches.
+A stack is considered applicable if any ProjectMatcher in the array matches.
 
 Each matcher has the following fields, all optional:
 

--- a/docs/reference/stack-specs.md
+++ b/docs/reference/stack-specs.md
@@ -1,6 +1,6 @@
 ---
 title: Stacks
-description: Stack spec schema for defining build system stacks in Nickel — packages, build commands, env vars, and project detection rules.
+description: Stack spec schema for defining build system stacks in Nickel: packages, build commands, env vars, and project detection rules.
 ---
 
 # Stacks

--- a/docs/reference/stack-specs.md
+++ b/docs/reference/stack-specs.md
@@ -1,6 +1,6 @@
 ---
 title: Stacks
-description: Stack spec schema for defining build system stacks in Nickel: packages, build commands, env vars, and project detection rules.
+description: "Stack spec schema for defining build system stacks in Nickel: packages, build commands, env vars, and project detection rules."
 ---
 
 # Stacks

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -1,6 +1,6 @@
 ---
 title: Tasks
-description: Full task schema reference: packages, exec/bash commands, state_key, env_vars, patches, profiles, args, and interactive mode.
+description: "Full task schema reference: packages, exec/bash commands, state_key, env_vars, patches, profiles, args, and interactive mode."
 ---
 
 # Tasks
@@ -52,6 +52,14 @@ above, `pnpm` runs as `/bin/pnpm`.
 bash = "echo \"hello\" > hello.txt"
 ```
 
+A third action, `echo`, prints a fixed string without composing a sandbox at
+all; useful for pointers and reminders:
+
+```toml
+[tasks.docs]
+echo = "Docs live at https://docs.minimal.dev"
+```
+
 When [args](#args) are set on the task, arguments can be substituted into the invocation using
 Nickel's string interpolation [syntax](https://nickel-lang.org/user-manual/syntax/#strings):
 
@@ -89,17 +97,15 @@ state_key = "dev" # Cache build artifacts under 'dev'
 
 ### `env_vars` - Environment variables to set
 
-_Optional, Alias `vars`_
+_Optional. `env_vars` is an alias of the canonical `vars` key; both parse_
 
 `env_vars` sets environment variables in the tasks' runtime environment. Variables
 set here take precedence over any inherited from the profile.
 
 ```toml
 [tasks.my_task]
-env_vars = {
-  CC = "gcc",
-  AWS_PROJECT = "zest",
-}
+env_vars.CC = "gcc"
+env_vars.AWS_PROJECT = "zest"
 ```
 
 Environment variables can also inherit their value from the parent process. To do this,
@@ -146,7 +152,7 @@ profile = "" # No profile applied to `my_task`
 
 ### `patches` - Map in files/directories from the system
 
-_Optional, Alias `patch`_
+_Optional. `patches` is an alias of the canonical `patch` key; both parse_
 
 `patches` configures files and directories to be mapped into the tasks' runtime environment.
 
@@ -163,7 +169,7 @@ mappings.
 
 If a mapped file or directory does not exist on the host, an empty file or directory is created.
 
-Mapped paths must be absolute or start with `~`, in which case the tilde is expanded to the user's
+Mapped paths must be absolute or start with `~/`, in which case the tilde is expanded to the user's
 home directory.
 
 ### `inherit_cwd` - Use parent working directory instead of repository root
@@ -187,10 +193,8 @@ being executed by the task.
 
 ```toml
 [tasks.greeter]
-args = {
-    name = "string",
-    greeting = "string",
-}
+args.name = "string"
+args.greeting = "string"
 exec = "echo %{greeting} %{name}"
 ```
 

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -1,6 +1,6 @@
 ---
 title: Tasks
-description: Full task schema reference — packages, exec/bash commands, state_key, env_vars, patches, profiles, args, and interactive mode.
+description: Full task schema reference: packages, exec/bash commands, state_key, env_vars, patches, profiles, args, and interactive mode.
 ---
 
 # Tasks
@@ -42,7 +42,7 @@ exec = ["pnpm", "build"]
 ```
 
 When `exec` names a command without an absolute path (or a `./` prefix), the
-command is resolved to `/bin/<command>` inside the sandbox — in the examples
+command is resolved to `/bin/<command>` inside the sandbox; in the examples
 above, `pnpm` runs as `/bin/pnpm`.
 
 `bash` describes a bash command that should run when the task is launched.

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -1,11 +1,12 @@
 ---
+title: Tasks
 description: Full task schema reference — packages, exec/bash commands, state_key, env_vars, patches, profiles, args, and interactive mode.
 ---
 
 # Tasks
 
-Tasks are defined in a [`minimal.toml`](/reference/minimal-dot-toml) file, and describe
-a runtime environment + command invocations to be executed using [`minimal run <taskname>`](/reference/cli#run)
+Tasks are defined in a [`minimal.toml`](./minimal-dot-toml.md) file, and describe
+a runtime environment + command invocations to be executed using [`mip run <taskname>`](./cli-mip.md#run)
 
 ## Tasks schema
 
@@ -15,8 +16,8 @@ Tasks are defined in a `[tasks.<task-name>]` block in your minimal file.
 
 _Optional_
 
-`packages` lists additional [packages](/concepts/packages) which will be installed in the tasks'
-runtime environment. Packages listed here are in addition to any installed due to the profile or harness.
+`packages` lists additional [packages](https://docs.minimal.dev/concepts/packages) which will be installed in the tasks'
+runtime environment. Packages listed here are in addition to any installed due to the profile or stack.
 
 ```toml
 [tasks.my_task]
@@ -40,6 +41,10 @@ or as a program and its list of arguments:
 exec = ["pnpm", "build"]
 ```
 
+When `exec` names a command without an absolute path (or a `./` prefix), the
+command is resolved to `/bin/<command>` inside the sandbox — in the examples
+above, `pnpm` runs as `/bin/pnpm`.
+
 `bash` describes a bash command that should run when the task is launched.
 
 ```toml
@@ -54,6 +59,19 @@ Nickel's string interpolation [syntax](https://nickel-lang.org/user-manual/synta
 [tasks.greet]
 args.name = "string"
 bash = "echo \"Hello %{name}!\""
+```
+
+
+### `description` - Describe the task
+
+_Optional_
+
+`description` is a free-text description of the task, shown alongside the task
+name in [`mip status`](./cli-mip.md).
+
+```toml
+[tasks.my_task]
+description = "Run the dev server with hot reload"
 ```
 
 
@@ -176,16 +194,31 @@ args = {
 exec = "echo %{greeting} %{name}"
 ```
 
-All arguments become mandatory for invoking the task. In the example above, running the task `greeter`
-without its two arguments will trigger an error:
+Arguments without a default become mandatory for invoking the task. In the example above, running
+the task `greeter` without its two arguments will trigger an error:
 
 ```shell
-$> minimal run greeter
+$> mip run greeter
 error: the following required arguments were not provided:
   --name <name>
   --greeting <greeting>
 
-Usage: minimal run greeter --name <name> --greeting <greeting>
+Usage: mip run greeter --name <name> --greeting <greeting>
 ```
 
-Valid datatypes are `string`, `number`, and `boolean`.
+Each argument's datatype may be:
+
+- a scalar: `"string"`, `"number"`, or `"boolean"` (alias `"bool"`);
+- an array of a scalar type: `"Array string"`, `"Array number"`, `"Array boolean"`;
+- an enum of permitted values, written either as the string `"[a, b]"` or as a
+  TOML array `["a", "b"]`.
+
+Instead of a bare datatype string, an argument can be declared as a table with a
+`type` field plus optional `help` (a human-readable description) and `default`
+(making the argument optional):
+
+```toml
+[tasks.greeter]
+args.name = { type = "string", help = "who to greet", default = "world" }
+exec = "echo Hello %{name}"
+```


### PR DESCRIPTION
Fifth PR in the `oss/integration` decomposition — the CLI & config **reference** section (WS8, first half). Pure docs. **12 files, +779/−207.**

## What

- **Per-binary CLI reference:** `cli-min.md`, `cli-mip.md`, `cli-minimald.md`, `cli-minvmd.md`, plus the `cli.md` overview.
- **Config & spec pages:** `minimal-dot-toml.md`, `tasks.md`, `build-specs.md`, `sandbox-operations.md`, and the `harness-specs.md` → **`stack-specs.md`** rename.
- **`manifest.json`** — the reference-page index.


## Accuracy fix

Removed a stale "known issues" note in the mip reference that cited `dump --stacks` (`todo!()`) and `patched-build --remote-addr`. Both were **since fixed** (dump --stacks by #842) and their issues **closed**, so citing them as current known issues was inaccurate.

## Verification

- **Links:** every relative `.md`/`.json` link resolves; no danglers. Nothing in this set links to `loadouts.md`, so deferring it is clean.
- **Manifest:** valid JSON; all 11 listed pages are present in this PR.
- **Scrub:** no leaked emails/secrets/inbox refs.
- **Staleness handled:** the branch's `cli.md` rewrite already omits the `--hostpath-deps` row that #842 removed (no reversion); `harness-specs` has no lingering references.

Depends on nothing already merged; branches off current `main`. The loadouts page (367 lines) follows as PR6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CLI command reference pages and update config/spec docs for mip, min, minimald, and minvmd
> - Replaces the monolithic [cli.md](https://github.com/gominimal/minimal/pull/863/files#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711) with an overview page that splits the session plane (`min`) from the package/build plane (`mip`) and links to new dedicated reference pages for each binary.
> - Adds new reference pages for [`cli-mip.md`](https://github.com/gominimal/minimal/pull/863/files#diff-562f454c0e56bf1e2de06237451cfb5f963df5cc2bb497cc0013d570ff3f3140), [`cli-min.md`](https://github.com/gominimal/minimal/pull/863/files#diff-f468e424e3aca5e5c314972c6f512d342f7746adac5a9177bfa23a1ae4c4e510), [`cli-minimald.md`](https://github.com/gominimal/minimal/pull/863/files#diff-5ca48971195f7550a4dfe4cbb9e04b126c770cbe145b6a2651256f4cdc367a4a), and [`cli-minvmd.md`](https://github.com/gominimal/minimal/pull/863/files#diff-5f2a9a2eb5b6598af8fd31507e8bdef9f09cd4c4bad4af9c4f17abca63299ba7), each generated from `--help` output.
> - Updates [`minimal-dot-toml.md`](https://github.com/gominimal/minimal/pull/863/files#diff-0245bb0859ba1be2420371a0c6491c493e8e649541ac2c224f9a8fd928bc2159), [`build-specs.md`](https://github.com/gominimal/minimal/pull/863/files#diff-ad12d4b17e2a2a038ffa30fde4b66eed48ef6a368925aa2d4942cb5cab63bb7b), [`tasks.md`](https://github.com/gominimal/minimal/pull/863/files#diff-bce6d0e6bae925167b7bec524622e6a06aede5b880999f7f1923b672b8f818dc), and [`sandbox-operations.md`](https://github.com/gominimal/minimal/pull/863/files#diff-a3aea9026a774e1bce30455d93e7e8c08ea2aa66e1d0e7407145b8e977fda2f2) to replace `minimal`/`harness` CLI references with `mip`/`stack` terminology and relative links.
> - Renames `harness-specs.md` to [`stack-specs.md`](https://github.com/gominimal/minimal/pull/863/files#diff-a67f4aa8e1cdaaccf0b9e651e0e300e88671b0dd54a13bad1c7b3bf85eaf5e0f) and updates all terminology, file paths, and schema references from harnesses to stacks.
> - Adds [`manifest.json`](https://github.com/gominimal/minimal/pull/863/files#diff-7e14008910517a576e6f0ad323c2cba9446e3289b9077901d8874b3064852765) enumerating reference pages for site navigation.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #863 opened
>
> - Rewrote CLI reference documentation to clarify that `min` is the primary session CLI that communicates with `minimald`, which runs inside a microVM managed by `minvmd` on macOS and optionally on Linux, and positioned `mip` as an advanced Linux-only interface to the underlying declarative package and build engine [31995e8]
> - Updated the `--gvproxy-bin` flag description for the `run` command in the `minimald` CLI reference to indicate it is used for networking and defaults to a typical system install path [31995e8]
> - Modified the `add` operation documentation in sandbox operations to indicate packages are recorded as session, runtime, or build dependencies in `minimal.toml` based on flags, removed the `--task` flag, and updated the `--session` flag description to state it also adds packages to the `[session]` packages list [31995e8]
> - Replaced global CLI flag `--minvmd` with `--provider <PROVIDER>` and added `--no-input` flag across CLI reference documentation [d8f700d]
> - Added comprehensive documentation for `[session]`, `[params]`, `[cache]`, and `[stdlib]` configuration sections in `minimal.toml` reference [d8f700d]
> - Updated `min attach` command to make SESSION parameter optional with automatic session resolution and interactive picker behavior [d8f700d]
> - Clarified canonical versus alias naming throughout configuration and task specifications [d8f700d]
> - Added `echo` action for tasks that prints a fixed string without composing a sandbox [d8f700d]
> - Updated runtime files and provider paths from legacy format to provider-based directory structure [d8f700d]
> - Documented `min add` command behavior differences between sessions and task sandboxes [d8f700d]
> - Added user namespaces disabled documentation for Linux host setup [d8f700d]
> - Updated bare `min` command behavior and auto-start exceptions in CLI reference [d8f700d]
> - Made `type` field optional with default `oci-image` in outputs configuration [d8f700d]
> - Refined patches path rule to require `~/` prefix for tilde expansion in task specifications [d8f700d]
> - Wrapped description values in quotes within YAML front matter across all reference documentation files [d8f700d]
> - Updated shell completion documentation wording from fixed list to include-based phrasing [d8f700d]
> - Removed known issues section related to `run --timeout` and `--detach` flags from minvmd CLI reference [d8f700d]
> - Updated known issues section to note `--stdlib-dir` flag is accepted but ignored in minimald CLI reference [d8f700d]
> - Added reference documentation for the loadouts feature covering schema definition, CLI interface, and configuration [0c6204d]
> - Registered the loadouts reference page in the documentation manifest [0c6204d]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfaddc4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added reference pages for the `min` session CLI, `mip`, `minimald`, and `minvmd`, plus a new `loadouts` guide.
  * Refreshed the CLI overview and expanded documentation for sandbox helper commands, tasks, stacks, build specifications, and `minimal.toml`.
  * Updated Linux host setup guidance with improved troubleshooting and added coverage for when user namespaces are disabled.
  * Updated the documentation reference manifest to include the new loadouts page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->