### PR TITLE
fix(minimald): reset terminal + provide message to attached sessions when shutting down

### DIFF
--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -609,14 +609,14 @@ impl Session {
                 });
             }
             SessionMessage::Stop(r) => {
-                self.stop_running().await;
+                self.stop_running(true).await;
                 #[cfg(target_os = "linux")]
                 self.deregister_hostname().await;
                 let _ = r.send(());
                 return ControlFlow::Break(Teardown::ManagerInitiated);
             }
             SessionMessage::Destroy(r) => {
-                self.stop_running().await;
+                self.stop_running(false).await;
                 // Withdraw the hostname before the fallible record delete, so
                 // a delete failure leaves a stale on-disk record (repairable
                 // on restart) but never a stale routing entry pointing at a
@@ -952,7 +952,11 @@ impl Session {
 
     /// Tears down any runtime objects, such as the host or side ops. Shutdown
     /// of these objects is complete once awaited.
-    async fn stop_running(&mut self) {
+    ///
+    /// `for_shutdown` is threaded to the host's kill so attached clients get
+    /// the daemon-shutdown message (and a terminal reset) rather than a bare
+    /// disconnect when the session dies because the daemon is going away.
+    async fn stop_running(&mut self, for_shutdown: bool) {
         let inner = match &mut self.inner {
             SessionInner::Active { host, sops, .. } => Some((host.take(), std::mem::take(sops))),
             SessionInner::Draft { .. } => None,
@@ -965,7 +969,7 @@ impl Session {
                 // Signal the process to die, then await the runtime loop so the
                 // sandbox files backing its rootfs are released before the caller
                 // removes the session's directory tree.
-                let _ = host.kill().await;
+                let _ = host.kill(for_shutdown).await;
                 let _ = task.await;
             }
         }

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -324,6 +324,7 @@ enum BindingMsg {
     TeardownDueToProcessExit(Option<std::io::Error>),
     TeardownDueToSuperceded(Vec<u8>),
     TeardownDueToDetach(Vec<u8>),
+    TeardownDueToDaemonShutdown(Vec<u8>),
 }
 
 /// A connection between a [`Host`] and an SSH channel.
@@ -379,6 +380,7 @@ impl Binding {
             Detach,
             Superceded,
             ProcessExited,
+            Shutdown,
         }
 
         // Reading from the remote stops once it sends EOF;
@@ -447,6 +449,11 @@ impl Binding {
                             let _ = w.write_all(&unwind_codes).await;
                             let _ = w.write_all(b"\r\nDisconnecting - session attached to from a different connection\r\n").await;
                             break MainloopExitReason::Superceded;
+                        }
+                        BindingMsg::TeardownDueToDaemonShutdown(unwind_codes) => {
+                            let _ = w.write_all(&unwind_codes).await;
+                            let _ = w.write_all(b"\r\nDisconnecting - minimald is shutting down\r\n").await;
+                            break MainloopExitReason::Shutdown;
                         }
                         BindingMsg::TeardownDueToDetach(unwind_codes) => {
                             let _ = w.write_all(&unwind_codes).await;
@@ -560,7 +567,7 @@ pub(crate) struct Launched<P, G> {
 
 /// Actor messages to a [`Host`].
 enum Message {
-    Kill,
+    Kill(bool),
     Attach(Channel<Msg>, WinSize),
     GetAttrs(oneshot::Sender<HostAttrs>),
 
@@ -636,8 +643,8 @@ impl HostHandle {
         }
     }
 
-    pub async fn kill(&self) -> Result<(), ()> {
-        match self.sender.send(Message::Kill).await {
+    pub async fn kill(&self, for_shutdown: bool) -> Result<(), ()> {
+        match self.sender.send(Message::Kill(for_shutdown)).await {
             Ok(()) => Ok(()),
             Err(_e) => Err(()), // closed
         }
@@ -1412,7 +1419,17 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
             // Read actor messages.
             Some(msg) = self.receiver.recv() => {
                 match msg {
-                    Message::Kill => {
+                    Message::Kill(for_shutdown) => {
+                        if for_shutdown
+                            && let Some((old_tx, old_join_hnd)) = self.remote.take() {
+                                // If there was a binding we just swapped out, tell it to
+                                // shut down and wait for it to finish.
+                                let _ = old_tx
+                                    .send(BindingMsg::TeardownDueToDaemonShutdown(self.unwind_codes()))
+                                    .await;
+                                let _ = old_join_hnd.await;
+                            }
+
                         if let Err(e) = self.process.kill() {
                             tracing::warn!(error = %e, "killing session process");
                         }
@@ -1811,7 +1828,10 @@ mod tests {
         .expect("failed to build host");
         let task = tokio::spawn(host.mainloop());
 
-        handle.kill().await.expect("kill should reach the host");
+        handle
+            .kill(false)
+            .await
+            .expect("kill should reach the host");
 
         // The mainloop must terminate (task resolves) without panicking. A
         // `JoinError` here would mean the host task panicked during teardown.
@@ -1991,7 +2011,7 @@ mod tests {
         );
 
         // Only now, on an explicit kill (destroy), is the network released.
-        handle.kill().await.expect("kill should reach the host");
+        handle.kill(true).await.expect("kill should reach the host");
         tokio::time::timeout(Duration::from_secs(10), task)
             .await
             .expect("mainloop should terminate after kill")


### PR DESCRIPTION
Actually say something and kindly reset the terminal when the session is forced to shutdown, and someone is attached.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset terminal and notify attached sessions when minimald shuts down
> - When `minimald` shuts down, attached bindings now receive a teardown message that writes unwind codes and `\r\nDisconnecting - minimald is shutting down\r\n` before closing, rather than silently disconnecting.
> - `HostHandle::kill` now accepts a `for_shutdown: bool` flag; when `true`, the host waits for the active binding to complete teardown before killing the session process.
> - `SessionMessage::Stop` passes `for_shutdown: true` and `SessionMessage::Destroy` passes `false`, preserving existing destroy behavior.
> - Behavioral Change: shutdown kills now block on binding teardown before terminating the process, which adds a small delay to daemon shutdown when sessions have active bindings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb6bd4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon shutdown handling for attached sessions.
  * Clients now receive a dedicated shutdown notification and terminal reset instead of an abrupt disconnection.
  * Normal session destruction and daemon shutdown now follow distinct teardown behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->