### PR TITLE
fix(minimald): surface daemon RPC errors to client and detect upload connection drops

### DIFF
--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -507,7 +507,6 @@ impl Client {
                 _ => {}
             }
         }
-        }
         if !err.is_empty() {
             anyhow::bail!(
                 "daemon failed to unpack {what}s: {}",

--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 
 use anyhow::Context as _;
 use minimald_rpc::OneshotSshRpc;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 /// Add a spinner-style progress bar to the process-global `MultiProgress`.
 /// Bars must be inserted before any style/message/tick configuration —
@@ -219,6 +218,11 @@ impl Client {
     ///
     /// The type parameter `R` picks the RPC from the wire contract; `request`
     /// is serialized to JSON and the response is deserialized from JSON.
+    ///
+    /// Uses `channel.wait()` rather than `channel.into_stream()` so that
+    /// extended-data (stream 1) — where the daemon writes handler errors
+    /// (#901) — is visible instead of silently discarded by the stream's
+    /// `AsyncRead` impl.
     pub async fn oneshot_rpc<R: OneshotSshRpc>(
         &mut self,
         request: R::Request<'_>,
@@ -226,28 +230,50 @@ impl Client {
     where
         <R as OneshotSshRpc>::Response: serde::de::DeserializeOwned,
     {
-        let channel = self
+        let mut channel = self
             .handle
             .channel_open_session()
             .await
             .with_context(|| format!("open channel for {}", R::NAME))?;
 
         send_traceparent(&channel).await;
+        // want_reply = true so an unknown subsystem (CLI/daemon version
+        // skew) surfaces as a Failure instead of the client writing into a
+        // channel nobody serves (#901).
         channel
-            .request_subsystem(false, R::NAME)
+            .request_subsystem(true, R::NAME)
             .await
             .with_context(|| format!("request subsystem {}", R::NAME))?;
 
         let body = serde_json::to_vec(&request).context("serialize request")?;
+        channel.data_bytes(body).await.context("write request")?;
+        channel.eof().await.context("shutdown write half")?;
 
-        let mut rpc = channel.into_stream();
-        rpc.write_all(&body).await.context("write request")?;
-        rpc.shutdown().await.context("shutdown write half")?;
-
+        // Drain the channel with wait() rather than into_stream() so that
+        // extended-data (stream 1) — where the daemon writes handler errors
+        // (#901) — is visible instead of silently discarded by the stream's
+        // AsyncRead impl.
         let mut resp_buf = Vec::with_capacity(256);
-        rpc.read_to_end(&mut resp_buf)
-            .await
-            .context("read response")?;
+        let mut err_buf = Vec::new();
+        while let Some(msg) = channel.wait().await {
+            match msg {
+                russh::ChannelMsg::Data { data } => {
+                    resp_buf.extend_from_slice(&data);
+                }
+                russh::ChannelMsg::ExtendedData { data, ext: 1 } => {
+                    err_buf.extend_from_slice(&data);
+                }
+                _ => {}
+            }
+        }
+
+        if !err_buf.is_empty() {
+            anyhow::bail!(
+                "{} RPC failed on the daemon side: {}",
+                R::NAME,
+                String::from_utf8_lossy(&err_buf)
+            );
+        }
 
         serde_json::from_slice(&resp_buf)
             .with_context(|| format!("decode response for {}", R::NAME))
@@ -461,21 +487,37 @@ impl Client {
         let writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(channel.make_writer());
         stream(writer).await?;
 
-        // Wait for the channel to close to signal that unpacking is done.
-        // The daemon relays any unpack failure on extended-data stream 1 and
-        // only then closes, so accumulate that stream under the same cap the
-        // diagnostic download uses — a daemon spraying extended data must not
-        // be able to balloon the client's memory.
+        // Drain the channel: collect extended-data (stream 1) errors from
+        // the daemon under the same cap the diagnostic download uses, and
+        // track whether we see an explicit Eof/Close to distinguish a clean
+        // post-unpack close from a dropped connection (#901). Without this
+        // check a connection drop mid-unpack looks identical to a successful
+        // close — empty err, Ok(()) — and cmd_activate proceeds with an
+        // empty workspace.
         let mut err = Vec::new();
+        let mut saw_close = false;
         while let Some(msg) = channel.wait().await {
-            if let russh::ChannelMsg::ExtendedData { data, ext: 1 } = msg {
-                append_daemon_error(&mut err, &data);
+            match msg {
+                russh::ChannelMsg::ExtendedData { data, ext: 1 } => {
+                    append_daemon_error(&mut err, &data);
+                }
+                russh::ChannelMsg::Eof | russh::ChannelMsg::Close => {
+                    saw_close = true;
+                }
+                _ => {}
             }
+        }
         }
         if !err.is_empty() {
             anyhow::bail!(
                 "daemon failed to unpack {what}s: {}",
                 String::from_utf8_lossy(&err)
+            );
+        }
+        if !saw_close {
+            anyhow::bail!(
+                "upload stream ended unexpectedly: the connection to the daemon \
+                 was lost before unpacking completed"
             );
         }
         Ok(())

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -18,8 +18,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, ReadBuf};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, ReadBuf};
 use tokio::task::spawn;
 
 use crate::{
@@ -77,8 +76,7 @@ trait ServeOneshot: OneshotSshRpc {
 
         match result {
             Ok(response_bytes) => {
-                c.data_bytes(response_bytes)
-                    .await?;
+                c.data_bytes(response_bytes).await?;
                 c.eof().await?;
                 c.close().await?;
                 Ok(())

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, ReadBuf};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::task::spawn;
 
 use crate::{
@@ -39,29 +40,55 @@ trait ServeOneshot: OneshotSshRpc {
     /// Helper to deserialize the request and serialize the response
     /// down the given SSH channel, calling the provided async handler
     /// function to compute the response.
-    async fn handle_channel<F>(&self, c: RuChannel<Msg>, handler: F) -> Result<(), ConnectionError>
+    ///
+    /// On a handler error the message is written to SSH extended data
+    /// (stream 1) before the channel is closed, so the client sees a
+    /// legible error instead of an opaque EOF (#901).
+    async fn handle_channel<F>(
+        &self,
+        mut c: RuChannel<Msg>,
+        handler: F,
+    ) -> Result<(), ConnectionError>
     where
         F: for<'a> AsyncFnOnce(Self::Request<'a>) -> Result<Self::Response, ConnectionError>,
     {
-        let mut stream = c.into_stream();
-
+        // Read the request by draining Data messages until Eof or the
+        // channel closes. Using wait() directly (rather than into_stream)
+        // so the channel remains available for extended_data_bytes() and
+        // close() on the error path (#901).
         let mut buf = Vec::with_capacity(1024);
-        stream
-            .read_to_end(&mut buf)
-            .await
-            .map_err(russh::Error::from)?;
+        while let Some(msg) = c.wait().await {
+            match msg {
+                russh::ChannelMsg::Data { data } => buf.extend_from_slice(&data),
+                russh::ChannelMsg::Eof | russh::ChannelMsg::Close => break,
+                _ => {}
+            }
+        }
 
-        let request: Self::Request<'_> = serde_json::from_slice(&buf)?;
-        let response = handler(request).await?;
-        let response_bytes = serde_json::to_vec(&response)?;
+        // All error paths — JSON parse, handler, serialization — are funneled
+        // through the same match so the client always sees a legible message
+        // on extended data instead of an opaque EOF (#901).
+        let result: Result<Vec<u8>, ConnectionError> = async {
+            let request: Self::Request<'_> = serde_json::from_slice(&buf)?;
+            let response = handler(request).await?;
+            Ok(serde_json::to_vec(&response)?)
+        }
+        .await;
 
-        stream
-            .write_all(&response_bytes)
-            .await
-            .map_err(russh::Error::from)?;
-        stream.flush().await.map_err(russh::Error::from)?;
-        stream.shutdown().await.map_err(russh::Error::from)?;
-        Ok(())
+        match result {
+            Ok(response_bytes) => {
+                c.data_bytes(response_bytes)
+                    .await?;
+                c.eof().await?;
+                c.close().await?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = c.extended_data_bytes(1, e.to_string()).await;
+                let _ = c.close().await;
+                Err(e)
+            }
+        }
     }
 }
 
@@ -1477,6 +1504,48 @@ mod tests {
         assert!(super::safe_relative_path(StdPath::new(
             ".config/helix/config.toml"
         )));
+    }
+
+    /// When the daemon fails to parse a request (or the handler errors),
+    /// the error message must reach the client on extended data instead
+    /// of the client seeing an opaque EOF on the response stream (#901).
+    #[tokio::test]
+    async fn oneshot_rpc_surfaces_handler_errors_as_extended_data() {
+        use russh::ChannelMsg;
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        // Send invalid JSON to a known subsystem: handle_channel will fail
+        // at serde_json::from_slice, which now writes the error to extended
+        // data before closing the channel.
+        let mut channel = client.open_subsystem(GetVersion::NAME, &[]).await;
+        channel
+            .data_bytes(b"not valid json".to_vec())
+            .await
+            .unwrap();
+        channel.eof().await.unwrap();
+
+        let mut err_buf = Vec::new();
+        let mut data_buf = Vec::new();
+        while let Some(msg) = channel.wait().await {
+            match msg {
+                ChannelMsg::ExtendedData { data, ext: 1 } => err_buf.extend_from_slice(&data),
+                ChannelMsg::Data { data } => data_buf.extend_from_slice(&data),
+                _ => {}
+            }
+        }
+
+        assert!(
+            !err_buf.is_empty(),
+            "expected an error on extended data, got data={:?}, err=empty",
+            String::from_utf8_lossy(&data_buf),
+        );
+        assert!(
+            data_buf.is_empty(),
+            "expected no response data on error, got {:?}",
+            String::from_utf8_lossy(&data_buf),
+        );
     }
 
     #[tokio::test]

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -25,7 +25,6 @@ use paths::DaemonAbsPath;
 use russh::keys::ssh_key;
 use sessions::SessionId;
 use tempfile::TempDir;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 
 use minimald_rpc::OneshotSshRpc;
@@ -209,17 +208,34 @@ impl TestClient {
     /// Panics on any transport or codec failure — appropriate for unit
     /// tests, which want loud failure rather than recovery.
     pub async fn call<R: OneshotSshRpc>(&mut self, req: &R::Request<'_>) -> R::Response {
-        let channel = self.handle.channel_open_session().await.unwrap();
-        channel.request_subsystem(false, R::NAME).await.unwrap();
+        let mut channel = self.handle.channel_open_session().await.unwrap();
+        channel.request_subsystem(true, R::NAME).await.unwrap();
 
         let body = serde_json::to_vec(req).expect("request serializes");
-        let mut stream = channel.into_stream();
-        stream.write_all(&body).await.unwrap();
-        stream.shutdown().await.unwrap();
+        channel.data_bytes(body).await.unwrap();
+        channel.eof().await.unwrap();
 
-        let mut response_buf = Vec::with_capacity(1024);
-        stream.read_to_end(&mut response_buf).await.unwrap();
-        serde_json::from_slice(&response_buf).expect("response deserializes")
+        let mut resp_buf = Vec::with_capacity(1024);
+        let mut err_buf = Vec::new();
+        while let Some(msg) = channel.wait().await {
+            match msg {
+                russh::ChannelMsg::Data { data } => resp_buf.extend_from_slice(&data),
+                russh::ChannelMsg::ExtendedData { data, ext: 1 } => {
+                    err_buf.extend_from_slice(&data)
+                }
+                _ => {}
+            }
+        }
+
+        if !err_buf.is_empty() {
+            panic!(
+                "{} RPC failed on the daemon side: {}",
+                R::NAME,
+                String::from_utf8_lossy(&err_buf)
+            );
+        }
+
+        serde_json::from_slice(&resp_buf).expect("response deserializes")
     }
 
     /// Opens an SFTP session attached to the given minimald session.


### PR DESCRIPTION
<summary>

Two defects in the SSH channel handling left the client with opaque failures or, worse, false success when the daemon-side operation failed.

## Defect 1 — Upload reports success when connection drops mid-unpack

`upload_workspace_files` drained the channel with `while let Some(msg) = channel.wait().await`. `channel.wait()` returns `None` for two reasons: (a) daemon closed after successful unpack, (b) SSH connection dropped. Only (a) means success. In case (b), the error buffer was empty and the function returned `Ok(())`, causing `cmd_activate` to proceed with an empty workspace.

**Fix**: Track `ChannelMsg::Eof`/`ChannelMsg::Close` — russh only delivers those on a clean close. If neither appeared, bail with a connection-dropped error.

## Defect 2 — Daemon RPC errors never reach the client

`handle_channel` returned early on handler errors, writing nothing to the channel. The `serve_*` wrappers logged to the daemon's own stderr. The client's `read_to_end` got 0 bytes, surfacing as an opaque "EOF while parsing a value."

**Fix (server)**: All error paths (JSON parse, handler, serialization) are funneled through a single match that writes the error to SSH extended data (stream 1) before closing — same mechanism `serve_stream_workspace_files` already uses.

**Fix (client)**: `oneshot_rpc` rewritten to use `channel.wait()` instead of `into_stream()` (whose `AsyncRead` silently discards `ExtendedData`), collecting data and extended-data separately. If extended data is present, bail with that error. `request_subsystem(false, ...)` changed to `true` so unknown subsystems surface as a Failure.

Closes #901.

</summary>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface daemon RPC errors to client and detect upload connection drops in minimald
> - `Client.oneshot_rpc` now reads SSH channel messages via `wait()` to capture extended-data (stream 1); if the daemon writes an error there, the client returns it as an error rather than seeing an opaque EOF.
> - `Client.upload` now tracks whether an explicit `Eof` or `Close` was received and fails with "upload stream ended unexpectedly" if the connection drops mid-transfer, preventing false success on mid-unpack disconnects.
> - `ServeOneshot.handle_channel` in [rpc.rs](https://github.com/gominimal/minimal/pull/919/files#diff-483e2e3e5623d7d67de4661e6024e9f281cec45e7e33d09b64a0bb8295ce297b) now writes handler/decode errors as human-readable text on SSH extended-data stream 1 before closing the channel, instead of silently closing.
> - A new test `oneshot_rpc_surfaces_handler_errors_as_extended_data` asserts that invalid JSON sent to a subsystem produces an error on extended-data with no response bytes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef3070a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->