### PR TITLE
fix(minimal in vm): raise rlimit to sane default

### DIFF
--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -650,6 +650,61 @@ pub fn mount_dev() {
     mount_if_absent("/dev", "devtmpfs", "devtmpfs");
 }
 
+/// Soft and hard `RLIMIT_NOFILE` the microVM's init installs, and so every
+/// session, task, and build forked from it inherits.
+///
+/// pid-1 starts at the kernel's 1024/4096 default with no service manager
+/// underneath to widen it. 64 Ki covers the fd-hungry cases (many SSH channels,
+/// a build fanning out to hundreds of processes) while staying well under the
+/// `fs.nr_open` ceiling, where the soft limit itself becomes a cost to code that
+/// closes fds by looping up to it.
+pub const DEFAULT_MICROVM_NOFILE_LIMIT: u64 = 65536;
+
+/// Raises `RLIMIT_NOFILE`, soft and hard, to `limit`; returns the soft limit in
+/// force afterwards, which can be below `limit` (see the fallback).
+pub fn raise_nofile_limit(limit: u64) -> std::io::Result<u64> {
+    let current = get_nofile_limit()?;
+    let target = limit as libc::rlim_t;
+    if current.rlim_cur >= target {
+        return Ok(current.rlim_cur);
+    }
+
+    // The kernel rejects a hard limit above `fs.nr_open` outright rather than
+    // clamping, so an overshooting request fails wholesale. Fall back to the
+    // hard limit we already have — no privilege needed — instead of leaving the
+    // 1024-fd default in place.
+    if set_nofile_limit(target, target).is_err() {
+        set_nofile_limit(current.rlim_max, current.rlim_max)?;
+    }
+
+    Ok(get_nofile_limit()?.rlim_cur)
+}
+
+fn get_nofile_limit() -> std::io::Result<libc::rlimit> {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: `limit` is a live `rlimit`, which is exactly what the kernel
+    // writes through the pointer.
+    let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limit) };
+    (rc == 0)
+        .then_some(limit)
+        .ok_or_else(std::io::Error::last_os_error)
+}
+
+fn set_nofile_limit(soft: libc::rlim_t, hard: libc::rlim_t) -> std::io::Result<()> {
+    let limit = libc::rlimit {
+        rlim_cur: soft,
+        rlim_max: hard,
+    };
+    // SAFETY: `limit` is a live `rlimit` the kernel only reads from.
+    let rc = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &raw const limit) };
+    (rc == 0)
+        .then_some(())
+        .ok_or_else(std::io::Error::last_os_error)
+}
+
 const NANOS_IN_SECOND: u64 = 1_000_000_000;
 
 /// How far the guest's `CLOCK_REALTIME` may sit from the host's before we step
@@ -1283,5 +1338,26 @@ mod tests {
             .unwrap();
         assert!(reason.len() <= MOUNT_FAILED_REASON_MAX_BYTES);
         assert!(reason.chars().all(|c| c == 'é'));
+    }
+
+    /// One test, not two: it mutates process-global state, so a sibling could
+    /// race it. Unprivileged, so it covers the no-op and the fallback; raising
+    /// the hard limit as pid-1 is proved by the VM boot itself.
+    #[test]
+    fn the_open_file_limit_only_ever_goes_up() {
+        let before = get_nofile_limit().unwrap();
+        assert_eq!(
+            raise_nofile_limit(before.rlim_cur).unwrap(),
+            before.rlim_cur,
+            "asking for the limit we already have must not change it",
+        );
+
+        // Above any possible `fs.nr_open`, so the hard-limit raise is refused
+        // (EPERM) regardless of privilege and we take the fallback.
+        assert_eq!(
+            raise_nofile_limit(1 << 40).unwrap(),
+            before.rlim_max,
+            "an unreachable request must still leave us at the hard limit",
+        );
     }
 }

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -210,6 +210,14 @@ pub struct ListenArgs {
     #[clap(hide = true)]
     mk_mount_state_volume: Option<String>,
 
+    /// Raise `RLIMIT_NOFILE`, soft and hard, to this many descriptors, which
+    /// everything the daemon forks inherits. Only useful as a VM init process,
+    /// where nothing else widens the kernel's 1024-fd default; `None` keeps the
+    /// limits we were started with.
+    #[arg(long)]
+    #[clap(hide = true)]
+    rlimit_nofile: Option<u64>,
+
     /// Vsock port to listen on for host time updates: 8-byte little-endian
     /// nanoseconds-since-epoch stamps, dialed in by the host half in `minvmd`
     /// (see `guest::run_timekeep_listener`). Only useful as a VM init process;
@@ -409,6 +417,8 @@ async fn async_main() -> Result<(), MainError> {
                 mount_rootfs: Some("/dev/vda".to_string()),
                 mk_mount_state_volume: Some("/dev/vdb".to_string()),
                 detach: false,
+                // No service manager above pid-1 to widen the kernel default.
+                rlimit_nofile: Some(guest::DEFAULT_MICROVM_NOFILE_LIMIT),
                 // Host time updates arrive on a vsock stream we listen on, from
                 // minvmd. Always listen: the guest cannot see what the
                 // host runs.
@@ -471,6 +481,26 @@ async fn async_main() -> Result<(), MainError> {
 
     // Handle setup specific to operating in a micro-vm.
     use minimald::guest;
+    // Before anything forks from us and inherits the limits. Best effort: the
+    // kernel default is the prior behaviour, not a reason to refuse to boot.
+    if let Some(limit) = listen_args.rlimit_nofile {
+        match guest::raise_nofile_limit(limit) {
+            Ok(effective) if effective >= limit => {
+                tracing::debug!(nofile = effective, "raised the open-file limit");
+            }
+            Ok(effective) => tracing::warn!(
+                requested = limit,
+                effective,
+                "the open-file limit could not be raised as far as requested; fd-hungry builds \
+                 may fail with EMFILE"
+            ),
+            Err(e) => tracing::warn!(
+                error = %e,
+                requested = limit,
+                "could not raise the open-file limit; fd-hungry builds may fail with EMFILE"
+            ),
+        }
+    }
     if listen_args.mount_dev {
         guest::mount_dev();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MicroVMs now support a higher open-file limit by default.
  * Added best-effort configuration to customize the open-file limit during startup.
  * Startup now safely falls back to the highest supported limit when the requested value is unavailable.

* **Bug Fixes**
  * Improved handling of unsupported open-file limit increases without preventing VM startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise RLIMIT_NOFILE to 65536 in minimald microVM init processes
> - Adds `raise_nofile_limit` in [guest.rs](https://github.com/gominimal/minimal/pull/1085/files#diff-f0dd3922eb27e86f3e4783c7469e18c89fd5165f3a119ef03217d32b6eb51296) that sets both soft and hard `RLIMIT_NOFILE` to a requested value, falling back to the current hard limit if the request exceeds `fs.nr_open`.
> - Adds `DEFAULT_MICROVM_NOFILE_LIMIT` constant (65536) used automatically when `minimald` runs as microVM init.
> - Adds a hidden `--rlimit-nofile` CLI flag in [main.rs](https://github.com/gominimal/minimal/pull/1085/files#diff-94e641147dfc527a957e34ac84f21d47f330c992b120da13441a31765c72f981) to override the limit; the effective soft limit and any failures are logged.
> - Child processes forked by the daemon inherit the resulting limits.
> - Behavioral Change: microVM init processes now start with a soft and hard `RLIMIT_NOFILE` of 65536 instead of the system default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93e97d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->