### PR TITLE
fix: command exec inside minvmd

### DIFF
--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -519,7 +519,18 @@ impl Exec for SessionExec {
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .kill_on_drop(true);
-            command.spawn().map(TokioProcess)
+            // This spawns the shim — us, re-exec'd — not the user's command, so
+            // a bare ENOENT reads as a missing shell. Name the path (#1175).
+            let shim = command.as_std().get_program().to_owned();
+            command.spawn().map(TokioProcess).map_err(|e| {
+                io::Error::new(
+                    e.kind(),
+                    format!(
+                        "re-execing {} as the session-namespace shim: {e}",
+                        std::path::Path::new(&shim).display()
+                    ),
+                )
+            })
         })
         .boxed()
     }

--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -271,8 +271,53 @@ pub fn enter_rootfs(device: &str) -> std::io::Result<()> {
         );
     }
 
+    stage_self_exe();
+
     tracing::info!(device, "switched to upstream rootfs (pivot_root)");
     Ok(())
+}
+
+/// Where the guest's own binary is staged so it stays runnable after the switch.
+/// On the `/run` tmpfs: boot-ephemeral, and the rootfs is read-only.
+pub const STAGED_SELF_EXE: &str = "/run/minimald";
+
+/// Stages a runnable copy of this binary at [`STAGED_SELF_EXE`] and registers it
+/// as the namespace-joining shim.
+///
+/// pid-1 *is* the initramfs `/init`, which the switch above just made
+/// unreachable — the initramfs stays mounted, but nothing names it. Since
+/// `current_exe()` still reports `/init`, every re-exec of ourselves fails with
+/// ENOENT; `min session attach <name> -c '<cmd>'` re-execs us as the
+/// [`crate::nsenter::SUBCOMMAND`] shim, so it broke (#1175).
+///
+/// The copy works post-switch because *opening* `/proc/self/exe` resolves to the
+/// inode, not the path. Costs one binary's worth of tmpfs (RAM) per boot.
+///
+/// Best-effort: this failing costs in-session exec, which is not worth
+/// downgrading the boot over — but it is logged loudly enough to explain the
+/// exec failures that follow.
+fn stage_self_exe() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let staged = || -> std::io::Result<()> {
+        std::fs::copy("/proc/self/exe", STAGED_SELF_EXE)?;
+        std::fs::set_permissions(STAGED_SELF_EXE, std::fs::Permissions::from_mode(0o755))
+    };
+    match staged() {
+        Ok(()) => {
+            crate::nsenter::set_shim_exe(STAGED_SELF_EXE);
+            tracing::info!(
+                path = STAGED_SELF_EXE,
+                "staged the daemon binary post-switch"
+            );
+        }
+        Err(e) => tracing::error!(
+            error = %e,
+            path = STAGED_SELF_EXE,
+            "could not stage the daemon binary; running a command in a session \
+             (`min session attach -c`) will fail with ENOENT",
+        ),
+    }
 }
 
 /// ext4 superblock magic (`0xEF53`), stored little-endian at byte offset 1080

--- a/crates/minimald/src/nsenter.rs
+++ b/crates/minimald/src/nsenter.rs
@@ -9,13 +9,42 @@ use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::process::{CommandExt as _, ExitStatusExt as _};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
 
 use nix::sched::CloneFlags;
 
 /// `argv[1]` the daemon re-execs itself with to run [`shim_main`].
 pub const SUBCOMMAND: &str = "__nsenter";
+
+/// Where this daemon can re-exec itself from. Registered by [`set_shim_exe`].
+static SHIM_EXE: OnceLock<PathBuf> = OnceLock::new();
+
+/// Registers `path` as the [`SUBCOMMAND`] shim, overriding `current_exe()` for
+/// every later [`Injection`].
+///
+/// For the microVM's pid-1, whose `current_exe()` is the initramfs `/init` —
+/// unreachable once it switches into the rootfs, so every re-exec is an ENOENT
+/// (#1175). Its boot path stages a runnable copy and names it here.
+///
+/// First registration wins: a stale path is worse than the one in use.
+pub fn set_shim_exe(path: impl Into<PathBuf>) {
+    let path = path.into();
+    if let Err(rejected) = SHIM_EXE.set(path) {
+        tracing::warn!(
+            in_use = %SHIM_EXE.get().expect("set failed, so a value is present").display(),
+            rejected = %rejected.display(),
+            "the nsenter shim path is already registered; keeping the first one",
+        );
+    }
+}
+
+/// The registered shim executable, if [`set_shim_exe`] has been called.
+#[must_use]
+pub fn shim_exe() -> Option<&'static Path> {
+    SHIM_EXE.get().map(PathBuf::as_path)
+}
 
 /// Descriptor number the pidfd is placed on, the shim joins the namespaces
 /// associated with this process.
