### PR TITLE
docs(migration): Create migrate-to-minimal-session.md

### DIFF
--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -41,7 +41,7 @@ The outputs section is unchanged.
 
 ### [tasks]
 
-Going forward, interactive tasks (bash, shell, interactive agent sessions) are supported by `session` definitions. Non-interactive tasks (test, build) are currently not supported by v0.5.0.
+Interactive tasks (bash, shell, interactive agent sessions) are supported by `session` definitions. Non-interactive tasks (test, build) are currently not supported by v0.5.0.
 
 ### [session] (NEW)
 

--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -13,6 +13,9 @@ WARNING: `tasks` are not supported by v0.5.0. If you rely on `tasks` for non-int
 Going forward, the Minimal command will become `min`, and will not conflict with the existing `minimal` command. 
 
 If you no longer need the legacy `minimal` command, you can uninstall it with:
+```shell
+./.minimal/shim/uninstall.sh
+```
 
 To install `min`, see [install](./install.md).
 

--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -10,7 +10,7 @@ If you are using a release of Minimal **older than v0.5.0**, you will need to up
 
 WARNING: `tasks` are not supported by v0.5.0. If you rely on `tasks` for non-interactive, job-like workflows, keep `minimal` (<=v0.4.1) installed for tasks and install `min` (v0.5.0) for sessions.
 
-Going forward, the Minimal command will become `min`, and will not conflict with the existing `minimal` command. 
+Going forward, the Minimal command will become `min`, and will not conflict with the legacy `minimal` command. The installer for legacy `minimal` will no longer be available after v0.5.0 is released. However, `minimal` will remain operational for the foreseeable future.
 
 If you no longer need the legacy `minimal` command, you can uninstall it with:
 ```shell
@@ -18,6 +18,25 @@ If you no longer need the legacy `minimal` command, you can uninstall it with:
 ```
 
 To install `min`, see [install](./install.md).
+
+### Linux
+To maintain backward compatibility for ephemeral systems on Linux, the installer for `min` will also install a version of Minimal that's functionally identical to `minimal`, and renamed to `mip` (Minimal-In-Place). All commands available to `minimal` are available in `mip`. Any commands using `minimal` should be upgraded to use `mip`.
+```shell
+minimal run --> mip run
+minimal update --> mip update
+minimal add --> mip update
+minimal status --> mip status
+minimal build --> mip build
+minimal test --> mip test
+minimal materialize --> mip materialize
+minimal package --> mip package
+minimal cache --> mip cache
+minimal check --> mip check
+minimal dep --> mip dep
+minimal completions --> mip completions
+minimal help --> mip help
+```
+The in-VM command `min add` remains unchanged.
 
 ## minimal.toml
 

--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -21,10 +21,10 @@ To install `min`, see [install](./install.md).
 
 ### Linux
 To maintain backward compatibility for ephemeral systems on Linux, the installer for `min` will also install a version of Minimal that's functionally identical to `minimal`, and renamed to `mip` (Minimal-In-Place). All commands available to `minimal` are available in `mip`. Any commands using `minimal` should be upgraded to use `mip`.
-```shell
+```
 minimal run --> mip run
 minimal update --> mip update
-minimal add --> mip update
+minimal add --> mip add
 minimal status --> mip status
 minimal build --> mip build
 minimal test --> mip test

