### PR TITLE
feat(rcache): closure-union index reads behind index_source="closure"

### DIFF
--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -607,8 +607,15 @@ pub enum IndexSourceMode {
     Pinned,
     /// The global root index only.
     Root,
-    /// The union of the per-commit *closure* snapshots of every pinned chain
-    /// link (upstream + sideloads); a missing closure is an error.
+    /// The union of the per-commit *closure* snapshots of the pinned chain.
+    /// Asymmetric by design: the upstream's closure is required (it is the
+    /// signed catalog — missing is an error), while each sideload's closure
+    /// is unioned best-effort — a sideload not covered by build
+    /// infrastructure publishes no closure, is skipped with a log line, and
+    /// its specs resolve locally. Distinct from [`Self::Pinned`] in both the
+    /// object read (`<commit>.closure.shisha`, the bounded signed catalog,
+    /// vs `<commit>.shisha`, a byte copy of the whole root index) and in
+    /// covering sideload closures at their own pins.
     Closure,
 }
 

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -607,6 +607,9 @@ pub enum IndexSourceMode {
     Pinned,
     /// The global root index only.
     Root,
+    /// The union of the per-commit *closure* snapshots of every pinned chain
+    /// link (upstream + sideloads); a missing closure is an error.
+    Closure,
 }
 
 impl std::str::FromStr for IndexSourceMode {
@@ -616,8 +619,9 @@ impl std::str::FromStr for IndexSourceMode {
             "auto" => Ok(Self::Auto),
             "pinned" => Ok(Self::Pinned),
             "root" => Ok(Self::Root),
+            "closure" => Ok(Self::Closure),
             other => Err(format!(
-                "unknown index source {other:?} (expected \"auto\", \"pinned\" or \"root\")"
+                "unknown index source {other:?} (expected \"auto\", \"pinned\", \"root\" or \"closure\")"
             )),
         }
     }
@@ -636,12 +640,21 @@ pub enum CacheConfig {
     /// Read the immutable per-commit snapshot `object`; if it doesn't exist,
     /// fail rather than fall back.
     CommitIndexOnly { object: String },
+    /// Read and union the immutable per-commit closure snapshots, one per
+    /// pinned chain link; any missing object fails rather than falls back.
+    CommitClosures { objects: Vec<String> },
 }
 
 /// Object key of the per-commit index snapshot for a repo + commit:
 /// `<host>/<owner>/<repo>/<commit>.shisha`, matching the publisher's keying.
 pub fn commit_index_object(repo_url: &str, commit_sha: &str) -> String {
     format!("{}/{commit_sha}.shisha", repo_slug(repo_url))
+}
+
+/// Object key of the per-commit *closure* snapshot (the bounded catalog at a
+/// commit): `<host>/<owner>/<repo>/<commit>.closure.shisha`.
+pub fn commit_closure_object(repo_url: &str, commit_sha: &str) -> String {
+    format!("{}/{commit_sha}.closure.shisha", repo_slug(repo_url))
 }
 
 /// Stable `host/owner/repo` slug for a repo URL: query/fragment, scheme,
@@ -1099,7 +1112,38 @@ impl File {
             (IndexSourceMode::Pinned, None) => Err(
                 "index_source \"pinned\" requires a git upstream with a locked_commit".to_string(),
             ),
+            (IndexSourceMode::Closure, _) => {
+                let objects = self.closure_objects();
+                if objects.is_empty() {
+                    Err("index_source \"closure\" requires at least one git link \
+                         (upstream or sideload) with a locked_commit"
+                        .to_string())
+                } else {
+                    Ok(CacheConfig::CommitClosures { objects })
+                }
+            }
         }
+    }
+
+    /// The per-commit closure object of every pinned git chain link: the
+    /// upstream first, then each sideload, in declaration order. Links
+    /// without a locked commit (or backed by a directory) have no remote
+    /// presence and contribute nothing.
+    fn closure_objects(&self) -> Vec<String> {
+        let Some(upstream) = self.upstream.as_ref() else {
+            return Vec::new();
+        };
+        std::iter::once(&upstream.link)
+            .chain(upstream.sideloads().iter().map(|s| s.link()))
+            .filter_map(|link| match link {
+                LinkConfig::Git {
+                    repo,
+                    locked_commit: Some(commit),
+                    ..
+                } => Some(commit_closure_object(repo, commit)),
+                _ => None,
+            })
+            .collect()
     }
 }
 
