### PR TITLE
feat(release): ship the VM stack to Linux installs [blocked on pkgs#533]

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -222,13 +222,28 @@ jobs:
                   mv "$BIN/libkrunfw-linux-amd64.so" "$LIB/libkrunfw.so.5"
                   chmod +x "$BIN/min" "$BIN/minvmd" "$BIN/mip" "$BIN/gvproxy-min"
                   echo "$BIN" >> "$GITHUB_PATH"
-                  ldd "$BIN/minvmd"
-                  if ldd "$BIN/minvmd" | grep -q "not found"; then
-                    echo "::error::shipped minvmd has unresolved libraries in the installer layout" >&2
+                  # Capture once, then match on the string. Piping into `grep -q`
+                  # under `set -o pipefail` can report the pipeline as SIGPIPE
+                  # (141) when grep exits early, which would make the guard below
+                  # silently evaluate false and pass a genuinely broken binary.
+                  ldd_out="$(ldd "$BIN/minvmd")"
+                  printf '%s\n' "$ldd_out"
+                  case "$ldd_out" in
+                    *"not found"*)
+                      echo "::error::shipped minvmd has unresolved libraries in the installer layout" >&2
+                      exit 1 ;;
+                  esac
+                  # ld.so expands $ORIGIN but does NOT normalize the rest of the
+                  # entry, so it reports <bin>/../lib/libkrun.so.1 verbatim.
+                  # Comparing raw strings against "$LIB/libkrun.so.1" could never
+                  # match; canonicalize both sides instead.
+                  resolved="$(printf '%s\n' "$ldd_out" | awk '/libkrun\.so\.1 =>/ {print $3; exit}')"
+                  if [ -z "$resolved" ] || [ ! -e "$resolved" ]; then
+                    echo "::error::shipped minvmd did not resolve libkrun at all (RUNPATH wrong)" >&2
                     exit 1
                   fi
-                  if ! ldd "$BIN/minvmd" | grep -q "$LIB/libkrun.so.1"; then
-                    echo "::error::shipped minvmd did not resolve libkrun from $LIB (RUNPATH wrong)" >&2
+                  if [ "$(readlink -f "$resolved")" != "$(readlink -f "$LIB/libkrun.so.1")" ]; then
+                    echo "::error::shipped minvmd resolved libkrun from $resolved, not $LIB (RUNPATH wrong)" >&2
                     exit 1
                   fi
             - name: Point the microVM env at the shipped guest artifacts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,10 +141,11 @@ jobs:
         # same proof ci-linux-kvm's `test-kvm` runs. Every moving part is a
         # downloaded release artifact: the native-glibc `minvmd`, the guest kernel
         # + ext4 rootfs + initramfs, the pinned `gvproxy-min` switch, and the
-        # shipped libkrun pair — laid out as a `lib/` sibling of `bin/` exactly as
-        # scripts/install.sh drops it, so minvmd resolves libkrun through its
-        # $ORIGIN/../lib RUNPATH and libkrun finds libkrunfw through its own
-        # $ORIGIN (mirrors what smoke-macos proves for the dylib). Deliberately
+        # shipped libkrun — laid out as a `lib/` sibling of `bin/` exactly as
+        # scripts/install.sh drops it, so minvmd resolves it through its
+        # $ORIGIN/../lib RUNPATH (mirrors what smoke-macos proves for the dylib;
+        # like macOS, no libkrunfw is shipped — minvmd brings its own kernel, so
+        # libkrun's bundled-GPL-kernel library is never loaded). Deliberately
         # NO LD_LIBRARY_PATH and no materialize step: this lane is what catches a
         # shipped libkrun whose RUNPATH is wrong, and either would mask exactly
         # that failure.
@@ -173,8 +174,7 @@ jobs:
                   sudo udevadm trigger --name-match=kvm
                   ls -l /dev/kvm
             - name: Download shipped linux-amd64 artifacts
-              # Pulls min, minvmd, mip, gvproxy and the libkrun/libkrunfw pair
-              # (plus minimald, unused on the host — it ships inside the
+              # Pulls min, minvmd, mip, gvproxy and libkrun (plus minimald, unused on the host — it ships inside the
               # initramfs). `*-linux-amd64` is a clean glob here: only darwin
               # artifacts carry the `temp-` prefix.
               uses: actions/download-artifact@v8
@@ -204,8 +204,8 @@ jobs:
               # or /usr/lib/minimal/bin (see resolve_gvproxy_path) — so the e2e
               # step below points MINVMD_GVPROXY_BIN at it.
               #
-              # The two .so's move to a lib/ SIBLING of bin/ under their sonames,
-              # which is where the shipped RUNPATHs look. Verified explicitly:
+              # The .so moves to a lib/ SIBLING of bin/ under its soname, which is
+              # where the shipped RUNPATH looks. Verified explicitly:
               # `ldd` must resolve libkrun out of that lib/ and leave nothing
               # "not found", so a bad RUNPATH fails here with a readable error
               # instead of an opaque VM boot timeout later.
@@ -219,7 +219,6 @@ jobs:
                   mv "$BIN/mip-linux-amd64" "$BIN/mip"
                   mv "$BIN/gvproxy-linux-amd64" "$BIN/gvproxy-min"
                   mv "$BIN/libkrun-linux-amd64.so" "$LIB/libkrun.so.1"
-                  mv "$BIN/libkrunfw-linux-amd64.so" "$LIB/libkrunfw.so.5"
                   chmod +x "$BIN/min" "$BIN/minvmd" "$BIN/mip" "$BIN/gvproxy-min"
                   echo "$BIN" >> "$GITHUB_PATH"
                   # Capture once, then match on the string. Piping into `grep -q`

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -140,7 +140,7 @@ jobs:
         # the SHIPPED minvmd and pass the session e2e over the vsock bridge, the
         # same proof ci-linux-kvm's `test-kvm` runs. Every moving part is a
         # downloaded release artifact: the native-glibc `minvmd`, the guest kernel
-        # + ext4 rootfs + initramfs, the pinned `mingvproxy` switch, and the
+        # + ext4 rootfs + initramfs, the pinned `gvproxy-min` switch, and the
         # shipped libkrun pair — laid out as a `lib/` sibling of `bin/` exactly as
         # scripts/install.sh drops it, so minvmd resolves libkrun through its
         # $ORIGIN/../lib RUNPATH and libkrun finds libkrunfw through its own
@@ -217,10 +217,10 @@ jobs:
                   mv "$BIN/minimal-linux-amd64" "$BIN/min"
                   mv "$BIN/minvmd-linux-amd64" "$BIN/minvmd"
                   mv "$BIN/mip-linux-amd64" "$BIN/mip"
-                  mv "$BIN/gvproxy-linux-amd64" "$BIN/mingvproxy"
+                  mv "$BIN/gvproxy-linux-amd64" "$BIN/gvproxy-min"
                   mv "$BIN/libkrun-linux-amd64.so" "$LIB/libkrun.so.1"
                   mv "$BIN/libkrunfw-linux-amd64.so" "$LIB/libkrunfw.so.5"
-                  chmod +x "$BIN/min" "$BIN/minvmd" "$BIN/mip" "$BIN/mingvproxy"
+                  chmod +x "$BIN/min" "$BIN/minvmd" "$BIN/mip" "$BIN/gvproxy-min"
                   echo "$BIN" >> "$GITHUB_PATH"
                   ldd "$BIN/minvmd"
                   if ldd "$BIN/minvmd" | grep -q "not found"; then
@@ -248,7 +248,7 @@ jobs:
               # session mint — dies with "Could not resolve host".
               env:
                   MINVMD_BOOT_LOG: ${{ runner.temp }}/cli-e2e-boot.log
-                  MINVMD_GVPROXY_BIN: ${{ runner.temp }}/bin/mingvproxy
+                  MINVMD_GVPROXY_BIN: ${{ runner.temp }}/bin/gvproxy-min
               run: E2E_VM=1 E2E_MINIMAL_ARGS="--provider local-minvmd" E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
             - name: Reap leftover VM processes
               # The autospawned minvmd can leak a __krun-vmm child on a failed
@@ -328,10 +328,10 @@ jobs:
                   path: ${{ runner.temp }}/dl
             - name: Assemble the installer layout
               # Reproduce the on-disk tree scripts/install.sh writes (spec 07):
-              # bin/{min,minvmd,mingvproxy}, lib/libkrun.1.dylib (bin's sibling,
+              # bin/{min,minvmd,gvproxy-min}, lib/libkrun.1.dylib (bin's sibling,
               # the @rpath target), data/{vmlinuz,rootfs.img,initramfs.cpio}. The
               # dylib basename MUST be libkrun.1.dylib — minvmd's load command is
-              # @rpath/libkrun.1.dylib. The switch installs as `mingvproxy`, not
+              # @rpath/libkrun.1.dylib. The switch installs as `gvproxy-min`, not
               # `gvproxy`: bin/ goes on PATH here exactly as ~/.local/bin is for a
               # real install, and the upstream name would collide with podman's.
               # Then bin/ joins PATH so `min` autospawns `minvmd` (which finds
@@ -345,12 +345,12 @@ jobs:
                   mkdir -p "$ROOT/bin" "$ROOT/lib" "$ROOT/data"
                   mv "$DL/minimal-macos-arm64" "$ROOT/bin/min"
                   mv "$DL/minvmd-macos-arm64" "$ROOT/bin/minvmd"
-                  mv "$DL/gvproxy-darwin-arm64" "$ROOT/bin/mingvproxy"
+                  mv "$DL/gvproxy-darwin-arm64" "$ROOT/bin/gvproxy-min"
                   mv "$DL/libkrun-macos-arm64.dylib" "$ROOT/lib/libkrun.1.dylib"
                   mv "$DL/vmlinuz-arm64" "$ROOT/data/vmlinuz"
                   mv "$DL/rootfs-arm64.img" "$ROOT/data/rootfs.img"
                   mv "$DL/initramfs-arm64.cpio" "$ROOT/data/initramfs.cpio"
-                  chmod +x "$ROOT/bin/min" "$ROOT/bin/minvmd" "$ROOT/bin/mingvproxy"
+                  chmod +x "$ROOT/bin/min" "$ROOT/bin/minvmd" "$ROOT/bin/gvproxy-min"
                   echo "$ROOT/bin" >> "$GITHUB_PATH"
             - name: Reap stale VM processes before the smoke
               # The mini is persistent and shared: a prior run's stray minvmd,
@@ -371,7 +371,7 @@ jobs:
                   MINVMD_ROOTFS_PATH: ${{ runner.temp }}/install/data/rootfs.img
                   MINVMD_INITRAMFS: ${{ runner.temp }}/install/data/initramfs.cpio
                   MINVMD_BOOT_LOG: ${{ runner.temp }}/cli-e2e-boot.log
-                  MINVMD_GVPROXY_BIN: ${{ runner.temp }}/install/bin/mingvproxy
+                  MINVMD_GVPROXY_BIN: ${{ runner.temp }}/install/bin/gvproxy-min
               run: E2E_VM=1 E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
             - name: Reap VM processes
               # Leave the shared mini clean for the next job (Guest teardown does

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -140,10 +140,14 @@ jobs:
         # the SHIPPED minvmd and pass the session e2e over the vsock bridge, the
         # same proof ci-linux-kvm's `test-kvm` runs. Every moving part is a
         # downloaded release artifact: the native-glibc `minvmd`, the guest kernel
-        # + ext4 rootfs + initramfs, and the pinned gvproxy switch. libkrun itself
-        # is NOT shipped on Linux (users resolve it from the system / the upstream
-        # package), so it is materialized here exactly as the release build linked
-        # it, reusing the shipped static `mip` to drive the cache fetch.
+        # + ext4 rootfs + initramfs, the pinned `mingvproxy` switch, and the
+        # shipped libkrun pair — laid out as a `lib/` sibling of `bin/` exactly as
+        # scripts/install.sh drops it, so minvmd resolves libkrun through its
+        # $ORIGIN/../lib RUNPATH and libkrun finds libkrunfw through its own
+        # $ORIGIN (mirrors what smoke-macos proves for the dylib). Deliberately
+        # NO LD_LIBRARY_PATH and no materialize step: this lane is what catches a
+        # shipped libkrun whose RUNPATH is wrong, and either would mask exactly
+        # that failure.
         needs: [release]
         runs-on: ubuntu-latest # x86_64; KVM-capable
         timeout-minutes: 30
@@ -168,15 +172,11 @@ jobs:
                   sudo udevadm control --reload-rules
                   sudo udevadm trigger --name-match=kvm
                   ls -l /dev/kvm
-            - name: Enable unprivileged user namespaces
-              # `mip materialize` (the libkrun cache fetch below) runs the build
-              # pipeline, which needs userns; Ubuntu 24.04 restricts it via
-              # AppArmor by default.
-              run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-            - name: Download shipped linux-amd64 binaries
-              # Pulls min, minvmd, mip and gvproxy (plus minimald, unused on the
-              # host — it ships inside the initramfs). `*-linux-amd64` is a clean
-              # glob here: only darwin artifacts carry the `temp-` prefix.
+            - name: Download shipped linux-amd64 artifacts
+              # Pulls min, minvmd, mip, gvproxy and the libkrun/libkrunfw pair
+              # (plus minimald, unused on the host — it ships inside the
+              # initramfs). `*-linux-amd64` is a clean glob here: only darwin
+              # artifacts carry the `temp-` prefix.
               uses: actions/download-artifact@v8
               with:
                   pattern: "*-linux-amd64"
@@ -197,32 +197,40 @@ jobs:
               with:
                   name: minimald-initramfs-amd64
                   path: ${{ runner.temp }}/guest
-            - name: Put the shipped binaries on PATH
-              # Rename off the platform suffix and prepend to PATH so `min`
-              # autospawns `minvmd` by bare name. gvproxy is NOT resolved from
-              # PATH — minvmd only honours MINVMD_GVPROXY_BIN, the installer
-              # bin dir, or /usr/lib/minimal/bin (see resolve_gvproxy_path) —
-              # so the e2e step below points MINVMD_GVPROXY_BIN at it.
+            - name: Assemble the installer layout (bin/ + lib/)
+              # Rename off the platform suffix and prepend bin/ to PATH so `min`
+              # autospawns `minvmd` by bare name. The switch is NOT resolved from
+              # PATH — minvmd honours MINVMD_GVPROXY_BIN, the installer bin dir,
+              # or /usr/lib/minimal/bin (see resolve_gvproxy_path) — so the e2e
+              # step below points MINVMD_GVPROXY_BIN at it.
+              #
+              # The two .so's move to a lib/ SIBLING of bin/ under their sonames,
+              # which is where the shipped RUNPATHs look. Verified explicitly:
+              # `ldd` must resolve libkrun out of that lib/ and leave nothing
+              # "not found", so a bad RUNPATH fails here with a readable error
+              # instead of an opaque VM boot timeout later.
               run: |
                   set -euo pipefail
                   BIN="$RUNNER_TEMP/bin"
+                  LIB="$RUNNER_TEMP/lib"
+                  mkdir -p "$LIB"
                   mv "$BIN/minimal-linux-amd64" "$BIN/min"
                   mv "$BIN/minvmd-linux-amd64" "$BIN/minvmd"
                   mv "$BIN/mip-linux-amd64" "$BIN/mip"
-                  mv "$BIN/gvproxy-linux-amd64" "$BIN/gvproxy"
-                  chmod +x "$BIN/min" "$BIN/minvmd" "$BIN/mip" "$BIN/gvproxy"
+                  mv "$BIN/gvproxy-linux-amd64" "$BIN/mingvproxy"
+                  mv "$BIN/libkrun-linux-amd64.so" "$LIB/libkrun.so.1"
+                  mv "$BIN/libkrunfw-linux-amd64.so" "$LIB/libkrunfw.so.5"
+                  chmod +x "$BIN/min" "$BIN/minvmd" "$BIN/mip" "$BIN/mingvproxy"
                   echo "$BIN" >> "$GITHUB_PATH"
