### PR TITLE
feat(rcache): read the index from per-commit snapshots (auto/pinned/root)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5273,6 +5273,7 @@ dependencies = [
  "graph",
  "hex",
  "lcache",
+ "mfile",
  "mockall",
  "ot",
  "reqwest",

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -15,9 +15,7 @@ use common::{SpecOrigin, Target};
 use google_cloud_storage::client::Storage as GcsStorage;
 use lcache::CacheBinProvider;
 use ot::OpTracker;
-use rcache::{
-    Error as RemoteError, IndexSource, RemoteBinProvider, RemoteCache, RemoteCacheWriter,
-};
+use rcache::{Error as RemoteError, RemoteBinProvider, RemoteCache, RemoteCacheWriter};
 
 mod error;
 pub use error::Error;
@@ -527,6 +525,9 @@ impl Context {
             None
         };
 
+        // Rollout lever: overrides the file setting while per-commit reads
+        // bed in. Retire (env var first, then likely the file setting) once
+        // snapshot reads are the settled default.
         let override_mode = match std::env::var("MINIMAL_INDEX_SOURCE") {
             Ok(v) => Some(
                 v.parse::<mfile::IndexSourceMode>()
@@ -534,37 +535,18 @@ impl Context {
             ),
             Err(_) => None,
         };
-        let (source, fallback) = match self
+        let config = self
             .mfile
             .cache_config(override_mode)
-            .map_err(RemoteError::Config)?
-        {
-            mfile::CacheConfig::GlobalIndex => (IndexSource::Root, false),
-            mfile::CacheConfig::CommitIndex { object } => (IndexSource::Snapshot { object }, true),
-            mfile::CacheConfig::CommitIndexOnly { object } => {
-                (IndexSource::Snapshot { object }, false)
-            }
-        };
-        if let IndexSource::Snapshot { object } = &source {
-            tracing::debug!("cache index: per-commit snapshot {object}");
-        }
-
-        let ot = self.daemon.config.ot.clone();
-        let res = RemoteCache::new_any(
-            url.clone(),
-            gcs_storage.clone(),
-            index_dir.clone(),
-            ot.clone(),
-            source,
+            .map_err(RemoteError::Config)?;
+        let res = RemoteCache::new_any_configured(
+            url,
+            gcs_storage,
+            index_dir,
+            self.daemon.config.ot.clone(),
+            &config,
         )
         .await;
-        let res = match res {
-            Err(RemoteError::SnapshotMissing { object }) if fallback => {
-                tracing::info!("per-commit index {object} not found; using root index");
-                RemoteCache::new_any(url, gcs_storage, index_dir, ot, IndexSource::Root).await
-            }
-            other => other,
-        };
         tracing::trace!("remote cache init took {:?}", start.elapsed());
         res
     }

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -15,7 +15,9 @@ use common::{SpecOrigin, Target};
 use google_cloud_storage::client::Storage as GcsStorage;
 use lcache::CacheBinProvider;
 use ot::OpTracker;
-use rcache::{Error as RemoteError, RemoteBinProvider, RemoteCache, RemoteCacheWriter};
+use rcache::{
+    Error as RemoteError, IndexSource, RemoteBinProvider, RemoteCache, RemoteCacheWriter,
+};
 
 mod error;
 pub use error::Error;
@@ -481,7 +483,10 @@ impl Context {
     /// Builds and returns a remote cache reader for the configured cache
     /// location. [Config] has already resolved where artifacts come from — a GCS
     /// bucket (the default) or an HTTPS mirror (honouring
-    /// `MINIMAL_REMOTE_CACHE_URL`) — so this just wires up the matching backend.
+    /// `MINIMAL_REMOTE_CACHE_URL`) — and the minimal file resolves *which index
+    /// object* to read ([`mfile::File::cache_config`], overridable via
+    /// `MINIMAL_INDEX_SOURCE`), so this just wires up the matching backend and
+    /// follows those instructions.
     ///
     /// `auth` selects authenticated vs. anonymous GCS access (the buildbot / mip
     /// upload path reads authed; anonymous CI reads use the public path). It's
@@ -521,8 +526,45 @@ impl Context {
         } else {
             None
         };
-        let res =
-            RemoteCache::new_any(url, gcs_storage, index_dir, self.daemon.config.ot.clone()).await;
+
+        let override_mode = match std::env::var("MINIMAL_INDEX_SOURCE") {
+            Ok(v) => Some(
+                v.parse::<mfile::IndexSourceMode>()
+                    .map_err(|e| RemoteError::Config(format!("MINIMAL_INDEX_SOURCE: {e}")))?,
+            ),
+            Err(_) => None,
+        };
+        let (source, fallback) = match self
+            .mfile
+            .cache_config(override_mode)
+            .map_err(RemoteError::Config)?
+        {
+            mfile::CacheConfig::GlobalIndex => (IndexSource::Root, false),
+            mfile::CacheConfig::CommitIndex { object } => (IndexSource::Snapshot { object }, true),
+            mfile::CacheConfig::CommitIndexOnly { object } => {
+                (IndexSource::Snapshot { object }, false)
+            }
+        };
+        if let IndexSource::Snapshot { object } = &source {
+            tracing::debug!("cache index: per-commit snapshot {object}");
+        }
+
+        let ot = self.daemon.config.ot.clone();
+        let res = RemoteCache::new_any(
+            url.clone(),
+            gcs_storage.clone(),
+            index_dir.clone(),
+            ot.clone(),
+            source,
+        )
+        .await;
+        let res = match res {
+            Err(RemoteError::SnapshotMissing { object }) if fallback => {
+                tracing::info!("per-commit index {object} not found; using root index");
+                RemoteCache::new_any(url, gcs_storage, index_dir, ot, IndexSource::Root).await
+            }
+            other => other,
+        };
         tracing::trace!("remote cache init took {:?}", start.elapsed());
         res
     }

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -533,7 +533,9 @@ impl Context {
                 v.parse::<mfile::IndexSourceMode>()
                     .map_err(|e| RemoteError::Config(format!("MINIMAL_INDEX_SOURCE: {e}")))?,
             ),
-            Err(_) => None,
+            Err(std::env::VarError::NotPresent) => None,
+            // A set-but-garbled override must be loud, like any other bad value.
+            Err(e) => return Err(RemoteError::Config(format!("MINIMAL_INDEX_SOURCE: {e}"))),
         };
         let config = self
             .mfile

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -585,6 +585,92 @@ pub struct Stdlib {
     pub minimum_version: Option<String>,
 }
 
+/// The `[cache]` section: how this project reads the shared remote cache.
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct CacheSettings {
+    /// Which index object the cache reader loads. Defaults to
+    /// [`IndexSourceMode::Auto`].
+    pub index_source: Option<IndexSourceMode>,
+}
+
+/// Selects which remote-cache index object the reader loads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IndexSourceMode {
+    /// The upstream pin's per-commit index snapshot when it exists, falling
+    /// back to the global root index when it doesn't.
+    Auto,
+    /// The per-commit snapshot only; a missing snapshot is an error.
+    Pinned,
+    /// The global root index only.
+    Root,
+}
+
+impl std::str::FromStr for IndexSourceMode {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(Self::Auto),
+            "pinned" => Ok(Self::Pinned),
+            "root" => Ok(Self::Root),
+            other => Err(format!(
+                "unknown index source {other:?} (expected \"auto\", \"pinned\" or \"root\")"
+            )),
+        }
+    }
+}
+
+/// How the remote-cache reader should locate its index. Resolved centrally
+/// from the project file and its upstream pin ([`File::cache_config`]) so the
+/// fetch layer follows instructions without policy of its own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CacheConfig {
+    /// Read the global mutable root index.
+    GlobalIndex,
+    /// Read the immutable per-commit snapshot `object`; if it doesn't exist,
+    /// fall back to the global root index.
+    CommitIndex { object: String },
+    /// Read the immutable per-commit snapshot `object`; if it doesn't exist,
+    /// fail rather than fall back.
+    CommitIndexOnly { object: String },
+}
+
+/// Object key of the per-commit index snapshot for a repo + commit:
+/// `<host>/<owner>/<repo>/<commit>.shisha`, matching the publisher's keying.
+pub fn commit_index_object(repo_url: &str, commit_sha: &str) -> String {
+    format!("{}/{commit_sha}.shisha", repo_slug(repo_url))
+}
+
+/// Stable `host/owner/repo` slug for a repo URL: query/fragment, scheme,
+/// credentials, trailing `/` and any `.git` suffix stripped; scp-like syntax
+/// (`git@host:owner/repo`) normalized to `host/owner/repo`.
+fn repo_slug(repo_url: &str) -> String {
+    let url = match repo_url.find(['?', '#']) {
+        Some(idx) => &repo_url[..idx],
+        None => repo_url,
+    };
+    let rest = match url.split_once("://") {
+        Some((_, rest)) => {
+            // Credentials end at the first `@` in the authority. Path
+            // components may legitimately contain `@` and are preserved.
+            let authority_end = rest.find('/').unwrap_or(rest.len());
+            match rest[..authority_end].find('@') {
+                Some(at) => &rest[at + 1..],
+                None => rest,
+            }
+        }
+        None => match (url.find('@'), url.find(':')) {
+            // scp-like `user@host:path` -> `host/path`
+            (Some(at), Some(colon)) if at < colon => {
+                return repo_slug(&format!("{}/{}", &url[at + 1..colon], &url[colon + 1..]));
+            }
+            _ => url,
+        },
+    };
+    let trimmed = rest.trim_end_matches('/');
+    trimmed.strip_suffix(".git").unwrap_or(trimmed).to_string()
+}
+
 /// Which directory layout this layer/repo used for minimal configuration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Layout {