@@ -1732,6 +1776,56 @@ mod tests {
             CacheConfig::CommitIndexOnly {
                 object: format!("github.com/gominimal/pkgs/{SHA}.shisha")
             }
+        );
+    }
+
+    #[test]
+    fn cache_config_closure_unions_pinned_links_and_skips_the_rest() {
+        const UP: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        const SIDE: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let mf: File = toml::from_str(&format!(
+            r#"
+            [upstream]
+            repo = "https://github.com/gominimal/pkgs"
+            locked_commit = "{UP}"
+
+            [[upstream.sideload]]
+            repo = "https://github.com/acme/extra"
+            locked_commit = "{SIDE}"
+
+            [[upstream.sideload]]
+            dir = "/tmp/local-overlay"
+
+            [[upstream.sideload]]
+            repo = "https://github.com/acme/unpinned"
+            "#
+        ))
+        .unwrap();
+        // Upstream first, then pinned sideloads in declaration order; the
+        // dir and unpinned links have no remote presence.
+        assert_eq!(
+            mf.cache_config(Some(IndexSourceMode::Closure)).unwrap(),
+            CacheConfig::CommitClosures {
+                objects: vec![
+                    format!("github.com/gominimal/pkgs/{UP}.closure.shisha"),
+                    format!("github.com/acme/extra/{SIDE}.closure.shisha"),
+                ]
+            }
+        );
+
+        // No pinned links at all: closure mode is a loud error.
+        let unpinned: File =
+            toml::from_str("[upstream]\nrepo = \"https://github.com/gominimal/pkgs\"\n").unwrap();
+        assert!(
+            unpinned
+                .cache_config(Some(IndexSourceMode::Closure))
+                .is_err()
+        );
+
+        // The env-override spelling parses.
+        assert_eq!(
+            "closure".parse::<IndexSourceMode>().unwrap(),
+            IndexSourceMode::Closure
         );
     }
 }

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -640,9 +640,14 @@ pub enum CacheConfig {
     /// Read the immutable per-commit snapshot `object`; if it doesn't exist,
     /// fail rather than fall back.
     CommitIndexOnly { object: String },
-    /// Read and union the immutable per-commit closure snapshots, one per
-    /// pinned chain link; any missing object fails rather than falls back.
-    CommitClosures { objects: Vec<String> },
+    /// Read and union the immutable per-commit closure snapshots. The
+    /// upstream's closure is required (it is the signed catalog); sideload
+    /// closures are best-effort — a sideload repo not covered by build
+    /// infrastructure publishes no index, and its specs resolve locally.
+    CommitClosures {
+        upstream: String,
+        sideloads: Vec<String>,
+    },
 }
 
 /// Object key of the per-commit index snapshot for a repo + commit:
@@ -1113,37 +1118,44 @@ impl File {
                 "index_source \"pinned\" requires a git upstream with a locked_commit".to_string(),
             ),
             (IndexSourceMode::Closure, _) => {
-                let objects = self.closure_objects();
-                if objects.is_empty() {
-                    Err("index_source \"closure\" requires at least one git link \
-                         (upstream or sideload) with a locked_commit"
-                        .to_string())
-                } else {
-                    Ok(CacheConfig::CommitClosures { objects })
-                }
-            }
-        }
-    }
-
-    /// The per-commit closure object of every pinned git chain link: the
-    /// upstream first, then each sideload, in declaration order. Links
-    /// without a locked commit (or backed by a directory) have no remote
-    /// presence and contribute nothing.
-    fn closure_objects(&self) -> Vec<String> {
-        let Some(upstream) = self.upstream.as_ref() else {
-            return Vec::new();
-        };
-        std::iter::once(&upstream.link)
-            .chain(upstream.sideloads().iter().map(|s| s.link()))
-            .filter_map(|link| match link {
-                LinkConfig::Git {
+                let Some(u) = self.upstream.as_ref() else {
+                    return Err(
+                        "index_source \"closure\" requires a git upstream with a locked_commit"
+                            .to_string(),
+                    );
+                };
+                let LinkConfig::Git {
                     repo,
                     locked_commit: Some(commit),
                     ..
-                } => Some(commit_closure_object(repo, commit)),
-                _ => None,
-            })
-            .collect()
+                } = &u.link
+                else {
+                    return Err(
+                        "index_source \"closure\" requires a git upstream with a locked_commit"
+                            .to_string(),
+                    );
+                };
+                // Sideloads in declaration order; links without a locked
+                // commit (or backed by a directory) have no remote presence
+                // and contribute nothing.
+                let sideloads = u
+                    .sideloads()
+                    .iter()
+                    .filter_map(|s| match s.link() {
+                        LinkConfig::Git {
+                            repo,
+                            locked_commit: Some(commit),
+                            ..
+                        } => Some(commit_closure_object(repo, commit)),
+                        _ => None,
+                    })
+                    .collect();
+                Ok(CacheConfig::CommitClosures {
+                    upstream: commit_closure_object(repo, commit),
+                    sideloads,
+                })
+            }
+        }
     }
 }
 
