### PR TITLE
feat(scripts): flag guest-kernel bumps that change vsock semantics

### DIFF
--- a/justfile
+++ b/justfile
@@ -136,6 +136,14 @@ clean:
 reap:
     scripts/reap-vms.sh
 
+# Run before landing a guest-kernel bump (the `virtio-linux` version in pkgs, or
+# the `locked_commit` that pulls it in): stable-tree commits touching vsock,
+# virtio and the guest console — the surface the guest control plane rides on.
+# `just kernel-review --pkgs ~/code/pkgs` reads both versions from a checkout.
+# Review a guest-kernel bump (`just kernel-review 6.12.43 6.12.94`). Needs `gh`.
+kernel-review *args:
+    scripts/kernel-bump-review.sh {{args}}
+
 # ── CI-parity gates ──────────────────────────────────────────────────────────
 
 # Fail fast with an install hint when a required tool is missing.

--- a/scripts/kernel-bump-review.sh
+++ b/scripts/kernel-bump-review.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+#
+# kernel-bump-review.sh — show a reviewer the stable-kernel commits a guest
+# kernel bump drags into the subsystems this project's guest depends on.
+#
+# WHY
+#
+# The guest kernel is pinned in gominimal/pkgs (packages/virtio-linux/build.ncl,
+# `let version = "..."`) and reaches this repo when `.minimal/minimal.toml`'s
+# `locked_commit` moves. A point-release bump can span thousands of commits, so
+# in practice nobody reads it, and a semantic change to the guest's control
+# plane lands unreviewed. That is how 6.12.43 -> 6.12.94 shipped a4f0b001782b
+# ("vsock/virtio: reset connection on receiving queue overflow"), which turned a
+# silently-dropped packet into a fatal connection reset and broke every sizeable
+# `min activate` for three weeks. The commit is public, its subject says exactly
+# what it does, and it sits in net/vmw_vsock/ — the subtree the entire guest
+# control plane rides on. A mechanical diff was all that was needed to catch it,
+# with no VM and no test run. This is that diff.
+#
+# WHICH SUBTREES, AND WHY
+#
+# A wide net is worse than none: a reviewer learns to skip a report that is
+# mostly noise. The default set is only what the guest cannot boot or be driven
+# without, and each entry earns its place:
+#
+#   net/vmw_vsock/                  every RPC, attach/PTY stream and file upload
+#                                   rides AF_VSOCK; the virtio transport lives
+#                                   here. The root cause above landed here.
+#   include/linux/virtio_vsock.h    credit accounting, buffer/packet limits and
+#   include/uapi/linux/virtio_vsock.h  the wire protocol constants shared with
+#                                   the host-side device. Tiny, high signal.
+#   drivers/virtio/                 virtio core: virtqueue/vring, feature
+#                                   negotiation, DMA — under every device below.
+#   drivers/char/virtio_console.c   the guest boots `console=hvc0`; all guest
+#                                   boot and minimald logs leave over it, so its
+#                                   loss/backpressure behaviour decides whether
+#                                   a guest-side hang is diagnosable at all.
+#   drivers/block/virtio_blk.c      the ext4 root disk and the persistent data
+#                                   volume are virtio-blk (krun_add_disk2/3);
+#                                   sparse/discard behaviour is load-bearing.
+#
+# Deliberately NOT in the default set:
+#
+#   drivers/vhost/vsock.c   the HOST-side vhost-vsock driver. libkrun implements
+#                           virtio-vsock in userspace and minvmd bridges it to a
+#                           host unix socket (krun_add_vsock_port2), so this
+#                           driver is never loaded on either side of our stack.
+#                           --wide includes it anyway as a cross-check, since a
+#                           vsock semantics change is often mirrored here.
+#   drivers/net/virtio_net.c  guest egress (gvproxy) rides it, but it is behind
+#                           the networking-proxy feature and off the control
+#                           plane. --wide includes it.
+#   fs/fuse/virtio_fs.c     not used: the rootfs is a raw ext4 disk, not virtiofs.
+#   arch/, mm/, sched/, …   real, but any bump touches thousands of these lines;
+#                           including them is how a report becomes wallpaper.
+#
+# WHERE THE DATA COMES FROM
+#
+# The stable tree, via the GitHub API. torvalds/linux does NOT carry v6.12.x
+# tags — querying it returns 404, and a 404 through `curl` is indistinguishable
+# from "no matching commits". Every request here is checked and every failure is
+# fatal: a tripwire that reports "no changes" when it cannot reach the source is
+# worse than no tripwire.
+#
+# HOW THE RANGE IS COMPUTED
+#
+# Both tags are resolved to commits, then each subtree is queried with a
+# committer-date window (since = old tag, until = new tag) on the new tag's
+# history. A stable branch is a linear sequence of cherry-picks whose committer
+# dates rise monotonically, so the window is exact. Its one imprecision is
+# benign: a commit sharing the old tag's exact timestamp is reported once too
+# often, never once too few. The size of the full range is reported alongside,
+# so "0 commits" is always distinguishable from "0 commits looked at".
+#
+# OUTPUT
+#
+#   ! <stable-sha> <upstream-sha> <date> <subject>
+#
+# `!` marks a subject matching a behavioural keyword (reset, drop, overflow,
+# credit, backpressure, queue, fatal) — read those before the pin lands.
+# <upstream-sha> is the mainline commit the stable patch backports, taken from
+# the "commit <sha> upstream." line; `-` when there is none. Browse any commit
+# at https://github.com/gregkh/linux/commit/<sha>.
+#
+# Usage:
+#   scripts/kernel-bump-review.sh <old-version> <new-version>
+#   scripts/kernel-bump-review.sh --pkgs DIR [old-ref] [new-ref]
+#
+# Options:
+#   --pkgs DIR       Read both versions from a gominimal/pkgs checkout instead
+#                    of the command line: `let version` in build.ncl at each ref
+#                    (default refs: origin/main and HEAD — i.e. what a pkgs pull
+#                    request changes). For a `locked_commit` bump in this repo,
+#                    pass the two pinned commits as the refs.
+#   --wide           Add the host-side/non-control-plane paths listed above.
+#   --fail-on-flag   Exit 2 when any commit is flagged (for a future CI gate).
+#   -h, --help       Show this help
+#
+# Examples:
+#   scripts/kernel-bump-review.sh 6.12.43 6.12.94
+#   scripts/kernel-bump-review.sh --pkgs ~/code/pkgs
+#   scripts/kernel-bump-review.sh --pkgs ~/code/pkgs c854d6b1 8f2a91c4
+#
+# Requires: an authenticated `gh` (public data; any token works), and `git` for
+# --pkgs. No kernel checkout, no VM, no network beyond api.github.com.
+set -euo pipefail
+
+# The stable tree. Do not point this at torvalds/linux (see above).
+REPO="gregkh/linux"
+NCL_PATH="packages/virtio-linux/build.ncl"
+
+# Subject keywords that separate "a behaviour changed" from "a typo was fixed".
+# Matched case-insensitively against the subject only.
+FLAG_RE='reset|drop|overflow|credit|backpressure|queue|fatal'
+
+# The guest's load-bearing surface. Rationale in the header — keep it earned.
+CORE_PATHS=(
+    net/vmw_vsock
+    include/linux/virtio_vsock.h
+    include/uapi/linux/virtio_vsock.h
+    drivers/virtio
+    drivers/char/virtio_console.c
+    drivers/block/virtio_blk.c
+)
+WIDE_PATHS=(
+    drivers/vhost/vsock.c
+    drivers/net/virtio_net.c
+)
+
+die() {
+    printf 'kernel-bump-review: %s\n' "$1" >&2
+    exit 1
+}
+
+usage() {
+    sed -n '/^# Usage:/,/^set -euo/{/^set -euo/!p;}' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+WIDE=0
+FAIL_ON_FLAG=0
+PKGS_DIR=""
+ARG1=""
+ARG2=""
+NARG=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --pkgs)
+            # Guard $2: under `set -u` a trailing valueless flag would abort
+            # with an unbound-variable error instead of a usable message.
+            [ $# -ge 2 ] || die "missing value for $1"
+            PKGS_DIR="$2"
+            shift 2 ;;
+        --wide)         WIDE=1; shift ;;
+        --fail-on-flag) FAIL_ON_FLAG=1; shift ;;
+        -h|--help)      usage 0 ;;
+        -*)             die "unknown argument: $1 (try --help)" ;;
+        *)
+            NARG=$((NARG + 1))
+            case "$NARG" in
+                1) ARG1="$1" ;;
+                2) ARG2="$1" ;;
+                *) die "unexpected argument: $1 (try --help)" ;;
+            esac
+            shift ;;
+    esac
+done
+
+command -v gh >/dev/null 2>&1 || die "gh not found (needed for the GitHub API)"
+
+# `let version = "6.12.94" in` -> 6.12.94, at a given ref of the pkgs checkout.
+version_at_ref() {
+    local ref="$1" blob ver
+    blob=$(git -C "$PKGS_DIR" show "$ref:$NCL_PATH" 2>&1) \
+        || die "cannot read $NCL_PATH at '$ref' in $PKGS_DIR: $blob"
+    ver=$(printf '%s\n' "$blob" | sed -n 's/^let version = "\([^"]*\)".*/\1/p' | head -1)
+    [ -n "$ver" ] || die "no 'let version = \"...\"' line in $NCL_PATH at '$ref'"
+    printf '%s' "$ver"
+}
+
+if [ -n "$PKGS_DIR" ]; then
+    command -v git >/dev/null 2>&1 || die "git not found (needed for --pkgs)"
+    [ -d "$PKGS_DIR" ] || die "--pkgs: not a directory: $PKGS_DIR"
+    git -C "$PKGS_DIR" rev-parse --git-dir >/dev/null 2>&1 \
+        || die "--pkgs: not a git checkout: $PKGS_DIR"
+    OLD_VERSION=$(version_at_ref "${ARG1:-origin/main}")
+    NEW_VERSION=$(version_at_ref "${ARG2:-HEAD}")
+    printf 'kernel-bump-review: %s in %s: %s -> %s (%s -> %s)\n' \
+        "$NCL_PATH" "$PKGS_DIR" "${ARG1:-origin/main}" "${ARG2:-HEAD}" \
+        "$OLD_VERSION" "$NEW_VERSION" >&2
+else
+    [ "$NARG" -eq 2 ] || usage 2
+    OLD_VERSION="$ARG1"
+    NEW_VERSION="$ARG2"
+fi
+
+[ "$OLD_VERSION" != "$NEW_VERSION" ] \
+    || die "both versions are $OLD_VERSION — nothing to review"
+
+# Stable tags are digits and dots. Refuse anything else rather than paste it
+# into an API path.
+for v in "$OLD_VERSION" "$NEW_VERSION"; do
+    case "${v#v}" in
+        ""|*[!0-9.]*) die "'$v' is not a stable kernel version (expected e.g. 6.12.94)" ;;
+    esac
+done
+
+OLD_TAG="v${OLD_VERSION#v}"
+NEW_TAG="v${NEW_VERSION#v}"
+
+# "<sha>\t<committer-date>" for a tag, or a loud death. This is the request that
+# catches a wrong repo, a nonexistent version, a typo, or no network.
+resolve_tag() {
+    local tag="$1" out
+    out=$(gh api "repos/$REPO/commits/$tag" --jq '[.sha, .commit.committer.date] | @tsv' 2>&1) \
+        || die "cannot resolve $tag in $REPO ($out)
+  Does $REPO carry stable tags? torvalds/linux does not — only the stable
+  mirror (gregkh/linux) has v6.12.x. Also check \`gh auth status\`."
+    printf '%s' "$out"
+}
+
+# Assign first: a `die` inside $( ) only kills the subshell, so the failure has
+# to be caught by the assignment's exit status (set -e) rather than swallowed by
+# a surrounding redirect.
+OLD_META=$(resolve_tag "$OLD_TAG")
+NEW_META=$(resolve_tag "$NEW_TAG")
+IFS=$'\t' read -r OLD_SHA OLD_DATE <<<"$OLD_META"
+IFS=$'\t' read -r NEW_SHA NEW_DATE <<<"$NEW_META"
+
+# Ordering is a real mistake mode (a reviewer pastes the versions the way the
+# diff shows them, new first) and it silently yields an empty report.
+[[ "$OLD_DATE" < "$NEW_DATE" ]] \
+    || die "$OLD_TAG ($OLD_DATE) is not older than $NEW_TAG ($NEW_DATE) — arguments reversed?"
+
+# Independent proof the range is real, so "no commits in these subtrees" can
+# never be confused with "the query found nothing at all". per_page=1 keeps the
+# response small; total_commits counts the whole range regardless.
+RANGE_TOTAL=$(gh api "repos/$REPO/compare/$OLD_TAG...$NEW_TAG?per_page=1" --jq '.total_commits' 2>&1) \
+    || die "cannot compare $OLD_TAG...$NEW_TAG in $REPO ($RANGE_TOTAL)"
+[ "$RANGE_TOTAL" -gt 0 ] 2>/dev/null \
+    || die "$OLD_TAG...$NEW_TAG spans $RANGE_TOTAL commits — refusing to report on an empty range"
+
+PATHS=("${CORE_PATHS[@]}")
+SCOPE="core"
+if [ "$WIDE" -eq 1 ]; then
+    PATHS+=("${WIDE_PATHS[@]}")
+    SCOPE="wide"
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+printf '\n== kernel bump review: %s %s -> %s ==\n\n' "$REPO" "$OLD_TAG" "$NEW_TAG"
+printf '  old  %-10s %s  %s\n' "$OLD_TAG" "${OLD_SHA:0:12}" "$OLD_DATE"
+printf '  new  %-10s %s  %s\n' "$NEW_TAG" "${NEW_SHA:0:12}" "$NEW_DATE"
+printf '  range spans %s commits; scanning the %s subtree set\n' "$RANGE_TOTAL" "$SCOPE"
+printf '  columns: [!] <stable-sha> <upstream-sha> <date> <subject>\n'
+printf '  browse:  https://github.com/%s/commit/<stable-sha>\n' "$REPO"
+
+TOTAL=0
+FLAGGED=0
+: >"$TMP/summary"
+
+for path in "${PATHS[@]}"; do
+    # One TSV line per commit touching $path in the range: stable sha, date,
+    # the mainline sha it backports ("commit <sha> upstream."), subject.
+    gh api --paginate -X GET "repos/$REPO/commits" \
+        -f sha="$NEW_SHA" \
+        -f path="$path" \
+        -f since="$OLD_DATE" \
+        -f until="$NEW_DATE" \
+        -f per_page=100 \
+        --jq '.[] | [
+                .sha[0:12],
+                .commit.committer.date[0:10],
+                ((.commit.message | capture("commit (?<u>[0-9a-f]{40}) upstream") | .u[0:12]) // "-"),
+                (.commit.message | split("\n")[0])
+              ] | @tsv' >"$TMP/commits" \
+        || die "commit query failed for $path in $REPO (see the error above)"
+
+    n=0
+    nf=0
+    : >"$TMP/body"
+    while IFS=$'\t' read -r sha when upstream subject; do
+        [ -n "$sha" ] || continue
+        n=$((n + 1))
+        mark=' '
+        if printf '%s' "$subject" | grep -Eqi "$FLAG_RE"; then
+            mark='!'
+            nf=$((nf + 1))
+        fi
+        printf '  %s  %s  %-12s  %s  %s\n' "$mark" "$sha" "$upstream" "$when" "$subject" >>"$TMP/body"
+    done <"$TMP/commits"
+
+    printf '\n-- %s (%d commits, %d flagged) --\n' "$path" "$n" "$nf"
+    if [ "$n" -eq 0 ]; then
+        printf '  (no changes in range)\n'
+    fi
+    cat "$TMP/body"
+
+    printf '  %-34s %4d commits %4d flagged\n' "$path" "$n" "$nf" >>"$TMP/summary"
+    TOTAL=$((TOTAL + n))
+    FLAGGED=$((FLAGGED + nf))
+done
+
+printf '\n== summary ==\n\n'
+cat "$TMP/summary"
+printf '  %-34s %4d commits %4d flagged\n' "TOTAL" "$TOTAL" "$FLAGGED"
+printf '\n'
+
+if [ "$TOTAL" -eq 0 ]; then
+    printf 'kernel-bump-review: %s commits in %s...%s, none touching the %s subtrees.\n' \
+        "$RANGE_TOTAL" "$OLD_TAG" "$NEW_TAG" "$SCOPE" >&2
+    printf '  Possible for adjacent point releases; suspicious for a long jump.\n' >&2
+fi
+
+if [ "$FLAGGED" -gt 0 ]; then
+    printf '  %d commit(s) marked [!]: a behavioural keyword (%s)\n' "$FLAGGED" "$FLAG_RE"
+    printf '  in the subject. Read those before landing the bump.\n\n'
+    if [ "$FAIL_ON_FLAG" -eq 1 ]; then
+        exit 2
+    fi
+fi
+
+exit 0

--- a/scripts/kernel-bump-review.sh
+++ b/scripts/kernel-bump-review.sh
@@ -72,6 +72,11 @@
 # often, never once too few. The size of the full range is reported alongside,
 # so "0 commits" is always distinguishable from "0 commits looked at".
 #
+# That reasoning holds only while the old tag is an ancestor of the new one, so
+# both versions must name the same stable branch; a cross-series pair (6.6.94 ->
+# 6.12.94) is refused rather than reported on. Review a series bump one branch
+# at a time.
+#
 # OUTPUT
 #
 #   ! <stable-sha> <upstream-sha> <date> <subject>
@@ -208,6 +213,28 @@ done
 
 OLD_TAG="v${OLD_VERSION#v}"
 NEW_TAG="v${NEW_VERSION#v}"
+
+# Both tags have to sit on the same stable branch. The scan below walks the NEW
+# tag's history through a committer-date window, which equals "the diff between
+# the tags" only while the old tag is an ancestor of the new one. Across series
+# they are not: `compare v6.6.94...v6.12.94` reports status=diverged, behind_by
+# 17883, with a merge base back in 2023 — so the window keeps the handful of
+# 6.12.y commits that happen to fall inside it and silently drops everything the
+# intervening series carried. That yields a short, plausible, wrong report,
+# which is the exact failure this tool exists to prevent. Refuse instead.
+series_of() {
+    local v="${1#v}" rest
+    rest="${v#*.}"
+    printf '%s.%s' "${v%%.*}" "${rest%%.*}"
+}
+OLD_SERIES=$(series_of "$OLD_VERSION")
+NEW_SERIES=$(series_of "$NEW_VERSION")
+[ "$OLD_SERIES" = "$NEW_SERIES" ] \
+    || die "$OLD_TAG and $NEW_TAG are on different stable branches ($OLD_SERIES.y vs $NEW_SERIES.y).
+  This tool reviews one stable branch at a time: the range is a committer-date
+  window over the new tag's history, which is only the true diff when the old
+  tag is an ancestor of the new one. A cross-series report would understate the
+  change. Review the bump one series at a time."
 
 # "<sha>\t<committer-date>" for a tag, or a loud death. This is the request that
 # catches a wrong repo, a nonexistent version, a typo, or no network.


### PR DESCRIPTION
## The miss this prevents

`gominimal/pkgs` bumped the guest kernel 6.12.43 → 6.12.94 ([gominimal/pkgs#311](https://github.com/gominimal/pkgs/pull/311), 2026-07-01). That range crosses v6.12.92, which carries [`a4f0b001782b`](https://github.com/gregkh/linux/commit/06fa755325df) — backported as `06fa755325df` — **"vsock/virtio: reset connection on receiving queue overflow"**. It converted a previously-silent packet drop into a fatal connection reset and broke every sizeable `min activate` ([#869](https://github.com/gominimal/minimal/issues/869)). Nobody noticed for three weeks.

Nothing exotic was needed to catch it. The commit is public, its subject says what it does, and it lives in a subtree the guest depends on completely: the entire control plane rides AF_VSOCK. A mechanical diff of `net/vmw_vsock/` between the two tags surfaces it at review time — no VM, no test run, no kernel checkout.

`scripts/kernel-bump-review.sh` is that diff, plus a `just kernel-review` recipe.

## Real output for 6.12.43 → 6.12.94

Run just now, unedited (`./scripts/kernel-bump-review.sh 6.12.43 6.12.94`). The acceptance test is the `!`-marked line six rows down:

```
== kernel bump review: gregkh/linux v6.12.43 -> v6.12.94 ==

  old  v6.12.43   9becd7c25c61  2025-08-20T16:30:58Z
  new  v6.12.94   0b8f247169e4  2026-06-19T11:42:39Z
  range spans 9025 commits; scanning the core subtree set
  columns: [!] <stable-sha> <upstream-sha> <date> <subject>
  browse:  https://github.com/gregkh/linux/commit/<stable-sha>

-- net/vmw_vsock (26 commits, 7 flagged) --
  !  149205a18bcf  4157501b9a8f  2026-06-19  vsock/virtio: fix skb overhead overflow on 32-bit builds
     f3bf0f3b8d5c  c6087c5aaad6  2026-06-19  vsock/virtio: fix skb overhead accounting to preserve full buf_alloc
  !  1eca304f97a3  059b7dbd20a6  2026-06-19  vsock/virtio: fix potential unbounded skb queue
     bcb275626055  c05fa14db43e  2026-06-19  vsock/vmci: fix sk_ack_backlog leak on failed handshake
     243277ae7cf1  -             2026-06-09  vsock: keep poll shutdown state consistent
  !  06fa755325df  a4f0b001782b  2026-06-01  vsock/virtio: reset connection on receiving queue overflow
  !  47e63077605c  99e22ddf4edb  2026-06-01  vsock/vmci: fix UAF when peer resets connection during handshake
  !  29371f3cc83e  52bcb57a4e8a  2026-05-17  vsock/virtio: fix accept queue count leak on transport mismatch
     06747f52ab15  3a3e3d90cbc7  2026-05-17  vsock/virtio: fix empty payload in tap skb for non-linear buffers
     d70b04a00e69  5f344d809e01  2026-05-17  vsock/virtio: fix length and offset in tap skb for split packets
     310da27932dd  d114bfdc9b76  2026-05-17  vsock: fix buffer size clamping order
     0fee717b1d92  080f22f5d302  2026-05-17  vsock/virtio: fix MSG_PEEK ignoring skb offset when calculating bytes to copy
     15eb24645948  b31681206e3f  2026-05-14  hv_sock: fix ARM64 support
     7ebd51c3f032  -             2026-03-04  vmw_vsock: bypass false-positive Wnonnull warning with gcc-16
     e6cee5d4a122  -             2026-01-30  vsock/virtio: Fix message iterator handling on transmit path
     69c5bf306115  -             2026-01-30  vsock/virtio: Allocate nonlinear SKBs for handling large transmit buffers
     2d651c3c035e  -             2026-01-30  vsock/virtio: Rename virtio_vsock_skb_rx_put()
     74ea6184df7f  -             2026-01-30  vsock/virtio: Rename virtio_vsock_alloc_skb()
     ca82ab9fd920  -             2026-01-30  vsock/virtio: Move length check to callers of virtio_vsock_skb_rx_put()
  !  c0e42fb0e054  -             2026-01-30  vsock/virtio: cap TX credit to local buffer size
  !  d05bc313788f  -             2026-01-30  vsock/virtio: fix potential underflow in virtio_transport_get_credit()
     568e9cd8ed7c  -             2026-01-30  vsock/virtio: Coalesce only linear skb
     6762937a8b45  -             2026-01-17  vsock: Make accept()ed sockets use custom setsockopt()
     f1c170cae285  -             2025-12-01  vsock: Ignore signal/timeout on connect() if already established
     251caee792a2  f7c877e75352  2025-10-29  vsock: fix lock inversion in vsock_assign_transport()
     faf332a10372  0dab92484474  2025-08-28  vsock/virtio: Validate length in packet header before skb_put()

-- include/linux/virtio_vsock.h (5 commits, 0 flagged) --
     65e808a6023f  -             2026-01-30  vhost/vsock: Allocate nonlinear SKBs for handling large receive buffers
     2d651c3c035e  -             2026-01-30  vsock/virtio: Rename virtio_vsock_skb_rx_put()
     bdea2c39fa06  -             2026-01-30  vsock/virtio: Move SKB allocation lower-bound check to callers
     74ea6184df7f  -             2026-01-30  vsock/virtio: Rename virtio_vsock_alloc_skb()
     ca82ab9fd920  -             2026-01-30  vsock/virtio: Move length check to callers of virtio_vsock_skb_rx_put()

-- include/uapi/linux/virtio_vsock.h (0 commits, 0 flagged) --
  (no changes in range)

-- drivers/virtio (2 commits, 0 flagged) --
     1d71d509b413  -             2026-01-08  mm/balloon_compaction: convert balloon_page_delete() to balloon_page_finalize()
     5f5cb2c99ae9  -             2025-12-18  virtio_vdpa: fix misleading return in void function

-- drivers/char/virtio_console.c (1 commits, 0 flagged) --
     828b59fdf8ef  5326ab737a47  2026-01-11  virtio_console: fix order of fields cols and rows

-- drivers/block/virtio_blk.c (1 commits, 1 flagged) --
  !  0073c41d4b99  -             2025-09-09  block: add a queue_limits_commit_update_frozen helper

== summary ==

  net/vmw_vsock                        26 commits    7 flagged
  include/linux/virtio_vsock.h          5 commits    0 flagged
  include/uapi/linux/virtio_vsock.h     0 commits    0 flagged
  drivers/virtio                        2 commits    0 flagged
  drivers/char/virtio_console.c         1 commits    0 flagged
  drivers/block/virtio_blk.c            1 commits    1 flagged
  TOTAL                                35 commits    8 flagged

  8 commit(s) marked [!]: a behavioural keyword (reset|drop|overflow|credit|backpressure|queue|fatal)
  in the subject. Read those before landing the bump.
```

**35 commits out of 9025 in the range**, 8 of them flagged. That is a five-minute read, and `06fa755325df` / `a4f0b001782b` is in it, marked. Two of its neighbours are the same story: `c0e42fb0e054` ("cap TX credit to local buffer size") and `d05bc313788f` ("fix potential underflow in `virtio_transport_get_credit()`") are the credit-accounting changes that set up the overflow the reset commit then made fatal.

The report is honest about its own coarseness: `0073c41d4b99` ("block: add a `queue_limits_commit_update_frozen` helper") is flagged only because "queue" appears in a function name. One false positive in 35 lines is the right side of the trade — the keyword list exists to make a reviewer *stop*, not to be right.

## Subtree selection

A wide net is worse than no net: a report that is mostly noise gets skimmed, and skimming is what let this through. The default set is only what the guest cannot boot or be driven without, and each path earns its place:

| Path | Why it is in |
|---|---|
| `net/vmw_vsock/` | Every RPC, attach/PTY stream and file upload rides AF_VSOCK; the virtio transport lives here. Tonight's root cause landed here. |
| `include/linux/virtio_vsock.h` | Credit accounting, buffer/packet limits, structs shared with the host device. Five commits in ten months. |
| `include/uapi/linux/virtio_vsock.h` | The wire protocol constants. Zero commits here in this range — which is itself the answer to "did the protocol change?" |
| `drivers/virtio/` | virtio core: virtqueue/vring, feature negotiation, DMA. Underneath every device below. |
| `drivers/char/virtio_console.c` | The guest boots `console=hvc0` (`crates/minvmd/src/vm.rs`); all guest boot and `minimald` logs leave over it. Its loss/backpressure behaviour decides whether a guest-side hang is diagnosable at all — a live question tonight. |
| `drivers/block/virtio_blk.c` | The ext4 root disk and the persistent data volume are virtio-blk (`krun_add_disk2`/`krun_add_disk3`); sparse/discard behaviour is load-bearing and was measured, not assumed. |

Deliberately **out** of the default set, with reasons:

- **`drivers/vhost/vsock.c`** — this is the *host-side* vhost-vsock driver. libkrun implements virtio-vsock in userspace and minvmd bridges it to a host unix socket (`krun_add_vsock_port2`, `crates/minvmd/src/sock.rs`), so neither side of our stack ever loads it. In this very range it contributes **7 commits and 0 flags** — pure noise for us. It is available under `--wide` as a cross-check, since vsock semantics changes are often mirrored there. Note that the genuinely relevant vhost change (`65e808a6023f`, nonlinear receive SKBs) reaches the default report anyway, through the shared header.
- **`drivers/net/virtio_net.c`** — guest egress rides it, but it is behind the `networking-proxy` feature and off the control plane (7 commits, 2 flagged, none of them ours). Under `--wide`.
- **`fs/fuse/virtio_fs.c`** — not used at all: the rootfs is a raw ext4 disk, not virtiofs.
- **`arch/`, `mm/`, `sched/`, …** — real dependencies, but any point-release bump touches thousands of lines there. Including them is how a report becomes wallpaper.

`--wide` on the same range gives 49 commits / 10 flagged instead of 35 / 8, and adds nothing that bears on the guest. That ratio is the argument for the default.

## Where the data comes from, and failing loudly

The stable tree is **`gregkh/linux`**. `torvalds/linux` does **not** carry stable tags:

```
$ gh api repos/torvalds/linux/commits/v6.12.94
{"message":"No commit found for SHA: v6.12.94", ... "status":"422"}
```

Through `curl` that is indistinguishable from "no matching commits", which is exactly the silent-empty-result failure this tool exists to avoid having. So:

- Both tags are resolved with a checked request before anything else; a failure names the trap in the error text.
- Every per-subtree query is checked; a failed query is fatal, never an empty section.
- The **total size of the range** (9025 commits) is reported next to the per-subtree counts, from an independent `compare` call. "0 commits in these subtrees" can never be confused with "0 commits looked at", and a fully-empty scan prints a loud stderr note.
- Argument order is checked by committer date — reversed versions die instead of reporting an empty range.
- Versions are validated as digits-and-dots before being pasted into an API path.
- Both versions must name the same stable branch. A cross-series pair is refused, not reported on (see below).

Range membership is a committer-date window (`since` = old tag, `until` = new tag) over the new tag's history. A stable branch is a linear sequence of cherry-picks with monotonically rising committer dates, so the window is exact; its one imprecision is benign (a commit sharing the old tag's exact second is reported once too often, never once too few). Verified on this range: the oldest commit reported, `faf332a10372`, is 80 commits *after* v6.12.43 and 8945 *before* v6.12.94, and the newest vsock commit reachable from v6.12.43 (`680c7d9d9197`, 16:30:40Z) falls 18 seconds outside the window and is correctly excluded.

That reasoning holds only while the old tag is an **ancestor** of the new one, which is why the same-branch check above is enforced rather than merely documented. Across series the tags are not related that way:

```
$ gh api repos/gregkh/linux/compare/v6.6.94...v6.12.94?per_page=1
{"status":"diverged","ahead_by":112743,"behind_by":17883,"base":"ffc253263a13","base_date":"2023-10-30T02:31:08Z"}
```

`behind_by: 17883` is the problem — the window would run over `v6.12.94`'s history, keep the few 6.12.y commits that happen to fall between the two timestamps, and drop everything the intervening series carried. Neither pre-existing guard catches it: both tags resolve, and v6.6.94 (2025-06-19) genuinely predates v6.12.94 (2026-06-19), so the date-ordering check passes. The output would be short, plausible and wrong — this tool's own failure mode. It now refuses:

```
$ ./scripts/kernel-bump-review.sh 6.6.94 6.12.94 ; echo $?
kernel-bump-review: v6.6.94 and v6.12.94 are on different stable branches (6.6.y vs 6.12.y).
  This tool reviews one stable branch at a time: the range is a committer-date
  window over the new tag's history, which is only the true diff when the old
  tag is an ancestor of the new one. A cross-series report would understate the
  change. Review the bump one series at a time.
1
```

The series is major.minor, so a `.0` release — tagged `v6.12`, not `v6.12.0` — still compares equal to `6.12.94` and runs. Reviewing a genuine series bump one branch at a time is the intended workflow; a `compare`-based fallback would mean a second range-computation path for a case the pin has never taken.

## How a human uses this on a pin bump

Two trigger points, one command.

**Reviewing a pkgs kernel bump** (the [gominimal/pkgs#311](https://github.com/gominimal/pkgs/pull/311) case). From a pkgs checkout on the PR branch:

```
just kernel-review --pkgs ~/code/pkgs          # defaults to origin/main -> HEAD
```

It reads `let version` from `packages/virtio-linux/build.ncl` at both refs and prints what it resolved before scanning:

```
kernel-bump-review: packages/virtio-linux/build.ncl in ~/code/pkgs: HEAD~200 -> HEAD (6.12.43 -> 6.12.94)
```

**Reviewing a `locked_commit` bump here** — where the new kernel actually reaches this repo. Take the two pkgs commits from the diff of `.minimal/minimal.toml` and pass them as refs:

```
just kernel-review --pkgs ~/code/pkgs <old-locked-commit> <new-locked-commit>
```

**Versions in hand**, no checkout needed:

```
just kernel-review 6.12.43 6.12.94
just kernel-review --wide 6.12.43 6.12.94     # add host-side / non-control-plane paths
```

Then read every `!` line. If a subject sounds like a behaviour change on a path the guest sits on, open it (`https://github.com/gregkh/linux/commit/<sha>`) and read the commit message — stable backports state their reasoning and name the mainline commit, which the report already prints for you.

Requirements: an authenticated `gh` (public data, any token) and `git` for `--pkgs`. No kernel checkout, no VM, nothing to build. The full run above takes a few seconds.

## CODEOWNER follow-up: wiring it into CI

**Not done here — `.github/workflows/` is frozen and CODEOWNER-gated, and this PR does not touch it.** The script is CI-ready: `--fail-on-flag` exits **2** when anything is flagged (verified), 0 otherwise, and 1 on any error.

For a CODEOWNER who wants this enforced, the smallest useful addition is a job on pull requests that touch `.minimal/minimal.toml`:

```yaml
# .github/workflows/<existing-pr-workflow>.yml
  kernel-bump-review:
    if: contains(github.event.pull_request.changed_files, '.minimal/minimal.toml')  # or a paths: filter
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # public data; default token is enough
        run: scripts/kernel-bump-review.sh <old> <new> --fail-on-flag
```

Two open questions that belong to whoever owns that file, not to this PR:

1. **Where the versions come from in CI.** The job has no pkgs checkout, so either add an `actions/checkout` of `gominimal/pkgs` at the two pinned commits and use `--pkgs`, or resolve the two `virtio-linux` versions in the workflow and pass them positionally.
2. **Gate or annotate.** `--fail-on-flag` makes it a hard gate, which will red-build on false positives like the `queue_limits` line above. A softer wiring — run without the flag and post the output as a job summary or PR comment — matches the intent (put it in front of a reviewer) without blocking on a keyword match. My recommendation is annotate first, gate later if it proves quiet.

Until then it is a local command, and `just --list` advertises it.

## Verified vs assumed

**Verified by running it:**

- The full 6.12.43 → 6.12.94 run above, surfacing `06fa755325df` / upstream `a4f0b001782b`, flagged. This is the acceptance test and it passes.
- `--wide` (49 commits / 10 flagged) and `--fail-on-flag` (exit code 2).
- `--pkgs` against a real `gominimal/pkgs` checkout: `HEAD~200 -> HEAD` resolves to `6.12.43 -> 6.12.94`, i.e. the real bump is discoverable from the checkout with no versions typed by hand.
- Failure modes, each loud and non-zero: reversed arguments; a nonexistent tag (`6.12.9999` → 422, with the torvalds hint); no/extra arguments; an unknown flag; a version containing shell metacharacters (rejected before it reaches the API); a cross-series pair (`6.6.94 6.12.94`), rejected before any API call.
- After the cross-series guard landed, the acceptance test re-run unchanged: 35 commits / 8 flagged, `06fa755325df` / `a4f0b001782b` still marked `[!]`, `--fail-on-flag` still exit 2, `6.12 -> 6.12.94` still runs, `shellcheck` still clean.
- `torvalds/linux` returning 422 for `v6.12.94` — the trap that motivated the hard-coded repo.
- Range-boundary correctness, by comparing the oldest reported commit against both tags and checking the newest vsock commit *inside* v6.12.43 is excluded.
- `shellcheck scripts/kernel-bump-review.sh` — clean. `just --list` shows the recipe; `just kernel-review --help` runs.

**Assumed (and why it is safe):**

- **Committer dates rise monotonically along a stable branch.** True for linear cherry-pick queues, which is what `linux-6.12.y` is. If it were ever violated the tool would over-report, not under-report.
- **The GitHub commits endpoint filters `since`/`until` by committer date.** Consistent with every boundary check above; if it used author date the report would be noisier, not emptier.
- **`commit <sha> upstream.` is the stable backport convention.** Where it is absent the column shows `-` (11 of 35 rows here, all of them genuine — direct stable commits or older-style backports); nothing depends on it being present.
- Not run in CI (deliberately — see above), and not run on Linux; it is `bash` + `gh` + `git` only, with no platform-specific calls.

## Notes for merge

- Touches `justfile` (one recipe appended at the end of the *run & inspect* section). Another branch in flight adds `scripts/bulk-upload-e2e.sh` and edits `scripts/soak-session-e2e.sh` plus the `justfile`; **expect a possible `justfile` conflict at merge**. It will be an add/add in different sections and should resolve by keeping both recipes.
- No Rust, no CI, no VM, no state touched.

Refs: [#869](https://github.com/gominimal/minimal/issues/869), [gominimal/pkgs#311](https://github.com/gominimal/pkgs/pull/311)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add script to flag guest-kernel bumps that change vsock semantics
> - Adds [scripts/kernel-bump-review.sh](https://github.com/gominimal/minimal/pull/893/files#diff-6c4430ac92263883a0f5c53b9535345228a01c16c6985d2f4939044b7b3f32e2), a Bash script that uses the GitHub API (`gh`) to scan commits in a Linux stable kernel version range across specified subtrees, flagging subjects matching behavioral keywords.
> - Accepts `--pkgs` to auto-derive versions from a pkgs checkout, `--wide` for broader subtree coverage, `--fail-on-flag` to exit non-zero when flagged commits are found, and `--help`.
> - Adds a `kernel-review` recipe in [justfile](https://github.com/gominimal/minimal/pull/893/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1) that invokes the script with passthrough arguments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bb6e65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
