### PR TITLE
feat(det-init): guest pid-1 that detonates untrusted packages under a BPF-LSM observer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,6 +1574,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "det-init"
+version = "0.5.0-rc1"
+dependencies = [
+ "libc",
+ "minimald",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "diagnostics"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/checkouts",
     "crates/common",
     "crates/decode",
+    "crates/det-init",
     "crates/diagnostics",
     "crates/graph",
     "crates/mctx",

--- a/crates/det-init/Cargo.toml
+++ b/crates/det-init/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "det-init"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+# `det-init` is the minimal-detonation guest pid-1 (`/init`). It reuses
+# `minimald`'s public guest-boot library (mounts, rootfs entry, root egress,
+# VM shutdown) instead of forking minimald, then stands up the in-guest
+# BPF-LSM observer and runs the untrusted sample as `nobody` under it. It does
+# NOT run minimald's SSH server: a detonation is a one-shot, so the sample is
+# executed directly and the observer streams the event feed out. See
+# gominimal/minimal-detonation#194.
+
+[[bin]]
+name = "det-init"
+path = "src/main.rs"
+
+[dependencies]
+# Path dep with NO version requirement, deliberately. Pinning `version = "0.0.1"` here broke the
+# build the moment the workspace bumped to 0.5.0-rc1 — a self-inflicted drift trap that has nothing
+# to do with API compatibility (all six `guest::` fns we call were unchanged). Cargo resolves a
+# bare path dep to whatever is in the tree, so version bumps can never break us again; the API
+# surface is what actually matters and the compiler checks that.
+minimald = { path = "../minimald" }
+tokio.workspace = true
+libc.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/det-init/src/main.rs
+++ b/crates/det-init/src/main.rs
@@ -1,0 +1,623 @@
+//! `det-init` — the minimal-detonation guest **pid-1** (`/init`).
+//!
+//! The kernel runs the initramfs `/init` (this binary) as pid-1 inside the
+//! detonation microVM. Rather than fork or patch `minimald`, `det-init`
+//! *embeds* `minimald`'s public guest-boot library ([`minimald::guest`]) for the
+//! parts that are pure pid-1 plumbing — mount `/dev`, enter the ext4 rootfs,
+//! bring up root-netns egress, take the VM down — and adds the detonation-
+//! specific behaviour on top:
+//!
+//!   1. mount the BPF pseudo-filesystems the observer needs (`securityfs` + `bpffs`),
+//!   2. stage the deny-channel tripwire *before* the LSM attaches,
+//!   3. load the per-scan binding nonce from a root-0400 file (for the ROOT
+//!      observer only) and prove `nobody` cannot read it,
+//!   4. start the root BPF-LSM observer (`detonation-monitor`) and block until it
+//!      signals readiness — so we never miss the sample's first syscalls,
+//!   5. route the sample's DNS through the observer's collector (networked model),
+//!   6. prove `nobody` cannot write the event feed (the uid boundary),
+//!   7. fire the tripwire, then run the untrusted sample as `nobody` (`droppriv`),
+//!      fork-and-reap so the observer can drain cleanly,
+//!   8. drain the observer (SIGTERM, bounded, SIGKILL backstop),
+//!   9. return — `main` then takes the VM down.
+//!
+//! Unlike `detonate.sh`/`init-launcher.sh` this does the boot mounts through the
+//! **same code** `minimald` uses (not a `mount` binary the rootfs may lack), and
+//! unlike the minvmd-session model it runs the sample **directly** — a detonation
+//! is a one-shot, so there is no SSH server, no session, and no dependency on the
+//! arbitrary-exec surface #709 removed. The observer streams the JSONL feed to
+//! the host over its own vsock port (file fallback); the host consumes that and
+//! runs `minimal-detonation verdict`.
+//!
+//! Isolation is the disposable microVM + `droppriv`'s uid drop — deliberately
+//! NOT an in-guest namespace sandbox, which would suppress the very behaviour we
+//! detonate to observe. See gominimal/minimal-detonation#194.
+
+use std::ffi::CString;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use minimald::guest;
+
+// ── Runtime path + parameter contract ───────────────────────────────────────
+// These are the interface between the bake (which stages the observer, droppriv,
+// tripwire, and honeytokens into the rootfs) and the host (`det-host-agent`,
+// which stages the per-scan sample command + binding nonce into the guest image
+// before boot). Kept as named constants so a change here is an obvious diff.
+
+/// The generic ext4 rootfs block device minvmd attaches (always `/dev/vda`).
+const ROOTFS_DEVICE: &str = "/dev/vda";
+/// The per-VM writable data volume (#672); mounted best-effort as the build-env.
+const STATE_VOLUME_DEVICE: &str = "/dev/vdb";
+
+/// The root BPF-LSM observer, baked into the rootfs.
+const MONITOR: &str = "/opt/detonation/detonation-monitor";
+/// The privilege-drop-then-exec helper, baked into the rootfs.
+const DROPPRIV: &str = "/opt/detonation/droppriv";
+
+/// Where the observer writes the JSONL feed (also streamed over vsock).
+const EVENTS: &str = "/run/det-events.jsonl";
+/// The observer touches this once its LSM programs are attached and it is ready.
+const READY: &str = "/run/mon.ready";
+
+/// The deny-channel tripwire path the LSM `file_open` hook denies with `-EPERM`.
+const TRIPWIRE: &str = "/det-tripwire-DENY";
+
+/// Root-0400 file holding the per-scan binding nonce (host-staged). Override with
+/// `DET_BINDING_NONCE_FILE`; a plain `DET_BINDING_NONCE` env var also works for
+/// local dev (but rides `/proc/<pid>/cmdline`, so it is not the secure channel).
+const NONCE_FILE_DEFAULT: &str = "/det/binding-nonce";
+/// File holding the exact sample command to detonate (host-staged, verbatim — no
+/// base64 needed since a file has no host→ssh→shell quoting to survive). Override
+/// with `DET_SAMPLE_FILE`; `DET_SAMPLE_CMD` env also works for local dev.
+const SAMPLE_FILE_DEFAULT: &str = "/det/sample.cmd";
+
+/// The sample's `$HOME`: the seeded honeytoken tree (decoy creds baked into the
+/// rootfs). A credential thief that reads `$HOME/.aws/credentials` takes the bait.
+const HONEYTOKEN_HOME: &str = "/home/det";
+/// The unprivileged uid the sample runs as (matches `droppriv` + the observer).
+const SAMPLE_UID: u32 = 65534;
+
+/// Bounded wait for the observer to become ready: `READY_ATTEMPTS × POLL`.
+const READY_ATTEMPTS: u32 = 100; // 100 × 100ms = 10s
+/// Bounded wait for the observer to drain after SIGTERM before SIGKILL.
+const DRAIN_ATTEMPTS: u32 = 50; // 50 × 100ms = 5s
+const POLL: Duration = Duration::from_millis(100);
+
+/// Deadline for the SAMPLE itself, deliberately shorter than the host's VM timeout
+/// (`det-host-agent` passes `--timeout-secs`, default 120).
+///
+/// Why this exists: the feed is drained AFTER the sample returns (step 8). A sample that never
+/// returns therefore takes the ENTIRE feed with it — the host kills the VM, `drain_monitor` and
+/// `emit_feed_to_stdout` never run, and a run that should have been BLOCK is reported as
+/// `substrate_failed: empty observer capture`. The observer captured everything; it just never
+/// shipped. See gominimal/minimal-detonation#272.
+///
+/// That is not an exotic input. A poisoned package whose C2 is unreachable — sinkholed, firewalled,
+/// or a documentation-range IP — blocks on connect() exactly like this, so the better the network
+/// defense, the more likely the whole feed was lost. It is also a one-line evasion: append a sleep
+/// and the verdict degrades from BLOCK to ERROR after the payload has already run.
+///
+/// Killing the sample at this deadline costs only whatever the sample would have done AFTER the
+/// deadline; keeping the events it already produced is strictly better than losing all of them.
+/// MUST stay comfortably below the host timeout, or the VM dies first and this is moot.
+const SAMPLE_DEADLINE: Duration = Duration::from_secs(90);
+
+/// A top-level error, mirroring `minimald::main`'s shape.
+#[derive(Debug)]
+enum MainError {
+    IO(std::io::Error, &'static str),
+    Other(String),
+}
+
+fn main() -> Result<(), MainError> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .thread_name("det-init-worker")
+        .enable_all()
+        .build()
+        .unwrap();
+    let result = runtime.block_on(async_main());
+
+    // As the microVM's pid-1 we must not return: exiting init panics the guest
+    // kernel and wedges the VM (minimald #730). Take the VM down instead — on a
+    // clean detonation and a failed one alike, since either way there is no init
+    // left to run. Guarded by `is_detonation_init` so a host-side test run never
+    // reboots the developer's machine (mirrors `minimald::is_minimal_microvm`).
+    if is_detonation_init() {
+        match &result {
+            Ok(()) => tracing::info!("detonation complete; taking the microVM down"),
+            Err(e) => tracing::error!(error = ?e, "detonation failed; taking the microVM down"),
+        }
+        let error = guest::shut_down_vm();
+        tracing::error!(%error, "shutting the VM down failed; parking pid-1 (exiting it would panic the guest kernel)");
+        loop {
+            std::thread::sleep(Duration::from_secs(3600));
+        }
+    }
+
+    result
+}
+
+async fn async_main() -> Result<(), MainError> {
+    init_tracing();
+
+    // ── Boot: reuse minimald's guest-boot library ──────────────────────────
+    guest::mount_dev();
+    if let Err(e) = guest::enter_rootfs(ROOTFS_DEVICE) {
+        // No rootfs disk: nothing to detonate. Emit the simple READY beacon so a
+        // watching minvmd host doesn't hang on its READY timeout, then fail.
+        tracing::error!(error = %e, device = ROOTFS_DEVICE, "entering rootfs failed");
+        let _ = guest::emit_simple_ready_marker().await;
+        return Err(MainError::IO(e, "entering rootfs"));
+    }
+    // The per-VM writable data volume (#672) is the build-env scratch space.
+    // Best-effort: a single-sample detonation can run without it (rootfs + /tmp
+    // tmpfs suffice); a real ecosystem install that needs GiB of scratch wants
+    // it. Not fatal on this prototype path.
+    if let Err(e) = guest::mount_state_volume(STATE_VOLUME_DEVICE, guest::STATE_VOLUME_MOUNTPOINT) {
+        tracing::warn!(error = %e, device = STATE_VOLUME_DEVICE, "data volume unavailable; build-env limited to rootfs + /tmp");
+    }
+
+    // Emit the READY vsock beacon NOW — the microVM supervisor (minvmd) waits for
+    // it (port 7350) with a short (~5s) timeout and tears the guest down if it
+    // never arrives. It must fire BEFORE the slow steps below (the observer-ready
+    // wait alone is bounded at 10s), so we announce "booted" as soon as the rootfs
+    // is entered, then detonate at leisure. Simple form: det-init runs no SSH
+    // server, so there is no host key to carry (the host reader tolerates that).
+    if let Err(e) = guest::emit_simple_ready_marker().await {
+        tracing::warn!(error = %e, "emitting READY beacon failed; the supervisor may time out");
+    }
+
+    // ── BPF pseudo-filesystems (detonation-specific; minimald does not mount
+    // these — a vanilla build VM should not carry bpffs). Best-effort: a kernel
+    // without them just degrades coverage (the host caps the verdict at REVIEW).
+    mount_fs("none", "/sys/kernel/security", "securityfs");
+    mount_fs("bpf", "/sys/fs/bpf", "bpf");
+    raise_memlock_rlimit();
+
+    // ── Stage the deny-channel tripwire BEFORE the LSM attaches ────────────
+    // Once the observer's `file_open` hook is live, even creating this sentinel
+    // is denied (chicken-and-egg). World-readable so the later unprivileged probe
+    // passes the DAC check and actually reaches the LSM hook. If staging fails
+    // (read-only rootfs), the probe later gets ENOENT, no denial is recorded, and
+    // the host honestly caps the verdict at REVIEW — never a false "confirmed".
+    stage_tripwire();
+
+    // ── Load the per-scan binding nonce (PR2/PR3), for the ROOT observer only ──
+    let nonce = load_binding_nonce();
+
+    // ── Capture the real DNS upstream before we repoint the resolver ───────
+    // `bring_up_root_egress` will point the resolver at the gvproxy DNS gateway;
+    // read whatever the resolver currently is so the collector can forward to it,
+    // then (once the collector is up) we repoint at 127.0.0.1 so every query name
+    // transits the observer. No-NIC model: this is loopback/empty and a no-op.
+    let dns_upstream_pre = read_nameserver();
+
+    // ── Root-netns egress via the host gvproxy shuttle (networked model) ───
+    // Held for the detonation's lifetime (dropping tears the relay down).
+    // Best-effort: no host gvproxy → the sample simply has no network (the prior
+    // no-NIC behaviour), which is still a valid detonation.
+    let egress = match guest::bring_up_root_egress().await {
+        Ok(relay) => Some(relay),
+        Err(e) => {
+            tracing::warn!(error = %e, "root egress unavailable; detonating without network");
+            None
+        }
+    };
+    // `bring_up_root_egress` set the resolver to the gvproxy DNS; re-read it so the
+    // collector forwards to the *real* upstream (falling back to the pre-egress one).
+    let dns_upstream = read_nameserver().or(dns_upstream_pre);
+
+    // ── Start the root observer, block on readiness ────────────────────────
+    let _ = std::fs::remove_file(READY);
+    let _ = std::fs::remove_file(EVENTS);
+    // File output is the reliable primary sink: the observer writes the feed to
+    // EVENTS and signals ready as soon as its hooks are attached. We deliberately
+    // do NOT pass `--vsock-port` here — that makes the observer BLOCK connecting
+    // its sink to a host vsock listener, and if none is up (as in a one-shot
+    // detonation) it never signals ready and this boot stalls. The host collects
+    // the feed via the drained file (streamed on stdout by `emit_feed_to_stdout`,
+    // or read from the data volume); live vsock streaming is a future opt-in that
+    // requires a host-side listener.
+    let mut mon = Command::new(MONITOR);
+    mon.arg("--output").arg(EVENTS).arg("--ready-file").arg(READY);
+    if let Some(n) = &nonce {
+        // The nonce is set on the OBSERVER's environment only; it is never set on
+        // the sample's, so uid 65534 never sees it (the F3/F4 guarantee).
+        mon.env("DET_BINDING_NONCE", n);
+    }
+    if let Some(up) = &dns_upstream {
+        mon.env("DET_DNS_UPSTREAM", up);
+    }
+    let mut monitor = mon
+        .spawn()
+        .map_err(|e| MainError::IO(e, "spawning the observer"))?;
+    let mon_pid = monitor.id();
+    tracing::info!(pid = mon_pid, output = EVENTS, "started root observer");
+
+    for attempt in 0..READY_ATTEMPTS {
+        if std::path::Path::new(READY).exists() {
+            break;
+        }
+        if let Some(status) = monitor
+            .try_wait()
+            .map_err(|e| MainError::IO(e, "polling the observer"))?
+        {
+            return Err(MainError::Other(format!(
+                "observer pid={mon_pid} exited before becoming ready ({status})"
+            )));
+        }
+        if attempt + 1 == READY_ATTEMPTS {
+            let _ = monitor.kill();
+            return Err(MainError::Other(
+                "observer did not become ready within 10s".to_string(),
+            ));
+        }
+        tokio::time::sleep(POLL).await;
+    }
+    tracing::info!("observer ready");
+
+    // ── Prove nobody cannot read the nonce (the nonce channel must not leak) ──
+    // The file channel exists precisely so the `nobody` sample can NEVER read the
+    // nonce — a sample that learns it could forge a feed that passes
+    // `--expect-nonce`. Fail closed if the leak-check ever succeeds.
+    if nonce.is_some() {
+        let nonce_file = nonce_file_path();
+        if nobody_can(&format!("cat {nonce_file}")) {
+            return Err(MainError::Other(format!(
+                "SECURITY: binding nonce {nonce_file} is readable by uid {SAMPLE_UID} — nonce channel leaks"
+            )));
+        }
+        tracing::info!("nonce leak-check passed (nobody cannot read the nonce file)");
+    }
+
+    // ── Route the sample's DNS through the collector (networked model only) ──
+    // The collector (127.0.0.1:53) is now listening and forwards to the upstream,
+    // so repointing the resolver keeps resolution working while making every
+    // query name observable. Gated on egress being UP: with no network there is
+    // nothing to collect, and doing the bind-mount anyway both wastes work and
+    // shows up as a spurious pid-1 Mount event the verdict reads as a
+    // container-escape signal (a false positive on an otherwise-benign run).
+    // Also skipped when the upstream is already loopback/empty (no-NIC model).
+    if egress.is_some() {
+        match dns_upstream.as_deref() {
+            None | Some("") | Some("127.0.0.1") | Some("::1") => {}
+            Some(up) => match install_local_resolver() {
+                Ok(()) => tracing::info!(upstream = up, "routed sample DNS through the collector"),
+                Err(e) => tracing::warn!(error = %e, "could not repoint resolver; DNS names may go unobserved"),
+            },
+        }
+    }
+
+    // ── uid-boundary self-check (PR3): nobody must not be able to write the feed ──
+    // The whole "a nobody sample can't forge the feed" guarantee rests on the feed
+    // being unwritable by uid 65534. Non-destructive (`test -w`); fail closed.
+    if nobody_can(&format!("test -w {EVENTS}")) {
+        return Err(MainError::Other(format!(
+            "SECURITY: feed {EVENTS} is writable by uid {SAMPLE_UID} — uid boundary broken"
+        )));
+    }
+    tracing::info!("uid-boundary self-check passed (nobody cannot write the feed)");
+
+    // ── Fire the tripwire (monitor is ready), then run the sample ──────────
+    // The open is EXPECTED to fail with EPERM (the LSM denies it); that recorded
+    // denial is what lets a clean run earn a confident PASS. Run in the same
+    // unprivileged scope the sample gets.
+    let _ = run_as_nobody(&format!("cat {TRIPWIRE} >/dev/null 2>&1; true"));
+    tracing::info!("fired deny-channel tripwire (expected EPERM on the tripwire path)");
+
+    let sample_cmd = load_sample_command()?;
+    tracing::info!("dropping privileges and launching the sample as a child");
+    // Fork-and-reap (not exec): keep pid-1 alive so we can drain the observer
+    // after the sample exits, before `main` takes the VM down. The sample never
+    // receives the nonce env (it was only ever set on the observer's Command).
+    //
+    // SECURITY — the sample's stdio is NULLED, not inherited. det-init emits the
+    // drained JSONL feed on the guest console (hvc0) and the host worker collects
+    // the feed by scanning that console for `{`-lines. If the untrusted `nobody`
+    // sample's stdout/stderr were inherited onto the same console, it could print
+    // forged `{"event":…}` lines that the worker would accept as real events —
+    // voiding the core invariant "a `nobody` sample cannot write the feed" (e.g.
+    // a forged NetworkDns re-contextualizing a real C2 connect → a signed
+    // BLOCK→PASS). The console is root-owned; nulling the inherited fds removes
+    // the sample's only path to it, so the feed on the console is written solely
+    // by pid-1 (det-init) and stays trustworthy. (The observer's root-0400
+    // /run/det-events.jsonl — provably unwritable by uid 65534, see the
+    // uid-boundary self-check above — is the source of record; draining it fully
+    // out-of-band via /dev/vdb or a host vsock listener is the robust follow-up.)
+    let mut sample = Command::new(DROPPRIV);
+    sample
+        .arg("/bin/sh")
+        .arg("-c")
+        .arg(&sample_cmd)
+        .env("HOME", HONEYTOKEN_HOME)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut sample = sample
+        .spawn()
+        .map_err(|e| MainError::IO(e, "spawning the sample under droppriv"))?;
+    let sample_pid = sample.id();
+    tracing::info!(pid = sample_pid, "sample running as nobody");
+    // Bounded wait — see SAMPLE_DEADLINE. A hung sample must not cost us the feed, so on expiry
+    // we kill it and fall through to the drain rather than letting the host reap the whole VM.
+    let deadline = Instant::now() + SAMPLE_DEADLINE;
+    let sample_rc = loop {
+        match sample.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    // SIGKILL: this is untrusted code that already ignored its chance to finish,
+                    // and a SIGTERM it can trap would just re-open the same hang.
+                    let _ = sample.kill();
+                    let _ = sample.wait(); // reap the zombie so the drain is not racing it
+                    tracing::warn!(
+                        pid = sample_pid,
+                        deadline_secs = SAMPLE_DEADLINE.as_secs(),
+                        "sample exceeded its deadline and was killed — draining the events it \
+                         produced so far (a hang no longer discards the whole feed; \
+                         gominimal/minimal-detonation#272)"
+                    );
+                    break None;
+                }
+                std::thread::sleep(POLL);
+            }
+            Err(e) => return Err(MainError::IO(e, "reaping the sample")),
+        }
+    };
+    match sample_rc {
+        Some(rc) => tracing::info!(rc = ?rc.code(), "sample exited"),
+        // Emitted on the console, which the host collects — so a timed-out run is
+        // distinguishable in triage from a genuine boot/attach failure.
+        None => tracing::warn!("sample TIMED OUT (killed); feed below is partial by construction"),
+    }
+
+    // ── Drain the observer: SIGTERM asks it to flush the ringbuf, bounded ──
+    drain_monitor(&mut monitor, mon_pid).await;
+
+    // Emit the captured feed on stdout so a host that collects via the console
+    // (rather than the observer's live vsock-1024 stream) still gets it — e.g.
+    // the boot-test harness that captures the guest console. Harmless in
+    // production, where vsock is the primary channel.
+    emit_feed_to_stdout();
+
+    tracing::info!("detonation complete");
+    Ok(())
+}
+
+/// Write the captured JSONL feed (the observer's `--output` file, now drained) to
+/// stdout, for a host that collects via the guest console rather than the vsock
+/// stream.
+fn emit_feed_to_stdout() {
+    use std::io::Write as _;
+    match std::fs::read(EVENTS) {
+        Ok(bytes) => {
+            let mut out = std::io::stdout().lock();
+            let _ = out.write_all(&bytes);
+            let _ = out.flush();
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, path = EVENTS, "could not read feed to emit on stdout")
+        }
+    }
+}
+
+/// Whether this process is the detonation microVM's init: the kernel runs the
+/// initramfs `/init` (this binary) as pid-1. Both halves are load-bearing — it
+/// gates `reboot(2)` via [`guest::shut_down_vm`], and `argv[0]` alone is
+/// caller-controlled while pid-1 alone could be a container init. Mirrors
+/// `minimald::is_minimal_microvm`.
+fn is_detonation_init() -> bool {
+    std::process::id() == 1
+        && std::env::args_os().next().is_some_and(|a0| {
+            std::path::Path::new(&a0).file_name() == Some(std::ffi::OsStr::new("init"))
+        })
+}
+
+fn init_tracing() {
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::registry()
+        // Log to stderr; keep stdout free of daemon noise.
+        .with(fmt::layer().with_ansi(false).with_writer(std::io::stderr))
+        .with(filter)
+        .init();
+}
+
+/// `mount(2)` a pseudo-filesystem, tolerating `EBUSY` (already mounted). Failures
+/// are logged, not fatal — a missing bpffs just degrades coverage.
+fn mount_fs(source: &str, target: &str, fstype: &str) {
+    let _ = std::fs::create_dir_all(target);
+    let (Ok(c_source), Ok(c_target), Ok(c_fstype)) = (
+        CString::new(source),
+        CString::new(target),
+        CString::new(fstype),
+    ) else {
+        tracing::warn!(target, "invalid mount argument");
+        return;
+    };
+    // SAFETY: `mount(2)` with valid, call-lifetime C strings for
+    // source/target/fstype, no flags, and a null data pointer.
+    let rc = unsafe {
+        libc::mount(
+            c_source.as_ptr(),
+            c_target.as_ptr(),
+            c_fstype.as_ptr(),
+            0,
+            std::ptr::null(),
+        )
+    };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::EBUSY) {
+            tracing::warn!(target, fstype, error = %err, "mount failed (coverage may degrade)");
+        }
+    } else {
+        tracing::info!(target, fstype, "mounted pseudo filesystem");
+    }
+}
+
+/// Raise the locked-memory rlimit to unlimited for the BPF maps/ringbuf.
+fn raise_memlock_rlimit() {
+    let unlimited = libc::rlimit {
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    // SAFETY: `setrlimit(2)` with a valid, fully-initialized rlimit pointer.
+    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &unlimited) } != 0 {
+        tracing::warn!(error = %std::io::Error::last_os_error(), "could not raise memlock rlimit");
+    }
+}
+
+/// Create the deny-channel tripwire sentinel (world-readable) if it is not already
+/// baked into the rootfs. Best-effort: on a read-only rootfs this is a no-op and
+/// the verdict honestly caps at REVIEW.
+fn stage_tripwire() {
+    use std::os::unix::fs::PermissionsExt;
+    if std::path::Path::new(TRIPWIRE).exists() {
+        tracing::info!(path = TRIPWIRE, "deny-channel tripwire present");
+        return;
+    }
+    match std::fs::File::create(TRIPWIRE) {
+        Ok(f) => {
+            let _ = f.set_permissions(std::fs::Permissions::from_mode(0o644));
+            tracing::info!(path = TRIPWIRE, "staged deny-channel tripwire");
+        }
+        Err(e) => tracing::warn!(path = TRIPWIRE, error = %e, "could not stage tripwire (verdict will cap at REVIEW)"),
+    }
+}
+
+fn nonce_file_path() -> String {
+    std::env::var("DET_BINDING_NONCE_FILE").unwrap_or_else(|_| NONCE_FILE_DEFAULT.to_string())
+}
+
+/// Load the per-scan binding nonce, in precedence order: the `DET_BINDING_NONCE`
+/// env (local-dev convenience) then the root-0400 file (the secure channel).
+/// `None` means no nonce this run — the nonce gate is simply inactive.
+fn load_binding_nonce() -> Option<String> {
+    if let Ok(n) = std::env::var("DET_BINDING_NONCE") {
+        if !n.is_empty() {
+            tracing::info!("binding nonce supplied via environment for the root observer");
+            return Some(n);
+        }
+    }
+    let path = nonce_file_path();
+    match std::fs::read_to_string(&path) {
+        Ok(n) if !n.trim().is_empty() => {
+            tracing::info!(from = %path, "loaded per-scan binding nonce for the root observer");
+            Some(n.trim().to_string())
+        }
+        _ => {
+            tracing::info!(tried = %path, "no binding nonce — nonce gate inactive this run");
+            None
+        }
+    }
+}
+
+/// Load the exact sample command to detonate: `DET_SAMPLE_CMD` env (local dev)
+/// then the host-staged file (verbatim).
+fn load_sample_command() -> Result<String, MainError> {
+    if let Ok(cmd) = std::env::var("DET_SAMPLE_CMD") {
+        if !cmd.trim().is_empty() {
+            return Ok(cmd);
+        }
+    }
+    let path =
+        std::env::var("DET_SAMPLE_FILE").unwrap_or_else(|_| SAMPLE_FILE_DEFAULT.to_string());
+    let cmd = std::fs::read_to_string(&path).map_err(|e| MainError::IO(e, "reading the sample command file"))?;
+    let cmd = cmd.trim();
+    if cmd.is_empty() {
+        return Err(MainError::Other(format!(
+            "sample command file {path} is empty; nothing to detonate"
+        )));
+    }
+    Ok(cmd.to_string())
+}
+
+/// The first `nameserver` in `/etc/resolv.conf`, if any.
+fn read_nameserver() -> Option<String> {
+    let contents = std::fs::read_to_string("/etc/resolv.conf").ok()?;
+    for line in contents.lines() {
+        let mut it = line.split_whitespace();
+        if it.next() == Some("nameserver") {
+            if let Some(ns) = it.next() {
+                return Some(ns.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Repoint `/etc/resolv.conf` at the loopback collector (127.0.0.1) with a plain
+/// WRITE — deliberately NOT a bind-mount. A bind-mount by pid-1 shows up as an
+/// `sb_mount` event the verdict reads as a container-escape signal: a false
+/// positive, since det-init's own infrastructure is not sample behaviour. On a
+/// read-only rootfs the write fails (EROFS) and the caller degrades to "DNS names
+/// unobserved", matching the legacy `detonate.sh` runner. (Full DNS-name capture
+/// on a RO rootfs — a writable `/etc` overlay — is a networked-detonation
+/// follow-up; the robust fix is verdict-side process-subtree scoping so pid-1
+/// infra never counts toward the sample verdict.)
+fn install_local_resolver() -> std::io::Result<()> {
+    std::fs::write("/etc/resolv.conf", "nameserver 127.0.0.1\n")
+}
+
+/// Run `sh -c <cmd>` as unprivileged `nobody` via `droppriv`, returning the exit
+/// status. Falls back to a bare shell only if `droppriv` is absent (which would
+/// itself be a rootfs-staging bug worth the loud path).
+fn run_as_nobody(cmd: &str) -> std::io::Result<std::process::ExitStatus> {
+    if std::path::Path::new(DROPPRIV).is_file() {
+        Command::new(DROPPRIV)
+            .arg("/bin/sh")
+            .arg("-c")
+            .arg(cmd)
+            .status()
+    } else {
+        tracing::warn!(path = DROPPRIV, "droppriv missing; running check without a uid drop");
+        Command::new("/bin/sh").arg("-c").arg(cmd).status()
+    }
+}
+
+/// Whether `nobody` can run `cmd` successfully (exit 0). Used by the security
+/// self-checks: a `true` from `cat <nonce>` or `test -w <feed>` means the boundary
+/// leaked and the run must not be trusted.
+fn nobody_can(cmd: &str) -> bool {
+    run_as_nobody(cmd)
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// SIGTERM the observer and wait (bounded) for it to drain the ringbuf + flush its
+/// sink, then SIGKILL as a backstop so a wedged observer can never hang teardown.
+async fn drain_monitor(monitor: &mut std::process::Child, mon_pid: u32) {
+    // Already gone?
+    if let Ok(Some(status)) = monitor.try_wait() {
+        tracing::warn!(pid = mon_pid, ?status, "observer already exited before drain");
+        return;
+    }
+    tracing::info!(pid = mon_pid, "signalling observer to drain and exit");
+    // SAFETY: `kill(2)` with a signal number; no pointers. A stale pid at worst
+    // signals nothing (ESRCH) — pid-1 reaps its own children so there is no
+    // pid-reuse window here.
+    unsafe {
+        libc::kill(mon_pid as libc::pid_t, libc::SIGTERM);
+    }
+    for attempt in 0..DRAIN_ATTEMPTS {
+        match monitor.try_wait() {
+            Ok(Some(_)) => {
+                tracing::info!("observer drained and exited");
+                return;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(error = %e, "waiting on observer during drain");
+                return;
+            }
+        }
+        if attempt + 1 == DRAIN_ATTEMPTS {
+            tracing::warn!(pid = mon_pid, "observer did not exit within 5s of SIGTERM; SIGKILL");
+            let _ = monitor.kill();
+            let _ = monitor.wait();
+            return;
+        }
+        tokio::time::sleep(POLL).await;
+    }
+}


### PR DESCRIPTION
Adds `det-init`, the minimal-detonation guest `/init`. It **embeds** `minimald::guest` rather than forking minimald, then stands up an in-guest BPF-LSM observer and runs an untrusted package install as `nobody` under it, streaming the event feed out for a host-side verdict.

It deliberately does **not** run minimald's SSH server — a detonation is one-shot, so the sample runs directly and the guest is discarded.

**Pure addition:** one new crate (+664 lines), plus its `Cargo.toml`/`Cargo.lock` workspace entries. No existing file is modified.

## Three load-bearing trust properties, each self-checked at boot

| Property | How it's proven |
|---|---|
| `nobody` cannot write the feed | sample stdio is **nulled**, not inherited — otherwise it could print forged `{"event":…}` lines onto the console the host scrapes |
| the binding nonce is root-only | leak-check asserts `nobody` gets EPERM |
| the event file is root-0400 | uid-boundary self-check |

## The sample is bounded

The feed is drained **after** the sample returns, so an unbounded sample that never returns takes the entire feed with it — the host reaps the VM, the drain never runs, and a detonation that should have been BLOCK reports as an empty capture.

Not an exotic input: a poisoned package whose C2 is unreachable blocks on `connect()` exactly like this, so *the better the network defense, the more likely the whole feed is lost*. On expiry the sample is SIGKILLed and the events it already produced drain normally.

## Verification

- `cargo check -p det-init --locked` on Linux, rustc 1.97.0 (the repo's pinned toolchain) — clean
- Live detonation on x86_64/KVM: 16/16 LSM hooks + 3/3 tracepoints attach; clean `npm install` → **PASS**; poisoned sample (honeytoken reads + non-registry beacon) → **BLOCK**, signed

Supersedes #981, which carried six commits — including fixes to its own earlier commits and two headers over commitlint's 100-char limit. Squashed to one, since this introduces a single new crate and that history was noise to review.

Refs gominimal/minimal-detonation#194, gominimal/minimal-detonation#272

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `det-init` guest pid-1 to detonate untrusted packages under a BPF-LSM observer
> - Introduces a new `det-init` binary crate ([Cargo.toml](https://github.com/gominimal/minimal/pull/983/files#diff-81a248dc8c4f239df90392c77711214f7992169c45e47e500d6382eff60275ed), [main.rs](https://github.com/gominimal/minimal/pull/983/files#diff-f322ecac9a0fe2e76da1d909c7e8a7c15c8eb44dd4917e084f1d85ca02765fee)) that runs as pid-1 inside the microVM and orchestrates the full detonation flow.
> - Mounts `/dev`, rootfs, securityfs, and bpffs; raises the memlock rlimit; then starts a root BPF-LSM observer (`detonation-monitor`) and waits up to 10s for it to signal readiness.
> - Executes the untrusted sample as uid 65534 (`nobody`) via a `droppriv` helper with a 90s deadline and SIGKILL backstop; emits the drained JSONL event feed to stdout for host collection.
> - Verifies security boundaries before sample launch: checks that `nobody` cannot read the binding nonce or write the event feed, and optionally repoints DNS to a local collector when egress is up.
> - Risk: as pid-1, any unhandled exit would cause a guest kernel panic; the process parks in an infinite sleep loop after `async_main` completes to prevent this.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb15b54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->