### PR TITLE
feat(min)!: re-parent session verbs under the session noun

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,7 @@ Verified against the current tree; sources in parentheses.
   typically the distribution shim (`~/.minimal/shim/bin/minimal`), distinct
   from anything this repo builds (justfile comments,
   `crates/minvmd/README.md`).
-- **`min attach -c` is not a general remote shell.** The daemon's exec
+- **`min session attach -c` is not a general remote shell.** The daemon's exec
   handler accepts only `min run <task>`, `min package build [args...]`, and
   `min check [args...]` (plus the internal `git-receive-pack min://` path);
   anything else fails the channel. Task

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ min init
 min add --session git gh claude-code
 
 # start and enter a sandbox, which copies up the CWD file tree into the sandbox
-min activate --attach .
+min session activate --attach .
 
 git init
 
@@ -112,7 +112,7 @@ min add --session git gh claude-code mermaid-cli kittyview less emacs
 security find-generic-password -w -s "PAT-foo-repo" -a "my-mac-user-name" | pbcopy
 
 # start and enter a sandbox, which copies up the CWD file tree into the sandbox
-min activate --attach .
+min session activate --attach .
 
 git init
 
@@ -145,7 +145,7 @@ cd ~/projects/foo
 git pull
 
 # don't copy any files up; we'll git pull inside the sandbox
-min activate --attach --sync none .
+min session activate --attach --sync none .
 
 # tell claude to pull https://github.com/<your-owner>/<your-repo>.git
 # then add new features, fix bugs, etc.
