### PR TITLE
feat(installer): ask before an upgrade ends live sessions

### DIFF
--- a/crates/common/tests/installer_stop_signal.rs
+++ b/crates/common/tests/installer_stop_signal.rs
@@ -1,0 +1,72 @@
+//! Convention-discovered gate pinning the one string the installer shares with
+//! the `min` CLI.
+//!
+//! `scripts/install.sh` decides whether a `curl … | sh` upgrade is about to
+//! destroy live work by matching `min stop`'s refusal message, not its exit
+//! status (a bare non-zero also means no daemon, a failed connect, or a `min`
+//! too old to know the subcommand). That reuses the CLI's existing signal
+//! rather than adding a parallel session check, but it couples a shell literal
+//! to a Rust one across crates with nothing in between. Reword the `bail!` and
+//! the installer silently stops asking and goes back to force-stopping every
+//! upgrade — the exact bug the prompt exists to prevent, with every installer
+//! test still green, because the harness stubs `min` with its own copy of the
+//! string and so cannot notice.
+//!
+//! Both files are read as text: this asserts the contract without `common`
+//! taking a dependency on `minimal` or on the installer. It lives beside
+//! `shell_lint.rs` for the same reason that one does — the workspace test run
+//! is the reviewed-code extension point CI schedules over
+//! (docs/ci-strategy.md §10), and `.github/workflows/` is frozen.
+
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is crates/common; the workspace root is two up.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root two levels above crates/common")
+        .to_path_buf()
+}
+
+#[test]
+fn installer_matches_the_message_the_cli_actually_prints() {
+    let root = repo_root();
+
+    let installer_path = root.join("scripts/install.sh");
+    let installer =
+        std::fs::read_to_string(&installer_path).expect("failed to read scripts/install.sh");
+
+    // The assignment the installer matches on, e.g.
+    //   sessions_live_msg='daemon has active sessions'
+    let needle = installer
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("sessions_live_msg='"))
+        .and_then(|rest| rest.strip_suffix('\''))
+        .unwrap_or_else(|| {
+            panic!(
+                "no `sessions_live_msg='…'` assignment in {}; the upgrade prompt's signal moved \
+                 or was renamed, and this gate must move with it",
+                installer_path.display()
+            )
+        });
+
+    assert!(
+        !needle.is_empty(),
+        "sessions_live_msg is empty: every `min stop` failure would match it and every upgrade \
+         with a stopped daemon would prompt"
+    );
+
+    let cli_path = root.join("crates/minimal/src/lib.rs");
+    let cli = std::fs::read_to_string(&cli_path).expect("failed to read crates/minimal/src/lib.rs");
+
+    assert!(
+        cli.contains(needle),
+        "scripts/install.sh gates the upgrade prompt on the substring {needle:?}, which no longer \
+         appears in {}. `min stop`'s active-sessions refusal is the installer's only signal that \
+         an upgrade is about to end live sessions; with the wording changed the installer stops \
+         asking and force-stops the daemon unconditionally. Update the literal on both sides \
+         together.",
+        cli_path.display(),
+    );
+}

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -60,8 +60,12 @@ that changed, swapping them into place atomically.
 Note: upgrading restarts the Minimal daemon, which interrupts any sessions that
 are currently active. When sessions are running, the installer lists them and
 asks on your terminal before ending them; declining leaves everything as it was.
-For a scripted upgrade that must not stop to ask, pass `--force-stop` (or set
-`MINIMAL_INSTALL_FORCE_STOP=1`).
+For a scripted upgrade that must not stop to ask, set
+`MINIMAL_INSTALL_FORCE_STOP=1`, or pass the flag through the shell:
+
+```shell
+curl --proto "=https" --tlsv1.2 -fsSL https://go.minimal.dev/stable | sh -s -- --force-stop
+```
 
 ## Uninstall
 

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -58,7 +58,10 @@ installed component against the current release and re-downloads only the ones
 that changed, swapping them into place atomically.
 
 Note: upgrading restarts the Minimal daemon, which interrupts any sessions that
-are currently active. Detach first, or expect to reattach after the upgrade.
+are currently active. When sessions are running, the installer lists them and
+asks on your terminal before ending them; declining leaves everything as it was.
+For a scripted upgrade that must not stop to ask, pass `--force-stop` (or set
+`MINIMAL_INSTALL_FORCE_STOP=1`).
 
 ## Uninstall
 

--- a/docs/specs/07-spec-installer/07-spec-installer.md
+++ b/docs/specs/07-spec-installer/07-spec-installer.md
@@ -278,8 +278,11 @@ outcome an upgrade must not decide on the user's behalf: it means live work is
 about to be destroyed. The installer then lists the running sessions
 (`<bin>/min ls`), asks whether to end them, and only on an explicit yes runs
 `<bin>/min stop --force` and carries on. A declined upgrade exits non-zero
-before the first replacement, dropping the temp download and leaving the daemon,
-its sessions, the installed files, and the install record exactly as they were.
+before the first **executable** replacement, dropping the temp download and
+leaving the daemon, its sessions, every installed executable, and the install
+record exactly as they were. It claims no more than that: the stop is attempted
+at the first `bin`/`lib` component, so a `data` component ordered ahead of it in
+the manifest may already have been replaced.
 
 The question is asked on the **controlling terminal**, never on stdin: in a
 `curl … | sh` pipeline stdin is the script itself, so reading the answer there
@@ -342,8 +345,14 @@ both hash columns in place of digests.
   on the terminal (a stand-in for `/dev/tty`, since stdin is the script pipe);
   answering yes escalates to `stop --force` and completes the upgrade.
 - **Test** (R5.5): answering no exits non-zero, never runs `stop --force`,
-  leaves the stale component and no temp file behind, and says nothing was
-  installed.
+  leaves the stale component and no temp file behind, and reports that no
+  executable was replaced.
+- **Test** (R5.5): the refusal message the installer matches on is asserted, by
+  the workspace test suite, to still be present in the CLI source that prints
+  it. The signal crosses a language boundary with nothing else holding the two
+  ends together, and a reword on the CLI side would otherwise return every
+  upgrade to an unconditional force-stop with the installer's own tests — which
+  supply their own copy of the message — still green.
 - **Test** (R5.5): with the same refusal and no openable terminal, the run exits
   non-zero naming the escape hatch, without prompting, force-stopping, or
   installing anything.

