### PR TITLE
feat(minimal): tab complete session ID/names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -2986,6 +2989,15 @@ name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "is_executable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -26,7 +26,20 @@ anyhow.workspace = true
 async-compression.workspace = true
 async-tar.workspace = true
 clap.workspace = true
-clap_complete.workspace = true
+# `unstable-dynamic` buys the completion engine behind `min`'s runtime session
+# completion. Three files depend on it:
+#
+#   completion.rs  `ArgValueCompleter` / `CompletionCandidate` — per-argument
+#                  candidates computed by the binary itself.
+#   main.rs        `CompleteEnv` — the entrypoint hook a completing shell
+#                  re-enters the binary through.
+#   lib.rs         `env::Shells` + `EnvCompleter::write_registration` — how
+#                  `min completions <shell>` renders the registration shim.
+#
+# Unstable in the semver sense: exempt from clap_complete's stability guarantee
+# and free to change under a minor bump. Those are the call sites to check when
+# it does.
+clap_complete = { workspace = true, features = ["unstable-dynamic"] }
 camino.workspace = true
 chrono.workspace = true
 constcat.workspace = true

--- a/crates/minimal/src/completion.rs
+++ b/crates/minimal/src/completion.rs
@@ -1,0 +1,282 @@
+//! Dynamic shell completion of session identifiers.
+//!
+//! Every session argument in the CLI takes "a UUID or a session name", and
+//! both are known only at runtime — nothing a statically generated completion
+//! script can enumerate. Two entry points share the one implementation here:
+//!
+//! - [`complete_session_arg`], attached to each session argument via
+//!   [`ArgValueCompleter`] and reached when a shell runs
+//!   `COMPLETE=<shell> min -- <words>` (see `CompleteEnv` in `main.rs`).
+//! - `min complete-session-str [<prefix>]`, a hidden subcommand printing the
+//!   same candidates one per line. It is what the completer would offer, minus
+//!   the shell: scriptable, and the way to debug a completion that came back
+//!   empty without a shell in the loop.
+//!
+//! Three rules hold for everything below, because the caller is a Tab press
+//! and not a person:
+//!
+//! 1. **Never autospawn.** Deliberately asymmetric with every other command,
+//!    for the same reason [`crate::cmd_stop`] is: the liveness probe runs
+//!    first, and a daemon that is down yields no candidates. Completing a name
+//!    is not worth booting a VM for, which is exactly what `ensure_daemon`
+//!    would do on macOS.
+//! 2. **Stay bounded.** The whole round-trip is capped at
+//!    [`COMPLETION_TIMEOUT`]. A Tab that hangs is worse than one that
+//!    completes nothing.
+//! 3. **Never fail.** A daemon that is down, an RPC refused by a version-skewed
+//!    server, a wedged socket — all of it degrades to an empty list. The
+//!    alternative is an error printed over the user's half-typed prompt.
+
+use std::ffi::OsStr;
+use std::time::Duration;
+
+use clap_complete::engine::{ArgValueCompleter, CompletionCandidate};
+use minimald_rpc::{ListSessions, ListSessionsEntry};
+
+use crate::GlobalArgs;
+
+/// Ceiling on a completion's daemon round-trip.
+const COMPLETION_TIMEOUT: Duration = Duration::from_millis(120);
+
+/// The name of the hidden completion subcommand, as clap spells it.
+pub const COMPLETE_SESSION_STR: &str = "complete-session-str";
+
+/// One completion candidate: the string the shell inserts, plus the
+/// description zsh and fish render beside it (bash discards it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionCandidate {
+    /// The session name or UUID to insert.
+    pub value: String,
+    /// Human-facing context for disambiguating same-looking sessions.
+    pub description: Option<String>,
+}
+
+/// The [`ArgValueCompleter`] to attach to a session argument.
+///
+/// A function rather than a closure so every session argument shares one
+/// implementation and the `#[arg(add = ...)]` attributes stay one line each.
+pub fn session_completer() -> ArgValueCompleter {
+    ArgValueCompleter::new(complete_session_arg)
+}
+
+/// Complete a session argument whose typed-so-far value is `current`.
+///
+/// Runs on the shell's completion path, which is synchronous and — because
+/// `CompleteEnv` is invoked before the CLI's runtime exists — has no reactor
+/// on this thread. It therefore drives its own current-thread runtime rather
+/// than blocking on an ambient one.
+///
+/// A non-UTF-8 prefix cannot prefix-match a name or a UUID, so it yields
+/// nothing rather than lossily converting into a match the user did not type.
+pub fn complete_session_arg(current: &OsStr) -> Vec<CompletionCandidate> {
+    let Some(prefix) = current.to_str() else {
+        return Vec::new();
+    };
+
+    let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        return Vec::new();
+    };
+
+    // The completer has no access to the rest of the command line: clap hands
+    // a value completer the current word and nothing else, so a `--provider`
+    // or `--minimal-dir` earlier in the line cannot be honoured here.
+    let global = GlobalArgs::default();
+    let candidates = runtime.block_on(session_candidates(&global, prefix));
+
+    candidates
+        .into_iter()
+        .map(|c| CompletionCandidate::new(c.value).help(c.description.map(Into::into)))
+        .collect()
+}
+
+/// The candidates for `prefix`, or an empty list when the daemon cannot be
+/// reached within [`COMPLETION_TIMEOUT`].
+pub async fn session_candidates(global: &GlobalArgs, prefix: &str) -> Vec<SessionCandidate> {
+    match fetch_sessions(global).await {
+        Some(sessions) => candidates_from(&sessions, prefix),
+        None => Vec::new(),
+    }
+}
+
+/// One `ListSessions` round-trip against an already-running daemon, or `None`
+/// if there isn't one, it didn't answer in time, or it answered with an error.
+async fn fetch_sessions(global: &GlobalArgs) -> Option<Vec<ListSessionsEntry>> {
+    if !crate::autospawn::is_daemon_running(global.use_minvmd(), global.minimal_dir.as_deref())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let rpc = async {
+        let mut client = crate::connect_daemon(global).await.ok()?;
+        let response = client.oneshot_rpc::<ListSessions>(()).await.ok()?;
+        Some(response.sessions)
+    };
+
+    tokio::time::timeout(COMPLETION_TIMEOUT, rpc).await.ok()?
+}
+
+/// Turn a session list into the candidates matching `prefix`.
+///
+/// Split from the RPC so the offering rules below are testable without a
+/// daemon — they are the part with actual behaviour in them.
+fn candidates_from(sessions: &[ListSessionsEntry], prefix: &str) -> Vec<SessionCandidate> {
+    let mut candidates = Vec::new();
+
+    for entry in sessions {
+        let description = describe(entry);
+
+        if let Some(name) = &entry.name
+            && name.starts_with(prefix)
+        {
+            candidates.push(SessionCandidate {
+                value: name.clone(),
+                description: description.clone(),
+            });
+        }
+
+        // A UUID is 36 characters of noise beside a handful of short names, so
+        // an ID is offered only when it is the sole way to name the session,
+        // or when the user has already typed something that could be an ID
+        // prefix. That is the same line `SessionLookup::parse` draws between
+        // the two forms, applied one keystroke earlier: an empty prefix means
+        // "show me the sessions", which is the names.
+        let id = entry.id.to_string();
+        if (entry.name.is_none() || !prefix.is_empty()) && id.starts_with(prefix) {
+            candidates.push(SessionCandidate {
+                value: id,
+                description,
+            });
+        }
+    }
+
+    candidates
+}
+
+/// The description shown beside a candidate: the session's terminal title if
+/// it has one, else the project directory it was built from.
+///
+/// Both are the things that distinguish two sessions the user would otherwise
+/// have to tell apart by UUID.
+fn describe(entry: &ListSessionsEntry) -> Option<String> {
+    if let Some(attrs) = &entry.attrs
+        && let Some(title) = &attrs.title
+        && !title.value.is_empty()
+    {
+        return Some(title.value.clone());
+    }
+
+    entry
+        .project_path
+        .as_ref()
+        .map(|path| path.as_str().to_string())
+}
+
+/// Print the candidates for `prefix`, one per line as `value<TAB>description`.
+///
+/// Always succeeds, and prints nothing when there is nothing to offer — the
+/// caller is a shell, and an exit code it would have to interpret is worse
+/// than silence.
+pub async fn cmd_complete_session_str(
+    global: &GlobalArgs,
+    args: crate::CompleteSessionStrArgs,
+) -> Result<(), anyhow::Error> {
+    let prefix = args.prefix.unwrap_or_default();
+    let mut out = String::new();
+
+    for candidate in session_candidates(global, &prefix).await {
+        out.push_str(&candidate.value);
+        if let Some(description) = &candidate.description {
+            out.push('\t');
+            out.push_str(description);
+        }
+        out.push('\n');
+    }
+
+    // One write, ignoring a closed stdout: a shell that has already collected
+    // enough candidates closes the pipe, and EPIPE there is not an error worth
+    // reporting to a user who is mid-keystroke.
+    use std::io::Write as _;
+    let _ = std::io::stdout().write_all(out.as_bytes());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sessions::SessionId;
+
+    fn entry(id: &str, name: Option<&str>) -> ListSessionsEntry {
+        ListSessionsEntry {
+            id: SessionId::parse_str(id).expect("valid test uuid"),
+            name: name.map(str::to_string),
+            project_path: None,
+            status: Default::default(),
+            attrs: None,
+        }
+    }
+
+    const ID_A: &str = "019f5d80-ff86-7322-8846-18b49b6aae89";
+    const ID_B: &str = "abcdef01-0000-7000-8000-000000000000";
+
+    #[test]
+    fn empty_prefix_offers_names_but_not_their_ids() {
+        let sessions = [entry(ID_A, Some("mars"))];
+        let got = candidates_from(&sessions, "");
+
+        assert_eq!(
+            got.iter().map(|c| c.value.as_str()).collect::<Vec<_>>(),
+            ["mars"],
+            "a bare Tab should list names, not pad them with 36-char UUIDs"
+        );
+    }
+
+    #[test]
+    fn a_nameless_session_offers_its_id_even_with_an_empty_prefix() {
+        let sessions = [entry(ID_A, None)];
+        let got = candidates_from(&sessions, "");
+
+        assert_eq!(
+            got.iter().map(|c| c.value.as_str()).collect::<Vec<_>>(),
+            [ID_A],
+            "the ID is the only way to name an unnamed session"
+        );
+    }
+
+    #[test]
+    fn a_typed_prefix_matches_names_and_ids_alike() {
+        let sessions = [entry(ID_A, Some("mars")), entry(ID_B, Some("moon"))];
+
+        let by_name = candidates_from(&sessions, "ma");
+        assert_eq!(
+            by_name.iter().map(|c| c.value.as_str()).collect::<Vec<_>>(),
+            ["mars"]
+        );
+
+        let by_id = candidates_from(&sessions, "019");
+        assert_eq!(
+            by_id.iter().map(|c| c.value.as_str()).collect::<Vec<_>>(),
+            [ID_A],
+            "an ID prefix should reach the ID once the user commits to typing one"
+        );
+    }
+
+    #[test]
+    fn a_prefix_matching_nothing_yields_nothing() {
+        let sessions = [entry(ID_A, Some("mars"))];
+        assert!(candidates_from(&sessions, "zz").is_empty());
+    }
+
+    #[test]
+    fn the_project_path_describes_a_session_without_a_title() {
+        let mut e = entry(ID_A, Some("mars"));
+        e.project_path =
+            Some(paths::HostAbsPath::try_new("/home/dev/minimal").expect("absolute test path"));
+
+        let got = candidates_from(&[e], "");
+        assert_eq!(got[0].description.as_deref(), Some("/home/dev/minimal"));
+    }
+}

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -1,7 +1,7 @@
 //! The minimal CLI which pairs/talks-with minimald.
 
 use anyhow::{Context as _, bail};