@@ -173,7 +173,7 @@ EDITOR = "hx"
 TERM   = { inherit = true, default = "xterm-256color" }
 ```
 
-Apply one with `min activate --loadout dev --attach .`, or list it in
+Apply one with `min session activate --loadout dev --attach .`, or list it in
 `default_loadouts` under `[loadouts]` in `~/.config/minimal/config.toml` to have it join every
 session automatically. `min loadout list` shows what's available. The full
 schema (file patches, lifecycle hooks, environment-variable inheritance,

--- a/crates/diagnostics/src/procs.rs
+++ b/crates/diagnostics/src/procs.rs
@@ -677,7 +677,10 @@ mod tests {
     fn argv0_matches_executable_basename_not_substring() {
         assert!(argv0_matches("/usr/bin/minimald run --detach", MARKERS));
         assert!(argv0_matches("minvmd __krun-vmm --token x", MARKERS));
-        assert!(argv0_matches("/home/u/.local/bin/min activate .", MARKERS));
+        assert!(argv0_matches(
+            "/home/u/.local/bin/min session activate .",
+            MARKERS
+        ));
         assert!(argv0_matches("gvproxy -mtu 1500", MARKERS));
 
         assert!(!argv0_matches("vim minutes.txt", MARKERS));

--- a/crates/minimal/src/attach.rs
+++ b/crates/minimal/src/attach.rs
@@ -1,6 +1,6 @@
 //! Smart session resolution and the interactive attach picker.
 //!
-//! When `min attach` is invoked without a session reference (or `min` is
+//! When `min session attach` is invoked without a session reference (or `min` is
 //! invoked bare), the client has to decide which session to attach to. The
 //! rules (issue #837) prefer a session built from the current working
 //! directory, fall back to the only session in the store when exactly one
@@ -46,7 +46,7 @@ pub(crate) enum SmartResolve {
     /// directly to this session.
     Attach(ListSessionsEntry),
     /// No sessions exist at all. The caller decides whether to error
-    /// (`min attach`) or activate a new session (bare `min`).
+    /// (`min session attach`) or activate a new session (bare `min`).
     NoSessions,
     /// More than one candidate; the caller must pick. The candidates are
     /// already limited to cwd-matches when any matched, else the full list.
@@ -233,7 +233,7 @@ pub(crate) fn ambiguous_no_input_message(
             .unwrap_or_else(|| "(unknown)".to_string());
         out.push_str(&format!("  {id}  {name}  {path}{cwd_marker}\n", id = c.id));
     }
-    out.push_str("Pass a session id or name explicitly: `min attach <id>`.");
+    out.push_str("Pass a session id or name explicitly: `min session attach <id>`.");
     out
 }
 
@@ -431,7 +431,7 @@ mod tests {
         assert!(msg.contains("019f5d0f-0a99-78b1-9165-0809440f0052"));
         assert!(msg.contains("019f5d0f-0a99-78b1-9165-0809440f0066"));
         assert!(msg.contains("(cwd)"));
-        assert!(msg.contains("min attach <id>"));
+        assert!(msg.contains("min session attach <id>"));
     }
 
     /// An entry from an older daemon that predates `project_path` (the field

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -41,18 +41,23 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Command {
     /// List sessions
+    //
+    // Deliberate exception to the `<noun> <verb>` convention (documented in
+    // docs/reference/cli.md): `min ls` is the highest-traffic command in the
+    // CLI and keeps its bare top-level form. Not an oversight — do not move it
+    // under `session`.
     Ls(LsArgs),
-    /// Activate (create) a new session
-    Activate(ActivateArgs),
-    /// Attach to an existing session
-    Attach(AttachArgs),
-    /// Destroy (terminate) a session
-    Destroy(DestroyArgs),
     /// Shut down the minimald daemon
+    //
+    // Stays top-level: it acts on the daemon backend, not on any session, and
+    // it is the daemon-lifecycle command people reach for. Documented as a
+    // deliberate exception in docs/reference/cli.md.
     Stop(StopArgs),
-    /// Session inspection subcommands
+    /// Session management subcommands
+    #[command(visible_alias = "sessions")]
     Session(SessionArgs),
     /// Loadout management subcommands
+    #[command(visible_alias = "loadouts")]
     Loadout(LoadoutArgs),
     /// Print important directories and file paths for debugging
     Dirs,
@@ -107,8 +112,11 @@ pub enum Command {
     ///        https://localhost:7655/
     #[command(verbatim_doc_comment)]
     Login(LoginArgs),
-    /// Rename an existing session
-    Rename(RenameArgs),
+    // `init`, `add`, and `update` are deliberate exceptions to the
+    // `<noun> <verb>` convention (documented in docs/reference/cli.md): they
+    // are passthroughs to the project-configuration commands of the same name
+    // in `mip`, and keeping the spelling identical across the two CLIs is
+    // worth more than the hierarchy. Do not move them under a noun.
     /// Automatically initialize minimal configuration based on your source tree
     Init(InitArgs),
     /// Add a new tool or dependency
@@ -120,7 +128,7 @@ pub enum Command {
     /// Demo the client's activity spinner (development aid).
     ///
     /// Draws the same build-hold-fade spinner used by the file-upload
-    /// phases of `min activate` so you can eyeball timing and layout
+    /// phases of `min session activate` so you can eyeball timing and layout
     /// without triggering a real upload. Stops after `--seconds` or
     /// on Ctrl-C, whichever comes first.
     #[command(hide = true)]
@@ -151,6 +159,14 @@ pub struct SessionArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum SessionCommand {
+    /// Activate (create) a new session
+    Activate(ActivateArgs),
+    /// Attach to an existing session
+    Attach(AttachArgs),
+    /// Destroy (terminate) a session
+    Destroy(DestroyArgs),
+    /// Rename an existing session
+    Rename(RenameArgs),
     /// Print the effective networking policy for a session as JSON
     Policy(PolicyArgs),
 }
@@ -270,7 +286,7 @@ pub struct GlobalArgs {
     #[arg(long, global = true, value_name = "PROVIDER")]
     pub provider: Option<Provider>,
     /// Skip interactive prompts that need a terminal (e.g. the session
-    /// picker shown by bare `min` or `min attach` with no session argument).
+    /// picker shown by bare `min` or `min session attach` with no session argument).
     /// When a choice is ambiguous, the command errors with a list of
     /// candidates instead of opening a picker. Implied when stdin/stdout is
     /// not a terminal.
@@ -417,7 +433,7 @@ fn parse_ingress_proto(proto: &str) -> Result<sessions::IpProto, anyhow::Error> 
 
 #[derive(Debug, Args)]
 pub struct AttachArgs {
-    /// Session identifier (UUID or session name). When omitted, `min attach`
+    /// Session identifier (UUID or session name). When omitted, `min session attach`
     /// resolves a session from the current working directory (or the only
     /// existing session), and opens an interactive picker if the choice is
     /// ambiguous. See `--no-input` to skip the picker in scripts.
@@ -589,15 +605,19 @@ async fn run_command(cli: Cli) -> Result<(), anyhow::Error> {
     client::migrate_legacy_provider_dirs(cli.global_args.minimal_dir.as_deref());
 
     match cli.command {
+        // A bare `min` (no subcommand) resolves-or-activates and attaches. A
+        // deliberate exception to the `<noun> <verb>` convention, documented
+        // in docs/reference/cli.md — see `cmd_default`.
         None => cmd_default(&cli.global_args).await,
         Some(Command::Ls(args)) => cmd_ls(&cli.global_args, args).await,
-        Some(Command::Activate(args)) => cmd_activate(&cli.global_args, args).await,
-        Some(Command::Attach(args)) => cmd_attach(&cli.global_args, args).await,
-        Some(Command::Destroy(args)) => cmd_destroy(&cli.global_args, args).await,
         Some(Command::Stop(args)) => cmd_stop(&cli.global_args, args).await,
-        Some(Command::Session(SessionArgs {
-            command: SessionCommand::Policy(args),
-        })) => cmd_session_policy(&cli.global_args, args).await,
+        Some(Command::Session(SessionArgs { command })) => match command {
+            SessionCommand::Activate(args) => cmd_activate(&cli.global_args, args).await,
+            SessionCommand::Attach(args) => cmd_attach(&cli.global_args, args).await,
+            SessionCommand::Destroy(args) => cmd_destroy(&cli.global_args, args).await,
+            SessionCommand::Rename(args) => cmd_rename(&cli.global_args, args).await,
+            SessionCommand::Policy(args) => cmd_session_policy(&cli.global_args, args).await,
+        },
         Some(Command::Loadout(LoadoutArgs {
             command: LoadoutCommand::List(args),
         })) => loadouts::cmd_loadout_list(args, &cli.global_args),
@@ -615,7 +635,6 @@ async fn run_command(cli: Cli) -> Result<(), anyhow::Error> {
         Some(Command::Login(args)) => cmd_login(&cli.global_args, args).await,
         Some(Command::Version) => cmd_version(&cli.global_args).await,
         Some(Command::Spin(args)) => cmd_spin(&cli.global_args, args).await,
-        Some(Command::Rename(args)) => cmd_rename(&cli.global_args, args).await,
         Some(Command::Init(args)) => cmd_init(&cli.global_args, args)
             .await
             .map_err(|e| anyhow::anyhow!("{e}")),
@@ -641,7 +660,7 @@ async fn run_command(cli: Cli) -> Result<(), anyhow::Error> {
 ///   (auto-resolve, or picker if ambiguous).
 /// - Otherwise → attach to the only session, or open a picker over all.
 ///
-/// Shares smart resolution with `min attach` (no session arg) via
+/// Shares smart resolution with `min session attach` (no session arg) via
 /// [`resolve_smart_attach`]; the only difference is the `NoSessions` case,
 /// which activates here instead of erroring.
 async fn cmd_default(global: &GlobalArgs) -> Result<(), anyhow::Error> {
@@ -669,7 +688,7 @@ async fn cmd_default(global: &GlobalArgs) -> Result<(), anyhow::Error> {
         None => {
             // No sessions exist: activate a new one for the current directory
             // (or -C/--repo-dir if set) and chain into attach, mirroring
-            // `min activate --attach`. `cmd_activate` resolves the path from
+            // `min session activate --attach`. `cmd_activate` resolves the path from
             // `global.repo_dir` when no positional is given, matching the
             // attach side's `cwd_host_path(global)`.
             drop(client);
@@ -1169,7 +1188,7 @@ async fn best_effort_destroy(client: &mut client::Client, session_id: sessions::
             eprintln!(
                 "DestroySession timed out after {DESTROY_TIMEOUT:?} while cleaning up \
                  session {session_id}; the session may still be present on the daemon \
-                 (run `min destroy {session_id}` to clean up manually)",
+                 (run `min session destroy {session_id}` to clean up manually)",
             );
         }
     }
@@ -1722,7 +1741,7 @@ pub async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), any
         }
         None => match resolve_smart_attach(&mut client, global).await? {
             Some(entry) => (entry.id, entry.name),
-            None => bail!("no sessions exist; use 'min activate' to create one"),
+            None => bail!("no sessions exist; use 'min session activate' to create one"),
         },
     };
 
@@ -1741,7 +1760,7 @@ pub async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), any
 /// (ambiguous), or errors (ambiguous but non-interactive).
 ///
 /// Returns `Ok(None)` when no sessions exist at all — the caller decides
-/// whether that is an error (`min attach`) or a cue to activate a new session
+/// whether that is an error (`min session attach`) or a cue to activate a new session
 /// (bare `min`).
 async fn resolve_smart_attach(
     client: &mut client::Client,
@@ -1782,8 +1801,8 @@ fn ensure_interactive_attach_tty(stdin_is_tty: bool) -> Result<(), anyhow::Error
         Ok(())
     } else {
         bail!(
-            "`min attach` needs an interactive terminal, but stdin is not a TTY. \
-             Run it from a terminal, or use `min attach --command <cmd>` to run a \
+            "`min session attach` needs an interactive terminal, but stdin is not a TTY. \
+             Run it from a terminal, or use `min session attach --command <cmd>` to run a \
              single command non-interactively."
         )
     }

--- a/crates/minimal/src/prompt.rs
+++ b/crates/minimal/src/prompt.rs
@@ -1,4 +1,4 @@
-//! Interactive policy prompts for `min activate`.
+//! Interactive policy prompts for `min session activate`.
 //!
 //! When the daemon returns a pending item (a Project or Package
 //! contribution the user's [`UserPolicy`] can't auto-decide), the
@@ -1241,7 +1241,7 @@ allow = [\"/etc/foo\"]
         // and a rule the caller isn't modifying.
         let original = "\
 # User policy for minimal
-# Edit by hand or via `min activate`.
+# Edit by hand or via `min session activate`.
 
 [vars]
 # Approved env vars from projects.

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -322,7 +322,7 @@ async fn upload_workspace_files_surfaces_daemon_unpack_error() {
 
 // --- attach (smart resolution) ---
 
-/// `min activate` with no positional path but `-C/--repo-dir` set uploads
+/// `min session activate` with no positional path but `-C/--repo-dir` set uploads
 /// from the repo-dir directory, not the process cwd (#873).
 #[tokio::test]
 async fn activate_uses_repo_dir_when_no_positional_path() {
@@ -371,7 +371,7 @@ async fn activate_uses_repo_dir_when_no_positional_path() {
     assert_eq!(hello, b"hello world");
 }
 
-/// `min attach` with no session argument and `--no-input` errors cleanly when
+/// `min session attach` with no session argument and `--no-input` errors cleanly when
 /// no sessions exist, rather than hanging or shelling out to ssh. The error
 /// surfaces before any ssh exec, so it is deterministic in a test environment.
 #[tokio::test]
@@ -395,7 +395,7 @@ async fn attach_with_no_session_errors_when_no_sessions_exist() {
     );
 }
 
-/// `min attach` with no session argument and `--no-input` errors with a list
+/// `min session attach` with no session argument and `--no-input` errors with a list
 /// of candidates when more than one session shares the current directory,
 /// rather than opening a picker. Both sessions are built from the same
 /// canonicalized tempdir so the cwd match is deterministic across platforms.
@@ -433,7 +433,7 @@ async fn attach_with_no_session_errors_when_ambiguous_and_no_input() {
     assert!(err.contains("amb-1"), "candidates list names: {err}");
     assert!(err.contains("amb-2"), "candidates list names: {err}");
     assert!(
-        err.contains("min attach <id>"),
+        err.contains("min session attach <id>"),
         "should suggest explicit attach, got: {err}"
     );
 }

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -870,7 +870,7 @@ mod tests {
     }
 
     /// A session left unfinalized when its creating connection closes —
-    /// the state an interrupted `min activate` (Ctrl-C at the gating
+    /// the state an interrupted `min session activate` (Ctrl-C at the gating
     /// prompt) leaves on the daemon — is reaped, while a finalized
     /// (`Active`) session created over that same connection survives.
     #[tokio::test]

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1131,11 +1131,11 @@ impl Session {
                 // requires. `finalize`'s per-op guard will refuse
                 // any later attempt against this Materializing
                 // record, so the operator has to destroy it and
-                // re-activate through `min activate`, which drives
+                // re-activate through `min session activate`, which drives
                 // the full flow.
                 return Err(AttachError::LoadoutFailed(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "composition has patches that can only be uploaded via `min activate` \
+                    "composition has patches that can only be uploaded via `min session activate` \
                      (ConfigureLoadout → WorkspacePatchesTarZst → FinalizeSession); \
                      the attach shortcut can't drive that sequence — destroy this session \
                      and re-activate through the CLI",
@@ -1739,7 +1739,7 @@ mod tests {
     /// Attaching to a session whose loadout was never configured must not
     /// blow up: nothing is in flight on a bare `Draft`, so the attach
     /// configures it with an empty contribution on the way in and mints the
-    /// shell as usual. Guards the `min activate` → `min attach` path against
+    /// shell as usual. Guards the `min session activate` → `min session attach` path against
     /// a caller that never reached the compose step (a compose failure
     /// leaves the actor `Draft` — attach has to still land it live), and
     /// any internal caller that only ever wanted a session to run something

--- a/crates/minimald/src/store.rs
+++ b/crates/minimald/src/store.rs
@@ -285,7 +285,7 @@ impl SessionRecordHandle {
     /// Atomically persists the composition snapshot for this session
     /// (tmp + rename). Called at composition-assembly time so a
     /// restart can re-apply the exact composition that was approved at
-    /// `min activate` time.
+    /// `min session activate` time.
     pub async fn store_composition(
         &self,
         composition: &sessions::core::compose::Composition,

--- a/crates/op/src/project/init.rs
+++ b/crates/op/src/project/init.rs
@@ -199,7 +199,7 @@ fn generate_mfile(
     content.push_str("[defaults]\n");
     content.push_str("state_key = \"dev\"\n");
     content.push('\n');
-    content.push_str("[session] # min attach\n");
+    content.push_str("[session] # min session attach\n");
     content.push_str("packages = [\"base\", \"vim\"");
     if std::fs::exists(repo_dir.join(".git")).unwrap_or_default() {
         content.push_str(", \"git\"");

--- a/crates/sessions/docs/COMPOSITION.md
+++ b/crates/sessions/docs/COMPOSITION.md
@@ -23,7 +23,7 @@ verdicts that come back.
 The daemon-side compose runs off the project files in the session's
 *daemon-side workspace*, and the composition's approved patches
 must land on the daemon's disk before the session is attachable —
-so `min activate` splits into four sequential RPCs bracketed by
+so `min session activate` splits into four sequential RPCs bracketed by
 two file-tree uploads:
 
 ```mermaid

