### PR TITLE
ci(promote): repoint docs rebuild dispatch to gominimal/webapp + docs-hotfix

### DIFF
--- a/.github/workflows/docs-hotfix.yml
+++ b/.github/workflows/docs-hotfix.yml
@@ -1,0 +1,79 @@
+name: docs-hotfix
+
+# Refresh the public docs on gominimal/webapp from a chosen gominimal/minimal
+# sha WITHOUT cutting or promoting a binary release. Use this to push a docs
+# correction live between releases.
+#
+# Mechanism: the webapp's deploy-time sync (gominimal/webapp
+# deploy-cloudrun.yml, restored in gominimal/webapp#489) resolves the docs sha
+# in priority order MINIMAL_DOCS_SHA -> stable channel -> unstable channel ->
+# main. A `reference-docs-promoted` repository_dispatch sets MINIMAL_DOCS_SHA
+# from client_payload.sha, so this workflow pins that deploy to the given sha
+# and syncs the allow-listed doc sections (reference/, concepts/, guide->start/)
+# at it.
+#
+# Scope / durability: this triggers ONE webapp deploy at the chosen sha. A later
+# webapp deploy that is not driven by this dispatch falls back to the channel
+# pointer, so a hotfix is a bridge until the fix ships in the next promoted
+# release (after which the channel pointer carries it durably).
+
+on:
+    workflow_dispatch:
+        inputs:
+            sha:
+                description: "gominimal/minimal sha to sync docs from (empty = this workflow's ref)"
+                required: false
+                type: string
+                default: ""
+
+permissions:
+    contents: read
+
+concurrency:
+    group: docs-hotfix
+    cancel-in-progress: false
+
+jobs:
+    dispatch:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Resolve sha
+              id: resolve
+              env:
+                  INPUT_SHA: ${{ inputs.sha }}
+                  REF_SHA: ${{ github.sha }}
+              run: |
+                  set -euo pipefail
+                  # Trim stray whitespace; SHAs are often pasted with spaces.
+                  SHA="$(printf '%s' "$INPUT_SHA" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+                  # Default to the ref this workflow runs from (main HEAD).
+                  [ -z "$SHA" ] && SHA="$REF_SHA"
+                  echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+                  echo "Docs hotfix will pin gominimal/webapp to ${SHA}"
+
+            # Mint a short-lived token scoped to gominimal/webapp via the
+            # gominimal-aw-bot GitHub App (org standard — App tokens over PATs,
+            # see gominimal/min-aw ADR-0002). The default GITHUB_TOKEN cannot
+            # dispatch other repos; this token carries the App's contents:write
+            # permission narrowed to the webapp repo only.
+            - name: Mint webapp-repo token (gominimal-aw-bot)
+              id: webapp-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+              with:
+                  app-id: ${{ vars.AW_BOT_APP_ID }}
+                  private-key: ${{ secrets.AW_BOT_PRIVATE_KEY }}
+                  owner: gominimal
+                  repositories: webapp
+
+            - name: Dispatch reference-docs-promoted
+              env:
+                  GH_TOKEN: ${{ steps.webapp-token.outputs.token }}
+                  SHA: ${{ steps.resolve.outputs.sha }}
+              run: |
+                  set -euo pipefail
+                  gh api repos/gominimal/webapp/dispatches \
+                    -f event_type=reference-docs-promoted \
+                    -F "client_payload[sha]=${SHA}"
+                  echo "Dispatched reference-docs-promoted to gominimal/webapp for ${SHA}"

--- a/.github/workflows/docs-hotfix.yml
+++ b/.github/workflows/docs-hotfix.yml
@@ -50,6 +50,10 @@ jobs:
                   SHA="$(printf '%s' "$INPUT_SHA" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
                   # Default to the ref this workflow runs from (main HEAD).
                   [ -z "$SHA" ] && SHA="$REF_SHA"
+                  # Fail fast on a malformed sha. The webapp validates too and
+                  # degrades to the channel pointer, but only after burning a full
+                  # deploy — cheaper to reject junk here before dispatching.
+                  [[ "$SHA" =~ ^[0-9a-f]{7,40}$ ]] || { echo "::error::not a commit sha: ${SHA}"; exit 1; }
                   echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
                   echo "Docs hotfix will pin gominimal/webapp to ${SHA}"
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -232,12 +232,14 @@ jobs:
                   # Export resolved SHA for the docs-rebuild dispatch step below.
                   echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
-            # Mint a short-lived token scoped to gominimal/docs via the
+            # Mint a short-lived token scoped to gominimal/webapp via the
             # gominimal-aw-bot GitHub App (org standard — App tokens over PATs, see
             # gominimal/min-aw ADR-0002). The default GITHUB_TOKEN cannot dispatch
             # other repos; this token carries the App's contents:write permission
-            # narrowed to the docs repo only.
-            - name: Mint docs-repo token (gominimal-aw-bot)
+            # narrowed to the webapp repo only. The standalone docs host was
+            # collapsed into the webapp (gominimal/webapp#470), which now runs the
+            # deploy-time docs sync, so promotions dispatch the rebuild there.
+            - name: Mint webapp-repo token (gominimal-aw-bot)
               id: docs-token
               if: ${{ inputs.dry_run != true }}
               uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
