### PR TITLE
feat(minimald): automatic cache cleaning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3800,6 +3800,7 @@ dependencies = [
  "graph",
  "hakoniwa",
  "indoc",
+ "lcache",
  "libc",
  "mctx",
  "mfile",

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -263,6 +263,26 @@ impl DaemonContext {
         self.config().daemon_id()
     }
 
+    /// Returns the base directory for build sandboxes.
+    pub fn builds_base_dir(&self) -> PathBuf {
+        self.config.builds_base_dir()
+    }
+
+    /// Returns the base directory for task sandboxes.
+    pub fn tasks_base_dir(&self) -> PathBuf {
+        self.config.task_base_dir()
+    }
+
+    /// Returns the base directory for the artifact/binary cache.
+    ///
+    /// DO NOT USE unless you really know what you are doing — prefer
+    /// [`DaemonContext::local_cache`]. Daemon-scoped twins of the
+    /// [`Context`] accessors of the same name, for callers (housekeeping,
+    /// diagnostics) that have no project mfile to hang a [`Context`] off.
+    pub fn cache_base_dir(&self) -> PathBuf {
+        self.config.built_cache_dir()
+    }
+
     /// Releases the local cache's read tracker (its held-open append-log fd).
     /// Called on daemon shutdown before unmounting the filesystem that holds
     /// the cache; harmless otherwise (read tracking is best-effort).
@@ -946,6 +966,18 @@ impl Context {
 
     /// Returns the list of all packages brought in through tasks, profiles and stacks.
     pub fn scaffolding_packages(&mut self) -> Result<Vec<BuildSpecRef>, Error> {
+        Ok(self.scaffolding_walk()?.0)
+    }
+
+    /// The spec hash of every package this project needs — the packages
+    /// [`scaffolding_packages`](Self::scaffolding_packages) finds, resolved
+    /// against the graph that same walk built.
+    pub fn needed_packages(&mut self) -> Result<HashSet<common::SpecHash>, Error> {
+        let (pkgs, graph) = self.scaffolding_walk()?;
+        Ok(pkgs.iter().map(|bsr| graph.spec_hash(bsr)).collect())
+    }
+
+    fn scaffolding_walk(&mut self) -> Result<(Vec<BuildSpecRef>, Graph), Error> {
         let mut out = std::collections::HashSet::new();
         let mut graph = self.graph_from_all_packages()?;
         let mfile = self.minimal_file().clone();
@@ -965,8 +997,12 @@ impl Context {
             out.extend(h.build_packages.clone());
             out.extend(h.runtime_packages.clone());
         }
+        if let Some(session) = &mfile.session {
+            out.extend(session.packages.clone());
+        }
 
-        out.as_bsrs(&graph)
+        let pkgs = out.as_bsrs(&graph)?;
+        Ok((pkgs, graph))
     }
 
     /// Downloads the specified packages and their dependencies, if they are missing locally

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -479,14 +479,19 @@ async fn attach_with_no_session_errors_when_ambiguous_and_no_input() {
 
 #[tokio::test]
 async fn destroy_removes_session() {
-    let (daemon, args) = setup().await;
+    let (daemon, mut args) = setup().await;
+    // Pin the gate headless. It reads `no_input || !stdin.is_terminal()`, and
+    // stdin here is whatever the runner handed us: `/dev/null` under nextest
+    // and CI, but a live terminal under a bare `cargo test` — where the gate
+    // would prompt and the test would sit waiting for a keystroke instead.
+    args.no_input = true;
 
     // Create a session via TestClient.
     let session_id = create_session(&daemon, "doomed").await;
 
-    // The session has no running host, so its at-risk state is unknowable
-    // — and this test binary's stdin is not a terminal, so the destroy
-    // gate must refuse headless without --force, naming the escape hatch.
+    // The session has no running host, so its at-risk state is unknowable,
+    // and the gate is headless, so the destroy must refuse without --force,
+    // naming the escape hatch.
     let err = cmd_destroy(
         &args,
         DestroyArgs {
@@ -525,11 +530,14 @@ async fn destroy_removes_session() {
 
 #[tokio::test]
 async fn destroy_by_name() {
-    let (daemon, args) = setup().await;
+    let (daemon, mut args) = setup().await;
+    // Headless by construction, not by whatever stdin the runner gave us —
+    // see `destroy_removes_session`.
+    args.no_input = true;
     let _ = create_session(&daemon, "by-name").await;
 
     // Name resolution precedes the gate: the headless refusal (unknowable
-    // at-risk state, non-terminal stdin) proves the name resolved...
+    // at-risk state, no input) proves the name resolved...
     let err = cmd_destroy(
         &args,
         DestroyArgs {

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -789,6 +789,61 @@ fn default_true() -> bool {
     true
 }
 
+/// Reclaim the daemon's local cache, streaming progress.
+///
+/// Not an [`OneshotSshRpc`]: the client writes one JSON-encoded
+/// [`CleanCacheRequest`] (an empty body asks for the daemon's defaults) and
+/// half-closes, then the daemon streams back one JSON-encoded
+/// [`CleanCacheUpdate`] per line — a `Removed` for each thing reclaimed, then
+/// exactly one terminal `Done` or `Failed` — and closes.
+pub const CLEAN_CACHE_SUBSYSTEM: &str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "CleanCache");
+
+/// Request body for [`CLEAN_CACHE_SUBSYSTEM`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CleanCacheRequest {
+    /// Only reclaim cache entries unread for at least this many seconds; `0`
+    /// means the daemon's default. Note that a small value is honored as
+    /// given — the daemon holds back what its sessions need, not what is
+    /// merely recent.
+    #[serde(default)]
+    pub older_than_secs: u64,
+}
+
+/// The type is `#[non_exhaustive]`, so other crates cannot write a struct
+/// literal for it; this is how a client departs from the defaults.
+impl CleanCacheRequest {
+    #[must_use]
+    pub fn with_older_than_secs(mut self, secs: u64) -> Self {
+        self.older_than_secs = secs;
+        self
+    }
+}
+
+/// One line of a [`CLEAN_CACHE_SUBSYSTEM`] response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CleanCacheUpdate {
+    /// Something was reclaimed. `detail` is the daemon's own rendering of it,
+    /// so every transport reports a clean identically; it is for humans, not
+    /// for parsing.
+    Removed { detail: String },
+    /// Terminal: the clean finished, having removed this many cache entries
+    /// and leftover execution directories.
+    Done { entries: usize, dirs: usize },
+    /// Terminal: the clean ran and failed. Nothing, some, or all of the
+    /// reclaimable set may have gone before it stopped.
+    Failed { error: String },
+}
+
+impl CleanCacheUpdate {
+    /// Whether this update ends the stream.
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Done { .. } | Self::Failed { .. })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -812,6 +867,59 @@ mod tests {
         assert_eq!(round_trip(&req), req);
         assert_eq!(
             DIAG_BUNDLE_SUBSYSTEM, "minimald-v1-DiagBundleTarZst",
+            "subsystem name is wire contract; changing it breaks old clients"
+        );
+    }
+
+    /// The clean-cache framing is wire contract: an empty request body means
+    /// the daemon's defaults, the updates are self-describing by `kind`, and
+    /// the subsystem name can't drift without breaking old clients.
+    #[test]
+    fn clean_cache_wire_shapes_round_trip() {
+        let req: CleanCacheRequest = serde_json::from_str("{}").expect("deserialize");
+        assert_eq!(req, CleanCacheRequest::default());
+        assert_eq!(req.older_than_secs, 0);
+        assert_eq!(
+            round_trip(&req.clone().with_older_than_secs(3600)).older_than_secs,
+            3600
+        );
+
+        for update in [
+            CleanCacheUpdate::Removed {
+                detail: "Deleting package curl [abc]".to_string(),
+            },
+            CleanCacheUpdate::Done {
+                entries: 2,
+                dirs: 1,
+            },
+            CleanCacheUpdate::Failed {
+                error: "nope".to_string(),
+            },
+        ] {
+            assert_eq!(round_trip(&update), update);
+        }
+        assert!(
+            !CleanCacheUpdate::Removed {
+                detail: String::new()
+            }
+            .is_terminal()
+        );
+        assert!(
+            CleanCacheUpdate::Done {
+                entries: 0,
+                dirs: 0
+            }
+            .is_terminal()
+        );
+        assert!(
+            CleanCacheUpdate::Failed {
+                error: String::new()
+            }
+            .is_terminal()
+        );
+
+        assert_eq!(
+            CLEAN_CACHE_SUBSYSTEM, "minimald-v1-CleanCache",
             "subsystem name is wire contract; changing it breaks old clients"
         );
     }

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -99,6 +99,8 @@ tokio.workspace = true
 # to the composition-only path from a nickel-declared BuildSpec.
 decode.workspace = true
 indoc.workspace = true
+# `maintenance.rs`'s tests seed the local cache the clean reclaims.
+lcache.workspace = true
 
 # The guest (initramfs pid-1) boot path is Linux-only.
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -7,6 +7,7 @@ pub mod env;
 mod exec;
 #[cfg(target_os = "linux")]
 pub mod guest;
+mod maintenance;
 #[cfg(target_os = "linux")]
 pub mod net;
 pub mod rpc;

--- a/crates/minimald/src/maintenance.rs
+++ b/crates/minimald/src/maintenance.rs
@@ -1,0 +1,390 @@
+//! Housekeeping the daemon runs on its own clock, with no client asking.
+//!
+//! Today that is one job: reclaiming the local cache. A long-lived daemon
+//! accumulates build artifacts nothing reads any more, plus the sandbox, task
+//! and temp directories of executions whose process is long gone. `mip cache
+//! clean` does this on demand for a project; here the same [`op::CleanCache`]
+//! runs for the daemon, with every live session's packages held back.
+//!
+//! Cleaning is an actor, not a bare timer, because there is more than one way
+//! to ask for one: the periodic tick, and anything that wants a clean *now*.
+//! Both arrive at [`Maintenance::mainloop`], which runs them one at a time —
+//! two cleans racing over the same cache would have one unlinking entries the
+//! other is walking. [`MaintenanceHandle::clean_now`] is the only way in from
+//! outside, and it queues rather than overlaps.
+//!
+//! [`spawn`] is called once by [`Server::run`](crate::server::Server::run);
+//! the actor lives as long as the daemon does.
+
+use std::io::ErrorKind;
+use std::time::Duration;
+
+use futures::StreamExt;
+use futures::channel::mpsc as event_chan;
+use op::{CleanCache, CleanEvent, CleanReport, StaleKind};
+use tokio::sync::mpsc;
+use tokio::task::AbortHandle;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+use crate::server::ServerStateHandle;
+use crate::sessions::Responder;
+
+/// How long after startup the first clean runs. Late enough to stay out of the
+/// way of a daemon that is still coming up (and of the session a user is
+/// probably waiting on), early enough that a machine whose daemon restarts
+/// often still gets cleaned.
+const STARTUP_DELAY: Duration = Duration::from_secs(5 * 60);
+
+/// How long after a clean the next one is due. Measured from the end of the
+/// last clean whatever asked for it, so an explicit
+/// [`clean_now`](MaintenanceHandle::clean_now) pushes the tick out rather than
+/// being followed by a redundant one.
+const CLEAN_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// How long a cache entry must have gone unread before it is reclaimed. Packages
+/// needed by sessions are retained separately.
+const UNUSED_FOR: Duration = Duration::from_secs(5 * 24 * 60 * 60);
+
+/// What the maintenance actor accepts.
+#[derive(Debug)]
+enum MaintenanceMessage {
+    /// Run a cache clean and report what it removed.
+    CleanNow {
+        /// Reclaim entries unread for at least this long; `None` for
+        /// [`UNUSED_FOR`].
+        older_than: Option<Duration>,
+        /// Where to mirror the clean's events, for a caller streaming them
+        /// somewhere (the `CleanCache` RPC streams them to its client). The
+        /// daemon log gets them either way.
+        events: Option<event_chan::UnboundedSender<CleanEvent>>,
+        responder: Responder<CleanReport>,
+    },
+}
+
+/// The daemon's housekeeping actor.
+///
+/// Follows the actor pattern, like [`crate::sessions::Manager`]. Here the
+/// pattern is load-bearing rather than incidental: being the single owner of
+/// cache cleaning is what keeps a requested clean from colliding with the
+/// periodic one.
+struct Maintenance {
+    state: ServerStateHandle,
+    receiver: mpsc::Receiver<MaintenanceMessage>,
+    /// The server shutdown token; ends the loop between cleans.
+    shutdown: CancellationToken,
+}
+
+impl Maintenance {
+    /// Runs cleans — one at a time — until shutdown.
+    ///
+    /// Each clean is awaited inline, so while one runs the next request simply
+    /// waits its turn in the channel. That is the whole serialization; nothing
+    /// here needs a lock.
+    async fn mainloop(mut self) {
+        let mut next_tick = Instant::now() + STARTUP_DELAY;
+        loop {
+            // A pending shutdown wins over a due clean (`biased`), so the loop
+            // never starts one it would have to be aborted out of.
+            tokio::select! {
+                biased;
+                () = self.shutdown.cancelled() => break,
+                msg = self.receiver.recv() => match msg {
+                    // Every handle is gone, so nothing can ask for a clean
+                    // again. Only reachable if the server state was dropped
+                    // without cancelling the token.
+                    None => break,
+                    Some(MaintenanceMessage::CleanNow { older_than, events, responder }) => {
+                        let older_than = older_than.unwrap_or(UNUSED_FOR);
+                        responder.handle(clean(&self.state, older_than, events)).await;
+                        next_tick = Instant::now() + CLEAN_INTERVAL;
+                    }
+                },
+                () = tokio::time::sleep_until(next_tick) => {
+                    // Nobody is waiting on this one; `clean` logged the outcome.
+                    let _ = clean(&self.state, UNUSED_FOR, None).await;
+                    next_tick = Instant::now() + CLEAN_INTERVAL;
+                }
+            }
+        }
+        tracing::debug!("maintenance actor stopped");
+    }
+}
+
+/// A handle to the maintenance actor.
+///
+/// Cloning is cheap and every clone reaches the same actor — which is the
+/// point: however many callers ask, cleans still happen one at a time.
+#[derive(Clone, Debug)]
+pub(crate) struct MaintenanceHandle {
+    sender: mpsc::Sender<MaintenanceMessage>,
+    abort: AbortHandle,
+}
+
+impl MaintenanceHandle {
+    /// Runs a cache clean, returning what it removed. `older_than` overrides
+    /// [`UNUSED_FOR`]; `events` receives the clean's progress as it happens,
+    /// for a caller relaying it (the `CleanCache` RPC streams it to its
+    /// client).
+    ///
+    /// Queues behind a clean already in progress rather than starting a second
+    /// one, so this can take as long as a full clean plus the one ahead of it,
+    /// and `events` stays silent until this request's turn comes.
+    /// `NotConnected` once the actor has stopped (shutdown).
+    pub(crate) async fn clean_now(
+        &self,
+        older_than: Option<Duration>,
+        events: Option<event_chan::UnboundedSender<CleanEvent>>,
+    ) -> Result<CleanReport, std::io::Error> {
+        let (send, recv) = Responder::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .sender
+            .send(MaintenanceMessage::CleanNow {
+                older_than,
+                events,
+                responder: send,
+            })
+            .await;
+        recv.await.unwrap_or_else(|_| {
+            Err(std::io::Error::new(
+                ErrorKind::NotConnected,
+                "maintenance actor is gone",
+            ))
+        })
+    }
+
+    /// Stops the actor, including a clean in flight. The shutdown token
+    /// already ends it between cleans; this covers the mid-clean case.
+    pub(crate) fn abort(&self) {
+        self.abort.abort();
+    }
+}
+
+/// Spawns the maintenance actor: a clean [`STARTUP_DELAY`] after boot, then one
+/// every [`CLEAN_INTERVAL`], plus whatever [`MaintenanceHandle::clean_now`]
+/// asks for, until `shutdown` fires.
+///
+/// A clean that fails is logged and the actor carries on; housekeeping never
+/// takes the daemon down with it.
+pub(crate) fn spawn(state: ServerStateHandle, shutdown: CancellationToken) -> MaintenanceHandle {
+    let (sender, receiver) = mpsc::channel(8);
+    let actor = Maintenance {
+        state,
+        receiver,
+        shutdown,
+    };
+    let abort = tokio::spawn(actor.mainloop()).abort_handle();
+
+    MaintenanceHandle { sender, abort }
+}
+
+/// One clean: work out what every session still needs, then reclaim everything
+/// else that has gone cold. Private to the actor — every caller arrives through
+/// [`MaintenanceHandle`], which is what keeps this from running twice at once.
+///
+/// Note the ordering hazard this deliberately does not solve: the `Shutdown`
+/// RPC quiesces the state volume *before* cancelling the token, so a clean that
+/// starts in the moment before a shutdown arrives can still be deleting under
+/// the mountpoint as it is synced. The window is small, the deletes are
+/// individually journalled, and the mainloop's `biased` select keeps it from
+/// starting a new one once the token is cancelled.
+async fn clean(
+    state: &ServerStateHandle,
+    older_than: Duration,
+    relay: Option<event_chan::UnboundedSender<CleanEvent>>,
+) -> Result<CleanReport, std::io::Error> {
+    let sessions = state.sessions_manager().await;
+
+    // The keep set is the whole safety story: everything not in it is a
+    // deletion candidate. A partial answer is therefore unusable — if any
+    // session can't say what it needs, skip the clean rather than reclaim
+    // something it was still using.
+    let keep = match sessions.needed_packages().await {
+        Ok(keep) => keep,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "skipping cache clean: could not determine what the sessions need",
+            );
+            return Err(error);
+        }
+    };
+
+    let daemon_ctx = state.daemon_context().await;
+    let cache = daemon_ctx.local_cache();
+    let (tx, rx) = event_chan::unbounded();
+    let renderer = tokio::spawn(log_events(rx, relay));
+
+    let op = CleanCache {
+        older_than,
+        keep,
+        sweep: vec![
+            (StaleKind::Sandbox, daemon_ctx.builds_base_dir()),
+            (StaleKind::Task, daemon_ctx.tasks_base_dir()),
+            (StaleKind::TempDir, daemon_ctx.cache_base_dir().join("temp")),
+        ],
+        // Never sweep this daemon's own live sandboxes and task dirs: they
+        // carry its id where another process's would carry a pid.
+        daemon_id: daemon_ctx.daemon_id(),
+        events: Some(tx),
+    };
+
+    // Walking the cache and unlinking trees is blocking work; it has no
+    // business on the runtime's async threads. Dropping `op` at the end of the
+    // closure closes the event stream, so the renderer finishes with it. The
+    // error is rendered in there too — `op::Error` is a large enum, and only
+    // its message crosses back.
+    let result =
+        tokio::task::spawn_blocking(move || op.run(&cache).map_err(|e| e.to_string())).await;
+    let _ = renderer.await;
+
+    match result {
+        Ok(Ok(report)) => {
+            tracing::info!(
+                entries = report.entries,
+                dirs = report.dirs,
+                "cache clean complete",
+            );
+            Ok(report)
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(%error, "cache clean failed");
+            Err(std::io::Error::other(error))
+        }
+        Err(error) => {
+            tracing::error!(%error, "cache clean panicked");
+            Err(std::io::Error::other(error))
+        }
+    }
+}
+
+/// Logs what the clean removed, one line per entry, until the sender drops,
+/// mirroring each event to `relay` if a caller asked for one. Best-effort on
+/// that half: a client that hung up mid-clean must not stop the clean, nor cost
+/// the daemon its own record of what was removed.
+async fn log_events(
+    mut rx: event_chan::UnboundedReceiver<CleanEvent>,
+    relay: Option<event_chan::UnboundedSender<CleanEvent>>,
+) {
+    while let Some(event) = rx.next().await {
+        tracing::info!("{}", event.render());
+        if let Some(relay) = &relay {
+            let _ = relay.unbounded_send(event);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use common::SpecHash;
+    use lcache::{EntryMeta, FileSystem, MetaInner};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::server::ServerStateHandle;
+
+    /// A daemon rooted at a fresh tempdir, with its maintenance actor running.
+    async fn daemon() -> (TempDir, ServerStateHandle, MaintenanceHandle) {
+        let dir = TempDir::new().unwrap();
+        let state = ServerStateHandle::new(crate::server::test_config(dir.path()), None)
+            .await
+            .unwrap();
+        let maintenance = spawn(state.clone(), CancellationToken::new());
+        (dir, state, maintenance)
+    }
+
+    /// Writes an entry into the daemon's local cache under `hash`. No read is
+    /// ever recorded against it, so a clean sees it as cold.
+    fn write_entry(cache: &mctx::Cache, hash: &SpecHash) {
+        let w = cache.write_dir(hash).unwrap();
+        w.open_write("f").unwrap().write_all(b"x").unwrap();
+        w.finalize(EntryMeta {
+            inner: MetaInner::Spec("test".to_string()),
+            fetched: false,
+            ..Default::default()
+        })
+        .unwrap();
+    }
+
+    /// A clean reclaims cold cache entries but not the ones a live session
+    /// still needs — the whole point of routing the keep set through the
+    /// sessions manager.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clean_keeps_what_a_session_needs_and_drops_the_rest() {
+        let (_dir, state, maintenance) = daemon().await;
+
+        // A session that needs exactly one package, and the hash it resolves.
+        let mngr = state.sessions_manager().await;
+        let _id = crate::sessions::tests::active_session_needing(&mngr, "sess", "pkg-a").await;
+        let needed: Vec<SpecHash> = mngr.needed_packages().await.unwrap().into_iter().collect();
+        assert_eq!(needed.len(), 1, "the session needs its one package");
+
+        // Both go into the cache with no recorded read: only the keep set
+        // separates them.
+        let cache = state.daemon_context().await.local_cache();
+        let cold = SpecHash::from_bytes([9; 32]);
+        write_entry(&cache, &needed[0]);
+        write_entry(&cache, &cold);
+
+        let report = maintenance.clean_now(None, None).await.unwrap();
+
+        assert_eq!(
+            report,
+            CleanReport {
+                entries: 1,
+                dirs: 0
+            }
+        );
+        let left: Vec<SpecHash> = cache.iter_entries().collect();
+        assert_eq!(left, vec![needed[0].clone()], "the cold entry should go");
+    }
+
+    /// With no sessions at all the keep set is empty, so a cold entry goes —
+    /// and the clean still completes cleanly (the sweep dirs exist, the temp
+    /// dir included).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clean_runs_with_no_sessions() {
+        let (_dir, state, maintenance) = daemon().await;
+        let cache = state.daemon_context().await.local_cache();
+        write_entry(&cache, &SpecHash::from_bytes([1; 32]));
+
+        assert_eq!(
+            maintenance.clean_now(None, None).await.unwrap(),
+            CleanReport {
+                entries: 1,
+                dirs: 0
+            },
+        );
+        assert_eq!(cache.iter_entries().count(), 0);
+    }
+
+    /// Two requests in flight at once don't overlap: the actor takes them in
+    /// turn, so one reclaims both entries and the other finds nothing left. If
+    /// they ran together they would be walking and unlinking the same cache
+    /// tree, and the counts would not add up to exactly what was there.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_requests_are_serialized() {
+        let (_dir, state, maintenance) = daemon().await;
+        let cache = state.daemon_context().await.local_cache();
+        write_entry(&cache, &SpecHash::from_bytes([1; 32]));
+        write_entry(&cache, &SpecHash::from_bytes([2; 32]));
+
+        let other = maintenance.clone();
+        let (first, second) = tokio::join!(
+            maintenance.clean_now(None, None),
+            other.clean_now(None, None)
+        );
+
+        let mut counts = [first.unwrap().entries, second.unwrap().entries];
+        counts.sort();
+        assert_eq!(
+            counts,
+            [0, 2],
+            "one clean took both entries, the other none"
+        );
+        assert_eq!(cache.iter_entries().count(), 0);
+    }
+}

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -1,13 +1,15 @@
+use futures::StreamExt as _;
 #[cfg(feature = "networking-proxy")]
 use minimald_rpc::IssueClientCertResponse;
 use minimald_rpc::{
-    AbortSession, AbortSessionResponse, CreateSession, DestroySession, DestroySessionResponse,
-    Errorable, FinalizeSession, FinalizeSessionResponse, GetMeshStatus, GetSessionPolicy,
-    GetSessionPolicyRequest, GetSessionRecord, GetSessionRecordRequest, GetSessionRecordResponse,
-    GetVersion, GetVersionResponse, IssueClientCert, IssueClientCertRequest, ListSessions,
-    ListSessionsEntry, ListSessionsResponse, OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession,
-    RenameSessionResponse, ResourcePool, SessionDelta, SessionDeltaRequest, SessionDeltaResponse,
-    Shutdown, ShutdownRequest, ShutdownResponse, SubmitVerdict,
+    AbortSession, AbortSessionResponse, CleanCacheRequest, CleanCacheUpdate, CreateSession,
+    DestroySession, DestroySessionResponse, Errorable, FinalizeSession, FinalizeSessionResponse,
+    GetMeshStatus, GetSessionPolicy, GetSessionPolicyRequest, GetSessionRecord,
+    GetSessionRecordRequest, GetSessionRecordResponse, GetVersion, GetVersionResponse,
+    IssueClientCert, IssueClientCertRequest, ListSessions, ListSessionsEntry, ListSessionsResponse,
+    OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession, RenameSessionResponse, ResourcePool,
+    SessionDelta, SessionDeltaRequest, SessionDeltaResponse, Shutdown, ShutdownRequest,
+    ShutdownResponse, SubmitVerdict,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
@@ -626,6 +628,121 @@ async fn serve_get_mesh_status(
         .await
 }
 
+/// Serves [`CLEAN_CACHE_SUBSYSTEM`]: runs a cache clean and streams its
+/// progress back as newline-delimited [`CleanCacheUpdate`]s.
+///
+/// The split between the two error surfaces is the wire contract: anything that
+/// goes wrong before the clean starts leaves the payload stream empty and says
+/// why on extended data, so a client that read no lines knows to look there.
+/// Once the clean is running, its own failure is a terminal `Failed` line. (A
+/// channel that breaks mid-stream also lands on the extended-data arm, where
+/// the write is best-effort — by then the client is already gone.)
+async fn serve_clean_cache(
+    s: ServerStateHandle,
+    mut c: RuChannel<Msg>,
+) -> Result<(), ConnectionError> {
+    match clean_cache_stream(&s, &mut c).await {
+        Ok(()) => {
+            c.eof().await?;
+            c.close().await?;
+            Ok(())
+        }
+        Err(e) => {
+            let _ = c.extended_data_bytes(1, e.to_string()).await;
+            let _ = c.close().await;
+            Err(e)
+        }
+    }
+}
+
+/// Reads the request, then runs the clean, writing each event out as it
+/// happens. The `Err` arm is for failures that precede the clean; a clean that
+/// runs reports its own outcome on the payload stream.
+async fn clean_cache_stream(
+    s: &ServerStateHandle,
+    c: &mut RuChannel<Msg>,
+) -> Result<(), ConnectionError> {
+    let req: CleanCacheRequest = read_channel_request(c).await?;
+    let older_than = match req.older_than_secs {
+        0 => None,
+        secs => Some(std::time::Duration::from_secs(secs)),
+    };
+    // Every clean goes through the one actor. No actor means no daemon
+    // housekeeping to ask (a state built outside `Server::run`), and a clean
+    // started here instead would be exactly the unsynchronized second cleaner
+    // the actor exists to prevent.
+    let maintenance = s.maintenance().await.ok_or_else(|| {
+        ConnectionError::Internal("daemon housekeeping is not running".to_string())
+    })?;
+
+    let (events, mut rx) = futures::channel::mpsc::unbounded();
+    let clean = maintenance.clean_now(older_than, Some(events));
+    let mut clean = std::pin::pin!(clean);
+
+    // Drain events as they arrive, until the clean itself resolves. Once the
+    // sender is dropped `rx` yields `None`, which disables that branch for the
+    // rest of this `select!` — the clean's own branch is irrefutable and never
+    // disabled, so the loop parks on it rather than spinning.
+    let report = loop {
+        tokio::select! {
+            Some(event) = rx.next() => write_update(c, &removed(event)).await?,
+            report = &mut clean => break report,
+        }
+    };
+    // The clean is done, so its sender is dropped: whatever is still queued is
+    // the tail, and the loop below ends on its own.
+    while let Some(event) = rx.next().await {
+        write_update(c, &removed(event)).await?;
+    }
+
+    let terminal = match report {
+        Ok(report) => CleanCacheUpdate::Done {
+            entries: report.entries,
+            dirs: report.dirs,
+        },
+        Err(e) => CleanCacheUpdate::Failed {
+            error: e.to_string(),
+        },
+    };
+    write_update(c, &terminal).await
+}
+
+/// The wire form of one reclaimed thing. `render` is the daemon's own
+/// rendering, so the RPC and the daemon log say the same words.
+fn removed(event: op::CleanEvent) -> CleanCacheUpdate {
+    CleanCacheUpdate::Removed {
+        detail: event.render(),
+    }
+}
+
+/// Writes one newline-delimited JSON update.
+async fn write_update(
+    c: &mut RuChannel<Msg>,
+    update: &CleanCacheUpdate,
+) -> Result<(), ConnectionError> {
+    let mut line = serde_json::to_vec(update)?;
+    line.push(b'\n');
+    c.data_bytes(line).await?;
+    Ok(())
+}
+
+/// Reads a JSON request body off `c`, draining until the client half-closes.
+/// The streaming handlers' equivalent of what
+/// [`ServeOneshot::handle_channel`] does inline.
+async fn read_channel_request<T: serde::de::DeserializeOwned>(
+    c: &mut RuChannel<Msg>,
+) -> Result<T, ConnectionError> {
+    let mut buf = Vec::with_capacity(1024);
+    while let Some(msg) = c.wait().await {
+        match msg {
+            russh::ChannelMsg::Data { data } => buf.extend_from_slice(&data),
+            russh::ChannelMsg::Eof | russh::ChannelMsg::Close => break,
+            _ => {}
+        }
+    }
+    Ok(serde_json::from_slice(&buf)?)
+}
+
 pub(crate) const STREAM_WORKSPACE_FILES: &str =
     constcat::concat!(RPC_SUBSYSTEM_PREFIX, "WorkspaceFilesTarZst");
 
@@ -1210,6 +1327,7 @@ pub async fn handle_ssh_rpc(
         | STREAM_WORKSPACE_FILES
         | STREAM_WORKSPACE_PATCHES
         | minimald_rpc::DIAG_BUNDLE_SUBSYSTEM
+        | minimald_rpc::CLEAN_CACHE_SUBSYSTEM
         | IssueClientCert::NAME => {
             let mut conn_lock = c.lock().await;
             let c_hnd = match conn_lock.take(id) {
@@ -1292,6 +1410,7 @@ pub async fn handle_ssh_rpc(
         minimald_rpc::DIAG_BUNDLE_SUBSYSTEM => {
             serve!(crate::diag::serve_stream_diag_bundle(s, config, channel))
         }
+        minimald_rpc::CLEAN_CACHE_SUBSYSTEM => serve!(serve_clean_cache(s, channel)),
         IssueClientCert::NAME => {
             #[cfg(feature = "networking-proxy")]
             serve!(serve_issue_client_cert(s, channel));
@@ -1400,6 +1519,100 @@ mod tests {
                 .await
                 .unwrap(),
             b"nested contents",
+        );
+    }
+
+    /// Drives the `CleanCache` subsystem to completion, returning every update
+    /// it streamed back in order.
+    async fn clean_cache(client: &mut TestClient, req: CleanCacheRequest) -> Vec<CleanCacheUpdate> {
+        let channel = client
+            .open_subsystem(minimald_rpc::CLEAN_CACHE_SUBSYSTEM, &[])
+            .await;
+        let mut stream = channel.into_stream();
+        stream
+            .write_all(&serde_json::to_vec(&req).unwrap())
+            .await
+            .unwrap();
+        // Half-close: the handler reads the request until the client is done.
+        stream.shutdown().await.unwrap();
+
+        let mut body = Vec::new();
+        stream.read_to_end(&mut body).await.unwrap();
+        String::from_utf8(body)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("each line is an update"))
+            .collect()
+    }
+
+    /// The clean runs through the daemon's actor and reports back: a line per
+    /// thing reclaimed, then exactly one terminal `Done` carrying the totals.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clean_cache_streams_progress_then_a_terminal_done() {
+        use lcache::{EntryMeta, FileSystem, MetaInner};
+        use std::io::Write as _;
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        // Two cold entries — nothing has read them, and no session needs them.
+        let cache = server.state.daemon_context().await.local_cache();
+        for byte in [1u8, 2] {
+            let w = cache
+                .write_dir(&common::SpecHash::from_bytes([byte; 32]))
+                .unwrap();
+            w.open_write("f").unwrap().write_all(b"x").unwrap();
+            w.finalize(EntryMeta {
+                inner: MetaInner::Spec(format!("pkg-{byte}")),
+                fetched: false,
+                ..Default::default()
+            })
+            .unwrap();
+        }
+
+        // `older_than_secs` of 1 rather than the daemon default, so entries
+        // written a moment ago are in scope.
+        let updates = clean_cache(
+            &mut client,
+            CleanCacheRequest::default().with_older_than_secs(1),
+        )
+        .await;
+
+        let (terminal, progress) = updates.split_last().expect("at least a terminal update");
+        assert_eq!(
+            *terminal,
+            CleanCacheUpdate::Done {
+                entries: 2,
+                dirs: 0
+            }
+        );
+        assert_eq!(
+            progress.len(),
+            2,
+            "one line per reclaimed entry: {progress:?}"
+        );
+        assert!(
+            progress.iter().all(|u| matches!(u, CleanCacheUpdate::Removed { detail } if detail.starts_with("Deleting package pkg-"))),
+            "progress should name what went: {progress:?}",
+        );
+        assert_eq!(cache.iter_entries().count(), 0);
+    }
+
+    /// An empty cache still terminates the stream properly — a client can
+    /// always read to a terminal update.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clean_cache_with_nothing_to_do_still_terminates() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        let updates = clean_cache(&mut client, CleanCacheRequest::default()).await;
+
+        assert_eq!(
+            updates,
+            vec![CleanCacheUpdate::Done {
+                entries: 0,
+                dirs: 0
+            }]
         );
     }
 

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -133,6 +133,19 @@ pub struct ServerState {
     sessions: sessions::ManagerHandle,
     daemon_id: String,
 
+    /// Daemon-scoped mctx state (dirs, VCS, local cache, stdlib), built once
+    /// at startup and shared with the sessions manager. Held here too so
+    /// daemon-level work that belongs to no session — [`crate::maintenance`]'s
+    /// cache clean — can reach the cache without a project mfile.
+    daemon_ctx: Arc<mctx::DaemonContext>,
+
+    /// The housekeeping actor, installed by [`Server::run`] once the state
+    /// exists (the actor holds a handle to it, so it can't be built in
+    /// [`ServerState::new`]). `None` before that, and for a state built
+    /// directly in a unit test. Held here so that anything wanting a cache
+    /// clean asks the one actor rather than starting its own.
+    maintenance: Option<crate::maintenance::MaintenanceHandle>,
+
     /// Fired by the `Shutdown` RPC handler once the session manager has been
     /// torn down, telling [`Server::run`]'s accept loop to stop accepting,
     /// drain in-flight connections, and return so the process can exit.
@@ -210,16 +223,25 @@ impl ServerState {
             .build()
             .map_err(|e| std::io::Error::other(format!("mctx config: {e}")))?;
 
+        // Build the daemon-scoped mctx state once at startup: every session
+        // stacks a per-session `Context` on it via `Context::from_daemon`.
+        let daemon_ctx = Arc::new(
+            mctx::DaemonContext::init(mctx_config)
+                .map_err(|e| std::io::Error::other(format!("mctx daemon init: {e}")))?,
+        );
+
         Ok(Self {
             sessions: sessions::Manager::init(
                 minimal_state_dir,
                 minimal_cache_dir,
-                mctx_config,
+                Arc::clone(&daemon_ctx),
                 net_switch,
             )
             .await?,
             config,
             daemon_id,
+            daemon_ctx,
+            maintenance: None,
             shutdown: CancellationToken::new(),
             log_release,
             host_key: None,
@@ -275,6 +297,28 @@ impl ServerStateHandle {
     /// Returns a handle to the sessions manager.
     pub async fn sessions_manager(&self) -> sessions::ManagerHandle {
         self.0.lock().await.sessions.clone()
+    }
+
+    /// Returns the daemon-scoped mctx state.
+    pub(crate) async fn daemon_context(&self) -> Arc<mctx::DaemonContext> {
+        Arc::clone(&self.0.lock().await.daemon_ctx)
+    }
+
+    /// Installs the housekeeping actor's handle. Called once by
+    /// [`Server::run`] just after spawning it.
+    pub(crate) async fn set_maintenance(&self, handle: crate::maintenance::MaintenanceHandle) {
+        self.0.lock().await.maintenance = Some(handle);
+    }
+
+    /// The housekeeping actor, for a caller that wants a cache clean run.
+    /// `None` on a state whose server never started it (unit tests).
+    ///
+    /// Going through the actor is the point: it is the one place a clean
+    /// starts, so a requested one queues behind the periodic one instead of
+    /// racing it.
+    #[allow(dead_code)] // No manual trigger is wired to this yet.
+    pub(crate) async fn maintenance(&self) -> Option<crate::maintenance::MaintenanceHandle> {
+        self.0.lock().await.maintenance.clone()
     }
 
     /// Returns a clone of the server shutdown token. [`Server::run`]'s accept
@@ -453,6 +497,13 @@ impl Server {
         // down; ends the accept loop below so the daemon can exit gracefully.
         let shutdown = state.shutdown_token().await;
 
+        // Housekeeping (cache clean) for the daemon's lifetime: periodic, plus
+        // whatever asks the actor for one. It stops on the same token that ends
+        // this loop. Installed on the state so every would-be trigger reaches
+        // the same actor rather than starting a competing clean.
+        let maintenance = crate::maintenance::spawn(state.clone(), shutdown.clone());
+        state.set_maintenance(maintenance.clone()).await;
+
         loop {
             // Drain any completed sessions to prevent unbounded growth.
             while let Some(result) = session_set.try_join_next() {
@@ -526,6 +577,11 @@ impl Server {
                 .instrument(span),
             );
         }
+
+        // Housekeeping has no client waiting on it and nothing to drain, so it
+        // goes first — the token has already stopped it between passes; this
+        // covers the case where it was mid-pass.
+        maintenance.abort();
 
         // Shutdown requested: stop accepting (done — loop exited) and drain
         // in-flight connections. The initiating client's own connection stays
@@ -771,11 +827,27 @@ async fn expose_proxy_on_host(daemon_ip: std::net::Ipv4Addr, port: u16) {
     }
 }
 
+/// A [`Config`] rooted at `dir` (state and cache both), with an ephemeral host
+/// key and no VM trappings — the daemon shape every unit test wants. Lives out
+/// here rather than in `tests` so sibling modules' tests can build a
+/// [`ServerStateHandle`] the same way.
+#[cfg(test)]
+pub(crate) fn test_config(dir: &std::path::Path) -> Config {
+    let path = camino::Utf8PathBuf::from_path_buf(dir.to_path_buf()).unwrap();
+    Config {
+        host_key: HostKey::Ephemeral,
+        minimal_state_dir: DaemonAbsPath::try_new(path.clone()).unwrap(),
+        minimal_cache_dir: DaemonAbsPath::try_new(path).unwrap(),
+        gvproxy_bin: None,
+        in_microvm: false,
+        state_volume_mounted: false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
-    use camino::Utf8PathBuf;
     use minimald_rpc::{Shutdown, ShutdownRequest, ShutdownResponse};
     use tempfile::TempDir;
 
@@ -784,15 +856,7 @@ mod tests {
 
     /// A `Config` backed by a fresh tempdir, mirroring `TestServer::new`.
     fn test_config(dir: &TempDir) -> Config {
-        let path = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        Config {
-            host_key: HostKey::Ephemeral,
-            minimal_state_dir: DaemonAbsPath::try_new(path.clone()).unwrap(),
-            minimal_cache_dir: DaemonAbsPath::try_new(path).unwrap(),
-            gvproxy_bin: None,
-            in_microvm: false,
-            state_volume_mounted: false,
-        }
+        super::test_config(dir.path())
     }
 
     /// The volume-log release must run exactly once no matter how many

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -9,6 +9,7 @@ use crate::{
     ChannelConfig,
     session_host::{self, HostAttrs, WinSize},
 };
+use common::SpecHash;
 use mctx::ConfigBuilder;
 use ot::OpTracker;
 use paths::DaemonAbsPath;
@@ -21,6 +22,7 @@ use sessions::{
     store::{DiskSession, SessionObject},
     wire::request::{ContributionVerdict, SessionStep, WireContribution},
 };
+use std::collections::HashSet;
 use std::fmt::{self};
 use std::ops::ControlFlow;
 use std::sync::Arc;
@@ -1642,6 +1644,26 @@ impl SessionHandle {
         let _ = self.0.send(SessionMessage::MakeContext(send)).await;
         recv.await
             .unwrap_or_else(|_| Err("session actor is gone".to_string()))
+    }
+
+    /// The spec hash of every package this session's project needs: its tasks,
+    /// its stack, and its `[session]` block.
+    ///
+    /// Resolved through this session's own workspace context, so the answer
+    /// reflects the `minimal.toml` currently in its worktree. Spec hashes
+    /// rather than `BuildSpecRef`s because a ref only means something against
+    /// the graph it was resolved in — see [`mctx::Context::needed_packages`].
+    ///
+    /// Runs off the actor: the resolve is nickel evaluation plus a graph
+    /// build, which has no business sitting in the session's mainloop, so it
+    /// goes to the blocking pool like every other graph build in the daemon.
+    pub async fn needed_packages(&self) -> Result<HashSet<SpecHash>, String> {
+        let mut ctx = self.context().await?;
+        // `mctx::Error` isn't `Send` (it carries nickel-language types), so it
+        // is rendered to a string inside the task.
+        tokio::task::spawn_blocking(move || ctx.needed_packages().map_err(|e| e.to_string()))
+            .await
+            .map_err(|e| format!("resolving needed packages: {e}"))?
     }
 
     /// Returns the session record currently held by the live session actor

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -1,10 +1,14 @@
-use std::{collections::BTreeMap, io::ErrorKind::NotFound};
+use std::{
+    collections::{BTreeMap, HashSet},
+    io::ErrorKind::NotFound,
+};
 
 use crate::{
     session::{Session, SessionConfig, SessionHandle},
     session_host::HostAttrs,
     store::{RecordPredicate, SessionRecordHandle, Store, StoreHandle},
 };
+use common::SpecHash;
 use paths::DaemonAbsPath;
 use sessions::SessionId;
 use std::sync::Arc;
@@ -149,8 +153,9 @@ pub struct Manager {
 
     /// Daemon-scoped mctx state (config, stdlib_dir, vcs, cache) cloned
     /// into each session actor, which composes its loadout and builds its
-    /// per-session `mctx::Context` on top. Held behind `Arc` so the
-    /// daemon-level setup work runs once per process rather than per session.
+    /// per-session `mctx::Context` on top. Built once at daemon startup by
+    /// the caller (which keeps its own handle on it, for the housekeeping
+    /// that runs outside any session) and shared here behind an `Arc`.
     daemon_ctx: Arc<mctx::DaemonContext>,
 
     minimal_state_dir: DaemonAbsPath,
@@ -175,7 +180,7 @@ impl Manager {
     pub async fn init(
         minimal_state_dir: DaemonAbsPath,
         minimal_cache_dir: DaemonAbsPath,
-        mctx_config: mctx::Config,
+        daemon_ctx: Arc<mctx::DaemonContext>,
         net_switch: Arc<Mutex<crate::net::SwitchClient>>,
     ) -> Result<ManagerHandle, std::io::Error> {
         let store = Store::init(minimal_state_dir.clone()).await?;
@@ -190,22 +195,6 @@ impl Manager {
         // them linger and confuse `min ls` / hold their names
         // hostage.
         reap_unresumable_records(&store).await?;
-
-        // Build the daemon-scoped mctx state once at startup. Each
-        // `CreateSession` will build a per-session `Context` on top of
-        // this via `Context::from_daemon` rather than repeating the
-        // setup (dir upsert / VCS init / cache init / stdlib
-        // materialization) per session. The caller supplies the
-        // `mctx::Config` so daemon-level flags (offline, num-parallel-
-        // builds, stdlib override, remote cache bucket) propagate.
-        // `mctx::Error` isn't `Send + Sync` (it carries nickel-language
-        // `Rc`s), so we can't preserve the source chain across the
-        // `io::Error` boundary. Stringify and move on; this only fires
-        // at daemon startup, at which point failure aborts the process.
-        let daemon_ctx = Arc::new(
-            mctx::DaemonContext::init(mctx_config)
-                .map_err(|e| std::io::Error::other(format!("mctx daemon init: {e}")))?,
-        );
 
         let running = BTreeMap::new();
         let (sender, receiver) = mpsc::channel(8);
@@ -683,6 +672,31 @@ impl ManagerHandle {
         recv.await.expect("corresponding sessions manager is dead")
     }
 
+    /// The union of what every active session needs: the spec hash of each package
+    /// reachable from any session's tasks, stack, or `[session]` block.
+    ///
+    /// Resolving a session brings its actor up if it isn't running, exactly as
+    /// [`get_session`](Self::get_session) does.
+    pub async fn needed_packages(&self) -> Result<HashSet<SpecHash>, SessionsError> {
+        let mut out = HashSet::new();
+        for info in self.list().await? {
+            if info.status != sessions::SessionStatus::Active {
+                continue;
+            }
+            // Deleted between the list and the lookup: gone, so needs nothing.
+            let Some(session) = self.get_session(SessionKeyPredicate::Id(info.id)).await? else {
+                continue;
+            };
+            let pkgs = session
+                .needed_packages()
+                .await
+                .map_err(|e| SessionsError::other(format!("session {}: {e}", info.id)))?;
+            out.extend(pkgs);
+        }
+
+        Ok(out)
+    }
+
     /// Gets a handle to the session corresponding with the given predicate.
     pub async fn get_session(
         &self,
@@ -735,7 +749,7 @@ impl ManagerHandle {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use paths::HostAbsPath;
     use sessions::daemon::composer::ComposeOutcome;
@@ -914,7 +928,8 @@ mod tests {
             .with_daemon_id("test".to_string())
             .build()
             .unwrap();
-        let mngr = Manager::init(daemon_dir(&state), daemon_dir(&cache), mctx_config, switch)
+        let daemon_ctx = Arc::new(mctx::DaemonContext::init(mctx_config).unwrap());
+        let mngr = Manager::init(daemon_dir(&state), daemon_dir(&cache), daemon_ctx, switch)
             .await
             .unwrap();
         (state, cache, mngr)
@@ -1454,6 +1469,85 @@ mod tests {
             session(&mngr, id).await.peek_composition().await.is_some(),
             "the create-flow actor should still hold its composition",
         );
+    }
+
+    /// Writes `pkg` as a package of the session's own workspace layer, so its
+    /// graph resolves the name with no upstream layer (and no network) in play.
+    async fn seed_workspace_package(mngr: &ManagerHandle, id: SessionId, pkg: &str) {
+        let paths = session(mngr, id).await.paths().await.unwrap();
+        let dir = paths.working.as_utf8_path().join("packages").join(pkg);
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(
+            dir.join("build.ncl"),
+            format!(
+                r#"let {{ BuildSpec, .. }} = import "minimal.ncl" in
+{{
+  name = "{pkg}",
+  build_deps = [],
+  runtime_deps = [],
+  outputs = {{}},
+}} | BuildSpec
+"#
+            ),
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Brings up an `Active` session called `name` whose workspace declares
+    /// local package `pkg` in its `[session]` block — a session that needs
+    /// exactly one package, and a different one per call.
+    pub(crate) async fn active_session_needing(
+        mngr: &ManagerHandle,
+        name: &str,
+        pkg: &str,
+    ) -> SessionId {
+        let config = minimald_rpc::SessionConfig {
+            name: Some(name.to_string()),
+            ..sample_config()
+        };
+        let id = mngr.create_session(config, None).await.unwrap();
+        seed_workspace_package(mngr, id, pkg).await;
+        seed_workspace_mfile(mngr, id, &format!("[session]\npackages = [\"{pkg}\"]\n")).await;
+
+        let handle = session(mngr, id).await;
+        handle
+            .configure_loadout(WireContribution::default())
+            .await
+            .expect("a project-only loadout gates nothing");
+        // The composition carries packages but no patches, so finalize skips
+        // the patches marker and the record lands `Active`.
+        handle.finalize().await.expect("finalize should succeed");
+        id
+    }
+
+    /// The manager's answer is the union of what each session answered, and
+    /// each session resolved its own package against its own workspace.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn needed_packages_unions_across_sessions() {
+        let (_state, _cache, mngr) = manager().await;
+        let a = active_session_needing(&mngr, "sess-a", "pkg-a").await;
+        let b = active_session_needing(&mngr, "sess-b", "pkg-b").await;
+
+        let from_a = session(&mngr, a).await.needed_packages().await.unwrap();
+        let from_b = session(&mngr, b).await.needed_packages().await.unwrap();
+        assert_eq!(from_a.len(), 1, "session a needs exactly its own package");
+        assert_eq!(from_b.len(), 1, "session b needs exactly its own package");
+        assert_ne!(from_a, from_b, "different packages hash differently");
+
+        let want: HashSet<SpecHash> = from_a.union(&from_b).cloned().collect();
+        assert_eq!(mngr.needed_packages().await.unwrap(), want);
+    }
+
+    /// A session that hasn't composed yet has no workspace context to resolve,
+    /// so it is skipped rather than faulting the whole union.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn needed_packages_skips_sessions_that_arent_active() {
+        let (_state, _cache, mngr) = manager().await;
+        // Created but never configured: the record stays `Pending`.
+        let _pending = mngr.create_session(sample_config(), None).await.unwrap();
+
+        assert!(mngr.needed_packages().await.unwrap().is_empty());
     }
 
     /// The held [`Composition`] actually carries the project

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -59,6 +59,12 @@ impl TestServer {
             state_volume_mounted: false,
         };
         let state = ServerStateHandle::new(config, None).await.unwrap();
+        // `Server::run` installs the housekeeping actor; a harness server never
+        // runs it, so do the same here — otherwise the `CleanCache` RPC has
+        // nothing to ask. Its own timer won't fire inside a test's lifetime.
+        let maintenance =
+            crate::maintenance::spawn(state.clone(), tokio_util::sync::CancellationToken::new());
+        state.set_maintenance(maintenance).await;
 
         let host_key = state.host_key().await.unwrap();
         let russh_config = Arc::new(russh::server::Config {

--- a/crates/mip/src/cmd_cache.rs
+++ b/crates/mip/src/cmd_cache.rs
@@ -1,9 +1,11 @@
-use std::{
-    collections::HashSet,
-    time::{Duration, SystemTime},
-};
+//! Command to maintain the local cache.
+
+use std::time::Duration;
 
 use anyhow::anyhow;
+use futures::StreamExt;
+use futures::channel::mpsc;
+use op::{CleanCache, CleanEvent, StaleKind};
 
 use crate::{Context, Error};
 
@@ -41,79 +43,39 @@ fn parse_duration(arg: &str) -> Result<std::time::Duration, anyhow::Error> {
 }
 
 pub async fn cmd_cache(args: CacheArgs, ctx: &mut Context) -> Result<(), Error> {
-    let graph = ctx.graph_from_all_packages()?;
-    let need_objs = ctx
-        .scaffolding_packages()?
-        .into_iter()
-        .map(|bsr| graph.spec_hash(&bsr))
-        .collect::<HashSet<_>>();
+    let CacheArgs::Clean { older_than } = args;
 
-    let cache = ctx.local_cache();
-    let rt = cache.atimes().unwrap();
-    let candidates = cache.iter_entries().filter_map(|e| {
-        if need_objs.contains(&e) {
-            None
-        } else {
-            let last_use = rt.last_read(&e);
-            Some((e, last_use))
-        }
-    });
+    // Everything this project's tasks and stack need, whatever its age.
+    let keep = ctx.needed_packages()?;
 
-    let now = SystemTime::now();
-    match args {
-        CacheArgs::Clean { older_than } => {
-            let cutoff = now.checked_sub(older_than).unwrap();
-            for (spec_hash, last_used) in candidates {
-                if last_used.is_none() || last_used.as_ref().unwrap() < &cutoff {
-                    let ident = if let Ok(meta) = cache.read_meta(&spec_hash) {
-                        format!("{} [{}]", meta.inner, spec_hash.0)
-                    } else {
-                        format!("Object [{}]", spec_hash.0)
-                    };
+    let (tx, rx) = mpsc::unbounded();
+    let renderer = tokio::spawn(print_events(rx));
 
-                    println!("Deleting {}", ident);
-                    cache
-                        .invalidate_dir(&spec_hash)
-                        .map_err(|e| Error::Other(anyhow!(e)))?;
-                }
-            }
-        }
-    }
+    let op = CleanCache {
+        older_than,
+        keep,
+        sweep: vec![
+            (StaleKind::Sandbox, ctx.builds_base_dir()),
+            (StaleKind::Task, ctx.tasks_base_dir()),
+            (StaleKind::TempDir, ctx.cache_base_dir().join("temp")),
+        ],
+        daemon_id: ctx.daemon_id(),
+        events: Some(tx),
+    };
+    let result = op.run(&ctx.local_cache());
 
-    for sandbox in std::fs::read_dir(ctx.builds_base_dir())
-        .map_err(|e| Error::IO("reading sandboxes dir", ctx.builds_base_dir(), e))?
-    {
-        let entry = sandbox.map_err(|e| Error::IO("sandbox entry", ctx.builds_base_dir(), e))?;
-        cleanup_stale("sandbox", entry)?;
-    }
-    for task in std::fs::read_dir(ctx.tasks_base_dir())
-        .map_err(|e| Error::IO("reading tasks dir", ctx.tasks_base_dir(), e))?
-    {
-        let entry = task.map_err(|e| Error::IO("task entry", ctx.tasks_base_dir(), e))?;
-        cleanup_stale("task", entry)?;
-    }
-    for at in std::fs::read_dir(ctx.cache_base_dir().join("temp"))
-        .map_err(|e| Error::IO("reading artifact temp dir", ctx.tasks_base_dir(), e))?
-    {
-        let entry = at.map_err(|e| Error::IO("artifact temp entry", ctx.tasks_base_dir(), e))?;
-        cleanup_stale("tempdir", entry)?;
-    }
+    // Closes the event stream, so the renderer's last lines land before the
+    // outcome is reported.
+    drop(op);
+    let _ = renderer.await;
 
+    result?;
     Ok(())
 }
 
-fn cleanup_stale(kind: &str, entry: std::fs::DirEntry) -> Result<(), Error> {
-    let name = entry.file_name();
-    let s = name.to_str().unwrap();
-    if s.contains("-")
-        && let Some(pid_str) = s.rsplit('-').next()
-        && let Ok(false) = std::fs::exists(format!("/proc/{}", pid_str))
-    {
-        // No such proc entry, therefore PID dead. Clean up directory.
-        println!("Cleaning up stale {} {}", kind, s);
-        common::remove_dir_all(entry.path())
-            .map_err(|e| Error::IO("rm stale sandbox", entry.path(), e))?;
+/// Prints progress until the sender is dropped.
+async fn print_events(mut rx: mpsc::UnboundedReceiver<CleanEvent>) {
+    while let Some(event) = rx.next().await {
+        println!("{}", event.render());
     }
-
-    Ok(())
 }

--- a/crates/op/src/cache_clean.rs
+++ b/crates/op/src/cache_clean.rs
@@ -1,0 +1,451 @@
+//! Reclaiming local disk: cache entries nothing has read in a while, plus the
+//! execution directories left behind by processes that have since exited.
+//!
+//! [`CleanCache`] deliberately knows nothing about where its inputs come from.
+//! The caller decides which entries are worth keeping (for `mip cache clean`,
+//! everything the current project's tasks and stack need) and which directories
+//! to sweep, so cleaning needs no project context and can run anywhere the
+//! local cache does.
+
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
+
+use anyhow::anyhow;
+use common::SpecHash;
+use futures::channel::mpsc::UnboundedSender;
+use lcache::{Cache, LocalDir};
+
+use crate::Error;
+
+/// A kind of execution directory [`CleanCache`] sweeps, named for how it reads
+/// in a rendered event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaleKind {
+    /// A build sandbox.
+    Sandbox,
+    /// A task execution directory.
+    Task,
+    /// A temporary directory used while an artifact was being built.
+    TempDir,
+}
+
+impl StaleKind {
+    /// The word naming this kind in a rendered event.
+    fn label(self) -> &'static str {
+        match self {
+            StaleKind::Sandbox => "sandbox",
+            StaleKind::Task => "task",
+            StaleKind::TempDir => "tempdir",
+        }
+    }
+}
+
+/// Progress emitted while cleaning. [`CleanCache`] never prints; every consumer
+/// renders these itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CleanEvent {
+    /// A cache entry was deleted. `name` is the entry's recorded identity,
+    /// absent when its metadata could not be read.
+    Deleted {
+        hash: SpecHash,
+        name: Option<String>,
+    },
+    /// A leftover execution directory whose owning process is gone was removed.
+    Swept { kind: StaleKind, name: String },
+}
+
+impl CleanEvent {
+    /// This event as one human-readable log line. Shared so every transport
+    /// reports a clean identically.
+    pub fn render(&self) -> String {
+        match self {
+            CleanEvent::Deleted { hash, name } => match name {
+                Some(name) => format!("Deleting {} [{}]", name, hash.0),
+                None => format!("Deleting Object [{}]", hash.0),
+            },
+            CleanEvent::Swept { kind, name } => {
+                format!("Cleaning up stale {} {}", kind.label(), name)
+            }
+        }
+    }
+}
+
+/// What a run of [`CleanCache`] removed.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CleanReport {
+    /// Cache entries deleted.
+    pub entries: usize,
+    /// Leftover execution directories removed.
+    pub dirs: usize,
+}
+
+/// Deletes cache entries whose last recorded read is older than `older_than` —
+/// or that have no recorded read at all — then removes the leftover execution
+/// directories under `sweep` whose owner is gone.
+///
+/// Entries in `keep` are never deleted, whatever their age, and directories
+/// stamped with `daemon_id` are never swept.
+pub struct CleanCache {
+    /// Only delete entries last read at least this long ago.
+    pub older_than: Duration,
+    /// Entries to keep regardless of age.
+    pub keep: HashSet<SpecHash>,
+    /// Directories whose per-owner subdirectories to sweep, each labelled with
+    /// what it holds.
+    pub sweep: Vec<(StaleKind, PathBuf)>,
+    /// The caller's own `daemon_id`, when it runs under one. Directories
+    /// stamped with it are this daemon's live work and are left alone — see
+    /// [`owner_is_gone`].
+    pub daemon_id: Option<String>,
+    /// Best-effort progress reporting; a hung-up receiver must never fail the
+    /// clean.
+    pub events: Option<UnboundedSender<CleanEvent>>,
+}
+
+impl CleanCache {
+    /// Runs the clean. Every step is blocking filesystem work, so an async
+    /// caller should `spawn_blocking` this.
+    #[tracing::instrument(skip_all, fields(older_than = ?self.older_than), err)]
+    pub fn run(&self, cache: &Cache<LocalDir>) -> Result<CleanReport, Error> {
+        let cutoff = SystemTime::now()
+            .checked_sub(self.older_than)
+            .ok_or_else(|| {
+                anyhow!(
+                    "`older_than` of {:?} reaches back past the unix epoch",
+                    self.older_than
+                )
+            })?;
+
+        let atimes = cache
+            .atimes()
+            .map_err(|e| anyhow!("reading the cache's access log: {e}"))?;
+
+        // Collected up front: deleting an entry removes the very directory
+        // `iter_entries` is walking to find the next one.
+        let stale: Vec<SpecHash> = cache
+            .iter_entries()
+            .filter(|hash| !self.keep.contains(hash))
+            .filter(|hash| atimes.last_read(hash).is_none_or(|last| last < cutoff))
+            .collect();
+
+        let mut report = CleanReport::default();
+        for hash in stale {
+            let name = cache
+                .read_meta(&hash)
+                .ok()
+                .map(|meta| meta.inner.to_string());
+            self.emit(CleanEvent::Deleted {
+                hash: hash.clone(),
+                name,
+            });
+            cache.invalidate_dir(&hash)?;
+            report.entries += 1;
+        }
+
+        // Liveness is `/proc/<pid>`, so without procfs every directory looks
+        // orphaned. Skip the sweep there rather than delete live state.
+        if !self.sweep.is_empty() && !Path::new("/proc/self").exists() {
+            tracing::warn!("no procfs mounted; skipping the stale-directory sweep");
+            return Ok(report);
+        }
+
+        for (kind, dir) in &self.sweep {
+            report.dirs += self.sweep_dir(*kind, dir)?;
+        }
+
+        Ok(report)
+    }
+
+    /// Removes every subdirectory of `dir` whose trailing `-<owner>` names an
+    /// owner that is gone, returning how many went.
+    fn sweep_dir(&self, kind: StaleKind, dir: &Path) -> Result<usize, Error> {
+        let mut removed = 0;
+        for entry in
+            std::fs::read_dir(dir).map_err(|e| anyhow!("reading {}: {e}", dir.display()))?
+        {
+            let entry = entry.map_err(|e| anyhow!("reading an entry of {}: {e}", dir.display()))?;
+            let name = entry.file_name();
+            // A name that isn't utf-8 can't carry the `-<owner>` suffix either.
+            let Some(name) = name.to_str() else { continue };
+            if !owner_is_gone(name, self.daemon_id.as_deref()) {
+                continue;
+            }
+
+            self.emit(CleanEvent::Swept {
+                kind,
+                name: name.to_string(),
+            });
+            common::remove_dir_all(entry.path())
+                .map_err(|e| anyhow!("removing {}: {e}", entry.path().display()))?;
+            removed += 1;
+        }
+
+        Ok(removed)
+    }
+
+    fn emit(&self, event: CleanEvent) {
+        if let Some(tx) = &self.events {
+            let _ = tx.unbounded_send(event);
+        }
+    }
+}
+
+/// Whether `name`'s trailing `-<owner>` marks work nobody is doing any more.
+///
+/// The stamp is a pid, or — when the work ran under a daemon — that daemon's
+/// `daemon_id` in the pid's place (`sandbox2::Config::daemon_id`). So:
+///
+/// - our own `daemon_id`: never. That is this daemon's live work, and the id is
+///   a random alphanumeric that can come out all-digits and read as a perfectly
+///   plausible dead pid — without this check a daemon eventually reclaims a
+///   sandbox out from under itself.
+/// - a pid with no `/proc` entry: gone, reclaim it.
+/// - anything else — a live pid, another daemon's id, a name nobody stamped:
+///   left alone. Not ours to judge.
+fn owner_is_gone(name: &str, daemon_id: Option<&str>) -> bool {
+    let Some((_, owner)) = name.rsplit_once('-') else {
+        return false;
+    };
+    if Some(owner) == daemon_id || owner.parse::<u32>().is_err() {
+        return false;
+    }
+
+    matches!(std::fs::exists(format!("/proc/{owner}")), Ok(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use lcache::{EntryMeta, FileSystem, MetaInner};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// A distinct spec hash per `n`.
+    fn hash(n: u8) -> SpecHash {
+        SpecHash::from_bytes([n; 32])
+    }
+
+    /// Writes an entry into `cache`, so it shows up in `iter_entries`.
+    fn write_entry(cache: &Cache<LocalDir>, hash: &SpecHash, name: &str) {
+        let w = cache.write_dir(hash).unwrap();
+        w.open_write("f").unwrap().write_all(b"x").unwrap();
+        w.finalize(EntryMeta {
+            inner: MetaInner::Spec(name.to_string()),
+            fetched: false,
+            ..Default::default()
+        })
+        .unwrap();
+    }
+
+    /// Records a read of each `(hash, epoch_secs)` in the cache's access log,
+    /// in the append-only record format `ReadSnapshot` loads: 32 bytes of hash
+    /// followed by 8 big-endian bytes of epoch seconds.
+    fn record_reads(dir: &Path, reads: &[(SpecHash, u64)]) {
+        // A tracker file name no `Cache` will hold open (those are pid % 32,
+        // climbing on contention).
+        let mut f = std::fs::File::create(dir.join("alog").join("900.v1")).unwrap();
+        for (hash, epoch_secs) in reads {
+            f.write_all(hash.as_bytes()).unwrap();
+            f.write_all(&epoch_secs.to_be_bytes()).unwrap();
+        }
+    }
+
+    fn secs_ago(d: Duration) -> u64 {
+        SystemTime::now()
+            .checked_sub(d)
+            .unwrap()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[test]
+    fn deletes_only_unused_unkept_entries() {
+        let tmp = TempDir::new().unwrap();
+        let cache = Cache::at_dir(tmp.path()).unwrap();
+
+        let (recent, old, never_read, kept) = (hash(1), hash(2), hash(3), hash(4));
+        for (h, name) in [
+            (&recent, "recent"),
+            (&old, "old"),
+            (&never_read, "never-read"),
+            (&kept, "kept"),
+        ] {
+            write_entry(&cache, h, name);
+        }
+        record_reads(
+            tmp.path(),
+            &[
+                (recent.clone(), secs_ago(Duration::from_secs(60 * 60))),
+                (
+                    old.clone(),
+                    secs_ago(Duration::from_secs(30 * 24 * 60 * 60)),
+                ),
+                // `kept` is old enough to delete, and survives on `keep` alone.
+                (
+                    kept.clone(),
+                    secs_ago(Duration::from_secs(30 * 24 * 60 * 60)),
+                ),
+            ],
+        );
+
+        let report = CleanCache {
+            older_than: Duration::from_secs(14 * 24 * 60 * 60),
+            keep: HashSet::from([kept.clone()]),
+            sweep: vec![],
+            daemon_id: None,
+            events: None,
+        }
+        .run(&cache)
+        .unwrap();
+
+        assert_eq!(
+            report,
+            CleanReport {
+                entries: 2,
+                dirs: 0
+            }
+        );
+        let mut left: Vec<SpecHash> = cache.iter_entries().collect();
+        left.sort();
+        let mut want = vec![recent, kept];
+        want.sort();
+        assert_eq!(left, want);
+    }
+
+    #[test]
+    fn reports_deletions_as_events() {
+        let tmp = TempDir::new().unwrap();
+        let cache = Cache::at_dir(tmp.path()).unwrap();
+        let gone = hash(7);
+        write_entry(&cache, &gone, "curl");
+
+        let (tx, mut rx) = futures::channel::mpsc::unbounded();
+        CleanCache {
+            older_than: Duration::from_secs(1),
+            keep: HashSet::new(),
+            sweep: vec![],
+            daemon_id: None,
+            events: Some(tx),
+        }
+        .run(&cache)
+        .unwrap();
+
+        let event = rx.try_recv().unwrap();
+        assert_eq!(
+            event,
+            CleanEvent::Deleted {
+                hash: gone.clone(),
+                name: Some("package curl".to_string()),
+            }
+        );
+        assert_eq!(
+            event.render(),
+            format!("Deleting package curl [{}]", gone.0)
+        );
+    }
+
+    /// The sweep reads `/proc`, so it only proves anything on Linux.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sweeps_only_directories_whose_owner_exited() {
+        let tmp = TempDir::new().unwrap();
+        let cache = Cache::at_dir(tmp.path()).unwrap();
+        let sandboxes = tmp.path().join("sandboxes");
+
+        // A pid no process can hold: pid 0 is the scheduler, never a /proc entry.
+        let dead = sandboxes.join("build-0");
+        let live = sandboxes.join(format!("build-{}", std::process::id()));
+        let unowned = sandboxes.join("build-scratch");
+        for dir in [&dead, &live, &unowned] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+
+        let (tx, mut rx) = futures::channel::mpsc::unbounded();
+        let report = CleanCache {
+            older_than: Duration::from_secs(1),
+            keep: HashSet::new(),
+            sweep: vec![(StaleKind::Sandbox, sandboxes.clone())],
+            daemon_id: None,
+            events: Some(tx),
+        }
+        .run(&cache)
+        .unwrap();
+
+        assert_eq!(
+            report,
+            CleanReport {
+                entries: 0,
+                dirs: 1
+            }
+        );
+        assert!(!dead.exists());
+        assert!(live.exists());
+        assert!(unowned.exists());
+
+        let event = rx.try_recv().unwrap();
+        assert_eq!(
+            event,
+            CleanEvent::Swept {
+                kind: StaleKind::Sandbox,
+                name: "build-0".to_string(),
+            }
+        );
+        assert_eq!(event.render(), "Cleaning up stale sandbox build-0");
+    }
+
+    /// A daemon never sweeps its own work, even though `sandbox2` stamps its
+    /// `daemon_id` where a pid would go — and even when that id is all digits
+    /// and so reads as a perfectly plausible dead pid.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_daemon_does_not_sweep_its_own_directories() {
+        let tmp = TempDir::new().unwrap();
+        let cache = Cache::at_dir(tmp.path()).unwrap();
+        let sandboxes = tmp.path().join("sandboxes");
+
+        // `common::random_alphanumeric` can produce an all-digit id; picking one
+        // here is what makes this a test rather than a coincidence.
+        let daemon_id = "31337";
+        assert!(
+            !std::fs::exists(format!("/proc/{daemon_id}")).unwrap(),
+            "the id must not collide with a live pid for this to prove anything",
+        );
+
+        let ours = sandboxes.join(format!("build-1700000000-0-{daemon_id}"));
+        let other_daemon = sandboxes.join("build-1700000000-0-a1b2c");
+        let dead_pid = sandboxes.join("build-1700000000-0-0");
+        for dir in [&ours, &other_daemon, &dead_pid] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+
+        let report = CleanCache {
+            older_than: Duration::from_secs(1),
+            keep: HashSet::new(),
+            sweep: vec![(StaleKind::Sandbox, sandboxes.clone())],
+            daemon_id: Some(daemon_id.to_string()),
+            events: None,
+        }
+        .run(&cache)
+        .unwrap();
+
+        assert_eq!(
+            report,
+            CleanReport {
+                entries: 0,
+                dirs: 1
+            }
+        );
+        assert!(ours.exists(), "our own live sandbox must survive");
+        assert!(
+            other_daemon.exists(),
+            "another daemon's id is not ours to judge",
+        );
+        assert!(!dead_pid.exists(), "a dead pid's sandbox still goes");
+    }
+}

--- a/crates/op/src/lib.rs
+++ b/crates/op/src/lib.rs
@@ -39,6 +39,9 @@ mod subsets;
 use ot::OpTracker;
 pub use subsets::SubsetBuild;
 
+mod cache_clean;
+pub use cache_clean::{CleanCache, CleanEvent, CleanReport, StaleKind};
+
 mod sources;
 pub use sources::{SourceFetcher, SourceLoad};
 mod specs;


### PR DESCRIPTION
<!-- PR title: use a Conventional Commit subject — `type(scope): summary`,
     imperative, lower-case, no trailing period. The PR title becomes the
     squash commit subject. See docs/commit-conventions.md. -->

## Summary

<!-- What changes, and why. Link related issues (`Refs: #123` / `Closes: #123`). -->

## Testing

<!-- What you ran (`cargo test`, `cargo clippy`, harness/e2e scripts, manual
     steps) — paste the relevant output as evidence. -->

## Checklist

- [ ] Docs updated if behavior changed
- [ ] `BREAKING CHANGE:` footer present if this is a breaking change


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add automatic cache cleaning to minimald with an SSH RPC and background maintenance actor
> - Introduces a `maintenance` actor in `minimald` that periodically sweeps the local cache, removing stale entries and directories; it also handles on-demand clean requests serialized through an mpsc channel.
> - Adds a `CleanCache` op in the `op` crate that computes a keep-set from live sessions, deletes unused cache entries older than a threshold, sweeps stale sandbox/task/temp directories by checking `/proc` for dead PIDs, and emits structured `CleanEvent` progress updates.
> - Exposes a new `CLEAN_CACHE_SUBSYSTEM` SSH RPC that streams newline-delimited `CleanCacheUpdate` JSON (per-removal `Removed` lines, then a terminal `Done` or `Failed`) to clients via `minimald-rpc`.
> - Rewrites `mip`'s `cmd_cache` to delegate all deletion and sweep logic to `op::CleanCache`, using `ctx.needed_packages()` to protect packages required by active sessions.
> - Behavioral Change: cache cleaning now skips packages needed by any active session and sweeps stale directories; previously, neither behavior existed in the daemon.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff428ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache cleanup through the command line and remote administration interface.
  * Cleanup removes stale cache entries and unused sandbox, task, and temporary data based on an age threshold.
  * Added progress updates and completion summaries.
* **Bug Fixes**
  * Active sessions’ required packages are preserved during cleanup.
  * Cleanup handles concurrent requests, empty caches, and daemon shutdowns safely.
* **Maintenance**
  * Automatic cleanup runs after startup and periodically while the daemon is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->