### PR TITLE
fix: update guest kernel to carry CONFIG_PROC_CHILDREN

### DIFF
--- a/.minimal/minimal.toml
+++ b/.minimal/minimal.toml
@@ -1,7 +1,7 @@
 [upstream] # Source of software & tooling
 repo = "https://github.com/gominimal/pkgs"
 branch = "main"
-locked_commit = "d299744531767b2edeb5b0ead2178dadc40bbeed"
+locked_commit = "b1a1b1b7275d06dcd9235708a648c88e928b9462"
 
 [stack]
 use = "rust"


### PR DESCRIPTION
Last one hopefully, this bumps the minvmd kernel we ship

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update guest kernel pin to include CONFIG_PROC_CHILDREN
> Updates the locked commit for `upstream` in [minimal.toml](https://github.com/gominimal/minimal/pull/1174/files#diff-b3c5759398e8468de864c730146c85ebc5a60e59a2e4b583147a9bc92eb550a6) to pull in a guest kernel build that carries the `CONFIG_PROC_CHILDREN` kernel config option.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c323cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned upstream version to incorporate the latest available changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->