### PR TITLE
test(scripts): canary the bulk host-to-guest upload path

### DIFF
--- a/justfile
+++ b/justfile
@@ -304,9 +304,15 @@ test-lifecycle: (_need "jq" "brew install jq (or apt install jq)") _kvm artifact
 
 # Reaps between iterations — this WILL kill this checkout's live dev stack each pass.
 #
-# Nightly soak parity: N session-e2e reps (nightly-tests.yml runs 10).
+# Nightly soak parity: N session-e2e reps (nightly-tests.yml runs 10), then `just bulk-upload`.
 soak n="10": _kvm artifacts gvproxy initramfs minimal-cli minvmd-build
     {{e2e-env}} MINVMD_GVPROXY_BIN="{{gvproxy}}" ./scripts/soak-session-e2e.sh {{n}} "{{scratch}}/soak-logs"
+
+# Each pass uploads a 49 MiB project (~13 MB on the wire) and destroys its session.
+#
+# Bulk host→guest upload proof (#869): N `min activate`s of a large, compressible project.
+bulk-upload n="5": _kvm artifacts gvproxy initramfs minimal-cli minvmd-build
+    {{e2e-env}} MINVMD_GVPROXY_BIN="{{gvproxy}}" ./scripts/bulk-upload-e2e.sh {{n}}
 
 # ── stack bring-up ───────────────────────────────────────────────────────────
 #

--- a/scripts/bulk-upload-e2e.sh
+++ b/scripts/bulk-upload-e2e.sh
@@ -115,11 +115,11 @@ PROJECT_DIR="$(mktemp -d /tmp/mnlb.XXXXXX)"
 # XDG_CACHE_HOME is deliberately left alone so package pulls stay warm.
 case "$(uname -s)" in
   Darwin)
-    WORK="$(mktemp -d /tmp/mnl-bulk.XXXXXX)"
+    WORK="$(mktemp -d /tmp/mnl-bulk.XXXXXX)" || { echo "::error::mktemp failed for WORK" >&2; exit 1; }
     export XDG_STATE_HOME="$WORK/state"
     ;;
   *)
-    WORK="$(mktemp -d "$HOME/.mnl-bulk.XXXXXX")"
+    WORK="$(mktemp -d "$HOME/.mnl-bulk.XXXXXX")" || { echo "::error::mktemp failed for WORK" >&2; exit 1; }
     export XDG_STATE_HOME="$WORK"
     ;;
 esac