--- a/docs/specs/07-spec-installer/07-spec-installer.md
+++ b/docs/specs/07-spec-installer/07-spec-installer.md
@@ -80,6 +80,9 @@ on tools present by default on every target: a downloader (`curl` **or**
   components that actually changed are downloaded.
 - **As a minimal employee**, I pass `unstable` as an argument and get the
   bleeding-edge version through the identical mechanism.
+- **As a user with long-running sessions**, an upgrade tells me what is running
+  and asks before it ends any of it, so I decide whether the upgrade is worth
+  the work it costs; scripted upgrades pass a flag and never stop to ask.
 
 ## Demoable Units of Work
 
@@ -111,7 +114,10 @@ exits with a clear error.
 
 **R2.1**, The script takes an optional first argument, the **target**,
 defaulting to `stable`. The target is validated against `^[A-Za-z0-9._-]+$`
-before use; a value containing any other character exits with an error.
+before use; a value containing any other character exits with an error. Install
+mode's one option, `--force-stop` (R5.5), is recognized wherever it appears in
+the arguments and removed from them before the target is read, so the target
+stays the sole positional on either side of the flag.
 
 **R2.2**, The script fetches `<BUCKET>/<target>` to obtain a version string.
 The result is validated against `^[A-Za-z0-9._-]+$` (command substitution having
@@ -260,19 +266,41 @@ mv -f "$target.tmp.$$" "$target"
 
 **R5.5**, Installing a new version over a **running daemon** wedges it: the
 daemon goes on serving from the old image while the newly-installed `min` speaks
-to it. Before the first component file is replaced, the installer therefore runs
-`<bin>/min stop --force`, the `min` **already on disk**, which is the build that
-matches the daemon it started and is the one about to be overwritten. `--force`
-because an upgrade must not be blocked by live sessions, and because a prompt is
-not available in a `curl … | sh` pipeline.
+to it. Before the first component file is replaced, the installer therefore stops
+it with the `min` **already on disk**, which is the build that matches the daemon
+it started and is the one about to be overwritten. Only `<bin>/min` is ever run,
+never a `min` found on `$PATH`, which is not this installer's footprint.
 
-The step is **best-effort and silent**, output discarded and exit status ignored:
-"no `min` installed yet" (a fresh install), "no daemon running" (`min stop`
-merely connects; it never autospawns, so this is a failed connect and nothing
-more), and "the installed `min` is too old to know `stop --force`" are all just
-*nothing to stop*, and none may fail an install whose binaries are otherwise
-fine. Only `<bin>/min` is ever run, never a `min` found on `$PATH`, which is not
-this installer's footprint.
+The stop is **graceful first**: `<bin>/min stop`, which succeeds when nothing is
+running and refuses while sessions are live. That refusal, recognized by the
+message the CLI prints for it rather than by a bare non-zero exit, is the one
+outcome an upgrade must not decide on the user's behalf: it means live work is
+about to be destroyed. The installer then lists the running sessions
+(`<bin>/min ls`), asks whether to end them, and only on an explicit yes runs
+`<bin>/min stop --force` and carries on. A declined upgrade exits non-zero
+before the first replacement, dropping the temp download and leaving the daemon,
+its sessions, the installed files, and the install record exactly as they were.
+
+The question is asked on the **controlling terminal**, never on stdin: in a
+`curl … | sh` pipeline stdin is the script itself, so reading the answer there
+would consume it. Where no controlling terminal can be opened (CI, any
+non-interactive invocation) there is nobody to consent, so the installer exits
+non-zero naming the escape hatch instead of hanging on a read or ending sessions
+unasked. That escape hatch — a `--force-stop` argument, or a non-empty
+`MINIMAL_INSTALL_FORCE_STOP` in the environment for a pipeline with no argv —
+skips both the graceful stop and the question and force-stops outright, so
+scripted upgrades never block. It is deliberately not spelled `--force`, which
+already means "remove modified files too" in uninstall mode.
+
+Every other outcome stays **best-effort and silent**, output discarded and exit
+status ignored: "no `min` installed yet" (a fresh install), "no daemon running"
+(`min stop` merely connects; it never autospawns, so this is a failed connect
+and nothing more), "the installed `min` is too old to know `stop`", and a
+transport drop on an otherwise successful stop are all just *nothing to stop*.
+None of them may fail an install whose binaries are otherwise fine, and none of
+them may raise the question — treating a bare failure as "sessions are live"
+would make every upgrade ask one. They fall through to the force stop, which
+remains unconditional for them.
 
 It is attempted **at most once per run**, and only from the path that actually
 replaces a file: a rerun where every component is already up to date, or a run
@@ -303,11 +331,25 @@ both hash columns in place of digests.
   it, the recorded installed hash does not mask a new release.
 - **Test** (R5.5): a fresh install stops nothing (no `min` on disk yet) and an
   up-to-date rerun stops nothing (nothing replaced); an upgrade whose components
-  are stale runs the on-disk `min` with exactly `stop --force`, once, however
-  many components it replaces.
+  are stale runs the on-disk `min` with exactly `stop`, once, however many
+  components it replaces, never escalating to `--force` and never asking
+  anything when the graceful stop succeeds.
 - **Test** (R5.5): an installed `min` whose `stop` exits non-zero and writes to
   both stdout and stderr still yields exit 0, leaks neither stream into the
-  installer's output, and completes the upgrade.
+  installer's output, asks nothing, and completes the upgrade.
+- **Test** (R5.5): an on-disk `min` whose graceful `stop` refuses with the
+  active-sessions message makes the installer list the running sessions and ask
+  on the terminal (a stand-in for `/dev/tty`, since stdin is the script pipe);
+  answering yes escalates to `stop --force` and completes the upgrade.
+- **Test** (R5.5): answering no exits non-zero, never runs `stop --force`,
+  leaves the stale component and no temp file behind, and says nothing was
+  installed.
+- **Test** (R5.5): with the same refusal and no openable terminal, the run exits
+  non-zero naming the escape hatch, without prompting, force-stopping, or
+  installing anything.
+- **Test** (R5.5): the escape hatch, given as an argument or through the
+  environment, force-stops without a graceful attempt and without asking, and
+  completes the upgrade; given after the target, the target still resolves.
 - **Test** (R5.6): a `symlink` component lands as a symlink at its `dest`
   pointing at the manifest target, with no download; a rerun skips it, and a
   retargeted link is repaired on the next run, still with no download.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,13 @@
 # Usage:
 #   curl --proto '=https' --tlsv1.2 -fsSL <URL>/install.sh | sh
 #   curl … | sh -s -- unstable          # pick a non-default target
+#   curl … | sh -s -- --force-stop      # stop live sessions without asking
 #   curl … | sh -s -- --uninstall       # remove what a prior run installed
+#
+# An upgrade must stop the running daemon before it swaps its binaries (R5.5).
+# When that daemon has active sessions the installer asks on the terminal before
+# ending them; --force-stop (or a non-empty MINIMAL_INSTALL_FORCE_STOP) skips the
+# question, for scripted upgrades that must not block.
 #
 # Uninstall walks the local install record (no network) and removes each file
 # whose on-disk bytes still match what the installer recorded writing; it accepts
@@ -62,6 +68,13 @@ MODE=install
 uninstall_force=0
 uninstall_purge=0
 dry_run=0
+# Install mode's escape hatch for the active-sessions prompt (R5.5), settable by
+# flag or environment because `curl … | sh` makes argv awkward. Deliberately NOT
+# named --force: that flag already means "remove modified files" in uninstall.
+force_stop=0
+if [ -n "${MINIMAL_INSTALL_FORCE_STOP:-}" ]; then
+    force_stop=1
+fi
 if [ "${1-}" = "--uninstall" ]; then
     MODE=uninstall
     shift
@@ -73,6 +86,19 @@ if [ "${1-}" = "--uninstall" ]; then
             *)            die "unknown uninstall option '$1' (allowed: --force, --purge, --dry-run)" ;;
         esac
         shift
+    done
+else
+    # Install mode's only option. Filter it out of "$@" wherever it appears (by
+    # rotating the kept arguments to the end) so the sole positional — the
+    # target — is still $1 for Unit 2, whichever side of the flag it was on.
+    argn=$#
+    while [ "$argn" -gt 0 ]; do
+        case "$1" in
+            --force-stop) force_stop=1 ;;
+            *)            set -- "$@" "$1" ;;
+        esac
+        shift
+        argn=$((argn - 1))
     done
 fi
 
