### PR TITLE
fix(minimald): raise the guest vsock receive window to 8 MiB

### DIFF
--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -21,6 +21,27 @@ use tokio_vsock::{VMADDR_CID_ANY, VsockAddr, VsockListener};
 #[cfg(target_os = "linux")]
 const DEFAULT_VSOCK_PORT_BASE: u32 = 2222;
 
+/// Receive window installed on the guest's vsock listener, in bytes.
+///
+/// `virtio_transport_inc_rx_pkt` refuses an incoming packet — resetting the
+/// connection and setting `sk_err` to `ENOBUFS` — when either the peer overruns
+/// its credit (`buf_used + len > buf_alloc`) or the queued socket-buffer
+/// overhead does (`(queue_len + 1) * SKB_TRUESIZE(0) > buf_alloc`). At the
+/// 256 KiB default window the second ceiling lands at 455 queued skbs on arm64,
+/// where `SKB_TRUESIZE(0)` is 576 bytes. libkrun clamps each read to the credit
+/// still outstanding, so under receiver backpressure its packets shrink to
+/// roughly 540 bytes — below that per-skb overhead — and a workspace upload
+/// trips the overhead ceiling with kilobytes of window still unused.
+///
+/// 8 MiB is empirical headroom, not immunity. It does not change the ratio
+/// between the two ceilings; it keeps a normal upload out of the credit-starved
+/// tail where packets degenerate, and a larger upload or a slower reader can
+/// still reach it. The real fix belongs in libkrun, which should not shrink a
+/// packet below the per-skb overhead it costs to queue; this is the
+/// consumer-side mitigation.
+#[cfg(target_os = "linux")]
+const VSOCK_RX_WINDOW_BYTES: u64 = 8 * 1024 * 1024;
+
 /// Env var `spawn_detached` sets on the child so `async_main` knows
 /// its stdio has been redirected to `/dev/null` and needs to swap
 /// the tracing writer over to a rolling log file.
@@ -715,6 +736,28 @@ async fn async_main() -> Result<(), MainError> {
         let port_num = DEFAULT_VSOCK_PORT_BASE + cli.listen_args().unwrap().instance_num;
         let listener = VsockListener::bind(VsockAddr::new(VMADDR_CID_ANY, port_num))
             .map_err(|e| MainError::IO(e, "binding vsock port"))?;
+
+        // Widen the receive window before anything connects: `__vsock_create`
+        // copies `buffer_size` from the listening socket onto every socket it
+        // accepts, so this one call covers every session. Best effort — a
+        // daemon with the default window is the old, buggy behaviour, not a
+        // reason to refuse to boot.
+        match set_vsock_rx_window(&listener, VSOCK_RX_WINDOW_BYTES) {
+            Ok(effective) if effective >= VSOCK_RX_WINDOW_BYTES => {
+                tracing::debug!(bytes = effective, "raised the vsock receive window");
+            }
+            Ok(effective) => tracing::warn!(
+                requested = VSOCK_RX_WINDOW_BYTES,
+                effective,
+                "vsock receive window clamped below the requested size; large uploads may still \
+                 fail with ENOBUFS"
+            ),
+            Err(e) => tracing::warn!(
+                error = %e,
+                "could not raise the vsock receive window; large uploads may fail with ENOBUFS"
+            ),
+        }
+
         tracing::info!("Started listening on vsock:{port_num}");
 
         if let Err(e) = guest::emit_ready_marker(host_private_key.public_key()).await {
@@ -738,6 +781,70 @@ async fn async_main() -> Result<(), MainError> {
             .await
             .map_err(|e| MainError::IO(e, "serving on guest vsock"))
     }
+}
+
+/// Raises the AF_VSOCK receive window on `listener` to `bytes`, returning the
+/// window the kernel actually installed.
+///
+/// Two things make this less obvious than a single `setsockopt`:
+///
+/// - `SO_VM_SOCKETS_BUFFER_MAX_SIZE` has to be raised first.
+///   `vsock_update_buffer_size` clamps the requested size to `buffer_max_size`,
+///   whose default is the same 256 KiB as the size itself, so setting the size
+///   alone succeeds having changed nothing.
+/// - A clamped request is not an error. `setsockopt` returns 0 either way, so
+///   the caller only learns what it got by reading the value back.
+///
+/// Both options take a `u64` at level `AF_VSOCK`.
+#[cfg(target_os = "linux")]
+fn set_vsock_rx_window(listener: &VsockListener, bytes: u64) -> std::io::Result<u64> {
+    use std::os::fd::AsRawFd as _;
+
+    /// `SO_VM_SOCKETS_BUFFER_SIZE`, `include/uapi/linux/vm_sockets.h`.
+    const SO_VM_SOCKETS_BUFFER_SIZE: libc::c_int = 0;
+    /// `SO_VM_SOCKETS_BUFFER_MAX_SIZE`, ditto.
+    const SO_VM_SOCKETS_BUFFER_MAX_SIZE: libc::c_int = 2;
+
+    let fd = listener.as_raw_fd();
+
+    let set = |option: libc::c_int| {
+        // SAFETY: `fd` is borrowed from `listener`, which outlives this call.
+        // The option value is a live `u64` and the length passed is its own, so
+        // the kernel reads exactly the bytes that back it.
+        let rc = unsafe {
+            libc::setsockopt(
+                fd,
+                libc::AF_VSOCK,
+                option,
+                std::ptr::from_ref(&bytes).cast(),
+                size_of::<u64>() as libc::socklen_t,
+            )
+        };
+        (rc == 0)
+            .then_some(())
+            .ok_or_else(std::io::Error::last_os_error)
+    };
+
+    set(SO_VM_SOCKETS_BUFFER_MAX_SIZE)?;
+    set(SO_VM_SOCKETS_BUFFER_SIZE)?;
+
+    let mut effective: u64 = 0;
+    let mut len = size_of::<u64>() as libc::socklen_t;
+    // SAFETY: `fd` as above. `effective` and `len` are live for the duration of
+    // the call, and `len` describes the buffer the kernel writes into, which is
+    // `effective` itself.
+    let rc = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::AF_VSOCK,
+            SO_VM_SOCKETS_BUFFER_SIZE,
+            std::ptr::from_mut(&mut effective).cast(),
+            &raw mut len,
+        )
+    };
+    (rc == 0)
+        .then_some(effective)
+        .ok_or_else(std::io::Error::last_os_error)
 }
 
 /// Whether this process is the microVM's init: the kernel runs the initramfs


