### PR TITLE
fix(OSX timekeeping): self-manage timekeeping on OSX

### DIFF
--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -672,66 +672,63 @@ fn clock_step_target(host_ns: u64, guest_ns: u64) -> Option<nix::sys::time::Time
     ))
 }
 
-/// Listens forever for host time updates and steps the guest's `CLOCK_REALTIME`
-/// onto the host's whenever the two have drifted apart.
+/// Vsock port the guest listens on for host time updates (see
+/// [`run_timekeep_listener`]).
 ///
-/// This is the guest half of libkrun's timesync worker
-/// ([`timesync.rs`](https://github.com/containers/libkrun/blob/main/src/devices/src/virtio/vsock/timesync.rs)),
-/// which libkrun initializes on macOS hosts only. It sends an AF_VSOCK
-/// **datagram** — eight bytes, the host's nanoseconds since the epoch, little
-/// endian — to a fixed port (123) every 60 s, and immediately after it notices
-/// the host slept. Without this the guest clock stops for the duration of a
-/// host suspend and every later timestamp is wrong: TLS handshakes fail on
-/// not-yet-valid certificates and build systems see sources "from the future".
+/// Sits next to [`BOOT_MARKER_PORT`] (7350) in the same private range. The host
+/// half in `minvmd` must register a bridge to this port, so the value is
+/// mirrored there — keep the two in step.
+pub const TIMEKEEP_PORT: u32 = 7351;
+
+/// How long a host timekeeper connection may stay silent before the guest
+/// treats it as dead. Several times the host's 60 s heartbeat, so an idle
+/// window this long means the peer is gone, not slow.
 ///
-/// Runs until the socket fails, hence the [`Infallible`] success type: every
-/// `Ok` path loops. Callers spawn it and log the error. Malformed datagrams
-/// (anything but exactly 8 bytes) are skipped, not fatal — one bad packet is
-/// not a reason to stop tracking the host clock.
+/// Connections are served one at a time, so this is what stops a peer that
+/// vanished *without* closing — a wedged bridge, a host end that never sends a
+/// FIN — from parking the listener in `read_exact` forever while the host's
+/// reconnect waits unaccepted in the backlog, leaving the guest clock
+/// uncorrected for the life of the VM.
+const TIMEKEEP_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Serves one host timekeeper connection: a stream of 8-byte little-endian
+/// nanosecond-since-epoch stamps, each applied to the guest clock as it
+/// arrives. Returns `Ok(())` on a clean end-of-stream (including a half-frame
+/// at EOF, which just means the host closed mid-write) and after `idle_timeout`
+/// of silence — both mean "done with this peer, go accept the next".
 ///
