### PR TITLE
fix(ci): stop the dogfood cargo cache from silently freezing at ENOSPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,19 @@ jobs:
     dogfood:
         needs: [changes]
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+        # `actions: read` is for the cache-save verification step below; the
+        # job-level block replaces the workflow-level grant, so `contents` has
+        # to be restated for actions/checkout.
+        permissions:
+            contents: read
+            actions: read
         runs-on: ubuntu-latest
-        timeout-minutes: 20
+        # 30, not 20: a cold build (no usable cache entry) is ~13 min of cargo
+        # on top of ~1 min of disk reclaim and up to ~4 min of cache restore,
+        # which left a slow runner no margin. Run #30482500938 was cancelled
+        # mid-`Compiling mip` at exactly 20:00 and took `ci-success` red with
+        # it -- the aggregator counts `cancelled` as failure.
+        timeout-minutes: 30
         steps:
             - name: Free Disk Space
               uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3
@@ -105,6 +116,16 @@ jobs:
                   remove_android: true
                   remove_dotnet: true
                   remove_haskell: true
+                  # The tool cache (~8 GB) and the cloud CLIs go too, to keep
+                  # the save step below off the ENOSPC wall. Nothing in this job
+                  # reads either: the two JS actions run on the runner's bundled
+                  # node, `run-task` is a shell composite, and the build itself
+                  # fetches over plain HTTPS. `remove_packages` takes a
+                  # space-separated list, NOT a boolean -- the action's `main.sh`
+                  # validates for an embedded space and `exit 0`s on `true`,
+                  # which would silently skip every reclaim above as well.
+                  remove_tool_cache: true
+                  remove_packages: azure-cli google-cloud-cli
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
               with:
                   persist-credentials: false
@@ -140,6 +161,16 @@ jobs:
               with:
                   path: ~/.local/state/minimal/state
                   key: ${{ steps.cargo-cache.outputs.cache-primary-key }}
+            - name: Verify the cache actually saved (main only)
+              # A save that runs out of disk is downgraded to `##[warning]Failed
+              # to save` and leaves the job green, so the entry can freeze for
+              # days while every run silently pays a cold build. Turn that into
+              # a red main. Rationale and the incident in the script header.
+              if: github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  CACHE_KEY: ${{ steps.cargo-cache.outputs.cache-primary-key }}
+              run: scripts/ci-verify-cache-saved.sh "$CACHE_KEY"
 
     cargo-deny:
         needs: [changes]

--- a/scripts/ci-verify-cache-saved.sh
+++ b/scripts/ci-verify-cache-saved.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Fail the job when an `actions/cache` save silently did not land.
+#
+# WHY THIS EXISTS
+# ---------------
+# `actions/cache/save` tars its payload into RUNNER_TEMP and compresses it in
+# place. When that write runs out of disk, tar and zstd die and the action
+# downgrades the failure to `##[warning]Failed to save:` — the step, the job,
+# and the required check all stay green while the cache entry silently freezes
+# at whatever version last fit.
+#
+# That is not hypothetical. The `dogfood` lane's Cargo-state entry grows by
+# roughly 100 MB per save (cargo never GCs, so each run appends the new
+# lockfile's artifacts on top of every older one). At ~5.9 GB the archive
+# stopped fitting on the runner and every save from 2026-07-27 on died with
+# `zstd: error 70 : Write error : cannot write block : No space left on
+# device`. Nobody noticed for two days: each later run restored the frozen
+# entry through `restore-keys`, rebuilt the tree from scratch — 55 s of cargo
+# became 10-13 min — and the lane only went red when a slow runner finally
+# overran the job timeout, which pointed at a cancelled build rather than at
+# the cache.
+#
+# Usage: ci-verify-cache-saved.sh <cache-key>
+#
+# Needs GH_TOKEN with `actions: read` and GITHUB_REPOSITORY (both are ambient
+# in Actions). A missing entry is a hard error; an unusable API is only a
+# warning, so a token or outage problem cannot fail an otherwise good build.
+set -euo pipefail
+
+key="${1:-}"
+if [ -z "$key" ]; then
+    echo "usage: $0 <cache-key>" >&2
+    exit 2
+fi
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is not set}"
+
+if ! total="$(gh api "repos/$repo/actions/caches?key=$key" --jq '.total_count')"; then
+    echo "::warning::could not query the Actions cache API; skipping the save check for $key"
+    exit 0
+fi
+
+if [ "$total" -gt 0 ]; then
+    echo "cache entry present: $key"
+    exit 0
+fi
+
+# The save step ran and reported success, yet no entry exists. Disk is the
+# usual culprit, so print it here — this output is the whole point of the
+# check, and it is what the next person will read first.
+echo "::error::cache key $key was not saved; the save step's failure was downgraded to a warning (check the log above for 'Failed to save')"
+echo "--- df -h ---"
+df -h / "${RUNNER_TEMP:-/tmp}" || true
+exit 1


### PR DESCRIPTION
## What broke

