### PR TITLE
fix(minimald): retry ENOBUFS on the guest vsock write path

### DIFF
--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -83,7 +83,9 @@ tokio-rustls = { workspace = true, optional = true }
 # The two-namespace UC7 mesh integration test (`tests/mesh_uc7.rs`) drives a
 # tokio runtime and `setns(2)` directly.
 libc.workspace = true
-tokio.workspace = true
+# `test-util` (not in tokio's `full`) for `#[tokio::test(start_paused = true)]`:
+# lets the ENOBUFS backoff cadence and stall deadline elapse in virtual time.
+tokio = { workspace = true, features = ["test-util"] }
 # Parity test in `sessions/composables.rs` compares `SetupForPackages` output
 # to the composition-only path from a nickel-declared BuildSpec.
 decode.workspace = true

--- a/crates/minimald/src/backpressure.rs
+++ b/crates/minimald/src/backpressure.rs
@@ -1,0 +1,473 @@
+//! Backpressure for a transport that under-delivers it.
+//!
+//! A `write(2)` on a guest AF_VSOCK socket fails with `ENOBUFS` when the
+//! virtio TX virtqueue is full — the guest has queued more than the host-side
+//! VMM has drained. Unlike `EWOULDBLOCK` this is a hard error: `tokio-vsock`
+//! surfaces the raw errno as an [`io::Error`] that is not
+//! [`ErrorKind::WouldBlock`](std::io::ErrorKind::WouldBlock), so no layer above
+//! retries it. In minimald that error escapes through russh and kills the whole
+//! SSH connection, not just the channel that was writing, which is how a file
+//! upload turns into `channel closed` on the client.
+//!
+//! [`EnobufsBackpressure`] is the missing backpressure: it absorbs `ENOBUFS`
+//! on the write path, waits for the host to drain, and re-issues the write.
+//!
+//! # Why a timer and not a readiness wait
+//!
+//! The obvious fix — register the waker and return [`Poll::Pending`] until the
+//! socket is writable again — does not work here. `tokio-vsock` reaches this
+//! error *through* a satisfied write-readiness guard, and a non-`WouldBlock`
+//! error does not clear that readiness, so there is no guarantee of a fresh
+//! writability edge to wake on: the wait can hang forever, and a bare
+//! retry-on-wake loop would busy-spin instead. What actually clears the
+//! condition is the host draining the virtqueue, which takes wall-clock time.
+//! Measurement agrees: inserting a 1 µs sleep between client writes makes a
+//! 1.28 GB upload succeed, while [`tokio::task::yield_now`] in the same place
+//! does not. So the retry is driven by a timer.
+//!
+//! # Relationship to the libkrun version floor
+//!
+//! [`Listener`](crate::server::Listener)'s vsock impl requires libkrun >=
+//! 1.19.0 because 1.18.1 had a multi-descriptor TX-chain bug in its vsock
+//! device. This is a different problem and a different kind of fix: the device
+//! is behaving correctly here — a full queue is a legitimate state — but the
+//! socket reports it as a fatal error rather than as backpressure. This adapter
+//! restores the backpressure semantics the caller already assumes; it does not
+//! work around a device defect, and it does not substitute for the version
+//! floor.
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll, ready};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::time::{Instant, Sleep};
+
+/// Delay before the first retry of an `ENOBUFS` write. Deliberately far below
+/// the drain time of a full queue: the common case is a queue that clears
+/// almost immediately, and a long first wait would cost throughput on every
+/// stall. Note that tokio's timer has millisecond granularity, so this is a
+/// floor of "one timer tick", not a literal 100 µs.
+const INITIAL_BACKOFF: Duration = Duration::from_micros(100);
+
+/// Ceiling for the exponential backoff. A queue that has not drained in a few
+/// milliseconds is not going to drain faster for being polled harder, and this
+/// bounds the wasted syscalls during a long stall.
+const MAX_BACKOFF: Duration = Duration::from_millis(4);
+
+/// How long a single contiguous run of `ENOBUFS` may last before the error is
+/// propagated to the caller. Past this the transport is not congested, it is
+/// broken, and reporting that is better than hanging the session forever.
+const MAX_STALL: Duration = Duration::from_secs(5);
+
+/// State of an in-progress `ENOBUFS` stall: one contiguous run of failed write
+/// attempts. Absent (`None` on the adapter) whenever the stream is healthy, so
+/// the fast path costs one `Option` check and allocates nothing.
+#[derive(Debug)]
+struct Stall {
+    /// The armed retry timer. Held here — not recreated per poll — so that
+    /// re-polling resumes the same wait instead of restarting it. `None` once
+    /// it has fired and the write has not yet been re-attempted.
+    timer: Option<Pin<Box<Sleep>>>,
+    /// Delay for the next backoff step, doubling up to [`MAX_BACKOFF`].
+    delay: Duration,
+    /// When this run of `ENOBUFS` began, for the [`MAX_STALL`] deadline.
+    started: Instant,
+    /// Retries issued in this run, for the logs.
+    retries: u32,
+}
+
+/// An [`AsyncRead`] + [`AsyncWrite`] adapter that treats `ENOBUFS` on the write
+/// path as backpressure rather than as a fatal error.
+///
+/// A write attempt that fails with `ENOBUFS` is retried after a short sleep,
+/// backing off exponentially from `INITIAL_BACKOFF` to `MAX_BACKOFF` and
+/// resetting once a write lands. A contiguous run of failures lasting longer
+/// than `MAX_STALL` gives up and returns the underlying error unchanged, so a
+/// genuinely wedged transport still surfaces instead of hanging.
+///
+/// Only `ENOBUFS` is retried. Every other error, and every read, passes through
+/// untouched, so a healthy stream behaves exactly like the stream it wraps.
+///
+/// Generic over the inner stream rather than tied to
+/// [`tokio_vsock::VsockStream`](https://docs.rs/tokio-vsock) so the retry state
+/// machine can be exercised against a mock writer in unit tests.
+///
+/// # Buffer safety
+///
+/// The adapter never consumes bytes it does not report and never retains the
+/// caller's buffer: `ENOBUFS` means the write moved zero bytes, so a retry is
+/// free to write whatever buffer the caller offers at that time. A caller is
+/// therefore allowed — as [`AsyncWrite`] permits — to poll again with a
+/// different buffer after a [`Poll::Pending`], and no partial write can be
+/// re-issued against mismatched data.
+#[derive(Debug)]
+pub struct EnobufsBackpressure<S> {
+    inner: S,
+    /// The current stall, if a write is presently backing off.
+    stall: Option<Stall>,
+    /// Stall runs seen on this stream, cumulative. Used to keep the log to one
+    /// `WARN` per stream (see [`Self::arm_backoff`]).
+    stalls: u64,
+}
+
+impl<S> EnobufsBackpressure<S> {
+    /// Wraps `inner`, retrying `ENOBUFS` on its write path.
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            stall: None,
+            stalls: 0,
+        }
+    }
+
+    /// Records an `ENOBUFS` write attempt and arms the next retry timer.
+    ///
+    /// Returns `false` when this run of failures has outlived `MAX_STALL`,
+    /// meaning the caller must propagate the error instead of retrying.
+    fn arm_backoff(&mut self) -> bool {
+        let now = Instant::now();
+        // Taken and put back so the whole update runs on an owned value; a
+        // give-up simply declines to put it back, clearing the stall.
+        let (mut stall, first) = match self.stall.take() {
+            Some(stall) => (stall, false),
+            None => {
+                self.stalls += 1;
+                let stall = Stall {
+                    timer: None,
+                    delay: INITIAL_BACKOFF,
+                    started: now,
+                    retries: 0,
+                };
+                (stall, true)
+            }
+        };
+
+        let elapsed = now.saturating_duration_since(stall.started);
+        if elapsed >= MAX_STALL {
+            tracing::warn!(
+                retries = stall.retries,
+                elapsed_ms = elapsed.as_millis(),
+                stalls = self.stalls,
+                "vsock tx queue still full past the ENOBUFS stall deadline; propagating the error"
+            );
+            return false;
+        }
+
+        let delay = stall.delay;
+        stall.delay = (delay * 2).min(MAX_BACKOFF);
+        stall.retries += 1;
+        stall.timer = Some(Box::pin(tokio::time::sleep(delay)));
+        let retries = stall.retries;
+        let stalls = self.stalls;
+        self.stall = Some(stall);
+
+        if first {
+            // One `WARN` per stream, then `DEBUG`: a sustained upload can stall
+            // hundreds of times, and burying boot.log under it would defeat the
+            // point of logging this at all. The give-up warning above is not
+            // rate-limited — it is the one that reports a real failure.
+            if stalls == 1 {
+                tracing::warn!(
+                    retries,
+                    elapsed_ms = elapsed.as_millis(),
+                    delay_us = delay.as_micros(),
+                    "vsock tx queue full; engaging ENOBUFS backoff (further stalls log at DEBUG)"
+                );
+            } else {
+                tracing::debug!(
+                    retries,
+                    delay_us = delay.as_micros(),
+                    stalls,
+                    "vsock tx queue full; backing off"
+                );
+            }
+        }
+        true
+    }
+}
+
+/// Whether `error` is the guest-side "virtio TX queue is full" report.
+///
+/// Matched on the raw errno rather than on [`io::ErrorKind`], which has no
+/// dedicated variant for `ENOBUFS` and would need a catch-all, and certainly
+/// not on the rendered message, which is not a stable interface.
+fn is_enobufs(error: &io::Error) -> bool {
+    error.raw_os_error() == Some(libc::ENOBUFS)
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for EnobufsBackpressure<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        loop {
+            // Drive an armed retry timer to completion first. Polling it here
+            // is also what registers the waker for the retry: `arm_backoff`
+            // only creates the timer, it never returns `Pending` itself.
+            if let Some(stall) = this.stall.as_mut()
+                && let Some(timer) = stall.timer.as_mut()
+            {
+                ready!(timer.as_mut().poll(cx));
+                stall.timer = None;
+            }
+
+            match Pin::new(&mut this.inner).poll_write(cx, buf) {
+                Poll::Ready(Ok(written)) => {
+                    if let Some(stall) = this.stall.take() {
+                        tracing::debug!(
+                            retries = stall.retries,
+                            stalled_us = stall.started.elapsed().as_micros(),
+                            "vsock tx queue drained; write resumed"
+                        );
+                    }
+                    return Poll::Ready(Ok(written));
+                }
+                Poll::Ready(Err(error)) if is_enobufs(&error) => {
+                    if this.arm_backoff() {
+                        // Loop back to poll the timer just armed.
+                        continue;
+                    }
+                    return Poll::Ready(Err(error));
+                }
+                // Anything else ends the stall run: the deadline measures a
+                // contiguous run of `ENOBUFS`, and a `Pending` from the inner
+                // stream is ordinary backpressure that already registered a
+                // waker of its own.
+                other => {
+                    this.stall = None;
+                    return other;
+                }
+            }
+        }
+    }
+
+    /// Forwarded unchanged. A vsock flush is a no-op — nothing is buffered
+    /// above the socket — so it has no queue of its own to overrun, and the
+    /// retry stays confined to [`Self::poll_write`].
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+
+    // `poll_write_vectored`/`is_write_vectored` are deliberately left at their
+    // defaults, which route through the retrying `poll_write` above. Nothing is
+    // lost: `VsockStream` does not implement vectored writes either.
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for EnobufsBackpressure<S> {
+    /// Forwarded unchanged: `ENOBUFS` is a send-side condition, and a read that
+    /// silently retried would change the stream's semantics for no benefit.
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    /// A stream whose write outcomes are scripted, recording the (virtual) time
+    /// of every attempt so the retry cadence is observable.
+    #[derive(Debug, Default)]
+    struct MockStream {
+        /// One entry per write attempt: `Some(errno)` fails it, `None` lets it
+        /// succeed. Once drained, [`Self::when_drained`] applies.
+        script: VecDeque<Option<i32>>,
+        /// Outcome for every attempt past the end of `script`.
+        when_drained: Option<i32>,
+        /// [`Instant`] of each write attempt, in order.
+        attempts: Vec<Instant>,
+        /// Bytes accepted by successful writes.
+        written: Vec<u8>,
+        /// Bytes a read will yield.
+        to_read: Vec<u8>,
+        /// Errno a read fails with instead of yielding [`Self::to_read`].
+        read_error: Option<i32>,
+    }
+
+    impl MockStream {
+        /// Fails the next `count` write attempts with `ENOBUFS`, then succeeds.
+        fn failing(count: usize) -> Self {
+            Self {
+                script: std::iter::repeat_n(Some(libc::ENOBUFS), count).collect(),
+                ..Self::default()
+            }
+        }
+
+        /// Gaps between successive write attempts.
+        fn gaps(&self) -> Vec<Duration> {
+            self.attempts
+                .windows(2)
+                .map(|pair| pair[1].saturating_duration_since(pair[0]))
+                .collect()
+        }
+    }
+
+    impl AsyncWrite for MockStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let this = self.get_mut();
+            this.attempts.push(Instant::now());
+            match this.script.pop_front().unwrap_or(this.when_drained) {
+                Some(errno) => Poll::Ready(Err(io::Error::from_raw_os_error(errno))),
+                None => {
+                    this.written.extend_from_slice(buf);
+                    Poll::Ready(Ok(buf.len()))
+                }
+            }
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncRead for MockStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            let this = self.get_mut();
+            if let Some(errno) = this.read_error {
+                return Poll::Ready(Err(io::Error::from_raw_os_error(errno)));
+            }
+            let n = this.to_read.len().min(buf.remaining());
+            buf.put_slice(&this.to_read[..n]);
+            this.to_read.drain(..n);
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn transient_enobufs_is_retried_until_the_write_lands() {
+        let mut stream = EnobufsBackpressure::new(MockStream::failing(3));
+
+        let written = stream.write(b"payload").await.expect("retries absorb it");
+
+        assert_eq!(written, b"payload".len());
+        assert_eq!(stream.inner.written, b"payload");
+        assert_eq!(
+            stream.inner.attempts.len(),
+            4,
+            "three failed attempts then the one that lands"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backoff_resets_after_a_successful_write() {
+        // Long enough for the delay to reach the cap, so a failure to reset is
+        // unmistakable in the cadence.
+        let mut stream = EnobufsBackpressure::new(MockStream::failing(8));
+        stream.write_all(b"a").await.expect("first write lands");
+        let first_run = stream.inner.gaps();
+
+        stream.inner.script = VecDeque::from([Some(libc::ENOBUFS)]);
+        stream.inner.attempts.clear();
+        stream.write_all(b"b").await.expect("second write lands");
+        let second_run = stream.inner.gaps();
+
+        let (initial, capped) = (first_run[0], *first_run.last().expect("8 retries"));
+        assert!(
+            capped > initial,
+            "backoff should grow within a stall: {first_run:?}"
+        );
+        assert_eq!(second_run.len(), 1, "one retry in the second stall");
+        assert!(
+            second_run[0] <= initial,
+            "backoff should restart from the initial delay, not continue from {capped:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_stall_past_the_deadline_propagates_the_original_error() {
+        let mut stream = EnobufsBackpressure::new(MockStream {
+            when_drained: Some(libc::ENOBUFS),
+            ..MockStream::default()
+        });
+
+        let start = Instant::now();
+        let error = stream.write(b"payload").await.expect_err("never drains");
+
+        assert_eq!(
+            error.raw_os_error(),
+            Some(libc::ENOBUFS),
+            "the inner error is propagated unchanged"
+        );
+        assert!(
+            start.elapsed() >= MAX_STALL,
+            "the deadline must be honoured before giving up"
+        );
+        assert!(
+            stream.inner.attempts.len() > 1,
+            "it should have retried before giving up"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_non_enobufs_error_is_never_retried() {
+        let mut stream = EnobufsBackpressure::new(MockStream {
+            script: VecDeque::from([Some(libc::EPIPE)]),
+            ..MockStream::default()
+        });
+
+        let error = stream.write(b"payload").await.expect_err("EPIPE is fatal");
+
+        assert_eq!(error.raw_os_error(), Some(libc::EPIPE));
+        assert_eq!(
+            stream.inner.attempts.len(),
+            1,
+            "no retry for an error that is not ENOBUFS"
+        );
+    }
+
+    #[tokio::test]
+    async fn reads_pass_through_untouched() {
+        let mut stream = EnobufsBackpressure::new(MockStream {
+            to_read: b"from the host".to_vec(),
+            ..MockStream::default()
+        });
+
+        let mut buf = [0u8; 13];
+        stream.read_exact(&mut buf).await.expect("read succeeds");
+
+        assert_eq!(&buf, b"from the host");
+    }
+
+    #[tokio::test]
+    async fn a_read_error_is_propagated_even_when_it_is_enobufs() {
+        let mut stream = EnobufsBackpressure::new(MockStream {
+            read_error: Some(libc::ENOBUFS),
+            ..MockStream::default()
+        });
+
+        let error = stream
+            .read(&mut [0u8; 8])
+            .await
+            .expect_err("reads are not retried");
+
+        assert_eq!(error.raw_os_error(), Some(libc::ENOBUFS));
+    }
+}

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+pub mod backpressure;
 pub mod channel_progress;
 pub mod connection;
 pub mod env;

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -11,6 +11,8 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument as _;
 
+#[cfg(target_os = "linux")]
+use crate::backpressure::EnobufsBackpressure;
 use crate::connection::Connection;
 use crate::sessions;
 
@@ -383,16 +385,26 @@ impl Listener for UnixListener {
 /// stalled a full session (a multi-descriptor TX-chain bug in libkrun's vsock
 /// device, fixed upstream by `0ecf4d5f7`); a socat relay was the prior
 /// workaround.
+///
+/// Accepted streams are wrapped in
+/// [`EnobufsBackpressure`](crate::backpressure::EnobufsBackpressure): the socket
+/// reports a full virtio TX virtqueue as a fatal `ENOBUFS` rather than as
+/// backpressure, which otherwise tears down the entire SSH connection
+/// mid-upload (see that type's docs). The UDS transport above is left
+/// unwrapped — `ENOBUFS` is not one of its failure modes, and keeping the
+/// wrapper off the native path keeps its behaviour byte-identical.
 #[cfg(target_os = "linux")]
 impl Listener for tokio_vsock::VsockListener {
-    type Stream = tokio_vsock::VsockStream;
+    type Stream = EnobufsBackpressure<tokio_vsock::VsockStream>;
     type Addr = tokio_vsock::VsockAddr;
 
     const TRANSPORT: &'static str = "vsock";
     const IS_LOCAL: bool = true;
 
     async fn accept(&self) -> std::io::Result<(Self::Stream, Self::Addr)> {
-        tokio_vsock::VsockListener::accept(self).await
+        tokio_vsock::VsockListener::accept(self)
+            .await
+            .map(|(stream, addr)| (EnobufsBackpressure::new(stream), addr))
     }
 }
 


### PR DESCRIPTION
Fixes [#869](https://github.com/gominimal/minimal/issues/869).

## What actually breaks

A `write(2)` on the guest AF_VSOCK socket fails with `ENOBUFS` (os error 105)
when the virtio TX virtqueue is full — the guest has queued more than the
host-side VMM has drained. `tokio-vsock` reaches that error *through* an already
satisfied write-readiness guard and surfaces the raw errno as an `io::Error`
that is **not** `ErrorKind::WouldBlock`, so nothing above it retries. In
`minimald` the error then escapes through russh and kills the **entire SSH
connection** rather than the one channel that was writing — which is why the
client sees `Failed to upload project files: … channel closed`, and why
`boot.log` shows the failure at connection scope:

```
WARN conn{conn=5 transport="vsock"}: minimald::server: session ended with error
     error=Protocol error: No buffer space available (os error 105)
```

## Measured evidence (controlled experiments, each repeated 3×)

The failure is **not** intermittent, not memory exhaustion, and not a function
of payload size, file count or wall-clock duration. The discriminator is the
client's *instantaneous write rate* into the vsock:

| Payload | Compresses to | Result |
|---|---|---|
| 512 MB incompressible random data | ~512 MB | **passes** — zstd self-throttles the client to ~180–256 MB/s |
| 20,000 small files / 78 MB | — | **passes** |
| 45 MiB slice of an ext4 image | 12.8 MB | **fails every time**, `ENOBUFS` 0.60 s after the connection is accepted |
| same-size slice, low entropy | 0.11 MB | **passes every time** |

Two further results pin down the mechanism:

- Inserting `tokio::time::sleep(1µs)` after each 64 KB client write makes it
  pass, including a 1.28 GB upload that ran 22 s.
- Replacing that sleep with `tokio::task::yield_now()` still **fails** at 0.60 s.
  Chunking to 64 KB with no sleep also still fails.

So the transport needs *wall-clock time to drain*, not scheduler fairness. Host
resources are not implicated (18 logical cores / 128 GiB, guest 10 vCPU /
16 GiB, zero swap in use, 8 host cores idle).

## The fix

A new `EnobufsBackpressure<S>` adapter (`crates/minimald/src/backpressure.rs`)
wraps the accepted vsock stream and restores the backpressure semantics every
caller above it already assumes:

- A write attempt failing with `ENOBUFS` — matched on
  `raw_os_error() == Some(libc::ENOBUFS)`, never on the rendered message — is
  retried after a short sleep instead of propagating.
- Backoff starts at 100 µs, doubles to a 4 ms cap, and **resets** as soon as any
  write lands. (Tokio's timer granularity is 1 ms, so the first step is in
  practice "one timer tick".)
- A contiguous run of `ENOBUFS` lasting longer than **5 s** gives up and returns
  the underlying `io::Error` unchanged, so a genuinely wedged transport still
  surfaces exactly as it does today rather than hanging the session forever.
- Reads, flush, shutdown and every non-`ENOBUFS` error pass through untouched. A
  healthy stream behaves exactly like the stream it wraps.
- `tracing::warn!` when the retry loop first engages and when it gives up (with
  retry count and elapsed time), so this is visible in `boot.log` next time.
  Subsequent stalls on the same stream drop to `DEBUG` so a sustained upload
  cannot bury the log under its own backpressure.

### Why a timer rather than a readiness wait

Registering the waker and returning `Poll::Pending` is the idiomatic move, and
it is wrong here. `tokio-vsock`'s `poll_write_priv` obtains a write-readiness
guard and then calls `write(2)`; a non-`WouldBlock` error does **not** clear that
readiness, so there is no guarantee of a fresh writability edge to wake on — the
wait can hang forever, while a bare retry-on-wake loop would busy-spin instead.
What clears the condition is the host draining the virtqueue, which costs
wall-clock time. The sleep-fixes / `yield_now`-does-not result above is the
direct evidence for that.

### Why this is not blunt throttling

Nothing is inserted into the healthy path. No rate limit, no chunking, no
unconditional sleep, and no allocation at all while writes are succeeding — the
fast path costs one `Option::is_none()` check. The backoff exists only while
`ENOBUFS` is actually being returned and unwinds the moment a write lands.

### Relationship to the libkrun >= 1.19.0 floor

`server.rs` already requires libkrun >= 1.19.0 because 1.18.1 had a
multi-descriptor TX-chain bug in its vsock device. This is a different problem
and a different kind of fix: the device is behaving *correctly* here — a full
queue is a legitimate state — but the socket reports it as a fatal error rather
than as backpressure. This adapter is a mitigation for a transport that
under-delivers backpressure. It does not work around a device defect and it does
not substitute for the version floor.

### Blast radius

Applied to the vsock listener's accepted stream only. The UDS path stays
byte-identical: `ENOBUFS` is not one of its failure modes, and narrowing the
blast radius matters more than uniformity here.

## Tests

Six unit tests against a mock writer with a scripted error sequence, in
`crates/minimald/src/backpressure.rs`. The adapter is generic over the inner
`AsyncRead + AsyncWrite` stream precisely so this is testable without a VM:

- N transient `ENOBUFS` then success — the write completes, and every attempt is
  accounted for.
- The backoff resets after a successful write — observed through the *cadence*
  of write attempts under `tokio::test(start_paused)`, not by reaching into
  internal state.
- A stall past the 5 s deadline propagates the original error unchanged.
- A non-`ENOBUFS` error (`EPIPE`) propagates immediately and is never retried.
- Reads pass through untouched.
- A read error is propagated even when it is `ENOBUFS` (reads are never
  retried).

## Verification: what was and was not done

**Done.** macOS cannot build `minimald` at all (it depends on `procfs`), so
everything below ran under `cross` + Docker against
`aarch64-unknown-linux-musl`, matching `just test-cross`:

```
$ CROSS_CONTAINER_OPTS="--env HOME=/tmp" cross test -p minimald --lib \
      --target aarch64-unknown-linux-musl --locked
running 151 tests
...
test backpressure::tests::a_non_enobufs_error_is_never_retried ... ok
test backpressure::tests::a_read_error_is_propagated_even_when_it_is_enobufs ... ok
test backpressure::tests::a_stall_past_the_deadline_propagates_the_original_error ... ok
test backpressure::tests::backoff_resets_after_a_successful_write ... ok
test backpressure::tests::reads_pass_through_untouched ... ok
test backpressure::tests::transient_enobufs_is_retried_until_the_write_lands ... ok

test result: ok. 151 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The full `cross test -p minimald` (all targets, including the integration
harnesses) is green as well; the `netns_root_integration` cases stay `ignored`
as they do on `main` — they are gated on `MINIMALD_NETNS_TEST` and run in the
`ci-linux-native` netns job.

`cross clippy -p minimald --all-targets --target aarch64-unknown-linux-musl -- -D warnings`
is clean, and `cargo fmt --all --check` passes.

**Not done:** this has **not** been verified in-guest. Confirming the fix for
real requires rebuilding the guest initramfs and restarting the VM, and a live
VM was in use on the development host. No `minvmd`, `min` binary, initramfs or
daemon state was rebuilt, re-signed or restarted for this change. **CI and an
in-guest run are the gates.**

### Repro recipe for whoever verifies in-guest

The trigger is a payload that compresses well enough that zstd does *not*
self-throttle the client, yet not so well that the compressed stream is trivial
— about 3.5:1. The measured case was a 45 MiB slice of an ext4 image, which
`zstd -3` takes to 12,784,144 bytes:

```sh
mkdir -p /tmp/enobufs-repro && cd /tmp/enobufs-repro
# 45 MiB at ~3.5:1. An ext4 image slice is what was measured; any payload with
# a comparable ratio should do.
dd if=/path/to/some.ext4 of=slice.bin bs=1M count=45
zstd -c -3 slice.bin | wc -c   # expect ~12.8 MB; 0.11 MB or ~45 MB will NOT repro

min activate --loadout dev --name enobufs-repro --attach .
```

Before this change that fails ~0.60 s after the vsock connection is accepted,
with `Failed to upload project files: copying tar stream to channel: channel
closed` on the client and the `session ended with error … (os error 105)` line
above in `boot.log`.

After this change the upload should complete. If the queue does fill, `boot.log`
carries `vsock tx queue full; engaging ENOBUFS backoff` at `WARN` once per
connection and nothing further. A `vsock tx queue still full past the ENOBUFS
stall deadline` `WARN` would mean the 5 s bound was reached and the error was
propagated exactly as before — that is the signal to widen the bound rather than
assume the fix regressed.

Controls that should keep passing either way: a 45 MiB all-zero file (compresses
to ~0.11 MB) and 512 MB from `/dev/urandom` (incompressible, so zstd
self-throttles the client).

## Adjacent things noticed, deliberately not touched

- `Server::run`'s benign-hangup classification (`server.rs`) matches on the
  rendered error string (`"early eof"`, `"Broken pipe"`, `"Disconnected"`). It is
  log framing only and the existing comment says so, but it is the same class of
  fragility this PR is careful to avoid on the `ENOBUFS` match.
- The `ENOBUFS` tore down the *whole* SSH connection rather than just the upload
  channel. This PR stops the error being raised in the common case, but the
  blast-radius question — should one channel's write error kill the session? —
  is untouched and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry ENOBUFS errors on the guest vsock write path with exponential backoff
> - Adds `EnobufsBackpressure<S>` in [backpressure.rs](https://github.com/gominimal/minimal/pull/874/files#diff-0a70211243435ecd6e988b758927d8bae895f0fb15e45beac4b51f36baae6ccd), an `AsyncRead + AsyncWrite` adapter that retries writes failing with `ENOBUFS` using exponential backoff (100µs initial, 4ms max, 5s deadline before giving up).
> - Wraps accepted `VsockStream` connections with `EnobufsBackpressure` in [server.rs](https://github.com/gominimal/minimal/pull/874/files#diff-6194757015134b93b4dd82adff3e05ff12029271e611911d4c2ebfcdec5095b4) so all vsock writes automatically get this retry behavior.
> - Non-`ENOBUFS` errors and all reads pass through unchanged.
> - Tests use `#[tokio::test(start_paused = true)]` with the `test-util` Tokio feature to verify backoff timing without real delays.
> - Behavioral Change: vsock write calls that previously surfaced `ENOBUFS` immediately will now stall for up to 5s before propagating the error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a48fe23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->