### PR TITLE
fix(client): Fix sessiongs getting in a bad state when creation is aborted

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -1120,6 +1120,59 @@ async fn upload_and_finalize(
     }
 }
 
+/// Guard that tears down a half-built session if the user interrupts the
+/// activation with Ctrl-C.
+///
+/// `dialoguer`/`console` re-raise SIGINT to this process on a Ctrl-C at
+/// the composition-gating prompt (console `unix_term.rs`). With no
+/// handler installed the default disposition kills `min` mid-prompt —
+/// before the abort-cleanup that [`drive_pending_to_active`] runs — so
+/// the daemon is left holding a `Pending` session that blocks its name.
+/// [`arm_activation_interrupt`] installs a SIGINT handler (keeping the
+/// process alive past console's re-raise) that best-effort
+/// `AbortSession`s the in-flight session over a fresh connection — the
+/// activation borrows the primary one — then exits. The daemon's
+/// connection-close reap is the backstop if the abort can't be
+/// delivered.
+///
+/// Dropping the guard cancels the handler, so a Ctrl-C after the session
+/// is safely `Active` (e.g. during the `--attach` hand-off) no longer
+/// tears it down.
+struct ActivationInterrupt {
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for ActivationInterrupt {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+fn arm_activation_interrupt(
+    global: &GlobalArgs,
+    session_id: sessions::SessionId,
+) -> ActivationInterrupt {
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd());
+    let task = tokio::spawn(async move {
+        // Only the first Ctrl-C is intercepted; a second falls through to
+        // the default disposition so a wedged cleanup can still be killed.
+        if tokio::signal::ctrl_c().await.is_err() {
+            return;
+        }
+        eprintln!("\nAborting activation; cleaning up session {session_id}…");
+        if let Ok(sock) = sock
+            && let Ok(mut client) = client::Client::connect(&sock).await
+        {
+            use minimald_rpc::{AbortSession, AbortSessionRequest};
+            let _ = client
+                .oneshot_rpc::<AbortSession>(AbortSessionRequest { id: session_id })
+                .await;
+        }
+        std::process::exit(130);
+    });
+    ActivationInterrupt { task }
+}
+
 /// Whether the project already has a `minimal.toml`, in either the root
 /// (`<project>/minimal.toml`) or `.minimal/`
 /// (`<project>/.minimal/minimal.toml`) layout.
@@ -1300,6 +1353,12 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
         }
     };
     let id = created.id;
+
+    // From here the session exists on the daemon in an unfinalized state.
+    // Arm a Ctrl-C guard so an interrupt during the (blocking) gating
+    // prompt tears it down instead of orphaning it in `Pending` — see
+    // [`ActivationInterrupt`]. Disarmed once the session is `Active`.
+    let interrupt_guard = arm_activation_interrupt(global, id);
 
     // Upload the project directory to the daemon so the session
     // workspace holds the user's files — `ConfigureLoadout`'s compose
@@ -1495,6 +1554,11 @@ pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(),
         best_effort_destroy(&mut client, id).await;
         return Err(e);
     }
+
+    // The session is `Active` now — a Ctrl-C must no longer tear it down
+    // (the attach hand-off below and the user's own session are fair game
+    // for interrupts, but not this cleanup).
+    drop(interrupt_guard);
 
     println!("{id}");
 

--- a/crates/minimald/src/connection.rs
+++ b/crates/minimald/src/connection.rs
@@ -125,6 +125,17 @@ pub struct Connection {
     /// State specific to an SSH channel.
     channels: BTreeMap<ChannelId, Channel>,
 
+    /// Session ids created via `CreateSession` over this connection.
+    /// When the connection closes, any of these still left in an
+    /// unfinalized state — `Pending` (never got a `SubmitVerdict`) or
+    /// `Materializing` (never got a `FinalizeSession`) — are reaped, so
+    /// a client that dropped mid-activation (e.g. Ctrl-C at the
+    /// composition-gating prompt) doesn't strand a half-built session
+    /// that holds its name hostage. Finalized (`Active`) sessions are
+    /// long-lived and outlive the connection, so they are never reaped
+    /// here.
+    created_sessions: Vec<SessionId>,
+
     serv: ServerStateHandle,
 }
 