[Run #30482500938](https://github.com/gominimal/minimal/actions/runs/30482500938) (PR #1064) showed a red `ci-success`. That job is only the messenger: `dogfood` was **cancelled**, not failed, and the aggregator accepts only `success` or `skipped`. `dogfood` was cancelled because it hit `timeout-minutes: 20` still mid-`Compiling mip`. Nothing in #1064 broke anything, it only touches `.minimal/minimal.toml`.

## Root cause

The dogfood Cargo-state cache had been frozen since 2026-07-27, and the freeze was invisible.

The entry grows on every save. Cargo never GCs, so each run restores the previous archive, appends the new lockfile's artifacts on top of every older one, and writes back bigger. From the run that seeded the last good entry ([30290858553](https://github.com/gominimal/minimal/actions/runs/30290858553)):

```
Cache hit for restore-key: dogfood-minimal-cargo-fed0923a…   (5805 MB)
Finished `dev` profile ... in 54.84s
Cache saved with key:      dogfood-minimal-cargo-42f102df…   (5918 MB)
```

At 5918 MB the archive stopped fitting. Every save since:

```
zstd: error 70 : Write error : cannot write block : No space left on device
/usr/bin/tar: cache.tzst: Wrote only 4096 of 10240 bytes
##[warning]Failed to save: "/usr/bin/tar" failed with error: … exit code 2
```

`actions/cache/save` downgrades that to a warning, so the job stayed green. Ten consecutive `main` runs sampled back to 2026-07-27T20:35Z all end this way (30480737509, 30478041284, 30475727135, 30462382952, 30425606668, 30421718357, 30303268598, 30307192493, 30315690735, 30323044555), and `gh api …/actions/caches` confirmed exactly one `dogfood-minimal-cargo-*` entry existed, `42f102…`, created 2026-07-27T17:56Z, three lockfile changes behind `main`.

So each run restored a stale entry via `restore-keys`, got little reuse across three lockfile bumps, and rebuilt the tree: **55 seconds of cargo became 10-13 minutes**. Add ~1 min of disk reclaim and ~4 min spent downloading and extracting 5.9 GB that barely helps, and `main` runs were landing at 16-17 of the 20 available minutes. This PR's run drew a slower runner (a 4-minute stall between `clap_complete` and `args`) and crossed the line.

## Changes

All in the `dogfood` job.

**Reclaim more disk.** `remove_tool_cache: true` (~8 GB) plus the two cloud CLIs, so the archive has headroom to grow again. Nothing in the job reads either: the JS actions use the runner's bundled node, `run-task` is a shell composite, and the build fetches over plain HTTPS.

Note for reviewers: `remove_packages` takes a space-separated list, **not** a boolean. The action's `main.sh` validates for an embedded space and `exit 0`s on `true` — passing a boolean would silently skip the android/dotnet/haskell reclaims too.

**Make a failed save loud.** New `scripts/ci-verify-cache-saved.sh` checks, on `main`, that the key actually exists after the save step, and fails with a `df -h` dump if not. The silent warning is the reason this ran unnoticed for two days and then surfaced as an unrelated-looking timeout. A missing entry is a hard error; an unusable API is only a warning, so a token or outage problem cannot fail an otherwise good build. This needs `actions: read`, added job-level (which replaces the workflow-level grant, hence `contents: read` restated).

**`timeout-minutes: 20` -> `30`.** Not the fix, the guard: a genuinely cold build on a slow runner should not be a red required check.

## Out-of-band

The frozen `42f102…` entry (6,205,485,947 B) has been deleted. That alone restores the fast path: the next `main` run reseeds from a build that no longer carries three lockfiles of dead artifacts, and PRs get an exact-key hit again.

## Note on the freeze

`.github/workflows/` is CODEOWNER-gated and frozen, and the contract routes new logic to `scripts/`. The verification logic lives there and is picked up by `scripts/lint-shell.sh` (25/25 scripts pass shellcheck). The three workflow edits are job config that cannot live anywhere else: an action input, a permission, and a timeout. Owner-directed.

## Verification

- `scripts/lint-shell.sh` passes (the convention test covers the new script).
- `ci.yml` parses; the `dogfood` job resolves to `timeout: 30`, `permissions: {contents: read, actions: read}`, 6 steps.
- The script was exercised against the live API on all four paths: present key -> exit 0, pruned key -> `::error::` + `df -h` + exit 1, missing arg -> exit 2, unreachable repo -> `::warning::` + exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability by increasing job time limits and freeing additional disk space before builds and caching.
  * Added validation to detect when a cache is reported as saved but is not actually available.
  * CI now reports cache-related disk issues more clearly and can fail when cache saving genuinely fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dogfood cargo cache to fail visibly on ENOSPC instead of silently freezing
> - Adds [`scripts/ci-verify-cache-saved.sh`](https://github.com/gominimal/minimal/pull/1076/files#diff-fb837e01660c501f84f13b56036ca0d2441cb05328eea404780a363da0527d26), which queries the GitHub Actions caches API for a given key and exits 1 if no entry exists, helping detect when a cache save silently failed due to disk exhaustion.
> - On `main` branch runs where the cache was not a hit, a new CI step invokes this script to confirm the cache was actually saved after the build.
> - Frees more disk space before building by also removing the runner tool cache and uninstalling `azure-cli` and `google-cloud-cli`.
> - Increases the dogfood job timeout from 20 to 30 minutes to accommodate the extra cleanup steps.
> - Behavioral Change: on `main`, the dogfood job now fails explicitly if the cargo cache save did not produce an entry, rather than succeeding silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54a9621.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->