### PR TITLE
feat!(mip,minimald): turn down build/test/shell shorthands, move pkg cmds under subcmd

### DIFF
--- a/crates/mctx/src/min_helper.sh
+++ b/crates/mctx/src/min_helper.sh
@@ -110,6 +110,25 @@ min_run() {
     __min_rpc "run" "$@"
 }
 
+min_package() {
+    local subcmd="$1"
+    shift
+
+    case "$subcmd" in
+        patched-build)
+            min_patched_pkg "$@"
+            ;;
+        build)
+            echo "error: 'build' subcommand not supported in mip sandbox." >&2
+            return 1
+            ;;
+        *)
+            echo "error: unknown subcommand '$subcmd'. Expected 'patched-build'" >&2
+            return 1
+            ;;
+    esac
+}
+
 min_check() {
     __min_rpc "check" "$@"
 }
@@ -128,14 +147,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         run)
             min_run "$@"
             ;;
-        build)
-            min_run build
-            ;;
-        test)
-            min_run test
-            ;;
-        patched-pkg)
-            min_patched_pkg "$@"
+        package|pkg)
+            min_package "$@"
             ;;
         check)
             min_check "$@"
@@ -147,7 +160,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
             echo "Search for packages: min search <query>" >&2
             echo "Check minimal configuration: min check" >&2
             echo "Run a task: min run <task name>" >&2
-            echo "Try building a package (with potentially-stale dependencies): min patched-pkg <package name>" >&2
+            echo "Try building a package (with potentially-stale dependencies): min package patched-build <package name>" >&2
             exit 1
             ;;
     esac

--- a/crates/minimald/src/env_min_helper.sh
+++ b/crates/minimald/src/env_min_helper.sh
@@ -108,8 +108,22 @@ min_run() {
     __min_rpc "run" "$@"
 }
 
-min_build() {
-    __min_rpc "build" "$@"
+min_package() {
+    local subcmd="$1"
+    shift
+
+    case "$subcmd" in
+        patched-build)
+            min_patched_pkg "$@"
+            ;;
+        build)
+            __min_rpc "build" "$@"
+            ;;
+        *)
+            echo "error: unknown subcommand '$subcmd'. Expected 'build' or 'patched-build'" >&2
+            return 1
+            ;;
+    esac
 }
 
 min_check() {
@@ -130,14 +144,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         run)
             min_run "$@"
             ;;
-        build)
-            min_build "$@"
-            ;;
-        test)
-            min_run test
-            ;;
-        patched-pkg)
-            min_patched_pkg "$@"
+        package|pkg)
+            min_package "$@"
             ;;
         check)
             min_check "$@"
@@ -149,8 +157,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
             echo "Search for packages: min search <query>" >&2
             echo "Check minimal configuration: min check" >&2
             echo "Run a task: min run <task name>" >&2
-            echo "Build packages: min build [packages]" >&2
-            echo "Try building a package (with potentially-stale dependencies): min patched-pkg <package name>" >&2
+            echo "Build packages: min package build <packages>" >&2
+            echo "Try building a package (with potentially-stale dependencies): min package patched-build <package name>" >&2
             exit 1
             ;;
     esac

--- a/crates/mip/src/cmd_pkg.rs
+++ b/crates/mip/src/cmd_pkg.rs
@@ -1,11 +1,35 @@
+use crate::cmd_pkg_build_plan::{PkgBuildPlanArgs, cmd_pkg_build_plan};
+use crate::cmd_pkg_dep::{PkgDepArgs, cmd_pkg_dep};
+use crate::cmd_pkg_patched_build::{PkgPatchedBuildArgs, cmd_pkg_patched_build};
+use crate::cmd_pkg_upload_cache::{PkgUploadCacheArgs, cmd_pkg_upload_cache};
 use futures::channel::mpsc;
 use graph::Graph;
 use mctx::{Cache, Context, Error};
 use orchestrator::{BuildEvent, BuildLineKind, BuildRenderer};
 use tracing::{info, trace};
 
