### PR TITLE
fix(minimal): bound the workspace-upload unpack-error buffer

### DIFF
--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -223,10 +223,14 @@ impl Client {
         crate::file_upload::stream_tar_zstd(dir, channel.make_writer()).await?;
 
         // Wait for the channel to close to signal that unpacking is done.
+        // The daemon relays any unpack failure on extended-data stream 1 and
+        // only then closes, so accumulate that stream under the same cap the
+        // diagnostic download uses — a daemon spraying extended data must not
+        // be able to balloon the client's memory.
         let mut err = Vec::new();
         while let Some(msg) = channel.wait().await {
             if let russh::ChannelMsg::ExtendedData { data, ext: 1 } = msg {
-                err.extend_from_slice(&data);
+                append_daemon_error(&mut err, &data);
             }
         }
         if !err.is_empty() {
@@ -359,8 +363,9 @@ impl Client {
     }
 }
 
-/// Cap on the accumulated daemon error message (extended-data stream 1) for a
-/// diagnostic-bundle download.
+/// Cap on the accumulated daemon error message (extended-data stream 1) a
+/// streaming RPC will buffer — shared by the diagnostic-bundle download and
+/// the workspace-file upload.
 const DAEMON_ERROR_MAX: usize = 64 * 1024;
 
 /// How long [`Client::download_diag_bundle`] keeps reading after the size cap
@@ -425,6 +430,19 @@ async fn send_traceparent(channel: &russh::Channel<russh::client::Msg>) {
 mod tests {
     use super::{Client, resolve_socket_path};
     use std::path::Path;
+
+    /// The daemon-error accumulator is bounded: a daemon that sprays extended
+    /// data on stream 1 (during a diagnostic download or a workspace upload)
+    /// must not be able to grow the client's buffer past the cap.
+    #[test]
+    fn append_daemon_error_is_capped() {
+        let mut buf = Vec::new();
+        let chunk = vec![b'x'; 8 * 1024];
+        for _ in 0..64 {
+            super::append_daemon_error(&mut buf, &chunk);
+        }
+        assert_eq!(buf.len(), super::DAEMON_ERROR_MAX);
+    }
 
     #[test]
     fn socket_path_honors_override() {

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -296,6 +296,30 @@ async fn activate_uploads_project_files() {
     assert!(mfile.starts_with(b"# test"));
 }
 
+/// A workspace upload whose unpack fails on the daemon must surface as an
+/// `Err`, not a silent success. The daemon relays the failure on
+/// extended-data stream 1 and only then closes the channel; the client reads
+/// to that close, so the failure cannot be swallowed. Regression test for the
+/// silent-upload-failure half of #824.
+#[tokio::test]
+async fn upload_workspace_files_surfaces_daemon_unpack_error() {
+    let (_daemon, args) = setup().await;
+    let mut client = connect_daemon(&args).await.unwrap();
+
+    // A well-formed but unknown session id: the daemon can't resolve a
+    // destination for the upload, reports the failure, and closes.
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::write(project.path().join("hello.txt"), "hello world").unwrap();
+
+    let result = client
+        .upload_workspace_files(SessionId::nil(), project.path())
+        .await;
+    assert!(
+        result.is_err(),
+        "upload to an unknown session must fail, not report success: {result:?}"
+    );
+}
+
 // --- attach (smart resolution) ---
 
 /// `min attach` with no session argument and `--no-input` errors cleanly when


### PR DESCRIPTION



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Bound the workspace-upload unpack-error buffer in `Client.upload_workspace_files`
- Replaces unbounded accumulation of daemon error output (`err.extend_from_slice(&data)`) with `append_daemon_error`, capping the buffer at `DAEMON_ERROR_MAX` during workspace-file uploads.
- Updates the `DAEMON_ERROR_MAX` doc comment to reflect that the cap applies to all streaming RPCs that buffer daemon errors, not just diagnostic-bundle downloads.
- Adds a unit test verifying the cap and an integration test confirming that daemon-side unpack failures propagate as a client-visible error rather than silent success.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6d8264.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace upload failures are now surfaced clearly instead of being silently ignored.
  * Error details from failed uploads are safely bounded to prevent excessive diagnostic data.
  * Improved reporting for invalid or expired workspace sessions. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->