@@ -1801,21 +1813,29 @@ mod tests {
             "#
         ))
         .unwrap();
-        // Upstream first, then pinned sideloads in declaration order; the
+        // Required upstream, then pinned sideloads in declaration order; the
         // dir and unpinned links have no remote presence.
         assert_eq!(
             mf.cache_config(Some(IndexSourceMode::Closure)).unwrap(),
             CacheConfig::CommitClosures {
-                objects: vec![
-                    format!("github.com/gominimal/pkgs/{UP}.closure.shisha"),
-                    format!("github.com/acme/extra/{SIDE}.closure.shisha"),
-                ]
+                upstream: format!("github.com/gominimal/pkgs/{UP}.closure.shisha"),
+                sideloads: vec![format!("github.com/acme/extra/{SIDE}.closure.shisha")],
             }
         );
 
-        // No pinned links at all: closure mode is a loud error.
-        let unpinned: File =
-            toml::from_str("[upstream]\nrepo = \"https://github.com/gominimal/pkgs\"\n").unwrap();
+        // An unpinned upstream is a loud error — even with a pinned sideload:
+        // the upstream closure is the required (signed) catalog.
+        let unpinned: File = toml::from_str(&format!(
+            r#"
+            [upstream]
+            repo = "https://github.com/gominimal/pkgs"
+
+            [[upstream.sideload]]
+            repo = "https://github.com/acme/extra"
+            locked_commit = "{SIDE}"
+            "#
+        ))
+        .unwrap();
         assert!(
             unpinned
                 .cache_config(Some(IndexSourceMode::Closure))

--- a/crates/rcache/src/index_file.rs
+++ b/crates/rcache/src/index_file.rs
@@ -138,6 +138,32 @@ impl IndexFile {
         }
         Ok(())
     }
+
+    /// Absorbs `other`'s entries into `self` (other wins on overlap).
+    /// Returns the number of entries whose value *changed* — overlapping
+    /// records should be byte-identical across per-link closures, so a
+    /// non-zero count is a divergence signal the caller should surface.
+    pub fn merge(&mut self, other: IndexFile) -> usize {
+        let mut conflicts = 0;
+        for (k, v) in other.idx {
+            if let Some(prev) = self.idx.insert(k, v.clone())
+                && prev != v
+            {
+                conflicts += 1;
+            }
+        }
+        conflicts
+    }
+
+    /// The number of entries in the index.
+    pub fn len(&self) -> usize {
+        self.idx.len()
+    }
+
+    /// Whether the index has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.idx.is_empty()
+    }
 }
 
 impl Extend<(SpecHash, [u8; 32])> for IndexFile {
@@ -206,5 +232,22 @@ mod tests {
                 &IndexEntry { sha256: [1u8; 32] },
             ))
         );
