### PR TITLE
feat(minimald): support min materialize within a session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3834,6 +3834,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sessions",
+ "size",
  "stdlib",
  "switch",
  "sysinfo",

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -523,6 +523,30 @@ pub struct Output {
     extra: HashMap<String, toml::Value>,
 }
 
+impl Output {
+    /// The target to build this output for. Arch precedence: `arch_override` >
+    /// the `arch` field > the host. The OS is always Linux.
+    pub fn target(
+        &self,
+        arch_override: Option<&str>,
+    ) -> Result<common::Target, common::target::ArchParseError> {
+        let arch = match arch_override.or(self.arch.as_deref()) {
+            Some(s) => s.parse()?,
+            None => common::Target::host().arch().clone(),
+        };
+        Ok(common::Target::new(arch, common::target::OS::Linux))
+    }
+
+    /// The graph top levels for this output; `base` when it names no packages.
+    pub fn top_levels(&self) -> Vec<String> {
+        if self.packages.is_empty() {
+            vec!["base".to_string()]
+        } else {
+            self.packages.clone()
+        }
+    }
+}
+
 impl TryFrom<OutputRaw> for Output {
     type Error = String;
 
@@ -1422,6 +1446,59 @@ mod tests {
         })
         .unwrap();
         assert_eq!(mf.outputs["image"].arch, Some("amd64".to_string()));
+    }
+
+    #[test]
+    fn output_target_arch_precedence() {
+        let pinned = Output {
+            arch: Some("arm64".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            pinned.target(Some("amd64")).unwrap().arch(),
+            &common::target::Arch::Amd64,
+            "the override must beat the output's own arch"
+        );
+        assert_eq!(
+            pinned.target(None).unwrap().arch(),
+            &common::target::Arch::Arm64,
+            "without an override the output's arch is used"
+        );
+        assert_eq!(
+            Output::default().target(None).unwrap().arch(),
+            common::Target::host().arch(),
+            "with neither set, the host's arch is used"
+        );
+    }
+
+    #[test]
+    fn output_target_os_is_always_linux() {
+        assert_eq!(
+            Output::default().target(None).unwrap().os(),
+            &common::target::OS::Linux
+        );
+    }
+
+    #[test]
+    fn output_target_rejects_an_unknown_arch() {
+        let err = Output::default()
+            .target(Some("s390x"))
+            .expect_err("s390x is not a supported architecture");
+        assert!(
+            err.to_string().contains("s390x"),
+            "the error should name the offending input, got {err}"
+        );
+    }
+
+    #[test]
+    fn output_top_levels_default_to_base() {
+        assert_eq!(Output::default().top_levels(), vec!["base".to_string()]);
+
+        let explicit = Output {
+            packages: vec!["openssl".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(explicit.top_levels(), vec!["openssl".to_string()]);
     }
 
     #[test]

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -37,6 +37,7 @@ constcat.workspace = true
 either.workspace = true
 fd-lock.workspace = true
 futures.workspace = true
+size.workspace = true
 hakoniwa.workspace = true
 libc.workspace = true
 nix.workspace = true

--- a/crates/minimald/src/env.rs
+++ b/crates/minimald/src/env.rs
@@ -33,13 +33,13 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use graph::{BuildSpecRef, Graph, SetupForPackages, Transitives};
 use mctx::{AddDepMode, Context, Error};
 use mfile::{EnvPatches, EnvVarValue};
 use op::Runnable;
 use ot::OpTracker;
-use paths::DaemonAbsPath;
+use paths::{DaemonAbsPath, DaemonRelPath, SandboxAbsPath, SandboxPath};
 use sandbox2::config::{Config, SandboxMapped};
 use sandbox2::{Container, Sandbox};
 use sessions::NetworkMode;
@@ -49,6 +49,16 @@ use tokio::task::{JoinHandle, spawn_blocking};
 
 /// The min helper script installed at `/usr/bin/min` inside the sandbox.
 const MIN_SCRIPT: &str = include_str!("env_min_helper.sh");
+
+/// Where the session's workspace appears *inside* the sandbox. The daemon sees
+/// the same directory at [`SessionChannel::working`], so this is the prefix
+/// that translates a path typed in the sandbox into one the daemon can write.
+const WORKSPACE_ROOT: &str = constcat::concat!("/", sandbox2::SESSION_DEFAULT_WD);
+
+/// Where the session's home directory appears inside the sandbox, backed by
+/// [`SessionChannel::home`]. The second of the two directories a sandbox path
+/// can name on the daemon's side.
+const HOME_ROOT: &str = constcat::concat!("/", sandbox2::SESSION_HOME);
 
 /// The parameters used to construct an [`Env`].
 ///
@@ -371,6 +381,7 @@ impl Env {
             .unwrap(),
             state_dir: args.state_base_dir.clone(),
             working: args.cwd.clone(),
+            home: args.home.clone(),
             has_packages: transitives.keys().copied().collect(),
             ot: args.ot.clone(),
             session: args.session.clone(),
@@ -500,8 +511,10 @@ struct SessionChannel {
     rootfs: DaemonAbsPath,
     /// The host directory backing `/state`.
     state_dir: DaemonAbsPath,
-    /// The host directory the working directory.
+    /// The host directory backing `/workbench`.
     working: DaemonAbsPath,
+    /// The host directory backing `/home`.
+    home: DaemonAbsPath,
 
     /// Packages already materialized into the rootfs.
     has_packages: HashSet<BuildSpecRef>,
@@ -585,6 +598,12 @@ impl SessionChannel {
             }
             Some(("build", args)) => {
                 self.run_build(stream, args).await;
+                None
+            }
+            // `<cwd>%<args>`: the helper's sandbox working directory, so a
+            // relative `--output` resolves where the user typed it.
+            Some(("materialize", request)) => {
+                self.run_materialize(stream, request).await;
                 None
             }
             _ => {
@@ -959,6 +978,92 @@ impl SessionChannel {
         }
     }
 
+    /// Implements `min materialize --output <path> [--arch <arch>] <name>`.
+    ///
+    /// The side-op streams the artifact's bytes rather than writing a file, so
+    /// landing it is this transport's job. `request` carries the helper's
+    /// sandbox working directory ahead of the arguments, so `--output` resolves
+    /// where the user typed it and stays inside the workspace — the one
+    /// directory the daemon and the sandbox share.
+    async fn run_materialize(&mut self, stream: &mut UnixStream, request: &str) {
+        use crate::session_sop::{MaterializeOutcome, MaterializeUpdate};
+        use tokio::io::AsyncWriteExt as _;
+
+        let prepared: Result<_, String> = async {
+            let MaterializeArgs { opts, output } = MaterializeArgs::from_request(request)?;
+            let session = self.session.upgrade().ok_or("session is gone")?;
+            let file = create_artifact(&self.working, &self.home, &output)
+                .await
+                .map_err(|e| format!("creating {output}: {e}"))?;
+            let updates = session
+                .start_materialize(opts)
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok((output, file, updates))
+        }
+        .await;
+        let (output, mut file, mut updates) = match prepared {
+            Ok(prepared) => prepared,
+            Err(msg) => {
+                let _ = writeln!(stream, "error: {msg}");
+                return;
+            }
+        };
+
+        let mut outcome = None;
+        let mut write_err = None;
+        while let Some(update) = updates.recv().await {
+            match &update {
+                MaterializeUpdate::Chunk(bytes) => {
+                    if let Err(e) = file.write_all(bytes).await {
+                        // Returning drops the receiver, which poisons the
+                        // assembly's writer — no point building the rest of an
+                        // artifact that has nowhere to land.
+                        write_err = Some(e.to_string());
+                        break;
+                    }
+                }
+                MaterializeUpdate::Finished(o) => outcome = Some(o.clone()),
+                MaterializeUpdate::Event(_) => {}
+            }
+            for line in update.render() {
+                let _ = writeln!(stream, "msg:{line}");
+            }
+        }
+
+        if let Some(msg) = write_err {
+            let _ = writeln!(stream, "error: writing {output}: {msg}");
+            return;
+        }
+        let (status, message) = MaterializeOutcome::summarize(outcome.as_ref());
+        if status != 0 {
+            let _ = writeln!(stream, "error: {message}");
+            return;
+        }
+
+        // A `tokio::fs::File` completes its writes in the background; dropping
+        // one unflushed truncates the artifact silently.
+        if let Err(e) = file.flush().await {
+            let _ = writeln!(stream, "error: writing {output}: {e}");
+            return;
+        }
+        // The byte stream carries no mode, so a raw-file output needs the
+        // source's back or an extracted binary arrives without its executable
+        // bit. On the fd, so it cannot land on a path swapped underneath us.
+        if let Some(MaterializeOutcome::Completed {
+            mode: Some(mode), ..
+        }) = outcome
+            && let Err(e) = file
+                .set_permissions(Permissions::from_mode(mode & 0o777))
+                .await
+        {
+            let _ = writeln!(stream, "error: setting mode on {output}: {e}");
+            return;
+        }
+
+        let _ = writeln!(stream, "msg:{message} to {output}");
+    }
+
     /// Writes an [`mctx::Error`] to the client as `msg:` lines (preserving its
     /// multi-line, richly-formatted report) followed by an `error:` terminator.
     fn write_error(e: &Error, stream: &mut UnixStream) {
@@ -967,6 +1072,233 @@ impl SessionChannel {
         }
         let _ = writeln!(stream, "error: sandbox command failed.");
     }
+}
+
+/// A parsed `min materialize` invocation: what to materialize, plus where in
+/// the session to put it.
+#[derive(Debug, PartialEq)]
+struct MaterializeArgs {
+    opts: crate::session_sop::MaterializeOpts,
+    /// Where the artifact lands, as an absolute path in the *sandbox* —
+    /// resolved against the sandbox cwd, and not yet tied to a daemon
+    /// directory. [`sandbox_to_daemon`] decides which one it names.
+    output: SandboxAbsPath,
+}
+
+impl MaterializeArgs {
+    /// Parses a `materialize%<cwd>%<args>` request line. The cwd is its own
+    /// field rather than a flag so no user argument can be mistaken for it.
+    fn from_request(request: &str) -> Result<Self, String> {
+        let Some((cwd, args)) = request.split_once('%') else {
+            return Err("malformed materialize request: no working directory".to_string());
+        };
+        Self::from_args(Utf8Path::new(cwd), args)
+    }
+
+    /// Mirrors the clap interface of `mip materialize`: a required
+    /// `-o`/`--output <PATH>`, an optional `--arch <ARCH>`, and exactly one
+    /// bare `<OUTPUT_NAME>`, with both `--flag value` and `--flag=value`
+    /// accepted. `--output` departs from `mip`'s: it resolves against `cwd`
+    /// and must land in the workspace (see [`resolve_output`]).
+    fn from_args(cwd: &Utf8Path, args: &str) -> Result<Self, String> {
+        let mut output: Option<String> = None;
+        let mut arch: Option<String> = None;
+        let mut names: Vec<String> = Vec::new();
+
+        let mut tokens = args.split_whitespace();
+        while let Some(token) = tokens.next() {
+            let (flag, inline) = match token.split_once('=') {
+                Some((flag, value)) => (flag, Some(value)),
+                None => (token, None),
+            };
+            // Takes the flag's value from `=` when it was attached, otherwise
+            // from the next token.
+            let mut value = |flag: &str| match inline {
+                Some(v) => Ok(v.to_string()),
+                None => tokens
+                    .next()
+                    .map(str::to_string)
+                    .ok_or_else(|| format!("`{flag}` requires a value")),
+            };
+
+            match flag {
+                "-o" | "--output" => output = Some(value(flag)?),
+                "--arch" => arch = Some(value(flag)?),
+                // Any leading dash, as `min check` does. A typo falling
+                // through to the positional would read as a second output
+                // name, and the error has to name the typo, not the count.
+                flag if flag.starts_with('-') => {
+                    return Err(format!(
+                        "unknown flag `{flag}` (expected --output or --arch)"
+                    ));
+                }
+                _ => names.push(token.to_string()),
+            }
+        }
+
+        let output = output.ok_or("`min materialize` requires --output <PATH>")?;
+        let output = resolve_output(cwd, SandboxPath::new(output))?;
+
+        let output_name = match names.len() {
+            1 => names.remove(0),
+            0 => return Err("`min materialize` requires the name of an output".to_string()),
+            _ => {
+                return Err(format!(
+                    "expected one output name, got {}",
+                    names.join(", ")
+                ));
+            }
+        };
+
+        Ok(Self {
+            opts: crate::session_sop::MaterializeOpts { output_name, arch },
+            output,
+        })
+    }
+}
+
+/// Resolves the `--output` path typed inside the sandbox to an absolute one,
+/// still in the sandbox's namespace. A relative path is joined onto `cwd`, the
+/// directory the user typed it in; an absolute one is already there.
+///
+/// Which daemon directory it lands in is [`sandbox_to_daemon`]'s decision, so
+/// nothing is stripped here.
+fn resolve_output(cwd: &Utf8Path, output: SandboxPath) -> Result<SandboxAbsPath, String> {
+    let absolute = match output {
+        SandboxPath::Abs(abs) => abs.as_utf8_path().to_path_buf(),
+        SandboxPath::Rel(rel) => {
+            if rel.as_str().is_empty() {
+                return Err("`--output` is empty".to_string());
+            }
+            if !cwd.is_absolute() {
+                return Err(format!(
+                    "cannot resolve `--output {rel}`: \
+                     the working directory `{cwd}` is not an absolute path"
+                ));
+            }
+            cwd.join(rel.as_utf8_path())
+        }
+    };
+    // Normalize here so `sandbox_to_daemon`'s prefix match is sound:
+    // `/workbench/../etc/passwd` must not pass on its first component.
+    // Lexical, not `canonicalize` — this is a sandbox path, and the artifact
+    // does not exist yet. `create_under` makes the on-disk check.
+    SandboxAbsPath::try_new(normalize_absolute(&absolute))
+        .map_err(|e| format!("`--output` is not a usable path: {e}"))
+}
+
+/// Resolves `.` and `..` textually. A `..` at the root stays there, so an
+/// escape can only show up as a path failing the workspace prefix check.
+fn normalize_absolute(path: &Utf8Path) -> Utf8PathBuf {
+    let mut out = Utf8PathBuf::new();
+    for component in path.components() {
+        match component {
+            camino::Utf8Component::CurDir => {}
+            camino::Utf8Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_str()),
+        }
+    }
+    out
+}
+
+/// Creates the file an artifact named by `path` should be written to.
+///
+/// Picks the session directory `path` falls under — [`WORKSPACE_ROOT`] maps to
+/// `working`, [`HOME_ROOT`] to `home` — and creates the directories leading to
+/// the destination. These two are the only directories a sandbox path and the
+/// daemon share, so anything else is refused rather than redirected:
+/// `/tmp/x.tar` names a file in the *sandbox*, which the daemon cannot write.
+///
+/// This is the one realm crossing a destination makes, and it is where the
+/// result is checked to really be inside the directory it named.
+/// [`resolve_output`] rules out escapes spelled with `..`, but it reasons about
+/// the sandbox's namespace and cannot see symlinks: the parent is canonicalized
+/// and checked, and the file opened `O_NOFOLLOW` so a link at the destination
+/// itself is refused at open time. The daemon is not confined to the sandbox,
+/// so either would otherwise have it writing wherever the link leads.
+///
+/// The bytes are written straight into the returned file: it is the artifact,
+/// not a staging copy, so a run that fails partway leaves a partial file.
+async fn create_artifact(
+    working: &DaemonAbsPath,
+    home: &DaemonAbsPath,
+    path: &SandboxAbsPath,
+) -> std::io::Result<tokio::fs::File> {
+    let invalid = |msg: String| std::io::Error::new(std::io::ErrorKind::InvalidInput, msg);
+
+    let (base, rel) = [(WORKSPACE_ROOT, working), (HOME_ROOT, home)]
+        .into_iter()
+        .find_map(|(root, base)| Some((base, path.as_utf8_path().strip_prefix(root).ok()?)))
+        .ok_or_else(|| {
+            invalid(format!(
+                "`{path}` is outside the session's {WORKSPACE_ROOT} and {HOME_ROOT}"
+            ))
+        })?;
+    // Stripping a root off itself leaves nothing to name a file with.
+    if rel.as_str().is_empty() {
+        return Err(invalid(format!(
+            "`{path}` is a session directory, not a file"
+        )));
+    }
+    // The typed join keeps the destination anchored: `DaemonAbsPath::join`
+    // takes a `DaemonRelPath`, where joining a raw string could replace the
+    // root outright. `try_new` re-checks that the remainder is relative and
+    // `..`-free — `resolve_output` normalized it, and this is the proof.
+    let rel = DaemonRelPath::try_new(rel)
+        .map_err(|e| invalid(format!("`{path}` cannot be resolved on the daemon: {e}")))?;
+    let dest = base.join(&rel);
+
+    let (parent, file_name) = match (
+        dest.as_utf8_path().parent(),
+        dest.as_utf8_path().file_name(),
+    ) {
+        (Some(parent), Some(file_name)) => (parent, file_name),
+        _ => return Err(invalid(format!("`{path}` does not name a file"))),
+    };
+    // `base` is canonicalized too: it may itself be reached through a symlink
+    // (`/var` -> `/private/var`), which would fail a textual comparison.
+    let real_base = canonicalize_utf8(base.as_utf8_path())?;
+    let contained = |dir: &Utf8Path| -> std::io::Result<Utf8PathBuf> {
+        let real = canonicalize_utf8(dir)?;
+        if !real.starts_with(&real_base) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!("`{path}` resolves to `{real}`, outside `{base}`"),
+            ));
+        }
+        Ok(real)
+    };
+
+    // Check the deepest directory that already exists *before* creating
+    // anything: `create_dir_all` through a symlinked parent would otherwise
+    // materialize directories outside the session before the check refused.
+    let existing = parent
+        .ancestors()
+        .find(|dir| dir.exists())
+        .ok_or_else(|| invalid(format!("`{path}` has no existing parent directory")))?;
+    contained(existing)?;
+
+    tokio::fs::create_dir_all(parent).await?;
+    // Re-checked after creating: `create_dir_all` only makes real directories,
+    // but the check above and this are not one atomic step.
+    let real_parent = contained(parent)?;
+
+    tokio::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(real_parent.join(file_name))
+        .await
+}
+
+/// [`std::fs::canonicalize`] keeping the path UTF-8.
+fn canonicalize_utf8(path: &Utf8Path) -> std::io::Result<Utf8PathBuf> {
+    let canonical = std::fs::canonicalize(path.as_std_path())?;
+    Utf8PathBuf::from_path_buf(canonical)
+        .map_err(|p| std::io::Error::other(format!("path is not utf-8: {}", p.display())))
 }
 
 /// An [`tokio::io::AsyncWrite`] that frames whatever is written to it into
