### PR TITLE
docs(reference): drop the "generated from --help" tagline

### DIFF
--- a/docs/reference/cli-minimald.md
+++ b/docs/reference/cli-minimald.md
@@ -12,8 +12,6 @@ microVM). End users normally never run it by hand: `min` auto-starts a
 native daemon on Linux, and [minvmd](./cli-minvmd.md) supervises it
 inside the microVM.
 
-Generated from `--help` at `3a05252c`.
-
 ## Global flags
 
 | Flag | Short | Description |

--- a/docs/reference/cli-minvmd.md
+++ b/docs/reference/cli-minvmd.md
@@ -11,8 +11,6 @@ description: "Ops reference for the minvmd VM daemon: boots and supervises the L
 the only session backend; on Linux it is selected with `min --provider local-minvmd`
 (see [min](./cli-min.md)).
 
-Generated from `--help` at `3a05252c`.
-
 ## Global flags
 
 | Flag | Description |

--- a/docs/reference/cli-mip.md
+++ b/docs/reference/cli-mip.md
@@ -14,8 +14,6 @@ content-addressed local cache.
 > the package/build plane directly. Most workflows are better served by the
 > [`min` session CLI](./cli-min.md).
 
-Generated from `--help` at `d9f20165`.
-
 ## Global flags
 
 These apply to every subcommand.


### PR DESCRIPTION
Removes the "Generated from `--help` at `<sha>`." line from the CLI reference pages for `mip`, `minimald`, and `minvmd`.

Team decision from #frontend: Alyssa asked whether the line should be on the pages, and the thread agreed it shouldn't. Karl approved the change.

## There is no generator

The obvious risk here was deleting a line that tooling would reinstate on the next regeneration. It won't — the CLI reference pages are hand-maintained:

- The string `Generated from` appears nowhere in the repo outside `docs/reference/`, in the current tree or anywhere in history (`git log --all -S`).
- No doc-generation tooling exists: nothing in `crates/`, `scripts/`, the `justfile`, or `.github/workflows/` writes to `docs/reference/`. The only clap doc-adjacent dependency is `clap_complete`, which generates shell completions, not markdown.
- The shas were inconsistent across pages (`d9f20165` for mip, `3a05252c` for minimald and minvmd, and `cb29f065` in cli-min.md before it was removed), which is what hand-written "as of" notes look like, not the output of a single generation pass.
- `cli-min.md` already had the line removed by hand in 9c1723e ("Grammar update cli-min.md"), and nothing put it back.

So the fix is the deletion itself; there is no generator to change.

## Files touched

- `docs/reference/cli-mip.md`
- `docs/reference/cli-minimald.md`
- `docs/reference/cli-minvmd.md`

Each line was its own paragraph between the intro prose and `## Global flags`; the line and one adjacent blank line came out, leaving no double blank lines. `cli-min.md` needed no change.

#1094 (`docs: link concepts pages relatively`) is already merged and touches a disjoint set of files (`build-specs.md`, `minimal-dot-toml.md`, `stack-specs.md`, `tasks.md`), so there is no overlap or rebase needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K131eRfYxJ5YdY1v3iMULi


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove "Generated from --help" tagline from CLI reference docs
> Drops the auto-generated attribution line (e.g. `Generated from --help at 3a05252c`) from [cli-minimald.md](https://github.com/gominimal/minimal/pull/1098/files#diff-5ca48971195f7550a4dfe4cbb9e04b126c770cbe145b6a2651256f4cdc367a4a), [cli-minvmd.md](https://github.com/gominimal/minimal/pull/1098/files#diff-5f2a9a2eb5b6598af8fd31507e8bdef9f09cd4c4bad4af9c4f17abca63299ba7), and [cli-mip.md](https://github.com/gominimal/minimal/pull/1098/files#diff-562f454c0e56bf1e2de06237451cfb5f963df5cc2bb497cc0013d570ff3f3140).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49b232d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed autogenerated provenance notes from the `minimald`, `minvmd`, and `mip` CLI reference pages.
  * CLI flags, commands, descriptions, and known-issues content remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->