### PR TITLE
chore(deps): update object to 0.40.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,7 @@ dependencies = [
  "lcache",
  "moka",
  "nickel-lang-core",
- "object 0.39.1",
+ "object 0.40.0",
  "op",
  "ot",
  "path-absolutize",
@@ -4670,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+checksum = "dd229a0361b9d0d4396176e02d65897f487eebeab7caa6d443855ee152ca0b9c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,11 +118,7 @@ opentelemetry-semantic-conventions = "0.32"
 # datagram socket and steps CLOCK_REALTIME from the host's updates.
 nix = { version = "0.31", features = ["fs", "sched", "socket", "time", "user"] }
 nutype = { version = "0.7", features = ["serde"] }
-# Held at 0.39: 0.40 turns `Object::exports()`/`imports()` from
-# `Result<Vec<_>>` into lazy `Result<_>`-yielding iterators, so crates/check
-# needs a policy for a per-symbol error mid-scan. A deliberate change, not a
-# version bump.
-object = { version = "0.39", default-features = false, features = ["archive", "elf", "read_core", "std"] }
+object = { version = "0.40", default-features = false, features = ["archive", "elf", "read_core", "std"] }
 oci-spec = "0.10"
 path-absolutize = "4.0"
 rand = "0.10"

--- a/crates/check/src/lib.rs
+++ b/crates/check/src/lib.rs
@@ -275,16 +275,32 @@ impl CheckCache {
                 let elf = object::File::parse(&*data)
                     .map_err(|e| anyhow!("parsing {}: {e}", full_path.display()))?;
 
-                let exports = elf.exports().unwrap();
-                let likely_glibc_stub_lib = exports.iter().any(|e| {
-                    e.name().ends_with(b"__libpthread_version_placeholder")
-                        || e.name().ends_with(b"__libdl_version_placeholder")
-                        || e.name().ends_with(b"__librt_version_placeholder")
+                // `exports()` is a lazy iterator that reports per-export parse
+                // errors as items, and it re-parses the export tables on every
+                // call, so collect once. A dropped export would surface as a
+                // bogus "missing symbol" against every dependent of this
+                // library, so a bad entry fails the whole lookup instead.
+                let exports = elf
+                    .exports()
+                    .and_then(|exports| exports.collect::<Result<Vec<_>, _>>())
+                    .map_err(|e| anyhow!("reading exports of {}: {e}", full_path.display()))?;
+                // `name()` is a name-or-ordinal: exporting by ordinal is a PE
+                // concept, and such an export carries no name for a dependent
+                // to link against, so it is not a symbol we can record.
+                let export_names: Vec<&[u8]> = exports
+                    .iter()
+                    .filter_map(|e| e.name().into_name())
+                    .collect();
+
+                let likely_glibc_stub_lib = export_names.iter().any(|name| {
+                    name.ends_with(b"__libpthread_version_placeholder")
+                        || name.ends_with(b"__libdl_version_placeholder")
+                        || name.ends_with(b"__librt_version_placeholder")
                 });
 
-                let mut symbols: HashSet<String> = exports
+                let mut symbols: HashSet<String> = export_names
                     .iter()
-                    .map(|e| String::from_utf8(e.name().to_vec()).unwrap())
+                    .map(|name| String::from_utf8(name.to_vec()).unwrap())
                     .chain(elf.dynamic_symbols().map(|s| s.name().unwrap().to_string()))
                     .collect();
 

--- a/crates/check/src/outputs.rs
+++ b/crates/check/src/outputs.rs
@@ -213,9 +213,30 @@ impl crate::GraphBasedChecker for MissingRuntimeDeps {
                         && let Ok(imports) = elf.imports()
                     {
                         let path_in_build = path.strip_prefix(cached_build.path()).unwrap();
-                        for import in imports.iter() {
+                        // `imports()` is a lazy iterator that reports per-import
+                        // parse errors as items. A malformed entry only costs us
+                        // one symbol's worth of coverage, so — like the
+                        // unparseable-import-table case above — skip it and keep
+                        // scanning rather than failing the whole check.
+                        for import in imports {
+                            let import = match import {
+                                Ok(import) => import,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        path = %path.display(),
+                                        "skipping unparseable import: {e}"
+                                    );
+                                    continue;
+                                }
+                            };
+                            // `name()` is a name-or-ordinal: importing by ordinal
+                            // is a PE concept, and there is no symbol name for
+                            // us to resolve against a dependency's exports.
+                            let Some(symbol_name) = import.name().into_name() else {
+                                continue;
+                            };
                             let lib = String::from_utf8(import.library().to_vec()).unwrap();
-                            let symbol = String::from_utf8(import.name().to_vec()).unwrap();
+                            let symbol = String::from_utf8(symbol_name.to_vec()).unwrap();
                             if lib.is_empty() {
                                 continue;
                             }


### PR DESCRIPTION
Needed to unblock dependabot https://github.com/gominimal/minimal/pull/1189 due to API change

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `object` dependency to 0.40.0 with safer import and export parsing
> - Updates the `object` crate from 0.39 to 0.40 in [Cargo.toml](https://github.com/gominimal/minimal/pull/1191/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542), removing the pinned-version comment.
> - Updates `lib_symbols` in [check/src/lib.rs](https://github.com/gominimal/minimal/pull/1191/files#diff-0957a64c4befe2db24c6a2061c084b5d1982c281192cab757007c656e057ca0f) to collect exports eagerly, propagate parse errors as `anyhow` errors instead of panicking, and drop ordinal-only exports via `into_name()`.
> - Updates `MissingRuntimeDeps::check` in [check/src/outputs.rs](https://github.com/gominimal/minimal/pull/1191/files#diff-5c4d83769915978fd5e6ce9707fc6d4f153678ba47063b5efc6d3be84dd13fb8) to iterate the lazy imports iterator, skip malformed entries with a warning, and ignore ordinal-only imports via `into_name()`.
> - Behavioral Change: `lib_symbols` now returns an error on export parse failure (previously panicked); both methods now silently drop ordinal-only symbols.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80986ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with updated binary parsing dependencies.
  - ELF export validation now handles malformed entries without crashing and ignores unnamed ordinal-only exports.
  - Dependency checks now continue when encountering malformed or unresolved imports, while still validating named imports.
  - Improved detection of relevant runtime symbols in supported binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->