### PR TITLE
docs(concepts): add the loadouts concept guide

### DIFF
--- a/docs/concepts/loadouts.md
+++ b/docs/concepts/loadouts.md
@@ -33,7 +33,8 @@ Both feed the same session, and the daemon merges them into one final
 configuration when the session comes up. The project contribution and every
 applied loadout compose together as peers: there is no override precedence,
 so a loadout adds to the project rather than silently replacing parts of it.
-(For the exact merge and conflict rules, see the
+If two contributors disagree on the same value, activation fails with a
+conflict. (For the exact merge and conflict rules, see the
 [loadout reference](../reference/loadouts.md).)
 
 One boundary worth stating up front: loadouts apply to **sessions**
@@ -104,8 +105,8 @@ of them) with a `dest` inside the session:
 
 ```toml
 patches = [
-    { dest = "~/.config/helix/config.toml", source = "~/dotfiles/helix/config.toml" },
-    { dest = "~/.config/zellij/",           source = "~/dotfiles/zellij/**/*.kdl" },
+    { dest = ".config/helix/config.toml", source = "~/dotfiles/helix/config.toml" },
+    { dest = ".config/zellij/",           source = "~/dotfiles/zellij/**/*.kdl" },
 ]
 ```
 
@@ -115,10 +116,10 @@ that may not be present on every machine.
 
 ### Lifecycle hooks
 
-Hooks are scripts that run at session transition points: `on_activate` when
-the session comes up, `on_destroy` when it is torn down, and `on_failure`
-when activation fails. Use them to warm a cache, fetch grammars, or clean up
-after a failed start:
+Hooks are scripts declared to run at session transition points: `on_activate`
+when the session comes up, `on_destroy` when it is torn down, and `on_failure`
+when activation fails. Declare them to warm a cache, fetch grammars, or clean
+up after a failed start:
 
 ```toml
 [[lifecycle_hooks]]
@@ -126,7 +127,9 @@ description = "warm the grammar cache"
 on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || true" }
 ```
 
-Hooks from every applied loadout concatenate and run in declaration order.
+Hooks from every applied loadout concatenate in declaration order. Note that
+in the current release hooks are composed and recorded with the session, but
+executing them is not yet wired up.
 
 ### A complete example
 
@@ -139,8 +142,8 @@ description = "helix + zellij with my dotfiles"
 packages    = ["helix", "zellij"]
 
 patches = [
-    { dest = "~/.config/helix/config.toml", source = "~/dotfiles/helix/config.toml" },
-    { dest = "~/.config/zellij/",           source = "~/dotfiles/zellij/**/*.kdl" },
+    { dest = ".config/helix/config.toml", source = "~/dotfiles/helix/config.toml" },
+    { dest = ".config/zellij/",           source = "~/dotfiles/zellij/**/*.kdl" },
 ]
 
 [vars]
@@ -220,6 +223,8 @@ per-kind summary of what it contributes:
   NAME   DESCRIPTION                     CONTRIBUTES
 * dev    helix + zellij with my dotfiles 2 pkg / 2 var / 2 patch / 1 hook
   extra                                  1 pkg / 0 var / 0 patch / 0 hook
