### PR TITLE
feat(diagnostics,minimal): incident collectors, mechanics in-crate

### DIFF
--- a/crates/diagnostics/src/capture.rs
+++ b/crates/diagnostics/src/capture.rs
@@ -44,6 +44,11 @@ pub enum CaptureError {
         timeout: Duration,
         partial: Capture,
     },
+    /// The command ran but exited non-zero and wrote nothing to stdout — no
+    /// usable output to salvage, so a caller can fall through to the next
+    /// source.
+    #[error("`{cmd}` exited unsuccessfully with no output")]
+    NonZero { cmd: String },
 }
 
 /// Runs `cmd args…` with stdin closed, capturing stdout and stderr until the
@@ -113,6 +118,29 @@ pub async fn command_capture(
     })
 }
 
+/// stdout of `cmd args…` when the command produced usable output: a clean
+/// exit, or a non-zero exit that still wrote to stdout — the `lsof`/`ss`
+/// convention, where exit 1 with a partial listing is evidence, not failure.
+/// [`Spawn`](CaptureError::Spawn) and [`Timeout`](CaptureError::Timeout)
+/// propagate so a caller can fall through to the next source; a silent
+/// non-zero exit is [`NonZero`](CaptureError::NonZero). This is the entry
+/// point the net/procs/power collectors run their command-shaped captures
+/// through.
+pub async fn command_stdout(
+    cmd: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> Result<String, CaptureError> {
+    let capture = command_capture(cmd, args, timeout).await?;
+    if capture.status.is_some_and(|s| s.success()) || !capture.stdout.is_empty() {
+        Ok(String::from_utf8_lossy(&capture.stdout).into_owned())
+    } else {
+        Err(CaptureError::NonZero {
+            cmd: cmd.to_string(),
+        })
+    }
+}
+
 /// First line of `cmd args…` stdout, or `None` when the command can't run,
 /// fails, or times out. The one-liner for collectors that want a single
 /// fact from a tool (`uname -srvm`) and treat any failure as "unknown".
@@ -167,6 +195,25 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, CaptureError::Spawn { .. }), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn command_stdout_keeps_output_from_a_nonzero_exit() {
+        // The lsof/ss convention: exit 1 with a partial listing is evidence.
+        let out = command_stdout(
+            "sh",
+            &["-c", "echo listing; exit 1"],
+            Duration::from_secs(10),
+        )
+        .await
+        .unwrap();
+        assert_eq!(out, "listing\n");
+
+        // A silent non-zero exit has nothing to salvage.
+        let err = command_stdout("sh", &["-c", "exit 1"], Duration::from_secs(10))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CaptureError::NonZero { .. }), "got: {err}");
     }
 
     #[tokio::test]

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -29,12 +29,18 @@ pub mod disk;
 pub mod listing;
 pub mod logs;
 pub mod manifest;
+#[cfg(unix)]
+pub mod net;
+#[cfg(unix)]
+pub mod power;
+#[cfg(unix)]
+pub mod procs;
 pub mod redact;
 #[cfg(unix)]
 pub mod system;
 
 pub use bundle::{BundleSink, BundleWriter, LOG_TAIL_CAP, open_regular_nofollow};
-pub use capture::{Capture, CaptureError, command_capture, first_stdout_line};
+pub use capture::{Capture, CaptureError, command_capture, command_stdout, first_stdout_line};
 #[cfg(unix)]
 pub use disk::{DiskUsage, disk_usage};
 pub use listing::{Listing, listing};

