### PR TITLE
fix(minimald): lead the shell-exit prompt with the files changed since activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,6 +3783,7 @@ dependencies = [
  "async-dialog",
  "async-tar",
  "base64 0.23.0",
+ "blake3",
  "boringtun",
  "bytes",
  "camino",
@@ -3835,6 +3836,7 @@ dependencies = [
  "uuid",
  "version",
  "vt100-ctt",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -28,6 +28,7 @@ test-support = []
 anyhow.workspace = true
 async-compression.workspace = true
 async-tar.workspace = true
+blake3.workspace = true
 bytes.workspace = true
 camino.workspace = true
 chrono.workspace = true
@@ -50,6 +51,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 vt100-ctt.workspace = true
+walkdir.workspace = true
 
 tokio.workspace = true
 tokio-util.workspace = true

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -12,6 +12,7 @@ pub mod net;
 pub mod rpc;
 pub mod server;
 mod session;
+mod session_delta;
 pub mod session_host;
 pub mod session_sop;
 mod sessions;

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -2036,6 +2036,95 @@ mod tests {
         );
     }
 
+    /// The shell-exit prompt leads with the files changed since activation:
+    /// write a file into the session's workspace while the shell is live, then
+    /// exit it and expect the delta header and the changed-file row above the
+    /// prompt. Answered with the default (keep), so the session survives.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shell_exit_prompt_lists_files_changed_since_activation() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        let mut channel = client.open_shell(session_id).await;
+
+        // Prove the shell is live first (mock echoes `got:<line>`); the
+        // baseline snapshot is taken before the process launches, so a write
+        // from here on is a change.
+        channel.data_bytes(b"hello\n".to_vec()).await.unwrap();
+        let mut stdout = Vec::new();
+        loop {
+            match channel.wait().await {
+                Some(ChannelMsg::Data { data }) => {
+                    stdout.extend_from_slice(&data);
+                    if String::from_utf8_lossy(&stdout).contains("got:hello") {
+                        break;
+                    }
+                }
+                Some(_) => {}
+                None => panic!("channel closed before the echo arrived"),
+            }
+        }
+
+        // Change the workspace daemon-side, as an in-session shell would.
+        let manager = server.state.sessions_manager().await;
+        let handle = manager
+            .get_session(crate::sessions::SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("session should resolve");
+        let paths = handle.paths().await.expect("paths should resolve");
+        let scratch = paths
+            .working
+            .join(&paths::DaemonRelPath::try_new("scratch.txt").unwrap());
+        tokio::fs::write(scratch.as_utf8_path(), b"made in session")
+            .await
+            .unwrap();
+
+        // Exit the shell; the prompt must lead with the delta.
+        channel
+            .data_bytes(format!("{}\n", crate::session_host::MOCK_EXIT_LINE).into_bytes())
+            .await
+            .unwrap();
+        let mut answered_prompt = false;
+        let mut prompt_out = Vec::new();
+        while let Ok(msg) = tokio::time::timeout(Duration::from_secs(10), channel.wait()).await {
+            match msg {
+                Some(ChannelMsg::Data { data }) => {
+                    prompt_out.extend_from_slice(&data);
+                    if !answered_prompt
+                        && String::from_utf8_lossy(&prompt_out)
+                            .contains(crate::session_host::SHELL_EXIT_PROMPT)
+                    {
+                        channel.data_bytes(b"\r".to_vec()).await.unwrap();
+                        answered_prompt = true;
+                    }
+                }
+                Some(_) => {}
+                None => break,
+            }
+        }
+        let prompt_out = String::from_utf8_lossy(&prompt_out);
+        assert!(
+            answered_prompt,
+            "expected the session-exit prompt to render; got: {prompt_out:?}"
+        );
+        assert!(
+            prompt_out.contains("changed since activation:"),
+            "prompt should lead with the delta header; got: {prompt_out:?}"
+        );
+        assert!(
+            prompt_out.contains("A scratch.txt"),
+            "prompt should list the added file; got: {prompt_out:?}"
+        );
+
+        // Keep (the default) must leave the session intact.
+        assert!(
+            record_exists(&mut client, session_id).await,
+            "keep must not delete the session record"
+        );
+    }
+
     /// Selecting "delete" on the shell-exit prompt must tear the connection down
     /// *and* destroy the session (record removed), routed through the manager
     /// via the binding's weak handle.

--- a/crates/minimald/src/session_delta.rs
+++ b/crates/minimald/src/session_delta.rs
@@ -12,6 +12,13 @@
 //! their signatures carry a content digest, so a same-length edit that
 //! preserves the modification time is still reported. Above the cap the
 //! comparison falls back to (length, mtime).
+//!
+//! The workspace root's `.git` directory is excluded from both walks: the
+//! delta reports working-tree files, and git-internal churn (index, refs,
+//! objects) no longer appears in it — without the exclusion, any in-session
+//! git operation floods the capped row list with `.git` noise. Only the
+//! root-level `.git` is skipped; a nested one (a vendored subrepo) is
+//! ordinary workspace content.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -100,11 +107,16 @@ impl DeltaSource {
 /// every non-directory entry keyed by its root-relative path. A symlink is
 /// recorded via its own metadata — never traversed, even when it points at a
 /// directory — so links out of the root or link cycles cannot widen or wedge
-/// the walk. Unreadable entries fail the whole snapshot: a partial baseline
-/// would misreport their contents as added later.
+/// the walk. The root-level `.git` directory is skipped entirely (see the
+/// module docs for the tradeoff). Unreadable entries fail the whole
+/// snapshot: a partial baseline would misreport their contents as added
+/// later.
 fn snapshot(root: &Path) -> std::io::Result<Snapshot> {
     let mut out = Snapshot::new();
-    for entry in WalkDir::new(root) {
+    for entry in WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|e| !(e.depth() == 1 && e.file_name() == ".git"))
+    {
         let entry = entry?;
         if entry.file_type().is_dir() {
             continue;
@@ -239,6 +251,36 @@ mod tests {
         assert_eq!(
             diff(&before, &snapshot(root).unwrap()),
             vec!["M sneaky.txt".to_string()],
+        );
+    }
+
+    /// The root `.git` directory is invisible to the walk: git-internal churn
+    /// must not appear in the delta, while a working-tree change — and a
+    /// nested (vendored) `.git` — still must.
+    #[test]
+    fn root_git_dir_is_excluded_from_the_delta() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, ".git/index", "v1");
+        write(root, "tracked.txt", "v1");
+        let before = snapshot(root).unwrap();
+        assert!(
+            !before.keys().any(|p| p.starts_with(".git")),
+            "the baseline must not contain root .git entries",
+        );
+
+        write(root, ".git/index", "v2 grown");
+        write(root, ".git/objects/aa/blob", "obj");
+        write(root, "tracked.txt", "v2 longer");
+        write(root, "vendor/dep/.git/config", "vendored");
+        let after = snapshot(root).unwrap();
+
+        assert_eq!(
+            diff(&before, &after),
+            vec![
+                "M tracked.txt".to_string(),
+                "A vendor/dep/.git/config".to_string(),
+            ],
         );
     }
 

--- a/crates/minimald/src/session_delta.rs
+++ b/crates/minimald/src/session_delta.rs
@@ -1,0 +1,158 @@
+//! Workspace-change detection for the shell-exit prompt.
+//!
+//! A [`DeltaSource`] pairs a baseline snapshot of the session's workspace,
+//! taken before the session process launches, with the workspace root, so the
+//! shell-exit prompt can lead with the files that changed during the session.
+//! Detection is best-effort throughout: a workspace that cannot be walked
+//! yields no [`DeltaSource`] at all, and the prompt falls back to its plain
+//! form rather than blocking or failing teardown.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+/// Per-file signature used to detect changes: byte length plus mtime. Content
+/// hashing would be exact but scales with workspace bytes, not entries; a
+/// (len, mtime) pair is metadata-only and catches every edit a filesystem
+/// timestamps.
+type Sig = (u64, Option<SystemTime>);
+
+/// Relative path -> signature for every regular file and symlink under the
+/// root. Directories are traversal structure, not entries: an empty added
+/// directory does not count as a change, matching what "files changed" means
+/// to the person reading the prompt.
+type Snapshot = BTreeMap<PathBuf, Sig>;
+
+/// A workspace root plus the baseline snapshot taken before the session
+/// process launched. Shared with each attached binding so the shell-exit
+/// prompt can compute the delta at exit time.
+pub(crate) struct DeltaSource {
+    root: PathBuf,
+    baseline: Snapshot,
+}
+
+impl DeltaSource {
+    /// Takes the baseline snapshot of `root` on the blocking pool. Returns
+    /// `None` when the workspace cannot be walked — change detection is then
+    /// disabled for the session's lifetime rather than misreporting.
+    pub(crate) async fn arm(root: PathBuf) -> Option<Arc<Self>> {
+        let walk_root = root.clone();
+        let baseline = tokio::task::spawn_blocking(move || snapshot(&walk_root))
+            .await
+            .ok()?
+            .ok()?;
+        Some(Arc::new(Self { root, baseline }))
+    }
+
+    /// Re-walks the workspace and renders one row per changed file, sorted by
+    /// path: `A <path>` added, `M <path>` modified, `D <path>` deleted. An
+    /// empty vec means nothing changed; `None` means the delta could not be
+    /// computed and the caller should not claim anything about the workspace.
+    pub(crate) async fn changed_files(self: &Arc<Self>) -> Option<Vec<String>> {
+        let src = Arc::clone(self);
+        tokio::task::spawn_blocking(move || {
+            let now = snapshot(&src.root).ok()?;
+            Some(diff(&src.baseline, &now))
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+}
+
+/// Walks `root` without following symlinks, recording every non-directory
+/// entry keyed by its root-relative path. Unreadable subdirectories fail the
+/// whole snapshot: a partial baseline would misreport their contents as
+/// added later.
+fn snapshot(root: &Path) -> std::io::Result<Snapshot> {
+    let mut out = Snapshot::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir)? {
+            let entry = entry?;
+            let meta = entry.metadata()?;
+            let path = entry.path();
+            if meta.is_dir() {
+                stack.push(path);
+            } else {
+                let rel = path
+                    .strip_prefix(root)
+                    .expect("walk stays under root")
+                    .to_path_buf();
+                out.insert(rel, (meta.len(), meta.modified().ok()));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn diff(before: &Snapshot, after: &Snapshot) -> Vec<String> {
+    let mut rows = Vec::new();
+    for (path, sig) in after {
+        match before.get(path) {
+            None => rows.push(format!("A {}", path.display())),
+            Some(old) if old != sig => rows.push(format!("M {}", path.display())),
+            Some(_) => {}
+        }
+    }
+    for path in before.keys() {
+        if !after.contains_key(path) {
+            rows.push(format!("D {}", path.display()));
+        }
+    }
+    rows.sort_by(|a, b| a[2..].cmp(&b[2..]));
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(root: &Path, rel: &str, contents: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn diff_reports_adds_modifies_and_deletes_sorted_by_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "kept.txt", "same");
+        write(root, "sub/edited.txt", "v1");
+        write(root, "removed.txt", "bye");
+
+        let before = snapshot(root).unwrap();
+        write(root, "sub/edited.txt", "v2 longer");
+        write(root, "added.txt", "new");
+        std::fs::remove_file(root.join("removed.txt")).unwrap();
+        let after = snapshot(root).unwrap();
+
+        assert_eq!(
+            diff(&before, &after),
+            vec![
+                "A added.txt".to_string(),
+                "D removed.txt".to_string(),
+                "M sub/edited.txt".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn unchanged_workspace_diffs_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a/b.txt", "x");
+        let snap = snapshot(dir.path()).unwrap();
+        assert!(diff(&snap, &snapshot(dir.path()).unwrap()).is_empty());
+        assert_eq!(snap.len(), 1);
+    }
+
+    #[test]
+    fn empty_added_directory_is_not_a_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let before = snapshot(dir.path()).unwrap();
+        std::fs::create_dir(dir.path().join("newdir")).unwrap();
+        assert!(diff(&before, &snapshot(dir.path()).unwrap()).is_empty());
+    }
+}

--- a/crates/minimald/src/session_delta.rs
+++ b/crates/minimald/src/session_delta.rs
@@ -3,20 +3,49 @@
 //! A [`DeltaSource`] pairs a baseline snapshot of the session's workspace,
 //! taken before the session process launches, with the workspace root, so the
 //! shell-exit prompt can lead with the files that changed during the session.
-//! Detection is best-effort throughout: a workspace that cannot be walked
-//! yields no [`DeltaSource`] at all, and the prompt falls back to its plain
-//! form rather than blocking or failing teardown.
+//! Detection is best-effort throughout: both walks are bounded by
+//! [`WALK_TIMEOUT`], and a workspace that cannot be walked in time yields no
+//! [`DeltaSource`] (at activation) or no delta (at exit), so the prompt falls
+//! back to its plain form rather than blocking or failing teardown.
+//!
+//! File comparison is exact for regular files up to [`DIGEST_CAP_BYTES`]:
+//! their signatures carry a content digest, so a same-length edit that
+//! preserves the modification time is still reported. Above the cap the
+//! comparison falls back to (length, mtime).
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
-/// Per-file signature used to detect changes: byte length plus mtime. Content
-/// hashing would be exact but scales with workspace bytes, not entries; a
-/// (len, mtime) pair is metadata-only and catches every edit a filesystem
-/// timestamps.
-type Sig = (u64, Option<SystemTime>);
+use walkdir::WalkDir;
+
+/// Upper bound on either workspace walk (the baseline at activation, the
+/// re-walk at exit). On expiry the walk's result is discarded: arming yields
+/// no [`DeltaSource`], and the exit prompt renders its plain form — neither
+/// activation nor teardown ever blocks on a wedged or oversized workspace.
+/// The abandoned walk keeps running on the blocking pool until it finishes;
+/// nothing awaits it.
+const WALK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Largest file that gets a content digest in its signature. Above the cap
+/// the digest is `None` and comparison falls back to (length, mtime):
+/// hashing scales with workspace bytes rather than entries, and an unbounded
+/// hash pass would blow [`WALK_TIMEOUT`] on large workspaces, while a
+/// same-length, mtime-preserved edit to a multi-megabyte file is outside
+/// this guard's realistic threat model.
+const DIGEST_CAP_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Per-file signature used to detect changes: byte length, mtime, and — for
+/// regular files up to [`DIGEST_CAP_BYTES`] — a blake3 content digest, so a
+/// same-length mtime-preserved edit cannot masquerade as "no files changed".
+/// Symlinks are signed by their own (link) metadata and carry no digest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Sig {
+    len: u64,
+    mtime: Option<SystemTime>,
+    digest: Option<blake3::Hash>,
+}
 
 /// Relative path -> signature for every regular file and symlink under the
 /// root. Directories are traversal structure, not entries: an empty added
@@ -33,13 +62,16 @@ pub(crate) struct DeltaSource {
 }
 
 impl DeltaSource {
-    /// Takes the baseline snapshot of `root` on the blocking pool. Returns
-    /// `None` when the workspace cannot be walked — change detection is then
-    /// disabled for the session's lifetime rather than misreporting.
+    /// Takes the baseline snapshot of `root` on the blocking pool, bounded by
+    /// [`WALK_TIMEOUT`]. Returns `None` when the workspace cannot be walked
+    /// in time — change detection is then disabled for the session's lifetime
+    /// rather than misreporting or stalling activation.
     pub(crate) async fn arm(root: PathBuf) -> Option<Arc<Self>> {
         let walk_root = root.clone();
-        let baseline = tokio::task::spawn_blocking(move || snapshot(&walk_root))
+        let walk = tokio::task::spawn_blocking(move || snapshot(&walk_root));
+        let baseline = tokio::time::timeout(WALK_TIMEOUT, walk)
             .await
+            .ok()?
             .ok()?
             .ok()?;
         Some(Arc::new(Self { root, baseline }))
@@ -48,43 +80,64 @@ impl DeltaSource {
     /// Re-walks the workspace and renders one row per changed file, sorted by
     /// path: `A <path>` added, `M <path>` modified, `D <path>` deleted. An
     /// empty vec means nothing changed; `None` means the delta could not be
-    /// computed and the caller should not claim anything about the workspace.
+    /// computed — including a re-walk that overruns [`WALK_TIMEOUT`] — and
+    /// the caller should not claim anything about the workspace.
     pub(crate) async fn changed_files(self: &Arc<Self>) -> Option<Vec<String>> {
         let src = Arc::clone(self);
-        tokio::task::spawn_blocking(move || {
+        let walk = tokio::task::spawn_blocking(move || {
             let now = snapshot(&src.root).ok()?;
             Some(diff(&src.baseline, &now))
-        })
-        .await
-        .ok()
-        .flatten()
+        });
+        tokio::time::timeout(WALK_TIMEOUT, walk)
+            .await
+            .ok()?
+            .ok()
+            .flatten()
     }
 }
 
-/// Walks `root` without following symlinks, recording every non-directory
-/// entry keyed by its root-relative path. Unreadable subdirectories fail the
-/// whole snapshot: a partial baseline would misreport their contents as
-/// added later.
+/// Walks `root` without following symlinks (walkdir's default), recording
+/// every non-directory entry keyed by its root-relative path. A symlink is
+/// recorded via its own metadata — never traversed, even when it points at a
+/// directory — so links out of the root or link cycles cannot widen or wedge
+/// the walk. Unreadable entries fail the whole snapshot: a partial baseline
+/// would misreport their contents as added later.
 fn snapshot(root: &Path) -> std::io::Result<Snapshot> {
     let mut out = Snapshot::new();
-    let mut stack = vec![root.to_path_buf()];
-    while let Some(dir) = stack.pop() {
-        for entry in std::fs::read_dir(&dir)? {
-            let entry = entry?;
-            let meta = entry.metadata()?;
-            let path = entry.path();
-            if meta.is_dir() {
-                stack.push(path);
-            } else {
-                let rel = path
-                    .strip_prefix(root)
-                    .expect("walk stays under root")
-                    .to_path_buf();
-                out.insert(rel, (meta.len(), meta.modified().ok()));
-            }
+    for entry in WalkDir::new(root) {
+        let entry = entry?;
+        if entry.file_type().is_dir() {
+            continue;
         }
+        // With symlink-following off, this is the entry's own (symlink)
+        // metadata, matching what the walk saw rather than the link target.
+        let meta = entry.metadata()?;
+        let digest = if entry.file_type().is_file() && meta.len() <= DIGEST_CAP_BYTES {
+            Some(hash_file(entry.path())?)
+        } else {
+            None
+        };
+        let rel = entry
+            .path()
+            .strip_prefix(root)
+            .expect("walk stays under root")
+            .to_path_buf();
+        out.insert(
+            rel,
+            Sig {
+                len: meta.len(),
+                mtime: meta.modified().ok(),
+                digest,
+            },
+        );
     }
     Ok(out)
+}
+
+fn hash_file(path: &Path) -> std::io::Result<blake3::Hash> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update_reader(std::fs::File::open(path)?)?;
+    Ok(hasher.finalize())
 }
 
 fn diff(before: &Snapshot, after: &Snapshot) -> Vec<String> {
@@ -154,5 +207,66 @@ mod tests {
         let before = snapshot(dir.path()).unwrap();
         std::fs::create_dir(dir.path().join("newdir")).unwrap();
         assert!(diff(&before, &snapshot(dir.path()).unwrap()).is_empty());
+    }
+
+    /// The CodeRabbit regression: an edit that keeps the byte length AND
+    /// restores the mtime must still be reported, via the content digest.
+    #[test]
+    fn same_length_mtime_preserved_edit_is_reported_as_modified() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "sneaky.txt", "aaaa");
+        let orig_mtime = std::fs::metadata(root.join("sneaky.txt"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        let before = snapshot(root).unwrap();
+
+        write(root, "sneaky.txt", "bbbb");
+        let file = std::fs::File::options()
+            .write(true)
+            .open(root.join("sneaky.txt"))
+            .unwrap();
+        file.set_times(std::fs::FileTimes::new().set_modified(orig_mtime))
+            .unwrap();
+        drop(file);
+        // The metadata guard must be genuinely defeated for this test to
+        // prove anything: same length, same mtime as the baseline.
+        let meta = std::fs::metadata(root.join("sneaky.txt")).unwrap();
+        assert_eq!(meta.len(), 4);
+        assert_eq!(meta.modified().unwrap(), orig_mtime);
+
+        assert_eq!(
+            diff(&before, &snapshot(root).unwrap()),
+            vec!["M sneaky.txt".to_string()],
+        );
+    }
+
+    /// Symlinks are entries, never traversal: a link out of the root must not
+    /// pull outside files into the snapshot, and a link cycle must not wedge
+    /// the walk.
+    #[test]
+    fn symlinks_are_recorded_but_never_traversed() {
+        let outside = tempfile::tempdir().unwrap();
+        write(outside.path(), "secret.txt", "outside");
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "real.txt", "inside");
+        std::os::unix::fs::symlink(outside.path(), root.join("escape")).unwrap();
+        std::os::unix::fs::symlink(root, root.join("cycle")).unwrap();
+
+        let snap = snapshot(root).unwrap();
+        let paths: Vec<_> = snap.keys().cloned().collect();
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("cycle"),
+                PathBuf::from("escape"),
+                PathBuf::from("real.txt"),
+            ],
+        );
+        // Nothing behind the links was walked.
+        assert!(!snap.keys().any(|p| p.to_string_lossy().contains("secret")));
     }
 }

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -500,87 +500,110 @@ impl Binding {
         tracing::info!(reason = ?exit_reason, "binding leaving mainloop");
 
         if exit_reason == MainloopExitReason::ProcessExited {
-            // The shell process exited. For a bash shell, this usually meant someone pressed ctrl-d absent-mindedly.
-            // We presume they didnt want to completely destroy the session, perhaps just detach, but lets prompt
-            // to see where they wanted to go from here.
-            let _ = w.write_all(b"\r\n").await;
-
-            // Lead with what a "delete" would lose. An unavailable delta (no
-            // baseline, or the re-walk failed) renders the plain prompt — the
-            // exit path never blocks on change detection.
-            let changed = match &self.delta {
-                Some(delta) => delta.changed_files().await,
-                None => None,
-            };
-            let mut delete_item = "Delete, all in-session files permanently deleted".to_string();
-            match &changed {
-                Some(rows) if rows.is_empty() => {
-                    let _ = w
-                        .write_all(format!("{SHELL_EXIT_NO_CHANGES}\r\n\r\n").as_bytes())
-                        .await;
-                    delete_item.push_str(" — nothing will be lost");
-                }
-                Some(rows) => {
-                    let n = rows.len();
-                    let plural = if n == 1 { "" } else { "s" };
-                    let _ = w
-                        .write_all(
-                            format!("{n} file{plural} changed since activation:\r\n").as_bytes(),
-                        )
-                        .await;
-                    for row in rows.iter().take(DELTA_ROWS_SHOWN) {
-                        let _ = w.write_all(format!("  {row}\r\n").as_bytes()).await;
-                    }
-                    if n > DELTA_ROWS_SHOWN {
-                        let _ = w
-                            .write_all(
-                                format!("  ... and {} more\r\n", n - DELTA_ROWS_SHOWN).as_bytes(),
-                            )
-                            .await;
-                    }
-                    let _ = w.write_all(b"\r\n").await;
-                }
-                None => {}
-            }
-            match async_dialog::Select::new()
-                .with_prompt(SHELL_EXIT_PROMPT)
-                .items([
-                    "Exit, leaving the session filesystem in place and recoverable",
-                    delete_item.as_str(),
-                ])
-                .interact(rs.make_reader(), &mut w)
-                .await
-            {
-                // User selected detach, keep going to disconnect
-                Ok(Selection::At(0)) => {}
-                // User cancelled selection, safest option is to detach
-                Ok(Selection::Cancelled) => {}
-                // User selected delete: ask the manager to tear the whole
-                // session down (kill the host, remove the on-disk record) before
-                // we close the channel. Awaiting is deadlock-free here — the
-                // destroy cascade waits on the host runtime loop (already exiting
-                // now that the process has ended), never on this binding task.
-                Ok(Selection::At(1)) => match &self.control {
-                    Some(control) => {
-                        let _ = w.write_all(b"\r\nDeleting session...\r\n").await;
-                        if let Err(e) = control.destroy().await {
-                            tracing::warn!(error = %e, "session delete failed");
-                            let _ = w
-                                .write_all(format!("Failed to delete session: {e}\r\n").as_bytes())
-                                .await;
-                        }
-                    }
-                    // No manager wired (test harness): degrade to a detach.
-                    None => tracing::warn!("delete selected but no session control available"),
-                },
-                Ok(Selection::At(_)) => unreachable!(),
-                Err(e) => tracing::warn!(error = %e, "session-exit prompt failed"),
-            }
+            Self::shell_exit_prompt(
+                self.delta.as_ref(),
+                self.control.as_ref(),
+                rs.make_reader(),
+                &mut w,
+            )
+            .await;
         }
 
         let _ = ws.eof().await;
         let _ = ws.exit_status(0).await;
         let _ = ws.close().await; // needed to release the remote
+    }
+
+    /// The shell-exit prompt, run after the session process ends: leads with
+    /// the files changed since activation (when `delta` is available), then
+    /// offers exit-vs-delete and drives the chosen teardown through
+    /// `control`. Extracted from [`Binding::run`]'s mainloop epilogue purely
+    /// for readability; the bytes written to the channel are identical. An
+    /// associated fn taking the binding's capabilities piecewise because
+    /// `run` has already moved the channel out of `self` by this point.
+    async fn shell_exit_prompt<R, W>(
+        delta: Option<&Arc<DeltaSource>>,
+        control: Option<&SessionControl>,
+        r: R,
+        mut w: W,
+    ) where
+        R: tokio::io::AsyncRead + Unpin,
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        // The shell process exited. For a bash shell, this usually meant someone pressed ctrl-d absent-mindedly.
+        // We presume they didnt want to completely destroy the session, perhaps just detach, but lets prompt
+        // to see where they wanted to go from here.
+        let _ = w.write_all(b"\r\n").await;
+
+        // Lead with what a "delete" would lose. An unavailable delta (no
+        // baseline, or the re-walk failed) renders the plain prompt — the
+        // exit path never blocks on change detection.
+        let changed = match delta {
+            Some(delta) => delta.changed_files().await,
+            None => None,
+        };
+        let mut delete_item = "Delete, all in-session files permanently deleted".to_string();
+        match &changed {
+            Some(rows) if rows.is_empty() => {
+                let _ = w
+                    .write_all(format!("{SHELL_EXIT_NO_CHANGES}\r\n\r\n").as_bytes())
+                    .await;
+                delete_item.push_str(" — nothing will be lost");
+            }
+            Some(rows) => {
+                let n = rows.len();
+                let plural = if n == 1 { "" } else { "s" };
+                let _ = w
+                    .write_all(format!("{n} file{plural} changed since activation:\r\n").as_bytes())
+                    .await;
+                for row in rows.iter().take(DELTA_ROWS_SHOWN) {
+                    let _ = w.write_all(format!("  {row}\r\n").as_bytes()).await;
+                }
+                if n > DELTA_ROWS_SHOWN {
+                    let _ = w
+                        .write_all(
+                            format!("  ... and {} more\r\n", n - DELTA_ROWS_SHOWN).as_bytes(),
+                        )
+                        .await;
+                }
+                let _ = w.write_all(b"\r\n").await;
+            }
+            None => {}
+        }
+        match async_dialog::Select::new()
+            .with_prompt(SHELL_EXIT_PROMPT)
+            .items([
+                "Exit, leaving the session filesystem in place and recoverable",
+                delete_item.as_str(),
+            ])
+            .interact(r, &mut w)
+            .await
+        {
+            // User selected detach, keep going to disconnect
+            Ok(Selection::At(0)) => {}
+            // User cancelled selection, safest option is to detach
+            Ok(Selection::Cancelled) => {}
+            // User selected delete: ask the manager to tear the whole
+            // session down (kill the host, remove the on-disk record) before
+            // we close the channel. Awaiting is deadlock-free here — the
+            // destroy cascade waits on the host runtime loop (already exiting
+            // now that the process has ended), never on this binding task.
+            Ok(Selection::At(1)) => match control {
+                Some(control) => {
+                    let _ = w.write_all(b"\r\nDeleting session...\r\n").await;
+                    if let Err(e) = control.destroy().await {
+                        tracing::warn!(error = %e, "session delete failed");
+                        let _ = w
+                            .write_all(format!("Failed to delete session: {e}\r\n").as_bytes())
+                            .await;
+                    }
+                }
+                // No manager wired (test harness): degrade to a detach.
+                None => tracing::warn!("delete selected but no session control available"),
+            },
+            Ok(Selection::At(_)) => unreachable!(),
+            Err(e) => tracing::warn!(error = %e, "session-exit prompt failed"),
+        }
     }
 }
 

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -24,9 +24,11 @@ use tracing::Instrument as _;
 
 use crate::RequestedPty;
 use crate::session::SessionPaths;
+use crate::session_delta::DeltaSource;
 use crate::sessions::SessionControl;
 #[cfg(not(test))]
 use sessions::NetworkMode;
+use std::sync::Arc;
 
 /// Command sequence for the ctrl-w key chord, when the kitty keyboard protocol
 /// is negotiated.
@@ -44,6 +46,16 @@ const CTRL_W_CSI_27: &[u8] = b"\x1b[27;5;119~";
 /// appearance in the channel output before answering.
 pub(crate) const SHELL_EXIT_PROMPT: &str =
     "Session shell process exited. What would you like to do with this session?";
+
+/// Line rendered above the shell-exit prompt when nothing in the workspace
+/// changed since activation. Exposed for the same test-await purpose as
+/// [`SHELL_EXIT_PROMPT`].
+pub(crate) const SHELL_EXIT_NO_CHANGES: &str = "No files changed since activation.";
+
+/// How many changed-file rows the shell-exit prompt lists before folding the
+/// rest into an "and N more" line, keeping the prompt readable on a 24-row
+/// terminal.
+const DELTA_ROWS_SHOWN: usize = 10;
 
 /// The dimensions of a terminal.
 ///
@@ -346,6 +358,10 @@ struct Binding {
     /// "delete" on the shell-exit prompt. `None` for hosts spawned without a
     /// manager (the test harness), where "delete" degrades to a detach.
     control: Option<SessionControl>,
+    /// Workspace-change detection, shared from the owning [`Host`], so the
+    /// shell-exit prompt can lead with the files changed since activation.
+    /// `None` when the baseline snapshot could not be taken.
+    delta: Option<Arc<DeltaSource>>,
 }
 
 impl Binding {
@@ -355,6 +371,7 @@ impl Binding {
         channel: Channel<Msg>,
         stdin_tx: mpsc::Sender<StdinMsg>,
         control: Option<SessionControl>,
+        delta: Option<Arc<DeltaSource>>,
     ) -> (mpsc::Sender<BindingMsg>, JoinHandle<()>) {
         let (tx, rx) = mpsc::channel(4);
 
@@ -363,6 +380,7 @@ impl Binding {
             stdin_tx,
             receiver: rx,
             control,
+            delta,
         };
 
         // The channel id ties every line this binding logs back to the
@@ -486,11 +504,49 @@ impl Binding {
             // We presume they didnt want to completely destroy the session, perhaps just detach, but lets prompt
             // to see where they wanted to go from here.
             let _ = w.write_all(b"\r\n").await;
+
+            // Lead with what a "delete" would lose. An unavailable delta (no
+            // baseline, or the re-walk failed) renders the plain prompt — the
+            // exit path never blocks on change detection.
+            let changed = match &self.delta {
+                Some(delta) => delta.changed_files().await,
+                None => None,
+            };
+            let mut delete_item = "Delete, all in-session files permanently deleted".to_string();
+            match &changed {
+                Some(rows) if rows.is_empty() => {
+                    let _ = w
+                        .write_all(format!("{SHELL_EXIT_NO_CHANGES}\r\n\r\n").as_bytes())
+                        .await;
+                    delete_item.push_str(" — nothing will be lost");
+                }
+                Some(rows) => {
+                    let n = rows.len();
+                    let plural = if n == 1 { "" } else { "s" };
+                    let _ = w
+                        .write_all(
+                            format!("{n} file{plural} changed since activation:\r\n").as_bytes(),
+                        )
+                        .await;
+                    for row in rows.iter().take(DELTA_ROWS_SHOWN) {
+                        let _ = w.write_all(format!("  {row}\r\n").as_bytes()).await;
+                    }
+                    if n > DELTA_ROWS_SHOWN {
+                        let _ = w
+                            .write_all(
+                                format!("  ... and {} more\r\n", n - DELTA_ROWS_SHOWN).as_bytes(),
+                            )
+                            .await;
+                    }
+                    let _ = w.write_all(b"\r\n").await;
+                }
+                None => {}
+            }
             match async_dialog::Select::new()
                 .with_prompt(SHELL_EXIT_PROMPT)
                 .items([
                     "Exit, leaving the session filesystem in place and recoverable",
-                    "Delete, all in-session files permanently deleted",
+                    delete_item.as_str(),
                 ])
                 .interact(rs.make_reader(), &mut w)
                 .await
@@ -752,6 +808,12 @@ pub(crate) struct Host<P: SessionProcess, G: Send + 'static> {
     // shell-exit "delete" can tear the whole session down. `None` for hosts
     // built without a manager (the test harness).
     control: Option<SessionControl>,
+
+    // Workspace baseline taken before the process launched, handed to each
+    // binding so the shell-exit prompt can list the files changed during the
+    // session. `None` when the workspace could not be walked at build time;
+    // the prompt then renders without a delta.
+    delta: Option<Arc<DeltaSource>>,
 
     // Keeps launcher-owned resources (the session's `Env`, which owns the
     // sandbox files backing the running process's rootfs along with the context
@@ -1347,6 +1409,11 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
     where
         L: SessionLauncher<Process = P, Guard = G>,
     {
+        // Baseline the workspace before the process launches, so nothing the
+        // session writes can leak into the "since activation" reference point.
+        let delta =
+            DeltaSource::arm(paths.working.as_utf8_path().as_std_path().to_path_buf()).await;
+
         let Launched {
             master,
             process,
@@ -1386,6 +1453,7 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
             stdin_buf: None,
             net_guard,
             control,
+            delta,
             _guard: guard,
         };
 
@@ -1642,8 +1710,13 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
                 .write_all(&self.parser.screen().state_formatted())
                 .await;
         }
-        let new_binding =
-            Binding::spawn(channel, self.remote_tx.clone(), self.control.clone()).await;
+        let new_binding = Binding::spawn(
+            channel,
+            self.remote_tx.clone(),
+            self.control.clone(),
+            self.delta.clone(),
+        )
+        .await;
 
         if let Some((old_tx, old_join_hnd)) = self.remote.replace(new_binding) {
             // If there was a binding we just swapped out, tell it to


### PR DESCRIPTION
Exiting a session asks keep-or-delete without saying what would be lost; the prompt now leads with the files changed since activation and the delete option says when nothing would be lost.

- Baseline snapshot (relative path -> len+mtime) taken before the session process launches; re-walk and diff at shell exit.
- Prompt shows `N files changed since activation:` with up to 10 `A/M/D <path>` rows, or `No files changed since activation.` (delete option gains `— nothing will be lost`).
- Best-effort throughout: an unavailable delta renders the previous prompt verbatim; the exit path never blocks on change detection.
- Covered by unit tests on the snapshot/diff module and an end-to-end prompt test in the session harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyZLpkRf9G4A2hUDgDvn5f

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lead the minimald shell-exit prompt with files changed since activation
> - Adds a new `session_delta` module that snapshots a session workspace at activation time using `walkdir` and `blake3`, then diffs it on shell exit to produce sorted A/M/D rows.
> - The shell-exit prompt in `session_host` now shows up to 10 changed-file rows with A/M/D markers; if no files changed, the Delete option appends '— nothing will be lost'.
> - Snapshot walk is bounded by a 5s timeout and skips symlink traversal; files over 4 MiB are signed by length and mtime only, without a digest.
> - Risk: if the baseline snapshot times out or fails, `delta` is left as `None` and the prompt falls back to the plain (no-diff) display.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1123 opened
>
> - Modified `snapshot` function in `session_delta` module to exclude the root-level .git directory from baseline and re-walk operations by adding a `filter_entry` that rejects entries where depth equals 1 and file_name equals ".git", while preserving nested .git directories as ordinary content [90ba487]
> - Refactored shell-exit prompt logic in `Binding.run` method within `session_host` module by extracting inline prompt code into a new generic async associated function `Binding.shell_exit_prompt` that computes changed files via `DeltaSource`, renders either a no-changes banner or a capped list of changed files, and presents a two-item selection menu for Exit or Delete actions [90ba487]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3767383.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell-exit prompts now show workspace files added, modified, or deleted during a session.
  * Changes are detected reliably even when file size and timestamps remain unchanged.
  * Changed files are listed consistently, with long lists limited for readability.
  * Cleanup options update based on whether changes are present.

* **Bug Fixes**
  * Sessions continue to exit safely when workspace change information cannot be collected.
  * Unchanged workspaces no longer display unnecessary file-change details.
  * Symbolic links are handled safely without scanning their targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->