### PR TITLE
fix(op): use a BTreeSet for override_deps so rootfs assembly is deterministic

### DIFF
--- a/crates/op/src/patched.rs
+++ b/crates/op/src/patched.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use anyhow::anyhow;
 use graph::{BuildSpecRef, Transitives};
@@ -37,7 +37,7 @@ impl<'a, SF: crate::SourceFetcher> Runnable for PatchedBuild<'a, SF> {
         let build = opts.graph.get(self.spec).unwrap();
 
         // Select dependencies by name to be used in the build.
-        let mut dependencies = HashSet::new();
+        let mut dependencies = BTreeSet::new();
         let transitives = Transitives::new(opts.graph, self.spec, true);
         let build_deps: Vec<_> = transitives
             .transitive_runtime_deps

--- a/crates/op/src/specs.rs
+++ b/crates/op/src/specs.rs
@@ -33,9 +33,8 @@ pub struct SpecBuild<'a, SF: crate::SourceFetcher> {
     /// Does not override `Local` or `Source` variant build_deps - those will
     /// always be made present automatically.
     ///
-    /// Ordered, because `rootfs_mapped` passes these to the sandbox, which hardlinks them
-    /// first-writer-wins: with a `HashSet` the winner of a path two deps both install was
-    /// decided by a per-process `RandomState` seed and so varied between runs.
+    /// Ordered: `rootfs_mapped` passes these to the sandbox, which hardlinks
+    /// them first-writer-wins, so iteration order must be deterministic.
     pub override_deps: Option<BTreeSet<PathBuf>>,
 
     /// Optional async writer that receives a copy of the sandbox's stdout stream.

--- a/crates/op/src/specs.rs
+++ b/crates/op/src/specs.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, path::PathBuf, time::Instant};
+use std::{
+    collections::{BTreeSet, HashSet},
+    path::PathBuf,
+    time::Instant,
+};
 
 use crate::{Error, Materialized, Options, Runnable, SubsetBuild};
 use anyhow::anyhow;
@@ -28,7 +32,11 @@ pub struct SpecBuild<'a, SF: crate::SourceFetcher> {
     ///
     /// Does not override `Local` or `Source` variant build_deps - those will
     /// always be made present automatically.
-    pub override_deps: Option<HashSet<PathBuf>>,
+    ///
+    /// Ordered, because `rootfs_mapped` passes these to the sandbox, which hardlinks them
+    /// first-writer-wins: with a `HashSet` the winner of a path two deps both install was
+    /// decided by a per-process `RandomState` seed and so varied between runs.
+    pub override_deps: Option<BTreeSet<PathBuf>>,
 
     /// Optional async writer that receives a copy of the sandbox's stdout stream.
     pub stdout_writer: Option<Box<dyn tokio::io::AsyncWrite + Unpin + Send + Sync>>,


### PR DESCRIPTION
## Summary

`SpecBuild.override_deps` was an `Option<HashSet<PathBuf>>`. That collection feeds rootfs assembly, which hardlinks entries first-writer-wins, so its iteration order decides which package provides a path that several packages install — and `HashSet` iteration follows a per-process `RandomState` seed, so the winner changed from one run of the binary to the next.

## Change

`Option<BTreeSet<PathBuf>>`: iteration is deterministic across processes, first write still wins. Packages installing overlapping paths remains a packaging bug to fix in the packages themselves — this only keeps the symptom deterministic (per review: no caller-chosen precedence).

Companion: #1180 makes the downstream `sandbox2::Config::rootfs` collection ordered too, which covers every rootfs producer.