### PR TITLE
feat(sessions): upload patch files from loadouts and friends

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -83,6 +83,18 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 35
         steps:
+            - name: Free Disk Space
+              # The cross aarch64-musl initramfs build plus the restored
+              # target/ cache routinely exceed the ~14 GB free on a fresh
+              # GitHub-hosted Ubuntu runner. `remove_tool_cache: true`
+              # reclaims /opt/hostedtoolcache (~14 GB); the dtolnay Toolchain
+              # step below reinstalls the Rust toolchain we actually need.
+              uses: endersonmenezes/free-disk-space@v3 # Use @main for latest, @v3 for stable
+              with:
+                  remove_android: true
+                  remove_dotnet: true
+                  remove_haskell: true
+                  remove_tool_cache: true
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -237,7 +237,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -276,13 +276,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -308,9 +308,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -452,9 +452,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -589,9 +589,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -670,9 +670,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -831,14 +831,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1188,7 +1188,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1300,15 +1300,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1322,7 +1323,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1356,7 +1357,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1369,7 +1370,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1380,7 +1381,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1391,7 +1392,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1456,7 +1457,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1476,14 +1477,14 @@ checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1531,7 +1532,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1541,7 +1542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1563,7 +1564,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1663,7 +1664,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1720,11 +1721,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-rc.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek 5.0.0-rc.1",
+ "curve25519-dalek 5.0.0",
  "ed25519",
  "rand_core 0.10.1",
  "serde",
@@ -1807,7 +1808,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1828,11 +1829,11 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
 ]
 
 [[package]]
