### PR TITLE
fix(ci): reclaim the session e2e's state dir so the soak stops filling the runner

### DIFF
--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -182,6 +182,21 @@ teardown() {
   fi
   [ -n "$SEED_DIR" ] && rm -rf "$SEED_DIR"
   [ -n "$SEEDED_MFILE" ] && rm -f "$SEEDED_MFILE"
+  # And the state dir — which is NOT just metadata. On a VM lane it holds the
+  # provider's per-VM writable data volume
+  # (`minimal/providers/local-minvmd0/data-vol.raw`), a sparse image whose HOST
+  # allocation is everything the guest wrote into it: its package cache, the
+  # session rootfs, the workspace. WORK is fresh per run, so nothing is shared
+  # and every run pays that allocation again. Leaving one behind is survivable;
+  # scripts/soak-session-e2e.sh runs this script TEN times back-to-back, so ten
+  # accumulate on one runner — and the nightly soak now dies inside that step
+  # with the runner agent gone (job `failure`, step still `in_progress`, no
+  # retrievable log lines and no uploaded artifacts), which is the shape a
+  # runner ENOSPC takes. The sibling harnesses (bulk-upload-e2e.sh,
+  # stress-session-e2e.sh) already remove theirs; this one was the outlier.
+  # `fail` collects every diagnostic — including the `min bug` bundle, which it
+  # writes OUTSIDE $WORK — before calling this.
+  rm -rf "$WORK"
 }
 trap teardown EXIT
 
@@ -204,10 +219,12 @@ fail() {
   # may be wedged or already gone, so bound the guest wait and fall back to a
   # host-only bundle. Written next to the boot log — under a VM soak that dir is
   # the job's uploaded soak-logs — so a failing nightly ships a real bundle, not
-  # just scraped tails. now_ms keeps per-iteration bundles from colliding.
+  # just scraped tails. now_ms keeps per-iteration bundles from colliding. The
+  # fallback is /tmp, NOT $WORK: teardown removes the state dir, so a bundle
+  # written there would die with it (same reasoning as bulk-upload-e2e.sh).
   echo "--- min bug (diagnostic bundle) ---"
   bug_dir="${MINVMD_BOOT_LOG:+$(dirname "$MINVMD_BOOT_LOG")}"
-  bug_out="${bug_dir:-$WORK}/minimal-diag-session-$(now_ms).tar.zst"
+  bug_out="${bug_dir:-/tmp}/minimal-diag-session-$(now_ms).tar.zst"
   if mnl bug --guest-timeout-secs 30 --output "$bug_out" >/dev/null 2>&1 \
     || mnl bug --no-guest --output "$bug_out" >/dev/null 2>&1; then
     echo "wrote diagnostic bundle: $bug_out ($(wc -c <"$bug_out" 2>/dev/null || echo '?') bytes)"

--- a/scripts/soak-session-e2e.sh
+++ b/scripts/soak-session-e2e.sh
@@ -19,6 +19,11 @@
 # same as the lane invocation. Each iteration runs session-e2e.sh, which
 # creates its own fresh XDG state, so every pass is a clean cold start.
 #
+# Environment:
+#   SOAK_MIN_FREE_MIB   free-space floor, in MiB, for the filesystem holding the
+#                       per-iteration state dirs (default 4096). See the
+#                       headroom check below for why this harness needs one.
+#
 # Usage: scripts/soak-session-e2e.sh [iterations] [boot-log-dir]
 set -uo pipefail
 
@@ -49,11 +54,66 @@ trap 'reap' EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
+# ── Disk headroom ────────────────────────────────────────────────────────────
+# Repeating a VM-backed e2e is the one thing this repo does that can genuinely
+# exhaust a CI runner's disk: each iteration's state dir carries the provider's
+# per-VM data volume, whose host allocation is everything the guest wrote (its
+# package cache, the session rootfs, the workspace). session-e2e.sh reclaims
+# its own state dir, so this should now stay flat — but "should" is what the
+# nightly already believed. The failure mode is what makes a check worth having:
+# a real ENOSPC kills the runner AGENT, and the job then reports `failure` with
+# this step still `in_progress` and NO retrievable log lines, no uploaded
+# artifacts, nothing to read. So measure the headroom, print it every iteration
+# (the per-check delta is exactly the number that says whether reclamation is
+# working), and stop with a real error while a runner is still alive to report.
+case "$(uname -s)" in
+  Darwin) STATE_FS=/tmp ;;    # where session-e2e.sh puts its state dir,
+  *) STATE_FS="$HOME" ;;      # per platform (its sun_path / hardlink split)
+esac
+MIN_FREE_MIB="${SOAK_MIN_FREE_MIB:-4096}"
+case "$MIN_FREE_MIB" in
+  '' | *[!0-9]*) echo "SOAK_MIN_FREE_MIB must be a non-negative integer, got: '$MIN_FREE_MIB'" >&2; exit 2 ;;
+esac
+
+# Free MiB on the filesystem holding "$1". `df -Pk` is the portable spelling:
+# -P pins one line per filesystem (GNU df wraps a long device name onto two
+# otherwise, which would shift the columns) and -k pins 1024-byte blocks
+# (macOS df reports 512-byte ones by default).
+free_mib() { df -Pk "$1" 2>/dev/null | awk 'NR == 2 { print int($4 / 1024) }'; }
+
+LAST_FREE=""
+# Report headroom, and fail the step if it has fallen below the floor. "$1"
+# names what is about to run, for the error text.
+check_free() {
+  local now delta
+  now="$(free_mib "$STATE_FS")"
+  case "$now" in
+    '' | *[!0-9]*)
+      echo "::warning::could not read free space on $STATE_FS — headroom check skipped"
+      return 0
+      ;;
+  esac
+  if [ -n "$LAST_FREE" ]; then
+    delta=$((now - LAST_FREE))
+    echo "disk: ${now} MiB free on $STATE_FS (${delta} MiB since the last check)"
+  else
+    echo "disk: ${now} MiB free on $STATE_FS (floor ${MIN_FREE_MIB} MiB)"
+  fi
+  LAST_FREE="$now"
+  [ "$now" -ge "$MIN_FREE_MIB" ] && return 0
+  echo "::error::only ${now} MiB free on $STATE_FS before $1 (floor ${MIN_FREE_MIB} MiB; override with SOAK_MIN_FREE_MIB). Stopping here so this reports as a failed step: an actual ENOSPC kills the runner agent, and the job then reports 'failure' with no log lines at all."
+  return 1
+}
+
 pass=0
 fail=0
 for i in $(seq 1 "$ITER"); do
   echo "::group::soak iteration $i/$ITER"
   reap
