### PR TITLE
fix(paths): dedup known_hosts on daemon spawn to bound file growth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4665,6 +4665,7 @@ dependencies = [
  "camino",
  "dirs",
  "serde",
+ "tempfile",
  "thiserror 2.0.19",
  "toml",
 ]

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -643,11 +643,19 @@ async fn async_main() -> Result<(), MainError> {
     // Ensure the SSH host key is accessible in a instance-specific known_hosts file.
     // R1.2: load once and reuse in the vsock beacon so there is no redundant disk read.
     let host_private_key = config.host_key()?;
+    let host = format!("local-{}", cli.instance_num());
+    let known_hosts = sub_path!(cli.client_instance_dir(), "known_hosts");
+    let known_hosts = known_hosts.as_utf8_path();
+    // Drop any prior entry for this host before re-recording, so the file does
+    // not grow one line per daemon spawn — `learn_known_hosts_path` only
+    // appends (issue #782).
+    paths::prune_known_hosts_host(known_hosts, &host)
+        .map_err(|e| MainError::IO(e, "pruning stale known_hosts entries"))?;
     russh::keys::known_hosts::learn_known_hosts_path(
-        &format!("local-{}", cli.instance_num()),
+        &host,
         22,
         host_private_key.public_key(),
-        sub_path!(cli.client_instance_dir(), "known_hosts").as_utf8_path(),
+        known_hosts,
     )?;
 
     // Preflight (advisory): every session sandbox starts by unsharing an

--- a/crates/minvmd/src/cmd/mod.rs
+++ b/crates/minvmd/src/cmd/mod.rs
@@ -370,6 +370,15 @@ pub(crate) fn read_ready_beacon<R: std::io::BufRead>(
                         tracing::warn!(error = %e, "failed to parse SSH host key from beacon");
                     }
                     Ok(pubkey) => {
+                        // Drop any prior entry for this host before re-recording:
+                        // `learn_known_hosts_path` only appends, and the guest
+                        // rotates its host key on each boot, so without this the
+                        // file grows unbounded and keeps every stale key
+                        // (issue #782). A prune failure is non-fatal, matching
+                        // the beacon's best-effort key handling (R2.3).
+                        if let Err(e) = paths::prune_known_hosts_host(known_hosts_path, "local-0") {
+                            tracing::warn!(error = %e, "failed to prune stale known_hosts entries");
+                        }
                         match russh::keys::known_hosts::learn_known_hosts_path(
                             // TODO: pass instance_num through once multi-instance is needed
                             "local-0",

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -12,6 +12,7 @@ serde.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+tempfile.workspace = true
 toml.workspace = true
 
 [lints.clippy]

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -154,6 +154,60 @@ pub const SSH_SOCK_FILE: &str = "ssh.sock";
 /// daemon's host key under the `local-<instance>` hostname. Written at startup
 /// by native minimald, and by minvmd from the guest's boot beacon.
 pub const KNOWN_HOSTS_FILE: &str = "known_hosts";
+/// Remove any existing `known_hosts` lines in `path` whose host field is
+/// `host`, so a freshly recorded key for that host replaces — rather than
+/// accumulates alongside — the prior entry.
+///
+/// `russh`'s `learn_known_hosts_path` only ever appends, so without pruning
+/// first, a daemon that re-records its host key on every spawn grows the file
+/// without bound; and when the guest rotates its key on each boot the file also
+/// keeps every stale key. Call this immediately before `learn_known_hosts_path`
+/// (issue #782).
+///
+/// A missing file is not an error (nothing to prune), and the file is left
+/// byte-for-byte untouched when no line matches. The host field is the first
+/// whitespace-delimited token; both the bare `host` (port 22) and the
+/// `[host]:port` forms `russh` emits are matched.
+///
+/// # Errors
+///
+/// Returns any I/O error from reading or rewriting the file, except a
+/// not-found read, which is treated as an empty file and yields `Ok`.
+pub fn prune_known_hosts_host(path: impl AsRef<Path>, host: &str) -> std::io::Result<()> {
+    let path = path.as_ref();
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    let kept: Vec<&str> = contents
+        .lines()
+        .filter(|line| !known_hosts_line_matches_host(line, host))
+        .collect();
+    // Nothing matched: leave the file (and its exact bytes) untouched.
+    if kept.len() == contents.lines().count() {
+        return Ok(());
+    }
+    let rewritten = if kept.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", kept.join("\n"))
+    };
+    std::fs::write(path, rewritten)
+}
+
+/// Whether a single `known_hosts` line's host field equals `host`, matching
+/// both the bare `host` and the bracketed `[host]:port` forms.
+fn known_hosts_line_matches_host(line: &str, host: &str) -> bool {
+    line.split_whitespace().next().is_some_and(|field| {
+        field == host
+            || field
+                .strip_prefix('[')
+                .and_then(|rest| rest.split_once("]:"))
+                .is_some_and(|(bracketed, _)| bracketed == host)
+    })
+}
+
 /// Native minimald's single-instance lock, held for the daemon's lifetime.
 pub const MINIMALD_LOCK_FILE: &str = "minimald.lock";
 /// The minvmd supervisor's alive lock, held for the daemon's lifetime.
@@ -1600,5 +1654,81 @@ mod tests {
         );
 
         unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
+    }
+
+    #[test]
+    fn known_hosts_line_match_covers_bare_and_bracketed_forms() {
+        assert!(known_hosts_line_matches_host(
+            "local-0 ssh-ed25519 AAAA",
+            "local-0"
+        ));
+        assert!(known_hosts_line_matches_host(
+            "[local-0]:2222 ssh-ed25519 AAAA",
+            "local-0"
+        ));
+        assert!(!known_hosts_line_matches_host(
+            "local-1 ssh-ed25519 AAAA",
+            "local-0"
+        ));
+        assert!(!known_hosts_line_matches_host("", "local-0"));
+    }
+
+    #[test]
+    fn prune_removes_only_the_named_host_and_bounds_growth() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(KNOWN_HOSTS_FILE);
+
+        // Simulate the pre-fix accumulation: three appended entries for the
+        // same host (as `learn_known_hosts_path` would leave), plus one entry
+        // for an unrelated host that must survive.
+        std::fs::write(
+            &path,
+            "local-0 ssh-ed25519 AAAAold1\n\
+             local-0 ssh-ed25519 AAAAold2\n\
+             other-host ssh-ed25519 AAAAkeep\n\
+             local-0 ssh-ed25519 AAAAold3\n",
+        )
+        .unwrap();
+
+        prune_known_hosts_host(&path, "local-0").unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(after, "other-host ssh-ed25519 AAAAkeep\n");
+    }
+
+    #[test]
+    fn prune_to_empty_yields_a_zero_byte_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(KNOWN_HOSTS_FILE);
+        // The steady state: the per-instance file holds only this host's
+        // entries, so a pre-record prune empties it entirely.
+        std::fs::write(
+            &path,
+            "local-0 ssh-ed25519 AAAAold1\nlocal-0 ssh-ed25519 AAAAold2\n",
+        )
+        .unwrap();
+        prune_known_hosts_host(&path, "local-0").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "");
+    }
+
+    #[test]
+    fn prune_is_a_noop_when_file_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(KNOWN_HOSTS_FILE);
+        prune_known_hosts_host(&path, "local-0").unwrap();
+        assert!(!path.exists(), "prune must not create the file");
+    }
+
+    #[test]
+    fn prune_leaves_file_untouched_when_nothing_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(KNOWN_HOSTS_FILE);
+        // No trailing newline: proves the untouched path preserves exact bytes.
+        std::fs::write(&path, "other-host ssh-ed25519 AAAAkeep").unwrap();
+        prune_known_hosts_host(&path, "local-0").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "other-host ssh-ed25519 AAAAkeep"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Both native `minimald` (at startup) and `minvmd` (from the guest boot beacon) record the daemon host key via russh's `learn_known_hosts_path`, which only ever **appends**. Every daemon spawn adds another line for the same `local-N` host, so the per-instance `providers/local-N/known_hosts` file grows by one line per stop/start cycle. When the guest VM rotates its host key on each boot it also accumulates stale keys, which `StrictHostKeyChecking=yes` then has to sift through.

