### PR TITLE
fix(diagnostics,minimald): re-pin socket-join pids and make the diag stream timeout idle-based

### DIFF
--- a/crates/diagnostics/src/procs.rs
+++ b/crates/diagnostics/src/procs.rs
@@ -366,6 +366,28 @@ async fn triage_pids(markers: &[&str], always: &[u32]) -> Result<Vec<(u32, bool)
     Ok(pids)
 }
 
+/// Re-pins a [`triage_pids`] result immediately before its per-pid `/proc`
+/// state is read. A pid from the caller-supplied `always` set
+/// (`from_snapshot == false`) is trusted unchanged — it is the caller's own
+/// process and its identity is not in question. A pid drawn from the table
+/// snapshot (`from_snapshot == true`) is re-checked against `markers` and
+/// dropped if it no longer matches: the snapshot is stale the moment it is
+/// taken, and a pid recycled in between would otherwise attribute an unrelated
+/// process's open sockets to our family. This is the same gate
+/// [`hang_triage_including`] applies inline; [`socket_join`] shares it so the
+/// fd→socket join cannot splice in a foreign process's sockets.
+#[cfg(target_os = "linux")]
+async fn repin_live(pids: Vec<(u32, bool)>, markers: &[&str]) -> Vec<u32> {
+    let mut live = Vec::with_capacity(pids.len());
+    for (pid, from_snapshot) in pids {
+        if from_snapshot && !still_matches(pid, markers).await {
+            continue;
+        }
+        live.push(pid);
+    }
+    live
+}
+
 /// `<dest>/proc/sockets.txt`: which of our processes holds which socket, in
 /// which state — every `socket:[inode]` fd of the family joined against the
 /// `/proc/net` tables.
@@ -408,6 +430,11 @@ async fn socket_join<W: BundleSink>(
         w.skip(path, "no marker-matched processes holding sockets");
         return Ok(());
     }
