### PR TITLE
docs(guide): lift the building, dev-shell, agents, tasks, and packages guides

### DIFF
--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -1,0 +1,61 @@
+---
+description: Sandbox AI coding agents like Claude Code in isolated environments with declared tools and host credentials.
+---
+
+# Agent shell
+
+Minimal can sandbox AI coding agents the same way it sandboxes your builds and dev tools. Define a task with the agent's package, and it runs in an isolated environment with access to your source code and only the tools you declare.
+
+## Example: Claude Code
+
+This documentation site is itself built and maintained using Claude Code inside Minimal. Here is the task definition from its `minimal.toml`:
+
+```toml
+[tasks.claude]
+interactive = true
+packages = ["claude-code", "base"]
+exec = "claude"
+```
+
+Run it with:
+
+```shell
+$ mip run claude
+```
+
+Claude Code launches inside a sandbox with your project's source code, `~/.claude` state files, and a read-only system containing the `claude-code` binary and core utilities from `base`. The sandbox has no additional access to anything on your host system unless you explicitly declare it.
+
+## Adding more tools
+
+Agents often need additional tools to be effective. Add packages to the task just like any other:
+
+```toml
+[tasks.claude]
+packages = ["claude-code", "base", "git", "curl"]
+exec = "claude"
+```
+
+## Passing through host credentials
+
+Use `patches` to give the agent access to host files it needs, like authentication state:
+
+```toml
+[tasks.claude]
+packages = ["claude-code", "base", "git"]
+exec = "claude"
+patches.file."~/.gitconfig" = "read-only"
+patches.dir."~/.ssh" = "read-only"
+```
+
+Environment variables can be inherited from the host as well:
+
+```toml
+[tasks.claude]
+packages = ["claude-code", "base"]
+exec = "claude"
+env_vars.ANTHROPIC_API_KEY = { inherit = true }
+```
+
+## Why sandbox agents?
+
+Running an AI agent in a Minimal sandbox means it can only access the tools and files you declare. It cannot install arbitrary software, read unrelated files, or modify your system. This is the same isolation model that Minimal applies to builds and dev shells, applied to agents.

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -1,62 +1,62 @@
 ---
-description: Sandbox AI coding agents like Claude Code in isolated environments with declared tools and host credentials.
+description: Run AI coding agents like Claude Code inside an isolated session with declared tools and host credentials.
 ---
 
 # Agent shell
 
-Minimal can sandbox AI coding agents the same way it sandboxes your builds and dev tools. Define a task with the agent's package, and it runs in an isolated environment with access to your source code and only the tools you declare.
+Minimal can sandbox AI coding agents the same way it sandboxes your dev tools: an agent runs inside a [session](./dev-shell.md), with access to your source code and only the tools and host state you declare.
 
 ## Example: Claude Code
 
-This documentation site is itself built and maintained using Claude Code inside Minimal. Here is the task definition from its `minimal.toml`:
+This documentation site is itself built and maintained using Claude Code inside a Minimal session. Add the agent's package to the project's `[session]` block, and grant it the host state it needs with a patch:
 
 ```toml
-[tasks.claude]
-interactive = true
+[session]
 packages = ["claude-code", "base"]
-exec = "claude"
-patches.dir."~/.claude" = "read-write"
+patches = [
+    { source = "~/.claude", dest = "~/.claude" },
+]
 ```
 
-Run it with:
+Then activate the session and run the agent inside it:
 
 ```shell
-$ mip run claude
+$ min activate --attach .
+$ claude
 ```
 
-Claude Code launches inside a sandbox with your project's source code, `~/.claude` state files, and a read-only system containing the `claude-code` binary and core utilities from `base`. The sandbox has no additional access to anything on your host system unless you explicitly declare it.
+Claude Code launches inside the session with your project's source code, its `~/.claude` state, and a read-only system containing the `claude-code` binary and core utilities from `base`. The session has no additional access to anything on your host system unless you explicitly declare it.
 
 ## Adding more tools
 
-Agents often need additional tools to be effective. Add packages to the task just like any other:
+Agents often need additional tools to be effective. Add packages to the `[session]` block just like any other:
 
 ```toml
-[tasks.claude]
+[session]
 packages = ["claude-code", "base", "git", "curl"]
-exec = "claude"
 ```
 
 ## Passing through host credentials
 
-Use `patches` to give the agent access to host files it needs, like authentication state:
+Use `patches` to give the agent access to host files it needs, like authentication state. Each patch maps a host `source` to a `dest` under the session user's home directory:
 
 ```toml
-[tasks.claude]
+[session]
 packages = ["claude-code", "base", "git"]
-exec = "claude"
-patches.file."~/.gitconfig" = "read-only"
-patches.dir."~/.ssh" = "read-only"
+patches = [
+    { source = "~/.claude",    dest = "~/.claude" },
+    { source = "~/.gitconfig", dest = "~/.gitconfig" },
+    { source = "~/.ssh",       dest = "~/.ssh" },
+]
 ```
 