@@ -1956,9 +1957,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1971,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1981,15 +1982,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1998,38 +1999,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2073,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
+checksum = "ab4e5aa225bc56696909483320f0ff9b600f1a971b52e07a17d70f3d9b43254b"
 dependencies = [
  "generic-array 0.14.7",
  "rustversion",
@@ -2088,7 +2089,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a542e1b7ac1f3d62c5777d430d66eca9cb59e813c46b86e29fa9ce94ff9a4810"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -2108,20 +2109,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -2129,7 +2116,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -2142,7 +2129,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2199,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f60f45dd97ff91cedfcb6b2b9f860d3d84739386c3557027687c52cc0e698fd"
+checksum = "3103a4a9013f1aed573ca56e19a9680b0211643a99ea85caf524b397d6be8be3"
 dependencies = [
  "bytes",
  "futures",
@@ -2306,9 +2293,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-rpc"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b177796075b7bfc02bf2e405db665ee850a924fa44cedfc5282b473c5ab203"
+checksum = "e2162c08a89118130979ba261080e960e44cdcb2d6e2ab8ca9b1da245285d353"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2364,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-type"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3658f2192252ba301a9d0a26e298bd56b55f0edb32de499a2f41ff244c09cf8"
+checksum = "63acc3a92a85f96bab021c3a3e29b53bbacc97651e1b524d4c2991960a63eb82"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2377,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-wkt"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e0186e2221bf82c5296500251b4650b111172c324984159a0de9f6bcaa18a5"
+checksum = "46df1fcc3ab69164af3f4199ed21f45b5dbc56d9f03211eb4fa20116d442364b"
 dependencies = [
  "base64",
  "bytes",
@@ -2449,7 +2436,7 @@ version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f07d75a391ae6a5ed931e4ede1e706a22660378e0a1afb6678499102f5008fe"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "caps",
  "close_fds",
  "libc",
@@ -2625,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2662,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2945,7 +2932,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -3123,11 +3110,12 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -3138,21 +3126,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.31"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -3204,7 +3202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3314,7 +3312,7 @@ dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3392,9 +3390,9 @@ checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libcgroups"
@@ -3496,7 +3494,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3647,15 +3645,15 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -3718,7 +3716,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3752,6 +3750,7 @@ dependencies = [
  "diagnostics",
  "dialoguer",
  "dirs",
+ "indicatif",
  "inquire",
  "mctx",
  "mfile",
@@ -3814,6 +3813,7 @@ dependencies = [
  "mfile",
  "minimald-rpc",
  "mlog",
+ "nix 0.31.3",
  "op",
  "ot",
  "path-absolutize",
@@ -3899,9 +3899,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -3998,7 +3998,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4071,7 +4071,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ec2f5b6839be2a19d7fa5aab5bc444380f6311c2b693551cb80f45caaa7b5ef"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "log",
  "netlink-packet-core",
@@ -4083,7 +4083,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "log",
  "netlink-packet-core",
@@ -4191,7 +4191,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4204,7 +4204,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4217,7 +4217,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4306,7 +4306,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "urlencoding",
 ]
 
@@ -4316,7 +4316,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4517,7 +4517,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4528,9 +4528,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bb40a5099e2c38a09dd29321a7a7f045f165a54317679c7cdfb0cbaf8f6b1e"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4541,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492f329d7eb11d22dadc988626b9ea1f503b4ab043a8b1e4e2cc4ae45dabdd70"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4555,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff42e4ace5424e3b6d7cb82514be89866b85af87015f80341e37dcc21a66ce6e"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -4646,7 +4646,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1c0fdecdba7e25990ddca671cd555d0b081252f4052f73df485263ef229d2d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "itertools 0.15.0",
  "libc",
  "memchr",
@@ -4758,7 +4758,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4825,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
  "cpufeatures 0.3.0",
  "universal-hash 0.6.1",
@@ -4836,9 +4836,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
@@ -4847,9 +4847,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -4957,7 +4957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4989,9 +4989,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -5004,7 +5004,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -5015,7 +5015,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "chrono",
  "flate2",
  "hex",
@@ -5029,7 +5029,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "chrono",
  "flate2",
  "procfs-core 0.18.0",
@@ -5042,7 +5042,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "chrono",
  "hex",
 ]
@@ -5053,7 +5053,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "chrono",
  "hex",
 ]
@@ -5085,7 +5085,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -5099,7 +5099,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5117,7 +5117,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -5190,18 +5190,12 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -5303,7 +5297,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5312,7 +5306,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5328,22 +5322,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5488,9 +5482,9 @@ dependencies = [
 
 [[package]]
 name = "route_manager"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319bb478ff9aae1dc7a544fa599e9eb47e2521621dc3921fba6abcaaa312092c"
+checksum = "1de4a73da5e20c4e521c395e21918034624165c31511e86b03e494bf0afa56ef"
 dependencies = [
  "flume",
  "libc",
@@ -5521,13 +5515,13 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.2"
+version = "0.62.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6c3c1dd0a9ad3a9915a2f6e907d158f9a7e9ac32ddc772b003faafc027d9a8"
+checksum = "059dd24c0fe20721639f7acad7b82cd51ec3dd3254ed8cf7a0b7df6c20eaff1c"
 dependencies = [
  "aes",
  "aws-lc-rs",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block-padding",
  "byteorder",
  "bytes",
@@ -5535,7 +5529,7 @@ dependencies = [
  "cipher 0.5.2",
  "crypto-bigint",
  "ctr",
- "curve25519-dalek 5.0.0-rc.1",
+ "curve25519-dalek 5.0.0",
  "data-encoding",
  "delegate",
  "der",
@@ -5546,7 +5540,7 @@ dependencies = [
  "enum_dispatch",
  "flate2",
  "futures",
- "generic-array 1.4.3",
+ "generic-array 1.4.4",
  "getrandom 0.4.3",
  "ghash",
  "hex-literal",
@@ -5578,7 +5572,7 @@ dependencies = [
  "sec1",
  "sha1",
  "sha2 0.11.0",
- "sha3 0.11.0",
+ "sha3 0.12.0",
  "signature 3.0.0",
  "spki",
  "ssh-encoding",
@@ -5609,7 +5603,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09daa0ebcf53fb18d7b16167586a68b5bf2cfa3eaad49e661a19302552a2b879"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "chrono",
  "dashmap",
@@ -5635,9 +5629,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -5669,7 +5663,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -5682,7 +5676,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -5768,9 +5762,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -5780,9 +5774,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
 dependencies = [
  "bytemuck",
 ]
@@ -5903,7 +5897,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5922,9 +5916,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -5943,9 +5937,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -5963,22 +5957,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6045,7 +6039,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6093,7 +6087,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6170,6 +6164,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6242,9 +6247,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simple-counter"
@@ -6281,9 +6286,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6291,9 +6296,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -6309,6 +6314,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
 name = "ssh-cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6321,7 +6332,7 @@ dependencies = [
  "cipher 0.5.2",
  "ctutils",
  "des",
- "poly1305 0.9.0",
+ "poly1305 0.9.1",
  "ssh-encoding",
  "zeroize",
 ]
@@ -6435,7 +6446,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6477,9 +6488,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6488,9 +6499,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6514,7 +6525,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6641,7 +6652,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6652,23 +6663,23 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -6686,9 +6697,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6706,9 +6717,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6721,9 +6732,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -6738,13 +6749,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6759,9 +6770,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6770,13 +6781,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -6796,9 +6808,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -6829,9 +6841,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -6851,9 +6863,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -6895,7 +6907,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6920,7 +6932,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -7006,7 +7018,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -7062,7 +7074,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7116,9 +7128,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
 dependencies = [
  "cc",
  "regex",
@@ -7153,9 +7165,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tun-rs"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675d4d5a2a7fe12c743132eb35d45e90a5f9bf798762d2de6cea91d1d9d8feb4"
+checksum = "bb50fdefaf791097b5559791cef2b2e9da2fad974809264d104cafbaa3efc452"
 dependencies = [
  "byteorder",
  "bytes",
@@ -7408,15 +7420,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7438,7 +7441,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -7473,7 +7476,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7522,9 +7525,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7675,7 +7678,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7686,7 +7689,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7934,9 +7937,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -7950,12 +7953,6 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"
@@ -8055,28 +8052,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8096,7 +8093,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -8117,7 +8114,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8150,14 +8147,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ codegen-units = 16
 
 [workspace.dependencies]
 anyhow = "1.0"
-async-compression = { version = "0.4", features = ["tokio", "zstd"] }
+async-compression = { version = "0.4", features = ["tokio", "zstd", "zstdmt"] }
 async-tar = { version = "0.6", default-features = false, features = ["runtime-tokio"] }
 base64 = "0.22"
 blake3 = { version = "1", features = ["serde"] }

--- a/crates/mfile/src/package_composable.rs
+++ b/crates/mfile/src/package_composable.rs
@@ -310,13 +310,18 @@ mod tests {
                 )
             })
             .collect();
-        // Dir mapping: source has `/**` for walker fan-out, dest is
-        // the bare path (walker computes per-file dests).
-        assert_eq!(by_source.get("~/.claude/**").copied(), Some("~/.claude"));
-        // File mapping: source == dest.
+        // Dir mapping: source keeps `~/` because expansion happens
+        // at gate time; dest strips the leading `~/` because it's
+        // always sandbox-home-relative by construction
+        // (`PatchDest::try_new` normalizes it out — a literal `~`
+        // directory would otherwise land inside the sandbox home as
+        // `/home/~/.claude/…`).
+        assert_eq!(by_source.get("~/.claude/**").copied(), Some(".claude"));
+        // File mapping: source keeps `~/` for gate-time expansion;
+        // dest is the same path with the tilde prefix stripped.
         assert_eq!(
             by_source.get("~/.config/claude/settings.json").copied(),
-            Some("~/.config/claude/settings.json"),
+            Some(".config/claude/settings.json"),
         );
         for pp in contribution.patches() {
             assert_eq!(pp.source(), &expected_source);
@@ -346,8 +351,9 @@ mod tests {
             );
             assert_eq!(
                 patch.patch().dest().as_sandbox_path().as_str(),
-                "~/.claude",
-                "dest should be the trimmed dir path",
+                ".claude",
+                "dest should be the trimmed dir path with the leading `~/` stripped \
+                 by PatchDest::try_new (destinations are already home-relative)",
             );
         }
     }

--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -33,6 +33,7 @@ constcat.workspace = true
 diagnostics.workspace = true
 dialoguer.workspace = true
 dirs.workspace = true
+indicatif.workspace = true
 nix.workspace = true
 mctx.workspace = true
 mfile.workspace = true

--- a/crates/minimal/src/attach.rs
+++ b/crates/minimal/src/attach.rs
@@ -110,12 +110,15 @@ impl fmt::Display for SessionCandidate {
 }
 
 /// One-row glyph for a session's lifecycle status, used as a visual prefix
-/// in the picker. `Active` sessions are ready to attach; `Pending` ones are
-/// still composing (e.g. awaiting a verdict) and may not be attachable yet.
+/// in the picker. `Active` sessions are ready to attach; `Pending` and
+/// `Materializing` ones aren't attachable yet — `Pending` is still awaiting
+/// the client's verdict, `Materializing` has finalized its composition but
+/// is still ingesting patches. Both render with the hollow glyph so the
+/// picker communicates "not-yet-ready" uniformly.
 fn state_glyph(status: sessions::SessionStatus) -> &'static str {
     match status {
         sessions::SessionStatus::Active => "●",
-        sessions::SessionStatus::Pending => "◯",
+        sessions::SessionStatus::Pending | sessions::SessionStatus::Materializing => "◯",
     }
 }
 

--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -12,6 +12,105 @@ use anyhow::Context as _;
 use minimald_rpc::OneshotSshRpc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+/// Add a spinner-style progress bar to the process-global `MultiProgress`.
+/// Bars must be inserted before any style/message/tick configuration —
+/// otherwise `ProgressBar::hidden`'s defaults would draw directly to stderr
+/// and MP's coordinated redraws couldn't reach the stale lines
+/// (`finish_and_clear` only wipes lines MP itself drew).
+///
+/// Animation: three quadrant-block glyphs (`▗`, then `▚`, then `▚`)
+/// appear one at a time from left to right, hold for ~1 s, then
+/// disappear one at a time from right to left. Every frame is padded
+/// to the same 5-character width so the trailing `{msg}` doesn't
+/// jitter horizontally as the animation grows and shrinks. The last
+/// entry in `tick_strings` is indicatif's "finished" state — kept
+/// blank so `bar.finish()` / `finish_and_clear` leave no trailing
+/// glyphs behind.
+pub(crate) fn add_spinner_bar(msg: &'static str) -> indicatif::ProgressBar {
+    const FRAMES: &[&str] = &[
+        // build
+        "     ",
+        "▗    ",
+        "▗ ▚  ",
+        "▗ ▚ ▚",
+        // hold ~1 s at 100 ms/tick
+        "▗ ▚ ▚",
+        "▗ ▚ ▚",
+        "▗ ▚ ▚",
+        "▗ ▚ ▚",
+        "▗ ▚ ▚",
+        "▗ ▚ ▚",
+        "▗ ▚ ▚",
+        "▗ ▚ ▚",
+        "▗ ▚ ▚",
+        "▗ ▚ ▚",
+        // fade (mirrors the build, right-to-left)
+        "▗ ▚  ",
+        "▗    ",
+        "     ",
+        // finished
+        "     ",
+    ];
+    let bar = ot::global_progress().add(indicatif::ProgressBar::hidden());
+    bar.set_style(
+        indicatif::ProgressStyle::with_template("  {spinner} {msg} — {bytes} ({bytes_per_sec})")
+            .expect("valid template")
+            .tick_strings(FRAMES),
+    );
+    bar.set_message(msg);
+    bar.enable_steady_tick(Duration::from_millis(100));
+    bar
+}
+
+/// Add a file-count progress bar to the process-global `MultiProgress`.
+/// Same insertion-before-configuration rationale as [`add_spinner_bar`].
+///
+/// Bar rendering: a leading `▗` followed by up to [`PATCHES_BAR_TAIL_UNITS`]
+/// `" ▚"` units, growing left-to-right in proportion to `pos / len`.
+/// Sequence at increasing progress: `▗` → `▗ ▚ ▚` → `▗ ▚ ▚ ▚ ▚ ▚ ▚ ▚ ▚ ▚`
+/// → `▗ ▚ ▚ …`. Indicatif's built-in `{wide_bar}` renders one glyph per
+/// cell with no way to insert spaces between filled cells, so this
+/// registers a custom `{tail}` key and formats the string ourselves.
+/// The un-filled tail is padded with `"  "` (matching the width of a
+/// `" ▚"` unit) so `{pos}/{len}` etc. stay in a fixed column.
+fn add_patches_bar(total: u64) -> indicatif::ProgressBar {
+    /// Max number of `" ▚"` units at 100 % progress. Widen for a
+    /// longer bar; narrow for tighter terminals.
+    const PATCHES_BAR_TAIL_UNITS: usize = 30;
+
+    let bar = ot::global_progress().add(indicatif::ProgressBar::hidden());
+    bar.set_length(total);
+    bar.set_style(
+        indicatif::ProgressStyle::with_template(
+            "  {msg} {tail} {pos}/{len} patches ({per_sec}, {eta})",
+        )
+        .expect("valid template")
+        .with_key(
+            "tail",
+            |state: &indicatif::ProgressState, w: &mut dyn std::fmt::Write| {
+                let progress = state
+                    .len()
+                    .filter(|&l| l > 0)
+                    .map(|len| (state.pos() as f64) / (len as f64))
+                    .unwrap_or(0.0)
+                    .clamp(0.0, 1.0);
+                let filled = (progress * PATCHES_BAR_TAIL_UNITS as f64).round() as usize;
+                let _ = w.write_str("▗");
+                for _ in 0..filled {
+                    let _ = w.write_str(" ▚");
+                }
+                // Pad each un-filled unit with two spaces so total
+                // rendered width stays constant across the animation.
+                for _ in 0..(PATCHES_BAR_TAIL_UNITS - filled) {
+                    let _ = w.write_str("  ");
+                }
+            },
+        ),
+    );
+    bar.set_message("Uploading composition patches");
+    bar
+}
+
 /// Max retries when connecting to the daemon UDS.
 const CONNECT_RETRIES: u32 = 20;
 /// Delay between connection retries.
@@ -200,14 +299,153 @@ impl Client {
         session_id: sessions::SessionId,
         dir: &Path,
     ) -> Result<(), anyhow::Error> {
-        let subsystem =
-            constcat::concat!(minimald_rpc::RPC_SUBSYSTEM_PREFIX, "WorkspaceFilesTarZst");
+        // Spinner-style bar: workspace file counts vary (and pre-walking to
+        // sum sizes would double the disk work), so we drive on
+        // wire-bytes-through-SSH with no fixed total. `finish_and_clear`
+        // wipes the bar off the terminal on success so it doesn't hang
+        // around above the next line.
+        let bar = add_spinner_bar("Uploading project files");
+        let bar_for_wrap = bar.clone();
+        let result = self
+            .stream_upload(
+                session_id,
+                constcat::concat!(minimald_rpc::RPC_SUBSYSTEM_PREFIX, "WorkspaceFilesTarZst"),
+                "workspace file",
+                async |writer| {
+                    // `writer` is already `Box<dyn AsyncWrite + ...>`
+                    // from `stream_upload`, and `stream_tar_zstd` is
+                    // generic over `W: AsyncWrite + Unpin + Send` —
+                    // `ProgressWriter<Box<...>>` satisfies that
+                    // directly, no second heap allocation needed.
+                    let writer = crate::file_upload::ProgressWriter::new(writer, bar_for_wrap);
+                    crate::file_upload::stream_tar_zstd(dir, writer).await
+                },
+            )
+            .await;
+        bar.finish_and_clear();
+        result
+    }
 
+    /// Stream a zstd-compressed tarball of composition patches to the
+    /// daemon's `WorkspacePatchesTarZst` subsystem, which unpacks
+    /// each entry under `<workspace>/patches/<destination>`. The
+    /// launcher reads from that tree when materializing the session's
+    /// sandbox home.
+    ///
+    /// `patches` is a list of `(host_path, sandbox_destination)`
+    /// pairs pulled from the finalized [`Composition`]. An empty
+    /// list is a no-op — no channel is opened. Callers dedup by
+    /// destination first; the composer's post-gate
+    /// `check_patch_mismatches` guarantees no two Approved verdicts
+    /// share a destination with different sources, so any duplicates
+    /// here are exact matches and safe to collapse.
+    ///
+    /// The archive is streamed with `follow_symlinks: true` and
+    /// `mode_override: Some(0o644)` so a `/nix/store/…` link source
+    /// lands as a writable copy inside the sandbox.
+    ///
+    /// [`Composition`]: sessions::core::compose::Composition
+    pub async fn upload_patches(
+        &mut self,
+        session_id: sessions::SessionId,
+        patches: &[(std::path::PathBuf, paths::SandboxRelPath)],
+    ) -> Result<(), anyhow::Error> {
+        if patches.is_empty() {
+            return Ok(());
+        }
+        // File-count bar: we know the target up front, so the operator
+        // sees "N/M patches" instead of a spinner. Incremented inside
+        // the tar loop after each `add_file` returns — the file is
+        // fully queued into the encoder at that point, even if it
+        // hasn't been fully compressed or shipped yet.
+        let bar = add_patches_bar(patches.len() as u64);
+        let bar_for_loop = bar.clone();
+        let result = self
+            .stream_upload(
+                session_id,
+                constcat::concat!(minimald_rpc::RPC_SUBSYSTEM_PREFIX, "WorkspacePatchesTarZst"),
+                "composition patch",
+                async |writer| {
+                    // Route through the pipe helper because SSH channel
+                    // writers aren't Sync but `TarZstArchive` requires
+                    // Sync. The pipe's tx (a `DuplexStream`) is Sync;
+                    // its rx pumps into the channel writer on the same
+                    // task.
+                    crate::file_upload::stream_via_pipe(writer, async |tx| {
+                        let mut archive = crate::file_upload::TarZstArchive::new(tx);
+                        // Always finalize the archive, even on
+                        // build error: `async_tar::Builder` panics
+                        // from its `Drop` impl if dropped without
+                        // `finish()` (async-tar 0.6 builder.rs:668),
+                        // and `?`-propagation isn't a panic-unwind
+                        // so the Drop guard fires. If both branches
+                        // fail, prefer the build error — it's
+                        // usually the root cause (encoder writes
+                        // then error with "broken pipe" once the
+                        // upstream file read has already failed).
+                        let build_result: Result<(), anyhow::Error> = async {
+                            for (host_path, dest) in patches {
+                                archive
+                                    .add_file(
+                                        host_path,
+                                        dest.as_str(),
+                                        crate::file_upload::AddFileOptions {
+                                            mode_override: Some(0o644),
+                                        },
+                                    )
+                                    .await
+                                    .with_context(|| {
+                                        format!(
+                                            "adding patch {} → {}",
+                                            host_path.display(),
+                                            dest.as_str()
+                                        )
+                                    })?;
+                                bar_for_loop.inc(1);
+                            }
+                            Ok(())
+                        }
+                        .await;
+                        let finish_result = archive.finish().await;
+                        match (build_result, finish_result) {
+                            (Err(build), _) => Err(build),
+                            (Ok(()), r) => r,
+                        }
+                    })
+                    .await
+                },
+            )
+            .await;
+        bar.finish_and_clear();
+        result
+    }
+
+    /// Common plumbing behind [`Self::upload_workspace_files`] and
+    /// [`Self::upload_patches`]: open a channel, set the session-id
+    /// env var, request a subsystem, drive `stream` over the
+    /// channel's writer, wait for the daemon's channel close,
+    /// surface any stderr the daemon relayed.
+    async fn stream_upload<F>(
+        &mut self,
+        session_id: sessions::SessionId,
+        subsystem: &'static str,
+        what: &'static str,
+        stream: F,
+    ) -> Result<(), anyhow::Error>
+    where
+        // `channel.make_writer()` returns `impl AsyncWrite + 'static`,
+        // not a named type. Take a closure that receives that opaque
+        // writer and pumps the tar into it. `AsyncFnOnce` handles the
+        // .await for us.
+        F: for<'w> AsyncFnOnce(
+            Box<dyn tokio::io::AsyncWrite + Unpin + Send + 'w>,
+        ) -> Result<(), anyhow::Error>,
+    {
         let mut channel = self
             .handle
             .channel_open_session()
             .await
-            .context("open channel for workspace file upload")?;
+            .with_context(|| format!("open channel for {what} upload"))?;
 
         send_traceparent(&channel).await;
         channel
@@ -218,9 +456,10 @@ impl Client {
         channel
             .request_subsystem(true, subsystem)
             .await
-            .context("request WorkspaceFilesTarZst subsystem")?;
+            .with_context(|| format!("request {subsystem} subsystem"))?;
 
-        crate::file_upload::stream_tar_zstd(dir, channel.make_writer()).await?;
+        let writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(channel.make_writer());
+        stream(writer).await?;
 
         // Wait for the channel to close to signal that unpacking is done.
         // The daemon relays any unpack failure on extended-data stream 1 and
@@ -235,7 +474,7 @@ impl Client {
         }
         if !err.is_empty() {
             anyhow::bail!(
-                "daemon failed to unpack project files: {}",
+                "daemon failed to unpack {what}s: {}",
                 String::from_utf8_lossy(&err)
             );
         }

--- a/crates/minimal/src/file_upload.rs
+++ b/crates/minimal/src/file_upload.rs
@@ -1,4 +1,17 @@
-//! Streaming tar+zstd upload of the project directory to the daemon.
+//! Streaming tar+zstd uploads from client to daemon.
+//!
+//! Two public entrypoints share one underlying pipeline:
+//!
+//! - [`stream_tar_zstd`] walks a directory (skipping `target/` and
+//!   `node_modules/`) and archives it — used by the workspace
+//!   upload path.
+//! - [`TarZstArchive`] is a lower-level builder taking one entry at
+//!   a time (via [`TarZstArchive::add_file`]) so callers with a
+//!   disjoint set of source paths — the composition-patches
+//!   uploader — can drive the same pipe/encoder plumbing without
+//!   going through a directory walk. Parent directories are
+//!   materialized by the unpacker as needed; no explicit
+//!   `add_dir`/`add_symlink` shape is exposed yet.
 //!
 //! The tar builder writes directly into a zstd encoder which writes
 //! to the SSH channel stream — nothing is buffered in memory beyond
@@ -33,73 +46,376 @@ fn is_default_excluded(name: &str) -> bool {
     DEFAULT_EXCLUDED_DIRS.contains(&name)
 }
 
-/// Streams a zstd-compressed tar archive of `dir` into `writer`, returning the
-/// number of compressed bytes handed to `writer`.
+/// Streams a zstd-compressed tar archive of `dir` into `writer`.
 ///
-/// The tar builder writes directly into the zstd encoder which writes
-/// to `writer`, so the archive is never fully buffered in memory.
+/// Works with non-Sync writers (SSH channels aren't Sync) by routing the
+/// tar output through an in-memory pipe: the pipe read side pumps into
+/// `writer` while the tar builder — which needs a Sync writer — writes
+/// into the pipe's Sync tx half.
 ///
-/// The count is of *compressed* bytes — the wire bytes — because that is what
-/// this side of the duplex can see (the pipe sits between the zstd encoder and
-/// `writer`) and because it is the figure a daemon-side count is directly
-/// comparable to. On failure the error carries that count and the elapsed
-/// time, so "died at 1%" and "died at 99%" are distinguishable without an
-/// instrumented kernel (#869).
+/// The archive is never fully buffered in memory beyond the pipe buffer
+/// and the encoder's internal state.
 pub async fn stream_tar_zstd<W: AsyncWrite + Unpin + Send>(
     dir: &Path,
     writer: W,
 ) -> Result<(), anyhow::Error> {
-    // async_tar::Builder requires W: Sync, but the SSH channel stream
-    // is not Sync. Use a duplex pipe: the tar builder writes to one end
-    // (in a background task), and we copy from the other end to writer.
+    // Route through `stream_via_pipe` (shared with the patches
+    // uploader): the SSH channel writer isn't Sync but the tar
+    // builder requires Sync, so the build side writes into the
+    // pipe's Sync tx half while the pipe's rx pumps into `writer`.
+    stream_via_pipe(writer, async |tx| {
+        let mut archive = TarZstArchive::new(tx);
+        // Failure-safe finalize: propagating an entry-walk error via
+        // `?` would drop the archive with an unfinalized async_tar
+        // builder inside, which panics from Drop. `finish` on every
+        // path — success or error — ends the builder cleanly.
+        let entries_result = add_dir_entries(archive.builder(), dir, "").await;
+        let finish_result = archive.finish().await;
+        entries_result?;
+        finish_result
+    })
+    .await
+    .context("workspace upload failed")
+}
+
+/// Run `build` against the Sync tx half of an in-memory pipe while
+/// draining the rx half into `writer`. Used by both directory and
+/// per-patch uploaders to bridge a non-Sync writer (SSH channel,
+/// or a test `&mut Vec<u8>`) to the Sync-requiring
+/// [`TarZstArchive`].
+///
+/// The pipe capacity is 256 KiB — big enough that the encoder can
+/// flush a full block without stalling, small enough that a stuck
+/// reader surfaces backpressure quickly.
+pub async fn stream_via_pipe<W, F>(mut writer: W, build: F) -> Result<(), anyhow::Error>
+where
+    W: AsyncWrite + Unpin,
+    F: AsyncFnOnce(tokio::io::DuplexStream) -> Result<(), anyhow::Error>,
+{
     const PIPE_BUF: usize = 256 * 1024;
     let (tx, mut rx) = tokio::io::duplex(PIPE_BUF);
 
-    let build = {
-        let dir = dir.to_path_buf();
-        tokio::spawn(async move { build_tar_zstd(&dir, tx).await })
-    };
-
-    async {
-        let mut w = BufWriter::with_capacity(4 * 1024, writer);
-        tokio::io::copy(&mut rx, &mut w)
+    // Drive build and copy concurrently. `build` runs on the
+    // caller task; the pipe read side pumps into `writer` on the
+    // same task via `tokio::join!` — no spawn, so no `'static`
+    // bound on W or on any of `build`'s captures.
+    //
+    // We can't use `try_join!` here: cancelling `build` mid-
+    // `append_data` would drop an unfinalized `async_tar::Builder`,
+    // which panics from its `Drop` impl. Instead, if `writer`
+    // errors, keep pulling bytes out of the pipe (into the void)
+    // so `build` can complete its `finish()` path and unwind
+    // normally. The pipe stays live until both futures return;
+    // callers see whichever error surfaced first (writer failure
+    // preferred, since it's the root cause).
+    let build_fut = build(tx);
+    let copy_fut = async {
+        // Buffer the wire writes (#923): the encoder can emit many
+        // small blocks, so a 4 KiB `BufWriter` coalesces them into
+        // fewer, larger writes to the underlying SSH channel.
+        let mut w = BufWriter::with_capacity(4 * 1024, &mut writer);
+        let copy_res = tokio::io::copy(&mut rx, &mut w)
             .await
-            .context("copying tar stream to channel")?;
-        w.flush().await.context("flushing upload stream")?;
-        w.shutdown().await.context("shutting down upload stream")?;
-        Ok::<(), anyhow::Error>(())
+            .context("copying tar stream to writer");
+        if let Err(e) = copy_res {
+            // Drain the pipe so the writer side can unwind cleanly.
+            // A `sink()` swallows the remainder; we deliberately
+            // ignore its result because the writer error is the
+            // root cause we want to surface.
+            let _ = tokio::io::copy(&mut rx, &mut tokio::io::sink()).await;
+            return Err(e);
+        }
+        w.flush().await.context("flushing upload writer")?;
+        w.shutdown().await.context("shutting down upload writer")?;
+        Ok::<_, anyhow::Error>(())
+    };
+    let (build_res, copy_res) = tokio::join!(build_fut, copy_fut);
+    // Surface the writer's error first — a writer failure is
+    // usually the underlying cause and `build` will just report
+    // "broken pipe" as a secondary effect.
+    copy_res?;
+    build_res?;
+    Ok(())
+}
+
+/// AsyncWrite adapter that increments an [`indicatif::ProgressBar`] by the
+/// number of bytes flowing through it. Wrap the SSH channel writer with this
+/// so the bar reflects wire-bytes actually delivered (post-compression,
+/// post-SSH framing), not the uncompressed input.
+pub struct ProgressWriter<W> {
+    inner: W,
+    bar: indicatif::ProgressBar,
+}
+
+impl<W: tokio::io::AsyncWrite + Unpin> ProgressWriter<W> {
+    pub fn new(inner: W, bar: indicatif::ProgressBar) -> Self {
+        Self { inner, bar }
     }
-    .await
-    .with_context(|| "workspace upload failed")?;
-
-    build.await.context("tar build task panicked")??;
-    Ok(())
 }
 
-/// Builds a zstd-compressed tar archive of `dir` into `writer`, finalizing
-/// the archive when done.
+impl<W: tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWrite for ProgressWriter<W> {
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        let this = &mut *self;
+        let inner = std::pin::Pin::new(&mut this.inner);
+        match inner.poll_write(cx, buf) {
+            std::task::Poll::Ready(Ok(n)) => {
+                this.bar.inc(n as u64);
+                std::task::Poll::Ready(Ok(n))
+            }
+            other => other,
+        }
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+/// Options controlling how a single file is added to a
+/// [`TarZstArchive`].
 ///
-/// `async_tar::Builder` panics from its `Drop` impl if it is dropped without
-/// `finish()` or `into_inner()` having been called. When the upload channel
-/// closes mid-stream the entry writes fail, so the builder is always
-/// finalized here — even on the error path — and the underlying failure is
-/// surfaced as an error instead of crashing the worker thread.
-async fn build_tar_zstd<W: AsyncWrite + Unpin + Send + Sync>(
-    dir: &Path,
-    writer: W,
-) -> Result<(), anyhow::Error> {
-    let encoder = async_compression::tokio::write::ZstdEncoder::new(writer);
-    let mut tar = Builder::new(encoder);
-    let entries = add_dir_entries(&mut tar, dir, "").await;
-    // Finalize the builder regardless of whether adding entries succeeded, so
-    // its Drop impl never fires the "dropped without finalizing" panic.
-    let finalized = tar.into_inner().await;
-    entries?;
-    let mut encoder = finalized.context("finalizing tar archive")?;
-    encoder.shutdown().await.context("flushing zstd encoder")?;
-    Ok(())
+/// `add_file` always follows symlinks (`tokio::fs::File::open` has no
+/// no-follow variant), so there's no `follow_symlinks` knob to lie
+/// about — the callers with archive-the-link-itself semantics go
+/// through `add_dir_entries`, which handles symlinks explicitly.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AddFileOptions {
+    /// Override the archive-entry mode. `None` copies the source
+    /// file's mode (masked to the standard permission bits) as-is;
+    /// `Some(m)` forces `m` (e.g. `0o644` for the patches uploader
+    /// normalizing writable copies into the sandbox home).
+    pub mode_override: Option<u32>,
 }
 
+/// Low-level tar+zstd archive builder over a Sync async writer.
+///
+/// Wraps `async_tar::Builder` inside a zstd encoder. `async_tar::Builder`
+/// requires `W: Sync`, so callers wanting to stream into a non-Sync
+/// writer (SSH channels aren't Sync) route through the [`stream_via_pipe`]
+/// helper first — the pipe's Sync `DuplexStream` tx half feeds this
+/// type, and the rx half drains into the non-Sync writer on the
+/// same task.
+///
+/// Callers should call [`Self::finish`] to produce a valid archive.
+/// If the archive is dropped before `finish` (typically because the
+/// caller's future was cancelled — a timeout, a Ctrl-C, an outer
+/// `select!` losing the race), the wrapped `async_tar::Builder` would
+/// otherwise panic from its `Drop` impl. We hold the builder inside a
+/// `ManuallyDrop`; on drop we call `mem::forget` on the taken builder
+/// instead, so no panic ever fires. The resulting archive on the wire
+/// is truncated — missing tar's trailing two 512-byte zero blocks —
+/// but a cancelled outer future has already torn down its writer
+/// (SSH channel closed, or the test `Vec` about to be discarded), so
+/// nothing downstream ever reads those bytes.
+pub struct TarZstArchive<W: AsyncWrite + Unpin + Send + Sync> {
+    /// `ManuallyDrop` because our `Drop` impl below has to prevent
+    /// the inner Builder's `Drop` from running when we get cancelled
+    /// before `finish` — that Drop panics on Tokio, and the panic
+    /// would be untriggerable-from-userland: it would come out of an
+    /// aborted task and crash the whole runtime.
+    tar: std::mem::ManuallyDrop<Builder<async_compression::tokio::write::ZstdEncoder<W>>>,
+}
+
+impl<W: AsyncWrite + Unpin + Send + Sync> Drop for TarZstArchive<W> {
+    fn drop(&mut self) {
+        // SAFETY: `self.tar` is initialized by `new` and this is the
+        // only `Drop` impl on `TarZstArchive`, so `take` runs exactly
+        // once. `mem::forget` on the taken builder skips the inner
+        // `Drop` — bypassing async_tar's panic path — at the cost of
+        // leaking the builder's internal buffers. On the happy path
+        // `finish` extracts the builder before we get here, so the
+        // taken value on cancellation is only the mid-write builder
+        // whose contents were already going to be discarded.
+        let tar = unsafe { std::mem::ManuallyDrop::take(&mut self.tar) };
+        std::mem::forget(tar);
+    }
+}
+
+impl<W: AsyncWrite + Unpin + Send + Sync> TarZstArchive<W> {
+    /// Create a new archive that streams into `writer` as entries
+    /// are added.
+    ///
+    /// Zstd is configured for interactive activate throughput —
+    /// **level 1** (2-3× compress throughput vs. the codec's default
+    /// 3, only modest ratio loss on text-y payloads) with **N-1
+    /// worker threads** where N = `available_parallelism`, so the
+    /// compressor pipelines across cores instead of running on the
+    /// caller thread.
+    pub fn new(writer: W) -> Self {
+        let workers = std::thread::available_parallelism()
+            .map(|n| u32::try_from(n.get().saturating_sub(1)).unwrap_or(0))
+            .unwrap_or(0);
+        let params = [async_compression::zstd::CParameter::nb_workers(workers)];
+        let encoder = async_compression::tokio::write::ZstdEncoder::with_quality_and_params(
+            writer,
+            async_compression::Level::Precise(1),
+            &params,
+        );
+        Self {
+            tar: std::mem::ManuallyDrop::new(Builder::new(encoder)),
+        }
+    }
+
+    /// Escape hatch for the directory-walker path that needs to
+    /// recurse over an owned mutable builder.
+    fn builder(&mut self) -> &mut Builder<async_compression::tokio::write::ZstdEncoder<W>> {
+        &mut self.tar
+    }
+
+    /// Add a file entry at `archive_path`, reading its contents
+    /// from `host_path`. Always follows symlinks (via
+    /// `tokio::fs::File::open`). The [`AddFileOptions::mode_override`]
+    /// value, if set, is stamped on the tar header in place of the
+    /// source file's mode.
+    pub async fn add_file(
+        &mut self,
+        host_path: &Path,
+        archive_path: &str,
+        opts: AddFileOptions,
+    ) -> Result<(), anyhow::Error> {
+        let file = fs::File::open(host_path)
+            .await
+            .with_context(|| format!("opening {}", host_path.display()))?;
+        let metadata = file
+            .metadata()
+            .await
+            .with_context(|| format!("statting {}", host_path.display()))?;
+        // Default mode: the source's own permission bits (masked to
+        // the standard nine + suid/sgid/sticky). Matches the
+        // `mode_override = None` docstring; otherwise an executable
+        // dropped in through `default()` would archive as 0o644 and
+        // silently lose its exec bit on unpack.
+        let default_mode = {
+            use std::os::unix::fs::PermissionsExt as _;
+            metadata.permissions().mode() & 0o7777
+        };
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(metadata.len());
+        header.set_mode(opts.mode_override.unwrap_or(default_mode));
+        header.set_entry_type(async_tar::EntryType::Regular);
+        // 1 MiB BufReader on the file: without it every 8 KiB chunk
+        // `tokio::io::copy(_buf)` moves is a separate blocking-pool
+        // round-trip through `tokio::fs`, and 1.3 GiB of patches
+        // means 168k of them. With the BufReader the file's read
+        // syscalls collapse to `size / 1 MiB` — a ~130× reduction
+        // that closes the throughput gap between the tar builder
+        // and the downstream SSH channel.
+        let mut buffered = tokio::io::BufReader::with_capacity(1024 * 1024, file);
+        // Fast path: bypass `append_data` so we can drive
+        // `fill_buf`/`consume` against the BufReader directly,
+        // sending up to the BufReader's full slice per `poll_write`
+        // into the zstd encoder. `append_data` internally calls
+        // `tokio::io::copy`, which uses an 8 KiB working buffer,
+        // producing an order of magnitude more async poll pairs for
+        // no wire-format benefit.
+        //
+        // `set_path` errors when the archive path doesn't fit in the
+        // standard 100-byte tar name field. Longer paths need
+        // async_tar's private GNULongName preamble helper, so those
+        // fall through to `append_data`.
+        if header.set_path(archive_path).is_ok() {
+            header.set_cksum();
+            let dst = self.tar.get_mut();
+            dst.write_all(header.as_bytes())
+                .await
+                .with_context(|| format!("writing tar header for {archive_path}"))?;
+
+            // Bound the copy to the size we declared in the header.
+            // A source that grew between the `stat` above and this
+            // read would otherwise push extra bytes into the stream
+            // and desync every following entry (the reader would
+            // parse those bytes as the next header). A source that
+            // *shrank* — file truncated after our stat call — is a
+            // hard error: silently zero-padding to make the tar
+            // frame line up would deliver a valid archive whose
+            // last entry's contents are the surviving prefix plus
+            // trailing NULs, and the client would report success
+            // for a corrupted upload. Better to fail loudly here;
+            // the outer future is dropped either way, so tar
+            // framing beyond this entry doesn't need to survive.
+            // Uses `fill_buf`/`consume` (not `tokio::io::copy_buf`)
+            // so we can cap the write at `declared - written` per
+            // iteration; still gets the full BufReader capacity per
+            // poll_write.
+            use tokio::io::AsyncBufReadExt as _;
+            let declared = metadata.len();
+            let mut written: u64 = 0;
+            while written < declared {
+                let buf = buffered
+                    .fill_buf()
+                    .await
+                    .with_context(|| format!("reading body of {archive_path}"))?;
+                if buf.is_empty() {
+                    break;
+                }
+                let take = std::cmp::min(buf.len() as u64, declared - written) as usize;
+                dst.write_all(&buf[..take])
+                    .await
+                    .with_context(|| format!("writing body of {archive_path}"))?;
+                buffered.consume(take);
+                written += take as u64;
+            }
+            if written < declared {
+                anyhow::bail!(
+                    "source file {} shrank during upload: declared {declared} bytes in the tar \
+                     header (from stat) but only {written} were readable — the file was truncated \
+                     between stat and read, so the archive would silently ship a corrupted entry",
+                    host_path.display(),
+                );
+            }
+
+            let pad = ((512 - (declared % 512)) % 512) as usize;
+            if pad > 0 {
+                const ZEROS: [u8; 512] = [0; 512];
+                dst.write_all(&ZEROS[..pad])
+                    .await
+                    .with_context(|| format!("writing tar padding for {archive_path}"))?;
+            }
+            Ok(())
+        } else {
+            // `append_data` sets the header checksum internally
+            // (async_tar 0.6 builder.rs:201-203), so no manual
+            // `set_cksum()` here.
+            self.tar
+                .append_data(&mut header, archive_path, &mut buffered)
+                .await
+                .with_context(|| format!("adding file {archive_path}"))
+        }
+    }
+
+    /// Finalize the tar archive and flush the zstd encoder.
+    /// Consuming self guarantees no more entries can be added.
+    pub async fn finish(mut self) -> Result<(), anyhow::Error> {
+        // SAFETY: `self.tar` is initialized by `new` and no other
+        // code path takes it. We take it here, then `mem::forget`
+        // `self` so our `Drop` impl doesn't also try to take it.
+        // On error inside `into_inner`, the builder is consumed
+        // regardless, so no panic path fires.
+        let tar = unsafe { std::mem::ManuallyDrop::take(&mut self.tar) };
+        std::mem::forget(self);
+        let mut encoder = tar.into_inner().await.context("finalizing tar archive")?;
+        encoder.shutdown().await.context("flushing zstd encoder")?;
+        Ok(())
+    }
+}
+
+/// The directory-walk uploader. Kept as a free function so
+/// `stream_tar_zstd` can pin down a single `&mut Builder` reference
+/// through the recursion (`TarZstArchive::builder()` returns one).
 async fn add_dir_entries<W: AsyncWrite + Unpin + Send + Sync>(
     tar: &mut Builder<W>,
     root: &Path,
@@ -303,10 +619,73 @@ mod tests {
         }
 
         let writer = FailingWriter { remaining: 1024 };
-        let result = build_tar_zstd(dir.path(), writer).await;
+        let result = stream_tar_zstd(dir.path(), writer).await;
         assert!(
             result.is_err(),
             "a mid-stream writer failure must surface as an error, not a panic"
+        );
+    }
+
+    /// Writer that accepts all writes/flushes but errors on `poll_shutdown`.
+    /// Wired to prove `TarZstArchive::finish`'s `encoder.shutdown().await?`
+    /// path actually surfaces its error — the earlier
+    /// `stream_via_pipe(dir, FailingWriter)` test can't cover it because
+    /// its drain half absorbs everything the tar builder writes.
+    struct ShutdownFailingWriter;
+
+    impl AsyncWrite for ShutdownFailingWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "shutdown failed",
+            )))
+        }
+    }
+
+    /// Regression test: `TarZstArchive::finish` must propagate errors from
+    /// the zstd encoder's `shutdown` call. A silently-dropped `?` on
+    /// `encoder.shutdown().await` would let the underlying writer's
+    /// shutdown failure disappear, and the returned archive bytes would
+    /// look valid to the caller even though the daemon-side reader would
+    /// see truncated / corrupt zstd framing.
+    #[tokio::test]
+    async fn finish_surfaces_encoder_shutdown_error() {
+        let mut archive = TarZstArchive::new(ShutdownFailingWriter);
+        // A no-body entry avoids relying on any body-copy internals —
+        // the tar bytes we do write all succeed under this writer, so
+        // the only path to an error is the encoder-shutdown call
+        // inside `finish`.
+        let src = tempfile::NamedTempFile::new().unwrap();
+        archive
+            .add_file(
+                src.path(),
+                "empty.txt",
+                AddFileOptions {
+                    mode_override: Some(0o644),
+                },
+            )
+            .await
+            .expect("adding the empty file succeeds");
+        let err = archive
+            .finish()
+            .await
+            .expect_err("shutdown-failing writer must produce a finish() error");
+        assert!(
+            format!("{err:#}").contains("zstd encoder")
+                || format!("{err:#}").contains("shutdown failed"),
+            "expected the encoder-shutdown error to surface, got: {err:#}",
         );
     }
 
@@ -316,8 +695,11 @@ mod tests {
     async fn stream_and_list(dir: &Path) -> Vec<String> {
         let mut buf = Vec::new();
         stream_tar_zstd(dir, &mut buf).await.unwrap();
+        unpack_and_list(&buf).await
+    }
 
-        let decoder = async_compression::tokio::bufread::ZstdDecoder::new(&buf[..]);
+    async fn unpack_and_list(archive_bytes: &[u8]) -> Vec<String> {
+        let decoder = async_compression::tokio::bufread::ZstdDecoder::new(archive_bytes);
         let out = tempfile::TempDir::new().unwrap();
         let archive = async_tar::Archive::new(decoder);
         archive.unpack(out.path().to_path_buf()).await.unwrap();
@@ -495,5 +877,257 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         std::fs::write(dir.path().join("hello.txt"), "hello").unwrap();
         assert!(!is_vcs_root(dir.path()));
+    }
+
+    // ---- TarZstArchive per-entry API ----
+
+    /// Build an archive against an owned `Vec<u8>` writer and
+    /// return the finished bytes. Test helper wrapping the
+    /// `TarZstArchive` API — an owned `Vec` is `AsyncWrite + Sync`
+    /// out of the box, which the archive requires.
+    async fn build_via_archive(
+        f: impl AsyncFnOnce(&mut TarZstArchive<Vec<u8>>) -> Result<(), anyhow::Error>,
+    ) -> Vec<u8> {
+        let mut archive = TarZstArchive::new(Vec::new());
+        f(&mut archive).await.unwrap();
+        // Take the builder past our `ManuallyDrop` and forget the
+        // wrapper (matching what `finish` does) — needed to reach
+        // into the encoder to reclaim the `Vec` without triggering
+        // our `Drop::forget` behavior twice.
+        // SAFETY: `archive.tar` is initialized and we `mem::forget`
+        // the archive on the next line so `Drop` never runs.
+        let tar = unsafe { std::mem::ManuallyDrop::take(&mut archive.tar) };
+        std::mem::forget(archive);
+        let mut encoder = tar.into_inner().await.unwrap();
+        encoder.shutdown().await.unwrap();
+        encoder.into_inner()
+    }
+
+    /// Adding files entry-at-a-time from arbitrary host paths (the
+    /// patches-upload shape) yields a valid archive with each entry
+    /// at the caller-supplied archive path.
+    #[tokio::test]
+    async fn tar_zst_archive_adds_files_at_specified_archive_paths() {
+        let src = tempfile::TempDir::new().unwrap();
+        let a_path = src.path().join("a.txt");
+        let b_path = src.path().join("b.txt");
+        std::fs::write(&a_path, "contents-a").unwrap();
+        std::fs::write(&b_path, "contents-b").unwrap();
+
+        let buf = build_via_archive(async |archive| {
+            // No explicit `add_dir` — the unpacker creates parent
+            // dirs from the file paths (`unpack_in` handles it).
+            archive
+                .add_file(
+                    &a_path,
+                    ".config/helix/config.toml",
+                    AddFileOptions::default(),
+                )
+                .await?;
+            archive
+                .add_file(
+                    &b_path,
+                    ".config/other.toml",
+                    AddFileOptions {
+                        mode_override: Some(0o644),
+                    },
+                )
+                .await
+        })
+        .await;
+
+        let paths = unpack_and_list(&buf).await;
+        assert!(
+            paths.iter().any(|p| p == ".config/helix/config.toml"),
+            "config.toml missing: got {paths:?}"
+        );
+        assert!(
+            paths.iter().any(|p| p == ".config/other.toml"),
+            "other.toml missing: got {paths:?}"
+        );
+    }
+
+    /// `add_file` follows symlinks — copies the target's contents.
+    /// The patches uploader relies on this so a `/nix/store/…` link
+    /// lands as a real file inside the sandbox.
+    #[tokio::test]
+    async fn tar_zst_archive_add_file_follows_symlinks() {
+        let src = tempfile::TempDir::new().unwrap();
+        let target = src.path().join("real.txt");
+        std::fs::write(&target, "target-contents").unwrap();
+        let link = src.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let buf = build_via_archive(async |archive| {
+            archive
+                .add_file(
+                    &link,
+                    "copied.txt",
+                    AddFileOptions {
+                        mode_override: None,
+                    },
+                )
+                .await
+        })
+        .await;
+
+        let decoder = async_compression::tokio::bufread::ZstdDecoder::new(&buf[..]);
+        let out = tempfile::TempDir::new().unwrap();
+        let archive = async_tar::Archive::new(decoder);
+        archive.unpack(out.path().to_path_buf()).await.unwrap();
+        let copied = out.path().join("copied.txt");
+        assert!(copied.is_file(), "expected a real file, got {copied:?}");
+        assert_eq!(std::fs::read_to_string(&copied).unwrap(), "target-contents");
+    }
+
+    /// `add_file` with `mode_override` honours the requested mode.
+    /// Verifies the patches uploader's normalize-to-0o644 story
+    /// (Nix-store 0o444 sources landing as writable copies).
+    #[tokio::test]
+    async fn tar_zst_archive_add_file_honours_mode_override() {
+        let src = tempfile::TempDir::new().unwrap();
+        let source = src.path().join("readonly.txt");
+        std::fs::write(&source, "ro").unwrap();
+        std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+        let buf = build_via_archive(async |archive| {
+            archive
+                .add_file(
+                    &source,
+                    "normalized.txt",
+                    AddFileOptions {
+                        mode_override: Some(0o644),
+                    },
+                )
+                .await
+        })
+        .await;
+
+        let decoder = async_compression::tokio::bufread::ZstdDecoder::new(&buf[..]);
+        let out = tempfile::TempDir::new().unwrap();
+        let ar = async_tar::Archive::new(decoder);
+        ar.unpack(out.path().to_path_buf()).await.unwrap();
+        let unpacked = out.path().join("normalized.txt");
+        let meta = std::fs::metadata(&unpacked).unwrap();
+        // Mask off the file-type bits; async-tar sets both.
+        assert_eq!(
+            meta.permissions().mode() & 0o777,
+            0o644,
+            "mode override should have made the unpacked file 0o644",
+        );
+    }
+
+    /// An archive with no entries still produces a valid empty
+    /// tar+zstd stream. The patches uploader takes this path when
+    /// the composition has no patches.
+    #[tokio::test]
+    async fn tar_zst_archive_empty_finish_produces_valid_stream() {
+        let buf = build_via_archive(async |_| Ok(())).await;
+        let paths = unpack_and_list(&buf).await;
+        assert!(paths.is_empty(), "empty archive should unpack to nothing");
+    }
+
+    /// Regression: a source file truncated between `stat` and the
+    /// body copy must fail loudly, not silently zero-pad to match
+    /// the header's declared size. Otherwise the archive is valid
+    /// tar+zstd but its last entry's contents are wrong, and the
+    /// client reports a successful upload for corrupt bytes.
+    #[tokio::test]
+    async fn add_file_errors_when_source_shrinks_during_read() {
+        let src = tempfile::TempDir::new().unwrap();
+        let path = src.path().join("shrinker.bin");
+        // Write a moderately-sized file so `add_file` will `stat`
+        // it at N bytes.
+        std::fs::write(&path, vec![0xAAu8; 128 * 1024]).unwrap();
+
+        // Take the stat picture, then truncate. This is the exact
+        // shape of a concurrent editor truncating a file that
+        // stream_tar_zstd/add_file already stat'd.
+        let mut archive = TarZstArchive::new(Vec::new());
+        // Force the stat-truncate race: `add_file` will `open`,
+        // then `metadata`, then start reading. Truncate *after*
+        // `add_file` starts by racing with a `spawn_blocking`.
+        // Simpler shape: shrink the file to zero before `add_file`
+        // reads it, but `add_file` re-`stat`s inside — so instead
+        // we shrink between `add_file`'s `stat` and its read by
+        // truncating from another task once `add_file` has entered
+        // the fill_buf loop. That's fiddly to synchronize; the
+        // easier test is a purely-behavioral one: pre-truncate to
+        // half the length after opening the file for read outside
+        // add_file. But add_file owns its own open, so we can't
+        // interpose there.
+        //
+        // The cleanest way is a targeted test: pre-populate a
+        // large file, then in a background task truncate it after
+        // a short sleep. Add_file's read loop uses `tokio::fs`,
+        // whose blocking-pool round-trips give the truncate task
+        // time to land.
+        let truncate_path = path.clone();
+        let truncate = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            let _ = std::fs::File::options()
+                .write(true)
+                .open(&truncate_path)
+                .and_then(|f| f.set_len(0));
+        });
+
+        let result = archive
+            .add_file(&path, "shrinker.bin", AddFileOptions::default())
+            .await;
+        let _ = truncate.await;
+
+        // Either the read races the truncate and succeeds (the
+        // truncate landed after add_file's read), or the read
+        // sees the truncated file and errors — but on the error
+        // path the error must name the shrink, not surface as
+        // a silent success with padded zeros.
+        match result {
+            Ok(()) => {
+                // Race lost — the truncate landed too late.
+                // Nothing to assert; the point is that the test
+                // doesn't panic and doesn't silently corrupt.
+            }
+            Err(e) => {
+                let msg = format!("{e:#}");
+                assert!(
+                    msg.contains("shrank during upload"),
+                    "expected the shrink-detection error, got: {msg}",
+                );
+            }
+        }
+    }
+
+    /// Regression: an outer future dropping a `TarZstArchive` before
+    /// `finish` (Ctrl-C, deadline elapsed, `select!` racing loss)
+    /// must not panic. `async_tar::Builder`'s own `Drop` would panic
+    /// on Tokio; our `ManuallyDrop`+`forget` wrapper suppresses it.
+    #[tokio::test]
+    async fn tar_zst_archive_survives_drop_without_finish() {
+        // Build enough to force the encoder to start committing to
+        // the writer, so we're not just dropping a fresh builder.
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(src.path().join("f.txt"), "abc").unwrap();
+
+        let mut archive = TarZstArchive::new(Vec::new());
+        archive
+            .add_file(
+                &src.path().join("f.txt"),
+                "f.txt",
+                AddFileOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        // Drop the archive after `add_file` succeeds and before
+        // `finish` — this is the exact shape a cancelled outer
+        // future exposes. Wrap the drop in `catch_unwind` so an
+        // async-tar Drop panic escapes as an `Err` we can assert
+        // on, rather than aborting the test task and confusing the
+        // outer harness.
+        let drop_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(archive)));
+        assert!(
+            drop_result.is_ok(),
+            "dropping a TarZstArchive before finish must not panic",
+        );
     }
 }

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -116,6 +116,14 @@ pub enum Command {
     Update(UpdateArgs),
     /// Print CLI and daemon version information
     Version,
+    /// Demo the client's activity spinner (development aid).
+    ///
+    /// Draws the same build-hold-fade spinner used by the file-upload
+    /// phases of `min activate` so you can eyeball timing and layout
+    /// without triggering a real upload. Stops after `--seconds` or
+    /// on Ctrl-C, whichever comes first.
+    #[command(hide = true)]
+    Spin(SpinArgs),
     /// Generate shell completion script
     #[command(
         long_about = "Generate a shell tab-completion script for the min CLI.\nSupported shells include bash, zsh, elvish and fish.\n\n   source <(min completions bash)"
@@ -443,6 +451,14 @@ pub struct AddKind {
 pub struct UpdateArgs {}
 
 #[derive(Debug, Args)]
+pub struct SpinArgs {
+    /// How long to keep the spinner visible before auto-exiting.
+    /// Ctrl-C cuts it short.
+    #[arg(long, default_value_t = 10)]
+    pub seconds: u64,
+}
+
+#[derive(Debug, Args)]
 pub struct ProxyArgs {
     /// UDS socket path to connect to
     #[arg(long)]
@@ -527,6 +543,7 @@ async fn run_command(cli: Cli) -> Result<(), anyhow::Error> {
         Some(Command::SshForward(args)) => cmd_ssh_forward(&cli.global_args, args).await,
         Some(Command::Login(args)) => cmd_login(&cli.global_args, args).await,
         Some(Command::Version) => cmd_version(&cli.global_args).await,
+        Some(Command::Spin(args)) => cmd_spin(&cli.global_args, args).await,
         Some(Command::Rename(args)) => cmd_rename(&cli.global_args, args).await,
         Some(Command::Init(args)) => cmd_init(&cli.global_args, args)
             .await
@@ -929,7 +946,7 @@ async fn submit_verdict_and_wait(
         }
     };
     match step {
-        SessionStep::Active { id } => Ok(id),
+        SessionStep::Materialized { id } => Ok(id),
         SessionStep::Fault { error } => {
             send_abort(client, session_id).await;
             bail!("SubmitVerdict faulted: {error}");
@@ -938,15 +955,26 @@ async fn submit_verdict_and_wait(
 }
 
 /// The interactive-prompt caller's happy path: gate, then submit,
-/// then return the finalized id + policy. Any gating failure aborts
-/// the daemon-side session before propagating.
+/// then return the finalized id + policy + the verdict that was
+/// submitted. The verdict is returned so the caller can pick the
+/// approved daemon-side patches out for upload — those files were
+/// only surfaced during Phase 3 and won't otherwise be available
+/// to the client-side upload step. Any gating failure aborts the
+/// daemon-side session before propagating.
 async fn drive_pending_to_active(
     client: &mut client::Client,
     response: sessions::wire::request::ContributionResponse,
     policy: sessions::core::policy::UserPolicy,
     options: sessions::core::compose::ComposeOptions,
     hooks: &dyn sessions::core::hooks::PolicyHooks,
-) -> Result<(sessions::SessionId, sessions::core::policy::UserPolicy), anyhow::Error> {
+) -> Result<
+    (
+        sessions::SessionId,
+        sessions::core::policy::UserPolicy,
+        Vec<(std::path::PathBuf, paths::SandboxRelPath)>,
+    ),
+    anyhow::Error,
+> {
     let session_id = response.session_id;
     let (verdict, final_policy) = match compute_verdict(response, policy, options, hooks) {
         Ok(v) => v,
@@ -955,8 +983,34 @@ async fn drive_pending_to_active(
             bail!("Composition gating failed: {e}");
         }
     };
+    // Extract the approved-patch destinations before submit consumes
+    // the verdict — avoids cloning the whole wire type (both vars
+    // and patches Vecs plus their owned strings) just so the caller
+    // can walk one field of it after the fact.
+    let approved_patches: Vec<_> = approved_patches_from_verdict(&verdict).collect();
     let id = submit_verdict_and_wait(client, session_id, verdict).await?;
-    Ok((id, final_policy))
+    Ok((id, final_policy, approved_patches))
+}
+
+/// Collect the sandbox destinations of every `Approved` patch
+/// verdict — the daemon-side patches the client just approved and
+/// now needs to upload. `Ignored`/`Denied` verdicts contribute
+/// nothing to the composition, so they're not uploaded.
+fn approved_patches_from_verdict(
+    verdict: &sessions::wire::request::ContributionVerdict,
+) -> impl Iterator<Item = (std::path::PathBuf, paths::SandboxRelPath)> + '_ {
+    verdict.patches.iter().filter_map(|v| match v {
+        sessions::wire::policy::WirePatchVerdict::Approved {
+            host_path,
+            destination,
+            ..
+        } => Some((
+            host_path.as_utf8_path().as_std_path().to_path_buf(),
+            destination.clone(),
+        )),
+        sessions::wire::policy::WirePatchVerdict::Ignored { .. }
+        | sessions::wire::policy::WirePatchVerdict::Denied { .. } => None,
+    })
 }
 
 /// Fire an `AbortSession` at the daemon for a `Pending` session the
@@ -973,6 +1027,71 @@ async fn send_abort(client: &mut client::Client, session_id: sessions::SessionId
         }
         Err(e) => {
             eprintln!("AbortSession RPC failed: {e}");
+        }
+    }
+}
+
+/// Best-effort destroy for a `Materializing` session the client
+/// couldn't finalize (patch upload failed, network blip, etc.).
+/// Unlike `AbortSession`, `DestroySession` works on any status
+/// past `Pending`. Errors are logged, not propagated — the caller
+/// is already reporting a primary error.
+///
+/// Bounded by a hard timeout: the same network conditions that
+/// caused the primary error (wedged daemon, half-open SSH channel,
+/// a VM whose bridge accepted but whose guest never answered) can
+/// make the RPC hang indefinitely, which would swallow the
+/// operator-visible primary error we're supposed to be racing
+/// back to `cmd_activate`.
+async fn best_effort_destroy(client: &mut client::Client, session_id: sessions::SessionId) {
+    /// Ceiling on how long we let a cleanup RPC run. Chosen well
+    /// above a healthy `DestroySession` (single-digit milliseconds
+    /// on a UDS) so the timeout only fires against pathologies.
+    const DESTROY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+    use minimald_rpc::DestroySession;
+    let call = client
+        .oneshot_rpc::<DestroySession>(minimald_rpc::DestroySessionRequest { id: session_id });
+    match tokio::time::timeout(DESTROY_TIMEOUT, call).await {
+        Ok(Ok(minimald_rpc::Errorable::Ok(_))) => {}
+        Ok(Ok(minimald_rpc::Errorable::Err { error })) => {
+            eprintln!("DestroySession failed while cleaning up: {error}");
+        }
+        Ok(Err(e)) => {
+            eprintln!("DestroySession RPC failed while cleaning up: {e}");
+        }
+        Err(_) => {
+            eprintln!(
+                "DestroySession timed out after {DESTROY_TIMEOUT:?} while cleaning up \
+                 session {session_id}; the session may still be present on the daemon \
+                 (run `min destroy {session_id}` to clean up manually)",
+            );
+        }
+    }
+}
+
+/// Upload the composition's patches (if any) and finalize the
+/// session. The session is `Materializing` at entry; `Active` on
+/// success. On upload/finalize failure the session is left in
+/// `Materializing` — the caller is responsible for destroying it.
+async fn upload_and_finalize(
+    client: &mut client::Client,
+    session_id: sessions::SessionId,
+    patches: &[(std::path::PathBuf, paths::SandboxRelPath)],
+) -> Result<(), anyhow::Error> {
+    client
+        .upload_patches(session_id, patches)
+        .await
+        .context("Failed to upload composition patches")?;
+
+    use minimald_rpc::{FinalizeSession, FinalizeSessionRequest};
+    let resp = client
+        .oneshot_rpc::<FinalizeSession>(FinalizeSessionRequest { session_id })
+        .await
+        .context("FinalizeSession RPC failed")?;
+    match resp {
+        minimald_rpc::Errorable::Ok(_) => Ok(()),
+        minimald_rpc::Errorable::Err { error } => {
+            bail!("FinalizeSession failed: {error}");
         }
     }
 }
@@ -1190,7 +1309,6 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
                     false,
                 )?;
             if should_upload {
-                eprintln!("Uploading project files...");
                 client
                     .upload_workspace_files(id, upload_root.as_std_path())
                     .await
@@ -1203,6 +1321,24 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
             }
         }
     };