+    // Re-pin before reading any fds: a snapshot pid recycled since the table
+    // would otherwise splice an unrelated process's sockets into the join. The
+    // caller's own `always` pids are trusted without a re-read — same gate as
+    // `hang_triage_including`.
+    let pids = repin_live(pids, markers).await;
     let mut tables = Vec::with_capacity(crate::net::PROC_NET_SOCKET_TABLES.len());
     for table in crate::net::PROC_NET_SOCKET_TABLES {
         if let Ok(text) = tokio::fs::read_to_string(format!("/proc/net/{table}")).await {
@@ -417,7 +444,7 @@ async fn socket_join<W: BundleSink>(
     let sockets = index_by_inode(&tables);
 
     let mut text = String::from("pid\tfd\tinode\ttable\tentry\n");
-    for (pid, _) in pids {
+    for pid in pids {
         let Ok(mut entries) = tokio::fs::read_dir(format!("/proc/{pid}/fd")).await else {
             let _ = writeln!(text, "{pid}\t-\t-\t-\t<fd directory unreadable>");
             continue;
@@ -747,5 +774,17 @@ ffff8880: 00000002 00000000 00010000 0001 01 41002 /run/minimald/ssh.sock
             .await
             .unwrap();
         assert_eq!(pids, vec![(4242, false)]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn repin_live_trusts_caller_pids_and_drops_stale_snapshot_pids() {
+        // A caller-named (`always`) pid arrives as (pid, false): it is kept
+        // without any /proc re-read, so pid 4242 — which need not exist —
+        // survives, proving its identity was never re-pinned. A snapshot pid
+        // arrives as (pid, true); u32::MAX exceeds any pid_max, so its
+        // /proc/<pid>/cmdline is unreadable, the re-pin fails, and it drops.
+        let live = repin_live(vec![(4242, false), (u32::MAX, true)], MARKERS).await;
+        assert_eq!(live, vec![4242]);
     }
 }

--- a/crates/minimald/src/diag.rs
+++ b/crates/minimald/src/diag.rs
@@ -61,12 +61,15 @@ const MAX_SESSION_FILE_BYTES: u64 = 8 * 1024 * 1024;
 const LOG_FILES_MAX: usize = 5;
 /// Entry cap for the recursive state-dir listing.
 const LISTING_MAX_ENTRIES: usize = 100_000;
-/// Ceiling on the whole client-facing transfer. Every collector is deadlined
-/// individually, but those deadlines only bound work — a client that holds the
-/// channel open and stops reading it parks the pump instead, and through the
-/// bounded duplex that stalls collection and finalization behind it. This is
-/// the bound on the peer rather than on ourselves.
-const STREAM_TIMEOUT: Duration = Duration::from_secs(300);
+/// How long a single write to the client may stall before the stream is
+/// abandoned. This bounds a *non-reading* peer, not total transfer time: the
+/// pump resets it on every write that makes progress, so a slow-but-advancing
+/// build — up to fifteen 30s [`diagnostics::COLLECTOR_TIMEOUT`] collectors,
+/// ~450s worst case — streams to completion, while a client that stops
+/// draining the channel (backpressure fills the duplex and parks the next
+/// write) trips it. A whole-transfer wall-clock cap, by contrast, would kill a
+/// legitimate slow run and wrongly blame the client for it.
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 /// Duplex buffer between the bundle writer and the channel pump.
 const PIPE_BUF: usize = 256 * 1024;
 /// The gvproxy management endpoint, reachable only from inside the switch
@@ -155,18 +158,35 @@ async fn stream_diag_bundle(s: &ServerStateHandle, c: &mut RuChannel<Msg>) -> Re
     };
 
     let mut writer = c.make_writer();
-    // Bounded here rather than around the build: cancelling the pump is safe,
-    // cancelling the builder is not (see `build_bundle`). On expiry the `drop`
-    // below turns the build task's next write into `BrokenPipe`, so it unwinds
-    // through its own error path instead of parking on the full duplex.
-    let copy_result =
-        match tokio::time::timeout(STREAM_TIMEOUT, tokio::io::copy(&mut rx, &mut writer)).await {
-            Ok(r) => r,
-            Err(_) => Err(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                format!("client stopped reading the bundle for {STREAM_TIMEOUT:?}"),
-            )),
+    // A hand-rolled pump so the deadline is per-write, not whole-transfer:
+    // reading from the build task is left unbounded (its collectors self-bound
+    // via `COLLECTOR_TIMEOUT`, so a slow-but-progressing build must not be
+    // killed), while each write to the client is bounded. A stalled write means
+    // the client stopped draining the channel — backpressure that fills the
+    // duplex and parks collection behind it — which is the non-reading-client
+    // DoS this bound exists for. The bound is on the pump rather than the build
+    // because cancelling the pump is safe and cancelling the builder is not
+    // (see `build_bundle`): on a stall the `drop` below turns the build task's
+    // next write into `BrokenPipe`, so it unwinds through its own error path
+    // instead of parking on the full duplex.
+    let mut buf = vec![0u8; PIPE_BUF];
+    let copy_result = loop {
+        let n = match rx.read(&mut buf).await {
+            Ok(0) => break Ok(()), // EOF: the build task finished and dropped tx.
+            Ok(n) => n,
+            Err(e) => break Err(e),
         };
+        match tokio::time::timeout(STREAM_IDLE_TIMEOUT, writer.write_all(&buf[..n])).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => break Err(e),
+            Err(_) => {
+                break Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("client read no bundle data for {STREAM_IDLE_TIMEOUT:?}"),
+                ));
+            }
+        }
+    };
     let shutdown_result = writer.shutdown().await;
     // The read half must be gone before waiting on the build task: if the copy
     // failed mid-stream (client vanished) the task is still writing, and only a


### PR DESCRIPTION

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix socket-join PID re-pinning and switch diagnostic stream to idle-based timeout
- `socket_join` in [procs.rs](https://github.com/gominimal/minimal/pull/927/files#diff-6a9c04a1ee6ec3a5b68e38d5bd9c252c86b4e9cea1dab122a920237948d39018) now calls `repin_live` before building socket tables, dropping snapshot-derived PIDs that no longer match markers while retaining caller-supplied PIDs unconditionally.
- The diagnostic stream in [diag.rs](https://github.com/gominimal/minimal/pull/927/files#diff-ed60839e8685efd73f65ba91318d4d49927b99b4dbd27171a941fc02fecd5a34) replaces a 300s whole-transfer timeout with a 60s per-write idle timeout, allowing slow builds to complete as long as the client keeps reading.
- Behavioral Change: sockets for stale snapshot PIDs are excluded from joined output; streams that stall for 60s are aborted even if the total transfer is under 300s.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96c0d93.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic process detection to avoid associating sockets with processes that have changed or exited.
  * Diagnostic bundle downloads now remain active for slow transfers while still timing out when the receiving connection stops accepting data.
  * Updated timeout messaging for stalled diagnostic bundle connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->