@@ -1044,6 +1376,7 @@ mod tests {
     fn setup_channel() -> (TempDir, TempDir, TempDir, SessionChannel) {
         let cwd = tempdir().unwrap();
         let state = tempdir().unwrap();
+        let home = tempdir().unwrap();
         let rootfs = tempdir().unwrap();
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let config = ConfigBuilder::new()
@@ -1072,6 +1405,8 @@ mod tests {
                 Utf8PathBuf::try_from(cwd.path().to_path_buf()).unwrap(),
             )
             .unwrap(),
+            home: DaemonAbsPath::try_new(Utf8PathBuf::try_from(home.path().to_path_buf()).unwrap())
+                .unwrap(),
             has_packages: HashSet::new(),
             ot: None,
             session: crate::session::WeakSessionHandle::dangling(),
@@ -1149,6 +1484,336 @@ mod tests {
     fn state_dirs_from_env_vars_ignores_bare_state() {
         let env = HashMap::from([("WEIRD".to_string(), "/state/".to_string())]);
         assert!(state_dirs_from_env_vars(&env).is_empty());
+    }
+
+    /// The sandbox working directory the helper sends, for tests that don't
+    /// care which subdirectory of the workspace the command was typed in.
+    fn wd(sub: &str) -> Utf8PathBuf {
+        Utf8Path::new(WORKSPACE_ROOT).join(sub)
+    }
+
+    /// A session's two daemon directories, `work` and `home`, under `dir`.
+    fn session_dirs(dir: &TempDir) -> (DaemonAbsPath, DaemonAbsPath) {
+        let root = Utf8PathBuf::try_from(dir.path().to_path_buf()).unwrap();
+        let dirs = (root.join("work"), root.join("home"));
+        std::fs::create_dir_all(&dirs.0).unwrap();
+        std::fs::create_dir_all(&dirs.1).unwrap();
+        (
+            DaemonAbsPath::try_new(dirs.0).unwrap(),
+            DaemonAbsPath::try_new(dirs.1).unwrap(),
+        )
+    }
+
+    /// An absolute sandbox path, as `resolve_output` produces.
+    fn sbx(path: &str) -> SandboxAbsPath {
+        SandboxAbsPath::try_new(path).unwrap()
+    }
+
+    /// The parse mirrors `mip materialize`'s clap interface, including the
+    /// `--flag=value` form clap accepts alongside `--flag value`.
+    #[test]
+    fn materialize_args_parse_both_flag_forms() {
+        let expected = MaterializeArgs {
+            opts: crate::session_sop::MaterializeOpts {
+                output_name: "image".to_string(),
+                arch: Some("arm64".to_string()),
+            },
+            output: SandboxAbsPath::try_new("/workbench/dist/image.tar").unwrap(),
+        };
+
+        let cwd = wd("");
+        assert_eq!(
+            MaterializeArgs::from_args(&cwd, "--output dist/image.tar --arch arm64 image").unwrap(),
+            expected
+        );
+        assert_eq!(
+            MaterializeArgs::from_args(&cwd, "-o=dist/image.tar --arch=arm64 image").unwrap(),
+            expected
+        );
+        // The positional is recognised wherever it lands.
+        assert_eq!(
+            MaterializeArgs::from_args(&cwd, "image -o dist/image.tar --arch arm64").unwrap(),
+            expected
+        );
+    }
+
+    /// The request line carries the helper's working directory ahead of the
+    /// arguments; without it there is nothing to resolve `--output` against,
+    /// which must be an error rather than a guess at the workspace root.
+    #[test]
+    fn materialize_request_carries_the_working_directory() {
+        let args = MaterializeArgs::from_request(&format!("{}%-o out.tar image", wd("sub")))
+            .expect("a well-formed request");
+        assert_eq!(args.output.as_str(), "/workbench/sub/out.tar");
+
+        let err = MaterializeArgs::from_request("-o out.tar image")
+            .expect_err("a request without a working directory is malformed");
+        assert!(
+            err.contains("working directory"),
+            "the error must say what is missing, got {err:?}",
+        );
+    }
+
+    /// The point of sending the cwd: `min materialize -o out.tar` run from a
+    /// subdirectory resolves *there*, not at the workspace root. Resolution
+    /// stops at an absolute sandbox path — which session directory it names is
+    /// `sandbox_to_daemon`'s decision, so `/home` resolves as readily as
+    /// `/workbench` and neither is checked here.
+    #[test]
+    fn materialize_output_resolves_against_the_working_directory() {
+        for (cwd, output, want) in [
+            // A bare name lands beside the user, wherever they are.
+            (
+                "/workbench/sub/deep",
+                "out.tar",
+                "/workbench/sub/deep/out.tar",
+            ),
+            ("/workbench", "out.tar", "/workbench/out.tar"),
+            ("/home/nested", "out.tar", "/home/nested/out.tar"),
+            // `..` and `.` are resolved away.
+            (
+                "/workbench/sub/deep",
+                "../out.tar",
+                "/workbench/sub/out.tar",
+            ),
+            (
+                "/workbench/sub",
+                "./dist/out.tar",
+                "/workbench/sub/dist/out.tar",
+            ),
+            // An absolute path is already a sandbox path: the cwd doesn't
+            // enter into it, so it resolves the same way from anywhere.
+            (
+                "/workbench/sub",
+                "/workbench/dist/out.tar",
+                "/workbench/dist/out.tar",
+            ),
+            ("/workbench", "/home/somefile", "/home/somefile"),
+            ("/home", "/workbench/somefile", "/workbench/somefile"),
+        ] {
+            let resolved = resolve_output(Utf8Path::new(cwd), SandboxPath::new(output))
+                .unwrap_or_else(|e| panic!("resolving {output:?} from {cwd:?}: {e}"));
+            assert_eq!(resolved.as_str(), want, "`-o {output}` from {cwd}");
+        }
+    }
+
+    /// Each of the two directories a sandbox path can name maps to its own
+    /// daemon directory — `/workbench` to the workspace, `/home` to the home.
+    #[tokio::test]
+    async fn sandbox_paths_land_in_the_session_directory_they_name() {
+        let tmp = tempdir().unwrap();
+        let (working, home) = session_dirs(&tmp);
+
+        for (path, want) in [
+            (
+                "/workbench/dist/out.tar",
+                working.as_utf8_path().join("dist/out.tar"),
+            ),
+            (
+                "/home/.cache/out.tar",
+                home.as_utf8_path().join(".cache/out.tar"),
+            ),
+        ] {
+            create_artifact(&working, &home, &sbx(path))
+                .await
+                .unwrap_or_else(|e| panic!("creating {path}: {e}"));
+            assert!(want.is_file(), "`{path}` should have landed at {want}");
+        }
+    }
+
+    /// Anything under neither directory is refused rather than redirected:
+    /// `/tmp/x.tar` names a file in the *sandbox*, which the daemon cannot
+    /// write, and a root names a directory, not an artifact.
+    #[tokio::test]
+    async fn sandbox_paths_outside_the_session_directories_are_refused() {
+        let tmp = tempdir().unwrap();
+        let (working, home) = session_dirs(&tmp);
+
+        for (path, want) in [
+            ("/tmp/x.tar", "outside the session's"),
+            ("/etc/passwd", "outside the session's"),
+            ("/", "outside the session's"),
+            // A prefix match must be by component, or this would resolve.
+            ("/workbenchx/out.tar", "outside the session's"),
+            ("/workbench", "is a session directory"),
+            ("/home", "is a session directory"),
+        ] {
+            let err = create_artifact(&working, &home, &sbx(path))
+                .await
+                .expect_err("a path outside the session directories");
+            assert!(
+                err.to_string().contains(want),
+                "expected {want:?} for {path}, got {err}",
+            );
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        }
+    }
+
+    /// A `..` that climbs out shows up as a path under neither directory —
+    /// `resolve_output` normalizes first precisely so the prefix match cannot
+    /// be fooled by a leading component.
+    #[tokio::test]
+    async fn traversals_out_of_the_session_directories_are_refused() {
+        let tmp = tempdir().unwrap();
+        let (working, home) = session_dirs(&tmp);
+
+        for (cwd, output) in [
+            ("/workbench", "/etc/passwd"),
+            ("/workbench", "../out.tar"),
+            ("/workbench/sub", "../../out.tar"),
+            ("/home", "../../../../etc/passwd"),
+            ("/workbench", "/workbench/../etc/passwd"),
+        ] {
+            let resolved = resolve_output(Utf8Path::new(cwd), SandboxPath::new(output))
+                .expect("resolution itself does not judge the destination");
+            let err = create_artifact(&working, &home, &resolved)
+                .await
+                .expect_err("a path leaving the session directories must be refused");
+            assert!(
+                err.to_string().contains("outside the session's"),
+                "expected a containment error for `-o {output}` from {cwd}, got {err}",
+            );
+        }
+    }
+
+    /// The directories leading to the artifact are created, and the bytes go
+    /// straight into it — there is no staging copy to publish.
+    #[tokio::test]
+    async fn create_artifact_creates_the_file_and_its_parents() {
+        use tokio::io::AsyncWriteExt as _;
+
+        let tmp = tempdir().unwrap();
+        let (working, home) = session_dirs(&tmp);
+
+        let mut file = create_artifact(&working, &home, &sbx("/workbench/dist/image.tar"))
+            .await
+            .expect("the parent directories are created");
+        file.write_all(b"tarball").await.unwrap();
+        file.flush().await.unwrap();
+        drop(file);
+
+        let dest = working.as_utf8_path().join("dist/image.tar");
+        assert_eq!(std::fs::read(&dest).unwrap(), b"tarball");
+    }
+
+    /// `resolve_output` reasons about a path in the sandbox's namespace, so it
+    /// cannot see a symlink in the workspace pointing out of it. The daemon is
+    /// not confined to the sandbox, so the check has to happen on disk or
+    /// `-o escape/x.tar` writes wherever the link leads.
+    #[tokio::test]
+    async fn create_artifact_refuses_a_parent_symlinked_out_of_the_session() {
+        let tmp = tempdir().unwrap();
+        let (working, home) = session_dirs(&tmp);
+        let outside = Utf8PathBuf::try_from(tmp.path().join("outside")).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, working.as_utf8_path().join("escape")).unwrap();
+
+        let err = create_artifact(&working, &home, &sbx("/workbench/escape/x.tar"))
+            .await
+            .expect_err("a symlinked parent leaving the session must be refused");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(
+            !outside.join("x.tar").exists(),
+            "nothing may be created outside the session directory"
+        );
+    }
+
+    /// The parent check cannot catch a symlink at the *destination itself*, so
+    /// the open refuses to follow one. Otherwise `-o out.tar`, with `out.tar`
+    /// linked to `/etc/passwd`, would have the daemon write through it.
+    #[tokio::test]
+    async fn create_artifact_refuses_a_symlinked_destination() {
+        let tmp = tempdir().unwrap();
+        let (working, home) = session_dirs(&tmp);
+        let outside = Utf8PathBuf::try_from(tmp.path().join("outside.tar")).unwrap();
+        std::os::unix::fs::symlink(&outside, working.as_utf8_path().join("out.tar")).unwrap();
+
+        create_artifact(&working, &home, &sbx("/workbench/out.tar"))
+            .await
+            .expect_err("a symlinked destination must not be followed");
+        assert!(
+            !outside.exists(),
+            "the link's target must not be created, let alone written"
+        );
+    }
+
+    /// The containment check has to run *before* any directory is created, or
+    /// `create_dir_all` walks through the link and materializes directories
+    /// outside the session on its way to a destination that is then refused.
+    #[tokio::test]
+    async fn create_artifact_creates_nothing_through_a_symlinked_parent() {
+        let tmp = tempdir().unwrap();
+        let (working, home) = session_dirs(&tmp);
+        let outside = Utf8PathBuf::try_from(tmp.path().join("outside")).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, working.as_utf8_path().join("escape")).unwrap();
+
+        let err = create_artifact(&working, &home, &sbx("/workbench/escape/deep/x.tar"))
+            .await
+            .expect_err("a destination below a symlinked parent must be refused");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(
+            !outside.join("deep").exists(),
+            "no directory may be created outside the session"
+        );
+    }
+
+    /// A symlinked *directory* that stays inside the session directory is
+    /// ordinary content and keeps working — the check is containment, not a
+    /// ban on links.
+    #[tokio::test]
+    async fn create_artifact_allows_a_symlink_within_the_session() {
+        let tmp = tempdir().unwrap();
+        let (working, home) = session_dirs(&tmp);
+        std::fs::create_dir_all(working.as_utf8_path().join("real")).unwrap();
+        std::os::unix::fs::symlink(
+            working.as_utf8_path().join("real"),
+            working.as_utf8_path().join("link"),
+        )
+        .unwrap();
+
+        create_artifact(&working, &home, &sbx("/workbench/link/x.tar"))
+            .await
+            .expect("a link inside the session directory is fine");
+        assert!(
+            working.as_utf8_path().join("real/x.tar").exists(),
+            "the file lands in the directory the link points at"
+        );
+    }
+
+    /// `--arch` is optional (the output's own arch, else the host's, applies);
+    /// `--output` and the name are not.
+    #[test]
+    fn materialize_args_require_an_output_path_and_a_name() {
+        let cwd = wd("");
+        let args = MaterializeArgs::from_args(&cwd, "-o image.tar image").unwrap();
+        assert_eq!(args.opts.arch, None);
+
+        for (args, want) in [
+            ("image", "--output"),
+            ("-o image.tar", "requires the name"),
+            ("-o", "requires a value"),
+            ("-o image.tar image other", "expected one output name"),
+        ] {
+            let err = MaterializeArgs::from_args(&cwd, args).expect_err("incomplete invocation");
+            assert!(
+                err.contains(want),
+                "expected {want:?} in the error for {args:?}, got {err:?}",
+            );
+        }
+    }
+
+    /// A mistyped flag must be an error, never a positional: read as one it
+    /// would be a second output name, and the report would complain about the
+    /// count instead of naming the typo.
+    #[test]
+    fn materialize_args_reject_unknown_flags() {
+        let err = MaterializeArgs::from_args(&wd(""), "--ouput image.tar image")
+            .expect_err("a mistyped flag must not parse as an output name");
+        assert!(
+            err.contains("unknown flag") && err.contains("--ouput"),
+            "the error must name the offending flag, got {err:?}",
+        );
     }
 
     /// A multi-component prefix that leaked past the extractor

--- a/crates/minimald/src/env_min_helper.sh
+++ b/crates/minimald/src/env_min_helper.sh
@@ -130,6 +130,12 @@ min_check() {
     __min_rpc "check" "$@"
 }
 
+min_materialize() {
+    # The working directory leads the arguments so a relative --output
+    # can be resolved.
+    __min_rpc "materialize" "${PWD}%$*"
+}
+
 # If invoked directly as a script (not sourced), handle invocation
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     subcmd="$1"
@@ -150,12 +156,16 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         check)
             min_check "$@"
             ;;