+  if ! check_free "soak iteration $i/$ITER"; then
+    echo "::endgroup::"
+    exit 1
+  fi
   if MINVMD_BOOT_LOG="$LOGDIR/boot-$i.log" "$ROOT/scripts/session-e2e.sh"; then
     pass=$((pass + 1))
     echo "iteration $i: OK"
@@ -67,6 +127,10 @@ done
 
 echo "::group::bulk host→guest upload proof"
 reap
+if ! check_free "the bulk upload proof"; then
+  echo "::endgroup::"
+  exit 1
+fi
 if MINVMD_BOOT_LOG="$LOGDIR/boot-bulk.log" "$ROOT/scripts/bulk-upload-e2e.sh"; then
   bulk=OK
 else
@@ -75,6 +139,9 @@ else
 fi
 echo "::endgroup::"
 
+# Closing headroom, reported not enforced: everything is already done, and a
+# `::error::` here would paint a run that passed red.
+echo "disk: $(free_mib "$STATE_FS") MiB free on $STATE_FS at the end of the run"
 echo "soak complete: $pass passed, $fail failed (of $ITER); bulk upload proof: $bulk"
 # Require every iteration to have run AND passed — a short-circuited loop that
 # ran zero iterations must not report success.


### PR DESCRIPTION
## The failure