+
+    // Collect the client-side patches (from loadouts, already gated
+    // in Phase 1) *before* the wire contribution moves into the
+    // ConfigureLoadout RPC. These land in the final Composition
+    // whether the response is `Materialized` or `Pending`, so the
+    // client is authoritative for them. Any daemon-side patches
+    // that come back through a `Pending` response's `SubmitVerdict`
+    // get appended below.
+    let mut collected_patches: Vec<(std::path::PathBuf, paths::SandboxRelPath)> = contribution
+        .patches
+        .iter()
+        .map(|p| {
+            (
+                p.patch.host_path.as_utf8_path().as_std_path().to_path_buf(),
+                p.patch.destination.clone(),
+            )
+        })
+        .collect();
 
     // The session exists but has no loadout yet; composing it is a
     // second round-trip because the daemon's composer reads the
@@ -1266,6 +1402,7 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
                     s = if count == 1 { "" } else { "s" },
                 );
             }
+            collected_patches.extend(approved_patches_from_verdict(&verdict));
             submit_verdict_and_wait(&mut client, session_id, verdict).await?;
         } else {
             // The hook stashes policy mutations in interior
@@ -1284,6 +1421,9 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
                 &hooks,
             )
             .await;
+            if let Ok((_, _, ref approved)) = result {
+                collected_patches.extend(approved.iter().cloned());
+            }
             let final_policy = hooks.into_final_policy();
             if final_policy != initial_policy {
                 // A `save_user_policy` failure is reported to
@@ -1309,6 +1449,22 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
     // above, so it appears unused to the compiler. Explicit `_` to
     // squash the lint without dropping the useful name.
     let _ = initial_policy;
+
+    // Upload composition patches and finalize the session. This
+    // has to happen before attach is allowed — a Materializing
+    // session isn't attachable, and the launcher reads patches
+    // from `<workspace>/patches/`. Dedup by sandbox destination:
+    // the composer's post-gate check guarantees any duplicates
+    // are exact matches (same source), so collapsing is safe.
+    collected_patches.sort_by(|a, b| a.1.as_str().cmp(b.1.as_str()));
+    collected_patches.dedup_by(|a, b| a.1.as_str() == b.1.as_str());
+    if let Err(e) = upload_and_finalize(&mut client, id, &collected_patches).await {
+        // Best-effort teardown: the session is stuck in
+        // Materializing on the daemon. Destroy it so the operator's
+        // `min ls` doesn't fill with half-finalized sessions.
+        best_effort_destroy(&mut client, id).await;
+        return Err(e);
+    }
 
     println!("{id}");
 
@@ -2097,6 +2253,32 @@ pub async fn cmd_update(global: &GlobalArgs, _args: UpdateArgs) -> Result<(), mc
     let ensure_pkgs = ctx.scaffolding_packages()?;
     ctx.download_if_available(&graph, ensure_pkgs).await?;
 
+    Ok(())
+}
+
+/// Draw the client's activity spinner on stderr for `args.seconds`
+/// (or until Ctrl-C), then clear it. Ticks the byte counter as it
+/// runs so the `{bytes}` / `{bytes_per_sec}` placeholders in the
+/// spinner template look alive instead of stuck at zero — makes it
+/// easier to eyeball the animation next to realistic template
+/// content.
+pub async fn cmd_spin(_global: &GlobalArgs, args: SpinArgs) -> Result<(), anyhow::Error> {
+    use std::time::Duration;
+    let bar = client::add_spinner_bar("Spinner demo");
+    let deadline = tokio::time::sleep(Duration::from_secs(args.seconds));
+    tokio::pin!(deadline);
+    // ~80 KB/s of fake throughput. Below indicatif's rate-average
+    // window smoothing so the reported `{bytes_per_sec}` stays
+    // legible instead of dancing every tick.
+    let mut fake_throughput = tokio::time::interval(Duration::from_millis(50));
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => break,
+            _ = &mut deadline => break,
+            _ = fake_throughput.tick() => bar.inc(4096),
+        }
+    }
+    bar.finish_and_clear();
     Ok(())
 }
 

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -657,6 +657,7 @@ async fn create_session_at(
 
     use minimald_rpc::{
         ConfigureLoadout, ConfigureLoadoutRequest, CreateSession, CreateSessionRequest,
+        FinalizeSession, FinalizeSessionRequest,
     };
     let id = match client
         .call::<CreateSession>(&CreateSessionRequest { config })
@@ -667,8 +668,9 @@ async fn create_session_at(
             panic!("CreateSession failed: {error}")
         }
     };
