### PR TITLE
docs(mctx): say why the MINIMAL_INDEX_SOURCE match arms differ

### DIFF
--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -969,6 +969,14 @@ impl Context {
         graph: &Graph,
         pkgs: I,
     ) -> Result<(), Error> {
+        // The two arms are NOT interchangeable, though they look it.
+        // `rcache::Error`'s Display is `write!(f, "{:?}", self)` — it
+        // Debug-formats itself — so the fallback arm renders a Config as
+        // `Config("MINIMAL_INDEX_SOURCE: unknown index source \"banana\" ...")`,
+        // variant name and escaped quotes included. Destructuring Config and
+        // formatting the inner `msg` is what yields the clean, user-facing
+        // message. Collapsing this to one arm reintroduces the panic-era
+        // output this replaced.
         let rc = self.remote_cache(false, true).await.map_err(|e| match e {
             RemoteError::Config(msg) => Error::Other(anyhow::anyhow!("{msg}")),
             other => Error::Other(anyhow::anyhow!("{other}")),


### PR DESCRIPTION
Comment-only follow-up to #1132. No behaviour change.

## The trap

Both arms of the `map_err` produce `Error::Other(anyhow!(...))` and read as interchangeable:

```rust
.map_err(|e| match e {
    RemoteError::Config(msg) => Error::Other(anyhow::anyhow!("{msg}")),
    other => Error::Other(anyhow::anyhow!("{other}")),
})?
```

They are not. `rcache::Error`'s Display is:

```rust
impl<BE: Debug> Display for Error<BE> {
    fn fmt(&self, f) -> Result { write!(f, "{:?}", self) }
}
```

It **Debug-formats itself**, so the fallback arm renders a `Config` as `Config("MINIMAL_INDEX_SOURCE: unknown index source \"banana\" ...")` — variant name and escaped quotes included. That is precisely the string gominimal/inbox#447 was filed about. Destructuring `Config` and formatting the inner `msg` is what yields the clean user-facing message.

Collapsing this to a single arm would reintroduce the defect **while looking like a simplification**.

## Why it's worth a comment

I found this reviewing #1132 and my first instinct was to file exactly that simplification. I only caught it by going and reading the `Display` impl in another crate. The next reader will have the same instinct with less reason to check.

## Verification

- `cargo check -p mctx --locked` — clean
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document why `MINIMAL_INDEX_SOURCE` match arms in `Context.download_if_available` differ
> Adds an inline comment in [lib.rs](https://github.com/gominimal/minimal/pull/1134/files#diff-0520562087c362dc86b027cb446d246e3a007036e5cba9f68953e2245c8bb39e) explaining that the two `map_err` arms for `RemoteError::Config` are not interchangeable: one formats via `Display` (which produces Debug output), the other destructures to extract a clean inner message for user-facing output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71d6673.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->