+
+* default (from `[loadouts].default_loadouts`)
 ```
 
 Loadouts named in `default_loadouts` are marked with a leading `*`, so the

--- a/docs/concepts/loadouts.md
+++ b/docs/concepts/loadouts.md
@@ -1,0 +1,239 @@
+---
+description: Loadouts are per-developer, session-level bundles of packages, vars, file patches, and lifecycle hooks that layer your personal environment on top of a project's shared config.
+---
+
+# Loadouts
+
+A **loadout** is your personal layer on a session. The project's
+[`minimal.toml`](../reference/minimal-dot-toml.md) describes what every
+contributor's [session](./sessions.md) needs to build and run the code. A
+loadout describes what *you* want on top of that: your editor, your terminal
+multiplexer, your shell prompt, your dotfiles. When you activate a session,
+the loadout is layered in, so the environment comes up matching your muscle
+memory without changing anything the rest of the team sees.
+
+Loadouts are deliberately per-developer. They live in your user config
+directory, not in the repository, and they never travel with the project.
+Two people working in the same codebase can activate the same session
+definition and still get their own editors, aliases, and prompts.
+
+## How a loadout differs from `minimal.toml`
+
+It helps to keep the two roles straight:
+
+- The project's `minimal.toml` is **shared and checked in**. It is the
+  contract for the codebase: the packages a build needs, the tasks everyone
+  runs, the session baseline the project expects. Changing it changes the
+  environment for every contributor.
+- A loadout is **personal and local**. It is never committed to the project
+  and never affects another developer. Deleting all your loadouts changes
+  nothing about how the project builds or what its sessions require.
+
+Both feed the same session, and the daemon merges them into one final
+configuration when the session comes up. The project contribution and every
+applied loadout compose together as peers: there is no override precedence,
+so a loadout adds to the project rather than silently replacing parts of it.
+(For the exact merge and conflict rules, see the
+[loadout reference](../reference/loadouts.md).)
+
+One boundary worth stating up front: loadouts apply to **sessions**
+(`min activate`). They do not apply to task sandboxes run through the package
+and build CLI, `mip`, which carry their own packages and environment through
+the task schema.
+
+## Where loadouts live
+
+Each loadout is a single TOML file in your user config directory:
+
+```
+~/.config/minimal/loadouts/<name>.toml
+```
+
+On Linux this is `$XDG_CONFIG_HOME/minimal/loadouts` (falling back to
+`~/.config/minimal/loadouts` when `XDG_CONFIG_HOME` is unset). macOS uses the
+same `~/.config` location for consistency with Minimal's state and cache
+directories. The global `--config-dir` flag overrides the base directory when
+you need a non-default location.
+
+The filename stem is the loadout's identifier. A file named `dev.toml`
+defines the loadout `dev`, and its `name` field inside the file must match
+that stem. The directory is not created for you: make it and drop
+`<name>.toml` files in to get started.
+
+## What a loadout carries
+
+A loadout can contribute four kinds of things to a session, and all four take
+effect inside the session when it is activated.
+
+### Packages
+
+A list of package names brought into the session alongside the project's
+baseline packages. This is how you land your editor and tools in the sandbox
+without asking the project to depend on them:
+
+```toml
+packages = ["helix", "zellij", "ripgrep"]
+```
+
+Packages compose as a set across all contributors, so listing something the
+project already provides is harmless: duplicates are deduplicated.
+
+### Vars
+
+Environment variables set in the session. A value can be a literal, or it can
+inherit from the host environment of the `min` process, optionally with a
+fallback:
+
+```toml
+[vars]
+EDITOR = "hx"
+VISUAL = "hx"
+TERM   = { inherit = true, default = "xterm-256color" }
+```
+
+Vars are the main lever for interactive setup, because the shell you get from
+`min attach` sources no rc files. Your prompt (`PS1`), a one-time banner, and
+similar touches all travel through `[vars]` rather than through a `.bashrc`
+patch. The [reference](../reference/loadouts.md) walks through the prompt and
+banner patterns in detail.
+
+### File patches
+
+Patches copy files from your host into the session, which is how your
+dotfiles arrive. Each entry pairs a host `source` (a path, a glob, or a list
+of them) with a `dest` inside the session:
+
+```toml
+patches = [
+    { dest = "~/.config/helix/config.toml", source = "~/dotfiles/helix/config.toml" },
+    { dest = "~/.config/zellij/",           source = "~/dotfiles/zellij/**/*.kdl" },
+]
+```
+
+A source that does not exist on your host is skipped with a warning rather
+than failing activation, so you can opportunistically patch a dotfile tree
+that may not be present on every machine.
+
+### Lifecycle hooks
+
+Hooks are scripts that run at session transition points: `on_activate` when
+the session comes up, `on_destroy` when it is torn down, and `on_failure`
+when activation fails. Use them to warm a cache, fetch grammars, or clean up
+after a failed start:
+
+```toml
+[[lifecycle_hooks]]
+description = "warm the grammar cache"
+on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || true" }
+```
+
+Hooks from every applied loadout concatenate and run in declaration order.
+
+### A complete example
+
+Putting the pieces together, a loadout that sets up the helix editor and the
+zellij multiplexer with your dotfiles looks like this:
+
+```toml
+name        = "dev"
+description = "helix + zellij with my dotfiles"
+packages    = ["helix", "zellij"]
+
+patches = [
+    { dest = "~/.config/helix/config.toml", source = "~/dotfiles/helix/config.toml" },
+    { dest = "~/.config/zellij/",           source = "~/dotfiles/zellij/**/*.kdl" },
+]
+
+[vars]
+EDITOR = "hx"
+TERM   = { inherit = true, default = "xterm-256color" }
+
+[[lifecycle_hooks]]
+on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || true" }
+```
+
+Saved as `~/.config/minimal/loadouts/dev.toml`, it is ready to apply.
+
+## Applying a loadout
+
+Name a loadout when you activate a session with `--loadout`, which is
+repeatable to stack several at once:
+
+```console
+$ min activate --loadout dev
+$ min activate --loadout dev --loadout scratch
+```
+
+Loadouts are read and composed on the client, before the CLI contacts the
+daemon, so a missing or malformed loadout file fails the activation loudly and
+immediately rather than producing a silently-empty session. When loadouts are
+applied, the CLI prints `Applying loadouts: <names>` to stderr.
+
+Applying a loadout is also the moment its contents are captured: files are
+read once, inherited vars are resolved against your current host environment,
+and the composed result is what the session runs with. Editing a loadout file
+does not retroactively change sessions that already exist, so destroy and
+re-activate to pick up an edit.
+
+To activate with no loadouts at all, including skipping the defaults described
+below, pass `--no-loadouts` (which conflicts with `--loadout`):
+
+```console
+$ min activate --no-loadouts
+```
+
+## Auto-applying with `default_loadouts`
+
+Typing `--loadout dev` on every activation gets old. Set the loadouts you
+almost always want in the client config at `~/.config/minimal/config.toml`,
+under a `[loadouts]` section:
+
+```toml
+[loadouts]
+default_loadouts = ["dev", "fish"]
+```
+
+With this in place, a plain `min activate` applies `dev` and `fish`
+automatically. The defaults are a convenience layer, and the activation flags
+take precedence over them:
+
+1. `--no-loadouts` applies nothing, regardless of the config.
+2. One or more `--loadout NAME` applies exactly those, and the config's
+   `default_loadouts` are ignored for that activation.
+3. Neither flag applies the `default_loadouts` list, which may be empty.
+
+So the defaults are your baseline, `--loadout` is an explicit override for a
+one-off session, and `--no-loadouts` is the clean-room escape hatch.
+
+## Listing your loadouts
+
+To see which loadouts you have and what each contributes, run:
+
+```console
+$ min loadout ls
+```
+
+`ls` is an alias for `min loadout list`. It enumerates every `*.toml` file in
+your loadouts directory, one row per file, with the name, description, and a
+per-kind summary of what it contributes:
+
+```
+  NAME   DESCRIPTION                     CONTRIBUTES
+* dev    helix + zellij with my dotfiles 2 pkg / 2 var / 2 patch / 1 hook
+  extra                                  1 pkg / 0 var / 0 patch / 0 hook
+```
+
+Loadouts named in `default_loadouts` are marked with a leading `*`, so the
+listing doubles as a quick check of what a plain `min activate` will pull in.
+A malformed file is listed with its parse error so you can fix it in place
+rather than hunting for which file is broken. Pass `--dir <DIR>` to list a
+loadouts directory other than the default.
+
+## Where to go next
+
+- The [loadout reference](../reference/loadouts.md) has the full TOML schema
+  for every field (`name`, `packages`, `[vars]`, `patches`,
+  `[[lifecycle_hooks]]`, and the rest), the client config keys, and the exact
+  composition and conflict rules.
+- [Sessions](./sessions.md) explains the session model that loadouts layer
+  onto: activation, attaching, and teardown.

--- a/docs/concepts/loadouts.md
+++ b/docs/concepts/loadouts.md
@@ -116,6 +116,10 @@ that may not be present on every machine.
 
 ### Lifecycle hooks
 
+> **Coming soon.** Lifecycle hooks are not yet live: a hook declared in a
+> loadout is accepted, but the current release excludes it from composition
+> and nothing executes it. The declaration format below is what will ship.
+
 Hooks are scripts declared to run at session transition points: `on_activate`
 when the session comes up, `on_destroy` when it is torn down, and `on_failure`
 when activation fails. Declare them to warm a cache, fetch grammars, or clean
@@ -127,9 +131,7 @@ description = "warm the grammar cache"
 on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || true" }
 ```
 
