### PR TITLE
Grammar update cli-min.md

### DIFF
--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -8,11 +8,11 @@ description: "Reference for the min session CLI: create, attach to, and manage s
 `min` is the Minimal session CLI. It talks to the `minimald` daemon (see
 [minimald](./cli-minimald.md)) to create, attach to, and manage sandboxed
 development sessions. Most commands start the daemon automatically when it
-isn't running (`bug`, `stop`, and `version` are the exceptions): natively on
-Linux, or inside the [`minvmd`](./cli-minvmd.md) microVM host daemon on macOS
-(and on Linux under `--provider local-minvmd`). Running bare `min` with no
-subcommand resolves a session for the current directory (activating one if
-needed) and attaches to it.
+isn't running, with `bug`, `stop`, and `version` being the exceptions. The 
+daemon starts natively on Linux (and under `--provider local-minvmd`) or 
+inside the [`minvmd`](./cli-minvmd.md) microVM host daemon on macOS. 
+Running bare `min` with no subcommand resolves a session for the current 
+directory (activating one if needed) and attaches to it.
 
 Commands are spelled `min <noun> <verb>`, and every noun accepts its singular
 and plural form (`session`/`sessions`, `loadout`/`loadouts`). Bare `min` and a
@@ -21,8 +21,6 @@ handful of bare verbs (`ls`, `stop`,
 exceptions, called out as such below; see
 [the CLI convention](./cli.md#command-naming-convention) for the rule and the
 full list of exceptions.
-
-Generated from `--help` at `cb29f065`.
 
 ## Global flags
 
@@ -150,12 +148,12 @@ broken install still yields a valid archive that explains what is
 missing.
 
 Diagnosing a wedged system must not change it: `bug` mutates no state and
-never starts a daemon; it works even when none is running.
+never starts a daemon; it works even when none are running.
 
 Secret-shaped values (env vars, tokens) are redacted before they enter
 the archive: only a small allowlist of env names (`RUST_LOG`, `HOME`,
 `SHELL`, `TERM`, `PATH`, and the `XDG_*` / `MINIMAL_*` / `MINVMD_*` /
-`MINIMALD_*` prefixes) has values captured verbatim (a sensitive-shaped
+`MINIMALD_*` prefixes) have values captured verbatim (a sensitive-shaped
 name always loses to the allowlist), and every other env var is reported
 by name only. Session and project file contents are never included, only
 name/size listings. Review the archive before sharing.


### PR DESCRIPTION
Super minor grammatical edits in a couple of spaces

<!-- PR title: use a Conventional Commit subject — `type(scope): summary`,
     imperative, lower-case, no trailing period. The PR title becomes the
     squash commit subject. See docs/commit-conventions.md. -->

## Summary

<!-- What changes, and why. Link related issues (`Refs: #123` / `Closes: #123`). -->

## Testing

<!-- What you ran (`cargo test`, `cargo clippy`, harness/e2e scripts, manual
     steps) — paste the relevant output as evidence. -->

## Checklist

- [ ] Docs updated if behavior changed
- [ ] `BREAKING CHANGE:` footer present if this is a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and readability in the CLI reference documentation.
  * Clarified descriptions of daemon startup behavior and environment-variable capture handling.
  * Removed an outdated generated-content marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix grammar and clarify daemon auto-start behavior in `cli-min.md`
> Updates [docs/reference/cli-min.md](https://github.com/gominimal/minimal/pull/1086/files#diff-f468e424e3aca5e5c314972c6f512d342f7746adac5a9177bfa23a1ae4c4e510) with several copy corrections: clarifies daemon auto-start contexts (natively on Linux, under `--provider local-minvmd`, and inside minvmd on macOS), fixes subject-verb agreement in the env var allowlist description, corrects plurality in the `bug` command description, and removes a stale generated-from line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9234fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->