### PR TITLE
docs(AGENTS.md): make just the only build/test surface for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,10 +127,6 @@ the CI YAML schedules, the logic lives here and in `scripts/`
 only their own artifacts there (which is why `clean` is scoped, never
 `rm -rf .scratch` wholesale).
 
-One warning `just --list` does not surface, because it renders only the last
-comment line above a recipe: `just soak` reaps between iterations, which WILL
-kill this checkout's live dev stack each pass.
-
 ## Footguns
 
 Verified against the current tree; sources in parentheses.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,66 +115,21 @@ mac-buildable (see the comments in `.github/workflows/ci-macos.yml`).
 
 ## justfile recipes
 
-42 recipes on Linux, 37 on macOS (`just --summary`; OS-specific recipes carry
-`[linux]`/`[macos]` attributes, so macOS trades six Linux recipes for
-`test-cross`). The justfile is the local twin of the frozen CI workflows:
+**Run `just --list` to see every recipe available here, each with its own
+description.** Bare `just` prints the same list. That output is generated from
+the justfile, so it cannot drift; this section deliberately does not restate it.
+`[linux]`/`[macos]` attributes scope recipes per OS, so the list on your host
+already shows only what you can run on it.
+
+The justfile is the local twin of the frozen CI workflows:
 the CI YAML schedules, the logic lives here and in `scripts/`
 (docs/ci-strategy.md §8). `.scratch/` is a shared scratchpad; recipes manage
 only their own artifacts there (which is why `clean` is scoped, never
 `rm -rf .scratch` wholesale).
 
