### PR TITLE
docs: fix all STE prose lint errors across the docs tree

### DIFF
--- a/docs/ci-strategy.md
+++ b/docs/ci-strategy.md
@@ -62,7 +62,7 @@ cannot nest virtualization); it is gated to trusted refs. Everything expensive,
 matrix-expanding, or advisory-flavored moves to a nightly cron that doubles as a
 cache-primer for main.
 
-Target: **≤ ~10 min PR wall-clock** on the common path (quick gates ~2 min, build ~4–6 min
+Target: **≤ ~10 min PR wall-clock** on the common path (quick gates ~2 min, build ~4-6 min
 warm, tests and VM smoke overlapping in parallel).
 
 ```mermaid
@@ -141,10 +141,10 @@ Order tests by cost; push each test into the cheapest tier that can catch its fa
 
 | Tier | What | Where | Cost |
 |---|---|---|---|
-| 1 | `cargo fmt --check`, `cargo clippy --all-targets`, `cargo-deny` | any runner, no VM | seconds–2 min |
+| 1 | `cargo fmt --check`, `cargo clippy --all-targets`, `cargo-deny` | any runner, no VM | seconds-2 min |
 | 2 | unit + integration tests (`cargo nextest run`), `cargo test --doc` | Linux + macOS runners | minutes, warm-cached |
 | 3 | **process-mode e2e**, guest daemon as a plain process, direct client connection | Linux runners, no KVM needed | minutes |
-| 4 | **VM smoke e2e**, boot real libkrun VM, client → vsock proxy → guest daemon round-trip, handful of scenarios | `ubuntu-latest` (KVM) + self-hosted Mac | ~5–10 min |
+| 4 | **VM smoke e2e**, boot real libkrun VM, client → vsock proxy → guest daemon round-trip, handful of scenarios | `ubuntu-latest` (KVM) + self-hosted Mac | ~5-10 min |
 | 5 | extended e2e, long scenarios, supervision/restart paths, stress, larger matrix | nightly | tens of minutes |
 
 **Tier 3 is this project's structural advantage.** The Linux no-KVM fallback (guest daemon
@@ -282,15 +282,15 @@ concurrency:
 | Job | Runner | Does | Est. (warm) |
 |---|---|---|---|
 | `fmt` | ubuntu-latest | `cargo fmt --check`, no cache, no deps | <1 min |
-| `clippy` | ubuntu-latest | `cargo clippy --workspace --all-targets --locked` (own cache key; clippy shares artifacts with `check`, not `build`) | 2–4 min |
+| `clippy` | ubuntu-latest | `cargo clippy --workspace --all-targets --locked` (own cache key; clippy shares artifacts with `check`, not `build`) | 2-4 min |
 | `deny` | ubuntu-latest | `cargo-deny check`, **licenses/bans blocking; advisories `continue-on-error`** (Embark's own recommendation: a newly published advisory must not break unrelated PRs) | 1 min |
 | `preflight` | ubuntu-latest | classify changed paths (cloud-hypervisor pattern); docs-only changes skip everything below | seconds |
-| `build-linux` | ubuntu-latest | workspace build, `nextest archive`, `cargo test --doc`, x86_64-musl guest → upload artifacts | 4–6 min |
-| `build-guest-arm64` | ubuntu-24.04-arm | aarch64-musl guest → artifact | 2–3 min |
-| `test-linux` | ubuntu-latest | nextest from archive (tier 2) + **process-mode e2e** (tier 3) | 2–4 min |
-| `vm-smoke-linux` | ubuntu-latest | KVM perms step → boot libkrun VM with real guest daemon → client→vsock→guest round-trip smoke; console logs uploaded `if: always()` | 3–6 min |
-| `build-test-macos` | macos-15 (arm64) | build + unit tests, **no VM** | 4–6 min |
-| `vm-smoke-macos` | self-hosted Mac | download client/host-daemon (from macOS build) + aarch64 guest artifacts → libkrun/HVF smoke. **Gated** (§7): same-repo PRs via label, always on main/merge-queue | 3–6 min |
+| `build-linux` | ubuntu-latest | workspace build, `nextest archive`, `cargo test --doc`, x86_64-musl guest → upload artifacts | 4-6 min |
+| `build-guest-arm64` | ubuntu-24.04-arm | aarch64-musl guest → artifact | 2-3 min |
+| `test-linux` | ubuntu-latest | nextest from archive (tier 2) + **process-mode e2e** (tier 3) | 2-4 min |
+| `vm-smoke-linux` | ubuntu-latest | KVM perms step → boot libkrun VM with real guest daemon → client→vsock→guest round-trip smoke; console logs uploaded `if: always()` | 3-6 min |
+| `build-test-macos` | macos-15 (arm64) | build + unit tests, **no VM** | 4-6 min |
+| `vm-smoke-macos` | self-hosted Mac | download client/host-daemon (from macOS build) + aarch64 guest artifacts → libkrun/HVF smoke. **Gated** (§7): same-repo PRs via label, always on main/merge-queue | 3-6 min |
 | `ci-ok` | ubuntu-latest | join job, `needs:` everything, `if: always()` + fail-on-any-failure | seconds |
 
 The KVM permissions step (used by GitHub's own changelog, android-emulator-runner, and

--- a/docs/ci-strategy.md
+++ b/docs/ci-strategy.md
@@ -230,7 +230,7 @@ artifacts:
    Test jobs need a same-revision checkout for fixtures, nothing else.
 2. **Guest musl binaries** built once per arch → artifact → consumed by VM-smoke jobs
    and the host-daemon packaging step.
-3. Doctests are the one thing nextest can't run, keep a cheap `cargo test --doc` step
+3. Doctests are the one thing nextest cannot run, keep a cheap `cargo test --doc` step
    in the build job (compiles against the already-built lib).
 
 Avoid the classic redundancy traps:
@@ -446,13 +446,13 @@ and make every test **discovered by convention, never registered**.
 
 ### 10.1 Freeze the workflow layer mechanically
 
-Instructions alone ("don't touch GitHub Actions") are policy; enforce them structurally:
+Instructions alone ("do not touch GitHub Actions") are policy; enforce them structurally:
 
 - **CODEOWNERS**: the repo-wide `* @gominimal/minimalists` rule (so the minimalists team
   owns `.github/` along with everything else) plus branch protection "require code owner
   review", any PR touching workflows is un-mergeable without human sign-off, no matter
   who or what authored it. This is the standard control; GitHub already treats workflow
-  edits as privileged (fork PRs modifying workflows don't run with secrets).
+  edits as privileged (fork PRs modifying workflows do not run with secrets).
 - **Preflight guard**: the existing `preflight` job fails fast if a PR from an
   agent-labeled branch modifies `.github/**`, cheap belt-and-suspenders, and it gives
   agents an immediate, legible error instead of a review-time rejection.
@@ -519,7 +519,7 @@ first two honest: new capabilities go through reviewed code, never through YAML.
 
 ### 10.4 Proofs
 
-"Provide proofs" becomes cheap when local and CI runs are identical (§8):
+"Getting proofs" becomes cheap when local and CI runs are identical (§8):
 
 - The local commands produce the same artifacts CI does: `cargo nextest run` writes the
   JUnit XML, and `just up` / `scripts/session-e2e.sh` produce the VM console logs and
@@ -527,7 +527,7 @@ first two honest: new capabilities go through reviewed code, never through YAML.
   reviewer re-derives it by reading the CI run, not by trusting the claim.
 - CI publishes the JUnit summary to `$GITHUB_STEP_SUMMARY` (libkrun's `--github-summary`
   flag is precedent), so per-PR test evidence is visible without downloading artifacts.
-- Optional soft gate: `preflight` warns (labels, doesn't fail) when a PR touches `src/`
+- Optional soft gate: `preflight` warns (labels, does not fail) when a PR touches `src/`
   without touching any test path, a nudge, with the real enforcement left to review.
 
 Document this contract in `CONTRIBUTING.md` / the agents' instruction file as a short

--- a/docs/concepts/packages.md
+++ b/docs/concepts/packages.md
@@ -6,7 +6,7 @@ description: Packages are reproducible, dependency-aware units of software in Mi
 
 Packages are the core of software production in Minimal. Packages are reproducible, maintainable, and dependency-aware building blocks designed for environment parity across the software development lifecycle (SDLC).
 
-Structurally, a package is the union of its declarative build specification and the resulting binary artifacts. A metaphor for Minimal's packages would be a recipe (the build specification) and the meal that's cooked from it (the resulting artifacts). This relationship is cemented by a [layer of metadata](#definition) that defines the package's dependencies, architecture, and provenance. In our metaphor, these would be the optional modifications made to tailor the dish so it's more to your liking. By binding the "recipe" to the "result," Minimal ensures that you have complete control over every dish you make, verifying that every component of your environment is transparent, verifiable, and maintainable at scale.
+Structurally, a package is the union of its declarative build specification and the resulting binary artifacts. A metaphor for Minimal's packages would be a recipe (the build specification) and the meal that's cooked from it (the resulting artifacts). This relationship is cemented by a [layer of metadata](#definition) that defines the package's dependencies, architecture, and provenance. In our metaphor, these would be the optional modifications made to tailor the dish so it's more to your liking. By binding the "recipe" to the "result," Minimal makes sure that you have complete control over every dish you make, verifying that every component of your environment is transparent, verifiable, and maintainable at scale.
 
 ## Using packages {#using}
 
@@ -34,7 +34,7 @@ The package definition captures a variety of useful information:
 ## Caching {#caching}
 
 Built packages are cached against their _spec hash_: a cryptographic hash of the metadata of the package, including the recipe for
-building the package (and the recipes for building all its transitive dependencies). Using these hashes as the storage key ensures
+building the package (and the recipes for building all its transitive dependencies). Using these hashes as the storage key makes sure
 that the exact package described in your repository or [software supply chain](./software-supply-chain.md) is used anywhere it is
 requested, as well as providing a reliable key for fetching packages remotely.
 

--- a/docs/concepts/sandboxing.md
+++ b/docs/concepts/sandboxing.md
@@ -4,13 +4,13 @@ description: How Minimal isolates all builds and tasks from the host system usin
 
 # Sandboxing
 
-Sandboxing is essential to ensure all builds and tasks are insulated from the machine they run in. **In Minimal, all tasks and builds run in a sandbox**.
+Sandboxing is essential to make sure all builds and tasks are insulated from the machine they run in. **In Minimal, all tasks and builds run in a sandbox**.
 
 
 ## Package builds
 
-Minimal packages encapsulate all tooling and software, so it's essential they are compiled in a hermetically-sealed environment to provide a strong
-foundation to the rest of the ecosystem. As such, package builds take place in a cleanroom sandbox that shares nothing with the host machine, aside from network access when a dependency calls for it.
+Minimal packages encapsulate all tooling and software, so it's essential they are compiled in a hermetically-sealed environment that gives the rest of the ecosystem a strong
+foundation. As such, package builds take place in a cleanroom sandbox that shares nothing with the host machine, aside from network access when a dependency calls for it.
 
 Specifically, the cleanroom sandbox wires:
 

--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -5,7 +5,7 @@ description: Stacks wire Minimal to build codebases with specific languages and 
 # Stacks
 
 Stacks wire Minimal to operate a codebase with specific tools and commands. When you name a stack
-in your [`minimal.toml`](../reference/minimal-dot-toml.md) file, build-plane commands like `mip run build` just work. Additionally, your [tasks](../reference/tasks.md) inherit these familiar tools and semantics automatically.
+in your [`minimal.toml`](../reference/minimal-dot-toml.md) file, build-plane commands like `mip run build` just work. Also, your [tasks](../reference/tasks.md) inherit these familiar tools and semantics automatically.
 
 Learn more about stacks in [the reference section](../reference/stack-specs.md).
 

--- a/docs/guide/building.md
+++ b/docs/guide/building.md
@@ -58,7 +58,7 @@ Similarly to `mip build`, you can run your test suite with:
 $ mip test
 ```
 
-This is shorthand for `mip run test`, and runs the `test` task from your `minimal.toml`; define one with `[tasks.test]`. Stacks provide a default `build` task only.
+This is shorthand for `mip run test`, and runs the `test` task from your `minimal.toml`; define one with `[tasks.test]`. Stacks only ship a default `build` task.
 
 ## Persisting build state
 
@@ -69,4 +69,4 @@ By default, each task invocation starts from a clean state. To cache build artif
 state_key = "dev"
 ```
 
-Tasks sharing the same `state_key` share cached state, so your builds don't start from scratch every time.
+Tasks sharing the same `state_key` share cached state, so your builds do not start from scratch every time.

--- a/docs/guide/dev-shell.md
+++ b/docs/guide/dev-shell.md
@@ -84,7 +84,7 @@ on_activate = { type = "inline", value = "cargo fetch >/dev/null 2>&1 || true" }
 
 ## Session lifecycle
 
-Exit the shell to detach; the session keeps running in the background. To reattach, list, or tear down sessions:
+Exit the shell to detach; the session keeps running in the background. To reattach, list, or remove sessions:
 
 ```shell
 $ min session attach            # reattach to a session (resolves from the current directory)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -6,6 +6,6 @@ description: "Quickstart for Minimal: install the CLI, initialize a project, and
 
 New to Minimal? Like everyday usage, getting started with Minimal is simple. This documentation will walk you through how to install Minimal, how to initialize projects, and how to define your toolchain and dependencies for use across the org.
 
-As a local-first, declarative build system, Minimal ensures that all builds and dev environments run entirely on your machine within isolated sandboxes. Minimal creates a consistent foundation for all users, whether developer, AI agent, or CI, around the org's tech stack.
+As a local-first, declarative build system, Minimal makes sure that all builds and dev environments run entirely on your machine within isolated sandboxes. Minimal creates a consistent foundation for all users, whether developer, AI agent, or CI, around the org's tech stack.
 
 Minimal is available for download on both Linux and macOS. [Learn more.](https://minimal.dev)

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -25,7 +25,7 @@ curl --proto "=https" --tlsv1.2 -fsSL https://go.minimal.dev/stable | sh
 min --version
 ```
 
-If installed correctly, it will provide you with the version.
+If installed correctly, it prints the version.
 
 ## macOS
 
@@ -49,7 +49,7 @@ curl --proto "=https" --tlsv1.2 -fsSL https://go.minimal.dev/stable | sh
 min --version
 ```
 
-If installed correctly, it will provide you with the version.
+If installed correctly, it prints the version.
 
 ## Upgrade
 

--- a/docs/internal/release-pipeline.md
+++ b/docs/internal/release-pipeline.md
@@ -34,7 +34,7 @@ override for green-but-unreported commits.
 
 - `build-release-linux-{amd64,arm64}`: static musl builds of `mip`, `min`
   (package `minimal`), and `minimald`, one cargo invocation per package so the
-  fat-LTO links serialize. The amd64 job additionally builds a native-glibc
+  fat-LTO links serialize. The amd64 job also builds a native-glibc
   `minvmd` against a materialized libkrun prefix (there is currently no
   `minvmd-linux-arm64` release artifact).
 - `build-release-macos-arm64` (self-hosted Apple Silicon, gated on the

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -8,7 +8,7 @@ description: "Reference for the min session CLI: create, attach to, and manage s
 `min` is the Minimal session CLI. It talks to the `minimald` daemon (see
 [minimald](./cli-minimald.md)) to create, attach to, and manage sandboxed
 development sessions. Most commands start the daemon automatically when it
-isn't running (`bug`, `stop`, and `version` are the exceptions): natively on
+is not running (`bug`, `stop`, and `version` are the exceptions): natively on
 Linux, or inside the [`minvmd`](./cli-minvmd.md) microVM host daemon on macOS
 (and on Linux under `--provider local-minvmd`). Running bare `min` with no
 subcommand resolves a session for the current directory (activating one if
@@ -68,7 +68,7 @@ the current directory).
 | `--sync <MODE>` | | How to load project files into the session: `tarball` (default: stream a tarball of your project and unpack it) or `none` (do not populate the worktree) |
 | `--loadout <NAME>` | | Apply the named loadout from `<config>/minimal/loadouts/<NAME>.toml`. Repeatable; if given, config-file `default_loadouts` are ignored |
 | `--no-loadouts` | | Apply no loadouts at all (also skips the config's `default_loadouts`). Conflicts with `--loadout` |
-| `--no-prompt` | | Fail instead of prompting when the daemon surfaces items user policy can't auto-decide; implied when stdin/stderr isn't a TTY |
+| `--no-prompt` | | Fail instead of prompting when the daemon surfaces items user policy cannot auto-decide; implied when stdin/stderr is not a TTY |
 | `--attach` | | Automatically attach after creation |
 
 ### `session attach`

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -134,11 +134,11 @@ COLORTERM = { inherit = true }               # inherit from the host env
 
 - A **literal** string sets the variable to that value.
 - `{ inherit = true }` passes the variable through from the environment of
-  the `min` process on the host. If the host doesn't have it set, the
+  the `min` process on the host. If the host does not have it set, the
   variable is dropped from the session (with a warning) rather than failing
   activation, so opportunistically inheriting things like `TERM` is safe.
 - `{ inherit = true, default = "..." }` inherits, falling back to `default`
-  when the host doesn't have the variable set.
+  when the host does not have the variable set.
 
 `inherit = false` is rejected; omit the variable instead.
 

--- a/docs/specs/01-spec-minvmd-host-daemon/01-spec-minvmd-host-daemon.md
+++ b/docs/specs/01-spec-minvmd-host-daemon/01-spec-minvmd-host-daemon.md
@@ -58,7 +58,7 @@ that macOS imposes. The daemon:
    cold; warm reattach is sub-second.
 4. `minvmd` auto-spawns on first CLI call and survives client exit.
 5. `minvmd status` / `minvmd stop` work; PID and socket discovery follow
-   XDG conventions; concurrent CLI invocations don't race lifecycle.
+   XDG conventions; concurrent CLI invocations do not race lifecycle.
 
 ## User Stories
 
@@ -122,9 +122,9 @@ with no rootfs work.
 1. **File:** `crates/minvmd/src/krun/raw.rs` contains FFI declarations
    for `krun_create_ctx`, `krun_set_vm_config`, `krun_set_exec`,
    `krun_start_enter`, `krun_free_ctx` with `// SAFETY:` comments,
-   demonstrates the FFI scaffold and safety discipline.
+   shows the FFI scaffold and safety discipline.
 2. **CLI:** `MINVMD_E2E=1 cargo test -p minvmd --test krun_smoke_integration -- --include-ignored`
-   exits 0 on a Mac with libkrun installed, demonstrates end-to-end
+   exits 0 on a Mac with libkrun installed, shows end-to-end
    FFI bring-up.
 
 ---
@@ -189,10 +189,10 @@ mounts `/proc`, `/sys`, `/dev`, and execs the workload set via
 
 1. **CLI:** `MINVMD_KERNEL_PATH=<path> MINVMD_ROOTFS_PATH=<path> minvmd boot --foreground`
    boots and prints `vm-up` to stdout within 5 s, and a host-side reader
-   on the vsock marker socket reads `READY`, demonstrates kernel+rootfs
+   on the vsock marker socket reads `READY`, shows kernel+rootfs
    come up.
 2. **Test:** `tests/boot_integration.rs` (gated `MINVMD_E2E=1`, `#[ignore]`)
-   asserts the marker round-trip end-to-end, demonstrates automated
+   asserts the marker round-trip end-to-end, shows automated
    boot verification.
 
 ---
@@ -246,14 +246,14 @@ permissions), guest-side vsock stub
 1. **Test:** `tests/bridge_e2e.rs` (gated `MINVMD_E2E=1`, `#[ignore]`)
    boots a VM whose guest listens on vsock `VSOCK_PORT`, opens 5
    concurrent host UDS connections, each writes a distinct payload and
-   reads it back. All 5 succeed, demonstrates libkrun-multiplexed
+   reads it back. All 5 succeed, shows libkrun-multiplexed
    bidirectional bridging. (Removed in the auto-discovery migration: it
    bridged the Stage-1 socat-echo stub that minimald-as-pid1 replaced
    with a direct SSH session server; session coverage of the bridge is
    now `tests/minimald_session_integration.rs`.)
 2. **CLI:** With a stub `minimald` reachable on vsock `VSOCK_PORT`,
    running `nc -U $XDG_RUNTIME_DIR/minimal/minimald.sock` from the host
-   yields the empty `list-sessions` response end-to-end, demonstrates
+   yields the empty `list-sessions` response end-to-end, shows
    the host→guest path.
 
 ---
@@ -310,14 +310,14 @@ auto-spawns it; subsequent calls reuse; `minvmd status` introspects;
 
 1. **Test:** `crates/minvmd/src/lifecycle.rs` includes table-driven
    `#[test]`s for every legal and illegal transition;
-   `cargo test -p minvmd lifecycle::` passes, demonstrates the pure
+   `cargo test -p minvmd lifecycle::` passes, shows the pure
    state machine.
 2. **CLI:** `minvmd stop && minvmd status --json` prints
-   `{"state":"stopped",...}` and exits 1, demonstrates stop + status
+   `{"state":"stopped",...}` and exits 1, shows stop + status
    semantics.
 3. **CLI:** From a clean state (no minvmd running), `minimal ls` on a
    Mac succeeds within 8 s and a subsequent `minvmd status` reports
-   `running`; a second `minimal ls` completes in < 500 ms, demonstrates
+   `running`; a second `minimal ls` completes in < 500 ms, shows
    auto-spawn + warm reuse.
 
 ## Non-Goals

--- a/docs/specs/02-spec-minvmd-linux-kvm/02-spec-minvmd-linux-kvm.md
+++ b/docs/specs/02-spec-minvmd-linux-kvm/02-spec-minvmd-linux-kvm.md
@@ -147,9 +147,9 @@ the guards are removed.
 **Proof Artifacts:**
 
 1. **CLI:** `cargo build -p minvmd` on a Linux host with libkrun installed
-   exits 0, demonstrates the crate links cleanly against libkrun on Linux.
+   exits 0, shows the crate links cleanly against libkrun on Linux.
 2. **Test:** `cargo test -p minvmd` (excluding e2e tests) on Linux exits 0,
-   demonstrates existing unit tests pass on Linux.
+   shows existing unit tests pass on Linux.
 
 ---
 
@@ -199,10 +199,10 @@ instead of Hypervisor.framework availability.
 **Proof Artifacts:**
 
 1. **CLI:** `MINVMD_KERNEL_PATH=<k> MINVMD_ROOTFS_PATH=<r> MINVMD_INITRAMFS=<i> minvmd boot --foreground`
-   on a Linux host with `/dev/kvm` prints `vm-up` within 10 s, demonstrates
+   on a Linux host with `/dev/kvm` prints `vm-up` within 10 s, shows
    KVM boot + READY marker round-trip on Linux.
 2. **Test:** `MINVMD_E2E=1 cargo test -p minvmd --test boot_integration -- --include-ignored`
-   on a Linux host with `/dev/kvm` exits 0, demonstrates the automated boot
+   on a Linux host with `/dev/kvm` exits 0, shows the automated boot
    e2e passes (test is un-gated from macOS in Unit 3).
 
 ---
@@ -258,7 +258,7 @@ establish the Linux/KVM baseline.
    session e2e passes on Linux over the host UDS→vsock bridge.
 2. **File:** The pull request description contains a latency table (min /
    median / max boot-to-READY) from the Linux/KVM benchmark run, cited
-   against the ~75 ms macOS baseline, demonstrates R3.5 was executed.
+   against the ~75 ms macOS baseline, shows R3.5 was executed.
 
 ---
 

--- a/docs/specs/02-spec-minvmd-linux-kvm/02-spec-minvmd-linux-kvm.md
+++ b/docs/specs/02-spec-minvmd-linux-kvm/02-spec-minvmd-linux-kvm.md
@@ -258,7 +258,7 @@ establish the Linux/KVM baseline.
    session e2e passes on Linux over the host UDS→vsock bridge.
 2. **File:** The pull request description contains a latency table (min /
    median / max boot-to-READY) from the Linux/KVM benchmark run, cited
-   against the ~75 ms macOS baseline, shows R3.5 was executed.
+   against the ~75 ms macOS baseline, covers R3.5 was executed.
 
 ---
 

--- a/docs/specs/03-spec-networking/03-spec-networking.md
+++ b/docs/specs/03-spec-networking/03-spec-networking.md
@@ -28,7 +28,7 @@ authenticated remote mesh, and an **HTTPS reverse proxy on minimald** for
 UC2b option B remote browser access. No root privilege is required per-invocation
 on any path covered by this spec.
 
-The five deployment models (DM1–DM5) from the requirements document are:
+The five deployment models (DM1-DM5) from the requirements document are:
 
 - **DM1**: macOS + one or more libkrun Linux VMs, each with `minimald`
 - **DM2**: native Linux, `minimald` on the host directly
@@ -160,10 +160,10 @@ extended network-mode types in `crates/minimald-rpc/`
 
 1. **Test:** Integration test (`crates/minimald/tests/` or `crates/minvmd/tests/`)
    starts two `OwnIp` PTasks and asserts a TCP connect from PTask A to PTask B's
-   switch IP succeeds, shows UC6 same-host PTask-to-PTask.
+   switch IP succeeds, covers UC6 same-host PTask-to-PTask.
 2. **Test:** Integration test starts a `NoNet` PTask and asserts that a TCP
    connect attempt from within it to `8.8.8.8:80` fails with connection
-   refused or ENETUNREACH, shows UC1 no-net isolation.
+   refused or ENETUNREACH, covers UC1 no-net isolation.
 
 ---
 
@@ -217,11 +217,11 @@ types, gvproxy filter/portfwd API integration
 
 1. **Test:** Integration test starts an `OwnIp` PTask with an egress allowlist
    permitting only `tcp` to a specific test IP. Asserts that a TCP connect to the
-   allowed IP succeeds and a connect to a different IP fails, shows UC3
+   allowed IP succeeds and a connect to a different IP fails, covers UC3
    egress enforcement.
 2. **Test:** Integration test configures a static ingress mapping on an `OwnIp`
    PTask, starts a listener inside it, and asserts that `connect("127.0.0.1",
-   external_port)` from the host reaches the in-PTask listener, shows
+   external_port)` from the host reaches the in-PTask listener, covers
    UC4 ingress port mapping.
 3. **CLI:** `minimal session policy <id>` returns the effective egress/ingress
    policy JSON for a running session, shows the R2.6 read-only RPC.
@@ -296,10 +296,10 @@ DNS integration), new hostname manager module, host-side DNS configuration path
 2. **CLI:** with an own-IP PTask that publishes a port (ingress `<external>:<internal>`,
    R2.3), `curl -x http://127.0.0.1:7654 http://<session-name>.<host-id>.min.internal:<external>/`
    from the local host returns HTTP 200 from a webserver running inside the PTask,
-   shows UC2a local browser access (hostname → published loopback port).
+   covers UC2a local browser access (hostname → published loopback port).
 3. **CLI:** `curl http://<session-name>.<host-id>.min.internal:<port>/` from the
    local host returns HTTP 200 from a webserver running inside a `HostNet` PTask
-   (hostname resolves to `127.0.0.1`), shows UC2 hostname-driven access
+   (hostname resolves to `127.0.0.1`), covers UC2 hostname-driven access
    for host-net PTask services (R3.6).
 
 ---
@@ -368,10 +368,10 @@ management)
 1. **Test:** Integration test with two `minimald` instances in separate test
    network namespaces, WireGuard mesh configured, asserts that a TCP connect from
    a PTask on instance A to a PTask on instance B (via their switch IPs across the
-   mesh tunnel) succeeds, shows UC7 remote PTask-to-PTask.
+   mesh tunnel) succeeds, covers UC7 remote PTask-to-PTask.
 2. **CLI:** From a laptop in the mesh, `curl http://<session-name>.<host-id>.min.internal/`
    returns HTTP 200 from a webserver in an own-IP PTask on a remote host, routed
-   over the WireGuard tunnel, shows UC2b option A remote mesh access.
+   over the WireGuard tunnel, covers UC2b option A remote mesh access.
 3. **CLI:** `minimal ssh-forward <session> 8080:127.0.0.1:80` with the WireGuard
    feature flag disabled establishes a TCP tunnel; `curl http://localhost:8080/`
    returns HTTP 200 from a webserver inside the PTask, shows the SSH
@@ -455,7 +455,7 @@ as a configuration error on DM2 (R2.5).
 `minimald` embeds `russh` for PTask re-attach (SSH over UDS/TCP). SSH
 `LocalForward`-style port-forwarding reuses that authenticated transport, no
 credential setup beyond `minimal login` is required. The WireGuard mesh
-(R4.1–R4.3) is the primary remote-access path for UC2b and UC7; SSH
+(R4.1-R4.3) is the primary remote-access path for UC2b and UC7; SSH
 port-forwarding (R4.9) is the fallback for networks where WireGuard's UDP cannot
 get out. The fallback supports TCP only and does not deliver the hostname-driven
 browser access of the mesh path, but it preserves authenticated remote service

--- a/docs/specs/03-spec-networking/03-spec-networking.md
+++ b/docs/specs/03-spec-networking/03-spec-networking.md
@@ -160,10 +160,10 @@ extended network-mode types in `crates/minimald-rpc/`
 
 1. **Test:** Integration test (`crates/minimald/tests/` or `crates/minvmd/tests/`)
    starts two `OwnIp` PTasks and asserts a TCP connect from PTask A to PTask B's
-   switch IP succeeds, demonstrates UC6 same-host PTask-to-PTask.
+   switch IP succeeds, shows UC6 same-host PTask-to-PTask.
 2. **Test:** Integration test starts a `NoNet` PTask and asserts that a TCP
    connect attempt from within it to `8.8.8.8:80` fails with connection
-   refused or ENETUNREACH, demonstrates UC1 no-net isolation.
+   refused or ENETUNREACH, shows UC1 no-net isolation.
 
 ---
 
@@ -217,14 +217,14 @@ types, gvproxy filter/portfwd API integration
 
 1. **Test:** Integration test starts an `OwnIp` PTask with an egress allowlist
    permitting only `tcp` to a specific test IP. Asserts that a TCP connect to the
-   allowed IP succeeds and a connect to a different IP fails, demonstrates UC3
+   allowed IP succeeds and a connect to a different IP fails, shows UC3
    egress enforcement.
 2. **Test:** Integration test configures a static ingress mapping on an `OwnIp`
    PTask, starts a listener inside it, and asserts that `connect("127.0.0.1",
-   external_port)` from the host reaches the in-PTask listener, demonstrates
+   external_port)` from the host reaches the in-PTask listener, shows
    UC4 ingress port mapping.
 3. **CLI:** `minimal session policy <id>` returns the effective egress/ingress
-   policy JSON for a running session, demonstrates the R2.6 read-only RPC.
+   policy JSON for a running session, shows the R2.6 read-only RPC.
 
 ---
 
@@ -296,10 +296,10 @@ DNS integration), new hostname manager module, host-side DNS configuration path
 2. **CLI:** with an own-IP PTask that publishes a port (ingress `<external>:<internal>`,
    R2.3), `curl -x http://127.0.0.1:7654 http://<session-name>.<host-id>.min.internal:<external>/`
    from the local host returns HTTP 200 from a webserver running inside the PTask,
-   demonstrates UC2a local browser access (hostname → published loopback port).
+   shows UC2a local browser access (hostname → published loopback port).
 3. **CLI:** `curl http://<session-name>.<host-id>.min.internal:<port>/` from the
    local host returns HTTP 200 from a webserver running inside a `HostNet` PTask
-   (hostname resolves to `127.0.0.1`), demonstrates UC2 hostname-driven access
+   (hostname resolves to `127.0.0.1`), shows UC2 hostname-driven access
    for host-net PTask services (R3.6).
 
 ---
@@ -368,13 +368,13 @@ management)
 1. **Test:** Integration test with two `minimald` instances in separate test
    network namespaces, WireGuard mesh configured, asserts that a TCP connect from
    a PTask on instance A to a PTask on instance B (via their switch IPs across the
-   mesh tunnel) succeeds, demonstrates UC7 remote PTask-to-PTask.
+   mesh tunnel) succeeds, shows UC7 remote PTask-to-PTask.
 2. **CLI:** From a laptop in the mesh, `curl http://<session-name>.<host-id>.min.internal/`
    returns HTTP 200 from a webserver in an own-IP PTask on a remote host, routed
-   over the WireGuard tunnel, demonstrates UC2b option A remote mesh access.
+   over the WireGuard tunnel, shows UC2b option A remote mesh access.
 3. **CLI:** `minimal ssh-forward <session> 8080:127.0.0.1:80` with the WireGuard
    feature flag disabled establishes a TCP tunnel; `curl http://localhost:8080/`
-   returns HTTP 200 from a webserver inside the PTask, demonstrates the SSH
+   returns HTTP 200 from a webserver inside the PTask, shows the SSH
    fallback for restricted networks (R4.9).
 
 ---
@@ -440,7 +440,7 @@ macOS root-write fallback, not the default.
 ### WireGuard implementation: wireguard-go vs boringtun
 
 R4.1 leaves the choice open. `boringtun` (Rust) avoids a Go toolchain dependency
-and produces a smaller binary. wireguard-go is more battle-tested and is the
+and produces a smaller binary. wireguard-go is more mature and is the
 reference implementation used in Tailscale's production stack. The decision is
 made during Unit 4 design, informed by build-chain and maintenance considerations.
 

--- a/docs/specs/03-spec-networking/architecture.md
+++ b/docs/specs/03-spec-networking/architecture.md
@@ -120,7 +120,7 @@ target-OS behaviour (see assumption `dns-hostname-mechanism`, needs-spike
 below). Both candidate paths are architecturally uniform from `minimald`'s
 perspective: `minimald` writes hostnames to either a local resolver
 configuration or the system resolver stub at launch, and removes them on exit.
-Unit 3 begins after the spike resolves this question.
+Unit 3 starts after the spike resolves this question.
 
 `HostNet` PTask hostnames (R3.6) use the same format; the resolved IP is
 `127.0.0.1` for local-only instances or the host's configured network
@@ -218,7 +218,7 @@ PTask".)
 ### pasta for the per-PTask Linux path
 
 Rejected. Pasta does TCP splicing rather than a full TCP/IP stack; it cannot
-run on macOS; it cannot provide UC6 without bridging. A shared gvproxy gives
+run on macOS; it cannot support UC6 without bridging. A shared gvproxy gives
 platform uniformity and direct PTask-to-PTask routing at no extra cost.
 (Informed by spec § rootless implementation analysis.)
 
@@ -268,7 +268,7 @@ proposed here is the typed replacement for that placeholder.
 | `dm2-uc5-collapse` | VM-wide egress (UC5) is a configuration error on DM2 (native Linux, no VM boundary); UC5 collapses to UC3 on DM2 | settled | spec R2.5 explicitly states this; DM2 has no VM boundary, `vm_egress` applies only when minvmd owns the VM |
 | `gvproxy-source-build` | gvproxy ships as a pinned **pre-built** release binary (gvisor-tap-vsock v0.8.9), fetched and verified against checked-in SHA-256 digests in `vendor/gvproxy/gvproxy.lock` via `scripts/fetch-gvproxy.sh`, not built from source | settled (maintainer decision; supersedes the spec's source-build preference) | spec § "Technical Considerations" lists a SHA-256-verified pre-built binary as the accepted alternative; chosen to avoid a Go toolchain + module-proxy egress in the build sandbox; supply-chain risk mitigated by pinned upstream digests (#495) |
 | `https-proxy-hyper-rustls` | The Unit 4 HTTPS reverse proxy uses hyper/axum for HTTP and rustls for TLS, matching the workspace's existing ecosystem | settled | spec § "Technical Considerations"; `rustls` is listed as a no-OpenSSL-dependency choice; `hyper`/`axum` are named as consistent with workspace deps |
-| `dns-hostname-mechanism` | The system resolver supports PTask hostname registration without root privilege per-invocation via either `*.localhost` wildcard (rootless on macOS; requires systemd-resolved or NetworkManager on Linux) or a one-time `/etc/resolver`-equivalent setup | needs-spike | spec Open Questions item 1: "Decision needed before Unit 3 implementation begins"; whether `*.localhost` wildcard resolution is reliably available on common Linux distributions (Ubuntu, Fedora, Arch, Debian) is not settleable from the repo working tree; R3.4 requires rootless per-invocation operation |
+| `dns-hostname-mechanism` | The system resolver supports PTask hostname registration without root privilege per-invocation via either `*.localhost` wildcard (rootless on macOS; requires systemd-resolved or NetworkManager on Linux) or a one-time `/etc/resolver`-equivalent setup | needs-spike | spec Open Questions item 1: "Decision needed before Unit 3 implementation starts"; whether `*.localhost` wildcard resolution is reliably available on common Linux distributions (Ubuntu, Fedora, Arch, Debian) is not settleable from the repo working tree; R3.4 requires rootless per-invocation operation |
 | `wireguard-implementation` | Unit 4 WireGuard implementation is **boringtun** (pure Rust); wireguard-go subprocess is the v2 escalation path if peer coordination is needed or boringtun stalls | settled | spike #486 concluded boringtun for v1: clean Cargo feature-flag support for R4.7, zero additional build-chain dependencies, sufficient production maturity (Cloudflare WARP, Mullvad VPN) for the AllowedIPs-based subnet-router model; cgo path substantially more complex than hypothesised; maintainer confirmed on #478 (informed by #486) |
 
 ALREADY EXISTS: `sandbox2::Config::disable_networking: bool`, covers R1.2 (NoNet) and R1.3 (HostNet) in boolean form. The trimodal enum refactor replaces this field, preserving its semantics for the two existing modes.

--- a/docs/specs/03-spec-networking/networking-with-diagrams.md
+++ b/docs/specs/03-spec-networking/networking-with-diagrams.md
@@ -577,7 +577,7 @@ access, no memorized ports). The two paths below preserve the hostname UX.
 
 Note that there are interesting options like embedded an egress webproxy in the
 gvproxy and using PAC file with MacOS's webproxy configuration to make it
-work seamlessly with the DNS hosts minimal creates for PTasks and VMs.
+work with the DNS hosts minimal creates for PTasks and VMs.
 
 ## Option A — Laptop joins the WireGuard mesh
 
@@ -637,6 +637,6 @@ service becomes a separately-managed `ssh -L` tunnel mapped to a `localhost:N`
 the user has to remember (or that a helper has to manage). Layered on top of a
 local resolver / proxy you could rebuild the hostname UX, but at that point you
 are re-implementing option A's UX with more moving parts and a transport that
-can't carry UDP. SSH-forward is best kept as a fallback for restricted
+cannot carry UDP. SSH-forward is best kept as a fallback for restricted
 networks where WireGuard cannot get out.
 

--- a/docs/specs/04-spec-ot-render-decoupling/04-spec-ot-render-decoupling.md
+++ b/docs/specs/04-spec-ot-render-decoupling/04-spec-ot-render-decoupling.md
@@ -236,7 +236,7 @@ paint.
   a per-request `UnixStream` rather than a `Channel<Msg>`, plus plumbing the real
   PTY `WinSize` down to supply `size`, is a separate follow-up.
 
-- **`StridesDriver`** (future), additive, Layers 1–2 untouched.
+- **`StridesDriver`** (future), additive, Layers 1-2 untouched.
 
 ## Migration plan
 

--- a/docs/specs/05-spec-minvmd-gvproxy-pidfd/05-spec-minvmd-gvproxy-pidfd.md
+++ b/docs/specs/05-spec-minvmd-gvproxy-pidfd/05-spec-minvmd-gvproxy-pidfd.md
@@ -68,7 +68,7 @@ is silenced identically to the existing `signal_child` behaviour; unexpected
 errors (`EPERM`, `EINVAL`) are logged via `tracing::warn!`.
 
 **R1.3** `stop()` and `GvproxySwitch::Drop` signal via `signal_pidfd`. The
-`stopping` atomic and its acquire/release ordering are unchanged, they continue
+`stopping` atomic and its get/release ordering are unchanged, they continue
 to classify exits as intentional vs. unexpected in `supervise_switch`.
 
 **R1.4** A new test `pidfd_signal_to_reaped_child_returns_esrch` spawns a

--- a/docs/specs/06-spec-ssh-host-key-in-beacon/06-spec-ssh-host-key-in-beacon.md
+++ b/docs/specs/06-spec-ssh-host-key-in-beacon/06-spec-ssh-host-key-in-beacon.md
@@ -17,7 +17,7 @@ The host (`minvmd boot` and `minvmd run`) receives this marker and signals boot
 completion to its caller.
 
 The native (non-VM) `minimald` path already writes the SSH host key to a
-per-instance `known_hosts` file on startup (`minimald/src/main.rs:377–382`,
+per-instance `known_hosts` file on startup (`minimald/src/main.rs:377-382`,
 via `russh::keys::known_hosts::learn_known_hosts_path`). In the VM path the
 equivalent write happens inside the VM into `/run/minimal/…` (a tmpfs the host
 SSH client never sees), so the first SSH connection to a fresh VM triggers a
@@ -152,7 +152,7 @@ implementation plan is in the tracking issue comment (ADR 0024).
 ## Open Questions
 
 None. The prior art (`learn_known_hosts_path` call at
-`minimald/src/main.rs:377–382`) settles the API, hostname, and port. The beacon
+`minimald/src/main.rs:377-382`) settles the API, hostname, and port. The beacon
 extension is additive and backward-compatible.
 
 ## Technical Considerations
@@ -180,7 +180,7 @@ extension is additive and backward-compatible.
 ## Verification
 
 1. `cargo test -p minimald`, the `emit_ready_marker` unit test (R1.1) passes.
-2. `cargo test -p minvmd`, the READY-marker integration test (R2.1–R2.4)
+2. `cargo test -p minvmd`, the READY-marker integration test (R2.1-R2.4)
    passes; the expected key entry is present in the temp `known_hosts`.
 3. End-to-end: `minvmd run` followed by a fresh SSH connect with
    `ssh -o UserKnownHostsFile=<path> local-minvmd0` succeeds with no host-key prompt.

--- a/docs/specs/07-spec-installer/07-spec-installer.md
+++ b/docs/specs/07-spec-installer/07-spec-installer.md
@@ -47,7 +47,7 @@ After the files are placed, the installer wires up shell integration (Unit 9):
 it generates per-shell init files that put the bin dir on `PATH`, installs tab
 completions for `min` by running the freshly-installed binary, and hooks the
 user's login-shell rc file with an idempotent, marker-fenced block. Uninstall
-(Units 7–8) undoes all of it.
+(Units 7-8) undoes all of it.
 
 The whole script targets POSIX `sh` (not bash) so it runs identically under
 `dash`, macOS's frozen bash 3.2, busybox, and zsh-invoked-`sh`. It depends only
@@ -375,12 +375,12 @@ lets the R5.1 signed-file skip stay correct across releases (skip only while the
 manifest still wants that artifact). A `symlink` row (R5.6) records
 `link:<target>` in both hash columns instead of digests, the `link:` prefix
 cannot collide with a hex digest and is what the uninstaller keys on (R7.3).
-The record also enables uninstall (Units 7–8) and surfaces prefix drift if
+The record also enables uninstall (Units 7-8) and surfaces prefix drift if
 `XDG_*` variables change between runs.
 
 **R6.1a**, **Renamed-component migration.** When a component is renamed, its old
 `dest` stops appearing in every subsequent manifest, so the record walk of Units
-7–8 never revisits it and the file is stranded on disk forever. For a `bin`
+7-8 never revisits it and the file is stranded on disk forever. For a `bin`
 component that is a live PATH collision, not just clutter. The installer
 therefore reverses a known rename from the *prior* record, on the same
 bytes-still-ours terms uninstall uses (R7.3): the old `dest` is removed only
@@ -431,7 +431,7 @@ the only rc edit it makes is Unit 9's announced, marker-fenced block (R9.2).
 
 The goal: after one install and one new shell, `min` is on `PATH` and
 tab-completes, in bash, zsh, and fish. Everything this unit writes is either an
-install-record row (so Units 7–8 remove it for free) or a marker-fenced rc
+install-record row (so Units 7-8 remove it for free) or a marker-fenced rc
 block (so uninstall can strip it precisely).
 
 **R9.1**, After the component loop, the installer **generates** (never
@@ -528,7 +528,7 @@ dead in every new shell until an unrelated `fpath` change. Dropping the cache
 forces a real rescan on the next zsh startup (the `zsh.sh` self-heal in R9.1
 is the belt-and-braces for dumps that go stale later).
 
-**R9.4**, Uninstall (Units 7–8) undoes shell integration completely:
+**R9.4**, Uninstall (Units 7-8) undoes shell integration completely:
 
 - the generated init and completion files are ordinary record rows, removed by
   the hash-verified walk (R7.3);
@@ -691,7 +691,7 @@ architecture record; design rationale is captured above.
 1. **Static**: `shellcheck --shell=sh` passes on the installer with no warnings.
 2. **Dash conformance**: the installer's test harness runs the script under
    `dash` (and, where available, macOS `/bin/sh`), not just `bash`, in CI.
-3. **Unit tests** (Units 1–6, 9) pass against fixture pointer files, manifests,
+3. **Unit tests** (Units 1-6, 9) pass against fixture pointer files, manifests,
    and a stubbed bucket/downloader, asserting: downloader/hasher/platform
    selection; target and version validation; field extraction; prefix resolution
    and traversal rejection; skip-on-rerun and checksum-mismatch handling; install
@@ -930,7 +930,7 @@ behind explicit `--purge` and confined to the `.../minimal` roots the tool owns.
 
 1. **Static/conformance**: the same `shellcheck --shell=sh` and `dash` CI gates
    cover the added uninstall path.
-2. **Unit tests** (Units 7–8): dispatch and record-absent no-op; hash-verified
+2. **Unit tests** (Units 7-8): dispatch and record-absent no-op; hash-verified
    removal; modified-file keep vs `--force`; already-absent idempotency;
    non-regular-file refusal; record teardown and empty-dir pruning; `--dry-run`
    removing nothing; `--purge` clearing the owned trees; rc-block stripping and

--- a/docs/specs/07-spec-installer/07-spec-installer.md
+++ b/docs/specs/07-spec-installer/07-spec-installer.md
@@ -119,7 +119,7 @@ mode's one option, `--force-stop` (R5.5), is recognized wherever it appears in
 the arguments and removed from them before the target is read, so the target
 stays the sole positional on either side of the flag.
 
-**R2.2**, The script fetches `<BUCKET>/<target>` to obtain a version string.
+**R2.2**, The script fetches `<BUCKET>/<target>` to get a version string.
 The result is validated against `^[A-Za-z0-9._-]+$` (command substitution having
 already stripped the trailing newline); a malformed value exits with an error.
 `<BUCKET>` is hardcoded into the script, but can be overridden with an environment
@@ -445,7 +445,7 @@ downloads) one init file per shell family under `<data>/shell-init/`:
   `fish_add_path --prepend` for fish), so sourcing is idempotent and becomes a
   no-op once the user manages `PATH` themselves.
 
-`zsh.sh` additionally adds the zsh completions dir (R9.3) to `fpath` and runs
+`zsh.sh` also adds the zsh completions dir (R9.3) to `fpath` and runs
 `compinit`, and then **self-heals a lying dump**: `compinit` trusts its cached
 `.zcompdump` whenever the dump's (zsh version, completion-file count) header
 matches, a check that misses real changes (one completions dir replacing
@@ -623,7 +623,7 @@ installer. The manifest is strictly *data*; prefix tokens are mapped through a
 `case`, never expanded.
 
 **On-disk hash as the skip oracle.** Comparing the manifest hash against the
-actual destination file (R5.1) is more robust than trusting a recorded state
+actual destination file (R5.1) is more reliable than trusting a recorded state
 file, which drifts when a user deletes a binary or a prior run dies mid-install.
 A local SHA-256 is far cheaper than the download it avoids.
 
@@ -844,7 +844,7 @@ prefixes resolve to `.../minimal` subdirectories the installer owns, and the
 when empty and otherwise left untouched. Pruning failures (a non-empty dir) are
 ignored, not fatal.
 
-**R8.2**, `--purge` additionally removes the `minimal`-owned trees in full,
+**R8.2**, `--purge` also removes the `minimal`-owned trees in full,
 the resolved `data`, `state`, and `cache` directories and everything under them
 (build cache included), because those live at fixed `.../minimal` paths the tool
 owns exclusively. `--purge` never touches the shared `bin` directory beyond the

--- a/docs/specs/08-spec-vm-ext4-volume/08-spec-vm-ext4-volume.md
+++ b/docs/specs/08-spec-vm-ext4-volume/08-spec-vm-ext4-volume.md
@@ -280,7 +280,7 @@ trees on a shared writable ext4 volume. Introduces the host provisioner, the
    the default posture is chosen from data. Does not gate merge.
 
    - **macOS/HVF/APFS, DONE (2026-07-07).** Sync-heavy (`O_DSYNC`/block):
-     `none` 4.7 GB/s, `relaxed` 3.1 GB/s, `full` 254 MB/s (~12–18× slower);
+     `none` 4.7 GB/s, `relaxed` 3.1 GB/s, `full` 254 MB/s (~12-18× slower);
      `direct_io=true` halves `relaxed` to 1.2 GB/s. → default `relaxed` +
      `direct_io=false`.
    - **Linux/KVM, REQUIRED, runs in CI.** On Linux, libkrun documents
@@ -363,7 +363,7 @@ loud rather than silently degraded.
    image is mountable (ext4 journal clean) on the host after teardown, shows
    the quiesce path flushed the journal.
 2. **Test:** A test boots a VM with a missing or incorrectly-sized `/dev/vdb` and
-   asserts that no `READY` marker arrives within the boot timeout, shows
+   asserts that no `READY` marker arrives within the boot timeout, covers
    R2.4 and R2.5 (loud failure, no silent fallback).
 
 ---
@@ -454,11 +454,11 @@ the host-side mapping from session id to volume image.
 
 1. **Test:** A test writes a deliberately corrupt `sessions/index.json` to the
    volume, boots the VM, and asserts `minimald` reaches READY without error and
-   the session count recovered from `record.json` matches expectation, shows
+   the session count recovered from `record.json` matches expectation, covers
    R3.1.
 2. **Test:** A test uploads a workspace to a non-empty worktree without `force=true`
    and asserts the RPC returns an error; uploads with `force=true` succeed and the
-   prior worktree content is atomically replaced, shows R3.3.
+   prior worktree content is atomically replaced, covers R3.3.
 
 ---
 
@@ -650,7 +650,7 @@ staging directory is adjacent to the live worktree on the same volume, making
 
 ## Technical Considerations
 
-- **ext4 superblock magic (`0x53EF`)** is at bytes 56–57 of the superblock, which
+- **ext4 superblock magic (`0x53EF`)** is at bytes 56-57 of the superblock, which
   starts at byte offset 1024 from the device start (total offset 1080 for the
   magic). This is stable across all ext4 versions and requires reading only 2
   bytes for the probe.

--- a/docs/specs/08-spec-vm-ext4-volume/08-spec-vm-ext4-volume.md
+++ b/docs/specs/08-spec-vm-ext4-volume/08-spec-vm-ext4-volume.md
@@ -178,7 +178,7 @@ trees on a shared writable ext4 volume. Introduces the host provisioner, the
   `sync_mode: SyncMode` and delegates to `raw::krun_add_disk3` via the same
   `CString` construction and `check_backend` error translation as `add_disk`.
 
-- **R1.3**: `crates/minvmd/src/volume.rs` (new file) shall provide a single
+- **R1.3**: `crates/minvmd/src/volume.rs` (new file) shall define a single
   idempotent provisioning function
   ```rust
   pub fn ensure_sparse_raw(path: &Path, size_bytes: u64) -> Result<(), VolumeError>;
@@ -247,7 +247,7 @@ trees on a shared writable ext4 volume. Introduces the host provisioner, the
 
 1. **Test:** An integration test (`crates/minvmd/tests/` or `crates/minimald/tests/`)
    boots the VM, runs a build that hardlinks from the cache into a sandbox staging
-   tree, and asserts the build succeeds with no `EXDEV` error, demonstrates the
+   tree, and asserts the build succeeds with no `EXDEV` error, shows the
    same-FS constraint is satisfied.
 2. **CLI:** `minvmd boot --foreground` on macOS/HVF starts the VM, the guest
    mounts `/dev/vdb`, and the READY marker arrives, confirms the second disk is
@@ -354,16 +354,16 @@ loud rather than silently degraded.
   `minvmd run` shall surface this condition as a user-visible error; the host
   decides whether the failure is fatal (e.g. fatal when a prior volume image for
   this VM already exists, recoverable when provisioning a fresh blank volume).
-  This ensures that a corrupt or unmountable volume does not produce a ghost
+  This makes sure that a corrupt or unmountable volume does not produce a ghost
   READY that appears to the host as a healthy VM.
 
 **Proof Artifacts:**
 
 1. **Test:** A test sends `minvmd stop` to a running VM, then confirms the volume
-   image is mountable (ext4 journal clean) on the host after teardown, demonstrates
+   image is mountable (ext4 journal clean) on the host after teardown, shows
    the quiesce path flushed the journal.
 2. **Test:** A test boots a VM with a missing or incorrectly-sized `/dev/vdb` and
-   asserts that no `READY` marker arrives within the boot timeout, demonstrates
+   asserts that no `READY` marker arrives within the boot timeout, shows
    R2.4 and R2.5 (loud failure, no silent fallback).
 
 ---
@@ -408,7 +408,7 @@ the host-side mapping from session id to volume image.
   file-open), but never on a corrupt JSON file alone.
 
 - **R3.2**: The guest boot path (`crates/minimald/src/guest.rs` or the volume
-  mount step) shall ensure `providers/` is reset on each boot while `sessions/`
+  mount step) shall make sure `providers/` is reset on each boot while `sessions/`
   is preserved. A `providers/` reset already occurs on the PR #573 branch via
   commit `ee5299cc` scoping the boot reset to `providers/`; this requirement
   makes that behaviour explicit and tested. The implementation shall log a
@@ -454,11 +454,11 @@ the host-side mapping from session id to volume image.
 
 1. **Test:** A test writes a deliberately corrupt `sessions/index.json` to the
    volume, boots the VM, and asserts `minimald` reaches READY without error and
-   the session count recovered from `record.json` matches expectation, demonstrates
+   the session count recovered from `record.json` matches expectation, shows
    R3.1.
 2. **Test:** A test uploads a workspace to a non-empty worktree without `force=true`
    and asserts the RPC returns an error; uploads with `force=true` succeed and the
-   prior worktree content is atomically replaced, demonstrates R3.3.
+   prior worktree content is atomically replaced, shows R3.3.
 
 ---
 
@@ -658,7 +658,7 @@ staging directory is adjacent to the live worktree on the same volume, making
   does not support `fallocate`, so `ftruncate` (which also creates a sparse/thin
   file on APFS and HFS+) is the portable fallback.
 - **Session UUIDv7**: globally unique, monotonically ordered by creation time.
-  The `ProviderIndex` key is the session UUIDs, ensuring no collision across VMs
+  The `ProviderIndex` key is the session UUIDs, so there is no collision across VMs
   or host reboots.
 - **krun_add_disk3 is in libkrun ≥ 1.19.0.** The installed version is confirmed
   at 1.19.0 (`libkrun.h:278-284`); no library upgrade is required.

--- a/docs/specs/09-spec-minvmd-resource-monitoring/architecture.md
+++ b/docs/specs/09-spec-minvmd-resource-monitoring/architecture.md
@@ -25,7 +25,7 @@ the next launch).
    persists to `config.toml` in the provider-instance dir, **separate from the
    runtime `State`** so a stop/crash reset cannot wipe it. `effective_vcpus()` /
    `effective_ram_mib()` resolve `env ?? config ?? default`; `vmm_child` boots
-   from them and `config show` reports them. The `Running` state additionally
+   from them and `config show` reports them. The `Running` state also
    records the resolved boot-time values (`State.booted_*`), and `status` reports
    *those* for a live VM.
 

--- a/docs/specs/10-spec-diagnostics/10-spec-diagnostics.md
+++ b/docs/specs/10-spec-diagnostics/10-spec-diagnostics.md
@@ -125,7 +125,7 @@ into shared crate surfaces, and a verbatim copy will not compile. Current
 state a later unit must build against (verify with `ls`/`cat` before
 starting, as the merged surface is the truth):
 
-- **`diagnostics` crate (Units 1–2, merged).** App-agnostic mechanics already
+- **`diagnostics` crate (Units 1-2, merged).** App-agnostic mechanics already
   exported: `bundle` (`BundleWriter`, `BundleSink`, `LOG_TAIL_CAP`,
   `open_regular_nofollow`), `capture` (`command_capture`, `first_stdout_line`,
   `Capture`), `disk` (`disk_usage`, `DiskUsage`), `listing`, `logs`
@@ -261,16 +261,16 @@ unified subprocess capture helper.
 1. **Test:** unit tests for redaction (compound public-key regressions:
    `public_key_token`, `public_key_password`, `private_public_key`), tail-cap
    bounding, symlink rejection, listing caps and truncation marker —
-   shows R1.4–R1.6.
+   covers R1.4-R1.6.
 2. **Test:** the same entry set written through `create` and through `stream`
    round-trips to identical archives modulo the root prefix, each carrying
    the manifest as its final entry at the exact mode-specific path
    (`{root}/manifest.json` file-backed; top-level `manifest.json` streamed)
-   — shows R1.2, R1.3.
-3. **Test:** archive created with mode `0600` — shows R1.2.
+   — covers R1.2, R1.3.
+3. **Test:** archive created with mode `0600` — covers R1.2.
 4. **Test:** a subprocess exceeding its timeout is terminated
    (`kill_on_drop`), with captured stdout/stderr/status retained alongside a
-   typed timeout error — shows R1.7.
+   typed timeout error — covers R1.7.
 
 ---
 
@@ -381,12 +381,12 @@ paths, and the archive layout.
 
 1. **Test:** `bug_without_daemon_still_produces_a_bundle` — valid tar.zst,
    manifest accounts for system.json/env.json/state listing, provider absence
-   recorded as a skip — shows R2.1, R2.2, R2.6.
+   recorded as a skip — covers R2.1, R2.2, R2.6.
 2. **Test:** a planted secret in a fake config dir appears as
    `<redacted:len=N>` in the bundled config and never verbatim anywhere in the
-   archive — shows R2.4, R2.5.
+   archive — covers R2.4, R2.5.
 3. **CLI:** `min bug` on a dev box; inspect manifest counts and `host/`
-   entries — shows R2.3, R2.7–R2.9.
+   entries — covers R2.3, R2.7-R2.9.
 
 ---
 
@@ -398,7 +398,7 @@ in-VM minimald onto the data volume without breaking the volume's clean
 unmount — the VMM console lands in a `boot.log` by default, and lifecycle
 records carry correlation ids on spans.
 
-**Depends on:** None (order-free with Units 1–2)
+**Depends on:** None (order-free with Units 1-2)
 
 **Affected areas:**
 - `crates/minvmd/src/{main.rs,lib.rs,cmd/run.rs,cmd/vmm_child.rs}`, `Cargo.toml`
@@ -477,17 +477,17 @@ records carry correlation ids on spans.
 1. **CLI (gate):** boot a VM, hold an idle attach, `minvmd stop`; the volume
    unmounts cleanly (no journal replay on next mount), `boot.log` is present
    in the host-side provider directory, and rotated `minimald.log*` appear on
-   the data volume at next boot — shows R3.2–R3.4. The
+   the data volume at next boot — covers R3.2-R3.4. The
    release-before-quiesce path is compile/unit-verified only on the reference
    branch; this live check gates the unit.
 2. **Test:** log-release runs exactly once and before quiesce returns;
-   harness passes `None` release unaffected — shows R3.4.
+   harness passes `None` release unaffected — covers R3.4.
 3. **Test:** the daily appender writes to its date-suffixed file; retention
    and rotation are `tracing_appender`'s own tested behavior, and the live
    gate (artifact 1) confirms rotated `minimald.log*` on the volume —
-   shows R3.6.
+   covers R3.6.
 4. **CLI:** grep a session's records by span-carried channel id across
-   accept/attach/close lines — shows R3.5.
+   accept/attach/close lines — covers R3.5.
 
 ---
 
@@ -559,13 +559,13 @@ the daemon across the SSH boundary.
 
 1. **Test:** a file-log line parses as JSON and carries level, target,
    timestamp, flattened span fields, and top-level resource fields —
-   shows R4.1, R4.2.
+   covers R4.1, R4.2.
 2. **CLI (gate):** run one attach with `min`; a single `trace_id` greps
    across the host CLI log and the guest daemon's on-volume log —
-   shows R4.3, R4.4.
+   covers R4.3, R4.4.
 3. **Test:** malformed `TRACEPARENT` values are ignored (fresh mint, no
    error), and client and daemon reference the same env-name constant —
-   shows R4.4.
+   covers R4.4.
 
 ---
 
@@ -623,12 +623,12 @@ established for its disk/log/env/system helpers.
 **Proof Artifacts:**
 
 1. **Test:** interfaces output masks full MACs to OUI; routes/listening
-   captures present in the bundle — shows R5.1.
+   captures present in the bundle — covers R5.1.
 2. **CLI:** `min bug` while a `min attach` runs: `host/proc/<pid>.sample.txt`
    (macOS) or `.stack.txt` (Linux) plus `host/proc/lsof.txt` appear for the
-   process family — shows R5.2, R5.4.
+   process family — covers R5.2, R5.4.
 3. **Test:** crate-level tests for markers matching (argv0 basename, not
-   substring) and power event caps — shows R5.2, R5.3.
+   substring) and power event caps — covers R5.2, R5.3.
 
 ---
 
@@ -714,16 +714,16 @@ same `manifest.json` schema as the host bundle.
 
 1. **Test:** in-crate tests fetch a bundle over the test harness and assert
    `meta.json` + `manifest.json` presence, session redaction, and the
-   pre-stream error path (extended data, zero payload) — shows R6.1,
+   pre-stream error path (extended data, zero payload) — covers R6.1,
    R6.2, R6.4.
 2. **CLI:** raw `ssh -s` subsystem invocation against a dev daemon returns a
-   decompressible rootless tar.zst — shows R6.2.
+   decompressible rootless tar.zst — covers R6.2.
 3. **Test:** oversized request body and oversized `log_tail_bytes` are
-   clamped/rejected — shows R6.3.
+   clamped/rejected — covers R6.3.
 4. **Test:** the harness bundle contains `net/routes.txt`, per-pid
    `proc/<pid>.stack.txt` for the daemon's own family, `proc/sockets.txt`
    with fd→inode-resolved sockets, and `env.json` with a planted
-   `MINIMALD_TOKEN`-style variable masked — shows R6.6.
+   `MINIMALD_TOKEN`-style variable masked — covers R6.6.
 
 ---
 
@@ -786,15 +786,15 @@ and logs harvested read-only from the volume image.
 
 1. **Test:** full-stack — `min bug` against the harness daemon nests a guest
    bundle whose manifest parses; loadout redaction and client-key skip hold
-   across layers — shows R7.1–R7.3.
+   across layers — covers R7.1-R7.3.
 2. **Test:** stale socket file → probe records the failed connect stage and
    `error.txt` explains the skip; volume fallback artifacts appear —
-   shows R7.1, R7.5.
+   covers R7.1, R7.5.
 3. **Test:** `--no-guest` against a live harness daemon performs zero daemon
-   contact — shows R7.4.
+   contact — covers R7.4.
 4. **CLI (gate):** kill a real VM's daemon mid-session, run `min bug`: probe
    stages + `volume-meta.json` + harvested `volume-logs/` present —
-   shows R7.5 end to end.
+   covers R7.5 end to end.
 
 ---
 
@@ -829,7 +829,7 @@ read both pre-convergence (`errors.json`) and post-convergence
 
 1. **CLI:** `summary`/`check`/`errors` against one pre-convergence bundle
    (a field-captured sample retained by the team) and one post-Unit-6 bundle
-   — both pass — shows R8.1–R8.3.
+   — both pass — covers R8.1-R8.3.
 
 ## Non-Goals
 
@@ -1093,13 +1093,13 @@ Unit 8's dual-format rework, sequenced after Unit 6.
 
 | Unit | Req | Proof type | Command / observable |
 |------|-----|-----------|----------------------|
-| 1 | R1.4–R1.6 | Test | `cargo test -p diagnostics` — redaction compound keys, tail cap, no-follow open, listing cap + truncation marker |
+| 1 | R1.4-R1.6 | Test | `cargo test -p diagnostics` — redaction compound keys, tail cap, no-follow open, listing cap + truncation marker |
 | 1 | R1.2, R1.3 | Test | file-vs-stream round-trip identical modulo root; manifest last at `{root}/manifest.json` / top-level `manifest.json` |
 | 1 | R1.7 | Test | capture timeout kills the child, retains stdout/stderr/status + typed error |
 | 2 | R2.1, R2.2, R2.6 | Test | `bug_without_daemon_still_produces_a_bundle` (Linux lane) |
 | 2 | R2.4, R2.5 | Test | planted secret → `<redacted:len=N>`, never verbatim |
-| 2 | R2.3, R2.7–R2.9 | CLI | `min bug` on dev box; manifest counts, `host/` entries |
-| 3 | R3.2–R3.4 | CLI (gate) | idle attach + `minvmd stop` → clean ext4 journal; `boot.log` in provider dir, `minimald.log*` on volume next boot |
+| 2 | R2.3, R2.7-R2.9 | CLI | `min bug` on dev box; manifest counts, `host/` entries |
+| 3 | R3.2-R3.4 | CLI (gate) | idle attach + `minvmd stop` → clean ext4 journal; `boot.log` in provider dir, `minimald.log*` on volume next boot |
 | 3 | R3.4 | Test | release runs exactly once, before quiesce returns |
 | 3 | R3.6 | Test | size-threshold rotation + retention pruning |
 | 3 | R3.5 | CLI | grep one channel id across accept/attach/close records |
@@ -1113,9 +1113,9 @@ Unit 8's dual-format rework, sequenced after Unit 6.
 | 6 | R6.2 | CLI | raw `ssh -s` subsystem fetch decompresses, rootless |
 | 6 | R6.3 | Test | oversized request/tail clamped |
 | 6 | R6.6 | Test | guest bundle carries routes, per-pid stacks, fd→socket join, allowlisted env (planted secret masked) |
-| 7 | R7.1–R7.3 | Test | full-stack nested-bundle test with redaction across layers |
+| 7 | R7.1-R7.3 | Test | full-stack nested-bundle test with redaction across layers |
 | 7 | R7.3 | Test | oversize/entry-bomb nested bundle → verification fails within caps, raw bytes + manifest error recorded |
 | 7 | R7.1, R7.5 | Test | stale socket → connect-stage failure + fallback artifacts |
 | 7 | R7.4 | Test | `--no-guest` → zero daemon contact against live harness |
 | 7 | R7.5 | CLI (gate) | kill VM daemon mid-session; `min bug` → probe stages + volume-meta + harvested logs |
-| 8 | R8.1–R8.3 | CLI | explorer `check` green on pre- and post-convergence bundles |
+| 8 | R8.1-R8.3 | CLI | explorer `check` green on pre- and post-convergence bundles |

--- a/docs/specs/10-spec-diagnostics/10-spec-diagnostics.md
+++ b/docs/specs/10-spec-diagnostics/10-spec-diagnostics.md
@@ -229,7 +229,7 @@ unified subprocess capture helper.
   `bundle.rs:92-133` uses `symlink_metadata` before open; this unit upgrades
   it). The read is bounded with `Read::take(cap)` so a file growing mid-read
   cannot exceed the recorded cap.
-- **R1.5**: `redact.rs` shall provide the key-based policy engine:
+- **R1.5**: `redact.rs` shall define the key-based policy engine:
   `is_sensitive_key` (substring parts list, with compound-key handling such
   that `public_key` only exempts when no sensitive part remains after
   stripping it — `public_key_token` masks), `is_env_table_name`,
@@ -244,7 +244,7 @@ unified subprocess capture helper.
   manifest error), per-entry read failures are recorded inline, and hitting
   the cap appends an explicit trailing truncation marker
   (`… truncated at N entries`).
-- **R1.7**: `capture.rs` (new) shall provide the single subprocess helper
+- **R1.7**: `capture.rs` (new) shall define the single subprocess helper
   ```rust
   pub async fn command_capture(cmd: &str, args: &[&str], timeout: Duration) -> Result<Capture>
   ```
@@ -261,16 +261,16 @@ unified subprocess capture helper.
 1. **Test:** unit tests for redaction (compound public-key regressions:
    `public_key_token`, `public_key_password`, `private_public_key`), tail-cap
    bounding, symlink rejection, listing caps and truncation marker —
-   demonstrates R1.4–R1.6.
+   shows R1.4–R1.6.
 2. **Test:** the same entry set written through `create` and through `stream`
    round-trips to identical archives modulo the root prefix, each carrying
    the manifest as its final entry at the exact mode-specific path
    (`{root}/manifest.json` file-backed; top-level `manifest.json` streamed)
-   — demonstrates R1.2, R1.3.
-3. **Test:** archive created with mode `0600` — demonstrates R1.2.
+   — shows R1.2, R1.3.
+3. **Test:** archive created with mode `0600` — shows R1.2.
 4. **Test:** a subprocess exceeding its timeout is terminated
    (`kill_on_drop`), with captured stdout/stderr/status retained alongside a
-   typed timeout error — demonstrates R1.7.
+   typed timeout error — shows R1.7.
 
 ---
 
@@ -369,7 +369,7 @@ paths, and the archive layout.
   (`minimald.log*`, `minvmd.log*`) and per known name (`run.log`,
   `boot.log`), the newest **5** files per prefix by rotation order,
   tail-capped, rejecting non-regular files (no-follow discipline per R1.4).
-  Absent files are manifest skips, not errors (the files only begin to exist
+  Absent files are manifest skips, not errors (the files only start to exist
   after Unit 3 — best-effort by design).
 - **R2.8**: `host/dirs.txt` shall capture the `min dirs` report; `dirs.rs`
   refactors to return `String` with `cmd_dirs` printing it (behavior of
@@ -381,12 +381,12 @@ paths, and the archive layout.
 
 1. **Test:** `bug_without_daemon_still_produces_a_bundle` — valid tar.zst,
    manifest accounts for system.json/env.json/state listing, provider absence
-   recorded as a skip — demonstrates R2.1, R2.2, R2.6.
+   recorded as a skip — shows R2.1, R2.2, R2.6.
 2. **Test:** a planted secret in a fake config dir appears as
    `<redacted:len=N>` in the bundled config and never verbatim anywhere in the
-   archive — demonstrates R2.4, R2.5.
+   archive — shows R2.4, R2.5.
 3. **CLI:** `min bug` on a dev box; inspect manifest counts and `host/`
-   entries — demonstrates R2.3, R2.7–R2.9.
+   entries — shows R2.3, R2.7–R2.9.
 
 ---
 
@@ -477,17 +477,17 @@ records carry correlation ids on spans.
 1. **CLI (gate):** boot a VM, hold an idle attach, `minvmd stop`; the volume
    unmounts cleanly (no journal replay on next mount), `boot.log` is present
    in the host-side provider directory, and rotated `minimald.log*` appear on
-   the data volume at next boot — demonstrates R3.2–R3.4. The
+   the data volume at next boot — shows R3.2–R3.4. The
    release-before-quiesce path is compile/unit-verified only on the reference
    branch; this live check gates the unit.
 2. **Test:** log-release runs exactly once and before quiesce returns;
-   harness passes `None` release unaffected — demonstrates R3.4.
+   harness passes `None` release unaffected — shows R3.4.
 3. **Test:** the daily appender writes to its date-suffixed file; retention
    and rotation are `tracing_appender`'s own tested behavior, and the live
    gate (artifact 1) confirms rotated `minimald.log*` on the volume —
-   demonstrates R3.6.
+   shows R3.6.
 4. **CLI:** grep a session's records by span-carried channel id across
-   accept/attach/close lines — demonstrates R3.5.
+   accept/attach/close lines — shows R3.5.
 
 ---
 
@@ -559,13 +559,13 @@ the daemon across the SSH boundary.
 
 1. **Test:** a file-log line parses as JSON and carries level, target,
    timestamp, flattened span fields, and top-level resource fields —
-   demonstrates R4.1, R4.2.
+   shows R4.1, R4.2.
 2. **CLI (gate):** run one attach with `min`; a single `trace_id` greps
    across the host CLI log and the guest daemon's on-volume log —
-   demonstrates R4.3, R4.4.
+   shows R4.3, R4.4.
 3. **Test:** malformed `TRACEPARENT` values are ignored (fresh mint, no
    error), and client and daemon reference the same env-name constant —
-   demonstrates R4.4.
+   shows R4.4.
 
 ---
 
@@ -597,7 +597,7 @@ established for its disk/log/env/system helpers.
   `netstat` with raw `/proc/net` fallback — verbatim output, no typed
   re-serialization), interfaces with MACs masked to their vendor OUI, and
   routes.
-- **R5.2**: `diagnostics::procs` shall provide the process tree and hang
+- **R5.2**: `diagnostics::procs` shall produce the process tree and hang
   triage for up to 8 pids matched by **argv0 basename** against a
   caller-supplied `markers: &[&str]`. The Linux path shall be **pure `/proc`
   reads** — wchan/syscall/kernel-stack/fd readlinks, plus an
@@ -623,12 +623,12 @@ established for its disk/log/env/system helpers.
 **Proof Artifacts:**
 
 1. **Test:** interfaces output masks full MACs to OUI; routes/listening
-   captures present in the bundle — demonstrates R5.1.
+   captures present in the bundle — shows R5.1.
 2. **CLI:** `min bug` while a `min attach` runs: `host/proc/<pid>.sample.txt`
    (macOS) or `.stack.txt` (Linux) plus `host/proc/lsof.txt` appear for the
-   process family — demonstrates R5.2, R5.4.
+   process family — shows R5.2, R5.4.
 3. **Test:** crate-level tests for markers matching (argv0 basename, not
-   substring) and power event caps — demonstrates R5.2, R5.3.
+   substring) and power event caps — shows R5.2, R5.3.
 
 ---
 
@@ -685,7 +685,7 @@ same `manifest.json` schema as the host bundle.
   — scrubbed per the R5.2 argv rule — only for marker-matched processes,
   `comm` otherwise), raw `/proc/net` tables, and `disk.json` — finishing
   with `manifest.json`.
-- **R6.6**: The bundle shall additionally capture the guest-side incident
+- **R6.6**: The bundle shall also capture the guest-side incident
   trio via the Unit 5 mechanics (all pure `/proc`, R5.2 — the microVM rootfs
   has no `lsof`/`ss`/`ip`):
   - `net/routes.txt` — `/proc/net/route` + `/proc/net/fib_trie` (routing
@@ -714,16 +714,16 @@ same `manifest.json` schema as the host bundle.
 
 1. **Test:** in-crate tests fetch a bundle over the test harness and assert
    `meta.json` + `manifest.json` presence, session redaction, and the
-   pre-stream error path (extended data, zero payload) — demonstrates R6.1,
+   pre-stream error path (extended data, zero payload) — shows R6.1,
    R6.2, R6.4.
 2. **CLI:** raw `ssh -s` subsystem invocation against a dev daemon returns a
-   decompressible rootless tar.zst — demonstrates R6.2.
+   decompressible rootless tar.zst — shows R6.2.
 3. **Test:** oversized request body and oversized `log_tail_bytes` are
-   clamped/rejected — demonstrates R6.3.
+   clamped/rejected — shows R6.3.
 4. **Test:** the harness bundle contains `net/routes.txt`, per-pid
    `proc/<pid>.stack.txt` for the daemon's own family, `proc/sockets.txt`
    with fd→inode-resolved sockets, and `env.json` with a planted
-   `MINIMALD_TOKEN`-style variable masked — demonstrates R6.6.
+   `MINIMALD_TOKEN`-style variable masked — shows R6.6.
 
 ---
 
@@ -786,15 +786,15 @@ and logs harvested read-only from the volume image.
 
 1. **Test:** full-stack — `min bug` against the harness daemon nests a guest
    bundle whose manifest parses; loadout redaction and client-key skip hold
-   across layers — demonstrates R7.1–R7.3.
+   across layers — shows R7.1–R7.3.
 2. **Test:** stale socket file → probe records the failed connect stage and
    `error.txt` explains the skip; volume fallback artifacts appear —
-   demonstrates R7.1, R7.5.
+   shows R7.1, R7.5.
 3. **Test:** `--no-guest` against a live harness daemon performs zero daemon
-   contact — demonstrates R7.4.
+   contact — shows R7.4.
 4. **CLI (gate):** kill a real VM's daemon mid-session, run `min bug`: probe
    stages + `volume-meta.json` + harvested `volume-logs/` present —
-   demonstrates R7.5 end to end.
+   shows R7.5 end to end.
 
 ---
 
@@ -829,7 +829,7 @@ read both pre-convergence (`errors.json`) and post-convergence
 
 1. **CLI:** `summary`/`check`/`errors` against one pre-convergence bundle
    (a field-captured sample retained by the team) and one post-Unit-6 bundle
-   — both pass — demonstrates R8.1–R8.3.
+   — both pass — shows R8.1–R8.3.
 
 ## Non-Goals
 
@@ -881,7 +881,7 @@ the move).
 
 No maintained crate does data-driven recursive key-based scrubbing of
 arbitrary JSON/TOML: `secrecy`/`veil`/`redact` are type-level (annotate your
-own structs — the opposite shape from walking config you didn't define), and
+own structs — the opposite shape from walking config you did not define), and
 `redactable` explicitly treats dynamic `serde_json::Value`s as opaque
 wholesale-redact leaves. Vector's VRL `redact()` is the only real prior art
 and is an entire language runtime. The ~200-line fail-closed key-walk stays,

--- a/docs/specs/10-spec-diagnostics/architecture.md
+++ b/docs/specs/10-spec-diagnostics/architecture.md
@@ -417,7 +417,7 @@ already enabled) are named follow-ups under #801, not foundations.
 
 **Redaction crates (`secrecy`, `veil`, `redact`, `redactable`, VRL).**
 Rejected: all type-level (annotate your own structs) — the opposite shape
-from walking user config you didn't define; `redactable` explicitly
+from walking user config you did not define; `redactable` explicitly
 wholesale-redacts dynamic values ("could contain anything") — i.e. the one
 crate that considered the problem punted on it; VRL is a language runtime.
 Nothing is fail-closed. The bespoke key-walk is ~200 lines no crate deletes.

--- a/docs/spikes/2026-06-20-wireguard-implementation.md
+++ b/docs/spikes/2026-06-20-wireguard-implementation.md
@@ -183,7 +183,7 @@ boringtun's integration advantages for a Rust project:
 | Cross-compilation | High, C cross-compiler | Medium, separate binary | Low, Rust toolchain |
 | Process count | Same (in-proc) | +1 (alongside gvproxy) | Same (in-proc) |
 | Production subnet-router | Tailscale-scale | Tailscale-scale | Cloudflare/Mullvad-scale |
-| Maintenance risk | Low | Low | Low–Medium (gap resolved in 2026) |
+| Maintenance risk | Low | Low | Low-Medium (gap resolved in 2026) |
 
 If boringtun's maintenance pace declines materially or the v1 manual-key-exchange
 model is replaced with Tailscale-style coordination, revisiting wireguard-go via
@@ -239,7 +239,7 @@ approach's in-process integration benefit.
    - `networking-with-diagrams.md` deployment-model diagram, `LapWG` node
      (line 503): "wireguard-go peer (bundled in minimal CLI)" → "boringtun peer
      (bundled in minimal CLI)"
-   - `networking-with-diagrams.md` Option A prose (lines 585–588): "Each
+   - `networking-with-diagrams.md` Option A prose (lines 585-588): "Each
      minimald is a wireguard-go peer" → "Each minimald is a boringtun peer";
      "wireguard-go is bundled" → "boringtun is bundled"
 3. **Workspace dependency pin:** When Unit 4 implementation starts, pin

--- a/docs/spikes/2026-06-20-wireguard-implementation.md
+++ b/docs/spikes/2026-06-20-wireguard-implementation.md
@@ -97,7 +97,7 @@ production adoption at the subnet-router level.
   an implementation-specific feature. Both wireguard-go and boringtun support it
   identically: set `AllowedIPs = 100.64.0.0/16` (the gvproxy switch subnet) on
   remote peers. The implementation-level difference between the two is nil for
-  this use case. Tailscale's "battle-tested subnet-router" advantage lies in
+  this use case. Tailscale's "mature subnet-router" advantage lies in
   their coordination and ACL layer, not in wireguard-go itself, which minimald
   does not need in v1 (manual key exchange per R4.1).
 - **Rust integration:** `cargo add boringtun` in the workspace `Cargo.toml`.
@@ -158,7 +158,7 @@ with no impact on binary size or startup time when unconfigured.
 
 **boringtun is the recommended choice for minimald v1.**
 
-The hypothesis is partially supported, wireguard-go is more battle-tested at
+The hypothesis is partially supported, wireguard-go is more mature at
 Tailscale's scale, and Go toolchain presence does reduce the raw toolchain
 footprint for cgo. However, the hypothesis underestimates two factors:
 
@@ -194,7 +194,7 @@ subprocess (not via cgo) is the recommended escalation path.
 **Status: partial.**
 
 The hypothesis holds for the production maturity claim: wireguard-go, via
-Tailscale's derivative, is more extensively battle-tested for the subnet-router
+Tailscale's derivative, is more extensively tested for the subnet-router
 model than boringtun. This is confirmed.
 
 The "reduced marginal CI cost" claim is partially confirmed (Go toolchain is
@@ -242,7 +242,7 @@ approach's in-process integration benefit.
    - `networking-with-diagrams.md` Option A prose (lines 585–588): "Each
      minimald is a wireguard-go peer" → "Each minimald is a boringtun peer";
      "wireguard-go is bundled" → "boringtun is bundled"
-3. **Workspace dependency pin:** When Unit 4 implementation begins, pin
+3. **Workspace dependency pin:** When Unit 4 implementation starts, pin
    `boringtun` in `[workspace.dependencies]` with `features = []` and add it to
    `minimald/Cargo.toml` behind the `wg` feature flag.
 4. **Risk register entry:** Note that boringtun exhibited an ~30-month release

--- a/docs/spikes/2026-06-21-gvproxy-attachment.md
+++ b/docs/spikes/2026-06-21-gvproxy-attachment.md
@@ -119,7 +119,7 @@ Notes:
   `forwards`, `vpnKitUUIDMacAddresses`, and `dnsSearchDomains` are **not**
   applied; they must be explicit in the YAML if needed.
 - `-ssh-port -1` disables the default `127.0.0.1:2222 → 192.168.127.2:22`
-  forward (that forward targets an IP that doesn't exist on our custom subnet).
+  forward (that forward targets an IP that does not exist on our custom subnet).
 - The warning `"CLI argument -ssh-port is unavailable with config file"` is
   emitted when `-config` is present; pass `-ssh-port -1` anyway to suppress
   the default forward that would be added without the flag.
@@ -193,7 +193,7 @@ assign IP via DHCP or static config
 connect(unix, /run/minimald/gvproxy-api.sock) ───►
 write("POST /connect HTTP/1.0\r\nHost: …\r\n\r\n") ─►
                                             hijack conn, register switch port
-        ◄─── [no response; raw frame exchange begins] ───►
+        ◄─── [no response; raw frame exchange starts] ───►
 
 async task rx: read(tap_fd) → LE_u16(len) + frame → write(sock)
 async task tx: read(sock) → LE_u16(len) → read(frame) → write(tap_fd)
@@ -538,7 +538,7 @@ was correct with one material correction.
 
 The following findings are source-confirmed but not yet live-tested. A live
 trial against an actual gvproxy process is recommended before U1-T2
-implementation begins:
+implementation starts:
 
 - **`dhcpStaticLeases` YAML assignment**: source reading confirms the
   `{ip: mac}` key format, but live behavior of gvproxy's DHCP server


### PR DESCRIPTION
## Summary

> Why use many word when few word do trick?

Ran Vale with the ASD-STE100 ruleset against every markdown file in `docs/`. Fixed all 101 error-level violations across 24 files, then fixed all 37 em-dash warnings (en dashes in numeric ranges replaced with ASCII hyphens). Vale now reports 0 errors and 0 warnings.

## What changed

| Rule | Fix | Count |
|---|---|---|
| Contractions | Expanded to full forms (`don't` to `do not`, `can't` to `cannot`, etc.) | 15 |
| BannedWords | `demonstrates` to `shows`, `begins` to `starts`, `additionally` to `also`, `ensure` to `make sure`, `acquire`/`obtain` to `get`, `begin` to `start` | 71 |
| Nominalization | Rephrased `provide X` patterns to plain verbs (`define`, `produce`, `support`) | 8 |
| MarketingAdjectives | Removed `seamlessly`, `battle-tested` (to `mature`/`tested`), `robust` (to `reliable`) | 6 |
| PhrasalVerbs | `tear down` to `remove` | 1 |
| EmDashes | Replaced en dashes in numeric ranges with ASCII hyphens | 37 |

## Files touched

24 files across `docs/concepts/`, `docs/guide/`, `docs/reference/`, `docs/internal/`, `docs/ci-strategy.md`, `docs/specs/`, and `docs/spikes/`.

## Verification

Ran Vale with the ASD-STE100 ruleset after all fixes. Result: 0 errors, 0 warnings.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix STE prose lint errors across the docs tree
> Applies Simplified Technical English (STE) lint fixes across all documentation. Changes are style-only with no semantic or technical content altered.
>
> - Expands contractions to formal equivalents (e.g. `can't` → `cannot`, `don't` → `do not`)
> - Replaces en-dash ranges with hyphen-minus (e.g. `1–2` → `1-2`) throughout specs and guides
> - Replaces informal verbs with STE-preferred alternatives (e.g. `demonstrates` → `shows`, `ensures` → `makes sure`, `additionally` → `also`)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 240a137.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Refined CI strategy documentation with clearer language around workflow-change review controls, fork security expectations, and minor formatting consistency in build/test pipeline tables.
  - Updated end-user guides and concepts for clearer phrasing around local-first builds, cached build state sharing, sandboxing expectations, stack inheritance, session cleanup, and verification messaging.
  - Standardized wording and formatting across references/specs/spikes (e.g., “ensures”→“makes sure”, “demonstrates”→“covers/shows”, and dash/line-wrapping tweaks) without changing meaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->