### PR TITLE
feat(minimal): guest fetch and degraded-mode fallback for `min bug`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3768,6 +3768,7 @@ dependencies = [
  "sessions",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "toml",
  "toml_edit",
  "tracing",

--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -43,7 +43,14 @@ russh.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sessions.workspace = true
+# Staging for the `min bug` volume fallback: `debugfs -c` rdumps the guest's
+# /logs into a temp dir before the readable files are tail-capped into the
+# bundle.
+tempfile.workspace = true
 tokio.workspace = true
+# Iterating `async_tar::Archive::entries()` (a `Stream`) for the bounded
+# streaming verification of a nested guest bundle.
+tokio-stream.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 tracing.workspace = true
@@ -60,7 +67,6 @@ inquire.workspace = true
 
 [dev-dependencies]
 minimald = { path = "../minimald", features = ["test-support"] }
-tempfile.workspace = true
 # `test-util` (not in tokio's `full`) for `#[tokio::test(start_paused = true)]`:
 # lets the client's handshake-deadline test elapse in virtual time.
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -237,6 +237,147 @@ impl Client {
         }
         Ok(())
     }
+
+    /// Requests the daemon's diagnostic bundle (`min bug`): sends `req` on the
+    /// [`minimald_rpc::DIAG_BUNDLE_SUBSYSTEM`] subsystem and collects the
+    /// streamed tar+zstd archive, up to `max_bytes`.
+    ///
+    /// Returns `(bytes, truncated)`. Errors the daemon reports — before or
+    /// during streaming — arrive over extended-data stream 1 and become the
+    /// `Err` here, discarding any partial bundle; a refused subsystem request
+    /// means the daemon predates the RPC.
+    ///
+    /// Hitting `max_bytes` ends *collection*, not the conversation: the
+    /// daemon may already have queued an error behind the frames that tripped
+    /// the cap, so the channel is drained for
+    /// [`TRUNCATED_DRAIN_GRACE`] — payload discarded, extended data kept —
+    /// before returning. That window is deliberately short: a daemon still
+    /// streaming a runaway archive cannot be waited out without handing it
+    /// the caller's whole deadline, and losing an already-capped bundle to a
+    /// timeout is worse than missing a message that had not been sent yet.
+    /// So an error the daemon emits *after* the cap trips is not observed.
+    pub async fn download_diag_bundle(
+        &mut self,
+        req: &minimald_rpc::DiagBundleRequest,
+        max_bytes: usize,
+    ) -> Result<(Vec<u8>, bool), anyhow::Error> {
+        let mut channel = self
+            .handle
+            .channel_open_session()
+            .await
+            .context("open channel for diagnostic bundle")?;
+
+        send_traceparent(&channel).await;
+        channel
+            .request_subsystem(true, minimald_rpc::DIAG_BUNDLE_SUBSYSTEM)
+            .await
+            .context(
+                "request DiagBundleTarZst subsystem \
+                 (daemon may predate the diagnostics RPC — upgrade minimald)",
+            )?;
+
+        let body = serde_json::to_vec(req).context("serialize diag request")?;
+        channel
+            .data(&body[..])
+            .await
+            .context("write diag request")?;
+        channel.eof().await.context("half-close diag request")?;
+
+        // Data carries the archive; extended-data stream 1 carries the
+        // daemon's error message.
+        let mut bundle = Vec::new();
+        let mut daemon_error = Vec::new();
+        let mut truncated = false;
+        while let Some(msg) = channel.wait().await {
+            match msg {
+                russh::ChannelMsg::Data { data } => {
+                    if bundle.len() + data.len() > max_bytes {
+                        bundle.extend_from_slice(&data[..max_bytes - bundle.len()]);
+                        truncated = true;
+                        break;
+                    }
+                    bundle.extend_from_slice(&data);
+                }
+                russh::ChannelMsg::ExtendedData { data, ext: 1 } => {
+                    append_daemon_error(&mut daemon_error, &data);
+                }
+                // The daemon refused the subsystem (`want_reply` failure). A
+                // healthy daemon replies `Success` then streams; a refusal
+                // means it doesn't serve this RPC — bail now rather than block
+                // on `wait()` until the caller's deadline, since a bare refusal
+                // doesn't close the channel.
+                russh::ChannelMsg::Failure => anyhow::bail!(
+                    "daemon refused the {} subsystem — it likely predates the \
+                     diagnostics RPC (upgrade minimald)",
+                    minimald_rpc::DIAG_BUNDLE_SUBSYSTEM
+                ),
+                _ => {}
+            }
+        }
+
+        // The cap stopped the collection loop, but an error the daemon put on
+        // the wire before that point may still be queued behind the frames
+        // that tripped it. Returning now would drop it and report a corrupt
+        // partial archive as a clean truncation. Payload is discarded here —
+        // the bundle is already at its cap — and only extended data is kept.
+        if truncated {
+            let drained = tokio::time::timeout(TRUNCATED_DRAIN_GRACE, async {
+                while let Some(msg) = channel.wait().await {
+                    if let russh::ChannelMsg::ExtendedData { data, ext: 1 } = msg {
+                        append_daemon_error(&mut daemon_error, &data);
+                    }
+                }
+            })
+            .await;
+            if drained.is_err() {
+                tracing::debug!(
+                    grace = ?TRUNCATED_DRAIN_GRACE,
+                    "daemon still streaming after the diag bundle cap; \
+                     stopped waiting for a trailing error"
+                );
+            }
+        }
+
+        // A daemon error can also arrive mid-stream (tar finalization failed
+        // after bytes were sent); a partial archive without the error would be
+        // a silently corrupt diagnostic.
+        if !daemon_error.is_empty() {
+            let msg = String::from_utf8_lossy(&daemon_error);
+            anyhow::bail!(
+                "daemon reported an error{}: {msg}",
+                if bundle.is_empty() {
+                    ""
+                } else {
+                    " after streaming a partial bundle"
+                }
+            );
+        }
+        if bundle.is_empty() {
+            anyhow::bail!("daemon sent no bundle");
+        }
+        Ok((bundle, truncated))
+    }
+}
+
+/// Cap on the accumulated daemon error message (extended-data stream 1) for a
+/// diagnostic-bundle download.
+const DAEMON_ERROR_MAX: usize = 64 * 1024;
+
+/// How long [`Client::download_diag_bundle`] keeps reading after the size cap
+/// trips, looking for an error the daemon already sent.
+///
+/// Sized for "already on the wire", not for "will finish streaming": a daemon
+/// with gigabytes still to write cannot be drained to completion without
+/// spending the caller's entire `--guest-timeout-secs`, which would turn a
+/// usable truncated bundle into a total loss.
+const TRUNCATED_DRAIN_GRACE: Duration = Duration::from_secs(2);
+
+/// Appends `data` to the daemon's error message, bounded: a daemon streaming
+/// only extended data must not balloon the CLI past the bound the archive
+/// itself respects.
+fn append_daemon_error(buf: &mut Vec<u8>, data: &[u8]) {
+    let room = DAEMON_ERROR_MAX.saturating_sub(buf.len());
+    buf.extend_from_slice(&data[..room.min(data.len())]);
 }
 
 /// Resolve the provider-instance dir (`<state dir>/providers/local-0`) the

--- a/crates/minimal/src/diag/collect.rs
+++ b/crates/minimal/src/diag/collect.rs
@@ -208,12 +208,91 @@ pub async fn state(w: &mut BundleWriter, paths: &DiagPaths) -> Result<(), anyhow
 /// How many rotated files per log prefix make it into the bundle.
 const LOG_FILES_PER_PREFIX: usize = 5;
 
