### PR TITLE
docs(minimal): hide `--network` and `--ingress` from the CLI surface

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -299,11 +299,24 @@ pub struct ActivateArgs {
     #[arg(long, value_enum, default_value_t = SyncMode::Tarball)]
     pub sync: SyncMode,
     /// Network mode: no-net, host-net (default), or own-ip.
+    ///
+    /// Hidden from `--help` while `own-ip` is not usable on an installed host:
+    /// the daemon resolves a switch binary that no install ships yet
+    /// (gominimal/minimal#980), so advertising the flag offers a mode that
+    /// cannot work outside a dev checkout. Still accepted, and `host-net`
+    /// remains the default, so nothing that passes it today breaks. Unhide,
+    /// and restore the row in docs/reference/cli-min.md, once own-ip works
+    /// from an install.
     #[arg(long, value_enum, default_value_t = CliNetworkMode::HostNet)]
+    #[clap(hide = true)]
     pub network: CliNetworkMode,
     /// Static ingress port mapping `EXT:INT[/PROTO]` (PROTO = tcp|udp, default
     /// tcp). Repeatable. Requires `--network own-ip`.
+    ///
+    /// Hidden for the same reason as `--network`: it is only meaningful with
+    /// `--network own-ip`.
     #[arg(long = "ingress", value_name = "EXT:INT[/PROTO]")]
+    #[clap(hide = true)]
     pub ingress: Vec<String>,
     /// Apply the named loadout from `<config>/minimal/loadouts/<NAME>.toml`.
     /// Repeatable. If any `--loadout` is specified, defaults from

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -55,8 +55,6 @@ the current directory).
 |------|-------|-------------|
 | `--name <NAME>` | `-n` | Optional session name |
 | `--sync <MODE>` | | How to load project files into the session: `tarball` (default: stream a tarball of your project and unpack it) or `none` (do not populate the worktree) |
-| `--network <MODE>` | | Network mode: `no-net`, `host-net` (default), or `own-ip` |
-| `--ingress <EXT:INT[/PROTO]>` | | Static ingress port mapping (`PROTO` = `tcp`\|`udp`, default `tcp`). Repeatable. Requires `--network own-ip` |
 | `--loadout <NAME>` | | Apply the named loadout from `<config>/minimal/loadouts/<NAME>.toml`. Repeatable; if given, config-file `default_loadouts` are ignored |
 | `--no-loadouts` | | Apply no loadouts at all (also skips the config's `default_loadouts`). Conflicts with `--loadout` |
 | `--no-prompt` | | Fail instead of prompting when the daemon surfaces items user policy can't auto-decide; implied when stdin/stderr isn't a TTY |


### PR DESCRIPTION
Split out of [#988](https://github.com/gominimal/minimal/pull/988) — unrelated to that PR's release packaging, and small enough to review on its own.

## Why

`own-ip` cannot work on an installed host. `minimald` resolves a switch binary that no install ships ([#980](https://github.com/gominimal/minimal/issues/980)), so the mode is only reachable from a dev checkout with an explicit override. Advertising the flag offers users a mode that fails for reasons they can neither see nor fix.

## Hidden, not removed

Both flags still parse and still validate. Only `--help` and the reference change:

```
$ min activate --help
      --sync <SYNC>
      --loadout <NAME>
      --no-loadouts
      ...                      # no --network, no --ingress

$ min activate --network own-ip --ingress 18080:80 …
                               # still accepted

$ min activate --network bogus
error: invalid value 'bogus' for '--network <NETWORK>'
  [possible values: no-net, host-net, own-ip]
```

`host-net` remains the default, so nothing that passes these flags today changes behaviour. Nothing in `scripts/`, the test harnesses, or the workflows passes them.

The matching rows come out of `docs/reference/cli-min.md` for the same reason — a documented flag that cannot work is worse than an undocumented one that can.

## Reversing this

The doc comments carry the unhide condition, so it does not become permanent by forgetting: unhide both, and restore the reference rows, once own-ip works from an install. [#988](https://github.com/gominimal/minimal/pull/988) is what makes that true on Linux by shipping the switch binary.

Worth being explicit that this is a judgement call about surface, not capability — happy to drop it if you would rather document the dev-checkout path instead.

## Verification

`just ci` green. Help output and both parse cases checked against a built `min` (shown above). `cargo test -p minimal` is not runnable on macOS — its dev-dependencies pull `minimald` → `procfs` — so the CLI-behaviour evidence here is the built binary rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide `--network` and `--ingress` options from the `activate` command CLI help
> Applies `#[clap(hide = true)]` to the `network` and `ingress` fields in `ActivateArgs` so they no longer appear in generated help output. Both options remain functional at runtime with the same defaults and parsing. The corresponding rows are also removed from [cli-min.md](https://github.com/gominimal/minimal/pull/999/files#diff-f468e424e3aca5e5c314972c6f512d342f7746adac5a9177bfa23a1ae4c4e510).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce58cab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `--sync` option, including its available modes and default behavior.
  * Removed `--network` and `--ingress` from the documented `min activate` options.

* **User Experience**
  * Hid the `--network` and `--ingress` options from `min --help` while preserving their availability for supported setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->