### PR TITLE
feat(minimal): add `--provider local-minvmd`, remove `--minvmd`

### DIFF
--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -347,7 +347,7 @@ jobs:
         # The SAME unified proof every target lane runs (scripts/session-e2e.sh)
         # against Deployment Model 3 (native Linux + VM — the target this
         # lane owns; see docs/specs/03-spec-networking): from a clean state
-        # `minimal --minvmd activate` must auto-spawn minvmd, boot the microVM,
+        # `minimal --provider local-minvmd activate` must auto-spawn minvmd, boot the microVM,
         # and round-trip a session exec over the vsock bridge — the Linux/KVM
         # counterpart of the macOS lane's CLI gate. Since #748 activate uploads
         # the project into the guest; E2E_PROJECT_DIR=/tmp still names a guest
@@ -355,7 +355,7 @@ jobs:
         env:
           MINVMD_BOOT_LOG: ${{ runner.temp }}/cli-e2e-boot.log
           MINVMD_GVPROXY_BIN: ${{ runner.temp }}/gvproxy
-        run: E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
+        run: E2E_VM=1 E2E_MINIMAL_ARGS="--provider local-minvmd" E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
 
       - name: Upload guest boot console logs
         if: always()

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -132,7 +132,7 @@ jobs:
           MINVMD_INITRAMFS: ${{ runner.temp }}/initramfs.cpio
           MINVMD_GVPROXY_BIN: ${{ runner.temp }}/gvproxy
           E2E_VM: "1"
-          E2E_MINIMAL_ARGS: --minvmd
+          E2E_MINIMAL_ARGS: --provider local-minvmd
           E2E_PROJECT_DIR: /tmp
         run: |
           export PATH="$PWD/target/debug:$PATH"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -241,7 +241,7 @@ jobs:
               env:
                   MINVMD_BOOT_LOG: ${{ runner.temp }}/cli-e2e-boot.log
                   MINVMD_GVPROXY_BIN: ${{ runner.temp }}/bin/gvproxy
-              run: E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
+              run: E2E_VM=1 E2E_MINIMAL_ARGS="--provider local-minvmd" E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
             - name: Reap leftover VM processes
               # The autospawned minvmd can leak a __krun-vmm child on a failed
               # teardown; reap defensively (ported from test-kvm). The runner is