-            - name: Materialize libkrun prefix (upstream package)
-              # minvmd links libkrun.so + dlopens libkrunfw.so.5 at runtime; the
-              # Linux release ships neither (its rpath resolves them from the
-              # system / LD_LIBRARY_PATH). Reuse the shipped static mip to drive
-              # the cache fetch (no Rust toolchain) — the exact libkrun the release
-              # build linked against. Publishes LIBKRUN_PREFIX and
-              # LD_LIBRARY_PATH=$HOME/.krun to later steps.
-              uses: ./.github/actions/setup-libkrun-linux
-              with:
-                  arch: x86_64
-                  mip: ${{ runner.temp }}/bin/mip
+                  ldd "$BIN/minvmd"
+                  if ldd "$BIN/minvmd" | grep -q "not found"; then
+                    echo "::error::shipped minvmd has unresolved libraries in the installer layout" >&2
+                    exit 1
+                  fi
+                  if ! ldd "$BIN/minvmd" | grep -q "$LIB/libkrun.so.1"; then
+                    echo "::error::shipped minvmd did not resolve libkrun from $LIB (RUNPATH wrong)" >&2
+                    exit 1
+                  fi
             - name: Point the microVM env at the shipped guest artifacts
               run: |
                   {
@@ -240,7 +248,7 @@ jobs:
               # session mint — dies with "Could not resolve host".
               env:
                   MINVMD_BOOT_LOG: ${{ runner.temp }}/cli-e2e-boot.log
-                  MINVMD_GVPROXY_BIN: ${{ runner.temp }}/bin/gvproxy
+                  MINVMD_GVPROXY_BIN: ${{ runner.temp }}/bin/mingvproxy
               run: E2E_VM=1 E2E_MINIMAL_ARGS="--provider local-minvmd" E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
             - name: Reap leftover VM processes
               # The autospawned minvmd can leak a __krun-vmm child on a failed
@@ -320,13 +328,16 @@ jobs:
                   path: ${{ runner.temp }}/dl
             - name: Assemble the installer layout
               # Reproduce the on-disk tree scripts/install.sh writes (spec 07):
-              # bin/{min,minvmd,gvproxy}, lib/libkrun.1.dylib (bin's sibling, the
-              # @rpath target), data/{vmlinuz,rootfs.img,initramfs.cpio}. The dylib
-              # basename MUST be libkrun.1.dylib — minvmd's load command is
-              # @rpath/libkrun.1.dylib. Then bin/ joins PATH so `min` autospawns
-              # `minvmd` (which finds libkrun via @loader_path/../lib) by bare
-              # name. gvproxy is NOT resolved from PATH — the e2e step below
-              # points MINVMD_GVPROXY_BIN at the laid-out binary.
+              # bin/{min,minvmd,mingvproxy}, lib/libkrun.1.dylib (bin's sibling,
+              # the @rpath target), data/{vmlinuz,rootfs.img,initramfs.cpio}. The
+              # dylib basename MUST be libkrun.1.dylib — minvmd's load command is
+              # @rpath/libkrun.1.dylib. The switch installs as `mingvproxy`, not
+              # `gvproxy`: bin/ goes on PATH here exactly as ~/.local/bin is for a
+              # real install, and the upstream name would collide with podman's.
+              # Then bin/ joins PATH so `min` autospawns `minvmd` (which finds
+              # libkrun via @loader_path/../lib) by bare name. The switch is NOT
+              # resolved from PATH — the e2e step below points
+              # MINVMD_GVPROXY_BIN at the laid-out binary.
               run: |
                   set -euo pipefail
                   DL="$RUNNER_TEMP/dl"
@@ -334,12 +345,12 @@ jobs:
                   mkdir -p "$ROOT/bin" "$ROOT/lib" "$ROOT/data"
                   mv "$DL/minimal-macos-arm64" "$ROOT/bin/min"
                   mv "$DL/minvmd-macos-arm64" "$ROOT/bin/minvmd"
-                  mv "$DL/gvproxy-darwin-arm64" "$ROOT/bin/gvproxy"
+                  mv "$DL/gvproxy-darwin-arm64" "$ROOT/bin/mingvproxy"
                   mv "$DL/libkrun-macos-arm64.dylib" "$ROOT/lib/libkrun.1.dylib"
                   mv "$DL/vmlinuz-arm64" "$ROOT/data/vmlinuz"
                   mv "$DL/rootfs-arm64.img" "$ROOT/data/rootfs.img"
                   mv "$DL/initramfs-arm64.cpio" "$ROOT/data/initramfs.cpio"
-                  chmod +x "$ROOT/bin/min" "$ROOT/bin/minvmd" "$ROOT/bin/gvproxy"
+                  chmod +x "$ROOT/bin/min" "$ROOT/bin/minvmd" "$ROOT/bin/mingvproxy"
                   echo "$ROOT/bin" >> "$GITHUB_PATH"
             - name: Reap stale VM processes before the smoke
               # The mini is persistent and shared: a prior run's stray minvmd,
@@ -360,7 +371,7 @@ jobs:
                   MINVMD_ROOTFS_PATH: ${{ runner.temp }}/install/data/rootfs.img
                   MINVMD_INITRAMFS: ${{ runner.temp }}/install/data/initramfs.cpio
                   MINVMD_BOOT_LOG: ${{ runner.temp }}/cli-e2e-boot.log
-                  MINVMD_GVPROXY_BIN: ${{ runner.temp }}/install/bin/gvproxy
+                  MINVMD_GVPROXY_BIN: ${{ runner.temp }}/install/bin/mingvproxy
               run: E2E_VM=1 E2E_PROJECT_DIR=/tmp ./scripts/session-e2e.sh
             - name: Reap VM processes
               # Leave the shared mini clean for the next job (Guest teardown does

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
                   mip: ${{ github.workspace }}/target/x86_64-unknown-linux-musl/release/mip-linux-amd64
             - name: Build native minvmd binary
               # Native host target (x86_64-unknown-linux-gnu), NOT musl: the binary
-              # links libkrun.so (and libkrunfw.so.5 is dlopen'd at runtime), so unlike
+              # links libkrun.so, so unlike
               # the three above it is not self-contained — running it still needs those
               # .so's reachable via rpath/LD_LIBRARY_PATH. LIBKRUN_PREFIX — published
               # by the setup-libkrun-linux composite above — drives the build.rs link
@@ -205,22 +205,20 @@ jobs:
                   mv target/release/minvmd target/release/minvmd-linux-amd64
             - name: Rewrite + verify minvmd/libkrun linkage (RUNPATH)
               # The Linux twin of the macOS @rpath rewrite: point minvmd at
-              # $ORIGIN/../lib (bin/minvmd -> lib/libkrun.so.1) and libkrun at
-              # $ORIGIN (its dlopen of libkrunfw.so.5 resolves against its OWN
-              # RUNPATH, not the executable's). Also hard-fails on a soname
-              # bump, which would silently break the lib/ dests in
+              # $ORIGIN/../lib (bin/minvmd -> lib/libkrun.so.1). Also hard-fails
+              # on a soname bump, which would silently break the lib/ dest in
               # stage-release.sh.
               run: ./scripts/rewrite-linux-linkage.sh target/release/minvmd-linux-amd64 "$LIBKRUN_PREFIX"
-            - name: Stage libkrun pair for upload
-              # Resolve the soname symlink chain to the real (now patched) files
-              # and copy them under platform-suffixed names, so merge-multiple's
-              # basename flatten does not collide with the arm64 build. The
-              # SONAME inside each file is unchanged; the installer stages them
-              # back under their soname (lib/libkrun.so.1, lib/libkrunfw.so.5).
+            - name: Stage libkrun for upload
+              # Resolve the soname symlink chain to the real file and copy it
+              # under a platform-suffixed name, so merge-multiple's basename
+              # flatten does not collide with the arm64 build. The SONAME inside
+              # is unchanged; the installer stages it back under that soname
+              # (lib/libkrun.so.1). libkrunfw is deliberately not shipped: it
+              # carries a bundled GPL-2 kernel and minvmd supplies its own.
               run: |
                   mkdir -p "$RUNNER_TEMP/libs"
                   cp "$(readlink -f "$LIBKRUN_PREFIX/libkrun.so.1")"   "$RUNNER_TEMP/libs/libkrun-linux-amd64.so"
-                  cp "$(readlink -f "$LIBKRUN_PREFIX/libkrunfw.so.5")" "$RUNNER_TEMP/libs/libkrunfw-linux-amd64.so"
             - name: Upload binary (minvmd)
               uses: actions/upload-artifact@v7
               with:
@@ -232,12 +230,6 @@ jobs:
               with:
                   name: libkrun-linux-amd64
                   path: ${{ runner.temp }}/libs/libkrun-linux-amd64.so
-                  retention-days: 7
-            - name: Upload libkrunfw (linux-amd64)
-              uses: actions/upload-artifact@v7
-              with:
-                  name: libkrunfw-linux-amd64
-                  path: ${{ runner.temp }}/libs/libkrunfw-linux-amd64.so
                   retention-days: 7
 
     build-release-linux-arm64:
@@ -330,19 +322,18 @@ jobs:
                   mip: ${{ github.workspace }}/target/aarch64-unknown-linux-musl/release/mip-linux-arm64
             - name: Build native minvmd binary
               # Native host target (aarch64-unknown-linux-gnu), NOT musl: links
-              # libkrun.so.1 with libkrunfw.so.5 dlopen'd at runtime, so unlike
-              # the three above it is not self-contained — the installer ships
-              # both under lib/ and the RUNPATH rewrite below points at them.
+              # libkrun.so.1, so unlike the three above it is not
+              # self-contained — the installer ships it under lib/ and the
+              # RUNPATH rewrite below points at it.
               run: |
                   cargo build --release --locked -p minvmd --bin minvmd
                   mv target/release/minvmd target/release/minvmd-linux-arm64
             - name: Rewrite + verify minvmd/libkrun linkage (RUNPATH)
               run: ./scripts/rewrite-linux-linkage.sh target/release/minvmd-linux-arm64 "$LIBKRUN_PREFIX"
-            - name: Stage libkrun pair for upload
+            - name: Stage libkrun for upload
               run: |
                   mkdir -p "$RUNNER_TEMP/libs"
                   cp "$(readlink -f "$LIBKRUN_PREFIX/libkrun.so.1")"   "$RUNNER_TEMP/libs/libkrun-linux-arm64.so"
-                  cp "$(readlink -f "$LIBKRUN_PREFIX/libkrunfw.so.5")" "$RUNNER_TEMP/libs/libkrunfw-linux-arm64.so"
             - name: Upload binary (minvmd)
               uses: actions/upload-artifact@v7
               with:
@@ -354,12 +345,6 @@ jobs:
               with:
                   name: libkrun-linux-arm64
                   path: ${{ runner.temp }}/libs/libkrun-linux-arm64.so
-                  retention-days: 7
-            - name: Upload libkrunfw (linux-arm64)
-              uses: actions/upload-artifact@v7
-              with:
-                  name: libkrunfw-linux-arm64
-                  path: ${{ runner.temp }}/libs/libkrunfw-linux-arm64.so
                   retention-days: 7
 
     build-release-macos-arm64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,9 @@ jobs:
                   fetch-depth: 0
                   fetch-tags: true
             - name: Install dependencies
-              run: sudo apt-get update && sudo apt-get install -y musl-tools protobuf-compiler
+              # patchelf: rewrites the shipped minvmd/libkrun RUNPATHs for the
+              # installer's bin/ + lib/ layout (scripts/rewrite-linux-linkage.sh).
+              run: sudo apt-get update && sudo apt-get install -y musl-tools protobuf-compiler patchelf
             - name: Add Rust target
               run: rustup target add x86_64-unknown-linux-musl
             - name: Cache Rust build artifacts (dependency-pruned)
@@ -201,11 +203,41 @@ jobs:
               run: |
                   cargo build --release --locked -p minvmd --bin minvmd
                   mv target/release/minvmd target/release/minvmd-linux-amd64
+            - name: Rewrite + verify minvmd/libkrun linkage (RUNPATH)
+              # The Linux twin of the macOS @rpath rewrite: point minvmd at
+              # $ORIGIN/../lib (bin/minvmd -> lib/libkrun.so.1) and libkrun at
+              # $ORIGIN (its dlopen of libkrunfw.so.5 resolves against its OWN
+              # RUNPATH, not the executable's). Also hard-fails on a soname
+              # bump, which would silently break the lib/ dests in
+              # stage-release.sh.
+              run: ./scripts/rewrite-linux-linkage.sh target/release/minvmd-linux-amd64 "$LIBKRUN_PREFIX"
+            - name: Stage libkrun pair for upload
+              # Resolve the soname symlink chain to the real (now patched) files
+              # and copy them under platform-suffixed names, so merge-multiple's
+              # basename flatten does not collide with the arm64 build. The
+              # SONAME inside each file is unchanged; the installer stages them
+              # back under their soname (lib/libkrun.so.1, lib/libkrunfw.so.5).
+              run: |
+                  mkdir -p "$RUNNER_TEMP/libs"
+                  cp "$(readlink -f "$LIBKRUN_PREFIX/libkrun.so.1")"   "$RUNNER_TEMP/libs/libkrun-linux-amd64.so"
+                  cp "$(readlink -f "$LIBKRUN_PREFIX/libkrunfw.so.5")" "$RUNNER_TEMP/libs/libkrunfw-linux-amd64.so"
             - name: Upload binary (minvmd)
               uses: actions/upload-artifact@v7
               with:
                   name: minvmd-linux-amd64
                   path: target/release/minvmd-linux-amd64
+                  retention-days: 7
+            - name: Upload libkrun (linux-amd64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: libkrun-linux-amd64
+                  path: ${{ runner.temp }}/libs/libkrun-linux-amd64.so
+                  retention-days: 7
+            - name: Upload libkrunfw (linux-amd64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: libkrunfw-linux-amd64
+                  path: ${{ runner.temp }}/libs/libkrunfw-linux-amd64.so
                   retention-days: 7
 
     build-release-linux-arm64:
@@ -234,7 +266,8 @@ jobs:
                   fetch-depth: 0
                   fetch-tags: true
             - name: Install dependencies
-              run: sudo apt-get update && sudo apt-get install -y musl-tools protobuf-compiler
+              # patchelf: see the amd64 job — the shipped RUNPATH rewrite.
+              run: sudo apt-get update && sudo apt-get install -y musl-tools protobuf-compiler patchelf
             - name: Add Rust target
               run: rustup target add aarch64-unknown-linux-musl
             - name: Cache Rust build artifacts (dependency-pruned)
@@ -282,6 +315,51 @@ jobs:
               with:
                   name: minimald-linux-arm64
                   path: target/aarch64-unknown-linux-musl/release/minimald-linux-arm64
+                  retention-days: 7
+            - name: Materialize libkrun prefix (upstream package)
+              # Mirrors the amd64 job: minvmd links libkrun's KVM backend
+              # dynamically, so it can't join the static-musl build above — it
+              # needs a native glibc build against a real libkrun. This runner
+              # IS aarch64, so the native target and the guest arch agree.
+              # Reuse the static mip just built (renamed above) rather than
+              # letting the fetch compile a second, debug mip to drive the
+              # cache pull.
+              uses: ./.github/actions/setup-libkrun-linux
+              with:
+                  arch: aarch64
+                  mip: ${{ github.workspace }}/target/aarch64-unknown-linux-musl/release/mip-linux-arm64
+            - name: Build native minvmd binary
+              # Native host target (aarch64-unknown-linux-gnu), NOT musl: links
+              # libkrun.so.1 with libkrunfw.so.5 dlopen'd at runtime, so unlike
+              # the three above it is not self-contained — the installer ships
+              # both under lib/ and the RUNPATH rewrite below points at them.
+              run: |
+                  cargo build --release --locked -p minvmd --bin minvmd
+                  mv target/release/minvmd target/release/minvmd-linux-arm64
+            - name: Rewrite + verify minvmd/libkrun linkage (RUNPATH)
+              run: ./scripts/rewrite-linux-linkage.sh target/release/minvmd-linux-arm64 "$LIBKRUN_PREFIX"
+            - name: Stage libkrun pair for upload
+              run: |
+                  mkdir -p "$RUNNER_TEMP/libs"
+                  cp "$(readlink -f "$LIBKRUN_PREFIX/libkrun.so.1")"   "$RUNNER_TEMP/libs/libkrun-linux-arm64.so"
+                  cp "$(readlink -f "$LIBKRUN_PREFIX/libkrunfw.so.5")" "$RUNNER_TEMP/libs/libkrunfw-linux-arm64.so"
+            - name: Upload binary (minvmd)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: minvmd-linux-arm64
+                  path: target/release/minvmd-linux-arm64
+                  retention-days: 7
+            - name: Upload libkrun (linux-arm64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: libkrun-linux-arm64
+                  path: ${{ runner.temp }}/libs/libkrun-linux-arm64.so
+                  retention-days: 7
+            - name: Upload libkrunfw (linux-arm64)
+              uses: actions/upload-artifact@v7
+              with:
+                  name: libkrunfw-linux-arm64
+                  path: ${{ runner.temp }}/libs/libkrunfw-linux-arm64.so
                   retention-days: 7
 
     build-release-macos-arm64:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6488,6 +6488,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 [[package]]
 name = "switch"
 version = "0.0.1"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "symlink"

--- a/crates/common/tests/script_harnesses.rs
+++ b/crates/common/tests/script_harnesses.rs
@@ -1,0 +1,59 @@
+//! Convention-discovered gate that runs the `scripts/*_test.sh` harnesses.
+//!
+//! Sibling of [`shell_lint`](./shell_lint.rs), which only *lints* `scripts/`.
+//! A harness that no lane runs is not a gate: `just test-linkage` was the only
+//! executable proof of `rewrite-linux-linkage.sh`'s RUNPATH logic, and `just
+//! ci` does not include it, `ci-shell-installer.yml` hardcodes install.sh, and
+//! `shell_lint` only drives shellcheck — so a regression that dropped the
+//! `$ORIGIN/../lib` entry would have been green on all five required
+//! aggregators and surfaced only as `libkrun.so.1: cannot open shared object
+//! file` on users' machines.
+//!
+//! Widening the frozen workflow YAML is not an option (CODEOWNER-gated), so
+//! this hangs the harness off the workspace test suite the always-running Linux
+//! lanes already execute — the reviewed-code extension point CI schedules over
+//! (docs/ci-strategy.md §10).
+//!
+//! `install_test.sh` is deliberately NOT run here: `ci-shell-installer.yml`
+//! already runs it under three shells, and duplicating it would double a
+//! multi-minute job for no added coverage.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is crates/common; the workspace root is two up.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root two levels above crates/common")
+        .to_path_buf()
+}
+
+/// Runs one harness and asserts it exits zero, surfacing its output on failure.
+///
+/// The harnesses stub every external tool they need, so this holds on any host
+/// — including macOS, where `rewrite-linux-linkage.sh` itself can never run.
+fn run_harness(name: &str) {
+    let root = repo_root();
+    let harness = root.join("scripts").join(name);
+    assert!(harness.is_file(), "missing script harness: {name}");
+
+    let output = Command::new("bash")
+        .arg(&harness)
+        .current_dir(&root)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run scripts/{name}: {e}"));
+
+    assert!(
+        output.status.success(),
+        "scripts/{name} failed\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn rewrite_linux_linkage_harness_passes() {
+    run_harness("rewrite-linux-linkage_test.sh");
+}

--- a/crates/minimal/src/diag/mod.rs
+++ b/crates/minimal/src/diag/mod.rs
@@ -77,6 +77,10 @@ const PROCESS_MARKERS: &[&str] = &[
     "minimald",
     "minvmd",
     "__krun-vmm",
+    // Both names: `mingvproxy` is what an install stamps into `bin/` (see
+    // `switch::GVPROXY_FILE`); a dev checkout and a system package still run
+    // the binary under its upstream name.
+    "mingvproxy",
     "gvproxy",
 ];
 

--- a/crates/minimal/src/diag/mod.rs
+++ b/crates/minimal/src/diag/mod.rs
@@ -77,10 +77,10 @@ const PROCESS_MARKERS: &[&str] = &[
     "minimald",
     "minvmd",
     "__krun-vmm",
-    // Both names: `mingvproxy` is what an install stamps into `bin/` (see
+    // Both names: `gvproxy-min` is what an install stamps into `bin/` (see
     // `switch::GVPROXY_FILE`); a dev checkout and a system package still run
     // the binary under its upstream name.
-    "mingvproxy",
+    "gvproxy-min",
     "gvproxy",
 ];
 

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -225,8 +225,10 @@ pub struct ListenArgs {
     detach: bool,
 
     /// Path to the gvproxy ("gvisor-tap-vsock") binary backing the per-host
-    /// `OwnIp` switch. Defaults to the fixed system install path when unset;
-    /// point it at a local build to run own-IP without a system install.
+    /// `OwnIp` switch. Defaults to the installed location when unset: the
+    /// user-local `bin/gvproxy-min` the installer stamps, else the system
+    /// install path. Point it at a local build to run own-IP without an
+    /// install.
     #[arg(long)]
     gvproxy_bin: Option<std::path::PathBuf>,
 }

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -57,7 +57,7 @@ pub struct Config {
 
 impl Config {
     /// Resolves the configured gvproxy binary path, falling back to the
-    /// installed location when unset: the user-local `bin/mingvproxy` the
+    /// installed location when unset: the user-local `bin/gvproxy-min` the
     /// curl|sh installer stamps, else the system-wide path. The `GVPROXY_BIN`
     /// env var is scoped to the `#[ignore]` netns proof and is never consulted
     /// by the daemon.

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -30,11 +30,6 @@ pub enum HostKey {
     },
 }
 
-/// Default install path for the gvproxy ("gvisor-tap-vsock") switch binary,
-/// used when [`Config::gvproxy_bin`] is unset. The `GVPROXY_BIN` env var is
-/// scoped to the `#[ignore]` netns proof and is never consulted by the daemon.
-const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy";
-
 /// Global Configuration for the minimald server.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
@@ -42,7 +37,7 @@ pub struct Config {
     pub minimal_state_dir: DaemonAbsPath,
     pub minimal_cache_dir: DaemonAbsPath,
     /// Path to the gvproxy binary backing the per-host `OwnIp` switch. Defaults
-    /// to [`DEFAULT_GVPROXY_BIN`] when unset.
+    /// to the installed location (`switch::installed_gvproxy_bin`) when unset.
     #[serde(default)]
     pub gvproxy_bin: Option<PathBuf>,
     /// Whether this `minimald` runs inside a `minvmd` libkrun VM (DM1/3/4). When
@@ -61,12 +56,15 @@ pub struct Config {
 }
 
 impl Config {
-    /// Resolves the configured gvproxy binary path, falling back to the fixed
-    /// install path when unset.
+    /// Resolves the configured gvproxy binary path, falling back to the
+    /// installed location when unset: the user-local `bin/mingvproxy` the
+    /// curl|sh installer stamps, else the system-wide path. The `GVPROXY_BIN`
+    /// env var is scoped to the `#[ignore]` netns proof and is never consulted
+    /// by the daemon.
     fn gvproxy_bin_path(&self) -> PathBuf {
         self.gvproxy_bin
             .clone()
-            .unwrap_or_else(|| PathBuf::from(DEFAULT_GVPROXY_BIN))
+            .unwrap_or_else(::switch::installed_gvproxy_bin)
     }
 
     /// Returns the SSH host key to use.

--- a/crates/minvmd/src/image.rs
+++ b/crates/minvmd/src/image.rs
@@ -113,32 +113,10 @@ pub fn resolve_initramfs_path() -> Result<PathBuf, VmError> {
     resolve_or_default("MINVMD_INITRAMFS", DEFAULT_INITRAMFS_FILE)
 }
 
-/// System-wide install path for the host gvproxy ("gvisor-tap-vsock") binary,
-/// used as the final fallback when `MINVMD_GVPROXY_BIN` is unset and no
-/// user-local install exists. Fetched + SHA-256-verified by
-/// `scripts/fetch-gvproxy.sh` (issue #495).
-pub const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy";
-
-/// Filename the installer stamps into the `bin/` prefix (see
-/// `scripts/stage-release.sh`: `bin/gvproxy`).
-const GVPROXY_FILE: &str = "gvproxy";
-
-/// The user-local bin directory the installer stamps into: `$MINIMAL_BIN`, else
-/// `$HOME/.local/bin`. Mirrors the installer's `bin` prefix resolution in
-/// `scripts/install.sh`. `None` when neither is set.
-fn installer_bin_dir() -> Option<PathBuf> {
-    if let Some(bin) = std::env::var("MINIMAL_BIN").ok().filter(|v| !v.is_empty()) {
-        return Some(PathBuf::from(bin));
-    }
-    std::env::var("HOME")
-        .ok()
-        .filter(|v| !v.is_empty())
-        .map(|home| PathBuf::from(home).join(".local/bin"))
-}
-
-/// Resolve the host gvproxy binary path in three tiers: the `MINVMD_GVPROXY_BIN`
-/// override, then an existing user-local install (`<bin-dir>/gvproxy`, where the
-/// installer stamps it), then the system-wide [`DEFAULT_GVPROXY_BIN`].
+/// Resolve the host gvproxy binary path: the `MINVMD_GVPROXY_BIN` override,
+/// then the installed location — the user-local `bin/mingvproxy` the curl|sh
+/// installer stamps, else the system-wide `switch::DEFAULT_GVPROXY_BIN`
+/// ([`switch::installed_gvproxy_bin`], the definition shared with minimald).
 ///
 /// Unlike the kernel/rootfs/initramfs resolvers this never errors: gvproxy is
 /// only spawned for an own-IP VM, so an absent override is the common case, and
@@ -146,21 +124,12 @@ fn installer_bin_dir() -> Option<PathBuf> {
 /// (the caller surfaces a spawn failure with that concrete path).
 #[must_use]
 pub fn resolve_gvproxy_path() -> PathBuf {
-    // Tier 1: explicit override, honoured verbatim.
-    if let Some(val) = std::env::var("MINVMD_GVPROXY_BIN")
+    // Explicit override, honoured verbatim.
+    std::env::var("MINVMD_GVPROXY_BIN")
         .ok()
         .filter(|v| !v.is_empty())
-    {
-        return PathBuf::from(val);
-    }
-    // Tier 2: user-local install from the curl|sh installer, if present.
-    if let Some(local) = installer_bin_dir().map(|dir| dir.join(GVPROXY_FILE))
-        && local.exists()
-    {
-        return local;
-    }
-    // Tier 3: system-wide install path (hardcoded fallback).
-    PathBuf::from(DEFAULT_GVPROXY_BIN)
+        .map(PathBuf::from)
+        .unwrap_or_else(switch::installed_gvproxy_bin)
 }
 
 #[cfg(test)]
@@ -274,7 +243,7 @@ mod tests {
         let _g = ENV_LOCK.lock().unwrap();
         clear_gvproxy_env();
         let tmp = tempfile::tempdir().unwrap();
-        let want = tmp.path().join(GVPROXY_FILE);
+        let want = tmp.path().join(switch::GVPROXY_FILE);
         std::fs::write(&want, b"gvproxy").unwrap();
         // MINIMAL_BIN steers installer_bin_dir without touching HOME.
         unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
@@ -289,7 +258,10 @@ mod tests {
         // MINIMAL_BIN points at an empty dir: no user-local gvproxy present.
         let tmp = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
-        assert_eq!(resolve_gvproxy_path(), PathBuf::from(DEFAULT_GVPROXY_BIN));
+        assert_eq!(
+            resolve_gvproxy_path(),
+            PathBuf::from(switch::DEFAULT_GVPROXY_BIN)
+        );
         clear_gvproxy_env();
     }
 

--- a/crates/minvmd/src/image.rs
+++ b/crates/minvmd/src/image.rs
@@ -114,7 +114,7 @@ pub fn resolve_initramfs_path() -> Result<PathBuf, VmError> {
 }
 
 /// Resolve the host gvproxy binary path: the `MINVMD_GVPROXY_BIN` override,
-/// then the installed location — the user-local `bin/mingvproxy` the curl|sh
+/// then the installed location — the user-local `bin/gvproxy-min` the curl|sh
 /// installer stamps, else the system-wide `switch::DEFAULT_GVPROXY_BIN`
 /// ([`switch::installed_gvproxy_bin`], the definition shared with minimald).
 ///

--- a/crates/minvmd/src/image.rs
+++ b/crates/minvmd/src/image.rs
@@ -115,8 +115,9 @@ pub fn resolve_initramfs_path() -> Result<PathBuf, VmError> {
 
 /// Resolve the host gvproxy binary path: the `MINVMD_GVPROXY_BIN` override,
 /// then the installed location — the user-local `bin/gvproxy-min` the curl|sh
-/// installer stamps, else the system-wide `switch::DEFAULT_GVPROXY_BIN`
-/// ([`switch::installed_gvproxy_bin`], the definition shared with minimald).
+/// installer stamps, else a system-wide path ([`switch::installed_gvproxy_bin`],
+/// the definition shared with minimald, which also honours the pre-rename
+/// `/usr/lib/minimal/bin/gvproxy` when only that exists).
 ///
 /// Unlike the kernel/rootfs/initramfs resolvers this never errors: gvproxy is
 /// only spawned for an own-IP VM, so an absent override is the common case, and
@@ -258,9 +259,15 @@ mod tests {
         // MINIMAL_BIN points at an empty dir: no user-local gvproxy present.
         let tmp = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
-        assert_eq!(
-            resolve_gvproxy_path(),
-            PathBuf::from(switch::DEFAULT_GVPROXY_BIN)
+        // One of the two system paths — the shared resolver prefers the legacy
+        // one on a host that still has it, so asserting a single path here
+        // would fail on exactly the pre-rename hosts that branch serves.
+        // `switch`'s own tests pin which branch wins; this one only proves the
+        // tier-2 miss falls through to a system path.
+        let got = resolve_gvproxy_path();
+        assert!(
+            got.starts_with("/usr/lib/minimal/bin"),
+            "expected a system-wide switch path, got {got:?}"
         );
         clear_gvproxy_env();
     }

--- a/crates/switch/Cargo.toml
+++ b/crates/switch/Cargo.toml
@@ -6,3 +6,6 @@ publish.workspace = true
 license.workspace = true
 
 [dependencies]
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/switch/src/lib.rs
+++ b/crates/switch/src/lib.rs
@@ -8,7 +8,7 @@
 
 use std::fmt;
 use std::net::Ipv4Addr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// MTU advertised to the switch and the tap devices. gvproxy's own default.
 pub const DEFAULT_MTU: u16 = 1500;
@@ -50,6 +50,16 @@ pub const GVPROXY_FILE: &str = "gvproxy-min";
 /// user-local install exists.
 pub const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy-min";
 
+/// The pre-rename system-wide path, still honoured when it exists and the
+/// current one does not.
+///
+/// This directory is not on `PATH`, so the collision that motivates
+/// [`GVPROXY_FILE`] never applied here — but an operator who provisioned the
+/// old path has no install record for us to migrate (`install.sh` only walks
+/// user-local rows), so renaming without this fallback would silently break
+/// own-IP on their hosts.
+const LEGACY_SYSTEM_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy";
+
 /// The user-local bin directory the installer stamps into: `$MINIMAL_BIN`, else
 /// `$HOME/.local/bin`. Mirrors the installer's `bin` prefix resolution in
 /// `scripts/install.sh`. `None` when neither is set.
@@ -81,7 +91,11 @@ pub fn installed_gvproxy_bin() -> PathBuf {
     {
         return local;
     }
-    PathBuf::from(DEFAULT_GVPROXY_BIN)
+    let system = PathBuf::from(DEFAULT_GVPROXY_BIN);
+    if !system.exists() && Path::new(LEGACY_SYSTEM_GVPROXY_BIN).exists() {
+        return PathBuf::from(LEGACY_SYSTEM_GVPROXY_BIN);
+    }
+    system
 }
 
 /// A subnet was constructed with a prefix outside the supported `8..=29` range —

--- a/crates/switch/src/lib.rs
+++ b/crates/switch/src/lib.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 use std::net::Ipv4Addr;
+use std::path::PathBuf;
 
 /// MTU advertised to the switch and the tap devices. gvproxy's own default.
 pub const DEFAULT_MTU: u16 = 1500;
@@ -33,6 +34,55 @@ pub const DEFAULT_SUBNET: SwitchSubnet = SwitchSubnet {
     base: Ipv4Addr::new(100, 64, 0, 0),
     prefix: 16,
 };
+
+/// Filename the switch binary is installed under, in both the user-local `bin/`
+/// prefix and the system-wide path below.
+///
+/// Deliberately **not** plain `gvproxy`: the installer's `bin` prefix is
+/// `~/.local/bin`, which is on `PATH`, and podman/crc/Docker Desktop all ship
+/// their own `gvproxy` there. Installing under the upstream name would let
+/// whichever came last win a `PATH` lookup — in either direction — so the
+/// binary carries a minimal-specific name even though the bytes are stock
+/// gvproxy (`scripts/fetch-gvproxy.sh` pins and SHA-256-verifies them).
+pub const GVPROXY_FILE: &str = "mingvproxy";
+
+/// System-wide install path for the switch binary: the final fallback when no
+/// user-local install exists.
+pub const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/mingvproxy";
+
+/// The user-local bin directory the installer stamps into: `$MINIMAL_BIN`, else
+/// `$HOME/.local/bin`. Mirrors the installer's `bin` prefix resolution in
+/// `scripts/install.sh`. `None` when neither is set.
+fn installer_bin_dir() -> Option<PathBuf> {
+    if let Some(bin) = std::env::var("MINIMAL_BIN").ok().filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(bin));
+    }
+    std::env::var("HOME")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(|home| PathBuf::from(home).join(".local/bin"))
+}
+
+/// Resolve the switch binary an install placed on this host: an existing
+/// user-local install (`<bin-dir>/mingvproxy`, where the curl|sh installer
+/// stamps it), else the system-wide [`DEFAULT_GVPROXY_BIN`].
+///
+/// One definition shared by `minimald` (which spawns the switch for native
+/// own-IP sessions) and `minvmd` (the host switch supervisor), so the two
+/// daemons and the installer cannot drift on where the binary lives;
+/// daemon-specific overrides (config field, env var) layer on top in the
+/// callers. Never errors: the system path is returned as a last resort even if
+/// nothing exists there, so the caller surfaces a spawn failure naming a
+/// concrete path.
+#[must_use]
+pub fn installed_gvproxy_bin() -> PathBuf {
+    if let Some(local) = installer_bin_dir().map(|dir| dir.join(GVPROXY_FILE))
+        && local.exists()
+    {
+        return local;
+    }
+    PathBuf::from(DEFAULT_GVPROXY_BIN)
+}
 
 /// A subnet was constructed with a prefix outside the supported `8..=29` range —
 /// a configuration error, distinct from runtime address exhaustion.
@@ -274,5 +324,50 @@ mod tests {
         let yaml = render_gvproxy_config(SwitchSubnet::default(), &[]);
         assert!(yaml.contains("dhcpStaticLeases:\n    {}\n"));
         assert!(yaml.contains("subnet: \"100.64.0.0/16\""));
+    }
+
+    // Resolver tests mutate process-global env (MINIMAL_BIN), so serialise
+    // them to avoid races when `cargo test` runs them in parallel.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn installed_name_is_not_the_upstream_one() {
+        // The whole point of the rename: a stock `gvproxy` on PATH (podman,
+        // crc) must not be mistaken for ours, nor ours for it.
+        assert_ne!(GVPROXY_FILE, "gvproxy");
+        assert!(DEFAULT_GVPROXY_BIN.ends_with(GVPROXY_FILE));
+    }
+
+    #[test]
+    fn installed_gvproxy_prefers_existing_user_local_install() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let want = tmp.path().join(GVPROXY_FILE);
+        std::fs::write(&want, b"gvproxy").unwrap();
+        unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
+        assert_eq!(installed_gvproxy_bin(), want);
+        unsafe { std::env::remove_var("MINIMAL_BIN") };
+    }
+
+    #[test]
+    fn installed_gvproxy_ignores_an_upstream_named_binary() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // A foreign `gvproxy` sitting in the same bin dir must not be picked
+        // up — only our own filename counts.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("gvproxy"), b"podman's").unwrap();
+        unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
+        assert_eq!(installed_gvproxy_bin(), PathBuf::from(DEFAULT_GVPROXY_BIN));
+        unsafe { std::env::remove_var("MINIMAL_BIN") };
+    }
+
+    #[test]
+    fn installed_gvproxy_falls_back_to_system_path() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // MINIMAL_BIN points at an empty dir: no user-local install present.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
+        assert_eq!(installed_gvproxy_bin(), PathBuf::from(DEFAULT_GVPROXY_BIN));
+        unsafe { std::env::remove_var("MINIMAL_BIN") };
     }
 }

--- a/crates/switch/src/lib.rs
+++ b/crates/switch/src/lib.rs
@@ -86,16 +86,29 @@ fn installer_bin_dir() -> Option<PathBuf> {
 /// concrete path.
 #[must_use]
 pub fn installed_gvproxy_bin() -> PathBuf {
-    if let Some(local) = installer_bin_dir().map(|dir| dir.join(GVPROXY_FILE))
+    resolve_installed(
+        installer_bin_dir(),
+        Path::new(DEFAULT_GVPROXY_BIN),
+        Path::new(LEGACY_SYSTEM_GVPROXY_BIN),
+    )
+}
+
+/// The resolution itself, with every probed location passed in.
+///
+/// Split out so the tests can drive both system-path branches against temp
+/// dirs. Probing the real `/usr/lib/minimal/bin` instead would make them depend
+/// on host install state — and fail on exactly the pre-rename hosts the legacy
+/// branch exists to serve.
+fn resolve_installed(bin_dir: Option<PathBuf>, system: &Path, legacy: &Path) -> PathBuf {
+    if let Some(local) = bin_dir.map(|dir| dir.join(GVPROXY_FILE))
         && local.exists()
     {
         return local;
     }
-    let system = PathBuf::from(DEFAULT_GVPROXY_BIN);
-    if !system.exists() && Path::new(LEGACY_SYSTEM_GVPROXY_BIN).exists() {
-        return PathBuf::from(LEGACY_SYSTEM_GVPROXY_BIN);
+    if !system.exists() && legacy.exists() {
+        return legacy.to_path_buf();
     }
-    system
+    system.to_path_buf()
 }
 
 /// A subnet was constructed with a prefix outside the supported `8..=29` range —
@@ -364,24 +377,67 @@ mod tests {
     }
 
     #[test]
-    fn installed_gvproxy_ignores_an_upstream_named_binary() {
-        let _g = ENV_LOCK.lock().unwrap();
-        // A foreign `gvproxy` sitting in the same bin dir must not be picked
-        // up — only our own filename counts.
+    fn ignores_an_upstream_named_binary_in_the_bin_dir() {
+        // A foreign `gvproxy` (podman's, crc's) sitting in the bin dir must not
+        // be picked up — only our own filename counts. Driven through
+        // `resolve_installed` so the assertion does not depend on what the host
+        // has under /usr/lib/minimal/bin.
         let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(tmp.path().join("gvproxy"), b"podman's").unwrap();
-        unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
-        assert_eq!(installed_gvproxy_bin(), PathBuf::from(DEFAULT_GVPROXY_BIN));
-        unsafe { std::env::remove_var("MINIMAL_BIN") };
+        let bin = tmp.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        std::fs::write(bin.join("gvproxy"), b"podman's").unwrap();
+        let system = tmp.path().join("gvproxy-min");
+        let legacy = tmp.path().join("gvproxy");
+        assert_eq!(resolve_installed(Some(bin), &system, &legacy), system);
+    }
+
+    // The system-path branches go through `resolve_installed` with temp paths.
+    // Calling the public resolver would probe the real /usr/lib/minimal/bin and
+    // flip on a host that has either binary installed — failing on precisely
+    // the pre-rename hosts the legacy branch exists to serve.
+
+    #[test]
+    fn falls_back_to_the_current_system_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let system = tmp.path().join("gvproxy-min");
+        let legacy = tmp.path().join("gvproxy");
+        std::fs::write(&system, b"current").unwrap();
+        std::fs::write(&legacy, b"legacy").unwrap();
+        // Both present: the current name wins.
+        assert_eq!(resolve_installed(None, &system, &legacy), system);
     }
 
     #[test]
-    fn installed_gvproxy_falls_back_to_system_path() {
-        let _g = ENV_LOCK.lock().unwrap();
-        // MINIMAL_BIN points at an empty dir: no user-local install present.
+    fn falls_back_to_the_legacy_system_path_when_only_it_exists() {
         let tmp = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("MINIMAL_BIN", tmp.path()) };
-        assert_eq!(installed_gvproxy_bin(), PathBuf::from(DEFAULT_GVPROXY_BIN));
-        unsafe { std::env::remove_var("MINIMAL_BIN") };
+        let system = tmp.path().join("gvproxy-min");
+        let legacy = tmp.path().join("gvproxy");
+        std::fs::write(&legacy, b"legacy").unwrap();
+        // An operator who provisioned the pre-rename path keeps working.
+        assert_eq!(resolve_installed(None, &system, &legacy), legacy);
+    }
+
+    #[test]
+    fn reports_the_current_system_path_when_neither_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let system = tmp.path().join("gvproxy-min");
+        let legacy = tmp.path().join("gvproxy");
+        // Nothing installed anywhere: name the current path, so the caller's
+        // spawn failure cites the location an install should have used.
+        assert_eq!(resolve_installed(None, &system, &legacy), system);
+    }
+
+    #[test]
+    fn user_local_install_beats_both_system_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        let want = bin.join(GVPROXY_FILE);
+        std::fs::write(&want, b"user-local").unwrap();
+        let system = tmp.path().join("gvproxy-min");
+        let legacy = tmp.path().join("gvproxy");
+        std::fs::write(&system, b"current").unwrap();
+        std::fs::write(&legacy, b"legacy").unwrap();
+        assert_eq!(resolve_installed(Some(bin), &system, &legacy), want);
     }
 }

--- a/crates/switch/src/lib.rs
+++ b/crates/switch/src/lib.rs
@@ -44,11 +44,11 @@ pub const DEFAULT_SUBNET: SwitchSubnet = SwitchSubnet {
 /// whichever came last win a `PATH` lookup — in either direction — so the
 /// binary carries a minimal-specific name even though the bytes are stock
 /// gvproxy (`scripts/fetch-gvproxy.sh` pins and SHA-256-verifies them).
-pub const GVPROXY_FILE: &str = "mingvproxy";
+pub const GVPROXY_FILE: &str = "gvproxy-min";
 
 /// System-wide install path for the switch binary: the final fallback when no
 /// user-local install exists.
-pub const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/mingvproxy";
+pub const DEFAULT_GVPROXY_BIN: &str = "/usr/lib/minimal/bin/gvproxy-min";
 
 /// The user-local bin directory the installer stamps into: `$MINIMAL_BIN`, else
 /// `$HOME/.local/bin`. Mirrors the installer's `bin` prefix resolution in
@@ -64,7 +64,7 @@ fn installer_bin_dir() -> Option<PathBuf> {
 }
 
 /// Resolve the switch binary an install placed on this host: an existing
-/// user-local install (`<bin-dir>/mingvproxy`, where the curl|sh installer
+/// user-local install (`<bin-dir>/gvproxy-min`, where the curl|sh installer
 /// stamps it), else the system-wide [`DEFAULT_GVPROXY_BIN`].
 ///
 /// One definition shared by `minimald` (which spawns the switch for native

--- a/docs/internal/release-pipeline.md
+++ b/docs/internal/release-pipeline.md
@@ -35,15 +35,14 @@ override for green-but-unreported commits.
 - `build-release-linux-{amd64,arm64}`: static musl builds of `mip`, `min`
   (package `minimal`), and `minimald`, one cargo invocation per package so the
   fat-LTO links serialize. Each job then builds a native-glibc `minvmd` against
-  a materialized libkrun prefix and uploads that prefix's `libkrun` +
-  `libkrunfw` pair, so a Linux install ships the VM backend rather than
-  depending on a system libkrun.
+  a materialized libkrun prefix and uploads that prefix's `libkrun`, so a Linux
+  install ships the VM backend rather than depending on a system libkrun.
+  `libkrunfw` is deliberately not shipped on either platform: it carries a
+  bundled GPL-2 guest kernel, and minvmd supplies its own (`data/vmlinuz`).
   [`scripts/rewrite-linux-linkage.sh`](../../scripts/rewrite-linux-linkage.sh)
-  sets the two RUNPATHs the shipped layout needs (`minvmd` →
-  `$ORIGIN/../lib`, `libkrun` → `$ORIGIN`, the latter because its `dlopen` of
-  `libkrunfw` resolves against the *calling* object's RUNPATH) and hard-fails
-  on a soname bump, which would otherwise silently invalidate the `lib/` dests
-  in stage-release.sh.
+  sets the RUNPATH the shipped layout needs (`minvmd` → `$ORIGIN/../lib`) and
+  hard-fails on a soname bump, which would otherwise silently invalidate the
+  `lib/` dest in stage-release.sh.
 - `build-release-macos-arm64` (self-hosted Apple Silicon, gated on the
   `RUN_MACOS_CI` kill-switch): builds `minvmd` (libkrun /
   Hypervisor.framework) and `min`, rewrites minvmd's libkrun linkage to
@@ -152,8 +151,8 @@ skip oracle, so reruns only touch changed components, and a running daemon is
 stopped before an executable is swapped. Per-platform sets (from
 stage-release.sh's `COMPONENTS` table): every platform gets the session stack —
 `bin/min`, `bin/minvmd`, `bin/gvproxy-min`, a `git-remote-min` symlink, the
-libkrun the VM backend links (`lib/libkrun.so.1` + `lib/libkrunfw.so.5` on
-Linux, `lib/libkrun.1.dylib` on macOS), and the guest payload
+libkrun the VM backend links (`lib/libkrun.so.1` on Linux,
+`lib/libkrun.1.dylib` on macOS), and the guest payload
 (`data/{vmlinuz,rootfs.img,initramfs.cpio}`) for its own arch. Linux
 additionally gets `bin/mip`, `bin/minimald`, and the AppArmor
 profile/tunable/loader under `data/`.

--- a/docs/internal/release-pipeline.md
+++ b/docs/internal/release-pipeline.md
@@ -151,14 +151,14 @@ SHA-256-verifies, and atomically installs the file. The on-disk hash is the
 skip oracle, so reruns only touch changed components, and a running daemon is
 stopped before an executable is swapped. Per-platform sets (from
 stage-release.sh's `COMPONENTS` table): every platform gets the session stack —
-`bin/min`, `bin/minvmd`, `bin/mingvproxy`, a `git-remote-min` symlink, the
+`bin/min`, `bin/minvmd`, `bin/gvproxy-min`, a `git-remote-min` symlink, the
 libkrun the VM backend links (`lib/libkrun.so.1` + `lib/libkrunfw.so.5` on
 Linux, `lib/libkrun.1.dylib` on macOS), and the guest payload
 (`data/{vmlinuz,rootfs.img,initramfs.cpio}`) for its own arch. Linux
 additionally gets `bin/mip`, `bin/minimald`, and the AppArmor
 profile/tunable/loader under `data/`.
 
-The switch binary installs as **`mingvproxy`**, not `gvproxy`: the `bin` prefix
+The switch binary installs as **`gvproxy-min`**, not `gvproxy`: the `bin` prefix
 is `~/.local/bin`, which is on `PATH`, and podman/crc ship their own `gvproxy`
 there — under the upstream name whichever was installed last would win a `PATH`
 lookup, in either direction. The bytes are stock gvproxy;

--- a/docs/internal/release-pipeline.md
+++ b/docs/internal/release-pipeline.md
@@ -34,9 +34,16 @@ override for green-but-unreported commits.
 
 - `build-release-linux-{amd64,arm64}`: static musl builds of `mip`, `min`
   (package `minimal`), and `minimald`, one cargo invocation per package so the
-  fat-LTO links serialize. The amd64 job additionally builds a native-glibc
-  `minvmd` against a materialized libkrun prefix (there is currently no
-  `minvmd-linux-arm64` release artifact).
+  fat-LTO links serialize. Each job then builds a native-glibc `minvmd` against
+  a materialized libkrun prefix and uploads that prefix's `libkrun` +
+  `libkrunfw` pair, so a Linux install ships the VM backend rather than
+  depending on a system libkrun.
+  [`scripts/rewrite-linux-linkage.sh`](../../scripts/rewrite-linux-linkage.sh)
+  sets the two RUNPATHs the shipped layout needs (`minvmd` →
+  `$ORIGIN/../lib`, `libkrun` → `$ORIGIN`, the latter because its `dlopen` of
+  `libkrunfw` resolves against the *calling* object's RUNPATH) and hard-fails
+  on a soname bump, which would otherwise silently invalidate the `lib/` dests
+  in stage-release.sh.
 - `build-release-macos-arm64` (self-hosted Apple Silicon, gated on the
   `RUN_MACOS_CI` kill-switch): builds `minvmd` (libkrun /
   Hypervisor.framework) and `min`, rewrites minvmd's libkrun linkage to
@@ -143,11 +150,22 @@ immutable `versions/<version>/components` manifest (refusing an unknown
 SHA-256-verifies, and atomically installs the file. The on-disk hash is the
 skip oracle, so reruns only touch changed components, and a running daemon is
 stopped before an executable is swapped. Per-platform sets (from
-stage-release.sh's `COMPONENTS` table): Linux amd64/arm64 get `bin/min`,
-`bin/mip`, `bin/minimald`, a `git-remote-min` symlink, and the AppArmor
-profile/tunable/loader under `data/`; macOS arm64 gets `bin/min`,
-`bin/minvmd`, `bin/gvproxy`, `lib/libkrun.1.dylib`, the `git-remote-min`
-symlink, and the guest payload (`data/{vmlinuz,rootfs.img,initramfs.cpio}`).
+stage-release.sh's `COMPONENTS` table): every platform gets the session stack —
+`bin/min`, `bin/minvmd`, `bin/mingvproxy`, a `git-remote-min` symlink, the
+libkrun the VM backend links (`lib/libkrun.so.1` + `lib/libkrunfw.so.5` on
+Linux, `lib/libkrun.1.dylib` on macOS), and the guest payload
+(`data/{vmlinuz,rootfs.img,initramfs.cpio}`) for its own arch. Linux
+additionally gets `bin/mip`, `bin/minimald`, and the AppArmor
+profile/tunable/loader under `data/`.
+
+The switch binary installs as **`mingvproxy`**, not `gvproxy`: the `bin` prefix
+is `~/.local/bin`, which is on `PATH`, and podman/crc ship their own `gvproxy`
+there — under the upstream name whichever was installed last would win a `PATH`
+lookup, in either direction. The bytes are stock gvproxy;
+[`switch::GVPROXY_FILE`](../../crates/switch/src/lib.rs) is the resolver's
+matching definition, and install.sh removes a `bin/gvproxy` left by a
+pre-rename install when its bytes are still the ones we recorded writing.
+
 It also wires shell integration (PATH init files, `min` completions, one
 marker-fenced rc block). `--uninstall` reverses all of it offline from the
 local install record, keeping user-modified files unless `--force`;

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -55,8 +55,6 @@ the current directory).
 |------|-------|-------------|
 | `--name <NAME>` | `-n` | Optional session name |
 | `--sync <MODE>` | | How to load project files into the session: `tarball` (default: stream a tarball of your project and unpack it) or `none` (do not populate the worktree) |
-| `--network <MODE>` | | Network mode: `no-net`, `host-net` (default), or `own-ip` |
-| `--ingress <EXT:INT[/PROTO]>` | | Static ingress port mapping (`PROTO` = `tcp`\|`udp`, default `tcp`). Repeatable. Requires `--network own-ip` |
 | `--loadout <NAME>` | | Apply the named loadout from `<config>/minimal/loadouts/<NAME>.toml`. Repeatable; if given, config-file `default_loadouts` are ignored |
 | `--no-loadouts` | | Apply no loadouts at all (also skips the config's `default_loadouts`). Conflicts with `--loadout` |
 | `--no-prompt` | | Fail instead of prompting when the daemon surfaces items user policy can't auto-decide; implied when stdin/stderr isn't a TTY |

--- a/docs/reference/cli-minimald.md
+++ b/docs/reference/cli-minimald.md
@@ -36,7 +36,7 @@ Runs the minimald server in the foreground.
 | `--instance-num <N>` | Instance number for this minimald; determines client-relevant paths under `<minimal_state_dir>/providers/local-minimald<N>`. The SSH socket is accessible as `ssh.sock`. Default: `0` |
 | `--vsock` | Host the SSH socket over vsock instead of UDS; the vsock port is the default port base plus `instance_num` |
 | `--detach` | Daemonize: spawn minimald in a new session (setsid) and return once the SSH socket accepts connections, or an 8s timeout elapses. Used by the `min` CLI to auto-start a native daemon on Linux |
-| `--gvproxy-bin <PATH>` | Path to the gvproxy ("gvisor-tap-vsock") binary used for networking. Defaults to a typical system install path. |
+| `--gvproxy-bin <PATH>` | Path to the gvproxy ("gvisor-tap-vsock") binary used for networking. Defaults to the installed location: the user-local `bin/mingvproxy` the installer stamps, else the system install path. |
 
 ### `completions`
 

--- a/docs/reference/cli-minimald.md
+++ b/docs/reference/cli-minimald.md
@@ -36,7 +36,7 @@ Runs the minimald server in the foreground.
 | `--instance-num <N>` | Instance number for this minimald; determines client-relevant paths under `<minimal_state_dir>/providers/local-minimald<N>`. The SSH socket is accessible as `ssh.sock`. Default: `0` |
 | `--vsock` | Host the SSH socket over vsock instead of UDS; the vsock port is the default port base plus `instance_num` |
 | `--detach` | Daemonize: spawn minimald in a new session (setsid) and return once the SSH socket accepts connections, or an 8s timeout elapses. Used by the `min` CLI to auto-start a native daemon on Linux |
-| `--gvproxy-bin <PATH>` | Path to the gvproxy ("gvisor-tap-vsock") binary used for networking. Defaults to the installed location: the user-local `bin/mingvproxy` the installer stamps, else the system install path. |
+| `--gvproxy-bin <PATH>` | Path to the gvproxy ("gvisor-tap-vsock") binary used for networking. Defaults to the installed location: the user-local `bin/gvproxy-min` the installer stamps, else the system install path. |
 
 ### `completions`
 

--- a/docs/specs/01-spec-minvmd-host-daemon/01-spec-minvmd-host-daemon.md
+++ b/docs/specs/01-spec-minvmd-host-daemon/01-spec-minvmd-host-daemon.md
@@ -429,7 +429,11 @@ hold under this model.
 - **libkrun linking**: pinned to a known-good version (v1.18.0).
   `build.rs` emits `cargo:rustc-link-search` and
   `cargo:rustc-link-arg=-Wl,-rpath` pointing at `/opt/homebrew/lib`
-  with a `LIBKRUN_PREFIX` env override.
+  with a `LIBKRUN_PREFIX` env override. That absolute rpath is the
+  **development** story only: a *shipped* binary resolves libkrun through a
+  binary-relative rpath into a `lib/` sibling of `bin/`, rewritten after the
+  build on both platforms. See
+  [spec 02, "libkrun installation on Linux"](../02-spec-minvmd-linux-kvm/02-spec-minvmd-linux-kvm.md).
 - **Hidden `__krun-vmm` subcommand**, not in `--help`;
   verified-via-auth-token; the only entry point that calls
   `krun_start_enter`.

--- a/docs/specs/02-spec-minvmd-linux-kvm/02-spec-minvmd-linux-kvm.md
+++ b/docs/specs/02-spec-minvmd-linux-kvm/02-spec-minvmd-linux-kvm.md
@@ -316,7 +316,10 @@ runners provisioned via the infrastructure team use the configured path.
 **An installed host resolves nothing from the system.** The release ships
 libkrun alongside `minvmd` and the installer places it in the `lib` prefix, a
 sibling of `bin` (`scripts/stage-release.sh`): `lib/libkrun.so.1` on Linux,
-`lib/libkrun.1.dylib` on macOS. The shipped binary finds it through a
+`lib/libkrun.1.dylib` on macOS. **`libkrunfw` is not shipped on either
+platform** — it exists to carry a bundled GPL-2 guest kernel, and minvmd
+supplies its own via `ctx.set_kernel` from the shipped `data/vmlinuz`, so it is
+neither linked nor loaded. The shipped binary finds it through a
 **binary-relative rpath** — `$ORIGIN/../lib` on Linux, `@loader_path/../lib` on
 macOS — rewritten from the build-time absolute prefix after the build, by
 `scripts/rewrite-linux-linkage.sh` and `scripts/rewrite-macos-linkage.sh`

--- a/docs/specs/02-spec-minvmd-linux-kvm/02-spec-minvmd-linux-kvm.md
+++ b/docs/specs/02-spec-minvmd-linux-kvm/02-spec-minvmd-linux-kvm.md
@@ -300,8 +300,11 @@ code-signing target are macOS-only and require no change.
 
 ### libkrun installation on Linux
 
-On macOS, libkrun is installed via the Homebrew tap (`slp/krun/libkrun`) at
-`/opt/homebrew/lib`. On Linux the typical install paths are:
+Two distinct situations, and they resolve libkrun differently.
+
+**A development or CI build** finds libkrun on the build host. On macOS that is
+the Homebrew tap (`slp/krun/libkrun`) at `/opt/homebrew/lib`. On Linux the
+typical paths are:
 - Fedora/RHEL: `dnf install libkrun-devel` → `/usr/lib`
 - Ubuntu/Debian: source build → `/usr/local/lib` (no distro package as of
   this writing)
@@ -309,6 +312,30 @@ On macOS, libkrun is installed via the Homebrew tap (`slp/krun/libkrun`) at
 
 The `build.rs` default of `/usr` covers the Fedora path; GCP nested-virt
 runners provisioned via the infrastructure team use the configured path.
+
+**An installed host resolves nothing from the system.** The release ships
+libkrun alongside `minvmd` and the installer places it in the `lib` prefix, a
+sibling of `bin` (`scripts/stage-release.sh`): `lib/libkrun.so.1` on Linux,
+`lib/libkrun.1.dylib` on macOS. The shipped binary finds it through a
+**binary-relative rpath** — `$ORIGIN/../lib` on Linux, `@loader_path/../lib` on
+macOS — rewritten from the build-time absolute prefix after the build, by
+`scripts/rewrite-linux-linkage.sh` and `scripts/rewrite-macos-linkage.sh`
+respectively. Those scripts also hard-fail on a soname/install-name change,
+because the `lib/` destination names in `stage-release.sh` encode it.
+
+Consequences worth stating, because they are easy to get wrong:
+
+- The absolute build-time prefix must **not** survive into a shipped binary; it
+  names a directory that exists only on the release runner. The Linux release
+  build drops it (`crates/minvmd/build.rs`) and the rewrite script verifies it.
+- Because the rpath is binary-relative, the `lib` prefix has to stay a sibling
+  of `bin`. See [spec 07 R4.1a](../07-spec-installer/07-spec-installer.md),
+  which specifies the installer's warning when a host's prefixes diverge.
+- Shipping libkrun sets a **glibc floor** on Linux: unlike `min`, `mip` and
+  `minimald` — static musl, self-contained — `minvmd` is a native-glibc build,
+  so an installed host older than the release runner cannot load it. Removing
+  that floor needs a musl libkrun; tracked in
+  [gominimal/pkgs#533](https://github.com/gominimal/pkgs/issues/533).
 
 ### Relation to the session domain model
 

--- a/docs/specs/07-spec-installer/07-spec-installer.md
+++ b/docs/specs/07-spec-installer/07-spec-installer.md
@@ -190,6 +190,7 @@ fixed `case`, **never** shell-expanded or `eval`ed from the manifest string:
 | token   | resolves to                                             |
 |---------|---------------------------------------------------------|
 | `bin`   | `${MINIMAL_BIN:-$HOME/.local/bin}`                      |
+| `lib`   | `${XDG_LIB_HOME:-$HOME/.local/lib}`                     |
 | `data`  | `${XDG_DATA_HOME:-$HOME/.local/share}/minimal`          |
 | `state` | `${XDG_STATE_HOME:-$HOME/.local/state}/minimal`         |
 | `cache` | `${XDG_CACHE_HOME:-$HOME/.cache}/minimal`               |
@@ -197,6 +198,21 @@ fixed `case`, **never** shell-expanded or `eval`ed from the manifest string:
 An unknown token exits with an error. (Note the correct XDG variable names,
 `XDG_DATA_HOME`/`XDG_STATE_HOME`/`XDG_CACHE_HOME`, and that `~/.local/bin` has
 no XDG variable, hence the `MINIMAL_BIN` override.)
+
+**R4.1a**, The `lib` prefix must resolve to a **sibling of the `bin` prefix**
+(`<bin>/../lib`). `minvmd` locates the libkrun it links through a
+binary-relative rpath — `$ORIGIN/../lib` on Linux, `@loader_path/../lib` on
+macOS — so a `lib` prefix anywhere else is unreachable at load time no matter
+what the manifest placed there. The two tokens resolve from unrelated variables
+(`MINIMAL_BIN` and `XDG_LIB_HOME`), so a host may set one and not the other.
+
+The installer therefore compares them once, before the component loop, and
+**warns** when they diverge, naming both resolved paths. It is a warning and not
+a hard error because the divergence only breaks VM-backed sessions: every other
+component still installs and works, and a host that never boots a microVM is
+unaffected. Diagnosing it here — where the cause is visible — is the point;
+left to runtime it surfaces as `libkrun.so.1: cannot open shared object file`
+from an autospawned daemon.
 
 **R4.2**, The `dest` subpath is rejected before use if it is absolute (`/…`) or
 contains a `..` component, preventing a manifest from writing outside the
@@ -261,8 +277,20 @@ mv -f "$target.tmp.$$" "$target"
 **R5.5**, Installing a new version over a **running daemon** wedges it: the
 daemon goes on serving from the old image while the newly-installed `min` speaks
 to it. Before the first component file is replaced, the installer therefore runs
-`<bin>/min stop --force`, the `min` **already on disk**, which is the build that
-matches the daemon it started and is the one about to be overwritten. `--force`
+the `min` **already on disk**, which is the build that matches the daemon it
+started and is the one about to be overwritten, **once per backend**:
+
+```
+<bin>/min stop --force
+<bin>/min --provider local-minvmd stop --force
+```
+
+Both, because bare `min stop` resolves the *default* provider — `local-minimald`
+on Linux — and since Linux began shipping `minvmd` and its libkrun, a single
+invocation would leave a live `minvmd` holding its socket while exactly those
+files are swapped underneath it. Stopping a backend that is not running is a
+failed connect and nothing more, so the second call is free on hosts that never
+use it. `--force`
 because an upgrade must not be blocked by live sessions, and because a prompt is
 not available in a `curl … | sh` pipeline.
 
@@ -303,8 +331,9 @@ both hash columns in place of digests.
   it, the recorded installed hash does not mask a new release.
 - **Test** (R5.5): a fresh install stops nothing (no `min` on disk yet) and an
   up-to-date rerun stops nothing (nothing replaced); an upgrade whose components
-  are stale runs the on-disk `min` with exactly `stop --force`, once, however
-  many components it replaces.
+  are stale runs the on-disk `min` with `stop --force` once per backend — the
+  default provider and `--provider local-minvmd` — however many components it
+  replaces.
 - **Test** (R5.5): an installed `min` whose `stop` exits non-zero and writes to
   both stdout and stderr still yields exit 0, leaks neither stream into the
   installer's output, and completes the upgrade.
@@ -327,6 +356,34 @@ cannot collide with a hex digest and is what the uninstaller keys on (R7.3).
 The record also enables uninstall (Units 7–8) and surfaces prefix drift if
 `XDG_*` variables change between runs.
 
+**R6.1a**, **Renamed-component migration.** When a component is renamed, its old
+`dest` stops appearing in every subsequent manifest, so the record walk of Units
+7–8 never revisits it and the file is stranded on disk forever. For a `bin`
+component that is a live PATH collision, not just clutter. The installer
+therefore reverses a known rename from the *prior* record, on the same
+bytes-still-ours terms uninstall uses (R7.3): the old `dest` is removed only
+when its SHA-256 still equals the `installed-hash` recorded for it, so a file
+the user replaced is kept and reported.
+
+The concrete case is the switch binary, installed as `gvproxy` before this
+release and as `gvproxy-min` after it — the `bin` prefix is on `PATH` and
+podman/crc ship their own `gvproxy` there, so the two cannot share a name.
+
+Three rules make the migration safe:
+
+- **Skip when the manifest still ships the old component.** Channels advance
+  independently, so a post-rename installer *will* be pointed at a pre-rename
+  manifest. There the file on disk is the one this very run installed, and
+  deleting it would leave the host with no switch binary at all, on every run.
+  The migration therefore runs only when this run's records contain no row for
+  the old component name.
+- **Report a refusal.** A hash mismatch means the user replaced the file; it is
+  kept and named.
+- **Retry a failure.** If removal fails (a read-only or root-owned `bin`), the
+  row is carried into this run's record so the next run tries again — without
+  it the migration gets exactly one attempt, because the record it reads is
+  replaced immediately afterwards.
+
 **R6.2**, If the resolved `bin` directory is not on `$PATH` **in the
 installing session**, the installer prints an advisory: the Unit 9 rc hook only
 takes effect in new shells, so the advisory tells the user to restart their
@@ -339,6 +396,14 @@ the only rc edit it makes is Unit 9's announced, marker-fenced block (R9.2).
   exists and lists the installed components with their destinations and hashes.
 - **Test**: With the `bin` prefix absent from `PATH`, the advisory is printed;
   with it present, it is not.
+- **Test** (R6.1a): a record naming the old component at a path whose bytes
+  still match the recorded hash has that file removed on the next install, the
+  removal is announced, and a further rerun says nothing (the row is gone).
+- **Test** (R6.1a): a record naming the old component whose file the user has
+  since replaced keeps the file, byte-for-byte, and reports that it was kept.
+- **Test** (R6.1a): when the manifest for *this* run still ships the old
+  component, the file it just installed survives and no removal is announced —
+  the case that would otherwise leave the host with no switch binary.
 
 ### Unit 9 - Shell integration: PATH, shell-init files, completions
 
@@ -752,10 +817,10 @@ already-absent. Teardown happens after the walk (not before) for the same reason
 an interrupted run leaves the inventory intact for the retry. Then each
 `minimal`-owned directory that the installer may have created is removed **only
 if empty**, via `rmdir` (never `rm -rf`): the `data`, `state`, and `cache`
-prefixes resolve to `.../minimal` subdirectories the installer owns, and the
-`bin` prefix (`~/.local/bin`) is shared with other tools so it is `rmdir`ed only
-when empty and otherwise left untouched. Pruning failures (a non-empty dir) are
-ignored, not fatal.
+prefixes resolve to `.../minimal` subdirectories the installer owns, while the
+`bin` (`~/.local/bin`) and `lib` (`~/.local/lib`) prefixes are shared with other
+tools, so those two are `rmdir`ed only when empty and otherwise left untouched.
+Pruning failures (a non-empty dir) are ignored, not fatal.
 
 **R8.2**, `--purge` additionally removes the `minimal`-owned trees in full,
 the resolved `data`, `state`, and `cache` directories and everything under them

--- a/docs/specs/08-spec-vm-ext4-volume/08-spec-vm-ext4-volume.md
+++ b/docs/specs/08-spec-vm-ext4-volume/08-spec-vm-ext4-volume.md
@@ -226,7 +226,7 @@ trees on a shared writable ext4 volume. Introduces the host provisioner, the
   directory (a bind-mount point for the writable volume) and include `e2fsprogs`
   (`mkfs.ext4`) in the rootfs closure. The rootfs image format stays raw ext4
   (`rootfs.img`); no packaging change to the release artifact shape (informed by
-  `.minimal/minimal.toml:52-56` and `scripts/stage-release.sh:118`).
+  `.minimal/minimal.toml:52-56` and `scripts/stage-release.sh` (its `rootfs` COMPONENTS rows)).
 
 - **R1.9**: The `sync_mode` and `direct_io` flags passed to `add_disk_with_sync`
   (R1.4) shall not be hardcoded. `crates/minvmd/src/vm.rs` shall read them from

--- a/docs/specs/08-spec-vm-ext4-volume/architecture.md
+++ b/docs/specs/08-spec-vm-ext4-volume/architecture.md
@@ -253,7 +253,7 @@ place; atomicity semantics and the non-empty check are new.
 as an empty directory (bind-mount point) and `e2fsprogs` (`mkfs.ext4`,
 `e2fsck`) to the rootfs closure. The rootfs format stays raw ext4 (`rootfs.img`); no change to
 the release artifact shape (informed by `.minimal/minimal.toml:52-56` and
-`scripts/stage-release.sh:118`).
+`scripts/stage-release.sh` (its `rootfs` COMPONENTS rows)).
 
 ## Alternatives considered
 

--- a/justfile
+++ b/justfile
@@ -239,6 +239,21 @@ test-installer:
 lint-shell:
     bash scripts/lint-shell.sh
 
+# Run the shipped-linkage rewriter's test harness (stubbed `patchelf`, no ELF
+# binaries); shellcheck runs when present. Runs anywhere — the script itself is
+# Linux-only, so this is the only way to exercise it on macOS.
+test-linkage:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v shellcheck >/dev/null 2>&1; then
+        echo "== shellcheck =="
+        shellcheck scripts/rewrite-linux-linkage.sh scripts/rewrite-linux-linkage_test.sh
+    else
+        echo "== shellcheck not found, skipping static check =="
+    fi
+    echo "== running rewrite-linux-linkage_test.sh =="
+    bash scripts/rewrite-linux-linkage_test.sh
+
 # Run the promotion provenance gate's test harness (stubbed `gh`, no network,
 # no auth); shellcheck runs when present.
 test-promote-gate:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -781,6 +781,34 @@ fi
 
 # --- Unit 6: install record and PATH advisory ------------------------------
 
+# Migration: the switch binary used to install as `bin/gvproxy` and now installs
+# as `bin/mingvproxy` (the bin prefix is on PATH, and podman/crc ship their own
+# `gvproxy` there). The renamed component is a *new* row, so the old file is no
+# longer referenced by any manifest and the record walk would never revisit it —
+# it would sit on PATH forever, which is the collision the rename exists to
+# remove. Undo it here on the same terms as uninstall: remove it only when its
+# bytes are still exactly what we recorded writing, so a user who replaced that
+# path with their own gvproxy keeps it.
+remove_renamed_gvproxy() {
+    [ -f "$prev_record" ] || return 0
+    _tab="$(printf '\t')"
+    while IFS="$_tab" read -r _comp _dest _ _want; do
+        [ "$_comp" = gvproxy ] || continue
+        [ -n "$_dest" ] && [ -f "$_dest" ] || continue
+        # A symlink row, or one we did not write, is not ours to remove.
+        [ -L "$_dest" ] && continue
+        case "$_want" in link:*) continue ;; esac
+        # No dry-run branch: --dry-run is an uninstall-only option, and
+        # uninstall is dispatched long before this runs.
+        if [ "$(sha256 "$_dest")" != "$_want" ]; then
+            say "  gvproxy: kept $_dest (modified since install; now shipped as mingvproxy)"
+        else
+            rm -f "$_dest" && say "  gvproxy: removed $_dest (renamed to mingvproxy)"
+        fi
+    done <"$prev_record"
+}
+remove_renamed_gvproxy
+
 # R6.1 — persist the resolved (component, dest, installed-hash) rows for this
 # platform, replacing the prior record read during the loop. Enables a future
 # uninstall and surfaces prefix drift across XDG changes.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,6 +160,21 @@ resolve_prefix() {
 # replaces it.
 bindir="$(resolve_prefix bin)"
 
+# minvmd finds its libkrun through a BINARY-RELATIVE rpath (`$ORIGIN/../lib` on
+# Linux, `@loader_path/../lib` on macOS), so the `lib` prefix has to be a
+# sibling of the `bin` one. The two resolve from unrelated knobs (MINIMAL_BIN
+# vs XDG_LIB_HOME), so a host that sets only one silently ends up with a layout
+# no rpath can bridge — minvmd then dies at autospawn with "libkrun.so.1:
+# cannot open shared object file". Warn at install time, where the cause is
+# still obvious, rather than letting it surface as a VM that never boots.
+if [ "$(dirname "$bindir")/lib" != "$(resolve_prefix lib)" ]; then
+    say "warning: bin and lib prefixes are not siblings:"
+    say "    bin: $bindir"
+    say "    lib: $(resolve_prefix lib)"
+    say "  minvmd resolves libkrun at <bin>/../lib, so VM-backed sessions will"
+    say "  fail to start. Set MINIMAL_BIN and XDG_LIB_HOME to a matching pair."
+fi
+
 # --- Unit 9: shared shell-integration paths and markers ---------------------
 
 # Where the generated (not downloaded) shell-integration files live. Init
@@ -532,7 +547,13 @@ stop_running_daemon() {
     [ "$daemon_stop_tried" -eq 0 ] || return 0
     daemon_stop_tried=1
     [ -x "$bindir/min" ] || return 0
+    # Both backends, because both are now swappable components: bare `min stop`
+    # resolves the DEFAULT provider (local-minimald on Linux), so it would leave
+    # a running minvmd holding its socket while its binary and libkrun are
+    # replaced underneath it. `--provider` is a global arg, and stopping a
+    # backend that isn't running is a failed connect and nothing more.
     "$bindir/min" stop --force >/dev/null 2>&1 || true
+    "$bindir/min" --provider local-minvmd stop --force >/dev/null 2>&1 || true
 }
 
 # The prior run's install record (R6.1) maps each component to the hash of the
@@ -792,6 +813,14 @@ fi
 remove_renamed_gvproxy() {
     [ -f "$prev_record" ] || return 0
     _tab="$(printf '\t')"
+    # Only a RENAME justifies deleting the old path. If the manifest this run
+    # installed still ships a `gvproxy` component, the file on disk is the one
+    # we just placed — deleting it would leave the host with no switch binary
+    # at all, on every run. Channels advance independently, so a post-rename
+    # installer WILL be pointed at a pre-rename manifest.
+    if cut -f1 "$records" | grep -qx gvproxy; then
+        return 0
+    fi
     while IFS="$_tab" read -r _comp _dest _ _want; do
         [ "$_comp" = gvproxy ] || continue
         [ -n "$_dest" ] || continue
@@ -803,8 +832,15 @@ remove_renamed_gvproxy() {
         # uninstall is dispatched long before this runs.
         if [ "$(sha256 "$_dest")" != "$_want" ]; then
             say "  gvproxy: kept $_dest (modified since install; now shipped as gvproxy-min)"
+        elif rm -f "$_dest"; then
+            say "  gvproxy: removed $_dest (renamed to gvproxy-min)"
         else
-            rm -f "$_dest" && say "  gvproxy: removed $_dest (renamed to gvproxy-min)"
+            # Carry the row into this run's record so the next run retries.
+            # Without it the migration gets exactly one attempt — the record is
+            # replaced below — and a stale gvproxy would sit on PATH forever,
+            # which is the collision the rename exists to remove.
+            say "  gvproxy: could not remove $_dest; will retry on the next install"
+            printf '%s\t%s\t%s\t%s\n' "$_comp" "$_dest" "$_want" "$_want" >>"$records"
         fi
     done <"$prev_record"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -794,7 +794,8 @@ remove_renamed_gvproxy() {
     _tab="$(printf '\t')"
     while IFS="$_tab" read -r _comp _dest _ _want; do
         [ "$_comp" = gvproxy ] || continue
-        [ -n "$_dest" ] && [ -f "$_dest" ] || continue
+        [ -n "$_dest" ] || continue
+        [ -f "$_dest" ] || continue
         # A symlink row, or one we did not write, is not ours to remove.
         [ -L "$_dest" ] && continue
         case "$_want" in link:*) continue ;; esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -782,7 +782,7 @@ fi
 # --- Unit 6: install record and PATH advisory ------------------------------
 
 # Migration: the switch binary used to install as `bin/gvproxy` and now installs
-# as `bin/mingvproxy` (the bin prefix is on PATH, and podman/crc ship their own
+# as `bin/gvproxy-min` (the bin prefix is on PATH, and podman/crc ship their own
 # `gvproxy` there). The renamed component is a *new* row, so the old file is no
 # longer referenced by any manifest and the record walk would never revisit it —
 # it would sit on PATH forever, which is the collision the rename exists to
@@ -802,9 +802,9 @@ remove_renamed_gvproxy() {
         # No dry-run branch: --dry-run is an uninstall-only option, and
         # uninstall is dispatched long before this runs.
         if [ "$(sha256 "$_dest")" != "$_want" ]; then
-            say "  gvproxy: kept $_dest (modified since install; now shipped as mingvproxy)"
+            say "  gvproxy: kept $_dest (modified since install; now shipped as gvproxy-min)"
         else
-            rm -f "$_dest" && say "  gvproxy: removed $_dest (renamed to mingvproxy)"
+            rm -f "$_dest" && say "  gvproxy: removed $_dest (renamed to gvproxy-min)"
         fi
     done <"$prev_record"
 }

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -969,6 +969,33 @@ run gvren_rerun "$H15"
 check 0 "$rc" "rerun after migration exits 0"
 want_err "rerun says nothing about gvproxy" grep -q "renamed to gvproxy-min" "$OUT"
 
+# A manifest that STILL ships a `gvproxy` component is not a rename: the file
+# on disk is the one this very run installed, so the migration must not touch
+# it. Channels advance independently, so a post-rename installer WILL be
+# pointed at a pre-rename manifest — deleting there would leave the host with
+# no switch binary at all, on every single run.
+H17="$root/h17"; mkdir -p "$H17"
+run gvship_seed "$H17"
+check 0 "$rc" "still-ships-gvproxy seed install exits 0"
+gvship_rec="$H17/xdg-state/minimal/installed"
+printf 'shipped-gvproxy-body\n' >"$H17/bin/gvproxy"
+gvship_h="$(hash_file "$H17/bin/gvproxy")"
+printf 'gvproxy\t%s\t%s\t%s\n' "$H17/bin/gvproxy" "$gvship_h" "$gvship_h" >>"$gvship_rec"
+# Make THIS run install a gvproxy component too, as a pre-rename manifest does.
+printf 'shipped-gvproxy-body\n' >"$mock/versions/v1/gvproxy-linux-amd64"
+h_gv="$(hash_file "$mock/versions/v1/gvproxy-linux-amd64")"
+{
+    cat "$mock/versions/v1/components"
+    printf '%-12s %-7s %-7s %-9s %-64s %-6s %-20s %s\n' \
+        gvproxy linux amd64 v1 "$h_gv" file bin/gvproxy versions/v1/gvproxy-linux-amd64
+} >"$mock/versions/v1/components.new"
+mv "$mock/versions/v1/components.new" "$mock/versions/v1/components"
+run gvship "$H17"
+check 0 "$rc" "install against a manifest that still ships gvproxy exits 0"
+want_ok "the just-installed bin/gvproxy survives" test -f "$H17/bin/gvproxy"
+want_err "no removal is announced" grep -q "renamed to gvproxy-min" "$OUT"
+write_manifest 1
+
 # A gvproxy the user replaced (podman's, say) is NOT ours to delete: the hash
 # no longer matches what we recorded writing, so it is kept and reported.
 H16="$root/h16"; mkdir -p "$H16"

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -944,9 +944,9 @@ check 0 "$rc" "data-only uninstall exits 0"
 want_ok "dump kept when no zsh completions were installed (R9.4)" \
     grep -q '# untouched user cache' "$H5/.zcompdump"
 
-# --- gvproxy -> mingvproxy rename migration --------------------------------
+# --- gvproxy -> gvproxy-min rename migration --------------------------------
 
-# The switch binary moved from bin/gvproxy to bin/mingvproxy (the bin prefix is
+# The switch binary moved from bin/gvproxy to bin/gvproxy-min (the bin prefix is
 # on PATH and podman/crc ship their own gvproxy). The old dest is in no
 # manifest any more, so nothing would ever revisit it — the install has to undo
 # it explicitly, on the same bytes-still-ours terms as uninstall.
@@ -963,11 +963,11 @@ printf 'gvproxy\t%s\t%s\t%s\n' "$H15/bin/gvproxy" "$gvren_h" "$gvren_h" >>"$gvre
 run gvren "$H15"
 check 0 "$rc" "rename-migration install exits 0"
 want_err "stale bin/gvproxy removed on upgrade" test -e "$H15/bin/gvproxy"
-want_ok "removal announced" grep -q "renamed to mingvproxy" "$OUT"
+want_ok "removal announced" grep -q "renamed to gvproxy-min" "$OUT"
 
 run gvren_rerun "$H15"
 check 0 "$rc" "rerun after migration exits 0"
-want_err "rerun says nothing about gvproxy" grep -q "renamed to mingvproxy" "$OUT"
+want_err "rerun says nothing about gvproxy" grep -q "renamed to gvproxy-min" "$OUT"
 
 # A gvproxy the user replaced (podman's, say) is NOT ours to delete: the hash
 # no longer matches what we recorded writing, so it is kept and reported.

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -944,6 +944,48 @@ check 0 "$rc" "data-only uninstall exits 0"
 want_ok "dump kept when no zsh completions were installed (R9.4)" \
     grep -q '# untouched user cache' "$H5/.zcompdump"
 
+# --- gvproxy -> mingvproxy rename migration --------------------------------
+
+# The switch binary moved from bin/gvproxy to bin/mingvproxy (the bin prefix is
+# on PATH and podman/crc ship their own gvproxy). The old dest is in no
+# manifest any more, so nothing would ever revisit it — the install has to undo
+# it explicitly, on the same bytes-still-ours terms as uninstall.
+H15="$root/h15"; mkdir -p "$H15"
+run gvren_seed "$H15"
+check 0 "$rc" "rename-migration seed install exits 0"
+
+# Seed what a pre-rename install left behind: the binary plus its record row.
+gvren_rec="$H15/xdg-state/minimal/installed"
+printf 'old-gvproxy-body\n' >"$H15/bin/gvproxy"
+gvren_h="$(hash_file "$H15/bin/gvproxy")"
+printf 'gvproxy\t%s\t%s\t%s\n' "$H15/bin/gvproxy" "$gvren_h" "$gvren_h" >>"$gvren_rec"
+
+run gvren "$H15"
+check 0 "$rc" "rename-migration install exits 0"
+want_err "stale bin/gvproxy removed on upgrade" test -e "$H15/bin/gvproxy"
+want_ok "removal announced" grep -q "renamed to mingvproxy" "$OUT"
+
+run gvren_rerun "$H15"
+check 0 "$rc" "rerun after migration exits 0"
+want_err "rerun says nothing about gvproxy" grep -q "renamed to mingvproxy" "$OUT"
+
+# A gvproxy the user replaced (podman's, say) is NOT ours to delete: the hash
+# no longer matches what we recorded writing, so it is kept and reported.
+H16="$root/h16"; mkdir -p "$H16"
+run gvkeep_seed "$H16"
+check 0 "$rc" "rename-keep seed install exits 0"
+gvkeep_rec="$H16/xdg-state/minimal/installed"
+printf 'ours-when-installed\n' >"$H16/bin/gvproxy"
+gvkeep_h="$(hash_file "$H16/bin/gvproxy")"
+printf 'gvproxy\t%s\t%s\t%s\n' "$H16/bin/gvproxy" "$gvkeep_h" "$gvkeep_h" >>"$gvkeep_rec"
+printf 'the-users-own-gvproxy\n' >"$H16/bin/gvproxy"
+
+run gvkeep "$H16"
+check 0 "$rc" "rename-keep install exits 0"
+want_ok "a user-replaced gvproxy is kept" test -f "$H16/bin/gvproxy"
+want_ok "kept content is untouched" grep -q 'the-users-own-gvproxy' "$H16/bin/gvproxy"
+want_ok "keeping it is announced" grep -q "modified since install" "$OUT"
+
 # ===========================================================================
 echo "# ---"
 printf '# %d passed, %d failed\n' "$pass" "$fail"

--- a/scripts/rewrite-linux-linkage.sh
+++ b/scripts/rewrite-linux-linkage.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Rewrite a Linux minvmd binary + its libkrun pair for the SHIPPED layout, then
+# verify the result. The Linux twin of scripts/rewrite-macos-linkage.sh.
+#
+# The installer drops bin/minvmd beside lib/libkrun.so.1 and lib/libkrunfw.so.5
+# (stage-release.sh's `lib/` rows), so two RUNPATHs have to be right:
+#
+#   minvmd       -> $ORIGIN/../lib    finds lib/libkrun.so.1 from bin/
+#   libkrun.so.1 -> $ORIGIN           finds its libkrunfw.so.5 SIBLING
+#
+# The second is not optional and not covered by the first: libkrun dlopen()s
+# libkrunfw by soname, and glibc resolves a dlopen from a library against the
+# RUNPATH of the *calling object*, never the executable's. Without it a shipped
+# libkrun finds no libkrunfw and every VM boot fails on a host that has no
+# system copy.
+#
+# build.rs already bakes `$ORIGIN` first plus the system lib dirs, and drops the
+# ephemeral $LIBKRUN_PREFIX on a Linux --release build; this inserts the
+# `../lib` entry after `$ORIGIN` and leaves the rest alone (so the system-libkrun
+# fallback keeps working, and the list is not duplicated here).
+#
+# Verifies afterwards that:
+#   - minvmd really links libkrun (not the stub) and its RUNPATH has $ORIGIN/../lib
+#   - no ephemeral build path (a $HOME/.krun prefix) leaked into any RUNPATH
+#   - the two sonames are exactly what stage-release.sh's `lib/` dests assume
+#   - libkrun's RUNPATH has $ORIGIN
+#
+# A soname mismatch is a HARD failure: it means a libkrun major bump landed and
+# the dest basenames in stage-release.sh must change with it. Failing here beats
+# shipping an install whose minvmd cannot resolve its library.
+#
+# Usage: scripts/rewrite-linux-linkage.sh <minvmd-binary> <libkrun-dir>
+#
+# `$ORIGIN` is an ELF loader token, not a shell variable: every occurrence below
+# is deliberately single-quoted so patchelf records it literally. Expanding it
+# would bake this runner's absolute paths into the shipped binary.
+# shellcheck disable=SC2016
+set -euo pipefail
+
+BIN="${1:?usage: rewrite-linux-linkage.sh <minvmd-binary> <libkrun-dir>}"
+LIBDIR="${2:?usage: rewrite-linux-linkage.sh <minvmd-binary> <libkrun-dir>}"
+
+# Kept in lockstep with the `lib/` dest basenames in scripts/stage-release.sh.
+WANT_KRUN_SONAME="libkrun.so.1"
+WANT_KRUNFW_SONAME="libkrunfw.so.5"
+
+command -v patchelf >/dev/null 2>&1 || {
+    echo "::error::patchelf not found (apt-get install patchelf)" >&2
+    exit 1
+}
+
+die() {
+    echo "::error::$1" >&2
+    exit 1
+}
+
+# Resolve the real regular file behind a soname symlink chain
+# (fetch-libkrun.sh copies the whole chain with `cp -a`).
+resolve_real() {
+    _p="$1"
+    while [ -L "$_p" ]; do
+        _l="$(readlink "$_p")"
+        case "$_l" in
+            /*) _p="$_l" ;;
+            *) _p="$(dirname "$_p")/$_l" ;;
+        esac
+    done
+    printf '%s\n' "$_p"
+}
+
+# --- minvmd ---------------------------------------------------------------
+
+needed="$(patchelf --print-needed "$BIN")" || die "$BIN is not an ELF binary"
+krun_needed="$(printf '%s\n' "$needed" | grep '^libkrun\.so' || true)"
+[ -n "$krun_needed" ] \
+    || die "$BIN has no libkrun DT_NEEDED; did it link the stub? (LIBKRUN_PREFIX unset at build time)"
+[ "$krun_needed" = "$WANT_KRUN_SONAME" ] \
+    || die "$BIN needs '$krun_needed' but stage-release.sh ships lib/$WANT_KRUN_SONAME; update both together"
+
+current="$(patchelf --print-rpath "$BIN" || true)"
+case ":$current:" in
+    *":\$ORIGIN/../lib:"*)
+        # Already rewritten — keep this idempotent so a re-run is safe.
+        ;;
+    *)
+        # Insert after the leading $ORIGIN when build.rs put one there, else
+        # prepend; either way the binary-relative entries stay ahead of the
+        # system dirs so a shipped libkrun wins over a system one.
+        case "$current" in
+            '$ORIGIN'|'$ORIGIN:'*)
+                new="\$ORIGIN:\$ORIGIN/../lib${current#\$ORIGIN}"
+                ;;
+            '') new='$ORIGIN:$ORIGIN/../lib' ;;
+            *) new="\$ORIGIN/../lib:$current" ;;
+        esac
+        patchelf --set-rpath "$new" "$BIN"
+        ;;
+esac
+
+rpath="$(patchelf --print-rpath "$BIN")"
+case ":$rpath:" in
+    *":\$ORIGIN/../lib:"*) ;;
+    *) die "$BIN is missing the \$ORIGIN/../lib RUNPATH; lib/$WANT_KRUN_SONAME will not be found" ;;
+esac
+# build.rs drops the materialized prefix on a Linux release build; a leaked
+# absolute path would resolve to a directory that exists only on the runner.
+case "$rpath" in
+    *.krun*) die "$BIN RUNPATH leaks an ephemeral build prefix: $rpath" ;;
+esac
+
+# --- libkrun + libkrunfw --------------------------------------------------
+
+krun="$(resolve_real "$LIBDIR/$WANT_KRUN_SONAME")"
+[ -f "$krun" ] || die "no $WANT_KRUN_SONAME under $LIBDIR (is the soname chain there?)"
+krunfw="$(resolve_real "$LIBDIR/$WANT_KRUNFW_SONAME")"
+[ -f "$krunfw" ] || die "no $WANT_KRUNFW_SONAME under $LIBDIR"
+
+for lib in "$krun" "$krunfw"; do
+    want="$WANT_KRUN_SONAME"
+    case "$lib" in *krunfw*) want="$WANT_KRUNFW_SONAME" ;; esac
+    got="$(patchelf --print-soname "$lib" || true)"
+    [ "$got" = "$want" ] \
+        || die "$lib has soname '$got', expected '$want' (a major bump: update the lib/ dests in stage-release.sh)"
+done
+
+# libkrun dlopen()s libkrunfw by soname; glibc searches the CALLING object's
+# RUNPATH, so this entry is what makes the shipped sibling resolvable.
+libkrun_rpath="$(patchelf --print-rpath "$krun" || true)"
+case ":$libkrun_rpath:" in
+    *':$ORIGIN:'*) ;;
+    *)
+        if [ -z "$libkrun_rpath" ]; then
+            patchelf --set-rpath '$ORIGIN' "$krun"
+        else
+            patchelf --set-rpath "\$ORIGIN:$libkrun_rpath" "$krun"
+        fi
+        ;;
+esac
+libkrun_rpath="$(patchelf --print-rpath "$krun")"
+case ":$libkrun_rpath:" in
+    *':$ORIGIN:'*) ;;
+    *) die "$krun is missing the \$ORIGIN RUNPATH; its dlopen of $WANT_KRUNFW_SONAME will not find the shipped sibling" ;;
+esac
+
+echo "minvmd  RUNPATH: $rpath"
+echo "libkrun RUNPATH: $libkrun_rpath"
+echo "sonames: $WANT_KRUN_SONAME, $WANT_KRUNFW_SONAME"
+echo "linkage rewrite OK: $BIN"

--- a/scripts/rewrite-linux-linkage.sh
+++ b/scripts/rewrite-linux-linkage.sh
@@ -115,13 +115,17 @@ krun="$(resolve_real "$LIBDIR/$WANT_KRUN_SONAME")"
 krunfw="$(resolve_real "$LIBDIR/$WANT_KRUNFW_SONAME")"
 [ -f "$krunfw" ] || die "no $WANT_KRUNFW_SONAME under $LIBDIR"
 
-for lib in "$krun" "$krunfw"; do
-    want="$WANT_KRUN_SONAME"
-    case "$lib" in *krunfw*) want="$WANT_KRUNFW_SONAME" ;; esac
-    got="$(patchelf --print-soname "$lib" || true)"
-    [ "$got" = "$want" ] \
-        || die "$lib has soname '$got', expected '$want' (a major bump: update the lib/ dests in stage-release.sh)"
-done
+# Checked by explicit (file, expected-soname) pairs rather than by pattern-
+# matching the path: `case "$lib" in *krunfw*` tested the WHOLE resolved path,
+# so a lib dir whose own path contained "krunfw" picked the wrong expectation
+# and hard-failed a release citing a soname bump that never happened.
+check_soname() {
+    got="$(patchelf --print-soname "$1" || true)"
+    [ "$got" = "$2" ] \
+        || die "$1 has soname '$got', expected '$2' (a major bump: update the lib/ dests in stage-release.sh)"
+}
+check_soname "$krun" "$WANT_KRUN_SONAME"
+check_soname "$krunfw" "$WANT_KRUNFW_SONAME"
 
 # libkrun dlopen()s libkrunfw by soname; glibc searches the CALLING object's
 # RUNPATH, so this entry is what makes the shipped sibling resolvable.
@@ -140,6 +144,13 @@ libkrun_rpath="$(patchelf --print-rpath "$krun")"
 case ":$libkrun_rpath:" in
     *':$ORIGIN:'*) ;;
     *) die "$krun is missing the \$ORIGIN RUNPATH; its dlopen of $WANT_KRUNFW_SONAME will not find the shipped sibling" ;;
+esac
+# Same leak check minvmd gets above. The upstream .so carries whatever RUNPATH
+# its own build host baked in, and we prepend to it rather than replacing it —
+# so without this an absolute build path ships to users in a file nothing else
+# in the pipeline inspects.
+case "$libkrun_rpath" in
+    *.krun*) die "$krun RUNPATH leaks an ephemeral build prefix: $libkrun_rpath" ;;
 esac
 
 echo "minvmd  RUNPATH: $rpath"

--- a/scripts/rewrite-linux-linkage.sh
+++ b/scripts/rewrite-linux-linkage.sh
@@ -1,32 +1,29 @@
 #!/usr/bin/env bash
-# Rewrite a Linux minvmd binary + its libkrun pair for the SHIPPED layout, then
+# Rewrite a Linux minvmd binary's libkrun linkage for the SHIPPED layout, then
 # verify the result. The Linux twin of scripts/rewrite-macos-linkage.sh.
 #
-# The installer drops bin/minvmd beside lib/libkrun.so.1 and lib/libkrunfw.so.5
-# (stage-release.sh's `lib/` rows), so two RUNPATHs have to be right:
+# The installer drops bin/minvmd beside lib/libkrun.so.1 (stage-release.sh's
+# `lib/` row), so one RUNPATH has to be right:
 #
-#   minvmd       -> $ORIGIN/../lib    finds lib/libkrun.so.1 from bin/
-#   libkrun.so.1 -> $ORIGIN           finds its libkrunfw.so.5 SIBLING
-#
-# The second is not optional and not covered by the first: libkrun dlopen()s
-# libkrunfw by soname, and glibc resolves a dlopen from a library against the
-# RUNPATH of the *calling object*, never the executable's. Without it a shipped
-# libkrun finds no libkrunfw and every VM boot fails on a host that has no
-# system copy.
+#   minvmd -> $ORIGIN/../lib    finds lib/libkrun.so.1 from bin/
 #
 # build.rs already bakes `$ORIGIN` first plus the system lib dirs, and drops the
 # ephemeral $LIBKRUN_PREFIX on a Linux --release build; this inserts the
 # `../lib` entry after `$ORIGIN` and leaves the rest alone (so the system-libkrun
 # fallback keeps working, and the list is not duplicated here).
 #
+# NOT libkrunfw: its purpose is to carry a bundled GPL-2 guest kernel, and
+# minvmd supplies its own (`ctx.set_kernel`, from the shipped data/vmlinuz), so
+# it is neither linked nor needed at runtime. macOS has shipped libkrun without
+# it all along. Nothing here touches it.
+#
 # Verifies afterwards that:
 #   - minvmd really links libkrun (not the stub) and its RUNPATH has $ORIGIN/../lib
-#   - no ephemeral build path (a $HOME/.krun prefix) leaked into any RUNPATH
-#   - the two sonames are exactly what stage-release.sh's `lib/` dests assume
-#   - libkrun's RUNPATH has $ORIGIN
+#   - no ephemeral build path (a $HOME/.krun prefix) leaked into the RUNPATH
+#   - libkrun's soname is exactly what stage-release.sh's `lib/` dest assumes
 #
 # A soname mismatch is a HARD failure: it means a libkrun major bump landed and
-# the dest basenames in stage-release.sh must change with it. Failing here beats
+# the dest basename in stage-release.sh must change with it. Failing here beats
 # shipping an install whose minvmd cannot resolve its library.
 #
 # Usage: scripts/rewrite-linux-linkage.sh <minvmd-binary> <libkrun-dir>
@@ -40,9 +37,8 @@ set -euo pipefail
 BIN="${1:?usage: rewrite-linux-linkage.sh <minvmd-binary> <libkrun-dir>}"
 LIBDIR="${2:?usage: rewrite-linux-linkage.sh <minvmd-binary> <libkrun-dir>}"
 
-# Kept in lockstep with the `lib/` dest basenames in scripts/stage-release.sh.
+# Kept in lockstep with the `lib/` dest basename in scripts/stage-release.sh.
 WANT_KRUN_SONAME="libkrun.so.1"
-WANT_KRUNFW_SONAME="libkrunfw.so.5"
 
 command -v patchelf >/dev/null 2>&1 || {
     echo "::error::patchelf not found (apt-get install patchelf)" >&2
@@ -108,52 +104,24 @@ case "$rpath" in
     *.krun*) die "$BIN RUNPATH leaks an ephemeral build prefix: $rpath" ;;
 esac
 
-# --- libkrun + libkrunfw --------------------------------------------------
+# --- libkrun ---------------------------------------------------------------
 
 krun="$(resolve_real "$LIBDIR/$WANT_KRUN_SONAME")"
 [ -f "$krun" ] || die "no $WANT_KRUN_SONAME under $LIBDIR (is the soname chain there?)"
-krunfw="$(resolve_real "$LIBDIR/$WANT_KRUNFW_SONAME")"
-[ -f "$krunfw" ] || die "no $WANT_KRUNFW_SONAME under $LIBDIR"
 
-# Checked by explicit (file, expected-soname) pairs rather than by pattern-
-# matching the path: `case "$lib" in *krunfw*` tested the WHOLE resolved path,
-# so a lib dir whose own path contained "krunfw" picked the wrong expectation
-# and hard-failed a release citing a soname bump that never happened.
-check_soname() {
-    got="$(patchelf --print-soname "$1" || true)"
-    [ "$got" = "$2" ] \
-        || die "$1 has soname '$got', expected '$2' (a major bump: update the lib/ dests in stage-release.sh)"
-}
-check_soname "$krun" "$WANT_KRUN_SONAME"
-check_soname "$krunfw" "$WANT_KRUNFW_SONAME"
+got="$(patchelf --print-soname "$krun" || true)"
+[ "$got" = "$WANT_KRUN_SONAME" ] \
+    || die "$krun has soname '$got', expected '$WANT_KRUN_SONAME' (a major bump: update the lib/ dest in stage-release.sh)"
 
-# libkrun dlopen()s libkrunfw by soname; glibc searches the CALLING object's
-# RUNPATH, so this entry is what makes the shipped sibling resolvable.
+# The upstream .so carries whatever RUNPATH its own build host baked in, and it
+# ships verbatim, so an absolute build path would reach users in a file nothing
+# else in the pipeline inspects. Same check minvmd gets above.
 libkrun_rpath="$(patchelf --print-rpath "$krun" || true)"
-case ":$libkrun_rpath:" in
-    *':$ORIGIN:'*) ;;
-    *)
-        if [ -z "$libkrun_rpath" ]; then
-            patchelf --set-rpath '$ORIGIN' "$krun"
-        else
-            patchelf --set-rpath "\$ORIGIN:$libkrun_rpath" "$krun"
-        fi
-        ;;
-esac
-libkrun_rpath="$(patchelf --print-rpath "$krun")"
-case ":$libkrun_rpath:" in
-    *':$ORIGIN:'*) ;;
-    *) die "$krun is missing the \$ORIGIN RUNPATH; its dlopen of $WANT_KRUNFW_SONAME will not find the shipped sibling" ;;
-esac
-# Same leak check minvmd gets above. The upstream .so carries whatever RUNPATH
-# its own build host baked in, and we prepend to it rather than replacing it —
-# so without this an absolute build path ships to users in a file nothing else
-# in the pipeline inspects.
 case "$libkrun_rpath" in
     *.krun*) die "$krun RUNPATH leaks an ephemeral build prefix: $libkrun_rpath" ;;
 esac
 
 echo "minvmd  RUNPATH: $rpath"
-echo "libkrun RUNPATH: $libkrun_rpath"
-echo "sonames: $WANT_KRUN_SONAME, $WANT_KRUNFW_SONAME"
+echo "libkrun RUNPATH: ${libkrun_rpath:-(none)}"
+echo "soname: $WANT_KRUN_SONAME"
 echo "linkage rewrite OK: $BIN"

--- a/scripts/rewrite-linux-linkage_test.sh
+++ b/scripts/rewrite-linux-linkage_test.sh
@@ -54,12 +54,10 @@ scenario() {
     s="$root/$1"; rm -rf "$s"; mkdir -p "$s/state" "$s/lib"
     : >"$s/minvmd"
     : >"$s/lib/libkrun.so.1"
-    : >"$s/lib/libkrunfw.so.5"
     printf 'libkrun.so.1\nlibc.so.6\n' >"$s/state/minvmd.needed"
     printf '$ORIGIN:/usr/local/lib:/usr/lib\n' >"$s/state/minvmd.rpath"
     printf 'libkrun.so.1\n' >"$s/state/libkrun.so.1.soname"
     printf '\n' >"$s/state/libkrun.so.1.rpath"
-    printf 'libkrunfw.so.5\n' >"$s/state/libkrunfw.so.5.soname"
 }
 
 run() {
@@ -81,8 +79,6 @@ run happy
 check 0 "$rc" "happy path exits 0"
 check '$ORIGIN:$ORIGIN/../lib:/usr/local/lib:/usr/lib' "$(rpath_of happy minvmd)" \
     "minvmd gains \$ORIGIN/../lib, system dirs preserved in order"
-check '$ORIGIN' "$(rpath_of happy libkrun.so.1)" \
-    "libkrun gains \$ORIGIN so its dlopen finds libkrunfw"
 
 # Re-running over already-rewritten state must be a no-op, not a second insert:
 # the release job and a manual re-run both hit this.
@@ -90,7 +86,6 @@ run happy
 check 0 "$rc" "re-run exits 0"
 check '$ORIGIN:$ORIGIN/../lib:/usr/local/lib:/usr/lib' "$(rpath_of happy minvmd)" \
     "re-run leaves minvmd RUNPATH unchanged (idempotent)"
-check '$ORIGIN' "$(rpath_of happy libkrun.so.1)" "re-run leaves libkrun RUNPATH unchanged"
 
 # --- the stub-backend trap -------------------------------------------------
 
@@ -113,11 +108,6 @@ run sonamebump
 check 1 "$rc" "a libkrun soname bump fails"
 if grep -q "stage-release" "$OUT"; then ok "soname failure points at stage-release.sh"; else bad "soname failure points at stage-release.sh"; fi
 
-scenario fwbump
-printf 'libkrunfw.so.6\n' >"$root/fwbump/state/libkrunfw.so.5.soname"
-run fwbump
-check 1 "$rc" "a libkrunfw soname mismatch fails"
-
 # --- ephemeral prefix leak -------------------------------------------------
 
 # build.rs drops the materialized prefix on a Linux release build; if one ever
@@ -135,23 +125,6 @@ rm -f "$root/nolib/lib/libkrun.so.1"
 run nolib
 check 1 "$rc" "a missing libkrun under the lib dir fails"
 
-scenario nofw
-rm -f "$root/nofw/lib/libkrunfw.so.5"
-run nofw
-check 1 "$rc" "a missing libkrunfw under the lib dir fails"
-
-# --- soname dispatch keys on the file, not the path ------------------------
-
-# A lib dir whose own path contains "krunfw" must not make libkrun be checked
-# against libkrunfw's soname. The old `case "$lib" in *krunfw*` matched the
-# whole resolved path and aborted the release citing a bump that never happened.
-scenario krunfwpath
-mv "$root/krunfwpath/lib" "$root/krunfwpath/libkrunfw-1.5"
-sed_dir="$root/krunfwpath/libkrunfw-1.5"
-PATH="$root/bin:$PATH" STUB_STATE="$root/krunfwpath/state" \
-    bash "$script" "$root/krunfwpath/minvmd" "$sed_dir" >"$root/out.krunfwpath" 2>&1
-check 0 "$?" "a lib dir path containing 'krunfw' still checks libkrun's own soname"
-
 # --- leaked build prefix in the SHIPPED libkrun ----------------------------
 
 # The upstream .so carries its own build host's RUNPATH and we prepend to it,
@@ -165,14 +138,15 @@ if grep -q "ephemeral" "$OUT"; then ok "libkrun leak failure names the ephemeral
 
 # --- libkrun with a pre-existing RUNPATH -----------------------------------
 
-# The upstream .so may already carry one; $ORIGIN is prepended, not substituted,
-# so whatever it resolved before still resolves.
+# The shipped .so is not rewritten at all — libkrunfw is not shipped, so libkrun
+# has no sibling to find and needs no $ORIGIN. A benign vendor RUNPATH is left
+# exactly as upstream built it.
 scenario prerpath
 printf '/opt/vendor/lib\n' >"$root/prerpath/state/libkrun.so.1.rpath"
 run prerpath
-check 0 "$rc" "a libkrun with an existing RUNPATH exits 0"
-check '$ORIGIN:/opt/vendor/lib' "$(rpath_of prerpath libkrun.so.1)" \
-    "\$ORIGIN is prepended, existing entries kept"
+check 0 "$rc" "a libkrun with a benign existing RUNPATH exits 0"
+check '/opt/vendor/lib' "$(rpath_of prerpath libkrun.so.1)" \
+    "libkrun's RUNPATH is left verbatim"
 
 # --- minvmd with no RUNPATH at all -----------------------------------------
 

--- a/scripts/rewrite-linux-linkage_test.sh
+++ b/scripts/rewrite-linux-linkage_test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# rewrite-linux-linkage_test.sh — test harness for
+# scripts/rewrite-linux-linkage.sh.
+#
+# `patchelf` is stubbed by prepending a temp dir to PATH with a fake that models
+# the real tool's state: --print-{needed,rpath,soname} replay canned per-file
+# values, and --set-rpath updates the value a later --print-rpath returns. No
+# ELF binaries and no patchelf install are needed, so the RUNPATH logic and
+# every hard-fail path are exercised on any host — including macOS, where the
+# real script can never run. Run directly or via `just test-linkage`.
+#
+# `$ORIGIN` is an ELF loader token: the expected values below are deliberately
+# single-quoted so they compare against the literal the script must record.
+# shellcheck disable=SC2016
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+script="$here/rewrite-linux-linkage.sh"
+[ -f "$script" ] || { echo "cannot find rewrite-linux-linkage.sh next to test" >&2; exit 1; }
+
+root="$(mktemp -d 2>/dev/null || mktemp -d -t minimal-linktest)"
+trap 'rm -rf "$root"' EXIT
+
+pass=0; fail=0
+ok()  { pass=$((pass + 1)); printf 'ok   - %s\n' "$*"; }
+bad() { fail=$((fail + 1)); printf 'FAIL - %s\n' "$*"; }
+check() { if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (want [$1] got [$2])"; fi; }
+
+# --- patchelf stub ---------------------------------------------------------
+
+mkdir -p "$root/bin"
+cat >"$root/bin/patchelf" <<'EOF'
+#!/usr/bin/env bash
+# Canned state lives in $STUB_STATE/<basename>.<field>; --set-rpath writes it
+# back so the script's own read-after-write sees the update, as with the real
+# tool.
+set -u
+state="${STUB_STATE:?}"
+field_file() { printf '%s/%s.%s\n' "$state" "$(basename "$2")" "$1"; }
+case "$1" in
+    --print-needed) cat "$(field_file needed "$2")" 2>/dev/null || exit 1 ;;
+    --print-rpath)  cat "$(field_file rpath  "$2")" 2>/dev/null ;;
+    --print-soname) cat "$(field_file soname "$2")" 2>/dev/null ;;
+    --set-rpath)    printf '%s\n' "$2" >"$(field_file rpath "$3")" ;;
+    *) echo "stub patchelf: unhandled $*" >&2; exit 2 ;;
+esac
+EOF
+chmod +x "$root/bin/patchelf"
+
+# Build a scenario: a minvmd binary plus the libkrun pair, with canned patchelf
+# state. Any field can be overridden per-scenario before the run.
+scenario() {
+    s="$root/$1"; rm -rf "$s"; mkdir -p "$s/state" "$s/lib"
+    : >"$s/minvmd"
+    : >"$s/lib/libkrun.so.1"
+    : >"$s/lib/libkrunfw.so.5"
+    printf 'libkrun.so.1\nlibc.so.6\n' >"$s/state/minvmd.needed"
+    printf '$ORIGIN:/usr/local/lib:/usr/lib\n' >"$s/state/minvmd.rpath"
+    printf 'libkrun.so.1\n' >"$s/state/libkrun.so.1.soname"
+    printf '\n' >"$s/state/libkrun.so.1.rpath"
+    printf 'libkrunfw.so.5\n' >"$s/state/libkrunfw.so.5.soname"
+}
+
+run() {
+    s="$root/$1"
+    OUT="$root/out.$1"
+    PATH="$root/bin:$PATH" STUB_STATE="$s/state" \
+        bash "$script" "$s/minvmd" "$s/lib" >"$OUT" 2>&1
+    rc=$?
+}
+
+rpath_of() { cat "$root/$1/state/$2.rpath"; }
+
+echo "# rewrite-linux-linkage.sh tests"
+
+# --- happy path ------------------------------------------------------------
+
+scenario happy
+run happy
+check 0 "$rc" "happy path exits 0"
+check '$ORIGIN:$ORIGIN/../lib:/usr/local/lib:/usr/lib' "$(rpath_of happy minvmd)" \
+    "minvmd gains \$ORIGIN/../lib, system dirs preserved in order"
+check '$ORIGIN' "$(rpath_of happy libkrun.so.1)" \
+    "libkrun gains \$ORIGIN so its dlopen finds libkrunfw"
+
+# Re-running over already-rewritten state must be a no-op, not a second insert:
+# the release job and a manual re-run both hit this.
+run happy
+check 0 "$rc" "re-run exits 0"
+check '$ORIGIN:$ORIGIN/../lib:/usr/local/lib:/usr/lib' "$(rpath_of happy minvmd)" \
+    "re-run leaves minvmd RUNPATH unchanged (idempotent)"
+check '$ORIGIN' "$(rpath_of happy libkrun.so.1)" "re-run leaves libkrun RUNPATH unchanged"
+
+# --- the stub-backend trap -------------------------------------------------
+
+# A minvmd built with LIBKRUN_PREFIX unset silently links the stub impl and has
+# no libkrun DT_NEEDED. Shipping it would install a VM backend that cannot boot
+# anything, so this must fail loudly at release time.
+scenario stubbed
+printf 'libc.so.6\n' >"$root/stubbed/state/minvmd.needed"
+run stubbed
+check 1 "$rc" "a stub-linked minvmd fails"
+if grep -q "stub" "$OUT"; then ok "stub failure names the cause"; else bad "stub failure names the cause"; fi
+
+# --- soname drift ----------------------------------------------------------
+
+# A libkrun major bump changes the soname; the lib/ dests in stage-release.sh
+# would then point at a filename nothing loads. Fail here instead.
+scenario sonamebump
+printf 'libkrun.so.2\nlibc.so.6\n' >"$root/sonamebump/state/minvmd.needed"
+run sonamebump
+check 1 "$rc" "a libkrun soname bump fails"
+if grep -q "stage-release" "$OUT"; then ok "soname failure points at stage-release.sh"; else bad "soname failure points at stage-release.sh"; fi
+
+scenario fwbump
+printf 'libkrunfw.so.6\n' >"$root/fwbump/state/libkrunfw.so.5.soname"
+run fwbump
+check 1 "$rc" "a libkrunfw soname mismatch fails"
+
+# --- ephemeral prefix leak -------------------------------------------------
+
+# build.rs drops the materialized prefix on a Linux release build; if one ever
+# survives, it points at a directory that exists only on the runner.
+scenario leak
+printf '$ORIGIN:/home/runner/.krun:/usr/lib\n' >"$root/leak/state/minvmd.rpath"
+run leak
+check 1 "$rc" "a leaked build prefix in RUNPATH fails"
+if grep -q "ephemeral" "$OUT"; then ok "leak failure names the ephemeral prefix"; else bad "leak failure names the ephemeral prefix"; fi
+
+# --- missing libraries -----------------------------------------------------
+
+scenario nolib
+rm -f "$root/nolib/lib/libkrun.so.1"
+run nolib
+check 1 "$rc" "a missing libkrun under the lib dir fails"
+
+scenario nofw
+rm -f "$root/nofw/lib/libkrunfw.so.5"
+run nofw
+check 1 "$rc" "a missing libkrunfw under the lib dir fails"
+
+# --- libkrun with a pre-existing RUNPATH -----------------------------------
+
+# The upstream .so may already carry one; $ORIGIN is prepended, not substituted,
+# so whatever it resolved before still resolves.
+scenario prerpath
+printf '/opt/vendor/lib\n' >"$root/prerpath/state/libkrun.so.1.rpath"
+run prerpath
+check 0 "$rc" "a libkrun with an existing RUNPATH exits 0"
+check '$ORIGIN:/opt/vendor/lib' "$(rpath_of prerpath libkrun.so.1)" \
+    "\$ORIGIN is prepended, existing entries kept"
+
+# --- minvmd with no RUNPATH at all -----------------------------------------
+
+scenario norpath
+: >"$root/norpath/state/minvmd.rpath"
+run norpath
+check 0 "$rc" "a minvmd with an empty RUNPATH exits 0"
+check '$ORIGIN:$ORIGIN/../lib' "$(rpath_of norpath minvmd)" \
+    "both binary-relative entries are set from empty"
+
+echo "# ---"
+printf '# %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/rewrite-linux-linkage_test.sh
+++ b/scripts/rewrite-linux-linkage_test.sh
@@ -140,6 +140,29 @@ rm -f "$root/nofw/lib/libkrunfw.so.5"
 run nofw
 check 1 "$rc" "a missing libkrunfw under the lib dir fails"
 
+# --- soname dispatch keys on the file, not the path ------------------------
+
+# A lib dir whose own path contains "krunfw" must not make libkrun be checked
+# against libkrunfw's soname. The old `case "$lib" in *krunfw*` matched the
+# whole resolved path and aborted the release citing a bump that never happened.
+scenario krunfwpath
+mv "$root/krunfwpath/lib" "$root/krunfwpath/libkrunfw-1.5"
+sed_dir="$root/krunfwpath/libkrunfw-1.5"
+PATH="$root/bin:$PATH" STUB_STATE="$root/krunfwpath/state" \
+    bash "$script" "$root/krunfwpath/minvmd" "$sed_dir" >"$root/out.krunfwpath" 2>&1
+check 0 "$?" "a lib dir path containing 'krunfw' still checks libkrun's own soname"
+
+# --- leaked build prefix in the SHIPPED libkrun ----------------------------
+
+# The upstream .so carries its own build host's RUNPATH and we prepend to it,
+# so the same leak check minvmd gets must apply here or an absolute build path
+# ships to users.
+scenario libleak
+printf '/home/builder/.krun/lib\n' >"$root/libleak/state/libkrun.so.1.rpath"
+run libleak
+check 1 "$rc" "a leaked build prefix in libkrun's own RUNPATH fails"
+if grep -q "ephemeral" "$OUT"; then ok "libkrun leak failure names the ephemeral prefix"; else bad "libkrun leak failure names the ephemeral prefix"; fi
+
 # --- libkrun with a pre-existing RUNPATH -----------------------------------
 
 # The upstream .so may already carry one; $ORIGIN is prepended, not substituted,

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -104,21 +104,48 @@ fi
 #     (the installer's completion generation runs `<bin>/min`, spec R9.3), while
 #     the component and artifact names keep the crate name.
 #
-# Linux hosts install just the three self-contained musl binaries. macOS hosts
-# additionally need minvmd + gvproxy and the guest microVM payload (kernel,
-# rootfs, initramfs) to boot Linux workloads under libkrun; macOS is arm64-only
-# here, and its guest is arm64, so it consumes the arm64 guest artifacts.
+# Every host — Linux and macOS alike — installs the full session stack: the
+# self-contained musl/native binaries, the `mingvproxy` switch, `minvmd`, the
+# libkrun pair it links, and the guest microVM payload (kernel, rootfs,
+# initramfs) needed to boot Linux workloads. The guest arch always matches the
+# host arch, so each platform consumes its own payload; macOS is arm64-only
+# here, so it consumes the arm64 one.
+#
+# The switch binary installs as `bin/mingvproxy`, NOT `bin/gvproxy`: the bin
+# prefix is `~/.local/bin`, which is on PATH, and podman/crc ship their own
+# `gvproxy` there. The bytes are stock gvproxy; only the installed name is
+# ours, and `switch::GVPROXY_FILE` is the resolver's matching definition.
 COMPONENTS=(
     # Linux amd64
     "minimald|linux|amd64|file|bin/minimald|minimald-linux-amd64"
     "mip|linux|amd64|file|bin/mip|mip-linux-amd64"
     "minimal|linux|amd64|file|bin/min|minimal-linux-amd64"
     "git-remote-min|linux|amd64|symlink|bin/git-remote-min|min"
+    "mingvproxy|linux|amd64|file|bin/mingvproxy|gvproxy-linux-amd64"
+    "minvmd|linux|amd64|file|bin/minvmd|minvmd-linux-amd64"
+    # libkrun + libkrunfw for the KVM backend, staged into lib/ (ie:
+    # minvmd/../lib) to mirror the macOS layout. The dest basenames MUST be the
+    # SONAMEs: minvmd's DT_NEEDED is `libkrun.so.1`, and libkrun dlopen()s
+    # `libkrunfw.so.5` by soname from its own directory. release.yml verifies
+    # both sonames and sets the matching RUNPATHs
+    # (scripts/rewrite-linux-linkage.sh) before upload.
+    "libkrun|linux|amd64|file|lib/libkrun.so.1|libkrun-linux-amd64.so"
+    "libkrunfw|linux|amd64|file|lib/libkrunfw.so.5|libkrunfw-linux-amd64.so"
+    "initramfs|linux|amd64|file|data/initramfs.cpio|initramfs-amd64.cpio"
+    "rootfs|linux|amd64|file|data/rootfs.img|rootfs-amd64.img"
+    "vmlinuz|linux|amd64|file|data/vmlinuz|vmlinuz-amd64"
     # Linux arm64
     "minimald|linux|arm64|file|bin/minimald|minimald-linux-arm64"
     "mip|linux|arm64|file|bin/mip|mip-linux-arm64"
     "minimal|linux|arm64|file|bin/min|minimal-linux-arm64"
     "git-remote-min|linux|arm64|symlink|bin/git-remote-min|min"
+    "mingvproxy|linux|arm64|file|bin/mingvproxy|gvproxy-linux-arm64"
+    "minvmd|linux|arm64|file|bin/minvmd|minvmd-linux-arm64"
+    "libkrun|linux|arm64|file|lib/libkrun.so.1|libkrun-linux-arm64.so"
+    "libkrunfw|linux|arm64|file|lib/libkrunfw.so.5|libkrunfw-linux-arm64.so"
+    "initramfs|linux|arm64|file|data/initramfs.cpio|initramfs-arm64.cpio"
+    "rootfs|linux|arm64|file|data/rootfs.img|rootfs-arm64.img"
+    "vmlinuz|linux|arm64|file|data/vmlinuz|vmlinuz-arm64"
     # macOS arm64 (darwin)
     "minimal|darwin|arm64|file|bin/min|minimal-macos-arm64"
     "git-remote-min|darwin|arm64|symlink|bin/git-remote-min|min"
@@ -128,7 +155,7 @@ COMPONENTS=(
     # Basename MUST be libkrun.1.dylib: minvmd's load command is @rpath/libkrun.1.dylib
     # and the release job adds a @loader_path/../lib rpath.
     "libkrun|darwin|arm64|file|lib/libkrun.1.dylib|libkrun-macos-arm64.dylib"
-    "gvproxy|darwin|arm64|file|bin/gvproxy|gvproxy-darwin-arm64"
+    "mingvproxy|darwin|arm64|file|bin/mingvproxy|gvproxy-darwin-arm64"
     "initramfs|darwin|arm64|file|data/initramfs.cpio|initramfs-arm64.cpio"
     "rootfs|darwin|arm64|file|data/rootfs.img|rootfs-arm64.img"
     "vmlinuz|darwin|arm64|file|data/vmlinuz|vmlinuz-arm64"

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -105,13 +105,13 @@ fi
 #     the component and artifact names keep the crate name.
 #
 # Every host — Linux and macOS alike — installs the full session stack: the
-# self-contained musl/native binaries, the `mingvproxy` switch, `minvmd`, the
+# self-contained musl/native binaries, the `gvproxy-min` switch, `minvmd`, the
 # libkrun pair it links, and the guest microVM payload (kernel, rootfs,
 # initramfs) needed to boot Linux workloads. The guest arch always matches the
 # host arch, so each platform consumes its own payload; macOS is arm64-only
 # here, so it consumes the arm64 one.
 #
-# The switch binary installs as `bin/mingvproxy`, NOT `bin/gvproxy`: the bin
+# The switch binary installs as `bin/gvproxy-min`, NOT `bin/gvproxy`: the bin
 # prefix is `~/.local/bin`, which is on PATH, and podman/crc ship their own
 # `gvproxy` there. The bytes are stock gvproxy; only the installed name is
 # ours, and `switch::GVPROXY_FILE` is the resolver's matching definition.
@@ -121,7 +121,7 @@ COMPONENTS=(
     "mip|linux|amd64|file|bin/mip|mip-linux-amd64"
     "minimal|linux|amd64|file|bin/min|minimal-linux-amd64"
     "git-remote-min|linux|amd64|symlink|bin/git-remote-min|min"
-    "mingvproxy|linux|amd64|file|bin/mingvproxy|gvproxy-linux-amd64"
+    "gvproxy-min|linux|amd64|file|bin/gvproxy-min|gvproxy-linux-amd64"
     "minvmd|linux|amd64|file|bin/minvmd|minvmd-linux-amd64"
     # libkrun + libkrunfw for the KVM backend, staged into lib/ (ie:
     # minvmd/../lib) to mirror the macOS layout. The dest basenames MUST be the
@@ -139,7 +139,7 @@ COMPONENTS=(
     "mip|linux|arm64|file|bin/mip|mip-linux-arm64"
     "minimal|linux|arm64|file|bin/min|minimal-linux-arm64"
     "git-remote-min|linux|arm64|symlink|bin/git-remote-min|min"
-    "mingvproxy|linux|arm64|file|bin/mingvproxy|gvproxy-linux-arm64"
+    "gvproxy-min|linux|arm64|file|bin/gvproxy-min|gvproxy-linux-arm64"
     "minvmd|linux|arm64|file|bin/minvmd|minvmd-linux-arm64"
     "libkrun|linux|arm64|file|lib/libkrun.so.1|libkrun-linux-arm64.so"
     "libkrunfw|linux|arm64|file|lib/libkrunfw.so.5|libkrunfw-linux-arm64.so"
@@ -155,7 +155,7 @@ COMPONENTS=(
     # Basename MUST be libkrun.1.dylib: minvmd's load command is @rpath/libkrun.1.dylib
     # and the release job adds a @loader_path/../lib rpath.
     "libkrun|darwin|arm64|file|lib/libkrun.1.dylib|libkrun-macos-arm64.dylib"
-    "mingvproxy|darwin|arm64|file|bin/mingvproxy|gvproxy-darwin-arm64"
+    "gvproxy-min|darwin|arm64|file|bin/gvproxy-min|gvproxy-darwin-arm64"
     "initramfs|darwin|arm64|file|data/initramfs.cpio|initramfs-arm64.cpio"
     "rootfs|darwin|arm64|file|data/rootfs.img|rootfs-arm64.img"
     "vmlinuz|darwin|arm64|file|data/vmlinuz|vmlinuz-arm64"

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -106,7 +106,7 @@ fi
 #
 # Every host — Linux and macOS alike — installs the full session stack: the
 # self-contained musl/native binaries, the `gvproxy-min` switch, `minvmd`, the
-# libkrun pair it links, and the guest microVM payload (kernel, rootfs,
+# libkrun it links, and the guest microVM payload (kernel, rootfs,
 # initramfs) needed to boot Linux workloads. The guest arch always matches the
 # host arch, so each platform consumes its own payload; macOS is arm64-only
 # here, so it consumes the arm64 one.
@@ -123,14 +123,14 @@ COMPONENTS=(
     "git-remote-min|linux|amd64|symlink|bin/git-remote-min|min"
     "gvproxy-min|linux|amd64|file|bin/gvproxy-min|gvproxy-linux-amd64"
     "minvmd|linux|amd64|file|bin/minvmd|minvmd-linux-amd64"
-    # libkrun + libkrunfw for the KVM backend, staged into lib/ (ie:
-    # minvmd/../lib) to mirror the macOS layout. The dest basenames MUST be the
-    # SONAMEs: minvmd's DT_NEEDED is `libkrun.so.1`, and libkrun dlopen()s
-    # `libkrunfw.so.5` by soname from its own directory. release.yml verifies
-    # both sonames and sets the matching RUNPATHs
-    # (scripts/rewrite-linux-linkage.sh) before upload.
+    # libkrun for the KVM backend, staged into lib/ (ie: minvmd/../lib) to
+    # mirror the macOS layout. The dest basename MUST be the SONAME: minvmd's
+    # DT_NEEDED is `libkrun.so.1`. release.yml verifies that soname and sets the
+    # matching RUNPATH (scripts/rewrite-linux-linkage.sh) before upload.
+    # No libkrunfw: it exists to carry a bundled GPL-2 guest kernel and minvmd
+    # supplies its own (data/vmlinuz), so it is neither linked nor loaded --
+    # which is why macOS has always shipped libkrun alone.
     "libkrun|linux|amd64|file|lib/libkrun.so.1|libkrun-linux-amd64.so"
-    "libkrunfw|linux|amd64|file|lib/libkrunfw.so.5|libkrunfw-linux-amd64.so"
     "initramfs|linux|amd64|file|data/initramfs.cpio|initramfs-amd64.cpio"
     "rootfs|linux|amd64|file|data/rootfs.img|rootfs-amd64.img"
     "vmlinuz|linux|amd64|file|data/vmlinuz|vmlinuz-amd64"
@@ -142,7 +142,6 @@ COMPONENTS=(
     "gvproxy-min|linux|arm64|file|bin/gvproxy-min|gvproxy-linux-arm64"
     "minvmd|linux|arm64|file|bin/minvmd|minvmd-linux-arm64"
     "libkrun|linux|arm64|file|lib/libkrun.so.1|libkrun-linux-arm64.so"
-    "libkrunfw|linux|arm64|file|lib/libkrunfw.so.5|libkrunfw-linux-arm64.so"
     "initramfs|linux|arm64|file|data/initramfs.cpio|initramfs-arm64.cpio"
     "rootfs|linux|arm64|file|data/rootfs.img|rootfs-arm64.img"
     "vmlinuz|linux|arm64|file|data/vmlinuz|vmlinuz-arm64"


### PR DESCRIPTION
> **Blocked, and being rebuilt.** Do not review the current diff — it ships a
> `minvmd` that [gominimal/pkgs#533](https://github.com/gominimal/pkgs/issues/533)
> has since shown we should not ship. See "Why this is parked" below.

Part of [#980](https://github.com/gominimal/minimal/issues/980).

## What already split off

| PR | Scope |
|---|---|
| [#994](https://github.com/gominimal/minimal/pull/994) | The switch binary: shipped to Linux (fixes own-ip on installs) and installed as `gvproxy-min` |
| [#999](https://github.com/gominimal/minimal/pull/999) | Hide `--network` / `--ingress` while own-ip is not usable from an install |

That leaves this PR as the VM stack: `minvmd` for both Linux arches, the libkrun it links, and the guest payload.

## Why this is parked

This PR ships `minvmd` as a **native-glibc binary with a dynamically-linked libkrun**, which is what forced everything else in it:

- `lib/libkrun.so.1` as a shipped component (~29 MB of libraries)
- `scripts/rewrite-linux-linkage.sh` + its test harness, to rewrite RUNPATHs for the shipped layout
- a `bin`/`lib` sibling constraint, and an installer warning when a host's prefixes diverge
- a **new glibc version floor** on Linux — the first time an install has had one, since `min`/`mip`/`minimald` are static musl

[gominimal/pkgs#533](https://github.com/gominimal/pkgs/issues/533) has now **proven `minvmd` can ship as a single static-musl binary**: it builds, links, boots a VM, and passes the session e2e — verified against a deliberate stub control, because `build.rs` silently falls back to a stub that links and runs fine and cannot boot anything.

Every item above then disappears. ~29 MB of shipped libraries becomes one ~8 MB binary, and the glibc floor goes with it. Landing the dynamic version first would mean shipping all of that to users and deleting it days later.

The unblocking discovery was @twitchyliquid64's, in review on this PR: `libkrunfw` is dead weight, because it exists to carry a bundled GPL-2 kernel and `minvmd` supplies its own. That mattered beyond one artifact — musl's static libc cannot `dlopen`, so "libkrun must `dlopen` libkrunfw" was the sole reason static musl looked unreachable. #533 confirmed it the strong way: with libkrunfw removed system-wide, the *dynamic* libkrun searched all five loader paths, got `ENOENT` on every one, and booted anyway.

## What comes back

Rebuilt on top of #994, with:

- `minvmd` built for `*-unknown-linux-musl`, statically linked
- a `scripts/build-libkrun-linux.sh` mirroring the macOS from-source build (same pin, same patch series, same trim), plus the archive merge/localize pass #533 worked out
- **no** `lib/` component, **no** RUNPATH rewriting, **no** sibling constraint
- the guest payload, which is only useful once `minvmd` ships

Outstanding before that lands: #533 verified on **aarch64** only, so x86_64 needs proving — which will happen in CI, since the release lane builds both arches.

## Worth keeping from the review here

Both reviews on this PR produced findings that survive the rewrite, and the fixes are already in this branch's history:

- the nightly `ldd` assertion could never match glibc's un-normalized `$ORIGIN/../lib` output (permanently red nightly)
- `pipefail` + `grep -q` silently masking the unresolved-libraries guard
- the pre-swap daemon stop never targeting a running `minvmd` on Linux
- the spec gaps in 07 (`lib` prefix, R5.5's second stop) and 02 ("libkrun is resolved from the system")

The spec text will need another pass once the static build lands, since it currently documents the shipped-`lib/` layout that is going away.
