### PR TITLE
feat(minimald): add debug log on workspace unpack error

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -1090,10 +1090,11 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
             // Guard against accidentally uploading a non-VCS directory
             // (e.g. `~`): if the resolved project root is not a recognized
             // VCS root, warn and ask for confirmation before the recursive
-            // upload. On non-interactive stdin (CI, pipes, agents) we
-            // proceed without prompting — `--sync none` remains available
-            // for explicit opt-out (#770).
+            // upload. On non-interactive stdin (CI, pipes, agents) and under
+            // `--no-prompt` we proceed without prompting — `--sync none`
+            // remains available for explicit opt-out (#770).
             let should_upload = file_upload::is_vcs_root(upload_root.as_std_path())
+                || args.no_prompt
                 || !can_prompt_interactively()
                 || confirm(
                     &format!(

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -2100,9 +2100,18 @@ mod tests {
 
     /// With no mfile anywhere up the tree, `resolve_upload_root` returns the
     /// input directory unchanged — the original activate behaviour.
+    ///
+    /// The temp dir is rooted directly in `$HOME` rather than `$TMPDIR`: the
+    /// upward walk stops at `$HOME`, so this is the only placement where "no
+    /// mfile up the tree" is guaranteed. Under `$TMPDIR` the walk escapes to
+    /// whatever encloses it — with `TMPDIR` inside a checkout of this repo it
+    /// finds the repo's own `minimal.toml` and the test fails.
     #[test]
     fn resolve_upload_root_returns_input_when_no_mfile() {
-        let dir = tempfile::tempdir().unwrap();
+        let Some(home) = std::env::home_dir() else {
+            return; // no HOME: no walk boundary to anchor the test to
+        };
+        let dir = tempfile::tempdir_in(&home).unwrap();
         let path = camino::Utf8Path::from_path(dir.path()).expect("temp path is UTF-8");
         assert_eq!(resolve_upload_root(path).unwrap(), path);
     }

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -204,8 +204,11 @@ async fn activate_creates_session() {
     let (daemon, args) = setup().await;
 
     // Create a temp project dir with a minimal.toml so the
-    // missing-mfile prompt doesn't fire.
+    // missing-mfile prompt doesn't fire. Mark it as a VCS root so
+    // the non-VCS upload confirmation (#790) short-circuits instead
+    // of blocking on stdin when the test binary is attached to a TTY.
     let project = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir(project.path().join(".git")).unwrap();
     std::fs::write(
         project.path().join("minimal.toml"),
         "# test minimal.toml\n[upstream]\nrepo = \"https://github.com/gominimal/pkgs\"\nbranch = \"main\"\n\n[stack]\nuse = \"shell\"\n",
@@ -240,7 +243,11 @@ async fn activate_uploads_project_files() {
     let (daemon, args) = setup().await;
 
     // Create a temp project dir with a minimal.toml and some files.
+    // Mark it as a VCS root so the non-VCS upload confirmation (#790)
+    // short-circuits instead of blocking on stdin when the test
+    // binary is attached to a TTY.
     let project = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir(project.path().join(".git")).unwrap();
     std::fs::write(
         project.path().join("minimal.toml"),
         "# test\n[upstream]\nrepo = \"https://github.com/gominimal/pkgs\"\nbranch = \"main\"\n\n[stack]\nuse = \"shell\"\n",

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -525,6 +525,7 @@ async fn serve_stream_workspace_files(
     mut c: RuChannel<Msg>,
 ) {
     if let Err(msg) = unpack_workspace_files(&s, &config, &mut c).await {
+        tracing::debug!(error = %msg, "workspace unpack failed");
         let _ = c.extended_data_bytes(1, msg).await;
     }
     let _ = c.close().await;


### PR DESCRIPTION
Aside from fixing a test failure, adds a debug log when the `unpack_workspace_files` handler fails.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add debug log on workspace unpack error in `serve_stream_workspace_files`
> - Adds a debug log in [`rpc.rs`](https://github.com/gominimal/minimal/pull/883/files#diff-483e2e3e5623d7d67de4661e6024e9f281cec45e7e33d09b64a0bb8295ce297b) that records the unpack error reason before relaying it over the SSH channel's extended data stream.
> - Fixes `cmd_activate` in [`lib.rs`](https://github.com/gominimal/minimal/pull/883/files#diff-1b62c63af5a5bd2dbc4b550bf4bc6d0fa87e649b54dc3a587da5a8fa947b3ce1) to skip the non-VCS upload confirmation prompt when `--no-prompt` is set.
> - Updates CLI tests to create a `.git` directory in temp projects so they are treated as VCS roots, preventing tests from blocking on stdin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6213f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted activation upload confirmation so `--no-prompt` reliably skips interactive confirmation in non-VCS contexts.
  * Added debug logging when workspace file unpacking fails to improve troubleshooting, while keeping user-facing error output unchanged.
* **Tests**
  * Hardened CLI integration tests to use a controlled temp `.git` setup and avoid environment-dependent path detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->