--- a/scripts/bulk-upload-e2e.sh
+++ b/scripts/bulk-upload-e2e.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Bulk host→guest upload proof: `min activate` a project carrying a large,
+# COMPRESSIBLE fixture, N times, and fail if ANY attempt errors or hangs.
+#
+# Regression cover for the vsock transport reset in
+# https://github.com/gominimal/minimal/issues/869. A guest kernel bump
+# (6.12.43 → 6.12.94, https://github.com/gominimal/pkgs/pull/311) crossed Linux
+# 6.12.92, where a new queued-skb-overhead check turned a previously silent
+# vsock protocol violation into a fatal connection reset. Every `min activate`
+# carrying a real project failed from that day on, and NOTHING went red for
+# three weeks — no test we had moves enough data through the guest vsock to
+# trip it. Client side the signature is:
+#
+#   error: Failed to upload project files: copying tar stream to channel: channel closed
+#
+# and guest side, in boot.log:
+#
+#   session ended with error error=Protocol error: No buffer space available (os error 105)
+#
+# WHY THE FIXTURE MUST BE COMPRESSIBLE. The trigger is write RATE, not volume,
+# duration or file count — the client has to hand the channel a large number of
+# already-compressed bytes as fast as it can produce them. Measured on the
+# issue, three runs each:
+#
+#   45 MiB ext4-image slice  → 12.78 MB on the wire  → FAILS ~89% of runs
+#   512 MB incompressible    → 512 MB on the wire    → passes (the zstd encoder
+#                                                      becomes the bottleneck
+#                                                      and throttles the writer)
+#   20,000 files / 78 MB     → 78 MB                 → passes
+#   45 MiB slice, other offset → 0.11 MB             → passes
+#
+# So a fixture of random bytes — the obvious thing to reach for — is exactly
+# wrong: it hides the bug. This script synthesizes one with the compressibility
+# of the measured reproducer instead of committing a 49 MiB binary: each MiB is
+# a fresh 256 KiB of xorshift32 output written four times, so zstd (level 3,
+# 2 MiB window — what async_compression defaults to) resolves three quarters of
+# every MiB to matches and emits ~1/4 of the input, while the literal quarter
+# stays incompressible enough to be stored raw. Measured: 51,380,224 bytes in,
+# 12,884,004 bytes out (3.99:1) — within 1% of the 12,784,144 bytes that
+# reproduced on the issue — and it costs ~0.4s of perl to generate. The
+# compressed size is re-checked at run time (below) so a future change that
+# accidentally makes the fixture incompressible fails loudly instead of
+# silently disarming this canary.
+#
+# The failure is probabilistic (~89%, not 100%), so a single activate is not a
+# detector: it would miss a regression 11% of the time. Five activates put the
+# miss probability at 0.11^5 = 1.6e-5 — one missed night per ~170 years of
+# nightlies — and keep detection at 97% even if CI hardware halves the trigger
+# rate to 50%. Any single failure fails the whole run.
+#
+# #869 also sometimes HANGS the client outright rather than erroring
+# (https://github.com/gominimal/inbox/issues/335, observed at 9 and 13 minutes),
+# so every activate runs under a wall-clock deadline and a hang counts as a
+# failure. A hang also stops the loop — five deadlines back to back would burn
+# the nightly's whole job budget, and one is already conclusive.
+#
+# Environment (same knobs as scripts/session-e2e.sh, which this mirrors):
+#   E2E_MINIMAL_ARGS              global args for every `min` call (e.g. --minvmd)
+#   E2E_VM                        set to 1 for VM-backed targets (extra teardown
+#                                 + guest boot log in the diagnostics)
+#   MINVMD_BOOT_LOG               optional override for the guest-console path
+#   BULK_ACTIVATE_TIMEOUT_SECS    per-activate deadline (default 420)
+#
+# Usage: scripts/bulk-upload-e2e.sh [iterations]
+set -uo pipefail # not -e: capture failures so we can dump diagnostics
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+E2E_VM="${E2E_VM:-}"
+
+ITER="${1:-5}"
+case "$ITER" in
+  '' | *[!0-9]*) echo "iterations must be a positive integer, got: '$ITER'" >&2; exit 2 ;;
+esac
+[ "$ITER" -ge 1 ] || { echo "iterations must be >= 1, got: $ITER" >&2; exit 2; }
+
+# Fixture geometry — see the compressibility discussion above. The band is wide
+# on purpose: it is a tripwire against a fixture that stops being compressible
+# (or becomes trivially compressible, the 0.11 MB case that passes), not a
+# golden-size assertion.
+FIXTURE_MIB=49
+FIXTURE_MIN_ZSTD=8000000
+FIXTURE_MAX_ZSTD=20000000
+
+# A warm activate is seconds; even a cold one (VM boot ≤150s, then the session
+# mint) fits well inside this, while the observed hangs ran 9-13 minutes.
+DEADLINE_SECS="${BULK_ACTIVATE_TIMEOUT_SECS:-420}"
+case "$DEADLINE_SECS" in
+  '' | *[!0-9]*) echo "BULK_ACTIVATE_TIMEOUT_SECS must be a positive integer, got: '$DEADLINE_SECS'" >&2; exit 2 ;;
+esac
+[ "$DEADLINE_SECS" -ge 1 ] || { echo "BULK_ACTIVATE_TIMEOUT_SECS must be >= 1, got: $DEADLINE_SECS" >&2; exit 2; }
+
+# Debug logging on either side of the transport makes #869 disappear (the issue
+# measured 4/4 passes under MINVMD_KRUN_LOG=debug, and RUST_LOG=debug on the
+# client is enough on its own). An inherited value would leave this script
+# unable to fail, so pin the level rather than defaulting it — and say so when
+# we drop one, so nobody thinks their debug run was a clean proof.
+if [ -n "${RUST_LOG:-}" ] && [ "$RUST_LOG" != warn ]; then
+  echo "note: ignoring inherited RUST_LOG='$RUST_LOG' — client debug logging masks #869"
+fi
+export RUST_LOG=warn
+if [ -n "${MINVMD_KRUN_LOG:-}" ]; then
+  echo "note: unsetting MINVMD_KRUN_LOG='$MINVMD_KRUN_LOG' — libkrun debug logging masks #869"
+  unset MINVMD_KRUN_LOG
+fi
+
+# Throwaway project dir, removed wholesale on teardown. Short template: the
+# basename is embedded in the task dir under the state root and the deepest
+# socket there has to fit sun_path's 108 bytes (see scripts/session-e2e.sh).
+PROJECT_DIR="$(mktemp -d /tmp/mnlb.XXXXXX)"
+
+# Fresh state dir so the daemon cold-starts, with the same platform split as
+# session-e2e.sh: on Linux the workdir must sit on the same filesystem as the
+# package cache (minimald hardlinks packages into each session rootfs, and
+# hardlinks cannot cross devices), on macOS $TMPDIR paths overflow sun_path.
+# XDG_CACHE_HOME is deliberately left alone so package pulls stay warm.
+case "$(uname -s)" in
+  Darwin)
+    WORK="$(mktemp -d /tmp/mnl-bulk.XXXXXX)"
+    export XDG_STATE_HOME="$WORK/state"
+    ;;
+  *)
+    WORK="$(mktemp -d "$HOME/.mnl-bulk.XXXXXX")"
+    export XDG_STATE_HOME="$WORK"
+    ;;
+esac
+export XDG_RUNTIME_DIR="$WORK/runtime"
+mkdir -p "$XDG_RUNTIME_DIR" "$XDG_STATE_HOME"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+# Every CLI call goes through this so E2E_MINIMAL_ARGS applies uniformly.
+# Word-splitting of the args is intended.
+mnl() {
+  # shellcheck disable=SC2086
+  min ${E2E_MINIMAL_ARGS:-} "$@"
+}
+
+# Leave nothing behind: a canary that strands a session (or a VM) per run is
+# worse than no canary. Sessions first — `min stop` refuses while any is live
+# unless forced, and the fixture dir goes whether or not the daemon cooperates.
+teardown() {
+  mnl destroy --all --force >/dev/null 2>&1 || true
+  mnl stop --force >/dev/null 2>&1 || true
+  if [ -n "$E2E_VM" ]; then
+    minvmd stop >/dev/null 2>&1 || true
+  fi
+  rm -rf "$PROJECT_DIR" "$WORK"
+}
+CUR_PID=''
+cleanup_child() {
+  [ -n "$CUR_PID" ] && kill "$CUR_PID" 2>/dev/null
+}
+trap 'cleanup_child; teardown' EXIT
+trap 'cleanup_child; teardown; exit 130' INT
+trap 'cleanup_child; teardown; exit 143' TERM
+
+# Dump what a detached daemon hides: the CLI's own stderr, the daemon state/log
+# files, and on VM targets the guest console — where #869 prints its half of the
+# story ("No buffer space available (os error 105)").
+diagnostics() {
+  echo "::group::bulk-upload diagnostics"
+  echo "--- activate stderr ---"; cat "$WORK/activate.err" 2>/dev/null || true
+  echo "--- activate stdout ---"; cat "$WORK/activate.out" 2>/dev/null || true
+  echo "--- min ls ---"; mnl ls 2>&1 || true
+  find "$XDG_STATE_HOME" -type f \( -name '*.log' -o -name '*.toml' \) 2>/dev/null \
+    | while read -r f; do echo "--- $f (tail) ---"; tail -40 "$f"; done
+  if [ -n "$E2E_VM" ]; then
+    echo "--- guest boot console (tail) ---"
+    tail -80 "${MINVMD_BOOT_LOG:-$XDG_STATE_HOME/minimal/providers/local-0/boot.log}" 2>/dev/null \
+      || echo "(no boot log — VM never started)"
+  fi
+  echo "::endgroup::"
+}
+
+# Run "$@" with stdin closed under a wall-clock deadline, returning its exit
+# status or 124 (GNU timeout's code) if it had to be killed. Hand-rolled
+# because `timeout` is not on a stock macOS, and because running the VM stack
+# under it wedges the boot: libkrun tcsetattr()s from timeout's background
+# process group and SIGTTOU stops the group. </dev/null is load-bearing for the
+# same reason — and it is also what puts `min activate` in its non-interactive
+# mode, where it neither prompts for the non-VCS upload confirmation (#770) nor
+# expects a keypress for policy gating.
+run_deadline() {
+  local secs="$1"
+  shift
+  "$@" </dev/null &
+  local pid=$!
+  CUR_PID=$pid
+  local waited=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$secs" ]; then
+      kill -TERM "$pid" 2>/dev/null
+      sleep 5
+      kill -KILL "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      CUR_PID=''
+      return 124
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  CUR_PID=''
+  wait "$pid"
+}
+
+# Seed the project exactly as session-e2e.sh does: the repo's `[upstream]`
+# verbatim (same locked_commit → same warmed cache keys, zero pin drift) plus a
+# light `shell` stack. The graph loader rejects an unpinned upstream, so verify
+# the block actually came across.
+{
+  awk '
+    /^\[upstream\]/            { grab = 1; print; next }
+    grab && (/^$/ || /^\[/)    { exit }
+    grab                       { print }
+  ' "$ROOT/.minimal/minimal.toml"
+  printf '\n[stack]\nuse = "shell"\n'
+} > "$PROJECT_DIR/minimal.toml"
+if ! grep -q '^\[upstream\]' "$PROJECT_DIR/minimal.toml" \
+   || ! grep -q '^locked_commit' "$PROJECT_DIR/minimal.toml"; then
+  echo "::error::seeded minimal.toml lacks a pinned [upstream] (need repo + locked_commit) from $ROOT/.minimal/minimal.toml"
+  exit 1
+fi
+
+# The payload. Each MiB is a fresh 256 KiB of xorshift32 output repeated four
+# times: deterministic (fixed seed → byte-identical every run, so a failure is
+# reproducible), ~4:1 under zstd, and cheap to both generate and compress —
+# which is the point, since a fixture the encoder has to work at throttles the
+# writer and hides the bug. 32-bit arithmetic keeps it independent of perl's
+# integer width; perl is already a dependency of scripts/session-e2e.sh.
+FIXTURE="$PROJECT_DIR/bulk-fixture.bin"
+echo "::group::fixture (${FIXTURE_MIB} MiB, ~4:1 compressible)"
+perl -e '
+  my $s = 0x9E3779B9;
+  for my $mib (1 .. $ARGV[0]) {
+    my $quarter = "";
+    for (1 .. (256 * 1024 / 4)) {
+      $s ^= ($s << 13) & 0xFFFFFFFF;
+      $s ^= ($s >> 17);
+      $s ^= ($s << 5)  & 0xFFFFFFFF;
+      $quarter .= pack("N", $s);
+    }
+    print $quarter x 4;
+  }
+' "$FIXTURE_MIB" > "$FIXTURE" || { echo "::error::could not generate the upload fixture"; exit 1; }
+
+raw_bytes="$(wc -c < "$FIXTURE" | tr -d ' ')"
+[ "$raw_bytes" -eq $((FIXTURE_MIB * 1024 * 1024)) ] \
+  || { echo "::error::fixture is $raw_bytes bytes, expected $((FIXTURE_MIB * 1024 * 1024))"; exit 1; }
+
+# On-the-wire size is the discriminator, so assert it rather than trusting the
+# generator. Level 3 single-threaded mirrors the client's encoder
+# (async_compression's ZstdEncoder default).
+if command -v zstd >/dev/null 2>&1; then
+  wire_bytes="$(zstd -3 -T1 -c "$FIXTURE" 2>/dev/null | wc -c | tr -d ' ')"
+  case "$wire_bytes" in
+    '' | *[!0-9]*)
+      echo "::warning::could not measure the fixture's compressed size — skipping the check"
+      ;;
+    *)
+      echo "fixture: $raw_bytes bytes raw, $wire_bytes bytes on the wire"
+      if [ "$wire_bytes" -lt "$FIXTURE_MIN_ZSTD" ] || [ "$wire_bytes" -gt "$FIXTURE_MAX_ZSTD" ]; then
+        echo "::error::fixture compresses to $wire_bytes bytes, outside [$FIXTURE_MIN_ZSTD, $FIXTURE_MAX_ZSTD]"
+        echo "  This proof needs a payload that is LARGE AFTER COMPRESSION and cheap to"
+        echo "  compress — see https://github.com/gominimal/minimal/issues/869. Too"
+        echo "  compressible and there is nothing on the wire; incompressible and the"
+        echo "  encoder throttles the writer. Either way the bug goes undetected."
+        exit 1
+      fi
+      ;;
+  esac
+else
+  echo "::warning::zstd not found — skipping the fixture compressibility check (expect ~12.9 MB on the wire)"
+fi
+echo "::endgroup::"
+
+# `min activate` uploads the CURRENT directory, not the path argument (#873),
+# so the project dir has to be the cwd. Everything else here is absolute.
+cd "$PROJECT_DIR" || { echo "::error::cannot cd into $PROJECT_DIR"; exit 1; }
+
+# Warm the daemon outside the timed loop: autospawn (a VM boot on VM targets) is
+# minutes of variance that has nothing to do with the upload, and folding it
+# into iteration 1's deadline would make that deadline meaningless.
+echo "::group::warm the daemon (autospawn)"
+# shellcheck disable=SC2086
+if ! run_deadline "$DEADLINE_SECS" min ${E2E_MINIMAL_ARGS:-} ls >/dev/null 2>"$WORK/activate.err"; then
+  echo "::error::the daemon did not come up ('min ls' failed or exceeded ${DEADLINE_SECS}s)"
+  diagnostics
+  exit 1
+fi
+echo "::endgroup::"
+
+pass=0
+fail=0
+for i in $(seq 1 "$ITER"); do
+  echo "::group::bulk upload $i/$ITER (${FIXTURE_MIB} MiB project)"
+  # shellcheck disable=SC2086
+  run_deadline "$DEADLINE_SECS" \
+    min ${E2E_MINIMAL_ARGS:-} activate . >"$WORK/activate.out" 2>"$WORK/activate.err"
+  rc=$?
+
+  sid="$(tail -n1 "$WORK/activate.out" 2>/dev/null | tr -d '\r')"
+  if [ "$rc" -eq 0 ] \
+     && printf '%s' "$sid" | grep -Eqx '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'; then
+    pass=$((pass + 1))
+    echo "iteration $i: OK (session $sid)"
+    # Destroy as we go: one live session at a time, and nothing to leak if the
+    # run is cancelled mid-loop.
+    mnl destroy "$sid" >/dev/null 2>&1 \
+      || echo "::warning::could not destroy session $sid (the teardown sweep will retry)"
+  else
+    fail=$((fail + 1))
+    # Close the iteration's group first: the annotations below are the point of
+    # the run, and folding them into a collapsed group buries them.
+    echo "::endgroup::"
+    if [ "$rc" -eq 124 ]; then
+      echo "::error::iteration $i: 'min activate' still running after ${DEADLINE_SECS}s — the #869 hang (https://github.com/gominimal/inbox/issues/335)"
+    elif [ "$rc" -eq 0 ]; then
+      echo "::error::iteration $i: activate's last stdout line is not a session UUID: '$sid'"
+    else
+      echo "::error::iteration $i: 'min activate' exited $rc — check for 'Failed to upload project files: copying tar stream to channel: channel closed' (https://github.com/gominimal/minimal/issues/869)"
+    fi
+    diagnostics
+    # Sweep whatever a failed activate left half-created before the next pass.
+    mnl destroy --all --force >/dev/null 2>&1 || true
+    # A hang costs a full deadline; five of them would burn the nightly's whole
+    # budget, and one is already conclusive. Errors are cheap, so keep going —
+    # the pass/fail tally is what identifies the ~89% signature.
+    if [ "$rc" -eq 124 ]; then
+      echo "::warning::stopping after a hang; $((ITER - i)) iteration(s) not run"
+      break
+    fi
+    continue
+  fi
+  echo "::endgroup::"
+done
+
+echo "bulk upload proof: $pass passed, $fail failed (of $ITER)"
+[ "$fail" -eq 0 ] && [ "$pass" -eq "$ITER" ]

