### PR TITLE
fix(release): ship gvproxy to Linux installs (native own-ip)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6488,6 +6488,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 [[package]]
 name = "switch"
 version = "0.0.1"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "symlink"

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -225,8 +225,9 @@ pub struct ListenArgs {
     detach: bool,
 
     /// Path to the gvproxy ("gvisor-tap-vsock") binary backing the per-host
-    /// `OwnIp` switch. Defaults to the fixed system install path when unset;
-    /// point it at a local build to run own-IP without a system install.
+    /// `OwnIp` switch. Defaults to the installed location when unset (the
+    /// user-local install the curl|sh installer stamps, else the fixed system
+    /// path); point it at a local build to run own-IP without an install.
     #[arg(long)]
     gvproxy_bin: Option<std::path::PathBuf>,
 }

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -30,11 +30,6 @@ pub enum HostKey {
     },
 }
 
-/// Default install path for the gvproxy ("gvisor-tap-vsock") switch binary,
-/// used when [`Config::gvproxy_bin`] is unset. The `GVPROXY_BIN` env var is
-/// scoped to the `#[ignore]` netns proof and is never consulted by the daemon.
-const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy";
-
 /// Global Configuration for the minimald server.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
@@ -42,7 +37,7 @@ pub struct Config {
     pub minimal_state_dir: DaemonAbsPath,
     pub minimal_cache_dir: DaemonAbsPath,
     /// Path to the gvproxy binary backing the per-host `OwnIp` switch. Defaults
-    /// to [`DEFAULT_GVPROXY_BIN`] when unset.
+    /// to the installed location (`switch::installed_gvproxy_bin`) when unset.
     #[serde(default)]
     pub gvproxy_bin: Option<PathBuf>,
     /// Whether this `minimald` runs inside a `minvmd` libkrun VM (DM1/3/4). When
@@ -61,12 +56,15 @@ pub struct Config {
 }
 
 impl Config {
-    /// Resolves the configured gvproxy binary path, falling back to the fixed
-    /// install path when unset.
+    /// Resolves the configured gvproxy binary path, falling back to the
+    /// installed location when unset: the user-local `bin/gvproxy` the curl|sh
+    /// installer stamps, else the system-wide `switch::DEFAULT_GVPROXY_BIN`.
+    /// The `GVPROXY_BIN` env var is scoped to the `#[ignore]` netns proof and
+    /// is never consulted by the daemon.
     fn gvproxy_bin_path(&self) -> PathBuf {
         self.gvproxy_bin
             .clone()
-            .unwrap_or_else(|| PathBuf::from(DEFAULT_GVPROXY_BIN))
+            .unwrap_or_else(::switch::installed_gvproxy_bin)
     }
 
     /// Returns the SSH host key to use.

--- a/crates/minvmd/src/image.rs
+++ b/crates/minvmd/src/image.rs
@@ -113,32 +113,10 @@ pub fn resolve_initramfs_path() -> Result<PathBuf, VmError> {
     resolve_or_default("MINVMD_INITRAMFS", DEFAULT_INITRAMFS_FILE)
 }
 
-/// System-wide install path for the host gvproxy ("gvisor-tap-vsock") binary,
-/// used as the final fallback when `MINVMD_GVPROXY_BIN` is unset and no
-/// user-local install exists. Fetched + SHA-256-verified by
-/// `scripts/fetch-gvproxy.sh` (issue #495).
-pub const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy";
-
-/// Filename the installer stamps into the `bin/` prefix (see
-/// `scripts/stage-release.sh`: `bin/gvproxy`).
-const GVPROXY_FILE: &str = "gvproxy";
-
-/// The user-local bin directory the installer stamps into: `$MINIMAL_BIN`, else
-/// `$HOME/.local/bin`. Mirrors the installer's `bin` prefix resolution in
-/// `scripts/install.sh`. `None` when neither is set.
-fn installer_bin_dir() -> Option<PathBuf> {
-    if let Some(bin) = std::env::var("MINIMAL_BIN").ok().filter(|v| !v.is_empty()) {
-        return Some(PathBuf::from(bin));
-    }
-    std::env::var("HOME")
-        .ok()
-        .filter(|v| !v.is_empty())
-        .map(|home| PathBuf::from(home).join(".local/bin"))
-}
-
-/// Resolve the host gvproxy binary path in three tiers: the `MINVMD_GVPROXY_BIN`
-/// override, then an existing user-local install (`<bin-dir>/gvproxy`, where the
-/// installer stamps it), then the system-wide [`DEFAULT_GVPROXY_BIN`].
+/// Resolve the host gvproxy binary path: the `MINVMD_GVPROXY_BIN` override,
+/// then the installed location — the user-local install the curl|sh installer
+/// stamps, else the system-wide `switch::DEFAULT_GVPROXY_BIN`
+/// ([`switch::installed_gvproxy_bin`], shared with minimald).
 ///
 /// Unlike the kernel/rootfs/initramfs resolvers this never errors: gvproxy is
 /// only spawned for an own-IP VM, so an absent override is the common case, and
@@ -146,21 +124,12 @@ fn installer_bin_dir() -> Option<PathBuf> {
 /// (the caller surfaces a spawn failure with that concrete path).
 #[must_use]
 pub fn resolve_gvproxy_path() -> PathBuf {
-    // Tier 1: explicit override, honoured verbatim.
-    if let Some(val) = std::env::var("MINVMD_GVPROXY_BIN")
+    // Explicit override, honoured verbatim.
+    std::env::var("MINVMD_GVPROXY_BIN")
         .ok()
         .filter(|v| !v.is_empty())
-    {
-        return PathBuf::from(val);
-    }
-    // Tier 2: user-local install from the curl|sh installer, if present.
-    if let Some(local) = installer_bin_dir().map(|dir| dir.join(GVPROXY_FILE))
-        && local.exists()
-    {
-        return local;
-    }
-    // Tier 3: system-wide install path (hardcoded fallback).
-    PathBuf::from(DEFAULT_GVPROXY_BIN)
+        .map(PathBuf::from)
+        .unwrap_or_else(switch::installed_gvproxy_bin)
 }
 
 #[cfg(test)]
@@ -274,7 +243,7 @@ mod tests {
         let _g = ENV_LOCK.lock().unwrap();
         clear_gvproxy_env();
         let tmp = tempfile::tempdir().unwrap();
-        let want = tmp.path().join(GVPROXY_FILE);
+        let want = tmp.path().join("gvproxy");
         std::fs::write(&want, b"gvproxy").unwrap();
         // MINIMAL_BIN steers installer_bin_dir without touching HOME.
         unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
@@ -289,7 +258,10 @@ mod tests {
         // MINIMAL_BIN points at an empty dir: no user-local gvproxy present.
         let tmp = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
-        assert_eq!(resolve_gvproxy_path(), PathBuf::from(DEFAULT_GVPROXY_BIN));
+        assert_eq!(
+            resolve_gvproxy_path(),
+            PathBuf::from(switch::DEFAULT_GVPROXY_BIN)
+        );
         clear_gvproxy_env();
     }
 

--- a/crates/switch/Cargo.toml
+++ b/crates/switch/Cargo.toml
@@ -6,3 +6,6 @@ publish.workspace = true
 license.workspace = true
 
 [dependencies]
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/switch/src/lib.rs
+++ b/crates/switch/src/lib.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 use std::net::Ipv4Addr;
+use std::path::PathBuf;
 
 /// MTU advertised to the switch and the tap devices. gvproxy's own default.
 pub const DEFAULT_MTU: u16 = 1500;
@@ -33,6 +34,48 @@ pub const DEFAULT_SUBNET: SwitchSubnet = SwitchSubnet {
     base: Ipv4Addr::new(100, 64, 0, 0),
     prefix: 16,
 };
+
+/// System-wide install path for the gvproxy ("gvisor-tap-vsock") switch
+/// binary: the final fallback when no user-local install exists. Fetched +
+/// SHA-256-verified by `scripts/fetch-gvproxy.sh` (issue #495).
+pub const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy";
+
+/// Filename the installer stamps into the `bin/` prefix (see
+/// `scripts/stage-release.sh`: `bin/gvproxy`).
+const GVPROXY_FILE: &str = "gvproxy";
+
+/// The user-local bin directory the installer stamps into: `$MINIMAL_BIN`, else
+/// `$HOME/.local/bin`. Mirrors the installer's `bin` prefix resolution in
+/// `scripts/install.sh`. `None` when neither is set.
+fn installer_bin_dir() -> Option<PathBuf> {
+    if let Some(bin) = std::env::var("MINIMAL_BIN").ok().filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(bin));
+    }
+    std::env::var("HOME")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(|home| PathBuf::from(home).join(".local/bin"))
+}
+
+/// Resolve the gvproxy binary an install placed on this host: an existing
+/// user-local install (`<bin-dir>/gvproxy`, where the curl|sh installer stamps
+/// it), else the system-wide [`DEFAULT_GVPROXY_BIN`].
+///
+/// One definition shared by `minimald` (which spawns gvproxy for native own-IP
+/// sessions) and `minvmd` (the host switch supervisor), so the two daemons and
+/// the installer agree on where gvproxy lives; daemon-specific overrides
+/// (config field, env var) layer on top in the callers. Never errors: the
+/// system path is returned as a last resort even if nothing exists there (the
+/// caller surfaces a spawn failure with that concrete path).
+#[must_use]
+pub fn installed_gvproxy_bin() -> PathBuf {
+    if let Some(local) = installer_bin_dir().map(|dir| dir.join(GVPROXY_FILE))
+        && local.exists()
+    {
+        return local;
+    }
+    PathBuf::from(DEFAULT_GVPROXY_BIN)
+}
 
 /// A subnet was constructed with a prefix outside the supported `8..=29` range —
 /// a configuration error, distinct from runtime address exhaustion.
@@ -274,5 +317,30 @@ mod tests {
         let yaml = render_gvproxy_config(SwitchSubnet::default(), &[]);
         assert!(yaml.contains("dhcpStaticLeases:\n    {}\n"));
         assert!(yaml.contains("subnet: \"100.64.0.0/16\""));
+    }
+
+    // Resolver tests mutate process-global env (MINIMAL_BIN), so serialise
+    // them to avoid races when `cargo test` runs them in parallel.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn installed_gvproxy_prefers_existing_user_local_install() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let want = tmp.path().join(GVPROXY_FILE);
+        std::fs::write(&want, b"gvproxy").unwrap();
+        unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
+        assert_eq!(installed_gvproxy_bin(), want);
+        unsafe { std::env::remove_var("MINIMAL_BIN") };
+    }
+
+    #[test]
+    fn installed_gvproxy_falls_back_to_system_path() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // MINIMAL_BIN points at an empty dir: no user-local gvproxy present.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
+        assert_eq!(installed_gvproxy_bin(), PathBuf::from(DEFAULT_GVPROXY_BIN));
+        unsafe { std::env::remove_var("MINIMAL_BIN") };
     }
 }

