### PR TITLE
test(common): gate the release job's CLI invocations pre-merge

### DIFF
--- a/crates/common/tests/release_cli_smoke.rs
+++ b/crates/common/tests/release_cli_smoke.rs
@@ -1,0 +1,65 @@
+//! Convention-discovered gate for the CLI invocations the release job makes.
+//!
+//! `release.yml`'s "Generate completions" step runs `mip` / `min` / `minimald`
+//! against the binaries it just built, but only on a `workflow_dispatch`
+//! release — so a breaking CLI change clears every PR gate and only surfaces
+//! when someone cuts a release, an hour of build time in, taking the GCS
+//! upload, the GitHub Release and `stage-installer` with it (#1035; the
+//! `completions <shell>` → `completions print <shell>` split shipped that way
+//! for twenty days, #1009/#1034).
+//!
+//! Gating the release job from inside itself would mean editing
+//! `.github/workflows/`, which is frozen and CODEOWNER-gated. Instead this test
+//! drives `scripts/release-cli-smoke.sh`, which reads those invocations back
+//! out of the workflow and replays them against the debug binaries — so the
+//! workspace suite the always-running Linux lanes execute is the pre-merge
+//! gate. This is the reviewed-code extension point CI schedules over
+//! (docs/ci-strategy.md §10): a new *kind* of check added through code, never
+//! through YAML.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is crates/common; the workspace root is two up.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root two levels above crates/common")
+        .to_path_buf()
+}
+
+/// The directory cargo built this test into (`<target>/<profile>/deps/..`),
+/// which is also where the binaries under test land. Derived rather than
+/// assumed so a custom `CARGO_TARGET_DIR` or profile still resolves — cargo
+/// does not export either to the test process.
+fn bin_dir() -> PathBuf {
+    std::env::current_exe()
+        .expect("test binary path")
+        .parent()
+        .and_then(|deps| deps.parent())
+        .expect("<target>/<profile> two levels above the test binary")
+        .to_path_buf()
+}
+
+#[test]
+fn release_job_cli_invocations_still_work() {
+    let root = repo_root();
+    // `--build`: under the workspace suite the binaries are already there and
+    // this is a no-op, but a bare `cargo test -p common` has not built them —
+    // build rather than skip, so the gate can never quietly cover nothing.
+    let output = Command::new("bash")
+        .arg(root.join("scripts/release-cli-smoke.sh"))
+        .arg("--build")
+        .env("BIN_DIR", bin_dir())
+        .current_dir(&root)
+        .output()
+        .expect("failed to run scripts/release-cli-smoke.sh");
+
+    assert!(
+        output.status.success(),
+        "scripts/release-cli-smoke.sh failed\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/justfile
+++ b/justfile
@@ -254,6 +254,13 @@ test-installer:
 lint-shell:
     bash scripts/lint-shell.sh
 
+# Replay the release job's shipped-binary CLI invocations against the debug
+# binaries (builds any that are missing). The frozen release.yml only runs them
+# on a dispatched release, so this is their pre-merge gate; CI runs the same
+# check through crates/common/tests/release_cli_smoke.rs (part of `just test`).
+test-release-cli:
+    bash scripts/release-cli-smoke.sh --build
+
 # Run the promotion provenance gate's test harness (stubbed `gh`, no network,
 # no auth); shellcheck runs when present.
 test-promote-gate:

--- a/scripts/release-cli-smoke.sh
+++ b/scripts/release-cli-smoke.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Exercise the shipped-binary CLI invocations the release job makes.
+#
+# WHY THIS EXISTS
+# ---------------
+# `release.yml`'s "Generate completions" step shells out to the freshly built
+# `mip` / `min` / `minimald` binaries. Those nine invocations only ever run on a
+# `workflow_dispatch` release, so a breaking CLI change passes every PR gate,
+# merges, and sits until someone cuts a release — where it takes the GCS upload,
+# the GitHub Release, and `stage-installer` down with it after an hour of build
+# time. That is exactly what #1009 (`completions <shell>` → `completions print
+# <shell>`) did, twenty days after merging (#1034 fixed the call site).
+#
+# Widening the release job to gate itself would mean editing
+# `.github/workflows/`, which is frozen and CODEOWNER-gated. Instead this
+# harness READS the invocations out of `release.yml` and replays them against
+# locally built debug binaries; CI picks it up through a convention-discovered
+# workspace test (crates/common/tests/release_cli_smoke.rs) and `just
+# test-release-cli` — the reviewed-code extension point CI schedules over
+# (docs/ci-strategy.md §10).
+#
+# Nothing here is a hand-maintained copy of the release job's command list: both
+# the artifact→binary map ("Rename binaries with platform suffix") and the
+# invocations themselves are parsed out of the workflow, so a call site the
+# release job adds or edits is covered on the next run without touching this
+# file. Discovering zero invocations is a hard failure, never a green skip.
+#
+# Each invocation is checked three ways, because exit 0 alone is too weak: the
+# #737 binary rename (`minimal` → `min`) left the release job writing `min`'s
+# completions to files named `minimal`, which a shell never autoloads — an
+# exit-code-only gate would have shipped that silently, as it did until #1034.
+#
+#   1. exits 0 and writes a non-empty file;
+#   2. the shell it generates for matches the directory it is written to;
+#   3. the shim registers the command its destination FILENAME implies —
+#      `bash/<cmd>`, `zsh/_<cmd>`, `fish/<cmd>.fish`.
+#
+# SCOPE
+# -----
+# The "Generate completions" step is, as of this writing, the only place the
+# release or `stage-installer` jobs invoke a shipped binary — everything else
+# they run is `gcloud`, `gh`, `tar`, or a reviewed `scripts/` helper with its own
+# harness (install.sh → install_test.sh, verify-nightly-provenance.sh →
+# verify-nightly-provenance_test.sh). If a later step starts calling one of the
+# binaries, widen the discovery pattern at the bottom of the loop to reach it.
+#
+# Usage: scripts/release-cli-smoke.sh [--build]
+#   --build  cargo-build any missing binary first (default: a missing binary is
+#            an error, so a stale target/ can never quietly narrow the check).
+# Env: BIN_DIR overrides where the binaries are looked up (default
+#      ${CARGO_TARGET_DIR:-<repo>/target}/debug).
+set -euo pipefail
+
+build_missing=0
+case "${1:-}" in
+    --build) build_missing=1 ;;
+    "") ;;
+    *) echo "usage: $0 [--build]" >&2; exit 2 ;;
+esac
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+workflow="$root/.github/workflows/release.yml"
+bin_dir="${BIN_DIR:-${CARGO_TARGET_DIR:-$root/target}/debug}"
+
+[ -f "$workflow" ] || { echo "release-cli-smoke: no such workflow: $workflow" >&2; exit 1; }
+
+# `minimald` does not build on macOS (its sandbox stack is Linux-only — see the
+# platform matrix in AGENTS.md), so its invocations are skipped there and gated
+# by the Linux lanes. Every other binary is checked on every platform.
+skip_on_this_os() {
+    [ "$1" = minimald ] && [ "$(uname -s)" != Linux ]
+}
+
+# artifact name -> binary name, from the release job's rename step
+# (`mv min minimal-linux-amd64`), as "<artifact> <binary>" lines. Sorted unique,
+# so the same rename repeated per architecture collapses to one entry and a
+# genuine conflict shows up as two lines for one artifact.
+# `|| true`: no matches is grep's exit 1, which `pipefail` would otherwise turn
+# into a silent early exit here. An empty map surfaces per-invocation instead.
+rename_map="$(
+    { grep -E '^[[:space:]]*mv [^[:space:]]+ [^[:space:]]+-(linux|darwin)-(amd64|arm64)$' "$workflow" |
+        awk '{print $3, $2}' | sort -u; } || true
+)"
+
+bin_for_artifact() {
+    awk -v want="$1" '$1 == want { print $2 }' <<<"$rename_map" | sort -u
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+discovered=0
+checked=0
+skipped=0
+failed=0
+
+fail() {
+    echo "FAIL  $1" >&2
+    failed=$((failed + 1))
+}
+
+# Replay every `artifacts/<binary> ... > artifacts/completions/<shell>/<file>`
+# line in the workflow.
+while IFS= read -r line; do
+    discovered=$((discovered + 1))
+    cmd="${line%%>*}"
+    dest="${line#*>}"
+    # shellcheck disable=SC2086 # deliberate: re-split the recorded argv
+    set -- $cmd
+    artifact="$(basename "$1")"
+    shift
+    args=("$@")
+    # shellcheck disable=SC2086
+    set -- $dest
+    dest="$1"
+
+    shell_dir="$(basename "$(dirname "$dest")")"
+    file="$(basename "$dest")"
+    invocation="$artifact ${args[*]} > $shell_dir/$file"
+
+    bin="$(bin_for_artifact "$artifact")"
+    if [ -z "$bin" ]; then
+        fail "$invocation: no rename step maps $artifact to a binary"
+        continue
+    fi
+    if [ "$(printf '%s\n' "$bin" | wc -l)" -ne 1 ]; then
+        fail "$invocation: $artifact maps to more than one binary ($(tr '\n' ' ' <<<"$bin"))"
+        continue
+    fi
+
+    if skip_on_this_os "$bin"; then
+        echo "SKIP  $invocation ($bin does not build on $(uname -s))"
+        skipped=$((skipped + 1))
+        continue
+    fi
+    checked=$((checked + 1))
+
+    # The shell the shim is generated for has to match the directory it lands
+    # in; the release job passes it as the last argument.
+    gen_shell="${args[$((${#args[@]} - 1))]}"
+    if [ "$gen_shell" != "$shell_dir" ]; then
+        fail "$invocation: generates for $gen_shell but is written to $shell_dir/"
+        continue
+    fi
+
+    # The command a shell will autoload this file for, per its naming rule.
+    case "$shell_dir" in
+        bash) cmd_name="$file" ;;
+        zsh)  cmd_name="${file#_}"; [ "_$cmd_name" = "$file" ] || cmd_name="" ;;
+        fish) cmd_name="${file%.fish}"; [ "$cmd_name.fish" = "$file" ] || cmd_name="" ;;
+        *) fail "$invocation: unknown completion shell directory '$shell_dir'"; continue ;;
+    esac
+    if [ -z "$cmd_name" ] || ! [[ "$cmd_name" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+        fail "$invocation: '$file' is not a valid $shell_dir completion filename"
+        continue
+    fi
+
+    exe="$bin_dir/$bin"
+    if [ ! -x "$exe" ]; then
+        if [ "$build_missing" = 1 ]; then
+            # `--workspace --bin`, not `-p <package> --bin`: selecting the whole
+            # workspace resolves features exactly as the workspace test build
+            # does, so this is a link (or a no-op) rather than a rebuild of every
+            # shared dependency under a narrower feature set. It also means no
+            # binary→package table to keep in sync (`min` comes from the
+            # `minimal` crate — the naming footgun in AGENTS.md).
+            echo "release-cli-smoke: building $bin" >&2
+            (cd "$root" && cargo build --locked --workspace --bin "$bin" >&2)
+            if [ ! -x "$exe" ]; then
+                fail "$invocation: built $bin but $exe is still missing (BIN_DIR mismatch?)"
+                continue
+            fi
+        else
+            fail "$invocation: $exe not built (run with --build, or \`cargo build\` it)"
+            continue
+        fi
+    fi
+
+    out="$tmp/$shell_dir/$file"
+    mkdir -p "$(dirname "$out")"
+    rc=0
+    "$exe" "${args[@]}" >"$out" 2>"$tmp/stderr" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        fail "$invocation: exited $rc — $(tr '\n' ' ' <"$tmp/stderr")"
+        continue
+    fi
+    if [ ! -s "$out" ]; then
+        fail "$invocation: wrote an empty completion file"
+        continue
+    fi
+
+    # The registration line, in whichever form the binary emits: clap's static
+    # (aot) generator and its dynamic (env) shim differ in flag spelling but
+    # both name the command they complete.
+    case "$shell_dir" in
+        bash) pattern="^[[:space:]]*complete[[:space:]].*[[:space:]]$cmd_name\$" ;;
+        zsh)  pattern="^#compdef[[:space:]]+$cmd_name([[:space:]]|\$)" ;;
+        fish) pattern="(^|[[:space:]])(-c|--command)[[:space:]]+$cmd_name([[:space:]]|\$)" ;;
+    esac
+    if ! grep -qE "$pattern" "$out"; then
+        fail "$invocation: does not register the command '$cmd_name' that '$file' completes"
+        continue
+    fi
+
+    echo "ok    $invocation"
+done < <(grep -E '^[[:space:]]*artifacts/[^[:space:]]+ .*>[[:space:]]*artifacts/completions/' "$workflow")
+
+if [ "$discovered" -eq 0 ]; then
+    # Discovery broke (the step moved, renamed, or changed shape) — never pass
+    # green having replayed nothing; that is the false signal this exists to end.
+    echo "release-cli-smoke: found no release-job CLI invocations in $workflow" >&2
+    exit 1
+fi
+if [ "$failed" -gt 0 ]; then
+    echo "release-cli-smoke: $failed of $discovered invocation(s) failed" >&2
+    exit 1
+fi
+summary="release-cli-smoke: $checked invocation(s) passed"
+if [ "$skipped" -gt 0 ]; then
+    summary="$summary, $skipped skipped"
+fi
+echo "$summary"