@@ -629,6 +715,9 @@ pub struct File {
     /// Configuration relevant to the standard library.
     #[serde(default)]
     pub stdlib: Stdlib,
+    /// How this project reads the shared remote cache.
+    #[serde(default)]
+    pub cache: CacheSettings,
     /// Project-level session contribution: packages, vars, patches,
     /// and lifecycle hooks that apply to every session activated on
     /// this project. Consumed by the `ProjectComposable` at
@@ -974,6 +1063,41 @@ impl File {
             )
         })
     }
+
+    /// Resolves how the remote-cache reader should locate its index:
+    /// `[cache] index_source` (or `override_mode`, which wins when set —
+    /// typically an environment variable) applied to the upstream pin.
+    ///
+    /// `auto`, the default, selects the upstream pin's per-commit snapshot
+    /// with root fallback, degrading to the root index when there is no git
+    /// upstream or no locked commit.
+    pub fn cache_config(
+        &self,
+        override_mode: Option<IndexSourceMode>,
+    ) -> Result<CacheConfig, String> {
+        let mode = override_mode
+            .or(self.cache.index_source)
+            .unwrap_or(IndexSourceMode::Auto);
+
+        let snapshot = self.upstream.as_ref().and_then(|u| match &u.link {
+            LinkConfig::Git {
+                repo,
+                locked_commit: Some(commit),
+                ..
+            } => Some(commit_index_object(repo, commit)),
+            _ => None,
+        });
+
+        match (mode, snapshot) {
+            (IndexSourceMode::Root, _) => Ok(CacheConfig::GlobalIndex),
+            (IndexSourceMode::Auto, Some(object)) => Ok(CacheConfig::CommitIndex { object }),
+            (IndexSourceMode::Auto, None) => Ok(CacheConfig::GlobalIndex),
+            (IndexSourceMode::Pinned, Some(object)) => Ok(CacheConfig::CommitIndexOnly { object }),
+            (IndexSourceMode::Pinned, None) => Err(
+                "index_source \"pinned\" requires a git upstream with a locked_commit".to_string(),
+            ),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1076,6 +1200,7 @@ mod tests {
                 )]
                 .into(),
                 stdlib: Default::default(),
+                cache: Default::default(),
                 session: None,
                 extra: HashMap::new(),
                 mfile_path: None,
@@ -1524,5 +1649,84 @@ mod tests {
         .unwrap();
         let session = mf.session.expect("populated block parses");
         assert!(session.extra.contains_key("weird_new_thing"));
+    }
+
+    #[test]
+    fn repo_slug_normalizes_common_url_forms() {
+        for url in [
+            "https://github.com/gominimal/pkgs",
+            "https://github.com/gominimal/pkgs.git",
+            "https://github.com/gominimal/pkgs/",
+            "https://oauth2:tok@github.com/gominimal/pkgs.git",
+            "ssh://git@github.com/gominimal/pkgs.git",
+            "git@github.com:gominimal/pkgs.git",
+            "https://github.com/gominimal/pkgs?ref=x#frag",
+        ] {
+            assert_eq!(repo_slug(url), "github.com/gominimal/pkgs", "{url}");
+        }
+    }
+
+    #[test]
+    fn cache_config_resolves_modes_against_the_pin() {
+        const SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+        let pinned: File = toml::from_str(&format!(
+            "[upstream]\nrepo = \"https://github.com/gominimal/pkgs\"\nlocked_commit = \"{SHA}\"\n"
+        ))
+        .unwrap();
+        let object = format!("github.com/gominimal/pkgs/{SHA}.shisha");
+
+        // Default is auto: snapshot with fallback.
+        assert_eq!(
+            pinned.cache_config(None).unwrap(),
+            CacheConfig::CommitIndex {
+                object: object.clone()
+            }
+        );
+        // Override wins over the (unset) file setting.
+        assert_eq!(
+            pinned.cache_config(Some(IndexSourceMode::Root)).unwrap(),
+            CacheConfig::GlobalIndex
+        );
+        assert_eq!(
+            pinned.cache_config(Some(IndexSourceMode::Pinned)).unwrap(),
+            CacheConfig::CommitIndexOnly { object }
+        );
+
+        // No locked commit: auto degrades to the root index, pinned errors.
+        let unpinned: File =
+            toml::from_str("[upstream]\nrepo = \"https://github.com/gominimal/pkgs\"\n").unwrap();
+        assert_eq!(
+            unpinned.cache_config(None).unwrap(),
+            CacheConfig::GlobalIndex
+        );
+        assert!(
+            unpinned
+                .cache_config(Some(IndexSourceMode::Pinned))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn cache_config_reads_the_file_setting_and_override_beats_it() {
+        const SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+        let mf: File = toml::from_str(&format!(
+            r#"
+            [upstream]
+            repo = "https://github.com/gominimal/pkgs"
+            locked_commit = "{SHA}"
+
+            [cache]
+            index_source = "root"
+            "#
+        ))
+        .unwrap();
+        assert_eq!(mf.cache.index_source, Some(IndexSourceMode::Root));
+        assert_eq!(mf.cache_config(None).unwrap(), CacheConfig::GlobalIndex);
+        assert_eq!(
+            mf.cache_config(Some(IndexSourceMode::Pinned)).unwrap(),
+            CacheConfig::CommitIndexOnly {
+                object: format!("github.com/gominimal/pkgs/{SHA}.shisha")
+            }
+        );
     }
 }

--- a/crates/rcache/Cargo.toml
+++ b/crates/rcache/Cargo.toml
@@ -22,5 +22,6 @@ tempfile.workspace = true
 
 common = { workspace = true }
 graph = { workspace = true }
+mfile = { workspace = true }
 lcache = { workspace = true }
 ot = { workspace = true }

--- a/crates/rcache/src/index_file.rs
+++ b/crates/rcache/src/index_file.rs
@@ -25,6 +25,9 @@ use common::SpecHash;
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 
+/// Size of one wire record (see the format description above).
+pub(crate) const WIRE_RECORD_LEN: u64 = 68;
+
 fn read_wire_kv<R: Read>(reader: &mut R) -> std::io::Result<(SpecHash, IndexEntry)> {
     let mut buf = [0u8; 32];
     reader.read_exact(&mut buf[..])?;

--- a/crates/rcache/src/lib.rs
+++ b/crates/rcache/src/lib.rs
@@ -1,7 +1,7 @@
 //! Remote cache implementation for fetching/uploading build artifacts over the network.
 
 mod remote;
-pub use remote::{Error, INDEX_FILENAME, RemoteCache};
+pub use remote::{Error, INDEX_FILENAME, IndexSource, RemoteCache};
 
 mod remote_writer;
 pub use remote_writer::RemoteCacheWriter;

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -344,6 +344,16 @@ impl<B: FetchBackend> RemoteCache<B> {
                 }
                 fetch_op.set_done();
 
+                // Same whole-record strictness as the local-copy load: the
+                // parser reads till EOF and would accept a body truncated
+                // mid-record as a shorter index — which the local write below
+                // would then launder into a well-formed (but incomplete) copy.
+                if !(buffer.len() as u64).is_multiple_of(crate::index_file::WIRE_RECORD_LEN) {
+                    return Err(Error::IO(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "fetched index length is not a whole number of records",
+                    )));
+                }
                 let index =
                     IndexFile::from_reader(&mut std::io::Cursor::new(buffer)).map_err(Error::IO)?;
 
@@ -770,6 +780,28 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(rc.sha256(&spec_hash), None);
+    }
+
+    #[tokio::test]
+    async fn truncated_index_body_is_an_error_not_a_shorter_index() {
+        const OBJECT: &str = "github.com/gominimal/pkgs/0123abcd.shisha";
+        // A body cut mid-record but delivered as a complete response
+        // (Content-Length matches), e.g. a misbehaving mirror. The transport
+        // can't catch it; the whole-record check must.
+        let mut bytes = index_bytes_for(&SpecHash::from_bytes([0x07; 32]), [0x42; 32]);
+        bytes.extend_from_slice(&[0xAA; 32]); // half of a second record
+        let base = serve_objects(vec![(OBJECT.to_string(), bytes)]);
+
+        let source = IndexSource::Snapshot {
+            object: OBJECT.to_string(),
+        };
+        let err = RemoteCache::new_any_https(&base, None, None, source)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&err, Error::IO(e) if e.kind() == std::io::ErrorKind::InvalidData),
+            "expected InvalidData, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -101,12 +101,13 @@ impl IndexSource {
         }
     }
 