-    // Finalize the session's loadout, as `min activate` does: its workspace
-    // is empty, so this composes to an empty `Ready` in one shot.
+    // Configure the loadout, then finalize — the workspace is
+    // empty so the composition has no patches and Finalize takes
+    // the empty-composition short-circuit past the marker check.
     match client
         .call::<ConfigureLoadout>(&ConfigureLoadoutRequest {
             session_id: id,
@@ -679,6 +681,15 @@ async fn create_session_at(
         minimald_rpc::Errorable::Ok(r) => unwrap_ready(r),
         minimald_rpc::Errorable::Err { error } => {
             panic!("ConfigureLoadout failed: {error}")
+        }
+    }
+    match client
+        .call::<FinalizeSession>(&FinalizeSessionRequest { session_id: id })
+        .await
+    {
+        minimald_rpc::Errorable::Ok(_) => {}
+        minimald_rpc::Errorable::Err { error } => {
+            panic!("FinalizeSession failed: {error}")
         }
     }
     id

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -285,7 +285,8 @@ pub struct ConfigureLoadoutRequest {
     pub session_id: SessionId,
     /// Client-side Phase 1 contribution. Defaulted (empty) by
     /// callers that aren't composing a session, which take the
-    /// empty-contribution fast path to [`ConfigureLoadoutResponse::Ready`].
+    /// empty-contribution fast path to
+    /// [`ConfigureLoadoutResponse::Materialized`].
     #[serde(default)]
     pub contribution: sessions::wire::request::WireContribution,
 }
@@ -293,18 +294,29 @@ pub struct ConfigureLoadoutRequest {
 /// The response for a [`ConfigureLoadout`] RPC.
 ///
 /// Both variants are part of the Phase 2 flow and reachable on the
-/// wire: `Ready` when the daemon's composer finalizes in one shot,
-/// `Pending` when it collects items the client must gate before
-/// composition completes (the client follows up via `SubmitVerdict`).
+/// wire: `Materialized` when the daemon's composer finalizes in one
+/// shot (the session record is now
+/// [`Materializing`](sessions::SessionStatus::Materializing), not
+/// yet `Active`), `Pending` when it collects items the client must
+/// gate before composition completes (the client follows up via
+/// `SubmitVerdict`).
+///
+/// In both `Materialized` branches the client still has to upload
+/// patches and call `FinalizeSession` before the session is
+/// attachable.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ConfigureLoadoutResponse {
-    /// No items need user gating; the session is finalized and
-    /// callers can immediately use it.
-    Ready,
-    /// Items need client-side gating. The session stays in flight;
-    /// the client follows up with `SubmitVerdict` carrying the same
-    /// id.
+    /// No items need user gating; composition is complete and the
+    /// session record has advanced to
+    /// [`Materializing`](sessions::SessionStatus::Materializing).
+    /// The client still has to upload the composition's patches
+    /// and call `FinalizeSession` before the session becomes
+    /// attachable.
+    Materialized,
+    /// Items need client-side gating. The session stays in
+    /// [`Pending`](sessions::SessionStatus::Pending); the client
+    /// follows up with `SubmitVerdict` carrying the same id.
     Pending {
         /// Pending items the client must gate.
         response: sessions::wire::request::ContributionResponse,
@@ -315,6 +327,38 @@ impl OneshotSshRpc for ConfigureLoadout {
     const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "ConfigureLoadout");
     type Request<'a> = ConfigureLoadoutRequest;
     type Response = Errorable<ConfigureLoadoutResponse>;
+}
+
+/// An RPC to promote a `Materializing` session to `Active`.
+///
+/// The client uploads composition patches to the daemon via
+/// `WorkspacePatchesTarZst`, then calls this RPC to signal "every
+/// side-channel upload is in and I'm ready for the session to be
+/// attachable." The daemon checks for the patches-ready marker
+/// under `<workspace>/patches/` and refuses to finalize if the
+/// upload never completed.
+///
+/// Idempotent: calling on an already-`Active` session returns
+/// success. Refused with `InvalidInput` on `Pending` sessions
+/// (configure the loadout first) or `Materializing` sessions
+/// missing the patches marker.
+pub struct FinalizeSession;
+
+/// The request for a [`FinalizeSession`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FinalizeSessionRequest {
+    /// The session to finalize.
+    pub session_id: SessionId,
+}
+
+/// The response for a [`FinalizeSession`] RPC — a unit-shaped ack.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FinalizeSessionResponse;
+
+impl OneshotSshRpc for FinalizeSession {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "FinalizeSession");
+    type Request<'a> = FinalizeSessionRequest;
+    type Response = Errorable<FinalizeSessionResponse>;
 }
 
 /// An RPC to rename an existing session.
@@ -389,9 +433,11 @@ impl OneshotSshRpc for Shutdown {
 }
 
 /// Resume a `Pending` session with the client's per-item
-/// [`ContributionVerdict`]. Terminal — the daemon promotes the
-/// record `Pending → Active` and replies with
-/// [`SessionStep::Active`](sessions::wire::request::SessionStep::Active).
+/// [`ContributionVerdict`]. The daemon promotes the record
+/// `Pending → Materializing` and replies with
+/// [`SessionStep::Materialized`](sessions::wire::request::SessionStep::Materialized);
+/// the client still has to upload patches and call
+/// `FinalizeSession` before the session is attachable.
 /// A `Fault` reply carries a structured
 /// [`WireError`](sessions::wire::errors::WireError) —
 /// `UnknownSessionId` for a verdict against no stashed session,
@@ -849,11 +895,11 @@ mod tests {
     }
 
     #[test]
-    fn configure_loadout_response_ready_round_trips() {
-        let resp = ConfigureLoadoutResponse::Ready;
+    fn configure_loadout_response_materialized_round_trips() {
+        let resp = ConfigureLoadoutResponse::Materialized;
         assert_eq!(round_trip(&resp), resp);
         let json = serde_json::to_string(&resp).unwrap();
-        assert!(json.contains(r#""kind":"ready""#), "got: {json}");
+        assert!(json.contains(r#""kind":"materialized""#), "got: {json}");
     }
 
     #[test]

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -38,6 +38,7 @@ fd-lock.workspace = true
 futures.workspace = true
 hakoniwa.workspace = true
 libc.workspace = true
+nix.workspace = true
 russh.workspace = true
 russh-sftp.workspace = true
 path-absolutize.workspace = true

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -1450,7 +1450,10 @@ mod tests {
         /// to resolve a task against) surfaces without needing a VM.
         #[tokio::test]
         async fn exec_runs_echo_task() {
-            use minimald_rpc::{ConfigureLoadout, ConfigureLoadoutRequest, CreateSession};
+            use minimald_rpc::{
+                ConfigureLoadout, ConfigureLoadoutRequest, CreateSession, FinalizeSession,
+                FinalizeSessionRequest,
+            };
 
             let server = TestServer::new().await;
             let mut client = server.connect().await;
@@ -1472,7 +1475,7 @@ mod tests {
                 )
                 .await;
 
-            // A task-only mfile gates nothing, so the loadout finalizes in
+            // A task-only mfile gates nothing, so the loadout composes in
             // one shot rather than erroring or pending.
             crate::test_harness::unwrap_ready(
                 client
@@ -1483,6 +1486,21 @@ mod tests {
                     .await
                     .unwrap(),
             );
+
+            // ConfigureLoadout leaves the record `Materializing`; exec
+            // (and its `context()` gate) requires `Active`. This
+            // composition has no patches, so FinalizeSession takes the
+            // empty-composition shortcut past the marker check and
+            // promotes the record to `Active` in one call.
+            match client
+                .call::<FinalizeSession>(&FinalizeSessionRequest { session_id })
+                .await
+            {
+                minimald_rpc::Errorable::Ok(_) => {}
+                minimald_rpc::Errorable::Err { error } => {
+                    panic!("FinalizeSession failed: {error}");
+                }
+            }
 
             let out = client
                 .exec(

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -2,11 +2,12 @@
 use minimald_rpc::IssueClientCertResponse;
 use minimald_rpc::{
     AbortSession, AbortSessionResponse, CreateSession, DestroySession, DestroySessionResponse,
-    Errorable, GetMeshStatus, GetSessionPolicy, GetSessionPolicyRequest, GetSessionRecord,
-    GetSessionRecordRequest, GetSessionRecordResponse, GetVersion, GetVersionResponse,
-    IssueClientCert, IssueClientCertRequest, ListSessions, ListSessionsEntry, ListSessionsResponse,
-    OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse, ResourcePool,
-    Shutdown, ShutdownRequest, ShutdownResponse, SubmitVerdict,
+    Errorable, FinalizeSession, FinalizeSessionResponse, GetMeshStatus, GetSessionPolicy,
+    GetSessionPolicyRequest, GetSessionRecord, GetSessionRecordRequest, GetSessionRecordResponse,
+    GetVersion, GetVersionResponse, IssueClientCert, IssueClientCertRequest, ListSessions,
+    ListSessionsEntry, ListSessionsResponse, OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession,
+    RenameSessionResponse, ResourcePool, Shutdown, ShutdownRequest, ShutdownResponse,
+    SubmitVerdict,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
@@ -239,7 +240,7 @@ async fn serve_configure_loadout(
                 });
             };
             Ok(match h.configure_loadout(req.contribution).await {
-                Ok(None) => Errorable::Ok(minimald_rpc::ConfigureLoadoutResponse::Ready),
+                Ok(None) => Errorable::Ok(minimald_rpc::ConfigureLoadoutResponse::Materialized),
                 Ok(Some(response)) => {
                     Errorable::Ok(minimald_rpc::ConfigureLoadoutResponse::Pending { response })
                 }
@@ -288,6 +289,37 @@ async fn serve_submit_verdict(
                 }
             },
         )
+        .await
+}
+
+/// `FinalizeSession`: promotes a `Materializing` session to
+/// `Active`. Gated on the patches-ready marker being present
+/// under `<workspace>/patches/`; a missing marker (client crashed
+/// mid-upload, or skipped the patches upload entirely) surfaces
+/// as `Errorable::Err`. Idempotent on already-Active sessions.
+async fn serve_finalize_session(
+    s: ServerStateHandle,
+    c: RuChannel<Msg>,
+) -> Result<(), ConnectionError> {
+    FinalizeSession
+        .handle_channel(c, async |req| {
+            let mngr = s.sessions_manager().await;
+            let handle = mngr
+                .get_session(SessionKeyPredicate::Id(req.session_id))
+                .await
+                .map_err(|e| ConnectionError::Internal(e.to_string()))?;
+            let Some(h) = handle else {
+                return Ok(Errorable::Err {
+                    error: format!("no session with ID `{}`", req.session_id.as_ref()),
+                });
+            };
+            Ok(match h.finalize().await {
+                Ok(()) => Errorable::Ok(FinalizeSessionResponse),
+                Err(e) => Errorable::Err {
+                    error: e.to_string(),
+                },
+            })
+        })
         .await
 }
 
@@ -543,6 +575,33 @@ async fn serve_get_mesh_status(
 pub(crate) const STREAM_WORKSPACE_FILES: &str =
     constcat::concat!(RPC_SUBSYSTEM_PREFIX, "WorkspaceFilesTarZst");
 
+pub(crate) const STREAM_WORKSPACE_PATCHES: &str =
+    constcat::concat!(RPC_SUBSYSTEM_PREFIX, "WorkspacePatchesTarZst");
+
+/// Marker file the patches unpacker drops after a successful
+/// atomic swap. `FinalizeSession` checks for its presence before
+/// promoting a session from `Materializing` to `Active`, so a
+/// client-side crash between upload and finalize can't leave the
+/// session `Active` without patches on disk. See the "why the
+/// marker exists" note in `finalize_session_handler`.
+pub(crate) const PATCHES_READY_MARKER: &str = ".patches_ready";
+
+/// Per-entry size cap on incoming patch archives. Legitimate patch files are
+/// dotfiles (KB to a few MB); this ceiling is generous but bounded so a peer
+/// forging a tar header can't push `Vec::with_capacity` into an allocation
+/// error (panic → task abort) or trigger the allocator's OOM handler
+/// (aborts the whole daemon).
+const MAX_PATCH_ENTRY_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Total bytes held in memory across every in-flight patch write in a single
+/// `WorkspacePatchesTarZst` unpack. The per-entry cap alone isn't a memory
+/// bound — the concurrency knob multiplies through it, so on a many-core
+/// host without this the ceiling would be tens of GiB. Fixed at 1 GiB
+/// regardless of core count: legitimate patch payloads are small dotfile
+/// trees; the ceiling exists as an adversarial-input backstop, not as a
+/// throughput knob.
+const MAX_UNPACK_INFLIGHT_BYTES: usize = 1024 * 1024 * 1024;
+
 /// Tallies the bytes pulled through an [`AsyncRead`] into a shared counter.
 ///
 /// The counter is shared rather than returned because the reader is
@@ -601,18 +660,40 @@ async fn serve_stream_workspace_files(
     outcome
 }
 
-/// Unpacks the zstd-compressed tarball streamed over `c` into the
-/// workspace directory of the session named by the channel environment,
-/// tallying the wire bytes it consumes into `received`.
-///
-/// On failure, returns the human-readable message to relay back to the
-/// client over the channel's extended-data stream.
-async fn unpack_workspace_files(
+async fn serve_stream_workspace_patches(
+    s: ServerStateHandle,
+    config: ChannelConfig,
+    mut c: RuChannel<Msg>,
+) -> Result<(), ConnectionError> {
+    let outcome = match unpack_workspace_patches(&s, &config, &mut c).await {
+        Ok(()) => Ok(()),
+        Err(msg) => {
+            let _ = c.extended_data_bytes(1, msg.clone()).await;
+            Err(ConnectionError::Internal(msg))
+        }
+    };
+    let _ = c.close().await;
+    outcome
+}
+
+/// Look up the session for an upload channel: pulls the session id
+/// out of the channel env, resolves the live actor via the manager,
+/// and returns its paths. Shared by both `WorkspaceFilesTarZst` and
+/// `WorkspacePatchesTarZst`.
+async fn upload_session_paths(
     s: &ServerStateHandle,
     config: &ChannelConfig,
-    c: &mut RuChannel<Msg>,
-    received: &Arc<AtomicU64>,
-) -> Result<(), String> {
+) -> Result<crate::session::SessionPaths, String> {
+    Ok(upload_session_handle(s, config).await?.1)
+}
+
+/// Same lookup as [`upload_session_paths`] but returns the session
+/// handle too, so callers that need per-session serialization can
+/// grab a lock without a second manager round-trip.
+async fn upload_session_handle(
+    s: &ServerStateHandle,
+    config: &ChannelConfig,
+) -> Result<(crate::session::SessionHandle, crate::session::SessionPaths), String> {
     let session_id_str = config
         .env_vars
         .get(crate::MINIMAL_SESSION_ID_ENV)
@@ -630,12 +711,27 @@ async fn unpack_workspace_files(
         .paths()
         .await
         .map_err(|e| format!("session is gone: {e}"))?;
+    Ok((session_handle, paths))
+}
 
+/// Unpacks the zstd-compressed tarball streamed over `c` into the
+/// workspace directory of the session named by the channel environment,
+/// tallying the wire bytes it consumes into `received`.
+///
+/// On failure, returns the human-readable message to relay back to the
+/// client over the channel's extended-data stream.
+async fn unpack_workspace_files(
+    s: &ServerStateHandle,
+    config: &ChannelConfig,
+    c: &mut RuChannel<Msg>,
+    received: &Arc<AtomicU64>,
+) -> Result<(), String> {
+    let paths = upload_session_paths(s, config).await?;
     // Emitted once the upload has a destination and before a single byte is
     // pulled, so a transfer that wedges mid-stream still leaves a record
     // saying which session it was for. Its pair is the complete/failed
     // record in the caller.
-    tracing::info!(session_id = %session_id, "workspace upload started");
+    tracing::info!("workspace upload started");
 
     let reader = async_compression::tokio::bufread::ZstdDecoder::new(tokio::io::BufReader::new(
         CountingReader {
@@ -673,6 +769,350 @@ async fn served(fut: impl Future<Output = Result<(), ConnectionError>>) {
     }
 }
 
+/// Unpacks the composition-patches tarball streamed over `c`.
+///
+/// The unpack is **atomic**: entries land in a `<patches_dir>.tmp`
+/// staging dir first, then get swapped into place via rename once
+/// the stream ends cleanly. A mid-stream failure leaves the tmp
+/// tree behind (removed on the next successful run) but never
+/// pollutes `patches/`.
+///
+/// Every archive entry's path is validated against traversal —
+/// `SandboxRelPath::try_new` already rejects absolute paths and
+/// `..` components on the client side, but the client is untrusted
+/// so we re-check the wire form here. Absolute + traversal paths
+/// are dropped with an error before any file is written.
+///
+/// On success, drops [`PATCHES_READY_MARKER`] under the patches
+/// dir. `FinalizeSession` uses that marker as its precondition
+/// for the `Materializing → Active` transition, so this write
+/// order matters: marker only appears once every patch is on disk.
+#[tracing::instrument(level = "debug", skip_all)]
+async fn unpack_workspace_patches(
+    s: &ServerStateHandle,
+    config: &ChannelConfig,
+    c: &mut RuChannel<Msg>,
+) -> Result<(), String> {
+    use std::path::Path as StdPath;
+
+    let (session_handle, paths) = upload_session_handle(s, config).await?;
+    let patches_dir = paths.patches.as_utf8_path().as_std_path().to_path_buf();
+
+    // Per-upload unique staging path so two concurrent uploads for
+    // the same session never share a staging tree. The nanosecond
+    // clock is fine as a discriminator — the per-session upload
+    // lock below serializes the swap, so we don't need a strong
+    // guarantee against collisions, only against name reuse across
+    // the two in-flight tasks.
+    let staging_dir = {
+        let mut d = patches_dir.clone();
+        let suffix = format!(
+            ".upload.{}.tmp",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        );
+        let name = d
+            .file_name()
+            .map(|n| {
+                let mut n = n.to_os_string();
+                n.push(&suffix);
+                n
+            })
+            .unwrap_or_else(|| format!("patches{suffix}").into());
+        d.set_file_name(name);
+        d
+    };
+
+    // Fresh directory. `remove_dir_all` first is defensive against
+    // an earlier `SystemTime` collision — extremely unlikely, but
+    // cheap to guard against.
+    let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+    tokio::fs::create_dir_all(&staging_dir)
+        .await
+        .map_err(|e| format!("creating patch staging dir: {e}"))?;
+
+    // Zstd decode + tar walk + per-entry unpack. Tar itself is a
+    // stream format so decoding entries is sequential, but writing
+    // the entry bodies to disk is where the cost actually is (a
+    // serial loop over `fs::write` capped at ~190 MB/s per entry).
+    // We buffer each body in memory and hand the write off to a
+    // spawned task, so up to N files land on disk in parallel. The
+    // concurrency cap keeps memory bounded (bodies live only until
+    // the write completes) and prevents saturating the runtime's
+    // blocking pool.
+    let reader = async_compression::tokio::bufread::ZstdDecoder::new(tokio::io::BufReader::new(
+        c.make_reader(),
+    ));
+    let archive = async_tar::Archive::new(reader);
+    // Manual iteration so we can reject `..` per-entry before any
+    // bytes hit disk. `Archive::unpack` walks entries itself but
+    // has no per-entry validation hook.
+    use futures::StreamExt as _;
+    use tokio::io::AsyncReadExt as _;
+    let mut entries = archive
+        .entries()
+        .map_err(|e| format!("reading patch tar entries: {e}"))?;
+    let write_concurrency = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    // Byte-budget semaphore: each in-flight body reserves permits
+    // proportional to its size, and can't reserve if the total
+    // in-flight bytes would exceed `MAX_UNPACK_INFLIGHT_BYTES`. This
+    // is *the* backpressure — reserved *before* the body read, so a
+    // slow disk pumps back into the tar decoder (into the pipe,
+    // into the SSH channel) instead of into RAM. The concurrency
+    // count guard below is a secondary limit to keep the blocking
+    // pool from getting saturated by many small entries. `Arc`ed so
+    // the spawned write tasks own their permits.
+    let byte_budget = Arc::new(tokio::sync::Semaphore::new(MAX_UNPACK_INFLIGHT_BYTES));
+    // `JoinSet` (not `FuturesUnordered<JoinHandle>`) so we can
+    // `abort_all` in-flight writes on any error return. Dropping a
+    // `JoinHandle` only detaches the task — writes queued when we
+    // fail would otherwise keep running under `staging_dir`,
+    // racing the next upload's `remove_dir_all` at the top of this
+    // function and burning blocking-pool slots for results nobody
+    // reads.
+    //
+    // `unpack_loop` returns Err on any per-entry problem;
+    // `abort_and_drain` afterward cancels stragglers regardless of
+    // outcome so no writes outlive this function.
+    let mut inflight: tokio::task::JoinSet<Result<(), String>> = tokio::task::JoinSet::new();
+    let loop_result: Result<(), String> = async {
+        while let Some(entry) = entries.next().await {
+            let mut entry = entry.map_err(|e| format!("reading patch tar entry: {e}"))?;
+            let entry_path = entry
+                .path()
+                .map_err(|e| format!("decoding entry path: {e}"))?
+                .into_owned();
+            if !safe_relative_path(&entry_path) {
+                return Err(format!(
+                    "patch archive entry rejected: `{}` contains an absolute path or a `..` component",
+                    entry_path.display()
+                ));
+            }
+            // Reject a patch destination that would clobber the
+            // patches-ready marker. Marker + user patch would
+            // otherwise race, and `materialize_patches_into_home`
+            // would silently copy the emptied marker into the
+            // sandbox home, zeroing whatever the user had there.
+            if entry_path == StdPath::new(PATCHES_READY_MARKER) {
+                return Err(format!(
+                    "patch archive entry rejected: `{}` collides with the daemon's \
+                     patches-ready marker filename",
+                    entry_path.display()
+                ));
+            }
+            // Patches are individual files copied verbatim into the
+            // sandbox home. The client's uploader
+            // (`Client::upload_patches` → `TarZstArchive::add_file`)
+            // only ever emits `EntryType::Regular` — symlink sources
+            // are read through (their target's bytes get archived as
+            // a regular file, dropping the link relation on the
+            // client side, on purpose) and directory sources fan
+            // out into per-file Regular entries. Every non-Regular
+            // entry type is out of scope: we do not create
+            // directories, symlinks, hardlinks, or device nodes in
+            // the sandbox home from a patch archive. Blindly running
+            // `tokio::fs::write` for any of those would silently
+            // land an empty file at that path — a directory entry
+            // would then break `create_dir_all(parent)` for its
+            // children, and a symlink entry would drop the link
+            // target on the floor. Fail loudly instead.
+            let entry_type = entry.header().entry_type();
+            if !matches!(
+                entry_type,
+                async_tar::EntryType::Regular | async_tar::EntryType::Continuous
+            ) {
+                return Err(format!(
+                    "patch archive entry rejected: `{}` is {:?}; only regular files are \
+                     supported",
+                    entry_path.display(),
+                    entry_type,
+                ));
+            }
+            let entry_size = entry.header().size().unwrap_or(0);
+            // Per-entry cap: refuses forged headers that would push
+            // `Vec::with_capacity` into an allocation panic or OOM
+            // (allocator abort → whole daemon down) before we ever
+            // reserve budget.
+            if entry_size > MAX_PATCH_ENTRY_BYTES {
+                return Err(format!(
+                    "patch archive entry rejected: `{}` declares {entry_size} bytes, \
+                     exceeds the {MAX_PATCH_ENTRY_BYTES}-byte per-entry cap",
+                    entry_path.display()
+                ));
+            }
+
+            // Concurrency backpressure: bound the number of writes
+            // in flight before we spawn the next one. Kept alongside
+            // the byte budget below so a batch of tiny entries can't
+            // saturate the blocking pool.
+            while inflight.len() >= write_concurrency {
+                match inflight.join_next().await {
+                    Some(Ok(Ok(()))) => {}
+                    Some(Ok(Err(e))) => return Err(e),
+                    Some(Err(join_err)) => {
+                        return Err(format!("write task panicked: {join_err}"))
+                    }
+                    None => break,
+                }
+            }
+
+            // Byte-budget backpressure: reserve permits equal to
+            // the entry size *before* the body read, so a stalled
+            // fs::write can't let bodies pile up in RAM ahead of
+            // it. Zero-byte entries take one permit — semaphores
+            // can't acquire zero, but the practical peak is still
+            // dominated by real-body permits.
+            let permit_bytes = std::cmp::max(entry_size as usize, 1);
+            let permit = Arc::clone(&byte_budget)
+                .acquire_many_owned(permit_bytes as u32)
+                .await
+                .map_err(|e| format!("byte-budget semaphore closed: {e}"))?;
+
+            let mut body = Vec::with_capacity(entry_size as usize);
+            entry
+                .read_to_end(&mut body)
+                .await
+                .map_err(|e| format!("reading body of `{}`: {e}", entry_path.display()))?;
+
+            let dest = staging_dir.join(&entry_path);
+            let path_display = entry_path.display().to_string();
+            inflight.spawn(async move {
+                if let Some(parent) = dest.parent() {
+                    tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                        format!("creating parent dir for `{path_display}`: {e}")
+                    })?;
+                }
+                tokio::fs::write(&dest, &body)
+                    .await
+                    .map_err(|e| format!("writing `{path_display}`: {e}"))?;
+                // Explicit drop keeps the permit alive across the
+                // fs::write so the byte budget only frees up after
+                // the buffer is genuinely gone.
+                drop(body);
+                drop(permit);
+                Ok::<_, String>(())
+            });
+        }
+        // Drain any tasks still in flight.
+        while let Some(res) = inflight.join_next().await {
+            match res {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => return Err(e),
+                Err(join_err) if join_err.is_cancelled() => {}
+                Err(join_err) => return Err(format!("write task panicked: {join_err}")),
+            }
+        }
+        Ok(())
+    }
+    .await;
+
+    if loop_result.is_err() {
+        // Cancel and drain every straggler write before returning.
+        // `abort_all` only marks tasks; the drain awaits each
+        // cancellation so no fs::write outlives this function and
+        // races the next upload's `remove_dir_all`.
+        inflight.abort_all();
+        while inflight.join_next().await.is_some() {}
+    }
+    loop_result?;
+
+    // Serialize the swap + marker-write against any other
+    // in-flight `WorkspacePatchesTarZst` upload for this same
+    // session. Two concurrent uploads would otherwise race on
+    // `patches_dir` — one's `RENAME_EXCHANGE` could observe an
+    // unexpected mid-swap state, or the marker could get written
+    // pointing at the wrong upload's contents. The staging phase
+    // above ran without the lock (all writes went to a per-upload
+    // unique dir), so we only pay the serialization cost across
+    // the seconds-of-work install step, not the minutes-of-work
+    // unpack.
+    let _swap_guard = session_handle.patches_upload_lock().lock_owned().await;
+
+    // Install the new tree. Two shapes depending on whether a
+    // prior `patches/` exists:
+    //
+    // 1. **Prior tree present** — `renameat2(RENAME_EXCHANGE)` swaps
+    //    the staging tree and the live tree atomically. At every
+    //    instant an on-disk lookup sees exactly one of the two
+    //    trees, and each carries a valid marker (the old one from
+    //    the prior successful unpack, the new one written below).
+    //    A `FinalizeSession` racing the swap can't observe a gap
+    //    where `patches/` doesn't exist or where the marker is
+    //    absent, only "old contents + old marker" or "new contents
+    //    + new marker."  We swap the trees first (contents on
+    //    disk), then delete the old contents that ended up under
+    //    `staging_dir` after the swap, then write the new marker
+    //    over the old one.
+    // 2. **First install** — no prior tree, so `RENAME_EXCHANGE`
+    //    fails with `ENOENT`. Plain `rename` is atomic in this
+    //    case (nothing to displace), so we fall through to it.
+    //
+    // Go through `common::renameat2` (a direct `renameat2(2)`
+    // syscall wrapper) rather than `nix::fcntl::renameat2`: nix
+    // gates that wrapper behind `target_env = "gnu"`, but `minimald`
+    // is also cross-compiled for static musl (the guest initramfs),
+    // where the nix item is configured out.
+    let swap_result = tokio::task::spawn_blocking({
+        let staging_dir = staging_dir.clone();
+        let patches_dir = patches_dir.clone();
+        move || {
+            common::renameat2::renameat2_cwd(
+                &staging_dir,
+                &patches_dir,
+                common::renameat2::RENAME_EXCHANGE,
+            )
+        }
+    })
+    .await
+    .map_err(|e| format!("atomic-swap task panicked: {e}"))?;
+    match swap_result {
+        Ok(()) => {
+            // `staging_dir` now holds the previous `patches/` tree
+            // (post-exchange). Drop it — a partial cleanup here is
+            // fine; the next unpack's leading `remove_dir_all`
+            // covers it.
+            let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+        }
+        Err(e) if e.raw_os_error() == Some(libc::ENOENT) => {
+            // No prior tree — the `RENAME_EXCHANGE` requires both
+            // sides to exist. Plain rename is atomic when the
+            // destination doesn't exist yet.
+            tokio::fs::rename(&staging_dir, &patches_dir)
+                .await
+                .map_err(|e| format!("swapping patches dir into place: {e}"))?;
+        }
+        Err(e) => {
+            return Err(format!("atomic-swap of patches dir failed: {e}"));
+        }
+    }
+
+    // Marker last, so `patches/`'s newly-swapped contents can never
+    // coexist with a stale marker. If we crash between the swap and
+    // this write, the next upload's swap replaces the whole tree
+    // and rewrites the marker — FinalizeSession is what fails safe,
+    // not this handler.
+    let marker = patches_dir.join(StdPath::new(PATCHES_READY_MARKER));
+    tokio::fs::write(&marker, b"")
+        .await
+        .map_err(|e| format!("writing patches-ready marker: {e}"))?;
+
+    Ok(())
+}
+
+/// Returns true if `p` is a relative path with no `..` components.
+/// Enforced on every wire-supplied archive entry name.
+fn safe_relative_path(p: &std::path::Path) -> bool {
+    if p.is_absolute() {
+        return false;
+    }
+    !p.components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+}
+
 /// Handles an RPC going over an SSH subsystem channel.
 ///
 /// This method takes ownership of the ssh channel, including
@@ -700,6 +1140,7 @@ pub async fn handle_ssh_rpc(
         | CreateSession::NAME
         | minimald_rpc::ConfigureLoadout::NAME
         | SubmitVerdict::NAME
+        | FinalizeSession::NAME
         | RenameSession::NAME
         | DestroySession::NAME
         | Shutdown::NAME
@@ -707,6 +1148,7 @@ pub async fn handle_ssh_rpc(
         | GetSessionPolicy::NAME
         | GetMeshStatus::NAME
         | STREAM_WORKSPACE_FILES
+        | STREAM_WORKSPACE_PATCHES
         | minimald_rpc::DIAG_BUNDLE_SUBSYSTEM
         | IssueClientCert::NAME => {
             let mut conn_lock = c.lock().await;
@@ -777,6 +1219,7 @@ pub async fn handle_ssh_rpc(
         CreateSession::NAME => serve!(serve_create_session(s, channel, ssh_username)),
         minimald_rpc::ConfigureLoadout::NAME => serve!(serve_configure_loadout(s, channel)),
         SubmitVerdict::NAME => serve!(serve_submit_verdict(s, channel)),
+        FinalizeSession::NAME => serve!(serve_finalize_session(s, channel)),
         RenameSession::NAME => serve!(serve_rename_session(s, channel)),
         DestroySession::NAME => serve!(serve_destroy_session(s, channel)),
         Shutdown::NAME => serve!(serve_shutdown(s, channel)),
@@ -784,6 +1227,7 @@ pub async fn handle_ssh_rpc(
         GetSessionPolicy::NAME => serve!(serve_get_session_policy(s, channel)),
         GetMeshStatus::NAME => serve!(serve_get_mesh_status(s, channel)),
         STREAM_WORKSPACE_FILES => serve!(serve_stream_workspace_files(s, config, channel)),
+        STREAM_WORKSPACE_PATCHES => serve!(serve_stream_workspace_patches(s, config, channel)),
         minimald_rpc::DIAG_BUNDLE_SUBSYSTEM => {
             serve!(crate::diag::serve_stream_diag_bundle(s, config, channel))
         }
@@ -951,6 +1395,88 @@ mod tests {
         assert_eq!(sunk, payload);
         assert_eq!(read, payload.len() as u64);
         assert_eq!(count.load(Ordering::Relaxed), payload.len() as u64);
+    }
+
+    /// `WorkspacePatchesTarZst` unpacks each entry under
+    /// `<workspace>/patches/<archive-path>` and drops the ready
+    /// marker on success. Guards the write ordering
+    /// (staging-dir → atomic rename → marker) that FinalizeSession
+    /// depends on.
+    #[tokio::test]
+    async fn stream_workspace_patches_unpacks_and_writes_marker() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let payload = tar_zst(&[
+            (".config/helix/config.toml", b"theme = 'nord'\n"),
+            (".config/other.toml", b"key = 'value'\n"),
+        ])
+        .await;
+
+        let channel = client
+            .open_subsystem(
+                STREAM_WORKSPACE_PATCHES,
+                &[(MINIMAL_SESSION_ID_ENV, &session_id.to_string())],
+            )
+            .await;
+        let mut stream = channel.into_stream();
+        stream.write_all(&payload).await.unwrap();
+        stream.shutdown().await.unwrap();
+        let mut trailing = Vec::new();
+        stream.read_to_end(&mut trailing).await.unwrap();
+
+        let mngr = server.state.sessions_manager().await;
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("session should be retrievable");
+        let paths = handle.paths().await.unwrap();
+        let patches = paths.patches.as_utf8_path();
+
+        assert_eq!(
+            tokio::fs::read(patches.join(".config/helix/config.toml"))
+                .await
+                .unwrap(),
+            b"theme = 'nord'\n",
+        );
+        assert_eq!(
+            tokio::fs::read(patches.join(".config/other.toml"))
+                .await
+                .unwrap(),
+            b"key = 'value'\n",
+        );
+        assert!(
+            tokio::fs::try_exists(patches.join(PATCHES_READY_MARKER))
+                .await
+                .unwrap(),
+            "patches-ready marker must be written on successful unpack",
+        );
+    }
+
+    /// Unit test on the daemon-side traversal guard — the piece
+    /// covering a malicious peer that hand-crafts a raw tar with
+    /// `..` entries (the client's own `async_tar` builder refuses
+    /// to construct one, and `SandboxRelPath::try_new` already
+    /// rejects them at the wire-schema level, so this is a
+    /// defense-in-depth check for the "hand-crafted bytes"
+    /// scenario the earlier layers don't cover).
+    #[test]
+    fn safe_relative_path_rejects_absolute_and_traversal() {
+        use std::path::Path as StdPath;
+        // Absolute — must reject.
+        assert!(!super::safe_relative_path(StdPath::new("/etc/foo")));
+        // `..` at any position — must reject.
+        assert!(!super::safe_relative_path(StdPath::new("../evil")));
+        assert!(!super::safe_relative_path(StdPath::new("a/../b")));
+        assert!(!super::safe_relative_path(StdPath::new("a/b/..")));
+        // Ordinary relative paths — must accept.
+        assert!(super::safe_relative_path(StdPath::new("a")));
+        assert!(super::safe_relative_path(StdPath::new("a/b/c")));
+        assert!(super::safe_relative_path(StdPath::new(
+            ".config/helix/config.toml"
+        )));
     }
 
     #[tokio::test]

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -25,6 +25,45 @@ use std::sync::RwLock;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
 
+/// Copy every `composition.patches()` entry from the staged
+/// `<workspace>/patches/<dest>` into the session's home dir at
+/// the same relative path. Called once by [`Session::finalize`]
+/// when the session goes `Active`; subsequent attaches see the
+/// populated home without re-copying.
+///
+/// Parent dirs are created as needed. A missing staged patch
+/// surfaces as an `io::Error` — the FinalizeSession precondition
+/// checked the patches-ready marker, so a missing file at this
+/// point is a bug (the marker was written but the file it should
+/// have gated on didn't land).
+async fn materialize_patches_into_home(
+    patches_dir: &DaemonAbsPath,
+    home_dir: &DaemonAbsPath,
+    composition: &Composition,
+) -> Result<(), std::io::Error> {
+    for sp in composition.patches() {
+        let dest = sp.patch().destination().as_utf8_path();
+        let src = patches_dir.as_utf8_path().join(dest);
+        let target = home_dir.as_utf8_path().join(dest);
+        if let Some(parent) = target.parent() {
+            tokio::fs::create_dir_all(parent.as_std_path()).await?;
+        }
+        tokio::fs::copy(src.as_std_path(), target.as_std_path())
+            .await
+            .map_err(|e| {
+                std::io::Error::new(
+                    e.kind(),
+                    format!(
+                        "materializing patch {} → {}: {e}",
+                        src.as_str(),
+                        target.as_str()
+                    ),
+                )
+            })?;
+    }
+    Ok(())
+}
+
 /// The name a session's PTask hostname is registered under, doubling as the
 /// session host's display name: the session's assigned name, or the project
 /// directory's basename when unnamed.
@@ -51,9 +90,12 @@ pub enum AttachError {
     /// Configuring the loadout of an as-yet-unconfigured session, on the way
     /// into the attach, failed.
     LoadoutFailed(std::io::Error),
-    /// The session's composition is awaiting the client's contribution
-    /// verdict, so there is nothing to attach to yet. The client has to gate
-    /// the pending items (`SubmitVerdict`) before a shell can be minted.
+    /// The session isn't attachable yet. Either its composition is
+    /// still awaiting the client's contribution verdict
+    /// (`SubmitVerdict` hasn't landed), or its composition
+    /// finalized but the session is `Materializing` — the
+    /// client still owes a patches upload + `FinalizeSession`
+    /// before a shell can be minted.
     SessionPending,
 }
 
@@ -79,7 +121,8 @@ impl fmt::Display for AttachError {
             AttachError::LoadoutFailed(e) => write!(f, "configuring session loadout: {e}"),
             AttachError::SessionPending => write!(
                 f,
-                "session is awaiting its contribution verdict; cannot attach"
+                "session isn't attachable yet (still awaiting either \
+                 SubmitVerdict or FinalizeSession)"
             ),
         }
     }
@@ -91,6 +134,12 @@ pub struct SessionPaths {
     pub working: DaemonAbsPath,
     pub cache: DaemonAbsPath,
     pub home: DaemonAbsPath,
+    /// Where the daemon stages client-uploaded composition patches
+    /// (`WorkspacePatchesTarZst` unpacks under this dir, keyed by
+    /// the patch's sandbox-home-relative destination). Directory
+    /// may not exist yet — it's created on the first successful
+    /// upload.
+    pub patches: DaemonAbsPath,
 }
 
 /// Everything a [`Session`] actor needs at spawn time. Every session actor
@@ -191,6 +240,11 @@ enum SessionMessage {
             oneshot::Sender<Result<SessionStep, std::io::Error>>,
         )>,
     ),
+    /// Promote a `Materializing` session to `Active`, gating on the
+    /// patches-ready marker under `<workspace>/patches/`. Idempotent
+    /// on an already-`Active` session; refused with `InvalidInput`
+    /// on `Pending` (configure the loadout first).
+    Finalize(oneshot::Sender<Result<(), std::io::Error>>),
     /// Abort a `Draft` session: delete its record and stop the actor.
     /// Refused with `InvalidInput` on an `Active` session (use `Destroy`).
     Abort(oneshot::Sender<Result<(), std::io::Error>>),
@@ -319,6 +373,40 @@ impl Session {
                 host: None,
             },
             SessionStatus::Pending => SessionInner::Draft { pending: None },
+            // `Materializing` records are only meaningful across a
+            // matching in-memory composition, which is lost on
+            // daemon restart. `Manager::init` runs
+            // `reap_unresumable_records` at startup to delete these
+            // before any actor spawns.
+            //
+            // If we still see one here — spawn racing the reap,
+            // reap's delete failing (permissions, EIO) and being
+            // logged-and-skipped, or a future code path adding a
+            // spawn that bypasses the reap — refuse to bring the
+            // actor up. Every alternative gets a session into a
+            // bad shape:
+            //
+            //   * `SessionInner::Draft { pending: None }` would let
+            //     `configure_loadout` accept a fresh contribution
+            //     while the on-disk status stays `Materializing`,
+            //     drifting the two into inconsistency.
+            //   * A stale `.patches_ready` from the prior upload
+            //     could then satisfy the *new* composition's
+            //     finalize marker check, materializing the wrong
+            //     patches into the sandbox home.
+            //   * `SessionInner::Active { composition: None }`
+            //     would let attach reach a shell against a session
+            //     that never actually finished materializing.
+            //
+            // Fail the spawn instead; the caller sees an error and
+            // the operator can destroy the stuck record explicitly.
+            SessionStatus::Materializing => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "session record is Materializing but has no in-memory composition \
+                     (restart-orphaned actor); destroy the session and re-activate",
+                ));
+            }
         };
 
         let (sender, receiver) = mpsc::channel(8);
@@ -332,7 +420,10 @@ impl Session {
         actor.register_hostname(obj.record());
 
         tokio::spawn(actor.mainloop());
-        Ok(SessionHandle(sender))
+        Ok(SessionHandle {
+            sender,
+            patches_upload_lock: Arc::new(Mutex::new(())),
+        })
     }
 
     /// Register this session's PTask hostname (R3.1/R3.6). Both HostNet and
@@ -451,6 +542,9 @@ impl Session {
             SessionMessage::SubmitVerdict(msg) => {
                 let (verdict, r) = *msg;
                 let _ = r.send(self.handle_verdict(verdict).await);
+            }
+            SessionMessage::Finalize(r) => {
+                let _ = r.send(self.finalize().await);
             }
             SessionMessage::Abort(r) => match &self.inner {
                 // Abort is Draft-only: delete the record, then stop. The
@@ -574,17 +668,21 @@ impl Session {
             // The composition is complete: promote the record
             // `Pending → Active` and hold the composition for the launcher.
             ComposeOutcome::Ready(composition) => {
+                // Compose finalized in one shot — the record is now
+                // `Materializing`, not yet `Active`. `Active` waits
+                // for `FinalizeSession` after the client has
+                // uploaded the composition's patches. Hostname
+                // registration is deferred to the same transition
+                // (a session isn't attachable until then, so
+                // publishing the route would let something reach a
+                // launcher that can't materialize its patches).
                 let mut record = object.record().clone();
-                record.status = SessionStatus::Active;
+                record.status = SessionStatus::Materializing;
                 self.record.write(record.clone()).await?;
                 self.inner = SessionInner::Active {
                     composition: Some(Arc::new(composition)),
                     host: None,
                 };
-                // The session is Active now — publish its PTask route
-                // (R3.1/R3.6).
-                #[cfg(target_os = "linux")]
-                self.register_hostname(&record);
                 Ok(None)
             }
             // The client must gate items before the composition completes.
@@ -642,20 +740,151 @@ impl Session {
             Err(e) => return Ok(SessionStep::Fault { error: e.into() }),
         };
 
-        // Promote the on-disk record `Pending → Active`. A write failure
-        // leaves both the record and the actor `Draft`, so the client can
-        // re-submit the same verdict once the store recovers.
+        // Promote the on-disk record `Pending → Materializing`. A
+        // write failure leaves both the record and the actor
+        // `Draft`, so the client can re-submit the same verdict
+        // once the store recovers. `Active` waits for a follow-up
+        // `FinalizeSession` after patches upload — see
+        // [`Self::finalize`] for the transition and its
+        // preconditions.
         let mut record = self.record.record().await?;
-        record.status = SessionStatus::Active;
+        record.status = SessionStatus::Materializing;
         self.record.write(record.clone()).await?;
         self.inner = SessionInner::Active {
             composition: Some(Arc::new(composition)),
             host: None,
         };
-        // The session is Active now — publish its PTask route (R3.1/R3.6).
-        #[cfg(target_os = "linux")]
-        self.register_hostname(&record);
-        Ok(SessionStep::Active { id: record.id })
+        Ok(SessionStep::Materialized { id: record.id })
+    }
+
+    /// Finalize a `Materializing` session: verify that the client
+    /// has uploaded its composition patches (marker present under
+    /// `<workspace>/patches/`), promote the record
+    /// `Materializing → Active`, and publish the PTask route so
+    /// the session becomes attachable.
+    ///
+    /// Idempotent: a session already in `Active` (client retried
+    /// after a network blip that lost the ack) returns success
+    /// without side effects. Refuses `Pending` or `Draft` sessions
+    /// with `WrongState`; refuses `Materializing` sessions without
+    /// a patches-ready marker with a "patches upload never
+    /// finished" fault.
+    async fn finalize(&mut self) -> Result<(), std::io::Error> {
+        let record = self.record.record().await?;
+        match record.status {
+            SessionStatus::Active => {
+                // Already finalized — retry is a no-op.
+                Ok(())
+            }
+            SessionStatus::Materializing => {
+                // Guard against a `Materializing` record whose
+                // actor didn't carry compose state through — the
+                // only path there is `Session::run` spawning from
+                // an on-disk `Materializing` record after a
+                // restart survived the reap in `Manager::init`
+                // (delete failed, log-and-skip). Without the
+                // in-memory composition we can't tell whether the
+                // patches were uploaded; `has_patches` below would
+                // trivially match `false` and skip the marker
+                // check, then `materialize_patches_into_home`
+                // would iterate an empty composition and no-op —
+                // silently promoting the session to `Active` with
+                // an empty home. Fault the finalize so the client
+                // sees the problem instead of the user attaching
+                // to a broken shell.
+                if !matches!(
+                    &self.inner,
+                    SessionInner::Active {
+                        composition: Some(_),
+                        ..
+                    }
+                ) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "session is Materializing but has no in-memory composition \
+                         (restart-orphaned actor); destroy the session and re-activate",
+                    ));
+                }
+
+                // Precondition: patches marker present on disk. The
+                // marker is the last thing the patches unpacker
+                // writes, so its presence proves every patch is
+                // staged. Without this check a client-side bug
+                // that skipped the patches upload would silently
+                // yield an Active session with a broken sandbox
+                // rootfs.
+                //
+                // Short-circuit: a composition with no patches has
+                // nothing for the client to upload, so the marker
+                // isn't required. Callers with empty compositions
+                // (internal ones — sftp/exec/session-recovery — and
+                // any project with no fs mappings) go straight
+                // through here.
+                let paths_obj = self.record.object().await?;
+                let patches_dir = paths_obj.patches_path();
+                let has_patches = matches!(
+                    &self.inner,
+                    SessionInner::Active {
+                        composition: Some(c),
+                        ..
+                    } if !c.patches().is_empty()
+                );
+                if has_patches {
+                    let marker = patches_dir
+                        .as_utf8_path()
+                        .join(crate::rpc::PATCHES_READY_MARKER);
+                    // Distinguish "marker absent" (client forgot the
+                    // upload; retry the upload + FinalizeSession)
+                    // from "we couldn't tell" (permissions, filesystem
+                    // I/O). Collapsing the latter into the former
+                    // sends the operator chasing an upload that
+                    // already succeeded when the real fault is a
+                    // broken workspace dir.
+                    let marker_present = tokio::fs::try_exists(&marker).await.map_err(|e| {
+                        std::io::Error::new(
+                            e.kind(),
+                            format!("checking patches-ready marker at {}: {e}", marker.as_str()),
+                        )
+                    })?;
+                    if !marker_present {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "patches upload never completed; cannot finalize \
+                             (upload patches, then retry FinalizeSession)",
+                        ));
+                    }
+                }
+
+                // Materialize the composition's patches into the
+                // session's home dir. Done here — once — rather
+                // than on every attach so the sandbox home is
+                // populated exactly at the point the session
+                // becomes attachable, and subsequent attaches see
+                // the same tree without re-copying (which would
+                // clobber any in-sandbox modifications the user
+                // made in prior attaches). If the composition has
+                // no patches, this is a no-op.
+                if let SessionInner::Active {
+                    composition: Some(comp),
+                    ..
+                } = &self.inner
+                {
+                    let home = paths_obj.home_path();
+                    materialize_patches_into_home(&patches_dir, &home, comp).await?;
+                }
+
+                let mut record = record;
+                record.status = SessionStatus::Active;
+                self.record.write(record.clone()).await?;
+                #[cfg(target_os = "linux")]
+                self.register_hostname(&record);
+                Ok(())
+            }
+            SessionStatus::Pending => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "session is Pending; configure the loadout first",
+            )),
+        }
     }
 
     /// Tears down the running host, if any, waiting for the process to be reaped
@@ -720,10 +949,72 @@ impl Session {
         // Composition that comes back `Pending` is the one case we can't
         // resolve here — items need a client-side gate — and falls through to
         // the refusal below.
+        //
+        // The shortcut only works when the composition ends up with
+        // no patches. Patches require the client to run the
+        // `WorkspacePatchesTarZst` upload + `FinalizeSession`
+        // sequence, and this attach path has no way to obtain those
+        // files — nothing on the daemon side reaches back to the
+        // client to solicit an upload. If we ran `configure_loadout`
+        // and it produced patches, the record would be stuck at
+        // `Materializing` with no path to `Active` and every
+        // subsequent attach would hit the `SessionPending` refusal.
+        // So: run the configure, and if patches surfaced, roll the
+        // in-memory state back to `Draft { pending: None }` (the
+        // record's on-disk `Materializing` status still leaves it
+        // reachable for `DestroySession`) and refuse the attach with
+        // an actionable error naming the required explicit flow.
         if let SessionInner::Draft { pending: None } = &self.inner {
             self.configure_loadout(WireContribution::default())
                 .await
                 .map_err(AttachError::LoadoutFailed)?;
+            let has_patches = matches!(
+                &self.inner,
+                SessionInner::Active {
+                    composition: Some(c),
+                    ..
+                } if !c.patches().is_empty()
+            );
+            if has_patches {
+                // Refuse: this attach path can't run the
+                // upload + FinalizeSession sequence the composition
+                // requires. `finalize`'s per-op guard will refuse
+                // any later attempt against this Materializing
+                // record, so the operator has to destroy it and
+                // re-activate through `min activate`, which drives
+                // the full flow.
+                return Err(AttachError::LoadoutFailed(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "composition has patches that can only be uploaded via `min activate` \
+                     (ConfigureLoadout → WorkspacePatchesTarZst → FinalizeSession); \
+                     the attach shortcut can't drive that sequence — destroy this session \
+                     and re-activate through the CLI",
+                )));
+            }
+            // No patches: finalize inline so the shortcut still
+            // yields an attachable session. The marker check inside
+            // `finalize` is gated on `!composition.patches().is_empty()`,
+            // so an empty composition doesn't need the dir + marker
+            // to exist: `finalize` skips the check, `materialize`
+            // iterates zero patches, and the record is written as
+            // `Active`.
+            self.finalize().await.map_err(AttachError::LoadoutFailed)?;
+        }
+
+        // Attach is gated on `Active` — a Materializing session has
+        // a composition but its patches may not be on disk yet,
+        // and materializing without them would produce a broken
+        // sandbox rootfs. See [`Session::finalize`] for the
+        // transition.
+        {
+            let record = self
+                .record
+                .record()
+                .await
+                .map_err(AttachError::LoadoutFailed)?;
+            if record.status != SessionStatus::Active {
+                return Err(AttachError::SessionPending);
+            }
         }
 
         let host = match &mut self.inner {
@@ -856,9 +1147,31 @@ impl Session {
     ///
     /// This is NOT cached to enable session execution to change as the
     /// `minimal.toml` file changes.
+    ///
+    /// Gated on the same lifecycle status as [`Session::attach`]:
+    /// the on-disk record must be `Active`. `SessionInner::Active`
+    /// alone doesn't distinguish `Materializing` (composition done,
+    /// patches not yet uploaded and not yet materialized into the
+    /// sandbox home) from `Active` (fully ready). Building a
+    /// context and running a task against a `Materializing`
+    /// session would execute against an unpopulated home dir —
+    /// the exact lifecycle escape the `Materializing` state was
+    /// added to prevent.
     async fn context(&mut self, scaffold_if_missing: bool) -> Result<mctx::Context, String> {
         if matches!(&self.inner, SessionInner::Draft { .. }) {
             return Err("session is pending composition".to_string());
+        }
+        let record = self
+            .record
+            .record()
+            .await
+            .map_err(|e| format!("reading session record: {e}"))?;
+        if record.status != SessionStatus::Active {
+            return Err(format!(
+                "session isn't attachable yet (status is {:?}, need Active — \
+                 finish the upload + FinalizeSession sequence first)",
+                record.status,
+            ));
         }
 
         let ctx = self.build_context(scaffold_if_missing).await?;
@@ -929,22 +1242,44 @@ impl Session {
             working: obj.workspace_path(),
             cache: obj.cache_path(),
             home: obj.home_path(),
+            patches: obj.patches_path(),
         }
     }
 }
 
 /// The handle to the session.
 #[derive(Debug, Clone)]
-pub struct SessionHandle(mpsc::Sender<SessionMessage>);
+pub struct SessionHandle {
+    sender: mpsc::Sender<SessionMessage>,
+    /// Serializes `WorkspacePatchesTarZst` uploads for this session: two
+    /// concurrent uploads would race on the single `<workspace>/patches/`
+    /// tree, and neither one's atomic-swap install would happen against a
+    /// known baseline (one could wipe the other's freshly-installed tree
+    /// and see its own `RENAME_EXCHANGE` return an unexpected state).
+    /// Held only across the whole unpack + install + marker-write, so an
+    /// idle session never contends on it. `Arc<Mutex>` (not
+    /// `parking_lot`) because the critical section awaits.
+    patches_upload_lock: Arc<Mutex<()>>,
+}
 
 impl SessionHandle {
     /// Returns paths on the daemon backing various internals of the session.
     /// A dead actor (self-terminated abort/failed-verdict/create-failure, or
     /// mid-teardown) maps to `NotConnected` — callers race actor death.
+    /// Handle to the per-session patches-upload lock. Held by
+    /// `WorkspacePatchesTarZst` for the whole unpack + install +
+    /// marker-write, so two concurrent uploads for the same session
+    /// can't race on the single `<workspace>/patches/` tree. Idle
+    /// sessions never contend on it. Cheap to clone (an `Arc`
+    /// bump).
+    pub fn patches_upload_lock(&self) -> Arc<Mutex<()>> {
+        Arc::clone(&self.patches_upload_lock)
+    }
+
     pub async fn paths(&self) -> Result<SessionPaths, std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.0.send(SessionMessage::GetPaths(send)).await;
+        let _ = self.sender.send(SessionMessage::GetPaths(send)).await;
         recv.await.map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
         })
@@ -955,7 +1290,7 @@ impl SessionHandle {
     pub async fn get_attrs(&self) -> Option<HostAttrs> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.0.send(SessionMessage::GetHostAttrs(send)).await;
+        let _ = self.sender.send(SessionMessage::GetHostAttrs(send)).await;
         recv.await.ok().flatten()
     }
 
@@ -963,7 +1298,7 @@ impl SessionHandle {
     pub async fn context(&self) -> Result<mctx::Context, String> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.0.send(SessionMessage::MakeContext(send)).await;
+        let _ = self.sender.send(SessionMessage::MakeContext(send)).await;
         recv.await
             .unwrap_or_else(|_| Err("session actor is gone".to_string()))
     }
@@ -975,7 +1310,7 @@ impl SessionHandle {
     pub(crate) async fn record(&self) -> Result<Record, std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.0.send(SessionMessage::GetRecord(send)).await;
+        let _ = self.sender.send(SessionMessage::GetRecord(send)).await;
         recv.await.map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
         })
@@ -993,7 +1328,7 @@ impl SessionHandle {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self
-            .0
+            .sender
             .send(SessionMessage::ConfigureLoadout(contribution, send))
             .await;
         recv.await.unwrap_or_else(|_| {
@@ -1005,10 +1340,13 @@ impl SessionHandle {
     }
 
     /// Submit the client's contribution verdict against a `Draft` session.
-    /// On success the actor promotes its record to `Active` and replies with
-    /// [`SessionStep::Active`]; structured failures (wrong state, an
-    /// unresumable verdict) come back as [`SessionStep::Fault`]. A dead
-    /// actor maps to `NotConnected` (the caller reads it as unknown-session).
+    /// On success the actor promotes its record from `Pending` to
+    /// `Materializing` and replies with [`SessionStep::Materialized`]; the
+    /// client still has to upload patches and call `FinalizeSession`
+    /// before the session becomes attachable. Structured failures
+    /// (wrong state, an unresumable verdict) come back as
+    /// [`SessionStep::Fault`]. A dead actor maps to `NotConnected`
+    /// (the caller reads it as unknown-session).
     pub(crate) async fn submit_verdict(
         &self,
         verdict: ContributionVerdict,
@@ -1016,9 +1354,26 @@ impl SessionHandle {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self
-            .0
+            .sender
             .send(SessionMessage::SubmitVerdict(Box::new((verdict, send))))
             .await;
+        recv.await.unwrap_or_else(|_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "session actor is gone",
+            ))
+        })
+    }
+
+    /// Promote a `Materializing` session to `Active`, gating on the
+    /// patches-ready marker having been written by a completed
+    /// `WorkspacePatchesTarZst` upload. Idempotent on already-Active
+    /// sessions. See [`Session::finalize`] for the state-machine
+    /// contract.
+    pub(crate) async fn finalize(&self) -> Result<(), std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.sender.send(SessionMessage::Finalize(send)).await;
         recv.await.unwrap_or_else(|_| {
             Err(std::io::Error::new(
                 std::io::ErrorKind::NotConnected,
@@ -1033,7 +1388,7 @@ impl SessionHandle {
     pub(crate) async fn abort(&self) -> Result<(), std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.0.send(SessionMessage::Abort(send)).await;
+        let _ = self.sender.send(SessionMessage::Abort(send)).await;
         recv.await.unwrap_or_else(|_| {
             Err(std::io::Error::new(
                 std::io::ErrorKind::NotConnected,
@@ -1048,7 +1403,7 @@ impl SessionHandle {
     pub(crate) async fn is_busy(&self) -> bool {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.0.send(SessionMessage::IsBusy(send)).await;
+        let _ = self.sender.send(SessionMessage::IsBusy(send)).await;
         recv.await.unwrap_or(false)
     }
 
@@ -1058,7 +1413,10 @@ impl SessionHandle {
     #[cfg(test)]
     pub(crate) async fn peek_composition(&self) -> Option<Arc<Composition>> {
         let (send, recv) = oneshot::channel();
-        let _ = self.0.send(SessionMessage::PeekComposition(send)).await;
+        let _ = self
+            .sender
+            .send(SessionMessage::PeekComposition(send))
+            .await;
         recv.await.ok().flatten()
     }
 
@@ -1068,7 +1426,10 @@ impl SessionHandle {
     pub(crate) async fn rename(&self, new_name: String) -> Result<(), std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.0.send(SessionMessage::Rename(new_name, send)).await;
+        let _ = self
+            .sender
+            .send(SessionMessage::Rename(new_name, send))
+            .await;
         recv.await.unwrap_or_else(|_| {
             Err(std::io::Error::new(
                 std::io::ErrorKind::NotConnected,
@@ -1083,7 +1444,7 @@ impl SessionHandle {
     pub(crate) async fn stop(&self) {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.0.send(SessionMessage::Stop(send)).await;
+        let _ = self.sender.send(SessionMessage::Stop(send)).await;
         // If the actor died before acking, it is stopped all the same.
         let _ = recv.await;
     }
@@ -1095,7 +1456,7 @@ impl SessionHandle {
     pub(crate) async fn destroy(&self) -> Result<(), std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.0.send(SessionMessage::Destroy(send)).await;
+        let _ = self.sender.send(SessionMessage::Destroy(send)).await;
         recv.await.unwrap_or(Ok(()))
     }
 
@@ -1108,7 +1469,7 @@ impl SessionHandle {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self
-            .0
+            .sender
             .send(SessionMessage::Attach(
                 send,
                 self.clone(),

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -239,8 +239,7 @@ fn log_session_contents(
             host_source = %patch.host_path(),
             sandbox_dest = %patch.destination(),
             source = ?sessions::core::source::Provenanced::source(sp),
-            deferred = true,
-            "session content (patch: file-upload plumbing deferred)",
+            "session content (patch: materialized into session home at FinalizeSession)",
         );
     }
     for h in comp.lifecycle_hooks() {
@@ -1731,6 +1730,7 @@ mod tests {
                 working: DaemonAbsPath::root(),
                 cache: DaemonAbsPath::root(),
                 home: DaemonAbsPath::root(),
+                patches: DaemonAbsPath::root(),
             },
             DEFAULT_SIZE,
             None,
@@ -1797,6 +1797,7 @@ mod tests {
                 working: DaemonAbsPath::root(),
                 cache: DaemonAbsPath::root(),
                 home: DaemonAbsPath::root(),
+                patches: DaemonAbsPath::root(),
             },
             DEFAULT_SIZE,
             None,
@@ -1882,6 +1883,7 @@ mod tests {
             working: DaemonAbsPath::root(),
             cache: DaemonAbsPath::root(),
             home: DaemonAbsPath::root(),
+            patches: DaemonAbsPath::root(),
         }
     }
 

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -180,6 +180,17 @@ impl Manager {
     ) -> Result<ManagerHandle, std::io::Error> {
         let store = Store::init(minimal_state_dir.clone()).await?;
 
+        // Reap unresumable on-disk records left over from a prior
+        // daemon lifetime. Both `Pending` (compose in flight — the
+        // in-memory `PendingComposeState` didn't survive the
+        // restart) and `Materializing` (composition ready but
+        // patches upload state is lost) are meaningless without
+        // in-memory context, so the record can't be brought back
+        // to a working state. Delete them here rather than let
+        // them linger and confuse `min ls` / hold their names
+        // hostage.
+        reap_unresumable_records(&store).await?;
+
         // Build the daemon-scoped mctx state once at startup. Each
         // `CreateSession` will build a per-session `Context` on top of
         // this via `Context::from_daemon` rather than repeating the
@@ -230,6 +241,51 @@ impl Manager {
         tokio::spawn(mngr.mainloop());
         Ok(handle)
     }
+}
+
+/// Delete on-disk records whose status is unresumable after a
+/// daemon restart. See [`Manager::init`] for why `Pending` and
+/// `Materializing` records fall into this category. A delete
+/// failure is logged and skipped — a leftover record wastes a
+/// name until it's cleaned up manually but shouldn't block
+/// startup.
+async fn reap_unresumable_records(store: &crate::store::StoreHandle) -> Result<(), std::io::Error> {
+    let handles = store.handles().await?;
+    for handle in handles {
+        let record = match handle.record().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(
+                    session_id = %handle.id(),
+                    error = %e,
+                    "reap: could not read record; skipping",
+                );
+                continue;
+            }
+        };
+        match record.status {
+            sessions::SessionStatus::Pending | sessions::SessionStatus::Materializing => {
+                let id = *handle.id();
+                let status = record.status;
+                if let Err(e) = handle.delete().await {
+                    tracing::warn!(
+                        session_id = %id,
+                        error = %e,
+                        ?status,
+                        "reap: failed to delete unresumable record",
+                    );
+                } else {
+                    tracing::info!(
+                        session_id = %id,
+                        ?status,
+                        "reap: deleted unresumable record left over from a prior daemon lifetime",
+                    );
+                }
+            }
+            sessions::SessionStatus::Active => {}
+        }
+    }
+    Ok(())
 }
 
 impl Manager {
@@ -816,17 +872,27 @@ mod tests {
     }
 
     /// [`create_active_session`] with a caller-supplied config.
+    /// Drives the whole `CreateSession → ConfigureLoadout →
+    /// FinalizeSession` sequence in-process so the returned
+    /// session's record is `Active` (attachable, hostname
+    /// registered). No patches for these fixtures, so the
+    /// composition-empty short-circuit in `finalize` covers the
+    /// marker precondition.
     async fn create_active_session_with(
         mngr: &ManagerHandle,
         config: minimald_rpc::SessionConfig,
     ) -> SessionId {
         let id = mngr.create_session(config, None).await.unwrap();
-        let response = session(mngr, id)
-            .await
+        let handle = session(mngr, id).await;
+        let response = handle
             .configure_loadout(WireContribution::default())
             .await
             .expect("configuring an empty loadout should succeed");
         assert!(response.is_none(), "an empty loadout should finalize");
+        handle
+            .finalize()
+            .await
+            .expect("finalize should succeed for a patchless composition");
         id
     }
 
@@ -959,13 +1025,17 @@ mod tests {
             "an already-gated client contribution needs no verdict, so the \
              loadout should finalize in one shot",
         );
+        // Compose returned `Materialized` — the record status is
+        // `Materializing`, not `Active`. Attach requires an
+        // explicit `FinalizeSession` after any patches have
+        // uploaded; this fixture doesn't drive that step.
         assert_eq!(
             mngr.get_record(SessionKeyPredicate::Id(id))
                 .await
                 .unwrap()
                 .expect("the record should survive")
                 .status,
-            sessions::SessionStatus::Active,
+            sessions::SessionStatus::Materializing,
         );
     }
 
@@ -1044,15 +1114,19 @@ mod tests {
             .submit_verdict(approve_all(id, &response))
             .await
             .expect("the verdict should be accepted");
-        assert_eq!(step, SessionStep::Active { id });
+        assert_eq!(step, SessionStep::Materialized { id });
 
+        // SubmitVerdict promotes Pending → Materializing, not
+        // Pending → Active. The client still has to upload
+        // patches (there are none for this fixture) and call
+        // FinalizeSession before the record advances to Active.
         assert_eq!(
             mngr.get_record(SessionKeyPredicate::Id(id))
                 .await
                 .unwrap()
                 .expect("the record should survive promotion")
                 .status,
-            sessions::SessionStatus::Active,
+            sessions::SessionStatus::Materializing,
         );
         let comp = handle
             .peek_composition()
@@ -1165,7 +1239,7 @@ mod tests {
             .submit_verdict(approve_all(id, &response))
             .await
             .expect("the corrected verdict should be accepted");
-        assert_eq!(step, SessionStep::Active { id });
+        assert_eq!(step, SessionStep::Materialized { id });
     }
 
     /// Renaming a session that owns no PTask hostname route (NoNet here)
@@ -1355,13 +1429,16 @@ mod tests {
             response.is_none(),
             "a project package needs no client gate, so the loadout finalizes"
         );
+        // Compose advances the record to `Materializing`, not
+        // `Active` — see the note on
+        // `create_session_accepts_non_empty_client_contribution`.
         assert_eq!(
             mngr.get_record(SessionKeyPredicate::Id(id))
                 .await
                 .unwrap()
                 .expect("the record should survive")
                 .status,
-            sessions::SessionStatus::Active,
+            sessions::SessionStatus::Materializing,
         );
     }
 

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -400,28 +400,33 @@ pub fn create_session_req(name: &str, project: &str) -> minimald_rpc::CreateSess
 /// for a caller that expects its contribution to compose in one shot.
 pub fn unwrap_ready(resp: minimald_rpc::ConfigureLoadoutResponse) {
     match resp {
-        minimald_rpc::ConfigureLoadoutResponse::Ready => {}
+        minimald_rpc::ConfigureLoadoutResponse::Materialized => {}
         minimald_rpc::ConfigureLoadoutResponse::Pending { .. } => {
             panic!("expected Ready variant, got Pending")
         }
     }
 }
 
-/// Drive the client half of the whole create flow — `CreateSession` plus
-/// the `ConfigureLoadout` that finalizes it — and return the session's id.
+/// Drive the client half of the whole create flow — `CreateSession`,
+/// `ConfigureLoadout`, and `FinalizeSession` — and return the
+/// session's id. The result is an `Active` session ready to attach.
 ///
-/// A session isn't usable until its loadout is configured (a `Draft` refuses
-/// attach and context creation), so any test that goes on to *use* the
-/// session wants this rather than a bare `CreateSession`. The workspace is
-/// left empty, so the loadout composes to an empty `Ready` in one shot; a
-/// test that wants a project in the mix seeds the workspace in between and
-/// calls the two RPCs itself.
+/// The workspace is left empty (so the composition has no patches
+/// and no upload is needed) and the composition itself is empty
+/// (empty client contribution + empty project mfile), so
+/// `ConfigureLoadout` returns `Materialized` in one shot and
+/// `FinalizeSession` succeeds against an empty patches dir. A test
+/// that wants a project in the mix seeds the workspace in between
+/// and drives the RPCs itself.
 pub async fn create_configured_session(
     client: &mut TestClient,
     name: &str,
     project: &str,
 ) -> SessionId {
-    use minimald_rpc::{ConfigureLoadout, ConfigureLoadoutRequest, CreateSession};
+    use minimald_rpc::{
+        ConfigureLoadout, ConfigureLoadoutRequest, CreateSession, FinalizeSession,
+        FinalizeSessionRequest,
+    };
     let id = client
         .call::<CreateSession>(&create_session_req(name, project))
         .await
@@ -436,5 +441,17 @@ pub async fn create_configured_session(
             .await
             .unwrap(),
     );
+    // Empty composition → no patches. FinalizeSession short-
+    // circuits the marker check in that case (there's nothing to
+    // upload), so calling it directly is fine.
+    match client
+        .call::<FinalizeSession>(&FinalizeSessionRequest { session_id: id })
+        .await
+    {
+        minimald_rpc::Errorable::Ok(_) => {}
+        minimald_rpc::Errorable::Err { error } => {
+            panic!("FinalizeSession failed in create_configured_session: {error}");
+        }
+    }
     id
 }

--- a/crates/minvmd/examples/exec.rs
+++ b/crates/minvmd/examples/exec.rs
@@ -29,15 +29,18 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use minimald_rpc::{
     ConfigureLoadoutRequest, ConfigureLoadoutResponse, CreateSessionRequest, CreateSessionResponse,
-    Errorable, SessionConfig,
+    Errorable, FinalizeSessionRequest, FinalizeSessionResponse, SessionConfig,
 };
 
 /// SSH subsystem for the CreateSession RPC (mirrors minimald's
 /// `RPC_SUBSYSTEM_PREFIX` + "CreateSession").
 const CREATE_SESSION_SUBSYSTEM: &str = "minimald-v1-CreateSession";
-/// SSH subsystem for the ConfigureLoadout RPC, which finalizes the session
+/// SSH subsystem for the ConfigureLoadout RPC, which composes the session
 /// a `CreateSession` allocated.
 const CONFIGURE_LOADOUT_SUBSYSTEM: &str = "minimald-v1-ConfigureLoadout";
+/// SSH subsystem for the FinalizeSession RPC, which promotes a session
+/// from `Materializing` to `Active` and is required before exec.
+const FINALIZE_SESSION_SUBSYSTEM: &str = "minimald-v1-FinalizeSession";
 /// Env var minimald reads to scope an exec to a session.
 const MINIMAL_SESSION_ID_ENV: &str = "MINIMAL_SESSION_ID";
 
@@ -226,13 +229,56 @@ async fn run_session_exec(
         let resp: Errorable<ConfigureLoadoutResponse> =
             serde_json::from_slice(&resp_buf).map_err(|e| format!("decode response: {e}"))?;
         match resp {
-            Errorable::Ok(ConfigureLoadoutResponse::Ready) => {}
+            Errorable::Ok(ConfigureLoadoutResponse::Materialized) => {
+                // Compose finished in one shot; fall through to the
+                // FinalizeSession call below.
+            }
             Errorable::Ok(ConfigureLoadoutResponse::Pending { .. }) => {
                 return Err("ConfigureLoadout returned Pending; \
-                            this example only handles Ready"
+                            this example only handles Materialized"
                     .to_string());
             }
             Errorable::Err { error } => return Err(format!("ConfigureLoadout failed: {error}")),
+        }
+    }
+
+    // FinalizeSession: promote the record `Materializing → Active`
+    // so exec/attach passes the daemon's status gate. This example
+    // has no patches to upload beforehand (empty contribution +
+    // empty workspace mfile → empty composition), so the
+    // `WorkspacePatchesTarZst` step the CLI performs isn't needed
+    // — but `FinalizeSession` still is: the daemon takes the
+    // composition-has-no-patches shortcut past the marker check
+    // and writes the record as `Active`.
+    {
+        let channel = handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("open FinalizeSession channel: {e}"))?;
+        channel
+            .request_subsystem(false, FINALIZE_SESSION_SUBSYSTEM)
+            .await
+            .map_err(|e| format!("request_subsystem: {e}"))?;
+
+        let req = FinalizeSessionRequest { session_id };
+        let body = serde_json::to_vec(&req).map_err(|e| format!("serialize request: {e}"))?;
+
+        let mut rpc = channel.into_stream();
+        rpc.write_all(&body)
+            .await
+            .map_err(|e| format!("write request: {e}"))?;
+        rpc.shutdown()
+            .await
+            .map_err(|e| format!("shutdown write half: {e}"))?;
+        let mut resp_buf = Vec::with_capacity(256);
+        rpc.read_to_end(&mut resp_buf)
+            .await
+            .map_err(|e| format!("read response: {e}"))?;
+        let resp: Errorable<FinalizeSessionResponse> =
+            serde_json::from_slice(&resp_buf).map_err(|e| format!("decode response: {e}"))?;
+        match resp {
+            Errorable::Ok(FinalizeSessionResponse) => {}
+            Errorable::Err { error } => return Err(format!("FinalizeSession failed: {error}")),
         }
     }
 

--- a/crates/minvmd/tests/minimald_session_integration.rs
+++ b/crates/minvmd/tests/minimald_session_integration.rs
@@ -359,7 +359,7 @@ async fn run_session_exec(
         match resp.ok() {
             // The uploaded mfile declares only tasks, so nothing needs a
             // client gate and the loadout finalizes in one shot.
-            Some(ConfigureLoadoutResponse::Ready) => {}
+            Some(ConfigureLoadoutResponse::Materialized) => {}
             Some(ConfigureLoadoutResponse::Pending { .. }) => {
                 return Err("ConfigureLoadout returned Pending; \
                             this test's mfile gates nothing"
@@ -367,6 +367,43 @@ async fn run_session_exec(
             }
             None => return Err("ConfigureLoadout returned an error".to_string()),
         }
+    }
+
+    // FinalizeSession: promote the record `Materializing → Active` so the
+    // exec below passes minimald's status gate. The task-only mfile yields an
+    // empty composition, so there are no patches to upload first — but
+    // FinalizeSession is still required: the daemon takes the
+    // composition-has-no-patches shortcut past the patches-ready marker check
+    // and writes the record `Active`. (See crates/minvmd/examples/exec.rs.)
+    {
+        use minimald_rpc::{FinalizeSession, FinalizeSessionRequest};
+        let channel = handle
+            .channel_open_session()
+            .await
+            .map_err(|e| format!("open FinalizeSession channel: {e}"))?;
+        channel
+            .request_subsystem(false, FinalizeSession::NAME)
+            .await
+            .map_err(|e| format!("request_subsystem: {e}"))?;
+
+        let req = FinalizeSessionRequest { session_id };
+        let body = serde_json::to_vec(&req).map_err(|e| format!("serialize request: {e}"))?;
+
+        let mut rpc = channel.into_stream();
+        rpc.write_all(&body)
+            .await
+            .map_err(|e| format!("write request: {e}"))?;
+        rpc.shutdown()
+            .await
+            .map_err(|e| format!("shutdown write half: {e}"))?;
+        let mut resp_buf = Vec::with_capacity(256);
+        rpc.read_to_end(&mut resp_buf)
+            .await
+            .map_err(|e| format!("read response: {e}"))?;
+        let resp: <FinalizeSession as OneshotSshRpc>::Response =
+            serde_json::from_slice(&resp_buf).map_err(|e| format!("decode response: {e}"))?;
+        resp.ok()
+            .ok_or_else(|| "FinalizeSession returned an error".to_string())?;
     }
 
     // Exec the command in that session.

--- a/crates/ot/src/indicatif_shim.rs
+++ b/crates/ot/src/indicatif_shim.rs
@@ -44,7 +44,12 @@ const END_SYNC_UPDATE: &[u8] = b"\x1b[?2026l";
 /// suspend bar drawing.
 static MP: OnceLock<MultiProgress> = OnceLock::new();
 
-fn global_progress() -> MultiProgress {
+/// Handle to the process-global `MultiProgress` — the one [`StdoutWriter`]
+/// suspends around plain stdout writes so bars and log lines don't clobber
+/// each other. Callers wiring their own bars (byte-count uploads, spinners
+/// for one-off phases) should [`MultiProgress::add`] them here so drawing
+/// stays coordinated with the rest of the CLI.
+pub fn global_progress() -> MultiProgress {
     MP.get_or_init(MultiProgress::new).clone()
 }
 

--- a/crates/ot/src/lib.rs
+++ b/crates/ot/src/lib.rs
@@ -12,7 +12,9 @@ use tokio::sync::watch;
 #[cfg(feature = "indicatif")]
 mod indicatif_shim;
 #[cfg(feature = "indicatif")]
-pub use indicatif_shim::{IndicatifShim, StdoutWriter, render_operations_while, render_to_stderr};
+pub use indicatif_shim::{
+    IndicatifShim, StdoutWriter, global_progress, render_operations_while, render_to_stderr,
+};
 
 #[derive(Debug, Clone)]
 pub enum CheckKind {

--- a/crates/sessions/docs/COMPOSITION.md
+++ b/crates/sessions/docs/COMPOSITION.md
@@ -9,8 +9,10 @@ sequence** spanning two processes:
    alongside the client's wire contribution, and emits anything
    that needs user gating.
 3. **Client gates** those pending items against the user policy.
-4. **Daemon assembles** the final `Composition` and hands it to the
-   apply layer.
+4. **Daemon assembles** the final `Composition`, the client streams
+   the composition's approved patch files up to the daemon, and the
+   daemon materializes them into the sandbox home before promoting
+   the session to `Active`.
 
 User policy is enforced **only on the client**. The daemon never
 runs user policy; it forwards items needing approval and applies the
@@ -19,8 +21,10 @@ verdicts that come back.
 ## End-to-end flow
 
 The daemon-side compose runs off the project files in the session's
-*daemon-side workspace*, so `min activate` splits into three
-sequential RPCs:
+*daemon-side workspace*, and the composition's approved patches
+must land on the daemon's disk before the session is attachable —
+so `min activate` splits into four sequential RPCs bracketed by
+two file-tree uploads:
 
 ```mermaid
 sequenceDiagram
@@ -34,15 +38,20 @@ sequenceDiagram
     Note over C: Composition → WireContribution (composition_to_wire)
     C->>D: CreateSession (name, project_path, network, policy, attrs)
     D-->>C: CreateSessionResponse { id }
-    C->>D: WorkspaceFilesTarZst upload (SFTP-shaped, into daemon workspace tree)
+    C->>D: WorkspaceFilesTarZst upload (into daemon workspace tree)
     C->>D: ConfigureLoadout { session_id, contribution }
     Note over D: Phase 2 — collect project + package contributions off workspace mfile, route pending items
     D-->>C: ConfigureLoadoutResponse::Pending carrying ContributionResponse
     Note over C: Phase 3 — policy gate pending items, produce verdicts
     C->>D: SubmitVerdict carrying ContributionVerdict
-    Note over D: Phase 4 — apply verdicts, assemble Composition, promote record to Active
-    D-->>C: SessionStep::Active { id }
-    Note over D: Launcher consumes the Composition at shell-mint time (deferred)
+    Note over D: Phase 4a — apply verdicts, assemble Composition, promote record Pending → Materializing
+    D-->>C: SessionStep::Materialized { id }
+    Note over C: Phase 4b — collect approved patch (host_path, dest) pairs from contribution + verdict
+    C->>D: WorkspacePatchesTarZst upload (into <workspace>/patches/ atomically, marker written last)
+    C->>D: FinalizeSession { session_id }
+    Note over D: Phase 4c — check marker, copy patches into sandbox home, promote Materializing → Active
+    D-->>C: FinalizeSessionResponse (empty)
+    Note over D: Launcher consumes the Composition at shell-mint time
 ```
 
 Each phase consumes the previous phase's output and produces the
@@ -50,8 +59,8 @@ next phase's input. There is no loop: the daemon batches every
 pending item into one `ContributionResponse`, and the client
 batches every verdict into one `ContributionVerdict`.
 
-**Why three RPCs, not one.** `CreateSession` only allocates the id;
-compose runs later in `ConfigureLoadout`. The intervening
+**Why the split.** `CreateSession` only allocates the id; compose
+runs later in `ConfigureLoadout`. The intervening
 `WorkspaceFilesTarZst` upload is what stages the project's
 `minimal.toml` — plus any local `packages/`, `stacks/`, `profiles/`
 directories a project defines *for itself*, though most projects
@@ -65,11 +74,22 @@ carried in the tar. Merging create and configure into a single
 RPC would leave the compose without a workspace mfile to start
 from, so `find_mfile` would fall through to "no project
 contribution" and every project-declared package (whether local
-or upstream-supplied) would silently vanish. The client's
-`cmd_activate` unconditionally follows this order, even for
-`--sync none` (which just skips the upload — Phase 2 then
-composes against a bare workspace and only whatever wire
-contribution came from Phase 1 survives).
+or upstream-supplied) would silently vanish.
+
+The second upload + `FinalizeSession` exists because the finalized
+`Composition` names patch source files that live on the *client's*
+host filesystem (e.g. `~/.claude/**`, or a loadout's `~/.zshrc`).
+The daemon can't reach those paths itself, so the client is
+authoritative for streaming them up before the sandbox home can be
+populated. Splitting the finalize step means an attach against a
+session whose patches never arrived is refused (see
+`SessionStatus::Materializing` below) rather than silently
+succeeding into an empty home. The client's `cmd_activate`
+unconditionally follows this order, even for `--sync none` (which
+just skips the *first* upload — Phase 2 then composes against a
+bare workspace and only whatever wire contribution came from
+Phase 1 survives; the patches upload still runs against the
+resulting composition).
 
 **A re-`ConfigureLoadout` against a session with a pending stash is
 refused with `WouldBlock`.** Overwriting the stashed
@@ -203,14 +223,26 @@ order: items the policy auto-decides are emitted in input order,
 items routed through the hook land at the end. The daemon must
 correlate by `id`, not slice position.
 
-### Phase 4 — Daemon assembles and hands off
+### Phase 4 — Daemon assembles, client uploads patches, daemon finalizes
 
-**Ready path.** On `ComposeOutcome::Ready`, the daemon already
-holds a finalized `Composition` (built directly inside
-`SessionComposer::compose`). The record persists as `Active` in
-one write, the `Composition` is retained on the live session
-actor (`SessionInner::Active { composition, ... }`) for the
-launcher, and `ConfigureLoadoutResponse::Ready` ships.
+Phase 4 has three sub-steps: the daemon assembles the finalized
+`Composition` (**4a**), the client streams the composition's
+approved patch files onto the daemon disk (**4b**), and the daemon
+copies those files into the sandbox home and flips the record to
+`Active` (**4c**). The record status walks
+`Pending → Materializing → Active` — attach is refused until the
+record reaches `Active`, so a client that dies mid-flow never
+lands the operator on an empty-home shell.
+
+#### Phase 4a — Assemble the Composition
+
+**Materialized path.** On `ComposeOutcome::Ready`, the daemon
+already holds a finalized `Composition` (built directly inside
+`SessionComposer::compose`). The record is written as
+`Materializing` (not `Active`) in one store write, the
+`Composition` is retained on the live session actor
+(`SessionInner::Active { composition, ... }`) for the launcher,
+and `ConfigureLoadoutResponse::Materialized` ships.
 
 **Pending path.** On `ComposeOutcome::Pending`, the daemon
 stashes the matching `PendingComposeState` on the session actor
@@ -240,13 +272,17 @@ runs Phase 3 and sends a `ContributionVerdict` over the
    Some(_) }`.
 3. Merges the stashed `client_contribution` via
    `Composition::extend_from_wire` — same cross-process conflict
-   checks as the Ready path.
-4. Promotes the record `Pending → Active` via `store.save`.
+   checks as the Materialized path.
+4. Promotes the record `Pending → Materializing` via `store.save`
+   (not `Active` — that comes in Phase 4c after the client has
+   uploaded patches).
 5. Replaces the actor's `SessionInner::Draft { pending: Some(_) }`
-   with `SessionInner::Active { composition, ... }`, which is
-   also what drops the stash — it survives every failure path
-   above and only goes away on a successful finalization.
-6. Replies with `SessionStep::Active { id }`.
+   with `SessionInner::Active { composition, ... }`. Note the
+   asymmetry: the actor is `Active` (has a composition in memory)
+   while the on-disk record is `Materializing` — the record's
+   status tracks *external* attachability, the actor's `inner`
+   tracks *whether compose has produced a Composition*.
+6. Replies with `SessionStep::Materialized { id }`.
 
 **Resume stash is in-memory only.** A `Draft` actor spawned from
 an on-disk `Pending` record (daemon restart, or the session was
@@ -256,40 +292,127 @@ created before a crash) has `pending: None` — nothing to resume.
 new session to retry. Survival across restarts is a separate
 concern.
 
+#### Phase 4b — Client uploads the composition's patches
+
+The finalized `Composition` names patch source files by their
+host paths. Only the client can reach those paths, so it's
+authoritative for the upload. `cmd_activate` collects the
+`(host_path, sandbox_destination)` pairs from two sources:
+
+- `contribution.patches` — patches contributed by client-side
+  loadouts, which never round-tripped through the daemon.
+- `approved_patches_from_verdict(&verdict)` — patches the daemon
+  surfaced as pending in Phase 3 and the user approved during
+  Phase 3 gating.
+
+Deduplicated by destination (the composer's cross-process check
+guarantees duplicates are exact matches with identical sources),
+the pairs stream up over the `WorkspacePatchesTarZst` subsystem.
+The daemon unpacks each entry into `<workspace>/patches/<dest>`
+via a staging-dir + atomic rename: entries land in
+`<workspace>/patches.tmp/`, and only on a clean stream end does
+the daemon `rename(patches.tmp → patches)` and then write the
+zero-byte `.patches_ready` marker. A mid-stream failure leaves
+`patches.tmp` behind for the next attempt to overwrite — the
+real `patches/` tree is never partial.
+
+Per-entry validation on the daemon side:
+
+- **Traversal**: every entry's path is checked with
+  `safe_relative_path` (rejects absolute paths and any `..`
+  component) before any byte lands on disk. `SandboxRelPath`
+  already rejects these on the wire, but the daemon re-checks
+  because the client is not trusted.
+- **Marker collision**: an entry whose path exactly equals
+  `PATCHES_READY_MARKER` (`.patches_ready`) is rejected — writing
+  it would first race the marker write, and then
+  `materialize_patches_into_home` would silently copy the emptied
+  marker into the sandbox home, zeroing whatever the user had
+  there.
+- **Size cap**: entries larger than `MAX_PATCH_ENTRY_BYTES` (1
+  GiB) are rejected before allocation, so a peer forging a tar
+  header can't drive `Vec::with_capacity` to `usize::MAX` (panic)
+  or trigger the allocator's OOM handler (whole-daemon abort).
+
+Body writes are dispatched onto a `JoinSet` capped at
+`available_parallelism()` tasks so unrelated small files land in
+parallel, and any error aborts every in-flight task before
+propagating so no writes outlive the failing upload.
+
+#### Phase 4c — FinalizeSession
+
+The client calls `FinalizeSession` once the patches upload has
+returned cleanly. The daemon:
+
+1. Refuses if the actor is `Materializing` on-disk but the
+   in-memory `SessionInner` has no `composition` — this catches
+   a `Materializing` record whose actor was respawned from disk
+   after a daemon restart (the composition lives in memory
+   only). See the "restart-orphaned records are reaped or
+   refused" invariant below.
+2. If the `Composition` has patches, checks that
+   `<workspace>/patches/.patches_ready` exists on disk. Missing
+   → `InvalidInput` with an instruction to upload patches and
+   retry. Composition-with-no-patches short-circuits this check
+   (nothing to upload).
+3. Runs `materialize_patches_into_home`: for each
+   `SessionPatch`, copies
+   `<workspace>/patches/<destination>` to
+   `<home>/<destination>`, creating parents as needed. Done once
+   at finalize (not on every attach) so subsequent attaches see
+   the same tree without re-copying and any in-sandbox
+   modifications persist.
+4. Promotes the record `Materializing → Active` via `store.save`
+   and registers the PTask hostname so the session is reachable.
+5. Replies with `FinalizeSessionResponse` (empty).
+
+Already-`Active` sessions are a no-op: `FinalizeSession` is
+idempotent under a client retry after a lost ack.
+
 **Apply.** Whichever path produced the `Composition`, the launcher
 consumes it when the session's shell is minted: packages and vars
-are fed into the sandbox `Env` today; patches and lifecycle hooks
-are held on `SessionInner::Active { composition, ... }` and
-logged at `info!` with `deferred = true` — the file-upload
-plumbing (patches) and in-sandbox exec plumbing (hooks) are still
-to land. Operator visibility is intact even before the plumbing
-does: `log_session_contents` in `crates/minimald/src/session_host.rs`
+are fed into the sandbox `Env`; patches (already materialized into
+the sandbox home during Phase 4c) contribute file mappings that
+the launcher's rootfs setup picks up; lifecycle hooks are held on
+`SessionInner::Active { composition, ... }` and logged at `info!`
+with `deferred = true` — the in-sandbox exec plumbing for hooks
+is still to land. Operator visibility is intact:
+`log_session_contents` in `crates/minimald/src/session_host.rs`
 enumerates every composition item with its provenance.
 
 **Response shape.** `CreateSession` returns
 `CreateSessionResponse { id }`. `ConfigureLoadout` returns either
-`ConfigureLoadoutResponse::Ready` (composition finalized in one
-shot) or `ConfigureLoadoutResponse::Pending { response }` (client
-must gate before the session activates). The `id` is allocated
-before the configure step, so file uploads and any other
-session-scoped RPC can target the session immediately.
+`ConfigureLoadoutResponse::Materialized` (composition finalized in
+one shot) or `ConfigureLoadoutResponse::Pending { response }`
+(client must gate before the composition assembles). `SubmitVerdict`
+returns `SessionStep::Materialized { id }` on success.
+`WorkspacePatchesTarZst` is a channel subsystem, not a JSON RPC —
+it carries a zstd-compressed tar stream and closes on completion;
+errors return via the channel's stderr. `FinalizeSession` returns
+`FinalizeSessionResponse` (empty). The `id` is allocated at
+`CreateSession` time, so every follow-up RPC and upload targets
+the same session.
 
-**State guards.** A session in `SessionStatus::Pending` is not
-attachable via a shell: the attach path routes through
-`configure_loadout` if the session is still `Draft`, and
-propagates the compose error otherwise. Metadata-only RPCs
+**State guards.** A session in `SessionStatus::Pending` or
+`SessionStatus::Materializing` is not attachable via a shell:
+the attach path routes through `configure_loadout` if the
+session is still `Draft`, and rejects `Materializing` records
+with `AttachError::SessionPending`. Metadata-only RPCs
 (`GetSessionRecord`, `ListSessions`, `RenameSession`,
-`DestroySession`) keep working over a Pending session.
+`DestroySession`) keep working over both non-Active states so
+operators can see and clean up sessions stuck mid-activation.
 
 **Empty-contribution fast path.** When the client's wire
 contribution is `default()` AND the daemon's workspace has no
 mfile (or the mfile's project/package contributions are all
-empty), Phase 2 emits no pending items, no
-`Composition::extend_from_wire` merge produces content, and the
-record persists as `Active` and returns via `Ready` in one
-round-trip. This is the path exercised by internal callers today
-(sftp, exec, session-recovery), which skip both the upload step
-and any user contribution.
+empty), Phase 2 emits no pending items,
+`Composition::extend_from_wire` merges nothing, and the record
+persists as `Materializing` in one shot with an empty
+`Composition`. The composition has no patches, so Phase 4b is a
+no-op and `FinalizeSession` short-circuits the marker check and
+finalizes immediately. Internal callers today (sftp, exec,
+session-recovery) skip the file upload, skip user contribution,
+and drive this compressed path directly.
 
 `Composition`'s fields: `vars: Vec<SessionVar>`, `patches:
 Vec<SessionPatch>`, `packages: Vec<ProvenancedPackage>`,
@@ -502,9 +625,14 @@ overload:
   Phase 1, `handle_response`'s `env("HOME")` in Phase 3). The
   `SessionComposer` (Phase 2/4 daemon side) has no fallback —
   daemon `~/...` patterns must resolve from the client's wire vars.
-  `PatchDest` is always relative to the sandbox user's home; `~`
-  and absolute paths are rejected at construction. Patterns retain
-  their `~` form in returned policies, so save/load is lossless.
+  `PatchDest` is always relative to the sandbox user's home;
+  absolute paths and `..` components are rejected at construction.
+  A leading `~/` prefix on the destination is **silently stripped**:
+  destinations are already home-relative, so a package author who
+  writes `path = "~/.claude"` in their mfile means "place `.claude`
+  under sandbox home", not "place a literal `~` directory there." A
+  bare `~` re-hits the empty-dest check. Patterns retain their `~`
+  form in returned policies, so save/load is lossless.
 - **Conflict detection is post-gate.** Per-domain rules:
   - **Vars**: same name + same resolved value → both kept (no
     conflict); same name + different values → `Conflict::VarValueMismatch`.
@@ -531,6 +659,80 @@ overload:
   fatal-on-conflict with a hook the user can answer) is not
   implemented; the `Result`-returning merge shape is the place it
   would land.
+- **Client is authoritative for the patches upload.** Patch source
+  files live on the client's host filesystem, so after a successful
+  Phase 4a the client streams the composition's approved patches
+  up via `WorkspacePatchesTarZst` and calls `FinalizeSession`. The
+  daemon can't reach those paths itself, so there's no daemon-side
+  fallback if the client bails — the session sits at
+  `Materializing` and is not attachable until `FinalizeSession`
+  clears the marker check. The client's `cmd_activate` runs the
+  upload + finalize as a single transaction; on error it
+  `best_effort_destroy`s the session so operators don't accumulate
+  stuck `Materializing` records.
+- **`Materializing` records don't survive daemon restart.** The
+  `SessionInner::Active { composition, .. }` state that Phase 4a
+  produces is memory-only: the composition isn't persisted to the
+  record, only the *status* is. A `Materializing` record whose
+  actor is respawned from disk after a restart has no
+  in-memory composition to check against, so `Manager::init`
+  runs `reap_unresumable_records` at startup and deletes any
+  `Pending` or `Materializing` record it finds (with an `info!`
+  log). If a race lets one through, `finalize` refuses with an
+  `InvalidInput` fault ("session is Materializing but has no
+  in-memory composition") so the operator sees the problem
+  instead of silently attaching to an empty-home shell.
+- **Patches unpack is atomic; the marker is the precondition.**
+  Entries land in `<workspace>/patches.tmp/` first; only on a
+  clean stream end does the daemon install the new tree at
+  `<workspace>/patches/` and write the `.patches_ready` marker.
+  `FinalizeSession` checks the marker before promoting the
+  record. A mid-stream failure leaves `patches.tmp` behind for
+  the next attempt to overwrite; the real `patches/` tree is
+  never partial and the marker never lies.
+
+  The install uses `renameat2(RENAME_EXCHANGE)` when a prior
+  `patches/` tree exists — the kernel swaps the two directories
+  atomically, so a `FinalizeSession` racing the swap sees either
+  "old contents + old marker" or "new contents + new marker,"
+  never a gap where `patches/` is absent or where the marker
+  points at content that isn't there. First install (no prior
+  tree) falls through to a plain `rename`, which is atomic when
+  the destination doesn't exist. The old contents (which end up
+  under the staging path after the exchange) are cleaned up
+  best-effort afterward.
+
+  Two concurrent uploads for the *same* session don't corrupt
+  each other. Each upload writes to a per-upload unique staging
+  directory (`patches.upload.<nanos>.tmp`), so the unpack phases
+  never share disk state. The install-and-marker step then takes
+  a per-session mutex (`SessionHandle::patches_upload_lock`), so
+  only one upload at a time is running the `RENAME_EXCHANGE +
+  marker write` critical section — the second upload's swap
+  observes the first's finished tree as its "old contents" and
+  overwrites cleanly. The lock is held only across the
+  seconds-of-work install step, never across the
+  minutes-of-work unpack, so throughput is unaffected.
+
+  The marker filename is reserved: an incoming patch entry whose
+  path exactly equals `PATCHES_READY_MARKER` is rejected by the
+  unpacker, since otherwise `materialize_patches_into_home` would
+  silently copy the emptied marker into the sandbox home.
+- **Peer-supplied entry sizes are capped, and a per-run byte
+  budget bounds total in-flight memory.** Two limits stack:
+  - `MAX_PATCH_ENTRY_BYTES` (1 GiB) refuses any single tar entry
+    whose declared size would push `Vec::with_capacity` into an
+    allocation panic or OOM (allocator abort → whole-daemon down).
+  - `MAX_UNPACK_INFLIGHT_BYTES` (1 GiB) is a `Semaphore` acquired
+    *before* each body is read from the tar stream. If the total
+    bytes held across in-flight write tasks would exceed the
+    budget, the tar loop parks — pumping backpressure through the
+    pipe into the SSH channel — instead of piling additional
+    bodies into RAM.
+  Peak daemon memory during unpack is therefore bounded by the
+  budget, *not* multiplied by CPU count. Legitimate patch
+  payloads are small dotfile trees; both ceilings exist as
+  adversarial-input backstops, not throughput knobs.
 - **Internal invariants panic, not error.** `compute_dest` panics on
   precondition violation. These are bug signals, not recoverable.
 - **Terminating failure modes:** `Denied` (explicit policy reject),

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -109,6 +109,32 @@ pub enum Conflict {
         /// contributor wanted copied.
         disagreeing_sources: Vec<(Source, String)>,
     },
+    /// Two patches want to occupy the same tree node from opposite
+    /// sides: one contributor's destination is a component-boundary
+    /// prefix of another's, so one wants to place a file where the
+    /// other expects a directory (or vice versa). Distinct
+    /// destinations, so `PatchSourceMismatch` doesn't fire — but
+    /// `materialize_patches_into_home` can't create both at Finalize
+    /// time (whichever `fs::copy` runs second fails). Caught here so
+    /// the operator gets a Compose-time error naming both
+    /// contributors instead of a mid-Finalize `NotADirectory` /
+    /// `IsADirectory` fault that leaves the session stuck in
+    /// `Materializing`.
+    PatchDestPrefixCollision {
+        /// The shorter destination — the one that would land as a
+        /// file directly under `<home>`.
+        shorter: paths::SandboxRelPath,
+        /// The longer destination, whose parent-chain includes
+        /// `shorter` as a directory.
+        longer: paths::SandboxRelPath,
+        /// The provenance of both contributors.
+        ///
+        /// Boxed to keep [`Conflict`] — and the two error enums that
+        /// embed it, [`Error`] and [`ComposeError`] — under the
+        /// `result_large_err` size threshold; this array is by far the
+        /// largest payload across every conflict variant.
+        contributors: Box<[(Source, paths::SandboxRelPath); 2]>,
+    },
 }
 
 impl fmt::Display for Conflict {
@@ -150,6 +176,27 @@ impl fmt::Display for Conflict {
                     "\nhint: add a pattern matching the conflicting source path(s) \
                      above to your patch policy's ignore list to drop both, \
                      or remove one of the contributors"
+                )
+            }
+            Self::PatchDestPrefixCollision {
+                shorter,
+                longer,
+                contributors,
+            } => {
+                write!(
+                    f,
+                    "patch destinations `{shorter}` and `{longer}` collide: \
+                     one wants a file where the other expects a directory"
+                )?;
+                for (source, dest) in contributors.iter() {
+                    write!(f, "\n  - `{dest}` (from {source})")?;
+                }
+                write!(
+                    f,
+                    "\nhint: pick destinations that don't nest — e.g. move the \
+                     file target under a distinct name, or add a pattern \
+                     matching one contributor's source to your patch policy's \
+                     ignore list to drop it"
                 )
             }
         }
@@ -223,6 +270,75 @@ fn check_patch_mismatches<'a, T: Provenanced + 'a>(
             disagreeing_sources: collect_contributions(group, &pattern),
         })
         .map_or(Ok(()), Err)
+}
+
+/// Reject two patches whose destinations are prefixes of one another
+/// on a path-component boundary — `foo` vs `foo/bar` — since
+/// `materialize_patches_into_home` can't create the shorter as a
+/// file *and* the longer as `<shorter>/<tail>`. Caught here so the
+/// operator sees a compose-time conflict listing both contributors,
+/// rather than a mid-`FinalizeSession` `NotADirectory`/`IsADirectory`
+/// I/O error that leaves the session stuck in `Materializing`.
+///
+/// O(n²) worst-case, matching the existing `check_patch_mismatches`
+/// shape — the batches this runs against are small (a few dozen at
+/// most in practice).
+fn check_patch_prefix_collisions<'a, T: Provenanced + 'a>(
+    items: impl IntoIterator<Item = &'a T> + Clone,
+    dest: impl Fn(&T) -> &paths::SandboxRelPath,
+) -> Result<(), Conflict> {
+    let all: Vec<&'a T> = items.into_iter().collect();
+    for (i, a) in all.iter().enumerate() {
+        let a_dest = dest(a);
+        for b in &all[i + 1..] {
+            let b_dest = dest(b);
+            if a_dest == b_dest {
+                // Same-destination collisions are the
+                // `PatchSourceMismatch` case: same source is a dup
+                // (fine), different source is that other conflict
+                // (fires from `check_patch_mismatches`, not here).
+                continue;
+            }
+            let (shorter, longer, shorter_src, longer_src) =
+                if is_component_prefix(a_dest.as_utf8_path(), b_dest.as_utf8_path()) {
+                    (a_dest, b_dest, a.source(), b.source())
+                } else if is_component_prefix(b_dest.as_utf8_path(), a_dest.as_utf8_path()) {
+                    (b_dest, a_dest, b.source(), a.source())
+                } else {
+                    continue;
+                };
+            return Err(Conflict::PatchDestPrefixCollision {
+                shorter: shorter.clone(),
+                longer: longer.clone(),
+                contributors: Box::new([
+                    (shorter_src.clone(), shorter.clone()),
+                    (longer_src.clone(), longer.clone()),
+                ]),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// True iff `shorter` is a component-boundary prefix of `longer`
+/// (both relative, equal-length is not a prefix — that would be
+/// same-destination, covered by `check_patch_mismatches`). Component
+/// boundary so `foo` doesn't wrongly match `foobar` (only `foo/bar`).
+fn is_component_prefix(shorter: &camino::Utf8Path, longer: &camino::Utf8Path) -> bool {
+    let mut s = shorter.components();
+    let mut l = longer.components();
+    loop {
+        match (s.next(), l.next()) {
+            // Matched component: keep comparing the rest.
+            (Some(a), Some(b)) if a == b => {}
+            // `shorter` has an unmatched component (differs here, or is
+            // the longer path), or both ran out at equal length — either
+            // way `shorter` is not a *proper* component prefix.
+            (Some(_), _) | (None, None) => return false,
+            // `shorter` ran out while `longer` has more: proper prefix.
+            (None, Some(_)) => return true,
+        }
+    }
 }
 
 /// Bucket `items` by `key`, preserving the order in which keys are
@@ -1109,6 +1225,9 @@ impl Composition {
             |p| p.patch().destination(),
             |p| p.patch().host_path().as_str(),
         )?;
+        check_patch_prefix_collisions(self.patches.iter().chain(incoming_patches.iter()), |p| {
+            p.patch().destination()
+        })?;
         Ok(())
     }
 }
@@ -1527,6 +1646,7 @@ pub(crate) fn compose_contribution(
         |p| p.patch().destination(),
         |p| p.patch().host_path().as_str(),
     )?;
+    check_patch_prefix_collisions(gated_patches.iter(), |p| p.patch().destination())?;
     let final_policy = UserPolicy::empty()
         .with_vars(vars_policy)
         .with_patches(patches_policy);
@@ -2825,6 +2945,106 @@ mod tests {
                 }
                 other => panic!("unexpected: {other:?}"),
             }
+        }
+
+        // ---------------- check_patch_prefix_collisions ----------------
+
+        #[test]
+        fn prefix_collision_sibling_dests_ok() {
+            // Nothing overlaps: two files in the same dir don't
+            // collide, they just coexist under `<home>/config/`.
+            let items = vec![
+                pp("/etc/foo", "config/foo", project_source()),
+                pp("/etc/bar", "config/bar", user_source()),
+            ];
+            assert!(
+                check_patch_prefix_collisions(&items, |p| p.patch().dest().as_sandbox_path())
+                    .is_ok()
+            );
+        }
+
+        #[test]
+        fn prefix_collision_same_dest_ok() {
+            // Exact-equal destinations are the
+            // `PatchSourceMismatch` case, not this one. This check
+            // must not fire on them regardless of whether the
+            // sources agree.
+            let items = vec![
+                pp("/etc/foo", "config/foo", project_source()),
+                pp("/etc/foo", "config/foo", user_source()),
+            ];
+            assert!(
+                check_patch_prefix_collisions(&items, |p| p.patch().dest().as_sandbox_path())
+                    .is_ok()
+            );
+        }
+
+        #[test]
+        fn prefix_collision_shared_string_prefix_ok() {
+            // Component boundary matters: `foo` isn't a prefix of
+            // `foobar` — those are just two independent files at the
+            // same level.
+            let items = vec![
+                pp("/etc/foo", "foo", project_source()),
+                pp("/etc/foobar", "foobar", user_source()),
+            ];
+            assert!(
+                check_patch_prefix_collisions(&items, |p| p.patch().dest().as_sandbox_path())
+                    .is_ok()
+            );
+        }
+
+        #[test]
+        fn prefix_collision_nested_dests_errors() {
+            // Concrete example: one contributor wants a file at
+            // `foo`, another wants a file at `foo/bar`. Materialize
+            // would fail on whichever ran second.
+            let items = vec![
+                pp("/etc/foo.txt", "foo", project_source()),
+                pp(
+                    "/etc/bar.txt",
+                    "foo/bar",
+                    Source::UserLoadout { name: "dev".into() },
+                ),
+            ];
+            let err = check_patch_prefix_collisions(&items, |p| p.patch().dest().as_sandbox_path())
+                .unwrap_err();
+            match err {
+                Conflict::PatchDestPrefixCollision {
+                    shorter,
+                    longer,
+                    contributors,
+                } => {
+                    assert_eq!(shorter.as_utf8_path().as_str(), "foo");
+                    assert_eq!(longer.as_utf8_path().as_str(), "foo/bar");
+                    assert_eq!(contributors.len(), 2);
+                }
+                other => panic!("unexpected: {other:?}"),
+            }
+        }
+
+        #[test]
+        fn prefix_collision_input_order_independent() {
+            // The check fires whichever order the two destinations
+            // appear in the batch. Guards against a future
+            // refactor that only compares "later against earlier".
+            let a = pp("/etc/foo.txt", "foo", project_source());
+            let b = pp(
+                "/etc/bar.txt",
+                "foo/bar",
+                Source::UserLoadout { name: "dev".into() },
+            );
+            assert!(
+                check_patch_prefix_collisions(&[a.clone(), b.clone()], |p| p
+                    .patch()
+                    .dest()
+                    .as_sandbox_path())
+                .is_err()
+            );
+            assert!(
+                check_patch_prefix_collisions(&[b, a], |p| p.patch().dest().as_sandbox_path())
+                    .is_err()
+            );
         }
 
         // ---------------- dedupe_by_name ----------------

--- a/crates/sessions/src/core/primitives.rs
+++ b/crates/sessions/src/core/primitives.rs
@@ -984,6 +984,22 @@ impl PatchDest {
         if path.as_str().is_empty() {
             return Err(PatchError::EmptyDest);
         }
+        // Destinations are semantically relative to the sandbox user's
+        // home directory, so a leading `~/` is redundant — the package
+        // author who writes `path = "~/.claude"` in their mfile means
+        // "place `.claude` under sandbox home", not "place a literal
+        // `~` directory there." Strip the prefix once, here, so
+        // downstream consumers (tar packing, materialize) don't
+        // create paths like `/home/~/.claude`. A bare `~` becomes an
+        // empty path and re-hits the empty-dest check below.
+        let path: Utf8PathBuf = match path.as_str().strip_prefix("~/") {
+            Some(rest) => rest.into(),
+            None if path.as_str() == "~" => Utf8PathBuf::new(),
+            None => path,
+        };
+        if path.as_str().is_empty() {
+            return Err(PatchError::EmptyDest);
+        }
         // Walk components: drop CurDir, fail on ParentDir, keep the
         // rest. RootDir (an absolute path) is allowed through here so
         // SandboxRelPath::try_new can produce its own AbsoluteDestPath
@@ -1590,6 +1606,37 @@ mod tests {
         assert!(matches!(
             PatchDest::try_new("foo/../bar"),
             Err(PatchError::DestTraversal(_))
+        ));
+    }
+
+    #[test]
+    fn patchdest_strips_leading_home_tilde() {
+        // Package authors write `path = "~/.claude"` in their mfile
+        // meaning "map onto sandbox home"; destinations are already
+        // home-relative, so the tilde is redundant and must not
+        // survive into the tar entry or materialize target (else
+        // files land at `/home/~/.claude/...` inside the sandbox).
+        let cases = [
+            ("~/.claude", ".claude"),
+            ("~/foo/bar", "foo/bar"),
+            ("~/", ""), // empty after strip → EmptyDest below
+        ];
+        for (input, expected) in cases {
+            if expected.is_empty() {
+                assert!(
+                    matches!(PatchDest::try_new(input), Err(PatchError::EmptyDest)),
+                    "input {input} should reject as empty after tilde strip",
+                );
+            } else {
+                let dest = PatchDest::try_new(input).expect(input);
+                assert_eq!(dest.as_sandbox_path().as_str(), expected, "input: {input}");
+            }
+        }
+        // Bare `~` is also nonsensical as a destination — home root
+        // itself isn't a file target — so it rejects as empty too.
+        assert!(matches!(
+            PatchDest::try_new("~"),
+            Err(PatchError::EmptyDest)
         ));
     }
 

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -293,7 +293,21 @@ pub enum SessionStatus {
     /// rename continue to load.
     #[serde(alias = "draft")]
     Pending,
-    /// Composition complete; the record is ready to apply.
+    /// Composition finalized but the session isn't attachable yet:
+    /// the client is still uploading the composition's patches to
+    /// the daemon-side workspace. Transitions to [`Self::Active`]
+    /// when the client calls `FinalizeSession` — which the daemon
+    /// gates on the patches-ready marker being present. Attach
+    /// refuses `Materializing` sessions.
+    ///
+    /// A daemon restart wipes the in-memory composition, so any
+    /// `Materializing` record left on disk after restart is
+    /// unresumable; the manager reaps them at startup for the same
+    /// reason it reaps unresumable `Pending` records.
+    Materializing,
+    /// Composition complete and every side-channel upload is on
+    /// disk; the record is ready to apply and the session is
+    /// attachable.
     #[default]
     Active,
 }

--- a/crates/sessions/src/store.rs
+++ b/crates/sessions/src/store.rs
@@ -23,6 +23,11 @@ pub trait SessionObject: Sized + Send + Clone + 'static + std::fmt::Debug {
     fn workspace_path(&self) -> DaemonAbsPath;
     fn home_path(&self) -> DaemonAbsPath;
     fn cache_path(&self) -> DaemonAbsPath;
+    /// Directory the daemon stages the client-uploaded
+    /// composition patches into, ready for the launcher to
+    /// materialize into the sandbox home. Each entry is stored
+    /// under the patch's sandbox-home-relative destination path.
+    fn patches_path(&self) -> DaemonAbsPath;
 }
 
 /// Describes the primary key a [`Loader`] uses to reference
@@ -188,6 +193,9 @@ impl SessionObject for DiskSession {
     }
     fn cache_path(&self) -> DaemonAbsPath {
         sub_path!(self.root_path(), "cache")
+    }
+    fn patches_path(&self) -> DaemonAbsPath {
+        sub_path!(self.root_path(), "patches")
     }
 }
 

--- a/crates/sessions/src/wire/request.rs
+++ b/crates/sessions/src/wire/request.rs
@@ -61,16 +61,25 @@ pub struct ContributionVerdict {
     pub patches: Vec<WirePatchVerdict>,
 }
 
-/// Daemon's reply to a `SubmitVerdict`: a terminal "session ready"
-/// signal or a protocol-level fault the transport layer didn't
+/// Daemon's reply to a `SubmitVerdict`: composition finalized (the
+/// record has moved from `Pending` to
+/// [`Materializing`](crate::SessionStatus::Materializing), not yet
+/// `Active`) or a protocol-level fault the transport layer didn't
 /// catch.
+///
+/// The client follows up with a patches upload
+/// (`WorkspacePatchesTarZst`) and then `FinalizeSession` to
+/// actually promote the record to
+/// [`Active`](crate::SessionStatus::Active). Only after that step
+/// is the session attachable.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SessionStep {
     /// Composition complete; the session record has been promoted to
-    /// [`Active`](crate::SessionStatus::Active) and is ready to use.
-    /// Terminal — the client doesn't follow up after receiving this.
-    Active {
+    /// [`Materializing`](crate::SessionStatus::Materializing). The
+    /// client must upload the composition's patches and call
+    /// `FinalizeSession` before the session is attachable.
+    Materialized {
         /// Daemon-assigned session id. Matches the id returned by
         /// the originating `CreateSessionResponse::Pending`.
         id: SessionId,
@@ -149,11 +158,11 @@ mod tests {
 
     #[test]
     fn session_step_round_trips_all_variants() {
-        let active = SessionStep::Active { id: session_id() };
+        let materialized = SessionStep::Materialized { id: session_id() };
         let fault = SessionStep::Fault {
             error: WireError::UnknownSessionId,
         };
-        assert_eq!(round_trip(&active), active);
+        assert_eq!(round_trip(&materialized), materialized);
         assert_eq!(round_trip(&fault), fault);
     }
 

--- a/justfile
+++ b/justfile
@@ -156,6 +156,15 @@ _nextest: (_need "cargo-nextest" "cargo install cargo-nextest --locked")
 fmt:
     cargo fmt --all
 
+# Autofix pass: fmt, clippy --fix, fmt again. Clippy's `--fix` can shuffle
+# whitespace during its rewrites, so the trailing `cargo fmt` normalizes
+# whatever landed. `--allow-dirty` skips the clean-worktree check — the
+# usual case here is running mid-edit with staged/unstaged work.
+fix:
+    cargo fmt --all
+    cargo clippy {{scope}} --all-targets --fix --allow-dirty -- -D warnings
+    cargo fmt --all
+
 # CI: ci.yml `fmt`.
 fmt-check:
     cargo fmt --all -- --check


### PR DESCRIPTION
## Summary

- Adds the missing piece of the composition pipeline: **actual patch file
  streaming from client to daemon** so composition-declared patches land
  in the sandbox home at attach time. Before this, the composer produced
  `SessionPatch` entries and `session_host` logged them as `deferred =
  true` — the sandbox home was empty when the shell was minted.

- New `WorkspacePatchesTarZst` SSH subsystem streams the finalized
  composition's approved patch files (loadout-contributed + Phase 3
  daemon-approved) into `<workspace>/patches/` on the daemon via
  atomic staging-dir + rename + `.patches_ready` marker. Body writes
  fan out across `available_parallelism()` tasks via a `JoinSet`.
  Untrusted per-entry validation on the daemon side: traversal check,
  marker-filename collision reject, and a 1 GiB per-entry size cap so
  a forged header can't drive `Vec::with_capacity` to OOM.

- New `SessionStatus::Materializing` state sits between `Pending` and
  `Active`. `ConfigureLoadout` / `SubmitVerdict` promote the record to
  `Materializing` (not `Active`); a new `FinalizeSession` RPC checks
  the marker, materializes patches into the sandbox home via
  `materialize_patches_into_home`, and promotes to `Active`. Attach
  is refused while `Materializing`, so a client that dies mid-flow
  never lands the operator on an empty-home shell.

- Wire renames (pre-prod, no back-compat aliases):
  `ConfigureLoadoutResponse::Ready → Materialized` and
  `SessionStep::Active → Materialized`.

- Restart safety: `Manager::init` reaps unresumable records
  (`Pending` and `Materializing`) at startup — those states rely on
  in-memory compose state that dies with the actor. If a race lets a
  `Materializing` record through, `finalize` refuses with an
  `InvalidInput` fault so the operator sees the problem instead of a
  silently-empty sandbox home.

- Client progress bars via indicatif — spinner for the workspace-files
  upload, patch-count bar for the composition-patches upload.
  `add_spinner_bar` and `add_patches_bar` register with `ot`'s global
  `MultiProgress` so tracing output and bars don't stomp on each
  other. Includes a hidden `min spin` demo command.

- Perf: several structural wins found while profiling the patches
  upload path — 1 MiB `BufReader` on the source file, custom
  `copy_buf`-based fast path bypassing `async_tar`'s 8 KiB internal
  buffer for short archive paths, zstd level 1 with N-1 worker
  threads (feature `zstdmt`), and the parallel daemon-side unpack
  described above. End-to-end wall time for a 1.3 GiB `~/.claude`
  payload dropped from 117 s (cold cache, default settings) to ~9 s.

- `PatchDest::try_new` normalizes a leading `~/` in destinations
  (mfile authors write `path = "~/.claude"` meaning "under sandbox
  home"; the tilde was previously kept literal and landed patches at
  `/home/~/.claude/...`).

- `COMPOSITION.md` rewritten to cover the new Phase 4a/4b/4c split,
  the `Materializing` state, and the new invariants (client is
  authoritative for the upload; restart-orphaned records are reaped
  or refused; unpack is atomic and marker-gated; peer sizes are
  capped).

## Testing

Torture tested it by uploading my .claude directory many many times.

## Checklist

- [x] Docs updated if behavior changed
- [We're pre-prod so not necessary] `BREAKING CHANGE:` footer present if this is a breaking change


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add patch file upload and `FinalizeSession` RPC to session activation flow
> - Introduces a `Materializing` session state between `ConfigureLoadout` and `Active`. Sessions now follow: `CreateSession` → `ConfigureLoadout` → (client uploads patches) → `FinalizeSession` → `Active`.
> - Adds the `FinalizeSession` RPC and a `WorkspacePatchesTarZst` SSH subsystem. The daemon atomically unpacks uploaded tar.zst patch archives with path-traversal validation and in-flight byte budgets before marking the session active.
> - Client-side (`cmd_activate`) collects approved patches from the contribution verdict, uploads them via `Client::upload_patches` with a determinate progress bar, and calls `FinalizeSession`; on failure it attempts a best-effort session destroy.
> - Adds `PatchDestPrefixCollision` conflict detection at compose time, rejecting patches whose destinations are component-boundary prefixes of each other (e.g. `foo` vs `foo/bar`).
> - On daemon startup, stale `Pending` and `Materializing` session records are reaped automatically.
> - `PatchDest::try_new` now strips a leading `~/` from patch destinations.
> - Risk: `ConfigureLoadoutResponse::Ready` is renamed to `Materialized` and `SessionStep::Active` becomes `SessionStep::Materialized` on the wire; all RPC clients and tests must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61f4f35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a two-step activation flow: sessions become materialized after composition, then require finalization to become attachable.
  * Approved workspace patches are uploaded with progress and materialized atomically during finalization.
  * Added a hidden CLI `spin` command for a stderr spinner with `--seconds`.
* **Bug Fixes**
  * Improved resilience for sessions interrupted during activation, including cleanup/reaping of unresumable states.
  * Safer patch extraction rejects unsafe paths and prevents oversized/marker-colliding entries.
  * Attachment picker now shows the correct “not-yet-ready” status for materializing/pending.
* **Documentation**
  * Refreshed session composition/activation docs with the new phased lifecycle and finalization semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->