### PR TITLE
fix(scripts): make bench-minvmd-boot safe beside other checkouts, and n>1 actually work

### DIFF
--- a/scripts/bench-minvmd-boot.sh
+++ b/scripts/bench-minvmd-boot.sh
@@ -56,12 +56,12 @@ fi
 # SIGTTOU then stops the whole group and the boot dies silently at the timeout.
 BOOT_TIMEOUT=12
 OUT="$(mktemp -t bench-minvmd.XXXXXX)"
-# Private state dir. minvmd refuses to boot when the default one already has a
-# VM registered ("minvmd is already running"), which a parallel checkout's dev
-# stack is enough to trigger — the state dir is shared across checkouts even
-# though the binaries are not. Isolating it also keeps the bench from touching
-# that stack's socket, pidfile, or logs.
-STATE_DIR="$(mktemp -d -t bench-minvmd-state.XXXXXX)"
+# Parent for the per-run state dirs (see boot_once). A SHORT /tmp template, not
+# `mktemp -d -t`: on macOS that honours TMPDIR and yields a ~50-byte
+# /var/folders/... path, and the daemon socket beneath it
+# (`providers/local-minvmd0/ssh.sock`) then blows the 103-byte sun_path limit,
+# so every boot dies before it starts. Matches scripts/session-e2e.sh.
+SCRATCH="$(mktemp -d /tmp/mnvb.XXXXXX)"
 
 now_ms() { perl -MTime::HiRes=time -e 'printf "%d", time()*1000'; }
 # SIGKILL, not TERM: a VM in krun_start_enter ignores SIGTERM, so a leaked
@@ -80,14 +80,34 @@ teardown() { pkill -9 -f "$BIN_ABS" 2>/dev/null; sleep 0.3; }
 
 # Tear down on normal exit AND on Ctrl-C / kill, so an interrupt never leaves a
 # detached VM running (and the run stops promptly instead of deferring).
-trap 'teardown; rm -f "$OUT"; rm -rf "$STATE_DIR"' EXIT
+trap 'teardown; rm -f "$OUT"; rm -rf "$SCRATCH"' EXIT
 trap 'echo; echo "interrupted — tearing down" >&2; teardown; exit 130' INT TERM
+
+# One boot into a FRESH state dir; 0 iff the guest reached READY.
+#
+# Fresh per run for two reasons. Correctness: teardown SIGKILLs the VM, which
+# leaves the bound `ssh.sock` behind, and libkrun registers that path with
+# listen=true on the next boot — it then hangs in krun_start_enter until the
+# timeout, so every run after the first silently FAILED. Fidelity: this is a
+# COLD-boot benchmark, and a reused state dir carries the previous run's data
+# volume, which is not the state a cold boot starts from.
+#
+# It also isolates the bench from any other checkout: minvmd refuses to boot
+# when the DEFAULT state dir already has a VM registered, and that dir is shared
+# across checkouts even though the binaries are not — so a sibling dev stack
+# alone was enough to make every run fail with "minvmd is already running".
+boot_once() {
+  local sd="$SCRATCH/run$1"
+  mkdir -p "$sd"
+  "$TIMEOUT" "$BOOT_TIMEOUT" "$BIN" --minimal-state-dir "$sd" boot </dev/null >"$OUT" 2>&1
+  grep -qx vm-up "$OUT"
+}
 
 # Warmup (page-cache the kernel/rootfs; the first boot is cold). Fail loudly here
 # if the artifacts/codesign are wrong, rather than silently N times below.
 echo "warming up (cold boot, discarded)…" >&2
 teardown
-if ! "$TIMEOUT" "$BOOT_TIMEOUT" "$BIN" --minimal-state-dir "$STATE_DIR" boot </dev/null >"$OUT" 2>&1 || ! grep -qx vm-up "$OUT"; then
+if ! boot_once warmup; then
   echo "warmup boot did not reach vm-up — check artifacts, codesign, and libkrun:" >&2
   tail -6 "$OUT" >&2
   exit 1
@@ -97,7 +117,7 @@ teardown
 samples=()
 for i in $(seq 1 "$N"); do
   t0="$(now_ms)"
-  if "$TIMEOUT" "$BOOT_TIMEOUT" "$BIN" --minimal-state-dir "$STATE_DIR" boot </dev/null >"$OUT" 2>/dev/null && grep -qx vm-up "$OUT"; then
+  if boot_once "$i"; then
     t1="$(now_ms)"; ms="$(( t1 - t0 ))"; samples+=( "$ms" )
     printf 'run %2d/%d: %4d ms\n' "$i" "$N" "$ms" >&2
   else