@@ -523,15 +549,62 @@ installed=0 skipped=0
 # serving from the old image while the new `min` talks to it. Stop it first,
 # using the `min` ALREADY on disk — that one matches the daemon it started, and
 # it is about to be overwritten. Deliberately best-effort and silent: nothing
-# installed yet, no daemon running, or a `min` too old to have `stop --force`
-# all mean "nothing to stop", and none of them should fail an install whose
-# binaries are otherwise fine. `min stop` only connects (it never autospawns),
-# so with no daemon up this is a failed connect and nothing more.
+# installed yet, no daemon running, or a `min` too old to have `stop` all mean
+# "nothing to stop", and none of them should fail an install whose binaries are
+# otherwise fine. `min stop` only connects (it never autospawns), so with no
+# daemon up this is a failed connect and nothing more.
+#
+# The graceful `min stop` goes first because it already refuses while sessions
+# are live, printing exactly this message — the one signal that an upgrade is
+# about to destroy someone's work, and worth a question. Matched literally
+# rather than on exit status: a bare non-zero also means no daemon, a failed
+# connect, or a transport drop on an otherwise successful stop, and none of
+# those may turn every upgrade into a prompt.
+sessions_live_msg='daemon has active sessions'
+
+# Ask, on the CONTROLLING TERMINAL, whether to end the live sessions. Under
+# `curl … | sh` stdin is the script pipe, so reading the answer from it would
+# consume the script; /dev/tty is the only sound source (overridable so the
+# test harness can drive both answers). No terminal to ask on — CI, a
+# non-interactive shell — means nobody can consent: say so and let the caller
+# abort, rather than hang or silently destroy work. Returns non-zero when the
+# upgrade must not proceed.
+confirm_force_stop() {
+    _tty="${MINIMAL_OVERRIDE_TTY:-/dev/tty}"
+    say ""
+    say "warning: the running daemon has active sessions:"
+    "$bindir/min" ls >&2 || true
+    say ""
+    if ! (exec <"$_tty") 2>/dev/null; then
+        say "there is no terminal to confirm on; rerun with --force-stop"
+        say "(or MINIMAL_INSTALL_FORCE_STOP=1) to stop those sessions anyway."
+        return 1
+    fi
+    printf 'Stopping the daemon ends them. Continue? [y/N] ' >&2
+    _ans=
+    read -r _ans <"$_tty" || _ans=
+    case "$_ans" in
+        [Yy]*) return 0 ;;
+        *)     return 1 ;;
+    esac
+}
+
 daemon_stop_tried=0
 stop_running_daemon() {
     [ "$daemon_stop_tried" -eq 0 ] || return 0
     daemon_stop_tried=1
     [ -x "$bindir/min" ] || return 0
+
+    if [ "$force_stop" -eq 0 ]; then
+        # Stopped gracefully (or there was nothing to stop): done, no --force.
+        if _stop_out="$("$bindir/min" stop 2>&1)"; then
+            return 0
+        fi
+        case "$_stop_out" in
+            *"$sessions_live_msg"*) confirm_force_stop || return 1 ;;
+        esac
+        # Any other failure falls through to the force stop, silent as before.
+    fi
     "$bindir/min" stop --force >/dev/null 2>&1 || true
 }
 
@@ -646,8 +719,16 @@ while read -r comp _ _ _ want kind dest src; do
     # first replaced component. Only executable images wedge a running daemon
     # (bin, and lib — minvmd's @rpath dylib); replacing a data file (e.g. a
     # re-shipped apparmor text) must not kill live sessions.
+    # A declined (or unconfirmable) stop aborts here, still before the first
+    # rename: the downloaded temp file is dropped, no record is written, and
+    # the daemon and its sessions are left exactly as they were.
     case "$prefix" in
-        bin|lib) stop_running_daemon ;;
+        bin|lib)
+            stop_running_daemon || {
+                rm -f "$tmp"
+                die "aborted: nothing was installed, the daemon is still running"
+            }
+            ;;
     esac
 
     mv -f "$tmp" "$target_file"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -560,6 +560,10 @@ installed=0 skipped=0
 # rather than on exit status: a bare non-zero also means no daemon, a failed
 # connect, or a transport drop on an otherwise successful stop, and none of
 # those may turn every upgrade into a prompt.
+#
+# Every `min` below reads from /dev/null: this runs inside the component loop,
+# whose stdin is the applicable-manifest file, and a child that ever read stdin
+# would eat the rows still to be installed.
 sessions_live_msg='daemon has active sessions'
 
 # Ask, on the CONTROLLING TERMINAL, whether to end the live sessions. Under
