### PR TITLE
test(common): gate the release job's completions pre-merge

### DIFF
--- a/crates/common/tests/release_completions.rs
+++ b/crates/common/tests/release_completions.rs
@@ -1,0 +1,164 @@
+//! Convention-discovered gate for the completions the release ships.
+//!
+//! `release.yml`'s "Generate completions" step runs the freshly built `mip` /
+//! `min` / `minimald` binaries, but only on a dispatched release — so a breaking
+//! CLI change cleared every PR gate and only surfaced an hour into a release,
+//! taking the GCS upload, the GitHub Release and `stage-installer` with it
+//! (#1035; the `completions <shell>` → `completions print <shell>` split shipped
+//! that way for twenty days, #1009/#1034).
+//!
+//! `.github/workflows/` is frozen and CODEOWNER-gated, so the release job cannot
+//! grow a gate of its own. Instead the generation moved into
+//! `scripts/gen-completions.sh`, which the release job calls and this test also
+//! calls — against `target/debug` rather than the release artifacts. The release
+//! path and the pre-merge gate are the same code, so they cannot drift; this is
+//! the reviewed-code extension point CI schedules over (docs/ci-strategy.md
+//! §10). `release_job_calls_the_generator` holds the other half: the workflow
+//! has to keep calling the helper rather than inlining the commands again.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is crates/common; the workspace root is two up.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root two levels above crates/common")
+        .to_path_buf()
+}
+
+/// The directory cargo built this test into (`<target>/<profile>/deps/..`),
+/// which is also where the binaries under test land. Derived rather than
+/// assumed so a custom `CARGO_TARGET_DIR` or profile still resolves — cargo
+/// exports neither to the test process.
+fn bin_dir() -> PathBuf {
+    std::env::current_exe()
+        .expect("test binary path")
+        .parent()
+        .and_then(|deps| deps.parent())
+        .expect("<target>/<profile> two levels above the test binary")
+        .to_path_buf()
+}
+
+/// The binaries the release generates completions for. `minimald` is left out
+/// on macOS, where its sandbox stack does not build (the platform matrix in
+/// AGENTS.md); the Linux lanes cover all three.
+fn binaries() -> Vec<&'static str> {
+    if cfg!(target_os = "linux") {
+        vec!["mip", "min", "minimald"]
+    } else {
+        vec!["mip", "min"]
+    }
+}
+
+/// Build any binary the workspace test build did not leave behind — cargo only
+/// links a package's bin when something selects it, so `mip` (no `tests/` dir)
+/// is often absent. `--workspace --bin`, not `-p <package> --bin`: selecting the
+/// whole workspace resolves features exactly as the test build did, so this is a
+/// link or a no-op instead of a rebuild of every shared dependency under a
+/// narrower feature set. Building rather than skipping keeps the gate from
+/// quietly covering nothing.
+fn ensure_built(root: &Path, bin_dir: &Path, names: &[&str]) {
+    for name in names {
+        let exe = bin_dir.join(name);
+        if exe.exists() {
+            continue;
+        }
+        let status = Command::new("cargo")
+            .args(["build", "--locked", "--workspace", "--bin", name])
+            .current_dir(root)
+            .status()
+            .unwrap_or_else(|e| panic!("failed to run cargo build --bin {name}: {e}"));
+        assert!(status.success(), "cargo build --bin {name} failed");
+        assert!(
+            exe.exists(),
+            "cargo built {name} but {} is missing",
+            exe.display()
+        );
+    }
+}
+
+/// Whether `body` registers completions for the command `name`, in whichever
+/// form clap emitted: the static (aot) generator and the dynamic (env) shim
+/// `min` prints differ in flag spelling, but both name the command.
+fn registers(shell: &str, name: &str, body: &str) -> bool {
+    body.lines().any(|line| {
+        let words: Vec<&str> = line.split_whitespace().collect();
+        match shell {
+            "bash" => words.first() == Some(&"complete") && words.last() == Some(&name),
+            "zsh" => words.first() == Some(&"#compdef") && words.contains(&name),
+            "fish" => words
+                .windows(2)
+                .any(|w| (w[0] == "-c" || w[0] == "--command") && w[1] == name),
+            _ => false,
+        }
+    })
+}
+
+#[test]
+fn release_completions_generate_and_register_their_command() {
+    let root = repo_root();
+    let bin_dir = bin_dir();
+    let names = binaries();
+    ensure_built(&root, &bin_dir, &names);
+
+    let out = std::env::temp_dir().join(format!("release-completions-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&out);
+
+    let output = Command::new("bash")
+        .arg(root.join("scripts/gen-completions.sh"))
+        .arg(&out)
+        .args(&names)
+        .env("BIN_DIR", &bin_dir)
+        .current_dir(&root)
+        .output()
+        .expect("failed to run scripts/gen-completions.sh");
+    assert!(
+        output.status.success(),
+        "scripts/gen-completions.sh failed\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // A completion file a shell will not autoload is as broken as one that
+    // failed to generate, and exits 0 all the same: assert each one registers
+    // the command its own filename says it completes.
+    for name in &names {
+        for (shell, file) in [
+            ("bash", (*name).to_string()),
+            ("zsh", format!("_{name}")),
+            ("fish", format!("{name}.fish")),
+        ] {
+            let path = out.join(shell).join(&file);
+            let body = fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+            assert!(
+                registers(shell, name, &body),
+                "{shell}/{file} does not register the command `{name}` it is autoloaded for",
+            );
+        }
+    }
+
+    fs::remove_dir_all(&out).ok();
+}
+
+#[test]
+fn release_job_calls_the_generator() {
+    let workflow = repo_root().join(".github/workflows/release.yml");
+    let body = fs::read_to_string(&workflow)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", workflow.display()));
+
+    assert!(
+        body.contains("scripts/gen-completions.sh"),
+        "release.yml does not call scripts/gen-completions.sh, so its completion \
+         invocations are unexercised until a release is dispatched — the gap #1035 \
+         is about. Point the \"Generate completions\" step at the helper.",
+    );
+    assert!(
+        !body.contains("> artifacts/completions/"),
+        "release.yml inlines completion invocations again; they belong in \
+         scripts/gen-completions.sh, which this test exercises pre-merge.",
+    );
+}

--- a/justfile
+++ b/justfile
@@ -254,6 +254,14 @@ test-installer:
 lint-shell:
     bash scripts/lint-shell.sh
 
+# release.yml's "Generate completions" step calls the same
+# scripts/gen-completions.sh this test does, so a breaking CLI change fails a PR
+# instead of a dispatched release (#1035). Part of `just test` on Linux.
+#
+# Generate the release's completions from the dev binaries and check each one.
+test-completions:
+    cargo test -p common --test release_completions --locked
+
 # Run the promotion provenance gate's test harness (stubbed `gh`, no network,
 # no auth); shellcheck runs when present.
 test-promote-gate:

--- a/scripts/gen-completions.sh
+++ b/scripts/gen-completions.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Generate the shell completions the release ships.
+#
+# WHY THIS EXISTS
+# ---------------
+# `release.yml` used to inline these invocations in its "Generate completions"
+# step, where they only ever ran on a `workflow_dispatch` release — so a
+# breaking CLI change cleared every PR gate, merged, and sat until someone cut a
+# release, taking the GCS upload, the GitHub Release and `stage-installer` down
+# with it an hour of build time in. That is how #1009 (`completions <shell>` →
+# `completions print <shell>`) shipped broken for twenty days (#1034, #1035).
+#
+# So this is the single definition of what the release generates, called both by
+# that step (against the built artifacts) and by
+# crates/common/tests/release_completions.rs (against `target/debug`) — the
+# convention-discovered workspace test the always-running Linux lanes execute.
+# Since the release path and the pre-merge gate are now the same code, they
+# cannot disagree; `.github/workflows/` stays frozen either way.
+#
+# The destination filenames are derived from the command name, never spelled out
+# per row, because a shell only autoloads completions from a file named for the
+# command they complete. The #737 binary rename (`minimal` → `min`) left the
+# release job writing `min`'s completions to files named `minimal` — inert, and
+# invisible to any exit-code check — until #1034. Deriving them makes that class
+# of mismatch unrepresentable rather than merely tested.
+#
+# Usage: scripts/gen-completions.sh <outdir> [binary...]
+#   binary...  which of mip / min / minimald to generate (default: all three).
+# Env: BIN_DIR                          where to find them (default target/debug)
+#      MIP_BIN / MIN_BIN / MINIMALD_BIN explicit path to one binary, which is how
+#                                       the release job points at its
+#                                       platform-suffixed artifacts.
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <outdir> [binary...]" >&2
+    exit 2
+fi
+out="$1"
+shift
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+bin_dir="${BIN_DIR:-$root/target/debug}"
+
+binaries=("$@")
+if [ "${#binaries[@]}" -eq 0 ]; then
+    binaries=(mip min minimald)
+fi
+
+mkdir -p "$out/bash" "$out/zsh" "$out/fish"
+
+generated=0
+for name in "${binaries[@]}"; do
+    # Per binary: where it lives, and the verb that prints a completion script.
+    # `min` splits printing from installing (`completions print <shell>`, #1009);
+    # `mip` and `minimald` keep the flat verb.
+    case "$name" in
+        mip)      exe="${MIP_BIN:-$bin_dir/mip}";           verb=(completions) ;;
+        min)      exe="${MIN_BIN:-$bin_dir/min}";           verb=(completions print) ;;
+        minimald) exe="${MINIMALD_BIN:-$bin_dir/minimald}"; verb=(completions) ;;
+        *) echo "gen-completions: unknown binary '$name'" >&2; exit 2 ;;
+    esac
+
+    if [ ! -x "$exe" ]; then
+        echo "gen-completions: $exe is not an executable" >&2
+        exit 1
+    fi
+
+    for shell in bash zsh fish; do
+        # Each shell's autoload name for the command `$name`.
+        case "$shell" in
+            bash) dest="$out/bash/$name" ;;
+            zsh)  dest="$out/zsh/_$name" ;;
+            fish) dest="$out/fish/$name.fish" ;;
+        esac
+        "$exe" "${verb[@]}" "$shell" >"$dest"
+        if [ ! -s "$dest" ]; then
+            echo "gen-completions: $name wrote an empty $shell completion" >&2
+            exit 1
+        fi
+        generated=$((generated + 1))
+    done
+done
+
+echo "gen-completions: wrote $generated completion file(s) to $out"


