### PR TITLE
docs(concepts): lift the supply-chain, sandboxing, packages, and stacks guides

### DIFF
--- a/docs/concepts/packages.md
+++ b/docs/concepts/packages.md
@@ -1,0 +1,52 @@
+---
+description: Packages are reproducible, dependency-aware units of software in Minimal. Covers usage, definition, caching, and hermetic builds.
+---
+
+# Minimal packages
+
+Packages are the core of software production in Minimal. Packages are reproducible, maintainable, and dependency-aware building blocks designed for environment parity across the software development lifecycle (SDLC).
+
+Structurally, a package is the union of its declarative build specification and the resulting binary artifacts. A metaphor for Minimal's packages would be a recipe (the build specification) and the meal that's cooked from it (the resulting artifacts). This relationship is cemented by a [layer of metadata](#definition) that defines the package's dependencies, architecture, and provenance. In our metaphor, these would be the optional modifications made to tailor the dish so it's more to your liking. By binding the "recipe" to the "result," Minimal ensures that you have complete control over every dish you make, verifying that every component of your environment is transparent, verifiable, and maintainable at scale.
+
+## Using packages {#using}
+
+A Minimal package is available anywhere it is called for:
+
+ - A package declared on a [task](../reference/tasks.md) will always be installed in the environment the task runs.
+ - A package declared as an input to a [build spec](../reference/build-specs.md) will always be present in the build sandbox.
+ - A package declared on a [stack](./stacks.md) will always be present
+   in the tasks or builds that use the stack.
+
+
+## Defining packages {#definition}
+
+Packages are defined in a [build spec](../reference/build-specs.md) file located at `packages/<package name>/build.ncl`. The `packages/` directory
+is always adjacent to the [`minimal.toml`](../reference/minimal-dot-toml.md) file at the base of the layer, but can be omitted if the layer does not
+define any packages.
+
+The package definition captures a variety of useful information:
+
+ - The build-time and runtime dependencies of the package, defined in terms of other packages
+ - How to build the package from source-code: including build commands, where to fetch the source, and what outputs compose the package
+ - Runtime semantics, such as state directories or environment variables that need to be configured at runtime
+ - Metadata, such as the current version of the software, the software license, and the authoritative source of releases.
+
+## Caching {#caching}
+
+Built packages are cached against their _spec hash_: a cryptographic hash of the metadata of the package, including the recipe for
+building the package (and the recipes for building all its transitive dependencies). Using these hashes as the storage key ensures
+that the exact package described in your repository or [software supply chain](./software-supply-chain.md) is used anywhere it is
+requested, as well as providing a reliable key for fetching packages remotely.
+
+When Minimal needs a package, it is first downloaded locally from a remote binary cache. If it's not available locally, it will be downloaded remotely. If remote fetch is disabled, then it will be built locally. Minimal defaults to building things locally if it cannot locate specific items.
+
+## Package builds
+
+All Minimal package builds take place in a hermetic, isolated environment to prevent interference or non-reproducibility from the machine running the build.
+
+## Sideloading additional packages
+
+Sometimes you may want to use packages defined in a separate repository, but still use the toolchains and software versions defined by your [`[upstream]`](../reference/minimal-dot-toml.md#upstream).
+
+Sideloads allow you to do this: each sideload specified in your `minimal.toml` brings in additional packages from other repositories, while building those packages
+using the version of packages defined by your [`[upstream]`](../reference/minimal-dot-toml.md#upstream). See the [`sideloading schema`](../reference/minimal-dot-toml.md#sideload) for additional information.

--- a/docs/concepts/packages.md
+++ b/docs/concepts/packages.md
@@ -14,8 +14,8 @@ A Minimal package is available anywhere it is called for:
 
  - A package declared on a [task](../reference/tasks.md) will always be installed in the environment the task runs.
  - A package declared as an input to a [build spec](../reference/build-specs.md) will always be present in the build sandbox.
- - A package declared on a [stack](./stacks.md) or [profile](./profiles.md) will always be present
-   in the tasks or builds that use the stack or profile.
+ - A package declared on a [stack](./stacks.md) will always be present in the tasks and builds that use the stack.
+ - A package declared on a [profile](./profiles.md) will always be present in the tasks that use the profile.
 
 
 ## Defining packages {#definition}

--- a/docs/concepts/packages.md
+++ b/docs/concepts/packages.md
@@ -14,8 +14,8 @@ A Minimal package is available anywhere it is called for:
 
  - A package declared on a [task](../reference/tasks.md) will always be installed in the environment the task runs.
  - A package declared as an input to a [build spec](../reference/build-specs.md) will always be present in the build sandbox.
- - A package declared on a [stack](./stacks.md) will always be present
-   in the tasks or builds that use the stack.
+ - A package declared on a [stack](./stacks.md) or [profile](./profiles.md) will always be present
+   in the tasks or builds that use the stack or profile.
 
 
 ## Defining packages {#definition}
@@ -38,7 +38,7 @@ building the package (and the recipes for building all its transitive dependenci
 that the exact package described in your repository or [software supply chain](./software-supply-chain.md) is used anywhere it is
 requested, as well as providing a reliable key for fetching packages remotely.
 
-When Minimal needs a package, it is first downloaded locally from a remote binary cache. If it's not available locally, it will be downloaded remotely. If remote fetch is disabled, then it will be built locally. Minimal defaults to building things locally if it cannot locate specific items.
+When Minimal needs a package, it first checks the local cache. If the package is not present locally, Minimal fetches it from the remote binary cache. If the remote fetch is disabled or the package is unavailable there, Minimal builds it locally.
 
 ## Package builds
 

--- a/docs/concepts/profiles.md
+++ b/docs/concepts/profiles.md
@@ -1,0 +1,52 @@
+---
+description: Profiles declare reusable customizations (packages, env vars, and filesystem mappings) that can be applied to tasks.
+---
+
+# Minimal Profiles
+
+In Minimal, profiles are used to declare customizations such as additional packages, environment variables, or filesystem mappings. These customizations
+can then be easily applied to an environment, such as a [task](../reference/tasks.md).
+
+## Defining a profile
+
+Like packages, profiles are defined in a configuration file located at `profiles/<profile name>/profile.ncl`, either in your
+codebase or any layer above it in the [software supply chain](./software-supply-chain.md). The `profiles/` directory is
+always adjacent to the [`minimal.toml`](../reference/minimal-dot-toml.md) file at the base of the layer, but can be omitted if
+the repository does not define any profiles.
+
+Like packages, profiles are defined using [Nickel](https://nickel-lang.org/):
+
+```ncl
+let { profile, .. } = import "minimal.ncl" in
+profile {
+  name = "my-terraform-debug",
+
+  env_vars.TF_LOG = "trace",
+  packages = [
+    # Make terraform package always present
+    "terraform",
+  ],
+}
+```
+
+## Using a profile
+
+### In all tasks
+
+Setting `defaults.profile` within a codebase [`minimal.toml`](../reference/minimal-dot-toml.md) will apply the profile to all tasks which do not have a profile explicitly set.
+
+```toml
+[defaults]
+profile = "my-profile" # my-profile is set on all tasks
+```
+
+### On specific tasks
+
+Profiles can be applied individually on tasks as well:
+
+```toml
+[tasks.shell]
+profile = "my-profile"
+```
+
+Tasks which explicitly set a profile do not inherit any profile defined in `[defaults]`. Thus, a task can be configured to not use the default profile by setting `profile = ""`.

--- a/docs/concepts/sandboxing.md
+++ b/docs/concepts/sandboxing.md
@@ -31,9 +31,9 @@ You can force the CLI to build artifacts locally using a combination of the `--n
 When a task is invoked, its configuration is used to setup and launch a task sandbox. This sandbox wires:
 
  - Files representing the packages requested and their runtime dependencies. The packages requested for a task includes
-   any that are explicitly defined on the task, and those defined by the repository stack (if set).
+   any that are explicitly defined on the task, those defined on the task's [profile](./profiles.md) (or the default profile if set), and those defined by the repository stack (if set).
  - The repository's files and directories, from the repository root downward, but not above it.
- - A `/state` directory, which can be shared between tasks & task invocations by specifying a task `state_key`. Packages managers
+ - A `/state` directory, which can be shared between tasks and task invocations by specifying a task `state_key`. Package managers
    are typically wired to cache source downloads and intermediate build artifacts in this directory.
  - Pinhole filesystem mappings, as declared by packages. For instance, the `claude-code` package wires the `~/.claude` directory into task sandboxes so claude-code
    can maintain state and access its API key.

--- a/docs/concepts/sandboxing.md
+++ b/docs/concepts/sandboxing.md
@@ -1,0 +1,40 @@
+---
+description: How Minimal isolates all builds and tasks from the host system using hermetic sandboxes.
+---
+
+# Sandboxing
+
+Sandboxing is essential to ensure all builds and tasks are insulated from the machine they run in. **In Minimal, all tasks and builds run in a sandbox**.
+
+
+## Package builds
+
+Minimal packages encapsulate all tooling and software, so it's essential they are compiled in a hermetically-sealed environment to provide a strong
+foundation to the rest of the ecosystem. As such, package builds take place in a cleanroom sandbox that shares nothing with the host machine.
+
+Specifically, the cleanroom sandbox wires:
+
+ - Files representing the build inputs and runtime dependencies of the package
+ - Working directories `/build`, `/tmp`, and an empty `/state`.
+ - The source of the package being built
+ - Network connectivity (when called-for by a dependency)
+
+At the completion of the build, artifacts are gathered based on the outputs specified in the packages' build-spec, and
+are cached for later consumption when needed by a task or another package build.
+
+By default, Minimal is configured to fetch completed builds from our binary cache, to avoid a slow process building everything locally the first time it is needed.
+You can force the CLI to build artifacts locally using a combination of the `--no-fetch` and `--no-cache` flags.
+
+
+## The task sandbox
+
+When a task is invoked, its configuration is used to setup and launch a task sandbox. This sandbox wires:
+
+ - Files representing the packages requested and their runtime dependencies. The packages requested for a task includes
+   any that are explicitly defined on the task, and those defined by the repository stack (if set).
+ - The repository's files and directories, from the repository root downward, but not above it.
+ - A `/state` directory, which can be shared between tasks & task invocations by specifying a task `state_key`. Packages managers
+   are typically wired to cache source downloads and intermediate build artifacts in this directory.
+ - Pinhole filesystem mappings, as declared by packages. For instance, the `claude-code` package wires the `~/.claude` directory into task sandboxes so claude-code
+   can maintain state and access its API key.
+ - Network connectivity when necessary.

--- a/docs/concepts/sandboxing.md
+++ b/docs/concepts/sandboxing.md
@@ -10,7 +10,7 @@ Sandboxing is essential to ensure all builds and tasks are insulated from the ma
 ## Package builds
 
 Minimal packages encapsulate all tooling and software, so it's essential they are compiled in a hermetically-sealed environment to provide a strong
-foundation to the rest of the ecosystem. As such, package builds take place in a cleanroom sandbox that shares nothing with the host machine.
+foundation to the rest of the ecosystem. As such, package builds take place in a cleanroom sandbox that shares nothing with the host machine, aside from network access when a dependency calls for it.
 
 Specifically, the cleanroom sandbox wires:
 
@@ -23,7 +23,7 @@ At the completion of the build, artifacts are gathered based on the outputs spec
 are cached for later consumption when needed by a task or another package build.
 
 By default, Minimal is configured to fetch completed builds from our binary cache, to avoid a slow process building everything locally the first time it is needed.
-You can force the CLI to build artifacts locally using a combination of the `--no-fetch` and `--no-cache` flags.
+You can force builds to run locally with the build CLI's `--no-fetch` and `--no-cache` flags.
 
 
 ## The task sandbox
@@ -35,6 +35,14 @@ When a task is invoked, its configuration is used to setup and launch a task san
  - The repository's files and directories, from the repository root downward, but not above it.
  - A `/state` directory, which can be shared between tasks and task invocations by specifying a task `state_key`. Package managers
    are typically wired to cache source downloads and intermediate build artifacts in this directory.
- - Pinhole filesystem mappings, as declared by packages. For instance, the `claude-code` package wires the `~/.claude` directory into task sandboxes so claude-code
-   can maintain state and access its API key.
+ - Pinhole filesystem mappings, as declared by packages.
  - Network connectivity when necessary.
+
+## The session sandbox
+
+A [session](./sessions.md) is hosted in a sandbox of its own: the one you drop
+into when you attach a shell. Its contents are the union of the project's
+`[session]` packages, the packages the repository's `[stack]` declares, and
+whatever your applied [loadouts](./loadouts.md) contribute. The session
+sandbox's working directory is the session's workspace, seeded with a copy of
+your project files at activation.

--- a/docs/concepts/software-supply-chain.md
+++ b/docs/concepts/software-supply-chain.md
@@ -26,7 +26,7 @@ The most common upstream is our public packages registry:
 [upstream] # Source of software & tooling
 repo = "https://github.com/gominimal/pkgs"
 branch = "main"
-# locked_commit is filled in automatically after the first upstream refresh
+# locked_commit is filled in when you run `min update`
 ```
 
 For more information, check out the [minimal.toml page](../reference/minimal-dot-toml.md) in the References section.
@@ -46,7 +46,7 @@ For readers familiar with Nix/Nixpkgs, package build-specs are similar to Nix de
 
 ## Everything is (composable) configuration
 
-In addition to declaring packages, each software supply chain layer also declares [stacks](./stacks.md) and [profiles](./profiles.md). Each layer inherits and can override definitions from the layers above it. Your codebase can use packages from the public registry while defining its own stacks or profiles, and an organization's internal registry can add private packages on top of the public one.
+In addition to declaring packages, each software supply chain layer also declares [stacks](./stacks.md) and [profiles](./profiles.md). Each layer inherits the definitions from the layers above it and adds its own on top; defining the same name twice is an error, with one exception: a profile may extend an upstream profile via `from_profile`. Your codebase can use packages from the public registry while defining its own stacks or profiles, and an organization's internal registry can add private packages on top of the public one.
 
 This composability means you can:
 

--- a/docs/concepts/software-supply-chain.md
+++ b/docs/concepts/software-supply-chain.md
@@ -1,0 +1,55 @@
+---
+description: Layered, composable model for declarative software dependencies, from public registries to organization-internal packages.
+---
+
+# The Minimal software supply chain
+
+To enable declarative, reproducible, and understandable software in Minimal, all software exists within a layered model
+we refer to as the _software supply chain_.
+
+The lowest layer of the software supply chain is your codebase, within which you invoke commands in the Minimal CLI. Each layer
+depends on configuration & software in the layer above it, which is itself a codebase. Each codebase links to the layer above it
+via the `[upstream]` section in the [`minimal.toml`](../reference/minimal-dot-toml.md) file:
+
+```toml
+[upstream]
+repo = "<git remote URL>"
+branch = "<git branch>"
+locked_commit = "<git commit hash the repo is currently pinned to>"
+```
+
+These all form the software supply chain.
+
+The most common upstream is our public packages registry:
+
+```toml
+[upstream] # Source of software & tooling
+repo = "https://github.com/gominimal/pkgs"
+branch = "main"
+# locked_commit is set after the first `mip update`
+```
+
+For more information, check out the [minimal.toml page](../reference/minimal-dot-toml.md) in the References section.
+
+## Software is configuration
+
+Software in any real environment is more complicated than binaries copied to disk, and these nuances are the basis of how Minimal operates. By building security into the way that products are created, Minimal makes software secure by default and removes pressure from the engineering staff.
+
+A piece of software is encapsulated in a [package](./packages.md), defined at any layer of the software supply chain and usable
+by packages at that layer or below. Packages themselves are defined by build specifications: config-as-code that describes the detailed
+semantics of what the software needs to function as well as an exact, reproducible description of how to build the software.
+
+Dependencies of packages are references to other packages, an approach that enables Minimal to build exact production and development environments
+from simple, composable descriptions of individual packages.
+
+For readers familiar with Nix/Nixpkgs, package build-specs are similar to Nix derivations.
+
+## Everything is (composable) configuration
+
+In addition to declaring packages, each software supply chain layer also declares [stacks](./stacks.md). Each layer inherits and can override definitions from the layers above it. Your codebase can use packages from the public registry while defining its own stacks, and an organization's internal registry can add private packages on top of the public one.
+
+This composability means you can:
+
+- **Use the public registry as-is** for standard open-source tooling
+- **Add an internal layer** with organization-specific packages, stacks, or policies
+- **Define project-local packages** for software unique to your codebase

--- a/docs/concepts/software-supply-chain.md
+++ b/docs/concepts/software-supply-chain.md
@@ -26,7 +26,7 @@ The most common upstream is our public packages registry:
 [upstream] # Source of software & tooling
 repo = "https://github.com/gominimal/pkgs"
 branch = "main"
-# locked_commit is set after the first `mip update`
+# locked_commit is filled in automatically after the first upstream refresh
 ```
 
 For more information, check out the [minimal.toml page](../reference/minimal-dot-toml.md) in the References section.

--- a/docs/concepts/software-supply-chain.md
+++ b/docs/concepts/software-supply-chain.md
@@ -8,7 +8,7 @@ To enable declarative, reproducible, and understandable software in Minimal, all
 we refer to as the _software supply chain_.
 
 The lowest layer of the software supply chain is your codebase, within which you invoke commands in the Minimal CLI. Each layer
-depends on configuration & software in the layer above it, which is itself a codebase. Each codebase links to the layer above it
+depends on configuration and software in the layer above it, which is itself a codebase. Each codebase links to the layer above it
 via the `[upstream]` section in the [`minimal.toml`](../reference/minimal-dot-toml.md) file:
 
 ```toml
@@ -46,7 +46,7 @@ For readers familiar with Nix/Nixpkgs, package build-specs are similar to Nix de
 
 ## Everything is (composable) configuration
 
-In addition to declaring packages, each software supply chain layer also declares [stacks](./stacks.md). Each layer inherits and can override definitions from the layers above it. Your codebase can use packages from the public registry while defining its own stacks, and an organization's internal registry can add private packages on top of the public one.
+In addition to declaring packages, each software supply chain layer also declares [stacks](./stacks.md) and [profiles](./profiles.md). Each layer inherits and can override definitions from the layers above it. Your codebase can use packages from the public registry while defining its own stacks or profiles, and an organization's internal registry can add private packages on top of the public one.
 
 This composability means you can:
 

--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -1,0 +1,63 @@
+---
+description: Stacks wire Minimal to build codebases with specific languages and tools. Covers available stacks, usage, and how to define custom ones.
+---
+
+# Stacks
+
+Stacks wire Minimal to operate a codebase with specific tools and commands. When you name a stack
+in your [`minimal.toml`](../reference/minimal-dot-toml.md) file, high-level commands like `mip build` just work. Additionally, your [tasks](../reference/tasks.md) inherit these familiar tools and semantics automatically.
+
+Learn more about stacks in [the reference section](../reference/stack-specs.md).
+
+## Available stacks
+
+The [Minimal Public Package Registry](https://github.com/gominimal/pkgs) ships stacks for most common languages and build systems:
+
+| Stack | Detected by | Build command |
+|---------|-------------|---------------|
+| `go` | `go.mod` + `go.sum` | `go build` |
+| `rust` | `Cargo.toml` | `cargo build --release` |
+| `pnpm` | `pnpm-lock.yaml` | `pnpm install && pnpm build` |
+| `npm` | `package-lock.json` | `npm ci && npm run build` |
+| `bun` | `bun.lock` | `bun install && bun run build` |
+| `deno` | `deno.json` | `deno compile` |
+| `uv` | `uv.lock`, `pyproject.toml` | `uv sync && uv build` |
+| `pip` | `requirements.txt`, `setup.py` | `pip3 install --target ./build .` |
+| `gradle` | `build.gradle` | `gradle build -x test` |
+| `make` | `Makefile` | `./configure && make` |
+| `meson` | `meson.build` | `meson setup && ninja` |
+| `cmake` | `CMakeLists.txt` | `cmake && make` |
+| `zig` | `build.zig` | `zig build -Doptimize=ReleaseSafe` |
+
+## Using a stack
+
+Stacks are declared in the [`[stack]` section](../reference/minimal-dot-toml.md#stack) of your `minimal.toml` file.
+
+```toml
+[stack]
+use = "<stack name>"
+```
+
+Any stack defined in your codebase (or defined in any layer in your [software supply chain](./software-supply-chain.md)) can be used.
+
+When a stack is defined, any [task](../reference/tasks.md) will inherit the packages, default tasks, and other wiring
+declared in the stack.
+
+### Declaring additional dependencies
+
+It's quite common for a specific codebase to need additional dependencies, either during the build (build packages) or
+on any system the built software runs (runtime packages). Both can be declared in your `minimal.toml`:
+
+```toml
+[stack]
+use = "..."
+build_packages = ["perl"]
+runtime_packages = ["openssl"]
+```
+
+Dependencies can also be added automatically using the [`mip add`](../reference/cli-mip.md) command.
+
+### Automatic initialization
+
+Minimal will auto-detect the stack to use for most languages and package managers. To have the Minimal CLI detect an appropriate stack
+and pre-fill your codebase's [`minimal.toml`](../reference/minimal-dot-toml.md) file, run `mip init` in the root directory.

--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -5,7 +5,7 @@ description: Stacks wire Minimal to build codebases with specific languages and 
 # Stacks
 
 Stacks wire Minimal to operate a codebase with specific tools and commands. When you name a stack
-in your [`minimal.toml`](../reference/minimal-dot-toml.md) file, high-level commands like `mip build` just work. Additionally, your [tasks](../reference/tasks.md) inherit these familiar tools and semantics automatically.
+in your [`minimal.toml`](../reference/minimal-dot-toml.md) file, build-plane commands like `mip build` just work. Additionally, your [tasks](../reference/tasks.md) inherit these familiar tools and semantics automatically.
 
 Learn more about stacks in [the reference section](../reference/stack-specs.md).
 

--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -11,7 +11,7 @@ Learn more about stacks in [the reference section](../reference/stack-specs.md).
 
 ## Available stacks
 
-The [Minimal Public Package Registry](https://github.com/gominimal/pkgs) ships stacks for most common languages and build systems:
+The [Minimal Public Package Registry](https://github.com/gominimal/pkgs) ships stacks for most common languages and build systems. The registry is the source of truth; the highlights:
 
 | Stack | Detected by | Build command |
 |---------|-------------|---------------|
@@ -40,8 +40,8 @@ use = "<stack name>"
 
 Any stack defined in your codebase (or defined in any layer in your [software supply chain](./software-supply-chain.md)) can be used.
 
-When a stack is defined, any [task](../reference/tasks.md) will inherit the packages, default tasks, and other wiring
-declared in the stack.
+When a stack is defined, any [task](../reference/tasks.md) inherits the packages and environment the stack
+declares; the stack also contributes default tasks, such as `build`.
 
 ### Declaring additional dependencies
 
@@ -55,9 +55,9 @@ build_packages = ["perl"]
 runtime_packages = ["openssl"]
 ```
 
-Dependencies can also be added automatically using the [`mip add`](../reference/cli-mip.md) command.
+Dependencies can also be added automatically with `min add --build` or `min add --runtime` (see the [`min` reference](../reference/cli-min.md)).
 
 ### Automatic initialization
 
 Minimal will auto-detect the stack to use for most languages and package managers. To have the Minimal CLI detect an appropriate stack
-and pre-fill your codebase's [`minimal.toml`](../reference/minimal-dot-toml.md) file, run `mip init` in the root directory.
+and pre-fill your codebase's [`minimal.toml`](../reference/minimal-dot-toml.md) file, run `min init` in the root directory.


### PR DESCRIPTION
Lifts four concept guides into `docs/concepts/`: software-supply-chain, sandboxing, packages (the content-addressed package model), and stacks (renamed from harnesses, all harness/profile wording retired). Links converted to repo-relative `.md`; `minimal <cmd>` corrected to `mip` per the clap definitions. Cross-links to `../reference/stack-specs.md` and `../reference/cli-mip.md` currently dangle and resolve once #863 (and the per-binary CLI reference pages) merge. Verification done: no em-dashes, no harness/profile mentions, no private-repo names, all internal links repo-relative.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add concepts documentation for supply chain, sandboxing, packages, stacks, and profiles
> Adds five new Markdown pages under `docs/concepts/` covering core Minimal concepts:
>
> - [software-supply-chain.md](https://github.com/gominimal/minimal/pull/938/files#diff-b67c32cc168c1fc5779b45b1d16151a9c2c7e63f81815933fc2f725955c6cfb5): explains the layered supply chain model, upstream linkage via `minimal.toml`, and how software is expressed as configuration
> - [sandboxing.md](https://github.com/gominimal/minimal/pull/938/files#diff-d6502121e98226a65863048bd781e2cfb7eed9870536a5d224979c565ff06e48): details the sandbox model for tasks and hermetic package builds, including input wiring, `/state`, pinhole mappings, and network access rules
> - [packages.md](https://github.com/gominimal/minimal/pull/938/files#diff-352355d69574a36675e2ef464a54af39afafa76f2e465f7cd251c74e4ec5af96): covers package definition, caching by spec hash, hermetic builds, and sideloading from other repositories
> - [stacks.md](https://github.com/gominimal/minimal/pull/938/files#diff-dec0bfed553b4a911d975844c9ee9b4727a353e8ed778eeec9b6a3318093bdbc): documents available stacks, auto-detection via `mip init`, and declaring build/runtime dependencies
> - [profiles.md](https://github.com/gominimal/minimal/pull/938/files#diff-bd5515802652c00ac9094a2dbc584b6917e90ae11574f40ee48202e18687da89): explains profile inheritance across supply chain layers, global defaults, and per-task overrides
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #938 opened
>
> - Updated terminology in documentation comments and descriptions [30adac9]
> - Added documentation for session sandbox composition and workspace initialization [ff5a61c]
> - Clarified configuration layer inheritance rules and profile extension behavior [ff5a61c]
> - Updated package presence scope for stacks and profiles [ff5a61c]
> - Enhanced cleanroom sandbox isolation documentation and local build instructions [ff5a61c]
> - Generalized task sandbox filesystem mapping documentation [ff5a61c]
> - Updated `locked_commit` documentation to reflect `min update` behavior [ff5a61c]
> - Updated dependency addition guidance to use `min add` flags [ff5a61c]
> - Corrected initialization command from `mip init` to `min init` [ff5a61c]
> - Clarified stack documentation regarding registry source and task inheritance [ff5a61c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d8b938.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->