-    /// File name for the locally-cached copy of this index. Snapshots use the
-    /// final path component (`<commit>.shisha`), unique by commit hash.
-    fn local_filename(&self) -> &str {
+    /// File name for the locally-cached copy of this index. Snapshots flatten
+    /// the full object key so distinct snapshots never share a local file,
+    /// even when different repos pin the same commit hash.
+    fn local_filename(&self) -> String {
         match self {
-            IndexSource::Root => INDEX_FILENAME,
-            IndexSource::Snapshot { object } => object.rsplit('/').next().unwrap_or(object),
+            IndexSource::Root => INDEX_FILENAME.to_string(),
+            IndexSource::Snapshot { object } => object.replace('/', "_"),
         }
     }
 }
@@ -248,20 +249,50 @@ impl<B: FetchBackend> RemoteCache<B> {
                 (_, None) => false,
             };
             if fresh {
-                tracing::debug!("Re-using local copy of {}", source.object());
-                return Ok(Self {
-                    backend,
-                    index: IndexFile::from_reader(
-                        &mut std::fs::File::open(&l_idx_path).map_err(Error::IO)?,
-                    )
-                    .map_err(Error::IO)?,
-                    dir: index_dir,
-                    base: url,
-                    ot,
-                    // Loading from local cache means we never asked GCS for
-                    // the current generation. into_writer must refetch.
-                    gcs_generation: None,
-                });
+                // A bad copy falls through to a refetch instead of wedging
+                // every subsequent run on it. The wire parser reads records
+                // till EOF and would silently accept a copy truncated
+                // mid-record as a shorter index, so add the strictness a
+                // whole file allows: its length must be a whole number of
+                // records. (Truncation at an exact record boundary is
+                // indistinguishable in-format; the atomic write below is the
+                // guard against truncation ever landing.)
+                let load = |path: &std::path::Path| -> std::io::Result<IndexFile> {
+                    let mut f = std::fs::File::open(path)?;
+                    if !f
+                        .metadata()?
+                        .len()
+                        .is_multiple_of(crate::index_file::WIRE_RECORD_LEN)
+                    {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "length is not a whole number of records",
+                        ));
+                    }
+                    IndexFile::from_reader(&mut f)
+                };
+                match load(&l_idx_path) {
+                    Ok(index) => {
+                        tracing::debug!("Re-using local copy of {}", source.object());
+                        return Ok(Self {
+                            backend,
+                            index,
+                            dir: index_dir,
+                            base: url,
+                            ot,
+                            // Loading from local cache means we never asked GCS
+                            // for the current generation. into_writer must
+                            // refetch.
+                            gcs_generation: None,
+                        });
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "local copy of {} unreadable: {e}; refetching",
+                            source.object()
+                        )
+                    }
+                }
             }
         }
 
