### PR TITLE
feat(minimal,diagnostics): raise the log tail default to 32 MiB and make it a flag

### DIFF
--- a/crates/diagnostics/src/bundle.rs
+++ b/crates/diagnostics/src/bundle.rs
@@ -21,6 +21,16 @@ use crate::manifest::{CollectedEntry, CollectorError, Manifest, Redaction, Skipp
 /// Default per-file tail cap for bundled logs.
 pub const LOG_TAIL_CAP: u64 = 5 * 1024 * 1024;
 
+/// Largest per-file tail cap [`BundleWriter::add_file_tail`] can honor.
+///
+/// The ceiling is structural, not politeness: `add_file_tail` seeks
+/// `-(cap as i64)` from the end, so a cap past `i64::MAX` is a nonsense seek,
+/// and any very large cap is an unbounded read into memory. A caller that
+/// takes this value from a user must *reject* anything above it rather than
+/// clamp — a silently clamped cap reports success while capturing less than
+/// was asked for, and the short log then reads as evidence.
+pub const MAX_LOG_TAIL_BYTES: u64 = 64 * 1024 * 1024;
+
 mod sealed {
     pub trait Sealed {}
     impl Sealed for tokio::fs::File {}

--- a/crates/diagnostics/src/bundle.rs
+++ b/crates/diagnostics/src/bundle.rs
@@ -19,7 +19,21 @@ use tokio::io::{AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
 use crate::manifest::{CollectedEntry, CollectorError, Manifest, Redaction, SkippedEntry};
 
 /// Default per-file tail cap for bundled logs.
-pub const LOG_TAIL_CAP: u64 = 5 * 1024 * 1024;
+///
+/// Sized against the shipping file format (`mlog`'s JSON-lines, measured at
+/// ~214 B/record on a real capture), so this holds order 157k records per
+/// file — about 6x what 5 MiB held. The wire cost of the increase is close to
+/// nothing: log text compresses ~70x inside the bundle's zstd stream, so five
+/// rotated files go from ~0.3 MiB to ~2.2 MiB of archive.
+///
+/// The real cost is uncompressed: `add_file_tail` buffers a whole tail in
+/// memory, and a bundle collects up to ~16 log files, so this value also sets
+/// peak allocation per file and bounds extraction at ~512 MiB. That is what
+/// keeps it here rather than higher — at `RUST_LOG=debug` no cap "holds the
+/// incident" anyway (a measured burst produced 36 MB of records in eight
+/// seconds, nearly all of it dependency chatter), so a larger default buys
+/// linear history for linear extraction cost, not a categorical win.
+pub const LOG_TAIL_CAP: u64 = 32 * 1024 * 1024;
 
 /// Largest per-file tail cap [`BundleWriter::add_file_tail`] can honor.
 ///
@@ -30,6 +44,12 @@ pub const LOG_TAIL_CAP: u64 = 5 * 1024 * 1024;
 /// clamp — a silently clamped cap reports success while capturing less than
 /// was asked for, and the short log then reads as evidence.
 pub const MAX_LOG_TAIL_BYTES: u64 = 64 * 1024 * 1024;
+
+/// The default has to leave room to ask for more, or a caller-facing knob
+/// validated against [`MAX_LOG_TAIL_BYTES`] becomes downward-only. Enforced at
+/// compile time so raising [`LOG_TAIL_CAP`] past the halfway mark cannot land
+/// silently.
+const _: () = assert!(LOG_TAIL_CAP * 2 <= MAX_LOG_TAIL_BYTES);
 
 mod sealed {
     pub trait Sealed {}

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -39,7 +39,9 @@ pub mod redact;
 #[cfg(unix)]
 pub mod system;
 
-pub use bundle::{BundleSink, BundleWriter, LOG_TAIL_CAP, open_regular_nofollow};
+pub use bundle::{
+    BundleSink, BundleWriter, LOG_TAIL_CAP, MAX_LOG_TAIL_BYTES, open_regular_nofollow,
+};
 pub use capture::{Capture, CaptureError, command_capture, command_stdout, first_stdout_line};
 #[cfg(unix)]
 pub use disk::{DiskUsage, disk_usage};

--- a/crates/minimal/src/diag/collect.rs
+++ b/crates/minimal/src/diag/collect.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 
 use super::redact::is_env_value_allowlisted;
 use diagnostics::redact::{masked_process_env, redact_toml};
-use diagnostics::{BundleWriter, LOG_TAIL_CAP, Redaction, open_regular_nofollow};
+use diagnostics::{BundleWriter, Redaction, open_regular_nofollow};
 
 /// Cap on entries in a recursive state-dir listing; a runaway tree (huge
 /// session workspaces) is truncated with a marker line, not walked forever.
@@ -208,7 +208,13 @@ pub async fn state(w: &mut BundleWriter, paths: &DiagPaths) -> Result<(), anyhow
 /// How many rotated files per log prefix make it into the bundle.
 const LOG_FILES_PER_PREFIX: usize = 5;
 
-pub async fn logs(w: &mut BundleWriter, paths: &DiagPaths) -> Result<(), anyhow::Error> {
+/// `tail_bytes` is the per-file cap, already validated by the caller against
+/// [`diagnostics::MAX_LOG_TAIL_BYTES`].
+pub async fn logs(
+    w: &mut BundleWriter,
+    paths: &DiagPaths,
+    tail_bytes: u64,
+) -> Result<(), anyhow::Error> {
     let log_dir = paths.state.join("logs");
     // Absence and inaccessibility are different facts: "no log directory"
     // may only be claimed on a real NotFound, never on EACCES or I/O errors.
@@ -229,7 +235,7 @@ pub async fn logs(w: &mut BundleWriter, paths: &DiagPaths) -> Result<(), anyhow:
                 for path in files {
                     let name = path.file_name().unwrap_or_default().to_string_lossy();
                     let dest = format!("logs/{name}");
-                    if let Err(e) = w.add_file_tail(&dest, &path, LOG_TAIL_CAP).await {
+                    if let Err(e) = w.add_file_tail(&dest, &path, tail_bytes).await {
                         w.skip(&dest, format!("unreadable: {e}"));
                     }
                 }
@@ -246,7 +252,7 @@ pub async fn logs(w: &mut BundleWriter, paths: &DiagPaths) -> Result<(), anyhow:
         for log_name in ["run.log", "boot.log"] {
             let dest = format!("providers/{name}/{log_name}");
             match w
-                .add_file_tail(&dest, &dir.join(log_name), LOG_TAIL_CAP)
+                .add_file_tail(&dest, &dir.join(log_name), tail_bytes)
                 .await
             {
                 Ok(()) => {}

--- a/crates/minimal/src/diag/mod.rs
+++ b/crates/minimal/src/diag/mod.rs
@@ -29,9 +29,10 @@ pub struct BugArgs {
     /// Bytes of each log file to capture, counted from the end
     ///
     /// Raise this when the interesting window is older than the tail the
-    /// default buys you. A daemon running at `RUST_LOG=debug` fills 5 MiB in
-    /// minutes, and the current day's file is not size-rotated, so the
-    /// default tail can start well after the incident.
+    /// default buys you. A daemon at `RUST_LOG=debug` can outrun any cap —
+    /// most of that volume is dependency chatter, not minimal's own records —
+    /// and the current day's file is not size-rotated, so a fixed tail can
+    /// start well after the incident.
     #[arg(long, default_value_t = LOG_TAIL_CAP, value_parser = parse_log_tail_bytes)]
     pub log_tail_bytes: u64,
 }
@@ -239,8 +240,10 @@ mod tests {
         Harness::try_parse_from(std::iter::once("bug").chain(argv.iter().copied())).map(|h| h.args)
     }
 
+    /// The flag tracks the shared default rather than restating it, so
+    /// raising `LOG_TAIL_CAP` raises what an unflagged `min bug` collects.
     #[test]
-    fn omitting_the_flag_keeps_the_historical_tail() {
+    fn omitting_the_flag_uses_the_shared_default() {
         assert_eq!(parse(&[]).unwrap().log_tail_bytes, LOG_TAIL_CAP);
     }
 

--- a/crates/minimal/src/diag/mod.rs
+++ b/crates/minimal/src/diag/mod.rs
@@ -17,7 +17,7 @@ pub mod collect;
 pub mod redact;
 
 use collect::DiagPaths;
-use diagnostics::{BundleWriter, Redaction};
+use diagnostics::{BundleWriter, LOG_TAIL_CAP, MAX_LOG_TAIL_BYTES, Redaction};
 
 use crate::GlobalArgs;
 
@@ -26,6 +26,35 @@ pub struct BugArgs {
     /// Output path (default: ./minimal-diag-<timestamp>.tar.zst)
     #[arg(long, short)]
     pub output: Option<PathBuf>,
+    /// Bytes of each log file to capture, counted from the end
+    ///
+    /// Raise this when the interesting window is older than the tail the
+    /// default buys you. A daemon running at `RUST_LOG=debug` fills 5 MiB in
+    /// minutes, and the current day's file is not size-rotated, so the
+    /// default tail can start well after the incident.
+    #[arg(long, default_value_t = LOG_TAIL_CAP, value_parser = parse_log_tail_bytes)]
+    pub log_tail_bytes: u64,
+}
+
+/// Parses `--log-tail-bytes`, refusing anything the bundle writer cannot
+/// honor.
+///
+/// Refusing rather than clamping is the point. A clamp reports success while
+/// quietly capturing less than was asked for, so the resulting short log
+/// reads as a fact about the system instead of a fact about the flag — the
+/// exact shape of mistake that makes a diagnostic bundle actively misleading.
+fn parse_log_tail_bytes(raw: &str) -> Result<u64, String> {
+    let bytes: u64 = raw
+        .parse()
+        .map_err(|_| format!("`{raw}` is not a whole number of bytes"))?;
+    match bytes {
+        0 => Err("must be at least 1 byte; 0 would collect empty log files".to_string()),
+        b if b > MAX_LOG_TAIL_BYTES => Err(format!(
+            "{b} exceeds the maximum of {MAX_LOG_TAIL_BYTES} bytes ({} MiB)",
+            MAX_LOG_TAIL_BYTES / (1024 * 1024)
+        )),
+        b => Ok(b),
+    }
 }
 
 /// A collector timeout generous enough for slow disks, small enough that a
@@ -114,7 +143,11 @@ pub async fn cmd_bug(global: &GlobalArgs, args: BugArgs) -> Result<(), anyhow::E
     collect_step!(w, "host.power", diagnostics::power::power(&mut w, "host"));
     collect_step!(w, "config", collect::config(&mut w, &paths));
     collect_step!(w, "state", collect::state(&mut w, &paths));
-    collect_step!(w, "logs", collect::logs(&mut w, &paths));
+    collect_step!(
+        w,
+        "logs",
+        collect::logs(&mut w, &paths, args.log_tail_bytes)
+    );
 
     // Daemon-side state (socket probes, guest bundles, per-provider status)
     // is collected over the daemon connection, not from the host bundle;
@@ -187,4 +220,60 @@ async fn dirs_report(w: &mut BundleWriter, global: &GlobalArgs) -> Result<(), an
     let report = crate::dirs::report(global);
     w.add_bytes("host/dirs.txt", report.as_bytes(), Redaction::None)
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser as _;
+
+    /// Parses `min bug`'s arguments the way the real CLI does, so these
+    /// assertions cover the `value_parser` wiring and not just the function.
+    #[derive(Debug, clap::Parser)]
+    struct Harness {
+        #[command(flatten)]
+        args: BugArgs,
+    }
+
+    fn parse(argv: &[&str]) -> Result<BugArgs, clap::Error> {
+        Harness::try_parse_from(std::iter::once("bug").chain(argv.iter().copied())).map(|h| h.args)
+    }
+
+    #[test]
+    fn omitting_the_flag_keeps_the_historical_tail() {
+        assert_eq!(parse(&[]).unwrap().log_tail_bytes, LOG_TAIL_CAP);
+    }
+
+    #[test]
+    fn a_cap_within_the_contract_is_accepted_verbatim() {
+        for bytes in [1, LOG_TAIL_CAP, MAX_LOG_TAIL_BYTES] {
+            let args = parse(&["--log-tail-bytes", &bytes.to_string()]).unwrap();
+            assert_eq!(args.log_tail_bytes, bytes, "{bytes} must survive intact");
+        }
+    }
+
+    /// The whole point of the flag's validation: an over-large cap fails the
+    /// command rather than being quietly reduced to the ceiling.
+    #[test]
+    fn an_over_large_cap_is_rejected_not_clamped() {
+        for bytes in [MAX_LOG_TAIL_BYTES + 1, u64::MAX] {
+            let Err(err) = parse(&["--log-tail-bytes", &bytes.to_string()]) else {
+                panic!("{bytes} is above the ceiling and must be rejected, not clamped");
+            };
+            let err = err.to_string();
+            assert!(
+                err.contains(&MAX_LOG_TAIL_BYTES.to_string()) && err.contains("exceeds"),
+                "the error must name the ceiling it broke: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_zero_or_non_numeric_cap_is_rejected() {
+        // 0 is the wire contract's "use the default" sentinel; taken
+        // literally here it would bundle empty logs labelled tail-capped.
+        assert!(parse(&["--log-tail-bytes", "0"]).is_err());
+        assert!(parse(&["--log-tail-bytes", "5MiB"]).is_err());
+        assert!(parse(&["--log-tail-bytes", "-1"]).is_err());
+    }
 }

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -77,6 +77,7 @@ fn global_args(state: &Path, config: &Path) -> GlobalArgs {
 fn bug_args(out: &Path) -> BugArgs {
     BugArgs {
         output: Some(out.to_path_buf()),
+        log_tail_bytes: diagnostics::LOG_TAIL_CAP,
     }
 }
 
@@ -258,6 +259,52 @@ async fn logs_collects_newest_five_per_prefix_and_provider_logs() {
         "absent boot.log is a skip: {skipped:?}"
     );
     assert_eq!(manifest["errors"].as_array().unwrap().len(), 0, "no errors");
+}
+
+/// The `--log-tail-bytes` cap reaches every log the collector bundles — the
+/// rotated host logs and the provider-scoped ones — and the manifest labels
+/// each capped file so a reader can tell a truncated log from a short one.
+#[tokio::test]
+async fn a_custom_tail_cap_applies_to_every_log() {
+    let state = tempfile::TempDir::new().unwrap();
+    let config = tempfile::TempDir::new().unwrap();
+
+    let log_dir = state.path().join("logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+    std::fs::write(log_dir.join("minimald.log.2026-07-21"), "x".repeat(500)).unwrap();
+    let provider = state.path().join("providers/local-0");
+    std::fs::create_dir_all(&provider).unwrap();
+    std::fs::write(provider.join("run.log"), "y".repeat(500)).unwrap();
+
+    let out_dir = tempfile::TempDir::new().unwrap();
+    let out = out_dir.path().join("diag.tar.zst");
+    let mut args = bug_args(&out);
+    args.log_tail_bytes = 100;
+    cmd_bug(&global_args(state.path(), config.path()), args)
+        .await
+        .unwrap();
+
+    let files = unpack(&out).await;
+    for suffix in ["logs/minimald.log.2026-07-21", "providers/local-0/run.log"] {
+        let contents = find(&files, suffix).unwrap_or_else(|| panic!("missing {suffix}"));
+        assert_eq!(contents.len(), 100, "{suffix} honors the requested cap");
+    }
+
+    let manifest: serde_json::Value =
+        serde_json::from_slice(find(&files, "manifest.json").expect("manifest")).unwrap();
+    let capped: Vec<&serde_json::Value> = manifest["collected"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|e| e["redaction"] == "tail-capped")
+        .collect();
+    assert_eq!(capped.len(), 2, "both logs recorded as tail-capped");
+    // Today the applied cap is only recoverable from a capped entry's own
+    // byte count; the manifest has no field naming it outright.
+    assert!(
+        capped.iter().all(|e| e["bytes"] == 100),
+        "a capped entry's size is the cap: {capped:?}"
+    );
 }
 
 /// R5.1–R5.3: the incident collectors (net/procs/power) land in the bundle,


### PR DESCRIPTION
## Why now

`min bug`'s per-log tail has been pinned at `LOG_TAIL_CAP` (5 MiB) since the
command landed, applied per file by `BundleWriter::add_file_tail`. That was a
comfortable window while the daemons logged at INFO. Two things have changed:

- [#872](https://github.com/gominimal/minimal/pull/872) merged tonight and
  forwards the host's `RUST_LOG` to the guest daemon over the kernel cmdline.
  `RUST_LOG=debug` is one of the documented workarounds on
  [#869](https://github.com/gominimal/minimal/issues/869) — so the user most
  likely to be capturing a bundle is now precisely the one whose guest daemon
  is logging at DEBUG, where 5 MiB is a very short window.
- There is no intra-day size rotation. The current day's file grows without
  bound while the tail stays fixed, so a 5 MiB tail of a large file can begin
  well *after* the incident being diagnosed.

The result is a bundle that looks complete and silently omits the interesting
part. This PR both raises the default and makes it adjustable.

## What this plumbs

- `LOG_TAIL_CAP` raised **5 MiB → 32 MiB**, so an unflagged `min bug` gets the
  bigger window. Arithmetic below.
- `--log-tail-bytes` on `BugArgs`, defaulting to `LOG_TAIL_CAP` rather than
  restating it, so the flag tracks the default automatically.
- Threaded to `collect::logs`, which forwards it to both `add_file_tail` call
  sites — the rotated host logs (`minimald.log*`, `minvmd.log*`) and the
  provider-scoped `run.log` / `boot.log`. Those are the only two on `main`.
- `MAX_LOG_TAIL_BYTES` (64 MiB) added to `diagnostics::bundle`, next to
  `LOG_TAIL_CAP`. It lives there because the reason for the ceiling lives
  there: `add_file_tail` seeks `-(cap as i64)` from the end, so a cap past
  `i64::MAX` is a nonsense seek and a very large one is an unbounded read.
- A `const _: () = assert!(LOG_TAIL_CAP * 2 <= MAX_LOG_TAIL_BYTES)` keeps the
  default from creeping up until the flag is downward-only. Compile-time, so
  it cannot land silently.

## Picking 32 MiB

Measured on a real `RUST_LOG=debug` capture from this machine (18.4 MB,
168,963 records), re-enveloped into `mlog`'s JSON-lines shipping format, since
the on-disk logs here predate Unit 4 and are still console-format:

| | raw | zstd -19 | ratio | B/record |
|---|---|---|---|---|
| console format (as captured) | 18,385,469 | 443,861 | 41.4x | 109 |
| mlog JSON-lines (shipping) | 36,126,536 | 505,227 | **71.5x** | **214** |

What each cap buys, measuring the compressed size of an actual tail of that
length rather than assuming a ratio:

| cap | records kept | wire bytes/file | 5 files, wire |
|---|---|---|---|
| 5 MiB | 24,521 | 64,170 | 320,850 |
| 16 MiB | 78,467 | 202,782 | 1,013,910 |
| **32 MiB** | **156,933** | **463,380** | **2,316,900** |
| 48 MiB | 235,400 | 703,884 | 3,519,420 |
| 64 MiB | 313,867 | 938,513 | 4,692,565 |

**Wire cost is not the constraint.** Log text compresses ~70x, so the whole
increase costs about 2 MiB of archive. Nobody notices that in a bundle they
are uploading once.

**The constraint that binds is uncompressed.** `add_file_tail` does
`Vec::with_capacity(len.min(cap))` and `read_to_end` — the entire tail is
buffered in memory, so the cap *is* peak allocation per file (sequential, so
peak is one cap, not twelve). And `collect::logs` gathers 2 prefixes x 5
rotated files + 2 per provider:

| cap | 1 provider | 3 providers |
|---|---|---|
| 5 MiB | 60 MiB extracted | 80 MiB |
| 16 MiB | 192 MiB | 256 MiB |
| **32 MiB** | **384 MiB** | **512 MiB** |
| 48 MiB | 576 MiB | 768 MiB |

**Why not higher.** The tempting argument for 48 MiB is that the measured
session is 36.1 MB in shipping format, so 32 MiB does not hold all of it. That
argument does not survive the rate: those 18.4 MB arrived in **8 seconds**
(22,316 records/s), and **168,962 of the 168,963 records are `russh`** — one
dependency, not minimal's own code. At that rate 32 MiB is ~7s of history and
48 MiB is ~11s. Neither "holds the incident", so stretching the default buys
linear history for linear extraction cost and no categorical win, while
pushing a normal bundle toward 768 MiB extracted and halving the flag's upward
headroom.

**Why not lower.** 16 MiB would be defensible on extraction size alone, but
32 MiB is still only ~512 MiB extracted worst case, and it doubles the
retained history for ~1.3 MiB more archive. Steady-state INFO on this machine
measures 61–852 KiB/day, so at INFO both values are effectively "weeks"; the
difference only matters at DEBUG, which is exactly the case #872 makes likely.

So the evidence supports the 32 MiB candidate — though for a different reason
than "6x the current": it is the largest value whose *uncompressed* footprint
still looks like a normal bundle.

## Truncation check

The premise that a 256 MiB client-side content limit might be pushed into
truncation does not apply, for two independent reasons:

1. **Nothing on `main` truncates.** `Redaction::Truncated` is declared in
   `manifest.rs` and has **no constructor anywhere on `main`**. The
   `GUEST_BUNDLE_MAX_BYTES = 256 MiB` constant lives on
   `feat/diag-unit7-guest-fetch`, not here.
2. **When it lands it will not bind.** It caps the *compressed* nested guest
   bundle streamed over vsock, and the daemon bundles 5 files at its own
   `log_tail_cap` (which defaults to `LOG_TAIL_CAP`). At 32 MiB that is
   ~2.3 MiB compressed — **0.9% of the cap**, ~110x headroom. Even at the
   64 MiB ceiling it is ~4.7 MiB.

## Validate, don't clamp

Over-large values are rejected at parse time with an error naming the ceiling,
rather than clamped to it. A clamp returns success while quietly capturing less
than was asked for, so the resulting short log reads as a fact about the system
instead of a fact about the flag — the same trap as `SO_VM_SOCKETS_BUFFER_SIZE`,
which returns success while changing nothing when the value exceeds an unrelated
maximum.

`0` is rejected too. On the wire contract `0` is the "use the daemon default"
sentinel; taken literally on the host side it would bundle empty files labelled
`tail-capped`. Rejecting it keeps the two from disagreeing about what `0` means
once the guest path lands.

## Manifest honesty

The manifest does **not** record which cap was applied, and this PR does not add
it. Today a reader can only recover the cap indirectly: a `tail-capped` entry's
`bytes` *is* the cap, because `add_file_tail` reads exactly `cap` bytes when it
caps. That is an inference, not a record, and it says nothing at all when no
file happened to exceed the cap.

**Recommendation:** add a `log_tail_bytes` field to `Manifest` so a non-default
cap is stated outright. It is deliberately not done here — it changes the bundle
schema and `BundleWriter::finish`'s signature, both of which
`feat/diag-unit6-daemon-bundle` already rewrites, and this PR is meant to be a
flag rather than a collector change.

The equality is unaffected by the raised default, because it is a property of
`add_file_tail` (`take(cap).read_to_end(...)` yields exactly `cap` bytes on a
capped file) rather than of the value. It stays pinned at two levels:
`bundle::tests::add_file_tail_caps_large_files` at the writer, and
`a_custom_tail_cap_applies_to_every_log` end-to-end through `cmd_bug`. Both use
explicit caps, so neither silently follows the default.

## What has to wait for Units 6/7

On `main` today:

- `BugArgs` has only `--output`. There is no `--no-guest` and no
  `--guest-timeout-secs` — those live on `feat/diag-unit7-guest-fetch`.
- There is no `DiagBundleRequest`, no `with_log_tail_bytes`, and no guest
  request of any kind. `crates/minimald/src/diag.rs` does not exist. `min bug`
  is host-only.

So **the guest-request half of this change is not implementable on `main`** and
is left for Unit 7. When it lands, `cmd_bug` should pass `args.log_tail_bytes`
through `DiagBundleRequest::with_log_tail_bytes` — a setter that today has no
non-test caller anywhere.

One thing to fix when Unit 7 lands: its daemon-side handler defines its own
private `MAX_LOG_TAIL_BYTES` in `crates/minimald/src/diag.rs` and **clamps**
(`requested.min(MAX_LOG_TAIL_BYTES)`), which is the exact pattern this PR argues
against. The daemon does need a hard ceiling — it cannot trust a remote caller —
but it should reject the request rather than silently serve a shorter tail than
was asked for, and it should import `diagnostics::MAX_LOG_TAIL_BYTES` instead of
keeping a second copy of the number.

## Verification

`cargo test -p minimal` does **not** build on macOS on `main`: `minimal`
dev-depends on `minimald`, which pulls `hakoniwa → libcgroups → procfs`, and
procfs' build script refuses any non-Linux target. Confirmed pre-existing by
stashing this branch and reproducing on a clean tree. Tests were therefore run
on Linux via `cross`, the path `just test-cross` documents for exactly this.

```
test diag::tests::a_cap_within_the_contract_is_accepted_verbatim ... ok
test diag::tests::a_zero_or_non_numeric_cap_is_rejected ... ok
test diag::tests::an_over_large_cap_is_rejected_not_clamped ... ok
test diag::tests::omitting_the_flag_uses_the_shared_default ... ok
test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

test a_custom_tail_cap_applies_to_every_log ... ok
test bug_without_daemon_still_produces_a_bundle ... ok
test incident_collectors_land_and_mask_macs ... FAILED
test logs_collects_newest_five_per_prefix_and_provider_logs ... FAILED
test planted_secrets_never_reach_the_bundle ... ok
test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```

`diagnostics`: 43 passed, 0 failed. `cross clippy -p minimal -p diagnostics
--all-targets -- -D warnings`: exit 0.

The two failures are **pre-existing and environmental** — the cross container
has no `ip`/`ss`, so `host/net/interfaces.txt` is never captured and the net
collectors record errors. Verified by stashing this branch and running the same
target on clean `main` in the same container: identical two failures, identical
assertions. They are unrelated to the log tail.
