### PR TITLE
feat(minimald): implement check session side-op

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,8 +205,9 @@ Verified against the current tree; sources in parentheses.
   from anything this repo builds (justfile comments,
   `crates/minvmd/README.md`).
 - **`min attach -c` is not a general remote shell.** The daemon's exec
-  handler accepts only `min run <task>` (and the internal
-  `git-receive-pack min://` path); anything else fails the channel. Task
+  handler accepts only `min run <task>`, `min package build [args...]`, and
+  `min check [args...]` (plus the internal `git-receive-pack min://` path);
+  anything else fails the channel. Task
   execs inherit the session's no-net/host-net mode, but an own-IP session's
   task exec currently falls back to host networking; use an interactive
   attach when the session's network identity matters

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
  "path-absolutize",
  "regex",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
 ]

--- a/crates/check/Cargo.toml
+++ b/crates/check/Cargo.toml
@@ -14,6 +14,7 @@ nickel-lang-core.workspace = true
 object.workspace = true
 regex.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 url.workspace = true
 moka.workspace = true
 tracing.workspace = true

--- a/crates/check/src/lib.rs
+++ b/crates/check/src/lib.rs
@@ -23,6 +23,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex};
 use tokio::sync::{RwLock, RwLockReadGuard, Semaphore};
+use tokio_util::sync::CancellationToken;
 
 /// A shared buffer that implements [`tokio::io::AsyncWrite`], allowing captured
 /// output to be retrieved after the writer is consumed.
@@ -81,6 +82,9 @@ use outputs::{MissingRuntimeDeps, OutputTypesValid};
 pub enum Error {
     IO(&'static str, PathBuf, std::io::Error),
     Graph(Box<graph::Error>),
+    /// The caller cancelled the run via [`CheckCtx`]'s token; the check stopped
+    /// at its last cancellation point and its results are incomplete.
+    Cancelled,
     Other(anyhow::Error),
 }
 
@@ -91,6 +95,7 @@ impl fmt::Display for Error {
                 write!(f, "{} I/O error at path {}: {}", ctx, path.display(), e)
             }
             Error::Graph(e) => write!(f, "graph: {:?}", e),
+            Error::Cancelled => write!(f, "cancelled"),
             Error::Other(e) => write!(f, "{}", e),
         }
     }
@@ -101,6 +106,7 @@ impl std::error::Error for Error {
         match self {
             Error::IO(_, _, e) => Some(e),
             Error::Graph(_e) => None,
+            Error::Cancelled => None,
             Error::Other(_e) => None,
         }
     }
@@ -339,6 +345,16 @@ pub struct CheckCtx {
     pub cache: Cache<LocalDir>,
     pub ot: Option<OpTracker>,
 
+    /// Fires when the caller wants the run to stop.
+    ///
+    /// Checkers observe this at coarse-grained points - between checkers, per
+    /// output file, per test - and give up with [`Error::Cancelled`] rather
+    /// than running to completion. It also reaches the sandbox running
+    /// standalone tests, so a cancelled run doesn't leave test processes
+    /// behind. Individual blocking steps (a Nickel typecheck, an ELF parse)
+    /// are not interruptible, so cancellation is prompt, not instant.
+    pub cancel: CancellationToken,
+
     /// Limits the number of concurrent package/harness/profile checks.
     semaphore: Arc<Semaphore>,
     pub check_cache: Arc<CheckCache>,
@@ -362,9 +378,33 @@ impl CheckCtx {
             stdlib_dir,
             cache,
             ot,
+            cancel: CancellationToken::new(),
             semaphore: Arc::new(Semaphore::new(20)),
             check_cache: Arc::new(CheckCache::new()),
         }
+    }
+
+    /// Returns this context with `cancel` as its cancellation token, replacing
+    /// the never-cancelled one [`CheckCtx::new`] installs.
+    pub fn with_cancel(mut self, cancel: CancellationToken) -> Self {
+        self.cancel = cancel;
+        self
+    }
+
+    /// `Err(Error::Cancelled)` once the caller has cancelled the run.
+    fn bail_if_cancelled(&self) -> Result<(), Error> {
+        bail_if_cancelled(&self.cancel)
+    }
+}
+
+/// `Err(Error::Cancelled)` once `cancel` has fired.
+///
+/// For the checkers that hand their token to a blocking closure rather than
+/// carrying the whole [`CheckCtx`] in.
+pub(crate) fn bail_if_cancelled(cancel: &CancellationToken) -> Result<(), Error> {
+    match cancel.is_cancelled() {
+        true => Err(Error::Cancelled),
+        false => Ok(()),
     }
 }
 
@@ -429,9 +469,17 @@ fn package_check_futures(packages_dir: PathBuf, ctx: CheckCtx) -> Result<Vec<Che
         .map::<CheckFuture, _>(move |(pkg, dir)| {
             let ctx = ctx.clone();
             Box::pin(async move {
-                let _permit = ctx.semaphore.clone().acquire_owned().await.unwrap();
-                let result = check_package(pkg.clone(), dir, ctx);
-                (CheckObj::Package(pkg), result.await)
+                let _permit = tokio::select! {
+                    biased;
+                    // Checks still queued behind the semaphore give up without
+                    // waiting their turn.
+                    _ = ctx.cancel.cancelled() => {
+                        return (CheckObj::Package(pkg), Err(Error::Cancelled));
+                    }
+                    permit = ctx.semaphore.clone().acquire_owned() => permit.unwrap(),
+                };
+                let result = check_package(pkg.clone(), dir, ctx).await;
+                (CheckObj::Package(pkg), result)
             })
         })
         .collect::<Vec<_>>())
@@ -475,11 +523,17 @@ fn profile_check_futures(profiles_dir: PathBuf, ctx: CheckCtx) -> Result<Vec<Che
             let profiles_dir = profiles_dir.clone();
 
             Box::pin(async move {
-                let _permit = ctx.semaphore.acquire().await.unwrap();
+                let name = pd.to_str().unwrap().to_string();
+                let _permit = tokio::select! {
+                    biased;
+                    _ = ctx.cancel.cancelled() => {
+                        return (CheckObj::Profile(name), Err(Error::Cancelled));
+                    }
+                    permit = ctx.semaphore.acquire() => permit.unwrap(),
+                };
                 (
-                    CheckObj::Profile(pd.to_str().unwrap().to_string()),
-                    profile::check_profile(pd.to_str().unwrap().to_string(), &ctx, profiles_dir)
-                        .await,
+                    CheckObj::Profile(name.clone()),
+                    profile::check_profile(name, &ctx, profiles_dir).await,
                 )
             })
         })
@@ -524,10 +578,17 @@ fn stack_check_futures(stacks_dir: PathBuf, ctx: CheckCtx) -> Result<Vec<CheckFu
             let stacks_dir = stacks_dir.clone();
 
             Box::pin(async move {
-                let _permit = ctx.semaphore.acquire().await.unwrap();
+                let name = pd.to_str().unwrap().to_string();
+                let _permit = tokio::select! {
+                    biased;
+                    _ = ctx.cancel.cancelled() => {
+                        return (CheckObj::Stack(name), Err(Error::Cancelled));
+                    }
+                    permit = ctx.semaphore.acquire() => permit.unwrap(),
+                };
                 (
-                    CheckObj::Stack(pd.to_str().unwrap().to_string()),
-                    stack::check_stack(pd.to_str().unwrap().to_string(), &ctx, stacks_dir).await,
+                    CheckObj::Stack(name.clone()),
+                    stack::check_stack(name, &ctx, stacks_dir).await,
                 )
             })
         })