@@ -573,7 +577,7 @@ confirm_force_stop() {
     _tty="${MINIMAL_OVERRIDE_TTY:-/dev/tty}"
     say ""
     say "warning: the running daemon has active sessions:"
-    "$bindir/min" ls >&2 || true
+    "$bindir/min" ls >&2 </dev/null || true
     say ""
     if ! (exec <"$_tty") 2>/dev/null; then
         say "there is no terminal to confirm on; rerun with --force-stop"
@@ -597,7 +601,7 @@ stop_running_daemon() {
 
     if [ "$force_stop" -eq 0 ]; then
         # Stopped gracefully (or there was nothing to stop): done, no --force.
-        if _stop_out="$("$bindir/min" stop 2>&1)"; then
+        if _stop_out="$("$bindir/min" stop 2>&1 </dev/null)"; then
             return 0
         fi
         case "$_stop_out" in
@@ -605,7 +609,7 @@ stop_running_daemon() {
         esac
         # Any other failure falls through to the force stop, silent as before.
     fi
-    "$bindir/min" stop --force >/dev/null 2>&1 || true
+    "$bindir/min" stop --force >/dev/null 2>&1 </dev/null || true
 }
 
 # The prior run's install record (R6.1) maps each component to the hash of the
@@ -721,12 +725,15 @@ while read -r comp _ _ _ want kind dest src; do
     # re-shipped apparmor text) must not kill live sessions.
     # A declined (or unconfirmable) stop aborts here, still before the first
     # rename: the downloaded temp file is dropped, no record is written, and
-    # the daemon and its sessions are left exactly as they were.
+    # the daemon and its sessions are left exactly as they were. The message
+    # claims only what the abort point guarantees — the stop runs before the
+    # FIRST bin/lib swap, so no executable has been replaced, but a `data` row
+    # earlier in the manifest may already have been.
     case "$prefix" in
         bin|lib)
             stop_running_daemon || {
                 rm -f "$tmp"
-                die "aborted: nothing was installed, the daemon is still running"
+                die "aborted: no executables were replaced, the daemon is still running"
             }
             ;;
     esac

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -598,77 +598,84 @@ want_ok "a non-sessions stop failure still force-stops (R5.5)" \
 # running and asks. The answer is read from the controlling terminal, never
 # from stdin — under `curl … | sh` stdin is the script itself — so the harness
 # points MINIMAL_OVERRIDE_TTY at a file standing in for /dev/tty.
-H16="$root/h16"; mkdir -p "$H16"
-stage_live_upgrade "$H16" liveyes
+#
+# These homes carry their own HL prefix rather than extending the plain H<n>
+# run, following the HAA_/HD/HU families above. Every scenario here deliberately
+# leaves a home a later run must not inherit — a `sessions.live` marker and a
+# `min` that refuses to stop while it exists — so a home reused by number
+# further down would not be the fresh install it reads as, and would abort on
+# the prompt instead.
+HL1="$root/hl1"; mkdir -p "$HL1"
+stage_live_upgrade "$HL1" liveyes
 printf 'y\n' >"$root/tty-yes"
 TTY_FILE="$root/tty-yes"
-run liveyes "$H16"
+run liveyes "$HL1"
 TTY_FILE=
 check 0 "$rc" "confirmed upgrade exits 0 (R5.5)"
 want_ok "the running sessions are listed (R5.5)" grep -q "session-alpha" "$OUT"
 want_ok "the user is asked before sessions die (R5.5)" grep -q "Continue?" "$OUT"
-want_ok "the graceful stop is tried first (R5.5)" grep -qx "stop" "$H16/stop.calls"
-want_ok "confirmation escalates to --force (R5.5)" grep -qx "stop --force" "$H16/stop.calls"
-check "$h_minimald" "$(hash_file "$H16/bin/minimald")" "a confirmed upgrade completes (R5.5)"
+want_ok "the graceful stop is tried first (R5.5)" grep -qx "stop" "$HL1/stop.calls"
+want_ok "confirmation escalates to --force (R5.5)" grep -qx "stop --force" "$HL1/stop.calls"
+check "$h_minimald" "$(hash_file "$HL1/bin/minimald")" "a confirmed upgrade completes (R5.5)"
 
 # Declining aborts before the first swap: non-zero, nothing installed, no
 # temp file left behind, and the daemon never force-stopped.
-H17="$root/h17"; mkdir -p "$H17"
-stage_live_upgrade "$H17" liveno
+HL2="$root/hl2"; mkdir -p "$HL2"
+stage_live_upgrade "$HL2" liveno
 printf 'n\n' >"$root/tty-no"
 TTY_FILE="$root/tty-no"
-run liveno "$H17"
+run liveno "$HL2"
 TTY_FILE=
 check 1 "$rc" "declining aborts the install (R5.5)"
 want_ok "the abort reports no executable was replaced (R5.5)" \
     grep -q "no executables were replaced" "$OUT"
-want_err "declining never force-stops (R5.5)" grep -qx "stop --force" "$H17/stop.calls"
-check "stale" "$(cat "$H17/bin/minimald")" "the stale component is left in place (R5.5)"
-want_err "no temp file survives the abort (R5.5)" ls "$H17/bin/"*.tmp.* 2>/dev/null
+want_err "declining never force-stops (R5.5)" grep -qx "stop --force" "$HL2/stop.calls"
+check "stale" "$(cat "$HL2/bin/minimald")" "the stale component is left in place (R5.5)"
+want_err "no temp file survives the abort (R5.5)" ls "$HL2/bin/"*.tmp.* 2>/dev/null
 
 # No terminal to ask on (CI, a non-interactive shell): abort promptly naming the
 # escape hatch rather than hang on a read or destroy sessions unasked.
-H18="$root/h18"; mkdir -p "$H18"
-stage_live_upgrade "$H18" livenotty
-run livenotty "$H18"
+HL3="$root/hl3"; mkdir -p "$HL3"
+stage_live_upgrade "$HL3" livenotty
+run livenotty "$HL3"
 check 1 "$rc" "an unconfirmable upgrade aborts (R5.5)"
 want_ok "the abort names the escape hatch (R5.5)" grep -q -- "--force-stop" "$OUT"
 want_err "nothing is asked without a terminal (R5.5)" grep -q "Continue?" "$OUT"
 want_err "an unconfirmable upgrade never force-stops (R5.5)" \
-    grep -qx "stop --force" "$H18/stop.calls"
-check "stale" "$(cat "$H18/bin/minimald")" "nothing is installed without confirmation (R5.5)"
+    grep -qx "stop --force" "$HL3/stop.calls"
+check "stale" "$(cat "$HL3/bin/minimald")" "nothing is installed without confirmation (R5.5)"
 
 # The escape hatch as a flag: force-stop straight away, no question, no hang.
-H19="$root/h19"; mkdir -p "$H19"
-stage_live_upgrade "$H19" liveforce
-run liveforce "$H19" --force-stop
+HL4="$root/hl4"; mkdir -p "$HL4"
+stage_live_upgrade "$HL4" liveforce
+run liveforce "$HL4" --force-stop
 check 0 "$rc" "--force-stop upgrade exits 0 (R5.5)"
 want_err "--force-stop asks nothing (R5.5)" grep -q "Continue?" "$OUT"
-want_err "--force-stop skips the graceful stop (R5.5)" grep -qx "stop" "$H19/stop.calls"
-want_ok "--force-stop force-stops (R5.5)" grep -qx "stop --force" "$H19/stop.calls"
-check "$h_minimald" "$(hash_file "$H19/bin/minimald")" "a forced upgrade completes (R5.5)"
+want_err "--force-stop skips the graceful stop (R5.5)" grep -qx "stop" "$HL4/stop.calls"
+want_ok "--force-stop force-stops (R5.5)" grep -qx "stop --force" "$HL4/stop.calls"
+check "$h_minimald" "$(hash_file "$HL4/bin/minimald")" "a forced upgrade completes (R5.5)"
 
 # The same hatch through the environment, for a pipeline with no argv at all.
-H20="$root/h20"; mkdir -p "$H20"
-stage_live_upgrade "$H20" liveforceenv
+HL5="$root/hl5"; mkdir -p "$HL5"
+stage_live_upgrade "$HL5" liveforceenv
 FORCE_STOP=1
-run liveforceenv "$H20"
+run liveforceenv "$HL5"
 FORCE_STOP=
 check 0 "$rc" "MINIMAL_INSTALL_FORCE_STOP upgrade exits 0 (R5.5)"
 want_err "the env hatch asks nothing (R5.5)" grep -q "Continue?" "$OUT"
-want_ok "the env hatch force-stops (R5.5)" grep -qx "stop --force" "$H20/stop.calls"
+want_ok "the env hatch force-stops (R5.5)" grep -qx "stop --force" "$HL5/stop.calls"
 
 # The flag is filtered out of the arguments wherever it sits, so the target
 # positional still resolves (R2.1). Deliberately a NON-default target: with
 # `stable` a filter that dropped every positional would land on the default and
 # still look right.
 printf 'v1\n' >"$mock/unstable"
-H21="$root/h21"; mkdir -p "$H21"
-stage_live_upgrade "$H21" liveforcepos
-run liveforcepos "$H21" unstable --force-stop
+HL6="$root/hl6"; mkdir -p "$HL6"
+stage_live_upgrade "$HL6" liveforcepos
+run liveforcepos "$HL6" unstable --force-stop
 check 0 "$rc" "target plus --force-stop exits 0 (R5.5/R2.1)"
 want_ok "the target survives the option filter (R2.1)" grep -q "target 'unstable'" "$OUT"
-want_ok "the trailing flag still force-stops (R5.5)" grep -qx "stop --force" "$H21/stop.calls"
+want_ok "the trailing flag still force-stops (R5.5)" grep -qx "stop --force" "$HL6/stop.calls"
 
 # --- Unit 9: shell-init files, rc hook, completions (R9.1-R9.3) -------------
 # A bash-login-shell install generates the three init files, hooks .bashrc

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -574,6 +574,7 @@ run daemonprep "$H9"
 check 0 "$rc" "prep install exits 0"
 cat >"$H9/bin/min" <<'EOF'
 #!/bin/sh
+printf '%s\n' "$*" >>"$HOME/stop.calls"
 echo "old min: unrecognized subcommand 'stop'" >&2
 echo "noise on stdout" >&1
 exit 2
@@ -586,9 +587,12 @@ want_err "min stop stderr is hidden (R5.5)" grep -q "unrecognized subcommand" "$
 want_err "min stop stdout is hidden (R5.5)" grep -q "noise on stdout" "$OUT"
 check "$h_minimald" "$(hash_file "$H9/bin/minimald")" "the upgrade still completed (R5.5)"
 # Only the active-sessions refusal may prompt: every other non-zero stop (no
-# daemon, a failed connect, a min too old) stays silent and best-effort.
+# daemon, a failed connect, a min too old) stays silent and best-effort, and
+# still falls through to the force stop — the arm that covers a wedged daemon.
 want_err "a non-sessions stop failure asks nothing (R5.5)" grep -q "Continue?" "$OUT"
 want_err "a non-sessions stop failure lists nothing (R5.5)" grep -q "active sessions" "$OUT"
+want_ok "a non-sessions stop failure still force-stops (R5.5)" \
+    grep -qx "stop --force" "$H9/stop.calls"
 
 # Live sessions turn the stop into a decision: the installer lists what is
 # running and asks. The answer is read from the controlling terminal, never
@@ -616,7 +620,8 @@ TTY_FILE="$root/tty-no"
 run liveno "$H17"
 TTY_FILE=
 check 1 "$rc" "declining aborts the install (R5.5)"
-want_ok "the abort says nothing was installed (R5.5)" grep -q "nothing was installed" "$OUT"
+want_ok "the abort reports no executable was replaced (R5.5)" \
+    grep -q "no executables were replaced" "$OUT"
 want_err "declining never force-stops (R5.5)" grep -qx "stop --force" "$H17/stop.calls"
 check "stale" "$(cat "$H17/bin/minimald")" "the stale component is left in place (R5.5)"
 want_err "no temp file survives the abort (R5.5)" ls "$H17/bin/"*.tmp.* 2>/dev/null
@@ -654,12 +659,15 @@ want_err "the env hatch asks nothing (R5.5)" grep -q "Continue?" "$OUT"
 want_ok "the env hatch force-stops (R5.5)" grep -qx "stop --force" "$H20/stop.calls"
 
 # The flag is filtered out of the arguments wherever it sits, so the target
-# positional still resolves (R2.1).
+# positional still resolves (R2.1). Deliberately a NON-default target: with
+# `stable` a filter that dropped every positional would land on the default and
+# still look right.
+printf 'v1\n' >"$mock/unstable"
 H21="$root/h21"; mkdir -p "$H21"
 stage_live_upgrade "$H21" liveforcepos
-run liveforcepos "$H21" stable --force-stop
+run liveforcepos "$H21" unstable --force-stop
 check 0 "$rc" "target plus --force-stop exits 0 (R5.5/R2.1)"
-want_ok "the target survives the option filter (R2.1)" grep -q "target 'stable'" "$OUT"
+want_ok "the target survives the option filter (R2.1)" grep -q "target 'unstable'" "$OUT"
 want_ok "the trailing flag still force-stops (R5.5)" grep -qx "stop --force" "$H21/stop.calls"
 
 # --- Unit 9: shell-init files, rc hook, completions (R9.1-R9.3) -------------

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -218,6 +218,14 @@ APPARMOR_DIR=
 # branch of the userns advisory.
 BIN_OVERRIDE=
 
+# Stand-in for /dev/tty, where the active-sessions prompt reads its answer
+# (R5.5). Empty points the installer at a path that cannot be opened — the
+# harness's own terminal must never be read, and every scenario that does not
+# stage an answer must behave like a non-interactive run. Scenarios point it at
+# a file holding the keystroke. FORCE_STOP fills MINIMAL_INSTALL_FORCE_STOP.
+TTY_FILE=
+FORCE_STOP=
+
 # run <label> <homeprefix> [args...] ; sets rc, captures combined output in $OUT.
 OUT=
 run() {
@@ -238,6 +246,8 @@ run() {
         STUB_UNAME_M="$PLAT_M" \
         MINIMAL_OVERRIDE_USERNS_SYSCTL="${USERNS_SYSCTL:-$root/no-such-sysctl}" \
         MINIMAL_OVERRIDE_APPARMOR_DIR="${APPARMOR_DIR:-$root/no-such-apparmor.d}" \
+        MINIMAL_OVERRIDE_TTY="${TTY_FILE:-$root/no-such-tty}" \
+        MINIMAL_INSTALL_FORCE_STOP="${FORCE_STOP:-}" \
         "$SH" "$installer" "$@" </dev/null >"$OUT" 2>&1
     rc=$?
     set -e
@@ -487,6 +497,41 @@ want_err "PATH advisory suppressed when bin present (R6.2)" grep -q "is not on y
 # The installed `min` (the mock records its `stop` calls to $HOME/stop.calls) is
 # run once, only on a run that actually replaces a file, and only when it was
 # already on disk beforehand.
+
+# The `min` an upgrade finds already on disk. It records every `stop` call,
+# answers `ls`, and — when the scenario drops a `sessions.live` marker in the
+# home — refuses a graceful stop with the real daemon's wording, exactly as
+# `min stop` does when sessions are running.
+write_min_stub() {
+    cat >"$1" <<'STUB'
+#!/bin/sh
+# mock min, previous release
+case "${1:-}" in
+    completions) printf '# mock min completions for %s\n' "$2" ;;
+    ls)          printf 'session-alpha  running\n' ;;
+    stop)
+        printf '%s\n' "$*" >>"$HOME/stop.calls"
+        if [ -f "$HOME/sessions.live" ] && [ "${2:-}" != "--force" ]; then
+            echo "daemon has active sessions; pass --force to shut down anyway" >&2
+            exit 1
+        fi
+        ;;
+esac
+STUB
+    chmod +x "$1"
+}
+
+# Seed <home> with a completed install, then stage the next run as an upgrade
+# (one stale component) whose on-disk `min` reports live sessions.
+stage_live_upgrade() {
+    run "$2_seed" "$1"
+    check 0 "$rc" "$2: seed install exits 0"
+    printf 'stale\n' >"$1/bin/minimald"
+    write_min_stub "$1/bin/min"
+    : >"$1/sessions.live"
+    rm -f "$1/stop.calls"
+}
+
 H8="$root/h8"; mkdir -p "$H8"
 run daemonfresh "$H8"
 check 0 "$rc" "fresh install exits 0"
