### PR TITLE
fix(sandbox2): let the sandbox leader own its namespace

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -12,6 +12,7 @@ pub use remote_storage::RemoteStorage;
 pub mod renameat2;
 
 pub mod repo_spec;
+pub mod sandbox_owner;
 mod spec_hash;
 pub use spec_hash::SpecHash;
 mod subsets;

--- a/crates/common/src/sandbox_owner.rs
+++ b/crates/common/src/sandbox_owner.rs
@@ -1,0 +1,131 @@
+//! Which process owns a sandbox directory.
+//!
+//! A sandbox directory is reclaimable once the process it belongs to is gone.
+//! Answering "which process" reliably is the whole point of this module, and it
+//! is less obvious than it looks.
+//!
+//! The directory name carries a trailing `-<pid>`, but that is the pid of
+//! whatever *created* the sandbox, recorded for uniqueness. Creator and owner
+//! coincide only when the creating process is also the one whose lifetime the
+//! sandbox tracks:
+//!
+//! * Under the CLI they do. `mip` creates the sandbox, runs it, and exits, so
+//!   its pid dying is a faithful signal that the directory is finished with.
+//! * Under a daemon they do not. `minimald` creates sandboxes and outlives them
+//!   all, and inside the microVM it is **pid 1** — alive by definition, and
+//!   still pid 1 after a restart. Every directory it creates looks permanently
+//!   owned, so nothing can ever be reclaimed and nothing can tell a running
+//!   build from an abandoned one.
+//!
+//! So ownership is recorded explicitly instead, in a [`LEADER_PID_FILE`] beside
+//! the sandbox contents. It names the creating process while the sandbox is
+//! being set up — a sandbox mid-construction must not look abandoned — and is
+//! rewritten with the sandbox **leader**'s pid as soon as one is spawned.
+//!
+//! The contract lives here, rather than in `sandbox2` where the writing
+//! happens, so that readers which do not (and should not) depend on the sandbox
+//! implementation can still answer the question.
+
+use std::path::Path;
+
+/// Name of the file, inside a sandbox directory, recording the pid whose death
+/// makes that directory reclaimable.
+pub const LEADER_PID_FILE: &str = "leader.pid";
+
+/// Record `pid` as the owner of the sandbox directory at `dir`.
+///
+/// Best-effort: a sandbox that cannot write its own marker still runs, it just
+/// cannot be attributed later. Failing a build over a housekeeping file would
+/// be the wrong trade. Returns whether the marker was written.
+pub fn set_owning_pid(dir: &Path, pid: u32) -> bool {
+    std::fs::write(dir.join(LEADER_PID_FILE), pid.to_string()).is_ok()
+}
+
+/// The pid owning the sandbox directory at `dir`, if it recorded one.
+///
+/// `None` means *unknown owner*, not *no owner* — a directory created before
+/// this marker existed has none, and so does one abandoned before its leader
+/// spawned. Callers reclaiming directories must treat the two the same way they
+/// treat a live owner: leave it alone.
+#[must_use]
+pub fn owning_pid(dir: &Path) -> Option<u32> {
+    std::fs::read_to_string(dir.join(LEADER_PID_FILE))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+/// Whether the sandbox directory at `dir` is reclaimable: it names an owner,
+/// and that owner is gone.
+///
+/// A `/proc` lookup, so this is only meaningful on the host whose pids the
+/// marker refers to. An unreadable `/proc/<pid>` reads as "still alive", which
+/// keeps a reaper off directories whose owner it cannot rule out.
+#[must_use]
+pub fn owner_is_gone(dir: &Path) -> bool {
+    match owning_pid(dir) {
+        Some(pid) => !std::fs::exists(format!("/proc/{pid}")).unwrap_or(true),
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_recorded_pid_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(set_owning_pid(tmp.path(), 4242));
+        assert_eq!(owning_pid(tmp.path()), Some(4242));
+    }
+
+    /// Rewriting is the handover from creating process to sandbox leader, so
+    /// the later write has to win outright rather than append.
+    #[test]
+    fn rewriting_the_marker_replaces_the_owner() {
+        let tmp = tempfile::tempdir().unwrap();
+        set_owning_pid(tmp.path(), 1);
+        set_owning_pid(tmp.path(), 99999);
+        assert_eq!(owning_pid(tmp.path()), Some(99999));
+    }
+
+    /// An unmarked directory is *unknown*, and unknown must never read as
+    /// reclaimable — that is what keeps a reaper off a sandbox still being
+    /// built, and off every directory created before this marker existed.
+    #[test]
+    fn an_unmarked_directory_is_never_reclaimable() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(owning_pid(tmp.path()), None);
+        assert!(!owner_is_gone(tmp.path()));
+    }
+
+    #[test]
+    fn a_malformed_marker_is_unknown_not_reclaimable() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(LEADER_PID_FILE), "not-a-pid").unwrap();
+        assert_eq!(owning_pid(tmp.path()), None);
+        assert!(!owner_is_gone(tmp.path()));
+    }
+
+    /// pid 0 is never a live process, so `/proc/0` never exists — the one pid
+    /// that lets this assert the reclaimable arm without racing a real process.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_dead_owner_makes_the_directory_reclaimable() {
+        let tmp = tempfile::tempdir().unwrap();
+        set_owning_pid(tmp.path(), 0);
+        assert!(owner_is_gone(tmp.path()));
+    }
+
+    /// This process is alive by construction, so its own directory must not be
+    /// reclaimable — the case the daemon got wrong by recording its own pid.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_live_owner_holds_the_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        set_owning_pid(tmp.path(), std::process::id());
+        assert!(!owner_is_gone(tmp.path()));
+    }
+}