@@ -305,11 +336,19 @@ impl<B: FetchBackend> RemoteCache<B> {
                 let index =
                     IndexFile::from_reader(&mut std::io::Cursor::new(buffer)).map_err(Error::IO)?;
 
+                // Best-effort local caching, via temp file + rename so a crash
+                // or concurrent reader never observes a partial file.
                 if let Some(index_dir) = index_dir.as_ref() {
-                    let l_idx_path = index_dir.join(source.local_filename());
-                    index
-                        .write_to(&mut std::fs::File::create(&l_idx_path).map_err(Error::IO)?)
-                        .unwrap();
+                    let write_atomic = || -> std::io::Result<()> {
+                        let mut tmp = tempfile::NamedTempFile::new_in(index_dir)?;
+                        index.write_to(tmp.as_file_mut())?;
+                        tmp.persist(index_dir.join(source.local_filename()))
+                            .map_err(|e| e.error)?;
+                        Ok(())
+                    };
+                    if let Err(e) = write_atomic() {
+                        tracing::warn!("failed to cache {} locally: {e}", source.object());
+                    }
                 }
                 index
             }
@@ -689,7 +728,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let stale = std::time::SystemTime::now()
             - std::time::Duration::from_secs(INDEX_EXPIRY_SECONDS + 60);
-        for name in ["0123abcd.shisha", INDEX_FILENAME] {
+        for name in ["github.com_gominimal_pkgs_0123abcd.shisha", INDEX_FILENAME] {
             let path = dir.path().join(name);
             std::fs::write(&path, index_bytes_for(&spec_hash, sha256)).unwrap();
             let f = std::fs::File::options().write(true).open(&path).unwrap();
@@ -720,6 +759,35 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(rc.sha256(&spec_hash), None);
+    }
+
+    #[tokio::test]
+    async fn corrupt_local_snapshot_copy_is_refetched_not_fatal() {
+        const OBJECT: &str = "github.com/gominimal/pkgs/0123abcd.shisha";
+        let spec_hash = SpecHash::from_bytes([0x07; 32]);
+        let sha256: [u8; 32] = [0x42; 32];
+        let base = serve_objects(vec![(
+            OBJECT.to_string(),
+            index_bytes_for(&spec_hash, sha256),
+        )]);
+
+        // Seed a corrupt local copy (a write cut short by a crash — not a
+        // whole number of records). Snapshot copies never expire, so recovery
+        // must come from the load-time whole-record check, not an age check.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("github.com_gominimal_pkgs_0123abcd.shisha"),
+            b"truncated",
+        )
+        .unwrap();
+
+        let source = IndexSource::Snapshot {
+            object: OBJECT.to_string(),
+        };
+        let rc = RemoteCache::new_any_https(&base, Some(dir.path().to_path_buf()), None, source)
+            .await
+            .unwrap();
+        assert_eq!(rc.sha256(&spec_hash), Some(sha256));
     }
 
     #[tokio::test]

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -222,6 +222,53 @@ impl RemoteCache<AnyBackend> {
         )
         .await
     }
