### PR TITLE
fix(release): call `min completions print` in the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -719,14 +719,19 @@ jobs:
             - name: Make binaries executable
               run: chmod +x artifacts/*-*-*
             - name: Generate completions
+              # `min` splits printing from installing (`completions print
+              # <shell>`); `mip` and `minimald` keep the flat verb. The `min`
+              # files are named for the `min` binary, not the crate — the shim
+              # it prints registers the command `min`, so a shell only autoloads
+              # it from a file of that name.
               run: |
                   mkdir -p artifacts/completions/{bash,zsh,fish}
                   artifacts/mip-linux-amd64 completions bash > artifacts/completions/bash/mip
                   artifacts/mip-linux-amd64 completions zsh  > artifacts/completions/zsh/_mip
                   artifacts/mip-linux-amd64 completions fish > artifacts/completions/fish/mip.fish
-                  artifacts/minimal-linux-amd64 completions bash > artifacts/completions/bash/minimal
-                  artifacts/minimal-linux-amd64 completions zsh  > artifacts/completions/zsh/_minimal
-                  artifacts/minimal-linux-amd64 completions fish > artifacts/completions/fish/minimal.fish
+                  artifacts/minimal-linux-amd64 completions print bash > artifacts/completions/bash/min
+                  artifacts/minimal-linux-amd64 completions print zsh  > artifacts/completions/zsh/_min
+                  artifacts/minimal-linux-amd64 completions print fish > artifacts/completions/fish/min.fish
                   artifacts/minimald-linux-amd64 completions bash > artifacts/completions/bash/minimald
                   artifacts/minimald-linux-amd64 completions zsh  > artifacts/completions/zsh/_minimald
                   artifacts/minimald-linux-amd64 completions fish > artifacts/completions/fish/minimald.fish


### PR DESCRIPTION
## What broke

[Release run 30425725370](https://github.com/gominimal/minimal/actions/runs/30425725370) failed in the `release` job's **Generate completions** step:

```
error: unrecognized subcommand 'bash'
Usage: minimal-linux-amd64 completions [OPTIONS] <COMMAND>
##[error]Process completed with exit code 2.
```

[#1009](https://github.com/gominimal/minimal/pull/1009) split `min completions <shell>` into `min completions print <shell>` and `min completions install`. The release job still called the flat form, so the step exited 2 and everything after it — GCS archive upload, Create Release, `stage-installer` — never ran. Every build job succeeded; only the packaging step is broken.

`mip` and `minimald` keep the flat `completions <shell>` verb, so their six lines are untouched.

## The fix

- The three `min` lines become `completions print <shell>`.
- Their outputs are renamed `min` / `_min` / `min.fish`. The shim `min completions print` emits registers the command **`min`** (`complete … _clap_complete_min min`, `compdef _clap_dynamic_completer_min min`, `complete --command min`), and every shell autoloads a completion file by the command name — so the `minimal` / `_minimal` / `minimal.fish` files shipped in `completions.tar.gz` have been dead on arrival since the binary rename in [#737](https://github.com/gominimal/minimal/pull/737). Flagging this as the one change beyond the literal build break; nothing in the tree consumes those filenames (the curl\|sh installer generates its own via `min completions install`).

## Verification

Locally, against `cargo build -p minimal`:

- `min completions print {bash,zsh,fish}` — all three emit a shim, exit 0.
- `min completions bash` — reproduces the run's exact error.
- Registration target inspected in all three outputs: `min`, confirming the filename change.
- `release.yml` re-parsed as YAML.

The step itself only runs on a release dispatch, so the real proof is the next release run — a `dry_run: true` dispatch exercises this step (it precedes the dry-run branch) without publishing anything.

## Note

The release job's CLI invocations have no pre-merge coverage; a breaking CLI change lands and only a release run finds out. Worth a follow-up guard, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `completions print` call and output filenames for `min` binary in release job
> The release job's "Generate completions" step was calling `completions <shell>` instead of `completions print <shell>` for the minimal binary, and writing files named `minimal`, `_minimal`, and `minimal.fish` instead of `min`, `_min`, and `min.fish`. This fixes both issues in [release.yml](.github/workflows/release.yml).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6384c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->