+    }
+
+    #[test]
+    fn merge_unions_and_counts_only_value_changes() {
+        let h = |b: u8| common::SpecHash::from_bytes([b; 32]);
+        let mut a = IndexFile::default();
+        a.extend([(h(1), [0x11; 32]), (h(2), [0x22; 32])]);
+        let mut b = IndexFile::default();
+        // h(2) identical (no conflict), h(3) new, h(1) DIFFERENT (conflict).
+        b.extend([(h(2), [0x22; 32]), (h(3), [0x33; 32]), (h(1), [0xFF; 32])]);
+
+        let conflicts = a.merge(b);
+        assert_eq!(conflicts, 1);
+        assert_eq!(a.len(), 3);
+        // Other wins on overlap.
+        assert_eq!(a.sha256(&h(1)), Some([0xFF; 32]));
+        assert_eq!(a.sha256(&h(3)), Some([0x33; 32]));
     }
 }

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -260,6 +260,9 @@ impl RemoteCache<AnyBackend> {
                 },
                 false,
             ),
+            mfile::CacheConfig::CommitClosures { objects } => {
+                return Self::new_any_closure_union(url, gcs_storage, index_dir, ot, objects).await;
+            }
         };
         if let IndexSource::Snapshot { object } = &source {
             tracing::debug!("cache index: per-commit snapshot {object}");
@@ -278,6 +281,63 @@ impl RemoteCache<AnyBackend> {
                 Self::new_any(url, gcs_storage, index_dir, ot, IndexSource::Root).await
             }
             other => other,
+        }
+    }
+
+    /// Reads and unions the per-commit *closure* snapshots of every pinned
+    /// chain link into one index. Strict by design (the `closure` rollout
+    /// mode): any missing object surfaces as [`Error::SnapshotMissing`]
+    /// naming that link's object — never a silent fallback. Each closure is
+    /// fetched through the same immutable-snapshot path as the byte-copy
+    /// (whole-record check, local cache forever).
+    async fn new_any_closure_union(
+        url: AnyUrl,
+        gcs_storage: Option<Storage>,
+        index_dir: Option<PathBuf>,
+        ot: Option<OpTracker>,
+        objects: &[String],
+    ) -> Result<Self, Error<AnyRespError>> {
+        let mut merged: Option<Self> = None;
+        for object in objects {
+            tracing::debug!("cache index: per-commit closure {object}");
+            let rc = Self::new_any(
+                url.clone(),
+                gcs_storage.clone(),
+                index_dir.clone(),
+                ot.clone(),
+                IndexSource::Snapshot {
+                    object: object.clone(),
+                },
+            )
+            .await?;
+            merged = Some(match merged {
+                None => rc,
+                Some(mut acc) => {
+                    let conflicts = acc.index.merge(rc.index);
+                    if conflicts > 0 {
+                        // Overlapping spec hashes must agree across links;
+                        // divergence means two closures claim different bytes
+                        // for one spec — surface it, last link wins.
+                        tracing::warn!(
+                            "closure union: {conflicts} conflicting entries merging {object}"
+                        );
+                    }
+                    acc
+                }
+            });
+        }
+        match merged {
+            Some(rc) => {
+                tracing::debug!(
+                    "cache index: closure union of {} link(s), {} entries",
+                    objects.len(),
+                    rc.index.len()
+                );
+                Ok(rc)
+            }
+            None => Err(Error::Config(
+                "closure mode resolved no snapshot objects".to_string(),
+            )),
         }
     }
 }
