### PR TITLE
feat(minimald): support arbitrary session exec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ nickel-lang-core = { git = "https://github.com/nickel-lang/nickel.git", rev = "2
 opentelemetry-semantic-conventions = "0.32"
 # `socket` + `time`: the guest's vsock timekeep listener binds an AF_VSOCK
 # datagram socket and steps CLOCK_REALTIME from the host's updates.
-nix = { version = "0.31", features = ["fs", "socket", "time", "user"] }
+nix = { version = "0.31", features = ["fs", "sched", "socket", "time", "user"] }
 nutype = { version = "0.7", features = ["serde"] }
 # Held at 0.39: 0.40 turns `Object::exports()`/`imports()` from
 # `Result<Vec<_>>` into lazy `Result<_>`-yielding iterators, so crates/check

--- a/crates/minimald/src/env.rs
+++ b/crates/minimald/src/env.rs
@@ -23,7 +23,7 @@
 //!   requests one at a time on the runtime, so every handler is a plain
 //!   `async fn` that `.await`s — no nested runtimes, no sync/async bridge writers.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::Permissions;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
@@ -226,9 +226,38 @@ pub struct Env {
     sandbox: Sandbox<BridgeChannel>,
     /// The command-channel actor task. `Some` until [`Drop`] aborts it.
     actor: Option<JoinHandle<()>>,
+    /// Variables the channel actor has added since launch; see
+    /// [`SessionChannel::runtime_env`].
+    runtime_env: RuntimeEnv,
     /// Extra directories kept alive for the environment's lifetime (e.g. a
     /// temporary `/state` directory). Dropped after the sandbox.
     _temp_dirs: Vec<TempDir>,
+}
+
+/// Environment variables a *running* session has acquired, on top of the ones
+/// it was launched with. Usually happens due to `min add`.
+///
+/// Shared between [`Env`] and the [`SessionChannel`] actor that learns of them.
+#[derive(Clone, Default)]
+pub(crate) struct RuntimeEnv(Arc<Mutex<BTreeMap<String, String>>>);
+
+impl RuntimeEnv {
+    /// Records a variable the session has just acquired. Last write wins, as it
+    /// does in the shell, where a later `export` overrides an earlier one.
+    fn record(&self, key: &str, value: &str) {
+        self.0
+            .lock()
+            .expect("runtime env lock is never held across a panic")
+            .insert(key.to_string(), value.to_string());
+    }
+
+    /// Everything recorded so far.
+    fn snapshot(&self) -> BTreeMap<String, String> {
+        self.0
+            .lock()
+            .expect("runtime env lock is never held across a panic")
+            .clone()
+    }
 }
 
 /// Derive the composition-path state-dir set by picking up any
@@ -375,11 +404,13 @@ impl Env {
         install_min_helpers(&sandbox.rootfs()).map_err(std::io::Error::other)?;
         sandbox.keep_dir(false);
 
+        let runtime_env = RuntimeEnv::default();
         let channel = SessionChannel {
             rootfs: DaemonAbsPath::try_new(
                 Utf8PathBuf::try_from(sandbox.rootfs().to_path_buf()).unwrap(),
             )
             .unwrap(),
+            runtime_env: runtime_env.clone(),
             state_dir: args.state_base_dir.clone(),
             working: args.cwd.clone(),
             home: args.home.clone(),
@@ -395,6 +426,7 @@ impl Env {
         Ok(Self {
             sandbox,
             actor: Some(actor),
+            runtime_env,
             _temp_dirs: Vec::new(),
         })
     }
@@ -426,6 +458,19 @@ impl Env {
         self.sandbox
             .command(container, program, args, [("", ""); 0])
             .map_err(sandbox_err_to_io)
+    }
+
+    /// The working directory and environment a command should run with in this
+    /// session **as it stands now** — `/workbench`, the composed session
+    /// variables, and anything `min add` has installed since launch.
+    #[cfg_attr(test, allow(dead_code))]
+    pub(crate) fn command_environment(&self) -> crate::session_host::SessionEnvironment {
+        let mut vars = self.sandbox.command_env();
+        vars.extend(self.runtime_env.snapshot());
+        crate::session_host::SessionEnvironment {
+            cwd: self.sandbox.command_cwd(),
+            vars,
+        }
     }
 }
 
@@ -523,6 +568,8 @@ struct SessionChannel {
     /// Weak handle to the owning session actor, used by session-scoped commands
     /// (e.g. `min build`) to drive side-ops.
     session: crate::session::WeakSessionHandle,
+    /// Accumulates env vars of newly-installed packages, shared with the owning [`Env`].
+    runtime_env: RuntimeEnv,
     rx: mpsc::Receiver<ChannelRequest>,
 }
 
@@ -621,6 +668,12 @@ impl SessionChannel {
         }
     }
 
+    /// Record and transmit a newly-acquired variable to the session shell.
+    fn announce_env(&self, stream: &mut UnixStream, key: &str, value: &str) {
+        self.runtime_env.record(key, value);
+        let _ = writeln!(stream, "set_env:{key}:{value}");
+    }
+
     /// Resolves a space-separated list of package names to `(name, ref)` pairs,
     /// returning the first unknown name as `Err`.
     fn parse_pkgs_line<'a>(&self, pkgs: &'a str) -> Result<Vec<(&'a str, BuildSpecRef)>, &'a str> {
@@ -674,7 +727,7 @@ impl SessionChannel {
                     }
                 }
                 for (k, v) in &setup.env_vars {
-                    let _ = writeln!(stream, "set_env:{k}:{v}");
+                    self.announce_env(stream, k, v);
                 }
             }
             Err(e) => {
@@ -1411,6 +1464,7 @@ mod tests {
             has_packages: HashSet::new(),
             ot: None,
             session: crate::session::WeakSessionHandle::dangling(),
+            runtime_env: RuntimeEnv::default(),
             ctx,
             graph,
             rx,
@@ -1440,6 +1494,49 @@ mod tests {
         assert!(
             lines[0].contains("error: unhandled input 'garbage-input'"),
             "unexpected output: {lines:?}"
+        );
+    }
+
+    /// A variable a running session acquires has to reach two places: the shell,
+    /// which exports it, and the daemon, which hands it to anything injected
+    /// into the session later. `min add` is the source in production; this
+    /// drives the announcement directly, since installing a package would mean
+    /// building one.
+    #[tokio::test]
+    async fn an_acquired_var_reaches_both_the_shell_and_the_daemon() {
+        let (_state, _rootfs, _cwd, chan) = setup_channel();
+        let (mut ours, theirs) = UnixStream::pair().unwrap();
+
+        chan.announce_env(&mut ours, "GOCACHE", "/state/gocache");
+        drop(ours);
+
+        assert_eq!(read_lines(&theirs), vec!["set_env:GOCACHE:/state/gocache"]);
+        assert_eq!(
+            chan.runtime_env
+                .snapshot()
+                .get("GOCACHE")
+                .map(String::as_str),
+            Some("/state/gocache"),
+            "the daemon's view is missing a variable the shell was given"
+        );
+    }
+
+    /// Installing over an earlier install replaces the value, as the shell's
+    /// second `export` does.
+    #[tokio::test]
+    async fn a_reannounced_var_takes_the_newer_value() {
+        let (_state, _rootfs, _cwd, chan) = setup_channel();
+        let (mut ours, _theirs) = UnixStream::pair().unwrap();
+
+        chan.announce_env(&mut ours, "PYTHONPATH", "/first");
+        chan.announce_env(&mut ours, "PYTHONPATH", "/second");
+
+        assert_eq!(
+            chan.runtime_env
+                .snapshot()
+                .get("PYTHONPATH")
+                .map(String::as_str),
+            Some("/second")
         );
     }
 

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -29,6 +29,7 @@ use tokio::{
     process::{Child, ChildStderr, ChildStdin, ChildStdout, Command},
     spawn,
 };
+use tracing::Instrument as _;
 
 use crate::{
     ChannelConfig, MINIMAL_SESSION_ID_ENV,
@@ -477,6 +478,53 @@ impl Exec for TokioExec {
     }
 }
 
+/// An [`Exec`] that runs a command *inside* the session's sandbox, joining the
+/// namespaces of the running session process.
+///
+/// `argv` is handed to the session's shell rather than split here, matching
+/// what `ssh host '...'` does everywhere else: the client wrote a shell command,
+/// and quoting, globs, pipes and redirections are part of what it means.
+#[derive(Debug, Clone)]
+pub struct SessionExec {
+    pub argv: String,
+    /// The SSH username, needed only if the session has no host running and one
+    /// has to be launched to service this request.
+    pub conn_username: String,
+}
+
+/// The shell a session's exec requests run under — the same absolute path the
+/// session launcher execs for an interactive shell, since the generic rootfs
+/// has no `/bin/bash`.
+const SESSION_SHELL: &str = "/usr/bin/bash";
+
+impl Exec for SessionExec {
+    type Process = TokioProcess;
+
+    fn exec(self, session: SessionHandle) -> BoxStream<'static, io::Result<Self::Process>> {
+        stream::once(async move {
+            // Launching the sandbox is part of servicing the request: an exec
+            // against an idle session should work, not fail because nobody
+            // happens to be holding a terminal open.
+            let host = session
+                .ensure_host(self.conn_username)
+                .await
+                .map_err(|e| io::Error::other(format!("{e}")))?;
+            let command = host
+                .command_in_session(SESSION_SHELL, ["-c", &self.argv])
+                .await?;
+
+            let mut command = Command::from(command);
+            command
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true);
+            command.spawn().map(TokioProcess)
+        })
+        .boxed()
+    }
+}
+
 /// `Process` implementation backed by [`tokio::process::Child`].
 #[derive(Debug)]
 pub struct TokioProcess(Child);
@@ -781,6 +829,7 @@ pub(crate) async fn handle_exec(
         session.channel_failure(id)?;
         return Ok(());
     };
+    let conn_username = conn_lock.ssh_username.clone().unwrap_or_default();
     drop(conn_lock);
 
     if let Some(ident) = argv.strip_prefix("git-receive-pack min://") {
@@ -824,18 +873,24 @@ pub(crate) async fn handle_exec(
         }
     };
 
+    // Logged for every accepted form, before the dispatch that decides which
+    // one it is: an operator reading the log should see what a client asked to
+    // run, whether it was serviced by the daemon, handed to the session, or
+    // refused below.
+    tracing::info!(%session_id, command = %argv, "exec request");
+
     let rem = match argv.strip_prefix("min ") {
         Some(c) => c,
+        // Not one of the daemon's own commands, so it is a command for the
+        // session: run it in the sandbox, the way `ssh host '<cmd>'` runs it on
+        // the host it names.
         None => {
-            tracing::warn!(%session_id, "execution request rejected: not an accepted command form");
-            // Accept the channel so the client gets a diagnostic on stderr: a
-            // bare `channel_failure` reaches it only as "exec request failed",
-            // naming neither the rejected command nor what would be accepted.
-            // Nothing is run — the request still fails with a non-zero exit.
+            let span = exec_span(&config, session_id, &argv);
             session.channel_success(id)?;
-            spawn(async move {
-                reject_unsupported_exec(channel, argv).await;
-            });
+            spawn(
+                run_in_session(serv, conn, session_handle, id, channel, argv, conn_username)
+                    .instrument(span),
+            );
             return Ok(());
         }
     }
