### PR TITLE
docs(readme): declare session tools via [session] packages, not min add --session

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ cd ~/projects/foo
 min init
 
 # declare your session's tools by editing the scaffolded [session] table in
-# minimal.toml; extend its packages list (don't add a second [session] table):
+# minimal.toml; extend its packages list from ["base", "vim"] (don't add a
+# second [session] table):
 #   [session] # min attach
 #   packages = ["base", "vim", "git", "gh", "claude-code"]
 
@@ -112,7 +113,8 @@ cd ~/projects/foo
 min init
 
 # declare your session's tools by editing the scaffolded [session] table in
-# minimal.toml; extend its packages list (don't add a second [session] table):
+# minimal.toml; extend its packages list from ["base", "vim"] (don't add a
+# second [session] table):
 #   [session] # min attach
 #   packages = ["base", "vim", "git", "gh", "claude-code", "mermaid-cli", "kittyview", "less", "emacs"]
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,13 @@ In this example we'll create a new git repo from within a Minimal sandbox, using
 mkdir -p ~/projects/foo
 cd ~/projects/foo
 
-# create and update a minimal.toml file
+# create a minimal.toml file
 min init
-min add --session git gh claude-code
+
+# declare your session's tools by editing the scaffolded [session] table in
+# minimal.toml; extend its packages list (don't add a second [session] table):
+#   [session] # min attach
+#   packages = ["base", "vim", "git", "gh", "claude-code"]
 
 # start and enter a sandbox, which copies up the CWD file tree into the sandbox
 min activate --attach .
@@ -104,9 +108,13 @@ Once you have created the PAT, copied it into your keychain (e.g. `security add-
 mkdir -p ~/projects/foo
 cd ~/projects/foo
 
-# create and update a minimal.toml file
+# create a minimal.toml file
 min init
-min add --session git gh claude-code mermaid-cli kittyview less emacs
+
+# declare your session's tools by editing the scaffolded [session] table in
+# minimal.toml; extend its packages list (don't add a second [session] table):
+#   [session] # min attach
+#   packages = ["base", "vim", "git", "gh", "claude-code", "mermaid-cli", "kittyview", "less", "emacs"]
 
 # copy the GitHub PAT to your clipboard from your macOS keychain
 security find-generic-password -w -s "PAT-foo-repo" -a "my-mac-user-name" | pbcopy


### PR DESCRIPTION
The host `min add` command accepts only `--runtime`, `--build`, or `--task <NAME>` (see `AddKind` in `crates/minimal/src/lib.rs`). It has **no `--session` flag**: that flag exists only on the separate in-sandbox `min add` helper. The Getting Started quickstarts ran `min add --session ...` on the host, before `min activate`, which fails.

This replaces both host-level invocations with the correct flow: after `min init`, declare the desired session tools by editing the scaffolded `[session]` `packages` list in `minimal.toml`, mirroring the wording in `docs/guide/setup.md`.

The valid in-sandbox `min add` comment (agents adding tools dynamically from inside a session) is left untouched.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README to declare session tools via the `[session]` packages list
> Replaces the `min add --session` command pattern in [README.md](https://github.com/gominimal/minimal/pull/946/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with instructions to edit the scaffolded `[session]` table in `minimal.toml` directly. Adds example package lists in comments to show both a minimal and a larger set of session tools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf1805f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Getting Started walkthrough to configure sessions by editing `minimal.toml` after initialization.
  * Replaced session-add command examples with commented package configuration snippets.
  * Expanded the example tool list to include additional utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->