--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -1,0 +1,71 @@
+---
+description: Migration to the new architecture after v0.5.0 release for Linux and macOS.
+---
+
+# Minimal Sessions Migration Guide
+
+If you are using a release of Minimal **older than v0.5.0**, you will need to update your configuration before using the Sessions architecture. You can check the version with `minimal --version` or `min --version`.
+
+## Upgrade from v0.4.1 or older
+
+WARNING: `tasks` are not supported by v0.5.0. If you rely on `tasks` for non-interactive, job-like workflows, it is recommended to keep using `minimal` (<=v0.4.1) for tasks, and `min` (v0.5.0) for sessions.
+
+Going forward, the Minimal command will become `min`, and will not conflict with the existing `minimal` command. 
+
+You can use the following to uninstall `minimal`.
+```bash
+./.minimal/shim/uninstall.sh
+```
+
+To install `min`, see [install](./install.md).
+
+
+## minimal.toml
+
+Prior to v0.5.0, `minimal.toml` had the following sections: upstream, harness, defaults, and tasks. 
+
+```toml
+[upstream]
+repo = "https://github.com/gominimal/pkgs"
+branch = "main"
+locked_commit = "11a8cf050340e3946171476b22ff4b3a8e08e66b"
+
+[harness]
+use = "shell"
+
+[defaults]
+state_key = "dev"
+
+[tasks.shell]
+interactive = true
+packages = ["base"]
+exec = "bash --noprofile -l"
+```
+
+### [upstream]
+
+The upstream section is unchanged.
+
+### [harness]
+
+The harness section is renamed to `stack`. The functionalities of `stack` remain unchanged. For more information on stack, see [stack](../concepts/stacks.md).
+
+### [defaults]
+
+The defaults section is unchanged.
+
+### [outputs]
+
+The outputs section is unchanged.
+
+### [tasks]
+
+Going forward, interactive tasks (bash, shell, interactive agent sessions) are supported by `session` definitions. Non-interactive tasks (test, build) are currently not supported by v0.5.0.
+
+### [session] (NEW)
+
+Session is a new concept in v0.5.0. `[session]` will define interactive environments where shell, bash, and interactive agent tasks. Task defined with 
+```toml
+interactive = true
+```
+should be migrated to a session definition. For how to define a session, please refer to [the session configuration in minimal.toml](../reference/minimal-dot-toml.md#session---what-every-contributors-session-gets-session). 

--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -4,83 +4,70 @@ description: Migration to the new architecture after v0.5.0 release for Linux an
 
 # Minimal Sessions Migration Guide
 
-If you are using a release of Minimal **older than v0.5.0**, you will need to update your configuration before using the Sessions architecture. You can check the version with `minimal --version` or `min --version`.
+If you're on a release **older than v0.5.0**, you'll need to update your configuration to use the new Sessions architecture. Check your version with `minimal --version` or `min --version`.
 
-## Upgrade from v0.4.1 or older
+## Upgrading from v0.4.1 or earlier
 
-WARNING: `tasks` are not supported by v0.5.0. If you rely on `tasks` for non-interactive, job-like workflows, keep `minimal` (<=v0.4.1) installed for tasks and install `min` (v0.5.0) for sessions.
+> **Note:** `tasks` are not supported by v0.5.0. If you rely on `tasks` for non-interactive, job-like workflows, keep `minimal` (<=v0.4.1) installed for tasks, and install `min` (v0.5.0) alongside it for sessions.
 
-Going forward, the Minimal command will become `min`, and will not conflict with the legacy `minimal` command. The installer for legacy `minimal` will no longer be available after v0.5.0 is released. However, `minimal` will remain operational for the foreseeable future.
+The Minimal command is becoming `min`, which won't conflict with the legacy `minimal` command. `minimal` will keep working for the foreseeable future, but its installer will no longer be available after v0.5.0 ships.
 
-If you no longer need the legacy `minimal` command, you can uninstall it with:
+To install `min`, see [install](./install.md). If you no longer need `minimal`, uninstall it with:
 ```shell
 ./.minimal/shim/uninstall.sh
 ```
 
-To install `min`, see [install](./install.md).
+### Linux: use `mip` in place of `minimal`
 
-### Linux
-To maintain backward compatibility for ephemeral build systems on Linux, the installer for `min` will also install a version of Minimal that's functionally identical to `minimal`, and renamed to `mip` (Minimal-In-Process). All commands available to `minimal` are available in `mip`. Any commands using `minimal` should be upgraded to use `mip`. For the complete documentation on `mip`, see [cli-mip](../reference/cli-mip.md).
-```
-minimal run --> mip run
-minimal update --> mip update
-minimal add --> mip add
-minimal status --> mip status
-minimal build --> mip build
-minimal test --> mip test
-minimal materialize --> mip materialize
-minimal package --> mip package
-minimal cache --> mip cache
-minimal check --> mip check
-minimal dep --> mip dep
-minimal completions --> mip completions
-minimal help --> mip help
-```
-The in-VM command `min add` remains unchanged.
+To keep ephemeral build systems on Linux working, the `min` installer also installs `mip` (Minimal-In-Process), which is functionally identical to `minimal`. Update any scripts using `minimal` to use `mip` instead — see [cli-mip](../reference/cli-mip.md) for full docs.
 
-## minimal.toml
+| Old | New |
+|---|---|
+| `minimal run` | `mip run` |
+| `minimal update` | `mip update` |
+| `minimal add` | `mip add` |
+| `minimal status` | `mip status` |
+| `minimal build` | `mip build` |
+| `minimal test` | `mip test` |
+| `minimal materialize` | `mip materialize` |
+| `minimal package` | `mip package` |
+| `minimal cache` | `mip cache` |
+| `minimal check` | `mip check` |
+| `minimal dep` | `mip dep` |
+| `minimal completions` | `mip completions` |
+| `minimal help` | `mip help` |
 
-Prior to v0.5.0, `minimal.toml` had the following sections: upstream, harness, defaults, outputs, and tasks. 
+The in-VM command `min add` is unchanged.
 
-### [upstream]
+## Changes to `minimal.toml`
 
-The upstream section is unchanged.
+Prior to v0.5.0, `minimal.toml` had five sections: `upstream`, `harness`, `defaults`, `outputs`, and `tasks`.
 
-### [harness]
+| Section | Status |
+|---|---|
+| `[upstream]` | Unchanged |
+| `[harness]` | Renamed to [`[stack]`](../concepts/stacks.md); functionality unchanged |
+| `[defaults]` | `profiles` deprecated — see [Profiles](#profiles) |
+| `[outputs]` | Unchanged |
+| `[tasks]` | Interactive tasks (bash, shell, interactive agent sessions) moved to [`[session]`](#session-new); non-interactive tasks (test, build) aren't supported in v0.5.0 |
 
-The harness section is renamed to `stack`. The functionalities of `stack` remain unchanged. For more information on stack, see [stack](../concepts/stacks.md).
+### `[session]` (new)
 
-### [defaults]
+`session` is a new concept in v0.5.0 for interactive environments — shell, bash, and interactive agent entry points. Migrate any task using `shell`, `bash`, or an interactive agent entry point to a session definition; see [the session configuration reference](../reference/minimal-dot-toml.md#session---what-every-contributors-session-gets-session) for how.
 
-`profiles` that was formerly defined in the defaults section has been deprecated.
+Unlike `tasks`, which supported multiple definitions each invoked with `minimal run <task>`, a project has only one `session`:
 
-### [outputs]
-
-The outputs section is unchanged.
-
-### [tasks]
-
-Interactive tasks (bash, shell, interactive agent sessions) are supported by `session` definitions. Non-interactive tasks (test, build) are currently not supported by v0.5.0.
-
-### [session] (NEW)
-
-Session is a new concept in v0.5.0. `[session]` will define interactive environments where shell, bash, and interactive agent tasks. Task defined with 
-```toml
-interactive = true
-```
-should be migrated to a session definition. For how to define a session, please refer to [the session configuration in minimal.toml](../reference/minimal-dot-toml.md#session---what-every-contributors-session-gets-session). 
-
-Unlike `tasks`, which can have multiple definitions and each can be invoked with `minimal run <task>`, `session` has only 1 definition, and is created with 
 ```shell
-min activate #produces session ID as output
+min activate          # creates a session, prints its ID
+min attach <session ID>  # enters an existing session
+min activate --attach    # creates and enters a session in one step
 ```
-You can enter a session with
-```shell
-min attach <session ID>
-```
-To create and then enter the new session immediately
-```shell
-min activate --attach
-```
+
 ## Profiles
-Profiles have been deprecated. `profile.env_vars` should be migrated to `session.vars`, and `profile.packages` should be migrated to `session.packages`. For how to define a session, please refer to [the session configuration in minimal.toml](../reference/minimal-dot-toml.md#session---what-every-contributors-session-gets-session). 
+
+Profiles have been deprecated:
+
+- `profile.env_vars` → `session.vars`
+- `profile.packages` → `session.packages`
+
+See [the session configuration reference](../reference/minimal-dot-toml.md#session---what-every-contributors-session-gets-session) for how to define a session.

--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -8,14 +8,11 @@ If you are using a release of Minimal **older than v0.5.0**, you will need to up
 
 ## Upgrade from v0.4.1 or older
 
-WARNING: `tasks` are not supported by v0.5.0. If you rely on `tasks` for non-interactive, job-like workflows, it is recommended to keep using `minimal` (<=v0.4.1) for tasks, and `min` (v0.5.0) for sessions.
+WARNING: `tasks` are not supported by v0.5.0. If you rely on `tasks` for non-interactive, job-like workflows, keep `minimal` (<=v0.4.1) installed for tasks and install `min` (v0.5.0) for sessions.
 
 Going forward, the Minimal command will become `min`, and will not conflict with the existing `minimal` command. 
 
-You can use the following to uninstall `minimal`.
-```bash
-./.minimal/shim/uninstall.sh
-```
+If you no longer need the legacy `minimal` command, you can uninstall it with:
 
 To install `min`, see [install](./install.md).
 

--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -19,28 +19,9 @@ You can use the following to uninstall `minimal`.
 
 To install `min`, see [install](./install.md).
 
-
 ## minimal.toml
 
-Prior to v0.5.0, `minimal.toml` had the following sections: upstream, harness, defaults, and tasks. 
-
-```toml
-[upstream]
-repo = "https://github.com/gominimal/pkgs"
-branch = "main"
-locked_commit = "11a8cf050340e3946171476b22ff4b3a8e08e66b"
-
-[harness]
-use = "shell"
-
-[defaults]
-state_key = "dev"
-
-[tasks.shell]
-interactive = true
-packages = ["base"]
-exec = "bash --noprofile -l"
-```
+Prior to v0.5.0, `minimal.toml` had the following sections: upstream, harness, defaults, outputs, and tasks. 
 
 ### [upstream]
 

--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -20,7 +20,7 @@ If you no longer need the legacy `minimal` command, you can uninstall it with:
 To install `min`, see [install](./install.md).
 
 ### Linux
-To maintain backward compatibility for ephemeral systems on Linux, the installer for `min` will also install a version of Minimal that's functionally identical to `minimal`, and renamed to `mip` (Minimal-In-Place). All commands available to `minimal` are available in `mip`. Any commands using `minimal` should be upgraded to use `mip`.
+To maintain backward compatibility for ephemeral build systems on Linux, the installer for `min` will also install a version of Minimal that's functionally identical to `minimal`, and renamed to `mip` (Minimal-In-Process). All commands available to `minimal` are available in `mip`. Any commands using `minimal` should be upgraded to use `mip`. For the complete documentation on `mip`, see [cli-mip](../reference/cli-mip.md).
 ```
 minimal run --> mip run
 minimal update --> mip update

--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -30,7 +30,7 @@ The harness section is renamed to `stack`. The functionalities of `stack` remain
 
 ### [defaults]
 
-The defaults section is unchanged.
+`profiles` that was formerly defined in the defaults section has been deprecated.
 
 ### [outputs]
 
@@ -60,3 +60,5 @@ To create and then enter the new session immediately
 ```shell
 min activate --attach
 ```
+## Profiles
+Profiles have been deprecated. `profile.env_vars` should be migrated to `session.vars`, and `profile.packages` should be migrated to `session.packages`. For how to define a session, please refer to [the session configuration in minimal.toml](../reference/minimal-dot-toml.md#session---what-every-contributors-session-gets-session). 

--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -50,3 +50,16 @@ Session is a new concept in v0.5.0. `[session]` will define interactive environm
 interactive = true
 ```
 should be migrated to a session definition. For how to define a session, please refer to [the session configuration in minimal.toml](../reference/minimal-dot-toml.md#session---what-every-contributors-session-gets-session). 
+
+Unlike `tasks`, which can have multiple definitions and each can be invoked with `minimal run <task>`, `session` has only 1 definition, and is created with 
+```shell
+min activate #produces session ID as output
+```
+You can enter a session with
+```shell
+min attach <session ID>
+```
+To create and then enter the new session immediately
+```shell
+min activate --attach
+```


### PR DESCRIPTION
<!-- PR title: use a Conventional Commit subject — `type(scope): summary`,
     imperative, lower-case, no trailing period. The PR title becomes the
     squash commit subject. See docs/commit-conventions.md. -->

## Summary
Added a migration guide for Minimal One
<!-- What changes, and why. Link related issues (`Refs: #123` / `Closes: #123`). -->

## Testing

<!-- What you ran (`cargo test`, `cargo clippy`, harness/e2e scripts, manual
     steps) — paste the relevant output as evidence. -->

## Checklist

- [x] Docs updated if behavior changed
- [ ] `BREAKING CHANGE:` footer present if this is a breaking change


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add migration guide for moving to the Minimal Sessions architecture in v0.5.0
> Adds [migrate-to-minimal-session.md](https://github.com/gominimal/minimal/pull/1003/files#diff-5e73bdda4c543bf93628b9d23a47694f5b9e5303592fd669edd1a939edd35276) covering the transition from legacy `minimal` to the new `min` command introduced in v0.5.0.
>
> - Documents that legacy `minimal` is preserved but tasks are unsupported in v0.5.0, with uninstall instructions and a pointer to `min` installation docs
> - Describes Linux backward compatibility via `mip` (Minimal-In-Process), including a command mapping from `minimal` to `mip`
> - Covers `minimal.toml` schema changes: `harness` renamed to `stack`, `profiles` deprecated, and a new `[session]` section added
> - Documents session lifecycle commands (`min activate`, `min attach`, `--attach`) and instructions for migrating profile env vars and packages to `session.vars` and `session.packages`
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1003 opened
>
> - Introduced `[session]` configuration section to replace interactive task definitions, with migration guidance from `shell`, `bash`, and `agent` task types to session-based workflows using `min activate` and `min attach` commands [a9a090f]
> - Documented renaming of `[harness]` configuration section to `[stack]` in `minimal.toml`, with guidance that `[upstream]` and `[outputs]` sections remain unchanged, `[defaults]` profiles are deprecated, and tasks split between interactive (moved to sessions) and non-interactive (remain as tasks) [a9a090f]
> - Replaced `minimal` CLI command with `mip` command on Linux, providing command mapping table showing old versus new command syntax and noting that in-VM `min add` command remains unchanged [a9a090f]
> - Documented migration path from `profile.env_vars` to `session.vars` and from `profile.packages` to `session.packages` as part of profiles deprecation [a9a090f]
> - Restructured migration guide with consolidated warnings about task support in v0.5.0, repositioned installation and uninstallation instructions, clarified version check commands, and recommended parallel installation of `min` alongside legacy `minimal` [a9a090f]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2969ef5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Expanded the “Minimal Sessions Migration Guide” for Linux/macOS upgrades to the Sessions architecture (v0.5.0+).
  * Added a v0.5.0 warning that interactive `tasks` must be migrated and that non-interactive, job-like workflows no longer support `tasks`.
  * Clarified `minimal` → `min`, including uninstall steps for legacy `minimal` and updated `minimal.toml` migration: rename `harness` → `stack`, add `[session]`, and deprecate `profiles` with a mapping to session `vars`/`packages`.
  * Documented Linux installer behavior introducing `mip` as an in-place command mapping for `minimal`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->