### PR TITLE
fix(ci::dogfood): reduce compute complexity of dogfood task

### DIFF
--- a/.minimal/minimal.toml
+++ b/.minimal/minimal.toml
@@ -21,8 +21,8 @@ exec = "cargo build --verbose"
 inherit_cwd = true
 
 [tasks.build-smoke]
-description = "Smoke-test that `mip run` can build the CLI"
-exec = "cargo build -p mip"
+description = "Smoke-test that a task can build something"
+exec = "cargo build -p common"
 inherit_cwd = true
 
 [tasks.test]


### PR DESCRIPTION
<!-- PR title: use a Conventional Commit subject — `type(scope): summary`,
     imperative, lower-case, no trailing period. The PR title becomes the
     squash commit subject. See docs/commit-conventions.md. -->

## Summary

<!-- What changes, and why. Link related issues (`Refs: #123` / `Closes: #123`). -->

## Testing

<!-- What you ran (`cargo test`, `cargo clippy`, harness/e2e scripts, manual
     steps) — paste the relevant output as evidence. -->

## Checklist

- [ ] Docs updated if behavior changed
- [ ] `BREAKING CHANGE:` footer present if this is a breaking change


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dogfood CI timeout by switching `build-smoke` task to `cargo build -p common`
> Updates [minimal.toml](https://github.com/gominimal/minimal/pull/1077/files#diff-b3c5759398e8468de864c730146c85ebc5a60e59a2e4b583147a9bc92eb550a6) to run `cargo build -p common` instead of `cargo build -p mip` in the `build-smoke` task, which fixes the CI timeout in the dogfood pipeline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0feed07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build smoke test to build the `common` component using its dedicated build command.
  * Replaced the previous smoke-test description to reflect the updated build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->