+        materialize)
+            min_materialize "$@"
+            ;;
         *)
             echo "Usage: min <subcommand>" >&2
             echo "" >&2
             echo "Add packages: min add [--session|--build|--runtime] <packages>" >&2
             echo "Search for packages: min search <query>" >&2
             echo "Check minimal configuration: min check" >&2
+            echo "Materialize an output into the workspace: min materialize --output <path> [--arch <arch>] <output name>" >&2
             echo "Run a task: min run <task name>" >&2
             echo "Build packages: min package build <packages>" >&2
             echo "Try building a package (with potentially-stale dependencies): min package patched-build <package name>" >&2

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1,5 +1,8 @@
 use crate::channel_progress::ChannelProgress;
-use crate::session_sop::{BuildUpdate, CheckOpts, CheckUpdate, SideOp};
+use crate::session_sop::{
+    BuildUpdate, CheckOpts, CheckUpdate, MaterializeOpts, MaterializeUpdate, SideOp,
+};
+
 use crate::sessions::{SessionControl, WeakManagerHandle, composables};
 use crate::store::SessionRecordHandle;
 use crate::{
@@ -312,6 +315,12 @@ enum SessionMessage {
     StartCheck {
         opts: CheckOpts,
         reply: oneshot::Sender<Result<mpsc::Receiver<CheckUpdate>, std::io::Error>>,
+    },
+    /// Kick off a background materialize run as a session side-op. Replies with
+    /// the receiver end of the run's stream.
+    StartMaterialize {
+        opts: MaterializeOpts,
+        reply: oneshot::Sender<Result<mpsc::Receiver<MaterializeUpdate>, std::io::Error>>,
     },
     /// Test-only inspection: an `Arc` clone of the held [`Composition`]
     /// (`None` in `Draft`, or `Active` without one post-restart). Lets tests
@@ -679,6 +688,9 @@ impl Session {
             SessionMessage::StartCheck { opts, reply } => {
                 let _ = reply.send(self.start_check(opts).await);
             }
+            SessionMessage::StartMaterialize { opts, reply } => {
+                let _ = reply.send(self.start_materialize(opts).await);
+            }
             SessionMessage::GetRecord(r) => {
                 let _ = r.send(self.record.record().await.unwrap());
             }
@@ -1018,6 +1030,27 @@ impl Session {
     ) -> Result<mpsc::Receiver<CheckUpdate>, std::io::Error> {
         let ctx = self.context(false).await.map_err(std::io::Error::other)?;
         let (sop, rx) = SideOp::spawn_check(self.weak_self.clone(), opts, ctx, 64).await?;
+        match &mut self.inner {
+            SessionInner::Active { sops, .. } => sops.push(sop),
+            SessionInner::Draft { .. } => {
+                sop.shutdown().await;
+                unreachable!("`context()` already rejected a `Draft`");
+            }
+        }
+        Ok(rx)
+    }
+
+    /// Kicks off a background materialize run as a side-op and registers it on
+    /// this session, returning the receiver end of its stream. Like
+    /// [`start_build`](Self::start_build) it runs against a fresh
+    /// workspace-rooted context, so it sees outputs declared since the session
+    /// came up. The receiver closes when the run ends.
+    async fn start_materialize(
+        &mut self,
+        opts: MaterializeOpts,
+    ) -> Result<mpsc::Receiver<MaterializeUpdate>, std::io::Error> {
+        let ctx = self.context(false).await.map_err(std::io::Error::other)?;
+        let (sop, rx) = SideOp::spawn_materialize(self.weak_self.clone(), opts, ctx, 64).await?;
         match &mut self.inner {
             SessionInner::Active { sops, .. } => sops.push(sop),
             SessionInner::Draft { .. } => {
@@ -1468,6 +1501,25 @@ impl SessionHandle {
         let _ = self
             .0
             .send(SessionMessage::StartCheck { opts, reply })
+            .await;
+        recv.await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
+        })?
+    }
+
+    /// Kicks off a background materialize run as a session side-op, returning
+    /// the receiver end of the run's stream. An unknown output name is refused
+    /// with `NotFound`; a `Draft` session with `InvalidInput`; a dead actor
+    /// maps to `NotConnected`.
+    pub async fn start_materialize(
+        &self,
+        opts: MaterializeOpts,
+    ) -> Result<mpsc::Receiver<MaterializeUpdate>, std::io::Error> {
+        let (reply, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .0
+            .send(SessionMessage::StartMaterialize { opts, reply })
             .await;
         recv.await.map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")

--- a/crates/minimald/src/session_sop.rs
+++ b/crates/minimald/src/session_sop.rs
@@ -4,6 +4,7 @@ use std::{io::ErrorKind::NotFound, sync::Arc};
 
 use futures::StreamExt as _;
 use mctx::{Context, PackageSelection};
+use op::Runnable as _;
 use orchestrator::BuildEvent;
 use tokio::{
     sync::{
@@ -111,10 +112,79 @@ impl CheckOutcome {
     }
 }
 
+/// The terminal result of a materialize side-op, delivered as the final
+/// [`MaterializeUpdate`] before the op's channel closes.
+#[derive(Debug, Clone)]
+pub enum MaterializeOutcome {
+    /// Every byte was delivered; `bytes` is the artifact's total size.
+    ///
+    /// `mode` is the source file's unix mode for a
+    /// [`RawFile`](op::OutputSpec::RawFile) output. The bytes travel as a
+    /// stream, which carries no mode, so a subscriber landing them in a file
+    /// has to reapply it — an extracted binary that arrived without its
+    /// executable bit would be useless.
+    Completed { bytes: u64, mode: Option<u32> },
+    /// The build or the assembly errored. Any chunks already delivered are a
+    /// partial artifact and must be discarded.
+    Failed(String),
+    /// Cancelled before the artifact was complete. As with `Failed`, discard
+    /// what arrived.
+    Cancelled,
+}
+
+/// An update from a running materialize side-op: the artifact's bytes
+/// interleaved with progress, then exactly one terminal
+/// [`MaterializeUpdate::Finished`] as the last item before the channel closes.
+/// The artifact never touches the daemon's filesystem; concatenating `Chunk`s
+/// in arrival order reconstructs it.
+///
+/// `Chunk` is delivered reliably ([`Sink::send`]) and backpressures the
+/// assembly, since a dropped chunk is a corrupt artifact. `Event` is
+/// best-effort ([`Sink::try_send`]).
+#[derive(Debug, Clone)]
+pub enum MaterializeUpdate {
+    Event(op::MaterializeEvent),
+    /// The next bytes of the artifact, in order.
+    Chunk(Vec<u8>),
+    Finished(MaterializeOutcome),
+}
+
+impl MaterializeUpdate {
+    /// The display lines for this update, as with [`CheckUpdate::render`].
+    /// `Chunk` renders nothing (it is bytes, not text), and `Finished` goes
+    /// through [`MaterializeOutcome::summarize`] instead.
+    pub fn render(&self) -> Vec<String> {
+        match self {
+            Self::Event(event) => vec![event.render()],
+            Self::Chunk(_) | Self::Finished(_) => vec![],
+        }
+    }
+}
+
+impl MaterializeOutcome {
+    /// The exit status and message to report once a run's channel has closed.
+    /// `None` is a channel that closed without a terminal update. Statuses
+    /// match the check path: 0 success, 1 failure, 130 cancelled.
+    pub fn summarize(outcome: Option<&Self>) -> (u32, String) {
+        match outcome {
+            Some(Self::Completed { bytes, .. }) => (
+                0,
+                format!("materialized {}", size::Size::from_bytes(*bytes)),
+            ),
+            Some(Self::Failed(e)) => (1, format!("materialize failed: {e}")),
+            Some(Self::Cancelled) => (130, "materialize cancelled".to_string()),
+            None => (
+                1,
+                "materialize ended without reporting an outcome".to_string(),
+            ),
+        }
+    }
+}
+
 /// A registration to recieve updates about the progress of a side-op.
 ///
-/// See the [`BuildSink`] and [`CheckSink`] aliases: the delivery discipline is
-/// the same for both, only the update type differs.
+/// See the [`BuildSink`], [`CheckSink`] and [`MaterializeSink`] aliases: the
+/// delivery discipline is the same for all, only the update type differs.
 #[derive(Debug)]
 pub(crate) enum Sink<T> {
     Structured(mpsc::Sender<T>),
@@ -143,6 +213,8 @@ impl<T> Sink<T> {
 pub(crate) type BuildSink = Sink<BuildUpdate>;
 /// A registration to recieve updates about the progress of a check run.
 pub(crate) type CheckSink = Sink<CheckUpdate>;
+/// A registration to recieve updates about the progress of a materialize run.
+pub(crate) type MaterializeSink = Sink<MaterializeUpdate>;
 
 /// The subscribers of one side-op, behind the op's lock.
 #[derive(Debug)]
@@ -216,6 +288,85 @@ impl CheckOpts {
     }
 }
 
+/// The [`std::io::Write`] half of the stream, handing each buffer to the pump.
+///
+/// Runs on the blocking assembly thread, hence `blocking_send` — which is also
+/// where backpressure bites: a full channel stalls the assembly instead of
+/// buffering an unbounded amount of image in the daemon.
+struct ChunkWriter {
+    tx: mpsc::Sender<Vec<u8>>,
+}
+
+impl std::io::Write for ChunkWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.tx.blocking_send(buf.to_vec()).map_err(|_| {
+            // Stops the assembly rather than grinding out an image nobody
+            // will receive.
+            std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "materialize stream has no receiver",
+            )
+        })?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Fans a run's bytes and progress out to its subscribers, until the assembly
+/// drops both senders or every subscriber has gone away.
+///
+/// Returning is how a lost audience is reported: it drops `byte_rx`, so the
+/// next [`ChunkWriter`] write fails with `BrokenPipe` and unwinds the
+/// assembly. Without it the artifact would be built in full for nobody.
+async fn pump_materialize(
+    inner: Arc<Mutex<Inner<MaterializeUpdate>>>,
+    mut byte_rx: mpsc::Receiver<Vec<u8>>,
+    mut event_rx: futures::channel::mpsc::UnboundedReceiver<op::MaterializeEvent>,
+) {
+    loop {
+        tokio::select! {
+            // Bytes win a tie; progress can wait a turn.
+            biased;
+            Some(chunk) = byte_rx.recv() => {
+                let inner = inner.lock().await;
+                let mut delivered = false;
+                for sink in &inner.sinks {
+                    // Waits for capacity on a live subscriber; errors at once
+                    // on one that is gone.
+                    delivered |= sink
+                        .send(MaterializeUpdate::Chunk(chunk.clone()))
+                        .await
+                        .is_ok();
+                }
+                if !delivered {
+                    tracing::debug!("materialize stream has no subscribers left, stopping");
+                    return;
+                }
+            }
+            Some(event) = event_rx.next() => {
+                let inner = inner.lock().await;
+                for sink in &inner.sinks {
+                    let _ = sink.try_send(MaterializeUpdate::Event(event.clone()));
+                }
+            }
+            else => break,
+        }
+    }
+}
+
+/// Which `[outputs.<name>]` of the session's `minimal.toml` to materialize.
+/// There is no destination; the artifact is streamed back to the subscriber.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterializeOpts {
+    /// The `[outputs.<name>]` key in the session's `minimal.toml`.
+    pub output_name: String,
+    /// Overrides the output's own architecture, as `mip materialize --arch`.
+    pub arch: Option<String>,
+}
+
 #[derive(Debug)]
 #[allow(dead_code)]
 enum Op {
@@ -234,6 +385,13 @@ enum Op {
         /// Interior mutability. Users MUST NEVER block while holding
         /// the lock: get in, read/update data, get out.
         inner: Arc<Mutex<Inner<CheckUpdate>>>,
+    },
+    Materialize {
+        /// What was requested
+        opts: MaterializeOpts,
+        /// Interior mutability. Users MUST NEVER block while holding
+        /// the lock: get in, read/update data, get out.
+        inner: Arc<Mutex<Inner<MaterializeUpdate>>>,
     },
 }
 
@@ -533,6 +691,175 @@ impl SideOp {
             handle,
         })
     }
+
+    /// Kicks off a materialize side-op wired to a single structured sink,
+    /// returning the op alongside the receiver end that streams the artifact's
+    /// bytes and progress until the run ends (at which point the sender is
+    /// dropped and the receiver closes). `buffer` bounds the queued updates; a
+    /// subscriber that stops draining stalls the assembly.
+    ///
+    /// Should only be called from the session actor.
+    pub(crate) async fn spawn_materialize(
+        session: WeakSessionHandle,
+        opts: MaterializeOpts,
+        ctx: Context,
+        buffer: usize,
+    ) -> Result<(Self, mpsc::Receiver<MaterializeUpdate>), std::io::Error> {
+        let (tx, rx) = mpsc::channel(buffer);
+        let sop = Self::new_materialize(session, opts, ctx, vec![MaterializeSink::Structured(tx)])
+            .await?;
+        Ok((sop, rx))
+    }
+
+    /// Called to kick off a new materialize run with the specified parameters.
+    /// The output is resolved here, before the op spawns, so a bad name or arch
+    /// errors to the caller rather than through a channel it has yet to be
+    /// handed. The cancel token stops the package build only: assembly is not
+    /// interruptible.
+    async fn new_materialize(
+        session: WeakSessionHandle,
+        opts: MaterializeOpts,
+        ctx: Context,
+        sinks: Vec<MaterializeSink>,
+    ) -> Result<Self, std::io::Error> {
+        let output = ctx
+            .minimal_file()
+            .outputs
+            .get(&opts.output_name)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    NotFound,
+                    format!("no such output named '{}'", opts.output_name),
+                )
+            })?
+            .clone();
+
+        let target = output
+            .target(opts.arch.as_deref())
+            .map_err(std::io::Error::other)?;
+        let spec = op::OutputSpec::try_from(output.kind.clone())
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        let top_levels = output.top_levels();
+
+        // Graph construction is CPU-heavy, run on blocking pool.
+        let (ctx, graph_result) = tokio::task::spawn_blocking(move || {
+            let mut ctx = ctx;
+            let r = ctx
+                .graph_from_package_names_with_target(top_levels, target)
+                .map_err(|e| e.to_string());
+
+            (ctx, r)
+        })
+        .await
+        .map_err(std::io::Error::other)?;
+        let graph = graph_result.map_err(std::io::Error::other)?;
+
+        let cancel = CancellationToken::new();
+        let inner = Arc::new(Mutex::new(Inner { sinks }));
+        let name = opts.output_name.clone();
+
+        let handle = {
+            let build_cancel = cancel.clone();
+            let cancel_flag = cancel.clone();
+            let pump_inner = inner.clone();
+            let op_inner = inner.clone();
+            tokio::task::spawn(async move {
+                let mut ctx = ctx;
+
+                let build_err = match ctx
+                    .build_graph_with_cancel(&graph, false, None, build_cancel)
+                    .await
+                {
+                    Ok(()) => None,
+                    Err(e) => {
+                        tracing::warn!("session materialize build failed: {e}");
+                        Some(e.to_string())
+                    }
+                };
+                if let Some(msg) = build_err {
+                    let outcome = match cancel_flag.is_cancelled() {
+                        true => MaterializeOutcome::Cancelled,
+                        false => MaterializeOutcome::Failed(msg),
+                    };
+                    finish(&op_inner, MaterializeUpdate::Finished(outcome)).await;
+                    return;
+                }
+                // Last chance to honour a cancel cheaply.
+                if cancel_flag.is_cancelled() {
+                    finish(
+                        &op_inner,
+                        MaterializeUpdate::Finished(MaterializeOutcome::Cancelled),
+                    )
+                    .await;
+                    return;
+                }
+
+                let (event_tx, event_rx) =
+                    futures::channel::mpsc::unbounded::<op::MaterializeEvent>();
+                // Bounded, so a slow subscriber stalls the assembly rather
+                // than growing a whole image in memory.
+                let (byte_tx, byte_rx) = mpsc::channel::<Vec<u8>>(3);
+
+                let pump = tokio::task::spawn(pump_materialize(pump_inner, byte_rx, event_rx));
+
+                // Assembly blocks its thread, so keep it off the async
+                // workers; its internal `rayon` scope needs a runtime entered.
+                let cache = ctx.local_cache();
+                let ot = ctx.op_tracker();
+                let runtime = tokio::runtime::Handle::current();
+                let result = tokio::task::spawn_blocking(move || {
+                    let _rt = runtime.enter();
+                    let opts = op::Options {
+                        cache,
+                        graph: &graph,
+                        exec_base: "/invalid".into(),
+                        ot,
+                    };
+                    // `tar` writes in small pieces; one send per 512-byte
+                    // header would be all overhead. `op::Materialize` flushes.
+                    let sink =
+                        std::io::BufWriter::with_capacity(4 * 1024, ChunkWriter { tx: byte_tx });
+                    futures::executor::block_on(
+                        op::Materialize {
+                            name,
+                            spec,
+                            sink: op::Sink::Writer(Box::new(sink)),
+                            events: Some(event_tx),
+                        }
+                        .run(&opts),
+                    )
+                    .map_err(|e| e.to_string())
+                })
+                .await;
+                let _ = pump.await;
+
+                let outcome = match result {
+                    Ok(Ok(report)) => MaterializeOutcome::Completed {
+                        bytes: report.bytes,
+                        mode: report.mode,
+                    },
+                    Ok(Err(msg)) => {
+                        tracing::warn!("session materialize failed: {msg}");
+                        match cancel_flag.is_cancelled() {
+                            true => MaterializeOutcome::Cancelled,
+                            false => MaterializeOutcome::Failed(msg),
+                        }
+                    }
+                    Err(e) => MaterializeOutcome::Failed(format!("materialize task failed: {e}")),
+                };
+
+                finish(&op_inner, MaterializeUpdate::Finished(outcome)).await;
+            })
+        };
+
+        Ok(Self {
+            id: uuid::Uuid::now_v7(),
+            cancel,
+            session,
+            op: Op::Materialize { opts, inner },
+            handle,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -600,6 +927,123 @@ mod tests {
         assert_eq!(
             opts.filter_names,
             vec!["some-pkg", "other.pkg", "under_score"]
+        );
+    }
+
+    /// Small writes must coalesce; `tar` emits 512-byte headers, so a send
+    /// apiece would be nearly all overhead.
+    #[test]
+    fn chunk_writer_buffers_small_writes_into_one_chunk() {
+        use std::io::Write as _;
+
+        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(3);
+        let mut w = std::io::BufWriter::with_capacity(4 * 1024, ChunkWriter { tx });
+        w.write_all(b"hello ").unwrap();
+        w.write_all(b"world").unwrap();
+        w.flush().unwrap();
+        // Closes the channel so the drain below terminates.
+        drop(w);
+
+        let mut chunks = Vec::new();
+        while let Some(chunk) = rx.blocking_recv() {
+            chunks.push(chunk);
+        }
+        assert_eq!(
+            chunks,
+            vec![b"hello world".to_vec()],
+            "two small writes under the buffer size must arrive as one chunk"
+        );
+    }
+
+    /// A hung-up subscriber must end the pump *and* poison the writer, or a
+    /// client that disconnects leaves the daemon building an image for nobody.
+    #[tokio::test]
+    async fn materialize_pump_stops_and_poisons_the_writer_when_nobody_is_left() {
+        let (sub_tx, sub_rx) = mpsc::channel::<MaterializeUpdate>(4);
+        let inner = Arc::new(Mutex::new(Inner {
+            sinks: vec![Sink::Structured(sub_tx)],
+        }));
+        let (byte_tx, byte_rx) = mpsc::channel::<Vec<u8>>(3);
+        let (event_tx, event_rx) = futures::channel::mpsc::unbounded();
+
+        drop(sub_rx);
+
+        let pump = tokio::task::spawn(pump_materialize(inner, byte_rx, event_rx));
+        byte_tx.send(vec![1, 2, 3]).await.expect("pump is alive");
+
+        // Bounded: the point is that it terminates rather than parking on a
+        // send nobody will receive.
+        tokio::time::timeout(std::time::Duration::from_secs(5), pump)
+            .await
+            .expect("the pump must not hang once its subscribers are gone")
+            .expect("the pump must not panic");
+
+        assert!(
+            byte_tx.send(vec![4]).await.is_err(),
+            "the pump's exit must close the byte channel, so the assembly's \
+             next write fails instead of continuing"
+        );
+        drop(event_tx);
+    }
+
+    /// The error kind is what distinguishes "nobody is listening" from a real
+    /// failure in the logs.
+    #[test]
+    fn chunk_writer_fails_once_the_receiver_is_gone() {
+        use std::io::Write as _;
+
+        let (tx, rx) = mpsc::channel::<Vec<u8>>(3);
+        drop(rx);
+
+        let err = ChunkWriter { tx }
+            .write(b"x")
+            .expect_err("a write with no receiver must fail");
+        assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
+    }
+
+    /// A channel that closed silently must never look like success.
+    #[test]
+    fn materialize_outcome_summarizes_status_and_message() {
+        let (status, message) =
+            MaterializeOutcome::summarize(Some(&MaterializeOutcome::Completed {
+                bytes: 3_170_893,
+                mode: None,
+            }));
+        assert_eq!((status, message.as_str()), (0, "materialized 3.02 MiB"));
+
+        assert_eq!(
+            MaterializeOutcome::summarize(Some(&MaterializeOutcome::Cancelled)).0,
+            130
+        );
+        assert_eq!(
+            MaterializeOutcome::summarize(Some(&MaterializeOutcome::Failed("boom".into()))).0,
+            1
+        );
+        assert_eq!(MaterializeOutcome::summarize(None).0, 1);
+    }
+
+    #[test]
+    fn materialize_update_renders_progress_but_not_the_outcome() {
+        assert_eq!(
+            MaterializeUpdate::Event(op::MaterializeEvent::Architecture {
+                arch: "arm64".to_string()
+            })
+            .render(),
+            vec!["OCI image architecture: arm64".to_string()]
+        );
+        assert!(
+            MaterializeUpdate::Finished(MaterializeOutcome::Completed {
+                bytes: 1,
+                mode: None
+            })
+            .render()
+            .is_empty()
+        );
+        // A transport rendering to a terminal must not spray a tarball at it.
+        assert!(
+            MaterializeUpdate::Chunk(vec![0x1f, 0x8b])
+                .render()
+                .is_empty()
         );
     }
 

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -1645,4 +1645,36 @@ mod tests {
             "expected exactly one clean terminal outcome, got {outcomes:?}",
         );
     }
+
+    /// The output is resolved before the side-op spawns, so an unknown name is
+    /// a plain error rather than a terminal update on a channel the caller
+    /// would first have to be handed and drain.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn start_materialize_rejects_an_unknown_output_by_name() {
+        use crate::session_sop::MaterializeOpts;
+
+        let (_state, _cache, mngr) = manager().await;
+        let id = create_active_session(&mngr).await;
+        // Builds a fresh workspace-rooted context, so an mfile must exist.
+        seed_workspace_mfile(&mngr, id, "").await;
+
+        let err = session(&mngr, id)
+            .await
+            .start_materialize(MaterializeOpts {
+                output_name: "no-such-output".to_string(),
+                arch: None,
+            })
+            .await
+            .expect_err("an output the minimal file does not declare must be refused");
+
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::NotFound,
+            "an undeclared output is a NotFound, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("no-such-output"),
+            "the error must name the output that was asked for, got {err}"
+        );
+    }
 }

