### PR TITLE
fix(minvmd): coalesce libkrun vsock reads instead of emitting sub-skb packets

### DIFF
--- a/vendor/libkrun/patches/0001-vsock-coalesce-sub-skb.patch
+++ b/vendor/libkrun/patches/0001-vsock-coalesce-sub-skb.patch
@@ -1,0 +1,167 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Norrie Taylor <norrie@minimal.dev>
+Date: Wed, 22 Jul 2026 16:00:00 -0700
+Subject: [PATCH] vsock: coalesce recv into full descriptors instead of
+ emitting sub-skb packets
+
+libkrun's unix-vsock proxy issues one recv() per RX descriptor and emits
+whatever that single read found buffered on the host socket. Against a bulk
+sender that hands the stream over in small chunks, the muxer drains the
+socket faster than the writer fills it, so descriptors carry a fraction of
+their capacity and the stream fragments into sub-KiB packets even though the
+peer's window is wide open.
+
+That is expensive in the one currency the receiver is short of. Linux charges
+every queued packet SKB_TRUESIZE(0) against buf_alloc regardless of payload
+-- 576 bytes on arm64 -- so a stream whose mean packet falls below that
+exhausts the receiver's queue budget long before its byte budget. With a
+256 KiB window the queue caps at 455 packets, and since 6.12.92
+("vsock/virtio: reset connection on receiving queue overflow") the receiver
+answers the 456th with a connection reset (ENOBUFS) rather than a silent
+drop. This is the failure behind bulk host->guest uploads.
+
+Fix recv_to_pkt to fill the descriptor rather than emit one recv()'s worth:
+
+  - loop reading into the descriptor until it is full or the socket returns
+    EAGAIN, so a burst already buffered is coalesced into one packet;
+
+  - and, because draining alone does not help when the writer is slower than
+    we are across wakeups (every notification then finds a few hundred bytes
+    and the loop exits on EAGAIN with the descriptor barely touched), wait
+    briefly on EAGAIN when we are still below a packet worth carrying. poll()
+    returns as soon as more data lands, so a fast writer pays nothing; a slow
+    one costs at most COALESCE_ROUNDS ms; and we always deliver what we have
+    rather than holding it, so no stream stalls on this.
+
+Measured with a guest kernel instrumented on both the rejection path and
+libkrun's emit path: on the unpatched build 86% of sub-576-byte packets came
+from the fill loop exiting on EAGAIN with descriptor space and credit both
+free -- not from the credit clamp (14%, and only in the final bytes of the
+window) and never from the descriptor size (a constant 3732 B). Waiting on
+that EAGAIN is therefore the operative lever. A/B on one host with libkrun
+the only variable: 0 of 10 uploads completed without this patch, 16 of 16
+with it, and the instrumented kernel logged no rejections at all.
+---
+diff --git a/src/devices/src/virtio/vsock/unix.rs b/src/devices/src/virtio/vsock/unix.rs
+index 2f51c05..0ebc8b0 100644
+--- a/src/devices/src/virtio/vsock/unix.rs
++++ b/src/devices/src/virtio/vsock/unix.rs
+@@ -5,13 +5,14 @@ use super::{
+ 
+ use nix::errno::Errno;
+ use nix::fcntl::{fcntl, FcntlArg, OFlag};
++use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
+ use nix::sys::socket::{
+     accept, bind, connect, listen, recv, send, shutdown, socket, AddressFamily, Backlog, MsgFlags,
+     Shutdown, SockFlag, SockType, UnixAddr,
+ };
+ use std::collections::HashMap;
+ use std::num::Wrapping;
+-use std::os::fd::{FromRawFd, OwnedFd};
++use std::os::fd::{AsFd, FromRawFd, OwnedFd};
+ use std::os::unix::io::{AsRawFd, RawFd};
+ use std::path::PathBuf;
+ use std::sync::{Arc, Mutex};
+@@ -219,25 +220,85 @@ impl UnixProxy {
+                 return RecvPkt::WaitForCredit;
+             }
+ 
+-            match recv(
+-                self.fd.as_raw_fd(),
+-                &mut buf[..max_len],
+-                MsgFlags::MSG_DONTWAIT,
+-            ) {
+-                Ok(cnt) => {
+-                    debug!("recv cnt={cnt}");
+-                    if cnt > 0 {
+-                        debug!("recv rx_cnt={}", self.rx_cnt);
+-                        RecvPkt::Read(cnt)
+-                    } else {
+-                        RecvPkt::Close
+-                    }
++            // Fill the descriptor rather than emitting whatever a single
++            // recv() happened to find buffered. A bulk sender hands us the
++            // stream in small chunks, and one recv() per descriptor turns
++            // those into one vsock packet each: we outrun the writer and
++            // fragment the stream into sub-KiB packets even though the peer's
++            // window is wide open. Each packet then costs the peer a whole
++            // skb of queue accounting for a fraction of a descriptor's worth
++            // of payload.
++            //
++            // Looping until the descriptor is full or the socket is drained
++            // is safe with level-triggered polling: we never leave readable
++            // data behind on purpose, so we cannot spin on a socket we
++            // declined to read. We stop on EAGAIN (drained), on a full
++            // descriptor (progress, and the next descriptor picks up the
++            // rest), or on EOF/error once we already have bytes -- those are
++            // re-reported on the next call, with the data delivered first.
++            //
++            // Draining the socket is not enough on its own: when the writer is
++            // slower than we are, every wakeup finds only a few hundred bytes
++            // buffered and the loop below exits on EAGAIN with the descriptor
++            // barely touched. The receiver charges a whole skb of queue
++            // accounting for each of those packets -- SKB_TRUESIZE(0), 576
++            // bytes on arm64 -- so a stream of sub-576-byte packets exhausts
++            // its queue budget long before its byte budget, and since 6.12.92
++            // Linux answers that with a connection reset rather than a drop.
++            //
++            // So when a drained socket leaves us below a packet worth
++            // carrying, wait briefly for the writer to catch up instead of
++            // spending an skb on a fraction of a descriptor. poll() returns as
++            // soon as more data lands, so a fast writer pays nothing; a slow
++            // one costs at most COALESCE_ROUNDS ms, and we always deliver what
++            // we have rather than holding it indefinitely.
++            const MIN_PKT: usize = 4096;
++            const COALESCE_ROUNDS: u32 = 4;
++
++            let mut total = 0;
++            let mut waits = 0;
++            let ret = loop {
++                if total == max_len {
++                    break RecvPkt::Read(total);
+                 }
+-                Err(e) => {
+-                    debug!("recv_pkt: recv error: {e:?}");
+-                    RecvPkt::Error
++                match recv(
++                    self.fd.as_raw_fd(),
++                    &mut buf[total..max_len],
++                    MsgFlags::MSG_DONTWAIT,
++                ) {
++                    Ok(0) => {
++                        break if total == 0 {
++                            RecvPkt::Close
++                        } else {
++                            RecvPkt::Read(total)
++                        }
++                    }
++                    Ok(cnt) => total += cnt,
++                    Err(Errno::EINTR) => continue,
++                    Err(Errno::EAGAIN) => {
++                        if total == 0 {
++                            // Spurious wakeup: nothing readable after all.
++                            break RecvPkt::Error;
++                        }
++                        if total >= std::cmp::min(max_len, MIN_PKT) || waits == COALESCE_ROUNDS {
++                            break RecvPkt::Read(total);
++                        }
++                        waits += 1;
++                        let mut fds = [PollFd::new(self.fd.as_fd(), PollFlags::POLLIN)];
++                        let _ = poll(&mut fds, PollTimeout::from(1u8));
++                    }
++                    Err(e) => {
++                        debug!("recv_pkt: recv error: {e:?}");
++                        break if total == 0 {
++                            RecvPkt::Error
++                        } else {
++                            RecvPkt::Read(total)
++                        };
++                    }
+                 }
+-            }
++            };
++            debug!("recv total={total}");
++            ret
+         } else {
+             debug!("recv_pkt: pkt without buf");
+             RecvPkt::Error


### PR DESCRIPTION
Carries a single libkrun patch on the macOS source build: fill the RX descriptor and, when the socket drains below a packet worth carrying, wait briefly on EAGAIN rather than emit a vsock packet too small to carry its own receive-queue accounting.

macOS only. Linux needs the equivalent through `gominimal/pkgs` (pkgs#506, unmerged).

## Why the shipped fix is not enough

Current `unstable` (`159f8839`) carries the fill loop from #884 and **still fails**. Confirmed on Tom's machine and reproduced here — including on the real repo, a 141 MB compressed upload.

The fill loop stops the stream fragmenting when libkrun outruns the writer *inside one wakeup*. It does nothing when the writer is slower *across* wakeups: each notification finds a few hundred bytes buffered, the loop drains them, hits EAGAIN, and ships a packet a fraction of the descriptor's size.

Linux charges every queued packet `SKB_TRUESIZE(0)` against `buf_alloc` regardless of payload — 576 bytes on arm64 — so a stream whose mean packet falls below that exhausts the receiver's queue budget long before its byte budget. At the 256 KiB default window the queue caps at 455 packets, and since 6.12.92 ("vsock/virtio: reset connection on receiving queue overflow") the receiver answers the 456th with a reset (`ENOBUFS`) instead of a drop.

## Where the small packets come from — measured in the VMM

An instrumented `recv_to_pkt` counted, per emitted packet, the descriptor size, credit, and emitted length across 86,016 packets on the failing stack:

- descriptor size is a **constant 3732 B** and is never the cause of a small packet;
- the credit clamp bounds a small packet only **14%** of the time, and only in the final bytes of the window;
- **86% of sub-576-byte packets come from the fill loop exiting on EAGAIN with descriptor space AND credit both free** — the writer was simply behind.

That is the single lever, and it is exactly where this patch inserts a bounded `poll()` wait. It also explains why anything that slows the host path makes the bug vanish (a client sleep, `RUST_LOG=debug`, `MINVMD_KRUN_LOG=debug`) while `tokio::task::yield_now()` does not: it needs wall-clock time for bytes to accumulate, not scheduler fairness.

The guest-kernel side agrees: every reset was the skb-depth branch, never the credit branch, `rx_qlen` exactly 455, `buf_alloc` 262144.

```
VSOCKDBG reject A_credit=0 B_skbdepth=1 buf_used=254632 len=308
  buf_alloc=262144 rx_qlen=455 skb_overhead=262656 SKB_TRUESIZE_0=576
```

## Measurement

libkrun the only variable — same host, same VMM binary, same installed guest, same fixture.

**This patch, built in isolation** (the exact single patch this PR carries, nothing else) against the current shipped unpatched dylib:

| dylib | patches | pass / fail |
|---|---|---|
| `94e9d72d` | none (current `unstable`) | 0 / 5 |
| `3b26aeb1` | **only this patch** | **6 / 0** |

Earlier three-way run (before #923 removed the old patches from the tree), fill loop as the baseline:

| dylib | patches | pass / fail |
|---|---|---|
| `db6d2629` | fill loop only (= then-shipped) | 0 / 10 |
| `5ddaf39f` | fill loop + 4 KiB credit floor | 0 / 10 |
| `01282c7e` | fill loop + this coalesce logic | **16 / 0** |

The credit floor is refuted twice — once against stock, once on top of the fill loop. It should not be proposed again.

## What changed since approval

#923 removed the old `0001`/`0002` libkrun patches from the tree (to test a client-side buffer in isolation). So this patch is now the **first and only** carried patch, and has been consolidated from a delta-on-the-fill-loop into a **single self-contained patch** (`0001-vsock-coalesce-sub-skb.patch`) that applies directly to the pinned libkrun commit `728df812`. Verified: it `git apply`s cleanly to stock and produces a tree byte-identical to the `16/0` build above. No behavioural change from the approved version — same emitted code.

It does **not** re-carry the separate signal-used-queue credit-request hang fix that #923 also removed; that is independent and worth its own PR.

## On the client-side buffer (#923)

#923's 4 KiB `BufWriter` around the upload does not help — measured **0/6**, with a socket write histogram identical to unbuffered. russh already batches at the transport, our writes average ~2.5 KB, and the fragmentation is created inside libkrun downstream of anything the client does. The fix has to live in the VMM.

## Cost

`poll()` returns as soon as more data lands, so a fast writer pays nothing. A slow one costs at most `COALESCE_ROUNDS` × 1 ms = 4 ms per descriptor, and data is always delivered rather than held, so no stream can stall on this.

## Upstreaming

Coalescing changes latency for every unix-backed vsock port, not just bulk uploads. Tom's read is that this "basically implements nagle's algorithm", which would break any consumer expecting `send()` to be 1:1 with `recv()` — not us (our protocol is stream-oriented), but worth putting behind an option if we upstream to containers/libkrun. Carrying it locally needs no such decision.

## Companion PRs

- #925 — removes the 8 MiB guest window (#885/#922) as redundant once this lands. The local stack does not carry that window regardless (installed build is `159f8839`, pre-#922; measured `buf_alloc` = 256 KiB), so all the failures above are against the true default baseline.

macOS CI exercises this patch — #910 folded `vendor/libkrun/patches/**` into the `setup-libkrun-macos` cache key, so adding or changing a patch invalidates the cache and forces a rebuild.

Refs: #869