@@ -149,6 +160,7 @@ impl Connection {
             auth: if is_local { Auth::Local } else { Auth::Pending },
             ssh_username: None,
             channels: BTreeMap::new(),
+            created_sessions: Vec::new(),
             serv,
         })));
 
@@ -196,6 +208,19 @@ pub struct ConnectionHandle(Arc<Mutex<Connection>>);
 impl ConnectionHandle {
     pub fn lock(&self) -> impl Future<Output = MutexGuard<'_, Connection>> {
         self.0.lock()
+    }
+
+    /// Record a session created via `CreateSession` over this connection,
+    /// so an unfinalized one can be reaped when the connection closes.
+    pub async fn record_created_session(&self, id: SessionId) {
+        self.0.lock().await.created_sessions.push(id);
+    }
+
+    /// Drain and return the ids of every session created over this
+    /// connection. Called once at connection teardown to decide which
+    /// half-built sessions to reap.
+    pub async fn take_created_sessions(&self) -> Vec<SessionId> {
+        std::mem::take(&mut self.0.lock().await.created_sessions)
     }
 }
 

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -171,6 +171,7 @@ const ANONYMOUS_SESSION: &str = "<anonymous>";
 /// by the `ConfigureLoadout` that follows.
 async fn serve_create_session(
     s: ServerStateHandle,
+    conn: ConnectionHandle,
     c: RuChannel<Msg>,
     ssh_username: Option<String>,
 ) -> Result<(), ConnectionError> {
@@ -184,6 +185,11 @@ async fn serve_create_session(
 
             Ok(match mngr.create_session(req.config, ssh_username).await {
                 Ok(id) => {
+                    // Tag the session to this connection so it is reaped if
+                    // the client drops before finalizing it (e.g. Ctrl-C at
+                    // the gating prompt) — see [`ConnectionHandle`] and the
+                    // teardown reap in `server.rs`.
+                    conn.record_created_session(id).await;
                     tracing::info!(
                         session_id = %id,
                         session_name = session_name.as_deref().unwrap_or(ANONYMOUS_SESSION),
@@ -1216,7 +1222,7 @@ pub async fn handle_ssh_rpc(
         GetVersion::NAME => serve!(serve_get_version(channel)),
         ListSessions::NAME => serve!(serve_list_sessions(s, channel)),
         GetSessionRecord::NAME => serve!(serve_get_session_record(s, channel)),
-        CreateSession::NAME => serve!(serve_create_session(s, channel, ssh_username)),
+        CreateSession::NAME => serve!(serve_create_session(s, c.clone(), channel, ssh_username)),
         minimald_rpc::ConfigureLoadout::NAME => serve!(serve_configure_loadout(s, channel)),
         SubmitVerdict::NAME => serve!(serve_submit_verdict(s, channel)),
         FinalizeSession::NAME => serve!(serve_finalize_session(s, channel)),

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -470,7 +470,7 @@ impl Server {
             span.in_scope(|| tracing::info!(?peer, "accepted connection"));
             let from_stream =
                 Connection::from_stream(stream, russh_config.clone(), state.clone(), L::IS_LOCAL);
-            let (_conn_hnd, session_fut) = match from_stream.instrument(span.clone()).await {
+            let (conn_hnd, session_fut) = match from_stream.instrument(span.clone()).await {
                 Ok(conn) => conn,
                 Err(e) => {
                     // A handshake failure must not take the daemon down — in
@@ -484,6 +484,7 @@ impl Server {
             };
             // Log session errors instead of silently dropping the spawned
             // future, so a failed handshake is visible on any transport.
+            let reap_state = state.clone();
             session_set.spawn(
                 async move {
                     match session_fut.await {
@@ -507,6 +508,13 @@ impl Server {
                             }
                         }
                     }
+                    // The connection is gone. Reap any session it created that
+                    // never reached `Active` — a client that dropped
+                    // mid-activation (Ctrl-C at the gating prompt, a crash, a
+                    // network blip) would otherwise strand a `Pending` /
+                    // `Materializing` session that holds its name hostage.
+                    reap_unfinalized_sessions(&reap_state, conn_hnd.take_created_sessions().await)
+                        .await;
                 }
                 .instrument(span),
             );
@@ -567,6 +575,59 @@ async fn build_russh_config(
         keepalive_max: KEEPALIVE_MAX,
         ..Default::default()
     }))
+}
+
+/// Reap sessions a now-closed connection created but never finalized.
+///
+/// `ids` are the sessions [`CreateSession`](crate::rpc) allocated over
+/// the connection. Only those still `Pending` (never got a
+/// `SubmitVerdict`) or `Materializing` (never got a `FinalizeSession`)
+/// are deleted — a client that dropped mid-activation (Ctrl-C at the
+/// gating prompt, a crash, a network blip) would otherwise strand a
+/// half-built session that holds its name hostage until the next daemon
+/// restart. A finalized (`Active`) session is long-lived and must
+/// survive the connection that created it, so it is left untouched.
+/// Best-effort and never fatal: minimald is pid-1 in the guest.
+async fn reap_unfinalized_sessions(state: &ServerStateHandle, ids: Vec<::sessions::SessionId>) {
+    if ids.is_empty() {
+        return;
+    }
+    let mngr = state.sessions_manager().await;
+    for id in ids {
+        // Re-read the status at teardown: a clean client abort already
+        // deleted the record (`get_record` → `None`), and a finalized
+        // session is `Active` — neither should be reaped here.
+        let status = match mngr.get_record(sessions::SessionKeyPredicate::Id(id)).await {
+            Ok(Some(record)) => record.status,
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::warn!(
+                    session_id = %id,
+                    error = %e,
+                    "could not read session status while reaping after connection close"
+                );
+                continue;
+            }
+        };
+        if !matches!(
+            status,
+            ::sessions::SessionStatus::Pending | ::sessions::SessionStatus::Materializing
+        ) {
+            continue;
+        }
+        match mngr.delete_session(id).await {
+            Ok(()) => tracing::info!(
+                session_id = %id,
+                ?status,
+                "reaped unfinalized session after its connection closed"
+            ),
+            Err(e) => tracing::warn!(
+                session_id = %id,
+                error = %e,
+                "failed to reap unfinalized session after connection close"
+            ),
+        }
+    }
 }
 
 /// Binds and serves minimald's two host-side proxies for the daemon's lifetime
@@ -808,5 +869,69 @@ mod tests {
             .expect("run must return after the grace period aborts lingering connections");
         assert!(res.unwrap().is_ok(), "run should return Ok after shutdown");
         drop(client);
+    }
+
+    /// A session left unfinalized when its creating connection closes —
+    /// the state an interrupted `min activate` (Ctrl-C at the gating
+    /// prompt) leaves on the daemon — is reaped, while a finalized
+    /// (`Active`) session created over that same connection survives.
+    #[tokio::test]
+    async fn dropping_a_connection_reaps_only_its_unfinalized_sessions() {
+        use crate::test_harness::{create_configured_session, create_session_req};
+        use minimald_rpc::{CreateSession, GetSessionRecord, GetSessionRecordRequest};
+
+        let dir = TempDir::new().unwrap();
+        let (run, sock) = spawn_server(&dir);
+
+        // Connection A: create a Pending session (no ConfigureLoadout) AND a
+        // fully-finalized Active session, then drop the connection.
+        let (pending_id, active_id) = {
+            let mut client = connect_uds(&sock).await;
+            let pending = client
+                .call::<CreateSession>(&create_session_req("interrupted", "/tmp"))
+                .await
+                .ok()
+                .expect("create pending session")
+                .id;
+            let active = create_configured_session(&mut client, "finalized", "/tmp").await;
+            (pending, active)
+            // `client` dropped here → connection closes → the server's
+            // per-connection task runs the teardown reap.
+        };
+
+        // The reap is asynchronous (it runs once the socket close is
+        // observed), so poll a fresh connection until the Pending record is
+        // gone. The Active record must remain throughout.
+        let mut client = connect_uds(&sock).await;
+        let mut reaped = false;
+        for _ in 0..100 {
+            let pending_gone = client
+                .call::<GetSessionRecord>(&GetSessionRecordRequest::Id(pending_id))
+                .await
+                .record
+                .is_none();
+            if pending_gone {
+                reaped = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            reaped,
+            "an unfinalized (Pending) session must be reaped when its creating connection closes",
+        );
+        assert!(
+            client
+                .call::<GetSessionRecord>(&GetSessionRecordRequest::Id(active_id))
+                .await
+                .record
+                .is_some(),
+            "an Active session must survive the connection that created it",
+        );
+
+        let _ = client
+            .call::<Shutdown>(&ShutdownRequest { force: false })
+            .await;
+        let _ = tokio::time::timeout(Duration::from_secs(5), run).await;
     }
 }


### PR DESCRIPTION
Problem

Aborting min activate during composition/permission gating — e.g. pressing Ctrl-C at a Package … wants to patch … prompt — left a session wedged on the daemon. It couldn't be re-activated (name already taken), couldn't be attached to ("awaiting its contribution verdict"), and only got cleaned up on a daemon restart. The session name was effectively occupied forever.

Root cause

At the gating prompt, dialoguer → console re-raises SIGINT to the process on Ctrl-C (console unix_term.rs → libc::raise(SIGINT)). min installed no SIGINT handler, so the default disposition killed the process mid-prompt — before the existing abort-cleanup (drive_pending_to_active → send_abort) could run. The daemon was left holding the session in Pending/Draft indefinitely.

(The in-menu "Abort activation" option was fine — it returns through the code and cleans up. It's specifically the raw Ctrl-C / any unclean client exit that orphaned the session.)

Changes

Client-side interrupt handling (crates/minimal/src/lib.rs)
- New ActivationInterrupt guard, armed in cmd_activate once the session id is known and dropped once the session is Active. It registers a Ctrl-C handler (so the process survives console's re-raise) and, on interrupt, best-effort AbortSessions the in-flight session over a fresh connection, then exits 130. Disarming on success means a Ctrl-C during the --attach hand-off no longer tears down the now-good session.

Daemon-side reaping (crates/minimald/src/{connection,rpc,server}.rs) — the robust backstop
- Connection now tracks the sessions created over it; serve_create_session records each one.
- When a connection closes, reap_unfinalized_sessions deletes any of its sessions still Pending/Materializing, while leaving Active sessions (which legitimately outlive their creating connection) untouched. This covers all unclean-exit paths — Ctrl-C, crash, and network loss — not just the graceful one.

Testing

- New end-to-end test dropping_a_connection_reaps_only_its_unfinalized_sessions: a Pending session is reaped when its creating connection closes, and an Active session created over the same connection survives.
- Full minimald session suite green; cargo clippy clean on the changed crates.

Recovery for already-stuck sessions

Existing daemons without this fix can free a wedged name with min destroy <name> (DestroySession has no Pending guard), or by restarting the daemon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pressing Ctrl-C during an in-progress session activation now triggers a best-effort abort and exits with code 130, preventing half-started sessions from lingering.
  * When a client disconnects early, any unfinalized sessions (e.g., Pending/Materializing) are now cleaned up automatically.
  * Sessions that have already reached activation (Active) are no longer removed by Ctrl-C or teardown cleanup.
  * Teardown cleanup failures are now handled gracefully without interrupting shutdown behavior.
* **Tests**
  * Added coverage to verify only unfinalized sessions are deleted on disconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->