@@ -350,7 +379,8 @@ impl Injection {
     ///
     /// The daemon always wants the running executable — it re-execs itself.
     /// This is for callers that are not the daemon: an integration test driving
-    /// the real shim out of `CARGO_BIN_EXE_minimald`, say.
+    /// the real shim out of `CARGO_BIN_EXE_minimald`, say. A daemon whose own
+    /// path is unrunnable uses [`set_shim_exe`] instead.
     pub fn with_shim(mut self, shim_exe: impl Into<PathBuf>) -> Self {
         self.shim_exe = Some(shim_exe.into());
         self
@@ -368,7 +398,7 @@ impl Injection {
     /// [`NsenterError::PidfdOpen`] if the session program exited before it
     /// could be pinned, [`NsenterError::ReadNamespace`] if its namespaces
     /// cannot be enumerated, [`NsenterError::CurrentExe`] if no shim was named
-    /// and this binary cannot be located.
+    /// or registered and this binary cannot be located.
     pub fn command(self) -> Result<Command, NsenterError> {
         // Resolved here rather than in the shim: the daemon holds the session's
         // PID and the shim holds only a pidfd, and naming the namespaces on the
@@ -376,7 +406,8 @@ impl Injection {
         // joined process.
         let namespaces = namespaces_to_join(self.leader_pid)?;
         let pidfd = pidfd_open(self.leader_pid)?;
-        let shim = match self.shim_exe {
+        // Caller's choice, then the registration, then our own path.
+        let shim = match self.shim_exe.or_else(|| shim_exe().map(Path::to_path_buf)) {
             Some(exe) => exe,
             None => {
                 std::env::current_exe().map_err(|source| NsenterError::CurrentExe { source })?
@@ -595,6 +626,47 @@ mod tests {
         let _ = sh.kill();
         let _ = sh.wait();
         assert_eq!(resolved.expect("resolving the sole child"), expected);
+    }
+
+    /// The production path: no shim is named per injection (only tests do
+    /// that), so this resolution order is what keeps #1175 fixed. One test,
+    /// because [`SHIM_EXE`] is process-wide and set once.
+    #[test]
+    fn the_registered_shim_overrides_current_exe_and_yields_to_an_explicit_one() {
+        // A plain child shares all our namespaces, so nothing is joined and no
+        // privilege is needed.
+        let mut sleep = Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawning /bin/sleep");
+        let target = sleep.id();
+        let injection = || Injection::new(target, "/bin/true", Vec::<&str>::new());
+
+        let unregistered = injection().command().map(|c| c.get_program().to_owned());
+        set_shim_exe("/run/minimald");
+        let registered = injection().command().map(|c| c.get_program().to_owned());
+        let explicit = injection()
+            .with_shim("/usr/bin/minimald")
+            .command()
+            .map(|c| c.get_program().to_owned());
+
+        let _ = sleep.kill();
+        let _ = sleep.wait();
+        assert_eq!(
+            PathBuf::from(unregistered.expect("building the command")),
+            std::env::current_exe().expect("locating the test binary"),
+            "with nothing registered the daemon re-execs itself",
+        );
+        assert_eq!(
+            registered.expect("building the command"),
+            OsStr::new("/run/minimald"),
+            "the registered shim replaces current_exe()",
+        );
+        assert_eq!(
+            explicit.expect("building the command"),
+            OsStr::new("/usr/bin/minimald"),
+            "a per-injection shim still wins over the registration",
+        );
     }
 
     #[test]

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -306,6 +306,39 @@ t1=$(now_ms)
 echo "warm 'min ls': $((t1 - t0))ms"
 
 # ---------------------------------------------------------------------------
+# Non-interactive exec proof: `min session attach <sid> -c '<cmd>'` runs the
+# command in the session's namespaces and relays its stdout and exit code. The
+# daemon services this by re-execing ITSELF as the nsenter shim, which is a
+# different path from the interactive attach below and the one that broke in
+# #1175 (in the VM, pid-1's `current_exe()` is the unreachable initramfs
+# `/init`, so every exec died with ENOENT while interactive attach worked).
+# Ordered before the pty proof, which deletes the session.
+echo "::group::session exec proof (min session attach -c)"
+# shellcheck disable=SC2016 # $PWD must expand in the SESSION's shell, not here.
+exec_out="$(mnl session attach "$sid" -c 'echo EXEC_OK $PWD' 2>"$WORK/attach-c.err")" || {
+  echo "::error::'min session attach $sid -c' failed"
+  echo "--- stdout ---"; printf '%s\n' "$exec_out"
+  echo "--- stderr ---"; cat "$WORK/attach-c.err" 2>/dev/null || true
+  fail
+}
+# The cwd proves it ran in the session's mount namespace, not on the host.
+if [[ "$exec_out" != *"EXEC_OK /workbench"* ]]; then
+  echo "::error::'min session attach -c' did not run in the session (expected 'EXEC_OK /workbench')"
+  echo "--- stdout ---"; printf '%s\n' "$exec_out"
+  echo "--- stderr ---"; cat "$WORK/attach-c.err" 2>/dev/null || true
+  fail
+fi
+# The command's exit code must be the CLI's, not a blanket 0/1.
+mnl session attach "$sid" -c 'exit 7' >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 7 ]; then
+  echo "::error::'min session attach -c \"exit 7\"' exited $rc (expected the command's 7)"
+  fail
+fi
+echo "session exec proof OK"
+echo "::endgroup::"
+
+# ---------------------------------------------------------------------------
 # `min task run` proof: a declared task runs in an ephemeral session — output
 # streamed through, the task's exit code relayed, the session destroyed
 # afterwards (or kept with --keep). Runs against its own tiny seeded project:


### PR DESCRIPTION
Fixes #1175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session process startup errors with clearer diagnostics.
  * Ensured session re-execution continues to work after switching to the guest root filesystem.
  * Improved namespace shim selection for session operations.

* **Tests**
  * Added coverage for shim resolution behavior.
  * Added end-to-end validation for non-interactive session commands, including output, working directory, exit codes, and failure diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix command exec inside minvmd by staging a runnable daemon binary for nsenter re-execs
> - After entering the upstream rootfs, [guest.rs](https://github.com/gominimal/minimal/pull/1176/files#diff-f0dd3922eb27e86f3e4783c7469e18c89fd5165f3a119ef03217d32b6eb51296) copies `/proc/self/exe` to a tmpfs path (`/run/minimald`) and registers it as the nsenter shim so subsequent re-execs resolve correctly.
> - [nsenter.rs](https://github.com/gominimal/minimal/pull/1176/files#diff-00e0bfd62d06cf3e0089a573a4753f06c3ff65ffdcfb98d05ccf1bedb8351a1e) adds a process-wide `OnceLock` shim registration (`set_shim_exe`/`shim_exe`), with `Injection::command` now preferring an explicit per-injection shim, then the registered shim, then `current_exe()`.
> - [exec.rs](https://github.com/gominimal/minimal/pull/1176/files#diff-d7bb305c5820ba4cc947bbf8a89b209dfdd48561cadd311f40fa0149e5ef7c8b) wraps spawn failures with a contextual error message including the resolved shim path.
> - An e2e test in [session-e2e.sh](https://github.com/gominimal/minimal/pull/1176/files#diff-004d118857e0d3f2629dc99ab9f489236e0cbfcdb0c00fade94c342b824358a7) validates non-interactive exec behavior and exit-code propagation.
> - Behavioral Change: daemons running inside a rootfs where their own path is unrunnable now automatically stage and use a copy from tmpfs; staging failures are logged but do not abort boot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eabd2b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->