### PR TITLE
feat(minimal,minimald): confirm single-session destroy with the workspace delta

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -536,8 +536,8 @@ pub struct DestroyArgs {
     /// Destroy all sessions
     #[arg(long)]
     pub all: bool,
-    /// Skip confirmation when destroying all sessions
-    #[arg(long, short, requires = "all")]
+    /// Skip the destroy confirmation
+    #[arg(long, short)]
     pub force: bool,
 }
 
@@ -2316,7 +2316,98 @@ pub async fn cmd_destroy(global: &GlobalArgs, args: DestroyArgs) -> Result<(), a
         .context("a session or --all is required")?;
     let record = resolve_session(&mut client, session).await?;
 
+    match destroy_gate(args.force, global.no_input, std::io::stdin().is_terminal())? {
+        DestroyGate::Proceed => {}
+        DestroyGate::Confirm => {
+            // Lead with what the destroy would lose. Best-effort by
+            // design: an unavailable delta (stopped session, RPC error,
+            // timeout, a daemon predating the RPC) renders the plain
+            // confirm — destroy never blocks on the listing.
+            print_destroy_delta(&session_delta(&mut client, record.id).await);
+            let label = record.name.as_deref().unwrap_or(session);
+            if !confirm(
+                &format!("Destroy session {label}? This permanently deletes all in-session files."),
+                false,
+            )? {
+                println!("Aborted.");
+                return Ok(());
+            }
+        }
+    }
+
     destroy_session(&mut client, record.id, record.name.as_deref()).await
