### PR TITLE
build(just): link the dev stack against the static libkrun on Linux

### DIFF
--- a/justfile
+++ b/justfile
@@ -138,7 +138,7 @@ min *args:
 # Print `export` lines for running the stack by hand: eval "$(just env)".
 env:
     @printf 'export %s="%s"\n' \
-      PATH "$PATH" LD_LIBRARY_PATH "$LD_LIBRARY_PATH" \
+      PATH "$PATH" \
       MINVMD_KERNEL_PATH "$MINVMD_KERNEL_PATH" MINVMD_ROOTFS_PATH "$MINVMD_ROOTFS_PATH" \
       MINVMD_INITRAMFS "$MINVMD_INITRAMFS" \
       MINVMD_GVPROXY_BIN "{{gvproxy}}" \

--- a/justfile
+++ b/justfile
@@ -78,17 +78,20 @@ artifacts:
     @[ -f {{kernel}} ] || scripts/fetch-prebuilt.sh kernel {{kernel}} {{arch}}
     @[ -f {{rootfs}} ] || scripts/fetch-prebuilt.sh rootfs {{rootfs}} {{arch}}
 
-# Fetch prebuilt libkrun + libkrunfw into the link/runtime prefix (DYNAMIC).
-# Not used by the dev stack any more — see `libkrun-static`. Kept because
+# Not on the dev stack's path any more — see `libkrun-static`. Kept because
 # nightly-tests.yml still builds against the upstream package, and this is how
 # you reproduce that locally.
+#
+# Fetch the prebuilt DYNAMIC libkrun + libkrunfw into the link/runtime prefix.
 [linux]
 libkrun:
     scripts/fetch-prebuilt.sh krun {{krun-prefix}} {{arch}}
 
-# Build the STATIC libkrun (libkrun.a) from the vendored pin — the linkage
-# Linux users receive, and what the dev stack and `just test-vm` link.
+# The linkage Linux users actually receive, and what `minvmd-build` and
+# `test-vm` link against. Built from the vendored pin rather than fetched.
 # Skips when already built; `just clean` forces a rebuild.
+#
+# Build the STATIC libkrun (libkrun.a) from the vendored pin.
 [linux]
 libkrun-static:
     @[ -f {{krun-static}}/libkrun.a ] || scripts/build-libkrun-linux.sh {{krun-static}} {{musl-target}}
@@ -111,9 +114,11 @@ minvmd-build:
     cargo build -p minvmd --bin minvmd --locked
     codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - {{minvmd-bin}}
 
-# Build minvmd (debug, static musl) — the same target and linkage the release
-# ships, so the dev stack exercises what users run. MINVMD_REQUIRE_LIBKRUN
-# makes a missing libkrun.a an error rather than a silent runtime-bailing stub.
+# The same target and linkage the release ships, so the dev stack exercises
+# what users run. MINVMD_REQUIRE_LIBKRUN makes a missing libkrun.a an error
+# rather than a silent runtime-bailing stub.
+#
+# Build minvmd (debug, static musl against the vendored libkrun.a).
 [linux]
 minvmd-build: libkrun-static
     MINVMD_REQUIRE_LIBKRUN=static LIBKRUN_PREFIX="{{krun-static}}" \
@@ -158,9 +163,10 @@ status:
 stop:
     @"{{minvmd-bin}}" stop
 
-# Remove the bring-up artifacts this justfile manages (never all of .scratch).
 # The built libkrun.a goes too: it is keyed to the vendored pin, so a stale one
 # would silently outlive a pin bump.
+#
+# Remove the bring-up artifacts this justfile manages (never all of .scratch).
 clean:
     rm -f {{kernel}} {{rootfs}} {{initramfs}} {{gvproxy}}
     rm -rf {{scratch}}/libkrun-static

--- a/justfile
+++ b/justfile
@@ -8,15 +8,24 @@
 scratch      := justfile_directory() / ".scratch"
 arch         := arch()
 musl-target  := arch + "-unknown-linux-musl"
-# Flat libkrun link/runtime prefix (Linux; macOS links the Homebrew install).
+# Flat libkrun link/runtime prefix for the DYNAMIC upstream package (Linux;
+# macOS links the Homebrew install). No longer on the dev stack's path — kept
+# for `just libkrun`, which still fetches it.
 krun-prefix  := env('HOME') / ".krun"
+# Prefix for the STATIC libkrun the dev stack links (Linux). Built from the
+# vendored pin, not fetched; `just clean` removes it.
+krun-static  := scratch / "libkrun-static" / musl-target
 # Guest networking features baked into the initramfs (networking-wg deferred).
 features     := "networking-proxy"
 kernel       := scratch / "vmlinuz"
 rootfs       := scratch / "rootfs.img"
 initramfs    := scratch / "initramfs.cpio"
 gvproxy      := scratch / "gvproxy"