-Hooks from every applied loadout concatenate in declaration order. Note that
-in the current release hooks are composed and recorded with the session, but
-executing them is not yet wired up.
+Hooks from every applied loadout concatenate in declaration order.
 
 ### A complete example
 

--- a/docs/concepts/loadouts.md
+++ b/docs/concepts/loadouts.md
@@ -37,9 +37,8 @@ so a loadout adds to the project rather than silently replacing parts of it.
 [loadout reference](../reference/loadouts.md).)
 
 One boundary worth stating up front: loadouts apply to **sessions**
-(`min activate`). They do not apply to task sandboxes run through the package
-and build CLI, `mip`, which carry their own packages and environment through
-the task schema.
+(`min activate`). They do not apply to task sandboxes, which carry their own
+packages and environment through the task schema.
 
 ## Where loadouts live
 


### PR DESCRIPTION
New concept guide at `docs/concepts/loadouts.md` covering what a loadout is versus the project's `minimal.toml`, where loadouts live, the four things they carry (packages, vars, patches, lifecycle hooks, all applied in-session), applying via `min activate --loadout`, auto-applying via `[loadouts].default_loadouts`, and listing via `min loadout ls`. The `../reference/loadouts.md` cross-link resolves once #868 merges; `./sessions.md` resolves once the sessions concept guide merges. Verification done: no em-dashes, no harness/profile terms, repo-relative `.md` links, `min` commands checked against crates/minimal/src/lib.rs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add loadouts concept guide to documentation
> Adds [loadouts.md](https://github.com/gominimal/minimal/pull/940/files#diff-2f71dadb7a4fa103904822c2e52a8afaa198b345552100dadfccedd7ec7dde5f), a new conceptual guide explaining loadouts as per-developer, session-level configuration bundles. Covers what loadouts can carry (packages, variables with inherit/default, file patches, lifecycle hooks), how to apply them via CLI flags (`--loadout`, `--no-loadouts`) and `default_loadouts` in client config, and how to list them with `min loadout ls`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #940 opened
>
> - Added notice clarifying that lifecycle hooks declared in loadouts are accepted but excluded from composition and not executed in the current release, while removing the previous caveat about hooks being composed and recorded but not executed [a3c8ce1]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8adca38.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for loadouts, including supported contribution types, storage and naming rules, and session-only behavior.
  * Documented loadout activation, default loadouts, disabling options, listing commands, precedence rules, and error handling.
  * Clarified editing behavior after session creation and lifecycle hook support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->