--- a/scripts/soak-session-e2e.sh
+++ b/scripts/soak-session-e2e.sh
@@ -29,7 +29,14 @@ esac
 [ "$ITER" -ge 1 ] || { echo "iterations must be >= 1, got: $ITER" >&2; exit 2; }
 
 LOGDIR="${2:-$(mktemp -d /tmp/mnl-soak.XXXXXX)}"
-mkdir -p "$LOGDIR"
+mkdir -p "$LOGDIR" || { echo "cannot create boot-log dir: '$LOGDIR'" >&2; exit 2; }
+# Absolutise: MINVMD_BOOT_LOG is consumed by minvmd as given (vmm_child.rs takes
+# the env value verbatim), and both child harnesses cd into their own project
+# dir before any `min` call, so a relative LOGDIR would resolve against that dir
+# instead. minvmd only warns and boots on when the console file cannot be
+# created, so the guest log — the half of #869 worth having — would vanish
+# silently, exactly when a failing run needs it.
+LOGDIR="$(cd "$LOGDIR" && pwd)"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Reap leftovers a failed boot may strand (the detached __krun-vmm grandchild

--- a/scripts/soak-session-e2e.sh
+++ b/scripts/soak-session-e2e.sh
@@ -5,6 +5,13 @@
 # vsock-bridge wedge class) that a single PR-lane run cannot surface. Reports
 # a pass/fail tally and exits non-zero if ANY iteration failed.
 #
+# Then, once, the bulk host→guest upload proof (scripts/bulk-upload-e2e.sh):
+# no session-e2e iteration pushes enough data through the guest vsock to catch
+# the transport-reset class (https://github.com/gominimal/minimal/issues/869),
+# which needs a project that is large AFTER compression. It runs on the same
+# VM-backed setup the caller already provides, does its own (probabilistic)
+# iterations, and cleans up after itself. Its result gates the exit status too.
+#
 # The caller sets the VM up exactly as the KVM lane does — minvmd + minimal
 # on PATH, MINVMD_KERNEL_PATH / MINVMD_ROOTFS_PATH / MINVMD_INITRAMFS set,
 # libkrun on the loader path — and passes the VM knobs through the
@@ -51,7 +58,17 @@ for i in $(seq 1 "$ITER"); do
 done
 # Final reap is handled by the EXIT trap.
 
-echo "soak complete: $pass passed, $fail failed (of $ITER)"
+echo "::group::bulk host→guest upload proof"
+reap
+if MINVMD_BOOT_LOG="$LOGDIR/boot-bulk.log" "$ROOT/scripts/bulk-upload-e2e.sh"; then
+  bulk=OK
+else
+  bulk=FAILED
+  echo "::warning::bulk upload proof FAILED"
+fi
+echo "::endgroup::"
+
+echo "soak complete: $pass passed, $fail failed (of $ITER); bulk upload proof: $bulk"
 # Require every iteration to have run AND passed — a short-circuited loop that
 # ran zero iterations must not report success.
-[ "$fail" -eq 0 ] && [ "$pass" -eq "$ITER" ]
+[ "$fail" -eq 0 ] && [ "$pass" -eq "$ITER" ] && [ "$bulk" = OK ]


### PR DESCRIPTION
## What this covers

**Failure class: bulk host→guest transfer over the vsock/SSH transport.**

A guest kernel bump (6.12.43 → 6.12.94, [gominimal/pkgs#311](https://github.com/gominimal/pkgs/pull/311), 2026-07-01) crossed Linux 6.12.92, where a new queued-`sk_buff`-overhead check turned a previously silent vsock protocol violation into a fatal connection reset — [gominimal/minimal#869](https://github.com/gominimal/minimal/issues/869). From that day every `min activate` carrying a real project failed:

```
error: Failed to upload project files: copying tar stream to channel: channel closed
```

with, guest side in `boot.log`:

```
session ended with error error=Protocol error: No buffer space available (os error 105)
```

Nothing went red for three weeks, until a human hit it by hand. Nothing we run moves enough data through the guest vsock to trip it — `session-e2e.sh` uploads a two-line `minimal.toml`.

`scripts/bulk-upload-e2e.sh` is that missing proof: `min activate` a project carrying a large, compressible fixture, five times over, failing if any attempt errors *or hangs*.

## Why the fixture has to be compressible

The trigger is **write rate**, not volume, duration or file count — the client has to hand the channel a large number of *already-compressed* bytes as fast as it can produce them. From the measurements on the issue (three runs each):

| Payload | On the wire | Result |
|---|---|---|
| 45 MiB ext4-image slice | 12.78 MB | **fails ~89% of runs** |
| 512 MB incompressible random | 512 MB | passes — the zstd encoder becomes the bottleneck and self-throttles the writer |
| 20,000 files / 78 MB | 78 MB | passes |
| 45 MiB slice, different offset | 0.11 MB | passes |

So the obvious fixture — `/dev/urandom` — is exactly the wrong one: it hides the bug. And 0.11 MB on the wire is equally useless. The fixture therefore has to be **large after compression and cheap to compress**.

Rather than commit a 49 MiB binary, the script synthesizes one: each MiB is a fresh 256 KiB of xorshift32 output written four times, so zstd (level 3, 2 MiB window — what `async_compression`'s `ZstdEncoder` defaults to) resolves three quarters of every MiB to matches while the literal quarter stays incompressible enough to be stored raw. Fixed seed, so it is byte-identical every run and a failure is reproducible.

Measured locally: **51,380,224 bytes in → 12,884,004 bytes out (3.99:1)** — within 1% of the 12,784,144 bytes that reproduce on the issue — generated in ~0.35 s of perl.

That ratio is then **asserted at run time** (`zstd -3 -T1`, band 8–20 MB): if a future change makes the fixture incompressible, or trivially compressible, the script fails loudly instead of silently disarming itself. The check is skipped with a warning where `zstd` is absent (it is on the nightly's `ubuntu-latest`; the justfile already lists it as a macOS prereq).

Two related traps are closed the same way: the issue measured 4/4 passes under `MINVMD_KRUN_LOG=debug`, and client-side `RUST_LOG=debug` is enough on its own to make the bug vanish. The script therefore **pins `RUST_LOG=warn` and unsets `MINVMD_KRUN_LOG`** (printing a note when it drops an inherited value) — an inherited debug level would otherwise leave the canary unable to fail.

## Iteration count: 5

The failure is probabilistic (~89%, not 100%), so one activate is not a detector.

| N | P(miss a live regression) |
|---|---|
| 1 | 11% |
| 3 | 0.13% |
| **5** | **0.0016%** |

At the measured p = 0.89, three would already be enough (99.87%). Five is chosen for margin against CI hardware that fails to reproduce as reliably: even if the trigger rate halved to p = 0.5, five iterations still detect 96.9% of the time. The cost is five `min activate`s against one already-booted VM (the daemon is warmed *outside* the loop, so a VM boot is not billed to any iteration's deadline).

**Any single failure across the set fails the script** (`$fail -eq 0 && $pass -eq $ITER` — the same shape `soak-session-e2e.sh` uses, which also refuses to call a short-circuited loop a pass).

## Timeout handling (the hang case)

[gominimal/inbox#335](https://github.com/gominimal/inbox/issues/335): the same defect sometimes **hangs the client indefinitely** instead of erroring (observed at 9 and 13 minutes before being killed). A canary that waits forever is a canary that reports nothing, so:

- every `min activate` runs under a wall-clock deadline (default 420 s, `BULK_ACTIVATE_TIMEOUT_SECS`), SIGTERM then SIGKILL, returning 124;
- 124 is reported as a distinct, named failure (`the #869 hang`), not a generic error;
- a hang **stops the loop** — five deadlines back to back would burn the nightly's whole job budget, and one hang is already conclusive. Plain errors are cheap, so those keep going: the pass/fail tally is what identifies the ~89% signature.

`timeout(1)` is deliberately not used: it does not exist on a stock macOS, and running the VM stack under it wedges the boot (libkrun `tcsetattr()`s from `timeout`'s background process group and SIGTTOU stops the group). The hand-rolled watchdog runs the client with `</dev/null` for the same reason — which also puts `min activate` in its non-interactive mode, where it neither prompts for the non-VCS upload confirmation ([#770](https://github.com/gominimal/minimal/issues/770)) nor waits on a keypress for policy gating.

## How it hooks into the nightly canary

**No workflow change is required, and none is made** (`.github/workflows/` is frozen and CODEOWNER-gated).

The nightly test tier does **not** discover scripts by convention: `nightly-tests.yml`'s `session-e2e-soak` job invokes one entry point explicitly, `./scripts/soak-session-e2e.sh 10 "$RUNNER_TEMP/soak-logs"`. That script is reviewed code, so the hook goes there: after its session-e2e reps it reaps, runs the bulk-upload proof once (with `MINVMD_BOOT_LOG` pointed into the same log dir that is already uploaded as an artifact), and folds the result into its tally and exit status. It inherits the job's whole VM setup — images, gvproxy, `PATH` — for free.

`just bulk-upload [n]` runs the same proof locally, and `just soak` keeps nightly parity.

**One thing a CODEOWNER may need to follow up on:** the proof now shares the `session-e2e-soak` job's `timeout-minutes: 60` with the ten session-e2e reps. It should add roughly 5–10 minutes (one VM boot plus five activates against a warm cache), but I could not measure it. If that job starts timing out, the fix is a workflow edit I cannot make — either bump `timeout-minutes`, or split it into its own job:

```yaml
      - name: Bulk host→guest upload proof
        env: # same MINVMD_*/E2E_* block as the soak step
        run: ./scripts/bulk-upload-e2e.sh 5
```

Either way the failure is legible, and `notify` already files a tracking issue when `session-e2e-soak` fails.

## Cleanup

A canary that leaks 89 sessions a week is worse than no canary:

- each iteration destroys its session immediately on success;
- a failed iteration sweeps with `min destroy --all --force` before the next pass;
- the `EXIT`/`INT`/`TERM` trap runs `destroy --all --force`, `stop --force`, `minvmd stop` on VM targets, and removes the fixture, the project dir and the private state dir;
- the script runs in its own `XDG_STATE_HOME`, so the sweep can never touch a developer's real sessions.

## Verification

**Verified.** The script's own logic was exercised end to end against a stub `min` on `PATH` (the real VM was never started — see below):

| Case | Result |
|---|---|
| Happy path, 2 iterations | `2 passed, 0 failed`, exit 0; call trace shows `ls` → `activate` → `destroy <sid>` per pass, then `destroy --all --force` + `stop --force`; no temp dirs left in `/tmp` or `$HOME` |
| `activate` exits 1 | both iterations reported with the `#869` pointer, diagnostics dumped, `0 passed, 2 failed`, exit 1 |
| `activate` hangs (deadline 3 s) | killed at the deadline, reported as the `#869` hang, loop stopped with `2 iteration(s) not run`, exit 1 |
| `activate` prints a non-UUID | reported as a UUID-validation failure, exit 1 |
| Fixture outside the compressibility band | run aborted before any activate, with the explanation, exit 1 |
| Inherited `RUST_LOG=debug` / `MINVMD_KRUN_LOG=debug` | both reported and overridden |
| Fixture generator | byte-identical across runs (same sha256); 51,380,224 → 12,884,004 bytes under `zstd -3 -T1` |
| `shellcheck scripts/bulk-upload-e2e.sh scripts/soak-session-e2e.sh` | clean, no findings, no suppressions beyond the two `SC2086`s that match `session-e2e.sh`'s intentional `E2E_MINIMAL_ARGS` word-splitting |
| `bash -n` both scripts, `just --list` | pass |

**Not verified — needs a reviewer or CI to run it.** Another agent is holding the only VM on this machine for a timing-sensitive measurement, and a second VM would collide on the provider directory, so I could not run this against a real stack. Specifically unproven:

1. **The end-to-end run itself** — that a real `min activate` of the 49 MiB project succeeds on a good stack (and, on a pre-fix stack, fails). Reviewer check: `just bulk-upload` on a KVM or macOS host. On a stack still carrying [#869](https://github.com/gominimal/minimal/issues/869) it should fail ~89% of iterations with the `channel closed` line.
2. **`scripts/soak-session-e2e.sh`'s new phase** — syntax-checked only; running it invokes `scripts/reap-vms.sh`, which would have killed the VM I was told not to touch.
3. **Runtime cost inside the nightly's 60-minute budget** (see the CODEOWNER note above).
4. **perl and zstd behaviour on the runner image** — verified on macOS/arm64 only. The generator uses 32-bit arithmetic precisely so it does not depend on perl's integer width, and `session-e2e.sh` already depends on perl.

Refs: [#869](https://github.com/gominimal/minimal/issues/869), [gominimal/inbox#335](https://github.com/gominimal/inbox/issues/335)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add canary e2e test for the bulk host-to-guest upload path
> - Adds [scripts/bulk-upload-e2e.sh](https://github.com/gominimal/minimal/pull/887/files#diff-b52c18308835b5f5c5053d8108f53b210cc7795cb4603e9970623eea37c8316b), a standalone bash harness that synthesizes a ~49 MiB compressible payload, then runs N timed `min activate` iterations, emitting CI annotations and failing if any iteration errors or hangs.
> - Adds a `just bulk-upload` task in [justfile](https://github.com/gominimal/minimal/pull/887/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1) to invoke the new script with a configurable iteration count (default 5).
> - Updates [scripts/soak-session-e2e.sh](https://github.com/gominimal/minimal/pull/887/files#diff-cf75f0484ad3e0afe305f607684d73e384859c7f610fff0aa752819d9eb55f44) to run the bulk upload proof after session-e2e iterations and fail overall if the bulk proof fails; also fixes `LOGDIR` to use an absolute path and adds error handling for boot-log directory creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66a09de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **bulk-upload** end-to-end verification task with a configurable repetition count (default **5**).
  * Updated soak workflows to include a bulk host→guest upload proof after session testing.
* **Bug Fixes**
  * Soak now requires both session checks **and** bulk-upload verification to pass.
  * Improved timeout handling and failure diagnostics for repeated checks.
* **Documentation**
  * Updated task documentation to clarify the nightly soak flow and the added bulk upload step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->