@@ -499,21 +544,17 @@ want_err "up-to-date rerun stops no daemon (R5.5)" test -e "$H8/stop.calls"
 
 # An upgrade (two components stale) stops the daemon exactly once, before the
 # swap, via the min that is on disk now — an older build than the manifest's,
-# still runnable, still able to reach the daemon it started.
+# still runnable, still able to reach the daemon it started. With no sessions
+# running the graceful stop succeeds, so nothing is forced and nothing is asked.
 printf 'stale\n' >"$H8/bin/minimald"
-cat >"$H8/bin/min" <<'EOF'
-#!/bin/sh
-# mock min, previous release
-case "${1:-}" in
-    completions) printf '# mock min completions for %s\n' "$2" ;;
-    stop)        printf '%s\n' "$*" >>"$HOME/stop.calls" ;;
-esac
-EOF
-chmod +x "$H8/bin/min"
+write_min_stub "$H8/bin/min"
 run daemonupgrade "$H8"
 check 0 "$rc" "upgrade exits 0"
-want_ok "upgrade runs min stop --force (R5.5)" test -f "$H8/stop.calls"
-check "stop --force" "$(cat "$H8/stop.calls")" "stop is called once, with --force (R5.5)"
+want_ok "upgrade runs min stop (R5.5)" test -f "$H8/stop.calls"
+check "stop" "$(cat "$H8/stop.calls")" "stop is called once, gracefully (R5.5)"
+want_err "a graceful stop is never escalated to --force (R5.5)" \
+    grep -qx "stop --force" "$H8/stop.calls"
+want_err "no sessions means no question (R5.5)" grep -q "Continue?" "$OUT"
 
 # Replacing only a data component must NOT stop the daemon: data files (the
 # apparmor profile/tunable/loader) are not executable images, and the running
