### PR TITLE
chore(deps): bump the pkgs pin

### DIFF
--- a/.minimal/minimal.toml
+++ b/.minimal/minimal.toml
@@ -1,7 +1,7 @@
 [upstream] # Source of software & tooling
 repo = "https://github.com/gominimal/pkgs"
 branch = "main"
-locked_commit = "c854d6b1e0fdc67efd84fc664251079c0719987d"
+locked_commit = "d299744531767b2edeb5b0ead2178dadc40bbeed"
 
 [stack]
 use = "rust"


### PR DESCRIPTION
One line, but worth reading the blast radius before approving.

## What this picks up

The pin was 9 days and **62 commits** stale (`c854d6b1`, 2026-07-20). The motivating change is gominimal/pkgs#534, which rebuilds `microvm-rootfs` from Alpine and drops the glibc closure. The pin is linear, so this necessarily carries everything before it too.

Materially in range:

| | |
|---|---|
| `microvm-rootfs` from Alpine (pkgs#534) | **186 MB → 45 MB** |
| libkrun vsock RX descriptor fill (pkgs#506) | on minvmd's path |
| libkrun packet-count backpressure (pkgs#512) | on minvmd's path |
| rust 1.97.1 (pkgs#502), glibc 2.44 (pkgs#529) | build stack |

The remaining ~57 are routine package version bumps.

Pinned at the branch tip rather than at #534's own commit: pinning mid-history buys nothing here, and the three commits after it are a `bottom` bump, a `graphviz` bump, and a license-metadata fix.

## Verification

`mip materialize --arch aarch64 minvmd-rootfs` at the new pin resolves **from cache** and yields:

```
47,212,544 bytes — Linux rev 1.0 ext2 filesystem data
interpreter: /lib/ld-musl-aarch64.so.1   (no glibc present)
```

That is #534's image, not a rebuild of the old one.

The same image has already been booted and driven through the full session e2e — cold activate 4296 ms, warm `ls` 16 ms, sandbox proof 8030 ms — and A/B'd for cold-boot latency against the outgoing rootfs:

| rootfs | min | median | max |
|---|---|---|---|
| 186 MB (outgoing) | 146 ms | 154 ms | 161 ms |
| 45 MB (this pin) | 122 ms | 129 ms | 147 ms |

n=10 each, distributions non-overlapping. ~16% faster cold boot alongside the 4× size cut.

`mip check` passes.

## Risk

**This changes the guest for macOS too**, which already ships the payload — the VM lanes are the real gate, not the local checks above. The other thing I cannot prove locally is the dogfood build smoke: if upstream's R2 mirror is not populated for the new pin, that build falls back to compiling from source. That surfaces in `ci`, by design.

Sequencing note: this is what makes the slimmed rootfs actually reach a release. `.github/actions/materialize` resolves guest artifacts through this pin, so until it moves, #534 is merged upstream but unreachable downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump pkgs pin to pick up the Alpine guest rootfs
> Updates the `locked_commit` in [minimal.toml](.minimal/minimal.toml) to `d299744` to pull in a newer upstream snapshot that includes the Alpine guest rootfs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3079a19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->