--- a/crates/diagnostics/src/net.rs
+++ b/crates/diagnostics/src/net.rs
@@ -1,0 +1,174 @@
+//! Network-state capture for diagnostic bundles: listening sockets, host
+//! interfaces (MACs masked to their vendor OUI), and routes.
+//!
+//! Mechanics only — verbatim tool output written at fixed relative paths under
+//! a caller-supplied `dest` group (the CLI passes `"host"`). Each capture tries
+//! the platform's tools in order and, on Linux, falls back to the raw
+//! `/proc/net` tables so a bundle from a stripped host still carries the socket
+//! picture. Commands run through [`crate::capture::command_stdout`].
+
+use std::time::Duration;
+
+use crate::bundle::{BundleSink, BundleWriter};
+use crate::capture::{CaptureError, command_stdout};
+use crate::manifest::Redaction;
+
+/// Per-command deadline: a wedged `ss`/`ifconfig` must not eat the collector
+/// budget on its own.
+const NET_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Runs the first of `attempts` that yields usable output, returning its
+/// echoed command banner and stdout. The last error survives for the caller's
+/// fallback message. `attempts` is never empty at any call site.
+async fn first_available(attempts: &[(&str, &[&str])]) -> Result<(String, String), CaptureError> {
+    let mut last_err = None;
+    for (cmd, args) in attempts {
+        match command_stdout(cmd, args, NET_TIMEOUT).await {
+            Ok(text) => return Ok((format!("$ {cmd} {}", args.join(" ")), text)),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.expect("attempts is never empty"))
+}
+
+/// `<dest>/net/listening.txt`: listening TCP/UDP sockets with owning pids.
+pub async fn listening_sockets<W: BundleSink>(
+    w: &mut BundleWriter<W>,
+    dest: &str,
+) -> Result<(), anyhow::Error> {
+    let attempts: &[(&str, &[&str])] = if cfg!(target_os = "linux") {
+        &[("ss", &["-ltnup"]), ("netstat", &["-ltnp"])]
+    } else {
+        &[("netstat", &["-anv", "-p", "tcp"])]
+    };
+    let text = match first_available(attempts).await {
+        Ok((banner, out)) => format!("{banner}\n{out}"),
+        #[cfg(target_os = "linux")]
+        Err(cmd_err) => format!(
+            "(commands unavailable: {cmd_err})\n{}",
+            proc_net_listeners().await
+        ),
+        #[cfg(not(target_os = "linux"))]
+        Err(cmd_err) => return Err(cmd_err.into()),
+    };
+    w.add_bytes(
+        &format!("{dest}/net/listening.txt"),
+        text.as_bytes(),
+        Redaction::None,
+    )
+    .await
+}
+
+/// `<dest>/net/interfaces.txt`: interface addresses, MACs masked to OUI. The
+/// IPs and subnets are the diagnostic payload (own-IP rides the 100.64/16
+/// CGNAT block VPNs also use, so collisions must be visible); MACs carry no
+/// such signal and are masked.
+pub async fn interfaces<W: BundleSink>(
+    w: &mut BundleWriter<W>,
+    dest: &str,
+) -> Result<(), anyhow::Error> {
+    let attempts: &[(&str, &[&str])] = if cfg!(target_os = "linux") {
+        &[("ip", &["addr"]), ("ifconfig", &["-a"])]
+    } else {
+        &[("ifconfig", &["-a"])]
+    };
+    let (banner, out) = first_available(attempts).await?;
+    let text = format!("{banner}\n{}", mask_macs(&out));
+    w.add_bytes(
+        &format!("{dest}/net/interfaces.txt"),
+        text.as_bytes(),
+        Redaction::Keys,
+    )
+    .await
+}
+
+/// `<dest>/net/routes.txt`: the host routing table — which gateway/tunnel the
+/// default route rides, and whether anything overlaps the own-IP or gvproxy
+/// switch subnets.
+pub async fn routes<W: BundleSink>(
+    w: &mut BundleWriter<W>,
+    dest: &str,
+) -> Result<(), anyhow::Error> {
+    let attempts: &[(&str, &[&str])] = if cfg!(target_os = "linux") {
+        &[("ip", &["route", "show"]), ("netstat", &["-rn"])]
+    } else {
+        &[("netstat", &["-rn"])]
+    };
+    let (banner, out) = first_available(attempts).await?;
+    w.add_bytes(
+        &format!("{dest}/net/routes.txt"),
+        format!("{banner}\n{out}").as_bytes(),
+        Redaction::None,
+    )
+    .await
+}
+
+/// Masks the device-unique half of every MAC address, keeping the vendor OUI:
+/// `f0:18:98:aa:bb:cc` → `f0:18:98:<redacted>`. Token-wise (whitespace-
+/// delimited) so IPv6 shorthand like `fe80::aa:bb:cc:dd:ee:ff` — colon-
+/// adjacent, never a standalone six-group token — is left alone.
+fn mask_macs(text: &str) -> String {
+    fn is_mac(tok: &str) -> bool {
+        tok.len() == 17
+            && tok.bytes().enumerate().all(|(i, b)| match i % 3 {
+                2 => b == b':',
+                _ => b.is_ascii_hexdigit(),
+            })
+    }
+    text.lines()
+        .map(|line| {
+            line.split(' ')
+                .map(|tok| {
+                    if is_mac(tok) {
+                        format!("{}:<redacted>", &tok[..8])
+                    } else {
+                        tok.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Raw `/proc/net` tables — not parsed; the dev team decodes hex
+/// address:port pairs, and fidelity beats prettiness in a fallback.
+#[cfg(target_os = "linux")]
+async fn proc_net_listeners() -> String {
+    let mut text = String::new();
+    for table in ["tcp", "tcp6", "udp", "unix"] {
+        let path = format!("/proc/net/{table}");
+        text.push_str(&format!("=== {path} ===\n"));
+        match tokio::fs::read_to_string(&path).await {
+            Ok(t) => text.push_str(&t),
+            Err(e) => text.push_str(&format!("<unreadable: {e}>\n")),
+        }
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mask_macs_keeps_oui_and_leaves_ipv6_alone() {
+        let input = "\tether f0:18:98:aa:bb:cc\n\
+                     \tinet6 fe80::aa:bb:cc:dd:ee:ff%en0 prefixlen 64\n\
+                     2: eth0: link/ether 02:42:ac:11:00:02 brd ff:ff:ff:ff:ff:ff\n\
+                     \tinet 192.168.1.10 netmask 0xffffff00";
+        let out = mask_macs(input);
+        assert!(out.contains("ether f0:18:98:<redacted>"), "{out}");
+        assert!(out.contains("link/ether 02:42:ac:<redacted>"), "{out}");
+        assert!(
+            out.contains("ff:ff:ff:<redacted>"),
+            "broadcast is MAC-shaped too: {out}"
+        );
+        assert!(
+            out.contains("fe80::aa:bb:cc:dd:ee:ff%en0"),
+            "IPv6 survives: {out}"
+        );
+        assert!(out.contains("192.168.1.10"), "IPv4 survives: {out}");
+    }
+}

--- a/crates/diagnostics/src/net.rs
+++ b/crates/diagnostics/src/net.rs
@@ -103,33 +103,50 @@ pub async fn routes<W: BundleSink>(
     .await
 }
 
-/// Masks the device-unique half of every MAC address, keeping the vendor OUI:
-/// `f0:18:98:aa:bb:cc` → `f0:18:98:<redacted>`. Token-wise (whitespace-
-/// delimited) so IPv6 shorthand like `fe80::aa:bb:cc:dd:ee:ff` — colon-
-/// adjacent, never a standalone six-group token — is left alone.
-fn mask_macs(text: &str) -> String {
-    fn is_mac(tok: &str) -> bool {
-        tok.len() == 17
-            && tok.bytes().enumerate().all(|(i, b)| match i % 3 {
-                2 => b == b':',
-                _ => b.is_ascii_hexdigit(),
-            })
-    }
-    text.lines()
-        .map(|line| {
-            line.split(' ')
-                .map(|tok| {
-                    if is_mac(tok) {
-                        format!("{}:<redacted>", &tok[..8])
-                    } else {
-                        tok.to_string()
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join(" ")
+/// True when `tok` is exactly a six-group MAC address.
+fn is_mac(tok: &str) -> bool {
+    tok.len() == 17
+        && tok.bytes().enumerate().all(|(i, b)| match i % 3 {
+            2 => b == b':',
+            _ => b.is_ascii_hexdigit(),
         })
-        .collect::<Vec<_>>()
-        .join("\n")
+}
+
+/// Masks the device-unique half of every MAC address, keeping the vendor OUI:
+/// `f0:18:98:aa:bb:cc` → `f0:18:98:<redacted>`.
+///
+/// Tokens are maximal runs of non-whitespace and every original separator is
+/// preserved byte-for-byte — `ifconfig` indents with tabs while `ip` uses
+/// spaces, and splitting on `' '` alone would leave a tab-adjacent MAC
+/// (`ether\tf0:18:98:aa:bb:cc`) inside a larger token and emit it unmasked.
+/// Whole-token matching is what keeps IPv6 shorthand like
+/// `fe80::aa:bb:cc:dd:ee:ff` — colon-adjacent, never a standalone six-group
+/// token — untouched.
+fn mask_macs(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while !rest.is_empty() {
+        // Copy the run of separators verbatim (spaces, tabs, newlines).
+        let sep = rest
+            .find(|c: char| !c.is_whitespace())
+            .unwrap_or(rest.len());
+        out.push_str(&rest[..sep]);
+        rest = &rest[sep..];
+        if rest.is_empty() {
+            break;
+        }
+        // Then the token itself.
+        let end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+        let tok = &rest[..end];
+        if is_mac(tok) {
+            out.push_str(&tok[..8]);
+            out.push_str(":<redacted>");
+        } else {
+            out.push_str(tok);
+        }
+        rest = &rest[end..];
+    }
+    out
 }
 
 /// Raw `/proc/net` tables — not parsed; the dev team decodes hex
@@ -170,5 +187,24 @@ mod tests {
             "IPv6 survives: {out}"
         );
         assert!(out.contains("192.168.1.10"), "IPv4 survives: {out}");
+    }
+
+    /// A MAC separated by a tab must mask too — `ifconfig` indents with tabs,
+    /// and splitting on `' '` alone would emit it verbatim.
+    #[test]
+    fn mask_macs_is_whitespace_delimited_not_space_delimited() {
+        let out = mask_macs("\tether\tf0:18:98:aa:bb:cc\n  ether  02:42:ac:11:00:02  \n");
+        assert!(
+            !out.contains("f0:18:98:aa:bb:cc"),
+            "tab-adjacent MAC: {out}"
+        );
+        assert!(out.contains("f0:18:98:<redacted>"), "{out}");
+        assert!(out.contains("02:42:ac:<redacted>"), "{out}");
+        // Separators survive byte-for-byte, so the capture still reads as the
+        // tool printed it.
+        assert_eq!(
+            out, "\tether\tf0:18:98:<redacted>\n  ether  02:42:ac:<redacted>  \n",
+            "original whitespace preserved"
+        );
     }
 }

--- a/crates/diagnostics/src/net.rs
+++ b/crates/diagnostics/src/net.rs
@@ -154,7 +154,7 @@ fn mask_macs(text: &str) -> String {
 #[cfg(target_os = "linux")]
 async fn proc_net_listeners() -> String {
     let mut text = String::new();
-    for table in ["tcp", "tcp6", "udp", "unix"] {
+    for table in ["tcp", "tcp6", "udp", "udp6", "unix"] {
         let path = format!("/proc/net/{table}");
         text.push_str(&format!("=== {path} ===\n"));
         match tokio::fs::read_to_string(&path).await {

--- a/crates/diagnostics/src/power.rs
+++ b/crates/diagnostics/src/power.rs
@@ -15,6 +15,12 @@ use crate::manifest::Redaction;
 const POWER_TIMEOUT: Duration = Duration::from_secs(10);
 /// Sleep/wake transitions kept from the (potentially huge) power log.
 const POWER_EVENTS_MAX: usize = 100;
+/// Journal lines read before filtering. The capture buffers the command's
+/// whole stdout, so the read is bounded at the source rather than after the
+/// fact; suspend/resume lines are sparse enough that the newest few thousand
+/// comfortably cover [`POWER_EVENTS_MAX`] transitions.
+#[cfg(not(target_os = "macos"))]
+const JOURNAL_LINES_MAX: &str = "5000";
 
 /// The last [`POWER_EVENTS_MAX`] of `events` — the whole slice when it is
 /// shorter. The full pmset/journal log runs to megabytes; only the tail of the
@@ -82,9 +88,13 @@ pub async fn power<W: BundleSink>(
     // journal.
     #[cfg(not(target_os = "macos"))]
     {
+        // `-n` bounds the read at the source: `command_stdout` buffers all of
+        // stdout before returning, and a whole boot's kernel journal can run to
+        // many megabytes of which we keep 100 lines. `-n` yields the *newest*
+        // lines, which is the end we filter for anyway.
         match command_stdout(
             "journalctl",
-            &["-b", "-k", "--no-pager", "-q"],
+            &["-b", "-k", "--no-pager", "-q", "-n", JOURNAL_LINES_MAX],
             POWER_TIMEOUT,
         )
         .await

--- a/crates/diagnostics/src/power.rs
+++ b/crates/diagnostics/src/power.rs
@@ -1,0 +1,139 @@
+//! Host power-state capture: sleep/wake history, so a bundle's timeline can
+//! interleave power transitions with connection events. A silently-dying
+//! long-lived stream (#788) has suspend/resume as its most plausible mundane
+//! explanation, and ruling that in or out previously meant asking the user to
+//! run `pmset -g log` by hand.
+
+use std::fmt::Write as _;
+use std::time::Duration;
+
+use crate::bundle::{BundleSink, BundleWriter};
+use crate::capture::command_stdout;
+use crate::manifest::Redaction;
+
+/// Per-command deadline for the power log tools.
+const POWER_TIMEOUT: Duration = Duration::from_secs(10);
+/// Sleep/wake transitions kept from the (potentially huge) power log.
+const POWER_EVENTS_MAX: usize = 100;
+
+/// The last [`POWER_EVENTS_MAX`] of `events` — the whole slice when it is
+/// shorter. The full pmset/journal log runs to megabytes; only the tail of the
+/// state transitions carries current signal.
+fn last_events<'a>(events: &'a [&'a str]) -> &'a [&'a str] {
+    &events[events.len().saturating_sub(POWER_EVENTS_MAX)..]
+}
+
+/// `<dest>/power.txt`: recent sleep/wake transitions. Best-effort — a host
+/// without the tooling records why instead of failing the collector.
+pub async fn power<W: BundleSink>(
+    w: &mut BundleWriter<W>,
+    dest: &str,
+) -> Result<(), anyhow::Error> {
+    let mut text = String::new();
+
+    #[cfg(target_os = "macos")]
+    {
+        match command_stdout(
+            "sysctl",
+            &["kern.boottime", "kern.sleeptime", "kern.waketime"],
+            POWER_TIMEOUT,
+        )
+        .await
+        {
+            Ok(out) => {
+                let _ = writeln!(text, "$ sysctl kern.boottime kern.sleeptime kern.waketime");
+                text.push_str(&out);
+            }
+            Err(e) => {
+                let _ = writeln!(text, "(sysctl unavailable: {e})");
+            }
+        }
+        // The full pmset log is mostly assertion chatter; only the state-
+        // transition lines carry sleep/wake signal.
+        match command_stdout("pmset", &["-g", "log"], POWER_TIMEOUT).await {
+            Ok(out) => {
+                let events: Vec<&str> = out
+                    .lines()
+                    .filter(|l| {
+                        l.contains("Entering Sleep")
+                            || l.contains("Wake from")
+                            || l.contains("DarkWake from")
+                    })
+                    .collect();
+                let tail = last_events(&events);
+                let _ = writeln!(
+                    text,
+                    "\n$ pmset -g log (sleep/wake transitions, last {} of {})",
+                    tail.len(),
+                    events.len()
+                );
+                for line in tail {
+                    let _ = writeln!(text, "{}", line.trim_end());
+                }
+            }
+            Err(e) => {
+                let _ = writeln!(text, "(pmset unavailable: {e})");
+            }
+        }
+    }
+
+    // Linux (and any other unix): the journal's kernel messages are the only
+    // common source, and "PM: suspend entry/exit" avoids grepping the whole
+    // journal.
+    #[cfg(not(target_os = "macos"))]
+    {
+        match command_stdout(
+            "journalctl",
+            &["-b", "-k", "--no-pager", "-q"],
+            POWER_TIMEOUT,
+        )
+        .await
+        {
+            Ok(out) => {
+                let events: Vec<&str> = out
+                    .lines()
+                    .filter(|l| {
+                        l.contains("PM: suspend") || l.contains("hibernat") || l.contains("resume")
+                    })
+                    .collect();
+                let tail = last_events(&events);
+                let _ = writeln!(
+                    text,
+                    "$ journalctl -b -k (suspend/resume lines, last {})",
+                    tail.len()
+                );
+                for line in tail {
+                    let _ = writeln!(text, "{}", line.trim_end());
+                }
+            }
+            Err(e) => {
+                let _ = writeln!(text, "(journalctl unavailable: {e})");
+            }
+        }
+    }
+
+    w.add_bytes(
+        &format!("{dest}/power.txt"),
+        text.as_bytes(),
+        Redaction::None,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn last_events_caps_to_the_most_recent() {
+        let all: Vec<String> = (0..250).map(|i| format!("evt{i}")).collect();
+        let refs: Vec<&str> = all.iter().map(String::as_str).collect();
+        let tail = last_events(&refs);
+        assert_eq!(tail.len(), POWER_EVENTS_MAX);
+        assert_eq!(tail[0], "evt150", "kept the newest 100");
+        assert_eq!(tail[POWER_EVENTS_MAX - 1], "evt249");
+
+        let few = ["a", "b", "c"];
+        assert_eq!(last_events(&few).len(), 3, "fewer than the cap: all kept");
+    }
+}

--- a/crates/diagnostics/src/procs.rs
+++ b/crates/diagnostics/src/procs.rs
@@ -9,12 +9,18 @@
 //! External tools are host-side extras used when present: `ps` for the table
 //! (a `/proc` scrape stands in), macOS `sample`, and one `lsof` over the set.
 
+// `Cow` and the placeholder are only reachable from the Linux `/proc` scrape,
+// which is the one path with true argv boundaries to redact per element.
+#[cfg(target_os = "linux")]
+use std::borrow::Cow;
 use std::time::Duration;
 
 use crate::bundle::{BundleSink, BundleWriter};
 use crate::capture::command_stdout;
 use crate::manifest::Redaction;
-use crate::redact::{is_sensitive_key, redaction_placeholder};
+use crate::redact::is_sensitive_key;
+#[cfg(target_os = "linux")]
+use crate::redact::redaction_placeholder;
 
 /// Timeout for `ps`; a wedged process table must not eat the collector budget.
 const PS_TIMEOUT: Duration = Duration::from_secs(5);
@@ -38,22 +44,53 @@ fn argv0_matches(args: &str, markers: &[&str]) -> bool {
     })
 }
 
-/// Scrubs an argv line token-wise: any `key=value` token whose key trips the
-/// [sensitive-key policy](is_sensitive_key) has its value replaced by the
-/// redaction placeholder, so a secret passed on a command line never rides out
-/// in the process table.
-fn scrub_argv(line: &str) -> String {
-    line.split(' ')
-        .map(|tok| match tok.split_once('=') {
-            Some((key, value)) if is_sensitive_key(key) => {
-                let placeholder =
-                    redaction_placeholder(&serde_json::Value::String(value.to_string()));
-                format!("{key}={}", placeholder.as_str().unwrap_or("<redacted>"))
-            }
-            _ => tok.to_string(),
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+/// Scrubs one *true* argv element: a `key=value` whose key trips the
+/// [sensitive-key policy](is_sensitive_key) has its entire value replaced by
+/// the redaction placeholder — spaces included, because the element boundary
+/// is known here.
+///
+/// Only the `/proc` scrape has real argv boundaries to work with, so this is
+/// Linux-only; everywhere else [`scrub_flattened`] takes over.
+#[cfg(target_os = "linux")]
+fn scrub_arg(arg: &str) -> Cow<'_, str> {
+    match arg.split_once('=') {
+        Some((key, value)) if is_sensitive_key(key) => {
+            let placeholder = redaction_placeholder(&serde_json::Value::String(value.to_string()));
+            Cow::Owned(format!(
+                "{key}={}",
+                placeholder.as_str().unwrap_or("<redacted>")
+            ))
+        }
+        _ => Cow::Borrowed(arg),
+    }
+}
+
+/// Scrubs a command line whose argv boundaries are already lost. `ps` joins
+/// arguments with spaces, so `--password=hunter two` is indistinguishable from
+/// a secret followed by a separate argument; masking only up to the first space
+/// would emit the tail of the value verbatim.
+///
+/// So this is **fail-closed**: once a sensitive `key=` appears, the remainder
+/// of the line goes with it. A truncated process line is a far smaller loss
+/// than a half-masked secret in a bundle that gets mailed out. Where the real
+/// boundaries survive — the `/proc` scrape, whose argv is NUL-separated —
+/// [`scrub_arg`] is used per element instead and nothing is over-redacted.
+fn scrub_flattened(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    for (i, tok) in line.split(' ').enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        if let Some((key, _)) = tok.split_once('=')
+            && is_sensitive_key(key)
+        {
+            out.push_str(key);
+            out.push_str("=<redacted> <argv tail withheld: token boundaries unrecoverable>");
+            return out;
+        }
+        out.push_str(tok);
+    }
+    out
 }
 
 /// `<dest>/process-tree.txt`, plus on Linux `<dest>/proc/<pid>.status` for each
@@ -224,7 +261,9 @@ async fn ps_table(markers: &[&str]) -> Result<(String, Vec<u32>), anyhow::Error>
         };
         let args = fields.skip(5).collect::<Vec<_>>().join(" ");
         if argv0_matches(&args, markers) {
-            text.push_str(&scrub_argv(line));
+            // `ps` already flattened argv to a space-joined string, so this
+            // line must be scrubbed fail-closed.
+            text.push_str(&scrub_flattened(line));
             text.push('\n');
             pids.push(pid);
         }
@@ -253,9 +292,20 @@ fn proc_scrape(markers: &[&str]) -> Result<(String, Vec<u32>), anyhow::Error> {
         let Ok(raw) = std::fs::read(format!("/proc/{pid}/cmdline")) else {
             continue;
         };
-        let cmdline = String::from_utf8_lossy(&raw).replace('\0', " ");
-        if argv0_matches(&cmdline, markers) {
-            let _ = writeln!(text, "{pid} {}", scrub_argv(cmdline.trim_end()));
+        // `/proc/<pid>/cmdline` is NUL-separated, so the true argv boundaries
+        // are still intact here. Scrub each element on its own — a secret
+        // containing spaces is masked whole, and nothing after it is lost.
+        let argv: Vec<String> = raw
+            .split(|b| *b == 0)
+            .filter(|part| !part.is_empty())
+            .map(|part| String::from_utf8_lossy(part).into_owned())
+            .collect();
+        let Some(argv0) = argv.first() else {
+            continue;
+        };
+        if argv0_matches(argv0, markers) {
+            let scrubbed: Vec<Cow<'_, str>> = argv.iter().map(|a| scrub_arg(a)).collect();
+            let _ = writeln!(text, "{pid} {}", scrubbed.join(" "));
             pids.push(pid);
         }
     }
@@ -328,21 +378,44 @@ mod tests {
         assert!(!argv0_matches("grep minimald /home/u/notes", MARKERS));
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
-    fn scrub_argv_masks_sensitive_key_value_tokens_only() {
-        let scrubbed = scrub_argv("minvmd --flag MINIMAL_AUTH_TOKEN=s3cr3t --port 8080");
-        assert!(
-            !scrubbed.contains("s3cr3t"),
-            "secret value masked: {scrubbed}"
+    fn scrub_arg_masks_the_whole_value_including_spaces() {
+        // True argv boundaries: the entire value is masked, spaces and all.
+        assert_eq!(
+            scrub_arg("--password=hunter two"),
+            "--password=<redacted:len=10>",
+            "a value with spaces must not be half-masked"
         );
+        assert_eq!(
+            scrub_arg("--port=8080"),
+            "--port=8080",
+            "non-sensitive kept"
+        );
+        assert_eq!(scrub_arg("--flag"), "--flag", "non key=value untouched");
+    }
+
+    #[test]
+    fn scrub_flattened_is_fail_closed_once_a_secret_appears() {
+        // `ps` already lost the boundaries, so everything after the secret is
+        // withheld rather than risking the tail of the value.
+        let scrubbed = scrub_flattened("minvmd --flag MINIMAL_AUTH_TOKEN=hunter two --port 8080");
+        assert!(!scrubbed.contains("hunter"), "secret masked: {scrubbed}");
+        assert!(
+            !scrubbed.contains("two"),
+            "the tail of a spaced secret must not survive: {scrubbed}"
+        );
+        assert!(!scrubbed.contains("8080"), "fail-closed tail: {scrubbed}");
+        assert!(scrubbed.starts_with("minvmd --flag"), "{scrubbed}");
         assert!(
             scrubbed.contains("MINIMAL_AUTH_TOKEN=<redacted"),
-            "sensitive key masked in place: {scrubbed}"
+            "{scrubbed}"
         );
-        assert!(scrubbed.contains("--flag"), "flags untouched: {scrubbed}");
-        assert!(
-            scrubbed.contains("--port 8080"),
-            "non-sensitive kept: {scrubbed}"
-        );
+    }
+
+    #[test]
+    fn scrub_flattened_leaves_a_clean_line_alone() {
+        let line = "minimald run --detach --instance-num 0";
+        assert_eq!(scrub_flattened(line), line);
     }
 }

--- a/crates/diagnostics/src/procs.rs
+++ b/crates/diagnostics/src/procs.rs
@@ -186,8 +186,22 @@ pub async fn hang_triage<W: BundleSink>(
         }
     }
 
+    // The pid set actually captured. On Linux each pid is re-checked against
+    // its own cmdline immediately before its state is read: the table snapshot
+    // is stale the moment it is taken, and a pid recycled in between would put
+    // an unrelated process's kernel state and open files into the bundle —
+    // precisely the "someone else's activity" this collector filters out.
+    #[cfg(target_os = "linux")]
+    let mut captured: Vec<u32> = Vec::with_capacity(pids.len());
     #[cfg(target_os = "linux")]
     for &pid in &pids {
+        if !still_matches(pid, markers).await {
+            w.skip(
+                format!("{dest}/proc/{pid}.stack.txt"),
+                "pid no longer matches a marker (exited or recycled since the snapshot)",
+            );
+            continue;
+        }
         let text = linux_park_state(pid).await;
         w.add_bytes(
             &format!("{dest}/proc/{pid}.stack.txt"),
@@ -195,9 +209,19 @@ pub async fn hang_triage<W: BundleSink>(
             Redaction::None,
         )
         .await?;
+        captured.push(pid);
     }
+    #[cfg(not(target_os = "linux"))]
+    let captured = pids;
 
-    let pid_list = pids
+    if captured.is_empty() {
+        w.skip(
+            format!("{dest}/proc/lsof.txt"),
+            "no marker-matched pids still live to inspect",
+        );
+        return Ok(());
+    }
+    let pid_list = captured
         .iter()
         .map(u32::to_string)
         .collect::<Vec<_>>()
@@ -310,6 +334,24 @@ fn proc_scrape(markers: &[&str]) -> Result<(String, Vec<u32>), anyhow::Error> {
         }
     }
     Ok((text, pids))
+}
+
+/// True when `pid` still names a marker-matched process *right now*.
+///
+/// Hang triage reads kernel state and open-file paths, so identity has to be
+/// re-pinned immediately before the read rather than trusted from the table
+/// snapshot: if a matched process exits and its pid is recycled in between, the
+/// bundle would carry an unrelated process's fds and stack. An unreadable
+/// `cmdline` (the process is gone) is a non-match, so the capture is skipped.
+/// Async `/proc` read — no blocking on the collector's worker.
+#[cfg(target_os = "linux")]
+async fn still_matches(pid: u32, markers: &[&str]) -> bool {
+    let Ok(raw) = tokio::fs::read(format!("/proc/{pid}/cmdline")).await else {
+        return false;
+    };
+    raw.split(|b| *b == 0)
+        .find(|part| !part.is_empty())
+        .is_some_and(|argv0| argv0_matches(&String::from_utf8_lossy(argv0), markers))
 }
 
 /// Where a Linux process is parked: wait channel, current syscall, kernel

--- a/crates/diagnostics/src/procs.rs
+++ b/crates/diagnostics/src/procs.rs
@@ -18,6 +18,12 @@ use crate::redact::{is_sensitive_key, redaction_placeholder};
 
 /// Timeout for `ps`; a wedged process table must not eat the collector budget.
 const PS_TIMEOUT: Duration = Duration::from_secs(5);
+/// Per-pid `sample` deadline on macOS. Samples run concurrently, so the macOS
+/// pass is bounded by this rather than by its sum across pids.
+#[cfg(target_os = "macos")]
+const SAMPLE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Deadline for the single `lsof` over the whole matched set.
+const LSOF_TIMEOUT: Duration = Duration::from_secs(8);
 /// Cap on how many matched processes get the deep hang-triage treatment — a
 /// runaway match list must not turn a bundle into a profiling session.
 const HANG_TRIAGE_PIDS_MAX: usize = 8;
@@ -67,7 +73,14 @@ pub async fn process_tree<W: BundleSink>(
 
     #[cfg(target_os = "linux")]
     for pid in pids {
-        if let Some(status) = proc_status(pid) {
+        // Synchronous `/proc` reads go to a blocking thread for the same reason
+        // as the scrape in `process_table`. A join error means the reader task
+        // panicked; treat it as "no status", the same as an unreadable `/proc`.
+        let status = tokio::task::spawn_blocking(move || proc_status(pid))
+            .await
+            .ok()
+            .flatten();
+        if let Some(status) = status {
             w.add_bytes(
                 &format!("{dest}/proc/{pid}.status"),
                 status.as_bytes(),
@@ -101,13 +114,38 @@ pub async fn hang_triage<W: BundleSink>(
         return Ok(());
     }
 
+    // macOS: sample every pid concurrently. Sequential per-pid deadlines would
+    // sum past the caller's collector budget — and a wedged process, the case
+    // this capture exists for, is exactly when each sample runs long — so the
+    // pass is bounded by one deadline instead of their sum. Worst case for the
+    // whole collector: ps (5s) + samples (10s) + lsof (8s) ≈ 23s.
     #[cfg(target_os = "macos")]
-    for &pid in &pids {
-        let path = format!("{dest}/proc/{pid}.sample.txt");
-        let pid_s = pid.to_string();
-        match command_stdout("sample", &[&pid_s, "1", "10"], Duration::from_secs(15)).await {
-            Ok(text) => w.add_bytes(&path, text.as_bytes(), Redaction::None).await?,
-            Err(e) => w.skip(path, format!("sample failed: {e}")),
+    {
+        let mut set = tokio::task::JoinSet::new();
+        for &pid in &pids {
+            set.spawn(async move {
+                let pid_s = pid.to_string();
+                let out = command_stdout("sample", &[&pid_s, "1", "10"], SAMPLE_TIMEOUT).await;
+                (pid, out)
+            });
+        }
+        let mut samples = Vec::with_capacity(pids.len());
+        while let Some(joined) = set.join_next().await {
+            match joined {
+                Ok(sample) => samples.push(sample),
+                // A panicked sample task is a bug, not a diagnostic outcome —
+                // record it rather than dropping the pid silently.
+                Err(e) => w.skip(format!("{dest}/proc/"), format!("sample task failed: {e}")),
+            }
+        }
+        // Completion order is nondeterministic; keep bundle order by pid.
+        samples.sort_by_key(|(pid, _)| *pid);
+        for (pid, result) in samples {
+            let path = format!("{dest}/proc/{pid}.sample.txt");
+            match result {
+                Ok(text) => w.add_bytes(&path, text.as_bytes(), Redaction::None).await?,
+                Err(e) => w.skip(path, format!("sample failed: {e}")),
+            }
         }
     }
 
@@ -128,7 +166,7 @@ pub async fn hang_triage<W: BundleSink>(
         .collect::<Vec<_>>()
         .join(",");
     let path = format!("{dest}/proc/lsof.txt");
-    match command_stdout("lsof", &["-nP", "-p", &pid_list], Duration::from_secs(10)).await {
+    match command_stdout("lsof", &["-nP", "-p", &pid_list], LSOF_TIMEOUT).await {
         Ok(text) => w.add_bytes(&path, text.as_bytes(), Redaction::None).await?,
         Err(e) => w.skip(path, format!("lsof unavailable: {e}")),
     }
@@ -145,8 +183,19 @@ async fn process_table(markers: &[&str]) -> Result<(String, Vec<u32>), anyhow::E
             #[cfg(target_os = "linux")]
             {
                 use anyhow::Context as _;
-                proc_scrape(markers)
-                    .with_context(|| format!("ps failed ({_ps_err}), /proc fallback also failed"))
+                // The scrape walks all of `/proc` synchronously, so it runs on a
+                // blocking thread: a wedged `/proc` must strand that thread, not
+                // the worker whose collector timeout is the failsafe. `ps` being
+                // absent (microVM pid-1, a starved host) is exactly when that
+                // read is most likely to hang.
+                let markers: Vec<String> = markers.iter().map(|m| (*m).to_string()).collect();
+                tokio::task::spawn_blocking(move || {
+                    let markers: Vec<&str> = markers.iter().map(String::as_str).collect();
+                    proc_scrape(&markers)
+                })
+                .await
+                .context("proc scrape worker")?
+                .with_context(|| format!("ps failed ({_ps_err}), /proc fallback also failed"))
             }
             #[cfg(not(target_os = "linux"))]
             {

--- a/crates/diagnostics/src/procs.rs
+++ b/crates/diagnostics/src/procs.rs
@@ -1,0 +1,299 @@
+//! Process-state capture for diagnostic bundles: a filtered process table and
+//! per-process hang triage — where each of our processes is parked and what it
+//! holds open — for the process family named by a caller-supplied marker list.
+//!
+//! The marker *data* is the caller's policy ([`crate::procs`] never names a
+//! process); matching, the argv scrub, and the reads are the mechanics here.
+//! The Linux path is pure `/proc` — wait-channel, syscall, kernel stack, and
+//! fd readlinks — so it runs as microVM pid-1 with no external binaries.
+//! External tools are host-side extras used when present: `ps` for the table
+//! (a `/proc` scrape stands in), macOS `sample`, and one `lsof` over the set.
+
+use std::time::Duration;
+
+use crate::bundle::{BundleSink, BundleWriter};
+use crate::capture::command_stdout;
+use crate::manifest::Redaction;
+use crate::redact::{is_sensitive_key, redaction_placeholder};
+
+/// Timeout for `ps`; a wedged process table must not eat the collector budget.
+const PS_TIMEOUT: Duration = Duration::from_secs(5);
+/// Cap on how many matched processes get the deep hang-triage treatment — a
+/// runaway match list must not turn a bundle into a profiling session.
+const HANG_TRIAGE_PIDS_MAX: usize = 8;
+
+/// True when `args` (a full command line) names one of `markers` as its
+/// executable — the argv0 basename only, never a substring of the whole line,
+/// so `vim minimald.log` or `tail -f minvmd.log` are not dragged in.
+fn argv0_matches(args: &str, markers: &[&str]) -> bool {
+    args.split_whitespace().next().is_some_and(|argv0| {
+        let bin = argv0.rsplit('/').next().unwrap_or(argv0);
+        markers.contains(&bin)
+    })
+}
+
+/// Scrubs an argv line token-wise: any `key=value` token whose key trips the
+/// [sensitive-key policy](is_sensitive_key) has its value replaced by the
+/// redaction placeholder, so a secret passed on a command line never rides out
+/// in the process table.
+fn scrub_argv(line: &str) -> String {
+    line.split(' ')
+        .map(|tok| match tok.split_once('=') {
+            Some((key, value)) if is_sensitive_key(key) => {
+                let placeholder =
+                    redaction_placeholder(&serde_json::Value::String(value.to_string()));
+                format!("{key}={}", placeholder.as_str().unwrap_or("<redacted>"))
+            }
+            _ => tok.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// `<dest>/process-tree.txt`, plus on Linux `<dest>/proc/<pid>.status` for each
+/// matched pid (VmRSS, threads, and fd pressure for one of our processes).
+pub async fn process_tree<W: BundleSink>(
+    w: &mut BundleWriter<W>,
+    dest: &str,
+    markers: &[&str],
+) -> Result<(), anyhow::Error> {
+    let (text, pids) = process_table(markers).await?;
+    w.add_bytes(
+        &format!("{dest}/process-tree.txt"),
+        text.as_bytes(),
+        Redaction::Keys,
+    )
+    .await?;
+
+    #[cfg(target_os = "linux")]
+    for pid in pids {
+        if let Some(status) = proc_status(pid) {
+            w.add_bytes(
+                &format!("{dest}/proc/{pid}.status"),
+                status.as_bytes(),
+                Redaction::None,
+            )
+            .await?;
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = pids;
+    Ok(())
+}
+
+/// Hang triage for the matched family (capped at [`HANG_TRIAGE_PIDS_MAX`]):
+/// thread samples on macOS, wait-channel + kernel stack + open fds on Linux,
+/// and one `lsof` over the set. This is the evidence "it's frozen" reports run
+/// on (#788: vCPUs in WFI, proxy in kevent, a unix socket open with no EOF), so
+/// it is captured while the hang is live.
+pub async fn hang_triage<W: BundleSink>(
+    w: &mut BundleWriter<W>,
+    dest: &str,
+    markers: &[&str],
+) -> Result<(), anyhow::Error> {
+    let (_, pids) = process_table(markers).await?;
+    let pids: Vec<u32> = pids.into_iter().take(HANG_TRIAGE_PIDS_MAX).collect();
+    if pids.is_empty() {
+        w.skip(
+            format!("{dest}/proc/"),
+            "no marker-matched processes to hang-triage",
+        );
+        return Ok(());
+    }
+
+    #[cfg(target_os = "macos")]
+    for &pid in &pids {
+        let path = format!("{dest}/proc/{pid}.sample.txt");
+        let pid_s = pid.to_string();
+        match command_stdout("sample", &[&pid_s, "1", "10"], Duration::from_secs(15)).await {
+            Ok(text) => w.add_bytes(&path, text.as_bytes(), Redaction::None).await?,
+            Err(e) => w.skip(path, format!("sample failed: {e}")),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    for &pid in &pids {
+        let text = linux_park_state(pid).await;
+        w.add_bytes(
+            &format!("{dest}/proc/{pid}.stack.txt"),
+            text.as_bytes(),
+            Redaction::None,
+        )
+        .await?;
+    }
+
+    let pid_list = pids
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    let path = format!("{dest}/proc/lsof.txt");
+    match command_stdout("lsof", &["-nP", "-p", &pid_list], Duration::from_secs(10)).await {
+        Ok(text) => w.add_bytes(&path, text.as_bytes(), Redaction::None).await?,
+        Err(e) => w.skip(path, format!("lsof unavailable: {e}")),
+    }
+    Ok(())
+}
+
+/// Filtered `ps` output plus the matched pids; on Linux a `/proc` scrape stands
+/// in when `ps` is unavailable. The header and a total count are kept so
+/// "nothing matched" is distinguishable from "ps saw nothing".
+async fn process_table(markers: &[&str]) -> Result<(String, Vec<u32>), anyhow::Error> {
+    match ps_table(markers).await {
+        Ok(v) => Ok(v),
+        Err(_ps_err) => {
+            #[cfg(target_os = "linux")]
+            {
+                use anyhow::Context as _;
+                proc_scrape(markers)
+                    .with_context(|| format!("ps failed ({_ps_err}), /proc fallback also failed"))
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                Err(_ps_err)
+            }
+        }
+    }
+}
+
+/// The portable `ps` keyword form (works on Linux and macOS), filtered to the
+/// marker-matched family and scrubbed token-wise.
+async fn ps_table(markers: &[&str]) -> Result<(String, Vec<u32>), anyhow::Error> {
+    let out = command_stdout(
+        "ps",
+        &["axww", "-o", "pid=,ppid=,user=,pcpu=,rss=,etime=,args="],
+        PS_TIMEOUT,
+    )
+    .await?;
+    let total = out.lines().count();
+    let mut text = format!("pid ppid user pcpu rss etime args   (filtered; {total} total)\n");
+    let mut pids = Vec::new();
+    for line in out.lines() {
+        let mut fields = line.split_whitespace();
+        let Some(pid) = fields.next().and_then(|p| p.parse::<u32>().ok()) else {
+            continue;
+        };
+        let args = fields.skip(5).collect::<Vec<_>>().join(" ");
+        if argv0_matches(&args, markers) {
+            text.push_str(&scrub_argv(line));
+            text.push('\n');
+            pids.push(pid);
+        }
+    }
+    Ok((text, pids))
+}
+
+/// Linux fallback: walk `/proc/<pid>/cmdline` directly when `ps` is absent.
+#[cfg(target_os = "linux")]
+fn proc_scrape(markers: &[&str]) -> Result<(String, Vec<u32>), anyhow::Error> {
+    use anyhow::Context as _;
+    use std::fmt::Write as _;
+    let mut text = String::from("pid cmdline   (from /proc scrape)\n");
+    let mut pids = Vec::new();
+    for entry in std::fs::read_dir("/proc")
+        .context("reading /proc")?
+        .flatten()
+    {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|n| n.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let Ok(raw) = std::fs::read(format!("/proc/{pid}/cmdline")) else {
+            continue;
+        };
+        let cmdline = String::from_utf8_lossy(&raw).replace('\0', " ");
+        if argv0_matches(&cmdline, markers) {
+            let _ = writeln!(text, "{pid} {}", scrub_argv(cmdline.trim_end()));
+            pids.push(pid);
+        }
+    }
+    Ok((text, pids))
+}
+
+/// Where a Linux process is parked: wait channel, current syscall, kernel
+/// stack (root-only; the error is data), and its open fds by readlink.
+#[cfg(target_os = "linux")]
+async fn linux_park_state(pid: u32) -> String {
+    use std::fmt::Write as _;
+    let mut text = String::new();
+    for label in ["wchan", "syscall", "stack"] {
+        let value = tokio::fs::read_to_string(format!("/proc/{pid}/{label}"))
+            .await
+            .unwrap_or_else(|e| format!("<unreadable: {e}>"));
+        let _ = writeln!(text, "=== {label} ===\n{}", value.trim_end());
+    }
+    text.push_str("=== fds ===\n");
+    match tokio::fs::read_dir(format!("/proc/{pid}/fd")).await {
+        Ok(mut entries) => {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let target = tokio::fs::read_link(entry.path())
+                    .await
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|e| format!("<unreadable: {e}>"));
+                let _ = writeln!(text, "{} -> {target}", entry.file_name().to_string_lossy());
+            }
+        }
+        Err(e) => {
+            let _ = writeln!(text, "<unreadable: {e}>");
+        }
+    }
+    text
+}
+
+/// `/proc/<pid>/status` plus an fd count — VmRSS, threads, and fd pressure.
+#[cfg(target_os = "linux")]
+fn proc_status(pid: u32) -> Option<String> {
+    let mut status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    if let Ok(fds) = std::fs::read_dir(format!("/proc/{pid}/fd")) {
+        use std::fmt::Write as _;
+        let _ = writeln!(status, "OpenFds:\t{}", fds.count());
+    }
+    Some(status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MARKERS: &[&str] = &["min", "minimald", "minvmd", "__krun-vmm", "gvproxy"];
+
+    #[test]
+    fn argv0_matches_executable_basename_not_substring() {
+        assert!(argv0_matches("/usr/bin/minimald run --detach", MARKERS));
+        assert!(argv0_matches("minvmd __krun-vmm --token x", MARKERS));
+        assert!(argv0_matches("/home/u/.local/bin/min activate .", MARKERS));
+        assert!(argv0_matches("gvproxy -mtu 1500", MARKERS));
+
+        assert!(!argv0_matches("vim minutes.txt", MARKERS));
+        assert!(!argv0_matches("/usr/bin/administrator --min 5", MARKERS));
+        // Marker names appearing as arguments (a user triaging our logs) must
+        // not drag their editor/pager into the bundle.
+        assert!(!argv0_matches("vim minimald.log", MARKERS));
+        assert!(!argv0_matches(
+            "tail -f /var/log/minvmd.log.2026-07-15",
+            MARKERS
+        ));
+        assert!(!argv0_matches("grep minimald /home/u/notes", MARKERS));
+    }
+
+    #[test]
+    fn scrub_argv_masks_sensitive_key_value_tokens_only() {
+        let scrubbed = scrub_argv("minvmd --flag MINIMAL_AUTH_TOKEN=s3cr3t --port 8080");
+        assert!(
+            !scrubbed.contains("s3cr3t"),
+            "secret value masked: {scrubbed}"
+        );
+        assert!(
+            scrubbed.contains("MINIMAL_AUTH_TOKEN=<redacted"),
+            "sensitive key masked in place: {scrubbed}"
+        );
+        assert!(scrubbed.contains("--flag"), "flags untouched: {scrubbed}");
+        assert!(
+            scrubbed.contains("--port 8080"),
+            "non-sensitive kept: {scrubbed}"
+        );
+    }
+}

--- a/crates/minimal/src/diag/mod.rs
+++ b/crates/minimal/src/diag/mod.rs
@@ -32,6 +32,19 @@ pub struct BugArgs {
 /// hung collector can't stall the whole run.
 const COLLECTOR_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Process names (argv0 basenames) that mark a process as one of ours. This is
+/// minimal's policy — the *data*; the matching mechanic lives in
+/// [`diagnostics::procs`], which takes this list as an argument so the same
+/// code serves the daemon-side capture.
+const PROCESS_MARKERS: &[&str] = &[
+    "min",
+    "minimal",
+    "minimald",
+    "minvmd",
+    "__krun-vmm",
+    "gvproxy",
+];
+
 /// Runs one collector future with [`COLLECTOR_TIMEOUT`]; failure or timeout
 /// is recorded in the manifest and the run continues. A macro (not a
 /// function) so the future's borrow of the writer ends before the
@@ -71,6 +84,34 @@ pub async fn cmd_bug(global: &GlobalArgs, args: BugArgs) -> Result<(), anyhow::E
     collect_step!(w, "host.system", collect::system(&mut w, &paths));
     collect_step!(w, "host.env", collect::env(&mut w));
     collect_step!(w, "host.dirs", dirs_report(&mut w, global));
+    // Incident collectors: the wedged-system captures. The mechanics live in
+    // `diagnostics`; minimal supplies the marker list and the "host" group.
+    collect_step!(
+        w,
+        "host.process-tree",
+        diagnostics::procs::process_tree(&mut w, "host", PROCESS_MARKERS)
+    );
+    collect_step!(
+        w,
+        "host.hang-triage",
+        diagnostics::procs::hang_triage(&mut w, "host", PROCESS_MARKERS)
+    );
+    collect_step!(
+        w,
+        "host.net.listening",
+        diagnostics::net::listening_sockets(&mut w, "host")
+    );
+    collect_step!(
+        w,
+        "host.net.interfaces",
+        diagnostics::net::interfaces(&mut w, "host")
+    );
+    collect_step!(
+        w,
+        "host.net.routes",
+        diagnostics::net::routes(&mut w, "host")
+    );
+    collect_step!(w, "host.power", diagnostics::power::power(&mut w, "host"));
     collect_step!(w, "config", collect::config(&mut w, &paths));
     collect_step!(w, "state", collect::state(&mut w, &paths));
     collect_step!(w, "logs", collect::logs(&mut w, &paths));

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -259,3 +259,46 @@ async fn logs_collects_newest_five_per_prefix_and_provider_logs() {
     );
     assert_eq!(manifest["errors"].as_array().unwrap().len(), 0, "no errors");
 }
+
+/// R5.1–R5.3: the incident collectors (net/procs/power) land in the bundle,
+/// and interface MACs are masked to their vendor OUI. No daemon needed — these
+/// capture host state.
+#[tokio::test]
+async fn incident_collectors_land_and_mask_macs() {
+    let state = tempfile::TempDir::new().unwrap();
+    let config = tempfile::TempDir::new().unwrap();
+    let out_dir = tempfile::TempDir::new().unwrap();
+    let out = out_dir.path().join("diag.tar.zst");
+    cmd_bug(&global_args(state.path(), config.path()), bug_args(&out))
+        .await
+        .unwrap();
+    let files = unpack(&out).await;
+
+    for suffix in [
+        "host/process-tree.txt",
+        "host/net/listening.txt",
+        "host/net/interfaces.txt",
+        "host/net/routes.txt",
+        "host/power.txt",
+    ] {
+        assert!(
+            find(&files, suffix).is_some(),
+            "missing incident capture: {suffix}"
+        );
+    }
+
+    // R5.1: no full MAC survives in the interfaces capture — every one is
+    // masked to its OUI, so a 17-char `xx:xx:xx:xx:xx:xx` token never appears.
+    let interfaces = String::from_utf8_lossy(find(&files, "host/net/interfaces.txt").unwrap());
+    for tok in interfaces.split_whitespace() {
+        let is_mac = tok.len() == 17
+            && tok.bytes().enumerate().all(|(i, b)| {
+                if i % 3 == 2 {
+                    b == b':'
+                } else {
+                    b.is_ascii_hexdigit()
+                }
+            });
+        assert!(!is_mac, "un-masked MAC leaked into interfaces.txt: {tok}");
+    }
+}


### PR DESCRIPTION
Unit 5 of the diagnostics series (spec: [#802](https://github.com/gominimal/minimal/pull/802), epic: [#801](https://github.com/gominimal/minimal/issues/801)). Branches off `main` — depends only on Units 1–2 (both merged), independent of the in-flight Unit 4 ([#835](https://github.com/gominimal/minimal/pull/835)). 750 insertions.

## What

The wedged-system captures — network state, process tree, hang triage, power history — land as **mechanics in the `diagnostics` crate**, parameterized by app inputs. `crates/minimal` keeps only the marker *data* and the six `collect_step!` wiring lines, holding the crate rule at series end (R5.5).

**`diagnostics::net`** *(R5.1)* — `listening_sockets` (ss/netstat, Linux `/proc/net` fallback), `interfaces` (MACs masked to their vendor OUI, token-wise so IPv6 shorthand survives), `routes`. Verbatim tool output, no typed re-serialization.

**`diagnostics::procs`** *(R5.2)* — process table + hang triage for ≤8 pids matched by **argv0 basename** against a caller-supplied `markers: &[&str]`. Linux path is **pure `/proc`** (wchan/syscall/kernel-stack/fd readlinks) so it runs as microVM pid-1 with no external binaries; macOS uses `sample` per pid + one `lsof`. Recorded argv is **scrubbed token-wise**: any `key=value` token whose key trips the sensitive-key policy has its value replaced by the redaction placeholder.

**`diagnostics::power`** *(R5.3)* — sleep/wake history (macOS `pmset`, Linux `journalctl`), event-capped.

**`diagnostics::capture::command_stdout`** *(R5.4)* — one lenient wrapper over `command_capture` that all three collectors consume; honors the `lsof`/`ss` exit-1-with-output convention.

## Crate boundary

The crate never names a process or a bundle-path prefix — both `markers` and the `dest` group (`"host"`) are passed in — so the same mechanics serve the daemon-side capture (Unit 6, R6.5). The net **socket-probe** is intentionally *not* here: it needs the CLI client (`crate::client::Client` + `minimald_rpc`) and belongs to Unit 7.



Refs: [#801](https://github.com/gominimal/minimal/issues/801)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Diagnostic bundles now include process tree capture, live hang triage evidence, network listening sockets, network interfaces, network routes, and host power-state history (Unix platforms).
  - Incident diagnostics expand with these additional, platform-aware collectors.
- **Improved Output Handling**
  - Non-zero command failures that still provide usable stdout are retained to improve bundle completeness.
- **Privacy**
  - Network interface MAC masking preserves vendor/OUI while masking device-specific portions; sensitive process command-line values remain redacted.
- **Tests**
  - Added an integration test that verifies incident outputs are present and MAC masking is enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add incident collectors for process, network, and power diagnostics to `minimal bug`
> - Adds `process_tree` and `hang_triage` collectors in [procs.rs](https://github.com/gominimal/minimal/pull/864/files#diff-6a9c04a1ee6ec3a5b68e38d5bd9c252c86b4e9cea1dab122a920237948d39018): captures a filtered/scrubbed process table and, for up to 8 matched pids, gathers stack traces (macOS `sample`, Linux `/proc` wchan/syscall/stack) plus open file descriptors via `lsof`.
> - Adds network collectors in [net.rs](https://github.com/gominimal/minimal/pull/864/files#diff-af10467550c9881b1e3ee144cd0ccdfa59ca53168d6c2128d4c671247fa9355b): listening sockets (`ss`/`netstat`/`/proc/net` fallback), interfaces (`ip addr`/`ifconfig` with MAC addresses masked to vendor OUI), and routes (`ip route`/`netstat -rn`).
> - Adds a power collector in [power.rs](https://github.com/gominimal/minimal/pull/864/files#diff-6b97a05dd9cad8e52d0ce16e3b10e13682106c53b4e8cb2e91e0cb109c059cdd): records recent sleep/wake transitions from `pmset` (macOS) or `journalctl` (Linux).
> - Wires all new collectors into `cmd_bug` in [mod.rs](https://github.com/gominimal/minimal/pull/864/files#diff-fd241628db1b595f1a2a02e25ed2c7359e33e944d11ea9ef6484cfb95726efdb), keyed to process markers: `min`, `minimal`, `minimald`, `minvmd`, `__krun-vmm`, `gvproxy`.
> - Scrubbing is fail-closed: `scrub_flattened` withholds the entire argument tail after a sensitive `key=` token to prevent partial secret leakage from flattened ps output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e19967.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->