--- a/scripts/bench-minvmd-boot.sh
+++ b/scripts/bench-minvmd-boot.sh
@@ -33,6 +33,9 @@ for v in MINVMD_KERNEL_PATH MINVMD_ROOTFS_PATH MINVMD_INITRAMFS; do
   [ -f "${!v}" ] || { echo "$v points at a missing file: ${!v}" >&2; exit 1; }
 done
 [ -x "$BIN" ] || { echo "minvmd binary not found/executable: $BIN" >&2; exit 1; }
+# Absolute path for the teardown pattern (see `teardown` below): the running
+# processes carry it, and it is what keeps a sibling checkout's VM out of range.
+BIN_ABS="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
 command -v perl >/dev/null || { echo "perl required for sub-ms timing" >&2; exit 1; }
 # GNU coreutils ships `timeout`, but Homebrew installs it as `gtimeout` unless
 # the gnubin dir is on PATH — accept either so the macOS path works out of box.
@@ -53,23 +56,38 @@ fi
 # SIGTTOU then stops the whole group and the boot dies silently at the timeout.
 BOOT_TIMEOUT=12
 OUT="$(mktemp -t bench-minvmd.XXXXXX)"
+# Private state dir. minvmd refuses to boot when the default one already has a
+# VM registered ("minvmd is already running"), which a parallel checkout's dev
+# stack is enough to trigger — the state dir is shared across checkouts even
+# though the binaries are not. Isolating it also keeps the bench from touching
+# that stack's socket, pidfile, or logs.
+STATE_DIR="$(mktemp -d -t bench-minvmd-state.XXXXXX)"
 
 now_ms() { perl -MTime::HiRes=time -e 'printf "%d", time()*1000'; }
 # SIGKILL, not TERM: a VM in krun_start_enter ignores SIGTERM, so a leaked
 # __krun-vmm (e.g. from a Ctrl-C'd foreground boot) would otherwise hold the
 # bridge socket and make every subsequent boot fail.
-teardown() { pkill -9 -f "__krun-vmm" 2>/dev/null; pkill -9 -f "$BIN boot" 2>/dev/null; sleep 0.3; }
+#
+# Matching is scoped to THIS checkout, the same discipline scripts/reap-vms.sh
+# documents: a bare `-f "__krun-vmm"` matches EVERY checkout's VM, so running
+# this bench beside a parallel working copy would SIGKILL that copy's live dev
+# stack — sessions and all — between every run. Both the supervisor and the
+# __krun-vmm grandchild re-exec via current_exe(), so both carry the binary's
+# absolute path in their cmdline. Resolved to an absolute path because $BIN is
+# conventionally passed relative (`./target/debug/minvmd`), which would match
+# nothing here.
+teardown() { pkill -9 -f "$BIN_ABS" 2>/dev/null; sleep 0.3; }
 
 # Tear down on normal exit AND on Ctrl-C / kill, so an interrupt never leaves a
 # detached VM running (and the run stops promptly instead of deferring).
-trap 'teardown; rm -f "$OUT"' EXIT
+trap 'teardown; rm -f "$OUT"; rm -rf "$STATE_DIR"' EXIT
 trap 'echo; echo "interrupted — tearing down" >&2; teardown; exit 130' INT TERM
 
 # Warmup (page-cache the kernel/rootfs; the first boot is cold). Fail loudly here
 # if the artifacts/codesign are wrong, rather than silently N times below.
 echo "warming up (cold boot, discarded)…" >&2
 teardown
-if ! "$TIMEOUT" "$BOOT_TIMEOUT" "$BIN" boot </dev/null >"$OUT" 2>&1 || ! grep -qx vm-up "$OUT"; then
+if ! "$TIMEOUT" "$BOOT_TIMEOUT" "$BIN" --minimal-state-dir "$STATE_DIR" boot </dev/null >"$OUT" 2>&1 || ! grep -qx vm-up "$OUT"; then
   echo "warmup boot did not reach vm-up — check artifacts, codesign, and libkrun:" >&2
   tail -6 "$OUT" >&2
   exit 1
@@ -79,7 +97,7 @@ teardown
 samples=()
 for i in $(seq 1 "$N"); do
   t0="$(now_ms)"