+
+    /// Builds a reader following a project's resolved [`mfile::CacheConfig`]:
+    /// per-commit snapshot with root fallback, snapshot only, or the root
+    /// index. The policy is decided by `mfile::File::cache_config`; this
+    /// executes it — including the fallback — so every caller gets the same
+    /// behavior.
+    pub async fn new_any_configured(
+        url: AnyUrl,
+        gcs_storage: Option<Storage>,
+        index_dir: Option<PathBuf>,
+        ot: Option<OpTracker>,
+        config: &mfile::CacheConfig,
+    ) -> Result<Self, Error<AnyRespError>> {
+        let (source, fallback) = match config {
+            mfile::CacheConfig::GlobalIndex => (IndexSource::Root, false),
+            mfile::CacheConfig::CommitIndex { object } => (
+                IndexSource::Snapshot {
+                    object: object.clone(),
+                },
+                true,
+            ),
+            mfile::CacheConfig::CommitIndexOnly { object } => (
+                IndexSource::Snapshot {
+                    object: object.clone(),
+                },
+                false,
+            ),
+        };
+        if let IndexSource::Snapshot { object } = &source {
+            tracing::debug!("cache index: per-commit snapshot {object}");
+        }
+        let res = Self::new_any(
+            url.clone(),
+            gcs_storage.clone(),
+            index_dir.clone(),
+            ot.clone(),
+            source,
+        )
+        .await;
+        match res {
+            Err(Error::SnapshotMissing { object }) if fallback => {
+                tracing::info!("per-commit index {object} not found; using root index");
+                Self::new_any(url, gcs_storage, index_dir, ot, IndexSource::Root).await
+            }
+            other => other,
+        }
+    }
 }
 
 impl<B: FetchBackend> RemoteCache<B> {
@@ -731,6 +778,49 @@ mod tests {
             object: OBJECT.to_string(),
         };
         let err = RemoteCache::new_any_https(&base, None, None, source)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&err, Error::SnapshotMissing { object } if object == OBJECT),