+#[derive(Debug, clap::Subcommand)]
+pub enum PkgCmd {
+    /// Builds the specified package(s) in a clean room, making them available in the local cache.
+    Build(PkgBuildArgs),
+    /// Prints the build plan for the specified package(s)
+    #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
+    BuildPlan(PkgBuildPlanArgs),
+    /// Generates Graphviz source code of the dependency graph
+    #[command(
+        long_about = "Generate an image of the dependency graph using graphviz's \"dot\" program.\n\n  mip package dep --input-deps-depth=0 | dot -Tpng > deps.png"
+    )]
+    Dep(PkgDepArgs),
+    /// Executes the build for a package, using stale dependencies.
+    #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
+    PatchedBuild(PkgPatchedBuildArgs),
+    /// Uploads the specified packages and their transitive needs to the cache.
+    #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
+    UploadCache(PkgUploadCacheArgs),
+}
+
 #[derive(Debug, clap::Args)]
-pub struct PkgArgs {
+pub struct PkgBuildArgs {
     /// Whether to log stdout/stderr during the build
     #[arg(short, long, default_value_t = false)]
     verbose: bool,
@@ -18,8 +42,18 @@ pub struct PkgArgs {
     packages: Vec<String>,
 }
 
-pub async fn cmd_pkg(args: PkgArgs, ctx: &mut Context) -> Result<(), Error> {
-    trace!("cmd_pkg");
+pub async fn cmd_pkg(sub_command: PkgCmd, ctx: &mut Context) -> Result<(), Error> {
+    match sub_command {
+        PkgCmd::Build(args) => cmd_pkg_build(args, ctx).await,
+        PkgCmd::BuildPlan(args) => cmd_pkg_build_plan(args, ctx).await,
+        PkgCmd::Dep(args) => cmd_pkg_dep(args, ctx).await,
+        PkgCmd::PatchedBuild(args) => cmd_pkg_patched_build(args, ctx).await,
+        PkgCmd::UploadCache(args) => cmd_pkg_upload_cache(args, ctx).await,
+    }
+}
+
+pub async fn cmd_pkg_build(args: PkgBuildArgs, ctx: &mut Context) -> Result<(), Error> {
+    trace!("cmd_pkg_build");
     let graph = if !args.packages.is_empty() {
         ctx.graph_from_package_names(args.packages.clone())?
     } else {

--- a/crates/mip/src/cmd_pkg_build_plan.rs
+++ b/crates/mip/src/cmd_pkg_build_plan.rs
@@ -3,14 +3,14 @@ use lcache::CacheBinProvider;
 use mctx::{Cache, Context, Error};
 use rcache::RemoteBinProvider;
 
-#[derive(clap::Args)]
-pub struct PlanArgs {
+#[derive(Debug, clap::Args)]
+pub struct PkgBuildPlanArgs {
     /// Packages to plan
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args=0..)]
     packages: Vec<String>,
 }
 
-pub async fn cmd_plan(args: PlanArgs, ctx: &mut Context) -> Result<(), Error> {
+pub async fn cmd_pkg_build_plan(args: PkgBuildPlanArgs, ctx: &mut Context) -> Result<(), Error> {
     let graph = if !args.packages.is_empty() {
         ctx.graph_from_package_names(args.packages.clone())?
     } else {

--- a/crates/mip/src/cmd_pkg_dep.rs
+++ b/crates/mip/src/cmd_pkg_dep.rs
@@ -23,7 +23,7 @@ enum OutputFormat {
 
 /// CLI options to control what goes in the generated graph
 #[derive(Debug, clap::Args)]
-pub struct DepArgs {
+pub struct PkgDepArgs {
     /// Packages left out of graph and not traversed. Overrides matching package entries
     #[arg(short, long, alias="exclude", value_delimiter=',', num_args=0..)]
     excludes: Option<Vec<String>>,
@@ -332,7 +332,7 @@ fn pgraph_copy_subset(
     graph: &Graph,
     pgraph: &DiGraph<NodeData, EdgeData>,
     bsname_to_node_index: &HashMap<String, NodeIndex>,
-    args: &DepArgs,
+    args: &PkgDepArgs,
 ) -> Result<DiGraph<NodeData, EdgeData>, Error> {
     // if the listest packages with -p reduce to just those node indices
     let node_indices = if !args.packages.is_empty() {
@@ -372,7 +372,7 @@ fn pgraph_copy_subset(
 fn pgraph_copy_subset_for_node(
     graph: &Graph,
     pgraph: &DiGraph<NodeData, EdgeData>,
-    args: &DepArgs,
+    args: &PkgDepArgs,
     node_index: NodeIndex,
     bsr: &BuildSpecRef,
     state: &TraversalState,
@@ -539,7 +539,7 @@ fn prune_edgeless(pgraph: &mut DiGraph<NodeData, EdgeData>) {
 }
 
 /// Prints graphviz DOT or Mermaid for the dependency graph as constrained by the CLI args to stdout.
-pub async fn cmd_dep(args: DepArgs, ctx: &mut Context) -> Result<(), Error> {
+pub async fn cmd_pkg_dep(args: PkgDepArgs, ctx: &mut Context) -> Result<(), Error> {
     let graph = if args.packages.is_empty() {
         ctx.graph_from_all_packages()
     } else {
@@ -810,7 +810,7 @@ mod tests {
         runtime_deps_depth: i32,
         excludes: Option<Vec<String>>,
     ) -> DiGraph<NodeData, EdgeData> {
-        let args = DepArgs {
+        let args = PkgDepArgs {
             excludes,
             build_spec_deps,
             source_deps: false,

--- a/crates/mip/src/cmd_pkg_patched_build.rs
+++ b/crates/mip/src/cmd_pkg_patched_build.rs
@@ -3,11 +3,14 @@ use anyhow::anyhow;
 use op::{PatchedBuild, Runnable};
 
 #[derive(Debug, clap::Args)]
-pub struct PatchedBuildArgs {
+pub struct PkgPatchedBuildArgs {
     package: String,
 }
 
-pub async fn cmd_patched_build(args: PatchedBuildArgs, ctx: &mut Context) -> Result<(), Error> {
+pub async fn cmd_pkg_patched_build(
+    args: PkgPatchedBuildArgs,
+    ctx: &mut Context,
+) -> Result<(), Error> {
     crate::enforce_science_mode()?;
 
     let graph = ctx.graph_from_package_names([args.package])?;

--- a/crates/mip/src/cmd_pkg_upload_cache.rs
+++ b/crates/mip/src/cmd_pkg_upload_cache.rs
@@ -5,13 +5,16 @@ use ot::OpTracker;
 use std::sync::mpsc::channel;
 use tracing::info;
 
-#[derive(clap::Args)]
-pub struct UploadArgs {
+#[derive(Debug, clap::Args)]
+pub struct PkgUploadCacheArgs {
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args=0..)]
     packages: Vec<String>,
 }
 
-pub async fn cmd_upload_cache(args: UploadArgs, ctx: &mut Context) -> Result<(), Error> {
+pub async fn cmd_pkg_upload_cache(
+    args: PkgUploadCacheArgs,
+    ctx: &mut Context,
+) -> Result<(), Error> {
     let op_root = ctx.op_tracker();
     let graph = if !args.packages.is_empty() {
         ctx.graph_from_package_names(args.packages.clone())?

--- a/crates/mip/src/main.rs
+++ b/crates/mip/src/main.rs
@@ -8,24 +8,22 @@ use std::io;
 use std::path::PathBuf;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+// `cmd_pkg` owns the `mip package` subcommand table and dispatches into the
+// `cmd_pkg_*` modules below.
 mod cmd_pkg;
-use cmd_pkg::{PkgArgs, cmd_pkg};
+mod cmd_pkg_build_plan;
+mod cmd_pkg_dep;
+mod cmd_pkg_patched_build;
+mod cmd_pkg_upload_cache;
+use cmd_pkg::{PkgCmd, cmd_pkg};
 mod cmd_check;
 use cmd_check::{CheckArgs, cmd_check};
-mod cmd_plan;
-use cmd_plan::{PlanArgs, cmd_plan};
 mod cmd_materialize;
 use cmd_materialize::{MaterializeArgs, cmd_materialize};
-mod cmd_upload_cache;
-use cmd_upload_cache::{UploadArgs, cmd_upload_cache};
-mod cmd_patched_build;
-use cmd_patched_build::{PatchedBuildArgs, cmd_patched_build};
 #[cfg(target_os = "linux")]
 mod cmd_run;
 #[cfg(target_os = "linux")]
 use cmd_run::{RunArgs, cmd_run, cmd_run_by_spec};
-mod cmd_dep;
-use cmd_dep::{DepArgs, cmd_dep};
 mod cmd_update;
 use cmd_update::{UpdateArgs, cmd_update};
 mod cmd_init;
@@ -45,7 +43,7 @@ use cmd_remote_build::{RemoteBuildArgs, cmd_remote_build};
 
 #[derive(Parser)]
 #[command(name = "mip", version = version::VERSION, long_version = version::LONG_VERSION)]
-#[command(about = "mip, the Minimal package/build CLI")]
+#[command(about = "Minimal-In-Process, the CLI for daemon-less Minimal operations")]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -67,17 +65,11 @@ enum Command {
     Init(InitArgs),
     /// Shows the status of Minimal in this codebase.
     Status(StatusArgs),
-    /// Launches a development shell. Shorthand for `mip run shell`.
-    Shell,
-    /// Runs the build task. Shorthand for `mip run build`.
-    Build,
-    /// Runs the test task. Shorthand for `mip run test`.
-    Test,
     /// Materializes an output specified in `minimal.toml`.
     Materialize(MaterializeArgs),
-    /// Builds the specified package(s) in a clean room, making them available in the local cache.
-    #[clap(alias = "pkg")]
-    Package(PkgArgs),
+    /// Package management operations, such as building.
+    #[clap(subcommand, alias = "pkg", alias = "packages")]
+    Package(PkgCmd),
     /// Execute a command on a remote build server.
     #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
     Rexec(RexecArgs),
@@ -90,23 +82,9 @@ enum Command {
 
     /// Validates minimal configuration including packages, stacks, and profiles
     Check(CheckArgs),
-    /// Prints the build plan for the specified package(s)
-    #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
-    Plan(PlanArgs),
-    /// Uploads the specified packages and their transitive needs to the cache.
-    #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
-    UploadCache(UploadArgs),
-    /// Executes the build for a package, using stale dependencies.
-    #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
-    PatchedBuild(PatchedBuildArgs),
     /// Dumps out information about the supply chain in a machine-readable format.
     #[clap(hide = !std::env::var("MINIMAL_SCIENCE_MODE").is_ok())]
     Dump(DumpArgs),
-    /// Generates Graphviz source code of the dependency graph
-    #[command(
-        long_about = "Generate an image of the dependency graph using graphviz's \"dot\" program.\n\n  mip dep --input-deps-depth=0 | dot -Tpng > deps.png"
-    )]
-    Dep(DepArgs),
 
     /// Generate shell completion script
     #[command(
@@ -266,51 +244,11 @@ async fn run_cli(cli: Cli) -> Result<(), Error> {
     match command {
         Command::Package(args) => cmd_pkg(args, &mut ctx).await,
         Command::Check(args) => cmd_check(args, &mut ctx).await,
-        Command::Plan(args) => cmd_plan(args, &mut ctx).await,
         Command::Add(args) => cmd_add(args, &mut ctx).await,
-        Command::UploadCache(args) => cmd_upload_cache(args, &mut ctx).await,
         Command::Materialize(args) => cmd_materialize(args, &mut ctx).await,
-        Command::PatchedBuild(args) => cmd_patched_build(args, &mut ctx).await,
         #[cfg(target_os = "linux")]
         Command::Run(args) => cmd_run(args, &mut ctx).await,
-        Command::Shell => {
-            cmd_run(
-                RunArgs {
-                    variant: cmd_run::RunVariant::ByName {
-                        task_name: "shell".to_string(),
-                    },
-                    task_args: vec![],
-                },
-                &mut ctx,
-            )
-            .await
-        }
-        Command::Build => {
-            cmd_run(
-                RunArgs {
-                    variant: cmd_run::RunVariant::ByName {
-                        task_name: "build".to_string(),
-                    },
-                    task_args: vec![],
-                },
-                &mut ctx,
-            )
-            .await
-        }
-        Command::Test => {
-            cmd_run(
-                RunArgs {
-                    variant: cmd_run::RunVariant::ByName {
-                        task_name: "test".to_string(),
-                    },
-                    task_args: vec![],
-                },
-                &mut ctx,
-            )
-            .await
-        }
         Command::Update(args) => cmd_update(args, &mut ctx).await,
-        Command::Dep(args) => cmd_dep(args, &mut ctx).await,
         Command::Dump(args) => cmd_dump(args, &mut ctx).await,
         Command::Status(args) => cmd_status(args, &mut ctx).await,
         Command::Rexec(args) => cmd_rexec(args, &mut ctx).await,

--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -5,7 +5,7 @@ description: Stacks wire Minimal to build codebases with specific languages and 
 # Stacks
 
 Stacks wire Minimal to operate a codebase with specific tools and commands. When you name a stack
-in your [`minimal.toml`](../reference/minimal-dot-toml.md) file, build-plane commands like `mip build` just work. Additionally, your [tasks](../reference/tasks.md) inherit these familiar tools and semantics automatically.
+in your [`minimal.toml`](../reference/minimal-dot-toml.md) file, build-plane commands like `mip run build` just work. Additionally, your [tasks](../reference/tasks.md) inherit these familiar tools and semantics automatically.
 
 Learn more about stacks in [the reference section](../reference/stack-specs.md).
 

--- a/docs/reference/cli-mip.md
+++ b/docs/reference/cli-mip.md
@@ -47,17 +47,6 @@ mip run [OPTIONS] --upstream <upstream> --task-spec <task_spec> [task_args]...
 | `--upstream <JSON>` | JSON stanza specifying the software supply chain; must be used with `--task-spec` |
 | `--task-spec <JSON>` | JSON stanza specifying a task inline; must be used with `--upstream` |
 
-### `shell`, `build`, `test`
-
-```
-mip shell
-mip build
-mip test
-```
-
-Shorthands for `mip run shell`, `mip run build`, and `mip run test`
-respectively. `shell` launches a development shell. *(Linux only)*
-
 ### `update`
 
 ```
@@ -117,10 +106,15 @@ Supported output types include `oci-image`, a Linux OCI image archive
 containing the configured packages, suitable for `docker load` or pushing
 to a registry.
 
-### `package` (alias: `pkg`)
+### `package` (aliases: `pkg`, `packages`)
+
+Package-level operations. Takes a subcommand; see `package build` and
+`package dep` below.
+
+#### `package build`
 
 ```
-mip package [OPTIONS] [PACKAGES]...
+mip package build [OPTIONS] [PACKAGES]...
 ```
 
 Builds the specified package(s) in a clean room, making them available in
@@ -130,6 +124,30 @@ the local cache.
 |------|-------|-------------|
 | `--verbose` | `-v` | Log stdout/stderr during the build |
 | `--rebuild` | | Always build the specified packages, even if they are already available |
+
+#### `package dep`
+
+```
+mip package dep [OPTIONS] [PACKAGES]...
+```
+
+Generates Graphviz source code of the dependency graph, e.g.
+`mip package dep --input-deps-depth=0 | dot -Tpng > deps.png`.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--excludes <PKGS>` | `-e` | | Packages left out of the graph and not traversed |
+| `--build-spec-deps <BOOL>` | | `true` | Include build spec `build_deps` (does not affect runtime deps) |
+| `--source-deps <BOOL>` | | `false` | Include source code `build_deps` |
+| `--local-deps <BOOL>` | | `false` | Include local (`build.sh`) input deps |
+| `--needs <BOOL>` | | `false` | Include "Needs" nodes and edges |
+| `--provides <BOOL>` | | `false` | Include "Provides" edges and "Needs" nodes |
+| `--bootstrap <BOOL>` | | `false` | Include replace-on-cycle/prebuilts/bootstrap |
+| `--subtrees-only <BOOL>` | | `false` | Require non-zero subtree deps for runtime/input deps |
+| `--input-deps-depth <N>` | | `-1` | How deeply input dependencies are followed (`-1` = all) |
+| `--runtime-deps-depth <N>` | | `-1` | How deeply runtime dependencies are followed (`-1` = all) |
+| `--prune-edgeless <BOOL>` | | `false` | Discard graph nodes with no edges |
+| `--output-format <FMT>` | | `dot` | Output format: `dot` or `mermaid` |
 
 ### `cache clean`
 
@@ -164,30 +182,6 @@ Validates minimal configuration including packages, stacks, and profiles.
 
 If no type flags are specified, all types are checked. If filter names
 are given, any package, stack, or profile matching a name is checked.
-
-### `dep`
-
-```
-mip dep [OPTIONS] [PACKAGES]...
-```
-
-Generates Graphviz source code of the dependency graph, e.g.
-`mip dep --input-deps-depth=0 | dot -Tpng > deps.png`.
-
-| Flag | Short | Default | Description |
-|------|-------|---------|-------------|
-| `--excludes <PKGS>` | `-e` | | Packages left out of the graph and not traversed |
-| `--build-spec-deps <BOOL>` | | `true` | Include build spec `build_deps` (does not affect runtime deps) |
-| `--source-deps <BOOL>` | | `false` | Include source code `build_deps` |
-| `--local-deps <BOOL>` | | `false` | Include local (`build.sh`) input deps |
-| `--needs <BOOL>` | | `false` | Include "Needs" nodes and edges |
-| `--provides <BOOL>` | | `false` | Include "Provides" edges and "Needs" nodes |
-| `--bootstrap <BOOL>` | | `false` | Include replace-on-cycle/prebuilts/bootstrap |
-| `--subtrees-only <BOOL>` | | `false` | Require non-zero subtree deps for runtime/input deps |
-| `--input-deps-depth <N>` | | `-1` | How deeply input dependencies are followed (`-1` = all) |
-| `--runtime-deps-depth <N>` | | `-1` | How deeply runtime dependencies are followed (`-1` = all) |
-| `--prune-edgeless <BOOL>` | | `false` | Discard graph nodes with no edges |
-| `--output-format <FMT>` | | `dot` | Output format: `dot` or `mermaid` |
 
 ### `completions`
 

--- a/docs/reference/stack-specs.md
+++ b/docs/reference/stack-specs.md
@@ -25,7 +25,7 @@ stack {
   runtime_packages = ["node"],
   build_packages = ["pnpm", "base"],
 
-  # A command that generates the build command, i.e. commands executed by `mip build`.
+  # A command that generates the build command, i.e. commands executed by `mip run build`.
   build_cmds_cmd = [
     "/bin/bash",
     "-c",
@@ -86,7 +86,7 @@ _`build_cmds_cmd`: String or array of strings for a command that generates the b
 `build_cmd` and `build_cmds_cmd` are mutually exclusive fields that declare the command for
 building software which uses this stack.
 
-`build_cmd` defines the command to run when [`mip build`](./cli-mip.md) is invoked. It can be a shell-style
+`build_cmd` defines the command to run when [`mip run build`](./cli-mip.md#run) is invoked. It can be a shell-style
 string or an array containing the executable followed by its arguments.
 
 ```ncl


### PR DESCRIPTION
 * `mip`:
 * * Remove `mip build/test/shell` shorthands for running a task of that name
 * * Move `mip pkg/package` to `mip pkg/package build`
 * * Move `mip dep` to `mip pkg/package dep`
 * * Move `mip upload-cache` to `mip pkg/package upload-cache`
 * * (science mode) Move `mip patched-build` to `mip pkg/package patched-build`
 * * (science mode) Move `mip plan` to `mip pkg/package build-plan`


 * Session `min` helper:
 * * Move `min build` to `min package build`
 * * Move `min patched-pkg` to `min package patched-build`
 
  * Legacy `min` helper:
  *  * Same as above, except `package build` errors as we don't have an implementation in mip

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move `mip` package commands under `mip package` subcommand and remove top-level build/test/shell shorthands
> - Removes top-level `mip` commands `shell`, `build`, `test`, `plan`, `upload-cache`, `patched-build`, and `dep`; equivalent operations are now under `mip run …` or `mip package …`.
> - Introduces `mip package` (alias `pkg`) with subcommands: `build`, `dep`, and hidden `build-plan`, `patched-build`, `upload-cache`.
> - Renames internal command modules and structs (e.g. `cmd_plan.rs` → `cmd_pkg_build_plan.rs`, `PlanArgs` → `PkgBuildPlanArgs`) to match the new subcommand structure.
> - Updates shell helper scripts in `mctx` and `minimald` to replace `min build`, `min test`, and `min patched-pkg` with `min package build` and `min package patched-build`.
> - Risk: Breaking change — any scripts or workflows calling removed top-level commands will fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58a8793.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `mip package` command with subcommands for build, build plans, dependency inspection, patched builds, and cache uploads.
  * Introduced `package`, `pkg`, and `packages` aliases and updated command dispatch accordingly.
  * Added `min package` routing, including `min package patched-build <name>` and rejecting unsupported `min package` invocations.

* **Documentation**
  * Updated CLI reference/help text to reflect the new `mip package ...` structure and removed guidance for prior top-level `build`, `test`, `shell`, and `dep` commands.
  * Refreshed stack/build examples to use `mip run build` terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->