@@ -245,7 +247,7 @@ jobs:
                   app-id: ${{ vars.AW_BOT_APP_ID }}
                   private-key: ${{ secrets.AW_BOT_PRIVATE_KEY }}
                   owner: gominimal
-                  repositories: docs
+                  repositories: webapp
 
             - name: Trigger docs rebuild
               env:
@@ -255,10 +257,10 @@ jobs:
               run: |
                   set -euo pipefail
                   if [ "$DRY_RUN" = "true" ]; then
-                    echo "[dry-run] would dispatch reference-docs-promoted to gominimal/docs for ${SHA}"
+                    echo "[dry-run] would dispatch reference-docs-promoted to gominimal/webapp for ${SHA}"
                   else
-                    gh api repos/gominimal/docs/dispatches \
+                    gh api repos/gominimal/webapp/dispatches \
                       -f event_type=reference-docs-promoted \
                       -F "client_payload[sha]=${SHA}"
-                    echo "Dispatched reference-docs-promoted to gominimal/docs for ${SHA}"
+                    echo "Dispatched reference-docs-promoted to gominimal/webapp for ${SHA}"
                   fi


### PR DESCRIPTION
## Summary

The standalone docs host `gominimal/docs` (VitePress) was retired and collapsed into `gominimal/webapp` (Astro), which now runs the deploy-time docs sync restored in [gominimal/webapp#489](https://github.com/gominimal/webapp/pull/489). That sync pulls `docs/{reference,concepts,guide→start}` from this repo at a resolved release sha and prerenders it.

This PR wires the upstream (this-repo) side of that mechanism:

- **`promote.yml`** — repoint the `reference-docs-promoted` `repository_dispatch` and the AW_BOT token scope from `gominimal/docs` → `gominimal/webapp`. On promote, the resolved release sha is pushed as the dispatch payload; the webapp pulls docs at that sha.
- **`docs-hotfix.yml`** (new) — a `workflow_dispatch` that fires the same `reference-docs-promoted` dispatch for a chosen sha (default `main` HEAD). This lets a docs correction go live on the webapp **without cutting or promoting a binary release**.

Resolves the upstream repoint tracked in [gominimal/webapp#486](https://github.com/gominimal/webapp/issues/486) and [gominimal/webapp#489](https://github.com/gominimal/webapp/pull/489)'s operator follow-up.

## Prerequisites (operator / cross-repo — not code)

1. **Sequence after [webapp#489](https://github.com/gominimal/webapp/pull/489)** (currently OPEN) — it adds the *receiving* `reference-docs-promoted` trigger. Until it merges, both dispatches are harmless no-ops.
2. **Provision AW_BOT on `gominimal/webapp`** with `contents: write` (`AW_BOT_APP_ID` var + `AW_BOT_PRIVATE_KEY` secret), or swap the mint step to the org `APP_ID`/`APP_PRIVATE_KEY` already on this repo. Without it the token-mint step fails. (webapp#489 operator follow-up.)
3. **Durable-hotfix decision (non-blocking)** — the webapp resolves the docs sha as `MINIMAL_DOCS_SHA → stable → unstable → main`. `docs-hotfix.yml` sets `MINIMAL_DOCS_SHA` for **one** deploy; a later webapp-driven deploy reverts to the channel pointer. So a hotfix is a bridge until the fix ships in the next promoted release. A durable alternative (a promote-written docs pointer the webapp reads first) needs a webapp-side change — tracked in [webapp#486](https://github.com/gominimal/webapp/issues/486).

## Verification

- Both workflows parse as valid YAML; no residual `gominimal/docs` refs remain in `.github/workflows/`.
- End-to-end (after prereqs 1–2): trigger `docs-hotfix` (or a dry-run promote) and confirm the webapp deploy resolves `MINIMAL_DOCS_SHA` and syncs the reference/concepts/guide sections at that sha.

> `.github/workflows/` is CODEOWNER-gated — this needs owner review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Repoint docs rebuild dispatch to `gominimal/webapp` and add `docs-hotfix` workflow
> - Updates [promote.yml](https://github.com/gominimal/minimal/pull/987/files#diff-e5ab57a220924d9818afbeee4bf25a06ebe32c416ff9b779fab1dd49da60265d) to dispatch the `reference-docs-promoted` event to `gominimal/webapp` instead of `gominimal/docs`, including token scope and API endpoint.
> - Adds [docs-hotfix.yml](https://github.com/gominimal/minimal/pull/987/files#diff-c60ce004b7002d8b778e23aff69307ea860d715cce074ebdf33bfe02446d4164), a manually triggered workflow that dispatches `reference-docs-promoted` to `gominimal/webapp` with a specified or default SHA, without requiring a binary promotion.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #987 opened
>
> - Added SHA validation to the 'Resolve sha' step in the `docs-hotfix` workflow [fa112e5]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 062015d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documentation rebuilds after CLI promotions are now dispatched to run through the web app.
  - Added an optional manual documentation hotfix workflow to synchronize a selected source revision.
  - Improved reliability by validating and using the correct commit revision when triggering documentation refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->