--- a/crates/mip/src/cmd_cache.rs
+++ b/crates/mip/src/cmd_cache.rs
@@ -102,14 +102,23 @@ pub async fn cmd_cache(args: CacheArgs, ctx: &mut Context) -> Result<(), Error> 
     Ok(())
 }
 
+/// Remove a sandbox/task/temp directory whose owning process is gone.
+///
+/// Ownership comes from the marker the sandbox writes
+/// ([`common::sandbox_owner`]), not from the trailing `-<pid>` in the directory
+/// name. That suffix is the pid of whatever *created* the sandbox, which is the
+/// right answer only when the creator is also the thing whose lifetime the
+/// sandbox tracks — true for this CLI, false for a long-lived daemon. Reading
+/// the marker means one rule works for both.
+///
+/// A directory with no marker is left alone: it predates the marker, or was
+/// abandoned before its leader spawned, and neither is distinguishable here
+/// from a sandbox mid-construction.
 fn cleanup_stale(kind: &str, entry: std::fs::DirEntry) -> Result<(), Error> {
     let name = entry.file_name();
     let s = name.to_str().unwrap();
-    if s.contains("-")
-        && let Some(pid_str) = s.rsplit('-').next()
-        && let Ok(false) = std::fs::exists(format!("/proc/{}", pid_str))
-    {
-        // No such proc entry, therefore PID dead. Clean up directory.
+    if common::sandbox_owner::owner_is_gone(&entry.path()) {
+        // No such proc entry, therefore the owner is dead. Clean up directory.
         println!("Cleaning up stale {} {}", kind, s);
         common::remove_dir_all(entry.path())
             .map_err(|e| Error::IO("rm stale sandbox", entry.path(), e))?;

--- a/crates/sandbox2/src/config.rs
+++ b/crates/sandbox2/src/config.rs
@@ -386,6 +386,12 @@ impl Config {
         // At this layer its plausible that there might be two packages of the same name
         // built at the same time, so we do an atomic directory creation dance /w an attempt
         // counter to make sure each sandbox gets its own folder.
+        //
+        // The pid here is for *uniqueness only*. Ownership — whose death makes
+        // this directory reclaimable — is recorded separately in
+        // [`common::sandbox_owner`], because the creating process is not the
+        // process whose lifetime the sandbox tracks. A reaper that reads this
+        // name instead sees the daemon (pid 1 in the guest), which never dies.
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -426,6 +432,13 @@ impl Config {
                 }
             }
         };
+
+        // Claim ownership for *this* process until a leader exists. Setup below
+        // (fs mappings, synth dir) runs before anything is spawned, and a
+        // concurrent reaper must not mistake a sandbox that is mid-construction
+        // for an abandoned one. `Sandbox::run` overwrites this with the leader's
+        // pid once there is one.
+        common::sandbox_owner::set_owning_pid(&build_base_dir, std::process::id());
 
         // Validate FS mappings, creating any non-existent files as we go.
         if let WdSetup::BoundDir { fs_mappings, .. } = &self.wd {

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -875,6 +875,15 @@ impl<C: Channel> Sandbox<C> {
                 .spawn()
                 .map_err(|e| Error::Execution(ExecutionError::SpawnFailed(e)))?;
 
+            // Hand ownership of the directory to the process that now occupies
+            // it. Until this point the marker named whoever built the sandbox,
+            // which for the daemon is itself — a process that outlives every
+            // sandbox it creates, and inside the microVM is pid 1 and so alive
+            // by definition. The leader is the process whose death actually
+            // means this directory is finished with. Rewritten per invocation,
+            // so a sandbox running several execs always names the current one.
+            common::sandbox_owner::set_owning_pid(&self.base_dir, child.id());
+
             // Apply the configured per-sandbox network to this invocation's
             // freshly-unshared netns (own-IP switch attach). No-op for
             // HostNet/NoNet and when no custom `Network` is set, so existing


### PR DESCRIPTION
Closes [#1001](https://github.com/gominimal/minimal/issues/1001).

A sandbox directory is reclaimable once the process it belongs to is gone, but
nothing recorded which process that is.

`sandbox2` names each directory `{name}-{timestamp}-{attempt}-{pid}` from
`std::process::id()` — whoever *created* the sandbox, stamped there for
uniqueness. Creator and owner coincide only when the creating process is also
the one whose lifetime the sandbox tracks:

- Under the **CLI** they do. `mip` creates the sandbox, runs it, and exits, so
  its pid dying is a faithful signal that the directory is finished with.
- Under a **daemon** they do not. `minimald` creates sandboxes and outlives them
  all, and inside the microVM it is **pid 1** — alive by definition, and still
  pid 1 after a restart.

## How this surfaced

Found while building [#1002](https://github.com/gominimal/minimal/pull/1002). On
a booted VM every directory under the build base was stamped `-1`, and the
maintenance cycle declined every single time with
`a task is in flight (build-1784239277-0-1)`. Nothing could distinguish a
running build from an abandoned one, so maintenance never ran and the
directory reap could never have removed anything either. That PR ships without
either half; this is what makes them possible.

Failed builds are the leak that matters here: `op/src/specs.rs` sets
`keep_dir(true)` for the duration of a build and clears it only on success, so
an interrupted or failed build deliberately leaves its tree behind.

## The change

Ownership is recorded explicitly, in a `leader.pid` file beside the sandbox
contents. The leader pid is already available — `child.id()` immediately after
`cmd.spawn()`, already used for the netns attach.

The marker is written **twice**, which is the subtle part:

1. At directory creation, naming the creating process. The window between
   `create_dir` and `spawn` does real work (fs mappings, synth dir), and a
   concurrent `mip cache clean` must not mistake a half-built sandbox for an
   abandoned one. Today that window is safe only by accident, because the name's
   pid happens to be the live creator's.
2. After `spawn`, naming the leader — the process whose death actually means the
   directory is finished with. Rewritten per invocation, so a sandbox running
   several execs always names the current one.

The contract lives in `common::sandbox_owner` rather than `sandbox2`, so readers
that should not depend on the sandbox implementation can still answer the
question. `mip cache clean` switches to it, and one rule now works for the CLI
and the daemon alike.

**Unknown stays distinct from unowned.** A directory with no marker predates it,
or was abandoned before its leader spawned; both must be left alone. That is
what keeps this safe to land on a tree full of pre-existing sandbox directories.

## Residual

If the daemon crashes *during* the setup window, the directory is left naming
pid 1, and after a restart pid 1 is alive again — so it is never reclaimed.
Narrow, and strictly better than today (where every directory has that property
permanently), but not zero. Closing it properly needs something a restart
invalidates, such as a boot id alongside the pid. Left out rather than guessed
at.

Also left out: the directory name keeps its `-<pid>` suffix, now purely for
uniqueness. Removing it is a bigger behavioural change and nothing reads it for
liveness any more.

## Not included

Re-adding the maintenance reap and a build-aware deferral to
[#1002](https://github.com/gominimal/minimal/pull/1002). That PR is already open
with both removed; they come back on this signal once both land. Note also that
`ListSessions` already exposes session liveness and activity timestamps, which
is a better basis for the deferral half than a pid scan — discussed on
[#1001](https://github.com/gominimal/minimal/issues/1001).

## Verification

- `cross` (aarch64 musl): `common` 52, `sandbox2` 12, `mip` 14 — all pass.
  Includes the two `/proc`-gated tests that cannot run on macOS, so the
  live-owner vs dead-owner distinction is genuinely exercised rather than just
  the parsing.
- `cross clippy -p common -p sandbox2 -p mip --all-targets -- -D warnings`: clean.
- `just ci` on macOS: green.

Not exercised: a real build writing and handing over its marker on a booted VM.
The write sites are two lines each on paths covered by the existing sandbox
tests, but the handover itself has not been observed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Let sandbox2 leader own its namespace via a `leader.pid` marker file
> - Adds a new `sandbox_owner` module in `crates/common` with `set_owning_pid`, `owning_pid`, and `owner_is_gone` helpers that read/write a `leader.pid` file inside sandbox directories.
> - When a sandbox directory is created, the creating process writes its PID to `leader.pid`; when a child process is spawned, ownership is handed off to the child's PID.
> - Replaces the previous `-<pid>` suffix heuristic in `mip`'s `cleanup_stale` with a call to `owner_is_gone`, so only directories whose recorded owner has exited are reclaimed.
> - Behavioral Change: sandbox directories without a `leader.pid` marker or with a live owner are no longer considered stale and will not be cleaned up.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bb13ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->