### PR TITLE
feat(minvmd): build against a static musl libkrun

### DIFF
--- a/.github/actions/build-libkrun-static-linux/action.yml
+++ b/.github/actions/build-libkrun-static-linux/action.yml
@@ -1,0 +1,99 @@
+name: Build static libkrun (Linux/musl)
+description: >
+  Provision the STATIC libkrun.a that minvmd links into a self-contained musl
+  binary — built from source at the commit pinned in vendor/libkrun/libkrun.lock
+  via scripts/build-libkrun-linux.sh — into a commit-keyed prefix, and publish
+  LIBKRUN_PREFIX to GITHUB_ENV. minvmd's build.rs treats a libkrun.a in the
+  prefix as the selector for a static link and records no rpath, so the
+  resulting binary has no runtime library dependency at all. The Linux twin of
+  setup-libkrun-macos, and the alternative to setup-libkrun-linux (which
+  materializes the DYNAMIC upstream package for dev/native builds).
+  Build-on-miss, riding actions/cache keyed by every build input. Requires a
+  Rust toolchain with the musl target, musl-tools, and the repository checked
+  out.
+
+inputs:
+  target:
+    description: musl target triple (e.g. x86_64-unknown-linux-musl)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve libkrun pin
+      id: pin
+      shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
+      run: |
+        set -euo pipefail
+        case "$TARGET" in
+          *-linux-musl) ;;
+          *) echo "::error::target '$TARGET' is not a musl triple" >&2; exit 1 ;;
+        esac
+        commit="$(sed -n 's/^commit=//p' vendor/libkrun/libkrun.lock)"
+        if [ -z "$commit" ]; then
+          echo "::error::no commit= line in vendor/libkrun/libkrun.lock" >&2
+          exit 1
+        fi
+        script_hash="$(sha256sum scripts/build-libkrun-linux.sh | cut -d' ' -f1)"
+        # Hash the carried patches (name + content, in apply order) so editing,
+        # adding, or removing a patch invalidates the build. Mirrors the macOS
+        # composite, including the `-d` guard: git drops the directory once the
+        # last patch is removed, and a non-zero `find` would become a step
+        # failure under pipefail.
+        patches_hash="$( { [ -d vendor/libkrun/patches ] && find vendor/libkrun/patches -name '*.patch' -type f -exec sha256sum {} + || true; } | sort | sha256sum | cut -d' ' -f1)"
+        {
+          echo "commit=$commit"
+          # The prefix embeds every build input, and the TARGET besides: one
+          # runner arch builds one triple, but keying on it keeps an amd64 and
+          # an arm64 prefix from ever colliding in a shared cache.
+          echo "prefix=$HOME/.cache/minimal-ci/libkrun-static/$TARGET/$commit-${script_hash:0:12}-${patches_hash:0:12}"
+          echo "script_hash=$script_hash"
+          echo "patches_hash=$patches_hash"
+        } >> "$GITHUB_OUTPUT"
+    - name: Cache built libkrun.a
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ~/.cache/minimal-ci/libkrun-static
+        key: libkrun-static-${{ inputs.target }}-${{ steps.pin.outputs.commit }}-${{ steps.pin.outputs.script_hash }}-${{ steps.pin.outputs.patches_hash }}
+    - name: Build static libkrun from source (on miss)
+      shell: bash
+      env:
+        PREFIX: ${{ steps.pin.outputs.prefix }}
+        TARGET: ${{ inputs.target }}
+      run: |
+        set -euo pipefail
+        if [ ! -f "$PREFIX/libkrun.a" ]; then
+          ./scripts/build-libkrun-linux.sh "$PREFIX" "$TARGET"
+        else
+          echo "libkrun.a already staged at $PREFIX (cache hit)"
+        fi
+    - name: Verify staged libkrun.a + export LIBKRUN_PREFIX
+      # Re-assert the API floor and the symbol surface on the staged (possibly
+      # cache-restored) archive, so a corrupt or hand-tampered prefix fails here
+      # with an actionable message instead of a link error — or worse, a
+      # duplicate-symbol collision — much later.
+      shell: bash
+      env:
+        PREFIX: ${{ steps.pin.outputs.prefix }}
+      run: |
+        set -euo pipefail
+        if [ ! -f "$PREFIX/libkrun.a" ]; then
+          echo "::error::libkrun.a missing from $PREFIX after build/restore" >&2
+          exit 1
+        fi
+        # Dump once and assert against the file: under pipefail a `grep -q` that
+        # exits early SIGPIPEs nm, and the non-zero producer fails the pipeline.
+        nm -g --defined-only "$PREFIX/libkrun.a" > /tmp/libkrun-staged.syms
+        if ! grep -q ' T krun_add_disk3$' /tmp/libkrun-staged.syms; then
+          echo "::error::staged libkrun lacks krun_add_disk3 (need >= 1.19.0); delete $PREFIX and re-run to rebuild" >&2
+          exit 1
+        fi
+        leaked="$(awk '$2 ~ /^[A-TV-Z]$/ {print $NF}' /tmp/libkrun-staged.syms | grep -v '^krun_' | head -5 || true)"
+        if [ -n "$leaked" ]; then
+          echo "::error::staged libkrun.a exports symbols outside the krun_* API; it would collide with minvmd's own libstd:" >&2
+          echo "$leaked" >&2
+          exit 1
+        fi
+        echo "LIBKRUN_PREFIX=$PREFIX" >> "$GITHUB_ENV"

--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -215,7 +215,9 @@ jobs:
           cp "$RUNNER_TEMP/initramfs.cpio" testbed/initramfs.cpio
           # Prove it before it leaves this job: a dynamically-linked minvmd
           # here means the lane silently stopped testing what we distribute.
-          file testbed/minvmd | grep -q 'statically linked' \
+          # x86_64-musl emits a static PIE, which file(1) reports as
+          # "static-pie linked"; aarch64-musl reports "statically linked".
+          file testbed/minvmd | grep -qE 'statically linked|static-pie linked' \
             || { echo "::error::built minvmd is not statically linked"; file testbed/minvmd; exit 1; }
 
       - name: Upload testbed
@@ -296,7 +298,8 @@ jobs:
           set -euo pipefail
           TESTBED="$RUNNER_TEMP/testbed"
           chmod +x "$TESTBED/minvmd" "$TESTBED/min"
