### PR TITLE
docs(README.md): actually remove example with authz issue this time

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,29 +72,7 @@ The examples below walk through the two most common workflows: starting a brand-
 
 ### Create a new project with Minimal
 
-In this example we'll create a new git repo from within a Minimal sandbox, using tools from the [Minimal Public Registry](https://github.com/gominimal/pkgs/). It assumes Claude Code has been granted access to your GitHub repos (via the Claude GitHub App) so it can push changes on your behalf.
-
-```shell
-mkdir -p ~/projects/foo
-cd ~/projects/foo
-
-# create and update a minimal.toml file
-min init
-min add --session git gh claude-code
-
-# start and enter a sandbox; the current directory's file tree is copied in
-min session activate --attach .
-
-git init
-
-# develop specs, generate & test code, push to GitHub, etc.
-# agents can add build/runtime dependencies from the Minimal Public Registry with "min add"
-claude
-
-exit
-```
-
-Prefer not to grant Claude Code access to your GitHub repos via the Claude GitHub App? This variant keeps the agent credential-free: it uses a fine-grained GitHub personal access token (PAT) stored in the macOS keychain, revealed to the sandbox only after the agent has exited.
+In this example we'll create a new git repo from within a Minimal sandbox, using tools from the [Minimal Public Registry](https://github.com/gominimal/pkgs/). The workflow keeps the agent credential-free: it uses a fine-grained GitHub personal access token (PAT) stored in the macOS keychain, revealed to the sandbox only after the agent has exited.
 
 First create the new, empty GitHub repo, then create a fine-grained PAT scoped to it at <https://github.com/settings/personal-access-tokens>. Store the PAT in your keychain with `security add-generic-password -s "PAT-foo-repo" -a "my-mac-user-name" -w`.
 
@@ -117,7 +95,8 @@ min session activate --attach .
 git init
 
 # develop specs, generate code, etc. — skipping permission prompts is
-# reasonable here: the agent is sealed in the sandbox with no credentials
+# reasonable here: the agent is sealed in the sandbox with no credentials;
+# agents can add build/runtime dependencies from the registry with "min add"
 claude --dangerously-skip-permissions
 
 # review the generated code before committing


### PR DESCRIPTION
## Summary

Removed first getting started example due to authz problems

## Testing

Renders correctly in my editor's markdown mode

## Checklist

- [x] Docs updated if behavior changed
- [x] `BREAKING CHANGE:` footer present if this is a breaking change


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove GitHub App example with authz issue from README
> Replaces the GitHub App-based setup flow in [README.md](https://github.com/gominimal/minimal/pull/1102/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with a credential-free workflow that uses a fine-grained GitHub PAT stored in the macOS keychain, revealed only after the agent exits. Also updates a comment in the command block to note that agents can add build/runtime dependencies via `min add`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dcb361b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Create a new project with Minimal” workflow to use a fine-grained GitHub personal access token stored securely in the macOS keychain.
  * Clarified that credentials remain unavailable inside the sandbox until the agent exits.
  * Added guidance on installing build and runtime dependencies from the registry with `min add`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->