-Environment variables can be inherited from the host as well:
+Environment variables can be inherited from the host as well, under `[session.vars]`:
 
 ```toml
-[tasks.claude]
-packages = ["claude-code", "base"]
-exec = "claude"
-env_vars.ANTHROPIC_API_KEY = { inherit = true }
+[session.vars]
+ANTHROPIC_API_KEY = { inherit = true }
 ```
 
 ## Why sandbox agents?
 
-Running an AI agent in a Minimal sandbox means it can only access the tools and files you declare. It cannot install arbitrary software, read unrelated files, or modify your system. This is the same isolation model that Minimal applies to builds and dev shells, applied to agents.
+Running an AI agent in a Minimal session means it can only access the tools and files you declare. It cannot install arbitrary software, read unrelated files, or modify your system. This is the same isolation model that Minimal applies to builds and dev shells, applied to agents.

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -55,6 +55,15 @@ Environment variables can be inherited from the host as well, under `[session.va
 ANTHROPIC_API_KEY = { inherit = true }
 ```
 
+Anything you pass through is available to the agent and to any code it runs: a
+patched `~/.ssh` means the agent can use your SSH keys, and an inherited
+`ANTHROPIC_API_KEY` is readable by every process in the session. Pass through
+the minimum the agent needs, and prefer scoped or short-lived credentials over
+long-lived ones. Activation helps you hold this line: each value inherited from
+your environment and each file patch is gated against your user policy, and
+anything your policy cannot decide is surfaced for approval before it enters
+the session.
+
 ## Why sandbox agents?
 
 Running an AI agent in a Minimal session means it can only access the tools and files you declare. It cannot install arbitrary software, read unrelated files, or modify your system. This is the same isolation model that Minimal applies to builds and dev shells, applied to agents.

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -27,6 +27,8 @@ $ claude
 
 Claude Code launches inside the session with your project's source code, its `~/.claude` state, and a read-only system containing the `claude-code` binary and core utilities from `base`. The session has no additional access to anything on your host system unless you explicitly declare it.
 
+Note that sessions are driven interactively: attaching needs a terminal, and the non-interactive `min attach -c` channel accepts only `min run <task>` invocations. Launch the agent from inside an attached shell as shown above, rather than scripting it from the host.
+
 ## Adding more tools
 
 Agents often need additional tools to be effective. Add packages to the `[session]` block just like any other:

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -8,14 +8,11 @@ Minimal can sandbox AI coding agents the same way it sandboxes your dev tools: a
 
 ## Example: Claude Code
 
-This documentation site is itself built and maintained using Claude Code inside a Minimal session. Add the agent's package to the project's `[session]` block, and grant it the host state it needs with a patch:
+This documentation site is itself built and maintained using Claude Code inside a Minimal session. Add the agent's package to the project's `[session]` block:
 
 ```toml
 [session]
 packages = ["claude-code", "base"]
-patches = [
-    { source = "~/.claude", dest = "~/.claude" },
-]
 ```
 
 Then activate the session and run the agent inside it:
@@ -25,7 +22,7 @@ $ min activate --attach .
 $ claude
 ```
 
-Claude Code launches inside the session with your project's source code, its `~/.claude` state, and a read-only system containing the `claude-code` binary and core utilities from `base`. The session has no additional access to anything on your host system unless you explicitly declare it.
+Claude Code launches inside the session with your project's source code and a read-only system containing the `claude-code` binary and core utilities from `base`. The session has no additional access to anything on your host system unless you explicitly declare it.
 
 Note that sessions are driven interactively: attaching needs a terminal, and the non-interactive `min attach -c` channel accepts only `min run <task>` invocations. Launch the agent from inside an attached shell as shown above, rather than scripting it from the host.
 
@@ -46,7 +43,6 @@ Use `patches` to give the agent access to host files it needs, like authenticati
 [session]
 packages = ["claude-code", "base", "git"]
 patches = [
-    { source = "~/.claude",    dest = "~/.claude" },
     { source = "~/.gitconfig", dest = "~/.gitconfig" },
     { source = "~/.ssh",       dest = "~/.ssh" },
 ]

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -15,6 +15,7 @@ This documentation site is itself built and maintained using Claude Code inside 
 interactive = true
 packages = ["claude-code", "base"]
 exec = "claude"
+patches.dir."~/.claude" = "read-write"
 ```
 
 Run it with:

--- a/docs/guide/building.md
+++ b/docs/guide/building.md
@@ -6,7 +6,7 @@ description: Run builds and tests in sandboxed environments using stacks. Covers
 
 Minimal builds your code reproducibly inside a sandbox, using a [stack](../concepts/stacks.md) to wire up the right tools and build commands for your language or build system.
 
-A build is a **one-shot** command that runs in its own fresh sandbox and exits, driven by the `mip` CLI. That is different from an interactive [dev session](./dev-shell.md), which is a long-lived environment you attach to with `min` for interactive development.
+A build is a **one-shot** command that runs in its own fresh sandbox and exits, driven by the `mip` CLI (Linux-only; on macOS, work inside a [dev session](./dev-shell.md) instead). That is different from an interactive dev session, which is a long-lived environment you attach to with `min` for interactive development.
 
 ## Running a build
 
