### PR TITLE
fix(minimald): return the served contract from the diag bundle handler

### DIFF
--- a/crates/minimald/src/diag.rs
+++ b/crates/minimald/src/diag.rs
@@ -30,6 +30,7 @@ use diagnostics::redact::{masked_process_env, redact_json};
 use diagnostics::{BundleSink, BundleWriter, LOG_TAIL_CAP, Redaction};
 
 use crate::ChannelConfig;
+use crate::connection::ConnectionError;
 use crate::server::ServerStateHandle;
 
 /// Longest request body accepted before the read is abandoned. The body is a
@@ -124,11 +125,16 @@ pub(crate) async fn serve_stream_diag_bundle(
     s: ServerStateHandle,
     _config: ChannelConfig,
     mut c: RuChannel<Msg>,
-) {
-    if let Err(msg) = stream_diag_bundle(&s, &mut c).await {
-        let _ = c.extended_data_bytes(1, msg).await;
-    }
+) -> Result<(), ConnectionError> {
+    let outcome = match stream_diag_bundle(&s, &mut c).await {
+        Ok(()) => Ok(()),
+        Err(msg) => {
+            let _ = c.extended_data_bytes(1, msg.clone()).await;
+            Err(ConnectionError::Internal(msg))
+        }
+    };
     let _ = c.close().await;
+    outcome
 }
 
 /// Reads the request, then streams the bundle. On failure returns the


### PR DESCRIPTION
Main is broken: [#895](https://github.com/gominimal/minimal/pull/895) changed the `serve!` dispatch so every handler returns `Result<(), ConnectionError>` for outcome logging, and [#878](https://github.com/gominimal/minimal/pull/878) merged 15 minutes later with `serve_stream_diag_bundle` still returning `()`. Each was green against a main that lacked the other; the E0271 type error only surfaces on branches built after both landed (first seen on [#916](https://github.com/gominimal/minimal/pull/916), also failing [#880](https://github.com/gominimal/minimal/pull/880)).

The handler now returns the outcome, mirroring `serve_stream_workspace_files`: failure still relays the message over the channel's extended-data stream, then surfaces as `ConnectionError::Internal` so dispatch logging records it.

Verified via cross (aarch64-linux): `clippy --all-targets -- -D warnings` clean, `minimald --lib` 164/164 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `serve_stream_diag_bundle` to return the served contract result
> Updates [`serve_stream_diag_bundle`](https://github.com/gominimal/minimal/pull/918/files#diff-ed60839e8685efd73f65ba91318d4d49927b99b4dbd27171a941fc02fecd5a34) to return `Result<(), ConnectionError>` instead of `()`. On failure, the error message is sent over the channel's extended-data stream before returning `Err(ConnectionError::Internal(msg))`; on success it returns `Ok(())`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b36c3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostic bundle streaming failures are now reported directly, improving error visibility and handling.
  * Detailed error information continues to be provided through the diagnostic channel when streaming fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->