### PR TITLE
fix(op): sort standalone-test dependencies so the test rootfs is deterministic

### DIFF
--- a/crates/op/src/standalone_test.rs
+++ b/crates/op/src/standalone_test.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use anyhow::anyhow;
 use graph::{BuildSpec, BuildSpecRef, SpecTest, SubsetInput, Transitives};
@@ -34,7 +34,7 @@ impl<'a> StandaloneTest<'a> {
         build: &BuildSpec,
         test: &SpecTest,
         opts: &Options<'a>,
-    ) -> Result<(Vec<SandboxMapped>, bool, bool), Error> {
+    ) -> Result<(BTreeSet<SandboxMapped>, bool, bool), Error> {
         let transitives = Transitives::for_toplevels(
             opts.graph,
             {
@@ -45,24 +45,16 @@ impl<'a> StandaloneTest<'a> {
             false,
         );
 
-        let mut dependencies = Vec::new();
-        let mut seen = HashSet::new();
+        let mut dependencies = BTreeSet::new();
         let (mut needs_dns, mut need_internet) = (false, false);
 
-        // Sorted, because the rootfs is assembled by hardlinking these first-writer-wins: with
-        // an unordered collection the winner of a path two dependencies both install was
-        // decided by a per-process `RandomState` seed and so varied between runs.
-        let mut build_deps: Vec<_> = transitives.into_iter().collect();
-        build_deps.sort_by_key(|(bsr, _)| *opts.graph.spec_hash(bsr).0.as_bytes());
+        let build_deps: Vec<_> = transitives.into_iter().collect();
         for (bsr, dep_info) in build_deps.into_iter() {
             match dep_info.outputs {
                 // Regular build
                 None => {
                     let cache_dir = opts.cache.read_dir(&opts.graph.spec_hash(&bsr))?;
-                    let path = cache_dir.path().to_path_buf();
-                    if seen.insert(path.clone()) {
-                        dependencies.push(SandboxMapped::Dir(path));
-                    }
+                    dependencies.insert(SandboxMapped::Dir(cache_dir.path().to_path_buf()));
                 }
                 // Subset
                 Some(outputs) => {
@@ -73,32 +65,31 @@ impl<'a> StandaloneTest<'a> {
                     let subset_hash = opts.graph.subset_hash(&subset);
 
                     // If the subset exists use it, otherwise build it
-                    let path = match opts.cache.read_dir(&subset_hash) {
-                        Ok(cache_dir) => cache_dir,
-                        Err(CacheErr::NotFound) => {
-                            let mut sb = SubsetBuild {
-                                subset: &subset,
-                                from_dir: None,
-                            };
-                            let pending_dir = sb.run(opts).await?;
-                            pending_dir.finalize(lcache::EntryMeta {
-                                inner: MetaInner::Subset(subset.as_spec(opts.graph)),
-                                fetched: false,
-                                origin: Some(build.from.as_ref().clone()),
-                                ..Default::default()
-                            })?;
+                    dependencies.insert(SandboxMapped::Dir(
+                        match opts.cache.read_dir(&subset_hash) {
+                            Ok(cache_dir) => cache_dir,
+                            Err(CacheErr::NotFound) => {
+                                let mut sb = SubsetBuild {
+                                    subset: &subset,
+                                    from_dir: None,
+                                };
+                                let pending_dir = sb.run(opts).await?;
+                                pending_dir.finalize(lcache::EntryMeta {
+                                    inner: MetaInner::Subset(subset.as_spec(opts.graph)),
+                                    fetched: false,
+                                    origin: Some(build.from.as_ref().clone()),
+                                    ..Default::default()
+                                })?;
 
-                            opts.cache.read_dir(&subset_hash)?
+                                opts.cache.read_dir(&subset_hash)?
+                            }
+                            Err(e) => {
+                                return Err(e.into());
+                            }
                         }
-                        Err(e) => {
-                            return Err(e.into());
-                        }
-                    }
-                    .path()
-                    .to_path_buf();
-                    if seen.insert(path.clone()) {
-                        dependencies.push(SandboxMapped::Dir(path));
-                    }
+                        .path()
+                        .to_path_buf(),
+                    ));
                 }
             }
 

--- a/crates/op/src/standalone_test.rs
+++ b/crates/op/src/standalone_test.rs
@@ -34,7 +34,7 @@ impl<'a> StandaloneTest<'a> {
         build: &BuildSpec,
         test: &SpecTest,
         opts: &Options<'a>,
-    ) -> Result<(HashSet<SandboxMapped>, bool, bool), Error> {
+    ) -> Result<(Vec<SandboxMapped>, bool, bool), Error> {
         let transitives = Transitives::for_toplevels(
             opts.graph,
             {
@@ -45,16 +45,24 @@ impl<'a> StandaloneTest<'a> {
             false,
         );
 
-        let mut dependencies = HashSet::new();
+        let mut dependencies = Vec::new();
+        let mut seen = HashSet::new();
         let (mut needs_dns, mut need_internet) = (false, false);
 
-        let build_deps: Vec<_> = transitives.into_iter().collect();
+        // Sorted, because the rootfs is assembled by hardlinking these first-writer-wins: with
+        // an unordered collection the winner of a path two dependencies both install was
+        // decided by a per-process `RandomState` seed and so varied between runs.
+        let mut build_deps: Vec<_> = transitives.into_iter().collect();
+        build_deps.sort_by_key(|(bsr, _)| *opts.graph.spec_hash(bsr).0.as_bytes());
         for (bsr, dep_info) in build_deps.into_iter() {
             match dep_info.outputs {
                 // Regular build
                 None => {
                     let cache_dir = opts.cache.read_dir(&opts.graph.spec_hash(&bsr))?;
-                    dependencies.insert(SandboxMapped::Dir(cache_dir.path().to_path_buf()));
+                    let path = cache_dir.path().to_path_buf();
+                    if seen.insert(path.clone()) {
+                        dependencies.push(SandboxMapped::Dir(path));
+                    }
                 }
                 // Subset
                 Some(outputs) => {
@@ -65,31 +73,32 @@ impl<'a> StandaloneTest<'a> {
                     let subset_hash = opts.graph.subset_hash(&subset);
 
                     // If the subset exists use it, otherwise build it
-                    dependencies.insert(SandboxMapped::Dir(
-                        match opts.cache.read_dir(&subset_hash) {
-                            Ok(cache_dir) => cache_dir,
-                            Err(CacheErr::NotFound) => {
-                                let mut sb = SubsetBuild {
-                                    subset: &subset,
-                                    from_dir: None,
-                                };
-                                let pending_dir = sb.run(opts).await?;
-                                pending_dir.finalize(lcache::EntryMeta {
-                                    inner: MetaInner::Subset(subset.as_spec(opts.graph)),
-                                    fetched: false,
-                                    origin: Some(build.from.as_ref().clone()),
-                                    ..Default::default()
-                                })?;
+                    let path = match opts.cache.read_dir(&subset_hash) {
+                        Ok(cache_dir) => cache_dir,
+                        Err(CacheErr::NotFound) => {
+                            let mut sb = SubsetBuild {
+                                subset: &subset,
+                                from_dir: None,
+                            };
+                            let pending_dir = sb.run(opts).await?;
+                            pending_dir.finalize(lcache::EntryMeta {
+                                inner: MetaInner::Subset(subset.as_spec(opts.graph)),
+                                fetched: false,
+                                origin: Some(build.from.as_ref().clone()),
+                                ..Default::default()
+                            })?;
 
-                                opts.cache.read_dir(&subset_hash)?
-                            }
-                            Err(e) => {
-                                return Err(e.into());
-                            }
+                            opts.cache.read_dir(&subset_hash)?
                         }
-                        .path()
-                        .to_path_buf(),
-                    ));
+                        Err(e) => {
+                            return Err(e.into());
+                        }
+                    }
+                    .path()
+                    .to_path_buf();
+                    if seen.insert(path.clone()) {
+                        dependencies.push(SandboxMapped::Dir(path));
+                    }
                 }
             }
 

--- a/crates/sandbox2/src/config.rs
+++ b/crates/sandbox2/src/config.rs
@@ -1,6 +1,6 @@
 use crate::network::Network;
 use crate::{Error, Sandbox};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
@@ -30,6 +30,30 @@ impl PartialEq for SandboxMapped {
     }
 }
 impl Eq for SandboxMapped {}
+
+// Ordered on (variant tag, path), mirroring the `PartialEq`/`Hash` key above,
+// so `BTreeSet<SandboxMapped>` iterates — and the rootfs therefore assembles —
+// in the same order in every process. Assembly is first-writer-wins
+// hardlinking, so an unordered collection let a per-process hash seed decide
+// which entry provided a path that two entries both contain.
+impl PartialOrd for SandboxMapped {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for SandboxMapped {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        fn key(m: &SandboxMapped) -> (u8, &Path) {
+            match m {
+                SandboxMapped::File(p) => (0, p),
+                SandboxMapped::Dir(p) => (1, p),
+                SandboxMapped::TempDir(t) => (2, t.path()),
+                SandboxMapped::FileCopy(p) => (3, p),
+            }
+        }
+        key(self).cmp(&key(other))
+    }
+}
 
 impl Hash for SandboxMapped {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -143,7 +167,10 @@ pub struct Config {
     ///    into the sandbox.
     pub wd: WdSetup,
     /// The set of files that should be mapped into the root filesystem of the sandbox.
-    pub rootfs: HashSet<SandboxMapped>,
+    ///
+    /// `BTreeSet`: iteration order is assembly order (entries are hardlinked
+    /// first-writer-wins), so it must be deterministic across processes.
+    pub rootfs: BTreeSet<SandboxMapped>,
 
     /// Synthesize DNS config.
     pub setup_dns_config: bool,
@@ -332,7 +359,7 @@ impl Config {
             hostname: None,
             username: None,
             keep_dirs: false,
-            rootfs: HashSet::with_capacity(64),
+            rootfs: BTreeSet::new(),
             state_dir: None,
             wd: WdSetup::Isolated {
                 working_inputs: Vec::with_capacity(6),


### PR DESCRIPTION
## Summary

Same class of issue as #1178, on the standalone-test path.

`StandaloneTest::dependencies` collects into a `HashSet<SandboxMapped>`, fed by an unsorted
`HashMap` iteration. The sandbox hardlinks these first-writer-wins, so when two
dependencies install the same path the winner is decided by iteration order, which comes
from a per-process `RandomState` seed. A test therefore ran against a different rootfs from
one invocation to the next.

## Change

Collect into a `Vec` sorted by spec hash, deduplicating by path and keeping the first
occurrence. One file.

## Why this one is worth doing

Unlike a build, a test that composes its rootfs differently can silently report the wrong
result rather than failing.

Concretely: `packages/gawk`'s `matching` test has `test_deps = [base-bootstrap]`, and that
closure contains `gawk-bootstrap` 5.3.2, which installs `usr/bin/gawk`, `usr/bin/awk` and
`usr/lib/gawk/*.so` — the same paths gawk 5.4.0 installs. `sandbox2` also symlinks
`/bin → usr/bin`, so command lookup resolves to whichever won. On an unlucky iteration
`minimal check gawk` asserts against the 5.3.2 binary and reports a pass for 5.4.0; it
would report a pass even if 5.4.0 could not start. `packages/mtools` has the same shape
with `bash`.

This PR makes that outcome consistent rather than random. It does not decide *which*
package ought to win — as with #1178, the overlapping paths are the underlying problem and
belong in the specs. Filing this separately so the variance is gone while that is sorted
out.

## Note

The queue builder does not run standalone tests, so no published artifact depends on these
verdicts today.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort standalone-test rootfs dependencies deterministically using `BTreeSet`
> - Replaces `HashSet<SandboxMapped>` with `BTreeSet<SandboxMapped>` in both [`Config.rootfs`](https://github.com/gominimal/minimal/pull/1180/files#diff-cae0fcb053d236a17a0fa33c43b824a9dba69e6c3b14956501a09d010016b3d5) and [`StandaloneTest.dependencies`](https://github.com/gominimal/minimal/pull/1180/files#diff-f45bf8f82ce4c76fd24aeaa1b80efccfd3a2fdfdf1f8462b3b3684998c6eddce) to give deterministic iteration order.
> - Adds `PartialOrd`/`Ord` implementations for `SandboxMapped`, ordering by variant (`File < Dir < TempDir < FileCopy`) then by associated path.
> - Behavioral Change: anything iterating over `Config.rootfs` now sees a stable, sorted order instead of hash-determined order.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afdbc22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->