@@ -932,8 +987,6 @@ pub(crate) async fn handle_exec(
         }
         Some(other) => {
             tracing::warn!(%session_id, "execution request rejected: unexpected min sub-command `{other}`");
-            // As with the missing-`min ` case above, report the rejection on
-            // stderr rather than failing the channel opaquely.
             session.channel_success(id)?;
             spawn(async move {
                 reject_unsupported_exec(channel, argv).await;
@@ -969,6 +1022,70 @@ fn unsupported_command_message(rejected: &str) -> String {
         "minimald: unsupported command '{rejected}'; accepted: \
          min run <task>, min package build [args...], min check [args...]\n"
     )
+}
+
+/// The tracing span an in-session exec runs under, mirroring the `rpc` span in
+/// [`crate::rpc::handle_ssh_rpc`].
+///
+/// The client's propagated trace context is adopted — same trace id, fresh span
+/// id, the client's span as parent — so one `trace_id` grep joins the CLI's log
+/// with the daemon's. A missing or malformed value mints a fresh context:
+/// propagation is a diagnostic aid and must never fail a request. The command
+/// rides on the span, so every record the exec emits names what was asked for.
+fn exec_span(config: &ChannelConfig, session_id: SessionId, argv: &str) -> tracing::Span {
+    use minimald_rpc::trace::{TRACEPARENT_ENV, TraceContext};
+
+    let client_ctx = config
+        .env_vars
+        .get(TRACEPARENT_ENV)
+        .and_then(|v| TraceContext::parse_traceparent(v));
+    let ctx = client_ctx
+        .as_ref()
+        .map(TraceContext::child)
+        .unwrap_or_else(TraceContext::mint);
+    let span = tracing::info_span!(
+        "exec",
+        %session_id,
+        command = %argv,
+        trace_id = %ctx.trace_id_hex(),
+        span_id = %ctx.span_id_hex(),
+        parent_span_id = tracing::field::Empty,
+    );
+    if let Some(client_ctx) = &client_ctx {
+        span.record(
+            "parent_span_id",
+            tracing::field::display(client_ctx.span_id_hex()),
+        );
+    }
+    span
+}
+
+/// Runs `argv` inside the session's sandbox, streamed over the SSH channel.
+///
+/// The fallback for every exec request the daemon does not service itself. It
+/// needs the session's sandbox up, which [`SessionExec`] arranges — launching a
+/// host for an idle session if there isn't one.
+#[allow(clippy::too_many_arguments)]
+async fn run_in_session(
+    serv: ServerStateHandle,
+    conn: ConnectionHandle,
+    session: SessionHandle,
+    channel_id: ChannelId,
+    channel: Channel<Msg>,
+    argv: String,
+    conn_username: String,
+) {
+    let exec_task = ExecTask {
+        conn,
+        serv,
+        session,
+        channel_id,
+        exec: SessionExec {
+            argv,
+            conn_username,
+        },
+    };
+    exec_task.run(channel).await;
 }
 
 /// Streams a `min package build [--verbose] [--rebuild] [pkgs...]` exec over the SSH
@@ -1712,44 +1829,59 @@ mod tests {
             create_configured_session(client, "exec-test", "/tmp").await
         }
 
-        /// An exec request that isn't an accepted form must never start a
-        /// process — the daemon services only specific safe invocations. The
-        /// refusal is reported on stderr (exit 1) rather than failing the
-        /// channel opaquely, so the client sees what was rejected and what it
-        /// could run instead.
+        /// A path in the daemon's own filesystem that a command would create if
+        /// it ran there. Unique per call so parallel tests cannot collide.
+        fn daemon_marker(tag: &str) -> std::path::PathBuf {
+            std::env::temp_dir().join(format!(
+                "minimald-exec-{tag}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id(),
+            ))
+        }
+
+        /// An exec request the daemon does not service itself is handed to the
+        /// session's sandbox — and must never run on the daemon's own
+        /// filesystem.
+        ///
+        /// The marker file is what pins that: had the command run here, it
+        /// would exist. This harness launches a mock host with no sandbox to
+        /// join, so the command fails rather than running in-session; where it
+        /// was *sent* is the part that matters and the part that can be proved
+        /// without a real sandbox.
         #[tokio::test]
-        async fn exec_rejects_arbitrary_command() {
+        async fn an_unrecognised_command_never_runs_on_the_daemon() {
             let server = TestServer::new().await;
             let mut client = server.connect().await;
             let session_id = fresh_session(&mut client).await;
             let session_str = session_id.to_string();
+            let marker = daemon_marker("arbitrary");
+            let _ = std::fs::remove_file(&marker);
 
             let out = client
                 .exec(
                     &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
                     false,
-                    "printf pwned",
+                    &format!("printf pwned > {}", marker.display()),
                     &[],
                 )
                 .await
-                .expect("the rejection is reported over the channel, not a channel failure");
+                .expect("the request is serviced over the channel, not a channel failure");
 
-            assert_eq!(
+            assert!(
+                !marker.exists(),
+                "an exec request ran on the daemon's filesystem, creating {}",
+                marker.display(),
+            );
+            assert_ne!(
                 out.exit_status,
-                Some(1),
-                "an arbitrary command must not exit 0; stdout was {:?}",
+                Some(0),
+                "the mock harness has no sandbox to run in, so this cannot succeed; stdout was {:?}",
                 String::from_utf8_lossy(&out.stdout),
             );
             let stderr = String::from_utf8_lossy(&out.stderr);
             assert!(
-                stderr.contains("printf pwned"),
-                "the rejected command should be named on stderr, got {stderr:?}",
-            );
-            assert!(
-                stderr.contains("min run <task>")
-                    && stderr.contains("min package build [args...]")
-                    && stderr.contains("min check [args...]"),
-                "the accepted forms should be listed on stderr, got {stderr:?}",
+                !stderr.contains("unsupported command"),
+                "the command should be routed to the session, not refused, got {stderr:?}",
             );
         }
 
@@ -1950,36 +2082,44 @@ mod tests {
             );
         }
 
-        /// `min check` takes its flags after the sub-command, so a form the
-        /// parser accepts must still route — a prefix-matched `min checkx`
-        /// must not run, and its refusal is reported on stderr with a non-zero
-        /// exit rather than an opaque channel failure.
+        /// `min check` takes its flags after the sub-command, so a prefix match
+        /// like `min checkx` must not be serviced as `min check`. A `min`
+        /// sub-command the daemon doesn't know is refused outright rather than
+        /// handed to the session — and refusing it means never running it, on
+        /// the daemon's filesystem least of all.
         #[tokio::test]
-        async fn exec_rejects_a_check_lookalike_subcommand() {
+        async fn a_check_lookalike_is_not_serviced_as_check() {
             let server = TestServer::new().await;
             let mut client = server.connect().await;
             let session_id = fresh_session(&mut client).await;
             let session_str = session_id.to_string();
+            let marker = daemon_marker("checkx");
+            let _ = std::fs::remove_file(&marker);
 
             let out = client
                 .exec(
                     &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
                     false,
-                    "min checkx",
+                    &format!("min checkx > {}", marker.display()),
                     &[],
                 )
                 .await
-                .expect("the rejection is reported over the channel, not a channel failure");
+                .expect("the request is serviced over the channel, not a channel failure");
 
-            assert_eq!(
+            assert!(
+                !marker.exists(),
+                "`min checkx` ran on the daemon's filesystem, creating {}",
+                marker.display(),
+            );
+            assert_ne!(
                 out.exit_status,
-                Some(1),
-                "`min checkx` is not `min check` and must not exit 0; stdout was {:?}",
+                Some(0),
+                "`min checkx` is not `min check` and must not succeed; stdout was {:?}",
                 String::from_utf8_lossy(&out.stdout),
             );
             assert!(
                 String::from_utf8_lossy(&out.stderr).contains("min checkx"),
-                "the rejected command should be named on stderr, got {:?}",
+                "the refusal should name the rejected command, got {:?}",
                 String::from_utf8_lossy(&out.stderr),
             );
         }

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -10,6 +10,7 @@ pub mod guest;
 mod maintenance;
 #[cfg(target_os = "linux")]
 pub mod net;
+pub mod nsenter;
 pub mod rpc;
 pub mod server;
 mod session;

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -144,6 +144,12 @@ enum Command {
     Completions(CompletionsArgs),
     /// Runs the minimald server in the foreground.
     Run(ListenArgs),
+    /// Internal: join a session's namespaces and run a program there.
+    ///
+    /// Not a supported command line — this is the daemon re-execing itself to
+    /// power launching a process in existing namespaces.
+    #[command(name = minimald::nsenter::SUBCOMMAND, hide = true)]
+    Nsenter(minimald::nsenter::ShimArgs),
 }
 
 /// The arguments for the completions subcommand.
@@ -259,6 +265,15 @@ impl From<russh::keys::Error> for MainError {
     }
 }
 
+/// Flattens an error and its `source()` chain into one line, so a typed error
+/// reaching [`MainError::Other`] keeps the context its variants carry.
+fn error_chain(err: &dyn std::error::Error) -> String {
+    std::iter::successors(err.source(), |e| e.source()).fold(err.to_string(), |mut acc, e| {
+        acc.push_str(&format!(": {e}"));
+        acc
+    })
+}
+
 /// Open (creating if absent) a lock file; only its fd matters, for flock.
 fn open_lock_file(path: impl AsRef<std::path::Path>) -> std::io::Result<std::fs::File> {
     std::fs::OpenOptions::new()
@@ -270,6 +285,23 @@ fn open_lock_file(path: impl AsRef<std::path::Path>) -> std::io::Result<std::fs:
 }
 
 fn main() -> Result<(), MainError> {
+    // We re-exec to power some machinery for joining namespaces, do that before async/other-threads
+    // are setup.
+    if std::env::args_os()
+        .nth(1)
+        .is_some_and(|arg| arg == minimald::nsenter::SUBCOMMAND)
+    {
+        let Command::Nsenter(args) = Cli::parse().command else {
+            unreachable!(
+                "argv[1] is {}, so clap parsed that subcommand",
+                minimald::nsenter::SUBCOMMAND
+            )
+        };
+        let code =
+            minimald::nsenter::shim_main(args).map_err(|e| MainError::Other(error_chain(&e)))?;
+        std::process::exit(code);
+    }
+
     let runtime = Builder::new_multi_thread()
         .thread_name("minimald-worker")
         .thread_stack_size(8 * 1024 * 1024)
@@ -408,7 +440,7 @@ async fn async_main() -> Result<(), MainError> {
     // would indicate we are operating in a single-purpose micro-vm.
     //
     // If we are not the init process, we load our config from CLI args.
-    let mut cli = if is_minimal_microvm() {
+    let cli = if is_minimal_microvm() {
         Cli {
             command: Command::Run(ListenArgs {
                 instance_num: 0,
@@ -441,12 +473,16 @@ async fn async_main() -> Result<(), MainError> {
     };
 
     // Handle non-{launch,run} commands.
-    if let Command::Completions(CompletionsArgs { shell }) = cli.command {
-        let mut cmd = Cli::command();
-        let name = cmd.get_name().to_string();
-        clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
-        return Ok(());
-    }
+    let mut cli = match cli.command {
+        Command::Nsenter(_) => unreachable!("nsenter is intercepted before CLI args are parsed"),
+        Command::Completions(CompletionsArgs { shell }) => {
+            let mut cmd = Cli::command();
+            let name = cmd.get_name().to_string();
+            clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
+            return Ok(());
+        }
+        _ => cli,
+    };
 
     // Install tracing. A foreground run logs to stdout only. A detached
     // native daemon (stdio null'd, marked by `MINIMALD_DETACHED`) and the

--- a/crates/minimald/src/nsenter.rs
+++ b/crates/minimald/src/nsenter.rs
@@ -1,0 +1,616 @@
+//! Injecting additional processes into a running session's namespaces.
+//!
+//! A session shell is launched into a sandbox by [`crate::session_host`], which
+//! hands hakoniwa a container and gets back a [`hakoniwa::Child`]. Running a
+//! *second* program in that same sandbox means joining the namespaces via
+//! `setns(2)`.
+
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::process::{CommandExt as _, ExitStatusExt as _};
+use std::path::PathBuf;
+use std::process::Command;
+
+use nix::sched::CloneFlags;
+
+/// `argv[1]` the daemon re-execs itself with to run [`shim_main`].
+pub const SUBCOMMAND: &str = "__nsenter";
+
+/// Descriptor number the pidfd is placed on, the shim joins the namespaces
+/// associated with this process.
+const PIDFD_FD: RawFd = 3;
+
+/// A namespace an injected process can join.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum Namespace {
+    /// Must be joined in the same `setns` call as any other namespace it owns.
+    User,
+    Mnt,
+    Pid,
+    Uts,
+    Ipc,
+    Cgroup,
+    Net,
+}
+
+impl Namespace {
+    /// Every namespace, in no significant order — a single `setns` call takes
+    /// the whole set at once and the kernel sequences it internally.
+    const ALL: [Self; 7] = [
+        Self::User,
+        Self::Mnt,
+        Self::Pid,
+        Self::Uts,
+        Self::Ipc,
+        Self::Cgroup,
+        Self::Net,
+    ];
+
+    /// The entry name under `/proc/<pid>/ns/`.
+    fn proc_name(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Mnt => "mnt",
+            Self::Pid => "pid",
+            Self::Uts => "uts",
+            Self::Ipc => "ipc",
+            Self::Cgroup => "cgroup",
+            Self::Net => "net",
+        }
+    }
+
+    /// The `clone(2)` flag `setns` selects this namespace with.
+    fn clone_flag(self) -> CloneFlags {
+        match self {
+            Self::User => CloneFlags::CLONE_NEWUSER,
+            Self::Mnt => CloneFlags::CLONE_NEWNS,
+            Self::Pid => CloneFlags::CLONE_NEWPID,
+            Self::Uts => CloneFlags::CLONE_NEWUTS,
+            Self::Ipc => CloneFlags::CLONE_NEWIPC,
+            Self::Cgroup => CloneFlags::CLONE_NEWCGROUP,
+            Self::Net => CloneFlags::CLONE_NEWNET,
+        }
+    }
+
+    /// The namespace `pid` is in, as the kernel's `ns:[inode]` identity, or
+    /// `None` if this kernel has no such namespace type.
+    fn identity(self, pid: Option<u32>) -> Result<Option<String>, NsenterError> {
+        let who = pid.map_or_else(|| "self".to_string(), |p| p.to_string());
+        let path = format!("/proc/{who}/ns/{}", self.proc_name());
+        match std::fs::read_link(&path) {
+            Ok(target) => Ok(Some(target.to_string_lossy().into_owned())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(source) => Err(NsenterError::ReadNamespace { path, source }),
+        }
+    }
+}
+
+/// The namespaces of `leader_pid` that the caller is not already in.
+///
+/// The set has to be computed, not hardcoded, and asking for one namespace too
+/// many is not free. Once `setns` switches our credentials into the sandbox's
+/// user namespace, we hold capabilities *there* and nowhere else — so asking in
+/// the same call for a namespace the sandbox never unshared, which is therefore
+/// still the host's, is refused with `EPERM` rather than quietly ignored.
+/// Measured, joining a sandbox that unshared user/mount/PID/UTS/cgroup but left
+/// IPC and (for a `HostNet` session) the network alone:
+///
+/// ```text
+///  setns(pidfd, user|mnt)    = ok        setns(pidfd, user|ipc) = EPERM
+///  setns(pidfd, user|pid)    = ok        setns(pidfd, user|net) = EPERM
+///  setns(pidfd, user|uts)    = ok
+///  setns(pidfd, user|cgroup) = ok
+/// ```
+///
+/// Diffing namespace identities against our own yields exactly the set the
+/// sandbox created, which is what makes this work across a `HostNet` session
+/// (network shared with the daemon, so not joined) and a `NoNet`/`OwnIp` one
+/// (network unshared, so joined) without either being a special case.
+///
+/// # Errors
+///
+/// [`NsenterError::ReadNamespace`] if `/proc` cannot be read for either process;
+/// a namespace type this kernel does not implement is skipped, not an error.
+pub fn namespaces_to_join(leader_pid: u32) -> Result<Vec<Namespace>, NsenterError> {
+    Namespace::ALL
+        .into_iter()
+        .filter_map(|ns| {
+            let differs = || {
+                Ok(match (ns.identity(Some(leader_pid))?, ns.identity(None)?) {
+                    (Some(theirs), Some(ours)) => theirs != ours,
+                    // A namespace type the kernel lacks entirely: nothing to join.
+                    _ => false,
+                })
+            };
+            match differs() {
+                Ok(true) => Some(Ok(ns)),
+                Ok(false) => None,
+                Err(e) => Some(Err(e)),
+            }
+        })
+        .collect()
+}
+
+/// A failure injecting a process into a session's namespaces.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum NsenterError {
+    /// The supervisor's `children` file could not be read. Absent on a kernel
+    /// built without `CONFIG_PROC_CHILDREN`; `ENOENT` also means the supervisor
+    /// itself is gone, i.e. the session has ended.
+    #[error("reading /proc/{pid}/task/{pid}/children (is CONFIG_PROC_CHILDREN enabled?)")]
+    ReadChildren {
+        pid: u32,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The supervisor has no children: the session program has exited, and its
+    /// namespaces are on their way out with it.
+    #[error("sandbox supervisor {pid} has no child process; the session program has exited")]
+    NoSessionLeader { pid: u32 },
+
+    /// The supervisor has more than one child, so "the session program" is
+    /// ambiguous. hakoniwa forks exactly once, so this means the process
+    /// structure this module is written against has changed.
+    #[error("sandbox supervisor {pid} has {count} children, expected exactly 1: {children}")]
+    AmbiguousSessionLeader {
+        pid: u32,
+        count: usize,
+        children: String,
+    },
+
+    /// The `children` file held something that is not a PID.
+    #[error("sandbox supervisor {pid} reported an unparseable child pid: {child:?}")]
+    MalformedChild { pid: u32, child: String },
+
+    /// A `/proc/<pid>/ns/*` link could not be read while working out which
+    /// namespaces the session actually has.
+    #[error("reading the namespace link {path}")]
+    ReadNamespace {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// `pidfd_open(2)` failed. `ESRCH` means the session program exited between
+    /// resolving its PID and pinning it.
+    #[error("pidfd_open({pid})")]
+    PidfdOpen {
+        pid: u32,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The daemon binary could not be located to re-exec.
+    #[error("resolving the running executable to re-exec as the {SUBCOMMAND} shim")]
+    CurrentExe {
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// `setns(2)` failed. `EPERM` on an otherwise sound setup means one of: the
+    /// caller is multi-threaded (which the user namespace forbids), the set
+    /// includes a namespace the sandbox never unshared (see
+    /// [`namespaces_to_join`]), or the sandbox's user namespace is not owned by
+    /// this user — a daemon can only join sandboxes it owns.
+    #[error("setns(2) onto the session's namespaces ({namespaces})")]
+    Setns {
+        namespaces: String,
+        #[source]
+        source: nix::Error,
+    },
+
+    /// The injected program could not be started. `ENOMEM` from the fork means
+    /// the sandbox's PID namespace has no live init left to reparent to — the
+    /// session shell exited while we were joining.
+    #[error("spawning {program:?} inside the session")]
+    Spawn {
+        program: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The shim could not reap the process it started.
+    #[error("waiting for {program:?} inside the session")]
+    Wait {
+        program: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Resolves the PID of the process hakoniwa exec'd, given the PID of its
+/// container supervisor — that is, [`hakoniwa::Child::id()`].
+///
+/// The supervisor's sole child is the exec'd program (see the module docs), and
+/// `/proc/<pid>/task/<pid>/children` names it. The read is race-free against a
+/// just-returned `spawn()`: hakoniwa's parent only reports setup-success to the
+/// caller *after* the second fork, so by the time a `hakoniwa::Child` exists the
+/// child entry does too. It is not race-free against the `execve` that follows,
+/// which matters only for reads that depend on it — `/proc/<pid>/environ` in
+/// that window still holds the daemon's environment, not the session's.
+///
+/// # Errors
+///
+/// [`NsenterError::NoSessionLeader`] once the session program has exited, and
+/// [`NsenterError::ReadChildren`] if `/proc` cannot answer — including on a
+/// kernel without `CONFIG_PROC_CHILDREN`.
+pub fn session_leader_pid(container_pid: u32) -> Result<u32, NsenterError> {
+    let path = format!("/proc/{container_pid}/task/{container_pid}/children");
+    let raw = std::fs::read_to_string(&path).map_err(|source| NsenterError::ReadChildren {
+        pid: container_pid,
+        source,
+    })?;
+
+    let children: Vec<&str> = raw.split_ascii_whitespace().collect();
+    match children.as_slice() {
+        [] => Err(NsenterError::NoSessionLeader { pid: container_pid }),
+        [child] => child.parse().map_err(|_| NsenterError::MalformedChild {
+            pid: container_pid,
+            child: (*child).to_string(),
+        }),
+        many => Err(NsenterError::AmbiguousSessionLeader {
+            pid: container_pid,
+            count: many.len(),
+            children: many.join(" "),
+        }),
+    }
+}
+
+/// Pins `pid` as a pidfd, so later use cannot be misdirected by PID reuse.
+fn pidfd_open(pid: u32) -> Result<OwnedFd, NsenterError> {
+    // SAFETY: `pidfd_open` takes a pid and a flags word and returns a fresh
+    // descriptor or -1; it reads no user memory. On success we own the
+    // descriptor and hand it straight to `OwnedFd`, which closes it exactly
+    // once.
+    let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0) };
+    if fd < 0 {
+        return Err(NsenterError::PidfdOpen {
+            pid,
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    // SAFETY: `fd` is a positive, freshly-opened descriptor owned by nobody else.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd as RawFd) })
+}
+
+/// A program to run inside a running session's sandbox.
+///
+/// Built against the PID of the session process — resolve it with
+/// [`session_leader_pid`], never `hakoniwa::Child::id()` — and turned into a
+/// [`Command`] by [`Self::command`]. What the namespaces do not carry is set
+/// here:
+///
+/// - **working directory** via [`Self::with_cwd`]. Without it the process
+///   starts at the container root, because joining a mount namespace puts both
+///   root and cwd there.
+/// - **environment** via [`Self::with_env`]. Without it the process inherits the
+///   daemon's environment, which describes the host rather than the sandbox.
+/// - **stdio** on the returned [`Command`], which the caller owns. For a PTY,
+///   open it daemon-side and pass slave descriptors exactly as the session
+///   launcher does — descriptors cross namespaces untouched.
+///
+/// `minimald` gets both of the first two from the session's
+/// [`SessionEnvironment`](crate::session_host::SessionEnvironment), which is
+/// what the session's own shell was launched with.
+#[derive(Debug)]
+#[must_use = "an Injection does nothing until `command` is called"]
+pub struct Injection {
+    leader_pid: u32,
+    program: OsString,
+    args: Vec<OsString>,
+    cwd: Option<PathBuf>,
+    env: Option<BTreeMap<String, String>>,
+    shim_exe: Option<PathBuf>,
+}
+
+impl Injection {
+    /// Runs `program` in the namespaces of the session process `leader_pid`.
+    pub fn new<I, S>(leader_pid: u32, program: impl AsRef<OsStr>, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        Self {
+            leader_pid,
+            program: program.as_ref().to_os_string(),
+            args: args
+                .into_iter()
+                .map(|a| a.as_ref().to_os_string())
+                .collect(),
+            cwd: None,
+            env: None,
+            shim_exe: None,
+        }
+    }
+
+    /// Starts the program in `cwd`, a path inside the container (`/workbench`
+    /// for a session's workspace).
+    ///
+    /// Applied by the shim after it joins, since the path only exists there.
+    pub fn with_cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    /// Runs the program with exactly `env`, replacing the daemon's environment
+    /// rather than adding to it.
+    ///
+    /// Carried on the shim's own environment and inherited from there, so no
+    /// value is ever visible in `ps` output.
+    pub fn with_env(mut self, env: impl Into<BTreeMap<String, String>>) -> Self {
+        self.env = Some(env.into());
+        self
+    }
+
+    /// Uses `shim_exe` as the namespace-joining shim instead of the running
+    /// executable.
+    ///
+    /// The daemon always wants the running executable — it re-execs itself.
+    /// This is for callers that are not the daemon: an integration test driving
+    /// the real shim out of `CARGO_BIN_EXE_minimald`, say.
+    pub fn with_shim(mut self, shim_exe: impl Into<PathBuf>) -> Self {
+        self.shim_exe = Some(shim_exe.into());
+        self
+    }
+
+    /// Builds the command that runs this program in the session.
+    ///
+    /// The pidfd is owned by the returned command and closed when it drops, so
+    /// the pin against PID reuse lasts exactly as long as it is needed. Waiting
+    /// on the resulting child waits on the shim, whose exit status is the
+    /// injected program's.
+    ///
+    /// # Errors
+    ///
+    /// [`NsenterError::PidfdOpen`] if the session program exited before it
+    /// could be pinned, [`NsenterError::ReadNamespace`] if its namespaces
+    /// cannot be enumerated, [`NsenterError::CurrentExe`] if no shim was named
+    /// and this binary cannot be located.
+    pub fn command(self) -> Result<Command, NsenterError> {
+        // Resolved here rather than in the shim: the daemon holds the session's
+        // PID and the shim holds only a pidfd, and naming the namespaces on the
+        // command line puts them in `ps` output for whoever is debugging a
+        // joined process.
+        let namespaces = namespaces_to_join(self.leader_pid)?;
+        let pidfd = pidfd_open(self.leader_pid)?;
+        let shim = match self.shim_exe {
+            Some(exe) => exe,
+            None => {
+                std::env::current_exe().map_err(|source| NsenterError::CurrentExe { source })?
+            }
+        };
+
+        let mut cmd = Command::new(shim);
+        cmd.arg(SUBCOMMAND).arg("--pidfd").arg(PIDFD_FD.to_string());
+        if !namespaces.is_empty() {
+            cmd.arg("--join").arg(
+                namespaces
+                    .iter()
+                    .map(|ns| ns.proc_name())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
+        if let Some(cwd) = &self.cwd {
+            cmd.arg("--chdir").arg(cwd);
+        }
+        if let Some(env) = self.env {
+            // The shim needs nothing from the daemon's environment — it holds
+            // its pidfd on a descriptor and everything else in argv — so this
+            // is the session's environment exactly, passed down by inheritance.
+            cmd.env_clear().envs(env);
+        }
+        cmd.arg("--").arg(&self.program).args(&self.args);
+
+        // SAFETY: the closure runs in the forked child between `fork` and
+        // `exec`, where only async-signal-safe calls are legal. `dup2` and
+        // `fcntl` are both on that list, and the closure allocates nothing and
+        // touches no lock. It borrows only `pidfd`, which it owns.
+        //
+        // std installs the child's stdio before running pre_exec closures, so
+        // fds 0-2 are already final and fd 3 is free to claim.
+        unsafe {
+            cmd.pre_exec(move || {
+                let raw = pidfd.as_raw_fd();
+                if raw == PIDFD_FD {
+                    // `dup2(fd, fd)` is a no-op that, unlike the copying case,
+                    // leaves FD_CLOEXEC set — which would close the pidfd out
+                    // from under the exec. Clear it directly instead.
+                    if libc::fcntl(raw, libc::F_SETFD, 0) == -1 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                } else if libc::dup2(raw, PIDFD_FD) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        Ok(cmd)
+    }
+}
+
+/// Arguments for the internal [`SUBCOMMAND`] shim.
+#[derive(Debug, clap::Args)]
+pub struct ShimArgs {
+    /// Descriptor number carrying the pidfd of the session process to join.
+    #[arg(long, default_value_t = PIDFD_FD)]
+    pidfd: RawFd,
+
+    /// Namespaces to join, as `/proc/<pid>/ns` names.
+    ///
+    /// Computed by [`namespaces_to_join`] rather than assumed: naming a
+    /// namespace the session does not have of its own is an `EPERM`, not a
+    /// no-op. Empty means the target shares every namespace with us and there
+    /// is nothing to join.
+    #[arg(long, value_delimiter = ',')]
+    join: Vec<Namespace>,
+
+    /// Directory to enter after joining, resolved inside the container.
+    ///
+    /// Optional: joining the mount namespace already puts both the root and the
+    /// working directory at the container's root.
+    #[arg(long)]
+    chdir: Option<PathBuf>,
+
+    /// The program to run inside the session, followed by its arguments.
+    #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+    argv: Vec<OsString>,
+}
+
+/// Joins the session's namespaces and runs the requested program there,
+/// returning the exit code to leave with.
+///
+/// **Must be called before the tokio runtime is built.** `setns(CLONE_NEWUSER)`
+/// refuses a multi-threaded caller, and the `fork` this performs is only safe
+/// because the process is single-threaded.
+///
+/// The spawn here is the fork that matters: `setns(CLONE_NEWPID)` placed *this*
+/// process's future children in the session's PID namespace without moving this
+/// process, so the program lands in the namespace and the shim stays outside it
+/// as its parent, able to reap it and report its status.
+///
+/// # Errors
+///
+/// [`NsenterError::Setns`] if the namespaces cannot be joined, and
+/// [`NsenterError::Spawn`] if the program cannot be started inside them.
+pub fn shim_main(args: ShimArgs) -> Result<i32, NsenterError> {
+    // SAFETY: `command_in_session` placed a pidfd on this descriptor and it
+    // survived the exec; nothing else in this freshly-exec'd process owns it.
+    // A wrong `--pidfd` yields a closed or unrelated descriptor, which fails
+    // `setns` with EBADF/EINVAL rather than doing damage.
+    let pidfd = unsafe { OwnedFd::from_raw_fd(args.pidfd) };
+    if !args.join.is_empty() {
+        // One call for the whole set: the kernel installs the user namespace
+        // first and validates the rest against the credentials that gives us,
+        // which is what makes the rest permitted. Joining them one at a time
+        // fails — and joining the mount namespace first would repoint `/proc`
+        // at the sandbox's procfs, where the remaining `/proc/<host pid>/ns`
+        // paths do not exist.
+        let flags = args
+            .join
+            .iter()
+            .fold(CloneFlags::empty(), |acc, ns| acc | ns.clone_flag());
+        nix::sched::setns(&pidfd, flags).map_err(|source| NsenterError::Setns {
+            namespaces: args
+                .join
+                .iter()
+                .map(|ns| ns.proc_name())
+                .collect::<Vec<_>>()
+                .join(","),
+            source,
+        })?;
+    }
+    drop(pidfd);
+
+    let (program, rest) = args
+        .argv
+        .split_first()
+        .expect("clap requires at least one argv entry");
+
+    let mut cmd = Command::new(program);
+    cmd.args(rest);
+    if let Some(dir) = &args.chdir {
+        cmd.current_dir(dir);
+    }
+
+    // SAFETY: the closure runs in the forked child between `fork` and `exec`,
+    // where only async-signal-safe calls are legal. `prctl` is on that list,
+    // and the closure allocates nothing and captures nothing.
+    unsafe {
+        cmd.pre_exec(|| {
+            // Tie the injected process's lifetime to this shim's. Nothing else
+            // does: the shim is its parent but sits outside the session's PID
+            // namespace, and killing the shim is exactly how the daemon cancels
+            // an exec whose client has gone away. Without this the command
+            // keeps running in the session, holding stdio pipes nobody reads.
+            //
+            // The usual `getppid()` race check — did the parent die before this
+            // ran? — is not available here: the parent is outside the PID
+            // namespace this process was just placed in, so `getppid` reports 0
+            // whether or not it is still alive. The window is a few
+            // instructions wide, and what escapes through it is bounded by the
+            // session: the sandbox's PID namespace dies with its shell, taking
+            // anything left in it.
+            if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let program = PathBuf::from(program);
+    let mut child = cmd.spawn().map_err(|source| NsenterError::Spawn {
+        program: program.clone(),
+        source,
+    })?;
+    let status = child.wait().map_err(|source| NsenterError::Wait {
+        program: program.clone(),
+        source,
+    })?;
+
+    // Mirror the shell's convention for a signalled child so the daemon sees
+    // the same code it would from a direct spawn.
+    Ok(status
+        .code()
+        .or_else(|| status.signal().map(|sig| 128 + sig))
+        .unwrap_or(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A process whose only child is known: `sh` prints the PID of the
+    /// background `sleep` it forked, so the expected answer arrives on stdout
+    /// after the fork rather than being guessed at.
+    fn shell_with_one_child() -> (std::process::Child, u32) {
+        use std::io::BufRead as _;
+
+        let mut sh = Command::new("/bin/sh")
+            .arg("-c")
+            .arg("sleep 30 & echo $!; wait")
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawning /bin/sh");
+        // One line, not to EOF: `sh` holds the pipe open until the background
+        // `sleep` it just forked has finished, which is the state under test.
+        let mut out = String::new();
+        std::io::BufReader::new(sh.stdout.as_mut().expect("piped stdout"))
+            .read_line(&mut out)
+            .expect("reading the child pid");
+        let child_pid = out.trim().parse().expect("sh printed a pid");
+        (sh, child_pid)
+    }
+
+    #[test]
+    fn resolves_the_grandchild_not_the_forking_process() {
+        let (mut sh, expected) = shell_with_one_child();
+
+        let resolved = session_leader_pid(sh.id());
+
+        let _ = sh.kill();
+        let _ = sh.wait();
+        assert_eq!(resolved.expect("resolving the sole child"), expected);
+    }
+
+    #[test]
+    fn a_process_without_children_is_not_a_container_supervisor() {
+        let mut sleep = Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawning /bin/sleep");
+
+        let resolved = session_leader_pid(sleep.id());
+
+        let _ = sleep.kill();
+        let _ = sleep.wait();
+        assert!(
+            matches!(resolved, Err(NsenterError::NoSessionLeader { .. })),
+            "expected NoSessionLeader, got {resolved:?}"
+        );
+    }
+}

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -244,10 +244,7 @@ enum SessionInner {
         composition: Option<Arc<Composition>>,
         /// The running host, if minted, paired with the `JoinHandle` of its
         /// runtime loop so teardown can be awaited on destroy.
-        host: Option<(
-            session_host::HostHandle,
-            JoinHandle<Result<i32, std::io::Error>>,
-        )>,
+        host: Option<LaunchedHost>,
         /// Side operations.
         sops: Vec<SideOp>,
     },
@@ -263,6 +260,22 @@ enum Teardown {
     SelfInitiated,
 }
 
+/// A launched host: its handle, paired with the `JoinHandle` of its runtime
+/// loop so teardown can be awaited on destroy.
+type LaunchedHost = (
+    session_host::HostHandle,
+    JoinHandle<Result<i32, std::io::Error>>,
+);
+
+/// The PTY size a host minted with nothing attached starts at. A client that
+/// attaches later resizes it; until then only an unattached shell sees it.
+const UNATTACHED_WIN_SIZE: WinSize = WinSize {
+    rows: 24,
+    cols: 80,
+    xpixel: 0,
+    ypixel: 0,
+};
+
 enum SessionMessage {
     GetPaths(oneshot::Sender<SessionPaths>),
     MakeContext(oneshot::Sender<Result<mctx::Context, String>>),
@@ -274,6 +287,15 @@ enum SessionMessage {
         ChannelConfig,
     ),
     GetHostAttrs(oneshot::Sender<Option<HostAttrs>>),
+    /// Hand back this session's host, minting one — with no channel bound to
+    /// it — if the session has none running. Used by the exec path, which runs
+    /// a command inside the session's sandbox and so needs the sandbox up, but
+    /// has no terminal to attach and nothing to render progress to.
+    EnsureHost(
+        oneshot::Sender<Result<session_host::HostHandle, AttachError>>,
+        SessionHandle,
+        String,
+    ),
     /// The workspace's at-risk report (what a destroy would lose), served
     /// to the `SessionDelta` RPC for the destroy confirm. `Unavailable`
     /// without a running host, or when the host cannot compute it.
@@ -625,6 +647,9 @@ impl Session {
                     self.attach(session_hnd, conn_username, channel, config)
                         .await,
                 );
+            }
+            SessionMessage::EnsureHost(r, session_hnd, conn_username) => {
+                let _ = r.send(self.ensure_host(session_hnd, conn_username).await);
             }
             SessionMessage::GetHostAttrs(r) => {
                 let _ = r.send(match &self.inner {
@@ -1286,17 +1311,27 @@ impl Session {
         }
     }
 
-    async fn mint_session_host(
+    /// Launches a host for this session.
+    ///
+    /// The one path both callers take: [`Self::attach`], which has a client
+    /// channel and passes it in as `progress` so the sandbox coming up is
+    /// rendered on the client's terminal, and [`Self::ensure_host`], which has
+    /// no channel at all. The channel goes in and comes back out because
+    /// progress rendering borrows it for the duration; storing the result is
+    /// left to the caller, since attach only keeps a host it could bind to.
+    async fn launch_host(
         &mut self,
         session_hnd: SessionHandle,
         conn_username: String,
-        channel: Channel<Msg>,
         sz: WinSize,
         attach_env: session_host::AttachEnv,
-    ) -> Result<(), AttachError> {
+        progress: Option<ChannelProgress>,
+    ) -> Result<(Option<Channel<Msg>>, LaunchedHost), AttachError> {
         let record = self.record.record().await.unwrap();
         let paths = self.paths().await;
-        let name = registry_name(&record);
+        let launcher = self
+            .session_launcher(session_hnd, &record, attach_env)
+            .await?;
         // Where the shell-exit prompt's save-then-delete lane archives the
         // changed files. Daemon-side and session-independent; created on
         // demand at save time.
@@ -1305,33 +1340,103 @@ impl Session {
             .as_utf8_path()
             .as_std_path()
             .join("archives");
+        let spawn = Box::pin(session_host::Host::spawn(
+            launcher,
+            registry_name(&record),
+            conn_username,
+            paths,
+            sz,
+            None,
+            // Mint a handle to this session ID in the sessions actor/manager.
+            Some(SessionControl::new(self.manager.clone(), record.id)),
+            archives_dir,
+        ));
 
-        // Mint a handle to this session ID in the sessions actor/manager.
-        let control = SessionControl::new(self.manager.clone(), record.id);
+        let (channel, spawned) = match progress {
+            Some(progress) => {
+                let (channel, spawned) = progress.run(spawn).await;
+                (Some(channel), spawned)
+            }
+            None => (None, spawn.await),
+        };
+        Ok((channel, spawned.map_err(AttachError::SpawnFailed)?))
+    }
 
-        // Spawn/setup the session in a closure that reports progress down the terminal.
-        let launcher = self
-            .session_launcher(session_hnd, &record, attach_env)
-            .await?;
-        let progress = ChannelProgress::new(channel, self.tracker.clone(), (sz.cols, sz.rows));
-        let (channel, spawned) = progress
-            .run(Box::pin(session_host::Host::spawn(
-                launcher,
-                name,
+    /// Hands back this session's host, launching one if none is running.
+    ///
+    /// Unlike [`Self::attach`] there is no channel: the host is minted with
+    /// nothing bound to it, because the caller wants the *sandbox* — to run a
+    /// command inside it — not a terminal. A client that attaches later reuses
+    /// this host and resizes its PTY, so the placeholder size is only ever what
+    /// an unattached session's shell sees.
+    ///
+    /// Gated on the same `Active` record status as `attach`, without its
+    /// draft-session shortcut: composing a loadout is a client-driven flow, and
+    /// an exec request is not the place to start one.
+    async fn ensure_host(
+        &mut self,
+        session_hnd: SessionHandle,
+        conn_username: String,
+    ) -> Result<session_host::HostHandle, AttachError> {
+        {
+            let record = self
+                .record
+                .record()
+                .await
+                .map_err(AttachError::LoadoutFailed)?;
+            if record.status != SessionStatus::Active {
+                return Err(AttachError::SessionPending);
+            }
+        }
+
+        let running = match &self.inner {
+            SessionInner::Draft { .. } => return Err(AttachError::SessionPending),
+            SessionInner::Active {
+                host: Some((h, _)), ..
+            } if h.is_alive() => Some(h.clone()),
+            SessionInner::Active { .. } => None,
+        };
+        if let Some(host) = running {
+            return Ok(host);
+        }
+
+        let (_, launched) = self
+            .launch_host(
+                session_hnd,
                 conn_username,
-                paths,
-                sz,
+                UNATTACHED_WIN_SIZE,
+                session_host::AttachEnv::default(),
                 None,
-                Some(control),
-                archives_dir,
-            )))
-            .await;
-        let h = spawned.map_err(AttachError::SpawnFailed)?;
+            )
+            .await?;
+
+        let host = launched.0.clone();
+        let SessionInner::Active { host: slot, .. } = &mut self.inner else {
+            unreachable!("ensure_host returns early on a Draft session");
+        };
+        *slot = Some(launched);
+        Ok(host)
+    }
+
+    async fn mint_session_host(
+        &mut self,
+        session_hnd: SessionHandle,
+        conn_username: String,
+        channel: Channel<Msg>,
+        sz: WinSize,
+        attach_env: session_host::AttachEnv,
+    ) -> Result<(), AttachError> {
+        let progress = ChannelProgress::new(channel, self.tracker.clone(), (sz.cols, sz.rows));
+        let (channel, launched) = self
+            .launch_host(session_hnd, conn_username, sz, attach_env, Some(progress))
+            .await?;
+        let channel = channel.expect("progress hands back the channel it was given");
 
         // Wire the channel to the freshly launched host. A failure here means
         // the host died in the window between launch and attach; surface it as
-        // a spawn failure rather than leaving a dead, channel-less host.
-        h.0.attach(channel, sz).await.map_err(|_| {
+        // a spawn failure rather than leaving a dead, channel-less host — which
+        // is why the host is stored only once it is bound.
+        launched.0.attach(channel, sz).await.map_err(|_| {
             AttachError::SpawnFailed(std::io::Error::other(
                 "session host exited before its channel could attach",
             ))
@@ -1339,7 +1444,7 @@ impl Session {
         let SessionInner::Active { host, .. } = &mut self.inner else {
             unreachable!("mint_session_host is only reachable from the Active state");
         };
-        *host = Some(h);
+        *host = Some(launched);
         Ok(())
     }
 
@@ -1815,6 +1920,40 @@ impl SessionHandle {
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(SessionMessage::Destroy(send)).await;
         recv.await.unwrap_or(Ok(()))
+    }
+
+    /// This session's host, launching one with nothing bound to it if the
+    /// session has none running.
+    ///
+    /// For callers that need the session's *sandbox* rather than its terminal —
+    /// an SSH exec request runs its command inside the sandbox, which means the
+    /// session process whose namespaces it joins has to exist.
+    ///
+    /// # Errors
+    ///
+    /// [`AttachError::SessionPending`] on a session that is not yet `Active`,
+    /// and [`AttachError::SpawnFailed`] if the host cannot be launched or the
+    /// session actor is gone.
+    pub async fn ensure_host(
+        &self,
+        conn_username: String,
+    ) -> Result<session_host::HostHandle, AttachError> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .0
+            .send(SessionMessage::EnsureHost(
+                send,
+                self.clone(),
+                conn_username,
+            ))
+            .await;
+        match recv.await {
+            Ok(result) => result,
+            Err(_) => Err(AttachError::SpawnFailed(std::io::Error::other(
+                "session actor terminated before the host could be launched",
+            ))),
+        }
     }
 
     pub async fn attach(
@@ -2836,6 +2975,48 @@ mod tests {
             handle.peek_composition().await.is_none(),
             "session with a missing sidecar should fall back to baseline \
              (composition None), not hold a stale composition"
+        );
+    }
+
+    /// An exec request needs the session's sandbox up, not a terminal: a
+    /// session sitting idle with nobody attached must still be able to launch
+    /// a host, and a second request must reuse it rather than starting a
+    /// second shell in the same session.
+    #[tokio::test]
+    async fn ensure_host_launches_an_unattached_host_and_then_reuses_it() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_configured_session(&mut client, "ensure-host", "/tmp").await;
+
+        let manager = server.state.sessions_manager().await;
+        let handle = manager
+            .get_session(crate::sessions::SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("session should resolve");
+
+        assert!(
+            handle.get_attrs().await.is_none(),
+            "no client has attached, so the session should have no host yet"
+        );
+
+        let host = handle
+            .ensure_host("tester".to_string())
+            .await
+            .expect("an Active session should be able to launch a host");
+        assert!(host.is_alive());
+        assert!(
+            handle.get_attrs().await.is_some(),
+            "the session should now be holding the host it launched"
+        );
+
+        let again = handle
+            .ensure_host("tester".to_string())
+            .await
+            .expect("a second request should be served by the running host");
+        assert!(
+            again.same_host(&host),
+            "a second exec request minted a second host instead of reusing the first"
         );
     }
 }

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -10,6 +10,7 @@ use russh::Channel;
 use russh::server::Msg;
 #[cfg(not(test))]
 use sandbox2::Network;
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::io;
 use std::io::{Read, Write};
@@ -719,6 +720,15 @@ impl Binding {
 /// driven against a real sandboxed process or a test double. The unused
 /// `hakoniwa::ExitStatus` payload is reduced to a portable exit code.
 pub(crate) trait SessionProcess: Send + 'static {
+    /// Returns the PID of hakoniwa's container supervisor — **not** the PID of
+    /// the shell it exec'd.
+    ///
+    /// The supervisor unshared the sandbox's namespaces itself, so this is a
+    /// valid handle for all of them except the PID namespace, which it created
+    /// for its children without entering. Use
+    /// [`Host::session_leader_pid`](Host::session_leader_pid) for the shell's
+    /// own PID; see [`crate::nsenter`] for why the distinction matters.
+    fn container_pid(&self) -> u32;
     /// Returns `Some(code)` if the process has exited, `None` if still running.
     fn try_wait(&mut self) -> io::Result<Option<i32>>;
     /// Blocks until the process exits, returning its exit code.
@@ -734,10 +744,10 @@ pub(crate) trait SessionProcess: Send + 'static {
 pub(crate) trait SessionLauncher {
     /// The running-process handle this launcher produces.
     type Process: SessionProcess;
-    /// A value held for the session's lifetime purely for its `Drop` (e.g. the
-    /// sandbox files backing the running process's rootfs). Dropped after
-    /// [`Self::Process`].
-    type Guard: Send + 'static;
+    /// A value held for the session's lifetime, for its `Drop` (it owns the
+    /// sandbox files backing the running process's rootfs) and as the live view
+    /// of the session's environment. Dropped after [`Self::Process`].
+    type Guard: SessionGuard;
 
     fn launch(
         self,
@@ -746,6 +756,42 @@ pub(crate) trait SessionLauncher {
         paths: SessionPaths,
         sz: WinSize,
     ) -> impl Future<Output = io::Result<Launched<Self::Process, Self::Guard>>> + Send;
+}
+
+/// Where a command should start in a session, and with what environment.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct SessionEnvironment {
+    /// Absolute path inside the sandbox: `/workbench` for a session.
+    pub(crate) cwd: String,
+    /// The composed session variables, layout defaults included, plus anything
+    /// installed into the session since it launched.
+    pub(crate) vars: BTreeMap<String, String>,
+}
+
+/// The launcher-owned value a [`Host`] holds for its session's lifetime.
+///
+/// Primarily a `Drop` guard — it owns the sandbox files backing the running
+/// process's rootfs — but it is also the live handle to the session's
+/// environment.
+pub(crate) trait SessionGuard: Send + 'static {
+    /// The working directory and environment a command should run with in this
+    /// session, as of now.
+    fn command_environment(&self) -> SessionEnvironment;
+}
+
+/// The mock launcher has no sandbox, so there is nothing to describe.
+#[cfg(test)]
+impl SessionGuard for () {
+    fn command_environment(&self) -> SessionEnvironment {
+        SessionEnvironment::default()
+    }
+}
+
+#[cfg(not(test))]
+impl SessionGuard for crate::env::Env {
+    fn command_environment(&self) -> SessionEnvironment {
+        crate::env::Env::command_environment(self)
+    }
 }
 
 /// The product of [`SessionLauncher::launch`].
@@ -772,6 +818,15 @@ enum Message {
     /// git repository, the changed-since-activation delta otherwise) and
     /// reply with it; `Unavailable` when neither can be computed.
     GetAtRisk(oneshot::Sender<minimald_rpc::SessionDeltaResponse>),
+    /// Build a command that runs `program` inside this session's sandbox, for
+    /// the caller to give stdio to and spawn. The host builds it because only
+    /// the host can: it holds the session process (whose namespaces are joined)
+    /// and the guard (which knows the session's current environment).
+    CommandInSession {
+        program: std::ffi::OsString,
+        args: Vec<std::ffi::OsString>,
+        reply: oneshot::Sender<Result<std::process::Command, crate::nsenter::NsenterError>>,
+    },
 
     SetTitleCallback(String),
     VisualBellCallback,
@@ -863,6 +918,54 @@ impl HostHandle {
         }
     }
 
+    /// Whether both handles address the same host.
+    pub fn same_host(&self, other: &Self) -> bool {
+        self.sender.same_channel(&other.sender)
+    }
+
+    /// Whether the host's runtime loop is still running.
+    ///
+    /// A cheap, non-blocking check — the channel closes when the loop ends — so
+    /// a caller deciding whether to reuse a host or mint a new one does not
+    /// have to round-trip through it.
+    pub fn is_alive(&self) -> bool {
+        !self.sender.is_closed()
+    }
+
+    /// Builds a command that runs `program` inside this session's sandbox,
+    /// joining the namespaces of the running session process.
+    ///
+    /// The returned command has no stdio configured: that belongs to whoever is
+    /// wiring it up (an SSH exec channel pipes all three, an interactive
+    /// attach would hand it a PTY). See [`Host::command_in_session`].
+    ///
+    /// # Errors
+    ///
+    /// The session process having exited, its namespaces being unreadable, or
+    /// the host having stopped between this call and its reply.
+    pub async fn command_in_session<I, S>(
+        &self,
+        program: impl AsRef<std::ffi::OsStr>,
+        args: I,
+    ) -> io::Result<std::process::Command>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        let (reply, recv) = oneshot::channel();
+        let message = Message::CommandInSession {
+            program: program.as_ref().to_os_string(),
+            args: args
+                .into_iter()
+                .map(|a| a.as_ref().to_os_string())
+                .collect(),
+            reply,
+        };
+        let dead = || io::Error::other("session host stopped before the command could be built");
+        self.sender.send(message).await.map_err(|_| dead())?;
+        recv.await.map_err(|_| dead())?.map_err(io::Error::other)
+    }
+
     /// Returns the terminal attributes.
     pub async fn get_attrs(&self) -> Result<HostAttrs, ()> {
         let (send, recv) = oneshot::channel();
@@ -914,7 +1017,7 @@ pub struct HostAttrs {
 /// Generic over the [`SessionProcess`] it supervises and the [`SessionLauncher`]
 /// guard kept alive for the session, so the runtime loop can be driven against a
 /// real sandboxed process or a test double.
-pub(crate) struct Host<P: SessionProcess, G: Send + 'static> {
+pub(crate) struct Host<P: SessionProcess, G: SessionGuard> {
     /// Channel for actor messages via [`HostHandle`].
     receiver: mpsc::Receiver<Message>,
 
@@ -981,9 +1084,9 @@ pub(crate) struct Host<P: SessionProcess, G: Send + 'static> {
     // sandbox files backing the running process's rootfs along with the context
     // and graph) alive for as long as this host (and thus the session process)
     // lives. Declared last so it is dropped after `process`: the process is torn
-    // down before the sandbox files backing its rootfs are removed. Never read;
-    // held purely for its `Drop`.
-    _guard: G,
+    // down before the sandbox files backing its rootfs are removed. Also read,
+    // via `SessionGuard`, for the session's current environment.
+    guard: G,
 }
 
 /// A launched session process backed by a sandboxed [`hakoniwa::Child`].
@@ -992,6 +1095,10 @@ pub(crate) struct SandboxProcess(hakoniwa::Child);
 
 #[cfg(not(test))]
 impl SessionProcess for SandboxProcess {
+    fn container_pid(&self) -> u32 {
+        self.0.id()
+    }
+
     fn try_wait(&mut self) -> io::Result<Option<i32>> {
         self.0
             .try_wait()
@@ -1557,6 +1664,10 @@ pub(crate) struct MockProcess(std::process::Child);
 
 #[cfg(test)]
 impl SessionProcess for MockProcess {
+    fn container_pid(&self) -> u32 {
+        self.0.id()
+    }
+
     fn try_wait(&mut self) -> io::Result<Option<i32>> {
         Ok(self.0.try_wait()?.map(|s| s.code().unwrap_or(-1)))
     }
@@ -1623,7 +1734,53 @@ impl SessionLauncher for MockLauncher {
     }
 }
 
-impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
+impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
+    /// The PID of hakoniwa's container supervisor for this session.
+    ///
+    /// Correct as a handle for every namespace the sandbox unshared *except*
+    /// the PID namespace — which is what the own-IP tap wiring uses it for. To
+    /// address the session's PID namespace, or to name the shell itself, use
+    /// [`Self::session_leader_pid`].
+    // Reachable only through `session_leader_pid`, which the exec path uses;
+    // kept as the named counterpart so the distinction stays visible.
+    #[allow(dead_code)]
+    pub(crate) fn container_pid(&self) -> u32 {
+        self.process.container_pid()
+    }
+
+    /// The PID of the session shell itself — the process hakoniwa exec'd inside
+    /// every one of the sandbox's namespaces.
+    ///
+    /// # Errors
+    ///
+    /// [`NsenterError::NoSessionLeader`](crate::nsenter::NsenterError::NoSessionLeader)
+    /// once the shell has exited; the session's namespaces do not outlive it.
+    pub(crate) fn session_leader_pid(&self) -> Result<u32, crate::nsenter::NsenterError> {
+        crate::nsenter::session_leader_pid(self.process.container_pid())
+    }
+
+    /// Builds a command that runs `program` inside this session's sandbox.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the shell's PID cannot be resolved or pinned; see
+    /// [`Self::session_leader_pid`].
+    pub(crate) fn command_in_session<I, S>(
+        &self,
+        program: impl AsRef<std::ffi::OsStr>,
+        args: I,
+    ) -> Result<std::process::Command, crate::nsenter::NsenterError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        let environment = self.guard.command_environment();
+        crate::nsenter::Injection::new(self.session_leader_pid()?, program, args)
+            .with_cwd(environment.cwd)
+            .with_env(environment.vars)
+            .command()
+    }
+
     /// Spawns a session host from the given launcher, wiring it to `channel` if
     /// one is supplied, and drives its runtime loop on a background task.
     ///
@@ -1727,7 +1884,7 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
             workspace_root,
             session_name,
             archives_dir,
-            _guard: guard,
+            guard,
         };
 
         if let Some(channel) = channel {
@@ -1857,6 +2014,13 @@ impl<P: SessionProcess, G: Send + 'static> Host<P, G> {
                     }
                     Message::GetAttrs(s) => {
                         let _ = s.send(self.attrs.clone());
+                    }
+                    Message::CommandInSession {
+                        program,
+                        args,
+                        reply,
+                    } => {
+                        let _ = reply.send(self.command_in_session(program, args));
                     }
                     Message::GetAtRisk(s) => {
                         // Computed on a spawned task: the git commands and

--- a/crates/minimald/tests/nsenter_integration.rs
+++ b/crates/minimald/tests/nsenter_integration.rs
@@ -1,0 +1,319 @@
+//! Proof that a process injected into a session's sandbox lands in *all* of the
+//! sandbox's namespaces — the PID namespace included.
+//!
+//! The PID namespace is the whole point of the exercise. hakoniwa's
+//! `Child::id()` is the container supervisor, which unshared the sandbox's
+//! namespaces but never entered the PID namespace it created (see
+//! [`minimald::nsenter`]), so joining namespaces off that PID silently leaves a
+//! process in the host's PID namespace while putting it under a `/proc` mounted
+//! from the sandbox's. `injected_process_joins_every_namespace` asserts the
+//! difference directly: the injected process's PID namespace must match the
+//! session program's and must *not* match the supervisor's.
+//!
+//! The container is built the way `sandbox2::new_container` builds one, minus
+//! the network isolation — the proof is about process structure, and a netns
+//! would drag the switch wiring in with it.
+//!
+//! `#[ignore]`, and additionally early-returns unless `MINIMALD_NSENTER_TEST` is
+//! set, so neither a plain `cargo test` run nor the ignored-test sweep attempts
+//! namespace work on a host that may not allow it. Needs unprivileged user
+//! namespaces (no root, unlike the netns proofs), a kernel with
+//! `CONFIG_PROC_CHILDREN`, and `setns` pidfd support (Linux 5.8+):
+//! `MINIMALD_NSENTER_TEST=1 cargo test -p minimald --test nsenter_integration -- --include-ignored`
+#![cfg(target_os = "linux")]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use minimald::nsenter::{Injection, session_leader_pid};
+
+/// Whether the gate env var is set; when absent the proofs early-return so the
+/// default test run never unshares anything.
+fn gated() -> bool {
+    if std::env::var_os("MINIMALD_NSENTER_TEST").is_some() {
+        return true;
+    }
+    eprintln!("skipping nsenter proof: MINIMALD_NSENTER_TEST not set");
+    false
+}
+
+/// The `minimald` binary under test, which doubles as the namespace-joining
+/// shim. Cargo builds and points at it for integration tests of this package.
+fn shim() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_minimald"))
+}
+
+/// A sandbox holding a long-lived program, shaped like a session's.
+///
+/// `isolate_network` mirrors the choice `sandbox2::new_container` makes from the
+/// session's network mode: a `HostNet` session stays in the daemon's network
+/// namespace, a `NoNet`/`OwnIp` one gets its own.
+fn sandbox(isolate_network: bool) -> hakoniwa::Child {
+    let mut container = hakoniwa::Container::new();
+    container
+        .rootfs("/")
+        .expect("bind-mounting the host rootfs")
+        .devfsmount("/dev")
+        .tmpfsmount("/tmp")
+        .unshare(hakoniwa::Namespace::Cgroup)
+        .unshare(hakoniwa::Namespace::Uts);
+    if isolate_network {
+        container.unshare(hakoniwa::Namespace::Network);
+    }
+    // No `Runctl::NewSession`: a real session claims the PTY as its controlling
+    // terminal, and there is no TTY on this pipe to claim.
+
+    let mut command = container.command("/bin/sleep");
+    command
+        .args(["60"])
+        .stdout(hakoniwa::Stdio::piped())
+        .stderr(hakoniwa::Stdio::piped());
+    command.spawn().expect("spawning the sandboxed program")
+}
+
+fn ns_of(pid: u32, kind: &str) -> String {
+    std::fs::read_link(format!("/proc/{pid}/ns/{kind}"))
+        .unwrap_or_else(|e| panic!("reading /proc/{pid}/ns/{kind}: {e}"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[test]
+#[ignore = "unshares namespaces; gated on MINIMALD_NSENTER_TEST"]
+fn injected_process_joins_every_namespace() {
+    if !gated() {
+        return;
+    }
+
+    let mut sandboxed = sandbox(false);
+    let supervisor = sandboxed.id();
+    let leader = session_leader_pid(supervisor).expect("resolving the session program's pid");
+
+    // Ask the injected process where it ended up, from inside. `/tmp` stands in
+    // for a session's `/workbench`: this container has no session layout, but
+    // it does have hakoniwa's tmpfs there, so the path exists only inside the
+    // sandbox's mount namespace — which is the point.
+    let output = Injection::new(
+        leader,
+        "/bin/sh",
+        [
+            "-c",
+            "readlink /proc/self/ns/pid; readlink /proc/self/ns/mnt; echo $$; pwd; echo \"$SESSION_MARKER\"",
+        ],
+    )
+    .with_shim(shim())
+    .with_cwd("/tmp")
+    .with_env(BTreeMap::from([(
+        "SESSION_MARKER".to_string(),
+        "from-the-session".to_string(),
+    )]))
+    .command()
+    .expect("building the injected command")
+    .output()
+    .expect("running the injected command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let reported: Vec<&str> = stdout.lines().collect();
+
+    let leader_pid_ns = ns_of(leader, "pid");
+    let leader_mnt_ns = ns_of(leader, "mnt");
+    let supervisor_pid_ns = ns_of(supervisor, "pid");
+    let own_pid_ns = ns_of(std::process::id(), "pid");
+
+    let _ = sandboxed.kill();
+    let _ = sandboxed.wait();
+
+    assert!(
+        output.status.success(),
+        "injected command failed: {:?}\nstdout: {stdout}\nstderr: {stderr}",
+        output.status
+    );
+    let [pid_ns, mnt_ns, inner_pid, cwd, marker] = reported.as_slice() else {
+        panic!("expected five lines from the injected process, got {reported:?} (stderr: {stderr})")
+    };
+
+    assert_eq!(
+        *pid_ns, leader_pid_ns,
+        "injected process is not in the session's PID namespace"
+    );
+    assert_eq!(
+        *mnt_ns, leader_mnt_ns,
+        "injected process is not in the session's mount namespace"
+    );
+
+    // The claim this whole module exists for: joining off the supervisor's PID
+    // would have left the process in the host's PID namespace.
+    assert_eq!(
+        supervisor_pid_ns, own_pid_ns,
+        "the container supervisor was expected to share our PID namespace"
+    );
+    assert_ne!(
+        *pid_ns, supervisor_pid_ns,
+        "the session's PID namespace must differ from the supervisor's"
+    );
+
+    // Neither of these rides along with the namespaces; both are set explicitly
+    // by the injection and would otherwise be the container root and the
+    // daemon's environment.
+    assert_eq!(*cwd, "/tmp", "injected process did not start in `with_cwd`");
+    assert_eq!(
+        *marker, "from-the-session",
+        "injected process did not get `with_env`"
+    );
+
+    // Being *in* the namespace is what makes the sandbox's /proc coherent: the
+    // process sees a namespace-local PID, not its host one.
+    let inner: u32 = inner_pid.parse().expect("the shell reported its pid");
+    assert!(
+        inner < 1024,
+        "expected a namespace-local pid, got {inner} (looks like a host pid)"
+    );
+}
+
+/// A network-isolated session is the case the joined set has to *widen* for.
+/// The same code must also not widen for a `HostNet` session, where asking for
+/// the network namespace would be an EPERM rather than a no-op — that half is
+/// covered by `injected_process_joins_every_namespace`, whose sandbox shares
+/// the daemon's network namespace.
+#[test]
+#[ignore = "unshares namespaces; gated on MINIMALD_NSENTER_TEST"]
+fn injected_process_joins_an_isolated_network_namespace() {
+    if !gated() {
+        return;
+    }
+
+    let mut sandboxed = sandbox(true);
+    let leader = session_leader_pid(sandboxed.id()).expect("resolving the session program's pid");
+
+    let output = Injection::new(leader, "/bin/sh", ["-c", "readlink /proc/self/ns/net"])
+        .with_shim(shim())
+        .command()
+        .expect("building the injected command")
+        .output()
+        .expect("running the injected command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let leader_net_ns = ns_of(leader, "net");
+    let own_net_ns = ns_of(std::process::id(), "net");
+
+    let _ = sandboxed.kill();
+    let _ = sandboxed.wait();
+
+    assert!(
+        output.status.success(),
+        "injected command failed: {:?}\nstderr: {stderr}",
+        output.status
+    );
+    assert_eq!(
+        stdout, leader_net_ns,
+        "injected process is not in the session's network namespace"
+    );
+    assert_ne!(
+        leader_net_ns, own_net_ns,
+        "this sandbox was supposed to have its own network namespace"
+    );
+}
+
+#[test]
+#[ignore = "unshares namespaces; gated on MINIMALD_NSENTER_TEST"]
+fn injected_exit_status_reaches_the_caller() {
+    if !gated() {
+        return;
+    }
+
+    let mut sandboxed = sandbox(false);
+    let leader = session_leader_pid(sandboxed.id()).expect("resolving the session program's pid");
+
+    let status = Injection::new(leader, "/bin/sh", ["-c", "exit 42"])
+        .with_shim(shim())
+        .command()
+        .expect("building the injected command")
+        .status()
+        .expect("running the injected command");
+
+    let _ = sandboxed.kill();
+    let _ = sandboxed.wait();
+
+    assert_eq!(
+        status.code(),
+        Some(42),
+        "the shim must report the injected program's exit code, not its own"
+    );
+}
+
+/// Whether `pid` exists and is not a reaped-but-unwaited zombie.
+fn still_running(pid: u32) -> bool {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return false;
+    };
+    // `state` is the field after the parenthesised comm, which can itself
+    // contain spaces — split on the last ')' rather than by whitespace.
+    let after_comm = stat.rsplit_once(')').map(|(_, rest)| rest).unwrap_or("");
+    !after_comm
+        .split_whitespace()
+        .next()
+        .is_some_and(|s| s == "Z")
+}
+
+/// Killing the shim must take the process it injected with it.
+///
+/// The shim is the injected process's parent but sits outside the session's PID
+/// namespace, so nothing about the namespaces makes the two die together. When
+/// a client drops its exec channel the daemon kills the shim, and without this
+/// the command it asked for keeps running in the session — holding the stdio
+/// pipes nobody is reading any more — until the session itself ends.
+#[test]
+#[ignore = "unshares namespaces; gated on MINIMALD_NSENTER_TEST"]
+fn killing_the_shim_kills_the_injected_process() {
+    if !gated() {
+        return;
+    }
+
+    let mut sandboxed = sandbox(false);
+    let leader = session_leader_pid(sandboxed.id()).expect("resolving the session program's pid");
+
+    let mut shim = Injection::new(leader, "/bin/sleep", ["120"])
+        .with_shim(shim())
+        .command()
+        .expect("building the injected command")
+        .spawn()
+        .expect("spawning the injected command");
+
+    // The shim's sole child is the injected process, the same way the container
+    // supervisor's sole child is the session program.
+    let injected = {
+        let mut found = None;
+        for _ in 0..100 {
+            if let Ok(pid) = session_leader_pid(shim.id()) {
+                found = Some(pid);
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        found.expect("the shim should have spawned the injected process")
+    };
+    assert!(still_running(injected), "the injected process should be up");
+
+    shim.kill().expect("killing the shim");
+    shim.wait().expect("reaping the shim");
+
+    // The kill is asynchronous on the injected side: the kernel delivers its
+    // death signal once the shim is actually gone.
+    let mut alive = true;
+    for _ in 0..100 {
+        if !still_running(injected) {
+            alive = false;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+
+    let _ = sandboxed.kill();
+    let _ = sandboxed.wait();
+    assert!(
+        !alive,
+        "the injected process outlived the shim that was killed"
+    );
+}

--- a/crates/sandbox2/src/config.rs
+++ b/crates/sandbox2/src/config.rs
@@ -1,6 +1,6 @@
 use crate::network::Network;
 use crate::{Error, Sandbox};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
@@ -207,6 +207,118 @@ pub struct Invocation {
 }
 
 impl Config {
+    /// The working directory a command in this sandbox starts in, as an
+    /// absolute path inside the sandbox — `/workbench` for a session (unless
+    /// the name is overridden), `/build` for a task.
+    #[must_use]
+    pub fn command_cwd(&self) -> String {
+        match &self.wd {
+            WdSetup::BoundDir { .. } => {
+                format!("/{}", self.wd.bound_dir_sandbox_cwd().to_str().unwrap())
+            }
+            WdSetup::Isolated { .. } => "/build".to_string(),
+            WdSetup::Session {
+                working_name_override,
+                ..
+            } => format!(
+                "/{}",
+                working_name_override
+                    .clone()
+                    .unwrap_or_else(|| crate::SESSION_DEFAULT_WD.to_string())
+            ),
+        }
+    }
+
+    /// The environment a command in this sandbox is launched with, before any
+    /// per-invocation additions.
+    ///
+    /// The layout defaults come first and the configured
+    /// [`env_vars`](Self::env_vars) last, so a composition's variables win on a
+    /// key collision — `PS1`, `LANG` and the login-shell identity are floors,
+    /// not policy.
+    #[must_use]
+    pub fn command_env(&self) -> BTreeMap<String, String> {
+        let mut env = BTreeMap::new();
+        let mut set = |k: &str, v: &str| {
+            env.insert(k.to_string(), v.to_string());
+        };
+
+        // XDG vars
+        if let WdSetup::Session { .. } = &self.wd {
+            set("XDG_STATE_HOME", "/home/.local/state");
+            set("XDG_CONFIG_HOME", "/home/.config");
+            set("XDG_DATA_HOME", "/home/.local/share");
+            set("PATH", "/usr/bin:/bin:/usr/sbin:/sbin:/home/.local/bin"); // adds /home/.local/bin
+            // A styled default shell prompt for interactive sessions. Set as a
+            // plain default here (not forced) so a user's composition var can
+            // override it: the composed `env_vars` are applied further down and
+            // win on key collision.
+            set(
+                "PS1",
+                r"\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ ",
+            );
+            // Login-shell identity, mirroring what sshd/pam would set from
+            // `/etc/passwd`. `USER`/`LOGNAME` track the configured username;
+            // `SHELL` points at the session shell (the `bash` package installs
+            // to `/usr/bin/bash`). All plain defaults, so composition vars win.
+            if let Some(user) = &self.username {
+                set("USER", user);
+                set("LOGNAME", user);
+            }
+            set("SHELL", "/usr/bin/bash");
+        } else {
+            // Both build and BoundWd layouts
+            set("XDG_STATE_HOME", "/state/state");
+            set("XDG_CONFIG_HOME", "/state/home");
+            set("XDG_DATA_HOME", "/state/data");
+            set("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+        }
+        set("XDG_CACHE_HOME", "/state/cache");
+        set("XDG_RUNTIME_DIR", "/run");
+
+        match &self.wd {
+            WdSetup::Isolated { .. } => set("HOME", "/state/home"),
+            WdSetup::Session { .. } => set("HOME", "/home"),
+            WdSetup::BoundDir { .. } => match std::env::var("HOME") {
+                Ok(h) => set("HOME", &h),
+                Err(_) => set("HOME", "/state/home"),
+            },
+        }
+
+        if let WdSetup::Isolated { .. } = self.wd {
+            set("OUTPUT_DIR", "/build/output");
+            set("GIT_TERMINAL_PROMPT", "0");
+            set("SOURCE_DATE_EPOCH", "0");
+            set("PYTHONHASHSEED", "0");
+        }
+
+        // Locale. Sessions get a safe, always-present `C.UTF-8` floor: it's
+        // built into glibc so it never triggers "cannot set locale" warnings
+        // the way `en_US.utf8` does when that locale isn't generated in the
+        // rootfs, and setting only `LANG` (the lowest-precedence locale knob,
+        // no `LC_ALL`) lets a session's composed `env_vars` or a client's
+        // forwarded `LANG`/`LC_*` override it. Build/task sandboxes keep the
+        // fixed `en_US.utf8` + `LC_ALL` they always had, for output stability.
+        if let WdSetup::Session { .. } = &self.wd {
+            set("LANG", "C.UTF-8");
+        } else {
+            set("LANG", "en_US.utf8");
+            set("LC_ALL", "en_US.utf8");
+        }
+        set("IS_SANDBOX", "1");
+        if let WdSetup::BoundDir { .. } = self.wd {
+            //  Quality-of-life wiring for task sandboxes
+            for var in ["TERM", "COLORTERM", "LS_COLORS"] {
+                if let Ok(value) = std::env::var(var) {
+                    set(var, &value);
+                }
+            }
+        }
+
+        self.env_vars.iter().for_each(|(var, val)| set(var, val));
+        env
+    }
+
     /// Initializes an empty config with the given name.
     pub fn new<S: Into<String>>(name: S) -> Self {
         Self {
@@ -510,5 +622,66 @@ impl Config {
         .map_err(|e| Error::IO("synthesizing user/group configuration", sd, e))?;
 
         Sandbox::new(build_base_dir, self, channel)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session_config() -> Config {
+        let mut config = Config::new("test");
+        config.wd = WdSetup::Session {
+            home: PathBuf::from("/tmp/home"),
+            working: PathBuf::from("/tmp/working"),
+            working_name_override: None,
+        };
+        config.username = Some("dev".to_string());
+        config
+    }
+
+    /// The pair a session's shell is launched with is the pair anything
+    /// injected into that session later has to be given, so both come from
+    /// here. `/workbench` is the contract the session layout promises.
+    #[test]
+    fn a_session_starts_in_workbench_with_its_login_identity() {
+        let config = session_config();
+
+        assert_eq!(config.command_cwd(), "/workbench");
+        let env = config.command_env();
+        assert_eq!(env.get("HOME").map(String::as_str), Some("/home"));
+        assert_eq!(env.get("USER").map(String::as_str), Some("dev"));
+        assert_eq!(env.get("LANG").map(String::as_str), Some("C.UTF-8"));
+    }
+
+    /// Composed variables are policy; the layout defaults are only a floor.
+    #[test]
+    fn configured_vars_override_the_layout_defaults() {
+        let mut config = session_config();
+        config
+            .env_vars
+            .insert("LANG".to_string(), "en_GB.UTF-8".to_string());
+        config
+            .env_vars
+            .insert("EDITOR".to_string(), "hx".to_string());
+
+        let env = config.command_env();
+
+        assert_eq!(env.get("LANG").map(String::as_str), Some("en_GB.UTF-8"));
+        assert_eq!(env.get("EDITOR").map(String::as_str), Some("hx"));
+    }
+
+    /// A build sandbox keeps the layout it always had — the extraction of this
+    /// logic out of `command_inner` must not have moved the task plane.
+    #[test]
+    fn a_build_sandbox_keeps_its_own_layout() {
+        let config = Config::new("test");
+
+        assert_eq!(config.command_cwd(), "/build");
+        let env = config.command_env();
+        assert_eq!(env.get("HOME").map(String::as_str), Some("/state/home"));
+        assert_eq!(env.get("SOURCE_DATE_EPOCH").map(String::as_str), Some("0"));
+        assert_eq!(env.get("LC_ALL").map(String::as_str), Some("en_US.utf8"));
+        assert_eq!(env.get("PS1"), None);
     }
 }

--- a/crates/sandbox2/src/lib.rs
+++ b/crates/sandbox2/src/lib.rs
@@ -112,6 +112,24 @@ impl<C: Channel> Drop for Sandbox<C> {
 
 // Sandbox initialization
 impl<C: Channel> Sandbox<C> {
+    /// The working directory a command in this sandbox starts in, as an
+    /// absolute path inside the sandbox.
+    ///
+    /// Exposed so a caller that runs a process in this sandbox by some route
+    /// other than [`Self::command`] — minimald joining a live session's
+    /// namespaces — starts it where the sandbox's own process started.
+    #[must_use]
+    pub fn command_cwd(&self) -> String {
+        self.config.command_cwd()
+    }
+
+    /// The environment a command in this sandbox is launched with, before any
+    /// per-invocation additions. Companion to [`Self::command_cwd`].
+    #[must_use]
+    pub fn command_env(&self) -> std::collections::BTreeMap<String, String> {
+        self.config.command_env()
+    }
+
     /// Creates a new sandbox, containing all filesystem state within `base_dir`.
     pub(crate) fn new(base_dir: PathBuf, config: Config, channel: C) -> Result<Self, Error> {
         // Setup the rootfs
@@ -369,114 +387,12 @@ impl Container {
     {
         let mut command = self.container.command(program);
         command.args(args);
-        command.current_dir(match &sandbox.config.wd {
-            WdSetup::BoundDir { .. } => format!(
-                "/{}",
-                sandbox.config.wd.bound_dir_sandbox_cwd().to_str().unwrap()
-            ),
-            WdSetup::Isolated { .. } => "/build".to_string(),
-            WdSetup::Session {
-                home: _,
-                working: _,
-                working_name_override,
-            } => {
-                format!(
-                    "/{}",
-                    working_name_override
-                        .as_ref()
-                        .cloned()
-                        .unwrap_or_else(|| SESSION_DEFAULT_WD.to_string())
-                )
-            }
-        });
-
-        // Set XDG vars
-        if let WdSetup::Session { .. } = &sandbox.config.wd {
-            command.env("XDG_STATE_HOME", "/home/.local/state");
-            command.env("XDG_CONFIG_HOME", "/home/.config");
-            command.env("XDG_DATA_HOME", "/home/.local/share");
-            command.env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin:/home/.local/bin"); // adds /home/.local/bin
-            // A styled default shell prompt for interactive sessions. Set as a
-            // plain default here (not forced) so a user's composition var can
-            // override it: the composed `env_vars` are applied further down and
-            // win on key collision.
-            command.env(
-                "PS1",
-                r"\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ ",
-            );
-            // Login-shell identity, mirroring what sshd/pam would set from
-            // `/etc/passwd`. `USER`/`LOGNAME` track the configured username;
-            // `SHELL` points at the session shell (the `bash` package installs
-            // to `/usr/bin/bash`). All plain defaults, so composition vars win.
-            if let Some(user) = &sandbox.config.username {
-                command.env("USER", user);
-                command.env("LOGNAME", user);
-            }
-            command.env("SHELL", "/usr/bin/bash");
-        } else {
-            // Both build and BoundWd layouts
-            command.env("XDG_STATE_HOME", "/state/state");
-            command.env("XDG_CONFIG_HOME", "/state/home");
-            command.env("XDG_DATA_HOME", "/state/data");
-            command.env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
-        }
-        command.env("XDG_CACHE_HOME", "/state/cache");
-        command.env("XDG_RUNTIME_DIR", "/run");
-
-        // Set HOME
-        match &sandbox.config.wd {
-            WdSetup::Isolated { .. } => {
-                command.env("HOME", "/state/home");
-            }
-            WdSetup::Session { .. } => {
-                command.env("HOME", "/home");
-            }
-            WdSetup::BoundDir { .. } => {
-                if let Ok(h) = std::env::var("HOME") {
-                    command.env("HOME", &h);
-                } else {
-                    command.env("HOME", "/state/home");
-                }
-            }
-        };
-
-        if let WdSetup::Isolated { .. } = sandbox.config.wd {
-            command.env("OUTPUT_DIR", "/build/output");
-            command.env("GIT_TERMINAL_PROMPT", "0");
-            command.env("SOURCE_DATE_EPOCH", "0");
-            command.env("PYTHONHASHSEED", "0");
-        }
-
-        // Locale. Sessions get a safe, always-present `C.UTF-8` floor: it's
-        // built into glibc so it never triggers "cannot set locale" warnings
-        // the way `en_US.utf8` does when that locale isn't generated in the
-        // rootfs, and setting only `LANG` (the lowest-precedence locale knob,
-        // no `LC_ALL`) lets a session's composed `env_vars` or a client's
-        // forwarded `LANG`/`LC_*` override it. Build/task sandboxes keep the
-        // fixed `en_US.utf8` + `LC_ALL` they always had, for output stability.
-        if let WdSetup::Session { .. } = &sandbox.config.wd {
-            command.env("LANG", "C.UTF-8");
-        } else {
-            command.env("LANG", "en_US.utf8");
-            command.env("LC_ALL", "en_US.utf8");
-        }
-        command.env("IS_SANDBOX", "1");
-        if let WdSetup::BoundDir { .. } = sandbox.config.wd {
-            //  Quality-of-life wiring for task sandboxes
-            if let Ok(term) = std::env::var("TERM") {
-                command.env("TERM", &term);
-            }
-            if let Ok(ct) = std::env::var("COLORTERM") {
-                command.env("COLORTERM", &ct);
-            }
-            if let Ok(lsc) = std::env::var("LS_COLORS") {
-                command.env("LS_COLORS", &lsc);
-            }
-        }
-
-        sandbox.config.env_vars.iter().for_each(|(var, val)| {
-            command.env(var, val);
-        });
+        // Both are derived from the config rather than built here, so that a
+        // process injected into a *running* sandbox (minimald's `nsenter`) can
+        // reproduce the same working directory and environment without a second
+        // definition of them drifting from this one.
+        command.current_dir(sandbox.config.command_cwd());
+        command.envs(sandbox.config.command_env());
         for (k, v) in envs.into_iter() {
             command.env(k.as_ref(), v.as_ref());
         }


### PR DESCRIPTION
Makes it possible to launch arbitrary commands within the session.

`min attach <name or id> -c 'pwd'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run SSH commands directly inside existing session sandboxes.
  * Automatically start or reuse session hosts for command execution.
  * Preserve working directories and environment variables across commands.
  * Propagate variables from installed packages to active shells.
  * Improve filesystem and namespace isolation during command execution.

* **Bug Fixes**
  * Corrected routing for valid session commands.
  * Ensured later environment values consistently override earlier ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add arbitrary SSH exec support for commands run inside session namespaces
> - Adds a new `nsenter`-based injection pathway in [`crates/minimald/src/nsenter.rs`](https://github.com/gominimal/minimal/pull/1173/files#diff-00e0bfd62d06cf3e0089a573a4753f06c3ff65ffdcfb98d05ccf1bedb8351a1e) that re-execs the `minimald` binary as a shim to `setns` into the session's namespaces, then spawns the target program with the correct cwd and environment.
> - SSH exec requests that are not `min` subcommands are now routed into the session sandbox via `SessionExec` in [`crates/minimald/src/exec.rs`](https://github.com/gominimal/minimal/pull/1173/files#diff-d7bb305c5820ba4cc947bbf8a89b209dfdd48561cadd311f40fa0149e5ef7c8b) instead of being rejected.
> - Adds `SessionGuard` trait and `SessionEnvironment` struct so `Host` can read current working directory and environment variables when building in-session commands.
> - Adds `SessionHandle::ensure_host` so a sandbox host can be started without attaching a terminal, enabling headless exec.
> - Exposes `Sandbox::command_cwd` and `Sandbox::command_env` from `sandbox2` config so the injection path uses the same environment logic as direct container invocations.
> - Risk: namespace joining uses `pidfd_open` and a single `setns` call; if the session leader exits between pid resolution and injection, the shim will fail with a `NsenterError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3ee61d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->