### PR TITLE
chore: scrub private-repo references ahead of open-sourcing

### DIFF
--- a/crates/decode/src/builds.rs
+++ b/crates/decode/src/builds.rs
@@ -701,8 +701,8 @@ pub struct BuildDecl {
     /// `None` means the build-decl did not explicitly declare a target and should
     /// be hydrated with the target of whatever graph is being constructed from it.
     /// This happens at the decode→graph seam in `graph::BuildSpec::from_decoded`,
-    /// which consults `Loader::for_target`. See gominimal/infra#18 for the arm64
-    /// res-server dispatch bug that motivated moving this from eager to deferred.
+    /// which consults `Loader::for_target`. Moved from eager to deferred to fix
+    /// an arm64 dispatch bug where the target was resolved before it was known.
     pub target: Option<Target>,
     /// Any attributes explicitly set on this build-decl.
     pub attrs: Option<IndexMap<String, AttrValue>>,

--- a/scripts/bulk-upload-e2e.sh
+++ b/scripts/bulk-upload-e2e.sh
@@ -49,7 +49,7 @@
 # rate to 50%. Any single failure fails the whole run.
 #
 # #869 also sometimes HANGS the client outright rather than erroring
-# (https://github.com/gominimal/inbox/issues/335, observed at 9 and 13 minutes),
+# (observed at 9 and 13 minutes),
 # so every activate runs under a wall-clock deadline and a hang counts as a
 # failure. A hang also stops the loop — five deadlines back to back would burn
 # the nightly's whole job budget, and one is already conclusive.
@@ -327,7 +327,7 @@ for i in $(seq 1 "$ITER"); do
     # the run, and folding them into a collapsed group buries them.
     echo "::endgroup::"
     if [ "$rc" -eq 124 ]; then
-      echo "::error::iteration $i: 'min activate' still running after ${DEADLINE_SECS}s — the #869 hang (https://github.com/gominimal/inbox/issues/335)"
+      echo "::error::iteration $i: 'min activate' still running after ${DEADLINE_SECS}s — the #869 hang"
     elif [ "$rc" -eq 0 ]; then
       echo "::error::iteration $i: activate's last stdout line is not a session UUID: '$sid'"
     else


### PR DESCRIPTION
Closes #792 (final remediation for the open-source security review — all other items verified clean, see the issue's status comment).

Part of #792 (open-source security review, item 4: cross-repo references to internal repos).

Removes the only private-tracker references in non-vendored code/docs:
- `scripts/bulk-upload-e2e.sh` — two `inbox#335` links, one of which sat inside a runtime `::error::` annotation that would print the private URL into public CI logs.
- `crates/decode/src/builds.rs` — a `gominimal/infra#18` doc-comment reference (also dropped internal `res-server` terminology).

The factual content is preserved (the #869 hang and its observed timing; the arm64 dispatch bug and the eager→deferred fix). `#869` stays — it is a same-repo minimal issue.

Full-history gitleaks scan came back clean (5 findings, all false positives); this was the remaining internal-reference cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove private issue references from doc comments and scripts ahead of open-sourcing
> Scrubs internal issue URLs from [builds.rs](https://github.com/gominimal/minimal/pull/997/files#diff-ff983f0007c5f6b8fe4adc2fa4fdf29e3a41c4cce463357940b03f4bdd58d435) and [bulk-upload-e2e.sh](https://github.com/gominimal/minimal/pull/997/files#diff-b52c18308835b5f5c5053d8108f53b210cc7795cb4603e9970623eea37c8316b) to prepare the repo for public release. No logic changes; only comments and error message text are affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbfc437.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
