### PR TITLE
fix(libkrun-ci): use patches in cache key

### DIFF
--- a/.github/actions/setup-libkrun-macos/action.yml
+++ b/.github/actions/setup-libkrun-macos/action.yml
@@ -26,15 +26,22 @@ runs:
           exit 1
         fi
         script_hash="$(shasum -a 256 scripts/build-libkrun-macos.sh | cut -d' ' -f1)"
+        # Hash the carried patches (name + content, in apply order) so editing,
+        # adding, or removing a patch invalidates the build. `shasum` over each
+        # file emits `<hash>  <path>`; sort pins a stable order, then a final
+        # digest folds them into one value. No patches => digest of empty input,
+        # still deterministic.
+        patches_hash="$(find vendor/libkrun/patches -name '*.patch' -type f -exec shasum -a 256 {} + 2>/dev/null | sort | shasum -a 256 | cut -d' ' -f1)"
         {
           echo "commit=$commit"
-          # The prefix embeds BOTH build inputs (pinned commit + build-script
-          # hash) so the persistent mini rebuilds when either changes — the
-          # same invalidation the actions/cache key gives GitHub-hosted
-          # runners. Stale sibling prefixes on the mini are inert (nothing
-          # references them) and may be deleted by hand.
-          echo "prefix=$HOME/.cache/minimal-ci/libkrun/$commit-${script_hash:0:12}"
+          # The prefix embeds ALL build inputs (pinned commit + build-script
+          # hash + patches hash) so the persistent mini rebuilds when any
+          # changes — the same invalidation the actions/cache key gives
+          # GitHub-hosted runners. Stale sibling prefixes on the mini are inert
+          # (nothing references them) and may be deleted by hand.
+          echo "prefix=$HOME/.cache/minimal-ci/libkrun/$commit-${script_hash:0:12}-${patches_hash:0:12}"
           echo "script_hash=$script_hash"
+          echo "patches_hash=$patches_hash"
         } >> "$GITHUB_OUTPUT"
     - name: Cache built libkrun (GitHub-hosted)
       # The mini needs no cache action: the input-keyed prefix under $HOME
@@ -43,7 +50,7 @@ runs:
       uses: actions/cache@v6
       with:
         path: ~/.cache/minimal-ci/libkrun
-        key: libkrun-macos-${{ runner.arch }}-${{ steps.pin.outputs.commit }}-${{ steps.pin.outputs.script_hash }}
+        key: libkrun-macos-${{ runner.arch }}-${{ steps.pin.outputs.commit }}-${{ steps.pin.outputs.script_hash }}-${{ steps.pin.outputs.patches_hash }}
     - name: Build libkrun from source (on miss)
       shell: bash
       env:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Include patch files in libkrun macOS cache key to trigger rebuilds on patch changes
The [action.yml](https://github.com/gominimal/minimal/pull/910/files#diff-a93af765577cc19e586fa790030b70936bcae3b4515b157afcbd394e067172e4) composite action now hashes all `*.patch` files under `vendor/libkrun/patches` and incorporates the resulting `patches_hash` into both the cache key and the persistent prefix path. Previously, adding, removing, or modifying patches would not invalidate the cache, causing stale builds to be used.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ca6120f. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS build caching to detect changes in bundled libkrun patches.
  * Prevented stale cached builds from being reused when the pinned source, build script, or patches change.
  * Preserved existing verification to ensure the required libkrun functionality is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->