--- a/crates/mip/src/cmd_materialize.rs
+++ b/crates/mip/src/cmd_materialize.rs
@@ -1,14 +1,13 @@
 //! Command to materialize outputs defined in the minimal file.
 
 use anyhow::anyhow;
-use common::Target;
-use common::target::{Arch, OS};
-use graph::Transitives;
-use mfile::{OutputKind, StrOrList};
-use std::collections::HashMap;
+use futures::StreamExt;
+use futures::channel::mpsc;
 use std::path::PathBuf;
+use tracing::info;
 
 use mctx::{Context, Error};
+use op::{Materialize, MaterializeEvent, Runnable, Sink};
 
 #[derive(clap::Args)]
 pub struct MaterializeArgs {
@@ -25,105 +24,49 @@ pub struct MaterializeArgs {
 }
 
 pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result<(), Error> {
-    let mfile = ctx.minimal_file();
-    let output = match mfile.outputs.get(&args.output_name) {
-        Some(t) => t.clone(),
-        None => {
-            return Err(Error::Other(anyhow!(
-                "no such output named '{}'",
-                args.output_name
-            )));
-        }
-    };
+    let output = ctx
+        .minimal_file()
+        .outputs
+        .get(&args.output_name)
+        .ok_or_else(|| Error::Other(anyhow!("no such output named '{}'", args.output_name)))?
+        .clone();
 
-    // Resolve target architecture: CLI flag > minimal.toml > host default.
-    // String-to-arch parsing is delegated to common::target::Arch so the
-    // alias set stays consistent across every consumer.
-    let arch: Arch = match args.arch.clone().or(output.arch) {
-        Some(s) => s
-            .parse()
-            .map_err(|e: common::target::ArchParseError| Error::Other(anyhow!("{e}")))?,
-        None => Target::host().arch().clone(),
-    };
-
-    // OCI images are always Linux
-    let target = Target::new(arch, OS::Linux);
-
-    // Build the graph for the target architecture
-    let graph = match output.packages.len() {
-        0 => ctx.graph_from_package_names_with_target(["base"], target)?,
-        _ => ctx.graph_from_package_names_with_target(output.packages.clone(), target)?,
-    };
-
+    let target = output
+        .target(args.arch.as_deref())
+        .map_err(|e| Error::Other(anyhow!("{e}")))?;
+    let graph = ctx.graph_from_package_names_with_target(output.top_levels(), target)?;
     crate::cmd_pkg::pkg_build_impl(&graph, ctx, ctx.local_cache(), true, false, None).await?;
 
-    match output.kind {
-        OutputKind::OciImage {
-            entrypoint,
-            cmd,
-            vars,
-        } => materialize_oci_image(&args, ctx, graph, output.packages, entrypoint, cmd, vars).await,
-        OutputKind::RawFile { path } => materialize_raw_file(&args, ctx, graph, path).await,
-    }
+    let (tx, rx) = mpsc::unbounded();
+    let renderer = tokio::spawn(log_events(rx));
+
+    let mut op = Materialize {
+        name: args.output_name,
+        spec: output.kind.try_into()?,
+        sink: Sink::Path(args.output),
+        events: Some(tx),
+    };
+    let result = op
+        .run(&op::Options {
+            cache: ctx.local_cache(),
+            graph: &graph,
+            exec_base: "/invalid".into(),
+            ot: ctx.op_tracker(),
+        })
+        .await;
+
+    // Closes the event stream, so the renderer's last lines land before the
+    // outcome is reported.
+    drop(op);
+    let _ = renderer.await;
+
+    result?;
+    Ok(())
 }
 
-async fn materialize_oci_image(
-    args: &MaterializeArgs,
-    ctx: &mut Context,
-    graph: graph::Graph,
-    packages: Vec<String>,
-    entrypoint: Option<StrOrList>,
-    cmd: Option<StrOrList>,
-    vars: HashMap<String, String>,
-) -> Result<(), Error> {
-    let mut op = op::OciImageCreate {
-        packages,
-        output_file: args.output.clone(),
-        name: Some(args.output_name.clone()),
-        entrypoint,
-        cmd,
-        vars,
-    };
-    let opts = op::Options {
-        cache: ctx.local_cache(),
-        graph: &graph,
-        exec_base: "/invalid".into(),
-        ot: ctx.op_tracker(),
-    };
-
-    use op::Runnable;
-    op.run(&opts).await.map_err(|e| Error::Other(anyhow!(e)))
-}
-
-async fn materialize_raw_file(
-    args: &MaterializeArgs,
-    ctx: &mut Context,
-    graph: graph::Graph,
-    path: String,
-) -> Result<(), Error> {
-    let rel_path = if let Some(stripped) = path.strip_prefix("/") {
-        stripped.to_string()
-    } else {
-        path.clone()
-    };
-
-    let cache = ctx.local_cache();
-    let transitives = Transitives::for_toplevels(&graph, graph.top_levels.clone(), false);
-
-    for dir in transitives
-        .keys()
-        .map(|bsr| cache.read_dir(&graph.spec_hash(bsr)))
-    {
-        let dir = dir.map_err(|e| Error::Other(anyhow!(e)))?;
-        let p = dir.path().join(&rel_path);
-        if p.exists() {
-            std::fs::copy(&p, &args.output).map_err(|e| Error::IO("copying output file", p, e))?;
-            return Ok(());
-        }
+/// Logs progress events until the sender is dropped.
+async fn log_events(mut rx: mpsc::UnboundedReceiver<MaterializeEvent>) {
+    while let Some(event) = rx.next().await {
+        info!("{}", event.render());
     }
-
-    Err(Error::Other(anyhow!(
-        "raw-file output {:?} was not found in the built package set",
-        path
-    )))
 }

--- a/crates/op/src/lib.rs
+++ b/crates/op/src/lib.rs
@@ -44,7 +44,9 @@ mod specs;
 pub use specs::{SpecBuild, SpecBuildResult};
 
 mod oci_image;
-pub use oci_image::OciImageCreate;
+
+mod materialize;
+pub use materialize::{Materialize, MaterializeEvent, OutputSpec, Report, Sink};
 
 mod patched;
 pub use patched::{PatchedBuild, PatchedBuildResult};

--- a/crates/op/src/materialize.rs
+++ b/crates/op/src/materialize.rs
@@ -1,0 +1,630 @@
+//! Materializing a declared output — an OCI image, or a single file lifted out
+//! of the built package closure — into a sink.
+//!
+//! [`Materialize`] requires [`Options::graph`]'s top levels to be built and in
+//! [`Options::cache`] already, and takes the target architecture from the
+//! graph. [`OutputSpec`] is self-contained, so a caller with no `minimal.toml`
+//! can build one directly.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use anyhow::anyhow;
+use futures::channel::mpsc::UnboundedSender;
+use graph::Transitives;
+
+use crate::oci_image::OciImage;
+use crate::{Error, Options, Runnable};
+
+/// What to produce, independent of where it goes or what built it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutputSpec {
+    /// A tarball of an OCI image layout, one layer per package in the closure.
+    OciImage {
+        /// The image's entrypoint, already split into argv.
+        entrypoint: Option<Vec<String>>,
+        /// The image's default command, already split into argv.
+        cmd: Option<Vec<String>>,
+        /// Environment variables baked into the image config.
+        vars: HashMap<String, String>,
+    },
+    /// A single file at `path`, taken from the first package in the closure
+    /// that ships it.
+    RawFile { path: String },
+}
+
+impl TryFrom<mfile::OutputKind> for OutputSpec {
+    type Error = Error;
+
+    /// Word-splits the shell-string forms `minimal.toml` permits, so an
+    /// unbalanced quote errors here rather than reaching the image config.
+    fn try_from(kind: mfile::OutputKind) -> Result<Self, Error> {
+        fn argv(field: &str, v: mfile::StrOrList) -> Result<Vec<String>, Error> {
+            match v {
+                mfile::StrOrList::Single(s) => shlex::split(&s).ok_or_else(|| {
+                    Error::Other(anyhow!("`{field}` is not a valid shell word list: {s:?}"))
+                }),
+                mfile::StrOrList::Multiple(v) => Ok(v),
+            }
+        }
+
+        Ok(match kind {
+            mfile::OutputKind::OciImage {
+                entrypoint,
+                cmd,
+                vars,
+            } => OutputSpec::OciImage {
+                entrypoint: entrypoint.map(|e| argv("entrypoint", e)).transpose()?,
+                cmd: cmd.map(|c| argv("cmd", c)).transpose()?,
+                vars,
+            },
+            mfile::OutputKind::RawFile { path } => OutputSpec::RawFile { path },
+        })
+    }
+}
+
+/// Where an artifact's bytes go.
+pub enum Sink {
+    /// Create (or truncate) this file and write into it.
+    Path(PathBuf),
+    /// Stream into a writer the caller owns. Carries no unix mode, so a
+    /// [`OutputSpec::RawFile`] arrives without its executable bit — see
+    /// [`Report::mode`].
+    Writer(Box<dyn Write + Send>),
+}
+
+/// Progress emitted while an artifact is assembled. [`Materialize`] never
+/// prints; every consumer renders these itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MaterializeEvent {
+    /// Assembly of the named output began, from these top-level packages.
+    Started {
+        output: String,
+        packages: Vec<String>,
+    },
+    /// The image will be assembled from this many layers, base layer included.
+    Layers { total: usize },
+    /// A layer's assembly started.
+    LayerStarted { package: String, subset: bool },
+    /// A layer was archived, compressed and digested. `bytes` is compressed.
+    LayerFinished {
+        package: String,
+        subset: bool,
+        bytes: u64,
+    },
+    /// The image's target architecture, as read from the graph.
+    Architecture { arch: String },
+    /// A [`OutputSpec::RawFile`] was located in this package's cached build.
+    Found { package: String, path: String },
+    /// The artifact is complete.
+    Finished { bytes: u64 },
+}
+
+impl MaterializeEvent {
+    /// This event as one human-readable log line. Shared so every transport
+    /// reports a materialize identically.
+    pub fn render(&self) -> String {
+        fn layer(package: &str, subset: bool) -> Cow<'_, str> {
+            match subset {
+                true => Cow::Owned(format!("{package} (subset)")),
+                false => Cow::Borrowed(package),
+            }
+        }
+
+        match self {
+            MaterializeEvent::Started { output, packages } => {
+                format!("Materializing {output} from packages: {packages:?}")
+            }
+            MaterializeEvent::Layers { total } => format!(
+                "Will create {total} layers: base layer + {} packages",
+                total.saturating_sub(1)
+            ),
+            MaterializeEvent::LayerStarted { package, subset } => {
+                format!("Creating layer for: {}", layer(package, *subset))
+            }
+            MaterializeEvent::LayerFinished {
+                package,
+                subset,
+                bytes,
+            } => format!(
+                "Created layer for {}: {}",
+                layer(package, *subset),
+                size::Size::from_bytes(*bytes)
+            ),
+            MaterializeEvent::Architecture { arch } => format!("OCI image architecture: {arch}"),
+            MaterializeEvent::Found { package, path } => format!("Found {path} in {package}"),
+            MaterializeEvent::Finished { bytes } => {
+                format!("Wrote {}", size::Size::from_bytes(*bytes))
+            }
+        }
+    }
+}
+
+/// Best-effort progress reporting; a hung-up receiver must never fail the
+/// artifact.
+#[derive(Clone)]
+pub(crate) struct Emitter(Option<UnboundedSender<MaterializeEvent>>);
+
+impl Emitter {
+    pub(crate) fn send(&self, event: MaterializeEvent) {
+        if let Some(tx) = &self.0 {
+            let _ = tx.unbounded_send(event);
+        }
+    }
+}
+
+/// What was produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Report {
+    /// Bytes written to the sink.
+    pub bytes: u64,
+    /// The source file's unix mode, for a [`OutputSpec::RawFile`]. Already
+    /// applied for [`Sink::Path`]; a [`Sink::Writer`] caller must reapply it.
+    pub mode: Option<u32>,
+}
+
+/// Produces the artifact described by `spec` from the already-built top levels
+/// of [`Options::graph`].
+pub struct Materialize {
+    /// The image's `org.opencontainers.image.ref.name` annotation.
+    pub name: String,
+    pub spec: OutputSpec,
+    pub sink: Sink,
+    pub events: Option<UnboundedSender<MaterializeEvent>>,
+}
+
+impl Runnable for Materialize {
+    type Result = Report;
+
+    /// Archives and gzips the whole closure on the calling thread (via
+    /// `rayon`): an async caller should `spawn_blocking` this.
+    #[tracing::instrument(skip_all, fields(output = %self.name), err)]
+    async fn run(&mut self, opts: &Options<'_>) -> Result<Report, Error> {
+        // Destructured for disjoint field borrows.
+        let Materialize {
+            name,
+            spec,
+            sink,
+            events,
+        } = self;
+        let events = Emitter(events.clone());
+
+        events.send(MaterializeEvent::Started {
+            output: name.clone(),
+            packages: opts
+                .graph
+                .top_levels
+                .iter()
+                .filter_map(|bsr| opts.graph.get(bsr))
+                .map(|build| build.name.clone())
+                .collect(),
+        });
+
+        let report = match spec {
+            OutputSpec::OciImage {
+                entrypoint,
+                cmd,
+                vars,
+            } => {
+                let image = OciImage {
+                    name,
+                    entrypoint: entrypoint.as_deref(),
+                    cmd: cmd.as_deref(),
+                    vars,
+                };
+                // Flushed explicitly: dropping a buffered sink would swallow
+                // the error and truncate the artifact silently.
+                let bytes = match sink {
+                    Sink::Path(path) => {
+                        let file = std::fs::File::create(&path).map_err(|e| {
+                            Error::Other(anyhow!("creating {}: {e}", path.display()))
+                        })?;
+                        let mut w = image.write(opts, Counted::new(file), &events).await?;
+                        w.flush()?;
+                        w.bytes
+                    }
+                    Sink::Writer(w) => {
+                        let mut w = image.write(opts, Counted::new(w), &events).await?;
+                        w.flush()?;
+                        w.bytes
+                    }
+                };
+                Report { bytes, mode: None }
+            }
+            OutputSpec::RawFile { path } => extract_raw_file(opts, path, sink, &events)?,
+        };
+
+        events.send(MaterializeEvent::Finished {
+            bytes: report.bytes,
+        });
+        Ok(report)
+    }
+}
+
+/// Finds `path` in the closure of the graph's top levels and delivers it to
+/// `sink`. Probed in package-name order: a path shipped by more than one
+/// package must resolve the same way on every run.
+fn extract_raw_file(
+    opts: &Options<'_>,
+    path: &str,
+    sink: &mut Sink,
+    events: &Emitter,
+) -> Result<Report, Error> {
+    let rel_path = path.strip_prefix('/').unwrap_or(path);
+
+    let mut closure: Vec<_> =
+        Transitives::for_toplevels(opts.graph, opts.graph.top_levels.to_vec(), false)
+            .into_keys()
+            .map(|bsr| (opts.graph.get(&bsr).map(|b| b.name.clone()), bsr))
+            .collect();
+    closure.sort();
+
+    for (package, bsr) in closure {
+        let dir = opts
+            .cache
+            .read_dir(&opts.graph.spec_hash(&bsr))
+            .map_err(|e| Error::Other(anyhow!(e)))?;
+        let candidate = dir.path().join(rel_path);
+        if !candidate.exists() {
+            continue;
+        }
+
+        let package = package.unwrap_or_default();
+        events.send(MaterializeEvent::Found {
+            package: package.clone(),
+            path: path.to_string(),
+        });
+        return deliver_file(&candidate, sink);
+    }
+
+    Err(Error::Other(anyhow!(
+        "raw-file output {path:?} was not found in the built package set"
+    )))
+}
+
+/// Copies `src` into `sink`, preserving its unix mode when the sink is a path.
+fn deliver_file(src: &Path, sink: &mut Sink) -> Result<Report, Error> {
+    let mode = std::fs::metadata(src)
+        .map_err(|e| Error::Other(anyhow!("reading {}: {e}", src.display())))?
+        .permissions()
+        .mode();
+
+    let bytes = match sink {
+        // `fs::copy` carries the mode across, which a writer cannot.
+        Sink::Path(dest) => std::fs::copy(src, &dest).map_err(|e| {
+            Error::Other(anyhow!(
+                "copying output file {} to {}: {e}",
+                src.display(),
+                dest.display()
+            ))
+        })?,
+        Sink::Writer(w) => {
+            let mut f = std::fs::File::open(src)
+                .map_err(|e| Error::Other(anyhow!("opening {}: {e}", src.display())))?;
+            let n = std::io::copy(&mut f, w)
+                .map_err(|e| Error::Other(anyhow!("streaming {}: {e}", src.display())))?;
+            // A buffered writer holds the tail until flushed.
+            w.flush()
+                .map_err(|e| Error::Other(anyhow!("flushing {}: {e}", src.display())))?;
+            n
+        }
+    };
+
+    Ok(Report {
+        bytes,
+        mode: Some(mode),
+    })
+}
+
+/// Tallies bytes passing through, so [`Report::bytes`] works for any [`Sink`].
+pub(crate) struct Counted<W> {
+    inner: W,
+    pub(crate) bytes: u64,
+}
+
+impl<W: Write> Counted<W> {
+    fn new(inner: W) -> Self {
+        Self { inner, bytes: 0 }
+    }
+}
+
+impl<W: Write> Write for Counted<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        self.bytes += n as u64;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use decode::Layer;
+    use graph::Graph;
+    use indoc::indoc;
+    use lcache::{Cache, EntryMeta, LocalDir, MetaInner};
+    use tempfile::TempDir;
+
+    /// A closure of two packages that both ship `bin/tool`: `zzz` is the top
+    /// level and `aaa` its runtime dependency. Name order therefore disagrees
+    /// with dependency order, which is what makes it a useful collision case.
+    const COLLIDING: &str = indoc! {r#"
+        let {BuildSpec, OutputData, ..} = import "minimal.ncl" in
+        let aaa = {
+            name = "aaa",
+            build_deps = [],
+            cmd = "",
+            outputs = { f = {glob = "bin/tool"} | OutputData },
+        } | BuildSpec
+        in
+        {
+            name = "zzz",
+            build_deps = [],
+            runtime_deps = [aaa],
+            cmd = "",
+            outputs = { f = {glob = "bin/tool"} | OutputData },
+        } | BuildSpec
+    "#};
+
+    /// Ingests `ncl` and makes `top_level` the graph's sole top level.
+    fn graph_from(ncl: &str, top_level: &str) -> Graph {
+        let mut g = Graph::new()
+            .ingest(Layer::new_for_test(ncl.to_string()).unwrap())
+            .unwrap();
+        g.top_levels = vec![*g.by_name(top_level).expect("package in graph")];
+        g
+    }
+
+    /// Fakes a completed build of `package` whose only file is `path`, holding
+    /// `content` and carrying `mode`.
+    fn fake_build(
+        cache: &Cache<LocalDir>,
+        graph: &Graph,
+        package: &str,
+        path: &str,
+        content: &[u8],
+        mode: u32,
+    ) {
+        let hash = graph.spec_hash(graph.by_name(package).expect("package in graph"));
+        let pending = cache.write_dir(&hash).expect("write cache dir");
+        let file = pending.path().join(path);
+        std::fs::create_dir_all(file.parent().unwrap()).expect("create parent dir");
+        std::fs::write(&file, content).expect("write build output");
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(mode))
+            .expect("set output mode");
+        pending
+            .finalize(EntryMeta {
+                inner: MetaInner::Spec(package.to_string()),
+                ..Default::default()
+            })
+            .expect("finalize cache entry");
+    }
+
+    fn materialize(graph: &Graph, cache: Cache<LocalDir>, sink: Sink) -> Result<Report, Error> {
+        let opts = Options {
+            cache,
+            graph,
+            exec_base: "/not-exists".into(),
+            ot: None,
+        };
+        futures::executor::block_on(
+            Materialize {
+                name: "out".to_string(),
+                spec: OutputSpec::RawFile {
+                    path: "/bin/tool".to_string(),
+                },
+                sink,
+                events: None,
+            }
+            .run(&opts),
+        )
+    }
+
+    /// A raw-file output is copied out of the package that ships it, and a
+    /// path sink preserves the source's mode — an extracted binary that lost
+    /// its executable bit would be useless.
+    #[test]
+    fn raw_file_copies_to_a_path_preserving_mode() {
+        let tmp = TempDir::new().unwrap();
+        let cache = Cache::at_dir(tmp.path()).unwrap();
+        let graph = graph_from(
+            indoc! {r#"
+                let {BuildSpec, OutputData, ..} = import "minimal.ncl" in
+                {
+                    name = "only",
+                    build_deps = [],
+                    cmd = "",
+                    outputs = { f = {glob = "bin/tool"} | OutputData },
+                } | BuildSpec
+            "#},
+            "only",
+        );
+        fake_build(&cache, &graph, "only", "bin/tool", b"#!/bin/sh\n", 0o755);
+
+        let dest = tmp.path().join("extracted");
+        let report = materialize(&graph, cache, Sink::Path(dest.clone())).expect("materialize");
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"#!/bin/sh\n");
+        assert_eq!(report.bytes, 10);
+        assert_eq!(
+            std::fs::metadata(&dest).unwrap().permissions().mode() & 0o777,
+            0o755,
+            "a path sink must carry the source's executable bit across"
+        );
+    }
+
+    /// A writer sink gets the bytes, but cannot carry a unix mode — so the
+    /// report has to hand the mode back for the caller to reapply.
+    #[test]
+    fn raw_file_streams_to_a_writer_and_reports_the_mode() {
+        let tmp = TempDir::new().unwrap();
+        let cache = Cache::at_dir(tmp.path()).unwrap();
+        let graph = graph_from(
+            indoc! {r#"
+                let {BuildSpec, OutputData, ..} = import "minimal.ncl" in
+                {
+                    name = "only",
+                    build_deps = [],
+                    cmd = "",
+                    outputs = { f = {glob = "bin/tool"} | OutputData },
+                } | BuildSpec
+            "#},
+            "only",
+        );
+        fake_build(&cache, &graph, "only", "bin/tool", b"streamed", 0o755);
+
+        // A file stands in for any writer the caller owns; the point is that
+        // `Materialize` never learns where the bytes are going.
+        let dest = tmp.path().join("streamed");
+        let sink = Sink::Writer(Box::new(std::fs::File::create(&dest).unwrap()));
+        let report = materialize(&graph, cache, sink).expect("materialize");
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"streamed");
+        assert_eq!(report.bytes, 8);
+        assert_eq!(
+            report.mode.expect("a raw file always has a mode") & 0o777,
+            0o755
+        );
+    }
+
+    /// When two packages in the closure ship the same path, the winner is
+    /// decided by package name — not by `HashMap` iteration order, which would
+    /// vary from run to run.
+    #[test]
+    fn raw_file_resolves_collisions_deterministically() {
+        for _ in 0..8 {
+            let tmp = TempDir::new().unwrap();
+            let cache = Cache::at_dir(tmp.path()).unwrap();
+            let graph = graph_from(COLLIDING, "zzz");
+            fake_build(&cache, &graph, "aaa", "bin/tool", b"from-aaa", 0o755);
+            fake_build(&cache, &graph, "zzz", "bin/tool", b"from-zzz", 0o755);
+
+            let dest = tmp.path().join("extracted");
+            materialize(&graph, cache, Sink::Path(dest.clone())).expect("materialize");
+
+            assert_eq!(
+                std::fs::read(&dest).unwrap(),
+                b"from-aaa",
+                "the first package in name order must win every time"
+            );
+        }
+    }
+
+    /// A path no package ships is a user-facing mistake, so the error has to
+    /// name it rather than reporting an empty search.
+    #[test]
+    fn raw_file_missing_from_the_closure_is_an_error() {
+        let tmp = TempDir::new().unwrap();
+        let cache = Cache::at_dir(tmp.path()).unwrap();
+        let graph = graph_from(
+            indoc! {r#"
+                let {BuildSpec, OutputData, ..} = import "minimal.ncl" in
+                {
+                    name = "only",
+                    build_deps = [],
+                    cmd = "",
+                    outputs = { f = {glob = "bin/other"} | OutputData },
+                } | BuildSpec
+            "#},
+            "only",
+        );
+        fake_build(&cache, &graph, "only", "bin/other", b"not it", 0o644);
+
+        let err = materialize(&graph, cache, Sink::Path(tmp.path().join("extracted")))
+            .expect_err("the path is in no package");
+        assert!(
+            err.to_string().contains("/bin/tool"),
+            "the error must name the path that was not found, got: {err}"
+        );
+    }
+
+    /// Every event renders to a line, and the ones carrying sizes render them
+    /// for humans rather than as raw byte counts. Any caller can produce the
+    /// CLI's output without reimplementing the wording.
+    #[test]
+    fn events_render_as_log_lines() {
+        assert_eq!(
+            MaterializeEvent::Layers { total: 3 }.render(),
+            "Will create 3 layers: base layer + 2 packages"
+        );
+        assert_eq!(
+            MaterializeEvent::LayerFinished {
+                package: "gcc".to_string(),
+                subset: true,
+                bytes: 3_170_893,
+            }
+            .render(),
+            "Created layer for gcc (subset): 3.02 MiB"
+        );
+        assert_eq!(
+            MaterializeEvent::LayerStarted {
+                package: "gcc".to_string(),
+                subset: false,
+            }
+            .render(),
+            "Creating layer for: gcc"
+        );
+        assert_eq!(
+            MaterializeEvent::Found {
+                package: "kernel".to_string(),
+                path: "/boot/vmlinuz".to_string(),
+            }
+            .render(),
+            "Found /boot/vmlinuz in kernel"
+        );
+    }
+
+    /// `minimal.toml` lets `entrypoint`/`cmd` be a shell string or an argv
+    /// list. Both must reach the image config as argv.
+    #[test]
+    fn output_spec_splits_shell_strings_into_argv() {
+        let spec: OutputSpec = mfile::OutputKind::OciImage {
+            entrypoint: Some(mfile::StrOrList::Single("/bin/sh -c 'echo hi'".to_string())),
+            cmd: Some(mfile::StrOrList::Multiple(vec!["--flag".to_string()])),
+            vars: HashMap::new(),
+        }
+        .try_into()
+        .expect("a well-formed entrypoint converts");
+
+        assert_eq!(
+            spec,
+            OutputSpec::OciImage {
+                entrypoint: Some(vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    "echo hi".to_string()
+                ]),
+                cmd: Some(vec!["--flag".to_string()]),
+                vars: HashMap::new(),
+            }
+        );
+    }
+
+    /// An unbalanced quote used to panic inside the image writer. Converting up
+    /// front turns it into an error naming the field at fault.
+    #[test]
+    fn output_spec_rejects_an_unparseable_entrypoint() {
+        let err: Error = mfile::OutputKind::OciImage {
+            entrypoint: Some(mfile::StrOrList::Single(
+                "/bin/sh -c 'unbalanced".to_string(),
+            )),
+            cmd: None,
+            vars: HashMap::new(),
+        }
+        .try_into()
+        .map(|_: OutputSpec| ())
+        .expect_err("an unbalanced quote cannot be split");
+
+        assert!(
+            err.to_string().contains("entrypoint"),
+            "the error must name the offending field, got: {err}"
+        );
+    }
+}