@@ -582,6 +643,10 @@ async fn check_package(
             run_checker!(sources::SourceUrlsValid),
         );
         for r in [r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11] {
+            // Checked first: a checker that was interrupted mid-flight reports
+            // whatever it tripped over on the way out, which isn't the useful
+            // error to hand back.
+            ctx.bail_if_cancelled()?;
             out.push(r.map_err(|e| Error::Other(anyhow!(e)))?);
         }
     }
@@ -604,6 +669,13 @@ async fn check_package(
 
             let mut results = Vec::new();
             for mut c in file_based.into_iter() {
+                // Only observable between checkers: the blocking pool can't
+                // interrupt one mid-run, and `ParseCheck`'s typecheck is the
+                // slowest thing here. The partial results are dropped by the
+                // `bail_if_cancelled` below.
+                if ctx.cancel.is_cancelled() {
+                    break;
+                }
                 let check_result = c
                     .as_mut()
                     .check(&ctx, &pkg, &package_dir, Some(check_op.clone()))
@@ -617,6 +689,7 @@ async fn check_package(
         .map_err(|e| Error::Other(anyhow!(e)))?
     };
 
+    ctx.bail_if_cancelled()?;
     out.extend(file_based_results);
 
     check_op.set_done();
@@ -980,12 +1053,19 @@ impl GraphBasedChecker for StandaloneTestCheck {
         result.verdict = CheckVerdict::Pass;
         if let Some(tests) = build.tests {
             let graph2 = graph.deref().clone();
+            let cancel = ctx.cancel.clone();
             drop(graph);
             result = tokio::task::spawn(async move {
                 let mut result = result;
                 for (name, test) in tests {
                     if test.build_test {
                         continue; // We only do standalone tests here
+                    }
+                    // This task is detached, so it outlives a dropped check
+                    // stream: without this it would keep running tests (and
+                    // their sandboxes) after the caller has given up.
+                    if cancel.is_cancelled() {
+                        break;
                     }
                     let temp_dir = cache.temp_dir().map_err(anyhow::Error::from)?;
 
@@ -996,6 +1076,7 @@ impl GraphBasedChecker for StandaloneTestCheck {
                         test_name: name.as_str(),
                         stdout_writer: Some(Box::new(stdout_buf.clone())),
                         stderr_writer: Some(Box::new(stderr_buf.clone())),
+                        cancel: cancel.clone(),
                     };
                     let opts = Options {
                         cache: cache.clone(),
@@ -1321,5 +1402,75 @@ impl GraphBasedChecker for BuildScriptIsExecutable {
         }
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    /// Lays out a project tree with one package, one profile, and one stack,
+    /// so `run_checks` produces a future of every kind.
+    fn make_project(suffix: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("check_cancel_test_{}_{suffix}", std::process::id()));
+        std::fs::create_dir_all(dir.join("packages").join("pkg")).expect("create packages dir");
+        std::fs::write(dir.join("packages").join("pkg").join("build.ncl"), "{}")
+            .expect("write build.ncl");
+        std::fs::create_dir_all(dir.join("profiles").join("prof")).expect("create profiles dir");
+        std::fs::create_dir_all(dir.join("stacks").join("stk")).expect("create stacks dir");
+        dir
+    }
+
+    fn make_ctx(dir: &Path) -> CheckCtx {
+        CheckCtx::new(
+            vec![],
+            vec![],
+            false,
+            None,
+            dir.to_path_buf(),
+            Cache::at_dir(dir).expect("Cache::at_dir"),
+            None,
+        )
+    }
+
+    /// The token `CheckCtx::new` installs must never fire on its own, otherwise
+    /// every caller that doesn't opt in to cancellation gets a run that bails.
+    #[test]
+    fn new_ctx_is_not_cancelled() {
+        let dir = make_project("default_token");
+        assert!(!make_ctx(&dir).cancel.is_cancelled());
+        std::fs::remove_dir_all(&dir).expect("cleanup test tmp dir");
+    }
+
+    /// A token that is already cancelled when `run_checks` is called must make
+    /// every check give up rather than run: none of them reach a checker.
+    #[tokio::test]
+    async fn run_checks_bails_on_cancelled_token() {
+        let dir = make_project("upfront");
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let mut stream = run_checks(
+            Some(dir.join("packages")),
+            Some(dir.join("profiles")),
+            Some(dir.join("stacks")),
+            make_ctx(&dir).with_cancel(cancel),
+        )
+        .expect("run_checks should still enumerate the tree");
+
+        let mut seen = Vec::new();
+        while let Some((obj, result)) = stream.next().await {
+            assert!(
+                matches!(result, Err(Error::Cancelled)),
+                "expected {obj} to be cancelled, got {:?}",
+                result.map(|r| r.len()),
+            );
+            seen.push(obj);
+        }
+
+        assert_eq!(seen.len(), 3, "expected one check per object, got {seen:?}");
+        std::fs::remove_dir_all(&dir).expect("cleanup test tmp dir");
     }
 }

--- a/crates/check/src/outputs.rs
+++ b/crates/check/src/outputs.rs
@@ -160,9 +160,11 @@ impl crate::GraphBasedChecker for MissingRuntimeDeps {
 
         // Clone the graph and release the read lock so other checkers can proceed.
         let graph = std::ops::Deref::deref(&graph).clone();
+        let cancel = ctx.cancel.clone();
 
         tokio::task::spawn_blocking(move || {
             (move || -> Result<CheckResult, Error> {
+            crate::bail_if_cancelled(&cancel)?;
             let build = graph.get(&bsr).unwrap();
             let spec_hash = graph.spec_hash(&bsr);
             let cached_build = if let Ok(cached_build) = cache.read_dir(&spec_hash) {
@@ -201,6 +203,9 @@ impl crate::GraphBasedChecker for MissingRuntimeDeps {
             for (name, output) in &build.outputs {
                 let glob = output.glob();
                 for path in check_cache.match_files_for_glob(cached_build.path(), glob)?.iter() {
+                    // Every output file gets read and ELF-parsed below, so this
+                    // is where a large package spends its time.
+                    crate::bail_if_cancelled(&cancel)?;
                     let data = std::fs::read(path)
                         .map_err(|e| Error::IO("reading output file", path.to_path_buf(), e))?;
                     if let (Ok(elf), BuildOutput::Binary { .. } | BuildOutput::Library { .. }) =
@@ -270,6 +275,8 @@ impl crate::GraphBasedChecker for MissingRuntimeDeps {
                 }
             }
             for (needed_lib, outputs) in &all_imports {
+                // Resolving a lib reads and parses it for its symbol table.
+                crate::bail_if_cancelled(&cancel)?;
                 match find_lib_in_deps(&check_cache, needed_lib, &deps)? {
                     Some((idx, lib_path)) => {
                         // There was a library, check that all the symbols we need are present.

--- a/crates/mctx/src/error.rs
+++ b/crates/mctx/src/error.rs
@@ -256,6 +256,9 @@ impl From<check::Error> for Error {
             check::Error::IO(s, p, e) => Self::IO(s, p, e),
             check::Error::Other(e) => Self::Other(e),
             check::Error::Graph(e) => Self::Graph(e),
+            // Unreachable through this crate: mctx never hands `check` a token
+            // it later fires.
+            check::Error::Cancelled => Self::Other(anyhow::anyhow!("checks were cancelled")),
         }
     }
 }

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -1265,6 +1265,7 @@ mod tests {
                 test_name: "smoke",
                 stdout_writer: None,
                 stderr_writer: None,
+                cancel: tokio_util::sync::CancellationToken::new(),
             };
             let opts = op::Options {
                 cache: ctx.local_cache(),

--- a/crates/minimald/src/env.rs
+++ b/crates/minimald/src/env.rs
@@ -34,7 +34,6 @@ use std::sync::{Arc, Mutex};
 use std::task::Poll;
 
 use camino::Utf8PathBuf;
-use futures::StreamExt;
 use graph::{BuildSpecRef, Graph, SetupForPackages, Transitives};
 use mctx::{AddDepMode, Context, Error};
 use mfile::{EnvPatches, EnvVarValue};
@@ -731,72 +730,49 @@ impl SessionChannel {
         }
     }
 
-    /// Implements `min check`.
+    /// Implements `min check [--packages] [--stacks] [--profiles] [--fix] [names...]`:
+    /// kicks off a session side-op check run and streams each object's results
+    /// back to the client until the run completes.
     async fn run_check(&mut self, stream: &mut UnixStream, args: &str) {
-        let mut flag_packages = false;
-        let mut flag_stacks = false;
-        let mut flag_profiles = false;
-        let mut fix = false;
-        let mut filter_names: Vec<String> = Vec::new();
+        use crate::session_sop::{CheckOpts, CheckOutcome, CheckUpdate};
 
-        for token in args.split_whitespace() {
-            match token {
-                "--packages" => flag_packages = true,
-                "--stacks" => flag_stacks = true,
-                "--profiles" => flag_profiles = true,
-                "--fix" => fix = true,
-                _ => filter_names.push(token.to_string()),
+        let Some(session) = self.session.upgrade() else {
+            let _ = writeln!(stream, "error: session is gone");
+            return;
+        };
+
+        let opts = match CheckOpts::from_args(args) {
+            Ok(opts) => opts,
+            Err(msg) => {
+                let _ = writeln!(stream, "error: {msg}");
+                return;
+            }
+        };
+
+        let mut updates = match session.start_check(opts).await {
+            Ok(rx) => rx,
+            Err(e) => {
+                let _ = writeln!(stream, "error: {e}");
+                return;
+            }
+        };
+
+        let mut outcome = None;
+        while let Some(update) = updates.recv().await {
+            if let CheckUpdate::Finished(o) = &update {
+                outcome = Some(o.clone());
+            }
+            for line in update.render() {
+                let _ = writeln!(stream, "msg:{line}");
             }
         }
 
-        // If no kind flags specified, check everything.
-        let check_all = !flag_packages && !flag_stacks && !flag_profiles;
-
-        let mut check_ctx = match self.ctx.cloned_reinit() {
-            Err(e) => return Self::write_error(&e, stream),
-            Ok(ctx) => ctx,
-        };
-        let graph = match check_ctx.graph_from_all_packages() {
-            Err(e) => return Self::write_error(&e, stream),
-            Ok(g) => g,
-        };
-
-        let upstream_dir = check_ctx.minimal_file().dir_path().unwrap().to_path_buf();
-
-        let mut checks_stream = match check::run_checks(
-            (check_all || flag_packages).then(|| upstream_dir.join("packages")),
-            (check_all || flag_profiles).then(|| upstream_dir.join("profiles")),
-            (check_all || flag_stacks).then(|| upstream_dir.join("stacks")),
-            check::CheckCtx::new(
-                filter_names,
-                vec![],
-                fix,
-                Some(Arc::new(tokio::sync::RwLock::new(graph))),
-                check_ctx.stdlib_dir().to_path_buf(),
-                check_ctx.local_cache(),
-                self.ot.clone(),
-            ),
-        ) {
-            Err(e) => return Self::write_error(&Error::from(e), stream),
-            Ok(res_stream) => res_stream,
-        };
-
-        while let Some((heading, result)) = checks_stream.next().await {
-            let checks = match result {
-                Ok(checks) => checks,
-                Err(e) => {
-                    let _ = writeln!(stream, "error: {e}");
-                    return;
-                }
-            };
-            let _ = writeln!(stream, "msg:");
-            let _ = writeln!(stream, "msg:{heading}");
-            for check in checks {
-                let _ = writeln!(stream, "msg:{}...{}", check.check, check.verdict);
-                for err in check.err {
-                    let _ = writeln!(stream, "msg:\t{err}");
-                }
-            }
+        // Report the propagated outcome; only a clean run claims success.
+        let (status, message) = CheckOutcome::summarize(outcome.as_ref());
+        if status == 0 {
+            let _ = writeln!(stream, "msg:{message}");
+        } else {
+            let _ = writeln!(stream, "error: {message}");
         }
     }
 

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -751,6 +751,8 @@ where
 ///    that must be set on the channel by the client
 ///  * `min package build <args>` - builds package(s), routed via a
 ///    `MINIMAL_SESSION_ID` env var that must be set on the channel by the client
+///  * `min check <args>` - lints the session's `minimal.toml`, packages,
+///    profiles, and stacks, routed the same way as `min package build`
 pub(crate) async fn handle_exec(
     argv: &[u8],
     serv: ServerStateHandle,
@@ -877,6 +879,13 @@ pub(crate) async fn handle_exec(
                 run_build_exec(session_handle, id, channel, build_args).await;
             });
         }
+        Some("check") => {
+            session.channel_success(id)?;
+            let check_args = rem.strip_prefix("check").unwrap_or("").trim().to_string();
+            spawn(async move {
+                run_check_exec(session_handle, id, channel, check_args).await;
+            });
+        }
         Some(other) => {
             tracing::warn!(%session_id, "execution request rejected: unexpected min sub-command `{other}`");
             session.channel_failure(id)?;
@@ -967,6 +976,77 @@ async fn run_build_exec(
         Err(err) => {
             let _ = e
                 .write_all(format!("minimald: failed to start build: {err}\n").as_bytes())
+                .await;
+            1
+        }
+    };
+
+    let _ = w.flush().await;
+    let _ = e.flush().await;
+    let _ = ws.eof().await;
+    let _ = ws.exit_status(exit_status).await; // otherwise considered -1
+    let _ = ws.close().await; // needed to release the remote
+}
+
+/// Streams a `min check [--packages] [--profiles] [--stacks] [--fix] [names...]`
+/// exec over the SSH channel. Kicks off a session side-op check run based on an
+/// existing session.
+async fn run_check_exec(
+    session: SessionHandle,
+    channel_id: ChannelId,
+    channel: Channel<Msg>,
+    args: String,
+) {
+    use crate::session_sop::{CheckOpts, CheckOutcome, CheckUpdate};
+
+    let (_rs, ws) = channel.split();
+    let mut w = ws.make_writer();
+    let mut e = ws.make_writer_ext(Some(1));
+
+    // A bad flag is reported here rather than refused at the request layer:
+    // a `channel_failure` would only tell the client "rejected", where this
+    // path gets the message across and still exits non-zero.
+    let opts = match CheckOpts::from_args(&args) {
+        Ok(opts) => opts,
+        Err(msg) => {
+            let _ = e.write_all(format!("minimald: {msg}\n").as_bytes()).await;
+            let _ = e.flush().await;
+            let _ = ws.eof().await;
+            let _ = ws.exit_status(1).await;
+            let _ = ws.close().await;
+            return;
+        }
+    };
+
+    let exit_status = match session.start_check(opts).await {
+        Ok(mut updates) => {
+            let mut outcome = None;
+            'drain: while let Some(update) = updates.recv().await {
+                if let CheckUpdate::Finished(o) = &update {
+                    outcome = Some(o.clone());
+                }
+                for line in update.render() {
+                    if let Err(err) = w.write_all(format!("{line}\n").as_bytes()).await {
+                        // No reader on the channel — the client went away. Stop
+                        // streaming; the side-op keeps running independently.
+                        tracing::warn!(%channel_id, error = %err, "min check: channel write failed");
+                        break 'drain;
+                    }
+                }
+            }
+
+            // Only a clean run exits 0; everything else reports on stderr.
+            let (status, message) = CheckOutcome::summarize(outcome.as_ref());
+            let out: &mut (dyn AsyncWrite + Unpin + Send) = match status {
+                0 => &mut w,
+                _ => &mut e,
+            };
+            let _ = out.write_all(format!("{message}\n").as_bytes()).await;
+            status
+        }
+        Err(err) => {
+            let _ = e
+                .write_all(format!("minimald: failed to start check: {err}\n").as_bytes())
                 .await;
             1
         }
@@ -1663,6 +1743,104 @@ mod tests {
                 out.stderr.is_empty(),
                 "echo task should produce no stderr: {:?}",
                 out.stderr,
+            );
+        }
+
+        /// End-to-end happy path for `min check`: the exec is accepted,
+        /// routed to a check side-op, and the run reports a terminal outcome
+        /// with an exit status. This workspace holds no `packages/`,
+        /// `profiles/`, or `stacks/` dirs, so there is nothing to lint and
+        /// the run completes clean — what's under test is the routing and the
+        /// exit-status contract a scripted `min check` depends on.
+        #[tokio::test]
+        async fn exec_runs_check_and_exits_zero_when_nothing_fails() {
+            let server = TestServer::new().await;
+            let mut client = server.connect().await;
+            let session_id = fresh_session(&mut client).await;
+            let session_str = session_id.to_string();
+            // `start_check` builds a fresh workspace-rooted context per call,
+            // so the workspace needs an mfile for it to resolve at all.
+            server.seed_workspace_mfile(session_id, "").await;
+
+            let out = client
+                .exec(
+                    &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
+                    false,
+                    "min check",
+                    &[],
+                )
+                .await
+                .expect("min check should be accepted");
+
+            assert_eq!(out.exit_status, Some(0));
+            assert_eq!(
+                String::from_utf8_lossy(&out.stdout).trim(),
+                "check finished",
+            );
+            assert!(
+                out.stderr.is_empty(),
+                "a clean check should produce no stderr: {:?}",
+                out.stderr,
+            );
+        }
+
+        /// A mistyped flag must exit non-zero. Parsed as a name filter it
+        /// would match nothing, so the run would check zero objects and report
+        /// success — and the exit status is the whole contract for a scripted
+        /// `min check` over SSH.
+        #[tokio::test]
+        async fn exec_check_rejects_a_typod_flag_rather_than_passing() {
+            let server = TestServer::new().await;
+            let mut client = server.connect().await;
+            let session_id = fresh_session(&mut client).await;
+            let session_str = session_id.to_string();
+            server.seed_workspace_mfile(session_id, "").await;
+
+            let out = client
+                .exec(
+                    &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
+                    false,
+                    "min check --packags",
+                    &[],
+                )
+                .await
+                .expect("the exec itself is accepted; the flag fails the run");
+
+            assert_eq!(
+                out.exit_status,
+                Some(1),
+                "a typo'd flag must not exit 0; stdout was {:?}",
+                String::from_utf8_lossy(&out.stdout),
+            );
+            assert!(
+                String::from_utf8_lossy(&out.stderr).contains("unknown flag `--packags`"),
+                "the bad flag should be named on stderr, got {:?}",
+                String::from_utf8_lossy(&out.stderr),
+            );
+        }
+
+        /// `min check` takes its flags after the sub-command, so a form the
+        /// parser accepts must still route — a prefix-matched `min checkx`
+        /// must not.
+        #[tokio::test]
+        async fn exec_rejects_a_check_lookalike_subcommand() {
+            let server = TestServer::new().await;
+            let mut client = server.connect().await;
+            let session_id = fresh_session(&mut client).await;
+            let session_str = session_id.to_string();
+
+            let result = client
+                .exec(
+                    &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
+                    false,
+                    "min checkx",
+                    &[],
+                )
+                .await;
+
+            assert!(
+                result.is_err(),
+                "`min checkx` is not `min check` and must be refused, got {result:?}",
             );
         }
     }

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1,5 +1,5 @@
 use crate::channel_progress::ChannelProgress;
-use crate::session_sop::{BuildUpdate, SideOp};
+use crate::session_sop::{BuildUpdate, CheckOpts, CheckUpdate, SideOp};
 use crate::sessions::{SessionControl, WeakManagerHandle, composables};
 use crate::store::SessionRecordHandle;
 use crate::{
@@ -306,6 +306,12 @@ enum SessionMessage {
         rebuild: bool,
         pkgs: Vec<String>,
         reply: oneshot::Sender<Result<mpsc::Receiver<BuildUpdate>, std::io::Error>>,
+    },
+    /// Kick off a background check run as a session side-op. Replies with the
+    /// receiver end of the run's result stream.
+    StartCheck {
+        opts: CheckOpts,
+        reply: oneshot::Sender<Result<mpsc::Receiver<CheckUpdate>, std::io::Error>>,
     },
     /// Test-only inspection: an `Arc` clone of the held [`Composition`]
     /// (`None` in `Draft`, or `Active` without one post-restart). Lets tests
@@ -670,6 +676,9 @@ impl Session {
             } => {
                 let _ = reply.send(self.start_build(rebuild, pkgs).await);
             }
+            SessionMessage::StartCheck { opts, reply } => {
+                let _ = reply.send(self.start_check(opts).await);
+            }
             SessionMessage::GetRecord(r) => {
                 let _ = r.send(self.record.record().await.unwrap());
             }
@@ -986,6 +995,29 @@ impl Session {
     ) -> Result<mpsc::Receiver<BuildUpdate>, std::io::Error> {
         let ctx = self.context(false).await.map_err(std::io::Error::other)?;
         let (sop, rx) = SideOp::spawn_build(self.weak_self.clone(), rebuild, pkgs, ctx, 64).await?;
+        match &mut self.inner {
+            SessionInner::Active { sops, .. } => sops.push(sop),
+            SessionInner::Draft { .. } => {
+                sop.shutdown().await;
+                unreachable!("`context()` already rejected a `Draft`");
+            }
+        }
+        Ok(rx)
+    }
+
+    /// Kicks off a background check run as a side-op and registers it on this
+    /// session, returning the receiver end of its result stream. Like
+    /// [`start_build`](Self::start_build) it runs against a fresh
+    /// workspace-rooted context, so it sees `minimal.toml` edits made since the
+    /// session came up.
+    ///
+    /// The returned receiver closes when the run ends.
+    async fn start_check(
+        &mut self,
+        opts: CheckOpts,
+    ) -> Result<mpsc::Receiver<CheckUpdate>, std::io::Error> {
+        let ctx = self.context(false).await.map_err(std::io::Error::other)?;
+        let (sop, rx) = SideOp::spawn_check(self.weak_self.clone(), opts, ctx, 64).await?;
         match &mut self.inner {
             SessionInner::Active { sops, .. } => sops.push(sop),
             SessionInner::Draft { .. } => {
@@ -1416,6 +1448,26 @@ impl SessionHandle {
                 pkgs,
                 reply,
             })
+            .await;
+        recv.await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
+        })?
+    }
+
+    /// Kicks off a background check run as a session side-op, returning the
+    /// receiver end of the run's result stream. Results flow until the run
+    /// finishes (completion, failure, or cancellation), at which point the
+    /// channel closes. A `Draft` session is refused with `InvalidInput`; a dead
+    /// actor maps to `NotConnected`.
+    pub(crate) async fn start_check(
+        &self,
+        opts: CheckOpts,
+    ) -> Result<mpsc::Receiver<CheckUpdate>, std::io::Error> {
+        let (reply, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .0
+            .send(SessionMessage::StartCheck { opts, reply })
             .await;
         recv.await.map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")

--- a/crates/minimald/src/session_sop.rs
+++ b/crates/minimald/src/session_sop.rs
@@ -1,6 +1,6 @@
 //! Session side-operations - operations run non-interactively in the context of a session.
 
-use std::sync::Arc;
+use std::{io::ErrorKind::NotFound, sync::Arc};
 
 use futures::StreamExt as _;
 use mctx::{Context, PackageSelection};
@@ -37,16 +37,93 @@ pub enum BuildUpdate {
     Finished(BuildOutcome),
 }
 
-/// A registration to recieve updates about the progress of a build.
-#[derive(Debug)]
-pub(crate) enum BuildSink {
-    Structured(mpsc::Sender<BuildUpdate>),
+/// The terminal result of a check side-op, delivered as the final
+/// [`CheckUpdate`] before the check's channel closes.
+#[derive(Debug, Clone)]
+pub enum CheckOutcome {
+    /// Every selected object was checked. `failed` is set when any checker
+    /// returned [`CheckVerdict::Fail`](check::CheckVerdict::Fail) — the run
+    /// itself completed either way.
+    Completed { failed: bool },
+    /// The run errored before checking everything; the string is the failure.
+    Failed(String),
+    /// The run was cancelled before completing (e.g. the session tore down).
+    Cancelled,
 }
 
-impl BuildSink {
+/// An update from a running check side-op: one [`CheckUpdate::Checked`] per
+/// object as its checks complete, then exactly one terminal
+/// [`CheckUpdate::Finished`] as the last item before the channel closes.
+///
+/// `Checked` delivery is best-effort (see [`Sink::try_send`]), so a subscriber
+/// that falls far enough behind can miss one. The `failed` flag on
+/// [`CheckOutcome::Completed`] is tallied from *every* result regardless of
+/// delivery, so a dropped update can cost a rendered line but never turns a
+/// failing run into a passing one.
+#[derive(Debug, Clone)]
+pub enum CheckUpdate {
+    /// Every checker for one object (a package, profile, or stack) finished.
+    Checked {
+        object: check::CheckObj,
+        results: Vec<check::CheckResult>,
+    },
+    Finished(CheckOutcome),
+}
+
+impl CheckUpdate {
+    /// The display lines for this update, in order and already formatted.
+    /// Framing is the caller's job: the env socket prefixes each with `msg:`,
+    /// the SSH exec path writes them to the channel's data stream.
+    ///
+    /// [`CheckUpdate::Finished`] renders nothing — the terminal outcome goes
+    /// through [`CheckOutcome::summarize`] instead, which also carries the
+    /// exit status each transport needs.
+    pub fn render(&self) -> Vec<String> {
+        let Self::Checked { object, results } = self else {
+            return vec![];
+        };
+        // A blank line separates objects, then the heading ("package: foo").
+        let mut lines = vec![String::new(), object.to_string()];
+        for check in results {
+            lines.push(format!("{}...{}", check.check, check.verdict));
+            lines.extend(check.err.iter().map(|err| format!("\t{err}")));
+        }
+        lines
+    }
+}
+
+impl CheckOutcome {
+    /// The exit status and message to report once a run's channel has closed.
+    /// `None` is a channel that closed without a terminal update — the side-op
+    /// died before reporting (e.g. the actor was torn down mid-run).
+    ///
+    /// A zero status is the only success: callers render it as ordinary output
+    /// and anything else as an error. Statuses match the build path — 1 for a
+    /// failure, 130 for a cancellation.
+    pub fn summarize(outcome: Option<&Self>) -> (u32, String) {
+        match outcome {
+            Some(Self::Completed { failed: false }) => (0, "check finished".to_string()),
+            Some(Self::Completed { failed: true }) => (1, "some checks failed".to_string()),
+            Some(Self::Failed(e)) => (1, format!("check failed: {e}")),
+            Some(Self::Cancelled) => (130, "check cancelled".to_string()),
+            None => (1, "check ended without reporting an outcome".to_string()),
+        }
+    }
+}
+
+/// A registration to recieve updates about the progress of a side-op.
+///
+/// See the [`BuildSink`] and [`CheckSink`] aliases: the delivery discipline is
+/// the same for both, only the update type differs.
+#[derive(Debug)]
+pub(crate) enum Sink<T> {
+    Structured(mpsc::Sender<T>),
+}
+
+impl<T> Sink<T> {
     /// Best-effort progress delivery: a full or disconnected sink drops the
-    /// update rather than blocking the build.
-    pub fn try_send(&self, u: BuildUpdate) -> Result<(), TrySendError<BuildUpdate>> {
+    /// update rather than blocking the op.
+    pub fn try_send(&self, u: T) -> Result<(), TrySendError<T>> {
         match self {
             Self::Structured(s) => s.try_send(u),
         }
@@ -55,16 +132,88 @@ impl BuildSink {
     /// Reliable delivery for the terminal outcome: awaits channel capacity so
     /// the `Finished` update isn't dropped under backpressure. Errors only if
     /// the subscriber has already gone away.
-    pub async fn send(&self, u: BuildUpdate) -> Result<(), mpsc::error::SendError<BuildUpdate>> {
+    pub async fn send(&self, u: T) -> Result<(), mpsc::error::SendError<T>> {
         match self {
             Self::Structured(s) => s.send(u).await,
         }
     }
 }
 
+/// A registration to recieve updates about the progress of a build.
+pub(crate) type BuildSink = Sink<BuildUpdate>;
+/// A registration to recieve updates about the progress of a check run.
+pub(crate) type CheckSink = Sink<CheckUpdate>;
+
+/// The subscribers of one side-op, behind the op's lock.
 #[derive(Debug)]
-struct BuildInner {
-    sinks: Vec<BuildSink>,
+struct Inner<T> {
+    sinks: Vec<Sink<T>>,
+}
+
+/// Which objects to check and how, as parsed from the `min check` invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CheckOpts {
+    pub packages: bool,
+    pub profiles: bool,
+    pub stacks: bool,
+    pub fix: bool,
+    pub filter_names: Vec<String>,
+    pub skip_checkers: Vec<String>,
+}
+
+impl CheckOpts {
+    /// Parses a `min check` argument string: the `--packages`, `--profiles`,
+    /// and `--stacks` kind flags, `--fix`, and every bare word as an
+    /// object-name filter. With no kind flag at all, every kind is checked.
+    ///
+    /// Shared by the two transports that accept the command (the in-sandbox
+    /// env socket and the SSH exec path) so they can't drift on what a flag
+    /// means.
+    ///
+    /// Returns the message to report if any token looks like a flag but isn't
+    /// one. Such a token must never fall through to `filter_names`: it would
+    /// filter for a name nothing matches, so zero objects get checked and the
+    /// run reports success — turning `min check --packags` into a silent pass
+    /// for anything scripting the exit status.
+    pub fn from_args(args: &str) -> Result<Self, String> {
+        let (mut packages, mut profiles, mut stacks, mut fix) = (false, false, false, false);
+        let mut filter_names = Vec::new();
+
+        for token in args.split_whitespace() {
+            match token {
+                "--packages" => packages = true,
+                "--profiles" => profiles = true,
+                "--stacks" => stacks = true,
+                "--fix" => fix = true,
+                // Anything leading with a dash, not just `--`: `mip check`
+                // carries an explicit guard for people typing `-p`, and no
+                // real package/profile/stack directory is named that way.
+                flag if flag.starts_with('-') => {
+                    return Err(format!(
+                        "unknown flag `{flag}` \
+                         (expected --packages, --profiles, --stacks, or --fix)"
+                    ));
+                }
+                name => filter_names.push(name.to_string()),
+            }
+        }
+
+        // No kind flag specified means check everything.
+        if !packages && !profiles && !stacks {
+            (packages, profiles, stacks) = (true, true, true);
+        }
+
+        Ok(Self {
+            packages,
+            profiles,
+            stacks,
+            fix,
+            filter_names,
+            // No flag exposes this yet; checkers are skipped by name only from
+            // `mip check --skip`.
+            skip_checkers: vec![],
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -73,9 +222,18 @@ enum Op {
     Build {
         /// Packages which were requested to be built
         packages: Vec<String>,
+        /// Whether named packages must be built even if cached
+        rebuild: bool,
         /// Interior mutability. Users MUST NEVER block while holding
         /// the lock: get in, read/update data, get out.
-        inner: Arc<Mutex<BuildInner>>,
+        inner: Arc<Mutex<Inner<BuildUpdate>>>,
+    },
+    Check {
+        /// What the check run was asked to cover
+        opts: CheckOpts,
+        /// Interior mutability. Users MUST NEVER block while holding
+        /// the lock: get in, read/update data, get out.
+        inner: Arc<Mutex<Inner<CheckUpdate>>>,
     },
 }
 
@@ -92,12 +250,22 @@ pub struct SideOp {
     handle: JoinHandle<()>,
 }
 
-/// How long to wait to hand a subscriber the terminal [`BuildUpdate::Finished`]
-/// before giving up. A subscriber that stopped draining but hasn't dropped its
-/// receiver would otherwise block the build task's reliable send forever — and
-/// [`SideOp::shutdown`] awaits that task, so this bound keeps teardown from
-/// wedging on a wedged consumer. Responsive consumers deliver far inside it.
+/// How long to wait to hand a subscriber a side-op's terminal update before
+/// giving up - without a timeout shutdown may hang forever.
 const FINISH_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Delivers the terminal `update` to every subscriber, then drops the sinks so
+/// their receivers close.
+async fn finish<T: Clone>(inner: &Mutex<Inner<T>>, update: T) {
+    let sinks = {
+        let mut inner = inner.lock().await;
+        std::mem::take(&mut inner.sinks)
+    };
+    for sink in &sinks {
+        let _ = tokio::time::timeout(FINISH_SEND_TIMEOUT, sink.send(update.clone())).await;
+    }
+    // `sinks` dropped here → each receiver observes the close.
+}
 
 impl SideOp {
     /// UUID of this operation.
@@ -118,6 +286,8 @@ impl SideOp {
     /// the build completes (at which point the sender is dropped and the
     /// receiver closes). The session actor stores the op and hands the receiver
     /// to whoever requested the build so it can render progress.
+    ///
+    /// Should only be called from the session actor.
     pub(crate) async fn spawn_build(
         session: WeakSessionHandle,
         rebuild: bool,
@@ -132,9 +302,7 @@ impl SideOp {
     }
 
     /// Called to kick off a new build with the specified parameters.
-    ///
-    /// Should only be called from the session actor.
-    pub(crate) async fn new_build(
+    async fn new_build(
         session: WeakSessionHandle,
         rebuild: bool,
         pkgs: Vec<String>,
@@ -156,13 +324,9 @@ impl SideOp {
             .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         let cancel = CancellationToken::new();
-        let inner = Arc::new(Mutex::new(BuildInner { sinks }));
+        let inner = Arc::new(Mutex::new(Inner { sinks }));
 
         let handle = {
-            // Two clones for the task (the original `cancel` stays on the
-            // `SideOp` so `shutdown` can trigger it): one drives the build,
-            // one classifies the outcome after it returns. All clones share
-            // the same cancellation state.
             let build_cancel = cancel.clone();
             let cancel_flag = cancel.clone();
             let pump_inner = inner.clone();
@@ -208,25 +372,7 @@ impl SideOp {
                     Some(msg) => BuildOutcome::Failed(msg),
                 };
 
-                // Deliver the outcome to every subscriber, then drop the sinks
-                // so their receivers close. Take the sinks out *under* the lock
-                // (never awaiting while holding it), then send outside it.
-                let sinks = {
-                    let mut inner = build_inner.lock().await;
-                    std::mem::take(&mut inner.sinks)
-                };
-                for sink in &sinks {
-                    // Bound the reliable delivery so a stuck-but-undropped
-                    // receiver can't stall this task (and thus `shutdown`); a
-                    // consumer that has fallen behind just misses the final
-                    // update, then sees the channel close below.
-                    let _ = tokio::time::timeout(
-                        FINISH_SEND_TIMEOUT,
-                        sink.send(BuildUpdate::Finished(outcome.clone())),
-                    )
-                    .await;
-                }
-                // `sinks` dropped here → each receiver observes the close.
+                finish(&build_inner, BuildUpdate::Finished(outcome)).await;
             })
         };
 
@@ -236,9 +382,285 @@ impl SideOp {
             session,
             op: Op::Build {
                 packages: pkgs,
+                rebuild,
                 inner,
             },
             handle,
         })
+    }
+
+    /// Kicks off a check side-op wired to a single structured sink, returning
+    /// the op alongside the receiver end that streams a [`CheckUpdate`] per
+    /// checked object until the run completes (at which point the sender is
+    /// dropped and the receiver closes). The session actor stores the op and
+    /// hands the receiver to whoever requested the run so it can render results.
+    ///
+    /// Should only be called from the session actor.
+    pub(crate) async fn spawn_check(
+        session: WeakSessionHandle,
+        opts: CheckOpts,
+        ctx: Context,
+        buffer: usize,
+    ) -> Result<(Self, mpsc::Receiver<CheckUpdate>), std::io::Error> {
+        let (tx, rx) = mpsc::channel(buffer);
+        let sop = Self::new_check(session, opts, ctx, vec![CheckSink::Structured(tx)]).await?;
+        Ok((sop, rx))
+    }
+
+    /// Called to kick off a new check run with the specified parameters.
+    async fn new_check(
+        session: WeakSessionHandle,
+        opts: CheckOpts,
+        ctx: Context,
+        sinks: Vec<CheckSink>,
+    ) -> Result<Self, std::io::Error> {
+        let dir = ctx
+            .minimal_file()
+            .dir_path()
+            .ok_or(std::io::Error::new(
+                NotFound,
+                "no minimal.toml in workbench",
+            ))?
+            .to_path_buf();
+
+        // `graph_from_all_packages` is CPU-heavy, run on blocking pool.
+        let (ctx, graph_result) = tokio::task::spawn_blocking(move || {
+            let mut ctx = ctx;
+            let r = ctx.graph_from_all_packages().map_err(|e| e.to_string());
+
+            (ctx, r)
+        })
+        .await
+        .map_err(std::io::Error::other)?;
+        let graph = graph_result.map_err(std::io::Error::other)?;
+
+        let cancel = CancellationToken::new();
+        let inner = Arc::new(Mutex::new(Inner { sinks }));
+
+        let handle = {
+            let check_cancel = cancel.clone();
+            let cancel_flag = cancel.clone();
+            let check_opts = opts.clone();
+            let check_inner = inner.clone();
+            tokio::task::spawn(async move {
+                let stream = check::run_checks(
+                    (check_opts.packages).then(|| dir.join("packages")),
+                    (check_opts.profiles).then(|| dir.join("profiles")),
+                    (check_opts.stacks).then(|| dir.join("stacks")),
+                    check::CheckCtx::new(
+                        check_opts.filter_names,
+                        check_opts.skip_checkers,
+                        check_opts.fix,
+                        Some(Arc::new(tokio::sync::RwLock::new(graph))),
+                        ctx.stdlib_dir().to_path_buf(),
+                        ctx.local_cache(),
+                        ctx.op_tracker(),
+                    )
+                    .with_cancel(check_cancel),
+                );
+
+                let mut stream = match stream.map_err(|e| e.to_string()) {
+                    Ok(s) => s,
+                    Err(msg) => {
+                        tracing::warn!("session check failed to start: {msg}");
+                        finish(
+                            &check_inner,
+                            CheckUpdate::Finished(CheckOutcome::Failed(msg)),
+                        )
+                        .await;
+                        return;
+                    }
+                };
+
+                // Drain the checks, forwarding results as they land; the first
+                // error ends the run.
+                let mut failed = false;
+                let outcome = loop {
+                    let Some((object, result)) = stream.next().await else {
+                        break CheckOutcome::Completed { failed };
+                    };
+                    // `check::Error` is `!Send` (nickel `Rc`s), so it must not
+                    // outlive this match.
+                    let results = match result.map_err(|e| match e {
+                        check::Error::Cancelled => None,
+                        e => Some(e.to_string()),
+                    }) {
+                        Ok(results) => results,
+                        Err(None) => break CheckOutcome::Cancelled,
+                        Err(Some(msg)) => {
+                            tracing::warn!("session check failed: {msg}");
+                            break CheckOutcome::Failed(msg);
+                        }
+                    };
+                    failed |= results
+                        .iter()
+                        .any(|r| matches!(r.verdict, check::CheckVerdict::Fail));
+                    let inner = check_inner.lock().await;
+                    for sink in &inner.sinks {
+                        let _ = sink.try_send(CheckUpdate::Checked {
+                            object: object.clone(),
+                            results: results.clone(),
+                        });
+                    }
+                };
+                drop(stream);
+
+                // Classify first: cancelling below would make every `Failed`
+                // look like teardown fallout.
+                let outcome = match outcome {
+                    CheckOutcome::Failed(_) if cancel_flag.is_cancelled() => {
+                        CheckOutcome::Cancelled
+                    }
+                    o => o,
+                };
+
+                // Dropping the stream can't reach `StandaloneTestCheck`'s
+                // detached task or in-flight blocking checkers; the token can.
+                // A `Completed` run has nothing left to stop.
+                if !matches!(outcome, CheckOutcome::Completed { .. }) {
+                    cancel_flag.cancel();
+                }
+
+                finish(&check_inner, CheckUpdate::Finished(outcome)).await;
+            })
+        };
+
+        Ok(Self {
+            id: uuid::Uuid::now_v7(),
+            cancel,
+            session,
+            op: Op::Check { opts, inner },
+            handle,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use check::{CheckObj, CheckResult, CheckVerdict};
+
+    /// A bare `min check` checks every kind, with no filters and no fixing.
+    #[test]
+    fn check_opts_default_to_every_kind() {
+        assert_eq!(
+            CheckOpts::from_args("").unwrap(),
+            CheckOpts {
+                packages: true,
+                profiles: true,
+                stacks: true,
+                fix: false,
+                filter_names: vec![],
+                skip_checkers: vec![],
+            }
+        );
+    }
+
+    /// Naming a kind narrows the run to exactly that kind — the "check
+    /// everything" default must not leak back in alongside an explicit flag.
+    #[test]
+    fn check_opts_kind_flag_excludes_the_others() {
+        let opts = CheckOpts::from_args("--packages").unwrap();
+        assert!(opts.packages);
+        assert!(!opts.profiles, "an explicit --packages excludes profiles");
+        assert!(!opts.stacks, "an explicit --packages excludes stacks");
+    }
+
+    /// Flags are recognised anywhere in the argument string, and every bare
+    /// word is an object-name filter (never silently dropped).
+    #[test]
+    fn check_opts_collect_flags_and_filters() {
+        let opts = CheckOpts::from_args("uroot --fix  busybox --stacks").unwrap();
+        assert_eq!(opts.filter_names, vec!["uroot", "busybox"]);
+        assert!(opts.fix);
+        assert!(opts.stacks && !opts.packages && !opts.profiles);
+    }
+
+    /// A mistyped flag must be an error, never a name filter. Treated as a
+    /// filter it would match no object, so the run would check nothing and
+    /// report success — a silent pass for anything scripting the exit status.
+    #[test]
+    fn check_opts_reject_unknown_flags() {
+        for args in ["--packags", "--fix --stacsk", "-p uroot", "uroot --verbose"] {
+            let err = CheckOpts::from_args(args)
+                .expect_err("an unrecognized flag must not parse as a filter");
+            assert!(
+                err.contains("unknown flag"),
+                "expected an unknown-flag error for {args:?}, got {err:?}",
+            );
+        }
+    }
+
+    /// The rejection keys on the leading dash, not on the token being unknown
+    /// in general: bare words are legitimate object names and stay filters.
+    #[test]
+    fn check_opts_keep_bare_words_as_filters() {
+        let opts = CheckOpts::from_args("some-pkg other.pkg under_score")
+            .expect("dashes inside a name are fine");
+        assert_eq!(
+            opts.filter_names,
+            vec!["some-pkg", "other.pkg", "under_score"]
+        );
+    }
+
+    /// The rendered form is what both transports print, so pin its shape: a
+    /// blank separator, the object heading, then one line per check with its
+    /// errors indented beneath.
+    #[test]
+    fn checked_update_renders_heading_then_indented_errors() {
+        let lines = CheckUpdate::Checked {
+            object: CheckObj::Package("uroot".to_string()),
+            results: vec![
+                CheckResult {
+                    check: "fmt".into(),
+                    verdict: CheckVerdict::Pass,
+                    err: vec![],
+                },
+                CheckResult {
+                    check: "parse".into(),
+                    verdict: CheckVerdict::Fail,
+                    err: vec!["build.ncl: bad".to_string()],
+                },
+            ],
+        }
+        .render();
+
+        assert_eq!(
+            lines,
+            vec![
+                "".to_string(),
+                "package: uroot".to_string(),
+                "fmt...Pass".to_string(),
+                "parse...Fail".to_string(),
+                "\tbuild.ncl: bad".to_string(),
+            ]
+        );
+    }
+
+    /// `Finished` carries no display lines of its own — it is reported via
+    /// `summarize`, and a transport that rendered both would print twice.
+    #[test]
+    fn finished_update_renders_nothing() {
+        assert!(
+            CheckUpdate::Finished(CheckOutcome::Completed { failed: false })
+                .render()
+                .is_empty()
+        );
+    }
+
+    /// Only a clean completion exits 0. Every other terminal state — including
+    /// a run that completed with failing checks — has to be distinguishable by
+    /// exit status, since that is all a scripted `min check` sees.
+    #[test]
+    fn only_a_clean_run_summarizes_as_success() {
+        let status = |o: CheckOutcome| CheckOutcome::summarize(Some(&o)).0;
+
+        assert_eq!(status(CheckOutcome::Completed { failed: false }), 0);
+        assert_eq!(status(CheckOutcome::Completed { failed: true }), 1);
+        assert_eq!(status(CheckOutcome::Failed("boom".into())), 1);
+        assert_eq!(status(CheckOutcome::Cancelled), 130);
+        // A channel that closed without a terminal update is a failure, never
+        // a silent pass.
+        assert_eq!(CheckOutcome::summarize(None).0, 1);
     }
 }

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -1597,4 +1597,52 @@ mod tests {
             other => panic!("expected Ready, got {other:?}"),
         }
     }
+
+    /// `min check` runs as a session side-op, so the stream contract the
+    /// renderer in `env::run_check` depends on has to hold: the actor accepts
+    /// a `StartCheck`, results flow, and the channel closes after exactly one
+    /// terminal outcome. This workspace holds no `packages/`, `profiles/`, or
+    /// `stacks/` dirs, so there is nothing to check and the run completes
+    /// clean — the terminal update is the whole point here.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn start_check_closes_with_exactly_one_terminal_outcome() {
+        use crate::session_sop::{CheckOpts, CheckOutcome, CheckUpdate};
+
+        let (_state, _cache, mngr) = manager().await;
+        let id = create_active_session(&mngr).await;
+        // `start_check` builds a fresh workspace-rooted context per call, so
+        // the workspace needs an mfile for it to resolve at all.
+        seed_workspace_mfile(&mngr, id, "").await;
+
+        let mut updates = session(&mngr, id)
+            .await
+            .start_check(CheckOpts {
+                packages: true,
+                profiles: true,
+                stacks: true,
+                fix: false,
+                filter_names: vec![],
+                skip_checkers: vec![],
+            })
+            .await
+            .expect("starting a check on an Active session should succeed");
+
+        let mut outcomes = Vec::new();
+        while let Some(update) = updates.recv().await {
+            match update {
+                CheckUpdate::Checked { object, .. } => {
+                    panic!("nothing to check in an empty workspace, got {object}")
+                }
+                CheckUpdate::Finished(o) => outcomes.push(o),
+            }
+        }
+
+        assert!(
+            matches!(
+                outcomes.as_slice(),
+                [CheckOutcome::Completed { failed: false }]
+            ),
+            "expected exactly one clean terminal outcome, got {outcomes:?}",
+        );
+    }
 }

--- a/crates/op/src/standalone_test.rs
+++ b/crates/op/src/standalone_test.rs
@@ -23,6 +23,9 @@ pub struct StandaloneTest<'a> {
     pub stdout_writer: Option<Box<dyn tokio::io::AsyncWrite + Unpin + Send + Sync>>,
     /// Optional async writer that receives a copy of the sandbox's stderr stream.
     pub stderr_writer: Option<Box<dyn tokio::io::AsyncWrite + Unpin + Send + Sync>>,
+
+    /// Cancellation token to stop the test.
+    pub cancel: tokio_util::sync::CancellationToken,
 }
 
 impl<'a> StandaloneTest<'a> {
@@ -137,10 +140,11 @@ impl<'a> StandaloneTest<'a> {
     ) -> Result<Vec<StandaloneTestError>, Error> {
         let invocations = self.invocations(test)?;
         match sandbox
-            .run(
+            .run_with_cancel(
                 invocations.clone(),
                 self.stdout_writer.take(),
                 self.stderr_writer.take(),
+                self.cancel.clone(),
             )
             .await
         {


### PR DESCRIPTION
Implements `check` session side op, workable via:

 * `min check <args>` in the session
 * `min check <args>` over ssh exec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `min check` support end-to-end (SSH exec and daemon/session streaming), including incremental output and a single final success/failure summary.
  - Added check cancellation support to stop in-progress work early and report cancellation cleanly.
- **Bug Fixes**
  - Ensured check session streams close with exactly one terminal outcome, even for empty workspaces.
- **Documentation**
  - Updated `min attach -c` documentation to reflect the accepted `min check` and `min package build` forms.
- **Tests**
  - Added/expanded SSH end-to-end and unit tests for `min check`, rendering/summarization, and cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `min check` as a session side-op in `minimald`
> - Adds `SideOp::spawn_check` in [`session_sop.rs`](https://github.com/gominimal/minimal/pull/1000/files#diff-3dbb111166e94a5a10338aa43c30544e9b94b1e1701413a2d0d5a20626b20d79) to run checks as background side-ops with cooperative cancellation, streaming per-object `CheckUpdate` results and a terminal `CheckOutcome` to subscribers.
> - Adds `CheckOpts` argument parsing for `min check`, rejecting unknown flags with an error rather than misinterpreting them as name filters.
> - Wires `min check` into the SSH exec handler ([`exec.rs`](https://github.com/gominimal/minimal/pull/1000/files#diff-d7bb305c5820ba4cc947bbf8a89b209dfdd48561cadd311f40fa0149e5ef7c8b)) and the env socket handler ([`env.rs`](https://github.com/gominimal/minimal/pull/1000/files#diff-ece548260b2c5052569423263e9b54827b352ed496728bed2f1bf4c52c251dc1)), streaming progress and exiting with status 0 (success), 1 (failure), or 130 (cancelled).
> - Adds a `CancellationToken` to `CheckCtx` in the `check` crate so individual checkers, semaphore waits, and sandboxed standalone tests all stop promptly when cancelled.
> - `SessionHandle::start_check` sends a `StartCheck` message to the session actor, which tracks the run and cancels it on shutdown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b2fbd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->