@@ -544,6 +585,82 @@ check 0 "$rc" "a failing min stop does not fail the install (R5.5)"
 want_err "min stop stderr is hidden (R5.5)" grep -q "unrecognized subcommand" "$OUT"
 want_err "min stop stdout is hidden (R5.5)" grep -q "noise on stdout" "$OUT"
 check "$h_minimald" "$(hash_file "$H9/bin/minimald")" "the upgrade still completed (R5.5)"
+# Only the active-sessions refusal may prompt: every other non-zero stop (no
+# daemon, a failed connect, a min too old) stays silent and best-effort.
+want_err "a non-sessions stop failure asks nothing (R5.5)" grep -q "Continue?" "$OUT"
+want_err "a non-sessions stop failure lists nothing (R5.5)" grep -q "active sessions" "$OUT"
+
+# Live sessions turn the stop into a decision: the installer lists what is
+# running and asks. The answer is read from the controlling terminal, never
+# from stdin — under `curl … | sh` stdin is the script itself — so the harness
+# points MINIMAL_OVERRIDE_TTY at a file standing in for /dev/tty.
+H16="$root/h16"; mkdir -p "$H16"
+stage_live_upgrade "$H16" liveyes
+printf 'y\n' >"$root/tty-yes"
+TTY_FILE="$root/tty-yes"
+run liveyes "$H16"
+TTY_FILE=
+check 0 "$rc" "confirmed upgrade exits 0 (R5.5)"
+want_ok "the running sessions are listed (R5.5)" grep -q "session-alpha" "$OUT"
+want_ok "the user is asked before sessions die (R5.5)" grep -q "Continue?" "$OUT"
+want_ok "the graceful stop is tried first (R5.5)" grep -qx "stop" "$H16/stop.calls"
+want_ok "confirmation escalates to --force (R5.5)" grep -qx "stop --force" "$H16/stop.calls"
+check "$h_minimald" "$(hash_file "$H16/bin/minimald")" "a confirmed upgrade completes (R5.5)"
+
+# Declining aborts before the first swap: non-zero, nothing installed, no
+# temp file left behind, and the daemon never force-stopped.
+H17="$root/h17"; mkdir -p "$H17"
+stage_live_upgrade "$H17" liveno
+printf 'n\n' >"$root/tty-no"
+TTY_FILE="$root/tty-no"
+run liveno "$H17"
+TTY_FILE=
+check 1 "$rc" "declining aborts the install (R5.5)"
+want_ok "the abort says nothing was installed (R5.5)" grep -q "nothing was installed" "$OUT"
+want_err "declining never force-stops (R5.5)" grep -qx "stop --force" "$H17/stop.calls"
+check "stale" "$(cat "$H17/bin/minimald")" "the stale component is left in place (R5.5)"
+want_err "no temp file survives the abort (R5.5)" ls "$H17/bin/"*.tmp.* 2>/dev/null
+
+# No terminal to ask on (CI, a non-interactive shell): abort promptly naming the
+# escape hatch rather than hang on a read or destroy sessions unasked.
+H18="$root/h18"; mkdir -p "$H18"
+stage_live_upgrade "$H18" livenotty
+run livenotty "$H18"
+check 1 "$rc" "an unconfirmable upgrade aborts (R5.5)"
+want_ok "the abort names the escape hatch (R5.5)" grep -q -- "--force-stop" "$OUT"
+want_err "nothing is asked without a terminal (R5.5)" grep -q "Continue?" "$OUT"
+want_err "an unconfirmable upgrade never force-stops (R5.5)" \
+    grep -qx "stop --force" "$H18/stop.calls"
+check "stale" "$(cat "$H18/bin/minimald")" "nothing is installed without confirmation (R5.5)"
+
+# The escape hatch as a flag: force-stop straight away, no question, no hang.
+H19="$root/h19"; mkdir -p "$H19"
+stage_live_upgrade "$H19" liveforce
+run liveforce "$H19" --force-stop
+check 0 "$rc" "--force-stop upgrade exits 0 (R5.5)"
+want_err "--force-stop asks nothing (R5.5)" grep -q "Continue?" "$OUT"
+want_err "--force-stop skips the graceful stop (R5.5)" grep -qx "stop" "$H19/stop.calls"
+want_ok "--force-stop force-stops (R5.5)" grep -qx "stop --force" "$H19/stop.calls"
+check "$h_minimald" "$(hash_file "$H19/bin/minimald")" "a forced upgrade completes (R5.5)"
+
+# The same hatch through the environment, for a pipeline with no argv at all.
+H20="$root/h20"; mkdir -p "$H20"
+stage_live_upgrade "$H20" liveforceenv
+FORCE_STOP=1
+run liveforceenv "$H20"
+FORCE_STOP=
+check 0 "$rc" "MINIMAL_INSTALL_FORCE_STOP upgrade exits 0 (R5.5)"
+want_err "the env hatch asks nothing (R5.5)" grep -q "Continue?" "$OUT"
+want_ok "the env hatch force-stops (R5.5)" grep -qx "stop --force" "$H20/stop.calls"
+
+# The flag is filtered out of the arguments wherever it sits, so the target
+# positional still resolves (R2.1).
+H21="$root/h21"; mkdir -p "$H21"
+stage_live_upgrade "$H21" liveforcepos
+run liveforcepos "$H21" stable --force-stop
+check 0 "$rc" "target plus --force-stop exits 0 (R5.5/R2.1)"
+want_ok "the target survives the option filter (R2.1)" grep -q "target 'stable'" "$OUT"
+want_ok "the trailing flag still force-stops (R5.5)" grep -qx "stop --force" "$H21/stop.calls"
 
 # --- Unit 9: shell-init files, rc hook, completions (R9.1-R9.3) -------------
 # A bash-login-shell install generates the three init files, hooks .bashrc


