### PR TITLE
chore(sessions): don't compose lifecycle hooks until we finish implementing them

### DIFF
--- a/crates/mfile/src/project_composable.rs
+++ b/crates/mfile/src/project_composable.rs
@@ -62,6 +62,11 @@ impl Composable for ProjectComposable {
         let source = Source::Project {
             path: self.project_path,
         };
+        // Session transition scripts declared in a project `[session]`
+        // block are accepted and composed like any other primitive; the
+        // feature is gated off for this release purely at the output and
+        // execution layers (see `crates/minimald/src/session_host.rs`),
+        // not by dropping them here.
         contribute_primitives(
             &source,
             self.session.packages,
@@ -114,6 +119,9 @@ mod tests {
         assert_eq!(contribution.vars().len(), 2);
         assert_eq!(contribution.patches().len(), 1);
         assert_eq!(contribution.packages().len(), 2);
+        // A declared project hook is accepted and composed — the feature
+        // is disabled downstream (output + execution), not by dropping it
+        // here.
         assert_eq!(contribution.lifecycle_hooks().len(), 1);
 
         // Provenance is Source::Project everywhere, carrying the

--- a/crates/minimal/src/loadouts.rs
+++ b/crates/minimal/src/loadouts.rs
@@ -99,6 +99,16 @@ pub(crate) fn compose_user_contribution(
     ),
     anyhow::Error,
 > {
+    // Session transition scripts declared in a loadout are not available
+    // in this release, so they are silently excluded here — before the
+    // loadouts reach the composer — rather than after composition. This
+    // keeps a declared hook from participating in composition at all.
+    // Drop the `without_lifecycle_hooks` map when the feature ships.
+    let loadouts: Vec<_> = loadouts
+        .into_iter()
+        .map(sessions::core::loadout::Loadout::without_lifecycle_hooks)
+        .collect();
+
     let mut composer = sessions::client::composer::UserComposer::new();
     composer
         .add_all(loadouts)
@@ -232,11 +242,10 @@ impl LoadoutRow {
                 name: entry.file_stem.clone(),
                 desc: l.description().unwrap_or("").to_string(),
                 counts: format!(
-                    "{} pkg / {} var / {} patch / {} hook",
+                    "{} pkg / {} var / {} patch",
                     l.packages().len(),
                     l.vars().len() + l.vars_lenient().len(),
                     l.patches().iter().count(),
-                    l.lifecycle_hooks().len(),
                 ),
             },
             Err(e) => Self {
@@ -312,5 +321,45 @@ mod tests {
         };
         let selection = LoadoutSelection::Cli(vec!["missing".to_string()]);
         assert!(resolve_active_loadouts(selection, &cfg, &global).is_err());
+    }
+
+    /// A loadout that declares a session transition script still composes
+    /// cleanly: the hook is excluded before composition (see
+    /// [`compose_user_contribution`]), so it neither errors nor lands in
+    /// the wire contribution, while the loadout's other items compose
+    /// normally.
+    #[test]
+    fn loadout_lifecycle_hook_is_excluded_without_affecting_composition() {
+        let loadout: sessions::core::loadout::Loadout = toml::from_str(
+            r#"
+name = "dev"
+packages = ["helix"]
+
+[vars]
+EDITOR = "hx"
+
+[[lifecycle_hooks]]
+on_activate = { type = "inline", value = "echo activated" }
+"#,
+        )
+        .expect("loadout parses");
+        // Sanity: the hook really is present on the loadout we feed in.
+        assert_eq!(loadout.lifecycle_hooks().len(), 1);
+
+        let (wire, _policy) = compose_user_contribution(
+            vec![loadout],
+            sessions::core::policy::UserPolicy::empty(),
+            sessions::core::compose::ComposeOptions::default(),
+        )
+        .expect("composition succeeds despite the declared hook");
+
+        // The declared hook is silently excluded...
+        assert!(
+            wire.lifecycle_hooks.is_empty(),
+            "declared lifecycle hook must be excluded from the contribution"
+        );
+        // ...while the loadout's other items compose normally.
+        assert_eq!(wire.requested_packages.len(), 1);
+        assert_eq!(wire.vars.len(), 1);
     }
 }

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -162,10 +162,10 @@ impl Pty {
 }
 
 /// Emit one `tracing::info!` per item the launcher folds into the
-/// session — packages, vars, patches, and lifecycle hooks —
-/// tagging each with its provenance so an operator can trace
-/// "where did `EDITOR=hx` come from?" back to the loadout /
-/// project / package that contributed it.
+/// session — packages, vars, and patches — tagging each with its
+/// provenance so an operator can trace "where did `EDITOR=hx` come
+/// from?" back to the loadout / project / package that contributed
+/// it.
 ///
 /// Baseline items (the launcher-defaults `PS1`, `base`, `coreutils`,
 /// `socat`) log with `source = "launcher-baseline"` so they can be
@@ -241,32 +241,36 @@ fn log_session_contents(
             "session content (patch: materialized into session home at FinalizeSession)",
         );
     }
-    for h in comp.lifecycle_hooks() {
-        let src = sessions::core::source::Provenanced::source(h);
-        let hook = h.hook();
-        [
-            ("on_activate", hook.on_activate()),
-            ("on_destroy", hook.on_destroy()),
-            ("on_failure", hook.on_failure()),
-        ]
-        .into_iter()
-        .filter_map(|(event, script)| script.map(|s| (event, s)))
-        .for_each(|(event, script)| {
-            let kind = match script {
-                sessions::core::lifecyclehook::HookScript::Inline(_) => "inline",
-                sessions::core::lifecyclehook::HookScript::External(_) => "external",
-            };
-            tracing::info!(
-                session = session_name,
-                domain = "lifecycle_hook",
-                event = event,
-                script_kind = kind,
-                source = ?src,
-                deferred = true,
-                "session content (lifecycle hook: exec plumbing deferred)",
-            );
-        });
-    }
+    // Session transition scripts are gated off for this release. A hook
+    // declared in a project `[session]` block is still accepted and
+    // composed into the session — it is disabled here, at the output
+    // layer, by suppressing the content-logging loop below (and it is
+    // never executed, as exec is deferred), rather than being refused at
+    // compose time. Restore the loop when the feature ships. (Hooks from
+    // loadouts are excluded earlier, before client-side composition — see
+    // `crates/minimal/src/loadouts.rs`.)
+    //
+    // for h in comp.lifecycle_hooks() {
+    //     let src = sessions::core::source::Provenanced::source(h);
+    //     let hook = h.hook();
+    //     [
+    //         ("on_activate", hook.on_activate()),
+    //         ("on_destroy", hook.on_destroy()),
+    //         ("on_failure", hook.on_failure()),
+    //     ]
+    //     .into_iter()
+    //     .filter_map(|(event, script)| script.map(|s| (event, s)))
+    //     .for_each(|(event, script)| {
+    //         let kind = match script {
+    //             sessions::core::lifecyclehook::HookScript::Inline(_) => "inline",
+    //             sessions::core::lifecyclehook::HookScript::External(_) => "external",
+    //         };
+    //         tracing::info!(
+    //             session = session_name,
+    //             ...
+    //         );
+    //     });
+    // }
 }
 
 /// Duplicate `fd` into a new close-on-exec `OwnedFd` via

--- a/crates/sessions/example_project/minimal.toml
+++ b/crates/sessions/example_project/minimal.toml
@@ -54,10 +54,10 @@
 
 [upstream]
 repo = "https://github.com/gominimal/pkgs"
-branch = "main"
+branch = "unstable"
 # Reused from the workspace's own `minimal.toml` — guaranteed to
 # resolve as long as that pin does.
-locked_commit = "23193970569b93e5e7a980aa598c3342c386d33f"
+locked_commit = "75884ceb9d227e7c97642ccdfff01fecbb8380a1"
 
 [stack]
 use = "shell"

--- a/crates/sessions/src/core/loadout.rs
+++ b/crates/sessions/src/core/loadout.rs
@@ -185,6 +185,16 @@ impl Loadout {
         new
     }
 
+    /// Drop every lifecycle hook from this loadout, returning the
+    /// hookless loadout. Used to exclude session transition scripts
+    /// before composition while the feature is gated off for a release,
+    /// so a declared hook cannot participate in composition at all.
+    #[must_use]
+    pub fn without_lifecycle_hooks(mut self) -> Self {
+        self.lifecycle_hooks.clear();
+        self
+    }
+
     /// Override the composer's default follow-symlinks behavior for
     /// this loadout's patches.
     #[must_use]

--- a/crates/sessions/src/daemon/composer.rs
+++ b/crates/sessions/src/daemon/composer.rs
@@ -172,7 +172,6 @@ impl SessionComposer {
             daemon_vars = vars.len(),
             daemon_patches = patches.len(),
             daemon_packages = packages.len(),
-            daemon_lifecycle_hooks = lifecycle_hooks.len(),
             "compose: daemon-side contribution collected",
         );
         if vars.is_empty() && patches.is_empty() {


### PR DESCRIPTION
## Summary

Lifecycle hooks won't be ready for open source launch, so for now we won't compose them in and won't print any output about them.

## Testing

Activated a session with a loadout that had a lifecycle hook defined and verified that there were no log messages about it

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate lifecycle hooks out of session composition before full implementation
> - Adds `Loadout::without_lifecycle_hooks` in [loadout.rs](https://github.com/gominimal/minimal/pull/975/files#diff-a86b16b1a266f81af7a3952e1a1127e44cf85c2a6e138f280af06a5668a58285) to strip lifecycle hooks from a loadout, used as a feature gate until hooks are fully implemented.
> - `compose_user_contribution` in [loadouts.rs](https://github.com/gominimal/minimal/pull/975/files#diff-ad282685b575b15a3ae014f466c2e2fdc73824ca16264b7603aec71ba7e5be3f) now drops lifecycle hooks from user loadouts before building the `UserComposer`, so no hooks appear in the resulting `WireContribution`.
> - Removes lifecycle hook count from the loadout listing display and from compose-time tracing logs in [session_host.rs](https://github.com/gominimal/minimal/pull/975/files#diff-ffcaac1a766e1712e9d5e9d4b54b8abaeb63c6137b5865acf411a835d3a8e39e) and [composer.rs](https://github.com/gominimal/minimal/pull/975/files#diff-7cf0a51983ffce8f78ac08cfec5718be1cafcbd265029a3dfbf1660fcf5d3564).
> - Behavioral Change: lifecycle hooks declared in user loadouts are silently excluded from composed sessions until this gating is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26cd1d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lifecycle hooks declared in sessions and loadouts are no longer included in composed contributions.
  * Session content logging no longer reports lifecycle-hook details, and daemon lifecycle hook counts are no longer logged.
  * Loadout listings now show package/variable/patch counts only.
* **New Features**
  * Added a `Loadout` helper to remove lifecycle hooks before composing.
* **Configuration**
  * Updated the example project upstream tracking to `unstable` with a new locked revision.
* **Tests**
  * Added coverage ensuring hook-containing loadouts are excluded from the resulting wire contribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->