### PR TITLE
fix(minvmd): carry libkrun vsock patches, fixing bulk host->guest uploads

### DIFF
--- a/scripts/build-libkrun-macos.sh
+++ b/scripts/build-libkrun-macos.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Build the trimmed libkrun.dylib for macOS from source, at the commit pinned
-# in vendor/libkrun/libkrun.lock, and stage it into PREFIX. This is the ONE
-# libkrun macOS CI links/boots against and the release ships — CI exercises
-# the exact dylib users receive, and no third-party bottle (the old slp/krun
-# Homebrew tap) is in the supply chain.
+# in vendor/libkrun/libkrun.lock plus every patch in vendor/libkrun/patches/,
+# and stage it into PREFIX. This is the ONE libkrun macOS CI links/boots
+# against and the release ships — CI exercises the exact dylib users receive,
+# and no third-party bottle (the old slp/krun Homebrew tap) is in the supply
+# chain.
 #
 # Trimmed build (this is exactly the Makefile's INIT_BLOB=0 config):
 #   -p libkrun            scope to the libkrun crate, so the src/input &
@@ -16,6 +17,12 @@
 #   --features blk,net    blk = rootfs disk (krun_add_disk2/3), net =
 #                         virtio-net. No gpu => no libepoxy/virglrenderer.
 #                         Hypervisor.framework is linked by src/vmm/build.rs.
+#
+# Patches: every *.patch in vendor/libkrun/patches/ is applied, in sorted
+# order, to the fetched tree before the build. Each is a fix carried against
+# the pin while it is upstream; a patch that no longer applies is a hard
+# error, never a skip — a silently-dropped patch would ship a dylib that
+# looks patched and is not. Drop the file when the fix lands in a new pin.
 #
 # The staged dylib's install name is set to @rpath/libkrun.1.dylib so anything
 # linking it (minvmd) records a relocatable load command from the start — the
@@ -62,6 +69,22 @@ actual="$(git -C "$WORK" rev-parse HEAD)"
 if [ "$actual" != "$COMMIT" ]; then
   echo "::error::fetched libkrun HEAD $actual != pinned commit $COMMIT" >&2
   exit 1
