### PR TITLE
feat(min): move session exec to own subcommand

### DIFF
--- a/crates/minimal-client/src/attach.rs
+++ b/crates/minimal-client/src/attach.rs
@@ -60,7 +60,7 @@ pub fn host_key_opts(known_hosts: &Path) -> [String; 2] {
 pub fn attach_command(
     sock: &Path,
     id: sessions::SessionId,
-    command: Option<&str>,
+    command: &[String],
 ) -> Result<std::process::Command, anyhow::Error> {
     // ProxyCommand points at our own `proxy` subcommand so we don't
     // depend on socat or nc being installed.
@@ -113,7 +113,7 @@ pub fn attach_command(
     // remote PTY, yet the interactive shell reading it never sees an EOF from a
     // redirected local stdin (`< /dev/null`, a pipe), so the command blocks
     // forever (#953). Callers must guarantee a terminal on stdin.
-    if command.is_none() {
+    if command.is_empty() {
         ssh.arg("-tt");
     }
 
@@ -130,7 +130,7 @@ pub fn attach_command(
 
     // If a command was provided, pass it to ssh (non-interactive exec).
     // Otherwise, ssh opens an interactive shell via shell_request.
-    if let Some(cmd) = command {
+    for cmd in command.iter() {
         ssh.arg(cmd);
     }
 
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn attach_command_targets_the_provider_alias() {
         let sock = PathBuf::from("/tmp/x/providers/local-minimald0/ssh.sock");
-        let cmd = attach_command(&sock, sessions::SessionId::nil(), None).unwrap();
+        let cmd = attach_command(&sock, sessions::SessionId::nil(), &[]).unwrap();
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
@@ -161,13 +161,21 @@ mod tests {
     #[test]
     fn attach_command_with_exec_has_no_forced_pty() {
         let sock = PathBuf::from("/tmp/x/providers/local-minvmd0/ssh.sock");
-        let cmd = attach_command(&sock, sessions::SessionId::nil(), Some("min run test")).unwrap();
+        let cmd = attach_command(
+            &sock,
+            sessions::SessionId::nil(),
+            &["min".to_string(), "run".to_string(), "test".to_string()],
+        )
+        .unwrap();
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
         assert!(!args.iter().any(|a| a == "-tt"));
-        assert_eq!(args.last().map(String::as_str), Some("min run test"));
+        assert_eq!(
+            args.into_iter().rev().take(3).rev().collect::<Vec<_>>(),
+            vec!["min".to_string(), "run".to_string(), "test".to_string()]
+        );
     }
     /// A VM-backed provider dir carries the guest's recorded host key, so
     /// attach must verify against it rather than waive the check.

--- a/crates/minimal-tui/src/app.rs
+++ b/crates/minimal-tui/src/app.rs
@@ -1065,7 +1065,7 @@ fn attach_and_resume(
     id: SessionId,
     model: &mut Model,
 ) {
-    let result = minimal_client::attach::attach_command(sock, id, None).and_then(|mut cmd| {
+    let result = minimal_client::attach::attach_command(sock, id, &[]).and_then(|mut cmd| {
         terminal.suspend();
         let status = cmd.status();
         // A failed resume leaves the TUI unusable; report it over the

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -189,12 +189,24 @@ pub enum SessionCommand {
     Activate(ActivateArgs),
     /// Attach to an existing session
     Attach(AttachArgs),
+    /// Execute a command in an existing session
+    Exec(ExecArgs),
     /// Destroy (terminate) a session
     Destroy(DestroyArgs),
     /// Rename an existing session
     Rename(RenameArgs),
     /// Print the effective networking policy for a session as JSON
     Policy(PolicyArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct ExecArgs {
+    /// Session identifier (UUID or session name).
+    #[arg(add = completion::session_completer())]
+    pub session: String,
+    /// Command to execute in the session context
+    #[arg(trailing_var_arg = true, required = true, num_args = 1..)]
+    pub command: Vec<String>,
 }
 
 #[derive(Debug, Args)]
@@ -521,9 +533,6 @@ pub struct AttachArgs {
     /// ambiguous. See `--no-input` to skip the picker in scripts.
     #[arg(add = completion::session_completer())]
     pub session: Option<String>,
-    /// Command to exec in the session context (non-interactive)
-    #[arg(long, short, hide = true)]
-    pub command: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -717,6 +726,7 @@ async fn run_command(cli: Cli) -> Result<(), anyhow::Error> {
             SessionCommand::List(args) => cmd_ls(&cli.global_args, args).await,
             SessionCommand::Activate(args) => cmd_activate(&cli.global_args, args).await,
             SessionCommand::Attach(args) => cmd_attach(&cli.global_args, args).await,
+            SessionCommand::Exec(args) => cmd_exec(&cli.global_args, args).await,
             SessionCommand::Destroy(args) => cmd_destroy(&cli.global_args, args).await,
             SessionCommand::Rename(args) => cmd_rename(&cli.global_args, args).await,
             SessionCommand::Policy(args) => cmd_session_policy(&cli.global_args, args).await,
@@ -879,7 +889,7 @@ async fn cmd_bare(global: &GlobalArgs) -> Result<(), anyhow::Error> {
                 session_name = ?entry.name,
                 "found session"
             );
-            attach_to_session(&sock, entry.id, None).await
+            session_via_ssh(&sock, entry.id, vec![]).await
         }
         // Two ways to land on create-and-attach: no sessions exist at all
         // (first run), or the ambiguity picker's `+ Create a new session`
@@ -2098,7 +2108,6 @@ async fn activate_session(
         }
         let attach_args = AttachArgs {
             session: Some(id.to_string()),
-            command: None,
         };
         return cmd_attach(global, attach_args).await;
     }
@@ -2144,7 +2153,31 @@ pub async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), any
         "found session"
     );
 
-    attach_to_session(&sock, id, args.command).await
+    session_via_ssh(&sock, id, vec![]).await
+}
+
+/// Executes a command in an existing session.
+///
+/// The session is resolved using the provided predicate, and the connection
+/// is provided by shelling out to `ssh`.
+pub async fn cmd_exec(global: &GlobalArgs, args: ExecArgs) -> Result<(), anyhow::Error> {
+    ensure_daemon(global)?;
+
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd())
+        .context("Failed to resolve daemon socket path")?;
+
+    let mut client = client::Client::connect(&sock)
+        .await
+        .context("Failed to connect to minimald")?;
+
+    let r = resolve_session(&mut client, &args.session).await?;
+    tracing::info!(
+        session_id = %r.id,
+        session_name = ?r.name,
+        "found session"
+    );
+
+    session_via_ssh(&sock, r.id, args.command).await
 }
 
 /// Resolve a session to attach to when the user supplied no explicit session
@@ -2248,28 +2281,25 @@ fn ensure_interactive_attach_tty(stdin_is_tty: bool) -> Result<(), anyhow::Error
     }
 }
 
-/// Shell out to `ssh` to attach to `id`. Both the interactive (no `command`)
-/// and `--command` (non-interactive exec) paths route through here; the
-/// daemon's shell_request handler mints a PTY-backed shell, and ssh handles
-/// termios/PTY management.
+/// Shell out to `ssh` to attach to `id` or run a command.
 ///
 /// Split from [`cmd_attach`] so the activate-then-attach chain and the
 /// smart-resolution picker can attach without re-resolving an entry they
 /// already hold.
-async fn attach_to_session(
+async fn session_via_ssh(
     sock: &std::path::Path,
     id: sessions::SessionId,
-    command: Option<String>,
+    command: Vec<String>,
 ) -> Result<(), anyhow::Error> {
     // The command itself lives in minimal-client, shared with the dash TUI's
     // suspend-attach-resume flow.
-    let mut ssh = minimal_client::attach::attach_command(sock, id, command.as_deref())?;
+    let mut ssh = minimal_client::attach::attach_command(sock, id, &command)?;
 
     // `-tt` over a *non-terminal* stdin is a trap: ssh still forces the
     // remote PTY, yet the interactive shell reading it never sees an EOF from a
     // redirected local stdin (`< /dev/null`, a pipe), so the command blocks
     // forever (#953). Fail fast instead of hanging.
-    if command.is_none() {
+    if command.is_empty() {
         ensure_interactive_attach_tty(std::io::stdin().is_terminal())?;
     }
 

--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -4,6 +4,7 @@ use std::io::IsTerminal as _;
 use std::process::ExitCode;
 
 use clap::{CommandFactory as _, Parser};
+use minimal::ExecArgs;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 /// Custom main: handle shell completion requests before launching the async world.
@@ -125,7 +126,7 @@ impl std::io::Write for DashLog {
 
 /// Whether the command's stdout is a data contract that tracing must not
 /// pollute, so its logs go to stderr instead. The `completions` handlers emit a
-/// shell shim on stdout, `session attach -c` carries only the exec'd
+/// shell shim on stdout, `session exec` carries only the exec'd
 /// command's output, and `task run` streams the task's stdout — a log line
 /// in any of them would be read as content. A bare `min` (no subcommand) is
 /// one too: its non-TTY twin promises an empty stdout to pipelines, and its
@@ -137,10 +138,7 @@ fn stdout_is_data_contract(command: &Option<minimal::Command>) -> bool {
             minimal::Command::CompleteSessionStr(_)
                 | minimal::Command::Completions(_)
                 | minimal::Command::Session(minimal::SessionArgs {
-                    command: minimal::SessionCommand::Attach(minimal::AttachArgs {
-                        command: Some(_),
-                        ..
-                    }),
+                    command: minimal::SessionCommand::Exec(ExecArgs { .. }),
                 })
                 | minimal::Command::Task(minimal::TaskArgs {
                     command: minimal::TaskCommand::Run(_),
@@ -152,26 +150,7 @@ fn stdout_is_data_contract(command: &Option<minimal::Command>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use minimal::{AttachArgs, Command, SessionArgs, SessionCommand};
-
-    fn attach(command: Option<&str>) -> Option<Command> {
-        Some(Command::Session(SessionArgs {
-            command: SessionCommand::Attach(AttachArgs {
-                session: None,
-                command: command.map(str::to_owned),
-            }),
-        }))
-    }
-
-    #[test]
-    fn attach_with_command_is_a_stdout_contract() {
-        assert!(stdout_is_data_contract(&attach(Some("min check"))));
-    }
-
-    #[test]
-    fn interactive_attach_is_not_a_stdout_contract() {
-        assert!(!stdout_is_data_contract(&attach(None)));
-    }
+    use minimal::Command;
 
     /// A bare `min` (no subcommand) keeps stdout clean: the non-TTY twin
     /// promises pipelines an empty stdout, so its tracing must go to stderr.

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -420,16 +420,10 @@ async fn attach_with_no_session_errors_when_no_sessions_exist() {
     let (_daemon, mut global) = setup().await;
     global.no_input = true;
 
-    let err = cmd_attach(
-        &global,
-        AttachArgs {
-            session: None,
-            command: None,
-        },
-    )
-    .await
-    .unwrap_err()
-    .to_string();
+    let err = cmd_attach(&global, AttachArgs { session: None })
+        .await
+        .unwrap_err()
+        .to_string();
     assert!(
         err.contains("no sessions exist"),
         "expected a 'no sessions' error, got: {err}"
@@ -457,16 +451,10 @@ async fn attach_with_no_session_errors_when_ambiguous_and_no_input() {
     // resolver, it equals the sessions' project_path above.
     global.repo_dir = Some(cwd.path().to_path_buf());
 
-    let err = cmd_attach(
-        &global,
-        AttachArgs {
-            session: None,
-            command: None,
-        },
-    )
-    .await
-    .unwrap_err()
-    .to_string();
+    let err = cmd_attach(&global, AttachArgs { session: None })
+        .await
+        .unwrap_err()
+        .to_string();
     assert!(
         err.contains("Multiple sessions match"),
         "expected an ambiguity error, got: {err}"

--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -315,7 +315,7 @@ fn stage_self_exe() {
             error = %e,
             path = STAGED_SELF_EXE,
             "could not stage the daemon binary; running a command in a session \
-             (`min session attach -c`) will fail with ENOENT",
+             (`min session exec`) will fail with ENOENT",
         ),
     }
 }

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -232,9 +232,9 @@ test run, a linter) that executes in a freshly composed sandbox built from the
 packages that task needs. If a needed package is not present, Minimal builds it
 or fetches it from a remote cache first. Loadouts contribute to the session's
 interactive shell only, never to tasks, so your personal tooling cannot
-influence a task's deterministic execution. Running `min session attach -c 'min run
-<task>'` is the non-interactive way to trigger a declared task against a
-session; arbitrary commands need an interactive shell.
+influence a task's deterministic execution. Running `min session exec <session> min run
+<task>` is the non-interactive way to trigger a declared task against a
+session.
 
 The through-line: a **session** is the durable, named environment a provider
 hosts; a **sandbox** is the isolated execution context composed from a package

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -306,33 +306,33 @@ t1=$(now_ms)
 echo "warm 'min ls': $((t1 - t0))ms"
 
 # ---------------------------------------------------------------------------
-# Non-interactive exec proof: `min session attach <sid> -c '<cmd>'` runs the
+# Non-interactive exec proof: `min session exec <sid> '<cmd>'` runs the
 # command in the session's namespaces and relays its stdout and exit code. The
 # daemon services this by re-execing ITSELF as the nsenter shim, which is a
 # different path from the interactive attach below and the one that broke in
 # #1175 (in the VM, pid-1's `current_exe()` is the unreachable initramfs
 # `/init`, so every exec died with ENOENT while interactive attach worked).
 # Ordered before the pty proof, which deletes the session.
-echo "::group::session exec proof (min session attach -c)"
+echo "::group::session exec proof (min session exec)"
 # shellcheck disable=SC2016 # $PWD must expand in the SESSION's shell, not here.
-exec_out="$(mnl session attach "$sid" -c 'echo EXEC_OK $PWD' 2>"$WORK/attach-c.err")" || {
-  echo "::error::'min session attach $sid -c' failed"
+exec_out="$(mnl session exec "$sid" 'echo EXEC_OK $PWD' 2>"$WORK/exec.err")" || {
+  echo "::error::'min session exec $sid' failed"
   echo "--- stdout ---"; printf '%s\n' "$exec_out"
-  echo "--- stderr ---"; cat "$WORK/attach-c.err" 2>/dev/null || true
+  echo "--- stderr ---"; cat "$WORK/exec.err" 2>/dev/null || true
   fail
 }
 # The cwd proves it ran in the session's mount namespace, not on the host.
 if [[ "$exec_out" != *"EXEC_OK /workbench"* ]]; then
-  echo "::error::'min session attach -c' did not run in the session (expected 'EXEC_OK /workbench')"
+  echo "::error::'min session exec' did not run in the session (expected 'EXEC_OK /workbench')"
   echo "--- stdout ---"; printf '%s\n' "$exec_out"
-  echo "--- stderr ---"; cat "$WORK/attach-c.err" 2>/dev/null || true
+  echo "--- stderr ---"; cat "$WORK/exec.err" 2>/dev/null || true
   fail
 fi
 # The command's exit code must be the CLI's, not a blanket 0/1.
-mnl session attach "$sid" -c 'exit 7' >/dev/null 2>&1
+mnl session exec "$sid" 'exit 7' >/dev/null 2>&1
 rc=$?
 if [ "$rc" -ne 7 ]; then
-  echo "::error::'min session attach -c \"exit 7\"' exited $rc (expected the command's 7)"
+  echo "::error::'min session exec \"exit 7\"' exited $rc (expected the command's 7)"
   fail
 fi
 echo "session exec proof OK"


### PR DESCRIPTION
 - 💣  `min session attach <sid> -c`
 - Replace with `min session exec <sid> <args>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `min session exec <session> <command...>` for running commands in sessions.
  * Session names and UUIDs support completion for command execution.
  * Commands preserve individual arguments during execution.

* **Changes**
  * Removed the hidden command option from `session attach`; use `session exec` for non-interactive commands.
  * Interactive session attachment behavior remains unchanged.

* **Documentation**
  * Updated session usage guidance and end-to-end examples for the new workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `min session exec` subcommand for non-interactive command execution in sessions
> - Introduces a new `SessionCommand::Exec` variant and `ExecArgs` struct, adding `min session exec <session> <command...>` as a dedicated CLI subcommand for running commands non-interactively in an existing session via SSH.
> - Removes the hidden `command` option from `min session attach`; attach is now purely interactive.
> - Renames `attach_to_session` to `session_via_ssh` in [lib.rs](https://github.com/gominimal/minimal/pull/1186/files#diff-1b62c63af5a5bd2dbc4b550bf4bc6d0fa87e649b54dc3a587da5a8fa947b3ce1), accepting a `Vec<String>` command; when empty, it performs an interactive attach (with TTY check), otherwise a non-interactive exec.
> - Updates `stdout_is_data_contract` in [main.rs](https://github.com/gominimal/minimal/pull/1186/files#diff-2de28b3eedf0f1f33732ac6964440611bf4defeec38486fab74e7eae01823ee5) to treat `session exec` (not `session attach`) as the stdout contract path.
> - Behavioral Change: `min session attach` no longer accepts a command argument; callers must switch to `min session exec`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d65a2d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->