### PR TITLE
feat(minimald): side-op subsystem, package builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3816,6 +3816,7 @@ dependencies = [
  "mlog",
  "nix 0.31.3",
  "op",
+ "orchestrator",
  "ot",
  "path-absolutize",
  "paths",
@@ -3840,6 +3841,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uuid",
  "version",
  "vt100-ctt",
 ]

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -47,6 +47,7 @@ serde_json.workspace = true
 sysinfo.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
+uuid.workspace = true
 vt100-ctt.workspace = true
 
 tokio.workspace = true
@@ -70,6 +71,7 @@ graph.workspace = true
 mctx.workspace = true
 mfile.workspace = true
 minimald-rpc.workspace = true
+orchestrator.workspace = true
 op.workspace = true
 ot.workspace = true
 paths.workspace = true

--- a/crates/minimald/src/env.rs
+++ b/crates/minimald/src/env.rs
@@ -73,6 +73,10 @@ pub struct EnvArgs {
     network_mode: NetworkMode,
     own_ip_tap: Option<sandbox2::config::OwnIpTap>,
     own_ip_dns: Option<std::net::Ipv4Addr>,
+    /// Weak handle to the owning session actor, wired into the command channel
+    /// so in-sandbox `min` commands can drive session side-ops (e.g. builds).
+    /// Every session env has one — this `Env` is always session-scoped.
+    session: crate::session::WeakSessionHandle,
     /// When true (default), [`Env::build`] consumes package
     /// [`SetupForPackages`] output for `env_vars`/`fs_mappings`.
     /// When false, the caller supplies both via `env_vars` /
@@ -85,12 +89,14 @@ pub struct EnvArgs {
 
 impl EnvArgs {
     /// Creates args for an environment named `name`, with working directory
-    /// `cwd` and `/state` backed by `state_base_dir`.
+    /// `cwd` and `/state` backed by `state_base_dir`. `session` is a weak
+    /// handle to the owning session actor.
     pub fn new(
         name: impl Into<String>,
         cwd: impl Into<DaemonAbsPath>,
         home: impl Into<DaemonAbsPath>,
         state_base_dir: impl Into<DaemonAbsPath>,
+        session: crate::session::WeakSessionHandle,
     ) -> Self {
         Self {
             name: name.into(),
@@ -105,6 +111,7 @@ impl EnvArgs {
             network_mode: NetworkMode::HostNet,
             own_ip_tap: None,
             own_ip_dns: None,
+            session,
             include_package_attr_wiring: true,
         }
     }
@@ -367,6 +374,7 @@ impl Env {
             working: args.cwd.clone(),
             has_packages: transitives.keys().copied().collect(),
             ot: args.ot.clone(),
+            session: args.session.clone(),
             ctx,
             graph,
             rx,
@@ -499,6 +507,9 @@ struct SessionChannel {
     /// Packages already materialized into the rootfs.
     has_packages: HashSet<BuildSpecRef>,
     ot: Option<OpTracker>,
+    /// Weak handle to the owning session actor, used by session-scoped commands
+    /// (e.g. `min build`) to drive side-ops.
+    session: crate::session::WeakSessionHandle,
     rx: mpsc::Receiver<ChannelRequest>,
 }
 
@@ -571,6 +582,10 @@ impl SessionChannel {
             Some(("run", args)) => {
                 let (name, rest) = args.split_once(' ').unwrap_or((args, ""));
                 self.run_task(stream, name, rest).await;
+                None
+            }
+            Some(("build", args)) => {
+                self.run_build(stream, args).await;
                 None
             }
             _ => {
@@ -906,6 +921,68 @@ impl SessionChannel {
         }
     }
 
+    /// Implements `min build [--verbose] [--rebuild] pkgs...`: kicks off
+    /// a session side-op build and streams its progress back to the client
+    /// until the build completes.
+    async fn run_build(&mut self, stream: &mut UnixStream, args: &str) {
+        let mut flag_verbose = false;
+        let mut flag_rebuild = false;
+        let mut pkgs: Vec<String> = Vec::new();
+
+        for token in args.split_whitespace() {
+            match token {
+                "--verbose" => flag_verbose = true,
+                "--rebuild" => flag_rebuild = true,
+                _ => pkgs.push(token.to_string()),
+            }
+        }
+
+        let Some(session) = self.session.upgrade() else {
+            let _ = writeln!(stream, "error: session is gone");
+            return;
+        };
+
+        let mut events = match session.start_build(flag_rebuild, pkgs).await {
+            Ok(rx) => rx,
+            Err(e) => {
+                let _ = writeln!(stream, "error: {e}");
+                return;
+            }
+        };
+
+        use crate::session_sop::{BuildOutcome, BuildUpdate};
+        let mut renderer = orchestrator::BuildRenderer::new(flag_verbose);
+        let mut outcome = None;
+        while let Some(update) = events.recv().await {
+            match update {
+                BuildUpdate::Event(event) => {
+                    if let Some(line) = renderer.render(event) {
+                        let _ = writeln!(stream, "msg:{}", line.text);
+                    }
+                }
+                BuildUpdate::Finished(o) => outcome = Some(o),
+            }
+        }
+
+        // Report the propagated outcome; only success claims completion.
+        match outcome {
+            Some(BuildOutcome::Success) => {
+                let _ = writeln!(stream, "msg:build finished");
+            }
+            Some(BuildOutcome::Failed(e)) => {
+                let _ = writeln!(stream, "error: build failed: {e}");
+            }
+            Some(BuildOutcome::Cancelled) => {
+                let _ = writeln!(stream, "error: build cancelled");
+            }
+            // The channel closed without a terminal update — the side-op died
+            // before reporting (e.g. the actor was torn down mid-build).
+            None => {
+                let _ = writeln!(stream, "error: build ended without reporting an outcome");
+            }
+        }
+    }
+
     /// Writes an [`mctx::Error`] to the client as `msg:` lines (preserving its
     /// multi-line, richly-formatted report) followed by an `error:` terminator.
     fn write_error(e: &Error, stream: &mut UnixStream) {
@@ -1021,6 +1098,7 @@ mod tests {
             .unwrap(),
             has_packages: HashSet::new(),
             ot: None,
+            session: crate::session::WeakSessionHandle::dangling(),
             ctx,
             graph,
             rx,

--- a/crates/minimald/src/env_min_helper.sh
+++ b/crates/minimald/src/env_min_helper.sh
@@ -108,6 +108,10 @@ min_run() {
     __min_rpc "run" "$@"
 }
 
+min_build() {
+    __min_rpc "build" "$@"
+}
+
 min_check() {
     __min_rpc "check" "$@"
 }
@@ -127,7 +131,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
             min_run "$@"
             ;;
         build)
-            min_run build
+            min_build "$@"
             ;;
         test)
             min_run test
@@ -145,6 +149,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
             echo "Search for packages: min search <query>" >&2
             echo "Check minimal configuration: min check" >&2
             echo "Run a task: min run <task name>" >&2
+            echo "Build packages: min build [packages]" >&2
             echo "Try building a package (with potentially-stale dependencies): min patched-pkg <package name>" >&2
             exit 1
             ;;

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -1,5 +1,5 @@
-//! SSH `exec` request handling: spawns a process and bridges its stdio
-//! over an SSH channel.
+//! SSH `exec` request handling: Launching tasks defined in the session,
+//! git recieve-pack, and launching side ops.
 //!
 //! Process spawning is abstracted via the [`Exec`] / [`Process`] traits
 //! so the bridge logic can be exercised with a mock in tests without
@@ -807,31 +807,156 @@ pub(crate) async fn handle_exec(
         }
     };
 
-    let task = match argv.strip_prefix("min run ") {
+    let rem = match argv.strip_prefix("min ") {
+        Some(c) => c,
         None => {
-            tracing::warn!(%session_id, "execution request rejected: expected `min run <task name>`");
+            tracing::warn!(%session_id, "execution request rejected: expected `min ` prefix");
             session.channel_failure(id)?;
             return Ok(());
         }
-        Some(t) => t,
-    }.to_string();
-    session.channel_success(id)?;
+    }
+    .to_string();
 
-    spawn(async move {
-        let exec_task = ExecTask {
-            conn,
-            serv,
-            session: session_handle,
-            channel_id: id,
-            exec: TaskExec {
-                args: None,
-                task: task.to_string(),
-            },
-        };
-        exec_task.run(channel).await;
-    });
+    let mut c = rem.split(' ');
+    match c.next() {
+        None => {
+            tracing::warn!(%session_id, "execution request rejected: expected `min <sub command>`");
+            session.channel_failure(id)?;
+            return Ok(());
+        }
+        Some("run") => {
+            // `min run` with no task name would leave `strip_prefix("run ")`
+            // as `None` (and a trailing-space `min run ` as empty) — reject
+            // both before acking, rather than panicking on `.unwrap()`.
+            let task = rem.strip_prefix("run ").unwrap_or("").trim();
+            if task.is_empty() {
+                tracing::warn!(%session_id, "execution request rejected: expected `min run <task name>`");
+                session.channel_failure(id)?;
+                return Ok(());
+            }
+            let task = task.to_string();
+            session.channel_success(id)?;
+
+            spawn(async move {
+                let exec_task = ExecTask {
+                    conn,
+                    serv,
+                    session: session_handle,
+                    channel_id: id,
+                    exec: TaskExec { args: None, task },
+                };
+                exec_task.run(channel).await;
+            });
+        }
+        Some("build") => {
+            session.channel_success(id)?;
+            // Everything after the sub-command is the build's args
+            // (`--verbose` / `--rebuild` / package names).
+            let build_args = rem.strip_prefix("build").unwrap_or("").trim().to_string();
+            spawn(async move {
+                run_build_exec(session_handle, id, channel, build_args).await;
+            });
+        }
+        Some(other) => {
+            tracing::warn!(%session_id, "execution request rejected: unexpected min sub-command `{other}`");
+            session.channel_failure(id)?;
+            return Ok(());
+        }
+    };
 
     Ok(())
+}
+
+/// Streams a `min build [--verbose] [--rebuild] [pkgs...]` exec over the SSH
+/// channel. Kicks off a session side-op build based on an existing session.
+async fn run_build_exec(
+    session: SessionHandle,
+    channel_id: ChannelId,
+    channel: Channel<Msg>,
+    args: String,
+) {
+    use orchestrator::{BuildLineKind, BuildRenderer};
+
+    let mut verbose = false;
+    let mut rebuild = false;
+    let mut pkgs: Vec<String> = Vec::new();
+    for token in args.split_whitespace() {
+        match token {
+            "--verbose" => verbose = true,
+            "--rebuild" => rebuild = true,
+            _ => pkgs.push(token.to_string()),
+        }
+    }
+
+    // Same channel-half handling as `ExecTask::run`: stdout on the data
+    // stream, stderr on SSH extended-data type 1.
+    let (_rs, ws) = channel.split();
+    let mut w = ws.make_writer();
+    let mut e = ws.make_writer_ext(Some(1));
+
+    let exit_status = match session.start_build(rebuild, pkgs).await {
+        Ok(mut events) => {
+            use crate::session_sop::{BuildOutcome, BuildUpdate};
+            let mut renderer = BuildRenderer::new(verbose);
+            let mut outcome = None;
+            while let Some(update) = events.recv().await {
+                let event = match update {
+                    BuildUpdate::Event(event) => event,
+                    BuildUpdate::Finished(o) => {
+                        outcome = Some(o);
+                        continue;
+                    }
+                };
+                let Some(line) = renderer.render(event) else {
+                    continue;
+                };
+                let out: &mut (dyn AsyncWrite + Unpin + Send) = match line.kind {
+                    BuildLineKind::Stderr => &mut e,
+                    BuildLineKind::Status => &mut w,
+                };
+                if let Err(err) = out.write_all(format!("{}\n", line.text).as_bytes()).await {
+                    // No reader on the channel — the client went away. Stop
+                    // streaming; the side-op keeps running independently.
+                    tracing::warn!(%channel_id, error = %err, "min build: channel write failed");
+                    break;
+                }
+            }
+            // Map the propagated outcome to an exit code, reporting a
+            // failure/cancellation on the SSH stderr stream. Only success
+            // exits 0.
+            match outcome {
+                Some(BuildOutcome::Success) => 0,
+                Some(BuildOutcome::Failed(msg)) => {
+                    let _ = e
+                        .write_all(format!("build failed: {msg}\n").as_bytes())
+                        .await;
+                    1
+                }
+                Some(BuildOutcome::Cancelled) => {
+                    let _ = e.write_all(b"build cancelled\n").await;
+                    130
+                }
+                None => {
+                    let _ = e
+                        .write_all(b"build ended without reporting an outcome\n")
+                        .await;
+                    1
+                }
+            }
+        }
+        Err(err) => {
+            let _ = e
+                .write_all(format!("minimald: failed to start build: {err}\n").as_bytes())
+                .await;
+            1
+        }
+    };
+
+    let _ = w.flush().await;
+    let _ = e.flush().await;
+    let _ = ws.eof().await;
+    let _ = ws.exit_status(exit_status).await; // otherwise considered -1
+    let _ = ws.close().await; // needed to release the remote
 }
 
 async fn handle_git_receive(

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -13,6 +13,7 @@ pub mod rpc;
 pub mod server;
 mod session;
 pub mod session_host;
+pub mod session_sop;
 mod sessions;
 mod sftp;
 mod store;

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -1036,7 +1036,12 @@ async fn unpack_workspace_patches(
     // unique dir), so we only pay the serialization cost across
     // the seconds-of-work install step, not the minutes-of-work
     // unpack.
-    let _swap_guard = session_handle.patches_upload_lock().lock_owned().await;
+    let _swap_guard = session_handle
+        .patches_upload_lock()
+        .await
+        .map_err(|e| format!("session is gone: {e}"))?
+        .lock_owned()
+        .await;
 
     // Install the new tree. Two shapes depending on whether a
     // prior `patches/` exists:

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1,4 +1,5 @@
 use crate::channel_progress::ChannelProgress;
+use crate::session_sop::{BuildUpdate, SideOp};
 use crate::sessions::{SessionControl, WeakManagerHandle, composables};
 use crate::store::SessionRecordHandle;
 use crate::{
@@ -22,6 +23,7 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 #[cfg(target_os = "linux")]
 use std::sync::RwLock;
+use tokio::sync::mpsc::WeakSender;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
 
@@ -196,6 +198,8 @@ enum SessionInner {
             session_host::HostHandle,
             JoinHandle<Result<i32, std::io::Error>>,
         )>,
+        /// Side operations.
+        sops: Vec<SideOp>,
     },
 }
 
@@ -263,6 +267,16 @@ enum SessionMessage {
     /// record.
     Destroy(oneshot::Sender<Result<(), std::io::Error>>),
     GetRecord(oneshot::Sender<Record>),
+    /// Hand back an `Arc` clone of this session's patches-upload lock, see
+    /// [`Session::patches_upload_lock`].
+    GetPatchesUploadLock(oneshot::Sender<Arc<Mutex<()>>>),
+    /// Kick off a background package build as a session side-op. Replies with
+    /// the receiver end of the build's event stream.
+    StartBuild {
+        rebuild: bool,
+        pkgs: Vec<String>,
+        reply: oneshot::Sender<Result<mpsc::Receiver<BuildUpdate>, std::io::Error>>,
+    },
     /// Test-only inspection: an `Arc` clone of the held [`Composition`]
     /// (`None` in `Draft`, or `Active` without one post-restart). Lets tests
     /// assert composition contents without disturbing the lifecycle.
@@ -307,6 +321,11 @@ pub struct Session {
     /// Session state machine.
     inner: SessionInner,
 
+    /// Serializes `WorkspacePatchesTarZst` uploads for this session: two
+    /// concurrent uploads would race on the single `<workspace>/patches/`
+    /// tree and step on each other.
+    patches_upload_lock: Arc<Mutex<()>>,
+
     /// A non-owning handle to the [`Manager`](crate::sessions::Manager), used to
     /// build the [`SessionControl`] handed to each [`Binding`] so a shell-exit
     /// "delete" tears this session down through the manager (record removal and
@@ -314,6 +333,11 @@ pub struct Session {
     /// actor-initiated termination. Weak by design — see
     /// [`crate::sessions::Manager::weak_self`].
     manager: WeakManagerHandle,
+
+    /// A non-owning handle to this session, handed to the runtime objects
+    /// we spawns (e.g. build [`SideOp`]s) so they can reach back into
+    /// the session.
+    weak_self: WeakSessionHandle,
 }
 
 impl Session {
@@ -323,6 +347,7 @@ impl Session {
         seed: SessionConfig,
         receiver: mpsc::Receiver<SessionMessage>,
         inner: SessionInner,
+        weak_self: WeakSessionHandle,
     ) -> Self {
         let SessionConfig {
             minimal_state_dir,
@@ -343,7 +368,9 @@ impl Session {
             net_switch,
             tracker: OpTracker::new_root(),
             inner,
+            patches_upload_lock: Arc::new(Mutex::new(())),
             manager,
+            weak_self,
             #[cfg(target_os = "linux")]
             hostnames,
         }
@@ -371,6 +398,7 @@ impl Session {
             SessionStatus::Active => SessionInner::Active {
                 composition: None,
                 host: None,
+                sops: vec![],
             },
             SessionStatus::Pending => SessionInner::Draft { pending: None },
             // `Materializing` records are only meaningful across a
@@ -410,7 +438,10 @@ impl Session {
         };
 
         let (sender, receiver) = mpsc::channel(8);
-        let actor = Self::assemble(conf, receiver, inner);
+        // A weak self-handle so the actor can hand its own mailbox to the
+        // runtime objects it spawns without a caller threading it in.
+        let weak_self = WeakSessionHandle(sender.downgrade());
+        let actor = Self::assemble(conf, receiver, inner, weak_self);
 
         // Register the PTask hostname before the actor goes live, so the
         // route exists by the time the caller can observe the session
@@ -420,10 +451,7 @@ impl Session {
         actor.register_hostname(obj.record());
 
         tokio::spawn(actor.mainloop());
-        Ok(SessionHandle {
-            sender,
-            patches_upload_lock: Arc::new(Mutex::new(())),
-        })
+        Ok(SessionHandle(sender))
     }
 
     /// Register this session's PTask hostname (R3.1/R3.6). Both HostNet and
@@ -581,14 +609,14 @@ impl Session {
                 });
             }
             SessionMessage::Stop(r) => {
-                self.stop_host().await;
+                self.stop_running().await;
                 #[cfg(target_os = "linux")]
                 self.deregister_hostname().await;
                 let _ = r.send(());
                 return ControlFlow::Break(Teardown::ManagerInitiated);
             }
             SessionMessage::Destroy(r) => {
-                self.stop_host().await;
+                self.stop_running().await;
                 // Withdraw the hostname before the fallible record delete, so
                 // a delete failure leaves a stale on-disk record (repairable
                 // on restart) but never a stale routing entry pointing at a
@@ -597,6 +625,16 @@ impl Session {
                 self.deregister_hostname().await;
                 let _ = r.send(self.record.clone().delete().await);
                 return ControlFlow::Break(Teardown::ManagerInitiated);
+            }
+            SessionMessage::GetPatchesUploadLock(r) => {
+                let _ = r.send(Arc::clone(&self.patches_upload_lock));
+            }
+            SessionMessage::StartBuild {
+                rebuild,
+                pkgs,
+                reply,
+            } => {
+                let _ = reply.send(self.start_build(rebuild, pkgs).await);
             }
             SessionMessage::GetRecord(r) => {
                 let _ = r.send(self.record.record().await.unwrap());
@@ -682,6 +720,7 @@ impl Session {
                 self.inner = SessionInner::Active {
                     composition: Some(Arc::new(composition)),
                     host: None,
+                    sops: vec![],
                 };
                 Ok(None)
             }
@@ -753,6 +792,7 @@ impl Session {
         self.inner = SessionInner::Active {
             composition: Some(Arc::new(composition)),
             host: None,
+            sops: vec![],
         };
         Ok(SessionStep::Materialized { id: record.id })
     }
@@ -887,19 +927,47 @@ impl Session {
         }
     }
 
-    /// Tears down the running host, if any, waiting for the process to be reaped
-    /// and the sandbox guard to be dropped before returning.
-    async fn stop_host(&mut self) {
-        let host = match &mut self.inner {
-            SessionInner::Active { host, .. } => host.take(),
+    /// Kicks off a background package build as a side-op and registers it on
+    /// this session, returning the receiver end of its event stream. The build
+    /// runs against a fresh workspace-rooted context (rebuilt per call so it
+    /// tracks `minimal.toml` edits).
+    ///
+    /// The returned receiver closes when the build ends.
+    async fn start_build(
+        &mut self,
+        rebuild: bool,
+        pkgs: Vec<String>,
+    ) -> Result<mpsc::Receiver<BuildUpdate>, std::io::Error> {
+        let ctx = self.context(false).await.map_err(std::io::Error::other)?;
+        let (sop, rx) = SideOp::spawn_build(self.weak_self.clone(), rebuild, pkgs, ctx, 64).await?;
+        match &mut self.inner {
+            SessionInner::Active { sops, .. } => sops.push(sop),
+            SessionInner::Draft { .. } => {
+                sop.shutdown().await;
+                unreachable!("`context()` already rejected a `Draft`");
+            }
+        }
+        Ok(rx)
+    }
+
+    /// Tears down any runtime objects, such as the host or side ops. Shutdown
+    /// of these objects is complete once awaited.
+    async fn stop_running(&mut self) {
+        let inner = match &mut self.inner {
+            SessionInner::Active { host, sops, .. } => Some((host.take(), std::mem::take(sops))),
             SessionInner::Draft { .. } => None,
         };
-        if let Some((host, task)) = host {
-            // Signal the process to die, then await the runtime loop so the
-            // sandbox files backing its rootfs are released before the caller
-            // removes the session's directory tree.
-            let _ = host.kill().await;
-            let _ = task.await;
+        if let Some((host, mut sops)) = inner {
+            for s in sops.drain(..) {
+                s.shutdown().await;
+            }
+            if let Some((host, task)) = host {
+                // Signal the process to die, then await the runtime loop so the
+                // sandbox files backing its rootfs are released before the caller
+                // removes the session's directory tree.
+                let _ = host.kill().await;
+                let _ = task.await;
+            }
         }
     }
 
@@ -1101,7 +1169,7 @@ impl Session {
     #[cfg(not(test))]
     async fn session_launcher(
         &mut self,
-        _session: SessionHandle,
+        session: SessionHandle,
         record: &Record,
     ) -> Result<session_host::SandboxLauncher, AttachError> {
         // R2.1: reject a policy that is incompatible with the network mode
@@ -1123,6 +1191,9 @@ impl Session {
             net_switch: Arc::clone(&self.net_switch),
             ingress,
             composition: self.composition(),
+            // A weak handle so in-sandbox `min build` can drive session
+            // side-ops without keeping the actor alive past teardown.
+            session: session.downgrade(),
         })
     }
 
@@ -1249,37 +1320,65 @@ impl Session {
 
 /// The handle to the session.
 #[derive(Debug, Clone)]
-pub struct SessionHandle {
-    sender: mpsc::Sender<SessionMessage>,
-    /// Serializes `WorkspacePatchesTarZst` uploads for this session: two
-    /// concurrent uploads would race on the single `<workspace>/patches/`
-    /// tree, and neither one's atomic-swap install would happen against a
-    /// known baseline (one could wipe the other's freshly-installed tree
-    /// and see its own `RENAME_EXCHANGE` return an unexpected state).
-    /// Held only across the whole unpack + install + marker-write, so an
-    /// idle session never contends on it. `Arc<Mutex>` (not
-    /// `parking_lot`) because the critical section awaits.
-    patches_upload_lock: Arc<Mutex<()>>,
-}
+pub struct SessionHandle(mpsc::Sender<SessionMessage>);
 
 impl SessionHandle {
+    /// Returns a non-owning handle to this session.
+    #[must_use]
+    pub fn downgrade(&self) -> WeakSessionHandle {
+        WeakSessionHandle(self.0.downgrade())
+    }
+
+    /// Handle to the per-session patches-upload lock, owned by the session
+    /// actor.
+    ///
+    /// Workspace patches are accumulated in a fixed per-session directory,
+    /// so this lock is used to serialize `WorkspacePatchesTarZst` RPCs so
+    /// they dont race and stomp each other.
+    pub async fn patches_upload_lock(&self) -> Result<Arc<Mutex<()>>, std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .0
+            .send(SessionMessage::GetPatchesUploadLock(send))
+            .await;
+        recv.await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
+        })
+    }
+
+    /// Kicks off a background package build as a session side-op, returning the
+    /// receiver end of the build's event stream. Events flow until the build
+    /// finishes (success or cancellation), at which point the channel closes.
+    /// A `Draft` session is refused with `InvalidInput`; a dead actor maps to
+    /// `NotConnected`.
+    pub async fn start_build(
+        &self,
+        rebuild: bool,
+        pkgs: Vec<String>,
+    ) -> Result<mpsc::Receiver<BuildUpdate>, std::io::Error> {
+        let (reply, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .0
+            .send(SessionMessage::StartBuild {
+                rebuild,
+                pkgs,
+                reply,
+            })
+            .await;
+        recv.await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
+        })?
+    }
+
     /// Returns paths on the daemon backing various internals of the session.
     /// A dead actor (self-terminated abort/failed-verdict/create-failure, or
     /// mid-teardown) maps to `NotConnected` — callers race actor death.
-    /// Handle to the per-session patches-upload lock. Held by
-    /// `WorkspacePatchesTarZst` for the whole unpack + install +
-    /// marker-write, so two concurrent uploads for the same session
-    /// can't race on the single `<workspace>/patches/` tree. Idle
-    /// sessions never contend on it. Cheap to clone (an `Arc`
-    /// bump).
-    pub fn patches_upload_lock(&self) -> Arc<Mutex<()>> {
-        Arc::clone(&self.patches_upload_lock)
-    }
-
     pub async fn paths(&self) -> Result<SessionPaths, std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.sender.send(SessionMessage::GetPaths(send)).await;
+        let _ = self.0.send(SessionMessage::GetPaths(send)).await;
         recv.await.map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
         })
@@ -1290,7 +1389,7 @@ impl SessionHandle {
     pub async fn get_attrs(&self) -> Option<HostAttrs> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.sender.send(SessionMessage::GetHostAttrs(send)).await;
+        let _ = self.0.send(SessionMessage::GetHostAttrs(send)).await;
         recv.await.ok().flatten()
     }
 
@@ -1298,7 +1397,7 @@ impl SessionHandle {
     pub async fn context(&self) -> Result<mctx::Context, String> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.sender.send(SessionMessage::MakeContext(send)).await;
+        let _ = self.0.send(SessionMessage::MakeContext(send)).await;
         recv.await
             .unwrap_or_else(|_| Err("session actor is gone".to_string()))
     }
@@ -1310,7 +1409,7 @@ impl SessionHandle {
     pub(crate) async fn record(&self) -> Result<Record, std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.sender.send(SessionMessage::GetRecord(send)).await;
+        let _ = self.0.send(SessionMessage::GetRecord(send)).await;
         recv.await.map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
         })
@@ -1328,7 +1427,7 @@ impl SessionHandle {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self
-            .sender
+            .0
             .send(SessionMessage::ConfigureLoadout(contribution, send))
             .await;
         recv.await.unwrap_or_else(|_| {
@@ -1354,7 +1453,7 @@ impl SessionHandle {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self
-            .sender
+            .0
             .send(SessionMessage::SubmitVerdict(Box::new((verdict, send))))
             .await;
         recv.await.unwrap_or_else(|_| {
@@ -1373,7 +1472,7 @@ impl SessionHandle {
     pub(crate) async fn finalize(&self) -> Result<(), std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.sender.send(SessionMessage::Finalize(send)).await;
+        let _ = self.0.send(SessionMessage::Finalize(send)).await;
         recv.await.unwrap_or_else(|_| {
             Err(std::io::Error::new(
                 std::io::ErrorKind::NotConnected,
@@ -1388,7 +1487,7 @@ impl SessionHandle {
     pub(crate) async fn abort(&self) -> Result<(), std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.sender.send(SessionMessage::Abort(send)).await;
+        let _ = self.0.send(SessionMessage::Abort(send)).await;
         recv.await.unwrap_or_else(|_| {
             Err(std::io::Error::new(
                 std::io::ErrorKind::NotConnected,
@@ -1403,7 +1502,7 @@ impl SessionHandle {
     pub(crate) async fn is_busy(&self) -> bool {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.sender.send(SessionMessage::IsBusy(send)).await;
+        let _ = self.0.send(SessionMessage::IsBusy(send)).await;
         recv.await.unwrap_or(false)
     }
 
@@ -1413,10 +1512,7 @@ impl SessionHandle {
     #[cfg(test)]
     pub(crate) async fn peek_composition(&self) -> Option<Arc<Composition>> {
         let (send, recv) = oneshot::channel();
-        let _ = self
-            .sender
-            .send(SessionMessage::PeekComposition(send))
-            .await;
+        let _ = self.0.send(SessionMessage::PeekComposition(send)).await;
         recv.await.ok().flatten()
     }
 
@@ -1426,10 +1522,7 @@ impl SessionHandle {
     pub(crate) async fn rename(&self, new_name: String) -> Result<(), std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self
-            .sender
-            .send(SessionMessage::Rename(new_name, send))
-            .await;
+        let _ = self.0.send(SessionMessage::Rename(new_name, send)).await;
         recv.await.unwrap_or_else(|_| {
             Err(std::io::Error::new(
                 std::io::ErrorKind::NotConnected,
@@ -1444,7 +1537,7 @@ impl SessionHandle {
     pub(crate) async fn stop(&self) {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.sender.send(SessionMessage::Stop(send)).await;
+        let _ = self.0.send(SessionMessage::Stop(send)).await;
         // If the actor died before acking, it is stopped all the same.
         let _ = recv.await;
     }
@@ -1456,7 +1549,7 @@ impl SessionHandle {
     pub(crate) async fn destroy(&self) -> Result<(), std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
-        let _ = self.sender.send(SessionMessage::Destroy(send)).await;
+        let _ = self.0.send(SessionMessage::Destroy(send)).await;
         recv.await.unwrap_or(Ok(()))
     }
 
@@ -1469,7 +1562,7 @@ impl SessionHandle {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self
-            .sender
+            .0
             .send(SessionMessage::Attach(
                 send,
                 self.clone(),
@@ -1487,6 +1580,32 @@ impl SessionHandle {
                 "session actor terminated before the attach completed",
             ))),
         }
+    }
+}
+
+/// A non-owning handle to the [`Session`] actor.
+#[derive(Debug, Clone)]
+pub struct WeakSessionHandle(WeakSender<SessionMessage>);
+
+impl WeakSessionHandle {
+    /// Promotes to a strong [`SessionHandle`], or `None` if the session actor
+    /// has already shut down (all strong senders dropped).
+    #[must_use]
+    pub fn upgrade(&self) -> Option<SessionHandle> {
+        Some(SessionHandle(self.0.upgrade()?))
+    }
+
+    /// A dangling handle whose actor is already gone (`upgrade` always yields
+    /// `None`). Test-only: lets fixtures that never exercise the session
+    /// round-trip satisfy an `EnvArgs`/`SessionChannel` that now requires a
+    /// handle, without standing up a live actor.
+    #[cfg(test)]
+    pub(crate) fn dangling() -> Self {
+        let (tx, _rx) = mpsc::channel::<SessionMessage>(1);
+        let weak = tx.downgrade();
+        // Drop the only strong sender so `upgrade()` returns `None`.
+        drop(tx);
+        Self(weak)
     }
 }
 

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -824,6 +824,9 @@ pub(crate) struct SandboxLauncher {
     /// Composition to merge into the launcher's baseline packages and
     /// vars. Patches and lifecycle hooks are ignored today.
     pub(crate) composition: Option<std::sync::Arc<sessions::core::compose::Composition>>,
+    /// Weak handle back to the owning session actor, for  `min` commands
+    /// (e.g. `min build`) to drive session side-ops.
+    pub(crate) session: crate::session::WeakSessionHandle,
 }
 
 /// Rolls back a native-own-IP phase-1 switch attach if the launch is abandoned
@@ -896,6 +899,7 @@ impl SessionLauncher for SandboxLauncher {
         // the sandbox env below.
         let session_name = name.clone();
         let composition = self.composition;
+        let session = self.session;
         // `graph_from_all_packages` is CPU-heavy (nickel evaluation,
         // graph construction) — run it on the blocking pool so it
         // doesn't stall the async executor.
@@ -1027,7 +1031,7 @@ impl SessionLauncher for SandboxLauncher {
             let mut env = crate::env::Env::build(
                 ctx,
                 graph,
-                crate::env::EnvArgs::new(name, paths.working, paths.home, paths.cache)
+                crate::env::EnvArgs::new(name, paths.working, paths.home, paths.cache, session)
                     .with_packages(packages)
                     .with_resolved_env_vars(env_vars)
                     // Session envs source package attrs (env_state_wiring,

--- a/crates/minimald/src/session_sop.rs
+++ b/crates/minimald/src/session_sop.rs
@@ -1,0 +1,244 @@
+//! Session side-operations - operations run non-interactively in the context of a session.
+
+use std::sync::Arc;
+
+use futures::StreamExt as _;
+use mctx::{Context, PackageSelection};
+use orchestrator::BuildEvent;
+use tokio::{
+    sync::{
+        Mutex,
+        mpsc::{self, error::TrySendError},
+    },
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::session::WeakSessionHandle;
+
+/// The terminal result of a build side-op, delivered as the final
+/// [`BuildUpdate`] before the build's channel closes.
+#[derive(Debug, Clone)]
+pub enum BuildOutcome {
+    /// The build finished and every top-level is available.
+    Success,
+    /// The build errored; the string is the (rendered) failure.
+    Failed(String),
+    /// The build was cancelled before completing (e.g. the session tore down).
+    Cancelled,
+}
+
+/// An update from a running build side-op: incremental progress
+/// ([`BuildUpdate::Event`]), then exactly one terminal
+/// [`BuildUpdate::Finished`] as the last item before the channel closes.
+#[derive(Debug, Clone)]
+pub enum BuildUpdate {
+    Event(BuildEvent),
+    Finished(BuildOutcome),
+}
+
+/// A registration to recieve updates about the progress of a build.
+#[derive(Debug)]
+pub(crate) enum BuildSink {
+    Structured(mpsc::Sender<BuildUpdate>),
+}
+
+impl BuildSink {
+    /// Best-effort progress delivery: a full or disconnected sink drops the
+    /// update rather than blocking the build.
+    pub fn try_send(&self, u: BuildUpdate) -> Result<(), TrySendError<BuildUpdate>> {
+        match self {
+            Self::Structured(s) => s.try_send(u),
+        }
+    }
+
+    /// Reliable delivery for the terminal outcome: awaits channel capacity so
+    /// the `Finished` update isn't dropped under backpressure. Errors only if
+    /// the subscriber has already gone away.
+    pub async fn send(&self, u: BuildUpdate) -> Result<(), mpsc::error::SendError<BuildUpdate>> {
+        match self {
+            Self::Structured(s) => s.send(u).await,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BuildInner {
+    sinks: Vec<BuildSink>,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+enum Op {
+    Build {
+        /// Packages which were requested to be built
+        packages: Vec<String>,
+        /// Interior mutability. Users MUST NEVER block while holding
+        /// the lock: get in, read/update data, get out.
+        inner: Arc<Mutex<BuildInner>>,
+    },
+}
+
+/// Session side-operation.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct SideOp {
+    id: uuid::Uuid,
+    session: WeakSessionHandle,
+
+    op: Op,
+
+    cancel: CancellationToken,
+    handle: JoinHandle<()>,
+}
+
+/// How long to wait to hand a subscriber the terminal [`BuildUpdate::Finished`]
+/// before giving up. A subscriber that stopped draining but hasn't dropped its
+/// receiver would otherwise block the build task's reliable send forever — and
+/// [`SideOp::shutdown`] awaits that task, so this bound keeps teardown from
+/// wedging on a wedged consumer. Responsive consumers deliver far inside it.
+const FINISH_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+impl SideOp {
+    /// UUID of this operation.
+    pub fn id(&self) -> &uuid::Uuid {
+        &self.id
+    }
+
+    /// Called by the session when it is being shut down.
+    pub(crate) async fn shutdown(self) {
+        self.cancel.cancel();
+        if let Err(e) = self.handle.await {
+            tracing::warn!(error = %e, "sop shutdown unexpected error on join");
+        }
+    }
+
+    /// Kicks off a build side-op wired to a single structured sink, returning
+    /// the op alongside the receiver end that streams its [`BuildEvent`]s until
+    /// the build completes (at which point the sender is dropped and the
+    /// receiver closes). The session actor stores the op and hands the receiver
+    /// to whoever requested the build so it can render progress.
+    pub(crate) async fn spawn_build(
+        session: WeakSessionHandle,
+        rebuild: bool,
+        pkgs: Vec<String>,
+        ctx: Context,
+        buffer: usize,
+    ) -> Result<(Self, mpsc::Receiver<BuildUpdate>), std::io::Error> {
+        let (tx, rx) = mpsc::channel(buffer);
+        let sop =
+            Self::new_build(session, rebuild, pkgs, ctx, vec![BuildSink::Structured(tx)]).await?;
+        Ok((sop, rx))
+    }
+
+    /// Called to kick off a new build with the specified parameters.
+    ///
+    /// Should only be called from the session actor.
+    pub(crate) async fn new_build(
+        session: WeakSessionHandle,
+        rebuild: bool,
+        pkgs: Vec<String>,
+        ctx: Context,
+        sinks: Vec<BuildSink>,
+    ) -> Result<Self, std::io::Error> {
+        // `graph_from_all_packages` is CPU-heavy, run on blocking pool.
+        let (ctx, graph_result) = tokio::task::spawn_blocking(move || {
+            let mut ctx = ctx;
+            let r = ctx.graph_from_all_packages().map_err(|e| e.to_string());
+
+            (ctx, r)
+        })
+        .await
+        .map_err(std::io::Error::other)?;
+        let mut graph = graph_result.map_err(std::io::Error::other)?;
+        graph.top_levels = pkgs
+            .as_bsrs(&graph)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+        let cancel = CancellationToken::new();
+        let inner = Arc::new(Mutex::new(BuildInner { sinks }));
+
+        let handle = {
+            // Two clones for the task (the original `cancel` stays on the
+            // `SideOp` so `shutdown` can trigger it): one drives the build,
+            // one classifies the outcome after it returns. All clones share
+            // the same cancellation state.
+            let build_cancel = cancel.clone();
+            let cancel_flag = cancel.clone();
+            let pump_inner = inner.clone();
+            let build_inner = inner.clone();
+            tokio::task::spawn(async move {
+                let mut ctx = ctx;
+                let (log_tx, mut log_rx) = futures::channel::mpsc::unbounded::<BuildEvent>();
+
+                // Pump task: drain the log channel until the build drops its
+                // sender (on completion or cancellation).
+                let pump = tokio::task::spawn(async move {
+                    while let Some(event) = log_rx.next().await {
+                        let inner = pump_inner.lock().await;
+                        for sink in &inner.sinks {
+                            let _ = sink.try_send(BuildUpdate::Event(event.clone()));
+                        }
+                    }
+                });
+
+                // Do the build. Reduce its `!Send` error (`mctx::Error` holds
+                // nickel `Rc`s) to an owned string right away, so nothing
+                // non-`Send` is held across the `pump.await` below.
+                let build_err = match ctx
+                    .build_graph_with_cancel(&graph, rebuild, Some(log_tx), build_cancel)
+                    .await
+                {
+                    Ok(()) => None,
+                    Err(e) => {
+                        tracing::warn!("session build failed: {e}");
+                        Some(e.to_string())
+                    }
+                };
+                let _ = pump.await;
+
+                // Classify the terminal outcome. A build that returned `Ok` is
+                // a success even if the token was cancelled afterwards (e.g. a
+                // `shutdown` racing the `pump.await` drain) — the work is done.
+                // Cancellation only reclassifies an *errored* build, whose error
+                // is just fallout from tearing the build down.
+                let outcome = match build_err {
+                    None => BuildOutcome::Success,
+                    Some(_) if cancel_flag.is_cancelled() => BuildOutcome::Cancelled,
+                    Some(msg) => BuildOutcome::Failed(msg),
+                };
+
+                // Deliver the outcome to every subscriber, then drop the sinks
+                // so their receivers close. Take the sinks out *under* the lock
+                // (never awaiting while holding it), then send outside it.
+                let sinks = {
+                    let mut inner = build_inner.lock().await;
+                    std::mem::take(&mut inner.sinks)
+                };
+                for sink in &sinks {
+                    // Bound the reliable delivery so a stuck-but-undropped
+                    // receiver can't stall this task (and thus `shutdown`); a
+                    // consumer that has fallen behind just misses the final
+                    // update, then sees the channel close below.
+                    let _ = tokio::time::timeout(
+                        FINISH_SEND_TIMEOUT,
+                        sink.send(BuildUpdate::Finished(outcome.clone())),
+                    )
+                    .await;
+                }
+                // `sinks` dropped here → each receiver observes the close.
+            })
+        };
+
+        Ok(Self {
+            id: uuid::Uuid::now_v7(),
+            cancel,
+            session,
+            op: Op::Build {
+                packages: pkgs,
+                inner,
+            },
+            handle,
+        })
+    }
+}

--- a/crates/mip/src/cmd_pkg.rs
+++ b/crates/mip/src/cmd_pkg.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-
 use futures::channel::mpsc;
 use graph::Graph;
 use mctx::{Cache, Context, Error};
-use orchestrator::{BuildEvent, BuildEventInner};
+use orchestrator::{BuildEvent, BuildLineKind, BuildRenderer};
 use tracing::{info, trace};
 
 #[derive(Debug, clap::Args)]
@@ -35,22 +33,14 @@ pub async fn cmd_pkg(args: PkgArgs, ctx: &mut Context) -> Result<(), Error> {
         let (tx, mut rx) = mpsc::unbounded::<BuildEvent>();
         tokio::spawn(async move {
             use futures::StreamExt;
-            let mut names: HashMap<usize, String> = HashMap::new();
-            while let Some(log) = rx.next().await {
-                match log.inner {
-                    BuildEventInner::Start { name, .. } => {
-                        names.insert(log.idx, name);
-                    }
-                    BuildEventInner::Stop => {}
-                    BuildEventInner::Log { is_stderr, line } => {
-                        let name = names[&log.idx].clone();
-                        if is_stderr {
-                            tracing::warn!(target: "build", name = %name, "{}", line);
-                        } else {
-                            tracing::info!(target: "build", name = %name, "{}", line);
-                        }
-                    }
-                    BuildEventInner::Hydrate { .. } => {}
+            let mut renderer = BuildRenderer::new(true);
+            while let Some(event) = rx.next().await {
+                let Some(line) = renderer.render(event) else {
+                    continue;
+                };
+                match line.kind {
+                    BuildLineKind::Stderr => tracing::warn!(target: "build", "{}", line.text),
+                    BuildLineKind::Status => tracing::info!(target: "build", "{}", line.text),
                 }
             }
         });

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -18,6 +18,9 @@ use tokio::{
 mod local_backend;
 pub use local_backend::{BuildEvent, BuildEventInner, LocalBackend};
 
+mod render;
+pub use render::{BuildLine, BuildLineKind, BuildRenderer};
+
 mod state;
 pub use state::{
     Deliverable, DeliverableInner, DeliverableRef, DeliverableState, State, StateHandle,

--- a/crates/orchestrator/src/render.rs
+++ b/crates/orchestrator/src/render.rs
@@ -1,0 +1,96 @@
+//! Human-readable rendering of a [`BuildEvent`] stream.
+//!
+//! [`BuildRenderer`] folds the raw event stream a build emits into
+//! line-oriented text, tracking the per-build-index → package-name map so log
+//! lines can be attributed to the package that produced them. It is the one
+//! place that decides how a build reads on a terminal, shared by the `mip pkg`
+//! CLI and the in-session `min build` command so both render identically.
+
+use std::collections::HashMap;
+
+use crate::{BuildEvent, BuildEventInner};
+
+/// Severity of a rendered [`BuildLine`], so a text sink can route it (stdout
+/// vs stderr, `info!` vs `warn!`, …).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildLineKind {
+    /// Progress or stdout content.
+    Status,
+    /// Content originating from a build's stderr.
+    Stderr,
+}
+
+/// A single rendered line of build output. `text` is fully formatted and
+/// self-contained (it already carries the package name where relevant), so a
+/// line-oriented sink can print it verbatim.
+#[derive(Debug, Clone)]
+pub struct BuildLine {
+    pub kind: BuildLineKind,
+    pub text: String,
+}
+
+/// Stateful renderer folding [`BuildEvent`]s into [`BuildLine`]s.
+///
+/// Feed each event to [`BuildRenderer::render`] in arrival order; it returns
+/// the line to show, if any. Progress lines (a build starting, a cache fetch)
+/// are always emitted; per-line build logs are emitted only when `verbose`.
+#[derive(Debug, Default)]
+pub struct BuildRenderer {
+    /// build idx → package name, learned from `Start` events so later `Log`
+    /// lines carrying the same idx can be attributed.
+    names: HashMap<usize, String>,
+    verbose: bool,
+}
+
+impl BuildRenderer {
+    /// A renderer. `verbose` enables per-line build-log output; progress lines
+    /// show regardless.
+    #[must_use]
+    pub fn new(verbose: bool) -> Self {
+        Self {
+            names: HashMap::new(),
+            verbose,
+        }
+    }
+
+    /// Renders one event, returning the line to display, or `None` when the
+    /// event produces no output (a suppressed non-verbose log line, or a
+    /// `Stop`).
+    pub fn render(&mut self, event: BuildEvent) -> Option<BuildLine> {
+        match event.inner {
+            BuildEventInner::Start {
+                name, full_build, ..
+            } => {
+                let verb = if full_build { "building" } else { "up-to-date" };
+                let text = format!("{verb} {name}");
+                // Remember the name so this build's log lines can be attributed.
+                self.names.insert(event.idx, name);
+                Some(BuildLine {
+                    kind: BuildLineKind::Status,
+                    text,
+                })
+            }
+            BuildEventInner::Hydrate { name, .. } => Some(BuildLine {
+                kind: BuildLineKind::Status,
+                text: format!("fetching {name}"),
+            }),
+            BuildEventInner::Log { is_stderr, line } => {
+                if !self.verbose {
+                    return None;
+                }
+                // Attribute the line to its package when we've seen its `Start`.
+                let text = match self.names.get(&event.idx) {
+                    Some(name) => format!("{name}: {line}"),
+                    None => line,
+                };
+                let kind = if is_stderr {
+                    BuildLineKind::Stderr
+                } else {
+                    BuildLineKind::Status
+                };
+                Some(BuildLine { kind, text })
+            }
+            BuildEventInner::Stop => None,
+        }
+    }
+}


### PR DESCRIPTION
 * Session `SideOp` subsystem and lifecycle plumbed into session actor
 * `min build [--verbose] [--rebuild] <pkgs>...` command in the session shell
 * `min build [--verbose] [--rebuild] <pkgs>...` command over an ssh exec request

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `min build` side-op subsystem to `minimald` for in-session package builds
> - Adds a `session_sop` module implementing cancellable background build side-ops, with `BuildUpdate`/`BuildOutcome` event types and a `BuildSink` for streaming progress to callers.
> - Extends `SessionHandle` with `start_build()` and `patches_upload_lock()` via actor message passing; introduces `WeakSessionHandle` so in-sandbox `min` commands can reference the owning session without creating a retain cycle.
> - Adds `min build [--verbose] [--rebuild] pkgs...` as an RPC command in [env.rs](https://github.com/gominimal/minimal/pull/960/files#diff-ece548260b2c5052569423263e9b54827b352ed496728bed2f1bf4c52c251dc1) and as an SSH exec command in [exec.rs](https://github.com/gominimal/minimal/pull/960/files#diff-d7bb305c5820ba4cc947bbf8a89b209dfdd48561cadd311f40fa0149e5ef7c8b), both streaming build output and returning structured exit codes.
> - Adds a `BuildRenderer` in the `orchestrator` crate to convert `BuildEvent` streams into attributed line output; reuses it in `mip` and both `minimald` build handlers.
> - `Session::stop_running` now tears down all active side-ops before stopping the host process, fixing a leak where background build tasks could outlive the session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c3174d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `min build` support for in-sandbox builds, including `--verbose` and `--rebuild`.
  * Stream build progress back to clients with hydration and “up-to-date”/status updates, with stderr rendering enabled only for `--verbose`.
  * Enhanced SSH `exec` handling to use `min <subcommand> ...` (including `min run ...` and `min build ...`), with clearer validation and routing.
* **Bug Fixes**
  * Improved reliability and user-facing error reporting when sessions end during patch upload and when build execution can’t be started (e.g., session gone).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->