### PR TITLE
fix(minimal): preserve file modes and mtimes in workspace upload

### DIFF
--- a/crates/minimal/src/file_upload.rs
+++ b/crates/minimal/src/file_upload.rs
@@ -562,9 +562,28 @@ fn add_dir_entries_inner<'a, W: AsyncWrite + Unpin + Send + Sync + 'a>(
                     .metadata()
                     .await
                     .with_context(|| format!("statting {}", entry_path.display()))?;
+                // Preserve the source's permission bits (masked to the
+                // standard nine + suid/sgid/sticky), same as
+                // `TarZstArchive::add_file`'s default. Hardcoding 0o644
+                // here silently strips the exec bit off scripts and
+                // binaries in every workspace upload.
+                let mode = {
+                    use std::os::unix::fs::PermissionsExt as _;
+                    metadata.permissions().mode() & 0o7777
+                };
+                // Preserve the mtime too: leaving the header's zero
+                // stamp unpacks every file at the epoch, which breaks
+                // mtime-keyed (make-style) builds inside the session.
+                // Pre-epoch mtimes (nonsensical but legal) clamp to 0.
+                let mtime = metadata
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map_or(0, |d| d.as_secs());
                 let mut header = async_tar::Header::new_gnu();
                 header.set_size(metadata.len());
-                header.set_mode(0o644);
+                header.set_mode(mode);
+                header.set_mtime(mtime);
                 header.set_entry_type(async_tar::EntryType::Regular);
                 header.set_cksum();
                 tar.append_data(&mut header, &archive_path, &mut file)
@@ -836,6 +855,64 @@ mod tests {
             "escape should be a symlink, not a copied file"
         );
         assert!(out.path().join("safe.txt").is_file());
+    }
+
+    /// The dir-walk uploader must preserve file permission bits: a
+    /// workspace upload that flattens everything to 0o644 strips the
+    /// exec bit off scripts (e.g. `scripts/setup-dev.sh`), so they
+    /// arrive in the session un-runnable.
+    #[tokio::test]
+    async fn stream_preserves_file_modes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let script = dir.path().join("setup-dev.sh");
+        std::fs::write(&script, "#!/bin/sh\necho hi\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let plain = dir.path().join("notes.txt");
+        std::fs::write(&plain, "notes").unwrap();
+        std::fs::set_permissions(&plain, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        let mut buf = Vec::new();
+        stream_tar_zstd(dir.path(), &mut buf).await.unwrap();
+
+        let decoder = async_compression::tokio::bufread::ZstdDecoder::new(&buf[..]);
+        let out = tempfile::TempDir::new().unwrap();
+        async_tar::Archive::new(decoder)
+            .unpack(out.path().to_path_buf())
+            .await
+            .unwrap();
+
+        let mode_of = |name: &str| {
+            std::fs::metadata(out.path().join(name))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777
+        };
+        assert_eq!(
+            mode_of("setup-dev.sh"),
+            0o755,
+            "executable bit must survive the upload round-trip"
+        );
+        assert_eq!(
+            mode_of("notes.txt"),
+            0o640,
+            "non-default permission bits must survive the upload round-trip"
+        );
+
+        let src_mtime_secs = |p: &std::path::Path| {
+            std::fs::metadata(p)
+                .unwrap()
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+        };
+        assert_eq!(
+            src_mtime_secs(&out.path().join("setup-dev.sh")),
+            src_mtime_secs(&script),
+            "mtime must survive the upload round-trip, not unpack at the epoch"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes gominimal/minimal#955.

`min activate`'s workspace upload stamped every regular file's tar header with mode `0644` and no mtime. Uploaded scripts lost their exec bit (`EACCES` when the session runs them, for example `packages/*/build.sh` in daemon-side builds) and every file unpacked dated at the epoch, which breaks mtime-keyed (make-style) builds.

The defect is not macOS-specific in code, but macOS is where it surfaces: on Linux host-native the daemon reads the real project dir, while VM sessions always receive the tarball.

## Changes

| File | Change |
|---|---|
| `crates/minimal/src/file_upload.rs` | Regular-file arm of the dir walker now stamps the source file's permission bits (masked to `0o7777`, matching `TarZstArchive::add_file`'s default) and its mtime (pre-epoch clamps to 0) on the tar header |
| `crates/minimal/src/file_upload.rs` (tests) | New `stream_preserves_file_modes` round-trip test: a `0755` script and a `0640` file go through upload and unpack, asserting mode and mtime survive |

## Verification

- `cargo test -p minimal --lib file_upload`: 22 passed
- `cargo clippy -p minimal --all-targets -- -D warnings`: clean
- `cargo fmt -p minimal`: clean

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve file modes and mtimes in workspace tar upload
> Previously, all files in workspace uploads were written with hardcoded `0644` permissions and no mtime. Now, `add_dir_entries_inner` in [file_upload.rs](https://github.com/gominimal/minimal/pull/1006/files#diff-b417966fca8aff7d83bfe7def43f0915d3cc2fcc1c3d02953c288fc85274bbf2) reads each file's permission bits (masked with `0o7777`) and modification time from metadata and applies them to the tar header.
> - A new test `stream_preserves_file_modes` verifies that mode bits (e.g. `0o755`, `0o640`) and mtimes survive a full `stream_tar_zstd` round-trip.
> - Behavioral Change: Unpacked files will now reflect their original executable bits and timestamps instead of defaulting to `0644` and epoch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57463dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directory uploads now preserve source file permissions, including executable and special permission bits.
  * File modification times are retained during upload and restored when unpacked.
  * Modification times before the Unix epoch are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->