--- a/crates/sessions/example_project/minimal.toml
+++ b/crates/sessions/example_project/minimal.toml
@@ -5,7 +5,7 @@
 #
 # Try it:
 #   cargo build -p minimal -p minimald
-#   ./target/debug/min activate crates/sessions/example_project --attach
+#   ./target/debug/min session activate crates/sessions/example_project --attach
 #
 # Then inside the session:
 #

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -1262,7 +1262,7 @@ impl Composition {
 /// [`WireComposition`](crate::wire::request::WireComposition)
 /// snapshot. The daemon writes the snapshot at composition-assembly
 /// time and reads it back at spawn-from-disk so a restart re-applies
-/// the exact composition that was approved at `min activate` time.
+/// the exact composition that was approved at `min session activate` time.
 ///
 /// Fallible only on lifecycle hooks (a wire hook with no callbacks
 /// is rejected); vars, patches, and packages convert infallibly via

--- a/crates/sessions/src/store.rs
+++ b/crates/sessions/src/store.rs
@@ -161,7 +161,7 @@ pub trait Loader {
     /// Atomically persists the composition snapshot for the session
     /// at `key` (tmp + rename, same crash-safety as [`Self::save`]).
     /// Called at composition-assembly time so a restart can re-apply
-    /// the exact composition that was approved at `min activate` time.
+    /// the exact composition that was approved at `min session activate` time.
     ///
     /// # Errors
     ///

--- a/crates/sessions/src/wire/request.rs
+++ b/crates/sessions/src/wire/request.rs
@@ -39,7 +39,7 @@ pub struct WireContribution {
 /// Persisted composition snapshot, written by the daemon as a sidecar
 /// to [`record.json`](crate::store) at composition-assembly time so a
 /// restart can re-apply the exact [`Composition`] that was approved at
-/// `min activate` time.
+/// `min session activate` time.
 ///
 /// Mirrors [`Composition`](crate::core::compose::Composition) via the
 /// same wire primitives used for the live RPC flow

--- a/docs/concepts/loadouts.md
+++ b/docs/concepts/loadouts.md
@@ -38,7 +38,7 @@ conflict. (For the exact merge and conflict rules, see the
 [loadout reference](../reference/loadouts.md).)
 
 One boundary worth stating up front: loadouts apply to **sessions**
-(`min activate`). They do not apply to task sandboxes, which carry their own
+(`min session activate`). They do not apply to task sandboxes, which carry their own
 packages and environment through the task schema.
 
 ## Where loadouts live
@@ -92,7 +92,7 @@ TERM   = { inherit = true, default = "xterm-256color" }
 ```
 
 Vars are the main lever for interactive setup, because the shell you get from
-`min attach` sources no rc files. Your prompt (`PS1`), a one-time banner, and
+`min session attach` sources no rc files. Your prompt (`PS1`), a one-time banner, and
 similar touches all travel through `[vars]` rather than through a `.bashrc`
 patch. The [reference](../reference/loadouts.md) walks through the prompt and
 banner patterns in detail.
@@ -164,8 +164,8 @@ Name a loadout when you activate a session with `--loadout`, which is
 repeatable to stack several at once:
 
 ```console
-$ min activate --loadout dev
-$ min activate --loadout dev --loadout scratch
+$ min session activate --loadout dev
+$ min session activate --loadout dev --loadout scratch
 ```
 
 Loadouts are read and composed on the client, before the CLI contacts the
@@ -183,7 +183,7 @@ To activate with no loadouts at all, including skipping the defaults described
 below, pass `--no-loadouts` (which conflicts with `--loadout`):
 
 ```console
-$ min activate --no-loadouts
+$ min session activate --no-loadouts
 ```
 
 ## Auto-applying with `default_loadouts`
@@ -197,7 +197,7 @@ under a `[loadouts]` section:
 default_loadouts = ["dev", "fish"]
 ```
 
-With this in place, a plain `min activate` applies `dev` and `fish`
+With this in place, a plain `min session activate` applies `dev` and `fish`
 automatically. The defaults are a convenience layer, and the activation flags
 take precedence over them:
 
@@ -230,7 +230,7 @@ per-kind summary of what it contributes:
 ```
 
 Loadouts named in `default_loadouts` are marked with a leading `*`, so the
-listing doubles as a quick check of what a plain `min activate` will pull in.
+listing doubles as a quick check of what a plain `min session activate` will pull in.
 A malformed file is listed with its parse error so you can fix it in place
 rather than hunting for which file is broken. Pass `--dir <DIR>` to list a
 loadouts directory other than the default.

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -65,10 +65,10 @@ it.
 You create a session by **activating** a project. From the project directory:
 
 ```console
-$ min activate --attach
+$ min session activate --attach
 ```
 
-`min activate` takes a project path that defaults to the current directory.
+`min session activate` takes a project path that defaults to the current directory.
 `--attach` drops you straight into a shell in the new session once it is ready.
 Without `--attach`, activation prints the new session's id and returns, leaving
 the session ready in the background for you to attach to later.
@@ -104,13 +104,13 @@ Useful activation options:
 To enter a session that already exists, **attach** to it by id or name:
 
 ```console
-$ min attach my-session
+$ min session attach my-session
 ```
 
 Attach opens an interactive shell inside the session, with your tools on `PATH`
 and the session's workspace (your project files, uploaded at activation) as your
 working directory. Exiting the shell detaches: the session keeps running in the
-background, and `min attach` rejoins it later. Changes you make inside stay in
+background, and `min session attach` rejoins it later. Changes you make inside stay in
 the session's workspace; bring them back to the host by pushing them out with
 `git push min://<session>`.
 
@@ -119,7 +119,7 @@ To run a declared task non-interactively instead of opening a shell, pass
 invocations; arbitrary commands need an interactive shell:
 
 ```console
-$ min attach my-session -c 'min run test'
+$ min session attach my-session -c 'min run test'
 ```
 
 ## How a session is composed
@@ -185,17 +185,18 @@ scripting, and `--json` prints the full list as JSON.
 Rename a session:
 
 ```console
-$ min rename my-session backend-work
+$ min session rename my-session backend-work
 ```
 
 Destroy a session when you are finished with it:
 
 ```console
-$ min destroy my-session
+$ min session destroy my-session
 ```
 
-`min destroy` terminates a single session by id or name. `min destroy --all`
-tears down every session at once (add `--force` to skip the confirmation).
+`min session destroy` terminates a single session by id or name.
+`min session destroy --all` tears down every session at once (add `--force` to
+skip the confirmation).
 
 Stop the provider itself:
 
@@ -203,12 +204,13 @@ Stop the provider itself:
 $ min stop
 ```
 
-`min stop` shuts down the active provider. Stopping the provider ends
+`min stop` shuts down the active provider.
+Stopping the provider ends
 every running shell, but the sessions themselves survive: their records and
 workspaces persist, and a provider that comes back up re-hosts them (the extras
 composed from loadouts are rebuilt when you re-activate). The provider refuses
 to shut down while any session is busy (a live shell, or an activation in
-flight) unless you pass `--force`. Contrast this with `min destroy`, which
+flight) unless you pass `--force`. Contrast this with `min session destroy`, which
 removes one session entirely and leaves the provider running to host the rest.
 Because `min` auto-spawns a provider on demand, the next `min` command after a
 stop simply brings one back up.
@@ -244,7 +246,7 @@ test run, a linter) that executes in a freshly composed sandbox built from the
 packages that task needs. If a needed package is not present, Minimal builds it
 or fetches it from a remote cache first. Loadouts contribute to the session's
 interactive shell only, never to tasks, so your personal tooling cannot
-influence a task's deterministic execution. Running `min attach -c 'min run
+influence a task's deterministic execution. Running `min session attach -c 'min run
 <task>'` is the non-interactive way to trigger a declared task against a
 session; arbitrary commands need an interactive shell.
 

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -18,13 +18,13 @@ packages = ["claude-code", "base"]
 Then activate the session and run the agent inside it:
 
 ```shell
-$ min activate --attach .
+$ min session activate --attach .
 $ claude
 ```
 
 Claude Code launches inside the session with your project's source code and a read-only system containing the `claude-code` binary and core utilities from `base`. The session has no additional access to anything on your host system unless you explicitly declare it.
 
-Note that sessions are driven interactively: attaching needs a terminal, and the non-interactive `min attach -c` channel accepts only `min run <task>` invocations. Launch the agent from inside an attached shell as shown above, rather than scripting it from the host.
+Note that sessions are driven interactively: attaching needs a terminal, and the non-interactive `min session attach -c` channel accepts only `min run <task>` invocations. Launch the agent from inside an attached shell as shown above, rather than scripting it from the host.
 
 ## Adding more tools
 

--- a/docs/guide/dev-shell.md
+++ b/docs/guide/dev-shell.md
@@ -11,10 +11,10 @@ Your dev shell in Minimal is a **session**: a long-lived, isolated development e
 From your project directory, activate a session and attach to it in one step:
 
 ```shell
-$ min activate --attach .
+$ min session activate --attach .
 ```
 
-This creates a session for the project and drops you into its interactive shell. The path argument defaults to the current directory, so `min activate --attach` on its own works too.
+This creates a session for the project and drops you into its interactive shell. The path argument defaults to the current directory, so `min session activate --attach` on its own works too.
 
 Your project files are uploaded into the session's workspace, so the shell starts with a copy of your project. Edits you make inside stay in the session; bring them back to the host by pushing them out with `git push min://<session>` (or by committing inside the session and pulling from it).
 
@@ -87,9 +87,9 @@ on_activate = { type = "inline", value = "cargo fetch >/dev/null 2>&1 || true" }
 Exit the shell to detach; the session keeps running in the background. To reattach, list, or tear down sessions:
 
 ```shell
-$ min attach              # reattach to a session (resolves from the current directory)
-$ min ls                  # list sessions
-$ min destroy <session>   # terminate a session by name or id (or --all)
+$ min session attach            # reattach to a session (resolves from the current directory)
+$ min ls                        # list sessions
+$ min session destroy <session> # terminate a session by name or id (or --all)
 ```
 
 For running one-shot commands in their own sandbox rather than an interactive session, see [Tasks](./tasks.md).

--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -1,5 +1,5 @@
 ---
-description: Set up a project with min init, declare your session's tools in minimal.toml, then enter an isolated session with min activate.
+description: Set up a project with min init, declare your session's tools in minimal.toml, then enter an isolated session with min session activate.
 ---
 
 # Set up a project
@@ -30,7 +30,7 @@ use = "rust"
 [defaults]
 state_key = "dev"
 
-[session] # min attach
+[session] # min session attach
 packages = ["base", "vim", "git"]
 ```
 
@@ -44,7 +44,7 @@ packages = ["base", "vim", "git"]
 Edit the `packages` list under `[session]` to add whatever your team works with. Extend the existing list; do not add a second `[session]` table, since TOML does not allow a table to be defined twice.
 
 ```toml
-[session] # min attach
+[session] # min session attach
 packages = ["base", "vim", "git", "gh", "ripgrep", "claude-code"]
 ```
 
@@ -55,9 +55,9 @@ Every name resolves against the [Minimal Public Registry](https://github.com/gom
 Create and attach to an isolated session for the project:
 
 ```shell
-min activate --attach .
+min session activate --attach .
 ```
 
-Minimal builds or fetches the declared packages, composes them into a sandbox seeded with a copy of your project (streamed in as a tarball), and drops you into a shell inside it. The `[session]` tools are on your `PATH`, and nothing touches the host. Type `exit` to leave; the session stays up, so you can `min attach` back to it later.
+Minimal builds or fetches the declared packages, composes them into a sandbox seeded with a copy of your project (streamed in as a tarball), and drops you into a shell inside it. The `[session]` tools are on your `PATH`, and nothing touches the host. Type `exit` to leave; the session stays up, so you can `min session attach` back to it later.
 
 Next: [start a dev shell](./dev-shell.md), or [work alongside an agent](./agents.md).

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -14,7 +14,15 @@ Linux, or inside the [`minvmd`](./cli-minvmd.md) microVM host daemon on macOS
 subcommand resolves a session for the current directory (activating one if
 needed) and attaches to it.
 
-Generated from `--help` at `3a05252c`.
+Commands are spelled `min <noun> <verb>`, and every noun accepts its singular
+and plural form (`session`/`sessions`, `provider`/`providers`,
+`loadout`/`loadouts`). Bare `min` and a handful of bare verbs (`ls`, `stop`,
+`init`, `add`, `update`) survive at the top level as deliberate ergonomic
+exceptions, called out as such below; see
+[the CLI convention](./cli.md#command-naming-convention) for the rule and the
+full list of exceptions.
+
+Generated from `--help` at `cb29f065`.
 
 ## Global flags
 
@@ -42,10 +50,13 @@ JSON. When the daemon reports a shared resource pool, the table is headed
 by a `RESOURCE POOL:` line (CPU cores, memory, and the number of sessions
 sharing them); `--raw` omits it.
 
-### `activate`
+A deliberate exception to the `min <noun> <verb>` convention: `ls` is the
+highest-traffic command in the CLI and keeps its bare top-level form.
+
+### `session activate`
 
 ```
-min activate [OPTIONS] [PATH]
+min session activate [OPTIONS] [PATH]
 ```
 
 Activates (creates) a new session for the project at `PATH` (defaults to
@@ -60,28 +71,36 @@ the current directory).
 | `--no-prompt` | | Fail instead of prompting when the daemon surfaces items user policy can't auto-decide; implied when stdin/stderr isn't a TTY |
 | `--attach` | | Automatically attach after creation |
 
-### `attach`
+### `session attach`
 
 ```
-min attach [-c <COMMAND>] [SESSION]
+min session attach [-c <COMMAND>] [SESSION]
 ```
 
 Attaches to an existing session, identified by UUID or session name. When
-`SESSION` is omitted, `min attach` resolves a session from the current
+`SESSION` is omitted, `min session attach` resolves a session from the current
 working directory (or the only existing session) and opens an interactive
 picker if the choice is ambiguous (`--no-input` errors instead).
 `-c/--command` execs a command in the session context non-interactively
 instead of opening an interactive shell; the daemon accepts only
 `min run <task name>` invocations on this channel, not arbitrary commands.
 
-### `destroy`
+### `session destroy`
 
 ```
-min destroy [--all] [-f|--force] [SESSION]
+min session destroy [--all] [-f|--force] [SESSION]
 ```
 
 Destroys (terminates) a session. `--all` destroys all sessions;
 `-f/--force` skips the confirmation when destroying all sessions.
+
+### `session rename`
+
+```
+min session rename <SESSION> <NEW_NAME>
+```
+
+Renames an existing session.
 
 ### `stop`
 
@@ -90,7 +109,13 @@ min stop [-f|--force]
 ```
 
 Shuts down the `minimald` daemon. `--force` shuts down even if active
-sessions exist.
+sessions exist. This stops the daemon backend that hosts sessions, and the
+sessions themselves survive it (contrast
+[`session destroy`](#session-destroy), which removes one session and leaves the
+daemon running).
+
+`stop` stays bare at the top level — a deliberate exception to the
+`min <noun> <verb>` convention: it acts on the daemon, not on any session.
 
 ### `loadout list` (alias: `ls`)
 
@@ -135,14 +160,6 @@ name always loses to the allowlist), and every other env var is reported
 by name only. Session and project file contents are never included, only
 name/size listings. Review the archive before sharing.
 
-### `rename`
-
-```
-min rename <SESSION> <NEW_NAME>
-```
-
-Renames an existing session.
-
 ### `init`, `add`, `update`
 
 ```
@@ -155,6 +172,10 @@ Project-configuration conveniences mirroring the corresponding `mip`
 commands: initialize minimal configuration from your source tree, add a
 tool or dependency, and refresh local checkouts of upstream packages and
 the standard library. See the [mip reference](./cli-mip.md) for details.
+
+These three are deliberate exceptions to the `min <noun> <verb>` convention:
+they are passthroughs to the `mip` commands of the same name, and keeping the
+spelling identical across the two CLIs is worth more than the hierarchy.
 
 ### `version`
 
@@ -175,11 +196,11 @@ Generates a shell tab-completion script. Supported shells include `bash`, `zsh`,
 
 What it emits is a short *registration* shim, not a completion table: it teaches
 the shell to ask `min` itself what to offer. That indirection is what makes
-session arguments completable — `min attach <TAB>` lists live session names, and
-`min attach 019<TAB>` lists session IDs, neither of which exists at the time a
-static script would be written. Every argument documented as "UUID or session
-name" completes this way: `attach`, `destroy`, `rename`, `session policy`, and
-`ssh-forward`.
+session arguments completable — `min session attach <TAB>` lists live session
+names, and `min session attach 019<TAB>` lists session IDs, neither of which
+exists at the time a static script would be written. Every argument documented
+as "UUID or session name" completes this way: `session attach`,
+`session destroy`, `session rename`, `session policy`, and `ssh-forward`.
 
 Session completion is best-effort by design. It never starts a daemon — with
 none running there is nothing to list, and booting a VM on a keystroke would be

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,6 +26,37 @@ drive it directly with the **`mip`** CLI.
 | `minimald` | Host daemon: serves sessions to `min` over SSH-on-UDS | [minimald](./cli-minimald.md) |
 | `minvmd` | VM daemon: boots the Linux microVM that hosts `minimald` | [minvmd](./cli-minvmd.md) |
 
+## Command naming convention {#command-naming-convention}
+
+Commands are spelled **`<noun> <verb>`**: `min session activate`,
+`min session policy`, `min loadout list`, `mip package build`. The noun names
+the thing being acted on; the verb names the action.
+
+Three rules follow from that:
+
+1. **Every noun accepts its singular and plural form.** `session`/`sessions`,
+   `loadout`/`loadouts`, `package`/`packages` (which also keeps `pkg`). Both
+   spellings are visible in `--help`, so neither is a hidden alias you have to
+   know about.
+2. **Verbs are shared across nouns, not owned by one.** `list`, `stop`,
+   `build`, and friends mean the same thing wherever they appear, so
+   `<noun> list` is guessable for any noun that has a list.
+3. **New surface gets a noun.** Reach for an existing noun before inventing
+   one; a genuinely new kind of thing gets a new noun rather than a new bare
+   verb at the top level.
+
+### Documented exceptions
+
+A few high-traffic forms stay bare at the top level. These are deliberate
+ergonomic choices, not leftovers — do not "fix" them:
+
+| Form | Why it stays |
+|------|--------------|
+| `min` (no subcommand) | Resolve-or-activate-and-attach for the current directory: the single most common thing anyone does with `min`. |
+| `min ls` | The highest-traffic command in the CLI; the break is not worth the consistency. |
+| `min stop` | Acts on the daemon backend rather than any session, and is the daemon-lifecycle command people reach for. |
+| `min init`, `min add`, `min update` | Passthroughs to the `mip` commands of the same name; keeping the spelling identical across the two CLIs beats the hierarchy. |
+
 ## Platform availability
 
 - **Linux**: installs ship `min`, `mip`, and `minimald`. `minimald` runs

--- a/docs/reference/linux-host-setup.md
+++ b/docs/reference/linux-host-setup.md
@@ -23,7 +23,7 @@ DIAG hakoniwa container/process exited non-zero code=125 exit_code=None
   reason=write("/proc/self/uid_map", ..) => Operation not permitted (os error 1)
 ```
 
-`min attach` shows this as a session that closes immediately. The daemon
+`min session attach` shows this as a session that closes immediately. The daemon
 also preflights this at startup: on a host that will refuse the namespace it
 logs a `sessions will fail to start` warning naming the restriction and this
 fix, so check the daemon log first. Confirm the host is the cause; this needs

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -13,7 +13,7 @@ session needs; a loadout carries what *you* want on top (your editor,
 terminal multiplexer, shell config, and dotfiles) so each development
 environment comes up matching your muscle memory.
 
-Loadouts apply to sessions (`min activate`); they are not used by task
+Loadouts apply to sessions (`min session activate`); they are not used by task
 sandboxes, which have their own `packages`/`env_vars`/`patches` schema
 described in [Tasks](./tasks.md).
 
@@ -76,7 +76,7 @@ on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || 
 ```
 
 Saved as `<config>/minimal/loadouts/dev.toml`, this is applied with
-`min activate --loadout dev`, or automatically via
+`min session activate --loadout dev`, or automatically via
 [`default_loadouts`](#client-config).
 
 ## Loadout schema
@@ -234,7 +234,7 @@ follow_symlinks = true
 
 ## Selecting loadouts at activation
 
-[`min activate`](./cli-min.md#activate) decides which loadouts to apply
+[`min session activate`](./cli-min.md#session-activate) decides which loadouts to apply
 from two flags:
 
 | Flag | Description |
@@ -330,7 +330,7 @@ file means an empty policy; a fresh install activates fine without it.
 
 ## Vars in the attach shell
 
-The interactive shell minted by [`min attach`](./cli-min.md#attach) is
+The interactive shell minted by [`min session attach`](./cli-min.md#session-attach) is
 `bash --noprofile -l`, a login shell that sources **no** startup files
 (not `/etc/profile`, `~/.bash_profile`, or `~/.bashrc`), so rc-file
 patches cannot influence it. Interactive setup travels through the

--- a/docs/reference/minimal-dot-toml.md
+++ b/docs/reference/minimal-dot-toml.md
@@ -124,7 +124,7 @@ When set, `defaults.state_key` will set a state key on all tasks which do not se
 ### `[session]` - What every contributor's session gets {#session}
 
 Contributes to [sessions](https://docs.minimal.dev/concepts/sessions) activated
-on this project (`min activate`). It carries the same primitives as a
+on this project (`min session activate`). It carries the same primitives as a
 [loadout](./loadouts.md) (packages, vars, patches, lifecycle hooks), scoped to
 the project rather than the developer: where a loadout says "what this
 developer wants everywhere", the session block says "what every session

--- a/justfile
+++ b/justfile
@@ -348,7 +348,7 @@ soak n="10": _kvm artifacts gvproxy initramfs minimal-cli minvmd-build
 
 # Each pass uploads a 49 MiB project (~13 MB on the wire) and destroys its session.
 #
-# Bulk host→guest upload proof (#869): N `min activate`s of a large, compressible project.
+# Bulk host→guest upload proof (#869): N `min session activate`s of a large, compressible project.
 bulk-upload n="5": _kvm artifacts gvproxy initramfs minimal-cli minvmd-build
     {{e2e-env}} MINVMD_GVPROXY_BIN="{{gvproxy}}" ./scripts/bulk-upload-e2e.sh {{n}}
 
@@ -409,7 +409,7 @@ up: minimald-build minimal-cli gvproxy && (_smoke "--minimal-dir" native-dir)
     # `activate` sandbox dies at uid_map EPERM until it's installed.
     just _userns-check || true
     echo "up: host-native minimald at $sock (pid $(cat "$pidf"))"
-    echo "  own-IP demo: min --minimal-dir {{native-dir}} activate -n net1 --network own-ip . && min --minimal-dir {{native-dir}} attach net1"
+    echo "  own-IP demo: min --minimal-dir {{native-dir}} session activate -n net1 --network own-ip . && min --minimal-dir {{native-dir}} session attach net1"
 
 # Bring the stack up: native Linux + one Linux VM over KVM (stop with `just stop`).
 [linux]

--- a/scripts/bulk-upload-e2e.sh
+++ b/scripts/bulk-upload-e2e.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Bulk host→guest upload proof: `min activate` a project carrying a large,
+# Bulk host→guest upload proof: `min session activate` a project carrying a large,
 # COMPRESSIBLE fixture, N times, and fail if ANY attempt errors or hangs.
 #
 # Regression cover for the vsock transport reset in
 # https://github.com/gominimal/minimal/issues/869. A guest kernel bump
 # (6.12.43 → 6.12.94, https://github.com/gominimal/pkgs/pull/311) crossed Linux
 # 6.12.92, where a new queued-skb-overhead check turned a previously silent
-# vsock protocol violation into a fatal connection reset. Every `min activate`
+# vsock protocol violation into a fatal connection reset. Every `min session activate`
 # carrying a real project failed from that day on, and NOTHING went red for
 # three weeks — no test we had moves enough data through the guest vsock to
 # trip it. Client side the signature is:
@@ -138,7 +138,7 @@ mnl() {
 # worse than no canary. Sessions first — `min stop` refuses while any is live
 # unless forced, and the fixture dir goes whether or not the daemon cooperates.
 teardown() {
-  mnl destroy --all --force >/dev/null 2>&1 || true
+  mnl session destroy --all --force >/dev/null 2>&1 || true
   mnl stop --force >/dev/null 2>&1 || true
   if [ -n "$E2E_VM" ]; then
     minvmd stop >/dev/null 2>&1 || true
@@ -191,7 +191,7 @@ diagnostics() {
 # because `timeout` is not on a stock macOS, and because running the VM stack
 # under it wedges the boot: libkrun tcsetattr()s from timeout's background
 # process group and SIGTTOU stops the group. </dev/null is load-bearing for the
-# same reason — and it is also what puts `min activate` in its non-interactive
+# same reason — and it is also what puts `min session activate` in its non-interactive
 # mode, where it neither prompts for the non-VCS upload confirmation (#770) nor
 # expects a keypress for policy gating.
 run_deadline() {
@@ -287,7 +287,7 @@ else
 fi
 echo "::endgroup::"
 
-# `min activate` uploads the CURRENT directory, not the path argument (#873),
+# `min session activate` uploads the CURRENT directory, not the path argument (#873),
 # so the project dir has to be the cwd. Everything else here is absolute.
 cd "$PROJECT_DIR" || { echo "::error::cannot cd into $PROJECT_DIR"; exit 1; }
 
@@ -309,7 +309,7 @@ for i in $(seq 1 "$ITER"); do
   echo "::group::bulk upload $i/$ITER (${FIXTURE_MIB} MiB project)"
   # shellcheck disable=SC2086
   run_deadline "$DEADLINE_SECS" \
-    min ${E2E_MINIMAL_ARGS:-} activate . >"$WORK/activate.out" 2>"$WORK/activate.err"
+    min ${E2E_MINIMAL_ARGS:-} session activate . >"$WORK/activate.out" 2>"$WORK/activate.err"
   rc=$?
 
   sid="$(tail -n1 "$WORK/activate.out" 2>/dev/null | tr -d '\r')"
@@ -319,7 +319,7 @@ for i in $(seq 1 "$ITER"); do
     echo "iteration $i: OK (session $sid)"
     # Destroy as we go: one live session at a time, and nothing to leak if the
     # run is cancelled mid-loop.
-    mnl destroy "$sid" >/dev/null 2>&1 \
+    mnl session destroy "$sid" >/dev/null 2>&1 \
       || echo "::warning::could not destroy session $sid (the teardown sweep will retry)"
   else
     fail=$((fail + 1))
@@ -327,15 +327,15 @@ for i in $(seq 1 "$ITER"); do
     # the run, and folding them into a collapsed group buries them.
     echo "::endgroup::"
     if [ "$rc" -eq 124 ]; then
-      echo "::error::iteration $i: 'min activate' still running after ${DEADLINE_SECS}s — the #869 hang"
+      echo "::error::iteration $i: 'min session activate' still running after ${DEADLINE_SECS}s — the #869 hang"
     elif [ "$rc" -eq 0 ]; then
       echo "::error::iteration $i: activate's last stdout line is not a session UUID: '$sid'"
     else
-      echo "::error::iteration $i: 'min activate' exited $rc — check for 'Failed to upload project files: copying tar stream to channel: channel closed' (https://github.com/gominimal/minimal/issues/869)"
+      echo "::error::iteration $i: 'min session activate' exited $rc — check for 'Failed to upload project files: copying tar stream to channel: channel closed' (https://github.com/gominimal/minimal/issues/869)"
     fi
     diagnostics
     # Sweep whatever a failed activate left half-created before the next pass.
-    mnl destroy --all --force >/dev/null 2>&1 || true
+    mnl session destroy --all --force >/dev/null 2>&1 || true
     # A hang costs a full deadline; five of them would burn the nightly's whole
     # budget, and one is already conclusive. Errors are cheap, so keep going —
     # the pass/fail tally is what identifies the ~89% signature.

--- a/scripts/e2e-attach-pty.py
+++ b/scripts/e2e-attach-pty.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Drive an interactive `min attach` over a REAL pty, like a user at a terminal.
+"""Drive an interactive `min session attach` over a REAL pty, like a user at a terminal.
 
 The session-exit path shows a Detach/Delete prompt (`async_dialog::Select`) and
 reads the answer as keystrokes from the channel. A piped stdin cannot answer it
@@ -10,7 +10,7 @@ interactive teardown a user performs.
 
 Usage: e2e-attach-pty.py <add_tool> <argv...>
   <add_tool>  package to `min add` (also its binary + `--version` subject)
-  <argv...>   the command to spawn under the pty, e.g. `min --provider local-minvmd attach <sid>`
+  <argv...>   the command to spawn under the pty, e.g. `min --provider local-minvmd session attach <sid>`
 
 Prints the full captured terminal output on stdout. Exits 0 iff the attach
 process exited 0.

--- a/scripts/kernel-bump-review.sh
+++ b/scripts/kernel-bump-review.sh
@@ -12,7 +12,7 @@
 # plane lands unreviewed. That is how 6.12.43 -> 6.12.94 shipped a4f0b001782b
 # ("vsock/virtio: reset connection on receiving queue overflow"), which turned a
 # silently-dropped packet into a fatal connection reset and broke every sizeable
-# `min activate` for three weeks. The commit is public, its subject says exactly
+# `min session activate` for three weeks. The commit is public, its subject says exactly
 # what it does, and it sits in net/vmw_vsock/ — the subtree the entire guest
 # control plane rides on. A mechanical diff was all that was needed to catch it,
 # with no VM and no test run. This is that diff.

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -9,7 +9,7 @@
 #
 # Two proofs, in order, on EVERY lane:
 #
-#  1. Lifecycle: from a guaranteed-clean state, `min activate` must auto-spawn
+#  1. Lifecycle: from a guaranteed-clean state, `min session activate` must auto-spawn
 #     the target's daemon and create a session; then list, warm-call, destroy
 #     (verified delisted), and a clean `min stop` that the next command
 #     auto-respawns from.
@@ -33,7 +33,7 @@
 #     tears the session down, so it must be delisted afterwards. The same daemon
 #     prompt runs whether local or in-guest, so the pty driver covers every lane.
 #
-# Host-side project seed: `min activate` runs client-side and, since #758,
+# Host-side project seed: `min session activate` runs client-side and, since #758,
 # BAILS (rather than scaffolding over an existing config) when the target dir
 # has no `minimal.toml` and stdin is non-interactive; and since #748 it UPLOADS
 # the project dir into the session. So we activate a small, self-seeded dir
@@ -53,7 +53,7 @@
 #   E2E_MINIMAL_ARGS    global args for every `min` call (e.g. --provider local-minvmd)
 #   E2E_PROJECT_DIR     project to activate (default: a self-seeded throwaway
 #                       dir; VM lanes pass /tmp)
-#   E2E_ACTIVATE_ARGS   extra args for `min activate` (e.g. a future
+#   E2E_ACTIVATE_ARGS   extra args for `min session activate` (e.g. a future
 #                       `--loadout dev` once the loadouts CLI lands, #686)
 #   E2E_VM              set to 1 for VM-backed targets (extra teardown +
 #                       diagnostics: minvmd stop, guest boot log)
@@ -75,7 +75,7 @@ E2E_VM="${E2E_VM:-}"
 ADD_TOOL="jq"
 ADD_TOOL_MARKER="jq-1"
 
-# Resolve + seed the project to activate. Since #748, `min activate` UPLOADS the
+# Resolve + seed the project to activate. Since #748, `min session activate` UPLOADS the
 # project dir into the session, so the target must (a) carry a `minimal.toml`
 # (also what the #758 client pre-flight requires) and (b) stay SMALL, as the
 # whole dir is uploaded. SEED_DIR is a throwaway we created and remove wholesale
@@ -115,7 +115,7 @@ if [ -n "$SEED_DIR" ] || { [ ! -e "$PROJECT_DIR/minimal.toml" ] && [ ! -e "$PROJ
     ' "$ROOT/.minimal/minimal.toml"
     printf '\n[stack]\nuse = "shell"\n'
   } > "$PROJECT_DIR/minimal.toml"
-  # The upstream MUST be pinned — `min activate` uploads this and the graph
+  # The upstream MUST be pinned — `min session activate` uploads this and the graph
   # loader rejects an unpinned upstream.
   if ! grep -q '^\[upstream\]' "$PROJECT_DIR/minimal.toml" \
      || ! grep -q '^locked_commit' "$PROJECT_DIR/minimal.toml"; then
@@ -240,14 +240,14 @@ if [ -z "$E2E_VM" ] && [ "$(uname -s)" = Linux ] \
   fi
 fi
 
-# Cold: `min activate` must auto-spawn the target's daemon and print the
+# Cold: `min session activate` must auto-spawn the target's daemon and print the
 # new session id on stdout. The id is the LAST stdout line (any log lines
 # that slip through the RUST_LOG filter precede it), validated as a UUID.
 echo "::group::cold activate (auto-spawns the daemon)"
 t0=$(now_ms)
 # shellcheck disable=SC2086
-activate_out="$(cd "$PROJECT_DIR" && mnl activate . ${E2E_ACTIVATE_ARGS:-} 2>"$WORK/activate.err")" \
-  || { echo "::error::cold 'min activate' failed to auto-spawn the daemon / create a session"; fail; }
+activate_out="$(cd "$PROJECT_DIR" && mnl session activate . ${E2E_ACTIVATE_ARGS:-} 2>"$WORK/activate.err")" \
+  || { echo "::error::cold 'min session activate' failed to auto-spawn the daemon / create a session"; fail; }
 t1=$(now_ms)
 sid="$(printf '%s\n' "$activate_out" | tail -n1 | tr -d '\r')"
 echo "session: $sid (cold activate: $((t1 - t0))ms)"
@@ -286,11 +286,11 @@ echo "::group::sandbox proof (interactive attach via pty: min add $ADD_TOOL + ru
 t0=$(now_ms)
 # shellcheck disable=SC2086
 attach_out="$(python3 "$ROOT/scripts/e2e-attach-pty.py" "$ADD_TOOL" \
-  min ${E2E_MINIMAL_ARGS:-} attach "$sid" 2>"$WORK/exec.err")"
+  min ${E2E_MINIMAL_ARGS:-} session attach "$sid" 2>"$WORK/exec.err")"
 rc=$?
 t1=$(now_ms)
 if [ "$rc" -ne 0 ]; then
-  echo "::error::interactive 'min attach $sid' (pty) exited $rc (expected 0)"
+  echo "::error::interactive 'min session attach $sid' (pty) exited $rc (expected 0)"
   echo "--- attach output ---"; printf '%s\n' "$attach_out"
   echo "--- driver stderr ---"; cat "$WORK/exec.err" 2>/dev/null || true
   fail

--- a/scripts/stress-session-e2e.sh
+++ b/scripts/stress-session-e2e.sh
@@ -25,7 +25,7 @@ esac
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 E2E_VM="${E2E_VM:-}"
 # Resolve + seed a SMALL pinned project to activate, exactly as session-e2e.sh
-# does: `min activate` uploads the dir, so it must carry a pinned [upstream] +
+# does: `min session activate` uploads the dir, so it must carry a pinned [upstream] +
 # a light `shell` stack and stay small. All N activates share this one dir (each
 # still mints a distinct session); a dir we create is removed wholesale on exit.
 SEED_DIR=""
@@ -107,7 +107,7 @@ echo "::group::mint $N sessions concurrently (cold start)"
 pids=""
 for i in $(seq 1 "$N"); do
   (
-    out="$(cd "$PROJECT_DIR" && mnl activate . 2>"$WORK/activate.$i.err")"
+    out="$(cd "$PROJECT_DIR" && mnl session activate . 2>"$WORK/activate.$i.err")"
     printf '%s\n' "$out" | tail -n1 | tr -d '\r' > "$WORK/activate.$i.out"
   ) &
   pids="$pids $!"


### PR DESCRIPTION
**Breaking change to the `min` command surface.** Second slice of the
`<noun> <verb>` sweep started by #976, which did the `mip package` half.

## Old → new

| Old | New |
|---|---|
| `min activate` | `min session activate` |
| `min attach` | `min session attach` |
| `min destroy` | `min session destroy` |
| `min rename` | `min session rename` |
| — | `min session policy` (unchanged, already noun-first) |

Unchanged by deliberate decision, and commented in the source as exceptions so
a later reader does not "fix" them:

- `min` with no subcommand — resolve-or-activate-and-attach, the most common
  thing anyone does with the CLI
- `min ls` — the highest-traffic command; the break is not worth the consistency
- `min stop` — acts on the daemon backend rather than any session, and is the
  daemon-lifecycle command people reach for
- `min init`, `min add`, `min update` — passthroughs to the `mip` commands of
  the same name; keeping the spelling identical across the two CLIs beats the
  hierarchy

Nouns accept singular and plural as a visible alias: `session`/`sessions`,
`loadout`/`loadouts`.

## The convention is written down

`docs/reference/cli.md` gains a **Command naming convention** section: the
`<noun> <verb>` rule, singular/plural aliasing, verbs shared across nouns
rather than owned by one, and a table of the documented exceptions above. This
is the part that stops the convention being re-derived from the command tree
every time someone adds a command.

## Verification

| Check | Result |
|---|---|
| `just ci` (darwin scope) | green — 521 tests, doctests ok |
| `just e2e` (VM-backed session e2e over HVF) | green — cold activate, warm `min ls`, sandbox proof (pty attach + `min add jq` + run) |
| `cargo build -p minimal` | green |
| `cargo clippy -p minimal` | green (the `sandbox2` dead-code findings are pre-existing on darwin — identical on clean `main`) |

`just e2e` is the check that matters here: `scripts/session-e2e.sh` drives the
renamed commands for real, so it proves the re-parenting end to end.

Not verifiable on macOS, left to CI: the `crates/minimald` call-site updates
(the crate does not build on darwin).

## Callers swept

`scripts/session-e2e.sh`, `scripts/bulk-upload-e2e.sh`,
`scripts/stress-session-e2e.sh`, `scripts/e2e-attach-pty.py`,
`scripts/kernel-bump-review.sh`, `justfile`, `crates/mctx`, `crates/minimald`,
`crates/op`, `crates/sessions`, `AGENTS.md`, `README.md`, and the docs tree.

## Out of scope

- Renaming the runnable unit defined in `minimal.toml` (`sandbox` vs `session`
  vs `task`) — still undecided, and it gates the shape of the run path.

## Note for reviewers

An earlier revision of this branch introduced a `provider` noun, making
`min provider stop` the long form with `min stop` as a shortcut. That has been
dropped: `stop` stays a plain top-level command. There is no `provider` noun.

Refs: #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-parent session verbs under `min session` noun in the CLI
> - Session lifecycle commands (`activate`, `attach`, `destroy`, `rename`, `policy`) are moved from top-level `min <verb>` to `min session <verb>` (with `sessions` as a visible alias); `ls` and `stop` remain at the top level.
> - All error messages, docs, scripts, and generated config comments are updated to reference the new `min session ...` forms.
> - Behavioral Change: the old top-level verbs (`min activate`, `min attach`, etc.) are no longer recognized; callers must use the new `min session <verb>` form.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f79f504.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / CLI Updates**
  * Session management commands now use the consistent `min session ...` format (activate, attach, rename, destroy), with corresponding help and error guidance updated when session arguments are omitted or ambiguous.
* **Documentation**
  * Updated guides, references, examples, and generated configuration/comment text to use `min session activate`/`min session attach` everywhere, plus added CLI command naming convention documentation and clarified top-level exceptions.
* **Tests**
  * Updated CLI and diagnostic tests to match the corrected `min session ...` command wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->