### PR TITLE
fix(scripts): shellcheck every script under scripts/, not just the installer

### DIFF
--- a/crates/common/tests/shell_lint.rs
+++ b/crates/common/tests/shell_lint.rs
@@ -1,0 +1,59 @@
+//! Convention-discovered gate that shellchecks every script under `scripts/`.
+//!
+//! The frozen `ci-shell-installer.yml` shellcheck job only lints `install.sh`
+//! and `install_test.sh`; every other shell script was unchecked, so a PR
+//! touching one reported a misleading "skipping" shellcheck context (#899).
+//! Widening that job would mean editing `.github/workflows/`, which is frozen
+//! and CODEOWNER-gated. Instead this test drives `scripts/lint-shell.sh`, so
+//! the workspace test suite — which the always-running Linux CI lanes run on
+//! any `crates/**` or `scripts/**` change — lints the whole directory. This is
+//! the reviewed-code extension point CI schedules over (docs/ci-strategy.md
+//! §10): a new *kind* of check added through code, never through YAML.
+//!
+//! When shellcheck is not installed the test skips with a message rather than
+//! failing, matching the harness's own lenient default and the repo's
+//! self-skip-locally convention. The primary Linux lane (ubuntu-latest) ships
+//! shellcheck, so the gate runs for real and fails on findings there.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is crates/common; the workspace root is two up.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root two levels above crates/common")
+        .to_path_buf()
+}
+
+#[test]
+fn all_scripts_pass_shellcheck() {
+    if Command::new("shellcheck")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("shellcheck not installed — skipping all_scripts_pass_shellcheck");
+        return;
+    }
+
+    let root = repo_root();
+    let harness = root.join("scripts/lint-shell.sh");
+    // We already confirmed shellcheck is on PATH above, so run --strict: if the
+    // harness can't find it (a PATH mismatch, not a genuine absence) that is a
+    // hard failure, never a silent green.
+    let output = Command::new("bash")
+        .arg(&harness)
+        .arg("--strict")
+        .current_dir(&root)
+        .output()
+        .expect("failed to run scripts/lint-shell.sh");
+
+    assert!(
+        output.status.success(),
+        "scripts/lint-shell.sh reported shellcheck findings\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/justfile
+++ b/justfile
@@ -224,6 +224,12 @@ test-installer:
         SH="$sh" "$sh" scripts/install_test.sh
     done
 
+# Shellcheck EVERY script under scripts/ (not just the installer's two files).
+# The reviewed harness the frozen ci-shell-installer.yml can't widen to; CI runs
+# the same check through crates/common/tests/shell_lint.rs (part of `just test`).
+lint-shell:
+    bash scripts/lint-shell.sh
+
 # Run the promotion provenance gate's test harness (stubbed `gh`, no network,
 # no auth); shellcheck runs when present.
 test-promote-gate:

--- a/scripts/bench-minvmd-boot.sh
+++ b/scripts/bench-minvmd-boot.sh
@@ -90,7 +90,8 @@ done
 
 [ "${#samples[@]}" -gt 0 ] || { echo "no successful boots" >&2; exit 1; }
 
-sorted=($(printf '%s\n' "${samples[@]}" | sort -n))
+sorted=()
+while IFS= read -r line; do sorted+=("$line"); done < <(printf '%s\n' "${samples[@]}" | sort -n)
 c="${#sorted[@]}"
 printf 'boot-to-READY (ms): min=%d median=%d max=%d  (n=%d)\n' \
   "${sorted[0]}" "${sorted[$((c / 2))]}" "${sorted[$((c - 1))]}" "$c"

--- a/scripts/lint-shell.sh
+++ b/scripts/lint-shell.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Lint every shell script under scripts/ with shellcheck.
+#
+# WHY THIS EXISTS
+# ---------------
+# The frozen `ci-shell-installer.yml` shellcheck job only lints
+# `scripts/install.sh` and `scripts/install_test.sh`; every other script in
+# this directory was unchecked, so a PR touching them reported a misleading
+# "skipping" shellcheck context (issue #899). Widening that job means editing
+# `.github/workflows/`, which is CODEOWNER-gated and frozen. Instead this
+# harness lints the whole directory and is picked up by CI through a
+# convention-discovered workspace test (crates/common/tests/shell_lint.rs) and
+# the `just lint-shell` recipe — the reviewed-code extension point CI schedules
+# over (docs/ci-strategy.md §10).
+#
+# Dialect is taken from each script's own shebang (shellcheck auto-detects it),
+# matching the `apparmor` job's shebang-based `shellcheck` call. install.sh and
+# install_test.sh carry `#!/bin/sh`, so they are still linted as strict POSIX
+# sh here, in addition to the dedicated frozen gate.
+#
+# When shellcheck is not installed this skips with a clear message and exits 0,
+# so local runs on machines without it (and CI lanes that lack it) do not hard
+# fail. Pass --strict, or set LINT_SHELL_STRICT=1, to make a missing shellcheck
+# an error instead. The primary Linux CI lane (ubuntu-latest) ships shellcheck,
+# so the gate runs for real there and fails on findings.
+set -euo pipefail
+
+strict="${LINT_SHELL_STRICT:-0}"
+case "${1:-}" in
+    --strict) strict=1 ;;
+    "") ;;
+    *) echo "usage: $0 [--strict]" >&2; exit 2 ;;
+esac
+
+# Resolve the repo's scripts/ directory relative to this file, so the harness
+# works regardless of the caller's working directory.
+here="$(cd "$(dirname "$0")" && pwd)"
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+    msg="shellcheck not installed"
+    if [ "$strict" = "1" ]; then
+        echo "lint-shell: $msg (strict mode)" >&2
+        exit 1
+    fi
+    echo "lint-shell: $msg — skipping static check" >&2
+    exit 0
+fi
+
+failed=0
+checked=0
+for f in "$here"/*.sh; do
+    [ -e "$f" ] || continue
+    # Only lint files that actually declare a shell interpreter.
+    read -r shebang <"$f" || true
+    case "$shebang" in
+        '#!'*sh*) ;;
+        *) continue ;;
+    esac
+    checked=$((checked + 1))
+    if ! shellcheck "$f"; then
+        failed=$((failed + 1))
+    fi
+done
+
+if [ "$checked" -eq 0 ]; then
+    # Discovery broke (moved scripts, wrong $here) — never pass green having
+    # linted nothing; that is the exact false-signal this harness exists to end.
+    echo "lint-shell: found no scripts to check under $here" >&2
+    exit 1
+fi
+if [ "$failed" -gt 0 ]; then
+    echo "lint-shell: $failed of $checked script(s) failed shellcheck" >&2
+    exit 1
+fi
+echo "lint-shell: $checked script(s) passed shellcheck"

--- a/scripts/prune-releases.sh
+++ b/scripts/prune-releases.sh
@@ -118,6 +118,9 @@ for row in "${rows[@]}"; do
     fi
 
     # Only consider tags the caller asked for (default: the auto-cut release-*).
+    # $MATCH is a deliberate glob pattern (default `release-*`), so it must
+    # stay unquoted to match as a glob rather than a literal.
+    # shellcheck disable=SC2254
     case "$tag" in
         $MATCH) ;;
         *) skipped=$((skipped + 1)); continue ;;


### PR DESCRIPTION
## Problem

The frozen `ci-shell-installer.yml` shellcheck job hardcodes `install.sh` and `install_test.sh`, so the other 14+ scripts under `scripts/` are never linted. A PR touching any of them shows a misleading "skipping" shellcheck context — a false-green (#899).

## Approach

`.github/workflows/` is frozen and CODEOWNER-gated, so widen coverage through reviewed code (docs/ci-strategy.md §10) rather than editing YAML:

- **`scripts/lint-shell.sh`** — shellcheck every `scripts/*.sh` by its own shebang (matching the `apparmor` job's shebang-based call). Fails on findings; fails green-never (errors if it discovers zero scripts). Skips cleanly when shellcheck is absent, or `--strict`/`LINT_SHELL_STRICT=1` to require it.
- **`crates/common/tests/shell_lint.rs`** — convention-discovered workspace test that runs the harness with `--strict`. The always-on `ci-linux-native` lane (whose path filter includes `scripts/**`) runs `cargo nextest run --workspace` on ubuntu-latest, which ships shellcheck — so the whole directory is linted for real and the required lane fails on findings.
- **`just lint-shell`** — local proof recipe.

The frozen installer gate is untouched and still enforces its dedicated `--shell=sh` POSIX check.

## Findings fixed

The wider sweep surfaced two: SC2207 in `bench-minvmd-boot.sh` (array-split → bash-3.2-safe `while read` loop) and SC2254 in `prune-releases.sh` (disable directive for an intentional `$MATCH` glob). All 23 scripts now pass `shellcheck --strict`.

## Verification

`bash scripts/lint-shell.sh --strict` → 23 passed; `cargo test -p common --test shell_lint` → ok.

Closes #899

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend shellcheck coverage to all scripts under `scripts/` via a lint harness
> - Adds [scripts/lint-shell.sh](https://github.com/gominimal/minimal/pull/933/files#diff-e8819e65f41c96d68ebff73fe3dd9b9345f35ced354c8099d03fa8f5a5df8195), a new harness that runs `shellcheck` on every `*.sh` file with a shell shebang under `scripts/`, exiting non-zero on any findings or if no scripts are found.
> - Adds a `just lint-shell` recipe and a Rust integration test in [crates/common/tests/shell_lint.rs](https://github.com/gominimal/minimal/pull/933/files#diff-9ca064cc88d11d82f6f3f9c955fc8c4adef473813ab7c84b87f946ab30c2bbe9) that invokes the harness in strict mode, skipping gracefully when `shellcheck` is not installed.
> - Fixes a word-splitting issue in [scripts/bench-minvmd-boot.sh](https://github.com/gominimal/minimal/pull/933/files#diff-8e03cea8cc69006063349a8b7c2987a082d0e5fe3a4ff8df49e9386002a902fa) by replacing command substitution array construction with a `while read -r` loop.
> - Adds a `shellcheck` SC2254 suppression directive to the unquoted glob pattern in [scripts/prune-releases.sh](https://github.com/gominimal/minimal/pull/933/files#diff-dc93e018de912e85a8bdd87e37c8973a3087e8abb506045cc7c7d1bf60ce67ba).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e65195e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->