### PR TITLE
fix: two reachable panics + two OCI image digest nondeterminisms

### DIFF
--- a/crates/lcache/src/fs.rs
+++ b/crates/lcache/src/fs.rs
@@ -7,6 +7,10 @@ use std::path::{Path, PathBuf};
 pub enum FileType {
     File,
     Dir,
+    /// Anything else found in a cache directory (symlink, socket, fifo,
+    /// device). The cache never creates these, but a walk must classify
+    /// them rather than panic.
+    Other,
 }
 
 /// An error returned from the filesystem.
@@ -53,7 +57,7 @@ impl DirEntry for std::fs::DirEntry {
             } else if ft.is_dir() {
                 FileType::Dir
             } else {
-                unreachable!();
+                FileType::Other
             }),
         }
     }

--- a/crates/mfile/src/tasks.rs
+++ b/crates/mfile/src/tasks.rs
@@ -91,8 +91,12 @@ impl Task {
         match &self.action {
             TaskAction::Exec(StrOrList::Single(s)) => Some({
                 let mut cmd = shlex::Shlex::new(s.trim());
-                let exec = cmd.next().unwrap();
-                (maybe_make_abs(&exec), cmd.collect())
+                match cmd.next() {
+                    Some(exec) => (maybe_make_abs(&exec), cmd.collect()),
+                    // No tokens (empty, whitespace, or comment-only exec
+                    // string): same shape as the empty Multiple arm below.
+                    None => ("".to_string(), vec![]),
+                }
             }),
             TaskAction::Exec(StrOrList::Multiple(v)) => Some(match v.len() {
                 0 => ("".to_string(), vec![]),
@@ -156,6 +160,16 @@ impl TaskAction {
 mod tests {
     use super::*;
     use indoc::indoc;
+
+    /// An exec string with no tokens (empty or whitespace-only) must resolve
+    /// like the empty Multiple form, not panic.
+    #[test]
+    fn exec_str_empty_does_not_panic() {
+        for raw in ["exec = \"\"", "exec = \"   \""] {
+            let t: Task = toml::from_str(raw).unwrap();
+            assert_eq!(t.exec_and_args(), Some(("".to_string(), vec![])));
+        }
+    }
 
     #[test]
     fn exec_str() {

--- a/crates/op/src/oci_image.rs
+++ b/crates/op/src/oci_image.rs
@@ -62,7 +62,7 @@ impl OciImage<'_> {
         let results =
             std::sync::Arc::new(std::sync::Mutex::new(Vec::with_capacity(all_deps.len())));
         rayon::scope(|s| {
-            for (bsr, dep) in &all_deps {
+            for (dep_idx, (bsr, dep)) in all_deps.iter().enumerate() {
                 let tokio_runtime = tokio_runtime.clone();
                 let results = results.clone();
                 let cache = opts.cache.clone();
@@ -91,16 +91,21 @@ impl OciImage<'_> {
                         &match_globs,
                         &events,
                     ));
-                    results.lock().unwrap().push(result);
+                    results.lock().unwrap().push((dep_idx, result));
                 });
             }
         });
+        // Threads finish in scheduler order; layer order is part of the
+        // manifest and therefore the image digest. Restore dep order.
+        let mut results = std::sync::Arc::into_inner(results)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        results.sort_by_key(|(dep_idx, _)| *dep_idx);
         layers.extend(
-            std::sync::Arc::into_inner(results)
-                .unwrap()
-                .into_inner()
-                .unwrap()
+            results
                 .into_iter()
+                .map(|(_, result)| result)
                 .collect::<Result<Vec<_>, _>>()?,
         );
 
@@ -145,9 +150,13 @@ impl OciImage<'_> {
                         cb = cb.cmd(cmd.to_vec());
                     };
                     if !self.vars.is_empty() {
+                        // HashMap iteration order is random per process; env
+                        // order is part of the config blob and therefore the
+                        // image digest. Sort by key.
+                        let mut vars: Vec<_> = self.vars.iter().collect();
+                        vars.sort_by_key(|(k, _)| k.as_str());
                         cb = cb.env(
-                            self.vars
-                                .iter()
+                            vars.into_iter()
                                 .map(|(k, v)| String::from_iter([k, "=", v]))
                                 .collect::<Vec<_>>(),
                         );


### PR DESCRIPTION
Four small independent fixes: two reachable panics and two sources of OCI image digest instability. None of them change `BuildSpec`, the spec-hash encoding, or any cache key — behavior only changes on inputs that previously crashed, and for OCI images whose digests were previously unstable between identical runs.

## 1. `mfile`: empty exec string panicked the task parser

`Task::exec_and_args` tokenized a task's `exec` string with `shlex` and called `.next().unwrap()` on the token stream. An `exec` that is empty, whitespace-only, or otherwise yields no tokens has no first token, so `minimal` panicked on a malformed-but-easy-to-write `minimal.toml`:

```toml
[tasks.oops]
exec = ""
```

The list form already handles this case: `exec = []` resolves to `("", [])` and fails downstream with a real error. The fix makes the string form take the same path. Regression test included (`exec_str_empty_does_not_panic`).

## 2. `lcache`: special files in a cache directory panicked the walker

`lcache`'s `DirEntry::file_type` classified entries as `File` or `Dir` and hit `unreachable!()` for anything else. But the local cache directory is ordinary host filesystem — a stray symlink, socket, or fifo (leftover tooling, a curious user, a crashed process) is entirely reachable, and one such entry made any cache walk panic. Added a `FileType::Other` variant so walks classify these instead of crashing. The cache itself never creates such entries; this only makes foreign ones survivable. No callers matched exhaustively on the enum, so no behavior changes for `File`/`Dir`.

## 3. `op`: OCI image layer order depended on thread scheduling

Image layers are built in parallel under a `rayon::scope`, and each worker pushed its finished layer into a shared `Vec` — i.e. layers landed in **completion order**, which varies run to run with thread scheduling. Layer order is part of the OCI manifest, and the manifest digest is the image digest, so two builds of the identical graph could produce different image digests. Workers now tag results with their dependency index and the results are sorted back into dependency order before manifest assembly — same layers, same content, stable order.

## 4. `op`: OCI config env order depended on HashMap iteration

The image config's `env` list was built by iterating a `HashMap` directly. Rust's `HashMap` iteration order is randomized per process, so the config blob — and with it the image digest — differed between identical builds. The vars are now sorted by key before serialization.

## Why 3 and 4 matter beyond tidiness

These made `op`'s OCI output non-reproducible even for perfectly reproducible inputs: the same graph, same artifacts, same everything produced a different image digest each run. Anything that wants to compare, cache, sign, or attest image digests needs digest stability first. (Because the previous digests were unstable, nothing could have validly pinned one — so stabilizing them breaks no existing expectation.)

## Provenance

All four were findings of the formal-verification readiness audit of minimal's pure cores (write-up circulating separately); they are its "phase 0" — fixes that stand on their own regardless of any decision about that effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix two reachable panics and two OCI image digest nondeterminisms
> - `lcache::fs::FileType` gains an `Other` variant; `file_type()` in [fs.rs](https://github.com/gominimal/minimal/pull/1105/files#diff-b4cab8ad6a1dbefef40e90acceae65c4b37266509927d614b4ea7405401b851e) returns it for symlinks, sockets, and other non-file/non-directory entries instead of calling `unreachable!()`.
> - `Task::exec_and_args()` in [tasks.rs](https://github.com/gominimal/minimal/pull/1105/files#diff-8d2b0bd24b6af583e8b4c76dbb22a783b6f73b2b49d9e50afe0aec3f18161c34) returns `Some(("", vec![]))` for empty or whitespace-only exec strings instead of panicking on an unwrap.
> - Layer order in the OCI image manifest is now deterministic: parallel layer results are sorted by dependency index after the rayon scope completes in [oci_image.rs](https://github.com/gominimal/minimal/pull/1105/files#diff-f1278e226e12338a6d3695fcc2f60ca15bfec7909b97440b7a6a0487ea8278ed).
> - Environment variables in the OCI image config are sorted by key before being written, fixing non-deterministic digest output.
> - Behavioral Change: callers matching on `lcache::fs::FileType` must now handle the new `Other` variant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8ae2d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->