### PR TITLE
docs(migration): fix min session commands in activate/attach example

### DIFF
--- a/docs/guide/migrate-to-minimal-session.md
+++ b/docs/guide/migrate-to-minimal-session.md
@@ -58,9 +58,9 @@ Prior to v0.5.0, `minimal.toml` had five sections: `upstream`, `harness`, `defau
 Unlike `tasks`, which supported multiple definitions each invoked with `minimal run <task>`, a project has only one `session`:
 
 ```shell
-min activate          # creates a session, prints its ID
-min attach <session ID>  # enters an existing session
-min activate --attach    # creates and enters a session in one step
+min session activate             # creates a session, prints its ID
+min session attach <session ID>  # enters an existing session
+min session activate --attach    # creates and enters a session in one step
 ```
 
 ## Profiles


### PR DESCRIPTION

<!-- PR title: use a Conventional Commit subject — `type(scope): summary`,
     imperative, lower-case, no trailing period. The PR title becomes the
     squash commit subject. See docs/commit-conventions.md. -->

## Summary

<!-- What changes, and why. Link related issues (`Refs: #123` / `Closes: #123`). -->

## Testing

<!-- What you ran (`cargo test`, `cargo clippy`, harness/e2e scripts, manual
     steps) — paste the relevant output as evidence. -->

## Checklist

- [ ] Docs updated if behavior changed
- [ ] `BREAKING CHANGE:` footer present if this is a breaking change


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `min session` command examples in migration guide
> Corrects command examples in [migrate-to-minimal-session.md](https://github.com/gominimal/minimal/pull/1090/files#diff-5e73bdda4c543bf93628b9d23a47694f5b9e5303592fd669edd1a939edd35276) to include the required `session` subcommand. Updates `min activate`, `min attach <session ID>`, and `min activate --attach` to their correct forms with the `session` subcommand.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0d60ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the migration guide to reflect the current interactive Sessions workflow.
  * Replaced legacy activation and attachment commands with the corresponding `min session` commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->