-minvmd-bin   := justfile_directory() / "target/debug/minvmd"
+# On Linux minvmd builds for the musl target (static libkrun — the linkage
+# users receive), so it lands under target/<triple>/ rather than target/debug.
+# macOS keeps the native debug dir.
+minvmd-dir   := if os() == "linux" { justfile_directory() / "target" / musl-target / "debug" } else { justfile_directory() / "target/debug" }
+minvmd-bin   := minvmd-dir / "minvmd"
 minimald-bin := justfile_directory() / "target/debug/minimald"
 # The CLI crate is `minimal`; its [[bin]] target is `min`.
 min-bin      := justfile_directory() / "target/debug/min"
@@ -37,8 +46,11 @@ e2e-env    := "E2E_VM=1 E2E_PROJECT_DIR=/tmp" + if os() == "linux" { " E2E_MINIM
 # binaries; MINVMD_* are inert outside the VM recipes. 150s timeouts: the
 # generic guest kernel can spend 40-70s probing hardware before pid-1 starts,
 # overrunning the 60s READY / 75s autospawn / 30s lifecycle defaults.
-export PATH := justfile_directory() / "target/debug:" + env('PATH')
-export LD_LIBRARY_PATH := krun-prefix + if env('LD_LIBRARY_PATH', '') == '' { '' } else { ':' + env('LD_LIBRARY_PATH') }
+#
+# minvmd-dir leads: on Linux it holds the musl build, and `min` autospawns
+# `minvmd` by bare name. No LD_LIBRARY_PATH — minvmd links libkrun statically
+# and dlopens nothing, so there is nothing for the loader to resolve.
+export PATH := minvmd-dir + ":" + justfile_directory() / "target/debug:" + env('PATH')
 export MINVMD_KERNEL_PATH := kernel
 export MINVMD_ROOTFS_PATH := rootfs
 export MINVMD_INITRAMFS := initramfs
@@ -66,10 +78,20 @@ artifacts:
     @[ -f {{kernel}} ] || scripts/fetch-prebuilt.sh kernel {{kernel}} {{arch}}
     @[ -f {{rootfs}} ] || scripts/fetch-prebuilt.sh rootfs {{rootfs}} {{arch}}
 
-# Fetch prebuilt libkrun + libkrunfw into the link/runtime prefix.
+# Fetch prebuilt libkrun + libkrunfw into the link/runtime prefix (DYNAMIC).
+# Not used by the dev stack any more — see `libkrun-static`. Kept because
+# nightly-tests.yml still builds against the upstream package, and this is how
+# you reproduce that locally.
 [linux]
 libkrun:
     scripts/fetch-prebuilt.sh krun {{krun-prefix}} {{arch}}
+
+# Build the STATIC libkrun (libkrun.a) from the vendored pin — the linkage
+# Linux users receive, and what the dev stack and `just test-vm` link.
+# Skips when already built; `just clean` forces a rebuild.
+[linux]
+libkrun-static:
+    @[ -f {{krun-static}}/libkrun.a ] || scripts/build-libkrun-linux.sh {{krun-static}} {{musl-target}}
 
 # Fetch the pinned gvproxy switch (guest egress + own-IP; missing = switchless boot).
 gvproxy:
@@ -89,10 +111,13 @@ minvmd-build:
     cargo build -p minvmd --bin minvmd --locked
     codesign --entitlements crates/minvmd/minvmd.entitlements --force -s - {{minvmd-bin}}
 
-# Build minvmd (debug); LIBKRUN_PREFIX links the real (non-stub) libkrun.
+# Build minvmd (debug, static musl) — the same target and linkage the release
+# ships, so the dev stack exercises what users run. MINVMD_REQUIRE_LIBKRUN
+# makes a missing libkrun.a an error rather than a silent runtime-bailing stub.
 [linux]
-minvmd-build: libkrun
-    LIBKRUN_PREFIX="{{krun-prefix}}" cargo build -p minvmd --bin minvmd --locked
+minvmd-build: libkrun-static
+    MINVMD_REQUIRE_LIBKRUN=static LIBKRUN_PREFIX="{{krun-static}}" \
+      cargo build -p minvmd --bin minvmd --locked --target {{musl-target}}
 
 # Build the `min` CLI.
 minimal-cli:
@@ -134,8 +159,11 @@ stop:
     @"{{minvmd-bin}}" stop
 
 # Remove the bring-up artifacts this justfile manages (never all of .scratch).
+# The built libkrun.a goes too: it is keyed to the vendored pin, so a stale one
+# would silently outlive a pin bump.
 clean:
     rm -f {{kernel}} {{rootfs}} {{initramfs}} {{gvproxy}}
+    rm -rf {{scratch}}/libkrun-static
 
 # Kill THIS checkout's stranded VM processes (they wedge the next VM's vsock bridge).
 reap:
@@ -349,8 +377,10 @@ test-vm: _nextest artifacts initramfs
 # minvmd's VM harnesses (tests/*_integration.rs). CI: ci-linux-kvm.yml `test-kvm`.
 [linux]
 test-vm: _nextest _kvm artifacts initramfs minvmd-build
-    MINVMD_E2E=1 MINVMD_BIN="{{minvmd-bin}}" XDG_STATE_HOME="{{scratch}}/test-state" LIBKRUN_PREFIX="{{krun-prefix}}" \
-      cargo nextest run -p minvmd --profile vm --run-ignored all --no-tests=fail \
+    MINVMD_E2E=1 MINVMD_BIN="{{minvmd-bin}}" XDG_STATE_HOME="{{scratch}}/test-state" \
+      MINVMD_REQUIRE_LIBKRUN=static LIBKRUN_PREFIX="{{krun-static}}" \
+      cargo nextest run -p minvmd --profile vm --target {{musl-target}} \
+      --run-ignored all --no-tests=fail \
       -E 'binary(/_integration$/) and not binary(/_root_integration$/)'
 
 # CI: ci-linux-native.yml `minimald-root-integration`. The AppArmor policy


### PR DESCRIPTION
> **Stacked on [#1070](https://github.com/gominimal/minimal/pull/1070)** (static musl libkrun), based on its branch. GitHub retargets to `main` when that merges. Independent of [#1104](https://github.com/gominimal/minimal/pull/1104) — this is the dev stack, that one is the release.

`just up` built minvmd against the **dynamic** upstream libkrun package and put `~/.krun` on `LD_LIBRARY_PATH`. Linux users receive a **static-musl** binary. The dev stack was exercising a linkage nobody ships.

Same principle as the CI change: don't develop against a configuration we don't distribute. Beyond the obvious "works locally, breaks in release" risk, it meant the merge-and-`objcopy`-localize pass that produces `libkrun.a` — the part most likely to misbehave at runtime — was never once hit by day-to-day development.

## Changes

| recipe | before | after |
|---|---|---|
| `libkrun-static` | — | **new**: builds `libkrun.a` from the vendored pin into `.scratch/libkrun-static/<triple>` |
| `minvmd-build` (Linux) | dynamic, `LIBKRUN_PREFIX=~/.krun` | musl target, static archive, `MINVMD_REQUIRE_LIBKRUN=static` |
| `test-vm` (Linux) | dynamic | same as above — a true twin of `ci-linux-kvm`'s test job |
| `clean` | — | also removes the built archive |

Two details worth calling out:

**`clean` removes `libkrun.a`.** It is keyed to the vendored pin, so a stale one would silently outlive a pin bump — exactly the failure the CI composite avoids by hashing the pin into its cache key.

**minvmd moves to `target/<triple>/debug` on Linux**, so `minvmd-dir` now leads `PATH`. `min` still autospawns `minvmd` by bare name, and every other recipe is unchanged.

**`LD_LIBRARY_PATH` export removed.** A static minvmd dlopens nothing; there is nothing for the loader to resolve.

## What stays

The `libkrun` fetch recipe remains. `nightly-tests.yml` still builds against the upstream dynamic package, and this is how you reproduce that locally — it is just no longer on the dev stack's path.

macOS is untouched: it ships a dylib and keeps the native debug dir.

## Verification

`just --evaluate` resolves the new variables correctly and every recipe parses. AGENTS.md's recipe map is updated (count, `libkrun`, new `libkrun-static`, `minvmd-build`).

**Not verified locally:** the Linux branch of the `minvmd-dir` conditional and the recipes themselves — this is a macOS host, where `[linux]` recipes don't run. `ci-linux-kvm` exercises the same script and target via [#1104](https://github.com/gominimal/minimal/pull/1104).

Refs [#1065](https://github.com/gominimal/minimal/issues/1065)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Link the Linux dev stack against a static libkrun built for the musl target
> - Adds a new `libkrun-static` recipe in [justfile](https://github.com/gominimal/minimal/pull/1108/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1) that builds `libkrun.a` for the musl target into `.scratch/libkrun-static/<musl-triple>`, skipping the build if the artifact already exists.
> - Changes the Linux `minvmd-build` recipe to depend on `libkrun-static` and build with `--target <musl-triple>`, setting `MINVMD_REQUIRE_LIBKRUN=static` and `LIBKRUN_PREFIX` to the static artifact directory.
> - Updates `minvmd-dir` to resolve to `target/<musl-triple>/debug` on Linux and `target/debug` on macOS, and removes `LD_LIBRARY_PATH` from the exported environment.
> - Updates `test-vm` on Linux to run `cargo nextest` with `--target <musl-triple>` and the static libkrun environment variables instead of the dynamic prefix.
> - Behavioral Change: the Linux dev environment no longer sets `LD_LIBRARY_PATH` and the produced `minvmd` binary is now a musl-linked static executable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1ad56d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->