-use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use clap_complete::Shell;
 use std::io::IsTerminal as _;
 use std::io::Write as _;
@@ -12,6 +12,7 @@ use tokio::io::AsyncWriteExt as _;
 mod attach;
 pub mod autospawn;
 pub mod client;
+pub mod completion;
 pub mod config;
 pub mod diag;
 pub mod dirs;
@@ -124,6 +125,17 @@ pub enum Command {
     /// on Ctrl-C, whichever comes first.
     #[command(hide = true)]
     Spin(SpinArgs),
+    /// Print session-identifier completion candidates (used by the shell).
+    ///
+    /// The completion path a shell actually takes runs in-process (see
+    /// `completion.rs`); this is the same candidate list on stdout, one
+    /// `value<TAB>description` per line. It exists to be debugged by hand and
+    /// scripted against, and to honour global args — `--provider`,
+    /// `--minimal-dir` — that the in-process completer cannot see.
+    ///
+    /// Never starts a daemon and never fails: no daemon means no output.
+    #[command(name = completion::COMPLETE_SESSION_STR, hide = true)]
+    CompleteSessionStr(CompleteSessionStrArgs),
     /// Generate shell completion script
     #[command(
         long_about = "Generate a shell tab-completion script for the min CLI.\nSupported shells include bash, zsh, elvish and fish.\n\n   source <(min completions bash)"
@@ -146,6 +158,7 @@ pub enum SessionCommand {
 #[derive(Debug, Args)]
 pub struct PolicyArgs {
     /// Session identifier (UUID or session name)
+    #[arg(add = completion::session_completer())]
     pub session: String,
 }
 
@@ -395,6 +408,7 @@ pub struct AttachArgs {
     /// resolves a session from the current working directory (or the only
     /// existing session), and opens an interactive picker if the choice is
     /// ambiguous. See `--no-input` to skip the picker in scripts.
+    #[arg(add = completion::session_completer())]
     pub session: Option<String>,
     /// Command to exec in the session context (non-interactive)
     #[arg(long, short)]
@@ -414,7 +428,11 @@ pub struct LsArgs {
 #[derive(Debug, Args)]
 pub struct DestroyArgs {
     /// Session identifier (UUID or session name)
-    #[arg(required_unless_present = "all", conflicts_with = "all")]
+    #[arg(
+        required_unless_present = "all",
+        conflicts_with = "all",
+        add = completion::session_completer()
+    )]
     pub session: Option<String>,
     /// Destroy all sessions
     #[arg(long)]
@@ -434,6 +452,7 @@ pub struct StopArgs {
 #[derive(Debug, Args)]
 pub struct RenameArgs {
     /// Session identifier (UUID or session name)
+    #[arg(add = completion::session_completer())]
     pub session: String,
     /// New name for the session
     pub new_name: String,
@@ -496,6 +515,7 @@ pub struct ProxyArgs {
 #[derive(Debug, Args)]
 pub struct SshForwardArgs {
     /// Session identifier (UUID or session name)
+    #[arg(add = completion::session_completer())]
     pub session: String,
     /// Port-forward specification: `<local-port>:<remote-host>:<remote-port>`
     ///
@@ -512,6 +532,13 @@ pub struct LoginArgs {
     /// (default: `~/.config/minimal/`).
     #[arg(long)]
     pub cert_dir: Option<PathBuf>,
+}
+
+/// Arguments for the hidden `min complete-session-str`.
+#[derive(Debug, Args)]
+pub struct CompleteSessionStrArgs {
+    /// Only offer candidates starting with this prefix (default: all).
+    pub prefix: Option<String>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -585,12 +612,10 @@ async fn run_command(cli: Cli) -> Result<(), anyhow::Error> {
         Some(Command::Update(args)) => cmd_update(&cli.global_args, args)
             .await
             .map_err(|e| anyhow::anyhow!("{e}")),
-        Some(Command::Completions(CompletionsArgs { shell })) => {
-            let mut cmd = Cli::command();
-            let name = cmd.get_name().to_string();
-            clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
-            Ok(())
+        Some(Command::CompleteSessionStr(args)) => {
+            completion::cmd_complete_session_str(&cli.global_args, args).await
         }
+        Some(Command::Completions(CompletionsArgs { shell })) => cmd_completions(shell),
     }
 }
 
@@ -781,6 +806,47 @@ fn confirm(question: &str, default: bool) -> Result<bool, anyhow::Error> {
         trimmed.eq_ignore_ascii_case("y") || trimmed.eq_ignore_ascii_case("yes")
     })
 }
+
+/// Print the shell integration for `shell` on stdout.
+///
+/// This is a *registration* shim, not a completion table: a dozen lines that
+/// teach the shell to ask `min` itself what to complete, rather than the
+/// thousand-line static script this used to emit. That indirection is the
+/// whole point — session names and IDs only exist at runtime, so a table
+/// baked at install time cannot contain them (see `completion.rs`).
+///
+/// The installed file paths are unchanged, and so is
+/// `scripts/install.sh` (R9.3): zsh's shim still opens with `#compdef min`,
+/// so it autoloads from an fpath dir as `_min`, and bash's and fish's are
+/// still plain source-able files.
+///
+/// The shim calls `min` by bare name so it resolves through `PATH` — an
+/// upgrade that moves the binary keeps working, and the installer puts its
+/// bindir on `PATH` in the same breath as writing this file.
+fn cmd_completions(shell: Shell) -> Result<(), anyhow::Error> {
+    let name = shell.to_string();
+    let shells = clap_complete::env::Shells::builtins();
+    let completer = shells
+        .completer(&name)
+        .with_context(|| format!("no shell integration for `{name}`"))?;
+
+    let mut out = Vec::new();
+    completer
+        .write_registration(COMPLETE_VAR, "min", "min", "min", &mut out)
+        .context("render shell integration")?;
+
+    std::io::stdout()
+        .write_all(&out)
+        .context("write shell integration to stdout")?;
+    Ok(())
+}
+
+/// The environment variable a shell sets to ask `min` for completions.
+///
+/// clap_complete's default, named here because both ends have to agree: the
+/// shim emitted by [`cmd_completions`] sets it, and the `CompleteEnv` call in
+/// `main.rs` reads it.
+pub const COMPLETE_VAR: &str = "COMPLETE";
 
 /// List sessions via the `ListSessions` RPC.
 pub async fn cmd_ls(global: &GlobalArgs, args: LsArgs) -> Result<(), anyhow::Error> {

--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -2,11 +2,20 @@
 
 use std::process::ExitCode;
 
-use clap::Parser;
+use clap::{CommandFactory as _, Parser};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+/// Custom main: handle shell completion requests before launching the async world.
+fn main() -> ExitCode {
+    clap_complete::CompleteEnv::with_factory(minimal::Cli::command)
+        .var(minimal::COMPLETE_VAR)
+        .complete();
+
+    run()
+}
+
 #[tokio::main]
-async fn main() -> ExitCode {
+async fn run() -> ExitCode {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new("info")
             .add_directive("topiary=off".parse().unwrap())
@@ -31,12 +40,20 @@ async fn main() -> ExitCode {
         };
     }
 
-    tracing_subscriber::registry()
-        .with(fmt::layer().with_writer(ot::StdoutWriter::new))
-        .with(filter)
-        .init();
-
+    // Parse before installing the subscriber, so the shell completion handler can
+    // be configured to log to stderr instead of stdout.
     let cli = minimal::Cli::parse();
+
+    let registry = tracing_subscriber::registry().with(filter);
+    if matches!(cli.command, Some(minimal::Command::CompleteSessionStr(_))) {
+        registry
+            .with(fmt::layer().with_writer(std::io::stderr))
+            .init();
+    } else {
+        registry
+            .with(fmt::layer().with_writer(ot::StdoutWriter::new))
+            .init();
+    }
 
     if let Err(e) = minimal::run(cli).await {
         eprintln!("error: {e:#}");

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -175,6 +175,31 @@ min completions <SHELL>
 Generates a shell tab-completion script. Supported shells include `bash`, `zsh`,
 `elvish`, `fish`. Usage: `source <(min completions bash)`.
 
+What it emits is a short *registration* shim, not a completion table: it teaches
+the shell to ask `min` itself what to offer. That indirection is what makes
+session arguments completable — `min attach <TAB>` lists live session names, and
+`min attach 019<TAB>` lists session IDs, neither of which exists at the time a
+static script would be written. Every argument documented as "UUID or session
+name" completes this way: `attach`, `destroy`, `rename`, `session policy`, and
+`ssh-forward`.
+
+Session completion is best-effort by design. It never starts a daemon — with
+none running there is nothing to list, and booting a VM on a keystroke would be
+a poor trade — and it gives up rather than make you wait if the daemon does not
+answer promptly. In both cases the shell simply offers nothing.
+
+To see the candidates without a shell in the loop, or to check completion
+against a non-default backend:
+
+```
+min complete-session-str [<prefix>]              # value<TAB>description per line
+min --provider local-minvmd complete-session-str # honours global args
+```
+
+The in-process completer cannot see global args (clap hands a value completer
+only the word being typed), so it always resolves the default backend; this
+hidden command is the way to check any other.
+
 ## `git push min://` - the git remote helper
 
 Installs of `min` lay down a `bin/git-remote-min` symlink pointing at the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dynamic shell completion for session names and UUIDs across session-related commands.
  - Completion candidates now include contextual descriptions (e.g., terminal titles or project paths).
  - Shell completion now uses a registration “shim” and fetches session candidates on-demand (best-effort; returns no candidates if the backend can’t respond quickly).
- **Documentation**
  - Updated CLI reference for `min completions <SHELL>` to explain the registration shim and the dynamic, best-effort completion behavior.
  - Added examples for the hidden completion inspection command (`min complete-session-str`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tab completion for session IDs and names in the `min` CLI
> - Adds dynamic shell completion for session arguments (`attach`, `destroy`, `rename`, `session policy`, `ssh-forward`) by querying live sessions via a bounded, non-autospawning RPC with a short timeout.
> - Introduces a new hidden `complete-session-str` subcommand that prints `value<TAB>description` lines for debugging and scripting.
> - Changes `min completions <shell>` to emit a dynamic-registration shim instead of a static completion table.
> - Completion candidates prefer session names; IDs are shown for unnamed sessions or when the prefix matches an ID.
> - Behavioral Change: `min completions <shell>` output changes from a static script to a dynamic shim — users must re-source or reinstall their completion setup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 290d2f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->