### PR TITLE
feat: plumb daemon IDs through to identify a process

### DIFF
--- a/crates/check/src/lib.rs
+++ b/crates/check/src/lib.rs
@@ -344,6 +344,7 @@ pub struct CheckCtx {
     pub stdlib_dir: PathBuf,
     pub cache: Cache<LocalDir>,
     pub ot: Option<OpTracker>,
+    pub daemon_id: Option<String>,
 
     /// Fires when the caller wants the run to stop.
     ///
@@ -361,6 +362,7 @@ pub struct CheckCtx {
 }
 
 impl CheckCtx {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         filter_names: Vec<String>,
         skip_checkers: Vec<String>,
@@ -369,6 +371,7 @@ impl CheckCtx {
         stdlib_dir: PathBuf,
         cache: Cache<LocalDir>,
         ot: Option<OpTracker>,
+        daemon_id: Option<String>,
     ) -> Self {
         Self {
             filter_names,
@@ -378,6 +381,7 @@ impl CheckCtx {
             stdlib_dir,
             cache,
             ot,
+            daemon_id,
             cancel: CancellationToken::new(),
             semaphore: Arc::new(Semaphore::new(20)),
             check_cache: Arc::new(CheckCache::new()),
@@ -1054,6 +1058,7 @@ impl GraphBasedChecker for StandaloneTestCheck {
         if let Some(tests) = build.tests {
             let graph2 = graph.deref().clone();
             let cancel = ctx.cancel.clone();
+            let daemon_id = ctx.daemon_id.clone();
             drop(graph);
             result = tokio::task::spawn(async move {
                 let mut result = result;
@@ -1083,6 +1088,7 @@ impl GraphBasedChecker for StandaloneTestCheck {
                         exec_base: temp_dir.path().to_path_buf(),
                         graph: &graph2,
                         ot: ot.clone(),
+                        daemon_id: daemon_id.clone(),
                     };
 
                     match t.run(&opts).await {
@@ -1431,6 +1437,7 @@ mod tests {
             None,
             dir.to_path_buf(),
             Cache::at_dir(dir).expect("Cache::at_dir"),
+            None,
             None,
         )
     }

--- a/crates/check/src/outputs.rs
+++ b/crates/check/src/outputs.rs
@@ -425,6 +425,7 @@ mod tests {
             cache_dir.to_path_buf(),
             cache,
             None,
+            None,
         )
     }
 

--- a/crates/check/src/sources.rs
+++ b/crates/check/src/sources.rs
@@ -111,6 +111,7 @@ mod tests {
             cache_dir.to_path_buf(),
             cache,
             None,
+            None,
         )
     }
 

--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -77,6 +77,7 @@ pub struct ConfigBuilder {
     no_fetch: Option<bool>,
     offline: Option<bool>,
     num_parallel_builds: Option<usize>,
+    daemon_id: Option<String>,
 
     minimal_state_dir: Option<PathBuf>,
     minimal_cache_dir: Option<PathBuf>,
@@ -156,6 +157,11 @@ impl ConfigBuilder {
         self.ot = Some(ot);
         self
     }
+    /// Use the specified ID to identify this process in temp files.
+    pub fn with_daemon_id(mut self, id: String) -> Self {
+        self.daemon_id = Some(id);
+        self
+    }
     /// Override where the remote cache lives. One value serves both reader and
     /// writer: a `gs://bucket` (or bare bucket name) uses the GCS client;
     /// an `https://…` value reads over plain unauthenticated HTTPS (e.g. a
@@ -197,6 +203,7 @@ impl ConfigBuilder {
             num_parallel_builds: self
                 .num_parallel_builds
                 .unwrap_or_else(common::default_parallelism),
+            daemon_id: self.daemon_id,
 
             minimal_state_dir: self.minimal_state_dir.unwrap_or_else(|| {
                 paths::minimal_state_dir()
@@ -229,6 +236,7 @@ impl Config {
             no_cache: Some(self.no_cache),
             no_fetch: Some(self.no_fetch),
             offline: Some(self.offline),
+            daemon_id: self.daemon_id,
             num_parallel_builds: Some(self.num_parallel_builds),
             minimal_state_dir: Some(self.minimal_state_dir),
             minimal_cache_dir: Some(self.minimal_cache_dir),
@@ -253,6 +261,8 @@ pub struct Config {
     offline: bool,
     /// Maximum number of concurrent builds.
     num_parallel_builds: usize,
+    /// The identifer for this process. Downstream machinery defaults to the PID if not set.
+    daemon_id: Option<String>,
 
     /// Path to the base of the minimal state directory, typically `$XDG_STATE_DIR/minimal`.
     pub(crate) minimal_state_dir: PathBuf,
@@ -351,6 +361,10 @@ impl Config {
     }
     pub(crate) fn layer_cache_dir(&self) -> PathBuf {
         self.minimal_cache_dir.join("lc")
+    }
+
+    pub(crate) fn daemon_id(&self) -> Option<String> {
+        self.daemon_id.clone()
     }
 }
 

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -26,6 +26,7 @@ struct EnvChannel<'a> {
     state_dir: PathBuf,
     has_packages: HashSet<BuildSpecRef>,
 
+    daemon_id: Option<String>,
     ot: Option<OpTracker>,
 }
 
@@ -198,6 +199,7 @@ impl EnvChannel<'_> {
                 check_ctx.stdlib_dir().to_path_buf(),
                 check_ctx.local_cache(),
                 self.ot.clone(),
+                self.daemon_id.clone(),
             ),
         ) {
             Err(e) => return EnvChannel::write_error(e.into(), stream),
@@ -263,6 +265,7 @@ impl EnvChannel<'_> {
                 graph: &graph,
                 exec_base: output_base,
                 ot: self.ot.clone(),
+                daemon_id: self.daemon_id.clone(),
             })
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -640,6 +643,9 @@ impl<'a> Env<'a> {
                 },
             ))
             .with_env_vars(pkg_env_vars.into_iter());
+        if let Some(id) = ctx.daemon_id() {
+            config = config.with_daemon_id(id);
+        }
         if let Some(hn) = &args.hostname {
             config = config.with_hostname(hn);
         }
@@ -647,6 +653,7 @@ impl<'a> Env<'a> {
             config = config.with_username(username);
         }
 
+        let daemon_id = ctx.daemon_id();
         let mut sandbox = config
             .build(
                 base_dir,
@@ -657,6 +664,7 @@ impl<'a> Env<'a> {
                     state_dir: args.state_base_dir.clone(),
                     has_packages: args.transitives.keys().cloned().collect(),
                     ot: args.ot.clone(),
+                    daemon_id,
                 },
             )
             .await?;
@@ -882,6 +890,7 @@ mod tests {
             state_dir: state_dir.path().to_path_buf(),
             has_packages: HashSet::new(),
             ot: None,
+            daemon_id: None,
         };
 
         let (mut ours, theirs) = std::os::unix::net::UnixStream::pair().unwrap();
@@ -908,6 +917,7 @@ mod tests {
             state_dir: state_dir.path().to_path_buf(),
             has_packages: HashSet::new(),
             ot: None,
+            daemon_id: None,
         };
 
         let (mut ours, theirs) = std::os::unix::net::UnixStream::pair().unwrap();
@@ -934,6 +944,7 @@ mod tests {
             state_dir: state_dir.path().to_path_buf(),
             has_packages: HashSet::new(),
             ot: None,
+            daemon_id: None,
         };
 
         let (mut ours, theirs) = std::os::unix::net::UnixStream::pair().unwrap();
@@ -961,6 +972,7 @@ mod tests {
             state_dir: state_dir.path().to_path_buf(),
             has_packages: HashSet::new(),
             ot: None,
+            daemon_id: None,
         };
 
         assert!(!std::fs::exists(rootfs.path().join("bin")).unwrap());

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -258,6 +258,11 @@ impl DaemonContext {
         self.cache.clone()
     }
 
+    /// Returns the daemon ID.
+    pub fn daemon_id(&self) -> Option<String> {
+        self.config().daemon_id()
+    }
+
     /// Releases the local cache's read tracker (its held-open append-log fd).
     /// Called on daemon shutdown before unmounting the filesystem that holds
     /// the cache; harmless otherwise (read tracking is best-effort).
@@ -420,6 +425,10 @@ impl Context {
     /// Returns the vcs manager.
     pub fn vcs_manager(&self) -> VcsManagerHandle {
         self.daemon.vcs.clone()
+    }
+    /// Returns the daemon ID, if one was configured.
+    pub fn daemon_id(&self) -> Option<String> {
+        self.daemon.config.daemon_id()
     }
 
     /// Returns true if the context is configured to use the local cache.
@@ -705,6 +714,7 @@ impl Context {
             self.daemon.config.num_parallel_builds(),
             graph.clone(),
             cache.clone(),
+            self.daemon_id(),
             log_sink,
             self.daemon.config.ot.clone(),
             cancel,
@@ -1275,6 +1285,7 @@ mod tests {
                 exec_base: temp_dir.path().to_path_buf(),
                 graph: &graph,
                 ot: ctx.daemon.config.ot.clone(),
+                daemon_id: ctx.daemon.config.daemon_id(),
             };
 
             assert_eq!(t.run(&opts).await.unwrap(), vec![]);

--- a/crates/minimald/src/env.rs
+++ b/crates/minimald/src/env.rs
@@ -357,6 +357,7 @@ impl Env {
             .with_own_ip_tap(args.own_ip_tap)
             .with_own_ip_dns(args.own_ip_dns)
             .with_hostname(args.name.clone())
+            .with_daemon_id(ctx.daemon_id().unwrap()) // Always set under minimald
             .with_username(args.username.unwrap_or_else(|| "user".to_string()));
 
         // Wire up the channel actor and build the sandbox around the bridge.
@@ -825,6 +826,7 @@ impl SessionChannel {
                 graph: &graph,
                 exec_base: output_base,
                 ot: self.ot.clone(),
+                daemon_id: build_ctx.daemon_id(),
             })
             .await
             .map_err(std::io::Error::other)?;

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -131,6 +131,7 @@ impl std::fmt::Debug for DaemonLogRelease {
 pub struct ServerState {
     config: Config,
     sessions: sessions::ManagerHandle,
+    daemon_id: String,
 
     /// Fired by the `Shutdown` RPC handler once the session manager has been
     /// torn down, telling [`Server::run`]'s accept loop to stop accepting,
@@ -165,6 +166,7 @@ impl ServerState {
     ) -> Result<Self, std::io::Error> {
         let minimal_state_dir = config.minimal_state_dir.clone();
         let minimal_cache_dir = config.minimal_cache_dir.clone();
+        let daemon_id = common::random_alphanumeric(5);
         // Construct the per-host switch once, here at daemon scope, so a single
         // gvproxy runs for the host and a single allocator never reuses an
         // address for the daemon's lifetime (R1.4/R1.6). Its config/socket/pid
@@ -204,6 +206,7 @@ impl ServerState {
         let mctx_config = mctx::ConfigBuilder::new()
             .with_cache_dir(minimal_cache_dir.as_utf8_path())
             .with_state_dir(minimal_state_dir.as_utf8_path())
+            .with_daemon_id(daemon_id.clone())
             .build()
             .map_err(|e| std::io::Error::other(format!("mctx config: {e}")))?;
 
@@ -216,6 +219,7 @@ impl ServerState {
             )
             .await?,
             config,
+            daemon_id,
             shutdown: CancellationToken::new(),
             log_release,
             host_key: None,
@@ -305,6 +309,11 @@ impl ServerStateHandle {
     /// of the two answered, and gates the guest-only gvproxy probe.
     pub(crate) async fn in_microvm(&self) -> bool {
         self.0.lock().await.config.in_microvm
+    }
+
+    /// Returns the daemon ID.
+    pub async fn daemon_id(&self) -> String {
+        self.0.lock().await.daemon_id.clone()
     }
 
     /// Returns the daemon's TLS certificate authority (only with

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1424,6 +1424,7 @@ impl Session {
             // task-exec path (via `MakeContext`) also feeds it, so task builds
             // surface on the same tracker even though only a mint renders it.
             .with_operation_tracker(self.tracker.clone())
+            .with_daemon_id(self.daemon_ctx.daemon_id().unwrap()) // always set under minimald
             .build()
             .map_err(|e| mctx::Error::from(e).to_string())
     }

--- a/crates/minimald/src/session_sop.rs
+++ b/crates/minimald/src/session_sop.rs
@@ -613,6 +613,7 @@ impl SideOp {
                         ctx.stdlib_dir().to_path_buf(),
                         ctx.local_cache(),
                         ctx.op_tracker(),
+                        ctx.daemon_id(),
                     )
                     .with_cancel(check_cancel),
                 );
@@ -806,6 +807,7 @@ impl SideOp {
                 // workers; its internal `rayon` scope needs a runtime entered.
                 let cache = ctx.local_cache();
                 let ot = ctx.op_tracker();
+                let daemon_id = ctx.daemon_id();
                 let runtime = tokio::runtime::Handle::current();
                 let result = tokio::task::spawn_blocking(move || {
                     let _rt = runtime.enter();
@@ -814,6 +816,7 @@ impl SideOp {
                         graph: &graph,
                         exec_base: "/invalid".into(),
                         ot,
+                        daemon_id,
                     };
                     // `tar` writes in small pieces; one send per 512-byte
                     // header would be all overhead. `op::Materialize` flushes.

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -911,6 +911,7 @@ mod tests {
         let mctx_config = mctx::ConfigBuilder::new()
             .with_cache_dir(cache.path())
             .with_state_dir(state.path())
+            .with_daemon_id("test".to_string())
             .build()
             .unwrap();
         let mngr = Manager::init(daemon_dir(&state), daemon_dir(&cache), mctx_config, switch)
@@ -1555,6 +1556,7 @@ mod tests {
         let mctx_config = mctx::ConfigBuilder::new()
             .with_cache_dir(cache.path())
             .with_state_dir(state.path())
+            .with_daemon_id("test".to_string())
             .build()
             .unwrap();
         let daemon = std::sync::Arc::new(mctx::DaemonContext::init(mctx_config).unwrap());

--- a/crates/mip/src/cmd_check.rs
+++ b/crates/mip/src/cmd_check.rs
@@ -107,6 +107,7 @@ pub async fn cmd_check(args: CheckArgs, ctx: &mut Context) -> Result<(), Error> 
         ctx.stdlib_dir().to_path_buf(),
         ctx.local_cache(),
         None,
+        ctx.daemon_id(),
     );
 
     let mut checks_stream = check::run_checks(

--- a/crates/mip/src/cmd_materialize.rs
+++ b/crates/mip/src/cmd_materialize.rs
@@ -52,6 +52,7 @@ pub async fn cmd_materialize(args: MaterializeArgs, ctx: &mut Context) -> Result
             graph: &graph,
             exec_base: "/invalid".into(),
             ot: ctx.op_tracker(),
+            daemon_id: ctx.daemon_id(),
         })
         .await;
 

--- a/crates/mip/src/cmd_pkg_patched_build.rs
+++ b/crates/mip/src/cmd_pkg_patched_build.rs
@@ -33,6 +33,7 @@ pub async fn cmd_pkg_patched_build(
         graph: &graph,
         exec_base: output_base,
         ot: ctx.op_tracker(),
+        daemon_id: ctx.daemon_id(),
     })
     .await
     .map_err(|e| Error::Other(anyhow!("build failed: {}", e)))?;

--- a/crates/op/src/lib.rs
+++ b/crates/op/src/lib.rs
@@ -15,6 +15,7 @@ pub struct Options<'a> {
     pub graph: &'a Graph,
     pub exec_base: PathBuf,
     pub ot: Option<OpTracker>,
+    pub daemon_id: Option<String>,
 }
 
 /// Describes an operation which is configured and ready to be executed.

--- a/crates/op/src/materialize.rs
+++ b/crates/op/src/materialize.rs
@@ -413,6 +413,7 @@ mod tests {
             graph,
             exec_base: "/not-exists".into(),
             ot: None,
+            daemon_id: None,
         };
         futures::executor::block_on(
             Materialize {

--- a/crates/op/src/specs.rs
+++ b/crates/op/src/specs.rs
@@ -68,6 +68,7 @@ impl<'a, SF: crate::SourceFetcher> SpecBuild<'a, SF> {
                         cache: opts.cache.clone(),
                         graph: opts.graph,
                         exec_base: opts.exec_base.clone(),
+                        daemon_id: opts.daemon_id.clone(),
                     })
                     .await?;
                     match resolved_src {
@@ -317,6 +318,9 @@ impl<'a, SF: crate::SourceFetcher> Runnable for SpecBuild<'a, SF> {
         if let Some(w) = self.cpu_weight {
             config = config.with_cpu_weight(w);
         }
+        if let Some(id) = &opts.daemon_id {
+            config = config.with_daemon_id(id.clone());
+        }
         let mut sandbox = config.build(&opts.exec_base, channel).await?;
         sandbox.keep_dir(true);
 
@@ -476,6 +480,7 @@ mod tests {
             graph: &dg,
             exec_base: "/not-exists".into(),
             ot: None,
+            daemon_id: None,
         };
 
         let result = futures::executor::block_on(sb.run(&opts)).unwrap();
@@ -514,6 +519,7 @@ mod tests {
             graph: &dg,
             exec_base: "/not-exists".into(),
             ot: None,
+            daemon_id: None,
         };
 
         let err = futures::executor::block_on(sb.run(&opts))

--- a/crates/op/src/standalone_test.rs
+++ b/crates/op/src/standalone_test.rs
@@ -201,7 +201,7 @@ impl<'a> Runnable for StandaloneTest<'a> {
 
         let (deps, needs_dns, needs_internet) = self.dependencies(build, test, opts).await?;
 
-        let config = sandbox2::config::Config::new("test")
+        let mut config = sandbox2::config::Config::new("test")
             .with_rootfs(deps.into_iter())
             .with_dns(needs_dns)
             .with_network_mode(if !needs_dns && !needs_internet {
@@ -211,6 +211,9 @@ impl<'a> Runnable for StandaloneTest<'a> {
             })
             .with_hostname("test")
             .with_env_var("HOME", "/tmp");
+        if let Some(id) = &opts.daemon_id {
+            config = config.with_daemon_id(id.clone());
+        }
         let mut sandbox = config.build(&opts.exec_base, ()).await?;
 
         self.execute_in_sandbox(&mut sandbox, test).await

--- a/crates/op/src/subsets.rs
+++ b/crates/op/src/subsets.rs
@@ -126,6 +126,7 @@ mod tests {
             graph: &dg,
             exec_base: "/not-exists".into(),
             ot: None,
+            daemon_id: None,
         };
         let pending_dir = futures::executor::block_on(sb.run(run_opts)).unwrap();
         pending_dir

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -41,6 +41,7 @@ pub struct Shared<B: Backend> {
     pub graph: Graph,
     pub cache: Cache<LocalDir>,
     pub backend: B,
+    pub daemon_id: Option<String>,
     pub fetch_semaphore: Semaphore,
 }
 
@@ -78,6 +79,7 @@ pub struct Orchestrator<B: Backend> {
     pub backend: B,
     pub graph: Graph,
     pub cache: Cache<LocalDir>,
+    pub daemon_id: Option<String>,
 }
 
 impl<B: Backend> Orchestrator<B> {
@@ -86,6 +88,7 @@ impl<B: Backend> Orchestrator<B> {
         let shared = Shared {
             graph: self.graph.clone(),
             cache: self.cache.clone(),
+            daemon_id: self.daemon_id.clone(),
             backend: self.backend,
             fetch_semaphore: Semaphore::new(8),
         };

--- a/crates/orchestrator/src/local_backend.rs
+++ b/crates/orchestrator/src/local_backend.rs
@@ -229,6 +229,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
                     graph: &shared.graph,
                     ot: shared.backend.ot.clone(),
                     exec_base: shared.backend.output_base.clone(),
+                    daemon_id: shared.daemon_id.clone(),
                 })
                 .await;
             log_sink.as_ref().iter().for_each(|s| {
@@ -361,6 +362,7 @@ impl<SF: SourceFetcher> Backend for LocalBackend<SF> {
                 graph: &shared.graph,
                 ot: shared.backend.ot.clone(),
                 exec_base: shared.backend.output_base.clone(),
+                daemon_id: shared.daemon_id.clone(),
             })
             .await;
             drop(shared);
@@ -394,6 +396,7 @@ impl<SF: SourceFetcher> LocalBackend<SF> {
         num_concurrent_builds: usize,
         graph: Graph,
         cache: Cache<LocalDir>,
+        daemon_id: Option<String>,
         log_sink: Option<mpsc::UnboundedSender<BuildEvent>>,
         ot: Option<OpTracker>,
         cancel: tokio_util::sync::CancellationToken,
@@ -411,6 +414,7 @@ impl<SF: SourceFetcher> LocalBackend<SF> {
             },
             graph,
             cache,
+            daemon_id,
         })
     }
 

--- a/crates/sandbox2/src/config.rs
+++ b/crates/sandbox2/src/config.rs
@@ -183,6 +183,10 @@ pub struct Config {
     /// CPU shares, for partitioning CPU when the system is contended. Maps roughly to
     /// cgroups v2 cpu.weights.
     pub cpu_weight: Option<u64>,
+
+    /// Suffix marker to identify the process in the names of temp files/directories. Defaults
+    /// to the PID when not set.
+    pub daemon_id: Option<String>,
 }
 
 /// A command to be run in the sandbox.
@@ -222,6 +226,7 @@ impl Config {
                 working_inputs: Vec::with_capacity(6),
             },
             cpu_weight: None,
+            daemon_id: None,
         }
     }
 
@@ -366,6 +371,12 @@ impl Config {
         self
     }
 
+    /// Sets the identifier for the process/daemon doing the build.
+    pub fn with_daemon_id(mut self, id: String) -> Self {
+        self.daemon_id = Some(id);
+        self
+    }
+
     /// Builds the sandbox using the given configuration, with temporary files and the rootfs
     /// contained within the given directory.
     pub async fn build<P: AsRef<Path>, C: super::Channel>(
@@ -382,7 +393,7 @@ impl Config {
             )
         })?;
 
-        // Create a unique directory name using sandbox name, timestamp, and process ID.
+        // Create a unique directory name using sandbox name, timestamp, and daemon ID.
         // At this layer its plausible that there might be two packages of the same name
         // built at the same time, so we do an atomic directory creation dance /w an attempt
         // counter to make sure each sandbox gets its own folder.
@@ -397,11 +408,14 @@ impl Config {
                 )
             })?
             .as_secs();
-        let pid = std::process::id();
+        let id = self
+            .daemon_id
+            .clone()
+            .unwrap_or_else(|| std::process::id().to_string());
         let build_base_dir = {
             let mut attempt = 0u32;
             loop {
-                let dir_name = format!("{}-{}-{}-{}", self.name, timestamp, attempt, pid);
+                let dir_name = format!("{}-{}-{}-{}", self.name, timestamp, attempt, id);
 
                 let candidate_dir = base_dir.as_ref().join(dir_name);
                 match fs::create_dir(&candidate_dir) {


### PR DESCRIPTION
Fixes: #1001

Temporary files are now minted using a `daemon_id` suffix, which if not provided defaults to `PID` like before.

Needed to fix cache/implement clean under minimald.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Plumb daemon IDs through sandbox, build, and check operations to identify processes
> - Generates a unique alphanumeric `daemon_id` in `minimald::ServerState` and propagates it through `mctx::Config` to all downstream components.
> - Adds `daemon_id: Option<String>` to `op::Options`, `CheckCtx`, `sandbox2::config::Config`, and the orchestrator, threading the ID through builds, checks, materializations, and standalone tests.
> - Changes sandbox temp directory naming in `sandbox2::config::Config.build` to use `daemon_id` as a suffix when set, falling back to the current PID.
> - CLI commands (`cmd_check`, `cmd_materialize`, `cmd_pkg_patched_build`) forward `ctx.daemon_id()` into their respective operations.
> - Behavioral Change: sandbox temp directories are now named by daemon ID rather than PID when running under `minimald`, which affects any tooling that parses sandbox directory names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a1f61f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional daemon identity support across build, check, materialization, and test operations.
  * Server sessions now receive an automatically generated daemon identifier.
  * Sandbox directories use the daemon identifier when available, improving isolation and traceability.
  * Exposed daemon identity through runtime context and server state APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->