### PR DESCRIPTION
Closes #1035.

## The gap

`release.yml`'s **Generate completions** step shells out to the freshly built `mip` / `min` / `minimald` binaries. Those invocations only ever run on a `workflow_dispatch` release, so a breaking CLI change clears every PR gate, merges, and sits until someone cuts a release. #1009 (`completions <shell>` → `completions print <shell>`) did exactly that: twenty days later it exited 2, an hour of build time in, taking the GCS upload, the GitHub Release, and the whole `stage-installer` job with it. #1034 fixed the call site; the structure that let it happen stayed.

## The fix

Move the generation into `scripts/gen-completions.sh` — one definition of what the release ships — and have both the release job and a workspace test call it. The pre-merge gate is then *the same code as the release path*, not a replay of it, so the two cannot drift.

```
release.yml  ─┐
              ├─→  scripts/gen-completions.sh
tests/        ─┘   (release artifacts / target/debug)
```

`crates/common/tests/release_completions.rs` runs the helper against `target/debug` and asserts every generated file registers the command it is autoloaded for. It is convention-discovered, so the always-running Linux lanes execute it through the core-tests suite with no CI edit — the extension point in docs/ci-strategy.md §10, same as `scripts/lint-shell.sh` (#899). `just test-completions` runs it directly.

Filenames are **derived** from the command name inside the helper rather than spelled out per row. A shell only autoloads completions from a file named for the command they complete, and the #737 binary rename left the release job writing `min`'s completions to files named `minimal` — inert, exit 0, invisible until #1034. Deriving makes that mismatch unrepresentable; the test still checks the registration line, because an exit-code-only gate would not have caught it.

## ⚠️ One edit for a CODEOWNER: this PR is red until it lands

`.github/workflows/` is frozen to agents, so the commit stops at the repo side. `release_job_calls_the_generator` fails by design until the step calls the helper — that failure *is* the gap #1035 describes, still open. Apply on this branch:

```diff
diff --git a/.github/workflows/release.yml b/.github/workflows/release.yml
index 25f571ec..b729cb07 100644
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -719,22 +719,17 @@ jobs:
             - name: Make binaries executable
               run: chmod +x artifacts/*-*-*
             - name: Generate completions
-              # `min` splits printing from installing (`completions print
-              # <shell>`); `mip` and `minimald` keep the flat verb. The `min`
-              # files are named for the `min` binary, not the crate — the shim
-              # it prints registers the command `min`, so a shell only autoloads
-              # it from a file of that name.
-              run: |
-                  mkdir -p artifacts/completions/{bash,zsh,fish}
-                  artifacts/mip-linux-amd64 completions bash > artifacts/completions/bash/mip
-                  artifacts/mip-linux-amd64 completions zsh  > artifacts/completions/zsh/_mip
-                  artifacts/mip-linux-amd64 completions fish > artifacts/completions/fish/mip.fish
-                  artifacts/minimal-linux-amd64 completions print bash > artifacts/completions/bash/min
-                  artifacts/minimal-linux-amd64 completions print zsh  > artifacts/completions/zsh/_min
-                  artifacts/minimal-linux-amd64 completions print fish > artifacts/completions/fish/min.fish
-                  artifacts/minimald-linux-amd64 completions bash > artifacts/completions/bash/minimald
-                  artifacts/minimald-linux-amd64 completions zsh  > artifacts/completions/zsh/_minimald
-                  artifacts/minimald-linux-amd64 completions fish > artifacts/completions/fish/minimald.fish
+              # Which binary uses which verb, and what each file is named, lives
+              # in the helper — the same code crates/common/tests/release_completions.rs
+              # runs against target/debug on every PR, so this step can no longer
+              # break unnoticed until a release is dispatched. Binaries are named
+              # here because only the workflow knows the platform-suffixed
+              # artifact names (and that `min` ships as the `minimal-*` one).
+              env:
+                  MIP_BIN: artifacts/mip-linux-amd64
+                  MIN_BIN: artifacts/minimal-linux-amd64
+                  MINIMALD_BIN: artifacts/minimald-linux-amd64
+              run: scripts/gen-completions.sh artifacts/completions
             - name: Authenticate to Google Cloud
               uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
               with:
```

Or: `gh pr checkout <this PR> && git apply <patch> && git commit -am 'ci(release): generate completions through scripts/gen-completions.sh'`.

The step keeps the artifact names because only the workflow knows them (platform suffixes, and that `min` ships as the `minimal-*` artifact); everything that can break — verbs, filenames, the shell list — moves into reviewed code. Output tree is byte-for-byte the layout the release produces today, so `completions.tar.gz` and `stage-release.sh` are untouched.

## Verification

- **Reproduces #1035.** Reverting the helper's `min` row to the pre-#1009 flat verb fails the test with `error: unrecognized subcommand 'bash'`.
- **Registration check is not vacuous.** Pointing `min`'s row at a different binary fails with ``bash/min does not register the command `min` it is autoloaded for``.
- **Release call form.** `MIP_BIN=… MIN_BIN=… scripts/gen-completions.sh artifacts/completions` against platform-suffixed copies reproduces today's six-file tree (`bash/min`, `zsh/_min`, `fish/min.fish`, …); a missing binary exits 1 rather than writing a partial tree.
- **With the workflow diff applied locally**, both tests pass.
- `cargo fmt --all --check`, `cargo clippy -p common --all-targets -- -D warnings`, `shellcheck`, `just lint-shell` (25/25). `minimald` is skipped on macOS (Linux-only crate) and covered by the Linux lanes here.

## Audit

Per the issue's ask: the completions step is the only place the `release` and `stage-installer` jobs invoke a shipped binary. The rest is `gcloud`, `gh`, `tar`, or a `scripts/` helper that already has a harness (`install.sh` → `install_test.sh`, `verify-nightly-provenance.sh` → `verify-nightly-provenance_test.sh`).

Complements #687's PR9b (post-release artifact smoke) — this is the pre-merge half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate the release job's completion generation with pre-merge integration tests
> - Adds [scripts/gen-completions.sh](https://github.com/gominimal/minimal/pull/1048/files#diff-e5d884ff559d437de249a2b281f9696480a401f57691109cc95b693903d92016), a Bash script that generates bash/zsh/fish completion files for `mip`, `min`, and `minimald`, with strict error checking and support for `BIN_DIR`/per-binary path overrides.
> - Adds [crates/common/tests/release_completions.rs](https://github.com/gominimal/minimal/pull/1048/files#diff-79da0823c593d853d054456e035ab10e055c9bad73c5c69fca79c1944d86747a) with two tests: one that runs `gen-completions.sh` against debug binaries and asserts each output file registers its command; one that asserts the release workflow calls `gen-completions.sh` rather than redirecting completions inline.
> - Adds a `just test-completions` recipe to run the new test file in isolation.
> - Risk: the test builds missing binaries via `cargo build` at test time, which can significantly increase CI time on cold caches.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6497f58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated generation of shell completion files for supported command-line tools.
  - Added completion support for Bash, Zsh, and Fish.

- **Bug Fixes**
  - Improved validation to detect missing, non-executable, or empty completion outputs.

- **Tests**
  - Added automated checks confirming generated completions and release workflow integration.
  - Added a convenient command for running completion checks locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->