### PR TITLE
feat(minimal): report bytes and elapsed time for workspace uploads

### DIFF
--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -220,7 +220,7 @@ impl Client {
             .await
             .context("request WorkspaceFilesTarZst subsystem")?;
 
-        crate::file_upload::stream_tar_zstd(dir, channel.make_writer()).await?;
+        let bytes = crate::file_upload::stream_tar_zstd(dir, channel.make_writer()).await?;
 
         // Wait for the channel to close to signal that unpacking is done.
         let mut err = Vec::new();
@@ -231,7 +231,7 @@ impl Client {
         }
         if !err.is_empty() {
             anyhow::bail!(
-                "daemon failed to unpack project files: {}",
+                "daemon failed to unpack project files after {bytes} bytes uploaded: {}",
                 String::from_utf8_lossy(&err)
             );
         }

--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -231,7 +231,7 @@ impl Client {
         }
         if !err.is_empty() {
             anyhow::bail!(
-                "daemon failed to unpack project files after {bytes} bytes uploaded: {}",
+                "daemon failed to unpack project files after {bytes} compressed bytes uploaded: {}",
                 String::from_utf8_lossy(&err)
             );
         }

--- a/crates/minimal/src/file_upload.rs
+++ b/crates/minimal/src/file_upload.rs
@@ -5,6 +5,9 @@
 //! the encoder's internal buffer.
 
 use std::path::Path;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
 
 use anyhow::Context as _;
 use async_tar::Builder;
@@ -33,14 +36,53 @@ fn is_default_excluded(name: &str) -> bool {
     DEFAULT_EXCLUDED_DIRS.contains(&name)
 }
 
-/// Streams a zstd-compressed tar archive of `dir` into `writer`.
+/// Wraps the upload writer and tallies the bytes it accepts, so a transfer
+/// that dies mid-stream can report how far it got. `tokio::io::copy` returns
+/// its byte count only on success, and the count at the moment of failure is
+/// exactly the figure that is missing when an upload fails (#869).
+struct CountingWriter<W> {
+    inner: W,
+    written: u64,
+}
+
+impl<W: AsyncWrite + Unpin> AsyncWrite for CountingWriter<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let poll = Pin::new(&mut self.inner).poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = &poll {
+            self.written += *n as u64;
+        }
+        poll
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+/// Streams a zstd-compressed tar archive of `dir` into `writer`, returning the
+/// number of compressed bytes handed to `writer`.
 ///
 /// The tar builder writes directly into the zstd encoder which writes
 /// to `writer`, so the archive is never fully buffered in memory.
+///
+/// The count is of *compressed* bytes — the wire bytes — because that is what
+/// this side of the duplex can see (the pipe sits between the zstd encoder and
+/// `writer`) and because it is the figure a daemon-side count is directly
+/// comparable to. On failure the error carries that count and the elapsed
+/// time, so "died at 1%" and "died at 99%" are distinguishable without an
+/// instrumented kernel (#869).
 pub async fn stream_tar_zstd<W: AsyncWrite + Unpin + Send>(
     dir: &Path,
-    mut writer: W,
-) -> Result<(), anyhow::Error> {
+    writer: W,
+) -> Result<u64, anyhow::Error> {
     // async_tar::Builder requires W: Sync, but the SSH channel stream
     // is not Sync. Use a duplex pipe: the tar builder writes to one end
     // (in a background task), and we copy from the other end to writer.
@@ -52,17 +94,47 @@ pub async fn stream_tar_zstd<W: AsyncWrite + Unpin + Send>(
         tokio::spawn(async move { build_tar_zstd(&dir, tx).await })
     };
 
-    tokio::io::copy(&mut rx, &mut writer)
-        .await
-        .context("copying tar stream to channel")?;
-    writer.flush().await.context("flushing upload stream")?;
-    writer
-        .shutdown()
-        .await
-        .context("shutting down upload stream")?;
+    let started = Instant::now();
+    let mut writer = CountingWriter {
+        inner: writer,
+        written: 0,
+    };
+
+    let transfer = async {
+        tokio::io::copy(&mut rx, &mut writer)
+            .await
+            .context("copying tar stream to channel")?;
+        writer.flush().await.context("flushing upload stream")?;
+        writer
+            .shutdown()
+            .await
+            .context("shutting down upload stream")?;
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+
+    let bytes = writer.written;
+    let elapsed = started.elapsed();
+    transfer.with_context(|| {
+        format!("workspace upload failed after {bytes} compressed bytes in {elapsed:.2?}")
+    })?;
 
     build.await.context("tar build task panicked")??;
-    Ok(())
+
+    let secs = elapsed.as_secs_f64();
+    let mib_per_s = if secs > 0.0 {
+        bytes as f64 / secs / (1024.0 * 1024.0)
+    } else {
+        0.0
+    };
+    tracing::debug!(
+        bytes,
+        elapsed_ms = elapsed.as_millis() as u64,
+        mib_per_s,
+        "workspace upload streamed"
+    );
+
+    Ok(bytes)
 }
 
 /// Builds a zstd-compressed tar archive of `dir` into `writer`, finalizing
@@ -296,6 +368,52 @@ mod tests {
         assert!(
             result.is_err(),
             "a mid-stream writer failure must surface as an error, not a panic"
+        );
+    }
+
+    /// The returned count is of compressed wire bytes: exactly what landed in
+    /// the writer, not the (larger) size of the tar stream feeding the encoder.
+    #[tokio::test]
+    async fn stream_returns_compressed_byte_count() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("big.txt"), "a".repeat(64 * 1024)).unwrap();
+
+        let mut buf = Vec::new();
+        let bytes = stream_tar_zstd(dir.path(), &mut buf).await.unwrap();
+
+        assert_eq!(
+            bytes,
+            buf.len() as u64,
+            "count must match the bytes written"
+        );
+        assert!(
+            bytes < 64 * 1024,
+            "compressible input should yield a compressed count, got {bytes}"
+        );
+    }
+
+    /// A transfer that dies mid-stream must say how far it got: without the
+    /// byte count and elapsed time, "channel closed" cannot distinguish a
+    /// transport that failed immediately from one that failed at 98% (#869).
+    #[tokio::test]
+    async fn stream_error_reports_bytes_and_elapsed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        for i in 0..64 {
+            std::fs::write(
+                dir.path().join(format!("f{i}.bin")),
+                incompressible(i as u64 + 1, 32 * 1024),
+            )
+            .unwrap();
+        }
+
+        let err = stream_tar_zstd(dir.path(), FailingWriter { remaining: 1024 })
+            .await
+            .unwrap_err();
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("after 1024 compressed bytes in "),
+            "error must carry bytes transferred and elapsed time, got: {msg}"
         );
     }
 