### PR DESCRIPTION
Closes #1035.

## Problem

`release.yml`'s **Generate completions** step shells out to the freshly built `mip` / `min` / `minimald` binaries — nine invocations at `release.yml:724-732`. They only ever execute on a `workflow_dispatch` release, so a breaking CLI change clears every PR gate, merges, and sits until someone cuts a release. That is exactly how #1009 (`completions <shell>` → `completions print <shell>`) shipped: twenty days later it exited 2 on run 30425725370 and took the GCS archive upload, the GitHub Release, and the whole `stage-installer` job down with it, an hour of build time in. #1034 fixed the call site; the structural gap stayed.

## Fix

`scripts/release-cli-smoke.sh` reads those invocations back **out of** `release.yml` and replays them against the debug binaries. Nothing here is a hand-maintained copy of the release job's command list — both the artifact→binary map (from the `mv min minimal-linux-amd64` rename step) and the invocations themselves are parsed from the workflow, so a call site the release job adds or edits is covered on the next run without touching the harness. Discovering zero invocations is a hard failure, never a green skip.

Each invocation is checked three ways, because exit 0 alone is too weak:

1. exits 0 and writes a non-empty file;
2. the shell it generates for matches the directory it is written to;
3. the shim registers the command its destination **filename** implies — `bash/<cmd>`, `zsh/_<cmd>`, `fish/<cmd>.fish`.

