### PR TITLE
chore(deps): update third-party crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3115,9 +3115,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -3141,9 +3141,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -4116,7 +4116,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 [[package]]
 name = "nickel-lang-core"
 version = "0.17.0"
-source = "git+https://github.com/nickel-lang/nickel.git?rev=e8a0ab95e52ab31ac9a8ae1a3bef854d8de73cea#e8a0ab95e52ab31ac9a8ae1a3bef854d8de73cea"
+source = "git+https://github.com/nickel-lang/nickel.git?rev=0d306feb13ff38b154a3beb8dccaaa59cdd18ee8#0d306feb13ff38b154a3beb8dccaaa59cdd18ee8"
 dependencies = [
  "base64 0.22.1",
  "bumpalo",
@@ -4161,7 +4161,7 @@ dependencies = [
 [[package]]
 name = "nickel-lang-parser"
 version = "0.2.0"
-source = "git+https://github.com/nickel-lang/nickel.git?rev=e8a0ab95e52ab31ac9a8ae1a3bef854d8de73cea#e8a0ab95e52ab31ac9a8ae1a3bef854d8de73cea"
+source = "git+https://github.com/nickel-lang/nickel.git?rev=0d306feb13ff38b154a3beb8dccaaa59cdd18ee8#0d306feb13ff38b154a3beb8dccaaa59cdd18ee8"
 dependencies = [
  "bumpalo",
  "codespan",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "nickel-lang-vector"
 version = "0.1.0"
-source = "git+https://github.com/nickel-lang/nickel.git?rev=e8a0ab95e52ab31ac9a8ae1a3bef854d8de73cea#e8a0ab95e52ab31ac9a8ae1a3bef854d8de73cea"
+source = "git+https://github.com/nickel-lang/nickel.git?rev=0d306feb13ff38b154a3beb8dccaaa59cdd18ee8#0d306feb13ff38b154a3beb8dccaaa59cdd18ee8"
 dependencies = [
  "imbl-sized-chunks",
  "serde",
@@ -5722,9 +5722,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5858,9 +5858,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -6032,7 +6032,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -6076,9 +6076,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -6090,13 +6090,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6863,9 +6863,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,13 +67,8 @@ boringtun = { version = "0.7", default-features = false }
 bytes = "1.11" # keep in sync with reqwest
 bzip2 = "0.6"
 camino = { version = "1", features = ["serde1"] }
-# Held at 4.5 (not 4.6): clap_derive 4.6 requires proc-macro2 >= 1.0.106, which
-# cannot unify with c2rust-bitfields 0.22's exact `proc-macro2 = "=1.0.103"` pin
-# (pulled in via hakoniwa's rustslirp feature -> tun-rs 2.8.3). clap_derive 4.5
-# needs only proc-macro2 ^1.0, letting the resolver settle on 1.0.103. Bump back
-# to 4.6 once tun-rs/c2rust relax that pin.
-clap = { version = "4.5", features = ["derive", "env", "string"] }
-clap_complete = { version = "4.5" }
+clap = { version = "4.6", features = ["derive", "env", "string"] }
+clap_complete = { version = "4.6" }
 codespan-reporting = { version = "0.13", features = ["serialization"] } # Keep in sync with nickel-lang-core
 constcat = "0.6"
 copy_dir = "0.1.3"
@@ -85,6 +80,13 @@ either = { version = "1.16", default-features = false }
 flate2 = "1.1"
 futures = "0.3"
 generational-arena = {version = "0.2", features = ["serde"] }
+# The google-cloud-* / reqwest cluster resolves below its latest releases and
+# cannot be raised yet: reqwest >= 0.13.2 pulls js-sys >= 0.3.85, which requires
+# an exact `wasm-bindgen = "=0.2.108"`, while nickel-lang-core's `format` feature
+# reaches topiary-core -> topiary-tree-sitter-facade, which pins an exact
+# `wasm-bindgen = "=0.2.100"`. The two cannot unify, so `cargo update` leaves the
+# whole cluster pinned. Revisit when topiary relaxes that pin (0.7.3 still has
+# it; 0.6.2 moved to =0.2.103, but 0.7.x went back to =0.2.100).
 google-cloud-gax = "1.13"
 google-cloud-auth = "1.5"
 google-cloud-storage = "1.7"
@@ -99,8 +101,11 @@ json-subscriber = "0.3"
 libc = "0.2"
 lzma-rs = "0.3"
 
-# Revert back to crates.io dep once new version is released.
-nickel-lang-core = { git = "https://github.com/nickel-lang/nickel.git", rev = "e8a0ab95e52ab31ac9a8ae1a3bef854d8de73cea", default-features = false, features = ["format"] }
+# Tracked as a git rev, not the crates.io release: crates.io lags master by a
+# long way (0.18.0 is the newest published, and master has moved well past it).
+# Bump the rev to pick up upstream fixes; revisit crates.io only once its
+# releases catch up. Current rev is master @ 2026-07-26.
+nickel-lang-core = { git = "https://github.com/nickel-lang/nickel.git", rev = "0d306feb13ff38b154a3beb8dccaaa59cdd18ee8", default-features = false, features = ["format"] }
 
 opentelemetry-semantic-conventions = "0.32"
 # `socket` + `time`: the guest's vsock timekeep listener binds an AF_VSOCK
@@ -129,7 +134,7 @@ resolv-conf = "0.7"
 russh = "0.62"
 russh-sftp = "2.1"
 serde_json = { version = "1.0" }
-serial_test = "3"
+serial_test = "4"
 sha2 = "0.11"
 shlex = "2.0"
 size = "0.5"


### PR DESCRIPTION
Bump nickel-lang-core's pinned git rev from e8a0ab95 (2026-06-17) to 0d306feb (2026-07-26), 32 commits upstream. Picks up a std.string.find panic fix on a match at the end of the string, a parse fix for negative number literals in match patterns, and new std.array.chunk/group plus a merge-sort std.array.sort. Stays on the git rev deliberately: crates.io's newest release (0.18.0) lags master by a long way, so the old "revert to crates.io once released" note is replaced with the actual rationale.

hakoniwa is already at the latest upstream release (1.7.2); no change.

Also:
- serial_test 3 -> 4 (dev-dep; needs Rust 1.93.1, under our 1.97.0 pin).
- clap/clap_complete 4.5 -> 4.6 in the manifest. The lockfile already resolved 4.6.4/4.6.8 since ^4.5 admits 4.6, so this changes no resolution; it drops a stale comment whose stated cause (c2rust-bitfields' exact proc-macro2 pin via tun-rs) is no longer in the tree at all.
- cargo update within semver: aes, cc, jiff, rustls-pki-types, schemars, toml_parser.
- rand_core stays at 0.6 (documented, matches boringtun/x25519-dalek).

Documents why the google-cloud-* / reqwest cluster resolves below its latest releases: reqwest >= 0.13.2 pulls js-sys >= 0.3.85, which requires an exact wasm-bindgen =0.2.108, while nickel's `format` feature reaches topiary-tree-sitter-facade, which pins =0.2.100. The two cannot unify, so the resolver silently freezes the cluster.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update third-party crates including clap, serial_test, and nickel-lang-core
> - Bumps `clap` and `clap_complete` from 4.5 to 4.6, and `serial_test` from 3 to 4
> - Updates `nickel-lang-core` git revision to `0d306feb` with expanded comments explaining the pin rationale
> - Adds comments in [Cargo.toml](https://github.com/gominimal/minimal/pull/991/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) documenting constraints around `google-cloud-*`/`reqwest` and `wasm-bindgen` pinning
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afd5e17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated command-line parsing and completion components.
  * Refreshed the Nickel language integration.
  * Updated test serialization support.
  * Documented dependency compatibility constraints for cloud and networking components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->