### PR TITLE
refactor(min): unify interactive prompts on inquire with a brand theme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,16 +1590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
-dependencies = [
- "console",
- "shell-words",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3751,7 +3741,6 @@ dependencies = [
  "clap_complete",
  "constcat",
  "diagnostics",
- "dialoguer",
  "dirs",
  "indicatif",
  "inquire",
@@ -6158,12 +6147,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ codespan-reporting = { version = "0.13", features = ["serialization"] } # Keep i
 constcat = "0.6"
 copy_dir = "0.1.3"
 chrono = {version = "0.4", features = ["serde", "std"]}
-dialoguer = { version = "0.12", default-features = false }
 dirs = "6"
 fd-lock = "4"
 either = { version = "1.16", default-features = false }

--- a/crates/minimal/Cargo.toml
+++ b/crates/minimal/Cargo.toml
@@ -45,7 +45,6 @@ camino.workspace = true
 chrono.workspace = true
 constcat.workspace = true
 diagnostics.workspace = true
-dialoguer.workspace = true
 dirs.workspace = true
 indicatif.workspace = true
 nix.workspace = true

--- a/crates/minimal/src/attach.rs
+++ b/crates/minimal/src/attach.rs
@@ -137,10 +137,16 @@ fn last_activity(entry: &ListSessionsEntry) -> Option<chrono::DateTime<chrono::U
 /// Formats a single session as a picker row: `glyph  name | title · path`,
 /// eliding the title segment when the session has none, and tagging rows
 /// built from the current working directory so the cwd match is visible at
-/// a glance even in the "pick over all sessions" case.
+/// a glance even in the "pick over all sessions" case. Unnamed sessions
+/// render as `(unnamed) · <id-prefix>` — the first id segment is enough to
+/// tell same-path rows apart without a full UUID.
 fn format_candidate(entry: &ListSessionsEntry, cwd: &paths::HostAbsPath) -> String {
     let glyph = state_glyph(entry.status);
-    let name = entry.name.clone().unwrap_or_else(|| entry.id.to_string());
+    let name = entry.name.clone().unwrap_or_else(|| {
+        let id = entry.id.to_string();
+        let short = id.split('-').next().unwrap_or(&id);
+        format!("(unnamed) · {short}")
+    });
     let title = entry
         .attrs
         .as_ref()
@@ -476,5 +482,23 @@ mod tests {
         let label = format_candidate(&entries[0], &cwd("/a"));
         assert!(label.contains("(unknown)"), "unknown path label: {label}");
         assert!(!label.contains("(cwd)"), "no cwd marker: {label}");
+    }
+
+    #[test]
+    fn unnamed_session_shows_short_id_not_full_uuid() {
+        let e = entry(
+            "019f5d0f-0a99-78b1-9165-0809440f0052",
+            "/a",
+            SessionStatus::Active,
+        );
+        let label = format_candidate(&e, &cwd("/a"));
+        assert!(
+            label.contains("(unnamed) · 019f5d0f"),
+            "short id form: {label}"
+        );
+        assert!(
+            !label.contains("0a99-78b1"),
+            "full uuid must not appear: {label}"
+        );
     }
 }

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -21,6 +21,7 @@ mod file_upload;
 pub mod git_remote;
 pub mod loadouts;
 pub mod prompt;
+pub mod theme;
 
 #[derive(Parser)]
 #[command(name = "min", version = version::VERSION, long_version = version::LONG_VERSION)]
@@ -980,11 +981,11 @@ fn format_memory(bytes: u64) -> String {
 /// renders on stderr (so stderr must be a terminal) and reads
 /// keypresses from stdin (so stdin must be a terminal too). If
 /// either side is redirected we take the `--no-prompt` path — going
-/// interactive when stdin is a pipe just hangs `dialoguer` and then
+/// interactive when stdin is a pipe just hangs the prompt and then
 /// aborts with a much less helpful error than the `--no-prompt`
 /// snippet the operator actually wants to paste.
 fn can_prompt_interactively() -> bool {
-    dialoguer::console::user_attended() && dialoguer::console::user_attended_stderr()
+    std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
 }
 
 /// Phase 3 gate: run the user policy + hooks over the daemon's
@@ -1200,13 +1201,13 @@ async fn upload_and_finalize(
 /// Guard that tears down a half-built session if the user interrupts the
 /// activation with Ctrl-C.
 ///
-/// `dialoguer`/`console` re-raise SIGINT to this process on a Ctrl-C at
-/// the composition-gating prompt (console `unix_term.rs`). With no
-/// handler installed the default disposition kills `min` mid-prompt —
-/// before the abort-cleanup that [`drive_pending_to_active`] runs — so
-/// the daemon is left holding a `Pending` session that blocks its name.
-/// [`arm_activation_interrupt`] installs a SIGINT handler (keeping the
-/// process alive past console's re-raise) that best-effort
+/// inquire (crossterm raw mode) captures a Ctrl-C at the
+/// composition-gating prompt as an error return, so the abort-cleanup
+/// that [`drive_pending_to_active`] runs gets to execute. During the
+/// non-prompt phases (waiting on the daemon) a Ctrl-C is a plain
+/// SIGINT, which would kill `min` before that cleanup, leaving the
+/// daemon holding a `Pending` session that blocks its name.
+/// [`arm_activation_interrupt`] installs a SIGINT handler that best-effort
 /// `AbortSession`s the in-flight session over a fresh connection — the
 /// activation borrows the primary one — then exits. The daemon's
 /// connection-close reap is the backstop if the abort can't be

--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -44,6 +44,7 @@ async fn run() -> ExitCode {
     // Parse before installing the subscriber, so the shell completion handler can
     // be configured to log to stderr instead of stdout.
     let cli = minimal::Cli::parse();
+    minimal::theme::install();
 
     let registry = tracing_subscriber::registry().with(filter);
     // Commands whose stdout is a data contract route tracing to stderr, so a log

--- a/crates/minimal/src/prompt.rs
+++ b/crates/minimal/src/prompt.rs
@@ -5,7 +5,7 @@
 //! composer asks a [`PolicyHooks`] implementation what to do. This
 //! module provides two:
 //!
-//! - [`InteractivePrompt`] — the default: shows a `dialoguer::Select`
+//! - [`InteractivePrompt`] — the default: shows an `inquire::Select`
 //!   for each item with six actions (Allow once, Allow permanent,
 //!   Ignore once, Ignore permanent, Abort, Deny permanent). The
 //!   permanent actions mutate the passed-in narrow policy so
@@ -52,7 +52,7 @@ pub(crate) enum UserChoice {
 }
 
 impl UserChoice {
-    /// Label rendered as the `dialoguer::Select` option.
+    /// Label rendered as the `inquire::Select` option.
     pub(crate) fn label(self) -> &'static str {
         match self {
             Self::AllowOnce => "Allow once",
@@ -85,8 +85,14 @@ impl UserChoice {
     }
 }
 
+impl std::fmt::Display for UserChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
 /// Abstraction over "ask the user for one choice." Real code uses
-/// `dialoguer`; tests inject a scripted answer stream.
+/// `inquire`; tests inject a scripted answer stream.
 pub(crate) trait Prompter {
     /// Show `message` and let the user pick one of `options`.
     /// Returns the chosen [`UserChoice`] or an IO error if the
@@ -94,24 +100,22 @@ pub(crate) trait Prompter {
     fn ask(&self, message: &str, options: &[UserChoice]) -> io::Result<UserChoice>;
 }
 
-/// Real `dialoguer`-backed prompter. Only used by the default
+/// Real `inquire`-backed prompter. Only used by the default
 /// [`InteractivePrompt::new`] constructor.
-pub(crate) struct DialoguerPrompter;
+pub(crate) struct InquirePrompter;
 
-impl Prompter for DialoguerPrompter {
+impl Prompter for InquirePrompter {
     fn ask(&self, message: &str, options: &[UserChoice]) -> io::Result<UserChoice> {
-        let labels: Vec<&str> = options.iter().map(|c| c.label()).collect();
-        // `default(0)` puts the cursor on "Allow once" — the safest
-        // one-shot action. A habitual user gets fast Enter-through.
-        // `dialoguer::Error` predominantly wraps `io::Error`; map to
-        // that so our `Prompter` trait can stay `io::Result`-shaped.
-        let idx = dialoguer::Select::new()
-            .with_prompt(message)
-            .items(&labels)
-            .default(0)
-            .interact()
-            .map_err(io::Error::other)?;
-        Ok(options[idx])
+        // Six fixed choices: type-to-filter would be noise, so filtering
+        // stays off. The cursor starts on index 0 ("Allow once", the
+        // safest one-shot action), giving a habitual user fast
+        // Enter-through. Esc (OperationCanceled) and Ctrl-C
+        // (OperationInterrupted) surface as errors so a dismissed prompt
+        // fails the activation, which then runs its abort cleanup.
+        inquire::Select::new(message, options.to_vec())
+            .without_filtering()
+            .prompt()
+            .map_err(io::Error::other)
     }
 }
 
@@ -147,7 +151,7 @@ impl Prompter for ScriptedPrompter {
 /// A [`PolicyHooks`] implementation that walks the user through each
 /// unapproved item interactively.
 ///
-/// Construct via [`Self::new`] (uses `dialoguer` + resolves the
+/// Construct via [`Self::new`] (uses `inquire` + resolves the
 /// read-only bit from the on-disk `user_policy.toml`) or, in tests,
 /// via [`Self::with_prompter`].
 ///
@@ -174,7 +178,7 @@ pub struct InteractivePrompt {
 }
 
 impl InteractivePrompt {
-    /// Real constructor: `dialoguer` prompter + read-only detection
+    /// Real constructor: `inquire` prompter + read-only detection
     /// against `policy_path`. `initial` seeds the internal policy
     /// state so the first hook call sees the same view as the
     /// composer.
@@ -182,7 +186,7 @@ impl InteractivePrompt {
     pub fn new(policy_path: &Path, initial: sessions::core::policy::UserPolicy) -> Self {
         let (vars, patches) = initial.into_parts();
         Self {
-            prompter: Box::new(DialoguerPrompter),
+            prompter: Box::new(InquirePrompter),
             can_persist: is_writable(policy_path),
             vars_policy: RefCell::new(vars),
             patches_policy: RefCell::new(patches),

--- a/crates/minimal/src/theme.rs
+++ b/crates/minimal/src/theme.rs
@@ -20,7 +20,9 @@ pub fn theme() -> RenderConfig<'static> {
                 .with_fg(Color::White)
                 .with_attr(Attributes::BOLD),
         )
-        .with_help_message(StyleSheet::new().with_fg(Color::Grey));
+        // Empty stylesheet: help text inherits the terminal default, the
+        // same color as the prompt message itself.
+        .with_help_message(StyleSheet::new());
     config.placeholder = StyleSheet::new().with_fg(Color::Grey);
     config
 }

--- a/crates/minimal/src/theme.rs
+++ b/crates/minimal/src/theme.rs
@@ -1,0 +1,31 @@
+//! Process-wide styling for interactive prompts (inquire).
+
+use inquire::ui::{Attributes, Color, RenderConfig, StyleSheet, Styled};
+
+/// The prompt theme. Monochrome like the website: white on near-black
+/// with gray secondary text, no color accents. The `▸` marker matches
+/// the `min dash` TUI's selection cursor.
+pub fn theme() -> RenderConfig<'static> {
+    let mut config = RenderConfig::default()
+        .with_prompt_prefix(Styled::new("▸").with_fg(Color::White))
+        .with_highlighted_option_prefix(Styled::new("▸").with_fg(Color::White))
+        .with_selected_option(Some(
+            StyleSheet::new()
+                .with_fg(Color::White)
+                .with_attr(Attributes::BOLD),
+        ))
+        .with_option(StyleSheet::new().with_fg(Color::Grey))
+        .with_answer(
+            StyleSheet::new()
+                .with_fg(Color::White)
+                .with_attr(Attributes::BOLD),
+        )
+        .with_help_message(StyleSheet::new().with_fg(Color::DarkGrey));
+    config.placeholder = StyleSheet::new().with_fg(Color::DarkGrey);
+    config
+}
+
+/// Install the theme process-wide; every inquire prompt inherits it.
+pub fn install() {
+    inquire::set_global_render_config(theme());
+}

--- a/crates/minimal/src/theme.rs
+++ b/crates/minimal/src/theme.rs
@@ -20,8 +20,8 @@ pub fn theme() -> RenderConfig<'static> {
                 .with_fg(Color::White)
                 .with_attr(Attributes::BOLD),
         )
-        .with_help_message(StyleSheet::new().with_fg(Color::DarkGrey));
-    config.placeholder = StyleSheet::new().with_fg(Color::DarkGrey);
+        .with_help_message(StyleSheet::new().with_fg(Color::Grey));
+    config.placeholder = StyleSheet::new().with_fg(Color::Grey);
     config
 }
 

--- a/crates/sessions/docs/COMPOSITION.md
+++ b/crates/sessions/docs/COMPOSITION.md
@@ -194,7 +194,7 @@ declared.
 
 **Two hook implementations ship in `crates/minimal/src/prompt.rs`:**
 
-- `InteractivePrompt` — a `dialoguer::Select`-driven prompter that
+- `InteractivePrompt` — an `inquire::Select`-driven prompter that
   offers `AllowOnce` / `AllowPermanent` / `IgnoreOnce` /
   `IgnorePermanent` / `DenyPermanent` / `Abort`. Permanent choices
   mutate a `RefCell`-held policy that `save_user_policy` writes to
@@ -214,7 +214,7 @@ declared.
   `submit_verdict_and_wait` normally.
 
 The TTY probe (`can_prompt_interactively`) requires both stdin
-(where `dialoguer` reads keypresses) and stderr (where prompts
+(where `inquire` reads keypresses) and stderr (where prompts
 render) to be terminals; either being redirected takes the
 `NoPromptHook` path.
 


### PR DESCRIPTION
## Summary

The CLI had two prompt stacks: the session attach picker used inquire, the activation policy prompt used dialoguer. Both are single-select prompts, so this standardizes on inquire and drops dialoguer from the dependency tree. It also adds a process-wide prompt theme matching the website branding: monochrome, white on near-black with gray secondary text, no color accents.

Two picker legibility fixes ride along:

- Unnamed sessions rendered as full UUIDs, making same-path rows indistinguishable; they now show `(unnamed) · <id-prefix>`, matching the dash TUI.
- The keybind help line (`[↑↓ to move, ...]`) inherits the terminal default color, the same as the prompt message, instead of hard-to-read dark gray.

## Changes

| File | Change |
|---|---|
| `crates/minimal/src/theme.rs` | New module: monochrome `RenderConfig` (bold white selection, gray options, default-color help text), installed via `inquire::set_global_render_config` |
| `crates/minimal/src/prompt.rs` | `DialoguerPrompter` becomes `InquirePrompter` behind the existing `Prompter` seam; filtering off for the fixed six-choice policy prompt (`without_filtering()`); `UserChoice` gains `Display` |
| `crates/minimal/src/attach.rs` | Picker rows for unnamed sessions show a short id prefix instead of the full UUID |
| `crates/minimal/src/lib.rs` | TTY probe uses `std::io::IsTerminal` instead of `dialoguer::console`; `ActivationInterrupt` docs updated |
| `crates/minimal/src/main.rs` | Theme installed at startup |
| `Cargo.toml`, `crates/minimal/Cargo.toml`, `Cargo.lock` | dialoguer removed |
| `crates/sessions/docs/COMPOSITION.md` | References updated to inquire |

One behavior note: inquire's crossterm backend captures Ctrl-C at a prompt as an error return instead of re-raising SIGINT, so dismissing the policy prompt now flows through the normal activation error path, which runs the abort cleanup. The SIGINT guard still covers the non-prompt phases.

## Verification

- `cargo test -p minimal`: 137 pass, including a new test for the short-id picker row.
- `cargo clippy -p minimal --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- dialoguer no longer appears in `Cargo.lock`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated interactive prompts with improved keyboard handling and consistent monochrome styling.
  * Added clearer prompt behavior for terminal and non-terminal environments.
  * Applied the prompt theme consistently when the application starts.
* **Bug Fixes**
  * Improved interrupt handling for interactive prompts and non-prompt phases.
  * Simplified unnamed session labels by showing a shortened identifier.
* **Documentation**
  * Updated session composition guidance to reflect current prompt and keypress behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->