@@ -922,6 +982,56 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(rc.sha256(&spec_hash), Some(sha256));
+    }
+
+    #[tokio::test]
+    async fn configured_closure_union_merges_per_link_closures() {
+        const OBJ_A: &str = "github.com/gominimal/pkgs/aaaa.closure.shisha";
+        const OBJ_B: &str = "github.com/acme/extra/bbbb.closure.shisha";
+        let spec_a = SpecHash::from_bytes([0x0A; 32]);
+        let spec_b = SpecHash::from_bytes([0x0B; 32]);
+        let base = serve_objects(vec![
+            (OBJ_A.to_string(), index_bytes_for(&spec_a, [0xA1; 32])),
+            (OBJ_B.to_string(), index_bytes_for(&spec_b, [0xB1; 32])),
+        ]);
+
+        let config = mfile::CacheConfig::CommitClosures {
+            objects: vec![OBJ_A.to_string(), OBJ_B.to_string()],
+        };
+        let rc = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
+            .await
+            .unwrap();
+        // Entries from BOTH links resolve through the one merged index.
+        assert_eq!(rc.sha256(&spec_a), Some([0xA1; 32]));
+        assert_eq!(rc.sha256(&spec_b), Some([0xB1; 32]));
+        assert_eq!(rc.sha256(&SpecHash::from_bytes([0x0C; 32])), None);
+    }
+
+    #[tokio::test]
+    async fn configured_closure_missing_link_is_a_loud_error() {
+        const OBJ_A: &str = "github.com/gominimal/pkgs/aaaa.closure.shisha";
+        const OBJ_B: &str = "github.com/acme/extra/bbbb.closure.shisha";
+        // Only the first link's closure exists; the root index also exists
+        // and must NOT be silently used.
+        let spec_a = SpecHash::from_bytes([0x0A; 32]);
+        let base = serve_objects(vec![
+            (OBJ_A.to_string(), index_bytes_for(&spec_a, [0xA1; 32])),
+            (
+                INDEX_FILENAME.to_string(),
+                index_bytes_for(&spec_a, [0xA1; 32]),
+            ),
+        ]);
+
+        let config = mfile::CacheConfig::CommitClosures {
+            objects: vec![OBJ_A.to_string(), OBJ_B.to_string()],
+        };
+        let err = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&err, Error::SnapshotMissing { object } if object == OBJ_B),
+            "expected SnapshotMissing for {OBJ_B}, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -260,8 +260,19 @@ impl RemoteCache<AnyBackend> {
                 },
                 false,
             ),
-            mfile::CacheConfig::CommitClosures { objects } => {
-                return Self::new_any_closure_union(url, gcs_storage, index_dir, ot, objects).await;
+            mfile::CacheConfig::CommitClosures {
+                upstream,
+                sideloads,
+            } => {
+                return Self::new_any_closure_union(
+                    url,
+                    gcs_storage,
+                    index_dir,
+                    ot,
+                    upstream,
+                    sideloads,
+                )
+                .await;
             }
         };
         if let IndexSource::Snapshot { object } = &source {
@@ -284,23 +295,37 @@ impl RemoteCache<AnyBackend> {
         }
     }
 
