### PR TITLE
docs: link concepts pages relatively, not via docs.minimal.dev

### DIFF
--- a/docs/reference/build-specs.md
+++ b/docs/reference/build-specs.md
@@ -5,7 +5,7 @@ description: "Build spec schema for defining Minimal packages in Nickel: build_d
 
 # Build specs
 
-Build specs declare everything about a [package](https://docs.minimal.dev/concepts/packages), the fundamental unit of software
+Build specs declare everything about a [package](../concepts/packages.md), the fundamental unit of software
 in Minimal.
 
 This declaration includes:
@@ -16,7 +16,7 @@ This declaration includes:
    directories used at runtime for state, and a number of other data points.
 
 Build specs are defined in a [Nickel](https://nickel-lang.org/) file located at `packages/<package name>/build.ncl`, either in your codebase
-or any layer in your [software supply chain](https://docs.minimal.dev/concepts/software-supply-chain). The `packages/` directory in a layer is always adjacent to
+or any layer in your [software supply chain](../concepts/software-supply-chain.md). The `packages/` directory in a layer is always adjacent to
 the [`minimal.toml`](./minimal-dot-toml.md) file at its base. The directory can be omitted if the layer does not define any packages.
 
 ## Example

--- a/docs/reference/minimal-dot-toml.md
+++ b/docs/reference/minimal-dot-toml.md
@@ -53,7 +53,7 @@ exec = "bash -l"
 ### `[upstream]` - Where software comes from {#upstream}
 
 The `[upstream]` section defines the precise source of packages, stacks, and profiles. This represents the
-preceding link in the [software supply chain](https://docs.minimal.dev/concepts/software-supply-chain).
+preceding link in the [software supply chain](../concepts/software-supply-chain.md).
 
 ```toml
 [upstream]
@@ -93,7 +93,7 @@ build_packages = ["<additional build package>"]     # optional
 runtime_packages = ["<additional runtime package>"] # optional
 ```
 
-The `[stack]` section configures the [stack](https://docs.minimal.dev/concepts/stacks) to use for building code, if any.
+The `[stack]` section configures the [stack](../concepts/stacks.md) to use for building code, if any.
 See [stack specs](./stack-specs.md) for how stacks themselves are defined.
 
 `use` is an accepted alias for the canonical `name` key; both parse. `[harness]`
@@ -115,7 +115,7 @@ profile = "<profile name>" # optional
 state_key = "<state key>"  # optional
 ```
 
-When set, `defaults.profile` will set a [profile](https://docs.minimal.dev/concepts/profiles) on all tasks which do not set a profile.
+When set, `defaults.profile` will set a [profile](../concepts/profiles.md) on all tasks which do not set a profile.
 
 When set, `defaults.state_key` will set a state key on all tasks which do not set `state_key`.
 
@@ -123,7 +123,7 @@ When set, `defaults.state_key` will set a state key on all tasks which do not se
 
 ### `[session]` - What every contributor's session gets {#session}
 
-Contributes to [sessions](https://docs.minimal.dev/concepts/sessions) activated
+Contributes to [sessions](../concepts/sessions.md) activated
 on this project (`min session activate`). It carries the same primitives as a
 [loadout](./loadouts.md) (packages, vars, patches, lifecycle hooks), scoped to
 the project rather than the developer: where a loadout says "what this

--- a/docs/reference/stack-specs.md
+++ b/docs/reference/stack-specs.md
@@ -8,7 +8,7 @@ description: "Stack spec schema for defining build system stacks in Nickel: pack
 Stacks specify a set of tools and how to use them in a codebase. They encapsulate a common pattern for building software.
 
 Stacks are defined in a [Nickel](https://nickel-lang.org/) file located at `stacks/<stack name>/stack.ncl`, either in your codebase
-or any layer in your [software supply chain](https://docs.minimal.dev/concepts/software-supply-chain). The `stacks/` directory in a layer is always adjacent to
+or any layer in your [software supply chain](../concepts/software-supply-chain.md). The `stacks/` directory in a layer is always adjacent to
 the [`minimal.toml`](./minimal-dot-toml.md) file at the base of the layer. The directory can be omitted if the layer does not define any stacks.
 
 ## Examples

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -16,7 +16,7 @@ Tasks are defined in a `[tasks.<task-name>]` block in your minimal file.
 
 _Optional_
 
-`packages` lists additional [packages](https://docs.minimal.dev/concepts/packages) which will be installed in the tasks'
+`packages` lists additional [packages](../concepts/packages.md) which will be installed in the tasks'
 runtime environment. Packages listed here are in addition to any installed due to the profile or stack.
 
 ```toml


### PR DESCRIPTION
Eight links in the reference docs point at `https://docs.minimal.dev/concepts/...` instead of the relative `../concepts/*.md` form used everywhere else. That breaks GitHub-native reading (no in-repo navigation) and bounces readers of the webapp's `/docs` rendering out to the external host.

This converts all eight to relative links. All targets exist in `docs/concepts/`. Deliberately untouched: `tasks.md`'s `echo = "Docs live at https://docs.minimal.dev"` (example content, not a link) and the prose mention in `docs/internal/release-pipeline.md`.

Context: found while shipping gominimal/webapp#491 — the webapp now also rewrites these at render time (`rewriteDocsHostHref`), which keeps older promoted shas working; this PR fixes the source of truth so newly synced docs are right by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K131eRfYxJ5YdY1v3iMULi

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Convert absolute docs.minimal.dev links to relative paths in reference docs
> Updates concept links in four reference docs ([build-specs.md](https://github.com/gominimal/minimal/pull/1094/files#diff-ad12d4b17e2a2a038ffa30fde4b66eed48ef6a368925aa2d4942cb5cab63bb7b), [minimal-dot-toml.md](https://github.com/gominimal/minimal/pull/1094/files#diff-0245bb0859ba1be2420371a0c6491c493e8e649541ac2c224f9a8fd928bc2159), [stack-specs.md](https://github.com/gominimal/minimal/pull/1094/files#diff-a67f4aa8e1cdaaccf0b9e651e0e300e88671b0dd54a13bad1c7b3bf85eaf5e0f), [tasks.md](https://github.com/gominimal/minimal/pull/1094/files#diff-bce6d0e6bae925167b7bec524622e6a06aede5b880999f7f1923b672b8f818dc)) to use relative paths instead of absolute URLs pointing to docs.minimal.dev. This ensures links work correctly in local previews and non-production environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57d5c32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference documentation links to use local pages for packages, software supply chains, stacks, and sessions.
  * Improved readability of session configuration guidance by separating related descriptions into distinct paragraphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->