Check 3 is the one an exit-code-only gate would have missed: the #737 binary rename left the release job writing `min`'s completions to files named `minimal`, which no shell autoloads, and that shipped silently until #1034. The check handles both shapes clap emits — `mip`/`minimald`'s static (aot) generator and `min`'s dynamic (env) registration shim.

`.github/workflows/` is frozen and CODEOWNER-gated, so CI reaches the harness the same way it reaches `scripts/lint-shell.sh` (#899): a convention-discovered workspace test, `crates/common/tests/release_cli_smoke.rs`, run by the always-on Linux lanes' core-tests suite — the reviewed-code extension point in docs/ci-strategy.md §10. Plus `just test-release-cli` for a direct local run.

The test passes `--build` so a bare `cargo test -p common` builds what is missing rather than silently covering nothing. The build uses `--workspace --bin <name>` rather than `-p <package> --bin <name>` deliberately: selecting the whole workspace resolves features exactly as the workspace test build does, so after the core-tests suite it is a link or a no-op instead of a rebuild of every shared dependency under a narrower feature set (measured: 3 min for the narrow form locally).

## Verification

- **Reproduces #1035 pre-merge.** Pointed at the pre-#1034 workflow, the Rust test fails with `FAIL … exited 2 — error: unrecognized subcommand 'bash'` for all three `min completions <shell>` calls.
- **Negative cases**, against synthetic workflows: `min` completions written to a file named `minimal` (the #737 class) → fails check 3; a zsh shim written to `bash/` → fails check 2; an artifact with no rename line; a missing binary without `--build`; a workflow with no invocations → the zero-discovery guard.
- **Green on `main`**: 6 passed, 3 skipped. `minimald` is Linux-only (platform matrix), so its three invocations self-skip on macOS by name and run for real on the Linux lanes. 0.24 s when the binaries already exist.
- `shellcheck` clean; `just lint-shell` 25/25; `cargo fmt --check`; `cargo clippy -p common --all-targets -- -D warnings`; `cargo test -p common`. Full `just ci` is not runnable on this host — the macOS scope excludes `common`, so the new test's real run is the Linux lanes on this PR.

## Audit

Per the issue's request to check the rest of the release path: the completions step is the only place the `release` and `stage-installer` jobs invoke a shipped binary. Everything else they run is `gcloud`, `gh`, `tar`, or a reviewed `scripts/` helper that already has its own harness (`install.sh` → `install_test.sh`, `verify-nightly-provenance.sh` → `verify-nightly-provenance_test.sh`). Recorded in the script's SCOPE header, with a pointer to where discovery widens if a later step starts calling one of the binaries.

Complements #687's PR9b (post-release artifact smoke); this is the pre-merge half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate release job CLI invocations with a pre-merge smoke test
> - Adds [scripts/release-cli-smoke.sh](https://github.com/gominimal/minimal/pull/1044/files#diff-c2fedc1cc26c147b1bdba3dd1bc68d6a35145aa8e03978ec190a2beba749cf91), a Bash harness that reads the release workflow's CLI completion invocations, maps each artifact to a local binary, builds missing binaries if `--build` is passed, runs them to generate completions, and validates output is non-empty and registers the expected command.
> - Adds a Rust test `release_job_cli_invocations_still_work` in [crates/common/tests/release_cli_smoke.rs](https://github.com/gominimal/minimal/pull/1044/files#diff-4d7454247d33e0ba2cd1a90bde993e18a4d559bd8e4df1752b2fbea3bc8e2de3) that invokes the script with `--build` and fails the test suite if the script exits non-zero.
> - Adds a `test-release-cli` recipe to [justfile](https://github.com/gominimal/minimal/pull/1044/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1) for running the smoke check locally.
> - `minimald` invocations are skipped on non-Linux platforms via a `skip_on_this_os` guard.
> - Risk: the test runs `cargo build --workspace --bin` for each missing binary, so CI time will increase proportionally to how many binaries are not already built.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7898557.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->