+}
+
+/// How a single-session destroy proceeds past its confirmation gate.
+#[derive(Debug, PartialEq, Eq)]
+enum DestroyGate {
+    /// `--force`: destroy without prompting.
+    Proceed,
+    /// Prompt interactively (default No) before destroying.
+    Confirm,
+}
+
+/// Decides whether a single-session destroy skips the confirm (`--force`),
+/// may prompt, or must refuse. Mirrors the `--all` headless precedent:
+/// without a terminal on stdin (or under `--no-input`) the command errors
+/// rather than letting EOF read as consent.
+fn destroy_gate(
+    force: bool,
+    no_input: bool,
+    stdin_is_terminal: bool,
+) -> Result<DestroyGate, anyhow::Error> {
+    if force {
+        return Ok(DestroyGate::Proceed);
+    }
+    if no_input || !stdin_is_terminal {
+        bail!("refusing to destroy the session without confirmation; pass --force")
+    }
+    Ok(DestroyGate::Confirm)
+}
+
+/// Best-effort fetch of the files changed since activation, for the destroy
+/// confirm. Any failure — RPC error, timeout, a daemon predating the RPC —
+/// reads as `None`, and the confirm renders without the listing.
+async fn session_delta(
+    client: &mut client::Client,
+    id: sessions::SessionId,
+) -> Option<Vec<String>> {
+    /// Client-side ceiling on the delta fetch. The daemon bounds its
+    /// workspace walk at 5 s; this sits just above so a slow-but-healthy
+    /// walk still answers while a wedged daemon cannot stall the confirm.
+    const SESSION_DELTA_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
+    use minimald_rpc::{SessionDelta, SessionDeltaRequest};
+    tokio::time::timeout(
+        SESSION_DELTA_TIMEOUT,
+        client.oneshot_rpc::<SessionDelta>(SessionDeltaRequest::Id(id)),
+    )
+    .await
+    .ok()?
+    .ok()?
+    .changed
+}
+
+/// Renders the destroy-confirm listing above the prompt: the changed-file
+/// rows as the shell-exit prompt renders them, the no-changes line, or —
+/// when the delta is unavailable — nothing at all.
+fn print_destroy_delta(changed: &Option<Vec<String>>) {
+    /// Cap on rows printed, matching the shell-exit prompt's.
+    const ROWS_SHOWN: usize = 10;
+    match changed {
+        Some(rows) if rows.is_empty() => println!("No files changed since activation."),
+        Some(rows) => {
+            let n = rows.len();
+            let plural = if n == 1 { "" } else { "s" };
+            println!("{n} file{plural} changed since activation:");
+            for row in rows.iter().take(ROWS_SHOWN) {
+                println!("  {row}");
+            }
+            if n > ROWS_SHOWN {
+                println!("  ... and {} more", n - ROWS_SHOWN);
+            }
+        }
+        None => {}
+    }
 }
 
 async fn destroy_all_sessions(
@@ -3195,14 +3286,41 @@ mod tests {
         assert!(parse(&["min", "session", "destroy"]).is_err());
         assert!(parse(&["min", "session", "destroy", "--all", "web"]).is_err());
 
-        // --force only makes sense with --all, and its error no longer hides
-        // that --all is the alternative the bare error omitted.
+        // --force skips the confirm on either target: --all, or — since the
+        // single-session confirm landed — a bare session too.
         assert!(parse(&["min", "session", "destroy", "--all", "--force"]).is_ok());
-        let bare = parse(&["min", "session", "destroy", "-f"])
-            .err()
-            .expect("-f without --all must fail to parse")
-            .to_string();
-        assert!(bare.contains("--all"), "usage must surface --all: {bare}");
+        assert!(parse(&["min", "session", "destroy", "web", "--force"]).is_ok());
+        assert!(parse(&["min", "session", "destroy", "web", "-f"]).is_ok());
+        // ... but never stands in for the required target.
+        assert!(parse(&["min", "session", "destroy", "-f"]).is_err());
+    }
+
+    /// The single-session destroy gate: `--force` proceeds promptless in
+    /// every mode; an interactive run without it prompts; a headless run
+    /// (no terminal on stdin, or `--no-input`) refuses, naming `--force` —
+    /// EOF must never read as consent.
+    #[test]
+    fn destroy_gate_headless_refuses_and_force_skips_the_prompt() {
+        assert_eq!(
+            destroy_gate(true, false, true).unwrap(),
+            DestroyGate::Proceed
+        );
+        assert_eq!(
+            destroy_gate(true, true, false).unwrap(),
+            DestroyGate::Proceed
+        );
+
+        assert_eq!(
+            destroy_gate(false, false, true).unwrap(),
+            DestroyGate::Confirm
+        );
+
+        for (no_input, tty) in [(true, true), (false, false), (true, false)] {
+            let err = destroy_gate(false, no_input, tty)
+                .expect_err("headless without --force must refuse")
+                .to_string();
+            assert!(err.contains("--force"), "error must name --force: {err}");
+        }
     }
 
     /// `min task run <task>` parses with `--keep` off by default; the flag

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -2316,14 +2316,26 @@ pub async fn cmd_destroy(global: &GlobalArgs, args: DestroyArgs) -> Result<(), a
         .context("a session or --all is required")?;
     let record = resolve_session(&mut client, session).await?;
 
-    match destroy_gate(args.force, global.no_input, std::io::stdin().is_terminal())? {
+    // Under --force the at-risk fetch is skipped outright — the gate is
+    // bypassed regardless, so there is nothing to ask the daemon for.
+    let at_risk = if args.force {
+        AtRiskState::Clean
+    } else {
+        assess_at_risk(session_delta(&mut client, record.id).await)
+    };
+    match destroy_gate(
+        args.force,
+        &at_risk,
+        global.no_input,
+        std::io::stdin().is_terminal(),
+    )? {
         DestroyGate::Proceed => {}
         DestroyGate::Confirm => {
-            // Lead with what the destroy would lose. Best-effort by
-            // design: an unavailable delta (stopped session, RPC error,
-            // timeout, a daemon predating the RPC) renders the plain
-            // confirm — destroy never blocks on the listing.
-            print_destroy_delta(&session_delta(&mut client, record.id).await);
+            if let AtRiskState::Dirty(lines) = &at_risk {
+                for line in lines {
+                    println!("{line}");
+                }
+            }
             let label = record.name.as_deref().unwrap_or(session);
             if !confirm(
                 &format!("Destroy session {label}? This permanently deletes all in-session files."),
@@ -2338,76 +2350,136 @@ pub async fn cmd_destroy(global: &GlobalArgs, args: DestroyArgs) -> Result<(), a
     destroy_session(&mut client, record.id, record.name.as_deref()).await
 }
 
+/// What the daemon's at-risk report means for the destroy gate.
+///
+/// The three-way split is deliberate: proven-clean destroys without a word,
+/// proven-dirty gates with the listing, and unknowable gates without one —
+/// an unreadable tree (stopped session, RPC failure) cannot prove dirt, but
+/// it cannot prove cleanliness either, so the gate stays conservative.
+#[derive(Debug, PartialEq, Eq)]
+enum AtRiskState {
+    /// Proven clean: everything committed and pushed, or nothing changed
+    /// since activation. Destroy proceeds without a prompt.
+    Clean,
+    /// At-risk work, with the rendered listing lines to print above the
+    /// confirm.
+    Dirty(Vec<String>),
+    /// The state could not be determined: gate, but without a listing.
+    Unknowable,
+}
+
+/// Classifies the daemon's [`minimald_rpc::SessionDeltaResponse`] (or its
+/// absence, on RPC failure/timeout) into the destroy gate's three-way
+/// state, rendering the listing lines for the dirty arm.
+fn assess_at_risk(resp: Option<minimald_rpc::SessionDeltaResponse>) -> AtRiskState {
+    use minimald_rpc::SessionDeltaResponse as R;
+    /// Cap on listing rows, matching the shell-exit prompt's.
+    const ROWS_SHOWN: usize = 10;
+    fn push_capped(rows: &[String], out: &mut Vec<String>) {
+        for row in rows.iter().take(ROWS_SHOWN) {
+            out.push(format!("  {row}"));
+        }
+        if rows.len() > ROWS_SHOWN {
+            out.push(format!("  ... and {} more", rows.len() - ROWS_SHOWN));
+        }
+    }
+    match resp {
+        None | Some(R::Unavailable) => AtRiskState::Unknowable,
+        Some(R::Vcs {
+            uncommitted,
+            unpushed_commits,
+        }) => {
+            if uncommitted.is_empty() && unpushed_commits == 0 {
+                return AtRiskState::Clean;
+            }
+            let mut lines = Vec::new();
+            if !uncommitted.is_empty() {
+                let n = uncommitted.len();
+                let s = if n == 1 { "" } else { "s" };
+                lines.push(format!("{n} file{s} with uncommitted changes:"));
+                push_capped(&uncommitted, &mut lines);
+            }
+            if unpushed_commits > 0 {
+                let s = if unpushed_commits == 1 { "" } else { "s" };
+                lines.push(format!(
+                    "{unpushed_commits} commit{s} not pushed to any remote"
+                ));
+            }
+            AtRiskState::Dirty(lines)
+        }
+        Some(R::ChangedSinceActivation { rows }) => {
+            if rows.is_empty() {
+                return AtRiskState::Clean;
+            }
+            let n = rows.len();
+            // Honest wording for the non-VCS fallback: the activation
+            // baseline cannot tell committed work from unsaved work.
+            let (noun, verb) = if n == 1 {
+                ("file", "differs")
+            } else {
+                ("files", "differ")
+            };
+            let mut lines = vec![format!(
+                "{n} {noun} {verb} from activation (may include committed work):"
+            )];
+            push_capped(&rows, &mut lines);
+            AtRiskState::Dirty(lines)
+        }
+    }
+}
+
 /// How a single-session destroy proceeds past its confirmation gate.
 #[derive(Debug, PartialEq, Eq)]
 enum DestroyGate {
-    /// `--force`: destroy without prompting.
+    /// Destroy without prompting: `--force`, or the session is proven
+    /// clean.
     Proceed,
     /// Prompt interactively (default No) before destroying.
     Confirm,
 }
 
-/// Decides whether a single-session destroy skips the confirm (`--force`),
-/// may prompt, or must refuse. Mirrors the `--all` headless precedent:
-/// without a terminal on stdin (or under `--no-input`) the command errors
-/// rather than letting EOF read as consent.
+/// Decides whether a single-session destroy proceeds promptless, may
+/// prompt, or must refuse — one match over (force, at-risk state,
+/// interactivity).
 fn destroy_gate(
     force: bool,
+    at_risk: &AtRiskState,
     no_input: bool,
     stdin_is_terminal: bool,
 ) -> Result<DestroyGate, anyhow::Error> {
-    if force {
-        return Ok(DestroyGate::Proceed);
+    let interactive = !no_input && stdin_is_terminal;
+    match (force, at_risk, interactive) {
+        // --force bypasses the gate; a proven-clean session has nothing to
+        // lose, so no friction either — including headless.
+        (true, _, _) | (false, AtRiskState::Clean, _) => Ok(DestroyGate::Proceed),
+        // At-risk (or unknowable) work with a human present: ask.
+        (false, _, true) => Ok(DestroyGate::Confirm),
+        // The `--all` headless precedent: EOF must never read as consent.
+        (false, _, false) => {
+            bail!("refusing to destroy the session without confirmation; pass --force")
+        }
     }
-    if no_input || !stdin_is_terminal {
-        bail!("refusing to destroy the session without confirmation; pass --force")
-    }
-    Ok(DestroyGate::Confirm)
 }
 
-/// Best-effort fetch of the files changed since activation, for the destroy
+/// Best-effort fetch of the session's at-risk report for the destroy
 /// confirm. Any failure — RPC error, timeout, a daemon predating the RPC —
-/// reads as `None`, and the confirm renders without the listing.
+/// reads as `None` (unknowable), and the confirm renders without a listing.
 async fn session_delta(
     client: &mut client::Client,
     id: sessions::SessionId,
-) -> Option<Vec<String>> {
-    /// Client-side ceiling on the delta fetch. The daemon bounds its
-    /// workspace walk at 5 s; this sits just above so a slow-but-healthy
-    /// walk still answers while a wedged daemon cannot stall the confirm.
+) -> Option<minimald_rpc::SessionDeltaResponse> {
+    /// Client-side ceiling on the fetch. The daemon bounds each of its
+    /// computations at 5 s; this sits just above so a slow-but-healthy
+    /// answer still lands while a wedged daemon cannot stall the confirm.
     const SESSION_DELTA_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
     use minimald_rpc::{SessionDelta, SessionDeltaRequest};
     tokio::time::timeout(
         SESSION_DELTA_TIMEOUT,
-        client.oneshot_rpc::<SessionDelta>(SessionDeltaRequest::Id(id)),
+        client.oneshot_rpc::<SessionDelta>(SessionDeltaRequest { id }),
     )
     .await
     .ok()?
-    .ok()?
-    .changed
-}
-
-/// Renders the destroy-confirm listing above the prompt: the changed-file
-/// rows as the shell-exit prompt renders them, the no-changes line, or —
-/// when the delta is unavailable — nothing at all.
-fn print_destroy_delta(changed: &Option<Vec<String>>) {
-    /// Cap on rows printed, matching the shell-exit prompt's.
-    const ROWS_SHOWN: usize = 10;
-    match changed {
-        Some(rows) if rows.is_empty() => println!("No files changed since activation."),
-        Some(rows) => {
-            let n = rows.len();
-            let plural = if n == 1 { "" } else { "s" };
-            println!("{n} file{plural} changed since activation:");
-            for row in rows.iter().take(ROWS_SHOWN) {
-                println!("  {row}");
-            }
-            if n > ROWS_SHOWN {
-                println!("  ... and {} more", n - ROWS_SHOWN);
-            }
-        }
-        None => {}
-    }
+    .ok()
 }
 
 async fn destroy_all_sessions(
@@ -3295,32 +3367,120 @@ mod tests {
         assert!(parse(&["min", "session", "destroy", "-f"]).is_err());
     }
 
-    /// The single-session destroy gate: `--force` proceeds promptless in
-    /// every mode; an interactive run without it prompts; a headless run
-    /// (no terminal on stdin, or `--no-input`) refuses, naming `--force` —
-    /// EOF must never read as consent.
+    /// The single-session destroy gate is dirty-only: `--force` and a
+    /// proven-clean session proceed promptless in every mode (including
+    /// headless); dirty and unknowable states prompt interactively and
+    /// refuse headless, naming `--force` — EOF must never read as consent.
     #[test]
-    fn destroy_gate_headless_refuses_and_force_skips_the_prompt() {
-        assert_eq!(
-            destroy_gate(true, false, true).unwrap(),
-            DestroyGate::Proceed
-        );
-        assert_eq!(
-            destroy_gate(true, true, false).unwrap(),
-            DestroyGate::Proceed
-        );
+    fn destroy_gate_fires_only_for_dirty_or_unknowable_state() {
+        let dirty = || AtRiskState::Dirty(vec!["1 file with uncommitted changes:".to_string()]);
 
+        // --force proceeds promptless regardless of state or mode.
+        for state in [AtRiskState::Clean, dirty(), AtRiskState::Unknowable] {
+            assert_eq!(
+                destroy_gate(true, &state, true, false).unwrap(),
+                DestroyGate::Proceed
+            );
+        }
+
+        // Proven clean proceeds without --force — even headless.
+        for (no_input, tty) in [(false, true), (true, true), (false, false)] {
+            assert_eq!(
+                destroy_gate(false, &AtRiskState::Clean, no_input, tty).unwrap(),
+                DestroyGate::Proceed
+            );
+        }
+
+        // Dirty and unknowable prompt interactively...
         assert_eq!(
-            destroy_gate(false, false, true).unwrap(),
+            destroy_gate(false, &dirty(), false, true).unwrap(),
+            DestroyGate::Confirm
+        );
+        assert_eq!(
+            destroy_gate(false, &AtRiskState::Unknowable, false, true).unwrap(),
             DestroyGate::Confirm
         );
 
-        for (no_input, tty) in [(true, true), (false, false), (true, false)] {
-            let err = destroy_gate(false, no_input, tty)
-                .expect_err("headless without --force must refuse")
-                .to_string();
-            assert!(err.contains("--force"), "error must name --force: {err}");
+        // ...and refuse headless (no tty, or --no-input), naming --force.
+        for state in [dirty(), AtRiskState::Unknowable] {
+            for (no_input, tty) in [(true, true), (false, false), (true, false)] {
+                let err = destroy_gate(false, &state, no_input, tty)
+                    .expect_err("headless without --force must refuse")
+                    .to_string();
+                assert!(err.contains("--force"), "error must name --force: {err}");
+            }
         }
+    }
+
+    /// Classification of the daemon's at-risk report: proven-clean VCS
+    /// state and an empty activation delta are `Clean`; uncommitted or
+    /// unpushed work is `Dirty` with truthful headers; the fallback header
+    /// admits it may include committed work; absent or `Unavailable`
+    /// responses are `Unknowable`.
+    #[test]
+    fn assess_at_risk_classifies_clean_dirty_and_unknowable() {
+        use minimald_rpc::SessionDeltaResponse as R;
+
+        assert_eq!(assess_at_risk(None), AtRiskState::Unknowable);
+        assert_eq!(
+            assess_at_risk(Some(R::Unavailable)),
+            AtRiskState::Unknowable
+        );
+
+        // Committed and pushed: proven clean.
+        assert_eq!(
+            assess_at_risk(Some(R::Vcs {
+                uncommitted: vec![],
+                unpushed_commits: 0
+            })),
+            AtRiskState::Clean
+        );
+        // Nothing changed since activation: clean in fallback mode too.
+        assert_eq!(
+            assess_at_risk(Some(R::ChangedSinceActivation { rows: vec![] })),
+            AtRiskState::Clean
+        );
+
+        // Uncommitted files and unpushed commits both render.
+        let lines = match assess_at_risk(Some(R::Vcs {
+            uncommitted: vec!["M src/main.rs".to_string(), "A notes.md".to_string()],
+            unpushed_commits: 2,
+        })) {
+            AtRiskState::Dirty(lines) => lines,
+            other => panic!("expected Dirty, got {other:?}"),
+        };
+        assert_eq!(lines[0], "2 files with uncommitted changes:");
+        assert!(lines.contains(&"  M src/main.rs".to_string()), "{lines:?}");
+        assert_eq!(
+            lines.last().unwrap(),
+            "2 commits not pushed to any remote",
+            "{lines:?}"
+        );
+
+        // Unpushed commits alone still gate, without a files header.
+        let lines = match assess_at_risk(Some(R::Vcs {
+            uncommitted: vec![],
+            unpushed_commits: 1,
+        })) {
+            AtRiskState::Dirty(lines) => lines,
+            other => panic!("expected Dirty, got {other:?}"),
+        };
+        assert_eq!(lines, vec!["1 commit not pushed to any remote".to_string()]);
+
+        // The fallback header must not over-claim.
+        let lines = match assess_at_risk(Some(R::ChangedSinceActivation {
+            rows: vec!["A scratch.txt".to_string()],
+        })) {
+            AtRiskState::Dirty(lines) => lines,
+            other => panic!("expected Dirty, got {other:?}"),
+        };
+        assert_eq!(
+            lines,
+            vec![
+                "1 file differs from activation (may include committed work):".to_string(),
+                "  A scratch.txt".to_string(),
+            ]
+        );
     }
 
     /// `min task run <task>` parses with `--keep` off by default; the flag

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -484,8 +484,10 @@ async fn destroy_removes_session() {
     // Create a session via TestClient.
     let session_id = create_session(&daemon, "doomed").await;
 
-    // Destroy it via cmd_destroy.
-    cmd_destroy(
+    // The session has no running host, so its at-risk state is unknowable
+    // — and this test binary's stdin is not a terminal, so the destroy
+    // gate must refuse headless without --force, naming the escape hatch.
+    let err = cmd_destroy(
         &args,
         DestroyArgs {
             session: Some(session_id.to_string()),
@@ -494,11 +496,29 @@ async fn destroy_removes_session() {
         },
     )
     .await
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("--force"), "refusal must name --force: {err}");
+
+    // The refusal must leave the session untouched.
+    let mut client = daemon.server.connect().await;
+    use minimald_rpc::ListSessions;
+    let resp = client.call::<ListSessions>(&()).await;
+    assert_eq!(resp.sessions.len(), 1, "refusal must not destroy anything");
+
+    // --force skips the gate and destroys it.
+    cmd_destroy(
+        &args,
+        DestroyArgs {
+            session: Some(session_id.to_string()),
+            all: false,
+            force: true,
+        },
+    )
+    .await
     .unwrap();
 
     // Verify the session is gone.
-    let mut client = daemon.server.connect().await;
-    use minimald_rpc::ListSessions;
     let resp = client.call::<ListSessions>(&()).await;
     assert!(resp.sessions.is_empty());
 }
@@ -508,12 +528,28 @@ async fn destroy_by_name() {
     let (daemon, args) = setup().await;
     let _ = create_session(&daemon, "by-name").await;
 
-    cmd_destroy(
+    // Name resolution precedes the gate: the headless refusal (unknowable
+    // at-risk state, non-terminal stdin) proves the name resolved...
+    let err = cmd_destroy(
         &args,
         DestroyArgs {
             session: Some("by-name".to_string()),
             all: false,
             force: false,
+        },
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("--force"), "refusal must name --force: {err}");
+
+    // ...and --force destroys by name.
+    cmd_destroy(
+        &args,
+        DestroyArgs {
+            session: Some("by-name".to_string()),
+            all: false,
+            force: true,
         },
     )
     .await

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -400,34 +400,45 @@ impl OneshotSshRpc for DestroySession {
     type Response = Errorable<DestroySessionResponse>;
 }
 
-/// An RPC to read the files changed in a session's workspace since
-/// activation — the same rows the shell-exit prompt leads with. Serves
-/// the destroy-confirm listing in `min session destroy`.
+/// An RPC to read what work is at risk in a session's workspace — what a
+/// destroy would permanently lose. Serves the destroy-confirm listing in
+/// `min session destroy`.
 pub struct SessionDelta;
 
-/// The request for a [`SessionDelta`] RPC.
-///
-/// Serialized examples:
-///
-///  * `{"name": "my-session"}`
-///  * `{"id": "<some-uuid>"}`
+/// The request for a [`SessionDelta`] RPC. By id only: every caller has
+/// already resolved the session record (destroy must, to name what it
+/// deletes), so there is no name-lookup arm.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SessionDeltaRequest {
-    Name(String),
-    Id(SessionId),
+pub struct SessionDeltaRequest {
+    pub id: SessionId,
 }
 
-/// The response for a [`SessionDelta`] RPC.
-///
-/// `changed` rows render as `A <path>` / `M <path>` / `D <path>`, sorted by
-/// path; an empty vec means nothing changed. `None` means the delta is
-/// unavailable — no such session, no running host, no baseline, or the
-/// daemon-side bounded re-walk failed — and the caller should not claim
-/// anything about the workspace.
+/// The response for a [`SessionDelta`] RPC: the session's at-risk state, in
+/// decreasing order of precision. Row strings render as `A <path>` /
+/// `M <path>` / `D <path>`, sorted by path.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SessionDeltaResponse {
-    pub changed: Option<Vec<String>>,
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SessionDeltaResponse {
+    /// The workspace is a git repository and git answered: what is at risk
+    /// is precisely the uncommitted work and the unpushed commits. Both
+    /// empty/zero means the session is proven clean — everything is
+    /// committed and pushed, and a destroy loses nothing.
+    Vcs {
+        /// One row per file with uncommitted changes (untracked renders
+        /// as `A`).
+        uncommitted: Vec<String>,
+        /// Commits on any branch that no remote has.
+        unpushed_commits: u64,
+    },
+    /// No usable VCS state (no root `.git`, git missing or failing): the
+    /// rows are the files that differ from the activation-time baseline,
+    /// which may include work that was committed during the session. An
+    /// empty vec means nothing changed since activation.
+    ChangedSinceActivation { rows: Vec<String> },
+    /// Neither VCS state nor a baseline delta could be computed — no such
+    /// session, no running host, no baseline, or the bounded computation
+    /// failed. The caller cannot claim anything about the workspace.
+    Unavailable,
 }
 
 impl OneshotSshRpc for SessionDelta {
@@ -882,17 +893,33 @@ mod tests {
         );
     }
 
-    /// `SessionDelta` distinguishes "nothing changed" (`Some([])`) from
-    /// "delta unavailable" (`None`); both shapes must survive the wire.
+    /// `SessionDelta` distinguishes proven-clean VCS state, the
+    /// activation-delta fallback, and "unavailable"; all three shapes must
+    /// survive the wire, tagged by `kind`.
     #[test]
     fn session_delta_response_round_trips() {
-        let resp = SessionDeltaResponse {
-            changed: Some(vec!["A notes.md".to_string(), "M src/main.rs".to_string()]),
+        let vcs = SessionDeltaResponse::Vcs {
+            uncommitted: vec!["A notes.md".to_string(), "M src/main.rs".to_string()],
+            unpushed_commits: 3,
         };
-        assert_eq!(round_trip(&resp), resp);
+        assert_eq!(round_trip(&vcs), vcs);
+        let json = serde_json::to_string(&vcs).unwrap();
+        assert!(json.contains(r#""kind":"vcs""#), "got: {json}");
 
-        let unavailable = SessionDeltaResponse { changed: None };
+        let fallback = SessionDeltaResponse::ChangedSinceActivation {
+            rows: vec!["A scratch.txt".to_string()],
+        };
+        assert_eq!(round_trip(&fallback), fallback);
+        let json = serde_json::to_string(&fallback).unwrap();
+        assert!(
+            json.contains(r#""kind":"changed_since_activation""#),
+            "got: {json}"
+        );
+
+        let unavailable = SessionDeltaResponse::Unavailable;
         assert_eq!(round_trip(&unavailable), unavailable);
+        let json = serde_json::to_string(&unavailable).unwrap();
+        assert!(json.contains(r#""kind":"unavailable""#), "got: {json}");
     }
 
     #[test]

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -400,6 +400,42 @@ impl OneshotSshRpc for DestroySession {
     type Response = Errorable<DestroySessionResponse>;
 }
 
+/// An RPC to read the files changed in a session's workspace since
+/// activation — the same rows the shell-exit prompt leads with. Serves
+/// the destroy-confirm listing in `min session destroy`.
+pub struct SessionDelta;
+
+/// The request for a [`SessionDelta`] RPC.
+///
+/// Serialized examples:
+///
+///  * `{"name": "my-session"}`
+///  * `{"id": "<some-uuid>"}`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionDeltaRequest {
+    Name(String),
+    Id(SessionId),
+}
+
+/// The response for a [`SessionDelta`] RPC.
+///
+/// `changed` rows render as `A <path>` / `M <path>` / `D <path>`, sorted by
+/// path; an empty vec means nothing changed. `None` means the delta is
+/// unavailable — no such session, no running host, no baseline, or the
+/// daemon-side bounded re-walk failed — and the caller should not claim
+/// anything about the workspace.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionDeltaResponse {
+    pub changed: Option<Vec<String>>,
+}
+
+impl OneshotSshRpc for SessionDelta {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "SessionDelta");
+    type Request<'a> = SessionDeltaRequest;
+    type Response = SessionDeltaResponse;
+}
+
 /// An RPC asking the daemon to shut down its session manager so the process
 /// can terminate gracefully.
 pub struct Shutdown;
@@ -844,6 +880,19 @@ mod tests {
                 ingress: None
             })
         );
+    }
+
+    /// `SessionDelta` distinguishes "nothing changed" (`Some([])`) from
+    /// "delta unavailable" (`None`); both shapes must survive the wire.
+    #[test]
+    fn session_delta_response_round_trips() {
+        let resp = SessionDeltaResponse {
+            changed: Some(vec!["A notes.md".to_string(), "M src/main.rs".to_string()]),
+        };
+        assert_eq!(round_trip(&resp), resp);
+
+        let unavailable = SessionDeltaResponse { changed: None };
+        assert_eq!(round_trip(&unavailable), unavailable);
     }
 
     #[test]

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -6,8 +6,8 @@ use minimald_rpc::{
     GetSessionPolicyRequest, GetSessionRecord, GetSessionRecordRequest, GetSessionRecordResponse,
     GetVersion, GetVersionResponse, IssueClientCert, IssueClientCertRequest, ListSessions,
     ListSessionsEntry, ListSessionsResponse, OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession,
-    RenameSessionResponse, ResourcePool, Shutdown, ShutdownRequest, ShutdownResponse,
-    SubmitVerdict,
+    RenameSessionResponse, ResourcePool, SessionDelta, SessionDeltaRequest, SessionDeltaResponse,
+    Shutdown, ShutdownRequest, ShutdownResponse, SubmitVerdict,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
@@ -548,6 +548,30 @@ async fn serve_get_session_policy(
                 // session record, not a hardcoded default.
                 Some(record) => Ok(Errorable::Ok(record.policy)),
             }
+        })
+        .await
+}
+
+/// `SessionDelta`: the files changed in the session's workspace since
+/// activation, as the shell-exit prompt renders them. Best-effort by
+/// contract: an unknown session, a session without a running host, and an
+/// unavailable delta all answer `changed: None` rather than an error — the
+/// client's destroy confirm renders with or without the listing.
+async fn serve_session_delta(
+    s: ServerStateHandle,
+    c: RuChannel<Msg>,
+) -> Result<(), ConnectionError> {
+    SessionDelta
+        .handle_channel(c, async |req| {
+            let predicate = match req {
+                SessionDeltaRequest::Id(id) => SessionKeyPredicate::Id(id),
+                SessionDeltaRequest::Name(name) => SessionKeyPredicate::Name(name),
+            };
+            let changed = match s.sessions_manager().await.get_session(predicate).await {
+                Ok(Some(h)) => h.workspace_delta().await,
+                Ok(None) | Err(_) => None,
+            };
+            Ok(SessionDeltaResponse { changed })
         })
         .await
 }
@@ -1182,6 +1206,7 @@ pub async fn handle_ssh_rpc(
         | Shutdown::NAME
         | AbortSession::NAME
         | GetSessionPolicy::NAME
+        | SessionDelta::NAME
         | GetMeshStatus::NAME
         | STREAM_WORKSPACE_FILES
         | STREAM_WORKSPACE_PATCHES
@@ -1261,6 +1286,7 @@ pub async fn handle_ssh_rpc(
         Shutdown::NAME => serve!(serve_shutdown(s, channel)),
         AbortSession::NAME => serve!(serve_abort_session(s, channel)),
         GetSessionPolicy::NAME => serve!(serve_get_session_policy(s, channel)),
+        SessionDelta::NAME => serve!(serve_session_delta(s, channel)),
         GetMeshStatus::NAME => serve!(serve_get_mesh_status(s, channel)),
         STREAM_WORKSPACE_FILES => serve!(serve_stream_workspace_files(s, config, channel)),
         STREAM_WORKSPACE_PATCHES => serve!(serve_stream_workspace_patches(s, config, channel)),

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -552,26 +552,25 @@ async fn serve_get_session_policy(
         .await
 }
 
-/// `SessionDelta`: the files changed in the session's workspace since
-/// activation, as the shell-exit prompt renders them. Best-effort by
-/// contract: an unknown session, a session without a running host, and an
-/// unavailable delta all answer `changed: None` rather than an error — the
-/// client's destroy confirm renders with or without the listing.
+/// `SessionDelta`: the session workspace's at-risk report — VCS-exact
+/// (uncommitted files, unpushed commits) when the tree is a git repository,
+/// the changed-since-activation rows otherwise. Best-effort by contract: an
+/// unknown session, a session without a running host, and a failed
+/// computation all answer `Unavailable` rather than an error — the client's
+/// destroy confirm renders with or without the listing.
 async fn serve_session_delta(
     s: ServerStateHandle,
     c: RuChannel<Msg>,
 ) -> Result<(), ConnectionError> {
     SessionDelta
-        .handle_channel(c, async |req| {
-            let predicate = match req {
-                SessionDeltaRequest::Id(id) => SessionKeyPredicate::Id(id),
-                SessionDeltaRequest::Name(name) => SessionKeyPredicate::Name(name),
-            };
-            let changed = match s.sessions_manager().await.get_session(predicate).await {
-                Ok(Some(h)) => h.workspace_delta().await,
-                Ok(None) | Err(_) => None,
-            };
-            Ok(SessionDeltaResponse { changed })
+        .handle_channel(c, async |req: SessionDeltaRequest| {
+            let predicate = SessionKeyPredicate::Id(req.id);
+            Ok(
+                match s.sessions_manager().await.get_session(predicate).await {
+                    Ok(Some(h)) => h.workspace_at_risk().await,
+                    Ok(None) | Err(_) => SessionDeltaResponse::Unavailable,
+                },
+            )
         })
         .await
 }

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -272,11 +272,10 @@ enum SessionMessage {
         ChannelConfig,
     ),
     GetHostAttrs(oneshot::Sender<Option<HostAttrs>>),
-    /// The files changed in the session's workspace since activation (the
-    /// shell-exit prompt's rows), served to the `SessionDelta` RPC for the
-    /// destroy confirm. `None` without a running host, or when the host's
-    /// delta is unavailable.
-    GetWorkspaceDelta(oneshot::Sender<Option<Vec<String>>>),
+    /// The workspace's at-risk report (what a destroy would lose), served
+    /// to the `SessionDelta` RPC for the destroy confirm. `Unavailable`
+    /// without a running host, or when the host cannot compute it.
+    GetWorkspaceDelta(oneshot::Sender<minimald_rpc::SessionDeltaResponse>),
     /// Compose a `Draft` session's loadout from the project config and the
     /// client's wire contribution. `None` finalizes the session (`Active`);
     /// `Some(response)` parks it in `Draft` awaiting a verdict. Refused with
@@ -637,16 +636,16 @@ impl Session {
                 SessionInner::Active {
                     host: Some((h, _)), ..
                 } => {
-                    // Forwarded off-actor: the host answers via a bounded
-                    // workspace re-walk that can take seconds, and this
-                    // actor must stay responsive while it runs.
+                    // Forwarded off-actor: the host answers via bounded git
+                    // commands / a workspace re-walk that can take seconds,
+                    // and this actor must stay responsive while they run.
                     let h = h.clone();
                     tokio::spawn(async move {
-                        let _ = r.send(h.changed_files().await);
+                        let _ = r.send(h.at_risk().await);
                     });
                 }
                 _ => {
-                    let _ = r.send(None);
+                    let _ = r.send(minimald_rpc::SessionDeltaResponse::Unavailable);
                 }
             },
             SessionMessage::ConfigureLoadout(contribution, r) => {
@@ -1615,16 +1614,16 @@ impl SessionHandle {
         recv.await.ok().flatten()
     }
 
-    /// Returns the files changed in the session's workspace since activation
-    /// (the shell-exit prompt's rows), or `None` when the delta is
-    /// unavailable — no running host, no baseline, a failed bounded re-walk,
-    /// or a dead actor. Never an error: the destroy confirm renders with or
-    /// without the listing.
-    pub async fn workspace_delta(&self) -> Option<Vec<String>> {
+    /// Returns the workspace's at-risk report (what a destroy would lose),
+    /// or `Unavailable` when it cannot be computed — no running host, no
+    /// baseline, failed bounded computation, or a dead actor. Never an
+    /// error: the destroy confirm renders with or without the listing.
+    pub async fn workspace_at_risk(&self) -> minimald_rpc::SessionDeltaResponse {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(SessionMessage::GetWorkspaceDelta(send)).await;
-        recv.await.ok().flatten()
+        recv.await
+            .unwrap_or(minimald_rpc::SessionDeltaResponse::Unavailable)
     }
 
     /// Returns a minimal context initialized on this sessions' worktree.
@@ -2159,39 +2158,27 @@ mod tests {
         );
     }
 
-    /// The `SessionDelta` RPC serves the destroy-confirm listing from the
-    /// running host's baseline: a file seeded before activation and edited
-    /// during the session comes back as an `M` row, a file created during
-    /// the session as an `A` row.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn session_delta_rpc_reports_changed_files_for_a_running_session() {
-        use minimald_rpc::{SessionDelta, SessionDeltaRequest};
-
-        let server = TestServer::new().await;
-        let mut client = server.connect().await;
-        let session_id = create_session(&mut client).await;
-
-        // Seed a file before the host launches, so the baseline snapshot
-        // includes it and the in-session edit below reads as `M`.
-        let manager = server.state.sessions_manager().await;
-        let handle = manager
+    /// Resolves a live session's handle and workspace paths.
+    async fn session_paths(
+        server: &TestServer,
+        session_id: SessionId,
+    ) -> crate::session::SessionPaths {
+        server
+            .state
+            .sessions_manager()
+            .await
             .get_session(crate::sessions::SessionKeyPredicate::Id(session_id))
             .await
             .unwrap()
-            .expect("session should resolve");
-        let paths = handle.paths().await.expect("paths should resolve");
-        let seeded = paths
-            .working
-            .join(&paths::DaemonRelPath::try_new("seeded.txt").unwrap());
-        tokio::fs::write(seeded.as_utf8_path(), b"v1")
+            .expect("session should resolve")
+            .paths()
             .await
-            .unwrap();
+            .expect("paths should resolve")
+    }
 
-        let mut channel = client.open_shell(session_id).await;
-
-        // Prove the shell is live (mock echoes `got:<line>`): the baseline
-        // is taken before the process launches, so changes from here on
-        // are "since activation".
+    /// Drives the shell until the mock echoes the line back, proving the
+    /// host is live (and the delta baseline armed).
+    async fn await_echo(channel: &mut russh::Channel<russh::client::Msg>) {
         channel.data_bytes(b"hello\n".to_vec()).await.unwrap();
         let mut stdout = Vec::new();
         loop {
@@ -2206,24 +2193,50 @@ mod tests {
                 None => panic!("channel closed before the echo arrived"),
             }
         }
+    }
 
-        // Change the workspace daemon-side, as an in-session shell would.
-        tokio::fs::write(seeded.as_utf8_path(), b"v2 longer")
+    /// Without a usable repository the `SessionDelta` RPC falls back to the
+    /// changed-since-activation baseline: a file seeded before activation
+    /// and edited during the session comes back as an `M` row, a file
+    /// created during the session as an `A` row. The workspace carries an
+    /// empty `.git` marker dir (as the e2e task seed does) to prove a
+    /// non-repository `.git` degrades to the fallback rather than erroring.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn session_delta_rpc_falls_back_to_activation_delta_without_a_repo() {
+        use minimald_rpc::{SessionDelta, SessionDeltaRequest, SessionDeltaResponse};
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        // Seed a file before the host launches, so the baseline snapshot
+        // includes it and the in-session edit below reads as `M`. The
+        // empty `.git` marker makes VCS mode decline, not fail.
+        let paths = session_paths(&server, session_id).await;
+        let working = paths.working.as_utf8_path();
+        tokio::fs::create_dir(working.join(".git")).await.unwrap();
+        tokio::fs::write(working.join("seeded.txt"), b"v1")
             .await
             .unwrap();
-        let added = paths
-            .working
-            .join(&paths::DaemonRelPath::try_new("scratch.txt").unwrap());
-        tokio::fs::write(added.as_utf8_path(), b"made in session")
+
+        let mut channel = client.open_shell(session_id).await;
+        await_echo(&mut channel).await;
+
+        // Change the workspace daemon-side, as an in-session shell would.
+        tokio::fs::write(working.join("seeded.txt"), b"v2 longer")
+            .await
+            .unwrap();
+        tokio::fs::write(working.join("scratch.txt"), b"made in session")
             .await
             .unwrap();
 
         let resp = client
-            .call::<SessionDelta>(&SessionDeltaRequest::Id(session_id))
+            .call::<SessionDelta>(&SessionDeltaRequest { id: session_id })
             .await;
-        let rows = resp
-            .changed
-            .expect("delta should be available for a running session");
+        let rows = match resp {
+            SessionDeltaResponse::ChangedSinceActivation { rows } => rows,
+            other => panic!("expected the activation-delta fallback, got {other:?}"),
+        };
         assert!(
             rows.contains(&"A scratch.txt".to_string()),
             "expected the added file; got: {rows:?}"
@@ -2234,12 +2247,107 @@ mod tests {
         );
     }
 
-    /// A session without a running host has no delta baseline: the RPC
-    /// answers `changed: None` (never an error), so the destroy confirm
-    /// degrades to its plain form.
+    /// With a real repository in the workspace the `SessionDelta` RPC
+    /// reports VCS-exact state through the whole stack: committed-and-pushed
+    /// is proven clean (even though the tree differs from an empty
+    /// activation baseline), and new work lists as uncommitted rows. The
+    /// unpushed-commit arm is covered by `session_delta`'s unit tests.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn session_delta_rpc_is_none_without_a_running_host() {
-        use minimald_rpc::{SessionDelta, SessionDeltaRequest};
+    async fn session_delta_rpc_reports_vcs_state_for_a_git_workspace() {
+        use minimald_rpc::{SessionDelta, SessionDeltaRequest, SessionDeltaResponse};
+
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            eprintln!("skipping: no git binary in this environment");
+            return;
+        }
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        let paths = session_paths(&server, session_id).await;
+        let working = paths.working.as_utf8_path().as_std_path();
+        tokio::fs::write(working.join("tracked.txt"), b"v1")
+            .await
+            .unwrap();
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(working)
+                .args([
+                    "-c",
+                    "user.name=t",
+                    "-c",
+                    "user.email=t@example.invalid",
+                    "-c",
+                    "commit.gpgsign=false",
+                ])
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        let bare = tempfile::tempdir().unwrap();
+        let init = std::process::Command::new("git")
+            .args(["init", "--bare", "-b", "main"])
+            .arg(bare.path())
+            .output()
+            .unwrap();
+        assert!(init.status.success(), "git init --bare failed");
+        git(&["init", "-b", "main"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-m", "initial"]);
+        git(&["remote", "add", "origin", bare.path().to_str().unwrap()]);
+        git(&["push", "origin", "main"]);
+
+        let mut channel = client.open_shell(session_id).await;
+        await_echo(&mut channel).await;
+
+        // Everything committed and pushed: proven clean.
+        let resp = client
+            .call::<SessionDelta>(&SessionDeltaRequest { id: session_id })
+            .await;
+        assert_eq!(
+            resp,
+            SessionDeltaResponse::Vcs {
+                uncommitted: vec![],
+                unpushed_commits: 0
+            },
+        );
+
+        // In-session work: an edit and an untracked file are at risk.
+        tokio::fs::write(working.join("tracked.txt"), b"v2")
+            .await
+            .unwrap();
+        tokio::fs::write(working.join("wip.txt"), b"unsaved")
+            .await
+            .unwrap();
+        let resp = client
+            .call::<SessionDelta>(&SessionDeltaRequest { id: session_id })
+            .await;
+        assert_eq!(
+            resp,
+            SessionDeltaResponse::Vcs {
+                uncommitted: vec!["M tracked.txt".to_string(), "A wip.txt".to_string()],
+                unpushed_commits: 0
+            },
+        );
+    }
+
+    /// A session without a running host cannot say what is at risk: the RPC
+    /// answers `Unavailable` (never an error), and the client gates the
+    /// destroy conservatively without a listing.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn session_delta_rpc_is_unavailable_without_a_running_host() {
+        use minimald_rpc::{SessionDelta, SessionDeltaRequest, SessionDeltaResponse};
 
         let server = TestServer::new().await;
         let mut client = server.connect().await;
@@ -2248,9 +2356,9 @@ mod tests {
         let session_id = create_session(&mut client).await;
 
         let resp = client
-            .call::<SessionDelta>(&SessionDeltaRequest::Id(session_id))
+            .call::<SessionDelta>(&SessionDeltaRequest { id: session_id })
             .await;
-        assert_eq!(resp.changed, None);
+        assert_eq!(resp, SessionDeltaResponse::Unavailable);
     }
 
     /// Selecting "delete" on the shell-exit prompt must tear the connection down

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -272,6 +272,11 @@ enum SessionMessage {
         ChannelConfig,
     ),
     GetHostAttrs(oneshot::Sender<Option<HostAttrs>>),
+    /// The files changed in the session's workspace since activation (the
+    /// shell-exit prompt's rows), served to the `SessionDelta` RPC for the
+    /// destroy confirm. `None` without a running host, or when the host's
+    /// delta is unavailable.
+    GetWorkspaceDelta(oneshot::Sender<Option<Vec<String>>>),
     /// Compose a `Draft` session's loadout from the project config and the
     /// client's wire contribution. `None` finalizes the session (`Active`);
     /// `Some(response)` parks it in `Draft` awaiting a verdict. Refused with
@@ -628,6 +633,22 @@ impl Session {
                     _ => None,
                 });
             }
+            SessionMessage::GetWorkspaceDelta(r) => match &self.inner {
+                SessionInner::Active {
+                    host: Some((h, _)), ..
+                } => {
+                    // Forwarded off-actor: the host answers via a bounded
+                    // workspace re-walk that can take seconds, and this
+                    // actor must stay responsive while it runs.
+                    let h = h.clone();
+                    tokio::spawn(async move {
+                        let _ = r.send(h.changed_files().await);
+                    });
+                }
+                _ => {
+                    let _ = r.send(None);
+                }
+            },
             SessionMessage::ConfigureLoadout(contribution, r) => {
                 let _ = r.send(self.configure_loadout(contribution).await);
             }
@@ -1594,6 +1615,18 @@ impl SessionHandle {
         recv.await.ok().flatten()
     }
 
+    /// Returns the files changed in the session's workspace since activation
+    /// (the shell-exit prompt's rows), or `None` when the delta is
+    /// unavailable — no running host, no baseline, a failed bounded re-walk,
+    /// or a dead actor. Never an error: the destroy confirm renders with or
+    /// without the listing.
+    pub async fn workspace_delta(&self) -> Option<Vec<String>> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.0.send(SessionMessage::GetWorkspaceDelta(send)).await;
+        recv.await.ok().flatten()
+    }
+
     /// Returns a minimal context initialized on this sessions' worktree.
     pub async fn context(&self) -> Result<mctx::Context, String> {
         let (send, recv) = oneshot::channel();
@@ -2124,6 +2157,100 @@ mod tests {
             record_exists(&mut client, session_id).await,
             "keep must not delete the session record"
         );
+    }
+
+    /// The `SessionDelta` RPC serves the destroy-confirm listing from the
+    /// running host's baseline: a file seeded before activation and edited
+    /// during the session comes back as an `M` row, a file created during
+    /// the session as an `A` row.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn session_delta_rpc_reports_changed_files_for_a_running_session() {
+        use minimald_rpc::{SessionDelta, SessionDeltaRequest};
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        // Seed a file before the host launches, so the baseline snapshot
+        // includes it and the in-session edit below reads as `M`.
+        let manager = server.state.sessions_manager().await;
+        let handle = manager
+            .get_session(crate::sessions::SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("session should resolve");
+        let paths = handle.paths().await.expect("paths should resolve");
+        let seeded = paths
+            .working
+            .join(&paths::DaemonRelPath::try_new("seeded.txt").unwrap());
+        tokio::fs::write(seeded.as_utf8_path(), b"v1")
+            .await
+            .unwrap();
+
+        let mut channel = client.open_shell(session_id).await;
+
+        // Prove the shell is live (mock echoes `got:<line>`): the baseline
+        // is taken before the process launches, so changes from here on
+        // are "since activation".
+        channel.data_bytes(b"hello\n".to_vec()).await.unwrap();
+        let mut stdout = Vec::new();
+        loop {
+            match channel.wait().await {
+                Some(ChannelMsg::Data { data }) => {
+                    stdout.extend_from_slice(&data);
+                    if String::from_utf8_lossy(&stdout).contains("got:hello") {
+                        break;
+                    }
+                }
+                Some(_) => {}
+                None => panic!("channel closed before the echo arrived"),
+            }
+        }
+
+        // Change the workspace daemon-side, as an in-session shell would.
+        tokio::fs::write(seeded.as_utf8_path(), b"v2 longer")
+            .await
+            .unwrap();
+        let added = paths
+            .working
+            .join(&paths::DaemonRelPath::try_new("scratch.txt").unwrap());
+        tokio::fs::write(added.as_utf8_path(), b"made in session")
+            .await
+            .unwrap();
+
+        let resp = client
+            .call::<SessionDelta>(&SessionDeltaRequest::Id(session_id))
+            .await;
+        let rows = resp
+            .changed
+            .expect("delta should be available for a running session");
+        assert!(
+            rows.contains(&"A scratch.txt".to_string()),
+            "expected the added file; got: {rows:?}"
+        );
+        assert!(
+            rows.contains(&"M seeded.txt".to_string()),
+            "expected the modified file; got: {rows:?}"
+        );
+    }
+
+    /// A session without a running host has no delta baseline: the RPC
+    /// answers `changed: None` (never an error), so the destroy confirm
+    /// degrades to its plain form.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn session_delta_rpc_is_none_without_a_running_host() {
+        use minimald_rpc::{SessionDelta, SessionDeltaRequest};
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        // Configured but never attached: no host was minted, as for a
+        // stopped session or one recovered after a daemon restart.
+        let session_id = create_session(&mut client).await;
+
+        let resp = client
+            .call::<SessionDelta>(&SessionDeltaRequest::Id(session_id))
+            .await;
+        assert_eq!(resp.changed, None);
     }
 
     /// Selecting "delete" on the shell-exit prompt must tear the connection down

--- a/crates/minimald/src/session_delta.rs
+++ b/crates/minimald/src/session_delta.rs
@@ -103,6 +103,105 @@ impl DeltaSource {
     }
 }
 
+/// Assesses what a destroy of the workspace at `root` would permanently
+/// lose, for the `SessionDelta` RPC.
+///
+/// Precision ladder: when the workspace has a root `.git` and git answers,
+/// the report is VCS-exact — uncommitted files and unpushed commits, so a
+/// fully committed-and-pushed tree is proven clean even though it differs
+/// from the activation baseline. Otherwise it falls back to the
+/// activation-delta walk (which may include committed work), and when that
+/// too is unavailable it says so. Best-effort throughout: every arm is
+/// bounded by [`WALK_TIMEOUT`] and failures degrade down the ladder, never
+/// error.
+pub(crate) async fn assess(
+    root: PathBuf,
+    delta: Option<Arc<DeltaSource>>,
+) -> minimald_rpc::SessionDeltaResponse {
+    if let Some(vcs) = vcs_at_risk(&root).await {
+        return vcs;
+    }
+    match delta {
+        Some(delta) => match delta.changed_files().await {
+            Some(rows) => minimald_rpc::SessionDeltaResponse::ChangedSinceActivation { rows },
+            None => minimald_rpc::SessionDeltaResponse::Unavailable,
+        },
+        None => minimald_rpc::SessionDeltaResponse::Unavailable,
+    }
+}
+
+/// VCS-mode assessment: `Some` only when `root` has a `.git` entry and both
+/// git commands succeed in time; any failure (no git binary, a `.git` that
+/// isn't a real repository, a timeout) yields `None` and the caller falls
+/// back to the activation delta.
+async fn vcs_at_risk(root: &Path) -> Option<minimald_rpc::SessionDeltaResponse> {
+    if !root.join(".git").exists() {
+        return None;
+    }
+    let status = run_git(root, &["status", "--porcelain=v1", "-unormal"]).await?;
+    let count = run_git(
+        root,
+        &["rev-list", "--branches", "--not", "--remotes", "--count"],
+    )
+    .await?;
+    Some(minimald_rpc::SessionDeltaResponse::Vcs {
+        uncommitted: parse_porcelain(&status),
+        unpushed_commits: count.trim().parse::<u64>().ok()?,
+    })
+}
+
+/// Runs one git command against `root`'s tree, mirroring the `checkouts`
+/// crate's shell-out precedent, on the blocking pool with the walk timeout.
+/// `None` on spawn failure (no git binary), non-zero exit, non-UTF-8
+/// output, or timeout — the abandoned process keeps running detached until
+/// it finishes; nothing awaits it.
+async fn run_git(root: &Path, args: &[&str]) -> Option<String> {
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C").arg(root).args(args);
+    let task = tokio::task::spawn_blocking(move || cmd.output());
+    let out = tokio::time::timeout(WALK_TIMEOUT, task)
+        .await
+        .ok()?
+        .ok()?
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout).ok()
+}
+
+/// Renders `git status --porcelain=v1` output as the delta's `A/M/D <path>`
+/// rows, sorted by path: untracked (`??`) and added entries render as `A`,
+/// deletions in either column as `D`, everything else as `M`. Rename/copy
+/// entries render their new path.
+fn parse_porcelain(status: &str) -> Vec<String> {
+    let mut rows = Vec::new();
+    for line in status.lines() {
+        if line.len() < 4 {
+            continue;
+        }
+        // Format: `XY <path>` — X the index column, Y the worktree column,
+        // both ASCII, so the byte split is a char split.
+        let (code, path) = line.split_at(3);
+        let path = match path.split_once(" -> ") {
+            Some((_, new)) => new,
+            None => path,
+        };
+        let marker = if code.starts_with("??") {
+            'A'
+        } else if code[..2].contains('D') {
+            'D'
+        } else if code[..2].contains('A') {
+            'A'
+        } else {
+            'M'
+        };
+        rows.push(format!("{marker} {path}"));
+    }
+    rows.sort_by(|a, b| a[2..].cmp(&b[2..]));
+    rows
+}
+
 /// Walks `root` without following symlinks (walkdir's default), recording
 /// every non-directory entry keyed by its root-relative path. A symlink is
 /// recorded via its own metadata — never traversed, even when it points at a
@@ -282,6 +381,118 @@ mod tests {
                 "A vendor/dep/.git/config".to_string(),
             ],
         );
+    }
+
+    /// Porcelain-v1 status codes map onto the delta's `A/M/D` marker style,
+    /// sorted by path: untracked and added are `A`, deletions in either
+    /// column are `D`, edits (staged or not) are `M`, and renames render
+    /// their new path.
+    #[test]
+    fn parse_porcelain_maps_status_codes_to_delta_markers() {
+        let status = "?? new.txt\n M edited.txt\nM  staged.txt\nD  gone.txt\n\
+                      A  staged-add.txt\nR  old.txt -> renamed.txt\n";
+        assert_eq!(
+            parse_porcelain(status),
+            vec![
+                "M edited.txt".to_string(),
+                "D gone.txt".to_string(),
+                "A new.txt".to_string(),
+                "M renamed.txt".to_string(),
+                "A staged-add.txt".to_string(),
+                "M staged.txt".to_string(),
+            ],
+        );
+        assert!(parse_porcelain("").is_empty());
+    }
+
+    /// The VCS assessment ladder against a real repository: committed but
+    /// unpushed work is at risk via the commit count, pushing makes the
+    /// tree proven-clean, new work lists as uncommitted — and a `.git`
+    /// that is not a repository (the e2e seed's marker dir) declines VCS
+    /// mode so the caller falls back to the activation delta.
+    #[tokio::test]
+    async fn vcs_at_risk_distinguishes_clean_uncommitted_and_unpushed() {
+        use minimald_rpc::SessionDeltaResponse as R;
+
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            eprintln!("skipping: no git binary in this environment");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "tracked.txt", "v1");
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args([
+                    "-c",
+                    "user.name=t",
+                    "-c",
+                    "user.email=t@example.invalid",
+                    "-c",
+                    "commit.gpgsign=false",
+                ])
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "-b", "main"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-m", "initial"]);
+
+        // Committed but nowhere pushed: the commit itself is at risk.
+        assert_eq!(
+            vcs_at_risk(root).await,
+            Some(R::Vcs {
+                uncommitted: vec![],
+                unpushed_commits: 1
+            }),
+        );
+
+        // Push to a bare remote: proven clean.
+        let bare = tempfile::tempdir().unwrap();
+        let init = std::process::Command::new("git")
+            .args(["init", "--bare", "-b", "main"])
+            .arg(bare.path())
+            .output()
+            .unwrap();
+        assert!(init.status.success(), "git init --bare failed");
+        git(&["remote", "add", "origin", bare.path().to_str().unwrap()]);
+        git(&["push", "origin", "main"]);
+        assert_eq!(
+            vcs_at_risk(root).await,
+            Some(R::Vcs {
+                uncommitted: vec![],
+                unpushed_commits: 0
+            }),
+        );
+
+        // New work since: an edit and an untracked file list as at risk.
+        write(root, "tracked.txt", "v2");
+        write(root, "wip.txt", "unsaved");
+        assert_eq!(
+            vcs_at_risk(root).await,
+            Some(R::Vcs {
+                uncommitted: vec!["M tracked.txt".to_string(), "A wip.txt".to_string()],
+                unpushed_commits: 0
+            }),
+        );
+
+        // An empty `.git` marker dir is not a repository: VCS mode declines.
+        let fake = tempfile::tempdir().unwrap();
+        std::fs::create_dir(fake.path().join(".git")).unwrap();
+        assert_eq!(vcs_at_risk(fake.path()).await, None);
     }
 
     /// Symlinks are entries, never traversal: a link out of the root must not

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -662,10 +662,10 @@ enum Message {
     Kill(bool),
     Attach(Channel<Msg>, WinSize),
     GetAttrs(oneshot::Sender<HostAttrs>),
-    /// Compute the workspace delta (files changed since activation) and
-    /// reply with its rendered rows; `None` when no baseline was armed or
-    /// the re-walk fails.
-    GetChangedFiles(oneshot::Sender<Option<Vec<String>>>),
+    /// Compute the workspace's at-risk report (VCS-exact when the tree is a
+    /// git repository, the changed-since-activation delta otherwise) and
+    /// reply with it; `Unavailable` when neither can be computed.
+    GetAtRisk(oneshot::Sender<minimald_rpc::SessionDeltaResponse>),
 
     SetTitleCallback(String),
     VisualBellCallback,
@@ -768,23 +768,20 @@ impl HostHandle {
         }
     }
 
-    /// Returns the files changed in the session's workspace since activation
-    /// — the shell-exit prompt's rows — or `None` when the delta is
-    /// unavailable: no baseline was armed, the bounded re-walk failed, or
-    /// the host is gone (a dead host reads as `None`, not a panic, because
-    /// callers race teardown). The walk itself runs off the host's runtime
-    /// loop and is bounded by [`DeltaSource`]'s internal timeout.
-    pub async fn changed_files(&self) -> Option<Vec<String>> {
+    /// Returns what a destroy of the session's workspace would lose: the
+    /// VCS-exact at-risk report when the workspace is a git repository, the
+    /// changed-since-activation rows otherwise, and `Unavailable` when
+    /// neither can be computed or the host is gone (a dead host reads as
+    /// `Unavailable`, not a panic, because callers race teardown). The
+    /// computation runs off the host's runtime loop, bounded per
+    /// [`crate::session_delta::assess`].
+    pub async fn at_risk(&self) -> minimald_rpc::SessionDeltaResponse {
         let (send, recv) = oneshot::channel();
-        if self
-            .sender
-            .send(Message::GetChangedFiles(send))
-            .await
-            .is_err()
-        {
-            return None;
+        if self.sender.send(Message::GetAtRisk(send)).await.is_err() {
+            return minimald_rpc::SessionDeltaResponse::Unavailable;
         }
-        recv.await.unwrap_or(None)
+        recv.await
+            .unwrap_or(minimald_rpc::SessionDeltaResponse::Unavailable)
     }
 }
 
@@ -860,6 +857,11 @@ pub(crate) struct Host<P: SessionProcess, G: Send + 'static> {
     // session. `None` when the workspace could not be walked at build time;
     // the prompt then renders without a delta.
     delta: Option<Arc<DeltaSource>>,
+
+    // The session's workspace root, kept for the at-risk assessment
+    // (`Message::GetAtRisk`): the VCS mode needs the tree path even when
+    // the baseline snapshot could not be armed.
+    workspace_root: std::path::PathBuf,
 
     // Keeps launcher-owned resources (the session's `Env`, which owns the
     // sandbox files backing the running process's rootfs along with the context
@@ -1457,8 +1459,8 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
     {
         // Baseline the workspace before the process launches, so nothing the
         // session writes can leak into the "since activation" reference point.
-        let delta =
-            DeltaSource::arm(paths.working.as_utf8_path().as_std_path().to_path_buf()).await;
+        let workspace_root = paths.working.as_utf8_path().as_std_path().to_path_buf();
+        let delta = DeltaSource::arm(workspace_root.clone()).await;
 
         let Launched {
             master,
@@ -1500,6 +1502,7 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
             net_guard,
             control,
             delta,
+            workspace_root,
             _guard: guard,
         };
 
@@ -1631,20 +1634,17 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
                     Message::GetAttrs(s) => {
                         let _ = s.send(self.attrs.clone());
                     }
-                    Message::GetChangedFiles(s) => match &self.delta {
-                        // Computed on a spawned task: the re-walk can take
-                        // up to the delta's walk timeout, and this loop must
-                        // keep pumping the pty while it runs.
-                        Some(delta) => {
-                            let delta = Arc::clone(delta);
-                            tokio::spawn(async move {
-                                let _ = s.send(delta.changed_files().await);
-                            });
-                        }
-                        None => {
-                            let _ = s.send(None);
-                        }
-                    },
+                    Message::GetAtRisk(s) => {
+                        // Computed on a spawned task: the git commands and
+                        // the re-walk are each bounded but can take seconds,
+                        // and this loop must keep pumping the pty while
+                        // they run.
+                        let root = self.workspace_root.clone();
+                        let delta = self.delta.clone();
+                        tokio::spawn(async move {
+                            let _ = s.send(crate::session_delta::assess(root, delta).await);
+                        });
+                    }
                 }
             },
             // Read from master - stdout of session process => ssh channel (if any)

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -662,6 +662,10 @@ enum Message {
     Kill(bool),
     Attach(Channel<Msg>, WinSize),
     GetAttrs(oneshot::Sender<HostAttrs>),
+    /// Compute the workspace delta (files changed since activation) and
+    /// reply with its rendered rows; `None` when no baseline was armed or
+    /// the re-walk fails.
+    GetChangedFiles(oneshot::Sender<Option<Vec<String>>>),
 
     SetTitleCallback(String),
     VisualBellCallback,
@@ -762,6 +766,25 @@ impl HostHandle {
             Err(SendError(Message::GetAttrs(_))) => Err(()),
             Err(e) => unreachable!("{:?}", e),
         }
+    }
+
+    /// Returns the files changed in the session's workspace since activation
+    /// — the shell-exit prompt's rows — or `None` when the delta is
+    /// unavailable: no baseline was armed, the bounded re-walk failed, or
+    /// the host is gone (a dead host reads as `None`, not a panic, because
+    /// callers race teardown). The walk itself runs off the host's runtime
+    /// loop and is bounded by [`DeltaSource`]'s internal timeout.
+    pub async fn changed_files(&self) -> Option<Vec<String>> {
+        let (send, recv) = oneshot::channel();
+        if self
+            .sender
+            .send(Message::GetChangedFiles(send))
+            .await
+            .is_err()
+        {
+            return None;
+        }
+        recv.await.unwrap_or(None)
     }
 }
 
@@ -1608,6 +1631,20 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
                     Message::GetAttrs(s) => {
                         let _ = s.send(self.attrs.clone());
                     }
+                    Message::GetChangedFiles(s) => match &self.delta {
+                        // Computed on a spawned task: the re-walk can take
+                        // up to the delta's walk timeout, and this loop must
+                        // keep pumping the pty while it runs.
+                        Some(delta) => {
+                            let delta = Arc::clone(delta);
+                            tokio::spawn(async move {
+                                let _ = s.send(delta.changed_files().await);
+                            });
+                        }
+                        None => {
+                            let _ = s.send(None);
+                        }
+                    },
                 }
             },
             // Read from master - stdout of session process => ssh channel (if any)

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -366,9 +366,17 @@ if [ -n "$SEED_DIR" ] || [ -n "$SEEDED_MFILE" ]; then
     mnl ls 2>&1 || true
     fail
   fi
-  mnl session destroy "$kept" >/dev/null 2>&1 \
+  # The destroy dirty gate: headless (no TTY) without --force must refuse,
+  # and the refusal must name the escape hatch.
+  if mnl session destroy "$kept" >/dev/null 2>"$WORK/destroy-refuse.err"; then
+    echo "::error::headless 'min session destroy' without --force should refuse"
+    fail
+  fi
+  grep -q -- "--force" "$WORK/destroy-refuse.err" \
+    || { echo "::error::headless destroy refusal does not name --force"; cat "$WORK/destroy-refuse.err" 2>/dev/null || true; fail; }
+  mnl session destroy --force "$kept" >/dev/null 2>&1 \
     || { echo "::error::could not destroy kept session $kept"; fail; }
-  echo "task run --keep: session $kept retained OK"
+  echo "task run --keep: session $kept retained; dirty gate refused headless destroy OK"
 
   # Unknown task: an instant client-side error listing what IS declared.
   if (cd "$TASK_SEED_DIR" && mnl task run no-such-task >/dev/null 2>"$WORK/task-unknown.err"); then

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -366,8 +366,12 @@ if [ -n "$SEED_DIR" ] || [ -n "$SEEDED_MFILE" ]; then
     mnl ls 2>&1 || true
     fail
   fi
-  # The destroy dirty gate: headless (no TTY) without --force must refuse,
-  # and the refusal must name the escape hatch.
+  # The destroy dirty gate: the kept session's task process has exited, so
+  # no host is running and its at-risk state is unknowable — the gate must
+  # refuse a headless (no TTY) destroy without --force, naming the escape
+  # hatch. (Were a host live, the seed's empty `.git` marker would make VCS
+  # mode decline into the activation-delta fallback instead; only a
+  # proven-clean tree may destroy headless without --force.)
   if mnl session destroy "$kept" >/dev/null 2>"$WORK/destroy-refuse.err"; then
     echo "::error::headless 'min session destroy' without --force should refuse"
     fail


### PR DESCRIPTION
`min session destroy` deletes unsaved in-session work without a word; it now lists the files changed since activation and confirms with default No — and headless runs refuse without `--force`, so EOF can never read as consent.

- A small oneshot RPC serves the running host's delta baseline (merged with the exit-prompt work); rows render exactly as the exit prompt's.
- Headless refusal mirrors the existing `--all` precedent; `--force` is unhooked from `--all` and skips the confirm.
- Delta unavailable (stopped session, error, timeout) degrades to the plain confirm; destroy never blocks on the listing. `--all` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyZLpkRf9G4A2hUDgDvn5f


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add confirmation prompt with workspace delta to single-session destroy
> - Single-session `min session destroy` now prompts for confirmation before destroying, showing changed files since activation when available (up to 10 rows).
> - A new `destroy_gate` function decides whether to prompt or proceed: `--force` skips the prompt; headless runs (no TTY or `--no-input`) without `--force` return an error instructing the user to pass `--force`.
> - A new `SessionDelta` RPC fetches changed files from the daemon with a 6-second timeout; timeouts and errors silently map to `None`, so the prompt still appears without the file listing.
> - The `--force` flag is no longer restricted to `--all` and now works for single-session destroys as well.
> - Behavioral Change: headless single-session destroy without `--force` now fails with an explicit error instead of proceeding.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1148 opened
>
> - Introduced VCS-aware workspace at-risk assessment in the daemon [87280ea]
> - Replaced `SessionDeltaRequest` enum with struct and introduced tagged `SessionDeltaResponse` enum in `minimald-rpc` [87280ea]
> - Implemented at-risk state classification and destroy gate logic in `minimal` client [87280ea]
> - Updated tests to verify new destroy gate behavior and at-risk classification [87280ea]
> - Updated end-to-end test script to reflect new destroy gate behavior [87280ea]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c10c935.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts before destroying sessions.
  * Added `--force` support for destroying individual sessions or all sessions.
  * Display up to 10 files changed since session activation before confirmation.
  * Added workspace change detection for active sessions.

* **Bug Fixes**
  * Headless and no-input commands now safely refuse destruction unless `--force` is provided.
  * Unavailable change information now falls back to the standard confirmation prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->