### PR DESCRIPTION
Fixes [gominimal/minimal#869](https://github.com/gominimal/minimal/issues/869): workspace uploads over the guest vsock die with `ENOBUFS`, and the client reports `copying tar stream to channel: channel closed`.

## Mechanism

The guest kernel (6.12.94, `net/vmw_vsock/virtio_transport_common.c`) rejects an incoming packet in `virtio_transport_inc_rx_pkt()` on **either** of two conditions:

1. **Credit** — `buf_used + len > buf_alloc`; the peer sent more than its advertised window.
2. **Overhead** — `(skb_queue_len + 1) * SKB_TRUESIZE(0) > buf_alloc`; the bookkeeping cost of the queued socket buffers alone exceeds the window.

Either rejection resets the connection and sets `sk_err = ENOBUFS`.

An instrumented guest kernel attributed **8 of 8** observed rejections to the *overhead* condition, never the credit one, each with 5–15 KB of window still unused. The arithmetic explains why. `SKB_TRUESIZE(0)` is 576 bytes on arm64 and `buf_alloc` defaults to `VSOCK_DEFAULT_BUFFER_SIZE` = 256 KiB, so the overhead ceiling sits at 455 queued skbs regardless of how much data those skbs carry. libkrun clamps each read to the credit still outstanding, so under receiver backpressure its packets shrink toward ~540 bytes — *less than the 576-byte per-skb overhead they cost to queue*. Past that crossover every additional packet consumes more window as overhead than it delivers as payload, and the overhead ceiling arrives before the credit ceiling ever can.

## The change

Raise the receive window on the guest's vsock listener to 8 MiB. `__vsock_create` (`af_vsock.c`) copies `buffer_size` from the listening socket onto every socket it accepts, so one call at bind time covers every session.

Two details are load-bearing, and getting either wrong fails silently:

- **`SO_VM_SOCKETS_BUFFER_MAX_SIZE` must be set before `SO_VM_SOCKETS_BUFFER_SIZE`.** `vsock_update_buffer_size()` clamps the requested size to `buffer_max_size`, whose default (`VSOCK_DEFAULT_BUFFER_MAX_SIZE`) is *also* 256 KiB. Set the size alone and `setsockopt` returns 0 having changed nothing. This produced a convincing false negative during investigation.
- **`setsockopt` returning 0 does not mean the value took effect.** A clamped request succeeds. The effective window is read back with `getsockopt` and the result logged.

A failed sockopt logs a warning and the daemon carries on booting: a daemon with the default window is the pre-existing bug, not a reason to refuse to start.

## Evidence

Fixture: a project whose single file compresses to exactly 12,784,144 bytes. Baseline failure rate on a stock guest is ~89% (8 of 9).

| Run | Effective window | Result |
|---|---|---|
| Control, stock guest | 256 KiB | **6/6 failed** |
| Patched, same machine and fixture | 8 MiB | **0/6 failed** |
| Accidental negative control | 256 KiB (request silently clamped — MAX not raised first) | **6/6 failed** |

The third run is the useful one. It ran the patched binary, so the only variable that differed from the passing run was the window the kernel actually installed — which isolates the window as the cause rather than any other difference between the two builds.

## This is headroom, not a fix

8 MiB does not change the *ratio* between the two ceilings; the overhead condition can still be reached. What it does is keep a normal upload out of the credit-starved tail where libkrun's packets degenerate below the per-skb overhead. A larger upload, a slower reader, or more aggressive backpressure could still get there.

The real fix belongs in libkrun, which should not shrink a packet below the overhead it costs to queue — a separate PR is in flight for that. This is the consumer-side mitigation, and it should stay useful regardless, since it also buys back ordinary buffering headroom.

## Testing

`cargo test -p minimald` does not build on macOS (procfs), which is pre-existing, so verification ran under `cross` against the Linux target:

```
CROSS_CONTAINER_OPTS="--env HOME=/tmp" cross test -p minimald --target aarch64-unknown-linux-musl
```

- lib: 145 passed, 0 failed
- `src/main.rs` unit tests: 3 passed, 0 failed
- `netns_root_integration`: 3 ignored (require netns + gvproxy; run in the `ci-linux-native` netns job)

`cross clippy -p minimald --target aarch64-unknown-linux-musl --all-targets -- -D warnings` is clean, as is `cargo fmt --check`.

The runtime evidence above was collected before this PR and is not reproduced by CI — the guest window is only observable from inside a booted microVM.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise guest vsock receive window to 8 MiB in `minimald`
> Sets `SO_VM_SOCKETS_BUFFER_MAX_SIZE` and `SO_VM_SOCKETS_BUFFER_SIZE` on the vsock listener socket immediately after binding, then reads back the effective size via `getsockopt`. The result is logged at debug level if the effective size meets the request, or warn level if the OS grants less or the call fails. This is Linux-only and runs before the daemon emits READY or begins accepting connections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac23be0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->