--- a/crates/op/src/oci_image.rs
+++ b/crates/op/src/oci_image.rs
@@ -4,12 +4,12 @@
 //! from minimal packages. It generates multi-layer images where each runtime dependency
 //! becomes a separate layer.
 
-use crate::{Error, Options, Runnable};
+use crate::materialize::{Emitter, MaterializeEvent};
+use crate::{Error, Options};
 use common::SpecHash;
 use flate2::{Compression, write::GzEncoder};
 use globset::{Glob, GlobSet};
 use graph::{BuildSpecRef, Transitives, TransitivesDep};
-use mfile::StrOrList;
 use oci_spec::image::{
     ANNOTATION_REF_NAME, ConfigBuilder, Descriptor, DescriptorBuilder, ImageConfigurationBuilder,
     ImageIndexBuilder, ImageManifestBuilder, MediaType, PlatformBuilder, RootFsBuilder,
@@ -18,40 +18,39 @@ use oci_spec::image::{
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::io::Seek;
-use std::path::PathBuf;
 use std::str::FromStr;
-use tracing::info;
 
-/// Creates an OCI image from a set of packages.
-pub struct OciImageCreate {
-    /// The packages to include in the image (used for logging)
-    pub packages: Vec<String>,
-    /// The output file path to write the OCI image tarball
-    pub output_file: PathBuf,
-
-    pub name: Option<String>,
-    pub entrypoint: Option<mfile::StrOrList>,
-    pub cmd: Option<mfile::StrOrList>,
-    pub vars: HashMap<String, String>,
+/// An OCI image assembled from the built top levels of [`Options::graph`] and
+/// their transitive runtime dependencies, one layer per package. The target
+/// architecture comes from the graph.
+pub(crate) struct OciImage<'a> {
+    /// The image's `org.opencontainers.image.ref.name` annotation.
+    pub name: &'a str,
+    pub entrypoint: Option<&'a [String]>,
+    pub cmd: Option<&'a [String]>,
+    pub vars: &'a HashMap<String, String>,
 }
 
-impl Runnable for OciImageCreate {
-    type Result = ();
-
+impl OciImage<'_> {
+    /// Writes the image tarball to `w` and returns it, so a caller that
+    /// wrapped its sink can recover the wrapper.
     #[tracing::instrument(skip_all, err)]
-    async fn run<'b>(&mut self, opts: &Options<'b>) -> Result<Self::Result, Error> {
+    pub(crate) async fn write<W: std::io::Write>(
+        &self,
+        opts: &Options<'_>,
+        w: W,
+        events: &Emitter,
+    ) -> Result<W, Error> {
         let mut all_deps: Vec<(BuildSpecRef, TransitivesDep)> =
             Transitives::for_toplevels(opts.graph, opts.graph.top_levels.to_vec(), false)
                 .into_iter()
                 .collect();
         all_deps.sort_by_key(|(bsr, _)| opts.graph.get(bsr).unwrap().name.clone());
 
-        info!("Creating OCI image for packages: {:?}", self.packages);
-        info!(
-            "Will create {} layers: base layer + {} packages",
-            all_deps.len() + 1,
-            all_deps.len()
-        );
+        // Plus the base layer holding the /lib64 symlink.
+        events.send(MaterializeEvent::Layers {
+            total: all_deps.len() + 1,
+        });
 
         let mut layers = Vec::new();
 
@@ -67,6 +66,7 @@ impl Runnable for OciImageCreate {
                 let tokio_runtime = tokio_runtime.clone();
                 let results = results.clone();
                 let cache = opts.cache.clone();
+                let events = events.clone();
 
                 let dep_spec = opts.graph.get(bsr).unwrap();
                 let dep_hash = opts.graph.spec_hash(bsr);
@@ -77,14 +77,10 @@ impl Runnable for OciImageCreate {
                     .unwrap()
                 });
 
-                info!(
-                    "Creating layer for: {}",
-                    if match_globs.is_some() {
-                        format!("{} (subset)", dep_spec.name)
-                    } else {
-                        dep_spec.name.to_string()
-                    }
-                );
+                events.send(MaterializeEvent::LayerStarted {
+                    package: dep_spec.name.clone(),
+                    subset: match_globs.is_some(),
+                });
 
                 s.spawn(move |_| {
                     let _rt = tokio_runtime.enter();
@@ -93,6 +89,7 @@ impl Runnable for OciImageCreate {
                         &dep_hash,
                         &dep_spec.name,
                         &match_globs,
+                        &events,
                     ));
                     results.lock().unwrap().push(result);
                 });
@@ -112,7 +109,6 @@ impl Runnable for OciImageCreate {
         // blobs/sha256/<manifest-digest> - image manifest, points to a image config and also all the layers in order
         // blobs/sha256/<image-config-digest> - image config, metadata about the image
         // blobs/sha256/<layer-gzip-digest> - the tar.gz of a filesystem layer
-        let w = std::fs::File::create(&self.output_file)?;
         let mut tb = tar::Builder::new(w);
 
         // ImageConfig - written as blob object by hash
@@ -121,7 +117,9 @@ impl Runnable for OciImageCreate {
             common::target::Arch::Arm64 => "arm64",
             common::target::Arch::Amd64 => "amd64",
         };
-        info!("OCI image architecture: {arch}");
+        events.send(MaterializeEvent::Architecture {
+            arch: arch.to_string(),
+        });
 
         let image_config_bytes = serde_json::to_vec(
             &ImageConfigurationBuilder::default()
@@ -140,17 +138,11 @@ impl Runnable for OciImageCreate {
                 )
                 .config({
                     let mut cb = ConfigBuilder::default();
-                    if let Some(entrypoint) = &self.entrypoint {
-                        cb = cb.entrypoint(match entrypoint {
-                            StrOrList::Single(s) => shlex::split(s).unwrap(),
-                            StrOrList::Multiple(v) => v.clone(),
-                        });
+                    if let Some(entrypoint) = self.entrypoint {
+                        cb = cb.entrypoint(entrypoint.to_vec());
                     };
-                    if let Some(cmd) = &self.cmd {
-                        cb = cb.cmd(match cmd {
-                            StrOrList::Single(s) => shlex::split(s).unwrap(),
-                            StrOrList::Multiple(v) => v.clone(),
-                        });
+                    if let Some(cmd) = self.cmd {
+                        cb = cb.cmd(cmd.to_vec());
                     };
                     if !self.vars.is_empty() {
                         cb = cb.env(
@@ -223,13 +215,10 @@ impl Runnable for OciImageCreate {
                             .build()
                             .unwrap(),
                     )
-                    .annotations({
-                        let mut annotations = HashMap::new();
-                        if let Some(name) = &self.name {
-                            annotations.insert(ANNOTATION_REF_NAME.to_string(), name.clone());
-                        }
-                        annotations
-                    })
+                    .annotations(HashMap::from([(
+                        ANNOTATION_REF_NAME.to_string(),
+                        self.name.to_string(),
+                    )]))
                     .build()?,
             ])
             .build()?;
@@ -264,8 +253,8 @@ impl Runnable for OciImageCreate {
             tb.append(&th, layer.targz)?;
         }
 
-        tb.finish()?;
-        Ok(())
+        // `into_inner` finishes the archive and hands the sink back.
+        Ok(tb.into_inner()?)
     }
 }
 
@@ -336,6 +325,7 @@ async fn create_layer_from_cache(
     spec_hash: &SpecHash,
     package_name: &str,
     match_globs: &Option<globset::GlobSet>,
+    events: &Emitter,
 ) -> anyhow::Result<BuiltLayer> {
     let cache_entry = cache
         .read_dir(spec_hash)
@@ -373,15 +363,11 @@ async fn create_layer_from_cache(
         .digest(Sha256Digest::from_str(&hex::encode(sha256))?)
         .build()?;
 
-    info!(
-        "Created layer for {}: {}",
-        if match_globs.is_some() {
-            format!("{} (subset)", package_name)
-        } else {
-            package_name.to_string()
-        },
-        size::Size::from_bytes(compressed_len)
-    );
+    events.send(MaterializeEvent::LayerFinished {
+        package: package_name.to_string(),
+        subset: match_globs.is_some(),
+        bytes: compressed_len,
+    });
 
     tar_file.seek(std::io::SeekFrom::Start(0))?;
     Ok(BuiltLayer {

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -44,7 +44,24 @@ impl Channel for () {
     }
 }
 
-const SESSION_DEFAULT_WD: &str = "workbench";
+/// The name of the working directory inside a session sandbox: the host
+/// directory given to [`Config::with_session_dirs`] is bind-mounted at
+/// `/{SESSION_DEFAULT_WD}` unless the config overrides the name.
+///
+/// Exported so callers that have to translate between a path typed inside the
+/// sandbox and the host directory backing it agree with the mount on where it
+/// lives.
+///
+/// [`Config::with_session_dirs`]: config::Config::with_session_dirs
+pub const SESSION_DEFAULT_WD: &str = "workbench";
+
+/// The name of the home directory inside a session sandbox: the host directory
+/// given to [`Config::with_session_dirs`] is bind-mounted at `/{SESSION_HOME}`.
+///
+/// Exported for the same reason as [`SESSION_DEFAULT_WD`].
+///
+/// [`Config::with_session_dirs`]: config::Config::with_session_dirs
+pub const SESSION_HOME: &str = "home";
 
 /// An initialized sandbox.
 ///
@@ -241,7 +258,7 @@ impl<C: Channel> Sandbox<C> {
                 );
                 fs::create_dir_all(&rootfs_cwd)
                     .map_err(|e| Error::IO("create cwd", rootfs_cwd, e))?;
-                let rootfs_home = rootfs.join("home");
+                let rootfs_home = rootfs.join(SESSION_HOME);
                 fs::create_dir_all(&rootfs_home)
                     .map_err(|e| Error::IO("create home", rootfs_home.clone(), e))?;
             }
@@ -668,10 +685,10 @@ impl<C: Channel> Sandbox<C> {
                 working,
                 working_name_override,
             } => {
-                // mount the given home path to /home
+                // mount the given home path to /{SESSION_HOME}
                 Self::bind_mount(
                     home,
-                    "/home",
+                    &format!("/{SESSION_HOME}"),
                     BindOpts {
                         recursive: true,
                         read_only: false,

--- a/docs/reference/sandbox-operations.md
+++ b/docs/reference/sandbox-operations.md
@@ -73,3 +73,14 @@ Builds the named package in a clean room using potentially-stale dependencies
 (the already-cached builds of its dependencies, without rebuilding them first),
 and commits the result to the local cache. Useful for quickly iterating on a
 single package's build.
+
+### `materialize [--arch <arch>] -o <out-file> <output-name>`
+
+Materializes an output specified in an
+[`[outputs.<name>]`](./minimal-dot-toml.md#outputs) section of
+`minimal.toml`.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output <PATH>` | `-o` | **(required)** The output file to write |
+| `--arch <ARCH>` | | Override the architecture used when building the output (e.g. `amd64`, `arm64`); takes precedence over the `arch` field in `minimal.toml` and the host default |


### PR DESCRIPTION
 - Move materialize implementation into type in `op` crate
 - Implement side session-op for materialize
 - Make callable via `min` helper in a session

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `materialize` subcommand to minimald sessions to stream build artifacts
> - Adds `op::Materialize` in [crates/op/src/materialize.rs](https://github.com/gominimal/minimal/pull/1054/files#diff-5141265c653ab7e63b86a6dc25faef0201966b50616fd9dd826cd9b6fc72132d) that produces OCI image tarballs or raw files from a build graph, emitting structured `MaterializeEvent` progress and returning a `Report` with byte count and file mode.
> - Adds `SideOp::new_materialize` in [crates/minimald/src/session_sop.rs](https://github.com/gominimal/minimal/pull/1054/files#diff-3dbb111166e94a5a10338aa43c30544e9b94b1e1701413a2d0d5a20626b20d79) to run materialize as a background side-op, streaming `MaterializeUpdate` (events, chunks, and a terminal `Finished`) to subscribers with backpressure; the pump stops assembly immediately when all subscribers disconnect.
> - Exposes `SessionHandle::start_materialize` in [crates/minimald/src/session.rs](https://github.com/gominimal/minimal/pull/1054/files#diff-e048623f216e46d87a60fe1de0c1c964bf23da2c6dbf259b1f43bbf354a4ad55) so callers can trigger a materialize run and receive the update stream.
> - Adds a `materialize` RPC in [crates/minimald/src/env.rs](https://github.com/gominimal/minimal/pull/1054/files#diff-ece548260b2c5052569423263e9b54827b352ed496728bed2f1bf4c52c251dc1) that resolves the `--output` path relative to the sandbox working directory, writes streamed bytes into the session workspace or home directory with symlink traversal protection, and sets file permissions from the reported mode.
> - Adds the `materialize` subcommand to [crates/minimald/src/env_min_helper.sh](https://github.com/gominimal/minimal/pull/1054/files#diff-075ce1ac57a8ff3e229daeeef3d63c7c44ea96ee55f24219375d4e33eb9ad8b8), forwarding the sandbox PWD and arguments to the daemon.
> - Refactors `mip`'s `cmd_materialize` in [crates/mip/src/cmd_materialize.rs](https://github.com/gominimal/minimal/pull/1054/files#diff-492e39ffc0059aef22b43648baef7579d2763ed426738eeb05c954937d8bd93e) to use the new unified `op::Materialize`.
> - Risk: `create_artifact` opens destination files with `O_NOFOLLOW` and refuses paths outside the session workspace or home; symlink escapes at any path component are denied with an IO error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6dd623.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `min materialize` to materialize `minimal.toml` outputs as OCI image archives or extracted raw-file artifacts.
  * Supports `--output` and `--arch` overrides, streams progress/events, reports completion, and applies executable permissions when produced by the build.
  * Outputs are validated and mapped safely to the session’s sandbox locations.
* **Bug Fixes**
  * Hardened handling for unknown outputs/architectures, missing raw artifacts, and attempts to write outside allowed sandbox roots.
  * Ensures deterministic raw-file selection and preserves file modes across conflicting paths.
* **Documentation**
  * Updated sandbox operations reference with `materialize` syntax and flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->