## Fix

Add `paths::prune_known_hosts_host`, which drops any existing entry for the host before the key is re-recorded, and call it immediately before `learn_known_hosts_path` on both write paths (`crates/minimald/src/main.rs`, `crates/minvmd/src/cmd/mod.rs`).

- A missing file is a no-op; the file is left byte-for-byte untouched when nothing matches.
- Matches both the bare `host` (port 22) and `[host]:port` forms; does not over-match (`local-0` vs `local-01`), and leaves unrelated hosts intact.
- The `minvmd` path treats a prune failure as non-fatal, matching the beacon's best-effort key handling (R2.3).

Net effect: repeated stop/start cycles leave the `known_hosts` line count stable, and a rotated guest key replaces the stale entry instead of piling up.

## Tests

New unit tests in `paths` cover matcher forms, multi-entry prune with a surviving unrelated host, prune-to-empty, absent-file no-op, and the untouched-preserves-exact-bytes path. `cargo test -p paths` and `cargo build -p minimald`/`cargo test -p minvmd` pass; `paths`/`minvmd` clippy clean.

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate `known_hosts` entries on daemon spawn to bound file growth
> - Adds `prune_known_hosts_host` to the `paths` crate ([lib.rs](https://github.com/gominimal/minimal/pull/937/files#diff-94f295a0746ecfa31f504df7b5ad95cd29b5c2266dfd3a650e0e0250394c2c36)) which removes all lines matching a given host (bare and bracketed `[host]:port` forms) before appending a new key, rewriting the file only when lines are removed.
> - In [`minimald`](https://github.com/gominimal/minimal/pull/937/files#diff-94e641147dfc527a957e34ac84f21d47f330c992b120da13441a31765c72f981), pruning runs at startup before `learn_known_hosts_path`; a prune failure aborts startup with `MainError::IO`.
> - In [`minvmd`](https://github.com/gominimal/minimal/pull/937/files#diff-b71fb541a122b1125f996147604918a80d9c28893205b31f8eaa12f4f8bfb62f), pruning runs best-effort when processing a READY beacon; failures are logged as warnings and do not abort boot.
> - Missing `known_hosts` files are treated as no-ops and return `Ok(())`.
> - Risk: pruning failure in `minimald` is now fatal, whereas previously no pruning occurred.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bcebc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->