+            "expected SnapshotMissing for {OBJECT}, got {err:?}"
+        );
+    }
+
+    fn https_url(base: &str) -> AnyUrl {
+        AnyUrl::Https(ReqwestUrl::from(reqwest::Url::parse(base).unwrap()))
+    }
+
+    #[tokio::test]
+    async fn configured_auto_falls_back_to_root_when_snapshot_is_missing() {
+        const OBJECT: &str = "github.com/gominimal/pkgs/0123abcd.shisha";
+        let spec_hash = SpecHash::from_bytes([0x07; 32]);
+        let sha256: [u8; 32] = [0x42; 32];
+        // Only the root index exists: auto mode must land on it.
+        let base = serve_index(Some(index_bytes_for(&spec_hash, sha256)));
+
+        let config = mfile::CacheConfig::CommitIndex {
+            object: OBJECT.to_string(),
+        };
+        let rc = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
+            .await
+            .unwrap();
+        assert_eq!(rc.sha256(&spec_hash), Some(sha256));
+    }
+
+    #[tokio::test]
+    async fn configured_pinned_missing_snapshot_is_an_error_not_a_fallback() {
+        const OBJECT: &str = "github.com/gominimal/pkgs/0123abcd.shisha";
+        // The root index exists and could serve the spec — pinned mode must
+        // NOT fall back to it.
+        let base = serve_index(Some(index_bytes_for(
+            &SpecHash::from_bytes([0x07; 32]),
+            [0x42; 32],
+        )));
+
+        let config = mfile::CacheConfig::CommitIndexOnly {
+            object: OBJECT.to_string(),
+        };
+        let err = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
             .await
             .unwrap_err();
         assert!(

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -33,6 +33,10 @@ pub enum Error<BE: std::fmt::Debug> {
     ArchiveError(archive::ArchiveError),
     /// The sha256 hash that was requested differed from what was written/downloaded.
     HashMismatch { want: String, got: String },
+    /// The requested per-commit index snapshot does not exist.
+    SnapshotMissing { object: String },
+    /// The cache configuration could not be resolved or followed.
+    Config(String),
 }
 
 impl<BE: std::fmt::Debug> std::fmt::Display for Error<BE> {
@@ -74,7 +78,42 @@ pub struct RemoteCache<B: FetchBackend> {
 pub const INDEX_FILENAME: &str = "index.shisha";
 const INDEX_EXPIRY_SECONDS: u64 = 5 * 60; // how long a fetch of the remote index is considered fresh for
 
+/// Which index object a [`RemoteCache`] reader loads. The choice is made by
+/// the caller (see `mfile::File::cache_config`); this layer only executes it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexSource {
+    /// The global mutable root index (`index.shisha`). Absent (404) means an
+    /// empty index: a fresh cache with nothing published yet.
+    Root,
+    /// An immutable per-commit snapshot object
+    /// (`<host>/<owner>/<repo>/<commit>.shisha`). Absent is
+    /// [`Error::SnapshotMissing`]; the caller decides whether to retry with
+    /// [`IndexSource::Root`].
+    Snapshot { object: String },
+}
+
+impl IndexSource {
+    /// The object name to fetch, relative to the cache base URL.
+    fn object(&self) -> &str {
+        match self {
+            IndexSource::Root => INDEX_FILENAME,
+            IndexSource::Snapshot { object } => object,
+        }
+    }
+
+    /// File name for the locally-cached copy of this index. Snapshots use the
+    /// final path component (`<commit>.shisha`), unique by commit hash.
+    fn local_filename(&self) -> &str {
+        match self {
+            IndexSource::Root => INDEX_FILENAME,
+            IndexSource::Snapshot { object } => object.rsplit('/').next().unwrap_or(object),
+        }
+    }
+}
+
 impl RemoteCache<Client> {
+    /// Always reads the root index: this constructor serves writer-adjacent
+    /// paths, for which the root object is authoritative.
     #[tracing::instrument(skip_all, err)]
     pub async fn new_over_https<URL: Into<ReqwestUrl>>(
         url: URL,
@@ -86,12 +125,14 @@ impl RemoteCache<Client> {
             .build()?;
         let url = url.into();
 
-        Self::new(backend, url, index_dir, ot).await
+        Self::new(backend, url, index_dir, ot, IndexSource::Root).await
     }
 }
 
 impl RemoteCache<Storage> {
     /// Instantiates a new remote cache using the given GCS client + bucket.
+    /// Always reads the root index: this constructor serves writer-adjacent
+    /// paths, for which the root object is authoritative.
     #[tracing::instrument(skip_all, fields(bucket_id = %bucket_id), err)]
     pub async fn new_with_gcs_bucket(
         storage: Storage,
@@ -104,7 +145,7 @@ impl RemoteCache<Storage> {
             object: "".to_string(),
         };
 
-        Self::new(storage, url, index_dir, ot).await
+        Self::new(storage, url, index_dir, ot, IndexSource::Root).await
     }
 
     /// Convert this reader into a writer, reusing the already-fetched index
@@ -142,6 +183,7 @@ impl RemoteCache<AnyBackend> {
         gcs_storage: Option<Storage>,
         index_dir: Option<PathBuf>,
         ot: Option<OpTracker>,
+        source: IndexSource,
     ) -> Result<Self, Error<AnyRespError>> {
         let backend = match &url {
             AnyUrl::Gcs(_) => AnyBackend::Gcs(Box::new(
@@ -155,7 +197,7 @@ impl RemoteCache<AnyBackend> {
                 AnyBackend::Https(client)
             }
         };
-        Self::new(backend, url, index_dir, ot).await
+        Self::new(backend, url, index_dir, ot, source).await
     }
 
     /// Convenience reader over a plain-HTTPS base-URL string (public GCS bucket
@@ -167,29 +209,46 @@ impl RemoteCache<AnyBackend> {
         url: &str,
         index_dir: Option<PathBuf>,
         ot: Option<OpTracker>,
+        source: IndexSource,
     ) -> Result<Self, Error<AnyRespError>> {
         let parsed = reqwest::Url::parse(url).map_err(AnyRespError::InvalidUrl)?;
-        Self::new_any(AnyUrl::Https(ReqwestUrl::from(parsed)), None, index_dir, ot).await
+        Self::new_any(
+            AnyUrl::Https(ReqwestUrl::from(parsed)),
+            None,
+            index_dir,
+            ot,
+            source,
+        )
+        .await
     }
 }
 
 impl<B: FetchBackend> RemoteCache<B> {
-    /// Creates a new remote cache based on the given backend and URL.
+    /// Creates a new remote cache based on the given backend and URL, loading
+    /// the index object selected by `source`.
     pub async fn new(
         backend: B,
         url: B::Url,
         index_dir: Option<PathBuf>,
         ot: Option<OpTracker>,
+        source: IndexSource,
     ) -> Result<Self, Error<<B::Response as FetchResponse>::Error>> {
-        // Fast path: Use locally-cached index if its recent
+        // Fast path: use the locally-cached index. The mutable root index is
+        // trusted for INDEX_EXPIRY_SECONDS; snapshots are immutable, so any
+        // cached copy is current.
         if let Some(id) = index_dir.as_ref() {
-            let l_idx_path = id.join(INDEX_FILENAME);
-            if let Ok(stat) = std::fs::metadata(&l_idx_path)
-                && let Ok(modified) = stat.modified()
-                && let Ok(elapsed) = modified.elapsed()
-                && elapsed.as_secs() <= INDEX_EXPIRY_SECONDS
-            {
-                tracing::debug!("Re-using remote index (fetched {}s ago)", elapsed.as_secs());
+            let l_idx_path = id.join(source.local_filename());
+            let age = std::fs::metadata(&l_idx_path)
+                .and_then(|stat| stat.modified())
+                .ok()
+                .and_then(|modified| modified.elapsed().ok());
+            let fresh = match (&source, age) {
+                (IndexSource::Root, Some(elapsed)) => elapsed.as_secs() <= INDEX_EXPIRY_SECONDS,
+                (IndexSource::Snapshot { .. }, Some(_)) => true,
+                (_, None) => false,
+            };
+            if fresh {
+                tracing::debug!("Re-using local copy of {}", source.object());
                 return Ok(Self {
                     backend,
                     index: IndexFile::from_reader(
@@ -207,7 +266,7 @@ impl<B: FetchBackend> RemoteCache<B> {
         }
 
         let fetch_start = Instant::now();
-        let index_req = backend.get(url.join(INDEX_FILENAME).unwrap())?;
+        let index_req = backend.get(url.join(source.object()).unwrap())?;
 
         let fetch_op = OpTracker::new_with_root(&ot).with_op(Operation::FetchIndex);
 
@@ -215,10 +274,21 @@ impl<B: FetchBackend> RemoteCache<B> {
         let mut index_resp = backend.execute(index_req).await?;
         // Capture the GCS generation, if the backend exposes one. Reads
         // need to do this before consuming chunks because the response
-        // metadata may not survive the body read in some impls.
-        let gcs_generation = index_resp.generation();
-        let index = match index_resp.status_code() {
-            404 => IndexFile::default(),
+        // metadata may not survive the body read in some impls. Writers
+        // compare-and-swap against the root index object, so a snapshot's
+        // generation must never seed that path: None forces into_writer
+        // to refetch the root.
+        let gcs_generation = match &source {
+            IndexSource::Root => index_resp.generation(),
+            IndexSource::Snapshot { .. } => None,
+        };
+        let index = match (index_resp.status_code(), &source) {
+            (404, IndexSource::Root) => IndexFile::default(),
+            (404, IndexSource::Snapshot { object }) => {
+                return Err(Error::SnapshotMissing {
+                    object: object.clone(),
+                });
+            }
             _ => {
                 // Progress total only; a plain-HTTPS backend may omit
                 // Content-Length (chunked transfer), so don't panic on None.
@@ -236,7 +306,7 @@ impl<B: FetchBackend> RemoteCache<B> {
                     IndexFile::from_reader(&mut std::io::Cursor::new(buffer)).map_err(Error::IO)?;
 
                 if let Some(index_dir) = index_dir.as_ref() {
-                    let l_idx_path = index_dir.join(INDEX_FILENAME);
+                    let l_idx_path = index_dir.join(source.local_filename());
                     index
                         .write_to(&mut std::fs::File::create(&l_idx_path).map_err(Error::IO)?)
                         .unwrap();
@@ -441,6 +511,7 @@ mod tests {
             MockUrl("mock://cache".to_string()),
             None,
             None,
+            IndexSource::Root,
         )
         .await
         .unwrap();
@@ -474,6 +545,7 @@ mod tests {
             MockUrl("mock://cache".to_string()),
             None,
             None,
+            IndexSource::Root,
         )
         .await
         .unwrap();
@@ -483,12 +555,12 @@ mod tests {
         assert_eq!(rc.sha256(&SpecHash::from_bytes([0x11; 32])), None);
     }
 
-    /// A throwaway single-purpose HTTP/1.1 server that answers `GET
-    /// /index.shisha` with `index` (200) or 404s it when `index` is `None`, and
-    /// 404s everything else. Returns the base URL (with the required trailing
-    /// `/`). Used to exercise the real reqwest transport behind
-    /// `AnyBackend::Https` end-to-end (not a mock backend).
-    fn serve_index(index: Option<Vec<u8>>) -> String {
+    /// A throwaway single-purpose HTTP/1.1 server that answers `GET /<path>`
+    /// with the matching entry in `objects` (200) and 404s everything else.
+    /// Returns the base URL (with the required trailing `/`). Used to exercise
+    /// the real reqwest transport behind `AnyBackend::Https` end-to-end (not a
+    /// mock backend).
+    fn serve_objects(objects: Vec<(String, Vec<u8>)>) -> String {
         use std::io::{Read, Write};
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -498,10 +570,12 @@ mod tests {
                 let mut buf = [0u8; 2048];
                 let _ = stream.read(&mut buf);
                 let req = String::from_utf8_lossy(&buf);
-                let wants_index = req.starts_with("GET /index.shisha ");
-                let (status, body): (&str, &[u8]) = match (&index, wants_index) {
-                    (Some(bytes), true) => ("200 OK", bytes),
-                    _ => ("404 Not Found", b""),
+                let hit = objects
+                    .iter()
+                    .find(|(path, _)| req.starts_with(&format!("GET /{path} ")));
+                let (status, body): (&str, &[u8]) = match hit {
+                    Some((_, bytes)) => ("200 OK", bytes),
+                    None => ("404 Not Found", b""),
                 };
                 let head = format!(
                     "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -513,6 +587,21 @@ mod tests {
             }
         });
         format!("http://{addr}/")
+    }
+
+    fn serve_index(index: Option<Vec<u8>>) -> String {
+        serve_objects(match index {
+            Some(bytes) => vec![(INDEX_FILENAME.to_string(), bytes)],
+            None => vec![],
+        })
+    }
+
+    fn index_bytes_for(spec_hash: &SpecHash, sha256: [u8; 32]) -> Vec<u8> {
+        let mut index = IndexFile::default();
+        index.extend(std::iter::once((spec_hash.clone(), sha256)));
+        let mut bytes = Vec::new();
+        index.write_to(&mut bytes).unwrap();
+        bytes
     }
 
     #[tokio::test]
@@ -528,7 +617,9 @@ mod tests {
 
         // Reads the index over real HTTPS-shaped transport (AnyBackend::Https ->
         // reqwest get/execute/chunk/content_length), then parses it.
-        let rc = RemoteCache::new_any_https(&base, None, None).await.unwrap();
+        let rc = RemoteCache::new_any_https(&base, None, None, IndexSource::Root)
+            .await
+            .unwrap();
         assert_eq!(rc.sha256(&spec_hash), Some(sha256));
         assert_eq!(rc.sha256(&SpecHash::from_bytes([0x99; 32])), None);
     }
@@ -538,13 +629,102 @@ mod tests {
         // A 404 on the index must yield an empty (not errored) cache, matching
         // the GCS path — a fresh bucket/mirror has no index yet.
         let base = serve_index(None);
-        let rc = RemoteCache::new_any_https(&base, None, None).await.unwrap();
+        let rc = RemoteCache::new_any_https(&base, None, None, IndexSource::Root)
+            .await
+            .unwrap();
         assert_eq!(rc.sha256(&SpecHash::from_bytes([0x07; 32])), None);
     }
 
     #[tokio::test]
+    async fn snapshot_source_fetches_the_per_commit_object() {
+        const OBJECT: &str = "github.com/gominimal/pkgs/0123abcd.shisha";
+        let spec_hash = SpecHash::from_bytes([0x07; 32]);
+        let sha256: [u8; 32] = [0x42; 32];
+        // Only the snapshot object exists; the root index deliberately 404s,
+        // proving the reader asked for the snapshot.
+        let base = serve_objects(vec![(
+            OBJECT.to_string(),
+            index_bytes_for(&spec_hash, sha256),
+        )]);
+
+        let source = IndexSource::Snapshot {
+            object: OBJECT.to_string(),
+        };
+        let rc = RemoteCache::new_any_https(&base, None, None, source)
+            .await
+            .unwrap();
+        assert_eq!(rc.sha256(&spec_hash), Some(sha256));
+    }
+
+    #[tokio::test]
+    async fn snapshot_source_404_is_snapshot_missing_not_empty() {
+        const OBJECT: &str = "github.com/gominimal/pkgs/0123abcd.shisha";
+        // Root index exists but the snapshot doesn't: the reader must surface
+        // SnapshotMissing (letting the caller decide on fallback), not
+        // silently read root or treat 404 as an empty index.
+        let base = serve_index(Some(index_bytes_for(
+            &SpecHash::from_bytes([0x07; 32]),
+            [0x42; 32],
+        )));
+
+        let source = IndexSource::Snapshot {
+            object: OBJECT.to_string(),
+        };
+        let err = RemoteCache::new_any_https(&base, None, None, source)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&err, Error::SnapshotMissing { object } if object == OBJECT),
+            "expected SnapshotMissing for {OBJECT}, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_local_cache_never_expires_but_root_does() {
+        const OBJECT: &str = "github.com/gominimal/pkgs/0123abcd.shisha";
+        let spec_hash = SpecHash::from_bytes([0x07; 32]);
+        let sha256: [u8; 32] = [0x42; 32];
+
+        // Seed the local index dir with copies older than the root expiry.
+        let dir = tempfile::tempdir().unwrap();
+        let stale = std::time::SystemTime::now()
+            - std::time::Duration::from_secs(INDEX_EXPIRY_SECONDS + 60);
+        for name in ["0123abcd.shisha", INDEX_FILENAME] {
+            let path = dir.path().join(name);
+            std::fs::write(&path, index_bytes_for(&spec_hash, sha256)).unwrap();
+            let f = std::fs::File::options().write(true).open(&path).unwrap();
+            f.set_times(std::fs::FileTimes::new().set_modified(stale))
+                .unwrap();
+        }
+
+        // Nothing is served remotely: a fetch attempt can only 404.
+        let base = serve_objects(vec![]);
+
+        // The snapshot copy is immutable, so its age doesn't matter.
+        let source = IndexSource::Snapshot {
+            object: OBJECT.to_string(),
+        };
+        let rc = RemoteCache::new_any_https(&base, Some(dir.path().to_path_buf()), None, source)
+            .await
+            .unwrap();
+        assert_eq!(rc.sha256(&spec_hash), Some(sha256));
+
+        // The root copy is past expiry: the reader refetches, and the 404
+        // yields an empty index rather than the stale local entries.
+        let rc = RemoteCache::new_any_https(
+            &base,
+            Some(dir.path().to_path_buf()),
+            None,
+            IndexSource::Root,
+        )
+        .await
+        .unwrap();
+        assert_eq!(rc.sha256(&spec_hash), None);
+    }
+
+    #[tokio::test]
     async fn new_any_https_rejects_malformed_url() {
-        let err = RemoteCache::new_any_https("not a url", None, None)
+        let err = RemoteCache::new_any_https("not a url", None, None, IndexSource::Root)
             .await
             .unwrap_err();
         assert!(

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -320,6 +320,17 @@ impl<B: FetchBackend> RemoteCache<B> {
                     object: object.clone(),
                 });
             }
+            // Any other error status must not fall through to body parsing:
+            // an error page is not an index, and an empty error body would
+            // "parse" as an empty index, masking the outage.
+            (status, _) if !index_resp.is_success() => {
+                return Err(match index_resp.error_for_status() {
+                    Err(e) => Error::Backend(e),
+                    Ok(_) => Error::IO(std::io::Error::other(format!(
+                        "index fetch failed with HTTP {status}"
+                    ))),
+                });
+            }
             _ => {
                 // Progress total only; a plain-HTTPS backend may omit
                 // Content-Length (chunked transfer), so don't panic on None.
@@ -759,6 +770,35 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(rc.sha256(&spec_hash), None);
+    }
+
+    #[tokio::test]
+    async fn index_fetch_error_status_is_an_error_not_an_empty_index() {
+        use std::io::{Read, Write};
+        // A server that 500s with an empty body: the worst case, since an
+        // empty body "parses" as an empty index.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut buf = [0u8; 2048];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(
+                    b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                );
+                let _ = stream.flush();
+            }
+        });
+        let base = format!("http://{addr}/");
+
+        let err = RemoteCache::new_any_https(&base, None, None, IndexSource::Root)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::Backend(_)),
+            "expected Backend error, got {err:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Phase 1 of #870, shaped per the [config-enum suggestion](https://github.com/gominimal/minimal/issues/870#issuecomment-5039089733): the *policy* (which index object to read) is resolved centrally and handed to the fetch layer as concrete instructions.

## What

- **mfile** — `CacheConfig` enum (`GlobalIndex` / `CommitIndex` / `CommitIndexOnly`), resolved by `File::cache_config()` from `[cache] index_source` (`auto` | `pinned` | `root`), the upstream pin (`repo` + `locked_commit` -> `<host>/<owner>/<repo>/<commit>.shisha`, matching the publisher's keying), and an optional override. `auto` is the default and degrades to the root index when there's no pin.
- **rcache** — `IndexSource { Root, Snapshot }` threaded through the reader constructors; no policy in this layer.
  - Snapshot 404 => `Error::SnapshotMissing` (the caller decides on fallback) — never an empty index, and corrupt-but-present snapshots still error rather than fall back.
  - Local index cache: snapshots are immutable => cached copies never expire (warm runs skip the index fetch entirely); the root copy keeps the 5-minute window.
  - A snapshot's GCS generation never seeds `into_writer` — writers always refetch and compare-and-swap against the root object.
  - `new_over_https` / `new_with_gcs_bucket` are unchanged and always read root (writer-adjacent paths, where root is authoritative).
- **mctx** — the one construction site translates `CacheConfig` -> `IndexSource`, honours the `MINIMAL_INDEX_SOURCE` env override, implements auto-mode fallback, and logs provenance (`debug` for the chosen snapshot, `info` when falling back).

## Modes

| mode | reads | missing snapshot |
| --- | --- | --- |
| `root` | root `index.shisha` | n/a (kill-switch / control arm) |
| `auto` (default) | per-commit snapshot | falls back to root (logged) |
| `pinned` | per-commit snapshot only | hard error naming the object (testing mode) |

## Testing

- `mfile`: slug normalization across URL forms (https, `.git`, credentials, `ssh://`, scp-like), mode x pin resolution matrix, `[cache]` parsing + override precedence.
- `rcache`: snapshot fetch over real HTTP transport, snapshot-404 => `SnapshotMissing` (root present, proving no silent root read), snapshot-cache-never-expires vs root-expiry behavior.
- Rollout is a no-op until snapshots exist for a pin: `auto` falls back identically to today's read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Read remote cache index from per-commit snapshots in `RemoteCache`
> - Adds `IndexSource` enum (`Root` or `Snapshot { object }`) to `rcache` so `RemoteCache::new` can load either the global root index or a per-commit snapshot index object.
> - Adds `CacheSettings` and `IndexSourceMode` (`auto`, `pinned`, `root`) to `mfile`, plus a `cache_config` resolver that maps the project's `minimal.toml` `[cache]` config and upstream pin to the appropriate `IndexSource`.
> - `mctx` reads an optional `MINIMAL_INDEX_SOURCE` env-var override and calls `cache_config` to select the index source, passing it to `RemoteCache::new_any`; returns `SnapshotMissing` errors and optionally falls back to the root index.
> - Snapshot local cache copies never expire; root index copies use a short TTL. Index data is validated against whole-record boundaries and written atomically via a temp file.
> - Behavioral Change: `RemoteCache` now returns `SnapshotMissing` instead of an empty index when a per-commit snapshot object is absent, and non-2xx responses are now hard errors rather than parsed.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #912 opened
>
> - Added configuration-based index source selection with automatic fallback to `rcache` [394dc17]
> - Replaced manual index source selection in `mctx` with configuration-based approach [394dc17]
> - Added `mfile` dependency to `rcache` crate [394dc17]
> - Modified `MINIMAL_INDEX_SOURCE` environment variable parsing in `mctx::Context` cache configuration to return configuration error for invalid values [beb0969]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa086ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable remote cache index selection (global, pinned commit, root) with an environment override for index source resolution.
  * Added support for immutable per-commit cache snapshots.
* **Bug Fixes**
  * Missing snapshot objects now surface a dedicated error and do not fall back to the root index, preventing unintended cache behavior.
* **Documentation**
  * Expanded remote cache documentation to clarify how the resolved minimal index source determines which remote index object is read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->