### PR DESCRIPTION
## The gap

`stream_tar_zstd` in `crates/minimal/src/file_upload.rs` called
`tokio::io::copy(&mut rx, &mut writer)` and discarded its return value — the
byte count. Nothing on the client side recorded how much of the archive reached
the daemon, how long it took, or the resulting rate. A failed upload said:

```
copying tar stream to channel: channel closed
```

That message is identical whether the transfer died on the first byte or the
last one.

## Motivation

During [#869](https://github.com/gominimal/minimal/issues/869) the connection
died at **98.2–98.9%** of a 12,784,144-byte transfer — consistently, every time.
That figure came from an instrumented guest kernel. Both ends of the transfer
knew it and neither wrote it down. Had the client's error carried "failed after
12.5 MB of 12.78 MB in 1.8 s", the shape of the bug — a transport that dies near
the end of a large, fast transfer — would have been visible on day one instead
of after a kernel rebuild.

## What changed

- **Counted the bytes.** `tokio::io::copy` returns its count only on success,
  and the count at the moment of *failure* is precisely the number that was
  missing. So the upload writer is wrapped in a small `CountingWriter` adapter
  that tallies bytes as they are accepted; `copy` is otherwise unchanged.
- **Threaded it out.** `stream_tar_zstd` now returns `Result<u64, _>`.
- **Put it in the error.** The transfer (copy + flush + shutdown) is run as a
  unit and its error gains the context
  `workspace upload failed after {bytes} compressed bytes in {elapsed:.2?}`,
  preserving the existing inner context chain:

  ```
  workspace upload failed after 12553216 compressed bytes in 1.81s: copying tar stream to channel: channel closed
  ```
- **Logged the success case** at `debug` with structured fields
  (`bytes`, `elapsed_ms`, `mib_per_s`) — the baseline a failure is measured
  against.
- **Caller**: `upload_workspace_files` in `crates/minimal/src/client.rs` keeps
  the count and includes it in the unpack-failure message, so the *other*
  failure mode of the same operation reports progress too. That is the whole
  `client.rs` diff (2 lines) — deliberately minimal, since another change to
  that file is in flight.

## Which byte count, and why

**Compressed (wire) bytes.** The duplex pipe sits between the zstd encoder and
the channel, so what `copy` observes is already the compressed stream — the
uncompressed tar size is not observable at this point without adding a second
counter inside the encoder's input side. More importantly, the compressed figure
is the one directly comparable to a daemon-side count: it is the number of bytes
that actually crossed the transport, which is what a truncated-transfer
investigation needs. Both error messages say "compressed bytes" explicitly so
nobody compares the figure against `du` of the project directory — the transport
failure raised in `stream_tar_zstd`, and the daemon-side unpack failure raised in
`client.rs` after the upload completed, which reports the same counter and so
needs the same unit named on it.

## Deliberately out of scope

- **Drain loop treats `channel.wait() == None` as success**
  ([gominimal/minimal#901](https://github.com/gominimal/minimal/issues/901)). The
  loop in `upload_workspace_files` is untouched beyond binding the byte count;
  that defect needs its own change and its own reviewer conversation.
- **No timeout anywhere on this path**
  ([gominimal/inbox#335](https://github.com/gominimal/inbox/issues/335)). Not
  built here. Noting the seam for whoever does: the transfer is now a single
  `async { copy; flush; shutdown }` block awaited in one place, so a
  `tokio::time::timeout` around that block is a one-line wrap — and because the
  byte count lives in the `CountingWriter` *outside* the block, a timeout error
  would automatically inherit the same "after N compressed bytes in T" context
  that transport errors now get.

## Tests

Two new unit tests in `file_upload.rs`:

- `stream_returns_compressed_byte_count` — the returned count equals the bytes
  that landed in the writer, and is smaller than the (compressible) input,
  pinning it as the compressed figure rather than the tar size.
- `stream_error_reports_bytes_and_elapsed` — a writer that accepts exactly 1024
  bytes and then fails produces an error whose chain contains
  `after 1024 compressed bytes in `.

```
$ cargo test -p minimal --lib
test file_upload::tests::stream_returns_compressed_byte_count ... ok
test file_upload::tests::stream_error_reports_bytes_and_elapsed ... ok

test result: ok. 73 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s

$ cargo clippy -p minimal --all-targets --no-deps -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
```

Note on the local commands: on macOS the `minimal` **lib** builds and lints
cleanly, but its *test targets* cannot be built at all — the `minimald`
dev-dependency pulls `hakoniwa → libcgroups → procfs`, which refuses to build on
non-Linux ("Currently only linux and android are supported"). That is
pre-existing and unrelated to this diff (it fails before `minimal` is compiled).
The runs above were therefore done with that Linux-only dev-dependency
temporarily neutralized locally so the lib unit tests could execute; the
manifest and `Cargo.lock` are unmodified in this PR. CI (Linux) exercises the
full `cargo test -p minimal` surface including the integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report compressed bytes and elapsed time for workspace file uploads
> - `stream_tar_zstd` in [file_upload.rs](https://github.com/gominimal/minimal/pull/894/files#diff-b417966fca8aff7d83bfe7def43f0915d3cc2fcc1c3d02953c288fc85274bbf2) now returns `u64` (compressed bytes written) instead of `()`, and wraps the inner writer in a new `CountingWriter` to track bytes.
> - On success, a debug log entry is emitted with byte count, elapsed time, and MiB/s throughput.
> - On transfer failure, the error message includes the compressed byte count and elapsed time.
> - In [client.rs](https://github.com/gominimal/minimal/pull/894/files#diff-9e29b53f60b5cd0ae317db17efc685735a41fb9e23b33e834d06f331db09b952), daemon unpack failures now include the compressed byte count in the error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18a633f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