@@ -14,7 +14,7 @@ A build is a **one-shot** command that runs in its own fresh sandbox and exits, 
 $ mip build
 ```
 
-This is shorthand for `mip run build`. The stack configured in your `minimal.toml` determines what happens. For example, a Rust stack runs `cargo build --release`, while a pnpm stack runs `pnpm install && pnpm build`.
+This is shorthand for `mip run build`. The stack configured in your `minimal.toml` determines what happens. For example, a Rust stack runs `cargo build --release`, while a pnpm stack runs roughly `pnpm install && pnpm build`.
 
 ## How stacks work
 
@@ -39,15 +39,15 @@ Most projects need additional dependencies beyond what the stack provides. Decla
 ```toml
 [stack]
 use = "rust"
-build_packages = ["protobuf-compiler", "perl"]
+build_packages = ["protobuf", "perl"]
 runtime_packages = ["openssl"]
 ```
 
 Or add them with the CLI:
 
 ```shell
-$ mip add --build protobuf-compiler
-$ mip add --runtime openssl
+$ min add --build protobuf
+$ min add --runtime openssl
 ```
 
 ## Running tests
@@ -58,7 +58,7 @@ Similarly to `mip build`, you can run your test suite with:
 $ mip test
 ```
 
-This is shorthand for `mip run test`, and uses the test command defined by your stack.
+This is shorthand for `mip run test`, and runs the `test` task from your `minimal.toml`; define one with `[tasks.test]`. Stacks provide a default `build` task only.
 
 ## Persisting build state
 

--- a/docs/guide/building.md
+++ b/docs/guide/building.md
@@ -1,0 +1,70 @@
+---
+description: Run builds and tests in sandboxed environments using stacks. Covers extra dependencies, test commands, and build state persistence.
+---
+
+# Building
+
+Minimal builds your code reproducibly inside a sandbox, using a [stack](../concepts/stacks.md) to wire up the right tools and build commands for your language or build system.
+
+## Running a build
+
+```shell
+$ mip build
+```
+
+This is shorthand for `mip run build`. The stack configured in your `minimal.toml` determines what happens. For example, a Rust stack runs `cargo build --release`, while a pnpm stack runs `pnpm install && pnpm build`.
+
+## How stacks work
+
+When you declare a stack, it provides:
+
+- **Build packages**: compilers, build tools, and other dependencies needed during compilation
+- **Runtime packages**: libraries needed wherever the built software runs
+- **Build commands**: the default commands executed by `mip build`
+- **Environment variables**: compiler flags, paths, and other configuration
+
+```toml
+[stack]
+use = "go"
+```
+
+With just this configuration, `mip build` will run `go build` with the Go compiler and all necessary toolchain packages available in the sandbox.
+
+## Adding extra dependencies
+
+Most projects need additional dependencies beyond what the stack provides. Declare them in the `[stack]` section:
+
+```toml
+[stack]
+use = "rust"
+build_packages = ["protobuf-compiler", "perl"]
+runtime_packages = ["openssl"]
+```
+
+Or add them with the CLI:
+
+```shell
+$ mip add --build protobuf-compiler
+$ mip add --runtime openssl
+```
+
+## Running tests
+
+Similarly to `mip build`, you can run your test suite with:
+
+```shell
+$ mip test
+```
+
+This is shorthand for `mip run test`, and uses the test command defined by your stack.
+
+## Persisting build state
+
+By default, each task invocation starts from a clean state. To cache build artifacts across runs (like `node_modules` or `target/`), set a `state_key`:
+
+```toml
+[defaults]
+state_key = "dev"
+```
+
+Tasks sharing the same `state_key` share cached state, so your builds don't start from scratch every time.

--- a/docs/guide/building.md
+++ b/docs/guide/building.md
@@ -6,6 +6,8 @@ description: Run builds and tests in sandboxed environments using stacks. Covers
 
 Minimal builds your code reproducibly inside a sandbox, using a [stack](../concepts/stacks.md) to wire up the right tools and build commands for your language or build system.
 
+A build is a **one-shot** command that runs in its own fresh sandbox and exits, driven by the `mip` CLI. That is different from an interactive [dev session](./dev-shell.md), which is a long-lived environment you attach to with `min` for interactive development.
+
 ## Running a build
 
 ```shell

--- a/docs/guide/dev-shell.md
+++ b/docs/guide/dev-shell.md
@@ -16,7 +16,7 @@ $ min activate --attach .
 
 This creates a session for the project and drops you into its interactive shell. The path argument defaults to the current directory, so `min activate --attach` on its own works too.
 
-Your project files are mapped into the session at the same path, so edits you make inside the shell are reflected on the host.
+Your project files are uploaded into the session's workspace, so the shell starts with a copy of your project. Edits you make inside stay in the session; bring them back to the host by pushing them out with `git push min://<session>` (or by committing inside the session and pulling from it).
 
 ## What's in the session?
 