--- a/docs/internal/release-pipeline.md
+++ b/docs/internal/release-pipeline.md
@@ -144,7 +144,8 @@ SHA-256-verifies, and atomically installs the file. The on-disk hash is the
 skip oracle, so reruns only touch changed components, and a running daemon is
 stopped before an executable is swapped. Per-platform sets (from
 stage-release.sh's `COMPONENTS` table): Linux amd64/arm64 get `bin/min`,
-`bin/mip`, `bin/minimald`, a `git-remote-min` symlink, and the AppArmor
+`bin/mip`, `bin/minimald`, `bin/gvproxy` (the switch for native own-IP
+sessions), a `git-remote-min` symlink, and the AppArmor
 profile/tunable/loader under `data/`; macOS arm64 gets `bin/min`,
 `bin/minvmd`, `bin/gvproxy`, `lib/libkrun.1.dylib`, the `git-remote-min`
 symlink, and the guest payload (`data/{vmlinuz,rootfs.img,initramfs.cpio}`).

--- a/docs/reference/cli-minimald.md
+++ b/docs/reference/cli-minimald.md
@@ -36,7 +36,7 @@ Runs the minimald server in the foreground.
 | `--instance-num <N>` | Instance number for this minimald; determines client-relevant paths under `<minimal_state_dir>/providers/local-minimald<N>`. The SSH socket is accessible as `ssh.sock`. Default: `0` |
 | `--vsock` | Host the SSH socket over vsock instead of UDS; the vsock port is the default port base plus `instance_num` |
 | `--detach` | Daemonize: spawn minimald in a new session (setsid) and return once the SSH socket accepts connections, or an 8s timeout elapses. Used by the `min` CLI to auto-start a native daemon on Linux |
-| `--gvproxy-bin <PATH>` | Path to the gvproxy ("gvisor-tap-vsock") binary used for networking. Defaults to a typical system install path. |
+| `--gvproxy-bin <PATH>` | Path to the gvproxy ("gvisor-tap-vsock") binary used for networking. Defaults to the installed location: the user-local `bin/gvproxy` the installer stamps, else the system install path. |
 
 ### `completions`
 

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -104,21 +104,26 @@ fi
 #     (the installer's completion generation runs `<bin>/min`, spec R9.3), while
 #     the component and artifact names keep the crate name.
 #
-# Linux hosts install just the three self-contained musl binaries. macOS hosts
-# additionally need minvmd + gvproxy and the guest microVM payload (kernel,
-# rootfs, initramfs) to boot Linux workloads under libkrun; macOS is arm64-only
-# here, and its guest is arm64, so it consumes the arm64 guest artifacts.
+# Linux hosts install the three self-contained musl binaries plus gvproxy, the
+# switch binary minimald spawns for native (DM2) own-IP sessions. macOS hosts
+# additionally need minvmd + the guest microVM payload (kernel, rootfs,
+# initramfs) to boot Linux workloads under libkrun; macOS is arm64-only here,
+# and its guest is arm64, so it consumes the arm64 guest artifacts. minvmd is
+# not yet staged for Linux hosts: it needs libkrun/libkrunfw and the guest
+# payload staged alongside it, and no arm64 minvmd is built yet (#980).
 COMPONENTS=(
     # Linux amd64
     "minimald|linux|amd64|file|bin/minimald|minimald-linux-amd64"
     "mip|linux|amd64|file|bin/mip|mip-linux-amd64"
     "minimal|linux|amd64|file|bin/min|minimal-linux-amd64"
     "git-remote-min|linux|amd64|symlink|bin/git-remote-min|min"
+    "gvproxy|linux|amd64|file|bin/gvproxy|gvproxy-linux-amd64"
     # Linux arm64
     "minimald|linux|arm64|file|bin/minimald|minimald-linux-arm64"
     "mip|linux|arm64|file|bin/mip|mip-linux-arm64"
     "minimal|linux|arm64|file|bin/min|minimal-linux-arm64"
     "git-remote-min|linux|arm64|symlink|bin/git-remote-min|min"
+    "gvproxy|linux|arm64|file|bin/gvproxy|gvproxy-linux-arm64"
     # macOS arm64 (darwin)
     "minimal|darwin|arm64|file|bin/min|minimal-macos-arm64"
     "git-remote-min|darwin|arm64|symlink|bin/git-remote-min|min"


### PR DESCRIPTION
## Summary

Part of [#980](https://github.com/gominimal/minimal/issues/980) — the gvproxy half. Linux installs now get `bin/gvproxy`, and both daemons agree with the installer on where it lives, so native (DM2) own-IP sessions work on installed hosts.

- **`scripts/stage-release.sh`**: add `gvproxy|linux|amd64` and `gvproxy|linux|arm64` rows. The release workflow already uploads the pin-verified `gvproxy-linux-{amd64,arm64}` artifacts ([#495](https://github.com/gominimal/minimal/issues/495)); they were just never mapped to Linux install components. The installer is manifest-driven and needs no change.
- **`switch::installed_gvproxy_bin()`** (new): staging the binary alone would not revive own-ip — the installer stamps `bin/` components into `~/.local/bin` (or `$MINIMAL_BIN`), but `minimald` resolved the switch only at the fixed `/usr/lib/minimal/bin/gvproxy`. The new function is the one shared definition of the installed location (user-local install if present, else the system path), in the crate whose charter is exactly "one definition rather than drifting copies" shared by both daemons.
- **`minimald`**: the `OwnIp` switch default now goes through the shared resolver; `--gvproxy-bin` / the config field still win, and the `GVPROXY_BIN` env var remains scoped to the netns proof only.
- **`minvmd`**: delegates tiers 2/3 of `resolve_gvproxy_path()` to the shared definition — it already had exactly this user-local tier, now the two daemons cannot drift. Its `MINVMD_GVPROXY_BIN` override tier is unchanged.

## Deferred — the minvmd half of [#980](https://github.com/gominimal/minimal/issues/980)

VM-backed sessions on Linux installs stay out of scope, per the issue's own open questions: `minvmd` needs `libkrun.so`/`libkrunfw.so` staged (plus an rpath story), the guest payload (`data/{vmlinuz,rootfs.img,initramfs.cpio}`) mapped for Linux, and an arm64 `minvmd` build — all requiring changes to the frozen, CODEOWNER-gated `release.yml`. Shipping `bin/minvmd` today would install a binary that cannot load libkrun, and the arm64 row would hard-fail staging (no `minvmd-linux-arm64` artifact exists).

## Verification

- `scripts/stage-release.sh --dry-run` against a stand-in artifacts dir emits both new rows with correct dest/src; `shellcheck` clean.
- `cargo test -p switch` (incl. 2 new resolver tests), `just test` (darwin scope, 511 pass), `just clippy`, `just fmt-check`, `just deny`, `just doctest` — all green locally (macOS).
- `cross check -p minimald --all-targets --target aarch64-unknown-linux-musl --locked` passes; the single warning is the pre-existing musl-only `libc::time_t` deprecation in `guest.rs`, untouched here.
- The end-to-end own-ip proof is Linux-only: `ci-linux-native`'s netns job (`netns_root_integration.rs`) covers the datapath, and the resolver change preserves its config-injection path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ship gvproxy to Linux installs for native own-IP sessions
> - Adds `gvproxy` to the Linux amd64 and arm64 component lists in [stage-release.sh](https://github.com/gominimal/minimal/pull/982/files#diff-b915b0588eb8e66e0e3fe26d502c3baea0ef85d884c47e9035989dcc64313bff), so the installer places `bin/gvproxy` on Linux hosts.
> - Moves gvproxy path resolution into a shared `switch::installed_gvproxy_bin()` function that prefers a user-local `bin/gvproxy` install, falling back to the system path.
> - Removes duplicated `DEFAULT_GVPROXY_BIN` and `installer_bin_dir` constants/helpers from `minimald` and `minvmd`; both now delegate to the `switch` crate.
> - Updates CLI docs and the release pipeline doc to reflect the new default and Linux inclusion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a919053.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->