-/// [`AsyncFd`]: tokio::io::unix::AsyncFd
-/// [`Infallible`]: std::convert::Infallible
-pub async fn run_timekeep_listener(port: u32) -> std::io::Result<std::convert::Infallible> {
-    use nix::sys::socket::{AddressFamily, MsgFlags, SockFlag, SockType, bind, recv, socket};
+/// `idle_timeout` is a parameter rather than a read of
+/// [`TIMEKEEP_IDLE_TIMEOUT`] so a test can drive the timeout path in
+/// milliseconds; the listener always passes the constant.
+///
+/// `warned_settime` is threaded from the accept loop so the `CAP_SYS_TIME`
+/// warning stays one-shot across reconnects rather than per connection.
+async fn serve_time_updates<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut R,
+    idle_timeout: Duration,
+    warned_settime: &mut bool,
+) -> std::io::Result<()> {
     use nix::time::{ClockId, clock_gettime, clock_settime};
-    use std::os::fd::AsRawFd as _;
-    use tokio::io::unix::AsyncFd;
-    use tokio_vsock::VMADDR_CID_ANY;
+    use tokio::io::AsyncReadExt as _;
 
-    // Non-blocking from birth: `AsyncFd` only reports readiness, the recv below
-    // is ours to issue, and a blocking one would stall a runtime worker.
-    let sock = socket(
-        AddressFamily::Vsock,
-        SockType::Datagram,
-        SockFlag::SOCK_CLOEXEC | SockFlag::SOCK_NONBLOCK,
-        None,
-    )?;
-    // The host addresses the guest by its own CID, which the guest does not need
-    // to know: `VMADDR_CID_ANY` binds the port on whatever CID we were given.
-    bind(sock.as_raw_fd(), &VsockAddr::new(VMADDR_CID_ANY, port))?;
-    let sock = AsyncFd::new(sock)?;
-    tracing::info!(port, "listening for host time updates on vsock");
-
-    // `clock_settime` needs CAP_SYS_TIME. The microVM's pid-1 has it, but a
-    // native daemon handed --timekeep-listener-port may not, and updates arrive
-    // every 60s — warn on the first denial and stay quiet after that.
-    let mut warned_settime = false;
-
+    let mut buf = [0u8; 8];
     loop {
-        let mut ready = sock.readable().await?;
-        let mut buf = [0u8; 8];
-        let received = match ready.try_io(|sock| {
-            recv(sock.as_raw_fd(), &mut buf, MsgFlags::empty()).map_err(std::io::Error::from)
-        }) {
-            // Spurious readiness; `try_io` cleared it, so wait for the next.
-            Err(_would_block) => continue,
-            Ok(Ok(n)) => n,
+        match tokio::time::timeout(idle_timeout, reader.read_exact(&mut buf)).await {
+            Ok(Ok(_)) => {}
+            // Clean close, or a truncated final frame — either way the host is
+            // done talking; the accept loop waits for the next connection.
+            Ok(Err(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
             Ok(Err(e)) if e.kind() == std::io::ErrorKind::Interrupted => continue,
             Ok(Err(e)) => return Err(e),
-        };
-        if received != 8 {
-            tracing::warn!(received, "ignoring malformed time update");
-            continue;
+            // Silent for several heartbeats: drop this connection (any partial
+            // frame with it) so a reconnect can be accepted.
+            Err(_elapsed) => {
+                tracing::debug!(
+                    timeout_s = idle_timeout.as_secs(),
+                    "no host time update within the idle window; dropping the connection"
+                );
+                return Ok(());
+            }
         }
 
         let host_ns = u64::from_le_bytes(buf);
@@ -746,10 +743,10 @@ pub async fn run_timekeep_listener(port: u32) -> std::io::Result<std::convert::I
         match clock_settime(ClockId::CLOCK_REALTIME, host_ts) {
             Ok(()) => {
                 tracing::info!(drift_ns, "stepped the guest clock onto the host's");
-                warned_settime = false;
+                *warned_settime = false;
             }
-            Err(e) if !warned_settime => {
-                warned_settime = true;
+            Err(e) if !*warned_settime => {
+                *warned_settime = true;
                 tracing::warn!(
                     error = %e,
                     drift_ns,
@@ -758,6 +755,65 @@ pub async fn run_timekeep_listener(port: u32) -> std::io::Result<std::convert::I
                 );
             }
             Err(e) => tracing::debug!(error = %e, drift_ns, "could not set the guest clock"),
+        }
+    }
+}
+
+/// Listens forever for host time updates and steps the guest's `CLOCK_REALTIME`
+/// onto the host's whenever the two have drifted apart.
+///
+/// The guest clock only advances while the VM is scheduled, so it stops for the
+/// duration of a host suspend and every later timestamp is wrong: TLS
+/// handshakes fail on not-yet-valid certificates and build systems see sources
+/// "from the future". This listener is the repair.
+///
+/// **Wire protocol.** The guest *listens* on a vsock **stream** at `port`
+/// (`VMADDR_CID_ANY`, so it needs no knowledge of its own CID) and the host
+/// dials in — the same direction as the SSH bridge, and the reason this is a
+/// stream socket: AF_VSOCK **datagrams** do not exist on a stock kernel's
+/// virtio-vsock transport. They are a libkrun/TSI extension carried by the
+/// patched kernel libkrun ships, which we do not boot — the original design
+/// took libkrun's timesync worker
+/// ([`timesync.rs`](https://github.com/containers/libkrun/blob/main/src/devices/src/virtio/vsock/timesync.rs))
+/// at its word and bound `SOCK_DGRAM` on port 123, which can never receive
+/// anything under our guest kernel. A stream listener works on any kernel with
+/// vsock + virtio, at the cost of owning the host half ourselves (in `minvmd`).
+///
+/// Each update is 8 bytes: the host's nanoseconds since the epoch, little
+/// endian (libkrun's payload, kept). A connection carries any number of them
+/// back to back, so the host may hold one long-lived connection and write every
+/// 60 s, or dial per update; both work. Connections are served one at a time —
+/// there is a single host timekeeper, and serializing keeps the clock updates
+/// ordered.
+///
+/// Runs until the listening socket fails, hence the [`Infallible`] success
+/// type: every `Ok` path loops. Callers spawn it and log the error. A failure
+/// on an accepted connection ends only that connection.
+///
+/// [`Infallible`]: std::convert::Infallible
+pub async fn run_timekeep_listener(port: u32) -> std::io::Result<std::convert::Infallible> {
+    use tokio_vsock::{VMADDR_CID_ANY, VsockListener};
+
+    let listener = VsockListener::bind(VsockAddr::new(VMADDR_CID_ANY, port))?;
+    tracing::info!(port, "listening for host time updates on vsock");
+
+    // `clock_settime` needs CAP_SYS_TIME. The microVM's pid-1 has it, but a
+    // native daemon handed --timekeep-listener-port may not, and updates arrive
+    // every 60s — warn on the first denial and stay quiet after that.
+    let mut warned_settime = false;
+
+    loop {
+        let (mut stream, peer) = listener.accept().await?;
+        tracing::debug!(
+            cid = peer.cid(),
+            port = peer.port(),
+            "host timekeeper connected"
+        );
+        match serve_time_updates(&mut stream, TIMEKEEP_IDLE_TIMEOUT, &mut warned_settime).await {
+            Ok(()) => tracing::debug!("host timekeeper disconnected"),
+            // One bad connection is not a reason to stop tracking the host
+            // clock: drop it and wait for the host to dial again.
+            Err(e) => tracing::warn!(error = %e, "host time update stream failed"),
         }
     }
 }
@@ -1094,16 +1150,60 @@ mod tests {
         assert_eq!(step.tv_nsec(), 999_999_999);
     }
 
-    /// The wire format libkrun's timesync worker writes: 8 bytes, little
-    /// endian, nanoseconds since the epoch.
+    /// The wire format of one update frame: 8 bytes, little endian,
+    /// nanoseconds since the epoch (libkrun's payload, kept when the transport
+    /// moved from a TSI datagram to a plain vsock stream).
     #[test]
-    fn a_time_update_datagram_decodes_little_endian() {
+    fn a_time_update_frame_decodes_little_endian() {
         let host_ns = 1_700_000_000 * NANOS_IN_SECOND + 123_456_789;
         assert_eq!(u64::from_le_bytes(host_ns.to_le_bytes()), host_ns);
         assert_eq!(
             u64::from_le_bytes([0x15, 0xcd, 0x5b, 0x07, 0x00, 0x00, 0x00, 0x00]),
             123_456_789,
         );
+    }
+
+    /// A connection carries back-to-back frames and ends cleanly at EOF —
+    /// including on a truncated final frame, which only means the host closed
+    /// mid-write.
+    ///
+    /// The stamps written are the guest's own current time, i.e. zero drift, so
+    /// the loop takes the no-step path: a test must never actually call
+    /// `clock_settime` (running as root, it would step the machine's clock).
+    #[tokio::test]
+    async fn a_stream_of_updates_is_read_frame_by_frame_to_eof() {
+        use nix::time::{ClockId, clock_gettime};
+
+        let now = clock_gettime(ClockId::CLOCK_REALTIME).unwrap();
+        let now_ns = now.tv_sec() as u64 * NANOS_IN_SECOND + now.tv_nsec() as u64;
+
+        let mut stream = Vec::new();
+        stream.extend_from_slice(&now_ns.to_le_bytes());
+        stream.extend_from_slice(&now_ns.to_le_bytes());
+        // A half-written final frame: EOF mid-frame is a clean end, not an error.
+        stream.extend_from_slice(&now_ns.to_le_bytes()[..3]);
+
+        let mut warned = false;
+        serve_time_updates(&mut stream.as_slice(), TIMEKEEP_IDLE_TIMEOUT, &mut warned)
+            .await
+            .expect("a truncated trailing frame ends the stream cleanly");
+        assert!(!warned, "an in-threshold update never touches the clock");
+    }
+
+    /// A peer that goes silent without closing must not hold the listener:
+    /// connections are served one at a time, so the idle timeout is what lets
+    /// the host's reconnect be accepted. Driven with a millisecond window —
+    /// the timeout is a parameter precisely so this costs no wall-clock time.
+    #[tokio::test]
+    async fn a_silent_connection_is_dropped_after_the_idle_window() {
+        // `_writer` stays alive for the whole test: the stream is open and
+        // idle, which is the case under test — not EOF.
+        let (_writer, mut reader) = tokio::io::duplex(64);
+
+        let mut warned = false;
+        serve_time_updates(&mut reader, Duration::from_millis(10), &mut warned)
+            .await
+            .expect("an idle connection ends cleanly, like EOF");
     }
 
     #[test]

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -210,10 +210,10 @@ pub struct ListenArgs {
     #[clap(hide = true)]
     mk_mount_state_volume: Option<String>,
 
-    /// Vsock port to listen on for time updates. This listens for updates emitted by
-    /// libkrun's timesync worker: https://github.com/libkrun/libkrun/blob/main/src/devices/src/virtio/vsock/timesync.rs#L16.
-    ///
-    /// This worker is only initialized for a MacOS host.
+    /// Vsock port to listen on for host time updates: 8-byte little-endian
+    /// nanoseconds-since-epoch stamps, dialed in by the host half in `minvmd`
+    /// (see `guest::run_timekeep_listener`). Only useful as a VM init process;
+    /// `None` leaves the guest clock free-running.
     #[arg(long)]
     #[clap(hide = true)]
     timekeep_listener_port: Option<u32>,
@@ -407,12 +407,10 @@ async fn async_main() -> Result<(), MainError> {
                 mount_rootfs: Some("/dev/vda".to_string()),
                 mk_mount_state_volume: Some("/dev/vdb".to_string()),
                 detach: false,
-                timekeep_listener_port: if cfg!(target_arch = "aarch64") {
-                    // Libkrun shares the time as datagrams down vsock 123 on MacOS.
-                    Some(123)
-                } else {
-                    None
-                },
+                // Host time updates arrive on a vsock stream we listen on, from
+                // minvmd. Always listen: the guest cannot see what the
+                // host runs.
+                timekeep_listener_port: Some(guest::TIMEKEEP_PORT),
                 // In-VM (DM1/3/4) the PTask attaches to the host gvproxy over the
                 // vsock shuttle, so no in-guest gvproxy binary path is needed.
                 gvproxy_bin: None,

--- a/crates/minvmd/src/cmd/vmm_child.rs
+++ b/crates/minvmd/src/cmd/vmm_child.rs
@@ -16,7 +16,11 @@
 //! 5. Registers the marker socket for `VSOCK_MARKER_PORT` (guest→host): the
 //!    guest workload connects to that vsock port and writes `READY\n`, which
 //!    libkrun bridges to the host UNIX socket where the parent listens.
-//! 6. Calls `krun_start_enter`, which boots the VM. On success libkrun
+//! 6. On macOS, registers the timekeep socket for `VSOCK_TIMEKEEP_PORT`
+//!    (host→guest) and starts the thread that sends the host wall clock to the
+//!    guest, so a host suspend does not leave the guest clock frozen
+//!    ([`crate::timekeep`]).
+//! 7. Calls `krun_start_enter`, which boots the VM. On success libkrun
 //!    `exit()`s with the guest workload's exit code and never returns here.
 //!
 //! Without libkrun this subcommand bails immediately with a "no libkrun" error.
@@ -108,6 +112,16 @@ fn run_vmm() -> Result<()> {
     ctx.add_vsock_port(VSOCK_MARKER_PORT, &marker_sock)
         .context("registering READY-marker vsock port")?;
 
+    // Host wall-clock updates (host→guest, `crate::timekeep`), macOS only.
+    //
+    // Best-effort: a VM that boots with a drifting clock beats one that does
+    // not boot, so every failure warns and carries on.
+    if cfg!(target_os = "macos")
+        && let Err(e) = start_timekeep(&mut ctx)
+    {
+        tracing::warn!(error = %e, "host time updates unavailable; the guest clock will drift");
+    }
+
     tracing::info!(
         port = VSOCK_MARKER_PORT,
         sock = %marker_sock,
@@ -120,4 +134,41 @@ fn run_vmm() -> Result<()> {
     // error so the parent can observe the child's non-zero exit.
     let err = ctx.start_enter();
     bail!("krun_start_enter returned unexpectedly: {err}");
+}
+
+/// Register the host→guest timekeep bridge and start the sender thread.
+///
+/// libkrun's vsock API takes a filesystem path and nothing else, so this
+/// goes via a temporary UDS path.
+///
+/// The sender starts here rather than after `start_enter`, which never
+/// returns. libkrun binds the socket while starting the VM and the guest
+/// listener appears later still, so the thread dials into a socket that does
+/// not exist yet and retries — by design.
+#[cfg(minvmd_libkrun)]
+fn start_timekeep(ctx: &mut crate::krun::Context) -> Result<()> {
+    use anyhow::Context as _;
+
+    let sock =
+        crate::timekeep::resolve_timekeep_sock().context("resolving the timekeep socket path")?;
+    // libkrun aborts the process on an over-long socket path instead of
+    // returning an error, so check before handing it over.
+    crate::sock::check_uds_path_len(&sock)?;
+    crate::sock::prepare_socket_dir(&sock)?;
+    // Drop a stale socket from a prior run; libkrun's listen-bind fails
+    // EEXIST otherwise (e.g. on a persistent runner).
+    crate::sock::remove_stale_socket(&sock)?;
+
+    ctx.add_vsock_port2(crate::timekeep::VSOCK_TIMEKEEP_PORT, &sock, true)
+        .context("registering the timekeep vsock port")?;
+    // Detached on purpose: the thread lives as long as the process, which
+    // libkrun `exit()`s when the guest ends.
+    let _sender = crate::timekeep::spawn(sock.clone()).context("spawning the timekeep sender")?;
+
+    tracing::info!(
+        port = crate::timekeep::VSOCK_TIMEKEEP_PORT,
+        sock = %sock.display(),
+        "registered host→guest timekeep bridge",
+    );
+    Ok(())
 }

--- a/crates/minvmd/src/lib.rs
+++ b/crates/minvmd/src/lib.rs
@@ -20,6 +20,7 @@ pub mod net;
 pub(crate) mod rpc_client;
 pub mod sock;
 pub mod state;
+pub mod timekeep;
 pub mod vm;
 pub mod volume;
 

--- a/crates/minvmd/src/timekeep.rs
+++ b/crates/minvmd/src/timekeep.rs
@@ -1,0 +1,316 @@
+//! Host→guest wall-clock updates: the host half of `minimald`'s
+//! `guest::run_timekeep_listener`.
+//!
+//! The guest clock only advances while the VM is scheduled, so a host that
+//! suspends leaves the guest's `CLOCK_REALTIME` frozen at the moment it went
+//! down, and every later guest timestamp is wrong — TLS handshakes fail on
+//! not-yet-valid certificates, build systems see sources "from the future".
+//! libkrun ships a timesync worker for exactly this, but it sends AF_VSOCK
+//! **datagrams**, which exist only under the TSI patchset carried by libkrun's
+//! own kernel; we boot the generic upstream kernel, where nothing can receive
+//! them. This module is the replacement: the guest *listens* on a vsock
+//! **stream** and the host dials in and writes timestamps.
+//!
+//! ```text
+//!  host (sender thread)               libkrun              guest
+//!  ┌──────────────────┐  UNIX sock   ┌─────────┐  vsock   ┌───────────────────┐
+//!  │ 8-byte LE stamps │─────────────▶│ vsock   │─────────▶│ minimald listener │
+//!  │ every 60s + wake │ timekeep.sock│ bridge  │  :7351   │ steps CLOCK_REALTIME
+//!  └──────────────────┘              └─────────┘          └───────────────────┘
+//! ```
+//!
+//! **Why a socket file on disk.** libkrun's whole vsock surface is
+//! `krun_add_vsock_port{,2}(ctx, port, const char *filepath[, listen])`: a
+//! filesystem path, registered before `krun_start_enter`. There is no
+//! fd-passing variant and no API to reach a guest vsock port from the host once
+//! the VM is up, so a host→guest channel *must* be a UDS on disk. It lands
+//! beside the two that already exist for the same reason (`ssh.sock`,
+//! `gvproxy-switch.sock`) in the minvmd provider dir.
+//!
+//! The registration is `listen = true` — libkrun binds the host UDS and bridges
+//! each accepted connection to the guest process listening on the vsock port —
+//! the same direction as the minimald SSH bridge
+//! ([`crate::sock::VSOCK_BRIDGE_PORT`]), and the mirror of the guest-initiated
+//! READY marker ([`crate::cmd::VSOCK_MARKER_PORT`]).
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// vsock port the in-guest listener binds, which libkrun bridges the host UDS
+/// to.
+///
+/// Mirrors `minimald`'s `guest::TIMEKEEP_PORT` — minvmd does not depend on the
+/// minimald crate, so the value is duplicated here, exactly as
+/// [`crate::cmd::VSOCK_MARKER_PORT`] duplicates the guest's boot-marker port.
+/// Keep the two in step. Distinct from every other vsock port minvmd registers
+/// (asserted in the tests below).
+pub const VSOCK_TIMEKEEP_PORT: u32 = 7351;
+
+/// How often a healthy sender re-states the host time. Matches the cadence of
+/// libkrun's own timesync worker; the guest ignores an update it is already
+/// within 80 ms of, so this is a cheap keepalive that costs 8 bytes a minute.
+const HEARTBEAT: Duration = Duration::from_secs(60);
+
+/// How often the sender wakes to check whether an update is due. Bounds how
+/// long a guest can stay frozen after the host wakes from suspend, and doubles
+/// as the retry interval while the bridge or the guest listener is not up yet
+/// (through boot, when both are still coming up).
+const TICK: Duration = Duration::from_secs(5);
+
+/// Wall-vs-monotonic disagreement across one tick that counts as the host
+/// having suspended (or had its clock stepped) rather than clock jitter.
+const CLOCK_JUMP_THRESHOLD: Duration = Duration::from_secs(1);
+
+/// Resolve the host UDS path libkrun binds for the timekeep bridge.
+///
+/// Placed beside the minimald bridge socket (same parent dir, already created
+/// with mode 0700 by [`crate::sock::prepare_socket_dir`]), like the gvproxy
+/// switch socket.
+///
+/// # Errors
+///
+/// Propagates [`crate::sock::resolve_uds_path`]'s error.
+pub fn resolve_timekeep_sock() -> io::Result<PathBuf> {
+    Ok(timekeep_sock_beside(&crate::sock::resolve_uds_path()?))
+}
+
+/// The timekeep socket path beside a given minimald bridge UDS (same parent
+/// dir). Pure — derived only from `uds`, no env — so it is unit-testable
+/// without mutating process-global state.
+fn timekeep_sock_beside(uds: &Path) -> PathBuf {
+    uds.parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("timekeep.sock")
+}
+
+/// Whether the wall clock moved further than the monotonic clock did over the
+/// same tick — the host suspended, or its clock was stepped, and the guest's
+/// frozen clock wants correcting now rather than at the next heartbeat.
+///
+/// On macOS [`Instant`] is `mach_absolute_time`, which does *not* advance while
+/// the machine is asleep, so a suspend shows up here as a large wall delta
+/// against a near-zero monotonic one.
+fn clock_jumped(monotonic: Duration, wall: Duration) -> bool {
+    wall.abs_diff(monotonic) > CLOCK_JUMP_THRESHOLD
+}
+
+/// Whether an update should go out on this tick: the heartbeat has come round
+/// (or nothing has been delivered yet), or a jump-triggered update is still
+/// outstanding.
+///
+/// `jump_pending` is deliberately not folded into `last_sent`: a clock jump is
+/// detected from one tick's deltas, so if the send that follows it fails, the
+/// next tick sees no jump at all. Without the flag the correction the guest
+/// most needs — the one right after the host wakes, exactly when the bridge is
+/// most likely to be broken — would wait for the next heartbeat.
+fn update_due(last_sent: Option<Instant>, now: Instant, jump_pending: bool) -> bool {
+    jump_pending || last_sent.is_none_or(|sent| now.duration_since(sent) >= HEARTBEAT)
+}
+
+/// The update payload: nanoseconds since the Unix epoch, as the guest decodes
+/// it (`u64::from_le_bytes`). `None` for a clock before the epoch or beyond
+/// what 64 bits of nanoseconds can carry (year 2554) — both unrepresentable in
+/// the wire format rather than errors to handle.
+fn stamp_nanos(now: SystemTime) -> Option<u64> {
+    u64::try_from(now.duration_since(UNIX_EPOCH).ok()?.as_nanos()).ok()
+}
+
+/// Start the sender thread for the timekeep bridge at `sock`.
+///
+/// Spawn this **before** `krun_start_enter`, which never returns: libkrun binds
+/// `sock` while starting the VM, and the guest listener only comes up once
+/// minimald is running, so the thread expects to find nothing there for the
+/// first tens of seconds and retries every [`TICK`] until it connects.
+///
+/// The thread runs for the life of the process (libkrun `exit()`s it when the
+/// guest ends), so the returned handle is safe to drop.
+///
+/// # Errors
+///
+/// Propagates the OS error if the thread cannot be spawned.
+pub fn spawn(sock: PathBuf) -> io::Result<std::thread::JoinHandle<()>> {
+    std::thread::Builder::new()
+        .name("timekeep".to_string())
+        .spawn(move || run(&sock))
+}
+
+/// Send the host wall clock to the guest every [`HEARTBEAT`], and immediately
+/// whenever the host looks to have woken from suspend.
+///
+/// Holds one connection across updates and redials on any failure. A dead
+/// connection can cost one update: libkrun accepts on the host UDS before it
+/// knows whether the guest port is listening, so an early write can be buffered
+/// into a bridge that then closes. The guest is idempotent — every update
+/// carries an absolute time, not a delta — so the next one repairs it.
+fn run(sock: &Path) {
+    let mut conn: Option<std::os::unix::net::UnixStream> = None;
+    let mut last_monotonic = Instant::now();
+    let mut last_wall = SystemTime::now();
+    // `None` until the guest has taken an update: until then every tick is due,
+    // which is what walks the sender through boot to the first success.
+    let mut last_sent: Option<Instant> = None;
+    // A detected jump stays outstanding until an update is actually delivered,
+    // so a failed send retries every TICK instead of falling back to the
+    // heartbeat (see `update_due`).
+    let mut jump_pending = false;
+    let mut announced = false;
+
+    loop {
+        std::thread::sleep(TICK);
+        let (monotonic, wall) = (Instant::now(), SystemTime::now());
+        // A wall clock that ran backwards is a step by definition; `Err` here
+        // *is* the jump, not a failure to measure one.
+        let jumped = match wall.duration_since(last_wall) {
+            Ok(elapsed_wall) => {
+                clock_jumped(monotonic.duration_since(last_monotonic), elapsed_wall)
+            }
+            Err(_) => true,
+        };
+        (last_monotonic, last_wall) = (monotonic, wall);
+        jump_pending |= jumped;
+
+        if !update_due(last_sent, monotonic, jump_pending) {
+            continue;
+        }
+        let Some(stamp) = stamp_nanos(wall) else {
+            tracing::warn!("host wall clock is not representable; skipping the time update");
+            continue;
+        };
+
+        if conn.is_none() {
+            match std::os::unix::net::UnixStream::connect(sock) {
+                // Bound the send: a bridge that accepts but never drains would
+                // otherwise park this thread in `write_all` for the life of the
+                // VM, ending updates entirely. One tick is ample for 8 bytes,
+                // and a timed-out write is handled like any other send failure
+                // — redial, retry next tick.
+                Ok(stream) => match stream.set_write_timeout(Some(TICK)) {
+                    Ok(()) => conn = Some(stream),
+                    Err(e) => {
+                        tracing::debug!(error = %e, "cannot bound the timekeep send; redialling");
+                        continue;
+                    }
+                },
+                // Expected until libkrun binds the socket and the guest
+                // listener is up; retried on the next tick.
+                Err(e) => {
+                    tracing::debug!(sock = %sock.display(), error = %e, "timekeep bridge not up yet");
+                    continue;
+                }
+            }
+        }
+        let stream = conn.as_mut().expect("connected just above");
+
+        use std::io::Write as _;
+        match stream
+            .write_all(&stamp.to_le_bytes())
+            .and_then(|()| stream.flush())
+        {
+            Ok(()) => {
+                last_sent = Some(monotonic);
+                jump_pending = false;
+                if !announced {
+                    announced = true;
+                    tracing::info!(sock = %sock.display(), "sending host time updates to the guest");
+                } else {
+                    tracing::trace!(stamp, jumped, "sent a host time update");
+                }
+            }
+            // Redial on the next tick — which is also the retry cadence, since
+            // a failed send leaves the update due: `jump_pending` is kept, so a
+            // post-wake correction retries every TICK until it lands.
+            Err(e) => {
+                tracing::debug!(error = %e, "timekeep connection failed; redialling");
+                conn = None;
+                announced = false;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timekeep_port_is_distinct_from_the_other_vsock_ports() {
+        assert_ne!(VSOCK_TIMEKEEP_PORT, crate::cmd::VSOCK_MARKER_PORT);
+        assert_ne!(VSOCK_TIMEKEEP_PORT, crate::sock::VSOCK_BRIDGE_PORT);
+        assert_ne!(VSOCK_TIMEKEEP_PORT, crate::net::VSOCK_GVPROXY_SHUTTLE_PORT);
+    }
+
+    #[test]
+    fn timekeep_sock_sits_beside_the_bridge_socket() {
+        // Pure helper, asserted directly — no env mutation, so this can't race
+        // other tests that read the env (std::env is process-global).
+        let uds = std::path::Path::new("/run/user/1000/minimal/ssh.sock");
+        assert_eq!(
+            timekeep_sock_beside(uds),
+            PathBuf::from("/run/user/1000/minimal/timekeep.sock")
+        );
+    }
+
+    /// Ordinary ticks are not suspends: a monotonic and a wall clock that
+    /// advanced together leave the heartbeat to do the work.
+    #[test]
+    fn a_tick_where_both_clocks_advanced_together_is_not_a_jump() {
+        assert!(!clock_jumped(TICK, TICK));
+        // Scheduling noise either side of the tick stays below the threshold.
+        assert!(!clock_jumped(TICK, TICK + Duration::from_millis(200)));
+        assert!(!clock_jumped(TICK + Duration::from_millis(200), TICK));
+    }
+
+    /// The case the detector exists for: the host slept for an hour, so the
+    /// wall clock advanced while `Instant` (mach_absolute_time on macOS) did
+    /// not. A clock stepped backwards counts too.
+    #[test]
+    fn a_wall_clock_that_outran_the_monotonic_one_is_a_jump() {
+        assert!(clock_jumped(
+            Duration::from_millis(20),
+            Duration::from_secs(3600)
+        ));
+        // Backwards is symmetric — `abs_diff`, not a signed comparison.
+        assert!(clock_jumped(
+            Duration::from_secs(3600),
+            Duration::from_millis(20)
+        ));
+    }
+
+    /// The send schedule: nothing delivered yet, or the heartbeat has come
+    /// round, or a jump is still outstanding.
+    #[test]
+    fn an_update_is_due_on_the_heartbeat_and_while_a_jump_is_outstanding() {
+        let now = Instant::now();
+        let recent = now.checked_sub(TICK).expect("an instant a tick ago");
+        let stale = now
+            .checked_sub(HEARTBEAT)
+            .expect("an instant a heartbeat ago");
+
+        // Nothing delivered yet: due every tick, which walks the sender
+        // through boot to its first success.
+        assert!(update_due(None, now, false));
+        // Delivered a tick ago, no jump: wait for the heartbeat.
+        assert!(!update_due(Some(recent), now, false));
+        assert!(update_due(Some(stale), now, false));
+
+        // A jump outstanding overrides the heartbeat — this is the retry that
+        // gets a post-wake correction through after a failed send, when the
+        // tick that detected the jump is long past.
+        assert!(update_due(Some(recent), now, true));
+    }
+
+    /// The wire format the guest decodes: 8 bytes, little endian, nanoseconds
+    /// since the epoch.
+    #[test]
+    fn the_stamp_is_little_endian_nanoseconds_since_the_epoch() {
+        let at = UNIX_EPOCH + Duration::new(1_700_000_000, 123_456_789);
+        let stamp = stamp_nanos(at).expect("a 2023 timestamp is representable");
+        assert_eq!(stamp, 1_700_000_000_123_456_789);
+        assert_eq!(u64::from_le_bytes(stamp.to_le_bytes()), stamp);
+
+        // The epoch itself is a valid stamp; anything before it is not.
+        assert_eq!(stamp_nanos(UNIX_EPOCH), Some(0));
+        assert_eq!(stamp_nanos(UNIX_EPOCH - Duration::from_secs(1)), None);
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/gominimal/minimal/issues/985

The guest kernel has no TSI or virtio-vsock datagram implementation, so the libkrun-managed timekeeper isnt accessible. We run our own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic host-to-guest wall-clock synchronization for minimal microVMs.
  * Time updates are delivered over a stream-based channel, with improved handling of clock changes (including after time jumps).
  * macOS VMM startup now best-effort initializes the timekeeping bridge automatically.
* **Bug Fixes**
  * Improved resilience to interrupted/incomplete updates and silent connections; truncated trailing frames now end cleanly without unintended clock adjustments.
  * Refined warning behavior to re-enable one-shot warnings after successful time updates.
* **Tests**
  * Updated and added async test coverage for stream frame decoding and idle-timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OSX timekeeping by self-managing host-to-guest clock sync over vsock
> - Adds a new `timekeep` module in `crates/minvmd` that runs a background sender thread on macOS, waking every 5s to detect clock jumps and sending heartbeats every 60s as 8-byte little-endian nanoseconds-since-epoch over a libkrun-bridged vsock stream (port 7351).
> - Refactors the guest-side listener in `crates/minimald` from a datagram socket on port 123 to a vsock stream server on `TIMEKEEP_PORT` (7351), reading 8-byte frames and calling `clock_settime` when drift exceeds threshold; idle connections are dropped after 300s.
> - The timekeep listener is now always enabled for microVM init (previously only on aarch64), using the fixed `guest::TIMEKEEP_PORT`.
> - Behavioral Change: datagram-based time sync on port 123 is removed and replaced with a stream-based protocol; any host or guest component relying on the old mechanism must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 048ae24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->