### PR TITLE
chore(sessions): don't allow packages to request user data for the session

### DIFF
--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -486,6 +486,32 @@ impl Contribution {
         Ok(())
     }
 
+    /// Drop the items a *package* supplied that we refuse to compose:
+    /// every patch tagged [`Source::Package`], and every
+    /// [`Source::Package`] var that carries user data (an env-inherited
+    /// value — [`ResolvedVar::carries_user_data`]).
+    ///
+    /// A package var with a static (non-user) value, a package's request
+    /// for a package (the `packages` list), and every item from a
+    /// non-package source are all left untouched. Because vars and
+    /// patches are never deduped across sources (each contributor keeps
+    /// its own entry — see [`Self::merge`]), dropping the package's own
+    /// entry here still leaves any project- or loadout-supplied entry for
+    /// the same var name / patch destination intact: an item requested by
+    /// a package *and* something else still composes in, via that other
+    /// source.
+    ///
+    /// [`Source::Package`]: crate::core::source::Source::Package
+    /// [`ResolvedVar::carries_user_data`]: crate::core::primitives::ResolvedVar::carries_user_data
+    pub(crate) fn drop_package_supplied_patches_and_user_data_vars(&mut self) {
+        use crate::core::source::{Provenanced, Source};
+        self.patches
+            .retain(|p| !matches!(p.source(), Source::Package { .. }));
+        self.vars.retain(|v| {
+            !(matches!(v.source(), Source::Package { .. }) && v.var().carries_user_data())
+        });
+    }
+
     /// True when no items have been contributed across any domain.
     /// Used by daemon-side composers to take the empty-contribution
     /// fast path (no pending items to ship back to the client).
@@ -3336,6 +3362,80 @@ mod tests {
                 contribution_with(vec![], vec![], vec![], vec![hook("echo hi", user_source())]);
             left.merge(right).unwrap();
             assert_eq!(left.lifecycle_hooks.len(), 2);
+        }
+
+        // ---------------- package-supplied fs / user-data filter ----------------
+
+        /// A package may not supply patches, nor vars that carry user
+        /// data (env-inherited values). Both are dropped; a package's
+        /// static var and every non-package item survive.
+        #[test]
+        fn package_supplied_patches_and_user_data_vars_are_dropped() {
+            let pkg_src = || Source::Package { name: "go".into() };
+            let mut c = Contribution::new();
+            // Patches: one from a package (dropped), one from the project (kept).
+            c.push_patch(pp("pkg/src", "etc/pkg.conf", pkg_src()));
+            c.push_patch(pp("proj/src", "etc/proj.conf", project_source()));
+            // Vars: package env-inherited (dropped), package static (kept),
+            // project env-inherited (kept).
+            c.push_var(ProvenancedVar::new(
+                ResolvedVar::from_env_value("SECRET".into(), "s".into()),
+                pkg_src(),
+            ));
+            c.push_var(ProvenancedVar::new(
+                ResolvedVar::from_literal("GOFLAGS".into(), "-mod=mod".into()),
+                pkg_src(),
+            ));
+            c.push_var(pv_value("EDITOR", "hx", project_source()));
+
+            c.drop_package_supplied_patches_and_user_data_vars();
+
+            // Only the project patch survives.
+            assert_eq!(c.patches().len(), 1);
+            assert!(matches!(c.patches()[0].source(), Source::Project { .. }));
+
+            // The package's env-inherited var is gone; its static var and
+            // the project var remain.
+            let names: Vec<&str> = c.vars().iter().map(|v| v.var().name()).collect();
+            assert_eq!(names.len(), 2);
+            assert!(
+                names.contains(&"GOFLAGS"),
+                "package static var kept: {names:?}"
+            );
+            assert!(names.contains(&"EDITOR"), "project var kept: {names:?}");
+            assert!(
+                !names.contains(&"SECRET"),
+                "package user-data var dropped: {names:?}"
+            );
+        }
+
+        /// An item requested by a package *and* another source still
+        /// composes in: dropping the package's own entry leaves the
+        /// project/loadout entry (same patch dest / var name) intact,
+        /// because vars and patches are never deduped across sources.
+        #[test]
+        fn item_from_package_and_another_source_survives_via_the_other_source() {
+            let pkg_src = || Source::Package { name: "go".into() };
+            let mut c = Contribution::new();
+            // Same patch destination from a package and the project.
+            c.push_patch(pp("pkg/src", "etc/shared.conf", pkg_src()));
+            c.push_patch(pp("proj/src", "etc/shared.conf", project_source()));
+            // Same env-inherited var name from a package and a loadout.
+            c.push_var(ProvenancedVar::new(
+                ResolvedVar::from_env_value("TOKEN".into(), "t".into()),
+                pkg_src(),
+            ));
+            c.push_var(pv_value("TOKEN", "t", user_source()));
+
+            c.drop_package_supplied_patches_and_user_data_vars();
+
+            // The shared patch destination still composes — via the project.
+            assert_eq!(c.patches().len(), 1);
+            assert!(matches!(c.patches()[0].source(), Source::Project { .. }));
+            // The shared var still composes — via the loadout.
+            assert_eq!(c.vars().len(), 1);
+            assert!(matches!(c.vars()[0].source(), Source::UserLoadout { .. }));
+            assert_eq!(c.vars()[0].var().name(), "TOKEN");
         }
 
         // ---------------- pure aggregation (no conflict check) ----------------

--- a/crates/sessions/src/daemon/composer.rs
+++ b/crates/sessions/src/daemon/composer.rs
@@ -153,9 +153,15 @@ impl SessionComposer {
     ) -> Result<ComposeOutcome, ComposeError> {
         let Self {
             client,
-            contribution,
+            mut contribution,
             env: _,
         } = self;
+        // Packages may not supply patches, nor vars that carry user data
+        // (env-inherited values). Strip them before gating so they never
+        // reach the client as pending items or land in the Composition;
+        // an item a package shares with a project or loadout still
+        // composes in via that other source's own entry.
+        contribution.drop_package_supplied_patches_and_user_data_vars();
         let Contribution {
             vars,
             patches,


### PR DESCRIPTION
## Summary

Removed the ability for packages to request user data on session creation including file patches and inherited environment variables.

## Testing

Verified that my claude config was not uploaded when creating a session with claude-code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip package-supplied patches and user data vars from sessions before composition
> - Adds `Contribution::drop_package_supplied_patches_and_user_data_vars()` in [compose.rs](https://github.com/gominimal/minimal/pull/993/files#diff-ff88bebd81b297f5ddc929f4cea4a570cbf5665982145663eb30afffc7df8624) that removes package-sourced patches and package-sourced vars carrying user data from a `Contribution` in-place.
> - `SessionComposer::compose` in [composer.rs](https://github.com/gominimal/minimal/pull/993/files#diff-7cf0a51983ffce8f78ac08cfec5718be1cafcbd265029a3dfbf1660fcf5d3564) now calls this method before destructuring and gating, so packages can no longer inject patches or user data vars into the final session composition or the pending client state.
> - Behavioral Change: package-supplied patches and user-data-carrying vars are now silently dropped rather than passed through to the client.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49c3545.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented package-supplied patches and user-data variables from being included in session compositions.
  * Ensured equivalent values provided by other sources continue to be applied correctly.
  * Prevented filtered items from appearing in pending session responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->