### PR DESCRIPTION
## Root cause

`scripts/install.sh:535` (on `main`) unconditionally force-stopped the daemon before the first
executable swap:

```sh
"$bindir/min" stop --force >/dev/null 2>&1 || true
```

Called from `scripts/install.sh:650`, before the `mv -f` of the first `bin`/`lib` component. So a
`curl … | sh` upgrade destroyed every live session with no signal and no way out. The daemon-side
mitigation ("minimald is shutting down and disconnecting") does not help: it is printed by the
daemon being *replaced*, so it only exists if you already upgraded past the release that added it,
and it is a notice after the fact rather than a decision point.

`min stop` already knows the answer — `crates/minimal/src/lib.rs:2137`:

```rust
bail!("daemon has active sessions; pass --force to shut down anyway")
```

The installer never asked it. It went straight to `--force`.

## Fix

The pre-upgrade stop is now graceful-first (`scripts/install.sh:597`):

```sh
if _stop_out="$("$bindir/min" stop 2>&1 </dev/null)"; then
    return 0
fi
case "$_stop_out" in
    *"$sessions_live_msg"*) confirm_force_stop || return 1 ;;
esac
# Any other failure falls through to the force stop, silent as before.
```

Design choices and why:

- **Matched on the message, not the exit status** (`sessions_live_msg`, `scripts/install.sh:567`).
  A bare non-zero from `min stop` also means no daemon, a failed connect, a `min` too old to know
  the subcommand, or a transport drop on an otherwise successful stop. Gating on the exit code
  would turn every upgrade into a prompt and would fail installs that are otherwise fine. Only the
  active-sessions refusal escalates; everything else keeps today's silent, best-effort behaviour
  and still falls through to the force stop.
- **Answer read from the controlling terminal, never stdin** (`confirm_force_stop`,
  `scripts/install.sh:576`). Under `curl … | sh` stdin is the script; reading it would consume the
  installer. Inside the component loop stdin is the applicable-manifest file, which is worse.
  `${MINIMAL_OVERRIDE_TTY:-/dev/tty}` is the source; the harness overrides it.
- **No terminal means abort, not force and not hang.** `(exec <"$_tty") 2>/dev/null` probes
  openability; if there is nobody to consent the run exits non-zero naming the escape hatch.
- **Escape hatch is `--force-stop` or a non-empty `MINIMAL_INSTALL_FORCE_STOP`**
  (`scripts/install.sh:74`, `:97`). Deliberately not `--force`, which already means "remove
  modified files too" in uninstall mode. The flag is filtered out of `"$@"` wherever it appears, so
  the target stays the sole positional.
- **Declining aborts before the first executable swap** (`scripts/install.sh:736`), dropping the
  temp download; no record is written. The message says `no executables were replaced` rather than
  "nothing was installed" — the stop fires at the first `bin`/`lib` row, so a `data` row ordered
  ahead of it in the manifest may already have been replaced, and the message claims only what the
  abort point actually guarantees.

The graceful-first path is also a strict improvement on the healthy case: an upgrade with no
sessions now stops cleanly and never force-stops at all.

`crates/common/tests/installer_stop_signal.rs` pins the cross-language coupling: it reads
`scripts/install.sh` and `crates/minimal/src/lib.rs` as text and asserts the installer's literal is
still present in the CLI source. Without it, rewording the `bail!` silently returns the installer to
an unconditional force-stop — the exact bug this PR fixes — with every installer test still green,
because the harness stubs `min` with its own copy of the string.

## Acceptance

