### PR TITLE
fix(minimal): honor -C/--repo-dir in `min activate` path resolution

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -261,9 +261,10 @@ pub struct ActivateArgs {
     /// Optional session name
     #[arg(long, short)]
     pub name: Option<String>,
-    /// Project path to activate (defaults to current directory)
-    #[arg(default_value = ".")]
-    pub path: String,
+    /// Project path to activate. Defaults to the directory set by
+    /// `-C`/`--repo-dir`, or the current working directory when neither
+    /// is given.
+    pub path: Option<String>,
     /// How to load project files into the session.
     #[arg(long, value_enum, default_value_t = SyncMode::Tarball)]
     pub sync: SyncMode,
@@ -582,18 +583,14 @@ async fn cmd_default(global: &GlobalArgs) -> Result<(), anyhow::Error> {
         }
         None => {
             // No sessions exist: activate a new one for the current directory
-            // and chain into attach, mirroring `min activate --attach`. Honor
-            // `--repo-dir` (`-C`) so `min -C /path` activates for /path, not
-            // the process's actual cwd — matching the attach side, which uses
-            // `cwd_host_path(global)` for its cwd comparison.
+            // (or -C/--repo-dir if set) and chain into attach, mirroring
+            // `min activate --attach`. `cmd_activate` resolves the path from
+            // `global.repo_dir` when no positional is given, matching the
+            // attach side's `cwd_host_path(global)`.
             drop(client);
-            let path = match global.repo_dir.as_deref() {
-                Some(dir) => dir.to_string_lossy().to_string(),
-                None => ".".to_string(),
-            };
             let activate_args = ActivateArgs {
                 name: None,
-                path,
+                path: None,
                 sync: SyncMode::Tarball,
                 network: CliNetworkMode::HostNet,
                 ingress: Vec::new(),
@@ -1070,8 +1067,14 @@ fn resolve_upload_root(dir: &camino::Utf8Path) -> Result<camino::Utf8PathBuf, an
 pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), anyhow::Error> {
     ensure_daemon(global)?;
 
-    let project_path = std::fs::canonicalize(&args.path)
-        .with_context(|| format!("Cannot resolve project path '{}'", args.path))?;
+    let effective_path = match (&args.path, &global.repo_dir) {
+        (Some(p), _) => std::path::PathBuf::from(p),
+        (None, Some(dir)) => dir.clone(),
+        (None, None) => std::path::PathBuf::from("."),
+    };
+
+    let project_path = std::fs::canonicalize(&effective_path)
+        .with_context(|| format!("Cannot resolve project path '{}'", effective_path.display()))?;
 
     let utf8_path = camino::Utf8PathBuf::from_path_buf(project_path)
         .map_err(|_| anyhow::anyhow!("Project path is not valid UTF-8"))?;

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -220,7 +220,7 @@ async fn activate_creates_session() {
 
     let activate_args = ActivateArgs {
         name: Some("test-session".to_string()),
-        path: project.path().to_string_lossy().to_string(),
+        path: Some(project.path().to_string_lossy().to_string()),
         sync: SyncMode::Tarball,
         network: CliNetworkMode::NoNet,
         ingress: vec![],
@@ -262,7 +262,7 @@ async fn activate_uploads_project_files() {
 
     let activate_args = ActivateArgs {
         name: Some("upload-test".to_string()),
-        path: project.path().to_string_lossy().to_string(),
+        path: Some(project.path().to_string_lossy().to_string()),
         sync: SyncMode::Tarball,
         network: CliNetworkMode::NoNet,
         ingress: vec![],
@@ -297,6 +297,55 @@ async fn activate_uploads_project_files() {
 }
 
 // --- attach (smart resolution) ---
+
+/// `min activate` with no positional path but `-C/--repo-dir` set uploads
+/// from the repo-dir directory, not the process cwd (#873).
+#[tokio::test]
+async fn activate_uses_repo_dir_when_no_positional_path() {
+    let (daemon, mut global) = setup().await;
+
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir(project.path().join(".git")).unwrap();
+    std::fs::write(
+        project.path().join("minimal.toml"),
+        "# test minimal.toml\n[upstream]\nrepo = \"https://github.com/gominimal/pkgs\"\nbranch = \"main\"\n\n[stack]\nuse = \"shell\"\n",
+    )
+    .unwrap();
+    std::fs::write(project.path().join("hello.txt"), "hello world").unwrap();
+
+    global.repo_dir = Some(project.path().to_path_buf());
+
+    let activate_args = ActivateArgs {
+        name: Some("repo-dir-test".to_string()),
+        path: None,
+        sync: SyncMode::Tarball,
+        network: CliNetworkMode::NoNet,
+        ingress: vec![],
+        loadout: vec![],
+        no_loadouts: false,
+        no_prompt: false,
+        attach: false,
+    };
+    cmd_activate(&global, activate_args).await.unwrap();
+
+    let mut client = daemon.server.connect().await;
+    use minimald_rpc::ListSessions;
+    let resp = client.call::<ListSessions>(&()).await;
+    assert_eq!(resp.sessions.len(), 1);
+    let session = &resp.sessions[0];
+
+    let project_canon = project.path().canonicalize().unwrap();
+    let session_path = session.project_path.as_ref().unwrap();
+    assert_eq!(
+        session_path.as_str(),
+        project_canon.to_str().unwrap(),
+        "session project_path should match -C/--repo-dir, not cwd"
+    );
+
+    let sftp = client.open_sftp(session.id).await;
+    let hello = sftp.read("hello.txt").await.unwrap();
+    assert_eq!(hello, b"hello world");
+}
 
 /// `min attach` with no session argument and `--no-input` errors cleanly when
 /// no sessions exist, rather than hanging or shelling out to ssh. The error


### PR DESCRIPTION
<summary>

`min activate` silently ignored the global `-C`/`--repo-dir` flag, always uploading from the current working directory instead of the specified directory. This caused wrong-directory uploads with no error — in a large repo, triggering multi-gigabyte uploads of the wrong project.

## Root cause

`ActivateArgs.path` had `default_value = "."`, so clap always filled it. `cmd_activate` canonicalized `args.path` and never consulted `global.repo_dir`. The flag worked for local build-system commands (`init`, `add`, `update`) via `build_config` but was a no-op for the daemon-facing `activate`.

## Fix

- Changed `path` from `String` (default `"."`) to `Option<String>` so the default is distinguishable from an explicit value.
- `cmd_activate` now resolves the effective project path: **explicit positional → `-C`/`--repo-dir` → current directory**.
- Updated the bare-`min` dispatch to pass `path: None` since `cmd_activate` handles resolution.
- Audited other daemon-facing subcommands: `attach` already uses `cwd_host_path(global)` which honors `repo_dir`; `destroy`, `rename`, `session policy` take session identifiers, not paths.

Closes #873.

</summary>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `min activate` to honor `-C/--repo-dir` when no positional path is given
> Previously, `ActivateArgs.path` defaulted to `"."` at parse time, so `-C/--repo-dir` was ignored during activation when no explicit path was provided. The fix makes `path` optional and adds explicit precedence resolution in `cmd_activate`: use the positional path if given, then `--repo-dir`, then `"."`. A new test in [cli.rs](https://github.com/gominimal/minimal/pull/909/files#diff-58596d6d225623d0dd1ee94ea00cc5642d5a412c81eb6bca18df848835a77caa) verifies the corrected behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4abaf94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `min activate` path handling when no project path is provided.
  * The `--repo-dir` option is now correctly used as the project directory when applicable.
  * Error messages now reference the resolved project path.

* **Tests**
  * Added coverage confirming sessions use the configured repository directory and retain existing project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->