### PR TITLE
build(deps): drop russh's default rsa feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,16 +1253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-primes"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
-dependencies = [
- "crypto-bigint",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "ctr"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4777,16 +4767,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs1"
-version = "0.8.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkcs5"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5505,25 +5485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.10.0-rc.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
-dependencies = [
- "const-oid",
- "crypto-bigint",
- "crypto-primes",
- "digest 0.11.3",
- "pkcs1",
- "pkcs8",
- "rand_core 0.10.1",
- "sha2 0.11.0",
- "signature 3.0.0",
- "spki",
- "zeroize",
-]
-
-[[package]]
 name = "russh"
 version = "0.62.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5568,13 +5529,11 @@ dependencies = [
  "p521",
  "pageant",
  "pbkdf2",
- "pkcs1",
  "pkcs5",
  "pkcs8",
  "polyval",
  "rand",
  "rand_core 0.10.1",
- "rsa",
  "russh-cryptovec",
  "russh-util",
  "salsa20",
@@ -6355,7 +6314,6 @@ checksum = "7b54d0ed0498daf3f78d82e00e28c8eec9d75a067c4cfbcc7a0f7d0f4077749e"
 dependencies = [
  "base64ct",
  "bytes",
- "crypto-bigint",
  "ctutils",
  "digest 0.11.3",
  "pem-rfc7468",
@@ -6378,7 +6336,6 @@ dependencies = [
  "p384",
  "p521",
  "rand_core 0.10.1",
- "rsa",
  "sec1",
  "sha1",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
 resolv-conf = "0.7"
-russh = "0.62"
+russh = { version = "0.62", default-features = false, features = ["aws-lc-rs", "flate2"] }
 russh-sftp = "2.1"
 serde_json = { version = "1.0" }
 serial_test = "4"

--- a/deny.toml
+++ b/deny.toml
@@ -7,8 +7,6 @@ ignore = [
     "RUSTSEC-2026-0009",
     # Deprecation notice of paste crate
     "RUSTSEC-2024-0436",
-    # RSA crate timing side-channel, not accessible when using ed25519 host keys
-    "RUSTSEC-2023-0071",
     # proc-macro-error2 is no longer maintained. oci-spec depends on getset which depends on it
     # Ignore until it is replaced upstream
     "RUSTSEC-2026-0173",


### PR DESCRIPTION
Turns off russh's default `rsa` feature, since this workspace only ever generates and parses Ed25519 SSH keys.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop russh's default RSA feature and use `aws-lc-rs` instead
> - Updates the `russh` dependency in [Cargo.toml](https://github.com/gominimal/minimal/pull/1051/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) to disable default features and explicitly enable `aws-lc-rs` and `flate2`.
> - Removes the RUSTSEC-2023-0071 advisory ignore from [deny.toml](https://github.com/gominimal/minimal/pull/1051/files#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3de), as the RSA feature causing that advisory is no longer included.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03826eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->