### PR TITLE
feat(release): ship the switch binary to Linux installs

### DIFF
--- a/docs/internal/release-pipeline.md
+++ b/docs/internal/release-pipeline.md
@@ -144,10 +144,12 @@ SHA-256-verifies, and atomically installs the file. The on-disk hash is the
 skip oracle, so reruns only touch changed components, and a running daemon is
 stopped before an executable is swapped. Per-platform sets (from
 stage-release.sh's `COMPONENTS` table): Linux amd64/arm64 get `bin/min`,
-`bin/mip`, `bin/minimald`, a `git-remote-min` symlink, and the AppArmor
-profile/tunable/loader under `data/`; macOS arm64 gets `bin/min`,
-`bin/minvmd`, `bin/gvproxy`, `lib/libkrun.1.dylib`, the `git-remote-min`
+`bin/mip`, `bin/minimald`, `bin/gvproxy-min`, a `git-remote-min` symlink, and
+the AppArmor profile/tunable/loader under `data/`; macOS arm64 gets `bin/min`,
+`bin/minvmd`, `bin/gvproxy-min`, `lib/libkrun.1.dylib`, the `git-remote-min`
 symlink, and the guest payload (`data/{vmlinuz,rootfs.img,initramfs.cpio}`).
+`minvmd` is not in the Linux set yet — see
+[#980](https://github.com/gominimal/minimal/issues/980).
 It also wires shell integration (PATH init files, `min` completions, one
 marker-fenced rc block). `--uninstall` reverses all of it offline from the
 local install record, keeping user-modified files unless `--force`;

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -104,21 +104,31 @@ fi
 #     (the installer's completion generation runs `<bin>/min`, spec R9.3), while
 #     the component and artifact names keep the crate name.
 #
-# Linux hosts install just the three self-contained musl binaries. macOS hosts
-# additionally need minvmd + gvproxy and the guest microVM payload (kernel,
-# rootfs, initramfs) to boot Linux workloads under libkrun; macOS is arm64-only
-# here, and its guest is arm64, so it consumes the arm64 guest artifacts.
+# Linux hosts install the three self-contained musl binaries plus the switch
+# binary, which `minimald` spawns for native (DM2) own-IP sessions. macOS hosts
+# additionally need minvmd and the guest microVM payload (kernel, rootfs,
+# initramfs) to boot Linux workloads under libkrun; macOS is arm64-only here,
+# and its guest is arm64, so it consumes the arm64 guest artifacts. minvmd is
+# not staged for Linux yet — see gominimal/minimal#980.
+#
+# The switch installs as `bin/gvproxy-min`, NOT `bin/gvproxy`: the bin prefix is
+# `~/.local/bin`, which is on PATH, and podman/crc ship their own `gvproxy`
+# there. The bytes are stock gvproxy (pinned and SHA-256-verified by
+# scripts/fetch-gvproxy.sh); only the installed name is ours, and
+# `switch::GVPROXY_FILE` is the resolver's matching definition.
 COMPONENTS=(
     # Linux amd64
     "minimald|linux|amd64|file|bin/minimald|minimald-linux-amd64"
     "mip|linux|amd64|file|bin/mip|mip-linux-amd64"
     "minimal|linux|amd64|file|bin/min|minimal-linux-amd64"
     "git-remote-min|linux|amd64|symlink|bin/git-remote-min|min"
+    "gvproxy-min|linux|amd64|file|bin/gvproxy-min|gvproxy-linux-amd64"
     # Linux arm64
     "minimald|linux|arm64|file|bin/minimald|minimald-linux-arm64"
     "mip|linux|arm64|file|bin/mip|mip-linux-arm64"
     "minimal|linux|arm64|file|bin/min|minimal-linux-arm64"
     "git-remote-min|linux|arm64|symlink|bin/git-remote-min|min"
+    "gvproxy-min|linux|arm64|file|bin/gvproxy-min|gvproxy-linux-arm64"
     # macOS arm64 (darwin)
     "minimal|darwin|arm64|file|bin/min|minimal-macos-arm64"
     "git-remote-min|darwin|arm64|symlink|bin/git-remote-min|min"
@@ -128,12 +138,6 @@ COMPONENTS=(
     # Basename MUST be libkrun.1.dylib: minvmd's load command is @rpath/libkrun.1.dylib
     # and the release job adds a @loader_path/../lib rpath.
     "libkrun|darwin|arm64|file|lib/libkrun.1.dylib|libkrun-macos-arm64.dylib"
-    # Installed as `gvproxy-min`, NOT `gvproxy`: the bin prefix is
-    # `~/.local/bin`, which is on PATH, and podman/crc ship their own `gvproxy`
-    # there — under the upstream name whichever landed last would win a PATH
-    # lookup, in either direction. The bytes are stock gvproxy (still pinned and
-    # SHA-256-verified by scripts/fetch-gvproxy.sh); only the installed name is
-    # ours, and `switch::GVPROXY_FILE` is the resolver's matching definition.
     "gvproxy-min|darwin|arm64|file|bin/gvproxy-min|gvproxy-darwin-arm64"
     "initramfs|darwin|arm64|file|data/initramfs.cpio|initramfs-arm64.cpio"
     "rootfs|darwin|arm64|file|data/rootfs.img|rootfs-arm64.img"


### PR DESCRIPTION
Own-IP is dead on every installed Linux host.

The native (DM2) datapath is implemented and proven by the netns job, but `minimald` resolves a switch binary that no Linux install ships, so the spawn fails on a path that was never populated. CI has never caught it because it fetches gvproxy itself and sets `GVPROXY_BIN`.

## The gap is two table rows

The release **already builds** pin-verified `gvproxy-linux-amd64` and `gvproxy-linux-arm64` — `release.yml` uploads both (lines 575–586). They were simply never mapped to install components, so `stage-release.sh` never put them in a manifest and the installer never had anything to place.

```diff
  # Linux amd64
  "minimal|linux|amd64|file|bin/min|minimal-linux-amd64"
  "git-remote-min|linux|amd64|symlink|bin/git-remote-min|min"
+ "gvproxy-min|linux|amd64|file|bin/gvproxy-min|gvproxy-linux-amd64"
```

(and the arm64 twin)

## Why nothing else changes

**The installer needs no change.** It is manifest-driven: it filters rows by host os/arch and marks anything under `bin` executable.

**The Rust tree needs no change.** The resolver already looks exactly where these rows land — `minimald` falls back to `switch::installed_gvproxy_bin()` when `GVPROXY_BIN` is unset, which probes `$MINIMAL_BIN` / `$HOME/.local/bin` for `gvproxy-min`. There is no `cfg(target_os)` anywhere in that path; it was written platform-agnostic and Linux was the half that had nothing to find.

**No migration is needed on Linux**, unlike macOS. `gvproxy` was never staged here, so no Linux install record carries the pre-rename name for `remove_renamed_gvproxy` to clean up.

The naming rationale (`gvproxy-min`, not `gvproxy` — the `bin` prefix is on `PATH` and podman/crc ship their own) moves from the darwin row up to the table header, since it now governs three rows rather than one.

## Verification

Dry-run stage against stub artifacts — both rows resolve, with distinct per-arch digests:

```
gvproxy-min  linux  amd64  testver  31db9278…  file  bin/gvproxy-min  versions/testver/gvproxy-linux-amd64
gvproxy-min  linux  arm64  testver  2a9953f0…  file  bin/gvproxy-min  versions/testver/gvproxy-linux-arm64
```

`shellcheck` clean at 0.11.0 and at CI's 0.10.0.

## Scope

`minvmd` and the guest payload stay out. the static-musl research in [#1065](https://github.com/gominimal/minimal/issues/1065) has shown `minvmd` can ship as a single self-contained binary, so shipping the dynamic-glibc build now would mean putting ~29 MB of libraries plus RUNPATH machinery, a `bin`/`lib` sibling constraint, and a glibc floor onto users' disks — then deleting all of it. That is the remaining half of [#980](https://github.com/gominimal/minimal/issues/980), tracked in [#1065](https://github.com/gominimal/minimal/issues/1065).

The `release-pipeline.md` per-platform component list is updated to match, including its macOS entry, which still read `bin/gvproxy` after the #994 rename.

Refs [#980](https://github.com/gominimal/minimal/issues/980)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ship `gvproxy-min` (switch binary) to Linux amd64 and arm64 installs
> Adds `gvproxy-min` entries for Linux amd64 and arm64 to the COMPONENTS table in [scripts/stage-release.sh](https://github.com/gominimal/minimal/pull/1063/files#diff-b915b0588eb8e66e0e3fe26d502c3baea0ef85d884c47e9035989dcc64313bff), placing the switch binary (standard gvproxy bytes) at `~/.local/bin/gvproxy-min` on Linux hosts. Updates [docs/internal/release-pipeline.md](https://github.com/gominimal/minimal/pull/1063/files#diff-c2cb69c525571ec653eac98496225396a528dd77d0f0e4ecea6183ecc6b8da02) to reflect the new per-platform component lists. Note: `minvmd` is not yet staged for Linux (tracked in issue #980).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf13a86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->