--- a/crates/minimal/src/autospawn.rs
+++ b/crates/minimal/src/autospawn.rs
@@ -96,7 +96,7 @@ fn classify(lifecycle: Lifecycle) -> Decision {
 /// On targets with no minvmd backend this is a no-op (see below).
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn ensure_minvmd_running(minimal_dir: Option<&Path>) -> io::Result<()> {
-    let provider_dir = crate::client::resolve_provider_dir(minimal_dir)?;
+    let provider_dir = crate::client::resolve_provider_dir(minimal_dir, true)?;
     let state_dir = minvmd::state::StateDir::new(provider_dir)?;
 
     match classify(state_dir.effective_state()?.lifecycle) {
@@ -183,7 +183,7 @@ pub fn ensure_minvmd_running(_minimal_dir: Option<&Path>) -> io::Result<()> {
 /// `Stopped` still resolves rather than pinning the wait to its deadline.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn wait_for_minvmd_stopped(minimal_dir: Option<&Path>) -> io::Result<()> {
-    let provider_dir = crate::client::resolve_provider_dir(minimal_dir)?;
+    let provider_dir = crate::client::resolve_provider_dir(minimal_dir, true)?;
     let state_dir = minvmd::state::StateDir::new(provider_dir)?;
 
     let deadline = Instant::now() + Duration::from_secs(STOPPED_WAIT_SECS);
@@ -243,7 +243,7 @@ pub fn ensure_daemon_running(use_minvmd: bool, minimal_dir: Option<&Path>) -> io
     if use_minvmd {
         return ensure_minvmd_running(minimal_dir);
     }
-    let sock = crate::client::resolve_socket_path(minimal_dir)
+    let sock = crate::client::resolve_socket_path(minimal_dir, false)
         .map_err(|e| io::Error::other(format!("resolving native minimald socket path: {e}")))?;
     ensure_minimald_running(&sock, minimal_dir)
 }
@@ -280,7 +280,7 @@ pub fn is_daemon_running(use_minvmd: bool, minimal_dir: Option<&Path>) -> io::Re
     if use_minvmd {
         return is_minvmd_running(minimal_dir);
     }
-    let sock = crate::client::resolve_socket_path(minimal_dir)
+    let sock = crate::client::resolve_socket_path(minimal_dir, false)
         .map_err(|e| io::Error::other(format!("resolving native minimald socket path: {e}")))?;
     Ok(minimald_socket_live(&sock))
 }
@@ -304,7 +304,7 @@ pub fn is_daemon_running(use_minvmd: bool, minimal_dir: Option<&Path>) -> io::Re
 /// return as though the VM were already down.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn is_minvmd_running(minimal_dir: Option<&Path>) -> io::Result<bool> {
-    let provider_dir = crate::client::resolve_provider_dir(minimal_dir)?;
+    let provider_dir = crate::client::resolve_provider_dir(minimal_dir, true)?;
     let state_dir = minvmd::state::StateDir::new(provider_dir)?;
     Ok(state_dir.effective_state()?.lifecycle.is_active())
 }
@@ -402,7 +402,8 @@ mod tests {
 
     /// The state dir a `--minimal-dir` override resolves to.
     fn state_dir_for(minimal_dir: &std::path::Path) -> StateDir {
-        StateDir::new(crate::client::resolve_provider_dir(Some(minimal_dir)).unwrap()).unwrap()
+        StateDir::new(crate::client::resolve_provider_dir(Some(minimal_dir), true).unwrap())
+            .unwrap()
     }
 
     #[test]
@@ -504,7 +505,7 @@ mod tests {
     #[test]
     fn native_minimald_is_running_when_the_socket_accepts() {
         let tmp = tempfile::tempdir().unwrap();
-        let sock = crate::client::resolve_socket_path(Some(tmp.path())).unwrap();
+        let sock = crate::client::resolve_socket_path(Some(tmp.path()), false).unwrap();
         std::fs::create_dir_all(sock.parent().unwrap()).unwrap();
         let _listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
         assert!(is_daemon_running(false, Some(tmp.path())).unwrap());
@@ -517,7 +518,7 @@ mod tests {
     #[test]
     fn native_minimald_is_not_running_when_the_socket_file_is_stale() {
         let tmp = tempfile::tempdir().unwrap();
-        let sock = crate::client::resolve_socket_path(Some(tmp.path())).unwrap();
+        let sock = crate::client::resolve_socket_path(Some(tmp.path()), false).unwrap();
         std::fs::create_dir_all(sock.parent().unwrap()).unwrap();
         drop(std::os::unix::net::UnixListener::bind(&sock).unwrap());
         assert!(
@@ -538,7 +539,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let long = tmp.path().join("d".repeat(120));
         std::fs::create_dir_all(&long).unwrap();
-        let sock = crate::client::resolve_socket_path(Some(&long)).unwrap();
+        let sock = crate::client::resolve_socket_path(Some(&long), false).unwrap();
         std::fs::create_dir_all(sock.parent().unwrap()).unwrap();
         assert!(
             std::os::unix::net::UnixStream::connect(&sock)

--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -639,6 +639,33 @@ pub(crate) fn client_provider_kind(use_minvmd: bool) -> paths::ProviderKind {
     }
 }
 
+/// The minimal state-dir root the CLI resolves paths under: `--minimal-dir`
+/// when set (made absolute), else the platform default.
+fn resolve_state_base(
+    minimal_dir_override: Option<&std::path::Path>,
+) -> std::io::Result<paths::DaemonAbsPath> {
+    match minimal_dir_override {
+        Some(dir) => {
+            let abs = std::path::absolute(dir)?;
+            let utf8 = abs
+                .to_str()
+                .ok_or_else(|| std::io::Error::other("--minimal-dir is not valid UTF-8"))?;
+            paths::DaemonAbsPath::try_new(utf8).map_err(std::io::Error::other)
+        }
+        None => Ok(paths::minimal_state_dir()),
+    }
+}
+
+/// Adopt any pre-split `providers/local-<N>` dirs into the kind-tagged scheme
+/// before the CLI resolves a provider dir, so an upgraded client finds an
+/// existing instance instead of missing it. Best-effort: a bad `--minimal-dir`
+/// is left for the resolve/connect path to report.
+pub(crate) fn migrate_legacy_provider_dirs(minimal_dir_override: Option<&std::path::Path>) {
+    if let Ok(base) = resolve_state_base(minimal_dir_override) {
+        paths::migrate_legacy_provider_dirs(&base);
+    }
+}
+
 /// Resolve the provider-instance dir (`<state dir>/providers/local-<kind>0`) the
 /// daemon and CLI agree on: `--minimal-dir` when set, else the default minimal
 /// state dir. `use_minvmd` selects the backend's dir (see [`client_provider_kind`]).
@@ -646,16 +673,7 @@ pub(crate) fn resolve_provider_dir(
     minimal_dir_override: Option<&std::path::Path>,
     use_minvmd: bool,
 ) -> std::io::Result<std::path::PathBuf> {
-    let base = match minimal_dir_override {
-        Some(dir) => {
-            let abs = std::path::absolute(dir)?;
-            let utf8 = abs
-                .to_str()
-                .ok_or_else(|| std::io::Error::other("--minimal-dir is not valid UTF-8"))?;
-            paths::DaemonAbsPath::try_new(utf8).map_err(std::io::Error::other)?
-        }
-        None => paths::minimal_state_dir(),
-    };
+    let base = resolve_state_base(minimal_dir_override)?;
     Ok(
         paths::provider_instance_dir(&base, client_provider_kind(use_minvmd), 0)
             .as_utf8_path()

--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -624,7 +624,7 @@ fn append_daemon_error(buf: &mut Vec<u8>, data: &[u8]) {
     buf.extend_from_slice(&data[..room.min(data.len())]);
 }
 
-/// The provider kind the CLI should talk to, given `--provider`/`--minvmd`.
+/// The provider kind the CLI should talk to, given `--provider`.
 ///
 /// The native minimald and minvmd backends now occupy distinct provider dirs,
 /// so connecting — not just spawning — must pick the right one. macOS is always

--- a/crates/minimal/src/client.rs
+++ b/crates/minimal/src/client.rs
@@ -624,11 +624,27 @@ fn append_daemon_error(buf: &mut Vec<u8>, data: &[u8]) {
     buf.extend_from_slice(&data[..room.min(data.len())]);
 }
 
-/// Resolve the provider-instance dir (`<state dir>/providers/local-0`) the
-/// daemon and CLI agree on: `--minimal-dir` when set, else the default
-/// minimal state dir.
+/// The provider kind the CLI should talk to, given `--provider`/`--minvmd`.
+///
+/// The native minimald and minvmd backends now occupy distinct provider dirs,
+/// so connecting — not just spawning — must pick the right one. macOS is always
+/// minvmd-backed regardless of the flag; keying on the compile target keeps the
+/// in-guest CLI (Linux, native) and the host CLI (macOS, minvmd) each pointed at
+/// the dir their local daemon actually uses.
+pub(crate) fn client_provider_kind(use_minvmd: bool) -> paths::ProviderKind {
+    if use_minvmd || cfg!(target_os = "macos") {
+        paths::ProviderKind::Minvmd
+    } else {
+        paths::ProviderKind::Minimald
+    }
+}
+
+/// Resolve the provider-instance dir (`<state dir>/providers/local-<kind>0`) the
+/// daemon and CLI agree on: `--minimal-dir` when set, else the default minimal
+/// state dir. `use_minvmd` selects the backend's dir (see [`client_provider_kind`]).
 pub(crate) fn resolve_provider_dir(
     minimal_dir_override: Option<&std::path::Path>,
+    use_minvmd: bool,
 ) -> std::io::Result<std::path::PathBuf> {
     let base = match minimal_dir_override {
         Some(dir) => {
@@ -640,19 +656,22 @@ pub(crate) fn resolve_provider_dir(
         }
         None => paths::minimal_state_dir(),
     };
-    Ok(paths::provider_instance_dir(&base, 0)
-        .as_utf8_path()
-        .as_std_path()
-        .to_path_buf())
+    Ok(
+        paths::provider_instance_dir(&base, client_provider_kind(use_minvmd), 0)
+            .as_utf8_path()
+            .as_std_path()
+            .to_path_buf(),
+    )
 }
 
-/// Resolve the daemon socket path: `<provider dir>/ssh.sock`. Both backends
-/// (native minimald and the minvmd bridge) serve the same endpoint, so the
-/// backend choice only matters for spawning, not for connecting.
+/// Resolve the daemon socket path: `<provider dir>/ssh.sock`. Each backend
+/// serves this endpoint under its own provider dir, so `use_minvmd` must select
+/// the same backend the daemon was spawned as.
 pub fn resolve_socket_path(
     minimal_dir_override: Option<&std::path::Path>,
+    use_minvmd: bool,
 ) -> std::io::Result<std::path::PathBuf> {
-    Ok(resolve_provider_dir(minimal_dir_override)?.join(paths::SSH_SOCK_FILE))
+    Ok(resolve_provider_dir(minimal_dir_override, use_minvmd)?.join(paths::SSH_SOCK_FILE))
 }
 
 /// Sends the process trace context as a `TRACEPARENT` channel env request.
@@ -685,10 +704,19 @@ mod tests {
 
     #[test]
     fn socket_path_honors_override() {
-        let sock = resolve_socket_path(Some(Path::new("/tmp/minimal-test"))).unwrap();
+        let sock = resolve_socket_path(Some(Path::new("/tmp/minimal-test")), false).unwrap();
         assert_eq!(
             sock,
-            Path::new("/tmp/minimal-test/providers/local-0/ssh.sock")
+            Path::new("/tmp/minimal-test/providers/local-minimald0/ssh.sock")
+        );
+    }
+
+    #[test]
+    fn socket_path_selects_the_minvmd_dir() {
+        let sock = resolve_socket_path(Some(Path::new("/tmp/minimal-test")), true).unwrap();
+        assert_eq!(
+            sock,
+            Path::new("/tmp/minimal-test/providers/local-minvmd0/ssh.sock")
         );
     }
 

--- a/crates/minimal/src/diag/collect.rs
+++ b/crates/minimal/src/diag/collect.rs
@@ -481,7 +481,7 @@ fn is_not_found(err: &anyhow::Error) -> bool {
         .any(|io| io.kind() == std::io::ErrorKind::NotFound)
 }
 
-// ── providers/local-<n>/ discovery ───────────────────────────────────────────
+// ── providers/local-<kind><n>/ discovery ───────────────────────────────────────────
 
 /// Provider instance dirs under `<state>/providers`, sorted. Empty when the
 /// providers dir doesn't exist (nothing was ever spawned); any other
@@ -706,8 +706,8 @@ mod tests {
             DaemonLogSources::ProvidersUnknown,
             DaemonLogSources::NoProviders,
             DaemonLogSources::NoneFetched,
-            DaemonLogSources::Nested(&["local-0"]),
-            DaemonLogSources::NestedUnconfirmed(&["local-0"]),
+            DaemonLogSources::Nested(&["local-minvmd0"]),
+            DaemonLogSources::NestedUnconfirmed(&["local-minvmd0"]),
         ];
 
         // minvmd is a host process wherever the providers are: nothing under
@@ -741,14 +741,15 @@ mod tests {
     /// told it holds recreates the dead end in the other direction.
     #[tokio::test]
     async fn only_a_confirmed_nested_bundle_is_named_as_the_carrier() {
-        let carrier = "providers/local-0/guest/daemon-diag.tar.zst";
+        let carrier = "providers/local-minvmd0/guest/daemon-diag.tar.zst";
 
-        let confirmed = reasons_for(DaemonLogSources::Nested(&["local-0"])).await;
+        let confirmed = reasons_for(DaemonLogSources::Nested(&["local-minvmd0"])).await;
         let reason = &confirmed["logs/minimald.log*"];
         assert!(reason.contains(carrier), "got: {reason}");
         assert!(reason.contains("are in this bundle"), "got: {reason}");
 
-        let unconfirmed = reasons_for(DaemonLogSources::NestedUnconfirmed(&["local-0"])).await;
+        let unconfirmed =
+            reasons_for(DaemonLogSources::NestedUnconfirmed(&["local-minvmd0"])).await;
         let reason = &unconfirmed["logs/minimald.log*"];
         assert!(reason.contains(carrier), "got: {reason}");
         assert!(reason.contains("could not confirm"), "got: {reason}");
@@ -801,7 +802,7 @@ mod tests {
         ])
         .await;
         w.add_bytes(
-            "providers/local-0/guest/daemon-diag.tar.zst",
+            "providers/local-minvmd0/guest/daemon-diag.tar.zst",
             &nested,
             Redaction::None,
         )
@@ -812,7 +813,7 @@ mod tests {
             &mut w,
             &paths,
             &absent,
-            DaemonLogSources::Nested(&["local-0"]),
+            DaemonLogSources::Nested(&["local-minvmd0"]),
         );
         w.finish(chrono::Utc::now(), std::time::Duration::ZERO)
             .await
@@ -859,7 +860,8 @@ mod tests {
             "a host-only daemon's absence is still plain absence"
         );
         assert!(
-            reason("logs/minimald.log*").contains("providers/local-0/guest/daemon-diag.tar.zst"),
+            reason("logs/minimald.log*")
+                .contains("providers/local-minvmd0/guest/daemon-diag.tar.zst"),
             "the skip must name where the logs actually are"
         );
     }

--- a/crates/minimal/src/diag/guest.rs
+++ b/crates/minimal/src/diag/guest.rs
@@ -670,7 +670,7 @@ pub(crate) mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let out = tmp.path().join("b.tar.zst");
         let mut w = BundleWriter::create(&out, "r", "v").await.unwrap();
-        volume_fallback(&mut w, "local-0", tmp.path())
+        volume_fallback(&mut w, "local-minvmd0", tmp.path())
             .await
             .unwrap();
         w.finish(chrono::Utc::now(), Duration::ZERO).await.unwrap();

--- a/crates/minimal/src/dirs.rs
+++ b/crates/minimal/src/dirs.rs
@@ -42,6 +42,7 @@ pub(crate) fn report(global: &GlobalArgs) -> String {
             .as_utf8_path()
             .as_std_path()
             .to_path_buf(),
+        provider: crate::client::client_provider_kind(global.use_minvmd()),
     };
     format_dir_rows(&build_dir_rows(&dirs))
 }
@@ -65,6 +66,9 @@ struct DirsLookup {
     state: PathBuf,
     /// `<cache>/minimal`.
     cache: PathBuf,
+    /// The backend whose provider dir the CLI would connect to, so the SSH
+    /// socket row names the right `providers/local-<kind>0` path.
+    provider: paths::ProviderKind,
 }
 
 /// Which top-level group the mesh-enrolment row prints under. Values
@@ -157,7 +161,10 @@ fn build_dir_rows(dirs: &DirsLookup) -> Vec<DirRow> {
         (
             "State",
             "SSH socket",
-            Some(dirs.state.join("providers/local-0/ssh.sock")),
+            Some(dirs.state.join(format!(
+                "providers/{}/ssh.sock",
+                paths::provider_instance_name(dirs.provider, 0)
+            ))),
             None,
         )
             .into_row(),
@@ -287,6 +294,7 @@ mod tests {
             mesh_group: MeshGroup::Config,
             state: PathBuf::from("/home/u/.local/state/minimal"),
             cache: PathBuf::from("/home/u/.cache/minimal"),
+            provider: paths::ProviderKind::Minimald,
         };
         let rows = build_dir_rows(&dirs);
         let shape: Vec<(&str, &str, String)> = rows
@@ -349,7 +357,7 @@ mod tests {
                 (
                     "State",
                     "SSH socket",
-                    "/home/u/.local/state/minimal/providers/local-0/ssh.sock".to_string()
+                    "/home/u/.local/state/minimal/providers/local-minimald0/ssh.sock".to_string()
                 ),
                 ("Cache", "Cache dir", "/home/u/.cache/minimal".to_string()),
                 (
@@ -371,6 +379,7 @@ mod tests {
             mesh_group: MeshGroup::Config,
             state: PathBuf::from("/s"),
             cache: PathBuf::from("/x"),
+            provider: paths::ProviderKind::Minimald,
         };
         let rows = build_dir_rows(&dirs);
         let daemon_logs = rows.iter().find(|r| r.name == "Daemon logs").unwrap();
@@ -410,6 +419,7 @@ mod tests {
             mesh_group: MeshGroup::State,
             state: PathBuf::from("/override"),
             cache: PathBuf::from("/x"),
+            provider: paths::ProviderKind::Minimald,
         };
         let rows = build_dir_rows(&dirs);
         let mesh = rows.iter().find(|r| r.name == "Mesh enrolment").unwrap();

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -250,10 +250,15 @@ pub struct GlobalArgs {
     /// state and cache dirs, not `~/Library/Application Support`.
     #[arg(long, global = true)]
     pub config_dir: Option<PathBuf>,
-    /// Linux: run minimald inside the minvmd microVM (DM1) instead of natively
-    /// on the host (DM2, the default). No effect on macOS, where minvmd is the
-    /// only backend.
-    #[arg(long, global = true)]
+    /// Select the daemon backend that hosts sessions. On Linux, `local-native`
+    /// (the default) runs minimald on the host; `local-minvmd` runs it inside
+    /// the minvmd microVM (DM1). No effect on macOS, where minvmd is the only
+    /// backend.
+    #[arg(long, global = true, value_name = "PROVIDER")]
+    pub provider: Option<Provider>,
+    /// Deprecated alias for `--provider local-minvmd`, kept for backward
+    /// compatibility and hidden from help. Prefer `--provider local-minvmd`.
+    #[arg(long, global = true, hide = true, conflicts_with = "provider")]
     pub minvmd: bool,
     /// Skip interactive prompts that need a terminal (e.g. the session
     /// picker shown by bare `min` or `min attach` with no session argument).
@@ -262,6 +267,14 @@ pub struct GlobalArgs {
     /// not a terminal.
     #[arg(long, global = true, default_value_t = false)]
     pub no_input: bool,
+}
+
+impl GlobalArgs {
+    /// Whether the minvmd microVM backend (DM1) is selected, via either
+    /// `--provider local-minvmd` or the deprecated `--minvmd` alias.
+    pub fn use_minvmd(&self) -> bool {
+        self.minvmd || matches!(self.provider, Some(Provider::LocalMinvmd))
+    }
 }
 
 #[derive(Debug, Args)]
@@ -302,6 +315,19 @@ pub struct ActivateArgs {
     /// Automatically attach after creation
     #[arg(long)]
     pub attach: bool,
+}
+
+/// Which daemon backend ("provider") hosts sessions.
+///
+/// On Linux the default is the host-native daemon (DM2); `local-minvmd` runs
+/// `minimald` inside the minvmd microVM (DM1) instead. On macOS minvmd is the
+/// only backend, so the choice has no effect there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Provider {
+    /// Linux: run minimald natively on the host (the default).
+    LocalNative,
+    /// Run minimald inside the minvmd microVM.
+    LocalMinvmd,
 }
 
 /// Configuration for file sync during activation.
@@ -733,7 +759,7 @@ pub async fn cmd_proxy(global: &GlobalArgs, args: ProxyArgs) -> Result<(), anyho
 
 /// Ensure the minimald daemon is running, autospawning it if necessary.
 fn ensure_daemon(global: &GlobalArgs) -> Result<(), anyhow::Error> {
-    autospawn::ensure_daemon_running(global.minvmd, global.minimal_dir.as_deref())
+    autospawn::ensure_daemon_running(global.use_minvmd(), global.minimal_dir.as_deref())
         .context("Failed to ensure the minimald daemon is running")
 }
 
@@ -1898,7 +1924,7 @@ pub async fn cmd_stop(global: &GlobalArgs, args: StopArgs) -> Result<(), anyhow:
     // Cheap and bounded (a state-file read, or a connect to a local socket that
     // refuses at once when nothing listens), so it runs inline rather than on
     // the blocking pool — unlike the shutdown wait below, which sleep-polls.
-    if !autospawn::is_daemon_running(global.minvmd, global.minimal_dir.as_deref())
+    if !autospawn::is_daemon_running(global.use_minvmd(), global.minimal_dir.as_deref())
         .context("Failed to determine whether the daemon is running")?
     {
         println!("Daemon is not running.");
@@ -1906,7 +1932,7 @@ pub async fn cmd_stop(global: &GlobalArgs, args: StopArgs) -> Result<(), anyhow:
     }
 
     // Racy by nature: the daemon may go down between the probe and this connect
-    // (or `--minvmd` may point the probe and the client at different backends),
+    // (or `--provider` may point the probe and the client at different backends),
     // so a connect failure is still a real error, not something to swallow.
     let mut client = connect_daemon(global).await?;
 
@@ -1926,7 +1952,7 @@ pub async fn cmd_stop(global: &GlobalArgs, args: StopArgs) -> Result<(), anyhow:
             // The wait polls the lifecycle file on a sleep loop, so it goes on
             // the blocking pool rather than stalling an async worker for up to
             // 20s (rust-coding-standards: no blocking in an async context).
-            let (use_minvmd, minimal_dir) = (global.minvmd, global.minimal_dir.clone());
+            let (use_minvmd, minimal_dir) = (global.use_minvmd(), global.minimal_dir.clone());
             tokio::task::spawn_blocking(move || {
                 autospawn::wait_for_daemon_stopped(use_minvmd, minimal_dir.as_deref())
             })
@@ -2373,6 +2399,42 @@ mod tests {
         assert!(
             hosts_file.contains(r#"q\"uote"#) && hosts_file.contains(r"back\\slash"),
             "path must reach ssh escaped, got: {hosts_file}"
+        );
+    }
+
+    #[test]
+    fn provider_local_minvmd_selects_the_vm_backend() {
+        use clap::Parser as _;
+        let cli = Cli::try_parse_from(["min", "--provider", "local-minvmd", "ls"]).unwrap();
+        assert!(cli.global_args.use_minvmd());
+    }
+
+    #[test]
+    fn provider_local_native_is_the_host_backend() {
+        use clap::Parser as _;
+        let cli = Cli::try_parse_from(["min", "--provider", "local-native", "ls"]).unwrap();
+        assert!(!cli.global_args.use_minvmd());
+    }
+
+    #[test]
+    fn no_provider_defaults_to_the_host_backend() {
+        use clap::Parser as _;
+        let cli = Cli::try_parse_from(["min", "ls"]).unwrap();
+        assert!(!cli.global_args.use_minvmd());
+    }
+
+    #[test]
+    fn deprecated_minvmd_flag_still_selects_the_vm_backend() {
+        use clap::Parser as _;
+        let cli = Cli::try_parse_from(["min", "--minvmd", "ls"]).unwrap();
+        assert!(cli.global_args.use_minvmd());
+    }
+
+    #[test]
+    fn provider_and_deprecated_minvmd_flag_conflict() {
+        use clap::Parser as _;
+        assert!(
+            Cli::try_parse_from(["min", "--provider", "local-native", "--minvmd", "ls"]).is_err()
         );
     }
 

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -539,6 +539,11 @@ pub async fn run(cli: Cli) -> Result<(), anyhow::Error> {
 }
 
 async fn run_command(cli: Cli) -> Result<(), anyhow::Error> {
+    // Adopt any pre-split `providers/local-<N>` dirs into the kind-tagged scheme
+    // once per invocation, before any command resolves a provider dir, so an
+    // upgraded CLI finds an existing instance rather than orphaning it.
+    client::migrate_legacy_provider_dirs(cli.global_args.minimal_dir.as_deref());
+
     match cli.command {
         None => cmd_default(&cli.global_args).await,
         Some(Command::Ls(args)) => cmd_ls(&cli.global_args, args).await,

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -256,10 +256,6 @@ pub struct GlobalArgs {
     /// backend.
     #[arg(long, global = true, value_name = "PROVIDER")]
     pub provider: Option<Provider>,
-    /// Deprecated alias for `--provider local-minvmd`, kept for backward
-    /// compatibility and hidden from help. Prefer `--provider local-minvmd`.
-    #[arg(long, global = true, hide = true, conflicts_with = "provider")]
-    pub minvmd: bool,
     /// Skip interactive prompts that need a terminal (e.g. the session
     /// picker shown by bare `min` or `min attach` with no session argument).
     /// When a choice is ambiguous, the command errors with a list of
@@ -270,10 +266,10 @@ pub struct GlobalArgs {
 }
 
 impl GlobalArgs {
-    /// Whether the minvmd microVM backend (DM1) is selected, via either
-    /// `--provider local-minvmd` or the deprecated `--minvmd` alias.
+    /// Whether the minvmd microVM backend (DM1) is selected via
+    /// `--provider local-minvmd`.
     pub fn use_minvmd(&self) -> bool {
-        self.minvmd || matches!(self.provider, Some(Provider::LocalMinvmd))
+        matches!(self.provider, Some(Provider::LocalMinvmd))
     }
 }
 
@@ -2439,21 +2435,6 @@ mod tests {
         use clap::Parser as _;
         let cli = Cli::try_parse_from(["min", "ls"]).unwrap();
         assert!(!cli.global_args.use_minvmd());
-    }
-
-    #[test]
-    fn deprecated_minvmd_flag_still_selects_the_vm_backend() {
-        use clap::Parser as _;
-        let cli = Cli::try_parse_from(["min", "--minvmd", "ls"]).unwrap();
-        assert!(cli.global_args.use_minvmd());
-    }
-
-    #[test]
-    fn provider_and_deprecated_minvmd_flag_conflict() {
-        use clap::Parser as _;
-        assert!(
-            Cli::try_parse_from(["min", "--provider", "local-minimald", "--minvmd", "ls"]).is_err()
-        );
     }
 
     #[test]

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -250,7 +250,7 @@ pub struct GlobalArgs {
     /// state and cache dirs, not `~/Library/Application Support`.
     #[arg(long, global = true)]
     pub config_dir: Option<PathBuf>,
-    /// Select the daemon backend that hosts sessions. On Linux, `local-native`
+    /// Select the daemon backend that hosts sessions. On Linux, `local-minimald`
     /// (the default) runs minimald on the host; `local-minvmd` runs it inside
     /// the minvmd microVM (DM1). No effect on macOS, where minvmd is the only
     /// backend.
@@ -325,7 +325,7 @@ pub struct ActivateArgs {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum Provider {
     /// Linux: run minimald natively on the host (the default).
-    LocalNative,
+    LocalMinimald,
     /// Run minimald inside the minvmd microVM.
     LocalMinvmd,
 }
@@ -604,7 +604,7 @@ async fn run_command(cli: Cli) -> Result<(), anyhow::Error> {
 async fn cmd_default(global: &GlobalArgs) -> Result<(), anyhow::Error> {
     ensure_daemon(global)?;
 
-    let sock = client::resolve_socket_path(global.minimal_dir.as_deref())
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd())
         .context("Failed to resolve daemon socket path")?;
 
     let mut client = client::Client::connect(&sock)
@@ -656,7 +656,7 @@ async fn cmd_default(global: &GlobalArgs) -> Result<(), anyhow::Error> {
 
 /// Connect to the daemon, resolving the socket path from global args.
 pub async fn connect_daemon(global: &GlobalArgs) -> Result<client::Client, anyhow::Error> {
-    let sock = client::resolve_socket_path(global.minimal_dir.as_deref())
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd())
         .context("Failed to resolve daemon socket path")?;
 
     client::Client::connect(&sock)
@@ -731,7 +731,7 @@ pub async fn cmd_proxy(global: &GlobalArgs, args: ProxyArgs) -> Result<(), anyho
         Some(socket_path) => socket_path,
         None => {
             ensure_daemon(global)?;
-            client::resolve_socket_path(global.minimal_dir.as_deref())
+            client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd())
                 .context("Failed to resolve daemon socket path")?
                 .to_str()
                 .unwrap()
@@ -1558,7 +1558,7 @@ fn host_key_opts(known_hosts: &std::path::Path) -> [String; 2] {
 pub async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), anyhow::Error> {
     ensure_daemon(global)?;
 
-    let sock = client::resolve_socket_path(global.minimal_dir.as_deref())
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd())
         .context("Failed to resolve daemon socket path")?;
 
     let mut client = client::Client::connect(&sock)
@@ -1664,7 +1664,16 @@ async fn attach_to_session(
     if command.is_none() {
         ssh.arg("-tt");
     }
-    ssh.arg("local-0");
+    // The SSH host identity must match the known_hosts entry the daemon wrote,
+    // which it keys on the provider-instance name — the provider dir's basename
+    // (`local-minimald<N>` / `local-minvmd<N>`). Derive it from the socket path
+    // so the client and daemon can never disagree on the name.
+    let host_alias = sock
+        .parent()
+        .and_then(std::path::Path::file_name)
+        .and_then(|n| n.to_str())
+        .context("daemon socket path has no provider-dir parent")?;
+    ssh.arg(host_alias);
 
     // If a command was provided, pass it to ssh (non-interactive exec).
     // Otherwise, ssh opens an interactive shell via shell_request.
@@ -2017,7 +2026,7 @@ pub async fn cmd_ssh_forward(
 ) -> Result<(), anyhow::Error> {
     ensure_daemon(global)?;
 
-    let sock = client::resolve_socket_path(global.minimal_dir.as_deref())
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd())
         .context("Failed to resolve daemon socket path")?;
 
     // Look up the session to validate it exists and to obtain its UUID for the
@@ -2052,6 +2061,14 @@ pub async fn cmd_ssh_forward(
     );
 
     let session_id = record.id.to_string();
+    // Host-key checking is disabled here, so the alias is cosmetic; still derive
+    // it from the provider dir (`local-minimald<N>` / `local-minvmd<N>`) to match
+    // the rest of the CLI rather than hard-coding a name.
+    let host_alias = sock
+        .parent()
+        .and_then(std::path::Path::file_name)
+        .and_then(|n| n.to_str())
+        .context("daemon socket path has no provider-dir parent")?;
     // Use `-N` (no command) so the foreground ssh keeps the tunnel alive after
     // `exec()` replaces this process. `-o ExitOnForwardFailure=yes` makes ssh
     // exit immediately if the local port cannot be bound rather than silently
@@ -2071,7 +2088,7 @@ pub async fn cmd_ssh_forward(
         "StrictHostKeyChecking=no",
         "-o",
         "UserKnownHostsFile=/dev/null",
-        "local-0",
+        host_alias,
     ]);
 
     // exec() replaces the process, so this call only returns on failure.
@@ -2317,7 +2334,8 @@ pub async fn cmd_spin(_global: &GlobalArgs, args: SpinArgs) -> Result<(), anyhow
 pub async fn cmd_version(global: &GlobalArgs) -> Result<(), anyhow::Error> {
     println!("Client: minimal {}", version::LONG_VERSION);
 
-    let sock = match client::resolve_socket_path(global.minimal_dir.as_deref()) {
+    let sock = match client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd())
+    {
         Ok(p) => p,
         Err(e) => {
             eprintln!("Server: (daemon unreachable: {e})");
@@ -2358,7 +2376,7 @@ mod tests {
     fn host_key_opts_pin_to_an_adjacent_known_hosts() {
         let tmp = tempfile::tempdir().unwrap();
         let known_hosts = tmp.path().join(paths::KNOWN_HOSTS_FILE);
-        std::fs::write(&known_hosts, "local-0 ssh-ed25519 AAAA...\n").unwrap();
+        std::fs::write(&known_hosts, "local-minimald0 ssh-ed25519 AAAA...\n").unwrap();
 
         let [strict, hosts_file] = host_key_opts(&known_hosts);
         assert_eq!(strict, "StrictHostKeyChecking=yes");
@@ -2392,7 +2410,7 @@ mod tests {
         let dir = tmp.path().join(r#"sp ace q"uote back\slash"#);
         std::fs::create_dir_all(&dir).unwrap();
         let known_hosts = dir.join(paths::KNOWN_HOSTS_FILE);
-        std::fs::write(&known_hosts, "local-0 ssh-ed25519 AAAA...\n").unwrap();
+        std::fs::write(&known_hosts, "local-minimald0 ssh-ed25519 AAAA...\n").unwrap();
 
         let [strict, hosts_file] = host_key_opts(&known_hosts);
         assert_eq!(strict, "StrictHostKeyChecking=yes");
@@ -2410,9 +2428,9 @@ mod tests {
     }
 
     #[test]
-    fn provider_local_native_is_the_host_backend() {
+    fn provider_local_minimald_is_the_host_backend() {
         use clap::Parser as _;
-        let cli = Cli::try_parse_from(["min", "--provider", "local-native", "ls"]).unwrap();
+        let cli = Cli::try_parse_from(["min", "--provider", "local-minimald", "ls"]).unwrap();
         assert!(!cli.global_args.use_minvmd());
     }
 
@@ -2434,7 +2452,7 @@ mod tests {
     fn provider_and_deprecated_minvmd_flag_conflict() {
         use clap::Parser as _;
         assert!(
-            Cli::try_parse_from(["min", "--provider", "local-native", "--minvmd", "ls"]).is_err()
+            Cli::try_parse_from(["min", "--provider", "local-minimald", "--minvmd", "ls"]).is_err()
         );
     }
 

--- a/crates/minimal/src/loadouts.rs
+++ b/crates/minimal/src/loadouts.rs
@@ -286,6 +286,7 @@ mod tests {
             repo_dir: None,
             minimal_dir: None,
             config_dir: Some(PathBuf::from("/definitely/does/not/exist")),
+            provider: None,
             minvmd: false,
             no_input: false,
         };
@@ -307,6 +308,7 @@ mod tests {
             repo_dir: None,
             minimal_dir: None,
             config_dir: Some(tmp.path().to_path_buf()),
+            provider: None,
             minvmd: false,
             no_input: false,
         };

--- a/crates/minimal/src/loadouts.rs
+++ b/crates/minimal/src/loadouts.rs
@@ -287,7 +287,6 @@ mod tests {
             minimal_dir: None,
             config_dir: Some(PathBuf::from("/definitely/does/not/exist")),
             provider: None,
-            minvmd: false,
             no_input: false,
         };
         let out = resolve_active_loadouts(LoadoutSelection::None, &cfg, &global)
@@ -309,7 +308,6 @@ mod tests {
             minimal_dir: None,
             config_dir: Some(tmp.path().to_path_buf()),
             provider: None,
-            minvmd: false,
             no_input: false,
         };
         let selection = LoadoutSelection::Cli(vec!["missing".to_string()]);

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -73,6 +73,7 @@ fn global_args(state: &Path, config: &Path) -> GlobalArgs {
         repo_dir: None,
         minimal_dir: Some(state.to_path_buf()),
         config_dir: Some(config.to_path_buf()),
+        provider: None,
         minvmd: false,
         no_input: false,
     }

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -74,7 +74,6 @@ fn global_args(state: &Path, config: &Path) -> GlobalArgs {
         minimal_dir: Some(state.to_path_buf()),
         config_dir: Some(config.to_path_buf()),
         provider: None,
-        minvmd: false,
         no_input: false,
     }
 }

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -224,7 +224,7 @@ async fn logs_collects_newest_five_per_prefix_and_provider_logs() {
             .unwrap();
     }
 
-    let provider = state.path().join("providers/local-0");
+    let provider = state.path().join("providers/local-minvmd0");
     std::fs::create_dir_all(&provider).unwrap();
     std::fs::write(provider.join("run.log"), "supervisor stderr\n").unwrap();
     // boot.log deliberately absent — recorded as a skip, not an error.
@@ -254,7 +254,7 @@ async fn logs_collects_newest_five_per_prefix_and_provider_logs() {
         "newest-first rotation order: {collected_logs:?}"
     );
 
-    assert!(find(&files, "providers/local-0/run.log").is_some());
+    assert!(find(&files, "providers/local-minvmd0/run.log").is_some());
     assert!(find(&files, "providers/remote-x/run.log").is_none());
     let manifest: serde_json::Value =
         serde_json::from_slice(find(&files, "manifest.json").expect("manifest")).unwrap();
@@ -262,7 +262,7 @@ async fn logs_collects_newest_five_per_prefix_and_provider_logs() {
     assert!(
         skipped
             .iter()
-            .any(|s| s["what"] == "providers/local-0/boot.log" && s["reason"] == "absent"),
+            .any(|s| s["what"] == "providers/local-minvmd0/boot.log" && s["reason"] == "absent"),
         "absent boot.log is a skip: {skipped:?}"
     );
     assert_eq!(manifest["errors"].as_array().unwrap().len(), 0, "no errors");
@@ -279,7 +279,7 @@ async fn a_custom_tail_cap_applies_to_every_log() {
     let log_dir = state.path().join("logs");
     std::fs::create_dir_all(&log_dir).unwrap();
     std::fs::write(log_dir.join("minimald.log.2026-07-21"), "x".repeat(500)).unwrap();
-    let provider = state.path().join("providers/local-0");
+    let provider = state.path().join("providers/local-minvmd0");
     std::fs::create_dir_all(&provider).unwrap();
     std::fs::write(provider.join("run.log"), "y".repeat(500)).unwrap();
 
@@ -292,7 +292,10 @@ async fn a_custom_tail_cap_applies_to_every_log() {
         .unwrap();
 
     let files = unpack(&out).await;
-    for suffix in ["logs/minimald.log.2026-07-21", "providers/local-0/run.log"] {
+    for suffix in [
+        "logs/minimald.log.2026-07-21",
+        "providers/local-minvmd0/run.log",
+    ] {
         let contents = find(&files, suffix).unwrap_or_else(|| panic!("missing {suffix}"));
         assert_eq!(contents.len(), 100, "{suffix} honors the requested cap");
     }
@@ -377,15 +380,16 @@ async fn bug_with_daemon_nests_a_verified_guest_bundle() {
     // R7.1: every stage of the probe reached the live daemon, and the
     // connection it opened was the one the download reused.
     let probe: serde_json::Value =
-        serde_json::from_slice(find(&files, "local-0/socket-probe.json").expect("probe")).unwrap();
+        serde_json::from_slice(find(&files, "local-minimald0/socket-probe.json").expect("probe"))
+            .unwrap();
     for stage in ["stat", "connect", "handshake", "get_version"] {
         assert_eq!(probe[stage]["outcome"], "ok", "stage {stage}: {probe}");
     }
     assert!(probe["version"]["long_version"].is_string());
 
     // R7.6: liveness status for the discovered provider.
-    assert!(find(&files, "local-0/status.json").is_some());
-    assert!(find(&files, "local-0/dir-listing.txt").is_some());
+    assert!(find(&files, "local-minimald0/status.json").is_some());
+    assert!(find(&files, "local-minimald0/dir-listing.txt").is_some());
 
     // R7.3: the daemon bundle is nested raw (it decompresses on its own) and
     // carries the Unit 6 manifest.
@@ -439,7 +443,7 @@ async fn bug_with_daemon_nests_a_verified_guest_bundle() {
 async fn bug_with_stale_socket_reports_the_connect_stage_and_falls_back() {
     let state = tempfile::TempDir::new().unwrap();
     let config = tempfile::TempDir::new().unwrap();
-    let provider = state.path().join("providers/local-0");
+    let provider = state.path().join("providers/local-minvmd0");
     std::fs::create_dir_all(&provider).unwrap();
     drop(std::os::unix::net::UnixListener::bind(provider.join("ssh.sock")).unwrap());
     // A data volume the fallback can date, standing in for a real image.
@@ -453,7 +457,8 @@ async fn bug_with_stale_socket_reports_the_connect_stage_and_falls_back() {
 
     let files = unpack(&out).await;
     let probe: serde_json::Value =
-        serde_json::from_slice(find(&files, "local-0/socket-probe.json").expect("probe")).unwrap();
+        serde_json::from_slice(find(&files, "local-minvmd0/socket-probe.json").expect("probe"))
+            .unwrap();
     assert_eq!(probe["stat"]["outcome"], "ok");
     assert_ne!(probe["connect"]["outcome"], "ok");
     assert!(
@@ -506,5 +511,5 @@ async fn bug_no_guest_makes_no_daemon_contact() {
     assert!(find(&files, "socket-probe.json").is_none());
     assert!(find(&files, "daemon-diag.tar.zst").is_none());
     // Host-side per-provider collection still ran.
-    assert!(find(&files, "local-0/status.json").is_some());
+    assert!(find(&files, "local-minimald0/status.json").is_some());
 }

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -31,7 +31,6 @@ async fn version_succeeds_without_daemon() {
         minimal_dir: Some(std::path::PathBuf::from("/nonexistent")),
         config_dir: None,
         provider: None,
-        minvmd: false,
         no_input: false,
     };
     // Should print client version and note daemon is unreachable, but return Ok.

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -30,6 +30,7 @@ async fn version_succeeds_without_daemon() {
         repo_dir: None,
         minimal_dir: Some(std::path::PathBuf::from("/nonexistent")),
         config_dir: None,
+        provider: None,
         minvmd: false,
         no_input: false,
     };

--- a/crates/minimal/tests/common/mod.rs
+++ b/crates/minimal/tests/common/mod.rs
@@ -8,8 +8,9 @@ use minimal::GlobalArgs;
 
 /// A running minimald test server plus the tempdir backing it.
 ///
-/// The UDS socket is placed at `<tempdir>/providers/local-0/ssh.sock` so
-/// that `resolve_socket_path(Some(tempdir), false)` finds it.
+/// The UDS socket is placed at `<tempdir>/providers/local-minimald0/ssh.sock`
+/// so that `resolve_socket_path(Some(tempdir), false)` finds it (the native
+/// minimald provider dir the CLI resolves without `--provider local-minvmd`).
 pub struct TestDaemon {
     /// The underlying minimald test server. Exposed so tests can create
     /// sessions directly via `server.state` or connect a `TestClient`.
@@ -29,7 +30,7 @@ impl TestDaemon {
         let server = minimald::test_harness::TestServer::new().await;
         let temp = tempfile::TempDir::new().unwrap();
 
-        let sock_dir = temp.path().join("providers/local-0");
+        let sock_dir = temp.path().join("providers/local-minimald0");
         std::fs::create_dir_all(&sock_dir).unwrap();
         let sock = sock_dir.join("ssh.sock");
         server.listen_on_uds(&sock).await;

--- a/crates/minimal/tests/common/mod.rs
+++ b/crates/minimal/tests/common/mod.rs
@@ -45,7 +45,6 @@ impl TestDaemon {
             minimal_dir: Some(self.temp.path().to_path_buf()),
             config_dir: None,
             provider: None,
-            minvmd: false,
             no_input: false,
         }
     }

--- a/crates/minimal/tests/common/mod.rs
+++ b/crates/minimal/tests/common/mod.rs
@@ -43,6 +43,7 @@ impl TestDaemon {
             repo_dir: None,
             minimal_dir: Some(self.temp.path().to_path_buf()),
             config_dir: None,
+            provider: None,
             minvmd: false,
             no_input: false,
         }

--- a/crates/minimal/tests/git_remote.rs
+++ b/crates/minimal/tests/git_remote.rs
@@ -28,7 +28,7 @@ async fn git_push_through_min_binary_lands_commit_in_workspace() {
     // point XDG_STATE_HOME at a tempdir and serve the UDS where
     // `resolve_socket_path(None)` will look.
     let state_home = tempfile::TempDir::new().unwrap();
-    let sock_dir = state_home.path().join("minimal/providers/local-0");
+    let sock_dir = state_home.path().join("minimal/providers/local-minimald0");
     std::fs::create_dir_all(&sock_dir).unwrap();
 
     let server = TestServer::new().await;

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -562,6 +562,11 @@ async fn async_main() -> Result<(), MainError> {
         }
     };
 
+    // Adopt any pre-split `providers/local-<N>` dir into the kind-tagged scheme
+    // before resolving our own instance dir, so an upgraded daemon reuses its
+    // existing state instead of orphaning it.
+    paths::migrate_legacy_provider_dirs(&cli.minimal_state_dir());
+
     // The host-key path lives under the instance dir; ensure it exists for
     // both the UDS and vsock paths.
     if let Err(e) = std::fs::create_dir_all(cli.client_instance_dir())

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -94,7 +94,11 @@ impl Cli {
 
     /// Returns the path to the directory containing sockets/info about this daemon for clients.
     pub fn client_instance_dir(&self) -> DaemonAbsPath {
-        paths::provider_instance_dir(&self.minimal_state_dir(), self.instance_num())
+        paths::provider_instance_dir(
+            &self.minimal_state_dir(),
+            paths::ProviderKind::Minimald,
+            self.instance_num(),
+        )
     }
 
     /// Returns fragments of the command-line arguments which should be passed to an ssh invocation in
@@ -120,7 +124,7 @@ impl Cli {
                         .to_string(),
                 ),
             ],
-            format!("local-{}", self.instance_num()),
+            paths::provider_instance_name(paths::ProviderKind::Minimald, self.instance_num()),
         )
     }
 
@@ -175,7 +179,7 @@ pub struct GlobalArgs {
 #[derive(Debug, Args)]
 pub struct ListenArgs {
     /// Instance number for this minimald; determines client-relevant paths under
-    /// `<minimal_state_dir>/providers/local-<instance-num>`.
+    /// `<minimal_state_dir>/providers/local-minimald<instance-num>`.
     ///
     /// The SSH socket is accessible as `ssh.sock`.
     #[arg(long, default_value_t = 0)]
@@ -579,8 +583,10 @@ async fn async_main() -> Result<(), MainError> {
     // it. Keyed on being the VM init — pid-1 owns its /run — NOT on the
     // `--vsock` flag: a native (possibly non-root) `--vsock` daemon may not
     // be able to write /run at all and keeps the provider-dir lock.
+    let instance_name =
+        paths::provider_instance_name(paths::ProviderKind::Minimald, cli.instance_num());
     let instance_lock_path = if is_minimal_microvm() {
-        DaemonAbsPath::try_new(format!("/run/minimald-local-{}.lock", cli.instance_num()))
+        DaemonAbsPath::try_new(format!("/run/minimald-{instance_name}.lock"))
             .expect("static /run lock path is absolute")
     } else {
         cli.client_instance_dir()
@@ -594,8 +600,7 @@ async fn async_main() -> Result<(), MainError> {
         Ok(guard) => guard,
         Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
             return Err(MainError::Other(format!(
-                "minimald local-{} is already running (instance lock held)",
-                cli.instance_num()
+                "minimald {instance_name} is already running (instance lock held)"
             )));
         }
         Err(e) => return Err(MainError::IO(e, "acquiring instance lock")),
@@ -605,7 +610,10 @@ async fn async_main() -> Result<(), MainError> {
         .set_len(0)
         .and_then(|()| writeln!(&*instance_guard, "{}", std::process::id()));
 
-    // A minvmd bridge binds the same ssh.sock; don't steal a live VM's socket.
+    // Native minimald and minvmd now own distinct provider dirs
+    // (`local-minimald<N>` vs `local-minvmd<N>`), so they no longer share a
+    // socket. This stays as a defensive guard for the unusual case of a minvmd
+    // instance pointed at *this* dir: don't steal a live VM's ssh.sock.
     if lock_held(
         cli.client_instance_dir()
             .sub_path_unchecked(paths::MINVMD_LOCK_FILE)
@@ -615,8 +623,7 @@ async fn async_main() -> Result<(), MainError> {
     .map_err(|e| MainError::IO(e, "probing minvmd lock"))?
     {
         return Err(MainError::Other(format!(
-            "a minvmd VM is serving local-{}'s socket; stop it first (`minvmd stop`)",
-            cli.instance_num()
+            "a minvmd VM is serving {instance_name}'s socket; stop it first (`minvmd stop`)"
         )));
     }
 
@@ -644,18 +651,19 @@ async fn async_main() -> Result<(), MainError> {
     // R1.2: load once and reuse in the vsock beacon so there is no redundant disk read.
     let host_private_key = config.host_key()?;
     let known_hosts = sub_path!(cli.client_instance_dir(), "known_hosts");
-    let ssh_host = format!("local-{}", cli.instance_num());
     // `learn_known_hosts_path` appends unconditionally; drop any prior entry for
     // this host so repeated daemon spawns record one current key instead of
     // growing known_hosts without bound (#782). Best-effort: a prune failure
     // must not block startup.
-    if let Err(e) =
-        paths::prune_known_hosts_entries(known_hosts.as_utf8_path().as_std_path(), &ssh_host, 22)
-    {
+    if let Err(e) = paths::prune_known_hosts_entries(
+        known_hosts.as_utf8_path().as_std_path(),
+        &instance_name,
+        22,
+    ) {
         tracing::warn!(error = %e, "failed to prune stale known_hosts entries");
     }
     russh::keys::known_hosts::learn_known_hosts_path(
-        &ssh_host,
+        &instance_name,
         22,
         host_private_key.public_key(),
         known_hosts.as_utf8_path(),

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -375,14 +375,16 @@ pub(crate) fn read_ready_beacon<R: std::io::BufRead>(
                         // exactly one current key instead of growing a line per
                         // spawn (#782). Best-effort: a prune failure must not
                         // abort boot (R2.3).
-                        if let Err(e) =
-                            paths::prune_known_hosts_entries(known_hosts_path, "local-0", 22)
-                        {
+                        if let Err(e) = paths::prune_known_hosts_entries(
+                            known_hosts_path,
+                            &paths::provider_instance_name(paths::ProviderKind::Minvmd, 0),
+                            22,
+                        ) {
                             tracing::warn!(error = %e, "failed to prune stale known_hosts entries");
                         }
                         match russh::keys::known_hosts::learn_known_hosts_path(
                             // TODO: pass instance_num through once multi-instance is needed
-                            "local-0",
+                            &paths::provider_instance_name(paths::ProviderKind::Minvmd, 0),
                             22,
                             &pubkey,
                             known_hosts_path,
@@ -545,8 +547,8 @@ mod beacon_tests {
         let contents =
             std::fs::read_to_string(&known_hosts_path).expect("known_hosts file must be created");
         assert!(
-            contents.contains("local-0"),
-            "known_hosts must contain 'local-0', got: {contents:?}"
+            contents.contains("local-minvmd0"),
+            "known_hosts must contain 'local-minvmd0', got: {contents:?}"
         );
         assert!(
             contents.contains(&openssh),

--- a/crates/minvmd/src/cmd/run.rs
+++ b/crates/minvmd/src/cmd/run.rs
@@ -53,6 +53,11 @@ pub fn run(detach: bool, timeout_secs: Option<u64>) -> Result<()> {
 
 #[cfg(minvmd_libkrun)]
 fn run_supervisor(detach: bool, timeout_secs: u64) -> Result<()> {
+    // Adopt any pre-split `providers/local-<N>` dir into the kind-tagged scheme
+    // before resolving our own `local-minvmd0` dir, so an upgraded host reuses
+    // its existing VM state (data volume, boot log) instead of orphaning it.
+    paths::migrate_legacy_provider_dirs(&crate::state::state_base_dir());
+
     // R2.4: fail fast with an actionable error if the hypervisor backend is
     // unavailable (Linux: /dev/kvm). No-op on macOS. Runs in the foreground
     // caller so the user sees the error directly, even under --detach.

--- a/crates/minvmd/src/main.rs
+++ b/crates/minvmd/src/main.rs
@@ -15,7 +15,7 @@ struct Cli {
     command: Command,
 
     /// Override the state dir base (default: $XDG_STATE_HOME/minimal).
-    /// Runtime files live under `<dir>/providers/local-0/`.
+    /// Runtime files live under `<dir>/providers/local-minvmd0/`.
     #[arg(long, global = true)]
     minimal_state_dir: Option<paths::CwdRelative<paths::Daemon>>,
 }

--- a/crates/minvmd/src/sock.rs
+++ b/crates/minvmd/src/sock.rs
@@ -1,10 +1,11 @@
 //! Host UDS path resolution and socket-directory management for the
 //! minimald bridge (R3.2).
 //!
-//! The bridge socket lives beside the minvmd state files in the
-//! provider-instance dir: `<minimal_state_dir>/providers/local-0/ssh.sock` —
-//! the same name native minimald binds, so clients see one endpoint
-//! regardless of backend.
+//! The bridge socket lives beside the minvmd state files in the minvmd
+//! provider-instance dir:
+//! `<minimal_state_dir>/providers/local-minvmd0/ssh.sock`. It mirrors the
+//! `ssh.sock` name native minimald binds under its own `local-minimald<N>`
+//! dir; the client selects the dir matching the requested backend.
 
 use std::io;
 use std::path::PathBuf;
@@ -147,7 +148,7 @@ mod tests {
         }
         assert_eq!(
             path,
-            PathBuf::from("/state/minimal/providers/local-0/ssh.sock"),
+            PathBuf::from("/state/minimal/providers/local-minvmd0/ssh.sock"),
         );
     }
 

--- a/crates/minvmd/src/state.rs
+++ b/crates/minvmd/src/state.rs
@@ -1,7 +1,7 @@
 //! State persistence for `minvmd` (R4.1, R4.6).
 //!
-//! All runtime files live in the shared provider-instance directory
-//! (`<minimal_state_dir>/providers/local-0/`, see
+//! All runtime files live in the minvmd provider-instance directory
+//! (`<minimal_state_dir>/providers/local-minvmd0/`, see
 //! [`paths::provider_instance_dir`]):
 //!
 //! - `minvmd.toml` — serialised [`State`] (lifecycle, pid, timestamp).
@@ -59,9 +59,9 @@ pub fn state_base_dir() -> DaemonAbsPath {
 }
 
 /// The provider-instance dir holding all minvmd runtime files:
-/// `<minimal_state_dir>/providers/local-0`.
+/// `<minimal_state_dir>/providers/local-minvmd0`.
 pub fn provider_dir() -> PathBuf {
-    paths::provider_instance_dir(&state_base_dir(), 0)
+    paths::provider_instance_dir(&state_base_dir(), paths::ProviderKind::Minvmd, 0)
         .as_utf8_path()
         .as_std_path()
         .to_path_buf()

--- a/crates/minvmd/src/volume.rs
+++ b/crates/minvmd/src/volume.rs
@@ -239,8 +239,8 @@ mod tests {
     #[test]
     fn data_volume_path_sits_in_provider_dir() {
         assert_eq!(
-            data_volume_path_in(Path::new("/state/minimal/providers/local-0")),
-            PathBuf::from("/state/minimal/providers/local-0/data-vol.raw"),
+            data_volume_path_in(Path::new("/state/minimal/providers/local-minvmd0")),
+            PathBuf::from("/state/minimal/providers/local-minvmd0/data-vol.raw"),
         );
     }
 

--- a/crates/minvmd/tests/boot_integration.rs
+++ b/crates/minvmd/tests/boot_integration.rs
@@ -22,7 +22,7 @@ use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 /// Isolated `XDG_STATE_HOME` under /tmp: macOS's $TMPDIR is deep enough that
-/// `<tempdir>/minimal/providers/local-0/*.sock` would overflow sun_path (104).
+/// `<tempdir>/minimal/providers/local-minvmd0/*.sock` would overflow sun_path (104).
 fn short_state_dir() -> tempfile::TempDir {
     tempfile::Builder::new()
         .prefix("mnl")

--- a/crates/minvmd/tests/minimald_session_integration.rs
+++ b/crates/minvmd/tests/minimald_session_integration.rs
@@ -33,7 +33,7 @@ use serial_test::serial;
 use tempfile::TempDir;
 
 /// Isolated `XDG_STATE_HOME` under /tmp: macOS's $TMPDIR is deep enough that
-/// `<tempdir>/minimal/providers/local-0/*.sock` would overflow sun_path (104).
+/// `<tempdir>/minimal/providers/local-minvmd0/*.sock` would overflow sun_path (104).
 fn short_state_dir() -> tempfile::TempDir {
     tempfile::Builder::new()
         .prefix("mnl")
@@ -94,7 +94,9 @@ impl Guest {
     /// blocks until the `vm-up` (READY) line. Panics on boot timeout.
     fn boot() -> Guest {
         let state = short_state_dir();
-        let sock_path = state.path().join("minimal/providers/local-0/ssh.sock");
+        let sock_path = state
+            .path()
+            .join("minimal/providers/local-minvmd0/ssh.sock");
 
         let exe = minvmd_bin();
         let mut child = Command::new(exe)

--- a/crates/minvmd/tests/volume_quiesce_integration.rs
+++ b/crates/minvmd/tests/volume_quiesce_integration.rs
@@ -90,7 +90,7 @@ impl TestEnv {
         // `volume::resolve_data_volume_path()` default: the provider dir
         // under `paths::minimal_state_dir()` (XDG_STATE_HOME honoured).
         self.state_home
-            .join("minimal/providers/local-0/data-vol.raw")
+            .join("minimal/providers/local-minvmd0/data-vol.raw")
     }
 }
 

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -151,19 +151,55 @@ pub fn minimal_state_dir() -> DaemonAbsPath {
 /// native minimald or by the minvmd host↔guest bridge — one endpoint either way.
 pub const SSH_SOCK_FILE: &str = "ssh.sock";
 /// File name of the SSH `known_hosts` in a provider instance dir, recording the
-/// daemon's host key under the `local-<instance>` hostname. Written at startup
-/// by native minimald, and by minvmd from the guest's boot beacon.
+/// daemon's host key under the `local-<kind><instance>` hostname. Written at
+/// startup by native minimald, and by minvmd from the guest's boot beacon.
 pub const KNOWN_HOSTS_FILE: &str = "known_hosts";
 /// Native minimald's single-instance lock, held for the daemon's lifetime.
 pub const MINIMALD_LOCK_FILE: &str = "minimald.lock";
 /// The minvmd supervisor's alive lock, held for the daemon's lifetime.
 pub const MINVMD_LOCK_FILE: &str = "minvmd.lock";
 
-/// `<state_dir>/providers/local-<instance>` — the directory holding the
+/// Which local daemon backend ("provider") an instance directory belongs to.
+///
+/// The kind is embedded in the instance name so the native host minimald and
+/// the minvmd microVM backends occupy distinct provider dirs — and distinct SSH
+/// host-key identities — rather than colliding on a shared `local-<N>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderKind {
+    /// Native host minimald (DM2).
+    Minimald,
+    /// minimald inside the minvmd microVM (DM1).
+    Minvmd,
+}
+
+impl ProviderKind {
+    /// The tag embedded in the instance name (`local-<tag><instance>`).
+    #[must_use]
+    pub fn tag(self) -> &'static str {
+        match self {
+            ProviderKind::Minimald => "minimald",
+            ProviderKind::Minvmd => "minvmd",
+        }
+    }
+}
+
+/// The provider-instance name, `local-<kind><instance>` (e.g. `local-minimald0`,
+/// `local-minvmd0`). Used both as the `providers/<name>` directory name and as
+/// the SSH host-key identity recorded in `known_hosts`.
+#[must_use]
+pub fn provider_instance_name(kind: ProviderKind, instance: u32) -> String {
+    format!("local-{}{instance}", kind.tag())
+}
+
+/// `<state_dir>/providers/local-<kind><instance>` — the directory holding the
 /// sockets, locks, and state files a client needs to reach one local daemon
 /// instance.
-pub fn provider_instance_dir(state_dir: &DaemonAbsPath, instance: u32) -> DaemonAbsPath {
-    sub_path!(state_dir, "providers").sub_path_unchecked(&format!("local-{instance}"))
+pub fn provider_instance_dir(
+    state_dir: &DaemonAbsPath,
+    kind: ProviderKind,
+    instance: u32,
+) -> DaemonAbsPath {
+    sub_path!(state_dir, "providers").sub_path_unchecked(&provider_instance_name(kind, instance))
 }
 
 /// Removes any existing [`KNOWN_HOSTS_FILE`] entries for `host` at `port` from
@@ -1577,12 +1613,16 @@ mod tests {
     fn provider_instance_dir_layout() {
         let state = DaemonAbsPath::try_new("/state/minimal").unwrap();
         assert_eq!(
-            provider_instance_dir(&state, 0).as_str(),
-            "/state/minimal/providers/local-0",
+            provider_instance_dir(&state, ProviderKind::Minimald, 0).as_str(),
+            "/state/minimal/providers/local-minimald0",
         );
         assert_eq!(
-            provider_instance_dir(&state, 3).as_str(),
-            "/state/minimal/providers/local-3",
+            provider_instance_dir(&state, ProviderKind::Minimald, 3).as_str(),
+            "/state/minimal/providers/local-minimald3",
+        );
+        assert_eq!(
+            provider_instance_dir(&state, ProviderKind::Minvmd, 0).as_str(),
+            "/state/minimal/providers/local-minvmd0",
         );
     }
 

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -202,6 +202,104 @@ pub fn provider_instance_dir(
     sub_path!(state_dir, "providers").sub_path_unchecked(&provider_instance_name(kind, instance))
 }
 
+/// Migrate legacy `providers/local-<N>` instance dirs — the pre-split naming,
+/// from before the native minimald and minvmd backends had distinct identities
+/// — to the kind-tagged scheme (`local-minimald<N>` / `local-minvmd<N>`), so
+/// existing on-disk instances are not orphaned by the rename.
+///
+/// Each legacy dir's kind is inferred from its contents (see
+/// [`classify_legacy_provider_dir`]). Best-effort and idempotent: it never
+/// aborts the caller. Only genuine I/O failures (an unreadable providers dir, a
+/// failed rename) warn on stderr — these are rare and actionable. The benign
+/// "nothing to migrate here" outcomes are silent so the CLI, which runs this on
+/// every command, does not repeat a warning: a dir whose contents are ambiguous
+/// or empty, or whose kind-tagged target already exists, is simply left in
+/// place rather than clobbered or guessed at. Runs over every legacy dir found,
+/// not just instance 0.
+///
+/// This renames the directory only; it does not coordinate with a running
+/// daemon. A live daemon keeps serving via its already-open socket/lock inodes
+/// (which survive a dir rename on Unix), but stopping daemons before upgrading
+/// avoids the edge entirely.
+pub fn migrate_legacy_provider_dirs(state_dir: &DaemonAbsPath) {
+    let providers = sub_path!(state_dir, "providers");
+    let providers = providers.as_utf8_path().as_std_path();
+    let entries = match std::fs::read_dir(providers) {
+        Ok(entries) => entries,
+        // Nothing was ever spawned here — no migration to do.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => {
+            eprintln!(
+                "warning: could not scan {} for legacy provider dirs: {e}",
+                providers.display()
+            );
+            return;
+        }
+    };
+
+    for entry in entries {
+        let Ok(entry) = entry else { continue };
+        if !entry.file_type().is_ok_and(|t| t.is_dir()) {
+            continue;
+        }
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        let Some(instance) = legacy_instance_num(&name) else {
+            continue;
+        };
+
+        let path = entry.path();
+        // Ambiguous or empty contents: can't tell the backend apart, so leave it
+        // untouched. Silent — this recurs on every CLI invocation otherwise.
+        let Some(kind) = classify_legacy_provider_dir(&path) else {
+            continue;
+        };
+
+        let target_name = provider_instance_name(kind, instance);
+        let target = providers.join(&target_name);
+        // Target already claimed: don't clobber it. Silent, for the same reason.
+        if target.exists() {
+            continue;
+        }
+        if let Err(e) = std::fs::rename(&path, &target) {
+            eprintln!(
+                "warning: failed to migrate legacy provider dir {name} -> {target_name}: {e}"
+            );
+        }
+    }
+}
+
+/// Parse the instance number from a legacy `local-<N>` dir name, where `<N>` is
+/// one or more decimal digits. Returns `None` for the kind-tagged names
+/// (`local-minimald<N>` / `local-minvmd<N>`, whose suffix is not all digits)
+/// and for anything not of the `local-<digits>` shape.
+fn legacy_instance_num(name: &str) -> Option<u32> {
+    let suffix = name.strip_prefix("local-")?;
+    if suffix.is_empty() || !suffix.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    suffix.parse().ok()
+}
+
+/// Infer which backend a legacy provider dir belonged to from its contents.
+///
+/// A minvmd instance carries VM artifacts the native daemon never writes — its
+/// `minvmd.toml` state file, its alive lock, or the data-volume image. A native
+/// minimald dir carries an on-disk SSH host key (the guest daemon writes its key
+/// inside the VM, not the host dir) or its own lock. Returns `None` when both or
+/// neither class of marker is present, so the caller can skip rather than guess.
+fn classify_legacy_provider_dir(dir: &std::path::Path) -> Option<ProviderKind> {
+    let has = |file: &str| dir.join(file).exists();
+    let minvmd = has("minvmd.toml") || has(MINVMD_LOCK_FILE) || has("data-vol.raw");
+    let minimald = has("ssh_host_ed25519_key") || has(MINIMALD_LOCK_FILE);
+    match (minvmd, minimald) {
+        (true, false) => Some(ProviderKind::Minvmd),
+        (false, true) => Some(ProviderKind::Minimald),
+        _ => None,
+    }
+}
+
 /// Removes any existing [`KNOWN_HOSTS_FILE`] entries for `host` at `port` from
 /// the file at `path`, so that a subsequent append records exactly one current
 /// entry instead of growing the file by a line on every daemon spawn
@@ -1624,6 +1722,142 @@ mod tests {
             provider_instance_dir(&state, ProviderKind::Minvmd, 0).as_str(),
             "/state/minimal/providers/local-minvmd0",
         );
+    }
+
+    /// A tempdir turned into a `DaemonAbsPath` state root.
+    fn state_root(tmp: &tempfile::TempDir) -> DaemonAbsPath {
+        DaemonAbsPath::try_new(tmp.path().to_str().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn migrate_renames_legacy_dirs_by_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let providers = tmp.path().join("providers");
+
+        // A legacy minvmd instance (its state file) and a legacy native
+        // minimald instance (its on-disk host key), at different numbers.
+        let vm = providers.join("local-0");
+        std::fs::create_dir_all(&vm).unwrap();
+        std::fs::write(vm.join("minvmd.toml"), "lifecycle = \"Stopped\"\n").unwrap();
+        let native = providers.join("local-2");
+        std::fs::create_dir_all(&native).unwrap();
+        std::fs::write(native.join("ssh_host_ed25519_key"), b"key").unwrap();
+
+        migrate_legacy_provider_dirs(&state_root(&tmp));
+
+        assert!(providers.join("local-minvmd0").join("minvmd.toml").exists());
+        assert!(!providers.join("local-0").exists());
+        assert!(
+            providers
+                .join("local-minimald2")
+                .join("ssh_host_ed25519_key")
+                .exists()
+        );
+        assert!(!providers.join("local-2").exists());
+    }
+
+    #[test]
+    fn migrate_skips_when_target_already_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let providers = tmp.path().join("providers");
+
+        let legacy = providers.join("local-0");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("minvmd.toml"), "x").unwrap();
+        // The kind-tagged target already exists — don't clobber it.
+        let target = providers.join("local-minvmd0");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("keep"), b"keep").unwrap();
+
+        migrate_legacy_provider_dirs(&state_root(&tmp));
+
+        assert!(
+            legacy.exists(),
+            "legacy dir left in place when target exists"
+        );
+        assert!(target.join("keep").exists(), "existing target untouched");
+    }
+
+    #[test]
+    fn migrate_leaves_new_scheme_and_ambiguous_dirs_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let providers = tmp.path().join("providers");
+
+        // Already-migrated names and non-provider entries must not be touched.
+        for kept in ["local-minvmd0", "local-minimald1", "remote-x"] {
+            std::fs::create_dir_all(providers.join(kept)).unwrap();
+        }
+        // A legacy dir with markers for BOTH backends is ambiguous -> skip.
+        let both = providers.join("local-0");
+        std::fs::create_dir_all(&both).unwrap();
+        std::fs::write(both.join("minvmd.toml"), "x").unwrap();
+        std::fs::write(both.join("ssh_host_ed25519_key"), b"k").unwrap();
+        // A legacy dir with no recognizable markers is skipped too.
+        let empty = providers.join("local-9");
+        std::fs::create_dir_all(&empty).unwrap();
+
+        migrate_legacy_provider_dirs(&state_root(&tmp));
+
+        for kept in ["local-minvmd0", "local-minimald1", "remote-x"] {
+            assert!(providers.join(kept).exists(), "{kept} must be left alone");
+        }
+        assert!(both.exists(), "ambiguous legacy dir left in place");
+        assert!(empty.exists(), "empty legacy dir left in place");
+        assert!(!providers.join("local-minvmd9").exists());
+        assert!(!providers.join("local-minimald9").exists());
+    }
+
+    #[test]
+    fn migrate_classifies_via_the_alternate_markers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let providers = tmp.path().join("providers");
+
+        // minvmd via its lock, minvmd via the data volume, minimald via its lock
+        // — none carry the primary `minvmd.toml` / `ssh_host_ed25519_key` marker.
+        let vm_lock_dir = providers.join("local-0");
+        std::fs::create_dir_all(&vm_lock_dir).unwrap();
+        std::fs::write(vm_lock_dir.join(MINVMD_LOCK_FILE), b"").unwrap();
+        let vm_volume_dir = providers.join("local-1");
+        std::fs::create_dir_all(&vm_volume_dir).unwrap();
+        std::fs::write(vm_volume_dir.join("data-vol.raw"), b"").unwrap();
+        let native_lock_dir = providers.join("local-2");
+        std::fs::create_dir_all(&native_lock_dir).unwrap();
+        std::fs::write(native_lock_dir.join(MINIMALD_LOCK_FILE), b"").unwrap();
+
+        migrate_legacy_provider_dirs(&state_root(&tmp));
+
+        assert!(providers.join("local-minvmd0").exists());
+        assert!(providers.join("local-minvmd1").exists());
+        assert!(providers.join("local-minimald2").exists());
+    }
+
+    #[test]
+    fn migrate_is_idempotent_on_a_second_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let providers = tmp.path().join("providers");
+        let legacy = providers.join("local-0");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("minvmd.toml"), "x").unwrap();
+
+        migrate_legacy_provider_dirs(&state_root(&tmp));
+        // A second pass finds only the kind-tagged name and does nothing.
+        migrate_legacy_provider_dirs(&state_root(&tmp));
+
+        assert!(providers.join("local-minvmd0").join("minvmd.toml").exists());
+        assert!(!providers.join("local-0").exists());
+    }
+
+    #[test]
+    fn legacy_instance_num_matches_only_all_digit_suffixes() {
+        assert_eq!(legacy_instance_num("local-0"), Some(0));
+        assert_eq!(legacy_instance_num("local-12"), Some(12));
+        // The kind-tagged names must never be treated as legacy.
+        assert_eq!(legacy_instance_num("local-minvmd0"), None);
+        assert_eq!(legacy_instance_num("local-minimald3"), None);
+        // Neither must anything else.
+        assert_eq!(legacy_instance_num("local-"), None);
+        assert_eq!(legacy_instance_num("remote-0"), None);
+        assert_eq!(legacy_instance_num("local-1a"), None);
     }
 
     #[test]

--- a/docs/specs/06-spec-ssh-host-key-in-beacon/06-spec-ssh-host-key-in-beacon.md
+++ b/docs/specs/06-spec-ssh-host-key-in-beacon/06-spec-ssh-host-key-in-beacon.md
@@ -33,7 +33,7 @@ Extend the ready-beacon wire format from one line (`READY\n`) to two lines
 SSH host private key at the moment it emits the beacon; the public key is cheap
 to serialize in OpenSSH authorized_keys format. `minvmd` reads the second line,
 parses it as an SSH public key, and writes it to
-`$XDG_STATE_HOME/minimal/providers/local-0/known_hosts` on the host so the
+`$XDG_STATE_HOME/minimal/providers/local-minvmd0/known_hosts` on the host so the
 SSH client finds it before the first connection attempt.
 
 ## Goals
@@ -76,14 +76,14 @@ line from the beacon connection immediately after validating `READY`.
 
 **R2.2**, If the second beacon line contains a valid SSH public key, `minvmd`
 records it in `known_hosts` at
-`$XDG_STATE_HOME/minimal/providers/local-0/known_hosts` for hostname `local-0`
+`$XDG_STATE_HOME/minimal/providers/local-minvmd0/known_hosts` for hostname `local-minvmd0`
 at port 22, using the same known-hosts API path already used by the native
 (non-VM) `minimald` flow.
 
 **R2.3**, If the second line is absent, empty, or fails to parse as an SSH
 public key, `minvmd` logs a warning and proceeds; the boot is not aborted.
 
-**R2.4**, The `providers/local-0/` directory hierarchy is created before
+**R2.4**, The `providers/local-minvmd0/` directory hierarchy is created before
 writing `known_hosts`.
 
 **R2.5**, `russh` is promoted from `[dev-dependencies]` to `[dependencies]`
@@ -97,8 +97,8 @@ in `minvmd/Cargo.toml` so the production code can call
   read path, and asserts the expected `known_hosts` entry is present in a temp
   directory. This test cannot pass against the current single-line reader.
 - **File**: After `minvmd run` completes boot against a real guest,
-  `$XDG_STATE_HOME/minimal/providers/local-0/known_hosts` exists and contains
-  a valid entry for `local-0` at port 22 matching the VM's SSH host key.
+  `$XDG_STATE_HOME/minimal/providers/local-minvmd0/known_hosts` exists and contains
+  a valid entry for `local-minvmd0` at port 22 matching the VM's SSH host key.
 
 ## Non-Goals
 
@@ -123,7 +123,7 @@ existing connection is the simplest extension that fits the established pattern.
 **Hostname and port in `known_hosts`**
 `minimald` uses `"local-{instance_num}"` as the SSH hostname (from `ssh_args()`
 at `minimald/src/main.rs:109`). In the VM case `instance_num` is always 0
-(hardcoded in `is_minimal_microvm()`). `minvmd` therefore hard-codes `"local-0"`
+(hardcoded in `is_minimal_microvm()`). `minvmd` therefore hard-codes `"local-minvmd0"`
 and port `22` in the `learn_known_hosts_path` call, matching the native path.
 
 **Non-fatal key parse**
@@ -134,7 +134,7 @@ default and preserves backward compatibility with an older guest that sends only
 one line.
 
 **Known_hosts path on the host**
-The path is `$XDG_STATE_HOME/minimal/providers/local-0/known_hosts`, derived the
+The path is `$XDG_STATE_HOME/minimal/providers/local-minvmd0/known_hosts`, derived the
 same way `minimald`'s native path is derived. `minvmd` already uses
 `dirs::state_dir()` for its own state (`$XDG_STATE_HOME/minimal/minvmd/`), so
 the derivation is consistent and needs no new configuration.
@@ -172,7 +172,7 @@ extension is additive and backward-compatible.
   PID+nonce path (`/tmp/minvmd-marker-<pid>-<nonce>.sock`) and used once. The
   socket's lifetime is the boot window (≤5 s); there is no persistent exposure.
 - The `learn_known_hosts_path` call uses TOFU semantics: the first key for
-  `local-0:22` is accepted; a later differing key from the same hostname is
+  `local-minvmd0:22` is accepted; a later differing key from the same hostname is
   treated as a possible MITM by the SSH client. Because the marker socket
   includes a random nonce and the VM is a locally controlled environment, this
   is an acceptable trust model.
@@ -183,4 +183,4 @@ extension is additive and backward-compatible.
 2. `cargo test -p minvmd`, the READY-marker integration test (R2.1–R2.4)
    passes; the expected key entry is present in the temp `known_hosts`.
 3. End-to-end: `minvmd run` followed by a fresh SSH connect with
-   `ssh -o UserKnownHostsFile=<path> local-0` succeeds with no host-key prompt.
+   `ssh -o UserKnownHostsFile=<path> local-minvmd0` succeeds with no host-key prompt.

--- a/docs/specs/09-spec-minvmd-resource-monitoring/09-spec-minvmd-resource-monitoring.md
+++ b/docs/specs/09-spec-minvmd-resource-monitoring/09-spec-minvmd-resource-monitoring.md
@@ -277,7 +277,7 @@ exhaustion when a guest workload exits non-zero.
   cgroup `memory.events` / in-guest `df`, i.e. an in-guest agent. The host-side
   proxies (RSS, sparse allocation) are unmeasurable and were removed; the reliable
   reactive signal is the supervisor exit hint (R3.2).
-- **Multi-VM config**: single `local-0` instance, per the v0.1 single-VM stance.
+- **Multi-VM config**: single `local-minvmd0` instance, per the v0.1 single-VM stance.
 
 ## Design Considerations
 

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ native-dir   := scratch / "native-state"
 # covers the rest. The Linux lanes run nextest's ci profile; macOS has none.
 scope      := if os() == "macos" { "-p minvmd -p sessions" } else { "--workspace" }
 ci-profile := if os() == "macos" { "" } else { "--profile ci" }
-e2e-env    := "E2E_VM=1 E2E_PROJECT_DIR=/tmp" + if os() == "linux" { " E2E_MINIMAL_ARGS=--minvmd" } else { "" }
+e2e-env    := "E2E_VM=1 E2E_PROJECT_DIR=/tmp" + if os() == "linux" { " E2E_MINIMAL_ARGS='--provider local-minvmd'" } else { "" }
 
 # Shared dev-stack env: target/debug on PATH so autospawn finds sibling
 # binaries; MINVMD_* are inert outside the VM recipes. 150s timeouts: the

--- a/justfile
+++ b/justfile
@@ -342,8 +342,10 @@ bulk-upload n="5": _kvm artifacts gvproxy initramfs minimal-cli minvmd-build
 # `just up` = this host's default run mode; `just down` stops it.
 #   macOS: Linux VM over Hypervisor.framework (the only macOS mode).
 #   Linux: host-native minimald, no VM. `just up-kvm`: Linux + VM over KVM.
-# The CLI dials providers/local-0/ssh.sock in every mode; minvmd binds it
-# directly (#690), so no bridge is needed.
+# Each backend has its own provider dir: the native daemon dials
+# providers/local-minimald0/ssh.sock, the minvmd VM providers/local-minvmd0/ssh.sock
+# (minvmd binds it directly, #690, so no bridge is needed). Select the VM
+# backend with `--provider local-minvmd`.
 
 # The daemon can reset the very first connect after boot/bind; retry briefly.
 _smoke *args:
@@ -363,7 +365,7 @@ up: artifacts gvproxy initramfs minvmd-build minimal-cli && (_smoke)
 up: minimald-build minimal-cli gvproxy && (_smoke "--minimal-dir" native-dir)
     #!/usr/bin/env sh
     set -eu
-    sock="{{native-dir}}/providers/local-0/ssh.sock"
+    sock="{{native-dir}}/providers/local-minimald0/ssh.sock"
     pidf="{{scratch}}/minimald.pid"
     mkdir -p "{{native-dir}}"
     # PID files survive reboots and PIDs get reused: only trust the pidfile if
@@ -389,9 +391,9 @@ up: minimald-build minimal-cli gvproxy && (_smoke "--minimal-dir" native-dir)
 
 # Bring the stack up: native Linux + one Linux VM over KVM (stop with `just stop`).
 [linux]
-up-kvm: _kvm artifacts gvproxy initramfs minvmd-build minimal-cli && (_smoke)
+up-kvm: _kvm artifacts gvproxy initramfs minvmd-build minimal-cli && (_smoke "--provider" "local-minvmd")
     MINVMD_GVPROXY_BIN="{{gvproxy}}" "{{minvmd-bin}}" run --detach --timeout "$MINVMD_READY_TIMEOUT_SECS"
-    @echo "up-kvm: VM booted; minimald reachable at providers/local-0/ssh.sock"
+    @echo "up-kvm: VM booted; minimald reachable at providers/local-minvmd0/ssh.sock"
 
 # Stop the stack `just up` started.
 [macos]

--- a/scripts/bulk-upload-e2e.sh
+++ b/scripts/bulk-upload-e2e.sh
@@ -165,7 +165,7 @@ diagnostics() {
     | while read -r f; do echo "--- $f (tail) ---"; tail -40 "$f"; done
   if [ -n "$E2E_VM" ]; then
     echo "--- guest boot console (tail) ---"
-    tail -80 "${MINVMD_BOOT_LOG:-$XDG_STATE_HOME/minimal/providers/local-0/boot.log}" 2>/dev/null \
+    tail -80 "${MINVMD_BOOT_LOG:-$XDG_STATE_HOME/minimal/providers/local-minvmd0/boot.log}" 2>/dev/null \
       || echo "(no boot log — VM never started)"
   fi
   echo "::endgroup::"

--- a/scripts/bulk-upload-e2e.sh
+++ b/scripts/bulk-upload-e2e.sh
@@ -55,7 +55,7 @@
 # the nightly's whole job budget, and one is already conclusive.
 #
 # Environment (same knobs as scripts/session-e2e.sh, which this mirrors):
-#   E2E_MINIMAL_ARGS              global args for every `min` call (e.g. --minvmd)
+#   E2E_MINIMAL_ARGS              global args for every `min` call (e.g. --provider local-minvmd)
 #   E2E_VM                        set to 1 for VM-backed targets (extra teardown
 #                                 + guest boot log in the diagnostics)
 #   MINVMD_BOOT_LOG               optional override for the guest-console path

--- a/scripts/e2e-attach-pty.py
+++ b/scripts/e2e-attach-pty.py
@@ -10,7 +10,7 @@ interactive teardown a user performs.
 
 Usage: e2e-attach-pty.py <add_tool> <argv...>
   <add_tool>  package to `min add` (also its binary + `--version` subject)
-  <argv...>   the command to spawn under the pty, e.g. `min --minvmd attach <sid>`
+  <argv...>   the command to spawn under the pty, e.g. `min --provider local-minvmd attach <sid>`
 
 Prints the full captured terminal output on stdout. Exits 0 iff the attach
 process exited 0.

--- a/scripts/minvmd-lifecycle.sh
+++ b/scripts/minvmd-lifecycle.sh
@@ -29,7 +29,7 @@ teardown() {
   minvmd stop >/dev/null 2>&1 || true
   # Drop the resource config this proof persisted so it cannot alter the
   # session-e2e boot that runs next on the same default state dir.
-  rm -f "${XDG_STATE_HOME:-$HOME/.local/state}/minimal/providers/local-0/config.toml"
+  rm -f "${XDG_STATE_HOME:-$HOME/.local/state}/minimal/providers/local-minvmd0/config.toml"
   rm -rf "$WORK"
 }
 trap teardown EXIT

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -4,7 +4,7 @@
 # so the IDENTICAL proof runs against all three deployment targets:
 #
 #   Linux native   minimald on the host          (no extra env)
-#   Linux KVM      minimald in a minvmd microVM  E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd
+#   Linux KVM      minimald in a minvmd microVM  E2E_VM=1 E2E_MINIMAL_ARGS="--provider local-minvmd"
 #   macOS HVF      minimald in a minvmd microVM  E2E_VM=1 (macOS is always VM-backed)
 #
 # Two proofs, in order, on EVERY lane:
@@ -50,7 +50,7 @@
 #   - MINVMD_BOOT_LOG (optional) to override the guest-console capture path
 #
 # Environment:
-#   E2E_MINIMAL_ARGS    global args for every `min` call (e.g. --minvmd)
+#   E2E_MINIMAL_ARGS    global args for every `min` call (e.g. --provider local-minvmd)
 #   E2E_PROJECT_DIR     project to activate (default: a self-seeded throwaway
 #                       dir; VM lanes pass /tmp)
 #   E2E_ACTIVATE_ARGS   extra args for `min activate` (e.g. a future

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -128,7 +128,7 @@ fi
 
 # Fresh state dir — a clean (no-daemon) cold-start on persistent runners:
 # post-#690, all daemon state (minvmd.toml, locks, the bridge socket) lives
-# under $XDG_STATE_HOME/minimal/providers/local-0 on every platform.
+# under $XDG_STATE_HOME/minimal/providers/local-minvmd0 on every platform.
 # XDG_CACHE_HOME is deliberately left alone so package pulls reuse the
 # host/CI cache across runs — which pins where the state dir may live on a
 # Linux-native lane: minimald HARDLINKS built packages from the cache into
@@ -197,7 +197,7 @@ fail() {
     | while read -r f; do echo "--- $f (tail) ---"; tail -40 "$f"; done
   if [ -n "$E2E_VM" ]; then
     echo "--- guest boot console (tail) ---"
-    tail -80 "${MINVMD_BOOT_LOG:-$XDG_STATE_HOME/minimal/providers/local-0/boot.log}" 2>/dev/null || echo "(no boot log — VM never started)"
+    tail -80 "${MINVMD_BOOT_LOG:-$XDG_STATE_HOME/minimal/providers/local-minvmd0/boot.log}" 2>/dev/null || echo "(no boot log — VM never started)"
   fi
   echo "::endgroup::"
   teardown

--- a/scripts/soak-session-e2e.sh
+++ b/scripts/soak-session-e2e.sh
@@ -15,7 +15,7 @@
 # The caller sets the VM up exactly as the KVM lane does — minvmd + minimal
 # on PATH, MINVMD_KERNEL_PATH / MINVMD_ROOTFS_PATH / MINVMD_INITRAMFS set,
 # libkrun on the loader path — and passes the VM knobs through the
-# environment (E2E_VM=1 E2E_MINIMAL_ARGS=--minvmd E2E_PROJECT_DIR=/tmp),
+# environment (E2E_VM=1 E2E_MINIMAL_ARGS="--provider local-minvmd" E2E_PROJECT_DIR=/tmp),
 # same as the lane invocation. Each iteration runs session-e2e.sh, which
 # creates its own fresh XDG state, so every pass is a clean cold start.
 #


### PR DESCRIPTION
## What

Replace the `min` CLI's opaque boolean `--minvmd` flag with a `--provider <PROVIDER>` global option:

- `--provider local-minimald` — host-native `minimald`, the default.
- `--provider local-minvmd` — `minimald` inside the minvmd microVM.

`--minvmd` is **removed outright** (it existed only transiently within this PR as a hidden alias). All callers now use `--provider local-minvmd`, including the three CI workflows, updated with codeowner approval. Backend selection is centralized behind `GlobalArgs::use_minvmd()`.

## Distinct per-backend provider identities

Previously both backends shared one provider-instance identity, `local-<N>` (e.g. `local-0`) — used for the on-disk `providers/<name>` dir, the SSH host-key identity in `known_hosts`, and the hostname the client verifies. That made native `minimald` and the `minvmd` VM collide (see #739). Now each backend gets a distinct identity:

- native minimald -> `local-minimald<N>`
- minvmd microVM  -> `local-minvmd<N>`

The name is produced in one place, `paths::provider_instance_name(kind, N)` (keyed on a new `paths::ProviderKind`). The client picks the backend's dir via `client_provider_kind(use_minvmd)` (minvmd when `--provider local-minvmd`, or always on macOS); `minimald`/`minvmd` each hard-code their own kind. The attach/forward SSH host alias is read back from the resolved provider dir so client and daemon can never disagree.

## Migration of existing on-disk instances

`paths::migrate_legacy_provider_dirs` renames any pre-split `providers/local-<N>` dir to the kind-tagged scheme so existing instances are not orphaned. Each dir's kind is inferred from its contents:

- minvmd markers: `minvmd.toml`, its alive lock, or `data-vol.raw`.
- native minimald markers: the on-disk `ssh_host_ed25519_key`, or its lock.
- both or neither present -> ambiguous, left untouched.

Best-effort and idempotent: only genuine I/O errors warn; benign skips (ambiguous/empty content, target already exists) are silent so the CLI does not repeat a warning every command. Invoked once where provider dirs are first resolved — native minimald startup, minvmd `run`, and the `min` client's command dispatch.

## Test

`cargo test` on `paths` (53, incl. migration cases) / `minimal` / `minvmd` (122) / `minimald` (166) passes; `minimal` integration `cli` (25) and `git_remote` (1) pass. `bug.rs` is 6 pass / 2 fail and `minimal` lib has 2 fails — all four are **pre-existing** environment failures (no network tooling; running as root), unrelated to this change. `clippy`/`fmt` clean for touched crates (remaining clippy warnings are pre-existing in `switch.rs`/`sandbox2`).

Closes #739

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `--minvmd` flag with `--provider {local-minimald|local-minvmd}` and rename provider directories to kind-tagged paths
> - Adds a `--provider` CLI flag (via a new `Provider` enum) replacing the deprecated `--minvmd` boolean, allowing explicit selection of `local-minimald` (host) or `local-minvmd` (VM) backends.
> - Renames provider instance directories from `providers/local-<N>` to `providers/local-minimald<N>` or `providers/local-minvmd<N>` depending on backend, affecting socket paths, lock files, known_hosts entries, and data volume paths.
> - Adds a best-effort, idempotent migration routine (`paths::migrate_legacy_provider_dirs`) that classifies and renames legacy `providers/local-<N>` directories to the new kind-tagged scheme on startup, both in `minimald` and `minvmd`.
> - SSH host aliases used in known_hosts are now derived from the provider instance directory name (e.g. `local-minimald0`) instead of being hardcoded as `local-0`.
> - Risk: On-disk provider directory names change for all existing installations; the migration routine handles this automatically but only when the kind can be inferred from directory contents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8647606.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