-  if "$TIMEOUT" "$BOOT_TIMEOUT" "$BIN" boot </dev/null >"$OUT" 2>/dev/null && grep -qx vm-up "$OUT"; then
+  if "$TIMEOUT" "$BOOT_TIMEOUT" "$BIN" --minimal-state-dir "$STATE_DIR" boot </dev/null >"$OUT" 2>/dev/null && grep -qx vm-up "$OUT"; then
     t1="$(now_ms)"; ms="$(( t1 - t0 ))"; samples+=( "$ms" )
     printf 'run %2d/%d: %4d ms\n' "$i" "$N" "$ms" >&2
   else


### PR DESCRIPTION
Three bugs in `scripts/bench-minvmd-boot.sh`, all found while using it to A/B a new guest rootfs. Two made the bench actively destructive or useless; the third made it unrunnable on macOS.

## 1. Teardown killed other checkouts' VMs

```sh
teardown() { pkill -9 -f "__krun-vmm" 2>/dev/null; … }
```

That pattern matches **every checkout's** VM. Running the bench beside a parallel working copy `SIGKILL`s that copy's live dev stack — sessions and all — between each of N runs, and once more on exit.

It matched a sibling checkout's 44-minute-old VM:

```
$ pgrep -f "__krun-vmm"
30474 /Users/norrie/code/minimal/target/debug/minvmd __krun-vmm   ← different checkout
```

`scripts/reap-vms.sh` already documents the rule this violates:

> Matching is scoped to THIS checkout's binaries […] a bare-name pkill would only add collateral — an unrelated checkout's live VM, or podman's gvproxy.

So the fix applies that existing discipline rather than inventing one. Both the supervisor and the `__krun-vmm` grandchild re-exec via `current_exe()`, so both carry the binary's absolute path in their cmdline. `$BIN` is resolved to an absolute path first, because it is conventionally passed relative (`./target/debug/minvmd`) and that would match nothing.

| pattern | matches |
|---|---|
| `__krun-vmm` (before) | the sibling's VM — pid 30474 |
| `/…/minimal2/target/debug/minvmd` (after) | 0 processes |

## 2. Only the first run was a real sample

Every run after the first reported `FAILED (no vm-up)`.

`teardown` SIGKILLs the VM, which leaves the bound `ssh.sock` behind in the state dir. libkrun registers that path with `listen=true` on the next boot, so it hangs in `krun_start_enter` until the 12 s timeout. With one state dir shared across runs, `n=10` really meant `n=1`.

Each boot now gets a fresh state dir. That is also the right fidelity — this is a **cold**-boot benchmark, and a reused state dir carries the previous run's data volume, which is not the state a cold boot starts from.

It additionally isolates the bench from any other checkout: minvmd refuses to boot when the *default* state dir has a VM registered, and that dir is shared across checkouts even though the binaries are not. A sibling dev stack alone was enough to fail every run with `minvmd is already running`.

## 3. `mktemp -d -t` blew the socket path limit

`-t` honours `TMPDIR`, which on macOS is a ~50-byte `/var/folders/...` path. The daemon socket beneath it then exceeds the 103-byte `sun_path` limit and the boot dies before it starts:

```
socket path /var/folders/…/providers/local-minvmd0/ssh.sock is 118 bytes, exceeds the 103-byte limit
```

A short `/tmp` template avoids it, matching what `scripts/session-e2e.sh` already does.

## Verification

`shellcheck` clean at 0.11.0 and at CI's 0.10.0.

Exercised end-to-end on the job it was written for — boot-to-READY across two guest rootfs images, 10 runs each, with a sibling checkout's stack up throughout:

| rootfs | min | median | max |
|---|---|---|---|
| 186 MB (current pin) | 146 ms | 154 ms | 161 ms |
| 45 MB (gominimal/pkgs#534) | 122 ms | 129 ms | 147 ms |

All 20 samples valid, distributions non-overlapping, and the sibling checkout was still running afterwards. Before this PR that comparison was not obtainable: run 1 of each set was the only sample, and the bench would have killed the sibling stack 22 times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `bench-minvmd-boot.sh` teardown to target only the current binary and isolate per-run state
> - Adds `BIN_ABS` (absolute path to the `minvmd` binary) so teardown uses `pkill -9 -f "$BIN_ABS"` instead of broad pattern matches, avoiding killing processes from other checkouts.
> - Adds a `SCRATCH` directory under `/tmp` (short path) as the parent for per-run minimal state dirs, avoiding socket path length issues.
> - Introduces a `boot_once` function that creates a fresh `--minimal-state-dir` per run and checks for exact `vm-up` output; warmup and timed loops both use it.
> - Extends the `EXIT` trap to `rm -rf "$SCRATCH"` on exit.
> - Behavioral Change: each boot now runs against a fresh isolated state directory rather than shared state, which changes timing characteristics slightly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9fc641.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->