### PR TITLE
fix(ci): boot the macOS VM lane on guest-pin bumps

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -58,6 +58,9 @@ jobs:
                         - "Cargo.lock"
                         # The toolchain pin: a rustc bump must re-run the Rust lanes.
                         - "rust-toolchain.toml"
+                        # The guest pin: a kernel / rootfs / libkrun bump must
+                        # boot the VM on HVF (parity with the KVM lane's filter).
+                        - ".minimal/minimal.toml"
                         - ".github/workflows/ci-macos.yml"
                         - "scripts/**"
                         # Composite actions this lane's setup runs through — without


### PR DESCRIPTION
## Problem

The macOS lane gates its expensive HVF VM-boot jobs (`artifacts`, `unit`, `e2e`) behind an in-workflow `dorny/paths-filter` `macos` block. That block omitted `.minimal/minimal.toml`, so a PR that only bumped the guest kernel / rootfs / libkrun pin produced `changes.outputs.macos == 'false'` and skipped every macOS VM job — the bump merged without a macOS VM boot. The Linux/KVM lane already lists `.minimal/minimal.toml` in its filter and boots on such bumps; macOS was the arch-specific (aarch64/HVF) gap.

## Fix

Add `.minimal/minimal.toml` to the `macos` filter list, matching the KVM lane. A pin-only PR now matches the filter, so the HVF VM boot runs as a pre-merge gate.

- Filter-only change: 3 lines (one path entry + a 2-line comment matching the surrounding style).
- The `ci-macos-success` aggregator (`if: always()`) and every job gate are untouched, so PRs that do not match the filter still path-skip cleanly and report green.

This is a codeowner-approved edit to the otherwise-frozen `.github/workflows/` tree.

Closes #897

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger macOS CI lane on guest pin (`minimal.toml`) changes
> Adds `.minimal/minimal.toml` to the `macos` path filter in [ci-macos.yml](.github/workflows/ci-macos.yml) so that bumping the guest pin triggers the macOS HVF boot job, matching the existing KVM lane behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c8a773.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->