### PR TITLE
fix(op): contain raw-file output paths inside the package directory

### DIFF
--- a/crates/common/src/archive.rs
+++ b/crates/common/src/archive.rs
@@ -211,7 +211,14 @@ pub fn extract_compressed_tar<R: Read>(
 /// This is the containment gate for prefix-stripped tar extraction: unlike
 /// [`Path::join`], it refuses entries and link targets that would resolve
 /// outside `dest_dir`.
-fn normalize_within_root(path: &Path) -> Option<PathBuf> {
+/// Public because more than one crate joins an untrusted relative path onto a
+/// root it must not escape. A second implementation is how this class of bug
+/// gets reintroduced — see the tar `strip_prefix` traversal (#651).
+///
+/// Lexical only: it cannot see symlinks, so a caller that then touches the
+/// filesystem must *also* check the resolved path. This is necessary, not
+/// sufficient.
+pub fn normalize_within_root(path: &Path) -> Option<PathBuf> {
     use std::path::Component;
     let mut out = PathBuf::new();
     for comp in path.components() {

--- a/crates/op/src/materialize.rs
+++ b/crates/op/src/materialize.rs
@@ -255,6 +255,16 @@ fn extract_raw_file(
 ) -> Result<Report, Error> {
     let rel_path = path.strip_prefix('/').unwrap_or(path);
 
+    // `strip_prefix('/')` removes one leading slash and nothing else, so `..`
+    // survives it untouched — and joining that onto a package directory walks
+    // straight out of the cache. Reject lexical escapes before any filesystem
+    // access: both `../../etc/shadow` and `/../../etc/shadow` land here.
+    let Some(rel_path) = common::archive::normalize_within_root(Path::new(rel_path)) else {
+        return Err(Error::Other(anyhow!(
+            "raw-file output {path:?} escapes the package directory"
+        )));
+    };
+
     let mut closure: Vec<_> =
         Transitives::for_toplevels(opts.graph, opts.graph.top_levels.to_vec(), false)
             .into_keys()
@@ -267,9 +277,35 @@ fn extract_raw_file(
             .cache
             .read_dir(&opts.graph.spec_hash(&bsr))
             .map_err(|e| Error::Other(anyhow!(e)))?;
-        let candidate = dir.path().join(rel_path);
+        let candidate = dir.path().join(&rel_path);
         if !candidate.exists() {
             continue;
+        }
+
+        // The lexical check above cannot see symlinks: a package shipping
+        // `escape -> /etc` makes `<pkg>/escape/passwd` lexically contained
+        // while resolving outside. Decide on the *real* path.
+        //
+        // A containment violation is an error, not a cache miss: `continue`ing
+        // would silently fall through to the next package and hide the fact
+        // that a package tried to serve a file it does not own.
+        let root = dir.path().canonicalize().map_err(|e| {
+            Error::Other(anyhow!(
+                "resolving package dir {}: {e}",
+                dir.path().display()
+            ))
+        })?;
+        let real = candidate.canonicalize().map_err(|e| {
+            Error::Other(anyhow!(
+                "resolving raw-file output {path:?} in {package:?}: {e}",
+                package = package.clone().unwrap_or_default()
+            ))
+        })?;
+        if !real.starts_with(&root) {
+            return Err(Error::Other(anyhow!(
+                "raw-file output {path:?} resolves to {}, outside the package directory",
+                real.display()
+            )));
         }
 
         let package = package.unwrap_or_default();
@@ -408,6 +444,17 @@ mod tests {
     }
 
     fn materialize(graph: &Graph, cache: Cache<LocalDir>, sink: Sink) -> Result<Report, Error> {
+        materialize_path(graph, cache, sink, "/bin/tool")
+    }
+
+    /// As [`materialize`], for a caller that needs to choose the requested
+    /// raw-file path (the containment tests below).
+    fn materialize_path(
+        graph: &Graph,
+        cache: Cache<LocalDir>,
+        sink: Sink,
+        path: &str,
+    ) -> Result<Report, Error> {
         let opts = Options {
             cache,
             graph,
@@ -419,7 +466,7 @@ mod tests {
             Materialize {
                 name: "out".to_string(),
                 spec: OutputSpec::RawFile {
-                    path: "/bin/tool".to_string(),
+                    path: path.to_string(),
                 },
                 sink,
                 events: None,
@@ -626,6 +673,88 @@ mod tests {
         assert!(
             err.to_string().contains("entrypoint"),
             "the error must name the offending field, got: {err}"
+        );
+    }
+
+    /// A `raw-file` output path is attacker-influenceable: it comes from
+    /// `minimal.toml`, and the daemon reads that out of a client-uploaded
+    /// workspace. `strip_prefix('/')` removes one leading slash and nothing
+    /// else, so `..` used to survive into `dir.path().join(..)` and stream a
+    /// daemon-side file straight back to the caller.
+    ///
+    /// Both spellings must be refused, and refused *distinguishably* from
+    /// "no package ships this path" — a containment violation is an error,
+    /// not a cache miss.
+    #[test]
+    fn raw_file_output_cannot_escape_the_package() {
+        for path in ["../../../../etc/passwd", "/../../etc/passwd"] {
+            let tmp = TempDir::new().unwrap();
+            let cache = Cache::at_dir(tmp.path()).unwrap();
+            let graph = graph_from(COLLIDING, "zzz");
+            fake_build(&cache, &graph, "zzz", "bin/tool", b"zzz", 0o755);
+
+            let out = TempDir::new().unwrap();
+            let err = materialize_path(&graph, cache, Sink::Path(out.path().join("got")), path)
+                .expect_err("an escaping raw-file path must be refused");
+
+            assert!(
+                err.to_string().contains("escapes the package directory"),
+                "{path:?} must be refused as a containment violation, got: {err}"
+            );
+        }
+    }
+
+    /// The lexical check cannot see symlinks. A package that ships
+    /// `escape -> /etc` makes `<pkg>/escape/passwd` lexically contained while
+    /// resolving outside it, so containment has to be decided on the resolved
+    /// path as well.
+    #[test]
+    fn raw_file_output_cannot_escape_through_a_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let cache = Cache::at_dir(tmp.path()).unwrap();
+        // Single-package closure: `COLLIDING` ships two, and an unbuilt
+        // second package makes the probe loop fall through to "not found"
+        // before it ever reaches the link.
+        let graph = graph_from(
+            indoc! {r#"
+                let {BuildSpec, OutputData, ..} = import "minimal.ncl" in
+                {
+                    name = "only",
+                    build_deps = [],
+                    cmd = "",
+                    outputs = { f = {glob = "bin/tool"} | OutputData },
+                } | BuildSpec
+            "#},
+            "only",
+        );
+
+        // Build a package whose tree contains a link pointing out of it.
+        let outside = TempDir::new().unwrap();
+        std::fs::write(outside.path().join("passwd"), b"root:x:0:0").unwrap();
+        let hash = graph.spec_hash(graph.by_name("only").expect("package in graph"));
+        let pending = cache.write_dir(&hash).expect("write cache dir");
+        std::fs::create_dir_all(pending.path().join("bin")).unwrap();
+        std::fs::write(pending.path().join("bin/tool"), b"zzz").unwrap();
+        std::os::unix::fs::symlink(outside.path(), pending.path().join("escape")).unwrap();
+        pending
+            .finalize(EntryMeta {
+                inner: MetaInner::Spec("only".to_string()),
+                ..Default::default()
+            })
+            .expect("finalize cache entry");
+
+        let out = TempDir::new().unwrap();
+        let err = materialize_path(
+            &graph,
+            cache,
+            Sink::Path(out.path().join("got")),
+            "/escape/passwd",
+        )
+        .expect_err("a path resolving outside the package must be refused");
+
+        assert!(
+            err.to_string().contains("outside the package directory"),
+            "expected a containment error, got: {err}"
         );
     }
 }


### PR DESCRIPTION
Found by the audit that followed #1162. `op::materialize::extract_raw_file` had **no containment check at all**.

```rust
let rel_path = path.strip_prefix('/').unwrap_or(path);
let candidate = dir.path().join(rel_path);
if !candidate.exists() { continue; }
return deliver_file(&candidate, sink);
```

`strip_prefix` removes one leading slash and nothing else, so `..` survives into the join and walks out of the cache dir; `.exists()` then greenlights it and `deliver_file` streams it back.

## Impact

The path comes from `[outputs.x] type = "raw-file"` in `minimal.toml`, which the daemon reads out of a **client-uploaded workspace** — so it is attacker-influenceable:

```toml
[outputs.leak]
type = "raw-file"
path = "../../../etc/shadow"
```

That is a daemon-side arbitrary file read, delivered over the client its own channel. No symlink required. It also bypasses `lcache::LocalDir` entirely by taking the raw `&Path` from `DirCacheEntry::path()`.

## Fix

Two checks, because neither alone suffices:

1. **Lexical** — normalize the request and reject an escape before any filesystem access. Covers `../../etc/passwd` and `/../../etc/passwd`.
2. **Resolved** — a package shipping `escape -> /etc` makes `<pkg>/escape/passwd` lexically contained while resolving outside, so containment is also decided on the canonicalized path.

A violation is an `Err`, deliberately **not** a `continue`: falling through to the next package would hide that a package tried to serve a file it does not own, and make the refusal indistinguishable from a cache miss.

`common::archive::normalize_within_root` is made public rather than growing a second implementation here — a second copy is exactly how this class got reintroduced before (#651). Its docs now state that it is lexical-only, so a caller touching the filesystem must also check the resolved path.

## Verification

Three regression cases, all verified to **fail without the fix** — with the check neutralized the symlink case returns `Report { bytes: 10 }`, i.e. it really does deliver a file from outside the package.

`cargo test -p op -p common` green (44 + 19). Pre-existing `sandbox2` clippy noise on macOS is unrelated (identical count on a clean tree; that code is Linux-only and cfg-d out here).

Independent of #1162 and #1164.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject raw-file output paths that escape the package directory in `extract_raw_file`
> - Adds a lexical containment check in [materialize.rs](https://github.com/gominimal/minimal/pull/1165/files#diff-5141265c653ab7e63b86a6dc25faef0201966b50616fd9dd826cd9b6fc72132d) using `common::archive::normalize_within_root` to reject paths with `..` components or absolute paths before joining.
> - Adds a runtime canonicalization check after locating the candidate file to reject symlinks that resolve outside the package directory.
> - Makes `archive::normalize_within_root` in [archive.rs](https://github.com/gominimal/minimal/pull/1165/files#diff-c3b59fcaa127815bc487babcda22a8fd129f71e318e19167b1b69ee729bc9daf) public so it can be reused cross-crate.
> - Adds tests for both lexical traversal and symlink-based escapes, verifying explicit error messages in each case.
> - Behavioral Change: paths that previously fell through as cache misses now return explicit errors when they escape the package directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7557a55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->