-CI-parity gates:
-
-- `ci`: the local PR gate set, cheapest first: `fmt-check clippy deny test doctest` (+ `test-ignored` on Linux). The canonical pre-PR command per [CONTRIBUTING.md](CONTRIBUTING.md#building-and-testing).
-- `fmt` / `fmt-check`: apply rustfmt across the workspace / the CI check variant (the fixer for a red `fmt-check` is `fmt`).
-- `fix`: the autofix pass — fmt, `clippy --fix` at this host's scope, fmt again; `--allow-dirty`, so it is the recipe for mid-edit iteration.
-- `clippy`: clippy over all targets with warnings denied (workspace on Linux; the darwin-capable `-p minvmd -p sessions` scope on macOS).
-- `deny`: cargo-deny's all-features check (advisories/bans/licenses/sources); a local advisories failure may just mean newer RUSTSEC data than CI's last run.
-- `test`: unit + in-process integration tests via nextest (CI profile on Linux; workspace on Linux, darwin scope on macOS).
-- `doctest`: doctests; nextest can't run them, so they are their own surface.
-- `test-ignored`: Linux: the locally-runnable `#[ignore]` tests that NO CI lane covers (the VM/netns harnesses self-skip here; `just test-vm` runs those for real).
-- `test-cross`: macOS: clippy + tests for the Linux-only crates via `cross` (musl in Docker; excludes `minvmd`). The first run compiles under emulation and can take an hour+.
-- `test-installer`: run the curl|sh installer's test harness under every available POSIX sh (+ shellcheck when present).
-- `test-promote-gate`: the promotion provenance gate's harness (stubbed `gh`, no network or auth).
-- `lint-shell`: shellcheck every script under `scripts/`, not just the installer's two (CI reaches the same check through `just test`).
-- `msrv`: the declared `package.rust-version` floor still type-checks, via cargo-hack. CI: `nightly-tests` (blocking).
-- `miri`: interpret the miri-clean crate set under nightly+miri. CI: `nightly-tests` (non-blocking).
-- `fuzz-check`: type-check every cargo-fuzz target — the bitrot guard for targets no CI lane runs (docs/fuzzing.md).
-- `fuzz crate target *args`: run one fuzz target (`just fuzz graph graph_from_bytes -max_total_time=60`); seed the corpus first.
-
-e2e & test harnesses (KVM on Linux, HVF on macOS):
-
-- `e2e`: the unified session e2e (`scripts/session-e2e.sh`) against the VM-backed daemon.
-- `e2e-native`: Linux: the SAME session e2e against a host-native `minimald`, no VM.
-- `test-vm`: `minvmd`'s VM harnesses (`tests/*_integration.rs`); on macOS this uses CI's archive pattern with the codesign as the last binary touch.
-- `test-root-integration`: Linux: `minimald`'s netns/tap proofs (the tests sudo their own netns commands); refuses to run where AppArmor restricts unprivileged userns.
-- `test-lifecycle`: daemon lifecycle proof (`run --detach` → Running → `stop` → Stopped), booted switchless like CI's step.
-- `soak n=10`: nightly soak parity: N session-e2e reps; reaps between iterations, which WILL kill this checkout's live dev stack each pass.
-- `stress n=5`: mints N sessions CONCURRENTLY against one daemon (the soak's reps are serial), then bulk-tears-down.
-- `bulk-upload n=5`: host→guest bulk-upload proof: N activations of a large, compressible project, each destroyed after.
-
-Stack bring-up & daemon lifecycle (`just up` = this host's default run mode):
-
-- `up`: macOS: Linux VM over Hypervisor.framework. Linux: host-native `minimald`, no VM, under `.scratch/native-state` (reach it via `min --minimal-dir`). Both end with a `min ls` smoke.
-- `up-kvm`: Linux: native host + one Linux VM over KVM; `minvmd` binds the CLI socket directly.
-- `down`: stop what `just up` started (macOS: delegates to `stop`; Linux: the pidfile-verified native `minimald`).
-- `status` / `stop`: report / stop (SIGTERM → SIGKILL) the supervised `minvmd`.
-- `min *args`: build `min` (+ `minimald` on Linux), then run `min` with `target/debug` on `PATH` (so auto-spawn finds the sibling daemons by name).
-- `env`: print `export` lines wiring the dev-built binaries and guest artifacts into the environment (`eval "$(just env)"`).
-- `shell`: subshell with that environment loaded.
-- `reap`: kill THIS checkout's stranded VM processes (`scripts/reap-vms.sh`); leftovers wedge the next VM's vsock bridge.
-
-Build artifacts and prerequisites:
-
-- `artifacts`: fetch the prebuilt guest kernel + generic rootfs into `.scratch` (skips when present; `clean` to force refresh).
-- `libkrun`: Linux: fetch prebuilt libkrun + libkrunfw into `~/.krun` (macOS links the Homebrew install instead).
-- `gvproxy`: fetch the pinned gvproxy switch binary into `.scratch` (missing = switchless boot).
-- `initramfs`: cross-compile `minimald` (static musl, `FEATURES` baked in) and pack it as the initramfs `/init`.
-- `minvmd-build`: build debug `minvmd` (codesigns last on macOS; links the real libkrun via `LIBKRUN_PREFIX` on Linux).
-- `minimald-build`: Linux: build a host-native `minimald` with the networking features (for `just up`).
-- `minimal-cli`: build the `min` CLI (the binary is `target/debug/min`).
-- `clean`: remove only the bring-up artifacts the justfile manages (never all of `.scratch`).
-- `kernel-review *args`: review a guest-kernel bump (`just kernel-review 6.12.43 6.12.94`); needs `gh`.
+One warning `just --list` does not surface, because it renders only the last
+comment line above a recipe: `just soak` reaps between iterations, which WILL
+kill this checkout's live dev stack each pass.
 
 ## Footguns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,22 +65,31 @@ The CLI reference overview is [docs/reference/cli.md](docs/reference/cli.md).
 
 | Platform | What you can build and test |
 |---|---|
-| Linux amd64 / arm64 | Full workspace: `just ci` builds, lints, and tests everything; all four binaries. |
-| macOS arm64 | Session stack only; see below. |
+| Linux amd64 / arm64 | Full workspace natively: `just ci` builds, lints, and tests everything; all four binaries. |
+| macOS arm64 | Session stack natively (`just ci`); every Linux-only crate via `just test-cross`. |
 
-On macOS, `minimald` does **not** build: its sandbox stack
-(`hakoniwa` → `libcgroups` → `procfs`) is Linux-only. Consequences:
+**Build and test only through `just`.** The recipes carry the per-OS scoping,
+the pinned flags, and the ordering constraints (notably the macOS codesign);
+a hand-rolled `cargo` invocation silently drops them. If something has no
+recipe, add one — the justfile is where local build knowledge lives.
 
-- `just test` and `just clippy` handle the scoping: on macOS they resolve to
-  `-p minvmd -p sessions` automatically (the justfile's `scope` variable). Reach
-  for a raw `cargo` invocation only for something the recipes don't cover.
-- `cargo build -p minimal` works, but `cargo test -p minimal` does not, because the
-  CLI's dev-dependencies pull `minimald` (test support).
-- The `min` CLI's macOS coverage is the end-to-end proof (`scripts/session-e2e.sh`,
+`minimald` does not build **natively** on macOS: its sandbox stack
+(`hakoniwa` → `libcgroups` → `procfs`) is Linux-only. That is a native-host
+limit, not a coverage gap. Consequences:
+
+- `just test`, `just clippy`, and `just fix` scope themselves: on macOS they
+  resolve to `-p minvmd -p sessions` automatically (the justfile's `scope`
+  variable), on Linux to `--workspace`.
+- `just test-cross` covers the Linux-only crates — `minimald` and the `min`
+  CLI's test targets included — by cross-compiling to musl in Docker
+  (`--workspace --exclude minvmd`). It is the macOS answer for anything the
+  darwin scope skips. The first run compiles under emulation and can take an
+  hour+.
+- The `min` CLI's macOS coverage is also proved end-to-end (`scripts/session-e2e.sh`,
   driven by `just e2e`), run in CI on the self-hosted Apple Silicon runner
   against a real microVM.
 
-This scoping is temporary: CI widens to `--workspace` once the tree is
+The native scoping is temporary: CI widens to `--workspace` once the tree is
 mac-buildable (see the comments in `.github/workflows/ci-macos.yml`).
 
 ## System dependencies
@@ -106,8 +115,8 @@ mac-buildable (see the comments in `.github/workflows/ci-macos.yml`).
 
 ## justfile recipes
 
-33 recipes on Linux (`just --summary`; OS-specific recipes carry
-`[linux]`/`[macos]` attributes, so macOS shows a smaller set plus
+42 recipes on Linux, 37 on macOS (`just --summary`; OS-specific recipes carry
+`[linux]`/`[macos]` attributes, so macOS trades six Linux recipes for
 `test-cross`). The justfile is the local twin of the frozen CI workflows:
 the CI YAML schedules, the logic lives here and in `scripts/`
 (docs/ci-strategy.md §8). `.scratch/` is a shared scratchpad; recipes manage
@@ -118,13 +127,20 @@ CI-parity gates:
 
 - `ci`: the local PR gate set, cheapest first: `fmt-check clippy deny test doctest` (+ `test-ignored` on Linux). The canonical pre-PR command per [CONTRIBUTING.md](CONTRIBUTING.md#building-and-testing).
 - `fmt` / `fmt-check`: apply rustfmt across the workspace / the CI check variant (the fixer for a red `fmt-check` is `fmt`).
-- `clippy`: `cargo clippy --all-targets -- -D warnings` (workspace on Linux; the darwin-capable `-p minvmd -p sessions` scope on macOS).
-- `deny`: `cargo deny --all-features check` (advisories/bans/licenses/sources); a local advisories failure may just mean newer RUSTSEC data than CI's last run.
+- `fix`: the autofix pass — fmt, `clippy --fix` at this host's scope, fmt again; `--allow-dirty`, so it is the recipe for mid-edit iteration.
+- `clippy`: clippy over all targets with warnings denied (workspace on Linux; the darwin-capable `-p minvmd -p sessions` scope on macOS).
+- `deny`: cargo-deny's all-features check (advisories/bans/licenses/sources); a local advisories failure may just mean newer RUSTSEC data than CI's last run.
 - `test`: unit + in-process integration tests via nextest (CI profile on Linux; workspace on Linux, darwin scope on macOS).
-- `doctest`: doctests (`cargo test --doc`); nextest can't run them, so they are their own surface.
+- `doctest`: doctests; nextest can't run them, so they are their own surface.
 - `test-ignored`: Linux: the locally-runnable `#[ignore]` tests that NO CI lane covers (the VM/netns harnesses self-skip here; `just test-vm` runs those for real).
 - `test-cross`: macOS: clippy + tests for the Linux-only crates via `cross` (musl in Docker; excludes `minvmd`). The first run compiles under emulation and can take an hour+.
 - `test-installer`: run the curl|sh installer's test harness under every available POSIX sh (+ shellcheck when present).
+- `test-promote-gate`: the promotion provenance gate's harness (stubbed `gh`, no network or auth).
+- `lint-shell`: shellcheck every script under `scripts/`, not just the installer's two (CI reaches the same check through `just test`).
+- `msrv`: the declared `package.rust-version` floor still type-checks, via cargo-hack. CI: `nightly-tests` (blocking).
+- `miri`: interpret the miri-clean crate set under nightly+miri. CI: `nightly-tests` (non-blocking).
+- `fuzz-check`: type-check every cargo-fuzz target — the bitrot guard for targets no CI lane runs (docs/fuzzing.md).
+- `fuzz crate target *args`: run one fuzz target (`just fuzz graph graph_from_bytes -max_total_time=60`); seed the corpus first.
 
 e2e & test harnesses (KVM on Linux, HVF on macOS):
 
@@ -134,6 +150,8 @@ e2e & test harnesses (KVM on Linux, HVF on macOS):
 - `test-root-integration`: Linux: `minimald`'s netns/tap proofs (the tests sudo their own netns commands); refuses to run where AppArmor restricts unprivileged userns.
 - `test-lifecycle`: daemon lifecycle proof (`run --detach` → Running → `stop` → Stopped), booted switchless like CI's step.
 - `soak n=10`: nightly soak parity: N session-e2e reps; reaps between iterations, which WILL kill this checkout's live dev stack each pass.
+- `stress n=5`: mints N sessions CONCURRENTLY against one daemon (the soak's reps are serial), then bulk-tears-down.
+- `bulk-upload n=5`: host→guest bulk-upload proof: N activations of a large, compressible project, each destroyed after.
 
 Stack bring-up & daemon lifecycle (`just up` = this host's default run mode):
 
@@ -154,8 +172,9 @@ Build artifacts and prerequisites:
 - `initramfs`: cross-compile `minimald` (static musl, `FEATURES` baked in) and pack it as the initramfs `/init`.
 - `minvmd-build`: build debug `minvmd` (codesigns last on macOS; links the real libkrun via `LIBKRUN_PREFIX` on Linux).
 - `minimald-build`: Linux: build a host-native `minimald` with the networking features (for `just up`).
-- `minimal-cli`: build the `min` CLI (`cargo build -p minimal`; the binary is `target/debug/min`).
+- `minimal-cli`: build the `min` CLI (the binary is `target/debug/min`).
 - `clean`: remove only the bring-up artifacts the justfile manages (never all of `.scratch`).
+- `kernel-review *args`: review a guest-kernel bump (`just kernel-review 6.12.43 6.12.94`); needs `gh`.
 
 ## Footguns
 
@@ -254,13 +273,13 @@ PR"): it runs the same gates the PR lanes run (fmt, clippy, cargo-deny,
 the test suite, doctests; plus `just test-ignored` on Linux), dispatched
 for your OS. Platform notes for agents:
 
-- **macOS**: the workspace does not fully build (see
+- **macOS**: the workspace does not build natively (see
   [Platform matrix](#platform-matrix)); `just ci` runs the darwin-capable
-  scope, and `just test-cross` additionally covers the Linux-only crates
-  via `cross` (Docker required).
+  scope, and `just test-cross` covers the Linux-only crates via `cross`
+  (Docker required). A change touching `minimald` or the `min` CLI's tests
+  is unverified until `just test-cross` has run.
 - **VM/daemon-path changes**: also run `just e2e` (the session proof)
   and/or `just test-vm` (the VM integration harnesses).
-- **Tight iteration loops**: `cargo test -p <crate>` on the crate under
-  edit is still the fastest inner loop; agents iterating on a working tree
-  may prefer the auto-fixing clippy variant:
-  `cargo clippy --allow-dirty --fix --all-targets -- -D warnings`.
+- **Tight iteration loops**: `just fix` (fmt → `clippy --fix` → fmt, with
+  `--allow-dirty` so it runs mid-edit) then `just test`. Both carry this
+  host's scope; neither needs a hand-written `cargo` line.

--- a/justfile
+++ b/justfile
@@ -1,7 +1,9 @@
 # justfile — repo-wide task runner; the local twin of the frozen CI workflows
 # (docs/ci-strategy.md §8: CI YAML schedules, the logic lives here + scripts/).
 # OS-specific recipes carry [linux]/[macos] attributes — `just --list` shows
-# only this host's. The comment line directly above a recipe is its caption.
+# only this host's. `just --list` renders ONLY the last comment line above a
+# recipe, so that line must be a standalone summary (warnings included);
+# rationale, CI pointers and caveats go above it, separated by a bare `#`.
 
 scratch      := justfile_directory() / ".scratch"
 arch         := arch()
@@ -159,26 +161,33 @@ _nextest: (_need "cargo-nextest" "cargo install cargo-nextest --locked")
 fmt:
     cargo fmt --all
 
-# Autofix pass: fmt, clippy --fix, fmt again. Clippy's `--fix` can shuffle
-# whitespace during its rewrites, so the trailing `cargo fmt` normalizes
-# whatever landed. `--allow-dirty` skips the clean-worktree check — the
-# usual case here is running mid-edit with staged/unstaged work.
+# Clippy's `--fix` can shuffle whitespace during its rewrites, so the trailing
+# `cargo fmt` normalizes whatever landed. `--allow-dirty` skips the
+# clean-worktree check — the usual case here is running mid-edit with
+# staged/unstaged work.
+#
+# Autofix pass: fmt, clippy --fix, fmt again (safe to run mid-edit).
 fix:
     cargo fmt --all
     cargo clippy {{scope}} --all-targets --fix --allow-dirty -- -D warnings
     cargo fmt --all
 
 # CI: ci.yml `fmt`.
+#
+# Check rustfmt across the workspace without writing (`just fmt` is the fixer).
 fmt-check:
     cargo fmt --all -- --check
 
 # CI: ci.yml `clippy` / the ci-macos.yml `unit` scope.
+#
+# Clippy over all targets at this host's scope, warnings denied.
 clippy:
     cargo clippy {{scope}} --all-targets --locked -- -D warnings
 
 # A local advisories failure may just mean newer RUSTSEC data than CI's last run.
-#
 # CI: ci.yml `cargo-deny` (advisories/bans/licenses/sources).
+#
+# cargo-deny's all-features check: advisories, bans, licenses, sources.
 deny: (_need "cargo-deny" "cargo install cargo-deny --locked")
     cargo deny --all-features check
 
@@ -186,6 +195,8 @@ deny: (_need "cargo-deny" "cargo install cargo-deny --locked")
 # by every crate) still type-checks. cargo-hack drives the check against the
 # declared version; the toolchain the check runs under is fetched by rustup.
 # CI: nightly-tests.yml `msrv` (blocking).
+#
+# The declared MSRV floor still type-checks (cargo-hack).
 msrv: (_need "cargo-hack" "cargo install cargo-hack --locked")
     cargo hack check --rust-version --workspace --all-targets --locked
 
@@ -194,6 +205,8 @@ msrv: (_need "cargo-hack" "cargo install cargo-hack --locked")
 # interprets under miri in seconds. Needs the nightly toolchain + miri component:
 #   rustup toolchain install nightly && rustup +nightly component add miri
 # CI: nightly-tests.yml `miri` (non-blocking). Widen the set as more crates prove clean.
+#
+# miri over `switch`'s vsock/subnet/MAC primitives (needs nightly + the miri component).
 miri:
     cargo +nightly miri test -p switch
 
@@ -275,14 +288,16 @@ test-installer:
         SH="$sh" "$sh" scripts/install_test.sh
     done
 
-# Shellcheck EVERY script under scripts/ (not just the installer's two files).
 # The reviewed harness the frozen ci-shell-installer.yml can't widen to; CI runs
 # the same check through crates/common/tests/shell_lint.rs (part of `just test`).
+#
+# Shellcheck EVERY script under scripts/ (not just the installer's two files).
 lint-shell:
     bash scripts/lint-shell.sh
 
-# Run the promotion provenance gate's test harness (stubbed `gh`, no network,
-# no auth); shellcheck runs when present.
+# Shellcheck runs too, when present.
+#
+# Run the promotion provenance gate's test harness (stubbed `gh`, no network or auth).
 test-promote-gate:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -338,10 +353,11 @@ test-vm: _nextest _kvm artifacts initramfs minvmd-build
       cargo nextest run -p minvmd --profile vm --run-ignored all --no-tests=fail \
       -E 'binary(/_integration$/) and not binary(/_root_integration$/)'
 
-# minimald's netns/tap proofs (the tests sudo their own netns commands).
 # CI: ci-linux-native.yml `minimald-root-integration`. The AppArmor policy
 # can't unlock this surface — its namespaces come from hashed-path test
 # binaries and /usr/bin/unshare, which a per-binary profile can't cover.
+#
+# minimald's netns/tap proofs (the tests sudo their own netns commands).
 [linux]
 test-root-integration: _nextest gvproxy
     @[ "$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0)" = "0" ] || { echo "this host restricts unprivileged user namespaces, which this surface needs from hashed-path test binaries (the AppArmor policy can't cover those); leave this lane to CI, or see docs/reference/linux-host-setup.md before relaxing the restriction host-wide" >&2; exit 1; }
@@ -353,8 +369,9 @@ test-root-integration: _nextest gvproxy
 e2e: _kvm artifacts gvproxy initramfs minimal-cli minvmd-build
     {{e2e-env}} MINVMD_GVPROXY_BIN="{{gvproxy}}" ./scripts/session-e2e.sh
 
-# The SAME session e2e against a host-native minimald (no VM).
 # CI: ci-linux-native.yml `native-daemon-e2e`.
+#
+# The SAME session e2e against a host-native minimald (no VM).
 [linux]
 e2e-native:
     cargo build -p minimald --bin minimald -p minimal --bin min --locked
@@ -367,9 +384,10 @@ e2e-native:
 test-lifecycle: (_need "jq" "brew install jq (or apt install jq)") _kvm artifacts initramfs minvmd-build
     XDG_STATE_HOME="{{scratch}}/test-state" ./scripts/minvmd-lifecycle.sh
 
-# Reaps between iterations — this WILL kill this checkout's live dev stack each pass.
+# nightly-tests.yml runs 10 reps, then `just bulk-upload`. The reap between
+# iterations kills THIS checkout's live dev stack — not just the soak's own VMs.
 #
-# Nightly soak parity: N session-e2e reps (nightly-tests.yml runs 10), then `just bulk-upload`.
+# Nightly soak parity: N session-e2e reps; reaps between them — WILL kill your dev stack.
 soak n="10": _kvm artifacts gvproxy initramfs minimal-cli minvmd-build
     {{e2e-env}} MINVMD_GVPROXY_BIN="{{gvproxy}}" ./scripts/soak-session-e2e.sh {{n}} "{{scratch}}/soak-logs"
 


### PR DESCRIPTION
## Why

The Platform matrix said `minimald` "does **not** build" on macOS. Read literally that is
true only of a *native* build — and agents took it as licence to declare daemon-side work
unverifiable on a Mac, or to hand-roll `cargo` invocations around the scoping. `just
test-cross` already cross-compiles `--workspace --exclude minvmd` to musl in Docker and
runs its tests, so `minimald` and the `min` CLI's test targets (whose dev-dependencies
pull `minimald`) are reachable from macOS.

## What changed

- **Platform matrix**: the native-only limit stated as such, with `just test-cross` named
  as the macOS answer for everything the darwin scope skips. Pre-PR verification now says
  outright that a `minimald` / CLI-test change is unverified until it has run.
- **just-only rule**, stated once at the top of the matrix: the recipes carry the per-OS
  scoping, the pinned flags, and the ordering constraints (the macOS codesign most
  sharply); a hand-rolled `cargo` line drops them silently. No recipe for a task → add one.
- **The two raw-cargo instructions are gone**: the `cargo test -p <crate>` inner loop and
  the `cargo clippy --allow-dirty --fix …` variant are now `just test` and `just fix` —
  which are exactly those commands, already scoped for the host.
- Recipe descriptions no longer quote runnable `cargo` lines; an agent copies what it sees.

## Inventory refresh (drive-by)

The recipe count and list had both fallen nine behind the justfile. Now 42 on Linux / 37 on
macOS (verified against `just --summary` plus the `[linux]`/`[macos]` attributes: six
Linux-only recipes, one macOS-only), with `fix`, `lint-shell`, `msrv`, `miri`, `fuzz`,
`fuzz-check`, `test-promote-gate`, `stress`, `bulk-upload`, and `kernel-review` documented.

## Not touched

`CONTRIBUTING.md:63` still pairs `cargo test --workspace --doc` with `just doctest` in its
CI-mapping table. That is a human-facing cross-reference, not an agent instruction — say
the word if you want it collapsed to the recipe too.

Docs only; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update AGENTS.md to make `just` recipes the sole build and test surface
> Updates [AGENTS.md](https://github.com/gominimal/minimal/pull/1115/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to establish `just` recipes as the canonical workflow for building and testing, replacing direct `cargo` commands throughout.
>
> - Clarifies per-OS scoping: Linux runs the full workspace natively; macOS runs the session stack via `just ci` and Linux-only crates via `just test-cross`
> - Adds documentation for new recipes: `fix`, `test-promote-gate`, `lint-shell`, `msrv`, `miri`, `fuzz-check`, `fuzz`, `stress`, `bulk-upload`, and `kernel-review`
> - Updates recipe counts to 42 on Linux and 37 on macOS, and notes OS-specific recipe visibility
> - Expands the footguns section to note that changes touching `minimald` or `min` CLI tests are unverified on macOS until `just test-cross` runs
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1115 opened
>
> - Replaced manual enumeration of justfile recipes with directive to run `just --list` or bare `just` for auto-generated, OS-scoped recipe list [b10f422]
> - Removed detailed subsections documenting CI-parity gates, e2e/test harnesses, stack bring-up, and build artifacts along with their per-recipe descriptions [b10f422]
> - Retained note about justfile mirroring CI workflows and clarified OS-scoped attribute filtering for recipe visibility [b10f422]
> - Added warning that `just soak` reaps between iterations and terminates the checkout's live dev stack, noting this may not surface in `just --list` output [b10f422]
> - Reworked comments throughout `justfile` to follow the convention that `just --list` displays only the last comment line above each recipe as a standalone summary, moving detailed rationale and warnings into preceding comment blocks [f71f5e2]
> - Removed warning paragraph from documentation stating that `just soak` reaps between iterations and terminates the checkout's live dev stack each pass [f71f5e2]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b398f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance for platform-specific builds and tests.
  * Added instructions for stress testing, bulk-upload testing, and kernel review workflows.
  * Clarified macOS testing guidance and recommended pre-PR validation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->