@@ -27,7 +27,7 @@ A session's tools come from the project's `[session]` block in `minimal.toml`. L
 packages = ["git", "curl", "ripgrep"]
 ```
 
-Inside the session you have access to your project's source code and exactly these declared tools, but nothing else from the host system. The session cannot globally install software, read unrelated files, or modify your system. Every developer working on the project gets the same isolated environment.
+Inside the session you have access to your project's source code and these declared tools (plus any [loadouts](../concepts/loadouts.md) you apply and the packages the project's stack declares), but nothing else from the host system. The session cannot globally install software, read unrelated files, or modify your system. Every developer working on the project gets the same isolated environment.
 
 ## Customizing your session
 
@@ -40,13 +40,13 @@ Add packages to the project's `[session]` block so everyone picks them up:
 packages = ["git", "curl", "ripgrep", "jq", "nano"]
 ```
 
-If you need a package mid-session, without editing config or restarting your shell, run `min add` from inside the running session:
+If you need a package mid-session, without editing config by hand or restarting your shell, run `min add` from inside the running session:
 
 ```shell
 $ min add nano
 ```
 
-This installs the tool into the running session. See the [`min` in-sandbox commands](../reference/sandbox-operations.md#add) for the full helper reference.
+This installs the tool into the running session and records it in the project's `[session]` `packages` list, so the next activation gets it too. See the [`min` in-sandbox commands](../reference/sandbox-operations.md#add) for the full helper reference.
 
 ### Access host files
 
@@ -87,9 +87,9 @@ on_activate = { type = "inline", value = "cargo fetch >/dev/null 2>&1 || true" }
 Exit the shell to detach; the session keeps running in the background. To reattach, list, or tear down sessions:
 
 ```shell
-$ min attach     # reattach to a session (resolves from the current directory)
-$ min ls         # list sessions
-$ min destroy    # terminate a session
+$ min attach              # reattach to a session (resolves from the current directory)
+$ min ls                  # list sessions
+$ min destroy <session>   # terminate a session by name or id (or --all)
 ```
 
 For running one-shot commands in their own sandbox rather than an interactive session, see [Tasks](./tasks.md).

--- a/docs/guide/dev-shell.md
+++ b/docs/guide/dev-shell.md
@@ -1,0 +1,80 @@
+---
+description: Launch an isolated interactive development shell with only declared tools. Covers customization, host file access, and environment variables.
+---
+
+# Dev shell
+
+Minimal sandboxes your development environment the same way it sandboxes builds and agents. Launch an interactive shell with only the tools you declare, isolated from your host system. Useful for running ad-hoc commands, debugging, or working interactively with your project's toolchain.
+
+## Launch a shell
+
+If your `minimal.toml` has a `shell` task defined (which `mip init` creates by default), you can launch it with:
+
+```shell
+$ mip shell
+```
+
+This is shorthand for `mip run shell`.
+
+## What's in the sandbox?
+
+The shell sandbox inherits all packages from your [stack](../concepts/stacks.md), plus any packages listed in the task definition. A typical shell task looks like:
+
+```toml
+[tasks.shell]
+interactive = true
+packages = ["base", "git", "curl"]
+exec = "bash -l"
+```
+
+Inside the sandbox, you have access to your project's source code and all declared tools, but nothing else from the host system. The shell cannot globally install software, read unrelated files, or modify your system. This ensures every developer gets the same isolated environment.
+
+## Customizing your shell
+
+### Add more tools
+
+You can add packages to your shell from the command line:
+
+```shell
+$ mip add --task shell ripgrep jq nano
+```
+
+This updates your `minimal.toml` automatically. You can also edit the shell task directly:
+
+```toml
+[tasks.shell]
+interactive = true
+packages = ["base", "git", "curl", "nano", "jq", "ripgrep"]
+exec = "bash -l"
+```
+
+If you need a package mid-session, you can use the [`min` command](../reference/sandbox-operations.md#add) to install it without restarting your
+shell or agent.
+
+### Access host files
+
+By default, Minimal mounts your current working directory into the sandbox. Your project files are available at the same path inside the shell, and changes you make are reflected on the host.
+
+For files outside your project directory, use `patches` to map them in:
+
+```toml
+[tasks.shell]
+packages = ["base", "git"]
+exec = "bash -l"
+patches.file."~/.gitconfig" = "read-only"
+patches.dir."~/.ssh" = "read-only"
+```
+
+### Set environment variables
+
+The sandbox starts with a clean environment. Host environment variables are not passed through by default. You can set variables explicitly or inherit them from the host:
+
+```toml
+[tasks.shell]
+packages = ["base", "git"]
+exec = "bash -l"
+env_vars.EDITOR = "nano"
+env_vars.AWS_PROFILE = { inherit = true }
+```
+
+Setting a string value like `EDITOR = "nano"` defines a fixed variable. Using `{ inherit = true }` passes through the value from your host environment, which is useful for credentials or configuration that varies per developer.

--- a/docs/guide/dev-shell.md
+++ b/docs/guide/dev-shell.md
@@ -1,80 +1,95 @@
 ---
-description: Launch an isolated interactive development shell with only declared tools. Covers customization, host file access, and environment variables.
+description: Enter an isolated interactive development session with only your declared tools. Covers customization, host file access, and environment variables.
 ---
 
 # Dev shell
 
-Minimal sandboxes your development environment the same way it sandboxes builds and agents. Launch an interactive shell with only the tools you declare, isolated from your host system. Useful for running ad-hoc commands, debugging, or working interactively with your project's toolchain.
+Your dev shell in Minimal is a **session**: a long-lived, isolated development environment for a project, driven by the `min` CLI. It gives you an interactive shell with only the tools you declare, isolated from your host system. Use it for everyday development, running ad-hoc commands, debugging, or working interactively with your project's toolchain.
 
 ## Launch a shell
 
-If your `minimal.toml` has a `shell` task defined (which `mip init` creates by default), you can launch it with:
+From your project directory, activate a session and attach to it in one step:
 
 ```shell
-$ mip shell
+$ min activate --attach .
 ```
 
-This is shorthand for `mip run shell`.
+This creates a session for the project and drops you into its interactive shell. The path argument defaults to the current directory, so `min activate --attach` on its own works too.
 
-## What's in the sandbox?
+Your project files are mapped into the session at the same path, so edits you make inside the shell are reflected on the host.
 
-The shell sandbox inherits all packages from your [stack](../concepts/stacks.md), plus any packages listed in the task definition. A typical shell task looks like:
+## What's in the session?
+
+A session's tools come from the project's `[session]` block in `minimal.toml`. List the packages every contributor should have when working on this codebase:
 
 ```toml
-[tasks.shell]
-interactive = true
-packages = ["base", "git", "curl"]
-exec = "bash -l"
+[session]
+packages = ["git", "curl", "ripgrep"]
 ```
 
-Inside the sandbox, you have access to your project's source code and all declared tools, but nothing else from the host system. The shell cannot globally install software, read unrelated files, or modify your system. This ensures every developer gets the same isolated environment.
+Inside the session you have access to your project's source code and exactly these declared tools, but nothing else from the host system. The session cannot globally install software, read unrelated files, or modify your system. Every developer working on the project gets the same isolated environment.
 
-## Customizing your shell
+## Customizing your session
 
 ### Add more tools
 
-You can add packages to your shell from the command line:
-
-```shell
-$ mip add --task shell ripgrep jq nano
-```
-
-This updates your `minimal.toml` automatically. You can also edit the shell task directly:
+Add packages to the project's `[session]` block so everyone picks them up:
 
 ```toml
-[tasks.shell]
-interactive = true
-packages = ["base", "git", "curl", "nano", "jq", "ripgrep"]
-exec = "bash -l"
+[session]
+packages = ["git", "curl", "ripgrep", "jq", "nano"]
 ```
 
-If you need a package mid-session, you can use the [`min` command](../reference/sandbox-operations.md#add) to install it without restarting your
-shell or agent.
+If you need a package mid-session, without editing config or restarting your shell, run `min add` from inside the running session:
+
+```shell
+$ min add nano
+```
+
+This installs the tool into the running session. See the [`min` in-sandbox commands](../reference/sandbox-operations.md#add) for the full helper reference.
 
 ### Access host files
 
-By default, Minimal mounts your current working directory into the sandbox. Your project files are available at the same path inside the shell, and changes you make are reflected on the host.
-
-For files outside your project directory, use `patches` to map them in:
+By default, only your project directory is available inside the session. To bring specific host files or directories in, declare `patches` in the `[session]` block. Each patch names a `source` on the host and a `dest` under the session user's home directory:
 
 ```toml
-[tasks.shell]
-packages = ["base", "git"]
-exec = "bash -l"
-patches.file."~/.gitconfig" = "read-only"
-patches.dir."~/.ssh" = "read-only"
+[session]
+packages = ["git"]
+patches = [
+    { source = "~/.gitconfig", dest = "~/.gitconfig" },
+    { source = "~/.ssh",       dest = "~/.ssh" },
+]
 ```
 
 ### Set environment variables
 
-The sandbox starts with a clean environment. Host environment variables are not passed through by default. You can set variables explicitly or inherit them from the host:
+The session starts with a clean environment; host environment variables are not passed through by default. Set variables explicitly, or inherit them from the host, under `[session.vars]`:
 
 ```toml
-[tasks.shell]
-packages = ["base", "git"]
-exec = "bash -l"
-env_vars.EDITOR = "nano"
-env_vars.AWS_PROFILE = { inherit = true }
+[session.vars]
+EDITOR = "nano"
+AWS_PROFILE = { inherit = true }
 ```
 
-Setting a string value like `EDITOR = "nano"` defines a fixed variable. Using `{ inherit = true }` passes through the value from your host environment, which is useful for credentials or configuration that varies per developer.
+A string value like `EDITOR = "nano"` defines a fixed variable. Using `{ inherit = true }` passes through the value from your host environment, which is useful for credentials or configuration that varies per developer.
+
+### Run setup on activation
+
+To run setup steps when a session comes up, declare lifecycle hooks in the `[session]` block:
+
+```toml
+[[session.lifecycle_hooks]]
+on_activate = { type = "inline", value = "cargo fetch >/dev/null 2>&1 || true" }
+```
+
+## Session lifecycle
+
+Exit the shell to detach; the session keeps running in the background. To reattach, list, or tear down sessions:
+
+```shell
+$ min attach     # reattach to a session (resolves from the current directory)
+$ min ls         # list sessions
+$ min destroy    # terminate a session
+```
+
+For running one-shot commands in their own sandbox rather than an interactive session, see [Tasks](./tasks.md).

--- a/docs/guide/packages.md
+++ b/docs/guide/packages.md
@@ -57,4 +57,4 @@ exec = "ruff check ."
 
 ## Available packages
 
-The [Minimal Public Package Registry](https://github.com/gominimal/pkgs/tree/main/packages) contains 150+ packages including compilers, interpreters, build tools, and common CLI utilities.
+The [Minimal Public Package Registry](https://github.com/gominimal/pkgs/tree/main/packages) contains hundreds of packages including compilers, interpreters, build tools, and common CLI utilities.

--- a/docs/guide/packages.md
+++ b/docs/guide/packages.md
@@ -1,19 +1,16 @@
 ---
-description: Add build, runtime, and task-specific package dependencies using mip add or minimal.toml.
+description: Add build, runtime, session, and task-specific package dependencies using the min and mip CLIs or minimal.toml.
 ---
 
 # Packages
 
-Minimal makes it easy to add tools and dependencies to your project using the `mip add` command.
+Minimal makes it easy to add tools and dependencies to your project. Where a package lives depends on when you need it: building your code, running it, developing interactively, or inside a specific task.
 
-## Adding a package
+## Build and runtime dependencies
 
-Every package needs a destination, which controls where it should be available. There are three options:
+Build and runtime dependencies belong to your build plane and are managed with `mip add`:
 
 ```shell
-# Add to a specific task
-$ mip add --task shell ripgrep jq
-
 # Add as a build dependency (needed to compile your code)
 $ mip add --build protobuf-compiler
 
@@ -23,9 +20,7 @@ $ mip add --runtime openssl
 
 Each command updates your `minimal.toml` automatically.
 
-## Build vs runtime dependencies
-
-**Build dependencies** are packages needed during compilation but not at runtime. These are declared in the `[stack]` section:
+**Build dependencies** are packages needed during compilation but not at runtime. They are declared in the `[stack]` section:
 
 ```toml
 [stack]
@@ -41,15 +36,26 @@ use = "rust"
 runtime_packages = ["openssl"]
 ```
 
-## Task-specific packages
+## Session tools
 
-Packages can also be added to individual [tasks](../reference/tasks.md). These are only available when that task runs:
+Tools you want available while developing interactively go in the project's `[session]` block, not the build plane. Every contributor's [dev session](./dev-shell.md) picks them up:
 
 ```toml
-[tasks.shell]
-packages = ["base", "git", "curl"]
-exec = "bash -l"
+[session]
+packages = ["git", "ripgrep", "jq"]
+```
 
+To add a tool to a running session without editing config, run `min add <package>` from inside the session shell.
+
+## Task-specific packages
+
+Packages can also be scoped to individual [tasks](../reference/tasks.md), where they are only available when that task runs. Add them with `mip add --task <name>`:
+
+```shell
+$ mip add --task lint ruff
+```
+
+```toml
 [tasks.lint]
 packages = ["python", "ruff"]
 exec = "ruff check ."

--- a/docs/guide/packages.md
+++ b/docs/guide/packages.md
@@ -8,14 +8,14 @@ Minimal makes it easy to add tools and dependencies to your project. Where a pac
 
 ## Build and runtime dependencies
 
-Build and runtime dependencies belong to your build plane and are managed with `mip add`:
+Build and runtime dependencies belong to your build plane and are managed with `min add`:
 
 ```shell
 # Add as a build dependency (needed to compile your code)
-$ mip add --build protobuf-compiler
+$ min add --build protobuf
 
 # Add as a runtime dependency (needed wherever your code runs)
-$ mip add --runtime openssl
+$ min add --runtime openssl
 ```
 
 Each command updates your `minimal.toml` automatically.
@@ -25,7 +25,7 @@ Each command updates your `minimal.toml` automatically.
 ```toml
 [stack]
 use = "rust"
-build_packages = ["protobuf-compiler", "perl"]
+build_packages = ["protobuf", "perl"]
 ```
 
 **Runtime dependencies** are packages that must be present wherever the built software runs:
@@ -49,10 +49,10 @@ To add a tool to a running session without editing config, run `min add <package
 
 ## Task-specific packages
 
-Packages can also be scoped to individual [tasks](../reference/tasks.md), where they are only available when that task runs. Add them with `mip add --task <name>`:
+Packages can also be scoped to individual [tasks](../reference/tasks.md), where they are only available when that task runs. Add them with `min add --task <name>`:
 
 ```shell
-$ mip add --task lint ruff
+$ min add --task lint ruff
 ```
 
 ```toml

--- a/docs/guide/packages.md
+++ b/docs/guide/packages.md
@@ -1,0 +1,60 @@
+---
+description: Add build, runtime, and task-specific package dependencies using mip add or minimal.toml.
+---
+
+# Packages
+
+Minimal makes it easy to add tools and dependencies to your project using the `mip add` command.
+
+## Adding a package
+
+Every package needs a destination, which controls where it should be available. There are three options:
+
+```shell
+# Add to a specific task
+$ mip add --task shell ripgrep jq
+
+# Add as a build dependency (needed to compile your code)
+$ mip add --build protobuf-compiler
+
+# Add as a runtime dependency (needed wherever your code runs)
+$ mip add --runtime openssl
+```
+
+Each command updates your `minimal.toml` automatically.
+
+## Build vs runtime dependencies
+
+**Build dependencies** are packages needed during compilation but not at runtime. These are declared in the `[stack]` section:
+
+```toml
+[stack]
+use = "rust"
+build_packages = ["protobuf-compiler", "perl"]
+```
+
+**Runtime dependencies** are packages that must be present wherever the built software runs:
+
+```toml
+[stack]
+use = "rust"
+runtime_packages = ["openssl"]
+```
+
+## Task-specific packages
+
+Packages can also be added to individual [tasks](../reference/tasks.md). These are only available when that task runs:
+
+```toml
+[tasks.shell]
+packages = ["base", "git", "curl"]
+exec = "bash -l"
+
+[tasks.lint]
+packages = ["python", "ruff"]
+exec = "ruff check ."
+```
+
+## Available packages
+
+The [Minimal Public Package Registry](https://github.com/gominimal/pkgs/tree/main/packages) contains 150+ packages including compilers, interpreters, build tools, and common CLI utilities.

--- a/docs/guide/tasks.md
+++ b/docs/guide/tasks.md
@@ -41,6 +41,11 @@ env_vars.RAILS_ENV = "production"
 env_vars.GITHUB_TOKEN = { inherit = true }
 ```
 
+`inherit = true` copies the value from your host environment into the task's
+sandbox, where every command the task runs can read it — including scripts the
+repository itself provides. Inherit sparingly, and prefer scoped, short-lived
+tokens over long-lived ambient credentials.
+
 ## Mapping host files
 
 Use `patches` to give a task access to specific files or directories on the host:
@@ -49,7 +54,11 @@ Use `patches` to give a task access to specific files or directories on the host
 [tasks.deploy]
 packages = ["railway"]
 exec = "railway up"
-patches.dir."~/.config/railway" = "read-write"
+patches.dir."~/.config/railway" = "read-only"
 ```
+
+Map host files `read-only` unless the task genuinely needs to write them: a
+`read-write` mapping lets anything the task runs modify those host files in
+place.
 
 See the [tasks reference](../reference/tasks.md) for the full schema.

--- a/docs/guide/tasks.md
+++ b/docs/guide/tasks.md
@@ -1,0 +1,53 @@
+---
+description: Define named tasks in minimal.toml that run commands in sandboxed environments with specific packages and env vars.
+---
+
+# Tasks
+
+Tasks define commands that run in a [sandbox](../concepts/sandboxing.md) with exactly your declared dependencies. Every developer on your team runs the same task in the same environment.
+
+## Defining a task
+
+Tasks are defined in your `minimal.toml` and run with `mip run <name>`:
+
+```toml
+[tasks.claude]
+packages = ["claude-code", "base"]
+exec = "claude"
+
+[tasks.greet]
+bash = "echo Hello from $(uname -s) && date"
+```
+
+```shell
+$ mip run greet
+Hello from Linux
+Tue Mar 17 12:00:00 UTC 2026
+```
+
+Use `exec` for a single command, or `bash` for shell scripts.
+
+## Environment variables
+
+Set environment variables directly, or inherit them from the host:
+
+```toml
+[tasks.deploy]
+packages = ["railway"]
+exec = "railway up"
+env_vars.RAILS_ENV = "production"
+env_vars.GITHUB_TOKEN = { inherit = true }
+```
+
+## Mapping host files
+
+Use `patches` to give a task access to specific files or directories on the host:
+
+```toml
+[tasks.deploy]
+packages = ["railway"]
+exec = "railway up"
+patches.dir."~/.config/railway" = "read-write"
+```
+
+See the [tasks reference](../reference/tasks.md) for the full schema.

--- a/docs/guide/tasks.md
+++ b/docs/guide/tasks.md
@@ -6,14 +6,16 @@ description: Define named tasks in minimal.toml that run commands in sandboxed e
 
 Tasks define commands that run in a [sandbox](../concepts/sandboxing.md) with exactly your declared dependencies. Every developer on your team runs the same task in the same environment.
 
+A task is a **one-shot** command that runs in its own fresh sandbox and exits, driven by the `mip` CLI. That makes it different from an interactive [dev session](./dev-shell.md), which is a long-lived environment you attach to with `min`. Reach for a task to run builds, tests, linters, and deploys; reach for a session for interactive development.
+
 ## Defining a task
 
 Tasks are defined in your `minimal.toml` and run with `mip run <name>`:
 
 ```toml
-[tasks.claude]
-packages = ["claude-code", "base"]
-exec = "claude"
+[tasks.lint]
+packages = ["python", "ruff"]
+exec = "ruff check ."
 
 [tasks.greet]
 bash = "echo Hello from $(uname -s) && date"

--- a/docs/guide/tasks.md
+++ b/docs/guide/tasks.md
@@ -6,7 +6,7 @@ description: Define named tasks in minimal.toml that run commands in sandboxed e
 
 Tasks define commands that run in a [sandbox](../concepts/sandboxing.md) with exactly your declared dependencies. Every developer on your team runs the same task in the same environment.
 
-A task is a **one-shot** command that runs in its own fresh sandbox and exits, driven by the `mip` CLI. That makes it different from an interactive [dev session](./dev-shell.md), which is a long-lived environment you attach to with `min`. Reach for a task to run builds, tests, linters, and deploys; reach for a session for interactive development.
+A task is a **one-shot** command that runs in its own fresh sandbox and exits, driven by the `mip` CLI (Linux-only; inside a session, `min run <name>` runs the same tasks on any platform). That makes it different from an interactive [dev session](./dev-shell.md), which is a long-lived environment you attach to with `min`. Reach for a task to run builds, tests, linters, and deploys; reach for a session for interactive development.
 
 ## Defining a task
 


### PR DESCRIPTION
Lifts the five Start workflow pages into `docs/guide/` (building, dev-shell, agents, tasks, packages), reframed around the two planes so each guide teaches the right tool:

**Session plane (`min`):**
- **dev-shell.md** and **agents.md** are rewritten around interactive sessions: `min activate --attach .`, with tools from the project's `[session]` block (`packages`), host files via `[session]` `patches`, env via `[session.vars]`, setup via `[[session.lifecycle_hooks]]`, and ad-hoc mid-session installs via the in-sandbox `min add <pkg>`. Session lifecycle covered with `min attach` / `min ls` / `min destroy`.

**Build plane (`mip`):**
- **building.md** (`mip build`/`mip test`, `[stack]`) and **tasks.md** (`[tasks.x]`, `mip run`) keep the build/task framing (genuinely one-shot sandboxes), each with a one-sentence session-vs-build distinction and a cross-link to dev-shell.
- **packages.md** routes build/runtime deps through `mip add --build/--runtime` -> `[stack]`, interactive dev tools through `[session]` `packages` (+ `min add`), and task-scoped packages via `mip add --task`.

De-numbered filenames, harness->stack, links repo-relative `.md`; cross-links to `../reference/*` resolve once #863 and sibling docs-lift PRs merge. Session patches are `{ source, dest }` rows (dest home-relative in the session), not the task/harness `patches.dir` form. Verification: em-dash/`min add --session`/stale-`mip shell` scrub clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add guide pages for building, dev-shell, agents, tasks, and packages
> Adds five new documentation pages to the guide covering core workflows:
>
> - [agents.md](https://github.com/gominimal/minimal/pull/942/files#diff-26313617f907237bd6d0bcea48cfd9ff8ff54c51f38731fc693e5ceaa8a93fe1): how to run AI coding agents (e.g. Claude Code) inside a sandboxed Minimal session, including credential passing and tool configuration
> - [building.md](https://github.com/gominimal/minimal/pull/942/files#diff-bbafdfebc74e6f9a62fa38da2fe2475c7e2d6f3650416d6d73736d34e325b340): how to run builds and tests using `mip build` and `mip test` with stacks, including extra dependencies and state persistence
> - [dev-shell.md](https://github.com/gominimal/minimal/pull/942/files#diff-2acec157e0ffb5b6024f53c1991731a55960f454b8843e9573902b958b245182): how to launch and manage interactive dev sessions with `min`, covering isolation, patches, env vars, and lifecycle hooks
> - [packages.md](https://github.com/gominimal/minimal/pull/942/files#diff-78cbabdf16c600579b19d1f5cf97af7d8b2fc4c159ba7af0e0d0390c7f381fc9): how packages are scoped across build, runtime, session, and task contexts using `min add` flags and `minimal.toml`
> - [tasks.md](https://github.com/gominimal/minimal/pull/942/files#diff-f7ba258c84500c1ba8506047998d82f54d310251eec2354ff2d83065bbb4609d): how to define and run sandboxed tasks via `mip run` or `min run`, with examples for exec/bash, env vars, and host file mapping
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #942 opened
>
> - Removed `~/.claude` host state access configuration from agent setup instructions [5d39eca]
> - Added guidance explaining that environment variables and patched files passed to agent and task sandboxes are available to all commands and subprocesses, recommending minimal pass-through and preference for scoped or short-lived credentials, with agent activation gating against user policy and surfacing undecidable items for approval [2e668aa]
> - Changed file patch mapping example to use read-only access and added guidance recommending read-only mappings unless writes are necessary [2e668aa]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a87911.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new guides for building/testing, development shells, tasks, packages, and AI coding agents.
  * Documented sandboxed one-shot and interactive workflows, including stack/session/task configuration via `minimal.toml`.
  * Explained adding dependencies, persisting build artifacts with `state_key`, and running tasks with `mip run`.
  * Covered environment variable inheritance and controlled host file/credential passthrough using `patches`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->