-    /// Reads and unions the per-commit *closure* snapshots of every pinned
-    /// chain link into one index. Strict by design (the `closure` rollout
-    /// mode): any missing object surfaces as [`Error::SnapshotMissing`]
-    /// naming that link's object — never a silent fallback. Each closure is
-    /// fetched through the same immutable-snapshot path as the byte-copy
-    /// (whole-record check, local cache forever).
+    /// Reads and unions per-commit *closure* snapshots into one index. The
+    /// upstream's closure is required — it is the signed catalog, and its
+    /// absence surfaces as [`Error::SnapshotMissing`] naming the object,
+    /// never a silent fallback. Sideload closures are best-effort: a sideload
+    /// repo not covered by build infrastructure publishes no index, so a
+    /// missing one is logged and skipped (its specs resolve locally as they
+    /// always have). Every closure is fetched through the same
+    /// immutable-snapshot path as the byte-copy (whole-record check, local
+    /// cache forever).
     async fn new_any_closure_union(
         url: AnyUrl,
         gcs_storage: Option<Storage>,
         index_dir: Option<PathBuf>,
         ot: Option<OpTracker>,
-        objects: &[String],
+        upstream: &str,
+        sideloads: &[String],
     ) -> Result<Self, Error<AnyRespError>> {
-        let mut merged: Option<Self> = None;
-        for object in objects {
-            tracing::debug!("cache index: per-commit closure {object}");
-            let rc = Self::new_any(
+        tracing::debug!("cache index: per-commit closure {upstream}");
+        let mut rc = Self::new_any(
+            url.clone(),
+            gcs_storage.clone(),
+            index_dir.clone(),
+            ot.clone(),
+            IndexSource::Snapshot {
+                object: upstream.to_string(),
+            },
+        )
+        .await?;
+
+        for object in sideloads {
+            let side = Self::new_any(
                 url.clone(),
                 gcs_storage.clone(),
                 index_dir.clone(),
@@ -309,11 +334,10 @@ impl RemoteCache<AnyBackend> {
                     object: object.clone(),
                 },
             )
-            .await?;
-            merged = Some(match merged {
-                None => rc,
-                Some(mut acc) => {
-                    let conflicts = acc.index.merge(rc.index);
+            .await;
+            match side {
+                Ok(s) => {
+                    let conflicts = rc.index.merge(s.index);
                     if conflicts > 0 {
                         // Overlapping spec hashes must agree across links;
                         // divergence means two closures claim different bytes
@@ -322,23 +346,20 @@ impl RemoteCache<AnyBackend> {
                             "closure union: {conflicts} conflicting entries merging {object}"
                         );
                     }
-                    acc
                 }
-            });
-        }
-        match merged {
-            Some(rc) => {
-                tracing::debug!(
-                    "cache index: closure union of {} link(s), {} entries",
-                    objects.len(),
-                    rc.index.len()
-                );
-                Ok(rc)
+                Err(Error::SnapshotMissing { object }) => {
+                    tracing::info!(
+                        "sideload closure {object} not published; its specs resolve locally"
+                    );
+                }
+                Err(e) => return Err(e),
             }
-            None => Err(Error::Config(
-                "closure mode resolved no snapshot objects".to_string(),
-            )),
         }
+        tracing::debug!(
+            "cache index: closure union ready, {} entries",
+            rc.index.len()
+        );
+        Ok(rc)
     }
 }
 
@@ -996,7 +1017,8 @@ mod tests {
         ]);
 
         let config = mfile::CacheConfig::CommitClosures {
-            objects: vec![OBJ_A.to_string(), OBJ_B.to_string()],
+            upstream: OBJ_A.to_string(),
+            sideloads: vec![OBJ_B.to_string()],
         };
         let rc = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
             .await
@@ -1008,30 +1030,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn configured_closure_missing_link_is_a_loud_error() {
-        const OBJ_A: &str = "github.com/gominimal/pkgs/aaaa.closure.shisha";
-        const OBJ_B: &str = "github.com/acme/extra/bbbb.closure.shisha";
-        // Only the first link's closure exists; the root index also exists
-        // and must NOT be silently used.
+    async fn configured_closure_missing_upstream_is_a_loud_error() {
+        const OBJ_UP: &str = "github.com/gominimal/pkgs/aaaa.closure.shisha";
+        // The root index exists and must NOT be silently used: the upstream
+        // closure is the required (signed) catalog.
         let spec_a = SpecHash::from_bytes([0x0A; 32]);
-        let base = serve_objects(vec![
-            (OBJ_A.to_string(), index_bytes_for(&spec_a, [0xA1; 32])),
-            (
-                INDEX_FILENAME.to_string(),
-                index_bytes_for(&spec_a, [0xA1; 32]),
-            ),
-        ]);
+        let base = serve_index(Some(index_bytes_for(&spec_a, [0xA1; 32])));
 
         let config = mfile::CacheConfig::CommitClosures {
-            objects: vec![OBJ_A.to_string(), OBJ_B.to_string()],
+            upstream: OBJ_UP.to_string(),
+            sideloads: vec![],
         };
         let err = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
             .await
             .unwrap_err();
         assert!(
-            matches!(&err, Error::SnapshotMissing { object } if object == OBJ_B),
-            "expected SnapshotMissing for {OBJ_B}, got {err:?}"
+            matches!(&err, Error::SnapshotMissing { object } if object == OBJ_UP),
+            "expected SnapshotMissing for {OBJ_UP}, got {err:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn configured_closure_missing_sideload_is_skipped_not_fatal() {
+        const OBJ_UP: &str = "github.com/gominimal/pkgs/aaaa.closure.shisha";
+        const OBJ_SIDE: &str = "github.com/acme/extra/bbbb.closure.shisha";
+        // Only the upstream closure exists — the sideload repo publishes no
+        // index (the common case: not covered by build infrastructure).
+        let spec_a = SpecHash::from_bytes([0x0A; 32]);
+        let base = serve_objects(vec![(
+            OBJ_UP.to_string(),
+            index_bytes_for(&spec_a, [0xA1; 32]),
+        )]);
+
+        let config = mfile::CacheConfig::CommitClosures {
+            upstream: OBJ_UP.to_string(),
+            sideloads: vec![OBJ_SIDE.to_string()],
+        };
+        let rc = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
+            .await
+            .unwrap();
+        // Upstream entries resolve; the sideload's specs simply miss (and
+        // would build locally), exactly as they do today.
+        assert_eq!(rc.sha256(&spec_a), Some([0xA1; 32]));
+        assert_eq!(rc.sha256(&SpecHash::from_bytes([0x0B; 32])), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Phase 2 of #870, per the [design comment](https://github.com/gominimal/minimal/issues/870#issuecomment-5106333952): read the bounded per-commit **closure** snapshots (`<commit>.closure.shisha`, ~53 KB and the signed object) instead of the full-index byte-copy (~3.1 MB and growing linearly — the ratio is 50× and widening).

## What

- **mfile** — `IndexSourceMode::Closure` (`index_source = "closure"` / `MINIMAL_INDEX_SOURCE=closure`) resolves the **required upstream closure** plus one closure per pinned git sideload, in declaration order (`CacheConfig::CommitClosures { upstream, sideloads }`). Directory and unpinned links have no remote presence and contribute nothing; an unpinned upstream is a loud error.
- **rcache** — the reader fetches each closure through the existing immutable-snapshot path (same 68-byte wire format, whole-record strictness, local cache forever) and **unions** them into one index (`IndexFile::merge`). Asymmetric strictness: the **upstream closure is required** (it is the signed catalog — missing is `SnapshotMissing` naming the object, never a fallback to root), while **sideload closures are best-effort** — sideload repos are typically not covered by build infrastructure and publish no index, so a missing one is logged and skipped and its specs resolve locally, exactly as they do today. No publishing requirement is imposed on sideload authors. Overlapping entries across links must agree; divergence merges last-wins and logs a warning (an equivocation-shaped signal).
- **mctx** — no changes; the config arm is handled inside `new_any_configured`.

## Rollout

Mirrors phase 1 exactly: `closure` is the opt-in testing lever; `auto` is untouched (still byte-copy → root) until the mode is proven in fleet testing, then folding closure in as the first link of the auto chain is a follow-up. Kill-switch (`root`) and `pinned` unchanged.

Sideload note: sideloaded projects work in this mode with zero requirements on the sideload repos — published closures contribute to the union, unpublished ones are skipped with an info log. The only degradation for an unpublished sideload is cache misses on its specs (local builds), which is their behavior today anyway.

## Testing

- mfile: closure resolution with upstream + pinned sideload + dir sideload + unpinned sideload (order and skipping pinned), no-pins error, env spelling parse.
- rcache: two-link union over real HTTP transport (both links' entries resolve through one index); missing **upstream** errors naming the object even with a valid root index present; missing **sideload** is skipped and upstream entries still resolve; `IndexFile::merge` conflict counting (identical overlap ≠ conflict, changed value = conflict, other wins).
- Deliberately not included: signature verification (`[cache.verify]`) — separable follow-up per the design comment; `require` remains gated on the signing-side decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add closure-union index reads behind `index_source="closure"` in rcache
> - Adds a new `IndexSourceMode::Closure` variant and `CacheConfig::CommitClosures` config, parsed from the string `"closure"` in [mfile](https://github.com/gominimal/minimal/pull/995/files#diff-242678e3526468cf14bac0c7428841f652cbef7d11edcad3898074f92b08f9e4), carrying upstream and sideload closure object paths per commit.
> - Adds `IndexFile.merge` in [rcache](https://github.com/gominimal/minimal/pull/995/files#diff-b50196204a4e8f2dfaca3adb9746243b539d9066d3ceade1dd995efb2185c92d) to union two indices, with incoming values winning on overlap and a conflict count returned.
> - Implements `RemoteCache::new_any_closure_union` in [remote.rs](https://github.com/gominimal/minimal/pull/995/files#diff-38597688b4a719c44bc4340f1c83d68259a610706da9dcacce3f5c365abb80d8): fetches the upstream closure snapshot (hard failure if missing), merges available sideload closures (skips missing ones with an info log), and warns on conflicting overlapping entries.
> - Risk: missing upstream closure snapshot is a hard error (`SnapshotMissing`) with no fallback to root.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75a52ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->