-          file "$TESTBED/minvmd" | grep -q 'statically linked' \
+          # See the build job for why both file(1) spellings are accepted.
+          file "$TESTBED/minvmd" | grep -qE 'statically linked|static-pie linked' \
             || { echo "::error::testbed minvmd is not statically linked"; file "$TESTBED/minvmd"; exit 1; }
           echo "$TESTBED" >> "$GITHUB_PATH"
           {

--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -70,10 +70,14 @@ jobs:
               - "rust-toolchain.toml"
               - ".minimal/minimal.toml"
               - ".github/workflows/ci-linux-kvm.yml"
+              # The libkrun this lane builds from source and links statically:
+              # the pin and the carried patches are build inputs, so a bump to
+              # either must re-run the boot test.
+              - "vendor/libkrun/**"
               # Composite actions this lane's setup runs through — without
               # these, a composite-only edit would skip this lane and break
               # it post-merge.
-              - ".github/actions/setup-libkrun-linux/**"
+              - ".github/actions/build-libkrun-static-linux/**"
               - ".github/actions/materialize/**"
 
   build-linux:
@@ -117,10 +121,20 @@ jobs:
         # explicitly since we use --no-install-recommends. cpio: packs the
         # guest initramfs (scripts/build-initramfs.sh). git: source fetches
         # during the CLI build.
+        #
+        # musl-tools: musl-gcc, the linker for the static-musl minvmd this lane
+        # now builds and boots (scripts/build-libkrun-linux.sh and the cargo
+        # build below both need it).
         run: |
           sudo sh -c \
             'apt-get update && apt-get install -y --no-install-recommends \
-               protobuf-compiler libprotobuf-dev cpio git'
+               protobuf-compiler libprotobuf-dev cpio git musl-tools'
+
+      - name: Add musl target
+        # Installs into the rust-toolchain.toml-pinned toolchain, which is what
+        # build-libkrun-linux.sh resolves and carries across its cd into the
+        # fetched libkrun tree.
+        run: rustup target add x86_64-unknown-linux-musl
 
       - name: Install cross + nextest
         uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2
@@ -141,21 +155,32 @@ jobs:
           key: ${{ runner.os }}-x86_64-minvmd-kvm-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-x86_64-minvmd-kvm-
 
-      - name: Materialize libkrun prefix (upstream package)
-        # Needed at BUILD time: minvmd links libkrun.so (build.rs link search
-        # + the minvmd_libkrun cfg for the real, non-stub impl). The prefix is
-        # shipped in the testbed so the test job runs against the exact
-        # libraries this job linked. Runs after the cargo cache restore so the
-        # CLI build the cache fetch drives is incremental.
-        uses: ./.github/actions/setup-libkrun-linux
+      - name: Build static libkrun (musl)
+        # Needed at BUILD time: minvmd links libkrun (build.rs link search +
+        # the minvmd_libkrun cfg for the real, non-stub impl).
+        #
+        # STATIC, matching what Linux users receive. This lane is the only
+        # pre-merge proof that boots a real microVM, so it has to boot the
+        # linkage we distribute: a dynamic build here would leave the shipped
+        # static one first exercised by nightly, after merge. The merge and
+        # objcopy-localize pass that produces libkrun.a is exactly the kind of
+        # change that links clean and misbehaves at runtime, so it needs a boot
+        # test, not a symbol check.
+        uses: ./.github/actions/build-libkrun-static-linux
         with:
-          arch: x86_64
+          target: x86_64-unknown-linux-musl
 
       - name: Build guest initramfs (minimald as /init)
         run: ./scripts/build-initramfs.sh "$RUNNER_TEMP/initramfs.cpio" x86_64-unknown-linux-musl
 
-      - name: Build minvmd
-        run: cargo build -p minvmd --bin minvmd --locked
+      - name: Build minvmd (static musl)
+        # Same target and same linkage as the release build, so what boots
+        # below is what ships. MINVMD_REQUIRE_LIBKRUN=static makes a build.rs
+        # that failed to find libkrun.a a hard error instead of a silent stub
+        # that would "pass" every test by bailing at VM boot.
+        env:
+          MINVMD_REQUIRE_LIBKRUN: static
+        run: cargo build -p minvmd --bin minvmd --locked --target x86_64-unknown-linux-musl
 
       - name: Build the minimal CLI
         # SEPARATE invocation from the minvmd build: a combined `cargo build
@@ -169,19 +194,29 @@ jobs:
         # `cargo nextest archive` replaces the hand-rolled testbins.json
         # manifest: the archive carries every minvmd test binary with exec
         # bits intact, and the test job selects harnesses with filtersets.
-        # The sidecar files stay explicit — libkrun lives outside target/ (an
-        # archive cannot carry it), and the harnesses/CLI locate minvmd via
+        # The sidecar files stay explicit — the harnesses/CLI locate minvmd via
         # MINVMD_BIN / PATH (their compile-time CARGO_BIN_EXE path does not
         # exist on the test runner).
+        #
+        # The harnesses link libkrun too, so they are archived for the SAME
+        # musl target with the same requirement; a native-gnu archive would
+        # test a different binary than the one shipped. No libkrun sidecar
+        # travels with the testbed any more: it is inside these binaries.
+        env:
+          MINVMD_REQUIRE_LIBKRUN: static
         run: |
           set -euo pipefail
           mkdir -p testbed
-          cargo nextest archive -p minvmd --locked --archive-file testbed/nextest-archive.tar.zst
-          cp target/debug/minvmd testbed/minvmd
+          cargo nextest archive -p minvmd --locked \
+            --target x86_64-unknown-linux-musl \
+            --archive-file testbed/nextest-archive.tar.zst
+          cp target/x86_64-unknown-linux-musl/debug/minvmd testbed/minvmd
           cp target/debug/min testbed/min
           cp "$RUNNER_TEMP/initramfs.cpio" testbed/initramfs.cpio
-          # Ship the exact libkrun prefix the binaries were linked against.
-          tar czf testbed/libkrun-prefix.tgz -C "$LIBKRUN_PREFIX" .
+          # Prove it before it leaves this job: a dynamically-linked minvmd
+          # here means the lane silently stopped testing what we distribute.
+          file testbed/minvmd | grep -q 'statically linked' \
+            || { echo "::error::built minvmd is not statically linked"; file testbed/minvmd; exit 1; }
 
       - name: Upload testbed
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -251,23 +286,22 @@ jobs:
         # harnesses at the shipped minvmd (their baked CARGO_BIN_EXE path only
         # exists on the build runner); the testbed joins PATH so the CLI's
         # autospawn and the lifecycle script resolve minvmd/minimal by name.
-        # The libkrun prefix is unpacked to the same $HOME/.krun path the
-        # build linked (rpath) and exported for the dynamic loader; its
-        # krun_add_disk3 export was verified at build time by the
-        # setup-libkrun-linux composite — minvmd loading it here is the
-        # runtime backstop.
+        #
+        # No libkrun prefix, no LD_LIBRARY_PATH: minvmd links libkrun
+        # statically and dlopens nothing, so there is nothing for the loader to
+        # find. Asserted rather than assumed — if this binary ever goes back to
+        # a dynamic link, the VM boots below would start depending on host
+        # state that the shipped binary does not have.
         run: |
           set -euo pipefail
           TESTBED="$RUNNER_TEMP/testbed"
           chmod +x "$TESTBED/minvmd" "$TESTBED/min"
-          mkdir -p "$HOME/.krun"
-          tar xzf "$TESTBED/libkrun-prefix.tgz" -C "$HOME/.krun"
+          file "$TESTBED/minvmd" | grep -q 'statically linked' \
+            || { echo "::error::testbed minvmd is not statically linked"; file "$TESTBED/minvmd"; exit 1; }
           echo "$TESTBED" >> "$GITHUB_PATH"
           {
             echo "TESTBED=$TESTBED"
             echo "MINVMD_BIN=$TESTBED/minvmd"
-            echo "LIBKRUN_PREFIX=$HOME/.krun"
-            echo "LD_LIBRARY_PATH=$HOME/.krun${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
             echo "MINVMD_E2E=1"
             echo "MINVMD_KERNEL_PATH=$RUNNER_TEMP/vmlinuz"
             echo "MINVMD_ROOTFS_PATH=$RUNNER_TEMP/rootfs.img"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -231,7 +231,9 @@ jobs:
               run: |
                   set -euo pipefail
                   bin="$RUNNER_TEMP/bin/minvmd"
-                  file "$bin" | grep -q 'statically linked' \
+                  # x86_64-musl emits a static PIE, which file(1) reports as
+                  # "static-pie linked"; aarch64-musl reports "statically linked".
+                  file "$bin" | grep -qE 'statically linked|static-pie linked' \
                     || { echo "::error::shipped minvmd is not statically linked"; file "$bin"; exit 1; }
                   echo "shipped minvmd is self-contained; no libkrun on the host"
             - name: Point the microVM env at the shipped guest artifacts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -147,11 +147,10 @@ jobs:
         # DM3 (native Linux + a minvmd/libkrun microVM): boot a REAL microVM from
         # the SHIPPED minvmd and pass the session e2e over the vsock bridge, the
         # same proof ci-linux-kvm's `test-kvm` runs. Every moving part is a
-        # downloaded release artifact: the native-glibc `minvmd`, the guest kernel
-        # + ext4 rootfs + initramfs, and the pinned gvproxy switch. libkrun itself
-        # is NOT shipped on Linux (users resolve it from the system / the upstream
-        # package), so it is materialized here exactly as the release build linked
-        # it, reusing the shipped static `mip` to drive the cache fetch.
+        # downloaded release artifact: the static-musl `minvmd`, the guest kernel
+        # + ext4 rootfs + initramfs, and the pinned gvproxy switch. Nothing is
+        # materialized and no LD_LIBRARY_PATH is set — minvmd links libkrun
+        # statically and dlopens nothing, so the host needs no libkrun at all.
         needs: [release]
         runs-on: ubuntu-latest # x86_64; KVM-capable
         timeout-minutes: 30
@@ -177,9 +176,11 @@ jobs:
                   sudo udevadm trigger --name-match=kvm
                   ls -l /dev/kvm
             - name: Enable unprivileged user namespaces
-              # `mip materialize` (the libkrun cache fetch below) runs the build
-              # pipeline, which needs userns; Ubuntu 24.04 restricts it via
-              # AppArmor by default.
+              # Ubuntu 24.04 restricts unprivileged userns via AppArmor by
+              # default, and the sandboxed build the session e2e drives needs it.
+              # (This used to be justified by the libkrun `mip materialize` step,
+              # which a static minvmd made unnecessary; the e2e's own need for
+              # userns is unchanged, so the sysctl stays.)
               run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
             - name: Download shipped linux-amd64 binaries
               # Pulls min, minvmd, mip and gvproxy (plus minimald, unused on the
@@ -220,17 +221,19 @@ jobs:
                   mv "$BIN/gvproxy-linux-amd64" "$BIN/gvproxy"
                   chmod +x "$BIN/min" "$BIN/minvmd" "$BIN/mip" "$BIN/gvproxy"
                   echo "$BIN" >> "$GITHUB_PATH"
-            - name: Materialize libkrun prefix (upstream package)
-              # minvmd links libkrun.so + dlopens libkrunfw.so.5 at runtime; the
-              # Linux release ships neither (its rpath resolves them from the
-              # system / LD_LIBRARY_PATH). Reuse the shipped static mip to drive
-              # the cache fetch (no Rust toolchain) — the exact libkrun the release
-              # build linked against. Publishes LIBKRUN_PREFIX and
-              # LD_LIBRARY_PATH=$HOME/.krun to later steps.
-              uses: ./.github/actions/setup-libkrun-linux
-              with:
-                  arch: x86_64
-                  mip: ${{ runner.temp }}/bin/mip
+            - name: Verify the shipped minvmd needs no libkrun at runtime
+              # The shipped minvmd links libkrun statically and dlopens nothing,
+              # so this job no longer materializes a libkrun prefix or sets
+              # LD_LIBRARY_PATH. Assert that rather than assume it: a regression
+              # to a dynamic build would otherwise surface as a confusing
+              # loader error mid-boot, and the smoke's whole point is to run the
+              # artifact exactly as a user receives it.
+              run: |
+                  set -euo pipefail
+                  bin="$RUNNER_TEMP/bin/minvmd"
+                  file "$bin" | grep -q 'statically linked' \
+                    || { echo "::error::shipped minvmd is not statically linked"; file "$bin"; exit 1; }
+                  echo "shipped minvmd is self-contained; no libkrun on the host"
             - name: Point the microVM env at the shipped guest artifacts
               run: |
                   {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,11 @@ jobs:
               run: |
                   set -euo pipefail
                   bin=target/x86_64-unknown-linux-musl/release/minvmd-linux-amd64
-                  file "$bin" | grep -q 'statically linked' \
+                  # Both spellings are static. x86_64-musl emits a static PIE,
+                  # which file(1) calls "static-pie linked"; aarch64-musl emits a
+                  # plain static executable, "statically linked". Neither has a
+                  # PT_INTERP or a DT_NEEDED, which is the property we want.
+                  file "$bin" | grep -qE 'statically linked|static-pie linked' \
                     || { echo "::error::$bin is not statically linked"; file "$bin"; exit 1; }
                   # The KVM backend's bindgen types are only present when libkrun
                   # is really linked in; the stub carries none of them.
@@ -326,7 +330,8 @@ jobs:
               run: |
                   set -euo pipefail
                   bin=target/aarch64-unknown-linux-musl/release/minvmd-linux-arm64
-                  file "$bin" | grep -q 'statically linked' \
+                  # See the amd64 job for why both file(1) spellings are accepted.
+                  file "$bin" | grep -qE 'statically linked|static-pie linked' \
                     || { echo "::error::$bin is not statically linked"; file "$bin"; exit 1; }
                   strings -a "$bin" | grep -q 'kvm_run' \
                     || { echo "::error::$bin does not contain libkrun's KVM backend (stub build?)"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,31 +182,51 @@ jobs:
                   name: minimald-linux-amd64
                   path: target/x86_64-unknown-linux-musl/release/minimald-linux-amd64
                   retention-days: 7
-            - name: Materialize libkrun prefix (upstream package)
-              # minvmd links libkrun's KVM backend dynamically, so unlike the three
-              # binaries above it can't join the static-musl cross build — it needs a
-              # native glibc build against a real libkrun. Reuse the static mip built
-              # above (mip:) instead of letting the fetch compile a second, debug mip
-              # just to drive the cache fetch.
-              uses: ./.github/actions/setup-libkrun-linux
+            - name: Build static libkrun (musl)
+              # Static libkrun.a from the vendored pin, so minvmd JOINS the
+              # static-musl build instead of being the one binary that can't.
+              # Publishes LIBKRUN_PREFIX; build.rs reads the .a there, selects a
+              # static link and records no rpath. libkrunfw is not involved —
+              # minvmd supplies its own kernel, and a static musl binary cannot
+              # dlopen one anyway. See gominimal/minimal#1065.
+              uses: ./.github/actions/build-libkrun-static-linux
               with:
-                  arch: x86_64
-                  mip: ${{ github.workspace }}/target/x86_64-unknown-linux-musl/release/mip-linux-amd64
-            - name: Build native minvmd binary
-              # Native host target (x86_64-unknown-linux-gnu), NOT musl: the binary
-              # links libkrun.so (and libkrunfw.so.5 is dlopen'd at runtime), so unlike
-              # the three above it is not self-contained — running it still needs those
-              # .so's reachable via rpath/LD_LIBRARY_PATH. LIBKRUN_PREFIX — published
-              # by the setup-libkrun-linux composite above — drives the build.rs link
-              # search and the `minvmd_libkrun` cfg (real, non-stub impl).
+                  target: x86_64-unknown-linux-musl
+            - name: Build static minvmd binary
+              # Same musl target as the three above, and self-contained for the
+              # same reason: nothing to resolve at load time, no lib/ sibling, no
+              # glibc floor. Its own cargo invocation so the fat-LTO link does
+              # not overlap theirs (see the build step above).
+              #
+              # MINVMD_REQUIRE_LIBKRUN=static: without it, a build.rs that fails
+              # to find libkrun quietly emits a runtime-bailing STUB that
+              # compiles and links perfectly well. That default keeps stock
+              # Linux CI green, but here it would ship. Demanding the static
+              # link turns the regression into a build error naming the prefix.
+              env:
+                  MINVMD_REQUIRE_LIBKRUN: static
               run: |
-                  cargo build --release --locked -p minvmd --bin minvmd
-                  mv target/release/minvmd target/release/minvmd-linux-amd64
+                  cargo build --release --locked --target x86_64-unknown-linux-musl -p minvmd --bin minvmd
+                  mv target/x86_64-unknown-linux-musl/release/minvmd target/x86_64-unknown-linux-musl/release/minvmd-linux-amd64
+            - name: Verify minvmd is static and links libkrun
+              # Both halves matter and neither is implied by a successful build:
+              # a stub minvmd (build.rs found no libkrun) also compiles and
+              # links, and would ship as a binary that bails at VM boot.
+              run: |
+                  set -euo pipefail
+                  bin=target/x86_64-unknown-linux-musl/release/minvmd-linux-amd64
+                  file "$bin" | grep -q 'statically linked' \
+                    || { echo "::error::$bin is not statically linked"; file "$bin"; exit 1; }
+                  # The KVM backend's bindgen types are only present when libkrun
+                  # is really linked in; the stub carries none of them.
+                  strings -a "$bin" | grep -q 'kvm_run' \
+                    || { echo "::error::$bin does not contain libkrun's KVM backend (stub build?)"; exit 1; }
+                  echo "minvmd OK: static, libkrun linked ($(stat -c%s "$bin") bytes)"
             - name: Upload binary (minvmd)
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: minvmd-linux-amd64
-                  path: target/release/minvmd-linux-amd64
+                  path: target/x86_64-unknown-linux-musl/release/minvmd-linux-amd64
                   retention-days: 7
 
     build-release-linux-arm64:
@@ -284,6 +304,38 @@ jobs:
               with:
                   name: minimald-linux-arm64
                   path: target/aarch64-unknown-linux-musl/release/minimald-linux-arm64
+                  retention-days: 7
+            - name: Build static libkrun (musl)
+              # See the amd64 job. arm64 had no minvmd artifact at all before
+              # this — the dynamic build needed a native glibc host per arch, and
+              # only amd64 got one. A static musl build has no such constraint,
+              # so the two Linux arches finally ship the same set of binaries.
+              uses: ./.github/actions/build-libkrun-static-linux
+              with:
+                  target: aarch64-unknown-linux-musl
+            - name: Build static minvmd binary
+              # See the amd64 job for MINVMD_REQUIRE_LIBKRUN.
+              env:
+                  MINVMD_REQUIRE_LIBKRUN: static
+              run: |
+                  cargo build --release --locked --target aarch64-unknown-linux-musl -p minvmd --bin minvmd
+                  mv target/aarch64-unknown-linux-musl/release/minvmd target/aarch64-unknown-linux-musl/release/minvmd-linux-arm64
+            - name: Verify minvmd is static and links libkrun
+              # See the amd64 job: a stub minvmd builds and links cleanly too, so
+              # neither half of this is implied by the build succeeding.
+              run: |
+                  set -euo pipefail
+                  bin=target/aarch64-unknown-linux-musl/release/minvmd-linux-arm64
+                  file "$bin" | grep -q 'statically linked' \
+                    || { echo "::error::$bin is not statically linked"; file "$bin"; exit 1; }
+                  strings -a "$bin" | grep -q 'kvm_run' \
+                    || { echo "::error::$bin does not contain libkrun's KVM backend (stub build?)"; exit 1; }
+                  echo "minvmd OK: static, libkrun linked ($(stat -c%s "$bin") bytes)"
+            - name: Upload binary (minvmd)
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+              with:
+                  name: minvmd-linux-arm64
+                  path: target/aarch64-unknown-linux-musl/release/minvmd-linux-arm64
                   retention-days: 7
 
     build-release-macos-arm64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,7 @@ jobs:
               run: |
                   set -euo pipefail
                   bin=target/x86_64-unknown-linux-musl/release/minvmd-linux-amd64
+                  syms="$RUNNER_TEMP/minvmd-amd64.strings"
                   # Both spellings are static. x86_64-musl emits a static PIE,
                   # which file(1) calls "static-pie linked"; aarch64-musl emits a
                   # plain static executable, "statically linked". Neither has a
@@ -223,7 +224,15 @@ jobs:
                     || { echo "::error::$bin is not statically linked"; file "$bin"; exit 1; }
                   # The KVM backend's bindgen types are only present when libkrun
                   # is really linked in; the stub carries none of them.
-                  strings -a "$bin" | grep -q 'kvm_run' \
+                  #
+                  # Dump once, then assert against the FILE, never against a live
+                  # pipe: `grep -q` exits at its first match and SIGPIPEs the
+                  # `strings -a` walking a ~10 MB binary, and under `pipefail`
+                  # that producer's death fails the step — so a PASSING check
+                  # reads as a stub build and kills a good release. Same reason
+                  # scripts/build-libkrun-linux.sh materializes its nm output.
+                  strings -a "$bin" > "$syms"
+                  grep -q 'kvm_run' "$syms" \
                     || { echo "::error::$bin does not contain libkrun's KVM backend (stub build?)"; exit 1; }
                   echo "minvmd OK: static, libkrun linked ($(stat -c%s "$bin") bytes)"
             - name: Upload binary (minvmd)
@@ -330,10 +339,14 @@ jobs:
               run: |
                   set -euo pipefail
                   bin=target/aarch64-unknown-linux-musl/release/minvmd-linux-arm64
-                  # See the amd64 job for why both file(1) spellings are accepted.
+                  syms="$RUNNER_TEMP/minvmd-arm64.strings"
+                  # See the amd64 job for why both file(1) spellings are accepted,
+                  # and why the symbol check runs against a dumped file rather
+                  # than a live `strings | grep -q` pipe under pipefail.
                   file "$bin" | grep -qE 'statically linked|static-pie linked' \
                     || { echo "::error::$bin is not statically linked"; file "$bin"; exit 1; }
-                  strings -a "$bin" | grep -q 'kvm_run' \
+                  strings -a "$bin" > "$syms"
+                  grep -q 'kvm_run' "$syms" \
                     || { echo "::error::$bin does not contain libkrun's KVM backend (stub build?)"; exit 1; }
                   echo "minvmd OK: static, libkrun linked ($(stat -c%s "$bin") bytes)"
             - name: Upload binary (minvmd)

--- a/crates/minvmd/build.rs
+++ b/crates/minvmd/build.rs
@@ -29,6 +29,21 @@
 //!   Linux-only workflow stays green; a Linux host *with* libkrun builds the
 //!   real implementation with a plain `cargo build -p minvmd`.
 //! - **Other targets**: stub only; never links libkrun.
+//!
+//! ## Static libkrun (musl)
+//!
+//! A prefix holding `libkrun.a` (built by `scripts/build-libkrun-linux.sh`)
+//! selects a static link instead: this emits `minvmd_libkrun_static`, which
+//! flips the `#[link]` in `src/krun/raw.rs` to `kind = "static"`, and no rpath
+//! is recorded — a statically linked binary has nothing to resolve at load
+//! time. That is what lets minvmd ship to Linux as a single self-contained
+//! musl binary rather than a glibc build trailing `libkrun.so` and
+//! `libkrunfw.so.5` (gominimal/minimal#1065).
+//!
+//! The archive wins when both it and a shared object are present: a prefix
+//! containing both is a dev host that has materialized the upstream package
+//! and then built the static one, and the static link is the shipping
+//! configuration.
 
 use std::path::Path;
 
@@ -46,11 +61,16 @@ const LINUX_LIB_DIRS: &[&str] = &[
     "/usr/lib/aarch64-linux-gnu",
 ];
 
+/// The static libkrun archive, as staged by `scripts/build-libkrun-linux.sh`.
+/// Its presence in the prefix is what selects a static link over a dynamic one.
+const STATIC_LIB: &str = "libkrun.a";
+
 fn main() {
     println!("cargo:rerun-if-env-changed=LIBKRUN_PREFIX");
     // Declared so `#[cfg(minvmd_libkrun)]` does not trip the unexpected-cfgs
     // lint under `-D warnings`.
     println!("cargo::rustc-check-cfg=cfg(minvmd_libkrun)");
+    println!("cargo::rustc-check-cfg=cfg(minvmd_libkrun_static)");
 
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
@@ -73,7 +93,20 @@ fn main() {
 
     if let Some(prefix) = prefix {
         println!("cargo:rustc-link-search=native={prefix}");
-        emit_rpaths(&target_os, &prefix);
+
+        // A `libkrun.a` in the prefix selects the static link. Linux only: the
+        // macOS pipeline builds and ships a dylib, and quietly switching that
+        // proven path because some other libkrun install happened to drop an
+        // archive in /opt/homebrew/lib would be a surprise, not a feature.
+        if target_os == "linux" && Path::new(&prefix).join(STATIC_LIB).exists() {
+            // No rpath: a static link resolves at build time, so there is
+            // nothing for the loader to search for. The `#[link]` kind is
+            // flipped in src/krun/raw.rs by this cfg.
+            println!("cargo::rustc-cfg=minvmd_libkrun_static");
+        } else {
+            emit_rpaths(&target_os, &prefix);
+        }
+
         println!("cargo::rustc-cfg=minvmd_libkrun");
     }
 }
@@ -134,8 +167,10 @@ fn find_libkrun_prefix() -> Option<String> {
         .map(|dir| (*dir).to_string())
 }
 
-/// True when `dir` contains a `libkrun.so*` file (the bare `.so` link or a
-/// versioned soname such as `libkrun.so.1`).
+/// True when `dir` contains a linkable libkrun: a `libkrun.so*` (the bare `.so`
+/// link or a versioned soname such as `libkrun.so.1`) or the static
+/// [`STATIC_LIB`] archive. Either form makes the directory a usable prefix;
+/// which link model it selects is decided in [`main`].
 fn dir_has_libkrun(dir: &str) -> bool {
     let Ok(entries) = std::fs::read_dir(Path::new(dir)) else {
         return false;
@@ -144,6 +179,6 @@ fn dir_has_libkrun(dir: &str) -> bool {
         entry
             .file_name()
             .to_str()
-            .is_some_and(|name| name.starts_with("libkrun.so"))
+            .is_some_and(|name| name.starts_with("libkrun.so") || name == STATIC_LIB)
     })
 }

--- a/crates/minvmd/build.rs
+++ b/crates/minvmd/build.rs
@@ -74,6 +74,7 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(minvmd_libkrun_static)");
 
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
 
     // Real backend is opt-in via the `libkrun` feature (default on; the `minimal`
     // CLI opts out). Off => stub, and no dependent binary inherits libkrun's
@@ -92,10 +93,18 @@ fn main() {
         })
         .flatten();
 
-    let has_static = prefix
-        .as_deref()
-        .is_some_and(|p| target_os == "linux" && Path::new(p).join(STATIC_LIB).exists());
-    enforce_requirement(prefix.as_deref(), has_static);
+    // `scripts/build-libkrun-linux.sh` only ever produces a MUSL archive (it
+    // rejects a non-musl triple outright), so the target env must match too.
+    // Gating on `target_os` alone let a default `*-linux-gnu` build pointed at
+    // a staged prefix select `kind = "static"` and try to link a musl
+    // staticlib into a glibc binary — and, worse, let it satisfy
+    // `MINVMD_REQUIRE_LIBKRUN=static`, whose whole job is to prove the shipped
+    // link model. A gnu build now falls back to the dynamic path, or fails the
+    // requirement honestly.
+    let has_static = prefix.as_deref().is_some_and(|p| {
+        target_os == "linux" && target_env == "musl" && Path::new(p).join(STATIC_LIB).exists()
+    });
+    enforce_requirement(prefix.as_deref(), has_static, &target_env);
 
     if let Some(prefix) = prefix {
         println!("cargo:rustc-link-search=native={prefix}");
@@ -134,7 +143,7 @@ fn main() {
 ///   dynamic is acceptable.
 ///
 /// Unset (or `0`) preserves the stub-on-miss behaviour.
-fn enforce_requirement(prefix: Option<&str>, has_static: bool) {
+fn enforce_requirement(prefix: Option<&str>, has_static: bool, target_env: &str) {
     let requirement = std::env::var("MINVMD_REQUIRE_LIBKRUN").unwrap_or_default();
     if requirement.is_empty() || requirement == "0" {
         return;
@@ -150,6 +159,18 @@ fn enforce_requirement(prefix: Option<&str>, has_static: bool) {
     };
 
     if requirement == "static" && !has_static {
+        // Distinguish the two ways `static` can go unmet: no archive at all,
+        // versus a non-musl target that must not consume the musl archive even
+        // when one is staged. Reporting "no libkrun.a" for a gnu build whose
+        // prefix visibly contains one sends the reader hunting the wrong thing.
+        if !target_env.is_empty() && target_env != "musl" {
+            panic!(
+                "MINVMD_REQUIRE_LIBKRUN=static but the target env is `{target_env}`, not `musl`. \
+                 {STATIC_LIB} is built for musl only (scripts/build-libkrun-linux.sh rejects any \
+                 other triple), so it cannot be linked into this build. Build for a \
+                 *-unknown-linux-musl target, or drop the `static` requirement."
+            );
+        }
         panic!(
             "MINVMD_REQUIRE_LIBKRUN=static but no {STATIC_LIB} in {prefix}; the build would link \
              libkrun DYNAMICALLY and produce a binary that needs libkrun.so at runtime. Build the \

--- a/crates/minvmd/build.rs
+++ b/crates/minvmd/build.rs
@@ -67,6 +67,7 @@ const STATIC_LIB: &str = "libkrun.a";
 
 fn main() {
     println!("cargo:rerun-if-env-changed=LIBKRUN_PREFIX");
+    println!("cargo:rerun-if-env-changed=MINVMD_REQUIRE_LIBKRUN");
     // Declared so `#[cfg(minvmd_libkrun)]` does not trip the unexpected-cfgs
     // lint under `-D warnings`.
     println!("cargo::rustc-check-cfg=cfg(minvmd_libkrun)");
@@ -91,6 +92,11 @@ fn main() {
         })
         .flatten();
 
+    let has_static = prefix
+        .as_deref()
+        .is_some_and(|p| target_os == "linux" && Path::new(p).join(STATIC_LIB).exists());
+    enforce_requirement(prefix.as_deref(), has_static);
+
     if let Some(prefix) = prefix {
         println!("cargo:rustc-link-search=native={prefix}");
 
@@ -98,7 +104,7 @@ fn main() {
         // macOS pipeline builds and ships a dylib, and quietly switching that
         // proven path because some other libkrun install happened to drop an
         // archive in /opt/homebrew/lib would be a surprise, not a feature.
-        if target_os == "linux" && Path::new(&prefix).join(STATIC_LIB).exists() {
+        if has_static {
             // No rpath: a static link resolves at build time, so there is
             // nothing for the loader to search for. The `#[link]` kind is
             // flipped in src/krun/raw.rs by this cfg.
@@ -108,6 +114,47 @@ fn main() {
         }
 
         println!("cargo::rustc-cfg=minvmd_libkrun");
+    }
+}
+
+/// Turn the silent stub fallback into a hard build error, when asked.
+///
+/// The default is deliberately permissive: a Linux host with no libkrun builds
+/// the stub, which is what keeps stock Linux CI green. The cost is that a build
+/// which SHOULD have linked libkrun and didn't — a release job whose libkrun
+/// step regressed, say — still succeeds, and ships a binary that compiles,
+/// links, and then bails at VM boot. Nothing in the build catches it.
+///
+/// `MINVMD_REQUIRE_LIBKRUN` is the opt-in that closes that gap; the release
+/// lanes set it. Values:
+///
+/// - `static` — a `libkrun.a` must have been found and the link must be static.
+///   This is what a shipped Linux `minvmd` requires.
+/// - anything else non-empty and not `0` — some libkrun must have been found;
+///   dynamic is acceptable.
+///
+/// Unset (or `0`) preserves the stub-on-miss behaviour.
+fn enforce_requirement(prefix: Option<&str>, has_static: bool) {
+    let requirement = std::env::var("MINVMD_REQUIRE_LIBKRUN").unwrap_or_default();
+    if requirement.is_empty() || requirement == "0" {
+        return;
+    }
+
+    let Some(prefix) = prefix else {
+        panic!(
+            "MINVMD_REQUIRE_LIBKRUN={requirement} but no libkrun was found, so this build would \
+             silently produce a STUB minvmd that bails at VM boot. Set LIBKRUN_PREFIX to a \
+             directory holding libkrun.a (static, see scripts/build-libkrun-linux.sh) or \
+             libkrun.so, or unset MINVMD_REQUIRE_LIBKRUN to allow the stub."
+        );
+    };
+
+    if requirement == "static" && !has_static {
+        panic!(
+            "MINVMD_REQUIRE_LIBKRUN=static but no {STATIC_LIB} in {prefix}; the build would link \
+             libkrun DYNAMICALLY and produce a binary that needs libkrun.so at runtime. Build the \
+             archive with scripts/build-libkrun-linux.sh, or drop the `static` requirement."
+        );
     }
 }
 

--- a/crates/minvmd/src/krun/raw.rs
+++ b/crates/minvmd/src/krun/raw.rs
@@ -111,7 +111,11 @@ pub enum SyncMode {
 //   context cannot be reused after this call.
 // - Return values are i32: zero or positive on success, negative errno on
 //   failure. [`crate::error::VmError::check_backend`] translates these.
-#[link(name = "krun")]
+// Link kind is chosen by build.rs. `minvmd_libkrun_static` is emitted when the
+// resolved prefix holds a `libkrun.a` (Linux/musl, the self-contained shipping
+// build); otherwise libkrun is a shared object resolved via rpath at load time.
+#[cfg_attr(minvmd_libkrun_static, link(name = "krun", kind = "static"))]
+#[cfg_attr(not(minvmd_libkrun_static), link(name = "krun"))]
 unsafe extern "C" {
     // ----- smoke-test bring-up surface -----
 

--- a/docs/internal/release-pipeline.md
+++ b/docs/internal/release-pipeline.md
@@ -33,10 +33,15 @@ override for green-but-unreported commits.
 **Build jobs.**
 
 - `build-release-linux-{amd64,arm64}`: static musl builds of `mip`, `min`
-  (package `minimal`), and `minimald`, one cargo invocation per package so the
-  fat-LTO links serialize. The amd64 job also builds a native-glibc
-  `minvmd` against a materialized libkrun prefix (there is currently no
-  `minvmd-linux-arm64` release artifact).
+  (package `minimal`), `minimald`, and `minvmd`, one cargo invocation per
+  package so the fat-LTO links serialize. `minvmd` links a static `libkrun.a`
+  built from the vendored pin by the `build-libkrun-static-linux` composite
+  ([`scripts/build-libkrun-linux.sh`](../../scripts/build-libkrun-linux.sh)),
+  so it ships as a single self-contained binary with no `lib/` sibling, no
+  RUNPATH, and no glibc floor — and both arches ship it, where only amd64 had
+  a (dynamic) `minvmd` before. Each job asserts the result is `statically
+  linked` and really contains the KVM backend, since a stub `minvmd` builds
+  and links just as cleanly.
 - `build-release-macos-arm64` (self-hosted Apple Silicon, gated on the
   `RUN_MACOS_CI` kill-switch): builds `minvmd` (libkrun /
   Hypervisor.framework) and `min`, rewrites minvmd's libkrun linkage to
@@ -144,12 +149,12 @@ SHA-256-verifies, and atomically installs the file. The on-disk hash is the
 skip oracle, so reruns only touch changed components, and a running daemon is
 stopped before an executable is swapped. Per-platform sets (from
 stage-release.sh's `COMPONENTS` table): Linux amd64/arm64 get `bin/min`,
-`bin/mip`, `bin/minimald`, `bin/gvproxy-min`, a `git-remote-min` symlink, and
-the AppArmor profile/tunable/loader under `data/`; macOS arm64 gets `bin/min`,
+`bin/mip`, `bin/minimald`, `bin/minvmd`, `bin/gvproxy-min`, a `git-remote-min`
+symlink, the guest payload (`data/{vmlinuz,rootfs.img,initramfs.cpio}`), and the
+AppArmor profile/tunable/loader under `data/`; macOS arm64 gets `bin/min`,
 `bin/minvmd`, `bin/gvproxy-min`, `lib/libkrun.1.dylib`, the `git-remote-min`
-symlink, and the guest payload (`data/{vmlinuz,rootfs.img,initramfs.cpio}`).
-`minvmd` is not in the Linux set yet — see
-[#980](https://github.com/gominimal/minimal/issues/980).
+symlink, and the same guest payload. Only macOS carries a `lib/` component:
+the Linux `minvmd` links libkrun statically.
 It also wires shell integration (PATH init files, `min` completions, one
 marker-fenced rc block). `--uninstall` reverses all of it offline from the
 local install record, keeping user-modified files unless `--force`;

--- a/docs/internal/release-pipeline.md
+++ b/docs/internal/release-pipeline.md
@@ -40,8 +40,9 @@ override for green-but-unreported commits.
   so it ships as a single self-contained binary with no `lib/` sibling, no
   RUNPATH, and no glibc floor — and both arches ship it, where only amd64 had
   a (dynamic) `minvmd` before. Each job asserts the result is `statically
-  linked` and really contains the KVM backend, since a stub `minvmd` builds
-  and links just as cleanly.
+  linked` or `static-pie linked` (amd64 musl emits a static PIE, which
+  `file(1)` names differently) and really contains the KVM backend, since a
+  stub `minvmd` builds and links just as cleanly.
 - `build-release-macos-arm64` (self-hosted Apple Silicon, gated on the
   `RUN_MACOS_CI` kill-switch): builds `minvmd` (libkrun /
   Hypervisor.framework) and `min`, rewrites minvmd's libkrun linkage to

--- a/scripts/build-libkrun-linux.sh
+++ b/scripts/build-libkrun-linux.sh
@@ -135,8 +135,24 @@ echo "building static libkrun for $TARGET (blk,net; no gpu, no init-blob, no lib
 #     [target.'cfg(target_env = "musl")']
 #     rustflags = ["--cfg", "musl_v1_2_3"]
 # which is load-bearing for a musl build. Running from the minimal repo root
-# with --manifest-path (as build-libkrun-macos.sh does) silently drops it.
+# with --manifest-path (as build-libkrun-macos.sh used to) silently drops it.
 #
+# But rustup resolves rust-toolchain.toml from the CWD too, and leaving the repo
+# would silently fall back to the DEFAULT toolchain — which is not the pinned
+# one and, in CI, is not the toolchain `rustup target add` installed the musl
+# target into (the build then dies with "can't find crate for `core`"). So
+# resolve the pin HERE, where rust-toolchain.toml still applies, and carry it
+# across the cd.
+#
+# This is a correctness requirement, not just convenience: libkrun.a is a Rust
+# staticlib linked into a Rust binary, and Rust has no stable ABI. libkrun and
+# minvmd must come out of the same rustc.
+if command -v rustup >/dev/null 2>&1; then
+  RUSTUP_TOOLCHAIN="$(cd "$ROOT" && rustup show active-toolchain 2>/dev/null | cut -d' ' -f1)"
+  [ -n "$RUSTUP_TOOLCHAIN" ] && export RUSTUP_TOOLCHAIN
+  echo "building with toolchain ${RUSTUP_TOOLCHAIN:-<rustup default>}"
+fi
+
 # --locked: build exactly upstream's committed Cargo.lock — a silent re-resolve
 # would undermine the pinned, reproducible-build guarantee.
 (

--- a/scripts/build-libkrun-linux.sh
+++ b/scripts/build-libkrun-linux.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Build a STATIC libkrun (libkrun.a) for musl from source, at the commit pinned
+# in vendor/libkrun/libkrun.lock plus every patch in vendor/libkrun/patches/,
+# and stage it into PREFIX. The Linux twin of build-libkrun-macos.sh: same pin,
+# same patch series, same trim — a different link model.
+#
+# Why static, and why this exists at all: minvmd is the only one of the four
+# binaries that cannot ship to Linux users today, because it links libkrun.so
+# and dlopens libkrunfw.so.5. Shipping that means ~29 MB of libraries plus
+# RUNPATH machinery, a bin/lib sibling constraint, and a glibc floor on users'
+# disks. Linked statically into a musl binary, minvmd becomes self-contained
+# like min/mip/minimald — see gominimal/minimal#1065.
+#
+# libkrunfw is NOT needed and is deliberately absent. It exists only to carry a
+# bundled guest kernel, which minvmd never uses (it supplies its own via
+# ctx.set_kernel). That matters twice over here: a static musl binary CANNOT
+# dlopen at all, so a real libkrunfw dependency would be fatal rather than
+# merely wasteful; and dropping it removes a GPL-2 kernel blob from the shipped
+# closure.
+#
+# Trimmed build (identical to the macOS script's, and to the Makefile's
+# INIT_BLOB=0 config):
+#   -p libkrun            scope to the libkrun crate, so the src/input &
+#                         src/display workspace members (whose bindgen build
+#                         scripts need libclang) are never built.
+#   --no-default-features drop `init-blob`, whose build script cross-compiles a
+#                         Linux init. minvmd supplies its own initramfs.
+#   --features blk,net    blk = rootfs disk (krun_add_disk2/3), net =
+#                         virtio-net. No gpu => no libepoxy/virglrenderer. The
+#                         KVM backend is linked by src/vmm/build.rs.
+#
+# Usage: scripts/build-libkrun-linux.sh <prefix-dir> [target-triple]
+# Requires: git, a Rust toolchain with the musl target, musl-gcc, GNU binutils
+# (ld, nm, objcopy, ar).
+set -euo pipefail
+
+PREFIX="${1:?usage: build-libkrun-linux.sh <prefix-dir> [target-triple]}"
+
+case "$(uname -s)" in
+  Linux) ;;
+  *) echo "build-libkrun-linux.sh is Linux-only (got $(uname -s))" >&2; exit 1 ;;
+esac
+
+# Default to this host's musl triple; CI passes the target explicitly so one
+# runner can produce either arch.
+case "${2:-}" in
+  "") case "$(uname -m)" in
+        x86_64)  TARGET=x86_64-unknown-linux-musl ;;
+        aarch64) TARGET=aarch64-unknown-linux-musl ;;
+        *) echo "unsupported host arch $(uname -m); pass a target triple" >&2; exit 1 ;;
+      esac ;;
+  *) TARGET="$2" ;;
+esac
+
+case "$TARGET" in
+  *-linux-musl) ;;
+  *) echo "::error::target '$TARGET' is not a musl triple; this script builds the static musl libkrun" >&2; exit 1 ;;
+esac
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOCK="$ROOT/vendor/libkrun/libkrun.lock"
+VERSION="$(sed -n 's/^version=//p' "$LOCK")"
+COMMIT="$(sed -n 's/^commit=//p' "$LOCK")"
+if [ -z "$VERSION" ] || [ -z "$COMMIT" ]; then
+  echo "::error::malformed $LOCK: need version= and commit= lines" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Fetch the pinned commit directly (not the tag): a moved or deleted tag can
+# never change what we build, and GitHub serves arbitrary-sha fetches.
+echo "fetching containers/libkrun @ $COMMIT ($VERSION)"
+git -C "$WORK" init -q
+git -C "$WORK" remote add origin https://github.com/containers/libkrun
+git -C "$WORK" fetch -q --depth 1 origin "$COMMIT"
+git -C "$WORK" checkout -q FETCH_HEAD
+actual="$(git -C "$WORK" rev-parse HEAD)"
+if [ "$actual" != "$COMMIT" ]; then
+  echo "::error::fetched libkrun HEAD $actual != pinned commit $COMMIT" >&2
+  exit 1
+fi
+
+# Apply the carried patches, in sorted order, on top of the verified commit.
+# `git apply` exits non-zero on any rejected hunk and, without --reject, leaves
+# the tree untouched — so a stale patch aborts the build instead of silently
+# producing an unpatched archive.
+PATCHES="$ROOT/vendor/libkrun/patches"
+if [ -d "$PATCHES" ]; then
+  for patch in "$PATCHES"/*.patch; do
+    [ -e "$patch" ] || continue
+    echo "applying $(basename "$patch")"
+    if ! git -C "$WORK" apply --verbose "$patch"; then
+      echo "::error::$(basename "$patch") does not apply to libkrun $COMMIT ($VERSION); rebase or drop it" >&2
+      exit 1
+    fi
+  done
+fi
+
+# Upstream declares crate-type = ["cdylib", "lib"], so cargo emits no
+# libkrun.a to link. Add `staticlib`. Done here rather than as a carried
+# .patch because it is not an upstream fix — it is a property of how WE
+# consume the crate, and a context-free sed survives a pin bump that would
+# reject a line-anchored patch.
+#
+# `cdylib` stays in the list but is inert: musl targets are crt-static, so
+# cargo produces no shared object for them.
+LIBTOML="$WORK/src/libkrun/Cargo.toml"
+grep -q '^crate-type = \["cdylib", "lib"\]$' "$LIBTOML" || {
+  echo "::error::unexpected crate-type in $LIBTOML; the staticlib edit needs rebasing:" >&2
+  grep -n 'crate-type' "$LIBTOML" >&2
+  exit 1
+}
+sed -i 's/^crate-type = \["cdylib", "lib"\]$/crate-type = ["cdylib", "staticlib", "lib"]/' "$LIBTOML"
+
+echo "building static libkrun for $TARGET (blk,net; no gpu, no init-blob, no libkrunfw)"
+# `cd "$WORK"` rather than --manifest-path: cargo resolves .cargo/config.toml
+# from the CURRENT DIRECTORY, not from the manifest's directory. libkrun ships
+# one, and at this pin it carries
+#     [target.'cfg(target_env = "musl")']
+#     rustflags = ["--cfg", "musl_v1_2_3"]
+# which is load-bearing for a musl build. Running from the minimal repo root
+# with --manifest-path (as build-libkrun-macos.sh does) silently drops it.
+#
+# --locked: build exactly upstream's committed Cargo.lock — a silent re-resolve
+# would undermine the pinned, reproducible-build guarantee.
+(
+  cd "$WORK"
+  cargo build --release --locked --target "$TARGET" \
+    -p libkrun --no-default-features --features blk,net
+)
+
+RAW="$WORK/target/$TARGET/release/libkrun.a"
+test -f "$RAW" || { echo "::error::build produced no $RAW" >&2; exit 1; }
+
+# --- Merge, then localize ------------------------------------------------
+#
+# libkrun.a carries libkrun plus its whole Rust dependency closure, including a
+# copy of libstd. Linked as-is into minvmd — itself a Rust binary with its own
+# libstd — the duplicate symbols collide. The fix is to reduce the archive to a
+# single object that exports only libkrun's C API.
+#
+# ORDER IS LOAD-BEARING. objcopy over an archive rewrites each member
+# independently, so a symbol defined in one member and referenced by another
+# gets localized in the definition and becomes unresolvable from the reference.
+# Merging first with `ld -r` makes every such reference intra-object, after
+# which localization is safe.
+echo "merging archive members into one relocatable object"
+ld -r --whole-archive "$RAW" -o "$WORK/libkrun-merged.o"
+
+# Keep exactly the public C API global; localize everything else. Derived from
+# the object rather than hardcoded, so a pin that adds or removes an entry
+# point needs no edit here.
+nm -g --defined-only "$WORK/libkrun-merged.o" \
+  | awk '{print $NF}' | grep '^krun_' | sort -u > "$WORK/keep.syms"
+count="$(wc -l < "$WORK/keep.syms" | tr -d ' ')"
+[ "$count" -gt 0 ] || { echo "::error::no krun_* symbols found in the merged object" >&2; exit 1; }
+echo "keeping $count krun_* symbols global, localizing the rest"
+
+objcopy --keep-global-symbols="$WORK/keep.syms" \
+  "$WORK/libkrun-merged.o" "$WORK/libkrun-local.o"
+
+rm -f "$WORK/libkrun.a"
+ar crs "$WORK/libkrun.a" "$WORK/libkrun-local.o"
+
+# Dump the final symbol table ONCE and assert against the file, never against a
+# live pipe: under `set -o pipefail` a `grep -q` that exits on its first match
+# SIGPIPEs `nm` mid-write, and the non-zero producer fails the whole pipeline —
+# so a passing assertion reads as a failing one.
+nm -g --defined-only "$WORK/libkrun.a" > "$WORK/final.syms"
+
+# krun_add_disk3 (the /dev/vdb attach) needs libkrun >= 1.19.0 — assert the pin
+# never silently regresses below the API surface minvmd uses. Mirrors the same
+# check in build-libkrun-macos.sh and the setup-libkrun-linux composite.
+if ! grep -q ' T krun_add_disk3$' "$WORK/final.syms"; then
+  echo "::error::built libkrun lacks krun_add_disk3 (need >= 1.19.0); check the pin in $LOCK" >&2
+  exit 1
+fi
+
+# Nothing outside the C API may still be global, or the symbol collision this
+# whole pass exists to prevent is still live. Text/data/bss globals only
+# (lowercase codes are already local, `U` is an undefined import).
+leaked="$(awk '$2 ~ /^[A-TV-Z]$/ {print $NF}' "$WORK/final.syms" | grep -v '^krun_' | head -5 || true)"
+if [ -n "$leaked" ]; then
+  echo "::error::symbols outside the krun_* API are still global after localization:" >&2
+  echo "$leaked" >&2
+  exit 1
+fi
+
+mkdir -p "$PREFIX"
+cp "$WORK/libkrun.a" "$PREFIX/libkrun.a"
+echo "staged static libkrun $VERSION ($COMMIT, $TARGET) -> $PREFIX/libkrun.a"

--- a/scripts/build-libkrun-linux.sh
+++ b/scripts/build-libkrun-linux.sh
@@ -114,6 +114,20 @@ grep -q '^crate-type = \["cdylib", "lib"\]$' "$LIBTOML" || {
 }
 sed -i 's/^crate-type = \["cdylib", "lib"\]$/crate-type = ["cdylib", "staticlib", "lib"]/' "$LIBTOML"
 
+# Cross-linking to musl needs musl-gcc as the linker. A musl-native host (Alpine)
+# builds its own triple and needs nothing; a glibc host with musl-tools does.
+# Default it here — cargo's documented env form of `[target.<triple>] linker`,
+# triple uppercased with dashes as underscores — so a standalone run works
+# without the caller knowing. An explicit value always wins.
+LINKER_VAR="CARGO_TARGET_$(printf '%s' "$TARGET" | tr 'a-z-' 'A-Z_')_LINKER"
+if [ -z "${!LINKER_VAR:-}" ] && [ "$TARGET" != "$(rustc -vV | sed -n 's/^host: //p')" ]; then
+  command -v musl-gcc >/dev/null || {
+    echo "::error::$TARGET is not the host triple and musl-gcc is not installed (apt install musl-tools)" >&2
+    exit 1
+  }
+  export "$LINKER_VAR=musl-gcc"
+fi
+
 echo "building static libkrun for $TARGET (blk,net; no gpu, no init-blob, no libkrunfw)"
 # `cd "$WORK"` rather than --manifest-path: cargo resolves .cargo/config.toml
 # from the CURRENT DIRECTORY, not from the manifest's directory. libkrun ships

--- a/scripts/build-libkrun-linux.sh
+++ b/scripts/build-libkrun-linux.sh
@@ -217,8 +217,12 @@ echo "merging archive members into one relocatable object"
 # Keep exactly the public C API global; localize everything else. Derived from
 # the object rather than hardcoded, so a pin that adds or removes an entry
 # point needs no edit here.
+# `{ grep || true; }`: grep exits 1 when nothing matches, and under `pipefail`
+# that aborts the script right here — so the explanatory error below would never
+# print and a symbol-free merge would fail with no diagnostic at all. Tolerate
+# the no-match status and let the count check report it.
 "${BU_PREFIX}nm" -g --defined-only "$WORK/libkrun-merged.o" \
-  | awk '{print $NF}' | grep '^krun_' | sort -u > "$WORK/keep.syms"
+  | awk '{print $NF}' | { grep '^krun_' || true; } | sort -u > "$WORK/keep.syms"
 count="$(wc -l < "$WORK/keep.syms" | tr -d ' ')"
 [ "$count" -gt 0 ] || { echo "::error::no krun_* symbols found in the merged object" >&2; exit 1; }
 echo "keeping $count krun_* symbols global, localizing the rest"
@@ -250,6 +254,27 @@ leaked="$(awk '$2 ~ /^[A-TV-Z]$/ {print $NF}' "$WORK/final.syms" | grep -v '^kru
 if [ -n "$leaked" ]; then
   echo "::error::symbols outside the krun_* API are still global after localization:" >&2
   echo "$leaked" >&2
+  exit 1
+fi
+
+# The other half of the isolation, and the one that is easy to lose silently:
+# nothing Rust may be left UNDEFINED either. libkrun.a carries its own copy of
+# libstd; if any Rust symbol is undefined here, the final link resolves it
+# against MINVMD's libstd instead, coalescing two independent Rust runtimes
+# into one binary — the fragility this pass is meant to rule out. A clean
+# archive imports only C: musl libc plus the `_Unwind_*` ABI, which is shared
+# on purpose (one unwinder per process is correct; two would be the bug).
+#
+# This is asserted rather than assumed because the failure is invisible at
+# build time and only surfaces at VM boot, and because `ld -r` +
+# `objcopy --keep-global-symbols` is binutils behaviour, not a stability
+# contract — a toolchain upgrade is the plausible way it regresses.
+"${BU_PREFIX}nm" -u "$WORK/libkrun.a" > "$WORK/undef.syms"
+rust_undef="$(awk '{print $NF}' "$WORK/undef.syms" \
+  | { grep -E '^(_ZN|_R[a-zA-Z0-9]|__rust|rust_eh_personality)' || true; } | head -5)"
+if [ -n "$rust_undef" ]; then
+  echo "::error::libkrun.a leaves Rust symbols undefined, so its libstd would coalesce with minvmd's:" >&2
+  echo "$rust_undef" >&2
   exit 1
 fi
 

--- a/scripts/build-libkrun-linux.sh
+++ b/scripts/build-libkrun-linux.sh
@@ -31,7 +31,9 @@
 #
 # Usage: scripts/build-libkrun-linux.sh <prefix-dir> [target-triple]
 # Requires: git, a Rust toolchain with the musl target, musl-gcc, GNU binutils
-# (ld, nm, objcopy, ar).
+# (ld, nm, objcopy, ar). Cross-building additionally needs target-prefixed
+# binutils (<arch>-linux-musl-* or <arch>-linux-gnu-*); the archive rewrite
+# below refuses to run the host's on foreign objects.
 set -euo pipefail
 
 PREFIX="${1:?usage: build-libkrun-linux.sh <prefix-dir> [target-triple]}"
@@ -41,8 +43,10 @@ case "$(uname -s)" in
   *) echo "build-libkrun-linux.sh is Linux-only (got $(uname -s))" >&2; exit 1 ;;
 esac
 
-# Default to this host's musl triple; CI passes the target explicitly so one
-# runner can produce either arch.
+# Default to this host's musl triple. CI passes the target explicitly, but
+# still builds each arch on its own runner (amd64 on ubuntu-latest, arm64 on
+# ubuntu-*-arm), so those runs are native. A genuine cross-build works only
+# with target binutils installed — see the archive-rewrite section.
 case "${2:-}" in
   "") case "$(uname -m)" in
         x86_64)  TARGET=x86_64-unknown-linux-musl ;;
@@ -120,10 +124,13 @@ sed -i 's/^crate-type = \["cdylib", "lib"\]$/crate-type = ["cdylib", "staticlib"
 # triple uppercased with dashes as underscores — so a standalone run works
 # without the caller knowing. An explicit value always wins.
 LINKER_VAR="CARGO_TARGET_$(printf '%s' "$TARGET" | tr 'a-z-' 'A-Z_')_LINKER"
-# `eval`, not bash's ${!VAR} indirection: this script is otherwise POSIX, and a
-# lone bashism made `sh scripts/build-libkrun-linux.sh` die with "bad
-# substitution" on any ash/dash host (Alpine, the natural musl build box).
-eval "linker_set=\${$LINKER_VAR:-}"
+# `printenv`, not `eval` and not bash's ${!VAR}: the name is derived from
+# $TARGET, which is only suffix-validated, so `eval` would re-parse
+# caller-controlled text as shell syntax. `printenv` reads the variable without
+# a second round of expansion, and unlike ${!VAR} it is not a bashism (a lone
+# one here once made `sh scripts/build-libkrun-linux.sh` die with "bad
+# substitution" on ash/dash). Absent variable => empty, hence the `|| true`.
+linker_set="$(printenv "$LINKER_VAR" 2>/dev/null || true)"
 if [ -z "$linker_set" ] && [ "$TARGET" != "$(rustc -vV | sed -n 's/^host: //p')" ]; then
   command -v musl-gcc >/dev/null || {
     echo "::error::$TARGET is not the host triple and musl-gcc is not installed (apt install musl-tools)" >&2
@@ -180,29 +187,53 @@ test -f "$RAW" || { echo "::error::build produced no $RAW" >&2; exit 1; }
 # gets localized in the definition and becomes unresolvable from the reference.
 # Merging first with `ld -r` makes every such reference intra-object, after
 # which localization is safe.
+# Binutils must match the TARGET's architecture, not the host's. Building
+# natively (what CI does: an x86_64 runner for amd64, an arm64 runner for arm64)
+# the plain names are correct. Cross-building, they are not: the host `ld -r`
+# cannot merge objects of a foreign architecture, and the failure surfaces deep
+# in the merge as "file format not recognized" rather than as the unsupported
+# configuration it is. Prefer a target-prefixed toolchain when the arches
+# differ, and say so plainly when none is installed.
+TARGET_ARCH_BU="${TARGET%%-*}"
+HOST_ARCH_BU="$(uname -m)"
+BU_PREFIX=""
+if [ "$TARGET_ARCH_BU" != "$HOST_ARCH_BU" ]; then
+  for candidate in "${TARGET_ARCH_BU}-linux-musl-" "${TARGET_ARCH_BU}-linux-gnu-"; do
+    if command -v "${candidate}ld" >/dev/null 2>&1; then
+      BU_PREFIX="$candidate"
+      break
+    fi
+  done
+  [ -n "$BU_PREFIX" ] || {
+    echo "::error::cross-building $TARGET on $HOST_ARCH_BU needs target binutils, but neither ${TARGET_ARCH_BU}-linux-musl-ld nor ${TARGET_ARCH_BU}-linux-gnu-ld is installed. Build $TARGET on a $TARGET_ARCH_BU host, or install the cross binutils." >&2
+    exit 1
+  }
+  echo "cross-build: using ${BU_PREFIX}* binutils"
+fi
+
 echo "merging archive members into one relocatable object"
-ld -r --whole-archive "$RAW" -o "$WORK/libkrun-merged.o"
+"${BU_PREFIX}ld" -r --whole-archive "$RAW" -o "$WORK/libkrun-merged.o"
 
 # Keep exactly the public C API global; localize everything else. Derived from
 # the object rather than hardcoded, so a pin that adds or removes an entry
 # point needs no edit here.
-nm -g --defined-only "$WORK/libkrun-merged.o" \
+"${BU_PREFIX}nm" -g --defined-only "$WORK/libkrun-merged.o" \
   | awk '{print $NF}' | grep '^krun_' | sort -u > "$WORK/keep.syms"
 count="$(wc -l < "$WORK/keep.syms" | tr -d ' ')"
 [ "$count" -gt 0 ] || { echo "::error::no krun_* symbols found in the merged object" >&2; exit 1; }
 echo "keeping $count krun_* symbols global, localizing the rest"
 
-objcopy --keep-global-symbols="$WORK/keep.syms" \
+"${BU_PREFIX}objcopy" --keep-global-symbols="$WORK/keep.syms" \
   "$WORK/libkrun-merged.o" "$WORK/libkrun-local.o"
 
 rm -f "$WORK/libkrun.a"
-ar crs "$WORK/libkrun.a" "$WORK/libkrun-local.o"
+"${BU_PREFIX}ar" crs "$WORK/libkrun.a" "$WORK/libkrun-local.o"
 
 # Dump the final symbol table ONCE and assert against the file, never against a
 # live pipe: under `set -o pipefail` a `grep -q` that exits on its first match
 # SIGPIPEs `nm` mid-write, and the non-zero producer fails the whole pipeline —
 # so a passing assertion reads as a failing one.
-nm -g --defined-only "$WORK/libkrun.a" > "$WORK/final.syms"
+"${BU_PREFIX}nm" -g --defined-only "$WORK/libkrun.a" > "$WORK/final.syms"
 
 # krun_add_disk3 (the /dev/vdb attach) needs libkrun >= 1.19.0 — assert the pin
 # never silently regresses below the API surface minvmd uses. Mirrors the same

--- a/scripts/build-libkrun-linux.sh
+++ b/scripts/build-libkrun-linux.sh
@@ -120,7 +120,11 @@ sed -i 's/^crate-type = \["cdylib", "lib"\]$/crate-type = ["cdylib", "staticlib"
 # triple uppercased with dashes as underscores — so a standalone run works
 # without the caller knowing. An explicit value always wins.
 LINKER_VAR="CARGO_TARGET_$(printf '%s' "$TARGET" | tr 'a-z-' 'A-Z_')_LINKER"
-if [ -z "${!LINKER_VAR:-}" ] && [ "$TARGET" != "$(rustc -vV | sed -n 's/^host: //p')" ]; then
+# `eval`, not bash's ${!VAR} indirection: this script is otherwise POSIX, and a
+# lone bashism made `sh scripts/build-libkrun-linux.sh` die with "bad
+# substitution" on any ash/dash host (Alpine, the natural musl build box).
+eval "linker_set=\${$LINKER_VAR:-}"
+if [ -z "$linker_set" ] && [ "$TARGET" != "$(rustc -vV | sed -n 's/^host: //p')" ]; then
   command -v musl-gcc >/dev/null || {
     echo "::error::$TARGET is not the host triple and musl-gcc is not installed (apt install musl-tools)" >&2
     exit 1

--- a/scripts/build-libkrun-macos.sh
+++ b/scripts/build-libkrun-macos.sh
@@ -88,10 +88,21 @@ if [ -d "$PATCHES" ]; then
 fi
 
 echo "building trimmed libkrun (blk,net; no gpu, no init-blob)"
+# `cd "$WORK"` rather than --manifest-path: cargo resolves .cargo/config.toml
+# from the CURRENT DIRECTORY, not from the manifest's directory, so building
+# from the minimal repo root read OUR config and ignored libkrun's. Harmless in
+# what it drops here (a macOS test runner), but the same file carries
+#     [target.'cfg(target_env = "musl")']
+#     rustflags = ["--cfg", "musl_v1_2_3"]
+# which IS load-bearing for the musl build in build-libkrun-linux.sh. Fixed in
+# both places so the two scripts cannot disagree about what they compiled.
+#
 # --locked: build exactly upstream's committed Cargo.lock — a silent
 # re-resolve would undermine the pinned, reproducible-build guarantee.
-cargo build --release --locked -p libkrun --no-default-features --features blk,net \
-  --manifest-path "$WORK/Cargo.toml"
+(
+  cd "$WORK"
+  cargo build --release --locked -p libkrun --no-default-features --features blk,net
+)
 DYLIB="$WORK/target/release/libkrun.dylib"
 test -f "$DYLIB" || { echo "::error::build produced no $DYLIB" >&2; exit 1; }
 

--- a/scripts/build-libkrun-macos.sh
+++ b/scripts/build-libkrun-macos.sh
@@ -97,6 +97,14 @@ echo "building trimmed libkrun (blk,net; no gpu, no init-blob)"
 # which IS load-bearing for the musl build in build-libkrun-linux.sh. Fixed in
 # both places so the two scripts cannot disagree about what they compiled.
 #
+# rustup resolves rust-toolchain.toml from the CWD too, so leaving the repo
+# falls back to the DEFAULT toolchain instead of the pin. Resolve it here, where
+# rust-toolchain.toml still applies, and carry it across the cd.
+if command -v rustup >/dev/null 2>&1; then
+  RUSTUP_TOOLCHAIN="$(cd "$ROOT" && rustup show active-toolchain 2>/dev/null | cut -d' ' -f1)"
+  [ -n "$RUSTUP_TOOLCHAIN" ] && export RUSTUP_TOOLCHAIN
+fi
+
 # --locked: build exactly upstream's committed Cargo.lock — a silent
 # re-resolve would undermine the pinned, reproducible-build guarantee.
 (

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -104,12 +104,16 @@ fi
 #     (the installer's completion generation runs `<bin>/min`, spec R9.3), while
 #     the component and artifact names keep the crate name.
 #
-# Linux hosts install the three self-contained musl binaries plus the switch
-# binary, which `minimald` spawns for native (DM2) own-IP sessions. macOS hosts
-# additionally need minvmd and the guest microVM payload (kernel, rootfs,
-# initramfs) to boot Linux workloads under libkrun; macOS is arm64-only here,
-# and its guest is arm64, so it consumes the arm64 guest artifacts. minvmd is
-# not staged for Linux yet — see gominimal/minimal#980.
+# Every host installs self-contained musl binaries, the switch binary that
+# `minimald` spawns for own-IP sessions, and — where it can boot a microVM —
+# minvmd plus the guest payload (kernel, rootfs, initramfs). macOS is arm64-only
+# here and its guest is arm64, so it consumes the arm64 guest artifacts; Linux
+# ships both arches.
+#
+# minvmd carries NO lib/ component on Linux, unlike darwin's libkrun.1.dylib:
+# it links libkrun statically (scripts/build-libkrun-linux.sh) and dlopens
+# nothing, so there is no sibling library to place, no RUNPATH to rewrite, and
+# no glibc floor. See gominimal/minimal#1065.
 #
 # The switch installs as `bin/gvproxy-min`, NOT `bin/gvproxy`: the bin prefix is
 # `~/.local/bin`, which is on PATH, and podman/crc ship their own `gvproxy`
@@ -123,12 +127,20 @@ COMPONENTS=(
     "minimal|linux|amd64|file|bin/min|minimal-linux-amd64"
     "git-remote-min|linux|amd64|symlink|bin/git-remote-min|min"
     "gvproxy-min|linux|amd64|file|bin/gvproxy-min|gvproxy-linux-amd64"
+    "minvmd|linux|amd64|file|bin/minvmd|minvmd-linux-amd64"
+    "initramfs|linux|amd64|file|data/initramfs.cpio|initramfs-amd64.cpio"
+    "rootfs|linux|amd64|file|data/rootfs.img|rootfs-amd64.img"
+    "vmlinuz|linux|amd64|file|data/vmlinuz|vmlinuz-amd64"
     # Linux arm64
     "minimald|linux|arm64|file|bin/minimald|minimald-linux-arm64"
     "mip|linux|arm64|file|bin/mip|mip-linux-arm64"
     "minimal|linux|arm64|file|bin/min|minimal-linux-arm64"
     "git-remote-min|linux|arm64|symlink|bin/git-remote-min|min"
     "gvproxy-min|linux|arm64|file|bin/gvproxy-min|gvproxy-linux-arm64"
+    "minvmd|linux|arm64|file|bin/minvmd|minvmd-linux-arm64"
+    "initramfs|linux|arm64|file|data/initramfs.cpio|initramfs-arm64.cpio"
+    "rootfs|linux|arm64|file|data/rootfs.img|rootfs-arm64.img"
+    "vmlinuz|linux|arm64|file|data/vmlinuz|vmlinuz-arm64"
     # macOS arm64 (darwin)
     "minimal|darwin|arm64|file|bin/min|minimal-macos-arm64"
     "git-remote-min|darwin|arm64|symlink|bin/git-remote-min|min"


### PR DESCRIPTION
First step of [#1065](https://github.com/gominimal/minimal/issues/1065): make `minvmd` buildable as a self-contained static-musl binary. **This does not wire it into the release yet** — that is the next PR, and it is where x86_64 gets proven.

## Why

`minvmd` is the only one of the four binaries that cannot ship to Linux users. `min`, `mip` and `minimald` are self-contained musl builds; `minvmd` is a native-glibc build that links `libkrun.so` and dlopens `libkrunfw.so.5`. `release.yml` states the constraint outright:

> minvmd links libkrun's KVM backend dynamically, so unlike the three binaries above it can't join the static-musl cross build — it needs a native glibc build against a real libkrun.

Shipping that as-is puts ~29 MB of libraries plus RUNPATH machinery, a `bin`/`lib` sibling constraint, and a glibc floor onto users' disks. This removes the reason to.

## `scripts/build-libkrun-linux.sh`

The Linux twin of `build-libkrun-macos.sh` — same vendored pin, same patch series, same trim, different link model. Three things it must do that the dylib build does not:

**Add `staticlib` to the crate-type.** Upstream declares `crate-type = ["cdylib", "lib"]`, so cargo emits no archive to link. Applied as a guarded `sed` rather than a carried `.patch`: this is not an upstream fix but a property of how *we* consume the crate, and a context-free edit survives a pin bump that would reject a line-anchored patch. The guard fails loudly if upstream's declaration ever changes shape.

**Merge, *then* localize — the order is load-bearing.** `libkrun.a` carries its whole Rust dependency closure, including a copy of libstd that collides with `minvmd`'s own. `ld -r --whole-archive` merges into a single object first; only then does `objcopy` cut it down to the `krun_*` globals. Doing it the other way round fails subtly: `objcopy` over an archive rewrites each member independently, so a symbol defined in one member and referenced from another gets localized at the definition and becomes unresolvable from the reference.

**Drop `libkrunfw` entirely.** It exists only to carry a bundled guest kernel that `minvmd` never uses — it supplies its own via `ctx.set_kernel`. This is what makes the whole thing possible: a static musl binary *cannot* `dlopen`, so a real `libkrunfw` dependency would have been fatal rather than merely wasteful. It also takes a GPL-2 kernel blob out of the shipped closure.

## Build-side changes

`build.rs` treats a `libkrun.a` in the resolved prefix as the selector for a static link: it emits `minvmd_libkrun_static` and records **no rpath**, since a static link has nothing to resolve at load time. `raw.rs`'s `#[link]` becomes conditional on that cfg.

Linux only, deliberately. macOS builds and ships a dylib, and quietly switching that proven path because some unrelated libkrun install happened to drop an archive in `/opt/homebrew/lib` would be a surprise, not a feature.

## Drive-by: a latent bug in the macOS script

It ran cargo with `--manifest-path` from the *minimal* repo root. Cargo resolves `.cargo/config.toml` from the **CWD**, not from the manifest's directory — so it read ours and ignored libkrun's. At the pin, that file contains:

```toml
[target.'cfg(target_env = "musl")']
rustflags = ["--cfg", "musl_v1_2_3"]
```

On darwin this only drops a test runner, which is why nobody noticed. On musl it silently drops `--cfg musl_v1_2_3`, which is load-bearing. Fixed in both scripts so the two cannot disagree about what they compiled.

## Verification

Built end-to-end on aarch64 (`rust:alpine`, GNU binutils 2.45.1):

| check | result |
|---|---|
| `libkrun.a` builds | ✅ — cargo confirms the crate-type edit landed by warning it dropped the now-inert `cdylib` for a `crt-static` target |
| symbol surface after localization | **67** `krun_*` globals, **0** non-`krun_` globals |
| `minvmd` links it | ✅ — 8,335,392-byte binary |
| `file` | `ELF 64-bit LSB executable, ARM aarch64, statically linked` |
| `ldd` | `not a valid dynamic program` — no dynamic deps at all |
| real backend, not the stub | `kvm_run`, `kvm_coalesced_mmio`, `KRUN_BLOCK_ROOT_FSTYPE` all present; no stub markers; binary runs |

~29 MB of shipped libraries becomes an 8 MB self-contained binary.

`shellcheck` clean at 0.11.0 and CI's 0.10.0. `cargo clippy -p minvmd --all-targets -- -D warnings` clean, and the static branch typechecks under a forced `--cfg minvmd_libkrun_static`.

**Not proven here:** x86_64, and actually booting a VM (needs KVM). Both belong in CI, in the follow-up that adds the release wiring.

Refs [#1065](https://github.com/gominimal/minimal/issues/1065), [#980](https://github.com/gominimal/minimal/issues/980)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build minvmd against a static musl libkrun on Linux
> - Adds [scripts/build-libkrun-linux.sh](https://github.com/gominimal/minimal/pull/1070/files#diff-cb8ac7b8a267453b00b6331f43b3d99a36f8a9f8c5cc1832354715cedb84cc3b) to build a static `libkrun.a` from source at a pinned commit, applying patches, merging archive members into a single relocatable object to localize non-`krun_*` symbols, and staging the result into a given prefix.
> - Updates [build.rs](https://github.com/gominimal/minimal/pull/1070/files#diff-adfb9d2ca5918d8192f83cf6ffe3922ac7f7041eab25d6bb29da016e6f7016ae) to detect `libkrun.a` in the prefix and emit `cfg(minvmd_libkrun_static)`; when set, rpath emission is skipped.
> - Updates the FFI extern block in [raw.rs](https://github.com/gominimal/minimal/pull/1070/files#diff-8f2259c33ed7f31bd14cb658b4ad27065d4b433dd99ff03703c24b663b8d30f9) to link `krun` with `kind = "static"` when `minvmd_libkrun_static` is set, falling back to dynamic linking otherwise.
> - Fixes the macOS build script to `cd` into the libkrun source directory so its `.cargo/config.toml` is respected, matching the Linux behavior.
> - Risk: static linking localizes non-`krun_*` symbols, which may cause conflicts if other crates in the binary also statically link libraries with overlapping symbol names.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1070 opened
>
> - Added environment variable-based build requirement enforcement and static library detection to the `minvmd` build script [697b3a9]
> - Modified `libkrun` build scripts to detect and export the active rustup toolchain from the repository root before changing directories [697b3a9]
> - Replaced bash-specific indirect expansion for reading target-specific linker environment variable with eval-based assignment to a new variable, updated conditional to test the new variable, and added a comment explaining the avoidance of bash-specific substitution for POSIX sh compatibility [9338e89]
> - Added composite action for building and staging static musl `libkrun.a` [bc6b20e]
> - Changed release workflow to build static musl `minvmd` for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets [bc6b20e]
> - Updated CI workflow to build and test static musl `minvmd` for `x86_64-unknown-linux-musl` [bc6b20e]
> - Updated nightly workflow to verify static linkage of shipped `minvmd` [bc6b20e]
> - Updated staging script and documentation to reflect static musl builds for Linux [bc6b20e]
> - Updated CI workflow validation checks to accept both 'statically linked' and 'static-pie linked' outputs from `file(1)` when verifying `minvmd` binary linkage [a26b89e]
> - Restricted static linking to musl targets only [4b51864]
> - Added cross-architecture build support with automatic binutils selection [4b51864]
> - Replaced `eval`-based environment variable reading with `printenv` [4b51864]
> - Added validation in `scripts/build-libkrun-linux.sh` to ensure the produced `libkrun.a` contains no undefined Rust symbols by running `nm -u` and filtering for Rust symbol patterns including C++ mangled symbols starting with `_ZN`, Rust v0 mangled symbols starting with `_R`, `__rust*` symbols, and `rust_eh_personality`, failing the build if any are detected [7a055e5]
> - Modified symbol extraction in `scripts/build-libkrun-linux.sh` to wrap the `grep '^krun_'` command in `{ grep '^krun_' || true; }` when generating `keep.syms` from the merged object, allowing the script to continue under `pipefail` mode when no `krun_*` symbols match and letting the subsequent explicit count check emit a diagnostic [7a055e5]
> - Replaced live piped symbol verification commands `strings -a "$bin" | grep -q 'kvm_run'` in both the amd64 and arm64 Linux release build workflows with a two-step process that first redirects `strings -a "$bin"` output to a temporary file (`$RUNNER_TEMP/minvmd-{amd64,arm64}.strings`) and then greps that file for `kvm_run` [7a055e5]
> - Clarified in `docs/internal/release-pipeline.md` that amd64 musl builds may be reported by `file(1)` as either 'statically linked' or 'static-pie linked' [7a055e5]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69f9dc6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux releases now include statically linked `minvmd` binaries with embedded libkrun support for amd64 and arm64.
  * Added Linux microVM payloads, including initramfs, rootfs, and kernel artifacts.
* **Bug Fixes**
  * Improved reliability of Linux and macOS libkrun builds.
  * Builds now validate required symbols and linkage before producing release artifacts.
* **Documentation**
  * Updated release pipeline documentation to reflect the new Linux components and static packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->