+/// The one phrasing that asserts a file simply is not there.
+///
+/// A skip may only carry it when nothing in the bundle — at any nesting level
+/// — holds the path it names. [`explain_absent_log_prefixes`] is where that is
+/// decided for the log prefixes; the constant exists so the invariant test can
+/// find every skip that makes the claim.
+const NO_SUCH_FILES: &str = "no files with this prefix";
+
+/// Where the daemon behind a log prefix runs — which decides whether the
+/// absence of its files under `<state>/logs` is the whole story.
+#[derive(Debug, Clone, Copy)]
+enum Locality {
+    /// A host process. Nothing under `<state>/logs` means nothing was written.
+    Host,
+    /// Not necessarily a host process at all: on macOS minimald runs *inside*
+    /// the microVM and logs to the guest data volume, so its records reach the
+    /// bundle through the per-provider guest fetch and never through this
+    /// directory. "Not here" is then a fact about this directory only.
+    HostOrGuest,
+}
+
+/// One searched log prefix and where its writer lives. Only obtainable from
+/// [`LOG_PREFIXES`], so a caller cannot invent a prefix with the wrong
+/// locality.
+#[derive(Debug, Clone, Copy)]
+pub struct LogPrefix {
+    name: &'static str,
+    locality: Locality,
+}
+
+/// The prefixes [`logs`] harvests from `<state>/logs`.
+const LOG_PREFIXES: [LogPrefix; 2] = [
+    LogPrefix {
+        name: "minimald.log",
+        locality: Locality::HostOrGuest,
+    },
+    LogPrefix {
+        name: "minvmd.log",
+        locality: Locality::Host,
+    },
+];
+
+/// What the provider loop established about the daemon's own logs reaching
+/// the bundle by another route — the fact a host-side absence has to be read
+/// against.
+///
+/// Every variant is a distinct epistemic state, because the skip reason is a
+/// claim and only two of these license the strong one. "The listing failed"
+/// is not "there are none", and "a bundle arrived" is not "the logs are in
+/// it": collapsing either into its neighbour is how the manifest ends up
+/// asserting something the archive does not back.
+#[derive(Debug, Clone, Copy)]
+pub enum DaemonLogSources<'a> {
+    /// The provider directory could not be listed, so whether any daemon
+    /// logged elsewhere is *unknown*. Absence may not be claimed.
+    ProvidersUnknown,
+    /// No provider instance exists, so no daemon could have logged elsewhere.
+    NoProviders,
+    /// Providers exist, but none yielded a daemon bundle this run.
+    NoneFetched,
+    /// These providers' nested bundles verified and were observed to hold
+    /// `logs/minimald.log*`. Non-empty by construction.
+    Nested(&'a [&'a str]),
+    /// A nested bundle arrived from these providers, but this run could not
+    /// confirm it holds the daemon's logs — truncated, failed verification,
+    /// or verified with no such entry. Non-empty by construction.
+    NestedUnconfirmed(&'a [&'a str]),
+}
+
+/// Collects the host-side log tails.
+///
+/// Prefixes that matched no file are *reported back* through `absent` rather
+/// than skipped on the spot: whether "nothing under `<state>/logs`" also means
+/// "nothing in this bundle" depends on what the provider loop finds
+/// afterwards, and the shared collector contract (`collect_step!`) fixes this
+/// signature's return type at `Result<(), _>`.
+/// [`explain_absent_log_prefixes`] records those skips once the answer is in.
+///
 /// `tail_bytes` is the per-file cap, already validated by the caller against
 /// [`diagnostics::MAX_LOG_TAIL_BYTES`].
 pub async fn logs(
     w: &mut BundleWriter,
     paths: &DiagPaths,
     tail_bytes: u64,
+    absent: &mut Vec<LogPrefix>,
 ) -> Result<(), anyhow::Error> {
     let log_dir = paths.state.join("logs");
     // Absence and inaccessibility are different facts: "no log directory"
@@ -225,11 +304,11 @@ pub async fn logs(
         }
         Err(e) => w.skip("logs/", format!("unreadable: {e}")),
         Ok(_) => {
-            for prefix in ["minimald.log", "minvmd.log"] {
+            for prefix in LOG_PREFIXES {
                 let files =
-                    diagnostics::newest_rotated(&log_dir, prefix, LOG_FILES_PER_PREFIX).await;
+                    diagnostics::newest_rotated(&log_dir, prefix.name, LOG_FILES_PER_PREFIX).await;
                 if files.is_empty() {
-                    w.skip(format!("logs/{prefix}*"), "no files with this prefix");
+                    absent.push(prefix);
                     continue;
                 }
                 for path in files {
@@ -261,8 +340,139 @@ pub async fn logs(
             }
         }
     }
-    Ok(())
+
+    // The legend for everything above, plus the daemon logs that arrive
+    // nested from the guest: two overlapping copies of the same output, each
+    // systematically missing what the other has.
+    w.add_bytes(
+        "logs/PROVENANCE.txt",
+        LOG_PROVENANCE.as_bytes(),
+        Redaction::None,
+    )
+    .await
 }
+
+/// Records the skips [`logs`] held back, now that the provider loop has said
+/// whether the daemon's own logs reached the bundle another way.
+///
+/// The plain absence claim ([`NO_SUCH_FILES`]) is made only where it is true
+/// of the *bundle*, not merely of `<state>/logs`. On macOS a `min bug` run
+/// finds no `minimald.log*` on the host — the daemon lives inside the microVM
+/// — while the very same bundle nests those logs under
+/// `providers/<name>/guest/`. A manifest that answers "no files with this
+/// prefix" there teaches a reader to stop looking, which is how a real
+/// incident's daemon logs went unread with 178 KB of them on the volume.
+pub fn explain_absent_log_prefixes(
+    w: &mut BundleWriter,
+    paths: &DiagPaths,
+    absent: &[LogPrefix],
+    sources: DaemonLogSources<'_>,
+) {
+    let log_dir = paths.state.join("logs");
+    let log_dir = log_dir.display();
+    // Where in the bundle a named provider's nested daemon bundle sits.
+    let carriers = |providers: &[&str]| {
+        providers
+            .iter()
+            .map(|p| format!("providers/{p}/guest/daemon-diag.tar.zst"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    for prefix in absent {
+        let reason = match (prefix.locality, sources) {
+            // A host process that wrote nothing here wrote nothing anywhere —
+            // including when the provider listing failed, which says nothing
+            // about a host writer. And with no provider instance there is no
+            // guest to have logged in either. Both are genuine absence.
+            (Locality::Host, _) | (Locality::HostOrGuest, DaemonLogSources::NoProviders) => {
+                format!("{NO_SUCH_FILES} in {log_dir}")
+            }
+            // The listing failed, so whether a guest daemon logged elsewhere
+            // was never established. Saying "absent" here would be asserting
+            // the one thing this run did not find out.
+            (Locality::HostOrGuest, DaemonLogSources::ProvidersUnknown) => format!(
+                "none in {log_dir}, and whether any exist elsewhere is unknown — the \
+                 provider directory could not be listed this run (see the `providers` \
+                 error in this manifest). Where minimald runs inside the microVM it \
+                 logs to the guest data volume, not to this host"
+            ),
+            (Locality::HostOrGuest, DaemonLogSources::Nested(providers)) => format!(
+                "none in {log_dir} — where minimald runs inside the microVM it logs \
+                 to the guest data volume, not to this host. Its own logs are in \
+                 this bundle, nested in {} (see logs/PROVENANCE.txt)",
+                carriers(providers)
+            ),
+            // A bundle came back, so "no daemon bundle was fetched" would be
+            // false; but it was truncated, failed its checks, or held no such
+            // entry, so naming it as the carrier would be false too.
+            (Locality::HostOrGuest, DaemonLogSources::NestedUnconfirmed(providers)) => format!(
+                "none in {log_dir} — where minimald runs inside the microVM it logs \
+                 to the guest data volume, not to this host. A daemon bundle was \
+                 collected at {}, but this run could not confirm it carries them; \
+                 see the guest.* entries in this manifest (see logs/PROVENANCE.txt)",
+                carriers(providers)
+            ),
+            (Locality::HostOrGuest, DaemonLogSources::NoneFetched) => format!(
+                "none in {log_dir} — where minimald runs inside the microVM it logs to \
+                 the guest data volume, not to this host, and no daemon bundle was \
+                 fetched this run; see providers/*/guest/ for why"
+            ),
+        };
+        w.skip(format!("logs/{}*", prefix.name), reason);
+    }
+}
+
+/// Which log is which, and what each one systematically lacks.
+///
+/// Two overlapping copies of the daemon's output can reach a bundle, and
+/// nothing in the archive said so: a reader who found the same lines in both
+/// had no way to know that the console holds the boot prologue and shutdown
+/// epilogue the volume appender can never see, nor that the two are no longer
+/// diffable without normalising format.
+const LOG_PROVENANCE: &str = "\
+Log provenance
+==============
+
+Where each log in this bundle came from, how long it is kept, and what it is
+known to be missing. Two overlapping copies of the daemon's output can appear
+here: they are not duplicates, and neither is a superset of the other.
+
+providers/<name>/boot.log
+  source     the VMM's hvc0 console, mirrored to this file by the VMM child
+  retention  truncated at every boot (created afresh per boot) — only the
+             current boot is present
+  format     human-readable tracing output
+  holds      the boot prologue: every record written before the state volume
+             is mounted (pseudo filesystems mounted, switch to the upstream
+             rootfs, writable state volume mounted, cache + state relocated),
+             and the shutdown epilogue after the volume appender is released
+             (state volume quiesced, connections drained, the final close)
+  lacks      nothing observed; a measured incident window showed no console
+             record absent under saturation
+
+providers/<name>/guest/daemon-diag.tar.zst -> logs/minimald.log.<date>
+  source     the on-volume file appender inside the guest, attached once the
+             state volume mounts
+  retention  daily rotation, 14 files
+  format     JSON lines
+  lacks      the boot prologue (the appender does not exist yet) and the
+             shutdown epilogue (it is released before the volume is quiesced,
+             so a clean shutdown's last records exist only on the console)
+
+providers/<name>/guest/volume-logs/*
+  source     the same on-volume appender, read straight off the ext4 image by
+             the degraded-mode harvest when the daemon could not be reached
+  lacks      the same as above, and may be torn mid-write
+
+An absent minimald.log* under logs/ is a fact about this host's state
+directory, not about the daemon: where minimald runs inside the microVM it
+never writes there. manifest.json's skip entry for that prefix names whichever
+of the sources above carries it instead.
+
+Over the window the console and the volume appender share, their records
+match — but the console is human-format and the volume log is JSON lines, so
+comparing them requires normalising one to the other first.
+";
 
 /// True when an `add_file_tail` failure was a plain missing file.
 fn is_not_found(err: &anyhow::Error) -> bool {
@@ -297,4 +507,398 @@ pub async fn provider_dirs(state: &Path) -> Result<Vec<(String, PathBuf)>, std::
     }
     dirs.sort();
     Ok(dirs)
+}
+
+/// Non-log per-provider evidence: what the instance dir holds, its raw
+/// lifecycle state, and whether anything is still alive behind it (R7.6).
+///
+/// `run.log`/`boot.log` are deliberately *not* collected here — [`logs`]
+/// already tail-caps them for every discovered provider, and a second copy
+/// would be a duplicate archive entry.
+pub async fn provider_files(
+    w: &mut BundleWriter,
+    name: &str,
+    dir: &Path,
+) -> Result<(), anyhow::Error> {
+    // Shallow inventory of the instance dir: which sockets, locks, keys and
+    // images exist. Metadata only — the walk is synchronous, so it runs on a
+    // blocking thread like every other listing.
+    let listing_dir = dir.to_path_buf();
+    let listing = tokio::task::spawn_blocking(move || {
+        diagnostics::listing(&listing_dir, LISTING_MAX_ENTRIES)
+    })
+    .await
+    .context("provider listing worker")?;
+    let dest = format!("providers/{name}/dir-listing.txt");
+    match listing {
+        Ok(listing) => {
+            w.add_bytes(&dest, listing.text.as_bytes(), Redaction::ListingOnly)
+                .await?
+        }
+        Err(e) => w.skip(&dest, format!("unreadable: {e:#}")),
+    }
+
+    w.skip(
+        format!("providers/{name}/ssh_host_ed25519_key"),
+        "private key material — never collected",
+    );
+
+    // Lifecycle state, verbatim (nothing sensitive: enum + pid + timestamp).
+    //
+    // Read through the same `O_NOFOLLOW` discipline as every other bundled
+    // file: `tokio::fs::read` would follow a symlink planted here and copy an
+    // unrelated readable host file into a bundle meant for sharing.
+    let dest = format!("providers/{name}/minvmd.toml");
+    match diagnostics::open_regular_nofollow(&dir.join("minvmd.toml")).await {
+        Ok((mut file, _)) => {
+            let mut bytes = Vec::new();
+            match tokio::io::AsyncReadExt::read_to_end(&mut file, &mut bytes).await {
+                Ok(_) => w.add_bytes(&dest, &bytes, Redaction::None).await?,
+                Err(e) => w.skip(&dest, format!("unreadable: {e}")),
+            }
+        }
+        Err(e) => match e.downcast_ref::<std::io::Error>() {
+            Some(io) if io.kind() == std::io::ErrorKind::NotFound => {}
+            _ => w.skip(&dest, format!("unreadable: {e:#}")),
+        },
+    }
+
+    let status_dir = dir.to_path_buf();
+    let status = tokio::task::spawn_blocking(move || provider_status(&status_dir))
+        .await
+        .context("provider status worker")?;
+    let json = serde_json::to_vec_pretty(&status).context("serializing provider status")?;
+    w.add_bytes(
+        &format!("providers/{name}/status.json"),
+        &json,
+        Redaction::None,
+    )
+    .await
+}
+
+#[derive(Serialize)]
+struct ProviderStatus {
+    /// Raw lifecycle from `minvmd.toml` — never repaired/written back.
+    state: Option<toml::Table>,
+    state_read_error: Option<String>,
+    /// A live minvmd (or its VMM child) holds `minvmd.lock`.
+    minvmd_alive: Option<bool>,
+    /// A live native minimald holds `minimald.lock`.
+    minimald_alive: Option<bool>,
+}
+
+/// Reads the provider's lifecycle state and probes the advisory locks.
+///
+/// Deliberately *not* `StateDir::effective_state()`, which repairs stale state
+/// by writing `Stopped` back — a diagnostic must never mutate what it reads.
+/// Synchronous (file locks and `std::fs`); callers run it on a blocking thread.
+fn provider_status(dir: &Path) -> ProviderStatus {
+    // `StateDir::new` runs `create_dir_all`, so probing a provider whose
+    // directory had been deleted would recreate it — leaving ghost state
+    // behind and making this collector a mutation, which the paragraph above
+    // says it must never be.
+    let state_dir = minvmd::state::StateDir::open_existing(dir.to_path_buf());
+    let (state, state_read_error) = match std::fs::read_to_string(state_dir.state_path()) {
+        Ok(s) => match s.parse::<toml::Table>() {
+            Ok(table) => (Some(table), None),
+            Err(e) => (None, Some(e.to_string())),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (None, None),
+        Err(e) => (None, Some(e.to_string())),
+    };
+    ProviderStatus {
+        state,
+        state_read_error,
+        minvmd_alive: state_dir.daemon_alive().ok(),
+        minimald_alive: state_dir.minimald_alive().ok(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use tokio::io::AsyncReadExt as _;
+    use tokio_stream::StreamExt as _;
+
+    /// Every entry path in a tar+zstd blob.
+    async fn entry_paths(bytes: &[u8]) -> Vec<String> {
+        let decoder = async_compression::tokio::bufread::ZstdDecoder::new(bytes);
+        let mut entries = async_tar::Archive::new(decoder).entries().unwrap();
+        let mut paths = Vec::new();
+        while let Some(entry) = entries.next().await {
+            paths.push(
+                entry
+                    .unwrap()
+                    .path()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+        }
+        paths
+    }
+
+    /// Unpacks a written bundle to `bundle-relative path -> contents`.
+    async fn unpack(out: &Path, root: &str) -> BTreeMap<String, Vec<u8>> {
+        let bytes = tokio::fs::read(out).await.unwrap();
+        let decoder = async_compression::tokio::bufread::ZstdDecoder::new(&bytes[..]);
+        let mut entries = async_tar::Archive::new(decoder).entries().unwrap();
+        let mut files = BTreeMap::new();
+        while let Some(entry) = entries.next().await {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().into_owned();
+            let mut contents = Vec::new();
+            entry.read_to_end(&mut contents).await.unwrap();
+            files.insert(
+                path.strip_prefix(&format!("{root}/"))
+                    .unwrap_or(&path)
+                    .to_string(),
+                contents,
+            );
+        }
+        files
+    }
+
+    fn paths(state: &Path) -> DiagPaths {
+        DiagPaths {
+            config: state.join("config"),
+            state: state.to_path_buf(),
+            cache: state.join("cache"),
+            mesh_enrolment: state.join("enrolment"),
+            cwd: state.to_path_buf(),
+        }
+    }
+
+    /// Records the held-back skips for `sources` over both log prefixes and
+    /// returns the manifest's `what -> reason` map.
+    async fn reasons_for(sources: DaemonLogSources<'_>) -> BTreeMap<String, String> {
+        let dir = tempfile::TempDir::new().unwrap();
+        let out = dir.path().join("diag.tar.zst");
+        let mut w = BundleWriter::create(&out, "r", "v").await.unwrap();
+        explain_absent_log_prefixes(&mut w, &paths(dir.path()), &LOG_PREFIXES, sources);
+        w.finish(chrono::Utc::now(), std::time::Duration::ZERO)
+            .await
+            .unwrap();
+        let files = unpack(&out, "r").await;
+        let manifest: serde_json::Value = serde_json::from_slice(&files["manifest.json"]).unwrap();
+        manifest["skipped"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| {
+                (
+                    s["what"].as_str().unwrap().to_string(),
+                    s["reason"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect()
+    }
+
+    /// The strong claim ([`NO_SUCH_FILES`]) is licensed by only some of the
+    /// states a run can end in. A run that could not list the provider
+    /// directory has not established absence, it has established nothing —
+    /// and "I did not find out" recorded as "it is not there" is the same
+    /// defect as the one this whole path exists to correct.
+    #[tokio::test]
+    async fn plain_absence_is_claimed_only_where_the_run_established_it() {
+        let all = [
+            DaemonLogSources::ProvidersUnknown,
+            DaemonLogSources::NoProviders,
+            DaemonLogSources::NoneFetched,
+            DaemonLogSources::Nested(&["local-0"]),
+            DaemonLogSources::NestedUnconfirmed(&["local-0"]),
+        ];
+
+        // minvmd is a host process wherever the providers are: nothing under
+        // <state>/logs is the whole story in every state.
+        for sources in all {
+            let reasons = reasons_for(sources).await;
+            assert!(
+                reasons["logs/minvmd.log*"].starts_with(NO_SUCH_FILES),
+                "a host-only writer's absence is plain absence under {sources:?}: {reasons:?}"
+            );
+        }
+
+        // minimald may be inside the microVM, so only a *settled* empty
+        // provider list rules out its logs having gone elsewhere.
+        for sources in all {
+            let reasons = reasons_for(sources).await;
+            let claims_absence = reasons["logs/minimald.log*"].starts_with(NO_SUCH_FILES);
+            let established = matches!(sources, DaemonLogSources::NoProviders);
+            assert_eq!(
+                claims_absence,
+                established,
+                "{sources:?} must {} claim absence: {reasons:?}",
+                if established { "" } else { "not" }
+            );
+        }
+    }
+
+    /// Naming a carrier is a claim too. A bundle that arrived truncated or
+    /// failed its checks may be offered as somewhere to look, never as the
+    /// answer — sending a reader to a file that does not hold what they were
+    /// told it holds recreates the dead end in the other direction.
+    #[tokio::test]
+    async fn only_a_confirmed_nested_bundle_is_named_as_the_carrier() {
+        let carrier = "providers/local-0/guest/daemon-diag.tar.zst";
+
+        let confirmed = reasons_for(DaemonLogSources::Nested(&["local-0"])).await;
+        let reason = &confirmed["logs/minimald.log*"];
+        assert!(reason.contains(carrier), "got: {reason}");
+        assert!(reason.contains("are in this bundle"), "got: {reason}");
+
+        let unconfirmed = reasons_for(DaemonLogSources::NestedUnconfirmed(&["local-0"])).await;
+        let reason = &unconfirmed["logs/minimald.log*"];
+        assert!(reason.contains(carrier), "got: {reason}");
+        assert!(reason.contains("could not confirm"), "got: {reason}");
+        assert!(
+            !reason.contains("are in this bundle"),
+            "an unconfirmed carrier must not be asserted as the answer: {reason}"
+        );
+    }
+
+    /// True when a skip's `what` — a bundle path, possibly a `*` suffix glob —
+    /// names `path`.
+    fn names(what: &str, path: &str) -> bool {
+        match what.strip_suffix('*') {
+            Some(prefix) => path.starts_with(prefix),
+            None => path == what,
+        }
+    }
+
+    /// The manifest's contract is that an absent file is always explainable,
+    /// and a reader who trusts it stops looking. So no skip may claim plain
+    /// absence for something the bundle is *carrying* — including inside a
+    /// nested bundle, which is exactly where the guest daemon's logs arrive
+    /// while `<state>/logs` on a macOS host holds none of them.
+    ///
+    /// The invariant is the fix; the wording is only its expression, so this
+    /// asserts over every skip rather than over one message.
+    #[tokio::test]
+    async fn no_skip_claims_absence_for_a_path_the_bundle_carries() {
+        let state = tempfile::TempDir::new().unwrap();
+        // The macOS shape: a log directory with neither prefix in it, because
+        // minimald is inside the microVM and minvmd never ran detached.
+        std::fs::create_dir_all(state.path().join("logs")).unwrap();
+        let paths = paths(state.path());
+
+        let out_dir = tempfile::TempDir::new().unwrap();
+        let out = out_dir.path().join("diag.tar.zst");
+        let mut w = BundleWriter::create(&out, "r", "v").await.unwrap();
+
+        let mut absent = Vec::new();
+        logs(&mut w, &paths, diagnostics::LOG_TAIL_CAP, &mut absent)
+            .await
+            .unwrap();
+        assert_eq!(absent.len(), 2, "both prefixes matched nothing on the host");
+
+        // The guest fetch nested the daemon's own bundle, which carries the
+        // very files the host state dir lacks.
+        let nested = crate::diag::guest::tests::pack(&[
+            ("manifest.json", b"{}"),
+            ("logs/minimald.log.2026-07-16", b"guest daemon log\n"),
+        ])
+        .await;
+        w.add_bytes(
+            "providers/local-0/guest/daemon-diag.tar.zst",
+            &nested,
+            Redaction::None,
+        )
+        .await
+        .unwrap();
+
+        explain_absent_log_prefixes(
+            &mut w,
+            &paths,
+            &absent,
+            DaemonLogSources::Nested(&["local-0"]),
+        );
+        w.finish(chrono::Utc::now(), std::time::Duration::ZERO)
+            .await
+            .unwrap();
+
+        let files = unpack(&out, "r").await;
+        let mut carried: Vec<String> = files.keys().cloned().collect();
+        for (path, bytes) in &files {
+            if path.ends_with(".tar.zst") {
+                carried.extend(entry_paths(bytes).await);
+            }
+        }
+
+        let manifest: serde_json::Value = serde_json::from_slice(&files["manifest.json"]).unwrap();
+        let skipped = manifest["skipped"].as_array().unwrap();
+        for skip in skipped {
+            let (what, reason) = (
+                skip["what"].as_str().unwrap(),
+                skip["reason"].as_str().unwrap(),
+            );
+            if !reason.starts_with(NO_SUCH_FILES) {
+                continue;
+            }
+            assert!(
+                !carried.iter().any(|p| names(what, p)),
+                "manifest claims `{what}` is absent ({reason:?}), but the bundle \
+                 carries it: {carried:?}"
+            );
+        }
+
+        // Non-vacuous in both directions: the claim is still made where it is
+        // true, and the prefix the guest carries points at its carrier.
+        let reason = |what: &str| {
+            skipped
+                .iter()
+                .find(|s| s["what"] == what)
+                .unwrap_or_else(|| panic!("no skip for {what}: {skipped:?}"))["reason"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        };
+        assert!(
+            reason("logs/minvmd.log*").starts_with(NO_SUCH_FILES),
+            "a host-only daemon's absence is still plain absence"
+        );
+        assert!(
+            reason("logs/minimald.log*").contains("providers/local-0/guest/daemon-diag.tar.zst"),
+            "the skip must name where the logs actually are"
+        );
+    }
+
+    /// A reader cannot tell the console mirror and the on-volume appender
+    /// apart, or know what each is missing, unless the bundle says so.
+    #[tokio::test]
+    async fn the_log_provenance_note_distinguishes_the_two_daemon_log_sources() {
+        let state = tempfile::TempDir::new().unwrap();
+        let out_dir = tempfile::TempDir::new().unwrap();
+        let out = out_dir.path().join("diag.tar.zst");
+        let mut w = BundleWriter::create(&out, "r", "v").await.unwrap();
+        logs(
+            &mut w,
+            &paths(state.path()),
+            diagnostics::LOG_TAIL_CAP,
+            &mut Vec::new(),
+        )
+        .await
+        .unwrap();
+        w.finish(chrono::Utc::now(), std::time::Duration::ZERO)
+            .await
+            .unwrap();
+
+        let files = unpack(&out, "r").await;
+        let note = String::from_utf8(files["logs/PROVENANCE.txt"].clone()).unwrap();
+        for expected in [
+            "providers/<name>/boot.log",
+            "hvc0 console",
+            "truncated at every boot",
+            "on-volume file appender",
+            "JSON lines",
+            "boot prologue",
+            "shutdown epilogue",
+        ] {
+            assert!(
+                note.contains(expected),
+                "provenance note lacks {expected:?}"
+            );
+        }
+    }
 }

--- a/crates/minimal/src/diag/guest.rs
+++ b/crates/minimal/src/diag/guest.rs
@@ -1,0 +1,695 @@
+//! Fetching the daemon's own diagnostic bundle for `min bug`.
+//!
+//! The daemon (native minimald or the in-VM one behind the minvmd bridge)
+//! streams a nested tar+zstd archive which is stored **raw** at
+//! `providers/<name>/guest/daemon-diag.tar.zst` — never re-packed, so "what
+//! the daemon said" stays exactly distinguishable from "what the host saw".
+//!
+//! When the daemon cannot be reached at all — the case where its logs matter
+//! most — the host falls back to the data volume image, which is plain ext4
+//! and safe to read read-only while the VM runs.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::Context as _;
+use serde::Serialize;
+use tokio::io::AsyncReadExt as _;
+use tokio_stream::StreamExt as _;
+
+use crate::client::Client;
+use diagnostics::{BundleWriter, LOG_TAIL_CAP, Redaction};
+
+/// Hard cap on the accepted guest bundle. A wedged vsock or a runaway log
+/// cannot make `min bug` itself balloon.
+pub const GUEST_BUNDLE_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+/// Deadline for the `debugfs` harvest of the volume image. It is scanning a
+/// possibly-large image on a possibly-sick disk; the fallback is best-effort.
+const DEBUGFS_TIMEOUT: Duration = Duration::from_secs(10);
+/// Host disk the volume harvest may spend staging `/logs` before the per-file
+/// caps apply. `rdump` writes the whole tree out first, so without this the
+/// only bound on a long-lived guest's logs is the host's free space.
+const VOLUME_HARVEST_MAX_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Where e2fsprogs puts `debugfs` when a plain `PATH` lookup will not find it.
+///
+/// Resolving by bare name alone left R7.5 inert on the primary dev platform:
+/// Homebrew keeps e2fsprogs keg-only, so `debugfs 1.47.4` sits installed and
+/// unreachable while the manifest reports "debugfs unavailable (No such file
+/// or directory)" — ENOENT on *exec*, not on the image, which reads as "the
+/// tool is missing" when it is not. Linux has the same shape: `/sbin` is not
+/// on a non-root user's `PATH`, and `min bug` is run by a user.
+const DEBUGFS_FALLBACK_PATHS: [&str; 4] = [
+    "/opt/homebrew/opt/e2fsprogs/sbin/debugfs",
+    "/usr/local/opt/e2fsprogs/sbin/debugfs",
+    "/usr/sbin/debugfs",
+    "/sbin/debugfs",
+];
+
+/// Picks the `debugfs` to run: whatever `PATH` offers first — an operator who
+/// put one there meant it — then the known install locations.
+///
+/// Falls back to the bare name when nothing is found, so an "unavailable"
+/// diagnosis still comes from a real exec attempt rather than from this probe.
+async fn debugfs_program() -> PathBuf {
+    let path_var = std::env::var_os("PATH").unwrap_or_default();
+    let candidates = std::env::split_paths(&path_var)
+        .map(|dir| dir.join("debugfs"))
+        .chain(DEBUGFS_FALLBACK_PATHS.iter().map(PathBuf::from));
+    for candidate in candidates {
+        if tokio::fs::metadata(&candidate)
+            .await
+            .is_ok_and(|m| m.is_file())
+        {
+            return candidate;
+        }
+    }
+    PathBuf::from("debugfs")
+}
+
+// ── R7.3: bounded verification of the nested bundle ──────────────────────────
+//
+// A malicious or corrupt daemon must not be able to make `min bug` decode an
+// unbounded amount from the blob it hands us. The blob is stored raw either
+// way (R7.3); verification only decides whether the manifest records it as
+// trustworthy. The decode is *streaming into a sink* — the decompressed bytes
+// are counted and dropped, never materialized — and stops the instant a cap
+// trips, so even a pathological input costs only bounded, transient work.
+//
+// Three independent caps, matching R7.3:
+//   * absolute decompressed ceiling — the real memory/CPU guard;
+//   * entry count — the header-dimension bomb (millions of empty members),
+//     which the byte budget deliberately does not charge for;
+//   * `manifest.json` present — a well-formed daemon bundle always ends with
+//     one, so its absence means the stream is not what it claims to be.
+//
+// DEVIATION FROM SPEC — the expansion *ratio*. R7.3 writes "4× the compressed
+// size". Measured against a representative bundle, real diagnostic content
+// (proc tables, JSON, logs — all highly compressible text) expands ~15×, so a
+// literal 4× budget rejects every legitimate nested bundle. The ratio still
+// earns its keep for genuinely large blobs, but below `NESTED_MIN_BUDGET` it is
+// meaningless (a few hundred KB decoded to check is free), so the budget is
+// `clamp(4×compressed, MIN_BUDGET, MAX_DECOMPRESSED)`. The two hard caps the
+// bomb guard actually rests on — the 1 GiB ceiling and the 10k-entry cap — are
+// exactly as specified.
+
+/// Entry-count ceiling for the nested bundle (R7.3). Bounds the header
+/// dimension of a bomb, which the byte budget does not charge for.
+const NESTED_MAX_ENTRIES: usize = 10_000;
+/// Decompressed content is allowed this multiple of the compressed size.
+const NESTED_EXPANSION_RATIO: u64 = 4;
+/// Floor under the ratio budget: below this, the ratio is not a meaningful
+/// bomb signal and decoding this much to find out is free. See the deviation
+/// note above.
+const NESTED_MIN_BUDGET: u64 = 64 * 1024 * 1024;
+/// Absolute ceiling on decompressed content, whatever the ratio allows (R7.3).
+const NESTED_MAX_DECOMPRESSED: u64 = 1024 * 1024 * 1024;
+/// Headroom over the content budget for the stream-level cap, covering the tar
+/// structure the content budget does not charge for: a 512-byte header plus up
+/// to 512 bytes of padding per entry, bounded by [`NESTED_MAX_ENTRIES`].
+///
+/// Without it the stream cap bites *before* the per-entry accounting can, and a
+/// genuine oversize bundle gets reported as an unreadable stream instead of by
+/// the check that actually caught it — the caps still hold, but the manifest
+/// stops naming the real cause.
+const NESTED_STREAM_SLACK: u64 = (NESTED_MAX_ENTRIES as u64 + 1) * 1024;
+
+/// What the guest step left in the bundle for one provider.
+///
+/// Read by [`crate::diag::collect::explain_absent_log_prefixes`], which uses
+/// it to decide what may be said about `logs/minimald.log*` missing from the
+/// host state dir. The distinction between the two nested variants is the
+/// whole point: pointing a reader at a carrier that turns out not to hold the
+/// logs is the same failure mode — a manifest claim the archive does not
+/// back — as claiming plain absence over a bundle that does hold them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuestOutcome {
+    /// A nested bundle that verified *and* was observed to carry
+    /// `logs/minimald.log*`. Only this warrants naming it as the carrier.
+    BundleWithDaemonLogs,
+    /// A nested bundle whose daemon logs this run could not confirm: the
+    /// download was truncated, verification failed, or the stream verified
+    /// with no `logs/minimald.log*` entry in it.
+    BundleUnconfirmed,
+    /// Nothing from the daemon: skipped, unreachable, or the fetch failed.
+    NoBundle,
+}
+
+/// Whether a verified nested bundle was seen to carry the daemon's own logs.
+///
+/// Only meaningful for a verification that ran to completion: the checks
+/// return the instant a cap trips, so a failed verdict has seen only a prefix
+/// of the stream and knows nothing about what the rest holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DaemonLogs {
+    Present,
+    Absent,
+}
+
+/// The prefix a daemon bundle's own log entries carry, mirroring the
+/// `logs/<file>` layout `minimald::diag` writes. The daemon streams rootless,
+/// so nested entries are bare paths with no bundle-name directory above them.
+const NESTED_DAEMON_LOG_PREFIX: &str = "logs/minimald.log";
+
+/// Downloads the daemon bundle over `client` and stores it under
+/// `providers/<provider>/guest/`. On failure writes `error.txt` there,
+/// records a collector error, and falls back to reading the data volume image
+/// from the host ([`volume_fallback`]) — `min bug` always produces a bundle,
+/// and a dead transport is exactly when the guest's logs matter.
+pub async fn collect(
+    w: &mut BundleWriter,
+    provider: &str,
+    provider_dir: &Path,
+    client: &mut Client,
+    timeout: Duration,
+) -> Result<GuestOutcome, anyhow::Error> {
+    let started = Instant::now();
+    let req = minimald_rpc::DiagBundleRequest::default();
+
+    let result = tokio::time::timeout(
+        timeout,
+        client.download_diag_bundle(&req, GUEST_BUNDLE_MAX_BYTES),
+    )
+    .await;
+
+    let dest = format!("providers/{provider}/guest/daemon-diag.tar.zst");
+    let failure = match result {
+        Ok(Ok((bytes, truncated))) => {
+            // Verify before recording, but record either way (R7.3): a bundle
+            // that fails its checks is still the only word from the daemon.
+            let verdict = verify_nested_bundle(&bytes).await;
+            // A truncated stream is still collected — the manifest entry's
+            // redaction records that only the leading bytes survived.
+            let redaction = if truncated {
+                Redaction::Truncated
+            } else {
+                Redaction::None
+            };
+            w.add_bytes(&dest, &bytes, redaction).await?;
+            return Ok(match verdict {
+                // A truncated download is never a confirmed carrier even if
+                // the prefix that arrived happened to verify: what the tail
+                // held is exactly what was lost.
+                Ok(DaemonLogs::Present) if !truncated => GuestOutcome::BundleWithDaemonLogs,
+                Ok(_) => GuestOutcome::BundleUnconfirmed,
+                Err(failed) => {
+                    w.error(
+                        format!("guest.{provider}.verify"),
+                        format!("nested bundle stored unverified — {failed}"),
+                        started.elapsed(),
+                    );
+                    GuestOutcome::BundleUnconfirmed
+                }
+            });
+        }
+        Ok(Err(e)) => format!("guest bundle download failed: {e:#}"),
+        Err(_) => format!("guest bundle download timed out after {timeout:?}"),
+    };
+
+    w.error(format!("guest.{provider}"), &failure, started.elapsed());
+    w.add_bytes(
+        &format!("providers/{provider}/guest/error.txt"),
+        failure.as_bytes(),
+        Redaction::None,
+    )
+    .await?;
+    volume_fallback(w, provider, provider_dir)
+        .await
+        .map(|()| GuestOutcome::NoBundle)
+}
+
+/// Verifies a nested guest bundle by **bounded streaming decode**: the
+/// decompressed stream is drained into a sink, never materialized, and the
+/// decode stops the moment a cap is breached (R7.3).
+///
+/// The `Err` names the check that failed, so the manifest says *why* the
+/// nested bundle is untrusted rather than only that it is. The `Ok` reports
+/// whether the walk saw the daemon's own logs, which is what lets the log
+/// collector name this bundle as their carrier without guessing.
+///
+/// Byte accounting covers entry *content* only; tar headers and padding are
+/// bounded by [`NESTED_MAX_ENTRIES`] instead (10k × 512 B), which keeps a
+/// header-only bomb bounded without letting incompressible padding distort the
+/// content ratio.
+async fn verify_nested_bundle(bytes: &[u8]) -> Result<DaemonLogs, String> {
+    // `clamp` cannot panic here: the floor is a compile-time constant below the
+    // ceiling (64 MiB < 1 GiB).
+    let budget = (bytes.len() as u64)
+        .saturating_mul(NESTED_EXPANSION_RATIO)
+        .clamp(NESTED_MIN_BUDGET, NESTED_MAX_DECOMPRESSED);
+
+    let decoder = async_compression::tokio::bufread::ZstdDecoder::new(bytes);
+    // The per-entry accounting below cannot see everything. `async_tar` reads
+    // GNU longname/longlink and PAX extension bodies to completion inside
+    // `entries()` (`poll_read_all`, archive.rs) before yielding the entry they
+    // belong to, so those bytes bypass both the byte budget and the entry
+    // count — a tiny archive declaring one enormous, highly compressible
+    // extension member would be decoded straight into memory. Capping the
+    // decompressed stream at its source is the only bound that covers reads
+    // this loop never performs.
+    //
+    // Set above the content budget by the tar structure's worth of headroom:
+    // headers come out of this same allowance, so a cap of exactly the budget
+    // would starve the last legitimate body read and report an oversize bundle
+    // as a corrupt one.
+    let limited =
+        tokio::io::AsyncReadExt::take(decoder, budget.saturating_add(NESTED_STREAM_SLACK));
+    let mut entries = async_tar::Archive::new(limited)
+        .entries()
+        .map_err(|e| format!("decode check: not a readable tar stream: {e}"))?;
+
+    let mut decompressed: u64 = 0;
+    let mut count: usize = 0;
+    let mut has_manifest = false;
+    let mut has_daemon_logs = false;
+    while let Some(entry) = entries.next().await {
+        let entry =
+            entry.map_err(|e| format!("decode check: entry {} unreadable: {e}", count + 1))?;
+        count += 1;
+        if count > NESTED_MAX_ENTRIES {
+            return Err(format!(
+                "entry-count check: more than {NESTED_MAX_ENTRIES} entries"
+            ));
+        }
+        // Both observations require a *regular file*: a directory or symlink
+        // wearing the name is not the thing a reader would be sent to find.
+        if entry.header().entry_type().is_file()
+            && let Ok(path) = entry.path()
+        {
+            has_manifest |= path.as_os_str() == std::ffi::OsStr::new("manifest.json");
+            has_daemon_logs |= path.to_string_lossy().starts_with(NESTED_DAEMON_LOG_PREFIX);
+        }
+        // One byte past what is left of the budget: enough to observe the
+        // breach, never enough to be one.
+        let room = budget - decompressed;
+        decompressed += tokio::io::copy(&mut entry.take(room + 1), &mut tokio::io::sink())
+            .await
+            .map_err(|e| format!("decode check: entry {count} body unreadable: {e}"))?;
+        if decompressed > budget {
+            return Err(format!(
+                "size check: decompressed past the {budget}-byte budget \
+                 ({NESTED_EXPANSION_RATIO}x of {} compressed, clamped to \
+                 [{NESTED_MIN_BUDGET}, {NESTED_MAX_DECOMPRESSED}])",
+                bytes.len()
+            ));
+        }
+    }
+    if !has_manifest {
+        return Err("manifest check: no manifest.json in the nested bundle".to_string());
+    }
+    Ok(if has_daemon_logs {
+        DaemonLogs::Present
+    } else {
+        DaemonLogs::Absent
+    })
+}
+
+// ── R7.5: volume fallback ────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct VolumeMeta {
+    path: String,
+    exists: bool,
+    bytes: Option<u64>,
+    mtime_unix: Option<u64>,
+}
+
+/// Host-side fallback when the daemon's own bundle couldn't be fetched: the
+/// data volume is plain ext4 and safe to read read-only while the VM runs.
+/// Records the image's vital signs (its mtime alone dates a stall) and
+/// best-effort harvests `/logs` from it via `debugfs -c` when e2fsprogs is
+/// installed; otherwise leaves the exact offline command in the manifest.
+pub async fn volume_fallback(
+    w: &mut BundleWriter,
+    provider: &str,
+    provider_dir: &Path,
+) -> Result<(), anyhow::Error> {
+    let image = provider_dir.join("data-vol.raw");
+    // "Absent" and "unreadable" are different diagnoses and must not collapse
+    // into the same `exists: false`. This runs when the daemon is already
+    // suspect, so "the image is not there" versus "the image is there and I
+    // could not read it" is often the answer itself.
+    let meta = match tokio::fs::metadata(&image).await {
+        Ok(m) => Some(m),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => {
+            w.error(
+                format!("guest.{provider}.volume_fallback"),
+                format!("stat {}: {e}", image.display()),
+                std::time::Duration::ZERO,
+            );
+            None
+        }
+    };
+    let info = VolumeMeta {
+        path: image.display().to_string(),
+        exists: meta.is_some(),
+        bytes: meta.as_ref().map(std::fs::Metadata::len),
+        mtime_unix: meta
+            .as_ref()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs()),
+    };
+    let json = serde_json::to_vec_pretty(&info).context("serializing volume meta")?;
+    w.add_bytes(
+        &format!("providers/{provider}/guest/volume-meta.json"),
+        &json,
+        Redaction::None,
+    )
+    .await?;
+    if meta.is_none() {
+        return Ok(());
+    }
+
+    let dest_dir = format!("providers/{provider}/guest/volume-logs");
+    // Resolved once and quoted into the hint: when the harvest is declined or
+    // fails, the reader gets the command that will actually run on this host,
+    // not one that depends on their `PATH` looking like ours.
+    let debugfs = debugfs_program().await;
+    let hint = format!(
+        "harvest offline with: {} -c -R 'rdump /logs .' {}",
+        debugfs.display(),
+        image.display()
+    );
+    // `rdump` writes the whole tree to disk before anything caps it, and the
+    // deadline below bounds only how long that runs — not how much it writes.
+    // A guest that has been logging for weeks would spend the host's free
+    // space during `min bug`, which is a poor trade for a best-effort
+    // fallback. Size the harvest first and decline one that does not fit.
+    match logs_tree_bytes(&debugfs, &image).await {
+        Ok(total) if total > VOLUME_HARVEST_MAX_BYTES => {
+            w.skip(
+                &dest_dir,
+                format!(
+                    "/logs is {total} bytes, over the {VOLUME_HARVEST_MAX_BYTES}-byte \
+                     harvest budget — not spending that much host disk here; {hint}"
+                ),
+            );
+            return Ok(());
+        }
+        Ok(_) => {}
+        // Unsized is not a reason to refuse: `ls -l` may fail on a corrupt
+        // image that `rdump` can still salvage something from, and that is
+        // exactly the case this fallback exists for. The deadline still caps it.
+        Err(e) => w.skip(
+            format!("{dest_dir}/.size-check"),
+            format!("could not size /logs before harvesting ({e}); proceeding"),
+        ),
+    }
+
+    let tmp = tempfile::TempDir::new().context("tempdir for volume harvest")?;
+    let rdump = format!("rdump /logs {}", tmp.path().display());
+    let result = tokio::time::timeout(
+        DEBUGFS_TIMEOUT,
+        tokio::process::Command::new(&debugfs)
+            .args(["-c", "-R", &rdump])
+            .arg(&image)
+            // On timeout the dropped future must not leave debugfs scanning a
+            // large image after its target TempDir is gone.
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await;
+    match result {
+        Ok(Ok(out)) => {
+            let harvested = harvest_dir(w, &dest_dir, &tmp.path().join("logs")).await;
+            // Only treat as successful if debugfs succeeded (zero exit) AND files
+            // were harvested; a nonzero exit means the dump may be partial/corrupt.
+            if !out.status.success() {
+                let code = out.status.code().unwrap_or(-1);
+                let first_err = String::from_utf8_lossy(&out.stderr)
+                    .lines()
+                    .next()
+                    .unwrap_or("no stderr")
+                    .to_string();
+                w.skip(
+                    &dest_dir,
+                    format!("debugfs exited with code {code} ({first_err}); {hint}"),
+                );
+            } else if harvested == 0 {
+                let first_err = String::from_utf8_lossy(&out.stderr)
+                    .lines()
+                    .next()
+                    .unwrap_or("no debugfs output")
+                    .to_string();
+                w.skip(
+                    &dest_dir,
+                    format!("debugfs harvested nothing ({first_err}); {hint}"),
+                );
+            }
+        }
+        Ok(Err(e)) => w.skip(&dest_dir, format!("debugfs unavailable ({e}); {hint}")),
+        Err(_) => w.skip(
+            &dest_dir,
+            format!("debugfs timed out after {DEBUGFS_TIMEOUT:?}; {hint}"),
+        ),
+    }
+    Ok(())
+}
+
+/// Total size of the regular files `debugfs` reports directly under `/logs`.
+///
+/// `ls -l` prints one row per entry; the mode is column 2 and the size is
+/// column 6. Only `100***` (regular file) rows count — directories and the
+/// `.`/`..` entries carry sizes that are not payload. Rows that do not parse
+/// are ignored rather than failing the check: this is a pre-flight estimate,
+/// and the deadline remains the backstop.
+async fn logs_tree_bytes(debugfs: &Path, image: &Path) -> Result<u64, String> {
+    let out = tokio::time::timeout(
+        DEBUGFS_TIMEOUT,
+        tokio::process::Command::new(debugfs)
+            .args(["-c", "-R", "ls -l /logs"])
+            .arg(image)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .map_err(|_| format!("timed out after {DEBUGFS_TIMEOUT:?}"))?
+    .map_err(|e| e.to_string())?;
+
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| {
+            let cols: Vec<&str> = line.split_whitespace().collect();
+            match cols.as_slice() {
+                [_, mode, ..] if !mode.starts_with("100") => None,
+                [_, _, _, _, _, size, ..] => size.parse::<u64>().ok(),
+                _ => None,
+            }
+        })
+        .sum())
+}
+
+/// Adds every regular file directly under `src` to the bundle under
+/// `dest_dir`, tail-capped. Returns how many made it.
+async fn harvest_dir(w: &mut BundleWriter, dest_dir: &str, src: &Path) -> usize {
+    let Ok(mut entries) = tokio::fs::read_dir(src).await else {
+        return 0;
+    };
+    let mut added = 0usize;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        if !entry.file_type().await.is_ok_and(|t| t.is_file()) {
+            continue;
+        }
+        let dest = format!("{dest_dir}/{}", entry.file_name().to_string_lossy());
+        match w.add_file_tail(&dest, &entry.path(), LOG_TAIL_CAP).await {
+            Ok(()) => added += 1,
+            Err(e) => w.skip(&dest, format!("unreadable: {e}")),
+        }
+    }
+    added
+}
+
+/// Records why guest collection didn't run (no daemon, `--no-guest`).
+pub async fn record_skipped(
+    w: &mut BundleWriter,
+    provider: &str,
+    reason: &str,
+) -> Result<(), anyhow::Error> {
+    w.add_bytes(
+        &format!("providers/{provider}/guest/error.txt"),
+        reason.as_bytes(),
+        Redaction::None,
+    )
+    .await
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt as _;
+
+    /// Packs `entries` into a tar+zstd blob the way a daemon would stream it.
+    pub(crate) async fn pack(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let encoder = async_compression::tokio::write::ZstdEncoder::new(Vec::new());
+        let mut builder = async_tar::Builder::new(encoder);
+        for (path, contents) in entries {
+            let mut header = async_tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(async_tar::EntryType::Regular);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, path, *contents)
+                .await
+                .unwrap();
+        }
+        let mut encoder = builder.into_inner().await.unwrap();
+        encoder.shutdown().await.unwrap();
+        encoder.into_inner()
+    }
+
+    #[tokio::test]
+    async fn a_well_formed_bundle_verifies() {
+        let bytes = pack(&[("meta.json", b"{}"), ("manifest.json", b"{}")]).await;
+        verify_nested_bundle(&bytes).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_bundle_without_a_manifest_fails_the_manifest_check() {
+        let bytes = pack(&[("meta.json", b"{}"), ("logs/minimald.log", b"hi")]).await;
+        let err = verify_nested_bundle(&bytes).await.unwrap_err();
+        assert!(err.starts_with("manifest check:"), "got: {err}");
+    }
+
+    /// A classic decompression bomb: an enormous run of zeros that zstd
+    /// squeezes to a few hundred bytes. The decode must stop at the budget
+    /// (the [`NESTED_MIN_BUDGET`] floor here, since 4× the tiny compressed
+    /// size is far below it), orders of magnitude short of the real size.
+    #[tokio::test]
+    async fn a_decompression_bomb_fails_the_size_check() {
+        // Comfortably past the floor so the size cap — not the entry cap —
+        // is what trips; zeros decode fast enough that draining to the floor
+        // costs the test nothing meaningful.
+        let bomb = vec![0u8; (NESTED_MIN_BUDGET + 8 * 1024 * 1024) as usize];
+        let bytes = pack(&[("manifest.json", b"{}"), ("bomb.bin", &bomb)]).await;
+        assert!(
+            (bytes.len() as u64).saturating_mul(NESTED_EXPANSION_RATIO) < NESTED_MIN_BUDGET,
+            "test bomb must compress below the budget floor, got {} bytes",
+            bytes.len()
+        );
+        let err = verify_nested_bundle(&bytes).await.unwrap_err();
+        assert!(err.starts_with("size check:"), "got: {err}");
+    }
+
+    /// The other bomb shape: no content at all, just more members than any
+    /// real bundle has. Header bytes are not charged against the byte budget,
+    /// so only the entry cap can stop this one.
+    #[tokio::test]
+    async fn too_many_entries_fails_the_entry_check() {
+        let names: Vec<String> = (0..=NESTED_MAX_ENTRIES).map(|i| format!("f{i}")).collect();
+        let entries: Vec<(&str, &[u8])> = names.iter().map(|n| (n.as_str(), &b""[..])).collect();
+        let bytes = pack(&entries).await;
+        let err = verify_nested_bundle(&bytes).await.unwrap_err();
+        assert!(err.starts_with("entry-count check:"), "got: {err}");
+    }
+
+    /// The bypass that made the caps ornamental, and the one hole in R7.3's
+    /// coverage. `async_tar` reads a PAX extension body to completion *inside*
+    /// `entries()` (`poll_read_all`, archive.rs:386) before yielding the entry
+    /// it describes, so those bytes reach neither the byte budget nor the
+    /// entry counter in the verify loop: a tiny zstd blob declaring one
+    /// enormous, highly compressible extension member could be decoded
+    /// straight into the CLI's memory. The bound now sits *under* the parser —
+    /// the decompressed stream is capped before `Archive::new` — so the read
+    /// this loop cannot see is capped anyway and the parser hits EOF instead
+    /// of a body.
+    ///
+    /// What this proves: the extension path is rejected, and by the stream cap
+    /// rather than by anything in the loop. What it does not prove: peak
+    /// allocation, which stays a structural argument.
+    #[tokio::test]
+    async fn a_pax_extension_bomb_is_stopped_by_the_stream_cap() {
+        // Past the stream cap (budget + slack), not merely past the content
+        // budget — the content budget is exactly what this entry shape evades.
+        let body = vec![0u8; (NESTED_MIN_BUDGET + NESTED_STREAM_SLACK + 8 * 1024 * 1024) as usize];
+        let encoder = async_compression::tokio::write::ZstdEncoder::new(Vec::new());
+        let mut builder = async_tar::Builder::new(encoder);
+        let mut header = async_tar::Header::new_ustar();
+        header.set_path("PaxHeaders/bomb").unwrap();
+        header.set_entry_type(async_tar::EntryType::XHeader);
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, &body[..]).await.unwrap();
+        let mut encoder = builder.into_inner().await.unwrap();
+        encoder.shutdown().await.unwrap();
+        let bytes = encoder.into_inner();
+
+        assert!(
+            (bytes.len() as u64).saturating_mul(NESTED_EXPANSION_RATIO) < NESTED_MIN_BUDGET,
+            "the bomb must compress below the budget floor, got {} bytes",
+            bytes.len()
+        );
+        let err = verify_nested_bundle(&bytes).await.unwrap_err();
+        assert!(err.starts_with("decode check:"), "got: {err}");
+    }
+
+    /// The manifest may name a nested bundle as the daemon logs' carrier only
+    /// when the verify walk actually saw them go past.
+    #[tokio::test]
+    async fn verification_reports_whether_the_daemon_logs_are_present() {
+        let with = pack(&[
+            ("manifest.json", b"{}"),
+            ("logs/minimald.log.2026-07-16", b"guest daemon log\n"),
+        ])
+        .await;
+        assert_eq!(
+            verify_nested_bundle(&with).await.unwrap(),
+            DaemonLogs::Present
+        );
+
+        // A bundle that verifies but carries only the *other* daemon's logs
+        // is not a carrier for this prefix.
+        let without = pack(&[
+            ("manifest.json", b"{}"),
+            ("logs/minvmd.log.2026-07-16", b"host daemon log\n"),
+        ])
+        .await;
+        assert_eq!(
+            verify_nested_bundle(&without).await.unwrap(),
+            DaemonLogs::Absent
+        );
+    }
+
+    #[tokio::test]
+    async fn a_truncated_stream_fails_the_decode_check() {
+        let bytes = pack(&[("manifest.json", b"{}"), ("logs/a.log", &[b'x'; 4096])]).await;
+        let err = verify_nested_bundle(&bytes[..bytes.len() / 2])
+            .await
+            .unwrap_err();
+        assert!(err.starts_with("decode check:"), "got: {err}");
+    }
+
+    /// The volume fallback must always leave the stall-dating signal, even
+    /// when there is no image at all to read.
+    #[tokio::test]
+    async fn volume_fallback_records_meta_for_a_missing_image() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let out = tmp.path().join("b.tar.zst");
+        let mut w = BundleWriter::create(&out, "r", "v").await.unwrap();
+        volume_fallback(&mut w, "local-0", tmp.path())
+            .await
+            .unwrap();
+        w.finish(chrono::Utc::now(), Duration::ZERO).await.unwrap();
+
+        let bytes = tokio::fs::read(&out).await.unwrap();
+        let mut entries = async_tar::Archive::new(
+            async_compression::tokio::bufread::ZstdDecoder::new(&bytes[..]),
+        )
+        .entries()
+        .unwrap();
+        let mut meta = None;
+        while let Some(entry) = entries.next().await {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap().ends_with("volume-meta.json") {
+                let mut buf = Vec::new();
+                entry.read_to_end(&mut buf).await.unwrap();
+                meta = Some(serde_json::from_slice::<serde_json::Value>(&buf).unwrap());
+            }
+        }
+        assert_eq!(meta.expect("volume-meta.json")["exists"], false);
+    }
+}

--- a/crates/minimal/src/diag/mod.rs
+++ b/crates/minimal/src/diag/mod.rs
@@ -1,18 +1,22 @@
 //! `min bug` — collect a diagnostic bundle for the minimal dev team.
 //!
 //! One command, one artifact: a `minimal-diag-<timestamp>.tar.zst` containing
-//! the logs, config (redacted), and state listings needed to root-cause
-//! field issues. Every collector is independent and failure-isolated: a
-//! fully broken install still yields a valid archive whose `manifest.json`
-//! explains what's missing. Nothing here mutates state or autospawns
-//! daemons — diagnosing a wedged system must not change it.
+//! the logs, config (redacted), state listings, process/network state, and
+//! per-provider daemon bundles needed to root-cause field issues. Every
+//! collector is independent and failure-isolated: a fully broken install
+//! still yields a valid archive whose `manifest.json` explains what's
+//! missing. Nothing here mutates state or autospawns daemons — diagnosing a
+//! wedged system must not change it.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::Context as _;
 use clap::Args;
 
 pub mod collect;
+pub mod guest;
+pub mod net;
 pub mod redact;
 
 use collect::DiagPaths;
@@ -25,6 +29,12 @@ pub struct BugArgs {
     /// Output path (default: ./minimal-diag-<timestamp>.tar.zst)
     #[arg(long, short)]
     pub output: Option<PathBuf>,
+    /// Skip contacting daemons; collect host-side state only
+    #[arg(long)]
+    pub no_guest: bool,
+    /// Deadline in seconds for each provider's daemon-bundle download
+    #[arg(long, default_value_t = 60)]
+    pub guest_timeout_secs: u64,
     /// Bytes of each log file to capture, counted from the end
     ///
     /// Raise this when the interesting window is older than the tail the
@@ -125,36 +135,73 @@ pub async fn cmd_bug(global: &GlobalArgs, args: BugArgs) -> Result<(), anyhow::E
     collect_step!(w, "host.power", diagnostics::power::power(&mut w, "host"));
     collect_step!(w, "config", collect::config(&mut w, &paths));
     collect_step!(w, "state", collect::state(&mut w, &paths));
+    // Log prefixes that matched nothing on the host come back rather than
+    // becoming skips here: whether "not under <state>/logs" also means "not in
+    // this bundle" is not known until the provider loop below has run.
+    let mut absent_log_prefixes = Vec::new();
     collect_step!(
         w,
         "logs",
-        collect::logs(&mut w, &paths, args.log_tail_bytes)
+        collect::logs(
+            &mut w,
+            &paths,
+            args.log_tail_bytes,
+            &mut absent_log_prefixes
+        )
     );
 
-    // Daemon-side state (socket probes, guest bundles, per-provider status)
-    // is collected over the daemon connection, not from the host bundle;
-    // record what exists so the manifest is honest about coverage. An
-    // unreadable providers dir is an error, not absence.
+    // ── Per-provider: files and liveness, then the staged socket probe, then
+    // (when the probe handshook and --no-guest wasn't given) the daemon's own
+    // bundle over the connection the probe already opened. An unreadable
+    // providers dir is an error, not absence.
     let providers_started = std::time::Instant::now();
-    match collect::provider_dirs(&paths.state).await {
-        Ok(providers) if providers.is_empty() => w.skip(
-            "providers/",
-            "no provider instances found — no daemon was ever spawned here",
-        ),
-        Ok(providers) => w.skip(
-            "providers/",
-            format!(
-                "{} provider instance(s) present — only run.log/boot.log captured; \
-                 daemon-side state not collected",
-                providers.len()
-            ),
-        ),
-        Err(e) => w.error(
-            "providers".to_string(),
-            format!("listing provider dirs: {e}"),
-            providers_started.elapsed(),
-        ),
+    // `None` is "the listing failed", which is not the same fact as an empty
+    // listing: one leaves provider existence unknown, the other settles it.
+    // The log skips below turn on that difference.
+    let providers = match collect::provider_dirs(&paths.state).await {
+        Ok(providers) => {
+            if providers.is_empty() {
+                w.skip(
+                    "providers/",
+                    "no provider instances found — no daemon was ever spawned here",
+                );
+            }
+            Some(providers)
+        }
+        Err(e) => {
+            w.error(
+                "providers".to_string(),
+                format!("listing provider dirs: {e}"),
+                providers_started.elapsed(),
+            );
+            None
+        }
+    };
+    let mut carriers: Vec<&str> = Vec::new();
+    let mut unconfirmed: Vec<&str> = Vec::new();
+    for (name, dir) in providers.iter().flatten() {
+        collect_step!(
+            w,
+            format!("providers.{name}"),
+            collect::provider_files(&mut w, name, dir)
+        );
+        match collect_guest(&mut w, &args, name, dir).await {
+            guest::GuestOutcome::BundleWithDaemonLogs => carriers.push(name),
+            guest::GuestOutcome::BundleUnconfirmed => unconfirmed.push(name),
+            guest::GuestOutcome::NoBundle => {}
+        }
     }
+
+    // The held-back log skips, now that the guest side has reported. A daemon
+    // that logs inside the microVM leaves nothing under `<state>/logs`, and
+    // saying so as plain absence would contradict the nested bundle this run
+    // just collected.
+    collect::explain_absent_log_prefixes(
+        &mut w,
+        &paths,
+        &absent_log_prefixes,
+        daemon_log_sources(providers.as_deref(), &carriers, &unconfirmed),
+    );
 
     let entries = w.entry_count();
     let errors = w.error_count();
@@ -174,6 +221,97 @@ pub async fn cmd_bug(global: &GlobalArgs, args: BugArgs) -> Result<(), anyhow::E
     );
     println!("Review the contents before sharing; send it to the minimal dev team.");
     Ok(())
+}
+
+/// Reduces what the provider loop learned to the single fact the held-back log
+/// skips are read against.
+///
+/// `providers` is `None` when the listing itself failed. A confirmed carrier
+/// outranks an unconfirmed one: if any nested bundle demonstrably holds the
+/// daemon's logs, naming it is true whatever the others managed.
+fn daemon_log_sources<'a>(
+    providers: Option<&[(String, PathBuf)]>,
+    carriers: &'a [&'a str],
+    unconfirmed: &'a [&'a str],
+) -> collect::DaemonLogSources<'a> {
+    match (providers, carriers, unconfirmed) {
+        (None, ..) => collect::DaemonLogSources::ProvidersUnknown,
+        (Some([]), ..) => collect::DaemonLogSources::NoProviders,
+        (Some(_), [], []) => collect::DaemonLogSources::NoneFetched,
+        (Some(_), [], names) => collect::DaemonLogSources::NestedUnconfirmed(names),
+        (Some(_), names, _) => collect::DaemonLogSources::Nested(names),
+    }
+}
+
+/// Probes one provider's daemon socket and, when it answers, nests the
+/// daemon's own bundle; otherwise falls back to the data volume image.
+///
+/// Never fails: every outcome — including "this collector itself broke" —
+/// becomes a manifest record. The download is not wrapped in
+/// [`collect_step!`]: it carries its own, longer `--guest-timeout-secs`
+/// deadline, since a large bundle over a slow bridge is not a hang.
+///
+/// Returns what the archive can now be said to hold for this provider, which
+/// is what the log collector's held-back skips are read against: not merely
+/// whether a bundle arrived, but whether it was confirmed to carry the
+/// daemon's own logs.
+async fn collect_guest(
+    w: &mut BundleWriter,
+    args: &BugArgs,
+    name: &str,
+    dir: &std::path::Path,
+) -> guest::GuestOutcome {
+    // `--no-guest` means "collect host-side state only" — the socket probe
+    // handshakes with the daemon (a GetVersion RPC), so it is a guest contact
+    // and must be skipped too, not just the bundle download (R7.4).
+    let started = std::time::Instant::now();
+    if args.no_guest {
+        if let Err(e) = guest::record_skipped(w, name, "guest collection skipped: --no-guest").await
+        {
+            w.error(format!("guest.{name}"), format!("{e:#}"), started.elapsed());
+        }
+        return guest::GuestOutcome::NoBundle;
+    }
+
+    let sock = dir.join(paths::SSH_SOCK_FILE);
+    let (probe, client) = net::probe_socket(&sock).await;
+    collect_step!(
+        w,
+        format!("providers.{name}.socket-probe"),
+        net::add_probe(w, name, &probe)
+    );
+
+    let started = std::time::Instant::now();
+    let result = match client {
+        // The daemon being unreachable is the volume fallback's marquee case:
+        // nothing else can say what the guest was doing when it died (R7.5).
+        None => match guest::record_skipped(
+            w,
+            name,
+            "guest collection skipped: daemon not reachable (see socket-probe.json)",
+        )
+        .await
+        {
+            Ok(()) => guest::volume_fallback(w, name, dir)
+                .await
+                .map(|()| guest::GuestOutcome::NoBundle),
+            Err(e) => Err(e),
+        },
+        Some(mut client) => {
+            guest::collect(
+                w,
+                name,
+                dir,
+                &mut client,
+                Duration::from_secs(args.guest_timeout_secs),
+            )
+            .await
+        }
+    };
+    result.unwrap_or_else(|e| {
+        w.error(format!("guest.{name}"), format!("{e:#}"), started.elapsed());
+        guest::GuestOutcome::NoBundle
+    })
 }
 
 /// Resolve every base path the collectors need, honoring the same overrides

--- a/crates/minimal/src/diag/net.rs
+++ b/crates/minimal/src/diag/net.rs
@@ -1,0 +1,225 @@
+//! The staged daemon-socket probe for `min bug`.
+//!
+//! The network *mechanics* — listening tables, interfaces, routes — live in
+//! [`diagnostics::net`] and are collected for the host as a whole. What lives
+//! here is the one network question only the CLI can ask: can this machine
+//! actually reach the daemon behind `providers/<name>/ssh.sock`, and if not,
+//! at which step does contact break?
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use anyhow::Context as _;
+use serde::Serialize;
+
+use diagnostics::{BundleWriter, Redaction};
+
+/// Deadline for the `GetVersion` RPC once the connection is handshaken. A
+/// healthy daemon answers in milliseconds; this only bounds the case where it
+/// accepted, authenticated, and then stopped answering.
+const GET_VERSION_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Result of one probe stage: what happened and how long it took.
+#[derive(Debug, Serialize)]
+pub struct Stage {
+    outcome: String,
+    duration_ms: u64,
+}
+
+impl Stage {
+    fn run(started: Instant, result: Result<(), String>) -> Self {
+        Self {
+            outcome: result.err().unwrap_or_else(|| "ok".to_string()),
+            duration_ms: started.elapsed().as_millis() as u64,
+        }
+    }
+
+    fn skipped() -> Self {
+        Self {
+            outcome: "skipped: prior stage failed".to_string(),
+            duration_ms: 0,
+        }
+    }
+
+    #[must_use]
+    pub fn is_ok(&self) -> bool {
+        self.outcome == "ok"
+    }
+}
+
+/// A staged connection-health record for one provider's daemon socket.
+///
+/// Reaching the daemon has four steps, each a prerequisite for the next:
+/// `stat()` the socket file, `connect()`, complete the SSH handshake + auth,
+/// then issue a `GetVersion` RPC. The probe attempts them in order and records
+/// how far it got — the *failing* stage is the diagnosis: no socket file
+/// (daemon never ran / cleaned up), connect refused (stale socket after a
+/// crash), handshake timeout (wedged guest behind libkrun's always-accepting
+/// bridge), RPC failure (daemon up but unhealthy).
+#[derive(Debug, Serialize)]
+pub struct SocketProbe {
+    socket_path: String,
+    /// `stat()` the socket file.
+    stat: Stage,
+    /// One raw `connect()` attempt — no retries; we are probing, not waiting
+    /// for a boot.
+    connect: Stage,
+    /// Full SSH handshake + auth (bounded by the client's own deadline).
+    handshake: Stage,
+    /// `GetVersion` RPC over the handshaken connection.
+    get_version: Stage,
+    version: Option<minimald_rpc::GetVersionResponse>,
+}
+
+/// Probes `sock_path` stage by stage, never failing — every outcome is data.
+///
+/// Returns the probe record and, when the handshake succeeded, the live client
+/// so the caller can reuse the connection for the guest-bundle download
+/// instead of handshaking again (R7.1).
+pub async fn probe_socket(sock_path: &Path) -> (SocketProbe, Option<crate::client::Client>) {
+    let mut probe = SocketProbe {
+        socket_path: sock_path.display().to_string(),
+        stat: Stage::skipped(),
+        connect: Stage::skipped(),
+        handshake: Stage::skipped(),
+        get_version: Stage::skipped(),
+        version: None,
+    };
+
+    let t = Instant::now();
+    probe.stat = Stage::run(
+        t,
+        tokio::fs::metadata(sock_path)
+            .await
+            .map(drop)
+            .map_err(|e| e.to_string()),
+    );
+    if !probe.stat.is_ok() {
+        return (probe, None);
+    }
+
+    let t = Instant::now();
+    probe.connect = Stage::run(
+        t,
+        tokio::net::UnixStream::connect(sock_path)
+            .await
+            .map(drop)
+            .map_err(|e| e.to_string()),
+    );
+    if !probe.connect.is_ok() {
+        return (probe, None);
+    }
+
+    let t = Instant::now();
+    let mut client = match crate::client::Client::connect(sock_path).await {
+        Ok(client) => {
+            probe.handshake = Stage::run(t, Ok(()));
+            client
+        }
+        Err(e) => {
+            // `Client::connect` opens its own connection rather than adopting
+            // the one probed above, so a daemon that died in between fails
+            // *here* — and filing that as a handshake fault is precisely the
+            // misdiagnosis this staged probe exists to prevent. Re-test the
+            // cheaper layer to tell "stopped accepting" from "accepted but
+            // would not handshake".
+            match tokio::net::UnixStream::connect(sock_path).await {
+                Ok(_) => probe.handshake = Stage::run(t, Err(format!("{e:#}"))),
+                Err(again) => {
+                    probe.connect = Stage::run(
+                        t,
+                        Err(format!(
+                            "accepted once, then stopped: {again} \
+                             (handshake never attempted: {e:#})"
+                        )),
+                    );
+                }
+            }
+            return (probe, None);
+        }
+    };
+
+    let t = Instant::now();
+    match tokio::time::timeout(
+        GET_VERSION_TIMEOUT,
+        client.oneshot_rpc::<minimald_rpc::GetVersion>(()),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => {
+            probe.get_version = Stage::run(t, Ok(()));
+            probe.version = Some(resp);
+        }
+        Ok(Err(e)) => probe.get_version = Stage::run(t, Err(format!("{e:#}"))),
+        Err(_) => {
+            probe.get_version =
+                Stage::run(t, Err(format!("timed out after {GET_VERSION_TIMEOUT:?}")))
+        }
+    }
+
+    (probe, Some(client))
+}
+
+/// Records `probe` as `providers/<provider>/socket-probe.json`.
+pub async fn add_probe(
+    w: &mut BundleWriter,
+    provider: &str,
+    probe: &SocketProbe,
+) -> Result<(), anyhow::Error> {
+    let json = serde_json::to_vec_pretty(probe).context("serializing socket probe")?;
+    w.add_bytes(
+        &format!("providers/{provider}/socket-probe.json"),
+        &json,
+        Redaction::None,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn probe_reports_missing_socket_at_the_stat_stage() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (probe, client) = probe_socket(&tmp.path().join("nope.sock")).await;
+        assert!(!probe.stat.is_ok());
+        assert!(probe.connect.outcome.starts_with("skipped"));
+        assert!(client.is_none());
+    }
+
+    /// A socket file that nothing is listening on (stale after a daemon
+    /// crash) must fail at the connect stage — the signature of the
+    /// stale-socket failure class.
+    #[tokio::test]
+    async fn probe_reports_stale_socket_at_the_connect_stage() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock = tmp.path().join("stale.sock");
+        drop(std::os::unix::net::UnixListener::bind(&sock).unwrap());
+
+        let (probe, client) = probe_socket(&sock).await;
+        assert!(probe.stat.is_ok());
+        assert!(!probe.connect.is_ok(), "got: {}", probe.connect.outcome);
+        assert!(probe.handshake.outcome.starts_with("skipped"));
+        assert!(client.is_none());
+    }
+
+    /// An accepting-but-mute listener (wedged guest behind the libkrun
+    /// bridge) must fail at the handshake stage, not hang.
+    #[tokio::test(start_paused = true)]
+    async fn probe_reports_mute_listener_at_the_handshake_stage() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock = tmp.path().join("mute.sock");
+        let _listener = tokio::net::UnixListener::bind(&sock).unwrap();
+
+        let (probe, client) = probe_socket(&sock).await;
+        assert!(probe.stat.is_ok());
+        assert!(probe.connect.is_ok());
+        assert!(
+            probe.handshake.outcome.contains("timed out"),
+            "got: {}",
+            probe.handshake.outcome
+        );
+        assert!(client.is_none());
+    }
+}

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -1,14 +1,17 @@
 //! Integration tests for `min bug` (the diagnostic bundle command).
 //!
-//! Each test runs `cmd_bug` against temp state/config dirs and unpacks the
-//! resulting tarball to assert the bundle contract: what's collected, what's
-//! redacted, and what the manifest records for everything that's missing.
-//! No daemon is involved — the command must be useful on a machine where
-//! nothing was ever spawned.
+//! Each test runs `cmd_bug` against a real minimald `TestServer` (or a
+//! deliberately empty state dir) and unpacks the resulting tarball to assert
+//! the bundle contract: what's collected, what's redacted, what the manifest
+//! records for everything that's missing, and how the command degrades when
+//! the daemon is unreachable.
+
+mod common;
 
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use common::setup;
 use minimal::GlobalArgs;
 use minimal::diag::{BugArgs, cmd_bug};
 
@@ -78,6 +81,8 @@ fn global_args(state: &Path, config: &Path) -> GlobalArgs {
 fn bug_args(out: &Path) -> BugArgs {
     BugArgs {
         output: Some(out.to_path_buf()),
+        no_guest: false,
+        guest_timeout_secs: 60,
         log_tail_bytes: diagnostics::LOG_TAIL_CAP,
     }
 }
@@ -349,4 +354,156 @@ async fn incident_collectors_land_and_mask_macs() {
             });
         assert!(!is_mac, "un-masked MAC leaked into interfaces.txt: {tok}");
     }
+}
+
+/// R7.1–R7.3: against a live daemon the probe completes every stage, the
+/// daemon's own bundle is nested raw and passes its bounded-decode checks,
+/// and the redaction guarantees hold across both layers.
+#[tokio::test]
+async fn bug_with_daemon_nests_a_verified_guest_bundle() {
+    let (_daemon, mut args) = setup().await;
+    let config = fake_config_dir();
+    args.config_dir = Some(config.path().to_path_buf());
+
+    let out_dir = tempfile::TempDir::new().unwrap();
+    let out = out_dir.path().join("diag.tar.zst");
+    cmd_bug(&args, bug_args(&out)).await.unwrap();
+
+    let files = unpack(&out).await;
+    let manifest: serde_json::Value =
+        serde_json::from_slice(find(&files, "manifest.json").expect("manifest")).unwrap();
+
+    // R7.1: every stage of the probe reached the live daemon, and the
+    // connection it opened was the one the download reused.
+    let probe: serde_json::Value =
+        serde_json::from_slice(find(&files, "local-0/socket-probe.json").expect("probe")).unwrap();
+    for stage in ["stat", "connect", "handshake", "get_version"] {
+        assert_eq!(probe[stage]["outcome"], "ok", "stage {stage}: {probe}");
+    }
+    assert!(probe["version"]["long_version"].is_string());
+
+    // R7.6: liveness status for the discovered provider.
+    assert!(find(&files, "local-0/status.json").is_some());
+    assert!(find(&files, "local-0/dir-listing.txt").is_some());
+
+    // R7.3: the daemon bundle is nested raw (it decompresses on its own) and
+    // carries the Unit 6 manifest.
+    let nested = find(&files, "guest/daemon-diag.tar.zst").expect("nested guest bundle");
+    let nested_path = out_dir.path().join("nested.tar.zst");
+    std::fs::write(&nested_path, nested).unwrap();
+    let guest_files = unpack(&nested_path).await;
+    let guest_manifest: serde_json::Value =
+        serde_json::from_slice(find(&guest_files, "manifest.json").expect("guest manifest"))
+            .unwrap();
+    assert_eq!(guest_manifest["schema_version"], 1);
+    let guest_meta: serde_json::Value =
+        serde_json::from_slice(find(&guest_files, "meta.json").expect("guest meta")).unwrap();
+    assert_eq!(guest_meta["in_microvm"], false);
+
+    // The verification passed: no check recorded a failure against it.
+    let errors = manifest["errors"].as_array().unwrap();
+    assert!(
+        !errors
+            .iter()
+            .any(|e| e["collector"].as_str().unwrap().starts_with("guest.")),
+        "guest collection recorded an error: {errors:?}"
+    );
+
+    // Redaction holds across layers: the loadout canary appears nowhere, in
+    // the host bundle or the nested one, and key material is never collected.
+    for layer in [&files, &guest_files] {
+        for (path, contents) in layer.iter() {
+            assert!(
+                !contents
+                    .windows(b"canary-secret-value".len())
+                    .any(|window| window == b"canary-secret-value"),
+                "secret value leaked into the bundle at {path}"
+            );
+        }
+    }
+    assert!(find(&files, "client.key").is_none());
+    let skipped = manifest["skipped"].as_array().unwrap();
+    assert!(
+        skipped
+            .iter()
+            .any(|s| s["what"].as_str().unwrap().contains("client.key")),
+        "client.key skip must be recorded: {skipped:?}"
+    );
+}
+
+/// R7.1, R7.5: a socket file nothing listens on — the classic
+/// stale-socket-after-crash state — fails at the connect stage, and the
+/// volume fallback leaves its stall-dating record.
+#[tokio::test]
+async fn bug_with_stale_socket_reports_the_connect_stage_and_falls_back() {
+    let state = tempfile::TempDir::new().unwrap();
+    let config = tempfile::TempDir::new().unwrap();
+    let provider = state.path().join("providers/local-0");
+    std::fs::create_dir_all(&provider).unwrap();
+    drop(std::os::unix::net::UnixListener::bind(provider.join("ssh.sock")).unwrap());
+    // A data volume the fallback can date, standing in for a real image.
+    std::fs::write(provider.join("data-vol.raw"), [0u8; 4096]).unwrap();
+
+    let out_dir = tempfile::TempDir::new().unwrap();
+    let out = out_dir.path().join("diag.tar.zst");
+    cmd_bug(&global_args(state.path(), config.path()), bug_args(&out))
+        .await
+        .unwrap();
+
+    let files = unpack(&out).await;
+    let probe: serde_json::Value =
+        serde_json::from_slice(find(&files, "local-0/socket-probe.json").expect("probe")).unwrap();
+    assert_eq!(probe["stat"]["outcome"], "ok");
+    assert_ne!(probe["connect"]["outcome"], "ok");
+    assert!(
+        probe["handshake"]["outcome"]
+            .as_str()
+            .unwrap()
+            .starts_with("skipped"),
+        "the handshake must not be attempted after a failed connect: {probe}"
+    );
+
+    let error = find(&files, "guest/error.txt").expect("guest error note");
+    assert!(
+        String::from_utf8_lossy(error).contains("daemon not reachable"),
+        "got: {}",
+        String::from_utf8_lossy(error)
+    );
+
+    let volume: serde_json::Value =
+        serde_json::from_slice(find(&files, "guest/volume-meta.json").expect("volume meta"))
+            .unwrap();
+    assert_eq!(volume["exists"], true);
+    assert_eq!(volume["bytes"], 4096);
+    assert!(volume["mtime_unix"].is_u64(), "the stall-dating signal");
+    assert!(find(&files, "daemon-diag.tar.zst").is_none());
+}
+
+/// R7.4: `--no-guest` skips *all* daemon contact, including the probe — which
+/// handshakes — even when a healthy daemon is right there.
+#[tokio::test]
+async fn bug_no_guest_makes_no_daemon_contact() {
+    let (_daemon, args) = setup().await;
+
+    let out_dir = tempfile::TempDir::new().unwrap();
+    let out = out_dir.path().join("diag.tar.zst");
+    let no_guest = BugArgs {
+        no_guest: true,
+        ..bug_args(&out)
+    };
+    cmd_bug(&args, no_guest).await.unwrap();
+
+    let files = unpack(&out).await;
+    let error = find(&files, "guest/error.txt").expect("guest skip note");
+    assert!(
+        String::from_utf8_lossy(error).contains("--no-guest"),
+        "got: {}",
+        String::from_utf8_lossy(error)
+    );
+    // No probe record: the probe handshakes, so its absence is the proof that
+    // nothing touched the daemon.
+    assert!(find(&files, "socket-probe.json").is_none());
+    assert!(find(&files, "daemon-diag.tar.zst").is_none());
+    // Host-side per-provider collection still ran.
+    assert!(find(&files, "local-0/status.json").is_some());
 }

--- a/crates/minimal/tests/common/mod.rs
+++ b/crates/minimal/tests/common/mod.rs
@@ -13,6 +13,12 @@ use minimal::GlobalArgs;
 pub struct TestDaemon {
     /// The underlying minimald test server. Exposed so tests can create
     /// sessions directly via `server.state` or connect a `TestClient`.
+    ///
+    // Each integration-test binary compiles this module separately and uses a
+    // different subset of it: `cli.rs` reads this field, `bug.rs` only needs
+    // the daemon listening at the socket path. `expect` would go unfulfilled in
+    // the `cli` binary, so the allow is the accurate annotation.
+    #[allow(dead_code)]
     pub server: minimald::test_harness::TestServer,
     temp: tempfile::TempDir,
 }

--- a/crates/minimald/src/diag.rs
+++ b/crates/minimald/src/diag.rs
@@ -30,6 +30,7 @@ use diagnostics::redact::{masked_process_env, redact_json};
 use diagnostics::{BundleSink, BundleWriter, LOG_TAIL_CAP, Redaction};
 
 use crate::ChannelConfig;
+use crate::connection::ConnectionError;
 use crate::server::ServerStateHandle;
 
 /// Longest request body accepted before the read is abandoned. The body is a
@@ -124,11 +125,16 @@ pub(crate) async fn serve_stream_diag_bundle(
     s: ServerStateHandle,
     _config: ChannelConfig,
     mut c: RuChannel<Msg>,
-) {
-    if let Err(msg) = stream_diag_bundle(&s, &mut c).await {
-        let _ = c.extended_data_bytes(1, msg).await;
-    }
+) -> Result<(), ConnectionError> {
+    let outcome = match stream_diag_bundle(&s, &mut c).await {
+        Ok(()) => Ok(()),
+        Err(msg) => {
+            let _ = c.extended_data_bytes(1, msg.clone()).await;
+            Err(ConnectionError::Internal(msg))
+        }
+    };
     let _ = c.close().await;
+    outcome
 }
 
 /// Reads the request, then streams the bundle. On failure returns the

--- a/crates/minvmd/src/state.rs
+++ b/crates/minvmd/src/state.rs
@@ -119,6 +119,18 @@ impl StateDir {
         Ok(Self { dir })
     }
 
+    /// Bind to `dir` without creating it, for readers that must not change
+    /// what they observe — the diagnostic collector reports on providers,
+    /// including deleted ones, and [`StateDir::new`] would resurrect the
+    /// directory as a side effect of looking. Every path accessor and the
+    /// read-only liveness probes work unchanged; the lock-taking and
+    /// state-writing methods will fail on a missing directory, which is the
+    /// correct outcome for a caller that has not created one.
+    #[must_use]
+    pub fn open_existing(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+
     /// Default path: [`provider_dir`].
     pub fn default_path() -> PathBuf {
         provider_dir()


### PR DESCRIPTION
Unit 7 of the diagnostics series (spec: [#802](https://github.com/gominimal/minimal/pull/802), epic: [#801](https://github.com/gominimal/minimal/issues/801)).

> [!IMPORTANT]
> **Stacked on [#878](https://github.com/gominimal/minimal/pull/878) (Unit 6) and must merge after it.** The base of this PR is `feat/diag-unit6-daemon-bundle`, not `main` — Unit 7 consumes Unit 6's `DIAG_BUNDLE_SUBSYSTEM` / `DiagBundleRequest` and the manifest-bearing guest bundle. Review the diff against that base; if GitHub shows Unit 6's changes too, Unit 6 has not merged yet.

## What

`min bug` now reaches into every provider: a staged socket probe that says exactly where daemon contact breaks, the bundle download over the probe's own connection, and — when the daemon or transport is the suspect — vital signs and logs harvested read-only from the volume image. All of it is `crates/minimal` only; `minimald`/`minimald-rpc` are untouched.

**`client.rs`** *(R7.2)* — `Client::download_diag_bundle`: writes one `DiagBundleRequest`, half-closes, and accumulates the streamed tar.zst up to a 256 MiB cap, returning `(bytes, truncated)`. Daemon errors ride extended-data stream 1 (capped at 64 KiB) and become the `Err`, discarding any partial bundle; a bare subsystem refusal (`Failure`) fails fast rather than blocking until the caller's deadline. Sends the traceparent so the download joins the CLI's trace.

**`diag/net.rs`** *(R7.1)* — the `SocketProbe`: `stat` → `connect` → SSH `handshake` → `GetVersion`, each a prerequisite for the next, recorded as `providers/<name>/socket-probe.json`. The failing stage *is* the diagnosis (no socket file / stale socket / wedged-behind-the-bridge / up-but-unhealthy). On a completed handshake it hands the live `Client` back so the download reuses the connection — no second handshake.

**`diag/guest.rs`** — `collect` downloads and nests the daemon bundle **raw** at `providers/<name>/guest/daemon-diag.tar.zst` *(R7.3)*; `volume_fallback` is the degraded path *(R7.5)*; `record_skipped` writes the per-provider skip note *(R7.4)*.

**`diag/collect.rs`** *(R7.6)* — `provider_files`: per-provider `dir-listing.txt`, verbatim `minvmd.toml`, and `status.json` (raw lifecycle + non-mutating `minvmd`/`minimald` liveness via `StateDir`, deliberately **not** `effective_state()` which repairs stale state by writing it back).

**`diag/mod.rs`** — the real provider loop replaces the Unit 2 skip, plus `--no-guest` and `--guest-timeout-secs` (default 60).

### R7.3 bounded decode (the one that has to be right)

The nested daemon bundle is stored raw either way; verification only decides whether the manifest records it as trustworthy. `verify_nested_bundle` drains the decompressed stream **into a sink** — bytes are counted and dropped, never materialized — and returns the instant a cap trips, so it never skips past a bomb's body. Three caps, each independent:

- **absolute decompressed ceiling — 1 GiB** (the real memory/CPU guard);
- **entry count — 10,000** (the header-dimension bomb: millions of empty members, which the byte budget deliberately does not charge for);
- **`manifest.json` required** (a well-formed daemon bundle always ends with one; absence means the stream is not what it claims).

A breach or decode failure still `add_bytes`-es the raw blob, then records a `guest.<name>.verify` manifest error naming the failed check (`size check:` / `entry-count check:` / `manifest check:` / `decode check:`).

> [!WARNING]
> **Deviation from R7.3's expansion ratio.** The spec writes "decompressed size capped at **4× the compressed size** with a 1 GiB hard ceiling." A real diagnostic bundle is almost entirely compressible text (proc tables, JSON, logs); a representative host bundle **measured 15.4×** (586 KB content / 38 KB compressed), and the daemon bundle is the same shape. A literal 4× budget would flag *every legitimate* nested bundle as a bomb — the integration test asserts a healthy fetch verifies with zero `guest.*` errors, which a strict 4× would break. The implementation keeps the ratio but clamps the budget to `[64 MiB, 1 GiB]`, so the two hard caps the bomb guard actually rests on (the 1 GiB ceiling and the 10k-entry cap) are exactly as specified, while the ratio no longer false-positives on real bundles. The `NESTED_MIN_BUDGET` floor and its rationale are documented at the constant. **Flagging rather than silently shipping — happy to swap the floor value or revisit if the ratio was meant literally.**

## Porting deltas against the reference (`77fc711e`)

- The reference stored the nested bundle with no verification at all; R7.3's bounded streaming decode is **new in this unit**, written to the spec and reconciled to the Unit 6 manifest (the reference predates the `errors.json` → `manifest.json` convergence, so its checks would have keyed on `errors.json`).
- The reference's `net.rs` mixed the host network collectors (listening tables, interfaces, routes) with the probe. Those collectors merged into `diagnostics::net` in Unit 5, so **only the `SocketProbe` half** lands here; `mask_macs` and the interface/route collectors are not re-added.
- `provider_files` does **not** re-collect `run.log`/`boot.log` — the merged tree's `collect::logs` already tail-caps them for every discovered provider, so a second copy would be a duplicate archive entry. (The reference collected them in both places, harmless only because its `logs` collector did not.)
- `DiagBundleRequest` is constructed via `::default()` (it is `#[non_exhaustive]`; a cross-crate struct literal will not compile).
- `tempfile` promotes dev-dep → main dep (volume-harvest staging); `tokio-stream` is added for iterating the nested archive during verification; `mod common;` (the daemon harness) enters `tests/bug.rs` — all three per the spec's baseline notes.

## Proof Artifacts

| # | Artifact | Status |
|---|----------|--------|
| 1 | **Test:** full-stack — `min bug` against the harness daemon nests a guest bundle whose manifest parses; loadout redaction and client-key skip hold across layers — R7.1–R7.3 | ✅ `bug_with_daemon_nests_a_verified_guest_bundle` |
| 2 | **Test:** stale socket file → probe records the failed connect stage and the skip is explained; volume-fallback artifacts appear — R7.1, R7.5 | ✅ `bug_with_stale_socket_reports_the_connect_stage_and_falls_back` |
| 3 | **Test:** `--no-guest` against a live harness daemon performs zero daemon contact — R7.4 | ✅ `bug_no_guest_makes_no_daemon_contact` |
| 4 | **CLI (gate):** kill a real VM's daemon mid-session, run `min bug`: probe stages + `volume-meta.json` + harvested `volume-logs/` present — R7.5 end to end | ⚠️ **Not verified.** Requires a real running microVM whose daemon is killed mid-session — an agent cannot honestly produce this. The volume-fallback path is exercised in-process by artifact 2 (probe fails, `volume-meta.json` written, `debugfs` path taken), but the live end-to-end gate against a real ext4 image has not been run. |

The R7.3 caps have dedicated unit tests in `diag::guest::tests`: `a_well_formed_bundle_verifies`, `a_bundle_without_a_manifest_fails_the_manifest_check`, `a_decompression_bomb_fails_the_size_check` (a 72 MiB zero run that zstd squeezes below the budget floor), `too_many_entries_fails_the_entry_check` (10,001 members), and `a_truncated_stream_fails_the_decode_check`.

## Verification

`crates/minimal`'s test suite is **Linux-only** — `minimald` is a dev-dependency and pulls `procfs`, so `cargo test -p minimal` does not build on the macOS dev host (pre-existing, not introduced here). It was verified **via `cross`, not natively**:

| Command | Result |
|---|---|
| `cargo build -p minimal` (native macOS) | clean |
| `cross clippy -p minimal --all-targets --target … -- -D warnings` | **clean** |
| `cross test -p minimal --target …` — lib | **73 passed, 0 failed** |
| `cross test -p minimal --target …` — `tests/bug.rs` | **5 passed, 2 failed** — environmental, see below |

Both `cross` invocations ran with `CROSS_CONTAINER_OPTS="--env HOME=/tmp/xhome"`; without a writable `HOME` some tests fail `PermissionDenied` on `/.cache`. `CARGO_BUILD_JOBS=1` is also needed on this host — linking `bin "min"` and `test "cli"` concurrently OOM-kills `ld` inside Docker's 7.7 GiB VM (`collect2: fatal error: ld terminated with signal 9`), which looks like a compile failure but is not one. `cargo clippy -p minimal --lib` is not usable natively — it trips **pre-existing** macOS-cfg dead-code errors in `crates/sandbox2` (`needs_lib_symlink`, `network_namespaces_available`, …) unrelated to this change — hence the `cross` clippy run for the real signal.

### The 2 `tests/bug.rs` failures are pre-existing, not from this PR

`incident_collectors_land_and_mask_macs` and `logs_collects_newest_five_per_prefix_and_provider_logs` are **Unit 5 tests** ([#864](https://github.com/gominimal/minimal/pull/864)). This branch does not modify either — the only deletions in `tests/bug.rs` are four doc-comment lines. They fail because the cross musl image ships **none** of `ip`, `ifconfig`, `ss`, `netstat`, `lsof` (verified by inspecting the image directly), so `host/net/interfaces.txt` cannot be produced and the manifest carries 2 collector errors against an `assert_eq!(errors, 0)`. CI's Linux lane is the authoritative environment for these two; they are called out here rather than left for a reviewer to trip over.

### Two lint failures that *were* ours — fixed in `f6c8a54a`

The first `--all-targets -D warnings` run over this series caught both:

- **`manual_clamp`** on the nested-bundle budget — the `.max().min()` pair is a clamp. The floor is a compile-time constant below the ceiling, so the rewrite cannot introduce the panic clippy warns about.
- **`dead_code`** on `common::TestDaemon::server` — adding `mod common;` to `tests/bug.rs` gives that binary its own copy of the module, and it does not read the field `tests/cli.rs` does. `expect` would go unfulfilled in the `cli` binary, so `allow` is the accurate annotation.

Refs: [#801](https://github.com/gominimal/minimal/issues/801)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add guest bundle fetch and degraded-mode fallback to `min bug` diagnostic command
> - Adds `Client::download_diag_bundle` in [client.rs](https://github.com/gominimal/minimal/pull/880/files#diff-9e29b53f60b5cd0ae317db17efc685735a41fb9e23b33e834d06f331db09b952) to stream a tar+zstd diagnostic bundle from the daemon over SSH, returning collected bytes and a truncated flag with bounded error capture.
> - Adds per-provider guest collection in [guest.rs](https://github.com/gominimal/minimal/pull/880/files#diff-241cf6e66780965d49c6fd381e85dee7b4ca07d453b33c27223d072373acedea): downloads and verifies the nested bundle, falls back to harvesting `/logs` from the ext4 volume via `debugfs` when the daemon is unreachable.
> - Adds socket reachability probing in [net.rs](https://github.com/gominimal/minimal/pull/880/files#diff-1ba58b97e90f981b03329110c71ab5cf43cea23dafb00bbf858374d0b034be74), recording SSH handshake stage and persisting results as `socket-probe.json` in the bundle.
> - Extends [collect.rs](https://github.com/gominimal/minimal/pull/880/files#diff-21bc21234980adc0d367d6c0f3817b218cb0d987b1ed4450767eab5c28173edd) with provider files (dir listing, lifecycle state, liveness) and deferred, context-aware log-skip reasoning via `explain_absent_log_prefixes`.
> - Exposes `--no-guest` and `--guest-timeout-secs` (default 60s) CLI flags; `tempfile` and `tokio-stream` are promoted from dev-only to runtime dependencies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10c7830.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->