- [x] **Graceful `min stop` is attempted first, and its signal is reused rather than a parallel
  session check** — `scripts/install_test.sh:535` (H8 `daemonupgrade`): asserts the on-disk `min`
  is called with exactly `stop`, once, however many components are replaced, never escalating to
  `--force`, and asking nothing.
- [x] **An active-sessions refusal lists what is running and prompts** —
  `scripts/install_test.sh:601` (H16): asserts `session-alpha` appears in the output and that
  `Continue?` is asked.
- [x] **Only explicit confirmation falls through to `min stop --force` and continues the upgrade** —
  `scripts/install_test.sh:601` (H16, answer `y`): asserts `stop` then `stop --force` in
  `stop.calls` and that the replaced component hashes to the manifest value.
- [x] **Declining aborts** — `scripts/install_test.sh:616` (H17, answer `n`): exit 1, `stop --force`
  never called, the stale component still on disk, no `*.tmp.*` left behind, and the abort reports
  no executable was replaced.
- [x] **Non-interactive / CI invocations do not hang** — `scripts/install_test.sh:631` (H18, no
  openable terminal: exits non-zero naming the hatch, never prompts, never forces, installs
  nothing); `:642` (H19, `--force-stop`: skips the graceful stop, asks nothing, completes); `:652`
  (H20, `MINIMAL_INSTALL_FORCE_STOP`, for a pipeline with no argv); `:666` (H21, flag after the
  target: the target still resolves).
- [x] **No other `min stop` failure may prompt or fail the install** —
  `scripts/install_test.sh:572` (H9, a `min` too old, exiting 2 and writing to both streams): exit
  0, neither stream leaked, nothing asked, nothing listed, the upgrade completed, and it still fell
  through to `stop --force`.
- [x] **The signal cannot rot silently** — `crates/common/tests/installer_stop_signal.rs`.

Non-vacuity was checked by mutation, not assumed. Against a scratch copy: reverting
`stop_running_daemon` to the unconditional force-stop → 13 failures; reading the answer from stdin
instead of `/dev/tty` → 3 failures; treating any non-zero stop as "sessions live" → 6 failures
(including H9's "a failing `min stop` does not fail the install"); dropping every positional in the
option filter → 7 failures, one of them H21's `target 'unstable'`; rewording `sessions_live_msg` →
`installer_stop_signal` fails with the intended message.

## Test plan

Run on macOS arm64 (Darwin 25.4.0), all green on the committed tree:

```
/opt/homebrew/bin/shellcheck scripts/install.sh scripts/install_test.sh
  → clean

/opt/homebrew/bin/just test-installer
  → shellcheck --shell=sh: clean
  → install_test.sh under sh   (macOS bash 3.2 in POSIX mode): 244 passed, 0 failed
  → install_test.sh under dash:                                244 passed, 0 failed

/opt/homebrew/bin/just fmt-check          → clean
cargo clippy -p common --all-targets -- -D warnings → clean
cargo test -p common                      → 44 + 1 + 1 passed, 0 failed
  (includes tests/installer_stop_signal.rs and the pre-existing shell_lint gate)
```

`just test-installer` is the same gate `ci-shell-installer` runs, and the lane triggers: both
installer paths are in its path filter.

Delegated to CI (cannot run on macOS — `minimald` does not build here, so the workspace test suite
is out of reach locally, per AGENTS.md "Platform matrix"):

- `ci-linux-native` / `ci-linux-kvm` — the workspace test run, which is what actually executes
  `crates/common/tests/installer_stop_signal.rs` in CI. Verified locally with
  `cargo test -p common`; `common` has no `minimald` dependency, so this one is genuinely runnable
  on macOS and was run.
- `ci` — workspace rustfmt (run locally) and workspace clippy (only `-p common` runnable here; the
  new file is the only Rust change and it is in `common`).
- `ci-macos` — its scope is `-p minvmd -p sessions`; no Rust in either crate changed.

No CI lane executes `install.sh` itself (`release.yml` only uploads it; `nightly.yml` hand-assembles
the layout it would write), so no lane can newly block on the prompt.

## Notes

- Two reviewer findings were deliberately not applied:
  - `MINIMAL_INSTALL_FORCE_STOP=0` counts as "on" because the check is `-n`. Real footgun, but
    "non-empty" is the convention this file already uses for its env overrides
    (`MINIMAL_INSTALL_TARGET_OVERRIDE`, `scripts/install.sh:499`) and it is documented as non-empty
    in the usage header, the spec, and the guide. Changing the semantics of a knob is a separate,
    deliberate decision, not review cleanup.
  - A backgrounded pipeline (`curl … | sh &`) that still has a controlling terminal passes the
    openability probe and would then take SIGTTIN on the `read`, stopping rather than aborting.
    There is no portable way to detect foreground process-group membership in POSIX sh, and
    `[ -t 0 ]` is wrong under `curl | sh`. The documented escape hatch is the way out. Related to
    the SIGTTOU footgun already recorded in AGENTS.md.
- `docs/specs/07-spec-installer/07-spec-installer.md` R5.5 was rewritten to describe the new
  behaviour, plus a new user story under R2.1 for `--force-stop`. Spec prose is functional
  throughout — no issue numbers, PR numbers, or names.
- `.github/workflows/` is untouched.

Closes gominimal/inbox#366


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ask for confirmation before stopping live sessions during upgrade in install.sh
> - When an upgrade detects active sessions, the installer now lists them via `min ls`, opens `/dev/tty`, and prompts the user before issuing a force stop.
> - Adds `--force-stop` flag and `MINIMAL_INSTALL_FORCE_STOP` env var to skip the prompt and proceed unconditionally.
> - If no controlling terminal is available and sessions are live, the installer aborts without replacing any executables, naming the escape hatch.
> - Graceful stop is attempted first; only if the CLI refuses with the active-sessions message does the prompt appear. Other failures fall through to a silent force stop.
> - Adds a cross-file sync test that fails if `sessions_live_msg` in [install.sh](https://github.com/gominimal/minimal/pull/1010/files#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09cc) no longer matches the string in [crates/minimal/src/lib.rs](https://github.com/gominimal/minimal/pull/1010/files#diff-1b62c63af5a5bd2dbc4b550bf4bc6d0fa87e649b54dc3a587da5a8fa947b3ce1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f5beae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgrades now detect active daemon sessions and ask for confirmation before stopping them.
  * Added `--force-stop` and `MINIMAL_INSTALL_FORCE_STOP` options for scripted or non-interactive upgrades.
  * Upgrades can proceed without prompts when forced; declined or unavailable confirmations safely abort before replacement.

* **Documentation**
  * Updated installation guidance and specifications to explain session handling and forced upgrades.

* **Tests**
  * Added coverage for interactive, non-interactive, forced, declined, and target-selection upgrade scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->