`session-e2e-soak` has been red on `nightly-tests` since the 2026-07-25 run (last green: [30073487997](https://github.com/gominimal/minimal/actions/runs/30073487997), 07-24). Every failure since has the identical shape:

| Run | Job duration | Step 15 (`Soak the session e2e (x10)`) | Logs |
|---|---|---|---|
| [30419924349](https://github.com/gominimal/minimal/actions/runs/30419924349) | 46 min / 90 | `in_progress` | `log not found` |
| [30244995348](https://github.com/gominimal/minimal/actions/runs/30244995348) | 22 min / 90 | never recorded | none |
| [30191843749](https://github.com/gominimal/minimal/actions/runs/30191843749) | 14 min / 90 | `in_progress` | none |
| [30182780159](https://github.com/gominimal/minimal/actions/runs/30182780159) | 63 min / 90 | `in_progress` | none |
| [30180328655](https://github.com/gominimal/minimal/actions/runs/30180328655) | 66 min / 90 | `in_progress` | none |

A step stuck at `in_progress` while the job reports `failure`, zero retrievable log lines, no uploaded artifacts, and the runner dead well inside its budget — that is the runner **agent** being killed, not a test assertion failing. It is the signature of ENOSPC on the runner. The single-session `ci-linux-kvm` lane, which runs the same e2e once, stays green throughout.

For scale: the last green soak ran all ten iterations plus the bulk proof in **3m25s**. The failing runs die inside that same step.

## The cause

`scripts/session-e2e.sh` never removed its `$WORK` state dir.

Its two sibling harnesses both do. `bulk-upload-e2e.sh` is explicit about why — *"Leave nothing behind: a canary that strands a session (or a VM) per run is worse than no canary"* — and `stress-session-e2e.sh` does the same. `session-e2e.sh` was the outlier, and it is the one `soak-session-e2e.sh` runs **ten times back-to-back on a single runner**.

That dir is not just metadata. On a VM lane it holds the provider's per-VM writable data volume, `minimal/providers/local-minvmd0/data-vol.raw` — a sparse image (`DEFAULT_VOLUME_BYTES` = 256 GiB nominal) whose *host* allocation is everything the guest wrote into it: its package cache, the session rootfs, the workspace. `$WORK` is minted fresh per iteration, so nothing is shared between them; each iteration re-pays that allocation, ten times, with nothing reclaiming any of it.

## The fix

**`scripts/session-e2e.sh`** — `rm -rf "$WORK"` on teardown, matching the siblings. The `min bug` diagnostic bundle's fallback moves from `$WORK` to `/tmp` so it survives that teardown (the same fallback, for the same reason, that `bulk-upload-e2e.sh` already uses). Every diagnostic `fail()` collects is gathered *before* teardown runs, so nothing is lost.

**`scripts/soak-session-e2e.sh`** — measure free space on the filesystem holding those state dirs, print it with a per-check delta on every iteration, and stop with a real `::error::` if it falls under a floor (4096 MiB, override with `SOAK_MIN_FREE_MIB`).

The floor is the part that matters beyond this one bug: a genuine ENOSPC leaves *nothing to read*, which is why five nights of failures produced no diagnosis. This fails the step while a runner is still alive to say why, and the per-iteration deltas make it immediately visible if reclamation ever regresses again.

No workflow files touched — `.github/workflows/` is frozen, and both changes land in the `scripts/` extension point CI already schedules over.

## Verification

- `scripts/lint-shell.sh` — 24 scripts pass shellcheck (the gate `crates/common/tests/shell_lint.rs` runs in CI).
- **Leak, before/after.** Stubbed `min` drives the harness through its `fail()` → `teardown()` path — the same path every soak iteration exits by:
  ```
  BEFORE-HEAD    (exit 1): state dirs left behind = 1   /private/tmp/mnl-e2e.SjgiKq
  AFTER-patched  (exit 1): state dirs left behind = 0
  ```
- **Headroom check**, exercised from an isolated copy (the live dev stack on this host would otherwise be reaped):
  - floor above actual free space → aborts before running anything (`exit 1`, zero iterations run), emitting the `::error::`
  - floor of 0 → all iterations plus the bulk proof run, deltas reported
  - non-numeric floor → rejected, `exit 2`

The real proof is the next nightly (or a `workflow_dispatch` of `nightly-tests`): the soak step should complete and report a flat per-iteration disk delta.

Note: the diff is shell-only and touches no Rust, so the `just ci` Rust gates cover nothing here; `just lint-shell` is the gate for it and passes. I deliberately did not run `just ci` on this host — `cargo clippy --all-targets -p minvmd` would relink `target/debug/minvmd` and drop the hypervisor codesign out from under the running dev stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reclaim session e2e state directory on teardown to stop soak runner disk fill
> - [session-e2e.sh](https://github.com/gominimal/minimal/pull/1021/files#diff-004d118857e0d3f2629dc99ab9f489236e0cbfcdb0c00fade94c342b824358a7) teardown now deletes the working/state directory (`$WORK`), reclaiming provider-managed data volumes after each run.
> - Diagnostic bundles from `mnl bug` now default to `/tmp` instead of the state directory when `MINVMD_BOOT_LOG` is unset, avoiding writes under the path being deleted.
> - [soak-session-e2e.sh](https://github.com/gominimal/minimal/pull/1021/files#diff-cf75f0484ad3e0afe305f607684d73e384859c7f610fff0aa752819d9eb55f44) adds a `check_free` guard before each iteration and before the bulk upload proof, aborting early with a GitHub Actions error if free space falls below a configurable `SOAK_MIN_FREE_MIB` floor.
> - A `free_mib` helper measures available disk space in MiB for a given path using portable `df` and `awk`, with platform-specific filesystem selection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e060ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->