### PR TITLE
feat(minimal): add min add --session for parity

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -459,6 +459,9 @@ pub struct AddArgs {
 #[derive(Debug, Args)]
 #[group(required = true, multiple = false)]
 pub struct AddKind {
+    /// Add to sessions using the project
+    #[arg(long)]
+    pub session: bool,
     /// Add as a runtime dependency
     #[arg(long)]
     pub runtime: bool,
@@ -2345,6 +2348,11 @@ pub async fn cmd_add(global: &GlobalArgs, args: AddArgs) -> Result<(), mctx::Err
             &graph,
             graph.top_levels.clone(),
             mctx::AddDepMode::TaskPackages { name: task },
+        )?,
+        AddKind { session: true, .. } => ctx.add_deps(
+            &graph,
+            graph.top_levels.clone(),
+            mctx::AddDepMode::SessionPackages,
         )?,
         _ => unreachable!(),
     }


### PR DESCRIPTION
We have `min add --session` in the session shell, this adds parity when configuring a local `minimal.toml`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--session` flag to `cmd_add` in the minimal CLI for parity
> Adds a new `--session` long flag to the `AddKind` mutually exclusive group in [lib.rs](https://github.com/gominimal/minimal/pull/963/files#diff-1b62c63af5a5bd2dbc4b550bf4bc6d0fa87e649b54dc3a587da5a8fa947b3ce1). When provided, `cmd_add` calls `ctx.add_deps` with `mctx::AddDepMode::SessionPackages` using the graph's top-level packages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a10a28a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--session` option to `min add`.
  * Packages can now be added directly to the current session’s package set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->