+fi
+
+# Apply the carried patches, in sorted order, on top of the verified commit.
+# `git apply` exits non-zero on any rejected hunk and, without --reject, leaves
+# the tree untouched — so a stale patch aborts the build instead of silently
+# producing an unpatched dylib.
+PATCHES="$ROOT/vendor/libkrun/patches"
+if [ -d "$PATCHES" ]; then
+  for patch in "$PATCHES"/*.patch; do
+    [ -e "$patch" ] || continue
+    echo "applying $(basename "$patch")"
+    if ! git -C "$WORK" apply --verbose "$patch"; then
+      echo "::error::$(basename "$patch") does not apply to libkrun $COMMIT ($VERSION); rebase or drop it" >&2
+      exit 1
+    fi
+  done
 fi
 
 echo "building trimmed libkrun (blk,net; no gpu, no init-blob)"

--- a/vendor/libkrun/patches/0001-vsock-signal-the-used-queue-when-requesting-credit.patch
+++ b/vendor/libkrun/patches/0001-vsock-signal-the-used-queue-when-requesting-credit.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Norrie Taylor <norrie@minimal.dev>
+Date: Tue, 21 Jul 2026 20:37:36 -0700
+Subject: [PATCH] vsock: signal the used queue when requesting a credit update
+
+A proxy that runs out of peer credit mid-batch sets WaitingCreditUpdate,
+emits a VSOCK_OP_CREDIT_REQUEST, and disarms polling on its host fd so the
+connection is driven only by the peer's reply.
+
+push_packet() places that request in the used ring but does not raise the
+interrupt: the IRQ comes solely from process_proxy_update(), and only when
+ProxyUpdate::signal_queue is set. signal_queue is taken from recv_pkt()'s
+have_used, which is false exactly when no data packet was produced -- i.e.
+when the first packet of the batch is the one that has to wait.
+
+In that case the peer is never woken. It does not see the credit request,
+so it sends no credit update, and polling is already disarmed on our side,
+so nothing on the host side wakes the connection either. The stream stalls
+until an unrelated event happens to signal the queue.
+
+This is usually masked, because a batch normally pushes data packets before
+credit runs out and those set signal_queue themselves, but it is reachable
+whenever a batch begins with no credit available. Set signal_queue
+explicitly when emitting the request.
+
+tsi_stream.rs has the identical construct and the identical gap; fix both.
+---
+ src/devices/src/virtio/vsock/tsi_stream.rs |  6 ++++++
+ src/devices/src/virtio/vsock/unix.rs       | 10 ++++++++++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/src/devices/src/virtio/vsock/tsi_stream.rs b/src/devices/src/virtio/vsock/tsi_stream.rs
+index c819398..b544896 100644
+--- a/src/devices/src/virtio/vsock/tsi_stream.rs
++++ b/src/devices/src/virtio/vsock/tsi_stream.rs
+@@ -834,6 +834,12 @@ impl Proxy for TsiStreamProxy {
+                         fwd_cnt: self.tx_cnt.0,
+                     };
+                     update.push_credit_req = Some(rx);
++                    // See the matching comment in unix.rs: push_packet() does
++                    // not raise the IRQ, and polling is disarmed just below,
++                    // so the request needs an explicit signal or the
++                    // connection can stall waiting for a credit update the
++                    // peer was never woken to send.
++                    update.signal_queue = true;
+                 }
+ 
+                 if self.status == ProxyStatus::Closed {
+diff --git a/src/devices/src/virtio/vsock/unix.rs b/src/devices/src/virtio/vsock/unix.rs
+index 2f51c05..3e622ab 100644
+--- a/src/devices/src/virtio/vsock/unix.rs
++++ b/src/devices/src/virtio/vsock/unix.rs
+@@ -576,6 +576,16 @@ impl Proxy for UnixProxy {
+                         fwd_cnt: self.tx_cnt.0,
+                     };
+                     update.push_credit_req = Some(rx);
++                    // push_packet() only places the request in the used ring;
++                    // the IRQ is raised solely by process_proxy_update() when
++                    // signal_queue is set. We disarm polling on this fd just
++                    // below, so a request delivered without an interrupt
++                    // leaves the connection stalled until some unrelated
++                    // event happens to signal the queue. Usually masked
++                    // because recv_pkt() pushed data packets first and set
++                    // signal_queue itself, but not when the very first packet
++                    // of the batch has to wait.
++                    update.signal_queue = true;
+                 }
+ 
+                 if self.status == ProxyStatus::Closed {

--- a/vendor/libkrun/patches/0002-vsock-fill-the-rx-descriptor-instead-of-one-recv-per-packet.patch
+++ b/vendor/libkrun/patches/0002-vsock-fill-the-rx-descriptor-instead-of-one-recv-per-packet.patch
@@ -1,0 +1,119 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Norrie Taylor <norrie@minimal.dev>
+Date: Tue, 21 Jul 2026 20:43:53 -0700
+Subject: [PATCH] vsock: fill the RX descriptor instead of one recv() per
+ packet
+
+recv_to_pkt() issues a single recv() per RX descriptor and emits whatever
+that call happened to find buffered on the host socket. Against a bulk
+sender that hands the stream over in small chunks, the muxer drains the
+socket faster than the writer fills it, so each descriptor carries a
+fraction of its capacity and the stream is fragmented into sub-KiB packets.
+
+Measured on a 12.8 MB host-to-guest transfer over a unix-backed port:
+40,749 packets, mean payload 1895 B, 35.6% of reads under 1 KiB. FIONREAD
+sampled immediately before each recv() averaged 2199 bytes while the peer's
+available credit averaged 239,848 of a 262,144-byte window, and the
+zero-credit path was reached 10 times in 40,749 reads. 74% of reads drained
+the socket completely with descriptor space still free. The peer's window
+was never the constraint -- socket occupancy at the instant of the read was.
+
+Fragmentation is expensive for the peer: a Linux receiver charges every
+queued packet SKB_TRUESIZE(0) (576 bytes on arm64) against buf_alloc
+regardless of payload, so sub-KiB packets burn queue budget far faster than
+they deliver bytes.
+
+Loop until the descriptor is full or the socket returns EAGAIN. This is
+safe under level-triggered polling because we never deliberately leave
+readable data behind: every exit either drained the socket or filled a
+descriptor, so the next notification always corresponds to new data or to a
+descriptor we can immediately make progress on. EOF and errors encountered
+after some bytes were read deliver the data first and are re-reported on
+the following call.
+---
+ src/devices/src/virtio/vsock/unix.rs | 70 +++++++++++++++++++++-------
+ 1 file changed, 53 insertions(+), 17 deletions(-)
+
+diff --git a/src/devices/src/virtio/vsock/unix.rs b/src/devices/src/virtio/vsock/unix.rs
+index 3e622ab..afb65d9 100644
+--- a/src/devices/src/virtio/vsock/unix.rs
++++ b/src/devices/src/virtio/vsock/unix.rs
+@@ -219,25 +219,61 @@ impl UnixProxy {
+                 return RecvPkt::WaitForCredit;
+             }
+ 
+-            match recv(
+-                self.fd.as_raw_fd(),
+-                &mut buf[..max_len],
+-                MsgFlags::MSG_DONTWAIT,
+-            ) {
+-                Ok(cnt) => {
+-                    debug!("recv cnt={cnt}");
+-                    if cnt > 0 {
+-                        debug!("recv rx_cnt={}", self.rx_cnt);
+-                        RecvPkt::Read(cnt)
+-                    } else {
+-                        RecvPkt::Close
+-                    }
++            // Fill the descriptor rather than emitting whatever a single
++            // recv() happened to find buffered. A bulk sender hands us the
++            // stream in small chunks, and one recv() per descriptor turns
++            // those into one vsock packet each: we outrun the writer and
++            // fragment the stream into sub-KiB packets even though the peer's
++            // window is wide open. Each packet then costs the peer a whole
++            // skb of queue accounting for a fraction of a descriptor's worth
++            // of payload.
++            //
++            // Looping until the descriptor is full or the socket is drained
++            // is safe with level-triggered polling: we never leave readable
++            // data behind on purpose, so we cannot spin on a socket we
++            // declined to read. We stop on EAGAIN (drained), on a full
++            // descriptor (progress, and the next descriptor picks up the
++            // rest), or on EOF/error once we already have bytes -- those are
++            // re-reported on the next call, with the data delivered first.
++            let mut total = 0;
++            let ret = loop {
++                if total == max_len {
++                    break RecvPkt::Read(total);
+                 }
+-                Err(e) => {
+-                    debug!("recv_pkt: recv error: {e:?}");
+-                    RecvPkt::Error
++                match recv(
++                    self.fd.as_raw_fd(),
++                    &mut buf[total..max_len],
++                    MsgFlags::MSG_DONTWAIT,
++                ) {
++                    Ok(0) => {
++                        break if total == 0 {
++                            RecvPkt::Close
++                        } else {
++                            RecvPkt::Read(total)
++                        }
++                    }
++                    Ok(cnt) => total += cnt,
++                    Err(Errno::EINTR) => continue,
++                    Err(Errno::EAGAIN) => {
++                        break if total == 0 {
++                            // Spurious wakeup: nothing readable after all.
++                            RecvPkt::Error
++                        } else {
++                            RecvPkt::Read(total)
++                        }
++                    }
++                    Err(e) => {
++                        debug!("recv_pkt: recv error: {e:?}");
++                        break if total == 0 {
++                            RecvPkt::Error
++                        } else {
++                            RecvPkt::Read(total)
++                        };
++                    }
+                 }
+-            }
++            };
++            debug!("recv total={total}");
++            ret
+         } else {
+             debug!("recv_pkt: pkt without buf");
+             RecvPkt::Error


### PR DESCRIPTION
Takes the 12,784,144-byte project upload from **0/6 to 12/12**. The credit-floor
patch this PR originally carried was refuted by measurement and has been
dropped; what replaces it is a different fix, aimed at the constraint that
actually binds.

## Counts, per build

Every batch ran on the same dev stack (`just up`), the same minvmd binary, and
libkrun built from the same pinned commit with the same script — only the dylib
differed, swapped under a stopped VM and confirmed by `lsof` on the live VMM
process before and after each batch.

| Build | Runs | Pass | Fail |
|---|---|---|---|
| stock (control) | 6 | 0 | **6** |
| credit floor + IRQ fix *(refuted, dropped)* | 6 | 0 | **6** |
| IRQ fix + instrumentation | 6 | 0 | **6** |
| **IRQ fix + descriptor fill-loop** | 6 | **6** | 0 |
| **IRQ fix + descriptor fill-loop** (repeat) | 6 | **6** | 0 |
| stock, `MINVMD_KRUN_LOG=debug` | 3 | 3 | 0 |
| credit floor, `MINVMD_KRUN_LOG=debug` | 3 | 3 | 0 |

The two `debug` rows are a **confound, not a result**: enabling libkrun's logger
perturbs timing enough to mask the bug on *both* builds. It is recorded because
it nearly produced a false positive, and because it disqualifies per-packet
logging as a diagnostic here.

Note the third row: the IRQ fix alone does **not** fix the upload. The fill-loop
does.

## What the measurement showed

Per-packet logging dissolves the bug, so the discriminator was counters only —
no locks, allocation, or formatting on the data path, one summary per connection
at teardown, with `FIONREAD` sampled immediately before each `recv()` so
available bytes are directly comparable with `max_len`.

**Instrument validated before being believed: it preserved the failure at 6/6.**

Aggregate over the six failing 12.8 MB uploads — 40,749 packets:

| Measure | Value |
|---|---|
| mean payload | 1895 B |
| reads under 1 KiB | 14,515 (35.6%) |
| **socket drained, descriptor space left** | **30,195 (74.1%)** |
| descriptor filled, socket had more | 10,530 (25.8%) |
| **zero-credit path reached** | **10 of 40,749** |
| **mean bytes available (FIONREAD)** | **2,199 B** |
| **mean peer credit** | **239,848 B** (of a 262,144 window) |
| in-flight at close | 262,144 B — the entire window |

Representative connection:

```
pkts=6828 bytes=12944350 min=16 max=3732 mean=1895
recv_calls=6828 under1k=2453 wait_credit=2
socket_limited=5069 credit_limited=1755 neither=4
avail_mean=2189 credit_mean=236528 inflight_at_close=262144 buf_alloc=262144
  payload_hist: 2^5:10 2^6:401 2^7:171 2^8:139 2^9:902 2^10:830 2^11:1492 2^12:2883
  avail_hist:   2^0:6  2^5:10  2^6:400 2^7:169 2^8:141 2^9:901 2^10:826 2^11:1492 2^12:1231 2^13:1652
```

The two histograms track each other almost exactly up to 2^11 (401/400,
171/169, 902/901, 830/826, 1492/1492): **we read precisely what the socket
happened to hold.** That is the signature of socket-buffer-limited. They diverge
only at the top, where `buf.len()` (~4 KiB) caps a read that could have taken
4–8 KiB — the descriptor, still not credit.

Credit had ~109× more headroom than the socket had data, and the zero-credit
path fired 10 times in 40,749 reads. **The peer's window was never the binding
constraint**, which is exactly why raising a credit floor did nothing.

One honest caveat on the counter names: `credit_limited` is computed against
`max_len = min(buf.len(), peer_credit)` and so conflates the two. Given
`credit_mean` ≈ 240 KB against a ~4 KiB `buf.len()`, that bucket is
**descriptor-full**, not credit-limited. Read it that way.

## The fix (0002)

`recv_to_pkt()` issued one `recv()` per RX descriptor and shipped whatever that
call happened to find. Against a bulk sender delivering the stream in chunks,
the muxer outruns the writer and fragments it. Each fragment then costs the peer
a whole skb of queue accounting — a Linux receiver charges every queued packet
`SKB_TRUESIZE(0)` (576 B on arm64) against `buf_alloc` regardless of payload —
so sub-KiB packets burn queue budget far faster than they deliver bytes.

The patch loops until the descriptor is full or the socket returns `EAGAIN`.

**On the level-triggered trap:** polling registers `EV_ADD` without `EV_CLEAR`
(`src/utils/src/macos/epoll.rs`), so anything that declines to read available
data spins. A fill-loop is safe precisely because it never leaves readable data
behind on purpose: every exit either drained the socket or filled a descriptor,
so the next notification corresponds to genuinely new data or to a descriptor we
can immediately make progress on. A threshold-and-defer design would have spun —
which is what the dropped credit-floor patch did, and why it needed 0001 to stop
hanging.

EOF and errors encountered after some bytes are read deliver the data first and
re-report on the next call.

## The IRQ fix (0001)

Independent of the upload bug and worth upstreaming on its own. A proxy that
runs out of credit sets `WaitingCreditUpdate`, emits `VSOCK_OP_CREDIT_REQUEST`,
and disarms polling on its host fd. But `push_packet()` only places the request
in the used ring — the IRQ comes solely from `process_proxy_update()` when
`ProxyUpdate::signal_queue` is set, and that is taken from `recv_pkt()`'s
`have_used`. When the first packet of a batch is the one that has to wait,
`have_used` is false: the peer is never woken, never sends the credit update,
and polling is already disarmed on our side.

Reachable on unpatched upstream, just rare — a batch normally pushes data
packets first, and those set `signal_queue` themselves. It was not rare under
the credit-floor patch, which turned it into a multi-minute hang; that hang is
how it was found. `tsi_stream.rs` has the identical construct and the identical
gap. Both fixed.

## Build wiring

`scripts/build-libkrun-macos.sh` had no patch step. It now applies every
`*.patch` in `vendor/libkrun/patches/`, sorted, with `git apply`, after the
pinned commit is fetched and its SHA verified. Verified both directions: the
real patches apply cleanly and build; a deliberately broken patch aborts with
exit 1 and `::error::9999-bogus.patch does not apply to libkrun 728df812…`.
A silently-skipped patch is impossible.

## Instrumentation: not in this PR, deliberately

The counter patch is a debugging aid, not shippable code. It writes to a file
path from an env var, bypasses `log!`/`debug!` on purpose (the macros are inert
unless the embedder installs a logger, and installing one masks the bug), and
adds a `FIONREAD` syscall per read. **My recommendation is that it does not
belong in the repo** — it has no value except while this specific question is
open, and a checked-in debug patch in `vendor/libkrun/patches/` would be applied
to every macOS build by the very mechanism this PR adds. It is preserved in the
investigation record; ask if you want it carried somewhere.

## Trustworthiness of the A/B

- Dev minvmd is ad-hoc signed (`flags=0x2(adhoc)`, `TeamIdentifier=not set`) with
  no hardened runtime, so library validation does not apply — that is what makes
  swapping a locally built dylib possible at all.
- `LIBKRUN_PREFIX` pointed at a private scratch dir. `/opt/homebrew` was never
  touched and never appeared in minvmd's rpath, and no `libkrun*` sat next to the
  binary, so neither a Homebrew copy nor `@loader_path` could mask a swap.
- Every batch prints the live minvmd path and `lsof`s the dylib actually mapped
  into the `__krun-vmm` process, before and after; mapped size tracked every swap.
- The stock control was rebuilt from the same pinned commit with the same script
  rather than reusing the shipped dylib, so arms differ only by the patches.
- Dev stack provably distinct from installed: `Server: minimald 0.5.0-rc1` vs
  `0.5.0-rc2.dev.10.g4bfdcb09`.
- A concurrent process respawned the installed minvmd mid-run once, and the smoke
  test happily talked to it. Caught by checking the live binary; every batch now
  verifies before and after.

## Verified vs assumed

**Verified**
- The bridge port is served by `UnixAcceptorProxy` → `UnixProxy::new_reverse` in
  `unix.rs`, not `muxer.rs`'s `UnixProxy::new` path.
- `push_packet()` does not raise the IRQ; only `process_proxy_update` does. The
  resulting stall was observed and the fix removed it.
- Reads are socket-occupancy-limited, not credit-limited (numbers above).
- Fill-loop: 12/12 pass across two independent batches, against 6/6 fail on
  stock and 6/6 on stock+IRQ-fix+instrumentation.
- Instrument does not mask the bug (6/6 fail with it).
- Both patches apply to `728df812…` and build; a stale patch aborts the build.
- Machine restored: installed dylib sha `e2e8ebca…` unchanged, installed stack
  live, `Server: minimald 0.5.0-rc2.dev.10.g4bfdcb09`, no `MINVMD_*` overrides,
  all validation sessions destroyed.

**Assumed / not verified**
- `SKB_TRUESIZE(0) == 576` on arm64 and the 455-skb ceiling — carried from the
  earlier investigation, not re-derived. The fix does not depend on the exact
  number, only on fragmentation being costly to the receiver.
- **No after-histogram.** I did not rebuild instrumentation on top of the
  fill-loop to show packet sizes rising. The mechanism is inferred from the
  before-numbers plus the fix working, not directly observed post-fix.
- Throughput impact unmeasured. The fill-loop should reduce syscalls and packets
  per byte, but no benchmark was run.
- Only exercised on the dev guest (`minimald 0.5.0-rc1`, `.scratch`
  kernel/rootfs/initramfs). Not run against the installed guest, which cannot
  load an unsigned dylib.
- 12/12 is a strong signal but this is a timing-sensitive failure; a soak would
  be more convincing than two batches of six.
- `tsi_dgram.rs` shares the one-recv-per-descriptor shape; untouched, untested.
- The fill-loop is applied only to `UnixProxy`. `tsi_stream.rs` has the same
  pattern and likely the same fragmentation, but it does not serve this port and
  was left alone to keep the change reviewable.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bulk host-to-guest vsock uploads by patching libkrun credit signaling and read aggregation
> - Adds a patch stage to [scripts/build-libkrun-macos.sh](https://github.com/gominimal/minimal/pull/884/files#diff-c16e3b4b41d010615bdfaa0ccc47a1803a90f183ffe7f3393296bf6ac0607e49) that applies all patches under [vendor/libkrun/patches/](https://github.com/gominimal/minimal/pull/884/files#diff-50c34edb294da996d61db0aad0552a413a71589d53c236263b8b079baa0db7a0) to the pinned libkrun commit before building; fails the build if any patch does not apply.
> - [Patch 0001](https://github.com/gominimal/minimal/pull/884/files#diff-5d4d818f4204b33eebff5ad04661d0eb10f403a908635dd7ac6e6dfeccfa4d5d) fixes a stall where a vsock proxy running out of credit would enqueue a credit request without signaling the used queue, leaving the peer waiting indefinitely.
> - [Patch 0002](https://github.com/gominimal/minimal/pull/884/files#diff-ae5eaa116a5153f0db49b29d96bf27ec82652e80f52657eabb9552b32b7562d9) changes the vsock `UnixProxy` recv path to loop reads until the RX descriptor is full or the socket blocks, reducing packet fragmentation on bulk transfers.
> - Behavioral Change: vsock credit requests now always raise an interrupt, and host socket reads are batched per descriptor rather than one read per packet.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5dc8cf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS virtual socket reliability by ensuring queued updates trigger promptly.
  * Improved data transfer efficiency by filling receive buffers more effectively, reducing unnecessarily small packets.
  * Preserved correct handling of interruptions, drained sockets, connection closures, and receive errors.

* **Build**
  * macOS builds now consistently apply required compatibility patches and fail with clear diagnostics if a patch cannot be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->