### PR TITLE
feat: make session detach key configurable (ctrl-] then d)

### DIFF
--- a/crates/common/fuzz/fuzz_targets/normalize_within_root.rs
+++ b/crates/common/fuzz/fuzz_targets/normalize_within_root.rs
@@ -1,13 +1,12 @@
 #![no_main]
 
-//! Fuzz `archive::normalize_within_root` — the containment primitive three
+//! Fuzz `archive::normalize_within_root` — the containment primitive two
 //! crates now depend on.
 //!
-//! `common::archive` uses it for tar entry paths and link targets,
+//! `common::archive` uses it for tar entry paths and link targets, and
 //! `op::materialize` for raw-file outputs ("both `../../etc/shadow` and
-//! `/../../etc/shadow` land here"), and `minimald` for the client's uploaded
-//! workspace tarball. Each trusts the same contract, so a gap here is a gap
-//! in all three at once — and none of them re-checks the result.
+//! `/../../etc/shadow` land here"). Each trusts the same contract, so a gap
+//! here is a gap in both at once — and neither re-checks the result.
 //!
 //! Fuzzed directly rather than only through `archive_extract` because it is a
 //! pure function: no tempdir, no extraction, so it runs orders of magnitude

--- a/crates/minimal-client/src/attach.rs
+++ b/crates/minimal-client/src/attach.rs
@@ -4,24 +4,9 @@
 //! command, replacing itself) and the `min dash` TUI (which spawns it as a
 //! child while the TUI is suspended and resumes when ssh exits).
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Context as _;
-
-/// Resolve the minimal config directory: `<config_dir>/minimal` when an
-/// override is given, else the platform default
-/// ([`paths::minimal_config_dir`]). The base under which `config.toml`,
-/// `loadouts/`, etc. live.
-pub fn minimal_config_dir(config_dir: Option<&Path>) -> PathBuf {
-    if let Some(dir) = config_dir {
-        dir.join("minimal")
-    } else {
-        paths::minimal_config_dir()
-            .as_utf8_path()
-            .as_std_path()
-            .to_path_buf()
-    }
-}
 
 /// Read and validate the session-key config, returning the resolved
 /// [`sessions::keys::SessionKeys`] to negotiate at attach. A missing config
@@ -35,7 +20,7 @@ pub fn minimal_config_dir(config_dir: Option<&Path>) -> PathBuf {
 pub fn resolve_session_keys(
     config_dir: Option<&Path>,
 ) -> Result<sessions::keys::SessionKeys, anyhow::Error> {
-    let cfg_path = minimal_config_dir(config_dir).join("config.toml");
+    let cfg_path = paths::minimal_config_dir_with_override(config_dir).join("config.toml");
     let cfg = sessions::client::config::read_config_or_default(&cfg_path)
         .map_err(|e| anyhow::anyhow!("reading session-keys config {cfg_path:?}: {e}"))?;
     cfg.session_keys

--- a/crates/minimal-client/src/attach.rs
+++ b/crates/minimal-client/src/attach.rs
@@ -4,9 +4,44 @@
 //! command, replacing itself) and the `min dash` TUI (which spawns it as a
 //! child while the TUI is suspended and resumes when ssh exits).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
+
+/// Resolve the minimal config directory: `<config_dir>/minimal` when an
+/// override is given, else the platform default
+/// ([`paths::minimal_config_dir`]). The base under which `config.toml`,
+/// `loadouts/`, etc. live.
+pub fn minimal_config_dir(config_dir: Option<&Path>) -> PathBuf {
+    if let Some(dir) = config_dir {
+        dir.join("minimal")
+    } else {
+        paths::minimal_config_dir()
+            .as_utf8_path()
+            .as_std_path()
+            .to_path_buf()
+    }
+}
+
+/// Read and validate the session-key config, returning the resolved
+/// [`sessions::keys::SessionKeys`] to negotiate at attach. A missing config
+/// file yields the shipped defaults; a present-but-invalid one (e.g. a
+/// termios-special leader) surfaces its error loudly so the user fixes the
+/// config rather than silently attaching with the wrong chord.
+///
+/// Only the interactive attach path needs the keys (non-interactive exec
+/// channels have no detach); callers pass `None` to [`attach_command`] for
+/// those.
+pub fn resolve_session_keys(
+    config_dir: Option<&Path>,
+) -> Result<sessions::keys::SessionKeys, anyhow::Error> {
+    let cfg_path = minimal_config_dir(config_dir).join("config.toml");
+    let cfg = sessions::client::config::read_config_or_default(&cfg_path)
+        .map_err(|e| anyhow::anyhow!("reading session-keys config {cfg_path:?}: {e}"))?;
+    cfg.session_keys
+        .to_session_keys()
+        .map_err(|e| anyhow::anyhow!("invalid session-keys config: {e}"))
+}
 
 /// Shell-quote a string for safe interpolation into `sh -c`.
 pub fn shell_quote(s: &str) -> String {
@@ -62,10 +97,17 @@ pub fn host_key_opts(known_hosts: &Path) -> [String; 2] {
 /// ssh handles termios/PTY management. The caller decides how to run the
 /// command: `min session attach` `exec()`s it, `min dash` spawns it as a
 /// child while suspended.
+///
+/// `session_keys` negotiates the configurable detach/forward chord per
+/// channel: when `Some`, each resolved key is sent as an env var (with a
+/// matching `SendEnv` option) the daemon reads back alongside
+/// `MINIMAL_SESSION_ID` and re-validates as a silent backstop. Pass `None`
+/// for non-interactive exec channels, which have no detach.
 pub fn attach_command(
     sock: &Path,
     id: sessions::SessionId,
     wire: Option<&str>,
+    session_keys: Option<&sessions::keys::SessionKeys>,
 ) -> Result<std::process::Command, anyhow::Error> {
     // ProxyCommand points at our own `proxy` subcommand so we don't
     // depend on socat or nc being installed.
@@ -87,7 +129,8 @@ pub fn attach_command(
     // full-path `min proxy …` that needs nothing but a POSIX `sh`, so force the
     // always-present `/bin/sh` rather than inherit the user's interactive shell.
     ssh.env("SHELL", "/bin/sh");
-    ssh.env("MINIMAL_SESSION_ID", id.to_string()).args([
+    ssh.env("MINIMAL_SESSION_ID", id.to_string());
+    ssh.args([
         "-o",
         "SendEnv=MINIMAL_SESSION_ID",
         // Forward the user's locale and timezone into the session, mirroring a
@@ -107,6 +150,37 @@ pub fn attach_command(
         "-o",
         &known_hosts_file,
     ]);
+    // Negotiate the session-key config per channel: send each resolved key
+    // as an env var the daemon reads back (alongside MINIMAL_SESSION_ID) and
+    // re-validates as a silent backstop. ssh's `SendEnv` forwards a var only
+    // when it's present in the child environment, so each `SendEnv` option is
+    // paired with its `env` set above. Only the interactive attach path sends
+    // these — exec/task channels pass `None`.
+    if let Some(keys) = session_keys {
+        ssh.env(sessions::keys::LEADER_ENV, keys.leader.as_config_str())
+            .env(
+                sessions::keys::DETACH_KEY_ENV,
+                keys.detach_key.as_config_str(),
+            )
+            .env(
+                sessions::keys::FORWARD_KEY_ENV,
+                keys.forward_key.as_config_str(),
+            )
+            .env(
+                sessions::keys::BELL_ENV,
+                if keys.bell_on_leader { "1" } else { "0" },
+            )
+            .args([
+                "-o",
+                &format!("SendEnv={}", sessions::keys::LEADER_ENV),
+                "-o",
+                &format!("SendEnv={}", sessions::keys::DETACH_KEY_ENV),
+                "-o",
+                &format!("SendEnv={}", sessions::keys::FORWARD_KEY_ENV),
+                "-o",
+                &format!("SendEnv={}", sessions::keys::BELL_ENV),
+            ]);
+    }
 
     // The interactive path opens the in-sandbox session shell via the daemon's
     // `shell_request`, which requires a PTY. Force one with `-tt` so ssh
@@ -182,7 +256,7 @@ mod tests {
     #[test]
     fn attach_command_targets_the_provider_alias() {
         let sock = PathBuf::from("/tmp/x/providers/local-minimald0/ssh.sock");
-        let cmd = attach_command(&sock, sessions::SessionId::nil(), None).unwrap();
+        let cmd = attach_command(&sock, sessions::SessionId::nil(), None, None).unwrap();
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
@@ -199,7 +273,7 @@ mod tests {
     fn attach_command_with_exec_has_no_forced_pty() {
         let sock = PathBuf::from("/tmp/x/providers/local-minvmd0/ssh.sock");
         let wire = remote_command(&["min".to_string(), "run".to_string(), "test".to_string()]);
-        let cmd = attach_command(&sock, sessions::SessionId::nil(), wire.as_deref()).unwrap();
+        let cmd = attach_command(&sock, sessions::SessionId::nil(), wire.as_deref(), None).unwrap();
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
@@ -264,6 +338,104 @@ mod tests {
                 "min --version".to_string()
             ))
         );
+    }
+
+    /// The interactive attach path negotiates the session-key config: each
+    /// resolved key is set on the child env with a matching `SendEnv` option
+    /// so the daemon adopts the user's chord for that channel.
+    #[test]
+    fn attach_command_negotiates_session_keys_when_given() {
+        let sock = PathBuf::from("/tmp/x/providers/local-minimald0/ssh.sock");
+        let keys = sessions::keys::SessionKeys::default();
+        let cmd = attach_command(&sock, sessions::SessionId::nil(), None, Some(&keys)).unwrap();
+
+        let env: std::collections::HashMap<String, String> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| {
+                v.map(|v| {
+                    (
+                        k.to_string_lossy().into_owned(),
+                        v.to_string_lossy().into_owned(),
+                    )
+                })
+            })
+            .collect();
+        assert_eq!(
+            env.get(sessions::keys::LEADER_ENV).map(String::as_str),
+            Some("ctrl-]")
+        );
+        assert_eq!(
+            env.get(sessions::keys::DETACH_KEY_ENV).map(String::as_str),
+            Some("d")
+        );
+        assert_eq!(
+            env.get(sessions::keys::FORWARD_KEY_ENV).map(String::as_str),
+            Some("ctrl-]")
+        );
+        assert_eq!(
+            env.get(sessions::keys::BELL_ENV).map(String::as_str),
+            Some("0")
+        );
+
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        for name in [
+            sessions::keys::LEADER_ENV,
+            sessions::keys::DETACH_KEY_ENV,
+            sessions::keys::FORWARD_KEY_ENV,
+            sessions::keys::BELL_ENV,
+        ] {
+            assert!(
+                args.iter().any(|a| a == format!("SendEnv={name}").as_str()),
+                "missing SendEnv={name} in {args:?}",
+            );
+        }
+    }
+
+    /// Passing no session keys (`None`) sets no session-key env vars and asks
+    /// ssh to forward none: exec channels have no detach chord.
+    #[test]
+    fn attach_command_omits_session_keys_when_none() {
+        let sock = PathBuf::from("/tmp/x/providers/local-minimald0/ssh.sock");
+        let cmd = attach_command(&sock, sessions::SessionId::nil(), None, None).unwrap();
+
+        let env: std::collections::HashMap<String, String> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| {
+                v.map(|v| {
+                    (
+                        k.to_string_lossy().into_owned(),
+                        v.to_string_lossy().into_owned(),
+                    )
+                })
+            })
+            .collect();
+        for name in [
+            sessions::keys::LEADER_ENV,
+            sessions::keys::DETACH_KEY_ENV,
+            sessions::keys::FORWARD_KEY_ENV,
+            sessions::keys::BELL_ENV,
+        ] {
+            assert!(!env.contains_key(name), "{name} should not be set for exec");
+        }
+
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        for name in [
+            sessions::keys::LEADER_ENV,
+            sessions::keys::DETACH_KEY_ENV,
+            sessions::keys::FORWARD_KEY_ENV,
+            sessions::keys::BELL_ENV,
+        ] {
+            assert!(
+                !args.iter().any(|a| a == format!("SendEnv={name}").as_str()),
+                "SendEnv={name} should not appear for exec in {args:?}",
+            );
+        }
     }
 
     /// A VM-backed provider dir carries the guest's recorded host key, so

--- a/crates/minimal-tui/src/app.rs
+++ b/crates/minimal-tui/src/app.rs
@@ -815,6 +815,10 @@ fn fetch_focused(model: &Model) -> Vec<Effect> {
 pub struct DashOptions {
     /// `--minimal-dir` override; `None` uses the platform default state dir.
     pub minimal_dir: Option<PathBuf>,
+    /// `--config-dir` override; `None` uses the platform default config dir.
+    /// Resolved into session keys at attach so a dash-attach honors the
+    /// `[session-keys]` config just like `min session attach`.
+    pub config_dir: Option<PathBuf>,
     /// The loadout contribution the CLI composed at startup (default
     /// loadouts + user policy), re-sent with every create so `n` in dash
     /// matches `min session activate`. Composition needs the CLI crate's
@@ -893,7 +897,13 @@ pub async fn run(opts: DashOptions) -> Result<(), anyhow::Error> {
                 Effect::Attach(key) => match providers.iter().find(|p| p.label == key.provider) {
                     Some(p) => {
                         let sock = p.sock.clone();
-                        attach_and_resume(&mut terminal, &sock, key.id, &mut model);
+                        attach_and_resume(
+                            &mut terminal,
+                            &sock,
+                            key.id,
+                            opts.config_dir.as_deref(),
+                            &mut model,
+                        );
                         inbox.push_back(Msg::Tick);
                     }
                     None => {
@@ -1067,23 +1077,34 @@ async fn exec_effect(
 }
 
 /// Suspend the TUI, attach to the session over ssh (blocking until the user
-/// detaches), then resume. The daemon recognizes `Ctrl-W` as detach.
+/// detaches), then resume. The session-key config is resolved from
+/// `config_dir` so the daemon adopts the user's detach/forward chord; a bad
+/// config is reported in the status bar rather than aborting the TUI.
 fn attach_and_resume(
     terminal: &mut TerminalGuard,
     sock: &std::path::Path,
     id: SessionId,
+    config_dir: Option<&std::path::Path>,
     model: &mut Model,
 ) {
-    let result = minimal_client::attach::attach_command(sock, id, None).and_then(|mut cmd| {
-        terminal.suspend();
-        let status = cmd.status();
-        // A failed resume leaves the TUI unusable; report it over the
-        // attach outcome.
-        terminal
-            .resume()
-            .context("restoring terminal after detach")?;
-        status.context("running ssh attach")
-    });
+    let session_keys = match minimal_client::attach::resolve_session_keys(config_dir) {
+        Ok(keys) => Some(keys),
+        Err(e) => {
+            model.status = Some(format!("error: {e:#}"));
+            return;
+        }
+    };
+    let result = minimal_client::attach::attach_command(sock, id, None, session_keys.as_ref())
+        .and_then(|mut cmd| {
+            terminal.suspend();
+            let status = cmd.status();
+            // A failed resume leaves the TUI unusable; report it over the
+            // attach outcome.
+            terminal
+                .resume()
+                .context("restoring terminal after detach")?;
+            status.context("running ssh attach")
+        });
     match result {
         Ok(status) => {
             model.status = Some(match status.code() {

--- a/crates/minimal/src/config.rs
+++ b/crates/minimal/src/config.rs
@@ -11,10 +11,10 @@ use crate::GlobalArgs;
 /// Resolve `<config>/minimal` on the platform's user config dir,
 /// or the `--config-dir` override if the caller passed one. The
 /// base for both the loadouts subdir and the client config file.
-/// Delegates to the `minimal-client` resolution the attach path
-/// uses, so the two can never drift.
+/// Delegates to `paths::minimal_config_dir_with_override`, which the
+/// attach path also uses, so every reader sees the same layout.
 pub fn resolve_minimal_config_dir(global: &GlobalArgs) -> PathBuf {
-    minimal_client::attach::minimal_config_dir(global.config_dir.as_deref())
+    paths::minimal_config_dir_with_override(global.config_dir.as_deref())
 }
 
 /// Read the client config once, so both loadout resolution and

--- a/crates/minimal/src/config.rs
+++ b/crates/minimal/src/config.rs
@@ -11,14 +11,10 @@ use crate::GlobalArgs;
 /// Resolve `<config>/minimal` on the platform's user config dir,
 /// or the `--config-dir` override if the caller passed one. The
 /// base for both the loadouts subdir and the client config file.
+/// Delegates to the `minimal-client` resolution the attach path
+/// uses, so the two can never drift.
 pub fn resolve_minimal_config_dir(global: &GlobalArgs) -> PathBuf {
-    if let Some(dir) = &global.config_dir {
-        return dir.join("minimal");
-    }
-    paths::minimal_config_dir()
-        .as_utf8_path()
-        .as_std_path()
-        .to_path_buf()
+    minimal_client::attach::minimal_config_dir(global.config_dir.as_deref())
 }
 
 /// Read the client config once, so both loadout resolution and

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -983,7 +983,7 @@ async fn cmd_bare(global: &GlobalArgs) -> Result<(), anyhow::Error> {
                 session_name = ?entry.name,
                 "found session"
             );
-            session_via_ssh(&sock, entry.id, None).await
+            session_via_ssh(&sock, entry.id, None, global.config_dir.as_deref()).await
         }
         // Two ways to land on create-and-attach: no sessions exist at all
         // (first run), or the ambiguity picker's `+ Create a new session`
@@ -1461,6 +1461,7 @@ pub async fn cmd_dash(global: &GlobalArgs) -> Result<(), anyhow::Error> {
         loadouts::compose_user_contribution(active, user_policy, compose_options, true)?;
     minimal_tui::run(minimal_tui::DashOptions {
         minimal_dir: global.minimal_dir.clone(),
+        config_dir: global.config_dir.clone(),
         contribution,
     })
     .await
@@ -2625,7 +2626,7 @@ pub async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), any
         "found session"
     );
 
-    session_via_ssh(&sock, id, None).await
+    session_via_ssh(&sock, id, None, global.config_dir.as_deref()).await
 }
 
 /// Executes a command in an existing session.
@@ -2656,6 +2657,7 @@ pub async fn cmd_exec(global: &GlobalArgs, args: ExecArgs) -> Result<(), anyhow:
         &sock,
         r.id,
         minimal_client::attach::remote_command(&args.command),
+        None,
     )
     .await
 }
@@ -2692,6 +2694,7 @@ pub async fn cmd_session_run(
         &sock,
         r.id,
         Some(minimald_rpc::exec::ExecRequest::TaskRun(args.task).encode()),
+        None,
     )
     .await
 }
@@ -2801,14 +2804,28 @@ fn ensure_interactive_attach_tty(stdin_is_tty: bool) -> Result<(), anyhow::Error
 /// Split from [`cmd_attach`] so the activate-then-attach chain and the
 /// smart-resolution picker can attach without re-resolving an entry they
 /// already hold.
+///
+/// The interactive path (no `wire`) negotiates the configurable session
+/// keys from `config_dir` so the daemon adopts the user's detach/forward
+/// chord for that channel; the exec path (`wire` set) has no detach
+/// and sends none.
 async fn session_via_ssh(
     sock: &std::path::Path,
     id: sessions::SessionId,
     wire: Option<String>,
+    config_dir: Option<&std::path::Path>,
 ) -> Result<(), anyhow::Error> {
     // The command itself lives in minimal-client, shared with the dash TUI's
-    // suspend-attach-resume flow.
-    let mut ssh = minimal_client::attach::attach_command(sock, id, wire.as_deref())?;
+    // suspend-attach-resume flow. The interactive path resolves the
+    // session-key config from `config_dir` and forwards it per channel; the
+    // exec path has no detach and passes `None`.
+    let session_keys = if wire.is_none() {
+        Some(minimal_client::attach::resolve_session_keys(config_dir)?)
+    } else {
+        None
+    };
+    let mut ssh =
+        minimal_client::attach::attach_command(sock, id, wire.as_deref(), session_keys.as_ref())?;
 
     // `-tt` over a *non-terminal* stdin is a trap: ssh still forces the
     // remote PTY, yet the interactive shell reading it never sees an EOF from a

--- a/crates/minimal/src/loadouts.rs
+++ b/crates/minimal/src/loadouts.rs
@@ -79,7 +79,7 @@ description = "orientation banner and shaped prompt"
 PROMPT_COMMAND = 'eval "$MINIMAL_MOTD"; unset PROMPT_COMMAND MINIMAL_MOTD'
 PS1 = 'minimal:\w\$ '
 MINIMAL_MOTD = '''
-[ -t 1 ] && { printf '\n     ████  ████▄\n  ▄▄▄ ▀███▄ ▀███▄\n  ▀███  ▀███  ▀███\n\n'; printf '  minimal · session %s · loadout %s\n  detach: ctrl-w' "${MINIMAL_SESSION_NAME:-unnamed}" "${MINIMAL_LOADOUTS:-default (built-in)}"; [ -f /workbench/minimal.toml ] || [ -f /workbench/.minimal/minimal.toml ] || printf ' · no minimal.toml here — min init to add one'; printf '\n\n  Add tools to this box:   min add --session <pkg>\n  Search the registry:     min search <query>\n\n'; }
+[ -t 1 ] && { printf '\n     ████  ████▄\n  ▄▄▄ ▀███▄ ▀███▄\n  ▀███  ▀███  ▀███\n\n'; printf '  minimal · session %s · loadout %s\n  detach: %s' "${MINIMAL_SESSION_NAME:-unnamed}" "${MINIMAL_LOADOUTS:-default (built-in)}" "${MINIMAL_DETACH_HINT:-ctrl-] then d}"; [ -f /workbench/minimal.toml ] || [ -f /workbench/.minimal/minimal.toml ] || printf ' · no minimal.toml here — min init to add one'; printf '\n\n  Add tools to this box:   min add --session <pkg>\n  Search the registry:     min search <query>\n\n'; }
 '''
 "#;
 
@@ -889,7 +889,8 @@ on_activate = { type = "inline", value = "sleep 90", timeout = 90 }
             !motd.contains("MINIMAL_BLUEPRINT"),
             "blueprint is a session-filesystem fact, not an env var"
         );
-        assert!(motd.contains("detach: ctrl-w"));
+        assert!(motd.contains("detach: %s"));
+        assert!(motd.contains("${MINIMAL_DETACH_HINT:-ctrl-] then d}"));
         assert!(motd.contains("min init"));
     }
 

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -15,6 +15,7 @@ use mctx::ConfigBuilder;
 use ot::OpTracker;
 use paths::DaemonAbsPath;
 use russh::{Channel, server::Msg};
+use sessions::keys::SessionKeys;
 use sessions::wire::request::ContributionResponse;
 use sessions::{
     Record, SessionStatus,
@@ -248,8 +249,11 @@ pub(crate) fn registry_name(record: &Record) -> String {
 /// The server-side `AcceptEnv` allowlist: locale and timezone vars a client is
 /// permitted to forward from its shell into the session (OpenSSH's default
 /// `AcceptEnv LANG LC_*`, plus `TZ`). Everything else the client set on the
-/// channel — e.g. `MINIMAL_SESSION_ID`, `TRACEPARENT` — is control plumbing and
-/// must not leak into the shell environment, so it is filtered out here.
+/// channel — e.g. `MINIMAL_SESSION_ID`, `TRACEPARENT`, and the session-key
+/// negotiation vars in `sessions::keys` (`LEADER_ENV`, `DETACH_KEY_ENV`,
+/// `FORWARD_KEY_ENV`, `BELL_ENV`) — is control plumbing read by the daemon's
+/// `shell_request` (and re-validated as a backstop) and must not leak into the
+/// shell environment, so it is filtered out here.
 fn inherited_session_env(
     channel_env: &std::collections::BTreeMap<String, String>,
 ) -> Vec<(String, String)> {
@@ -1665,14 +1669,21 @@ impl Session {
         // Capture the environment this attach contributes to the shell it may
         // mint: the locale/timezone vars the client forwarded (folded as
         // defaults below the composition) and the per-connection facts folded
-        // above it. Currently the only connection fact is `TERM`, from the
-        // client's PTY request.
+        // above it — `TERM` from the client's PTY request, and the banner's
+        // detach hint derived from the negotiated keys below.
         //
         // `SSH_TTY` and `SSH_CONNECTION`/`SSH_CLIENT` are intentionally omitted:
         // the session sandbox has no host `/dev/pts` and the transport is a
         // local Unix socket (no peer IP/port), so any value would name something
         // that doesn't exist in-session and would only mislead audit logs,
         // source-IP checks, or `$SSH_TTY` consumers.
+        // The negotiated session keys: the leader chord and detach/forward
+        // subcommand keys the client sent on this channel, re-validated here as
+        // a silent safety backstop (a bad chord falls back to the default,
+        // never garbling the screen). Per-channel: two clients with different
+        // configs on the same session each get their own chord.
+        let session_keys = SessionKeys::from_env(&config.env_vars).validated_or_default();
+
         let attach_env = {
             let inherited = inherited_session_env(&config.env_vars);
             let mut connection = Vec::new();
@@ -1696,6 +1707,20 @@ impl Session {
                      keeping the last published TERM"
                 ),
             }
+            // The orientation banner's detach hint: derived from the negotiated
+            // keys so a remapped leader/detach chord advertises itself. Seeded
+            // daemon-side (like MINIMAL_SESSION_NAME), never forwarded from the
+            // client — the client sends raw key names, the daemon builds the
+            // display string. The MOTD template interpolates this with a
+            // `${VAR:-fallback}` so an unset var (no negotiation) still renders.
+            connection.push((
+                "MINIMAL_DETACH_HINT".to_string(),
+                format!(
+                    "{} then {}",
+                    session_keys.leader.as_config_str(),
+                    session_keys.detach_key.as_config_str(),
+                ),
+            ));
             session_host::AttachEnv {
                 inherited,
                 connection,
@@ -1795,7 +1820,7 @@ impl Session {
         // improve `TERM` is a bad trade. That case rides on the per-attach
         // environment the host republishes instead.
         let respawn_for_terminal =
-            self.host_origin == HostOrigin::Hooks && !attach_env.connection.is_empty();
+            self.host_origin == HostOrigin::Hooks && attach_env.declares_terminal();
         if respawn_for_terminal
             && let SessionInner::Active {
                 host: slot @ Some(_),
@@ -1818,19 +1843,36 @@ impl Session {
         };
         match host {
             None => {
-                self.mint_session_host(session_hnd, conn_username, channel, sz, attach_env)
-                    .await
+                self.mint_session_host(
+                    session_hnd,
+                    conn_username,
+                    channel,
+                    sz,
+                    attach_env,
+                    session_keys,
+                )
+                .await
             }
             Some((h, _)) => {
                 // Every attach carries the connection facts, not just the one
                 // that mints the shell: `TERM` describes whichever terminal is
                 // on the other end of *this* channel.
-                match h.attach(channel, sz, attach_env.connection_env()).await {
+                match h
+                    .attach(channel, sz, attach_env.connection_env(), session_keys)
+                    .await
+                {
                     Ok(()) => Ok(()),
                     Err((channel, sz)) => {
                         // session host is dead
-                        self.mint_session_host(session_hnd, conn_username, channel, sz, attach_env)
-                            .await
+                        self.mint_session_host(
+                            session_hnd,
+                            conn_username,
+                            channel,
+                            sz,
+                            attach_env,
+                            session_keys,
+                        )
+                        .await
                     }
                 }
             }
@@ -2046,6 +2088,7 @@ impl Session {
         channel: Channel<Msg>,
         sz: WinSize,
         attach_env: session_host::AttachEnv,
+        session_keys: SessionKeys,
     ) -> Result<(), AttachError> {
         let progress = ChannelProgress::new(channel, self.tracker.clone(), (sz.cols, sz.rows));
         let (channel, launched) = self
@@ -2070,7 +2113,12 @@ impl Session {
         // them, and an empty map means "no revision", not "no terminal".
         launched
             .0
-            .attach(channel, sz, session_host::ConnectionEnv::new())
+            .attach(
+                channel,
+                sz,
+                session_host::ConnectionEnv::new(),
+                session_keys,
+            )
             .await
             .map_err(|_| {
                 AttachError::SpawnFailed(std::io::Error::other(
@@ -3841,12 +3889,13 @@ mod tests {
         );
     }
 
-    /// The ctrl-w detach chord (a single `0x17` byte) detaches the current
+    /// The detach chord (leader `ctrl-]` then `d`) detaches the current
     /// channel — sending a detach notice down it before it closes — without
     /// tearing the session down, so a later channel resumes it (the earlier
-    /// `got:hello` is flushed on reattach).
+    /// `got:hello` is flushed on reattach). The default keys apply because the
+    /// test's `open_shell` sends no session-key env vars.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn ctrl_w_detaches_channel_then_session_resumes_on_reattach() {
+    async fn detach_chord_detaches_channel_then_session_resumes_on_reattach() {
         let server = TestServer::new().await;
         let mut client = server.connect().await;
         let session_id = create_session(&mut client).await;
@@ -3872,9 +3921,11 @@ mod tests {
             }
         }
 
-        // Send the detach chord. The host writes a detach notice down the
-        // channel and then closes it.
-        first.data_bytes(vec![0x17]).await.unwrap();
+        // Send the detach chord as two separate chunks — the leader (0x1d)
+        // enters command mode (swallowed), then `d` detaches. Sent separately
+        // so the state machine sees each as its own keystroke, not a paste.
+        first.data_bytes(vec![0x1d]).await.unwrap();
+        first.data_bytes(vec![b'd']).await.unwrap();
         let mut detach_out = Vec::new();
         let mut first_closed = false;
         while let Ok(msg) = tokio::time::timeout(Duration::from_secs(5), first.wait()).await {
@@ -3889,7 +3940,7 @@ mod tests {
         }
         let detach_out = String::from_utf8_lossy(&detach_out);
         assert!(
-            detach_out.contains("Detaching due to ctrl-w."),
+            detach_out.contains("Detaching from session."),
             "expected a detach notice on the channel before it closed, got: {detach_out:?}",
         );
         assert!(first_closed, "channel should close after the detach chord");
@@ -3911,6 +3962,77 @@ mod tests {
         assert!(
             flushed.contains("got:hello"),
             "reattaching should flush prior terminal state, got: {flushed:?}",
+        );
+    }
+
+    /// A remapped leader (negotiated via env vars at attach) is honored: the
+    /// old default leader (`ctrl-]`, `0x1d`) no longer detaches — it forwards to
+    /// the shell — while the remapped leader (`ctrl-^`, `0x1e`) then the
+    /// remapped detach key (`x`) does. Proves the per-channel negotiation and
+    /// the dynamic matcher end-to-end through the real attach path.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn remapped_leader_detaches_old_leader_forwards() {
+        use sessions::keys::{DETACH_KEY_ENV, LEADER_ENV};
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        // Attach with a remapped leader (ctrl-^) and detach key (x).
+        let mut ch = client
+            .open_shell_with_keys(session_id, &[(LEADER_ENV, "ctrl-^"), (DETACH_KEY_ENV, "x")])
+            .await;
+
+        // The old default leader (0x1d, ctrl-]) must no longer detach: it
+        // forwards to the shell. Send it, then a normal line; the shell echoes
+        // both back, proving the channel survived (no detach fired).
+        ch.data_bytes(vec![0x1d]).await.unwrap();
+        ch.data_bytes(b"ping\n".to_vec()).await.unwrap();
+        let mut out = Vec::new();
+        loop {
+            match tokio::time::timeout(Duration::from_secs(5), ch.wait()).await {
+                Ok(Some(ChannelMsg::Data { data })) => {
+                    out.extend_from_slice(&data);
+                    if String::from_utf8_lossy(&out).contains("got:") {
+                        break;
+                    }
+                }
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    let out = String::from_utf8_lossy(&out);
+                    panic!(
+                        "channel closed after the old leader; it should have forwarded, got: {out:?}"
+                    );
+                }
+                Err(_) => panic!("timed out waiting for echo after the old leader"),
+            }
+        }
+
+        // The remapped leader (0x1e, ctrl-^) enters command mode (swallowed),
+        // then `x` detaches. Two separate chunks so the state machine sees each
+        // as its own keystroke.
+        ch.data_bytes(vec![0x1e]).await.unwrap();
+        ch.data_bytes(vec![b'x']).await.unwrap();
+        let mut detach_out = Vec::new();
+        let mut closed = false;
+        while let Ok(msg) = tokio::time::timeout(Duration::from_secs(5), ch.wait()).await {
+            match msg {
+                Some(ChannelMsg::Data { data }) => detach_out.extend_from_slice(&data),
+                Some(_) => {}
+                None => {
+                    closed = true;
+                    break;
+                }
+            }
+        }
+        let detach_out = String::from_utf8_lossy(&detach_out);
+        assert!(
+            detach_out.contains("Detaching from session."),
+            "remapped chord should detach, got: {detach_out:?}",
+        );
+        assert!(
+            closed,
+            "channel should close after the remapped detach chord"
         );
     }
 

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -3922,8 +3922,9 @@ mod tests {
         }
 
         // Send the detach chord as two separate chunks — the leader (0x1d)
-        // enters command mode (swallowed), then `d` detaches. Sent separately
-        // so the state machine sees each as its own keystroke, not a paste.
+        // enters command mode (swallowed), then `d` detaches. (The streaming
+        // matcher also handles the two bytes coalesced into one chunk; split
+        // sends exercise the cross-chunk pending path instead.)
         first.data_bytes(vec![0x1d]).await.unwrap();
         first.data_bytes(vec![b'd']).await.unwrap();
         let mut detach_out = Vec::new();
@@ -4009,8 +4010,9 @@ mod tests {
         }
 
         // The remapped leader (0x1e, ctrl-^) enters command mode (swallowed),
-        // then `x` detaches. Two separate chunks so the state machine sees each
-        // as its own keystroke.
+        // then `x` detaches — sent as two separate chunks here to exercise the
+        // cross-chunk pending path; the coalesced form is covered by
+        // `reattach_renegotiates_the_chord_per_channel`.
         ch.data_bytes(vec![0x1e]).await.unwrap();
         ch.data_bytes(vec![b'x']).await.unwrap();
         let mut detach_out = Vec::new();
@@ -4033,6 +4035,150 @@ mod tests {
         assert!(
             closed,
             "channel should close after the remapped detach chord"
+        );
+    }
+
+    /// Drives `ch` until `needle` appears in its stdout (the mock echoes each
+    /// input line as `got:<line>`), panicking if the channel closes or stalls
+    /// first. Returns everything received anew.
+    async fn recv_until(ch: &mut russh::Channel<russh::client::Msg>, needle: &str) -> String {
+        let mut out = Vec::new();
+        loop {
+            match tokio::time::timeout(Duration::from_secs(5), ch.wait()).await {
+                Ok(Some(ChannelMsg::Data { data })) => {
+                    out.extend_from_slice(&data);
+                    let text = String::from_utf8_lossy(&out);
+                    if text.contains(needle) {
+                        return text.into_owned();
+                    }
+                }
+                Ok(Some(_)) => {}
+                Ok(None) => panic!("channel closed before {needle:?} appeared; got {out:?}"),
+                Err(_) => panic!("timed out waiting for {needle:?}; got {out:?}"),
+            }
+        }
+    }
+
+    /// Drains `ch` until it closes (e.g. after a detach chord), returning
+    /// everything received. Panics if the channel stays open.
+    async fn collect_to_close(ch: &mut russh::Channel<russh::client::Msg>) -> String {
+        let mut out = Vec::new();
+        while let Ok(msg) = tokio::time::timeout(Duration::from_secs(5), ch.wait()).await {
+            match msg {
+                Some(ChannelMsg::Data { data }) => out.extend_from_slice(&data),
+                Some(_) => {}
+                None => return String::from_utf8_lossy(&out).into_owned(),
+            }
+        }
+        panic!("channel did not close within the timeout; got {out:?}");
+    }
+
+    /// A client negotiating an unsafe leader (`ctrl-c`) hits the daemon's
+    /// silent backstop: the leader falls back to `ctrl-]` while the valid
+    /// detach remap (`x`) survives — the fallback is field-scoped, so the
+    /// effective chord is `ctrl-]` then `x`. The unsafe byte forwards as data.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rejected_leader_falls_back_to_default_chord() {
+        use sessions::keys::{DETACH_KEY_ENV, LEADER_ENV};
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        let mut ch = client
+            .open_shell_with_keys(session_id, &[(LEADER_ENV, "ctrl-c"), (DETACH_KEY_ENV, "x")])
+            .await;
+
+        // 0x03 must NOT enter command mode: it is data (the shell renders it
+        // `^C` and it never reaches the echoed line). If it had entered, the
+        // `x` below would be the detach subcommand and the channel would
+        // close; instead the mock echoes the line back.
+        ch.data_bytes(vec![0x03]).await.unwrap();
+        ch.data_bytes(b"xping\n".to_vec()).await.unwrap();
+        recv_until(&mut ch, "got:xping").await;
+
+        // The fallback chord — default leader, surviving detach remap — fires.
+        ch.data_bytes(vec![0x1d]).await.unwrap();
+        ch.data_bytes(b"x".to_vec()).await.unwrap();
+        let out = collect_to_close(&mut ch).await;
+        assert!(
+            out.contains("Detaching from session."),
+            "fallback leader + surviving detach remap should detach, got {out:?}"
+        );
+    }
+
+    /// Two channels on one session each get their own negotiated chord. The
+    /// first attach uses the defaults; the second negotiates `ctrl-^`/`x`,
+    /// finds its *own* old leader bytes (0x1d here) reduced to inert data,
+    /// and detaches via the remapped chord. Both chords are sent COALESCED —
+    // single SSH data messages exercising the streaming matcher's
+    // coalescing path.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reattach_renegotiates_the_chord_per_channel() {
+        use sessions::keys::{DETACH_KEY_ENV, LEADER_ENV};
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        // First attach: defaults — detach via the coalesced `\x1dd` chord.
+        let mut first = client.open_shell(session_id).await;
+        first.data_bytes(b"boot\n".to_vec()).await.unwrap();
+        recv_until(&mut first, "got:boot").await;
+        first.data_bytes(b"\x1dd".to_vec()).await.unwrap();
+        let out = collect_to_close(&mut first).await;
+        assert!(
+            out.contains("Detaching from session."),
+            "coalesced default chord should detach, got {out:?}"
+        );
+
+        // Reattach with negotiated keys: the per-channel renegotiation.
+        let mut second = client
+            .open_shell_with_keys(session_id, &[(LEADER_ENV, "ctrl-^"), (DETACH_KEY_ENV, "x")])
+            .await;
+        // The old leader 0x1d is inert data on this channel: if it entered
+        // command mode, the `ping\n` below would be swallowed/mistaken; the
+        // mock echo proves it flowed as data instead.
+        second.data_bytes(vec![0x1d]).await.unwrap();
+        second.data_bytes(b"ping\n".to_vec()).await.unwrap();
+        recv_until(&mut second, "got:\u{1d}ping").await;
+        // The remapped chord, coalesced, detaches.
+        second.data_bytes(b"\x1ex".to_vec()).await.unwrap();
+        let out = collect_to_close(&mut second).await;
+        assert!(
+            out.contains("Detaching from session."),
+            "coalesced remapped chord should detach, got {out:?}"
+        );
+    }
+
+    /// An unbound subcommand key is swallowed and cancels command mode: the
+    /// key never reaches the shell, the line after forwards normally, and the
+    /// real chord still works afterwards.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unbound_subcommand_swallows_and_cancels_command_mode() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        let mut ch = client.open_shell(session_id).await;
+        ch.data_bytes(b"boot\n".to_vec()).await.unwrap();
+        recv_until(&mut ch, "got:boot").await;
+
+        // Leader enters command mode; `q` is unbound: swallowed, mode
+        // cancelled. The next line must arrive as plain `ping` — a leaked `q`
+        // would echo as `got:qping` and this would time out.
+        ch.data_bytes(vec![0x1d]).await.unwrap();
+        ch.data_bytes(b"q".to_vec()).await.unwrap();
+        ch.data_bytes(b"ping\n".to_vec()).await.unwrap();
+        recv_until(&mut ch, "got:ping").await;
+
+        // The real chord is unaffected by the cancelled attempt.
+        ch.data_bytes(vec![0x1d]).await.unwrap();
+        ch.data_bytes(b"d".to_vec()).await.unwrap();
+        let out = collect_to_close(&mut ch).await;
+        assert!(
+            out.contains("Detaching from session."),
+            "the chord should still detach after a cancelled command mode, got {out:?}"
         );
     }
 

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -38,6 +38,13 @@ use std::sync::Arc;
 pub(crate) const SHELL_EXIT_PROMPT: &str =
     "Session shell process exited. What would you like to do with this session?";
 
+/// How long a held chord-matcher split candidate (e.g. a lone `ESC`, a strict
+/// prefix of every kitty form) is held before being flushed to the PTY as
+/// data. Long enough that a chord split across SSH chunks (which reassemble
+/// within milliseconds) still resolves as a chord, short enough that a bare
+/// `ESC` reaching the app (e.g. leaving vim insert mode) is imperceptible.
+const CHORD_FLUSH_IDLE: std::time::Duration = std::time::Duration::from_millis(50);
+
 /// Line rendered above the shell-exit prompt when nothing in the workspace
 /// changed since activation. Exposed for the same test-await purpose as
 /// [`SHELL_EXIT_PROMPT`].
@@ -1561,6 +1568,12 @@ pub(crate) struct Host<P: SessionProcess, G: SessionGuard> {
     // sends no keys.
     chord_matcher: ChordMatcher,
 
+    // Deadline for flushing a held chord-matcher split candidate: armed when a
+    // stdin chunk leaves the matcher holding a partial form (e.g. a lone `ESC`,
+    // a prefix of every kitty form), cleared when the next chunk resolves it or
+    // the idle gap elapses and the candidate is flushed to the PTY as data.
+    chord_flush_deadline: Option<tokio::time::Instant>,
+
     // Keeps launcher-owned resources (the session's `Env`, which owns the
     // sandbox files backing the running process's rootfs along with the context
     // and graph) alive for as long as this host (and thus the session process)
@@ -2915,6 +2928,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             connection_env,
             home_dir,
             chord_matcher: ChordMatcher::new(SessionKeys::default()),
+            chord_flush_deadline: None,
             guard,
         };
 
@@ -3146,6 +3160,12 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
     }
 
     pub async fn step(&mut self) -> Result<(), ()> {
+        // Snapshot the chord-flush deadline for the select below: the arm
+        // sleeps until this absolute instant, so the timer survives the select
+        // being rebuilt on every `step()` call (a bare `sleep` would restart
+        // each iteration and never fire while other events keep waking the
+        // loop).
+        let chord_flush_deadline = self.chord_flush_deadline;
         tokio::select! {
             // Read actor messages.
             Some(msg) = self.receiver.recv() => {
@@ -3327,6 +3347,16 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                         if !forward.is_empty() {
                             self.stdin_buf = Some((bytes::Bytes::from(forward), 0));
                         }
+
+                        // Arm (or clear) the idle-flush timer: a chunk that
+                        // leaves the matcher holding a split candidate (a lone
+                        // `ESC`, a prefix of every kitty form) must not wedge
+                        // that candidate forever — flush it to the PTY as data
+                        // once the stream goes quiet.
+                        self.chord_flush_deadline = self
+                            .chord_matcher
+                            .has_pending()
+                            .then(|| tokio::time::Instant::now() + CHORD_FLUSH_IDLE);
                     }
                     StdinMsg::TerminalUpdate(sz) => {
                         self.set_size(WinSize::from(&sz));
@@ -3373,6 +3403,24 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                     Err(_would_block) => {},
                 }
             }
+            // Flush a held chord-matcher split candidate once the stream goes
+            // quiet. A lone `ESC` is a strict prefix of every kitty form, so
+            // the matcher holds it for the next chunk; without this, a bare
+            // `ESC` (e.g. leaving vim insert mode) would be held until the
+            // user's next keystroke. `pending()` keeps the arm inert while no
+            // candidate is held.
+            _ = async {
+                match chord_flush_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                self.chord_flush_deadline = None;
+                let flushed = self.chord_matcher.flush();
+                if !flushed.is_empty() {
+                    self.stdin_buf = Some((bytes::Bytes::from(flushed), 0));
+                }
+            }
 
         }
 
@@ -3402,6 +3450,9 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         // chord, and a reattach never inherits a stale awaiting-subcommand
         // state.
         self.chord_matcher = ChordMatcher::new(keys);
+        // A fresh matcher holds no candidate, so any pending idle-flush
+        // deadline from the previous channel is stale.
+        self.chord_flush_deadline = None;
 
         if !skip_flush {
             self.parser.screen_mut().set_size(sz.rows, sz.cols);

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -29,18 +29,8 @@ use crate::session_delta::DeltaSource;
 use crate::sessions::SessionControl;
 #[cfg(not(test))]
 use sessions::NetworkMode;
+use sessions::keys::{CommandMode, KeyAction, SessionKeys};
 use std::sync::Arc;
-
-/// Command sequence for the ctrl-w key chord, when the kitty keyboard protocol
-/// is negotiated.
-///
-/// Corresponds to: Kitty: CSI 119 ; 5 u
-const CTRL_W_CSI_U: &[u8] = b"\x1b[119;5u";
-/// Command sequence for the ctrl-w key chord, when the modifyOtherKeys key
-/// sequences are used by the outer terminal.
-///
-/// Corrsponds to: modifyOtherKeys: CSI 27 ; 5 ; 119 ~
-const CTRL_W_CSI_27: &[u8] = b"\x1b[27;5;119~";
 
 /// Header of the prompt shown over the channel when a session's shell process
 /// exits, offering to detach or delete. Exposed so tests can await its
@@ -679,7 +669,7 @@ impl Binding {
                         }
                         BindingMsg::TeardownDueToDetach(unwind_codes) => {
                             let _ = w.write_all(&unwind_codes).await;
-                            let _ = w.write_all(b"\r\nDetaching due to ctrl-w.\r\n").await;
+                            let _ = w.write_all(b"\r\nDetaching from session.\r\n").await;
                             break MainloopExitReason::Detach;
                         }
                     };
@@ -1098,8 +1088,9 @@ enum Message {
     Kill(bool),
     /// Bind a client channel to this host. The [`ConnectionEnv`] rides along
     /// on every attach — not just the one that minted the host — because it
-    /// describes the terminal on the other end of *this* channel.
-    Attach(Channel<Msg>, WinSize, ConnectionEnv),
+    /// describes the terminal on the other end of *this* channel; the
+    /// [`SessionKeys`] give the new channel its own negotiation state.
+    Attach(Channel<Msg>, WinSize, ConnectionEnv, SessionKeys),
     GetAttrs(oneshot::Sender<HostAttrs>),
     /// Compute the workspace's at-risk report (VCS-exact when the tree is a
     /// git repository, the changed-since-activation delta otherwise) and
@@ -1301,22 +1292,27 @@ impl HostHandle {
     }
     /// Binds `c` to this host, carrying the attaching terminal's facts.
     ///
-    /// `connection` is applied on every attach, so a client attaching from a
-    /// different terminal than the one that minted the shell updates `TERM`
-    /// for everything the session spawns from here on. An empty map leaves the
-    /// last known facts in place rather than clearing them: a client whose own
-    /// `TERM` is unset (OpenSSH then sends an empty pty-req term string) has
-    /// nothing to say about the terminal, which is not the same as saying
-    /// there isn't one.
+    /// `connection` is merged into the host's stored facts on every attach, so
+    /// a client attaching from a different terminal than the one that minted
+    /// the shell updates `TERM` for everything the session spawns from here
+    /// on. A `TERM` the attach does not declare leaves the last known value
+    /// standing rather than clearing it: a client whose own `TERM` is unset
+    /// (OpenSSH then sends an empty pty-req term string) has nothing to say
+    /// about the terminal, which is not the same as saying there isn't one.
     pub async fn attach(
         &self,
         c: Channel<Msg>,
         sz: WinSize,
         connection: ConnectionEnv,
+        keys: SessionKeys,
     ) -> Result<(), (Channel<Msg>, WinSize)> {
-        match self.sender.send(Message::Attach(c, sz, connection)).await {
+        match self
+            .sender
+            .send(Message::Attach(c, sz, connection, keys))
+            .await
+        {
             Ok(()) => Ok(()),
-            Err(SendError(Message::Attach(c, sz, _))) => Err((c, sz)),
+            Err(SendError(Message::Attach(c, sz, _, _))) => Err((c, sz)),
             Err(e) => unreachable!("{:?}", e),
         }
     }
@@ -1554,6 +1550,18 @@ pub(crate) struct Host<P: SessionProcess, G: SessionGuard> {
     // Daemon-side directory the save-then-delete lane archives into, handed
     // to each binding alongside `delta`.
     archives_dir: std::path::PathBuf,
+
+    // The negotiated per-channel session keys: the leader chord that enters
+    // command mode, the detach/forward subcommand keys, and the bell flag.
+    // Refreshed from the channel's env vars on every attach (so two clients
+    // with different configs on the same session each get their own chord);
+    // defaults to `ctrl-]` / `d` when a client sends no keys.
+    session_keys: SessionKeys,
+
+    // Per-channel command-mode state for the session-key state machine: idle
+    // (keystrokes forward) or awaiting the subcommand that follows a
+    // swallowed leader. Reset to idle on every attach.
+    command_mode: CommandMode,
 
     // Keeps launcher-owned resources (the session's `Env`, which owns the
     // sandbox files backing the running process's rootfs along with the context
@@ -1815,8 +1823,9 @@ pub(crate) struct AttachEnv {
     /// `LC_*`, `TZ`) — OpenSSH's `AcceptEnv` set. Applied as defaults *below*
     /// the composition, so a loadout's explicit locale still wins.
     pub(crate) inherited: Vec<(String, String)>,
-    /// Per-connection facts — currently just `TERM` from the PTY request.
-    /// Applied *above* the composition, the way sshd sets `TERM`
+    /// Per-connection facts — `TERM` from the PTY request, plus the banner's
+    /// detach hint the daemon derives from the channel's session keys. Applied
+    /// *above* the composition, the way sshd sets `TERM`
     /// authoritatively regardless of shell dotfiles. (`SSH_TTY` and
     /// `SSH_CONNECTION`/`SSH_CLIENT` are deliberately not set: the session
     /// sandbox has no host `/dev/pts` and the Unix-socket transport has no peer
@@ -1829,10 +1838,18 @@ impl AttachEnv {
     pub(crate) fn connection_env(&self) -> ConnectionEnv {
         self.connection.iter().cloned().collect()
     }
+
+    /// Whether this attach declares a terminal (`TERM` from the PTY
+    /// request). The detach hint the daemon seeds every attach with is not a
+    /// terminal fact, so an empty-vs-non-empty map no longer answers this.
+    pub(crate) fn declares_terminal(&self) -> bool {
+        self.connection.iter().any(|(k, _)| k == "TERM")
+    }
 }
 
 /// The facts that describe *the terminal currently attached*, as opposed to
-/// the session's own composed environment: `TERM` today.
+/// the session's own composed environment: `TERM` from the PTY request, plus
+/// the banner's detach hint derived from the channel's session keys.
 ///
 /// Kept apart from [`AttachEnv`] because its lifetime is different. A session
 /// shell is spawned once and lives across many attaches, so its `environ` is
@@ -1927,7 +1944,7 @@ const SESSION_WORKSPACE_ROOT: &str = constcat::concat!("/", sandbox2::SESSION_DE
 /// and attaches from unrelated host directories. TTY-gated, plain text —
 /// `NO_COLOR`-safe, no box drawing.
 const BASELINE_MOTD: &str = constcat::concat!(
-    r#"[ -t 1 ] && { printf 'minimal · session %s · loadout %s\ndetach: ctrl-w' "${MINIMAL_SESSION_NAME:-unnamed}" "${MINIMAL_LOADOUTS:-none}"; [ -f "#,
+    r#"[ -t 1 ] && { printf 'minimal · session %s · loadout %s\ndetach: %s' "${MINIMAL_SESSION_NAME:-unnamed}" "${MINIMAL_LOADOUTS:-none}" "${MINIMAL_DETACH_HINT:-ctrl-] then d}"; [ -f "#,
     SESSION_WORKSPACE_ROOT,
     r#"/minimal.toml ] || [ -f "#,
     SESSION_WORKSPACE_ROOT,
@@ -2899,6 +2916,8 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             archives_dir,
             connection_env,
             home_dir,
+            session_keys: SessionKeys::default(),
+            command_mode: CommandMode::Idle,
             guard,
         };
 
@@ -2907,7 +2926,14 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             // environment, so pass an empty map rather than re-applying them:
             // `attach` treats empty as "nothing new to say" and publishes what
             // the host already holds.
-            host.attach(channel, sz, true, ConnectionEnv::new()).await;
+            host.attach(
+                channel,
+                sz,
+                true,
+                ConnectionEnv::new(),
+                SessionKeys::default(),
+            )
+            .await;
         } else {
             // No client to bind, so nothing calls `attach` — publish anyway,
             // so a host minted headlessly still has the files in place before
@@ -3159,8 +3185,8 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                         // `mainloop` reap via `wait()` and return.
                         return Err(());
                     }
-                    Message::Attach(channel, sz, connection) => {
-                        self.attach(channel, sz, false, connection).await;
+                    Message::Attach(channel, sz, connection, keys) => {
+                        self.attach(channel, sz, false, connection, keys).await;
                     }
                     Message::SetTitleCallback(title) => {
                         self.attrs.title = Some((title, SystemTime::now()));
@@ -3251,25 +3277,56 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                     StdinMsg::Bytes(b) => {
                         self.attrs.stdin_last = Some(SystemTime::now());
 
-                        // ctrl-w
-                        let is_detach = b.len() == 1 && b[0] == 0x17 ||
-                            b == CTRL_W_CSI_U ||
-                            b == CTRL_W_CSI_27;
-
-                        if is_detach {
-                            let uc = self.unwind_codes();
-                            if let Some((tx, _hnd)) = self.remote.as_mut() {
-                                match tx.send(BindingMsg::TeardownDueToDetach(uc)).await {
-                                    Ok(()) => {},
-                                    Err(e) => {
-                                        tracing::warn!("failed sending detach signal to remote: {e}");
-                                    }
-                                };
-                                self.remote = None;
+                        // Session-key command-mode state machine: the leader
+                        // chord is swallowed and enters command mode; the next
+                        // keystroke is the subcommand — detach, forward, or an
+                        // unbound key that cancels. The leader is never
+                        // forwarded except via the explicit forward subcommand.
+                        let (next_mode, action) =
+                            self.session_keys.advance(self.command_mode, &b);
+                        match action {
+                            KeyAction::Forward => {
+                                self.stdin_buf = Some((b, 0));
                             }
-                        } else {
-                            self.stdin_buf = Some((b, 0));
-                        };
+                            KeyAction::Swallow => {}
+                            KeyAction::EnterCommandMode => {
+                                // Ring the terminal bell on the channel back to
+                                // the user (never the PTY, so the app never
+                                // sees it) when the client opted in.
+                                if self.session_keys.bell_on_leader
+                                    && let Some((tx, _)) = self.remote.as_ref()
+                                {
+                                    let _ = tx.send(BindingMsg::Stdin(vec![0x07])).await;
+                                }
+                            }
+                            KeyAction::Detach => {
+                                let uc = self.unwind_codes();
+                                if let Some((tx, _hnd)) = self.remote.as_mut() {
+                                    match tx.send(BindingMsg::TeardownDueToDetach(uc)).await {
+                                        Ok(()) => {},
+                                        Err(e) => {
+                                            tracing::warn!("failed sending detach signal to remote: {e}");
+                                        }
+                                    };
+                                    self.remote = None;
+                                }
+                            }
+                            KeyAction::ForwardLeader => {
+                                // Verbatim-forward a leader byte down the PTY
+                                // and exit command mode, handing the next
+                                // keystroke to the layer below (a nested daemon,
+                                // if any). Safe to over-send: a stray leader
+                                // past the deepest layer hits the app's own
+                                // non-destructive leader binding.
+                                self.stdin_buf = Some((
+                                    bytes::Bytes::from(vec![
+                                        self.session_keys.leader.plain_byte(),
+                                    ]),
+                                    0,
+                                ));
+                            }
+                        }
+                        self.command_mode = next_mode;
                     }
                     StdinMsg::TerminalUpdate(sz) => {
                         self.set_size(WinSize::from(&sz));
@@ -3328,15 +3385,24 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         sz: WinSize,
         skip_flush: bool,
         connection: ConnectionEnv,
+        keys: SessionKeys,
     ) {
-        // Before anything the client can see: the facts describe the terminal
-        // that is arriving, and the shell's first prompt after this should
-        // already read them. Empty means the client had nothing to say (see
-        // [`HostHandle::attach`]), so the previous facts stand.
-        if !connection.is_empty() {
-            self.connection_env = connection;
-        }
+        // Merge the connection facts rather than replacing the stored map.
+        // Every attach carries the banner's detach hint (derived from this
+        // channel's keys), but only some carry a terminal — replacing
+        // wholesale would let a terminal-less attach drop the last published
+        // `TERM` (see the attach-side log about keeping it). Merging updates
+        // whatever this attach declares and leaves the rest standing.
+        self.connection_env.extend(connection);
         self.publish_connection_env().await;
+
+        // A new channel means a fresh key negotiation and a fresh command-mode
+        // state: two clients with different configs on the same session each
+        // get their own chord, and a reattach never inherits a stale
+        // awaiting-subcommand state.
+        self.session_keys = keys;
+        self.command_mode = CommandMode::Idle;
+
 
         if !skip_flush {
             self.parser.screen_mut().set_size(sz.rows, sz.cols);
@@ -4041,6 +4107,10 @@ mod tests {
         // Static template, dynamic vars: interpolated in-shell, unset-safe.
         assert!(motd.contains("${MINIMAL_SESSION_NAME:-"));
         assert!(motd.contains("${MINIMAL_LOADOUTS:-"));
+        // The detach hint is a third %s filled by the negotiated keys var,
+        // with the default chord as the unset fallback.
+        assert!(motd.contains("detach: %s"));
+        assert!(motd.contains("${MINIMAL_DETACH_HINT:-ctrl-] then d}"));
         // The blueprint clause tests the session workspace itself at
         // print time — both mfile layouts — pinned to the same constant
         // that is the shell's initial cwd.
@@ -4050,8 +4120,29 @@ mod tests {
             !motd.contains("MINIMAL_BLUEPRINT"),
             "blueprint is a session-filesystem fact, not an env var"
         );
-        assert!(motd.contains("detach: ctrl-w"));
         assert!(motd.contains("min init"));
+    }
+
+    /// The detach hint in the orientation banner reflects the negotiated
+    /// session keys: when the connection layer seeds `MINIMAL_DETACH_HINT`
+    /// (the daemon does this from the channel's key env vars at attach), the
+    /// layered env carries it so the banner's `${MINIMAL_DETACH_HINT:-…}`
+    /// renders the actual chord rather than the default fallback.
+    #[test]
+    fn connection_layer_seeds_negotiated_detach_hint() {
+        let env = layer_session_env(
+            session_baseline_env("box-1", None),
+            vec![],
+            vec![],
+            vec![(
+                "MINIMAL_DETACH_HINT".to_string(),
+                "ctrl-^ then x".to_string(),
+            )],
+        );
+        assert_eq!(
+            env.get("MINIMAL_DETACH_HINT").map(String::as_str),
+            Some("ctrl-^ then x"),
+        );
     }
 
     /// A missing loadout display (old client / no composition) leaves
@@ -4427,10 +4518,11 @@ mod tests {
         );
     }
 
-    /// The other half of "detach != exit": a ctrl-w (detach) keystroke is
-    /// swallowed as a detach signal — never forwarded to the shell — and does not
-    /// end the session or release the network. The shell keeps running (a later
-    /// line still round-trips) and only an explicit kill/exit releases the network.
+    /// The other half of "detach != exit": the detach chord (leader then `d`)
+    /// is swallowed as a detach signal — never forwarded to the shell — and does
+    /// not end the session or release the network. The shell keeps running (a
+    /// later line still round-trips) and only an explicit kill/exit releases the
+    /// network.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn detach_keystroke_holds_the_session_and_network() {
         let torn_down = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -4455,16 +4547,24 @@ mod tests {
         let stdin = host.remote_tx.clone();
         let task = tokio::spawn(host.mainloop());
 
-        // A bare ctrl-w (0x17) is the detach chord. It must be consumed as a
-        // detach signal rather than written to the pty.
+        // The default detach chord is `ctrl-]` (0x1d, the leader) then `d`.
+        // Both bytes are consumed by the command-mode state machine rather
+        // than written to the pty: the leader enters command mode, `d`
+        // detaches. (The host is built without a binding, so the detach is a
+        // no-op on the channel — what matters is that neither byte reaches
+        // the shell.)
         stdin
-            .send(StdinMsg::Bytes(bytes::Bytes::from(vec![0x17])))
+            .send(StdinMsg::Bytes(bytes::Bytes::from(vec![0x1d])))
             .await
-            .expect("failed to send ctrl-w");
+            .expect("failed to send leader");
+        stdin
+            .send(StdinMsg::Bytes(bytes::Bytes::from(b"d".to_vec())))
+            .await
+            .expect("failed to send detach key");
 
         // The shell survived the detach: a normal line still echoes back, which
-        // stamps stdout activity. (If ctrl-w had been forwarded or had killed the
-        // process, no echo would ever arrive.)
+        // stamps stdout activity. (If the chord had been forwarded or had killed
+        // the process, no echo would ever arrive.)
         stdin
             .send(StdinMsg::Bytes(bytes::Bytes::from(b"ping\n".to_vec())))
             .await

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -29,7 +29,7 @@ use crate::session_delta::DeltaSource;
 use crate::sessions::SessionControl;
 #[cfg(not(test))]
 use sessions::NetworkMode;
-use sessions::keys::{CommandMode, KeyAction, SessionKeys};
+use sessions::keys::{ChordMatcher, FeedOutcome, KeyAction, SessionKeys};
 use std::sync::Arc;
 
 /// Header of the prompt shown over the channel when a session's shell process
@@ -1551,17 +1551,15 @@ pub(crate) struct Host<P: SessionProcess, G: SessionGuard> {
     // to each binding alongside `delta`.
     archives_dir: std::path::PathBuf,
 
-    // The negotiated per-channel session keys: the leader chord that enters
-    // command mode, the detach/forward subcommand keys, and the bell flag.
-    // Refreshed from the channel's env vars on every attach (so two clients
-    // with different configs on the same session each get their own chord);
-    // defaults to `ctrl-]` / `d` when a client sends no keys.
-    session_keys: SessionKeys,
-
-    // Per-channel command-mode state for the session-key state machine: idle
-    // (keystrokes forward) or awaiting the subcommand that follows a
-    // swallowed leader. Reset to idle on every attach.
-    command_mode: CommandMode,
+    // The per-channel session-key chord matcher: the negotiated leader chord
+    // that enters command mode, the detach/forward subcommand keys, the bell
+    // flag, plus the command-mode state and the pending split-candidate
+    // buffer. Refreshed from the channel's env vars on every attach (so two
+    // clients with different configs on the same session each get their own
+    // chord, and a reattach never inherits a stale awaiting-subcommand state
+    // or half a split candidate); defaults to `ctrl-]` / `d` when a client
+    // sends no keys.
+    chord_matcher: ChordMatcher,
 
     // Keeps launcher-owned resources (the session's `Env`, which owns the
     // sandbox files backing the running process's rootfs along with the context
@@ -2916,8 +2914,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             archives_dir,
             connection_env,
             home_dir,
-            session_keys: SessionKeys::default(),
-            command_mode: CommandMode::Idle,
+            chord_matcher: ChordMatcher::new(SessionKeys::default()),
             guard,
         };
 
@@ -3277,56 +3274,59 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                     StdinMsg::Bytes(b) => {
                         self.attrs.stdin_last = Some(SystemTime::now());
 
-                        // Session-key command-mode state machine: the leader
-                        // chord is swallowed and enters command mode; the next
-                        // keystroke is the subcommand — detach, forward, or an
-                        // unbound key that cancels. The leader is never
-                        // forwarded except via the explicit forward subcommand.
-                        let (next_mode, action) =
-                            self.session_keys.advance(self.command_mode, &b);
-                        match action {
-                            KeyAction::Forward => {
-                                self.stdin_buf = Some((b, 0));
-                            }
-                            KeyAction::Swallow => {}
-                            KeyAction::EnterCommandMode => {
-                                // Ring the terminal bell on the channel back to
-                                // the user (never the PTY, so the app never
-                                // sees it) when the client opted in.
-                                if self.session_keys.bell_on_leader
-                                    && let Some((tx, _)) = self.remote.as_ref()
-                                {
-                                    let _ = tx.send(BindingMsg::Stdin(vec![0x07])).await;
+                        // Session-key chord matching over the stdin byte
+                        // stream: the leader chord is swallowed and enters
+                        // command mode; the next keystroke is the subcommand —
+                        // detach, forward, or an unbound key that cancels. The
+                        // leader is never forwarded except via the explicit
+                        // forward subcommand. Coalesced and split chunks are
+                        // handled by the matcher; the decisions below only map
+                        // outcomes to I/O, with every PTY-bound byte (data
+                        // runs and verbatim leaders) collected in stream order.
+                        let mut forward: Vec<u8> = Vec::new();
+                        for outcome in self.chord_matcher.feed(&b) {
+                            match outcome {
+                                FeedOutcome::Forward(bytes) => {
+                                    forward.extend_from_slice(&bytes);
                                 }
-                            }
-                            KeyAction::Detach => {
-                                let uc = self.unwind_codes();
-                                if let Some((tx, _hnd)) = self.remote.as_mut() {
-                                    match tx.send(BindingMsg::TeardownDueToDetach(uc)).await {
-                                        Ok(()) => {},
-                                        Err(e) => {
-                                            tracing::warn!("failed sending detach signal to remote: {e}");
-                                        }
-                                    };
-                                    self.remote = None;
+                                FeedOutcome::Action(KeyAction::Swallow) => {}
+                                FeedOutcome::Action(KeyAction::EnterCommandMode) => {
+                                    // Ring the terminal bell on the channel back
+                                    // to the user (never the PTY, so the app
+                                    // never sees it) when the client opted in.
+                                    if self.chord_matcher.keys().bell_on_leader
+                                        && let Some((tx, _)) = self.remote.as_ref()
+                                    {
+                                        let _ = tx.send(BindingMsg::Stdin(vec![0x07])).await;
+                                    }
                                 }
-                            }
-                            KeyAction::ForwardLeader => {
-                                // Verbatim-forward a leader byte down the PTY
-                                // and exit command mode, handing the next
-                                // keystroke to the layer below (a nested daemon,
-                                // if any). Safe to over-send: a stray leader
-                                // past the deepest layer hits the app's own
-                                // non-destructive leader binding.
-                                self.stdin_buf = Some((
-                                    bytes::Bytes::from(vec![
-                                        self.session_keys.leader.plain_byte(),
-                                    ]),
-                                    0,
-                                ));
+                                FeedOutcome::Action(KeyAction::Detach) => {
+                                    let uc = self.unwind_codes();
+                                    if let Some((tx, _hnd)) = self.remote.as_mut() {
+                                        match tx.send(BindingMsg::TeardownDueToDetach(uc)).await {
+                                            Ok(()) => {},
+                                            Err(e) => {
+                                                tracing::warn!("failed sending detach signal to remote: {e}");
+                                            }
+                                        };
+                                        self.remote = None;
+                                    }
+                                }
+                                FeedOutcome::Action(KeyAction::ForwardLeader) => {
+                                    // Queue a verbatim leader byte in the PTY
+                                    // stream, handing the next keystroke to the
+                                    // layer below (a nested daemon *that
+                                    // negotiated the same leader*, if any).
+                                    // Safe to over-send: a stray leader past the
+                                    // deepest layer hits the app's own
+                                    // non-destructive leader binding.
+                                    forward.push(self.chord_matcher.keys().leader.plain_byte());
+                                }
                             }
                         }
-                        self.command_mode = next_mode;
+                        if !forward.is_empty() {
+                            self.stdin_buf = Some((bytes::Bytes::from(forward), 0));
+                        }
                     }
                     StdinMsg::TerminalUpdate(sz) => {
                         self.set_size(WinSize::from(&sz));
@@ -3396,13 +3396,12 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         self.connection_env.extend(connection);
         self.publish_connection_env().await;
 
-        // A new channel means a fresh key negotiation and a fresh command-mode
-        // state: two clients with different configs on the same session each
-        // get their own chord, and a reattach never inherits a stale
-        // awaiting-subcommand state.
-        self.session_keys = keys;
-        self.command_mode = CommandMode::Idle;
-
+        // A new channel means a fresh matcher: fresh key negotiation, idle
+        // command-mode state, and no pending split candidate — two clients
+        // with different configs on the same session each get their own
+        // chord, and a reattach never inherits a stale awaiting-subcommand
+        // state.
+        self.chord_matcher = ChordMatcher::new(keys);
 
         if !skip_flush {
             self.parser.screen_mut().set_size(sz.rows, sz.cols);

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -480,8 +480,29 @@ impl PtyOp {
     }
 }
 
-/// Messages from the binding (user terminal) to the shell process / host.
-enum StdinMsg {
+/// A message from the binding (user terminal) to the shell process / host.
+///
+/// Every message tags the generation of the [`Binding`] that sent it. The
+/// host bumps its active generation on every attach — before the superseded
+/// binding has shut down — and discards a queued message with a stale
+/// generation: input typed at the old channel predates the attach that
+/// installed the current session keys, so interpreting it would apply the
+/// new channel's chord (or its size) to the old channel's keystrokes.
+struct StdinMsg {
+    // The sender's binding generation; must equal the host's active
+    // generation to be honored.
+    generation: u64,
+    kind: StdinMsgKind,
+}
+
+impl StdinMsg {
+    /// Stamps `kind` as sent by a binding of `generation`.
+    fn new(generation: u64, kind: StdinMsgKind) -> Self {
+        Self { generation, kind }
+    }
+}
+
+enum StdinMsgKind {
     Bytes(bytes::Bytes),
     /// A binding left its mainloop for a reason that counts as a detach.
     TerminalUpdate(RequestedPty),
@@ -493,6 +514,22 @@ enum StdinMsg {
     },
 }
 
+/// Queues bytes for the PTY master, appended after the unwritten remainder
+/// of whatever is already queued: buffered bytes are strictly older in
+/// stream order than a freshly fed chunk, so replacing the buffer on top
+/// would drop forwarded keystrokes — e.g. one chunk `x`+`ESC` forwards `x`
+/// into the buffer and holds `ESC` as a split chord candidate, and a pty
+/// still unwritable at the idle-flush deadline would then overwrite that
+/// queued `x` with `ESC`.
+fn queue_stdin(buf: &mut Option<(bytes::Bytes, usize)>, bytes: Vec<u8>) {
+    let mut next = match buf.take() {
+        Some((pending, written)) => pending[written..].to_vec(),
+        None => Vec::with_capacity(bytes.len()),
+    };
+    next.extend_from_slice(&bytes);
+    *buf = Some((bytes::Bytes::from(next), 0));
+}
+
 /// A connection between a [`Host`] and an SSH channel.
 ///
 /// The [`Binding`] is owned by the spawned async task, but the
@@ -501,6 +538,10 @@ enum StdinMsg {
 struct Binding {
     /// The remote end of this binding.
     channel: Channel<Msg>,
+    /// Which host binding-generation this binding owns; stamped on every
+    /// [`StdinMsg`] it sends so the host can discard the queue once the
+    /// binding is superseded.
+    generation: u64,
     /// Channel the binding writes down to communicate stdin to the host.
     stdin_tx: mpsc::Sender<StdinMsg>,
     /// Channel the [`Host`] uses to communicate with this [`Binding`].
@@ -527,6 +568,7 @@ impl Binding {
     pub(crate) async fn spawn(
         channel: Channel<Msg>,
         stdin_tx: mpsc::Sender<StdinMsg>,
+        generation: u64,
         control: Option<SessionControl>,
         delta: Option<Arc<DeltaSource>>,
         name: String,
@@ -536,6 +578,7 @@ impl Binding {
 
         let binding = Self {
             channel,
+            generation,
             stdin_tx,
             receiver: rx,
             control,
@@ -583,7 +626,10 @@ impl Binding {
                     Some(msg) => {
                         match msg {
                             russh::ChannelMsg::Data{ data } => {
-                                let _ = self.stdin_tx.send(StdinMsg::Bytes(data)).await;
+                                let _ = self
+                                    .stdin_tx
+                                    .send(StdinMsg::new(self.generation, StdinMsgKind::Bytes(data)))
+                                    .await;
                             }
                             russh::ChannelMsg::RequestPty {
                                 want_reply: _,
@@ -594,12 +640,18 @@ impl Binding {
                                 pix_height,
                                 terminal_modes,
                             } => {
-                                let _ = self.stdin_tx.send(StdinMsg::TerminalUpdate(RequestedPty {
-                                    char_sizes: (col_width, row_height),
-                                    pixel_sizes: (pix_width, pix_height),
-                                    term: term.to_string(),
-                                    modes: terminal_modes.to_vec(),
-                                })).await;
+                                let _ = self
+                                    .stdin_tx
+                                    .send(StdinMsg::new(
+                                        self.generation,
+                                        StdinMsgKind::TerminalUpdate(RequestedPty {
+                                            char_sizes: (col_width, row_height),
+                                            pixel_sizes: (pix_width, pix_height),
+                                            term: term.to_string(),
+                                            modes: terminal_modes.to_vec(),
+                                        }),
+                                    ))
+                                    .await;
                             },
                             russh::ChannelMsg::WindowChange{
                                 col_width,
@@ -607,9 +659,15 @@ impl Binding {
                                 pix_width,
                                 pix_height,
                             } => {
-                                let _ = self.stdin_tx.send(StdinMsg::WindowChange{
-                                    col_width, row_height, pix_width, pix_height,
-                                }).await;
+                                let _ = self
+                                    .stdin_tx
+                                    .send(StdinMsg::new(
+                                        self.generation,
+                                        StdinMsgKind::WindowChange {
+                                            col_width, row_height, pix_width, pix_height,
+                                        },
+                                    ))
+                                    .await;
                             },
                             // Flow-control window updates fire on every
                             // burst of bytes forwarded through the
@@ -1496,6 +1554,12 @@ pub(crate) struct Host<P: SessionProcess, G: SessionGuard> {
     // Recieve-end for bytes coming from the remote - i.e. 'stdin' keystrokes.
     // We process this end.
     remote_rx: mpsc::Receiver<StdinMsg>,
+
+    // Monotonic identity of the currently active binding. Bumped by
+    // `attach()` before the new binding is spawned, so an [`StdinMsg`] whose
+    // generation lags this was queued by a superseded binding and gets
+    // discarded rather than interpreted under the new channel's session keys.
+    binding_generation: u64,
 
     // Temporary buffer for reading from the pty master (i.e. 'stdout').
     stdout_buf: Vec<u8>,
@@ -2912,6 +2976,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
 
             remote_tx,
             remote_rx,
+            binding_generation: 0,
             stdout_buf: vec![0u8; 8 * 1024],
             stdin_buf: None,
             net_guard,
@@ -3290,8 +3355,15 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             // we only consume new keystrokes if we have none waiting to be written to the pty, and
             // pending writes to the pty are serviced async by their own select arm (below).
             Some(msg) = self.remote_rx.recv(), if self.stdin_buf.is_none() => {
-                match msg {
-                    StdinMsg::Bytes(b) => {
+                // Discard input queued by the superseded binding: its bytes
+                // predate the attach that installed the current session keys,
+                // and matching them now would hand the old channel's
+                // keystrokes to the new channel's chord (or its size).
+                if msg.generation != self.binding_generation {
+                    return Ok(());
+                }
+                match msg.kind {
+                    StdinMsgKind::Bytes(b) => {
                         self.attrs.stdin_last = Some(SystemTime::now());
 
                         // Session-key chord matching over the stdin byte
@@ -3345,7 +3417,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                             }
                         }
                         if !forward.is_empty() {
-                            self.stdin_buf = Some((bytes::Bytes::from(forward), 0));
+                            queue_stdin(&mut self.stdin_buf, forward);
                         }
 
                         // Arm (or clear) the idle-flush timer: a chunk that
@@ -3358,10 +3430,10 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                             .has_pending()
                             .then(|| tokio::time::Instant::now() + CHORD_FLUSH_IDLE);
                     }
-                    StdinMsg::TerminalUpdate(sz) => {
+                    StdinMsgKind::TerminalUpdate(sz) => {
                         self.set_size(WinSize::from(&sz));
                     },
-                    StdinMsg::WindowChange{ col_width, row_height, pix_height, pix_width } => {
+                    StdinMsgKind::WindowChange{ col_width, row_height, pix_height, pix_width } => {
                         self.set_size(WinSize {
                             rows: row_height as u16,
                             cols: col_width as u16,
@@ -3416,9 +3488,13 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                 }
             } => {
                 self.chord_flush_deadline = None;
+                // Appended after anything already queued: forwarded input
+                // still waiting on an unwritable pty predates the candidate
+                // the flush releases, and replacing the buffer would drop it
+                // (see `queue_stdin`).
                 let flushed = self.chord_matcher.flush();
                 if !flushed.is_empty() {
-                    self.stdin_buf = Some((bytes::Bytes::from(flushed), 0));
+                    queue_stdin(&mut self.stdin_buf, flushed);
                 }
             }
 
@@ -3454,6 +3530,12 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         // deadline from the previous channel is stale.
         self.chord_flush_deadline = None;
 
+        // Bump before spawning the new binding: anything the superseded
+        // binding already queued into the shared stdin channel carries the
+        // old generation from here on, so the stdin arm drops it instead of
+        // interpreting those keystrokes under this channel's fresh keys.
+        self.binding_generation += 1;
+
         if !skip_flush {
             self.parser.screen_mut().set_size(sz.rows, sz.cols);
             let _ = channel
@@ -3464,6 +3546,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         let new_binding = Binding::spawn(
             channel,
             self.remote_tx.clone(),
+            self.binding_generation,
             self.control.clone(),
             self.delta.clone(),
             self.session_name.clone(),
@@ -3585,6 +3668,13 @@ mod tests {
         xpixel: 0,
         ypixel: 0,
     };
+
+    /// Wraps a chunk as a current-generation [`StdinMsg`] for the test
+    /// harness: hosts here never attach a binding, so the host's active
+    /// binding generation stays 0.
+    fn stdin_bytes(b: impl Into<bytes::Bytes>) -> StdinMsg {
+        StdinMsg::new(0, StdinMsgKind::Bytes(b.into()))
+    }
 
     /// Builds the `hakoniwa` account of a normal exit: the inner process
     /// reported its own status, so `exit_code` is `Some`.
@@ -3778,9 +3868,7 @@ mod tests {
         let task = tokio::spawn(host.mainloop());
 
         stdin
-            .send(StdinMsg::Bytes(bytes::Bytes::from(
-                format!("{MOCK_EXIT_LINE}\n").into_bytes(),
-            )))
+            .send(stdin_bytes(format!("{MOCK_EXIT_LINE}\n").into_bytes()))
             .await
             .expect("failed to send exit line");
         tokio::time::timeout(Duration::from_secs(10), task)
@@ -3863,15 +3951,13 @@ mod tests {
         let mut line = MOUSE_ON.to_vec();
         line.push(b'\n');
         stdin
-            .send(StdinMsg::Bytes(bytes::Bytes::from(line)))
+            .send(stdin_bytes(line))
             .await
             .expect("failed to send the mouse-enable line");
         await_forwarded(&mut rx, MOUSE_ON).await;
 
         stdin
-            .send(StdinMsg::Bytes(bytes::Bytes::from(
-                format!("{MOCK_EXIT_LINE}\n").into_bytes(),
-            )))
+            .send(stdin_bytes(format!("{MOCK_EXIT_LINE}\n").into_bytes()))
             .await
             .expect("failed to send exit line");
         tokio::time::timeout(Duration::from_secs(10), task)
@@ -4364,7 +4450,7 @@ mod tests {
         let title = "hello-title";
         let osc = format!("\x1b]0;{title}\x07\n");
         stdin
-            .send(StdinMsg::Bytes(bytes::Bytes::from(osc.into_bytes())))
+            .send(stdin_bytes(osc.into_bytes()))
             .await
             .expect("failed to send stdin");
 
@@ -4552,9 +4638,7 @@ mod tests {
 
         // Make the shell exit; the network must then be released.
         stdin
-            .send(StdinMsg::Bytes(bytes::Bytes::from(
-                format!("{MOCK_EXIT_LINE}\n").into_bytes(),
-            )))
+            .send(stdin_bytes(format!("{MOCK_EXIT_LINE}\n").into_bytes()))
             .await
             .expect("failed to send exit line");
         tokio::time::timeout(Duration::from_secs(10), task)
@@ -4604,11 +4688,11 @@ mod tests {
         // no-op on the channel — what matters is that neither byte reaches
         // the shell.)
         stdin
-            .send(StdinMsg::Bytes(bytes::Bytes::from(vec![0x1d])))
+            .send(stdin_bytes(vec![0x1d]))
             .await
             .expect("failed to send leader");
         stdin
-            .send(StdinMsg::Bytes(bytes::Bytes::from(b"d".to_vec())))
+            .send(stdin_bytes(b"d".to_vec()))
             .await
             .expect("failed to send detach key");
 
@@ -4616,7 +4700,7 @@ mod tests {
         // stamps stdout activity. (If the chord had been forwarded or had killed
         // the process, no echo would ever arrive.)
         stdin
-            .send(StdinMsg::Bytes(bytes::Bytes::from(b"ping\n".to_vec())))
+            .send(stdin_bytes(b"ping\n".to_vec()))
             .await
             .expect("failed to send line after detach");
         tokio::time::timeout(Duration::from_secs(10), async {
@@ -4646,5 +4730,81 @@ mod tests {
             torn_down.load(std::sync::atomic::Ordering::SeqCst),
             "kill/destroy must release the network",
         );
+    }
+
+    /// The PTY write queue appends: bytes queued later land *after* anything
+    /// already buffered, so an idle chord-candidate flush can never overwrite
+    /// forwarded input still waiting on an unwritable pty.
+    #[test]
+    fn queue_stdin_appends_after_unwritten_remainder() {
+        // Two bytes of a queued chunk written; three still pending. The flush
+        // must not resurrect the written prefix or drop either remainder.
+        let mut buf = Some((bytes::Bytes::from_static(b"abcde"), 2));
+        queue_stdin(&mut buf, vec![0x1b]);
+        let (pending, written) = buf.as_ref().unwrap();
+        assert_eq!(*written, 0);
+        assert_eq!(&pending[..], b"cde\x1b");
+
+        // An empty queue takes the new bytes wholesale.
+        let mut buf = None;
+        queue_stdin(&mut buf, vec![0x1d, 0x64]);
+        let (pending, written) = buf.as_ref().unwrap();
+        assert_eq!(*written, 0);
+        assert_eq!(&pending[..], b"\x1d\x64");
+    }
+
+    /// Input stamped with a stale binding generation — what a superseded
+    /// binding left queued in the shared stdin channel — must never reach
+    /// the shell. (A real supersession attaches a new channel; here no
+    /// binding ever attaches, so the active generation stays 0 and a manual
+    /// generation-1 message stands in for the queued leftovers.)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stale_binding_generation_input_is_discarded() {
+        let (host, _handle) = Host::build(
+            MockLauncher,
+            "test-session".to_string(),
+            "user".to_string(),
+            test_paths(),
+            DEFAULT_SIZE,
+            None,
+            None,
+            None,
+            std::env::temp_dir(),
+            sessions::SessionId::nil(),
+            None,
+            ConnectionEnv::new(),
+        )
+        .await
+        .expect("failed to build host");
+        let stdin = host.remote_tx.clone();
+        let mut task = tokio::spawn(host.mainloop());
+
+        // The exit sentinel on a stale generation: if this reached the shell
+        // the mainloop would reap the process and the task would complete.
+        stdin
+            .send(StdinMsg::new(
+                1,
+                StdinMsgKind::Bytes(bytes::Bytes::from(
+                    format!("{MOCK_EXIT_LINE}\n").into_bytes(),
+                )),
+            ))
+            .await
+            .expect("failed to send stale stdin");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert!(
+            !task.is_finished(),
+            "stale-generation input must not reach the shell",
+        );
+
+        // The same bytes on the active generation must still go through.
+        stdin
+            .send(stdin_bytes(format!("{MOCK_EXIT_LINE}\n").into_bytes()))
+            .await
+            .expect("failed to send stdin");
+        tokio::time::timeout(Duration::from_secs(10), &mut task)
+            .await
+            .expect("mainloop should terminate after the shell exits")
+            .expect("host task should not panic during teardown")
+            .expect("mainloop should return the reaped exit status");
     }
 }

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -299,7 +299,8 @@ impl TestClient {
         &mut self,
         session_id: SessionId,
     ) -> russh::Channel<russh::client::Msg> {
-        self.open_shell_with_term(session_id, "xterm").await
+        self.open_shell_with_term_and_keys(session_id, "xterm", &[])
+            .await
     }
 
     /// [`Self::open_shell`], naming the terminal type the PTY request
@@ -311,11 +312,41 @@ impl TestClient {
         session_id: SessionId,
         term: &str,
     ) -> russh::Channel<russh::client::Msg> {
+        self.open_shell_with_term_and_keys(session_id, term, &[])
+            .await
+    }
+
+    /// Like [`Self::open_shell`], but also sets session-key env vars on the
+    /// channel — mirroring a `min` client that negotiated a remapped leader
+    /// chord. Each `(name, value)` pair is sent via `set_env` before the PTY
+    /// and shell requests, so the daemon parses them from the channel's env
+    /// vars at attach.
+    pub async fn open_shell_with_keys(
+        &mut self,
+        session_id: SessionId,
+        keys: &[(&str, &str)],
+    ) -> russh::Channel<russh::client::Msg> {
+        self.open_shell_with_term_and_keys(session_id, "xterm", keys)
+            .await
+    }
+
+    /// [`Self::open_shell_with_term`] plus [`Self::open_shell_with_keys`]:
+    /// names both the terminal type the PTY request carries and the
+    /// session-key env vars set before it.
+    pub async fn open_shell_with_term_and_keys(
+        &mut self,
+        session_id: SessionId,
+        term: &str,
+        keys: &[(&str, &str)],
+    ) -> russh::Channel<russh::client::Msg> {
         let channel = self.handle.channel_open_session().await.unwrap();
         channel
             .set_env(true, crate::MINIMAL_SESSION_ID_ENV, session_id.to_string())
             .await
             .unwrap();
+        for (name, value) in keys {
+            channel.set_env(true, *name, *value).await.unwrap();
+        }
         channel
             .request_pty(true, term, 80, 24, 0, 0, &[])
             .await

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -370,6 +370,27 @@ pub fn minimal_config_dir() -> DaemonAbsPath {
     default_dir(xdg_config_home, ".config")
 }
 
+/// Returns minimal's config directory, honouring the `--config-dir`
+/// override: `<override>/minimal` when `over` is given, else the platform
+/// default ([`minimal_config_dir`]). Which flag feeds `over` is the caller's
+/// business; this only fixes that an override names the *parent* of the
+/// `minimal/` subdirectory, so both branches produce the same layout.
+///
+/// The return is a plain [`std::path::PathBuf`]: a user-passed flag is
+/// untyped on the way in and is not daemon-realm data, so forcing the
+/// realm-tagged type on `Some` would lie — and the default branch is
+/// converted down to match.
+#[must_use]
+pub fn minimal_config_dir_with_override(over: Option<&Path>) -> std::path::PathBuf {
+    match over {
+        Some(dir) => dir.join("minimal"),
+        None => minimal_config_dir()
+            .as_utf8_path()
+            .as_std_path()
+            .to_path_buf(),
+    }
+}
+
 /// Return `$XDG_CONFIG_HOME` if it's set to an absolute path. Matches the
 /// spec: [XDG Base Directory Specification, "XDG_CONFIG_HOME"](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
 /// says relative paths are invalid and should be ignored.

--- a/crates/sessions/src/client/config.rs
+++ b/crates/sessions/src/client/config.rs
@@ -187,24 +187,28 @@ impl SessionKeysConfig {
     /// Resolve this config into the negotiated [`keys::SessionKeys`],
     /// filling omitted fields with the shipped defaults (`forward`
     /// falls back to the resolved leader, so a double-press
-    /// forwards) and validating the leader loudly.
+    /// forwards), rejecting an unsafe leader or a detach key that
+    /// shadows another binding loudly.
     ///
     /// # Errors
     ///
     /// Returns [`keys::KeyError`] when the resolved leader is
-    /// termios-special or wrapping-ambiguous.
+    /// termios-special or wrapping-ambiguous, or the detach key
+    /// aliases the leader or forward key (shadowing a binding).
     pub fn to_session_keys(&self) -> Result<keys::SessionKeys, keys::KeyError> {
         let default = keys::SessionKeys::default();
         let leader = self.leader.unwrap_or(default.leader);
         keys::validate_leader(&leader)?;
         let detach_key = self.subcommands.detach.unwrap_or(default.detach_key);
         let forward_key = self.subcommands.forward.unwrap_or(leader);
-        Ok(keys::SessionKeys {
+        let keys = keys::SessionKeys {
             leader,
             detach_key,
             forward_key,
             bell_on_leader: self.bell_on_leader,
-        })
+        };
+        keys::validate_detach_unaliased(&keys)?;
+        Ok(keys)
     }
 }
 

--- a/crates/sessions/src/client/config.rs
+++ b/crates/sessions/src/client/config.rs
@@ -1,14 +1,17 @@
 //! User-level configuration for the minimal client, read from
 //! `<config>/minimal/config.toml`.
 //!
-//! Small on purpose: today it carries only the default loadouts the
+//! Small on purpose: today it carries the default loadouts the
 //! client applies when the user activates a session without naming
-//! any explicit ones. Additional keys can be added as sections
+//! any explicit ones, and the configurable session leader/subcommand
+//! keys (`[session-keys]`). Additional keys can be added as sections
 //! grow, but every new field should start with a
 //! `#[serde(default)]` so an old config keeps parsing after an
 //! upgrade.
 
 use std::path::{Path, PathBuf};
+
+use crate::keys;
 
 /// Root of the minimal client config.
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -19,6 +22,14 @@ pub struct Config {
     /// loadout subsystem.
     #[serde(default)]
     pub loadouts: LoadoutsConfig,
+    /// `[session-keys]` section: the configurable session leader chord
+    /// and its command-mode subcommand keys. Negotiated with the
+    /// daemon per attach channel; see [`keys`] and
+    /// [`SessionKeysConfig::to_session_keys`]. Renamed to the kebab
+    /// table form (`[session-keys]`) the on-disk config uses; fields
+    /// within stay `snake_case` to match the rest of the config.
+    #[serde(default, rename = "session-keys")]
+    pub session_keys: SessionKeysConfig,
 }
 
 /// The `[loadouts]` section.
@@ -40,6 +51,51 @@ pub struct LoadoutsConfig {
     pub follow_symlinks: bool,
 }
 
+/// The `[session-keys]` section: the configurable session leader
+/// chord, its command-mode subcommand keys, and the bell flag. Every
+/// field defaults (omitted means the shipped default), so an old
+/// config keeps parsing; [`SessionKeysConfig::to_session_keys`]
+/// resolves the defaults and validates the leader loudly at load.
+///
+/// See the [`keys`] module for why the leader must not be
+/// termios-special, and how the daemon re-runs the same check as a
+/// silent backstop.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct SessionKeysConfig {
+    /// The chord that enters command mode, as a logical key name
+    /// (e.g. `"ctrl-]"`). Omitted means the default `ctrl-]`.
+    /// Validated loudly at load against the termios-special and
+    /// wrapping-ambiguous reject sets.
+    #[serde(default)]
+    pub leader: Option<keys::Key>,
+    /// The command-mode subcommand keys (`[session-keys.subcommands]`).
+    #[serde(default)]
+    pub subcommands: SubcommandsConfig,
+    /// Whether entering command mode rings the terminal bell
+    /// (BEL `0x07`). Off by default.
+    #[serde(default)]
+    pub bell_on_leader: bool,
+}
+
+/// The `[session-keys.subcommands]` table: the keys bound in command
+/// mode. Named fields (not a free-form map) so a typo fails loudly via
+/// `deny_unknown_fields`, and so each key is typed as a [`keys::Key`].
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct SubcommandsConfig {
+    /// The command-mode key that detaches the channel. Omitted means `d`.
+    #[serde(default)]
+    pub detach: Option<keys::Key>,
+    /// The command-mode key that verbatim-forwards a leader byte down
+    /// the PTY (for nested sessions). Omitted means the resolved
+    /// leader, so a double-press forwards.
+    #[serde(default)]
+    pub forward: Option<keys::Key>,
+}
+
 /// Failure loading the config file.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -59,24 +115,40 @@ pub enum ConfigError {
         #[source]
         source: toml::de::Error,
     },
+    /// The file parsed but a section failed validation — e.g. an
+    /// unsafe session-key leader (termios-special or
+    /// wrapping-ambiguous). Surfaced loudly at load rather than
+    /// acting on the chord later.
+    #[error("invalid config `{path}`: {source}")]
+    Validation {
+        path: PathBuf,
+        #[source]
+        source: keys::KeyError,
+    },
 }
 
-/// Parse the config at `path`.
+/// Parse and validate the config at `path`.
 ///
 /// # Errors
 ///
-/// See [`ConfigError`]. A missing file returns
-/// [`ConfigError::Io`] — use [`read_config_or_default`] if you
-/// want the default config in that case.
+/// See [`ConfigError`]. A missing file returns [`ConfigError::Io`] —
+/// use [`read_config_or_default`] if you want the default config in
+/// that case. A file that parses but fails section validation (e.g.
+/// an unsafe session-key leader) returns [`ConfigError::Validation`].
 pub fn read_config_file(path: &Path) -> Result<Config, ConfigError> {
     let contents = std::fs::read_to_string(path).map_err(|source| ConfigError::Io {
         path: path.to_path_buf(),
         source,
     })?;
-    toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+    let cfg: Config = toml::from_str(&contents).map_err(|source| ConfigError::Parse {
         path: path.to_path_buf(),
         source,
-    })
+    })?;
+    cfg.validate().map_err(|source| ConfigError::Validation {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(cfg)
 }
 
 /// Parse the config at `path`, or return [`Config::default`] when
@@ -94,6 +166,45 @@ pub fn read_config_or_default(path: &Path) -> Result<Config, ConfigError> {
             Ok(Config::default())
         }
         Err(e) => Err(e),
+    }
+}
+
+impl Config {
+    /// Validate every section, failing loudly. Currently validates
+    /// the session-key leader against the termios-special and
+    /// wrapping-ambiguous reject sets (the UX gate; the daemon re-runs
+    /// the same check as a silent backstop).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`keys::KeyError`] when a section is invalid.
+    pub fn validate(&self) -> Result<(), keys::KeyError> {
+        self.session_keys.to_session_keys().map(|_| ())
+    }
+}
+
+impl SessionKeysConfig {
+    /// Resolve this config into the negotiated [`keys::SessionKeys`],
+    /// filling omitted fields with the shipped defaults (`forward`
+    /// falls back to the resolved leader, so a double-press
+    /// forwards) and validating the leader loudly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`keys::KeyError`] when the resolved leader is
+    /// termios-special or wrapping-ambiguous.
+    pub fn to_session_keys(&self) -> Result<keys::SessionKeys, keys::KeyError> {
+        let default = keys::SessionKeys::default();
+        let leader = self.leader.unwrap_or(default.leader);
+        keys::validate_leader(&leader)?;
+        let detach_key = self.subcommands.detach.unwrap_or(default.detach_key);
+        let forward_key = self.subcommands.forward.unwrap_or(leader);
+        Ok(keys::SessionKeys {
+            leader,
+            detach_key,
+            forward_key,
+            bell_on_leader: self.bell_on_leader,
+        })
     }
 }
 
@@ -194,5 +305,198 @@ mod tests {
         let path = write_file(dir.path(), "config.toml", "= not = toml =");
         let err = read_config_or_default(&path).unwrap_err();
         assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+
+    // --- [session-keys] ------------------------------------------------
+
+    /// A populated `[session-keys]` section round-trips through the
+    /// parser and resolves to the configured keys.
+    #[test]
+    fn session_keys_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r#"
+                [session-keys]
+                leader = "ctrl-]"
+                bell_on_leader = true
+
+                [session-keys.subcommands]
+                detach = "d"
+                forward = "ctrl-]"
+            "#},
+        );
+        let cfg = read_config_file(&path).unwrap();
+        let keys = cfg.session_keys.to_session_keys().unwrap();
+        assert_eq!(keys.leader, keys::Key::parse("ctrl-]").unwrap());
+        assert_eq!(keys.detach_key, keys::Key::parse("d").unwrap());
+        assert_eq!(keys.forward_key, keys::Key::parse("ctrl-]").unwrap());
+        assert!(keys.bell_on_leader);
+    }
+
+    /// An omitted `[session-keys]` section resolves to the shipped
+    /// defaults.
+    #[test]
+    fn session_keys_omitted_resolves_to_default() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "config.toml", "# empty");
+        let cfg = read_config_file(&path).unwrap();
+        assert_eq!(
+            cfg.session_keys.to_session_keys().unwrap(),
+            keys::SessionKeys::default()
+        );
+    }
+
+    /// `forward` omitted falls back to the *resolved* leader, not a
+    /// hardcoded key: a custom leader with no forward gets forward =
+    /// leader.
+    #[test]
+    fn session_keys_forward_defaults_to_leader() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r#"
+                [session-keys]
+                leader = "ctrl-^"
+            "#},
+        );
+        let cfg = read_config_file(&path).unwrap();
+        let keys = cfg.session_keys.to_session_keys().unwrap();
+        assert_eq!(keys.leader, keys::Key::parse("ctrl-^").unwrap());
+        assert_eq!(keys.forward_key, keys.leader);
+        // detach still defaults to `d`.
+        assert_eq!(keys.detach_key, keys::Key::parse("d").unwrap());
+    }
+
+    /// A termios-special leader is rejected loudly at load.
+    #[test]
+    fn session_keys_rejects_termios_special_leader() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r#"
+                [session-keys]
+                leader = "ctrl-c"
+            "#},
+        );
+        let err = read_config_file(&path).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Validation { .. }),
+            "expected Validation, got {err:?}"
+        );
+    }
+
+    /// A wrapping-ambiguous leader is rejected loudly at load.
+    #[test]
+    fn session_keys_rejects_ambiguous_leader() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r#"
+                [session-keys]
+                leader = "ctrl-i"
+            "#},
+        );
+        assert!(matches!(
+            read_config_file(&path).unwrap_err(),
+            ConfigError::Validation { .. }
+        ));
+    }
+
+    /// The old default `ctrl-w` (`VWERASE`) is now rejected — the
+    /// hard-cut retires it as a latent termios footgun.
+    #[test]
+    fn session_keys_rejects_old_ctrl_w_default() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r#"
+                [session-keys]
+                leader = "ctrl-w"
+            "#},
+        );
+        assert!(matches!(
+            read_config_file(&path).unwrap_err(),
+            ConfigError::Validation { .. }
+        ));
+    }
+
+    /// A safe custom leader parses and validates.
+    #[test]
+    fn session_keys_accepts_safe_custom_leader() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r#"
+                [session-keys]
+                leader = "ctrl-^"
+            "#},
+        );
+        let cfg = read_config_file(&path).unwrap();
+        assert!(cfg.validate().is_ok());
+    }
+
+    /// An unknown key in `[session-keys]` is a parse error
+    /// (`deny_unknown_fields`), not a silent no-op.
+    #[test]
+    fn session_keys_unknown_field_errors() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r#"
+                [session-keys]
+                laeder = "ctrl-]"
+            "#},
+        );
+        assert!(matches!(
+            read_config_file(&path).unwrap_err(),
+            ConfigError::Parse { .. }
+        ));
+    }
+
+    /// An unknown subcommand name is a parse error, not silently
+    /// ignored.
+    #[test]
+    fn session_keys_unknown_subcommand_errors() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r#"
+                [session-keys.subcommands]
+                detach = "d"
+                detatch = "x"
+            "#},
+        );
+        assert!(matches!(
+            read_config_file(&path).unwrap_err(),
+            ConfigError::Parse { .. }
+        ));
+    }
+
+    /// Validation also surfaces through `read_config_or_default` (the
+    /// path `min` uses): only `NotFound` is silenced, not a bad leader.
+    #[test]
+    fn read_config_or_default_surfaces_validation_error() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "config.toml",
+            indoc::indoc! {r#"
+                [session-keys]
+                leader = "ctrl-z"
+            "#},
+        );
+        assert!(matches!(
+            read_config_or_default(&path).unwrap_err(),
+            ConfigError::Validation { .. }
+        ));
     }
 }

--- a/crates/sessions/src/keys.rs
+++ b/crates/sessions/src/keys.rs
@@ -1,0 +1,825 @@
+//! The session leader/subcommand key model: parsing logical key names from
+//! config, deriving their wire encodings across terminal keyboard protocols,
+//! and validating leaders against termios-special and wrapping-ambiguous
+//! chords.
+//!
+//! Two consumers share this module:
+//! - The *client* config ([`crate::client::config`]) holds keys as logical
+//!   names and validates them loudly at load (the UX gate).
+//! - The *daemon* reads the same names from per-channel SSH env vars at
+//!   attach and re-runs [`validate_leader`] as a silent safety backstop
+//!   before acting on the chord (the trust-boundary gate).
+//!
+//! ## Why the leader must not be termios-special
+//!
+//! A leader chord is *swallowed* by the daemon that sees it first, but the
+//! verbatim-forward subcommand writes a literal leader byte down the PTY, and
+//! a leaked leader could reach the PTY too. If that byte is a termios
+//! `c_cc` special — e.g. `ctrl-\` (`0x1c`, `VQUIT`) delivers `SIGQUIT` — the
+//! kernel line discipline acts on it *before* the application reads it,
+//! turning a detach gesture into a signal. [`validate_leader`] rejects such
+//! chords; see `termios(3)`. This is the finding that retired the issue's
+//! proposed `ctrl-\` default in favour of `ctrl-]` (`0x1d`, not special).
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Env var carrying the negotiated leader chord, e.g. `MINIMAL_SESSION_LEADER=ctrl-]`.
+///
+/// Sent by the client on the attach channel (alongside `MINIMAL_SESSION_ID`)
+/// and read back by the daemon's per-channel env handler. Each session-key
+/// var is independently optional; the daemon falls back per field.
+pub const LEADER_ENV: &str = "MINIMAL_SESSION_LEADER";
+/// Env var carrying the detach subcommand key, e.g. `MINIMAL_DETACH_KEY=d`.
+pub const DETACH_KEY_ENV: &str = "MINIMAL_DETACH_KEY";
+/// Env var carrying the verbatim-forward subcommand key, e.g.
+/// `MINIMAL_FORWARD_KEY=ctrl-]`.
+pub const FORWARD_KEY_ENV: &str = "MINIMAL_FORWARD_KEY";
+/// Env var carrying the bell-on-leader flag, e.g. `MINIMAL_BELL_ON_LEADER=0`.
+pub const BELL_ENV: &str = "MINIMAL_BELL_ON_LEADER";
+
+/// Control bytes the kernel line discipline consumes before the application
+/// reads them (the termios `c_cc` set on Linux). Binding the leader to one
+/// means a leaked or verbatim-forwarded leader triggers kernel behavior — a
+/// signal, flow control, or line editing — not an application binding. See
+/// `termios(3)`.
+///
+/// Note this includes the *old* default `ctrl-w` (`0x17`, `VWERASE`), which
+/// the hard-cut to `ctrl-]` retires as a latent footgun.
+const TERMIOS_SPECIAL: &[u8] = &[
+    0x03, // ctrl-C  VINTR   (SIGINT)
+    0x04, // ctrl-D  VEOF
+    0x0f, // ctrl-O  VDISCARD
+    0x11, // ctrl-Q  VSTART  (XON)
+    0x12, // ctrl-R  VREPRINT
+    0x13, // ctrl-S  VSTOP   (XOFF)
+    0x15, // ctrl-U  VKILL
+    0x16, // ctrl-V  VLNEXT
+    0x17, // ctrl-W  VWERASE
+    0x1a, // ctrl-Z  VSUSP   (SIGTSTP)
+    0x1c, // ctrl-\  VQUIT   (SIGQUIT)
+    0x7f, // DEL     VERASE
+];
+
+/// Control bytes that alias another commonly-typed key, so binding the leader
+/// to one is fragile across terminals: `NUL` (`ctrl-@`), `TAB` (`ctrl-i`),
+/// `LF` (`ctrl-j`), `CR` (`ctrl-m`), `ESC` (`ctrl-[`).
+///
+/// The parser's `ctrl-<glyph>` range (`@`..`~`, codepoint `0x40`..`0x7e`)
+/// already excludes `ctrl-<digit>` forms, so the historical case-wrapping
+/// aliases (`ctrl-2` = `ctrl-@`, `ctrl-6` = `ctrl-^`, …) — which depend on
+/// terminal-specific digit mappings — cannot arise; users get the canonical
+/// `ctrl-@`/`ctrl-^` forms or a parse error.
+const AMBIGUOUS: &[u8] = &[0x00, 0x09, 0x0a, 0x0d, 0x1b];
+
+/// A logical key as expressed in config: a base glyph plus an optional Ctrl
+/// modifier. Alt/Shift are not configurable yet; the parser rejects them.
+///
+/// Canonical config forms: `"ctrl-]"` (Ctrl + `]`), `"d"` (the plain glyph).
+/// Ctrl-chords accept any single ASCII glyph in `@`..`~` (codepoint
+/// `0x40`..`0x7e`); their wire byte is `codepoint & 0x1f`, the standard
+/// control-code mapping the kernel line discipline uses. Letters are
+/// normalised to lowercase, since `Ctrl+a` and `Ctrl+A` produce the same
+/// control code and terminals send the lowercase codepoint. Plain keys accept
+/// any single printable ASCII glyph (`0x20`..`0x7e`) and are case-sensitive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Key {
+    codepoint: u32,
+    ctrl: bool,
+}
+
+/// Failure parsing or validating a [`Key`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum KeyError {
+    /// The string was not a single ASCII glyph or `ctrl-<glyph>`: e.g. `""`,
+    /// `"ctrl-"`, `"ctrl-foo"`, or a multi-byte glyph.
+    #[error("unknown key `{0}`: expected a single ASCII glyph or `ctrl-<glyph>`")]
+    UnknownKey(String),
+    /// A modifier other than `ctrl-` was used. Only `ctrl-` is configurable.
+    #[error("unsupported modifier in `{0}`: only `ctrl-` is configurable")]
+    UnsupportedModifier(String),
+    /// The leader is a termios `c_cc` special the kernel line discipline
+    /// consumes before the app (see `termios(3)`).
+    #[error(
+        "termios-special leader `{0}`: the kernel line discipline consumes it before the app (see termios(3))"
+    )]
+    TermiosSpecial(String),
+    /// The leader aliases another commonly-typed key (e.g. `ctrl-i` = `TAB`).
+    #[error("wrapping-ambiguous leader `{0}`: it aliases another key (e.g. ctrl-i = TAB)")]
+    Ambiguous(String),
+}
+
+impl Key {
+    /// Parses a logical key name.
+    ///
+    /// Accepts `"ctrl-<glyph>"` (case-insensitive `ctrl-` prefix; the glyph
+    /// is a single ASCII char in `@`..`~`, letters normalised to lowercase)
+    /// and `"<glyph>"` (a single printable ASCII char, case-sensitive).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyError::UnsupportedModifier`] for `alt-`/`shift-`/etc., and
+    /// [`KeyError::UnknownKey`] for anything else unparseable.
+    pub fn parse(s: &str) -> Result<Self, KeyError> {
+        let lower = s.to_ascii_lowercase();
+        if let Some(glyph) = lower.strip_prefix("ctrl-") {
+            return Self::parse_ctrl(glyph, s);
+        }
+        for other in ["alt-", "shift-", "meta-", "super-"] {
+            if lower.starts_with(other) {
+                return Err(KeyError::UnsupportedModifier(s.to_string()));
+            }
+        }
+        // Plain single printable ASCII glyph.
+        let Some(ch) = s.chars().next() else {
+            return Err(KeyError::UnknownKey(s.to_string()));
+        };
+        if s.chars().count() == 1 && ch.is_ascii() && (0x20..=0x7e).contains(&(ch as u32)) {
+            Ok(Self {
+                codepoint: ch as u32,
+                ctrl: false,
+            })
+        } else {
+            Err(KeyError::UnknownKey(s.to_string()))
+        }
+    }
+
+    fn parse_ctrl(glyph: &str, original: &str) -> Result<Self, KeyError> {
+        let Some(ch) = glyph.chars().next() else {
+            return Err(KeyError::UnknownKey(original.to_string()));
+        };
+        if glyph.chars().count() != 1 || !ch.is_ascii() || !(0x40..=0x7e).contains(&(ch as u32)) {
+            return Err(KeyError::UnknownKey(original.to_string()));
+        }
+        // Normalise letters to lowercase: Ctrl+a and Ctrl+A are the same
+        // control code, and terminals send the lowercase codepoint.
+        let codepoint = if ch.is_ascii_uppercase() {
+            ch.to_ascii_lowercase() as u32
+        } else {
+            ch as u32
+        };
+        Ok(Self {
+            codepoint,
+            ctrl: true,
+        })
+    }
+
+    /// The single-byte form: the control code for a Ctrl-chord
+    /// (`codepoint & 0x1f`), or the glyph's own byte for a plain key.
+    ///
+    /// Safe: `parse` validates codepoints to the ASCII range (`0x20`..`0x7e`
+    /// for plain glyphs, `0x40`..`0x7e` for Ctrl-chords), so the cast never
+    /// truncates.
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn plain_byte(&self) -> u8 {
+        if self.ctrl {
+            // `& 0x1f` yields 0..=31 regardless of the codepoint.
+            (self.codepoint & 0x1f) as u8
+        } else {
+            self.codepoint as u8
+        }
+    }
+
+    /// All wire forms this key can arrive as, across the plain, kitty, and
+    /// modifyOtherKeys keyboard protocols. A keystroke matches this key when
+    /// the *whole* received chunk equals any form (matching mirrors the
+    /// existing chord matcher: a chunk that is the chord plus more bytes is
+    /// not a match, so pastes never trigger command mode).
+    ///
+    /// The kitty and modifyOtherKeys modifier field is `1 + bitmask`, where
+    /// Control is bit `4` — so a Ctrl-chord uses `5` (matching the shipped
+    /// `ctrl-w` encodings), and a plain key uses `1`. modifyOtherKeys only
+    /// CSI-encodes *modified* keys, so plain keys have no modifyOtherKeys
+    /// form (they arrive as [`Self::plain_byte`]); the kitty form is still
+    /// included since kitty can CSI-encode unmodified keys under "report all
+    /// keys", and it cannot false-match another key.
+    #[must_use]
+    pub fn encodings(&self) -> Vec<Vec<u8>> {
+        let mods = 1 + u32::from(self.ctrl) * 4;
+        let cp = self.codepoint;
+        let mut out = Vec::with_capacity(3);
+        out.push(vec![self.plain_byte()]);
+        out.push(format!("\x1b[{cp};{mods}u").into_bytes());
+        if self.ctrl {
+            out.push(format!("\x1b[27;{mods};{cp}~").into_bytes());
+        }
+        out
+    }
+
+    /// Whether a received stdin chunk is exactly this key, across all its
+    /// wire forms (plain, kitty, modifyOtherKeys). A chunk that is the key
+    /// plus more bytes — a paste — is not a match, so pastes never trigger
+    /// command mode. This is the whole-chunk match the daemon's chord matcher
+    /// has always used, now derived from the key instead of hardcoded.
+    #[must_use]
+    pub fn matches_chunk(&self, chunk: &[u8]) -> bool {
+        self.encodings().iter().any(|e| e.as_slice() == chunk)
+    }
+
+    /// The canonical config-string form, for display and round-tripping.
+    #[must_use]
+    pub fn as_config_str(&self) -> String {
+        let Some(ch) = char::from_u32(self.codepoint) else {
+            return String::new();
+        };
+        if self.ctrl {
+            format!("ctrl-{ch}")
+        } else {
+            ch.to_string()
+        }
+    }
+}
+
+impl Serialize for Key {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.as_config_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Key {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Validates a leader chord, rejecting termios-special and wrapping-ambiguous
+/// keys. This is the shared check both gates run: loudly at client config
+/// load (UX), and again at the daemon before acting on the negotiated chord
+/// (safety).
+///
+/// Only Ctrl-chords can be termios-special or ambiguous — plain keys are
+/// printable bytes (`0x20`..`0x7e`), never control codes — so a plain leader
+/// always passes. (A plain-printable leader is a poor choice — every press
+/// enters command mode — but it is the user's explicit choice and not a
+/// correctness or safety hazard, so it is not rejected here.)
+///
+/// # Errors
+///
+/// Returns [`KeyError::TermiosSpecial`] or [`KeyError::Ambiguous`] when the
+/// leader's control byte is in the corresponding reject set.
+pub fn validate_leader(key: &Key) -> Result<(), KeyError> {
+    if key.ctrl {
+        let byte = key.plain_byte();
+        if TERMIOS_SPECIAL.contains(&byte) {
+            return Err(KeyError::TermiosSpecial(key.as_config_str()));
+        }
+        if AMBIGUOUS.contains(&byte) {
+            return Err(KeyError::Ambiguous(key.as_config_str()));
+        }
+    }
+    Ok(())
+}
+
+/// The negotiated per-channel session-key config: the leader chord that
+/// enters command mode, the subcommand keys, and whether entering command
+/// mode rings the terminal bell.
+///
+/// Defaults match the shipped config: `leader = ctrl-]`, `detach = d`,
+/// `forward = ctrl-]` (forward defaults to the leader, so a double-press
+/// verbatim-forwards), `bell_on_leader = false`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SessionKeys {
+    /// The chord that enters command mode (swallowed, never forwarded except
+    /// via the forward subcommand).
+    pub leader: Key,
+    /// The command-mode key that detaches this channel.
+    pub detach_key: Key,
+    /// The command-mode key that verbatim-forwards a leader byte down the PTY
+    /// (hands the next keystroke to the layer below, for nested sessions).
+    pub forward_key: Key,
+    /// Whether entering command mode writes BEL (`0x07`) to the channel.
+    pub bell_on_leader: bool,
+}
+
+/// State of the per-channel session-key command mode: idle (keystrokes
+/// forward to the PTY) or awaiting the subcommand that follows a swallowed
+/// leader. Held per attach channel on the daemon; reset whenever a new
+/// channel attaches.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CommandMode {
+    /// No leader pending; keystrokes forward to the PTY verbatim.
+    #[default]
+    Idle,
+    /// The leader was swallowed; the next keystroke is the subcommand.
+    AwaitingSubcommand,
+}
+
+/// What the session-key state machine does with one stdin chunk. The daemon
+/// maps each variant to its I/O effect; the decision itself is pure, so the
+/// transitions are unit-testable without a PTY or ssh channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyAction {
+    /// Forward the chunk verbatim to the PTY.
+    Forward,
+    /// Swallow the chunk — an unbound command-mode key that cancels command
+    /// mode (the key is dropped, not forwarded, mirroring tmux).
+    Swallow,
+    /// The leader matched: swallow it and enter command mode.
+    EnterCommandMode,
+    /// The detach subcommand matched: tear down the attach channel (detach,
+    /// not exit — the session and its process keep running).
+    Detach,
+    /// The forward subcommand matched: write a leader byte down the PTY so a
+    /// nested daemon, if any, swallows it and enters its own command mode.
+    ForwardLeader,
+}
+
+impl Default for SessionKeys {
+    fn default() -> Self {
+        // `parse` is infallible for these shipped defaults; panicking here
+        // would mean the defaults themselves are broken, which is a
+        // programmer error worth surfacing immediately.
+        let leader = Key::parse("ctrl-]").expect("default leader parses");
+        Self {
+            leader,
+            detach_key: Key::parse("d").expect("default detach key parses"),
+            forward_key: leader, // forward defaults to the leader
+            bell_on_leader: false,
+        }
+    }
+}
+
+impl SessionKeys {
+    /// Parses the per-channel session keys from the SSH channel's env vars,
+    /// falling back per field to the defaults when a var is absent (so an old
+    /// `min` client, or a non-`min` ssh client, still gets a working leader).
+    ///
+    /// `forward` falls back to the negotiated `leader`, not a hardcoded key,
+    /// so a remapped leader still gets a sensible default forward. Parse
+    /// failures are silent here — the daemon's [`Self::validated_or_default`]
+    /// is the backstop that logs and falls back on a *valid-but-unsafe* chord.
+    #[must_use]
+    pub fn from_env(env: &BTreeMap<String, String>) -> Self {
+        let default = Self::default();
+        let leader = env
+            .get(LEADER_ENV)
+            .and_then(|v| Key::parse(v).ok())
+            .unwrap_or(default.leader);
+        let detach_key = env
+            .get(DETACH_KEY_ENV)
+            .and_then(|v| Key::parse(v).ok())
+            .unwrap_or(default.detach_key);
+        let forward_key = env
+            .get(FORWARD_KEY_ENV)
+            .and_then(|v| Key::parse(v).ok())
+            .unwrap_or(leader);
+        let bell_on_leader = env
+            .get(BELL_ENV)
+            .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
+        Self {
+            leader,
+            detach_key,
+            forward_key,
+            bell_on_leader,
+        }
+    }
+
+    /// Re-validates the leader at the trust boundary (the daemon). On failure
+    /// — a termios-special or ambiguous chord a buggy or malicious client
+    /// could send — returns the default keys so a bad chord never garbles the
+    /// screen. The client's load-time validation is the loud/UX gate; this is
+    /// the silent safety backstop.
+    #[must_use]
+    pub fn validated_or_default(self) -> Self {
+        match validate_leader(&self.leader) {
+            Ok(()) => self,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    leader = self.leader.as_config_str(),
+                    "rejecting negotiated session leader; falling back to default",
+                );
+                Self::default()
+            }
+        }
+    }
+
+    /// Advance the command-mode state machine by one stdin chunk, returning
+    /// the next state and the action to take. Pure: no I/O.
+    ///
+    /// In [`CommandMode::Idle`], a chunk matching the leader enters command
+    /// mode (the leader is swallowed); anything else forwards. In
+    /// [`CommandMode::AwaitingSubcommand`], the next chunk is the subcommand:
+    /// the detach key detaches, the forward key verbatim-forwards a leader
+    /// byte, and any other key is swallowed and cancels command mode — so a
+    /// stray leader can always be cancelled by pressing any unbound key (no
+    /// stuck state, no explicit cancel key).
+    #[must_use]
+    pub fn advance(&self, mode: CommandMode, chunk: &[u8]) -> (CommandMode, KeyAction) {
+        match mode {
+            CommandMode::Idle => {
+                if self.leader.matches_chunk(chunk) {
+                    (CommandMode::AwaitingSubcommand, KeyAction::EnterCommandMode)
+                } else {
+                    (CommandMode::Idle, KeyAction::Forward)
+                }
+            }
+            CommandMode::AwaitingSubcommand => {
+                if self.detach_key.matches_chunk(chunk) {
+                    (CommandMode::Idle, KeyAction::Detach)
+                } else if self.forward_key.matches_chunk(chunk) {
+                    (CommandMode::Idle, KeyAction::ForwardLeader)
+                } else {
+                    (CommandMode::Idle, KeyAction::Swallow)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ctrl_chord() {
+        assert_eq!(
+            Key::parse("ctrl-]").unwrap(),
+            Key {
+                codepoint: 93,
+                ctrl: true
+            }
+        );
+        assert_eq!(
+            Key::parse("ctrl-w").unwrap(),
+            Key {
+                codepoint: 119,
+                ctrl: true
+            }
+        );
+    }
+
+    #[test]
+    fn ctrl_prefix_is_case_insensitive() {
+        assert_eq!(
+            Key::parse("CTRL-]").unwrap(),
+            Key {
+                codepoint: 93,
+                ctrl: true
+            }
+        );
+        assert_eq!(
+            Key::parse("Ctrl-]").unwrap(),
+            Key {
+                codepoint: 93,
+                ctrl: true
+            }
+        );
+    }
+
+    #[test]
+    fn ctrl_letter_normalised_to_lowercase() {
+        // Ctrl+A and Ctrl+a are the same control code; terminals send the
+        // lowercase codepoint, so both parse to 97 (not 65).
+        assert_eq!(
+            Key::parse("ctrl-A").unwrap(),
+            Key {
+                codepoint: 97,
+                ctrl: true
+            }
+        );
+        assert_eq!(
+            Key::parse("ctrl-a").unwrap(),
+            Key {
+                codepoint: 97,
+                ctrl: true
+            }
+        );
+    }
+
+    #[test]
+    fn parses_plain_glyph_case_sensitive() {
+        assert_eq!(
+            Key::parse("d").unwrap(),
+            Key {
+                codepoint: 100,
+                ctrl: false
+            }
+        );
+        assert_eq!(
+            Key::parse("D").unwrap(),
+            Key {
+                codepoint: 68,
+                ctrl: false
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_unparseable() {
+        assert!(matches!(Key::parse(""), Err(KeyError::UnknownKey(_))));
+        assert!(matches!(Key::parse("ctrl-"), Err(KeyError::UnknownKey(_))));
+        assert!(matches!(
+            Key::parse("ctrl-foo"),
+            Err(KeyError::UnknownKey(_))
+        ));
+        // ctrl-<digit> is outside the @..~ range: rejected, so the
+        // ctrl-2=ctrl-@ case-wrapping alias cannot arise.
+        assert!(matches!(Key::parse("ctrl-2"), Err(KeyError::UnknownKey(_))));
+        assert!(matches!(Key::parse("ctrl-?"), Err(KeyError::UnknownKey(_))));
+        assert!(matches!(Key::parse("ab"), Err(KeyError::UnknownKey(_))));
+        assert!(matches!(Key::parse("é"), Err(KeyError::UnknownKey(_))));
+    }
+
+    #[test]
+    fn rejects_other_modifiers() {
+        assert!(matches!(
+            Key::parse("alt-x"),
+            Err(KeyError::UnsupportedModifier(_))
+        ));
+        assert!(matches!(
+            Key::parse("shift-x"),
+            Err(KeyError::UnsupportedModifier(_))
+        ));
+    }
+
+    #[test]
+    fn default_leader_encodings_match_plan() {
+        let leader = Key::parse("ctrl-]").unwrap();
+        assert_eq!(leader.plain_byte(), 0x1d);
+        assert_eq!(
+            leader.encodings(),
+            vec![
+                vec![0x1d],
+                b"\x1b[93;5u".to_vec(),
+                b"\x1b[27;5;93~".to_vec(),
+            ]
+        );
+    }
+
+    #[test]
+    fn encodings_match_shipped_ctrl_w_forms() {
+        // The derived forms for ctrl-w must equal the old hardcoded constants,
+        // proving the derivation is a faithful generalisation.
+        let w = Key::parse("ctrl-w").unwrap();
+        assert_eq!(w.plain_byte(), 0x17);
+        assert_eq!(
+            w.encodings(),
+            vec![
+                vec![0x17],
+                b"\x1b[119;5u".to_vec(),
+                b"\x1b[27;5;119~".to_vec(),
+            ]
+        );
+    }
+
+    #[test]
+    fn plain_key_has_no_modifyotherkeys_form() {
+        let d = Key::parse("d").unwrap();
+        assert_eq!(d.encodings(), vec![vec![0x64], b"\x1b[100;1u".to_vec(),]);
+    }
+
+    #[test]
+    fn config_str_round_trips() {
+        for s in ["ctrl-]", "ctrl-w", "ctrl-a", "d", "D", "^", "@"] {
+            assert_eq!(Key::parse(s).unwrap().as_config_str(), s);
+        }
+    }
+
+    #[test]
+    fn validate_accepts_safe_leaders() {
+        assert!(validate_leader(&Key::parse("ctrl-]").unwrap()).is_ok());
+        assert!(validate_leader(&Key::parse("ctrl-^").unwrap()).is_ok());
+        // A plain-printable leader is a poor choice but not unsafe.
+        assert!(validate_leader(&Key::parse("d").unwrap()).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_termios_special() {
+        for bad in [
+            "ctrl-c", "ctrl-d", "ctrl-o", "ctrl-q", "ctrl-r", "ctrl-s", "ctrl-u", "ctrl-v",
+            "ctrl-w", "ctrl-z", "ctrl-\\",
+        ] {
+            let err = validate_leader(&Key::parse(bad).unwrap()).unwrap_err();
+            assert!(
+                matches!(err, KeyError::TermiosSpecial(_)),
+                "{bad} should be termios-special, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_ambiguous() {
+        for bad in ["ctrl-@", "ctrl-i", "ctrl-j", "ctrl-m", "ctrl-["] {
+            let err = validate_leader(&Key::parse(bad).unwrap()).unwrap_err();
+            assert!(
+                matches!(err, KeyError::Ambiguous(_)),
+                "{bad} should be ambiguous, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_env_uses_defaults_when_empty() {
+        let keys = SessionKeys::from_env(&BTreeMap::new());
+        assert_eq!(keys, SessionKeys::default());
+    }
+
+    #[test]
+    fn from_env_parses_all_fields() {
+        let mut env = BTreeMap::new();
+        env.insert(LEADER_ENV.to_string(), "ctrl-^".to_string());
+        env.insert(DETACH_KEY_ENV.to_string(), "x".to_string());
+        env.insert(FORWARD_KEY_ENV.to_string(), "ctrl-]".to_string());
+        env.insert(BELL_ENV.to_string(), "1".to_string());
+        let keys = SessionKeys::from_env(&env);
+        assert_eq!(keys.leader, Key::parse("ctrl-^").unwrap());
+        assert_eq!(keys.detach_key, Key::parse("x").unwrap());
+        assert_eq!(keys.forward_key, Key::parse("ctrl-]").unwrap());
+        assert!(keys.bell_on_leader);
+    }
+
+    #[test]
+    fn from_env_forward_falls_back_to_leader() {
+        // forward absent -> defaults to the negotiated leader, not ctrl-].
+        let mut env = BTreeMap::new();
+        env.insert(LEADER_ENV.to_string(), "ctrl-^".to_string());
+        let keys = SessionKeys::from_env(&env);
+        assert_eq!(keys.forward_key, Key::parse("ctrl-^").unwrap());
+    }
+
+    #[test]
+    fn from_env_silently_ignores_unparseable() {
+        let mut env = BTreeMap::new();
+        env.insert(LEADER_ENV.to_string(), "nonsense".to_string());
+        let keys = SessionKeys::from_env(&env);
+        assert_eq!(keys.leader, SessionKeys::default().leader);
+    }
+
+    #[test]
+    fn from_env_bell_truthy_values() {
+        for (val, expected) in [
+            ("0", false),
+            ("1", true),
+            ("true", true),
+            ("TRUE", true),
+            ("yes", false),
+        ] {
+            let mut env = BTreeMap::new();
+            env.insert(BELL_ENV.to_string(), val.to_string());
+            assert_eq!(
+                SessionKeys::from_env(&env).bell_on_leader,
+                expected,
+                "bell={val:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validated_or_default_keeps_safe_leader() {
+        let mut env = BTreeMap::new();
+        env.insert(LEADER_ENV.to_string(), "ctrl-^".to_string());
+        let keys = SessionKeys::from_env(&env);
+        assert_eq!(
+            keys.validated_or_default().leader,
+            Key::parse("ctrl-^").unwrap()
+        );
+    }
+
+    #[test]
+    fn validated_or_default_falls_back_on_termios_special() {
+        let mut env = BTreeMap::new();
+        env.insert(LEADER_ENV.to_string(), "ctrl-c".to_string());
+        let keys = SessionKeys::from_env(&env);
+        // A malicious/buggy client sending ctrl-c falls back to the default,
+        // never acting on the unsafe chord.
+        assert_eq!(keys.validated_or_default(), SessionKeys::default());
+    }
+
+    #[test]
+    fn default_forward_is_the_leader() {
+        let default = SessionKeys::default();
+        assert_eq!(default.forward_key, default.leader);
+        assert_eq!(default.leader, Key::parse("ctrl-]").unwrap());
+        assert_eq!(default.detach_key, Key::parse("d").unwrap());
+        assert!(!default.bell_on_leader);
+    }
+
+    #[test]
+    fn matches_chunk_accepts_every_encoding() {
+        let leader = Key::parse("ctrl-]").unwrap();
+        // Plain byte, kitty, and modifyOtherKeys forms all match.
+        assert!(leader.matches_chunk(&[0x1d]));
+        assert!(leader.matches_chunk(b"\x1b[93;5u"));
+        assert!(leader.matches_chunk(b"\x1b[27;5;93~"));
+    }
+
+    #[test]
+    fn matches_chunk_rejects_paste_and_prefix() {
+        let leader = Key::parse("ctrl-]").unwrap();
+        // A paste (leader byte plus more) is not a match.
+        assert!(!leader.matches_chunk(b"\x1dxyz"));
+        // A bare prefix of a multi-byte form is not a match.
+        assert!(!leader.matches_chunk(b"\x1b[93"));
+        // A different key is not a match.
+        assert!(!leader.matches_chunk(b"\x1b[119;5u"));
+    }
+
+    #[test]
+    fn advance_idle_forwards_non_leader() {
+        let keys = SessionKeys::default();
+        assert_eq!(
+            keys.advance(CommandMode::Idle, b"hello"),
+            (CommandMode::Idle, KeyAction::Forward),
+        );
+    }
+
+    #[test]
+    fn advance_idle_leader_enters_command_mode() {
+        let keys = SessionKeys::default();
+        // Every leader encoding enters command mode.
+        for chunk in [&[0x1d][..], b"\x1b[93;5u", b"\x1b[27;5;93~"] {
+            assert_eq!(
+                keys.advance(CommandMode::Idle, chunk),
+                (CommandMode::AwaitingSubcommand, KeyAction::EnterCommandMode),
+                "chunk={chunk:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn advance_command_mode_detach_key_detaches() {
+        let keys = SessionKeys::default();
+        // The leader enters command mode; `d` detaches and returns to idle.
+        let (mode, _) = keys.advance(CommandMode::Idle, &[0x1d]);
+        assert_eq!(mode, CommandMode::AwaitingSubcommand);
+        assert_eq!(
+            keys.advance(mode, b"d"),
+            (CommandMode::Idle, KeyAction::Detach),
+        );
+    }
+
+    #[test]
+    fn advance_command_mode_forward_key_forwards_leader() {
+        let keys = SessionKeys::default();
+        // Default forward key is the leader itself: a double-press forwards.
+        let (mode, _) = keys.advance(CommandMode::Idle, &[0x1d]);
+        assert_eq!(
+            keys.advance(mode, &[0x1d]),
+            (CommandMode::Idle, KeyAction::ForwardLeader),
+        );
+    }
+
+    #[test]
+    fn advance_command_mode_unbound_key_swallows_and_cancels() {
+        let keys = SessionKeys::default();
+        let (mode, _) = keys.advance(CommandMode::Idle, &[0x1d]);
+        // An unbound key is swallowed (not forwarded) and exits command mode.
+        assert_eq!(
+            keys.advance(mode, b"x"),
+            (CommandMode::Idle, KeyAction::Swallow),
+        );
+        // After the cancel, idle resumes: a normal key forwards again.
+        assert_eq!(
+            keys.advance(CommandMode::Idle, b"x"),
+            (CommandMode::Idle, KeyAction::Forward),
+        );
+    }
+
+    #[test]
+    fn advance_command_mode_paste_is_unbound_swallow() {
+        let keys = SessionKeys::default();
+        let (mode, _) = keys.advance(CommandMode::Idle, &[0x1d]);
+        // A multi-byte paste in command mode matches no subcommand: swallowed,
+        // command mode cancelled (the paste is dropped, not forwarded).
+        assert_eq!(
+            keys.advance(mode, b"detach"),
+            (CommandMode::Idle, KeyAction::Swallow),
+        );
+    }
+
+    #[test]
+    fn advance_remapped_leader_uses_negotiated_keys() {
+        // A client that remapped leader=ctrl-^, detach=x, forward=ctrl-].
+        let mut env = BTreeMap::new();
+        env.insert(LEADER_ENV.to_string(), "ctrl-^".to_string());
+        env.insert(DETACH_KEY_ENV.to_string(), "x".to_string());
+        env.insert(FORWARD_KEY_ENV.to_string(), "ctrl-]".to_string());
+        let keys = SessionKeys::from_env(&env);
+
+        // The old default leader (ctrl-]) no longer enters command mode.
+        assert_eq!(
+            keys.advance(CommandMode::Idle, &[0x1d]),
+            (CommandMode::Idle, KeyAction::Forward),
+        );
+        // The remapped leader (ctrl-^, 0x1e) does.
+        assert_eq!(
+            keys.advance(CommandMode::Idle, &[0x1e]),
+            (CommandMode::AwaitingSubcommand, KeyAction::EnterCommandMode),
+        );
+        // The remapped detach key (x) detaches.
+        assert_eq!(
+            keys.advance(CommandMode::AwaitingSubcommand, b"x"),
+            (CommandMode::Idle, KeyAction::Detach),
+        );
+        // The remapped forward key (ctrl-]) forwards.
+        assert_eq!(
+            keys.advance(CommandMode::AwaitingSubcommand, &[0x1d]),
+            (CommandMode::Idle, KeyAction::ForwardLeader),
+        );
+    }
+}

--- a/crates/sessions/src/keys.rs
+++ b/crates/sessions/src/keys.rs
@@ -673,6 +673,14 @@ impl ChordMatcher {
         self.mode
     }
 
+    /// Whether a split candidate is currently held in the pending buffer —
+    /// the last chunk ended mid-form and the next chunk (or an idle flush)
+    /// must resolve it.
+    #[must_use]
+    pub fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
     /// Whether `prefix` is a strict prefix of a wire form of either bound
     /// subcommand key.
     fn is_subcommand_form_prefix(&self, prefix: &[u8]) -> bool {
@@ -768,6 +776,26 @@ impl ChordMatcher {
             out.push(FeedOutcome::Forward(buf[frs..].to_vec()));
         }
         out
+    }
+
+    /// Release any held split candidate as data, cancelling command mode.
+    ///
+    /// A held candidate is a *strict* prefix of some wire form, so on its own
+    /// it can never complete a chord — the stream stopped mid-keystroke. The
+    /// caller invokes this after an idle gap (see the daemon's stdin loop) so
+    /// a lone `ESC` (a prefix of every kitty form) is forwarded to the PTY
+    /// instead of being held until the next, possibly never-arriving, chunk —
+    /// which would wedge it in e.g. vim insert mode. Command mode is
+    /// cancelled, tmux-style, since the subcommand never completed.
+    ///
+    /// Returns the held bytes (empty when nothing is held); the daemon writes
+    /// them to the PTY as ordinary data.
+    pub fn flush(&mut self) -> Vec<u8> {
+        if self.pending.is_empty() {
+            return Vec::new();
+        }
+        self.mode = CommandMode::Idle;
+        std::mem::take(&mut self.pending)
     }
 }
 
@@ -1259,6 +1287,47 @@ mod tests {
         assert_eq!(m.feed(b"\x1b"), vec![]);
         assert_eq!(m.feed(b"[A"), vec![FeedOutcome::Action(KeyAction::Swallow)]);
         assert_eq!(m.mode(), CommandMode::Idle);
+    }
+
+    #[test]
+    fn flush_empty_is_a_noop() {
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        assert!(!m.has_pending());
+        assert_eq!(m.flush(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn flush_releases_held_idle_candidate_as_data() {
+        // A bare ESC ends the chunk: held as a possible kitty prefix of the
+        // leader. The stream goes quiet, so the idle flush releases it as
+        // data instead of holding it for a next chunk that never comes.
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        assert_eq!(m.feed(b"\x1b"), vec![]);
+        assert!(m.has_pending());
+        assert_eq!(m.mode(), CommandMode::Idle);
+        assert_eq!(m.flush(), vec![0x1b]);
+        assert!(!m.has_pending());
+        // A second flush is a no-op.
+        assert_eq!(m.flush(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn flush_cancels_command_mode_and_releases_held_subcommand() {
+        // In command mode, a bare ESC is a prefix of the bound subcommands'
+        // kitty forms, so it is held. The stream goes quiet: the idle flush
+        // releases the ESC as data and cancels command mode (the subcommand
+        // never completed).
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        assert_eq!(
+            m.feed(&[0x1d]),
+            vec![FeedOutcome::Action(KeyAction::EnterCommandMode)]
+        );
+        assert_eq!(m.feed(b"\x1b"), vec![]);
+        assert!(m.has_pending());
+        assert_eq!(m.mode(), CommandMode::AwaitingSubcommand);
+        assert_eq!(m.flush(), vec![0x1b]);
+        assert_eq!(m.mode(), CommandMode::Idle);
+        assert!(!m.has_pending());
     }
 
     #[test]

--- a/crates/sessions/src/keys.rs
+++ b/crates/sessions/src/keys.rs
@@ -47,6 +47,12 @@ pub const BELL_ENV: &str = "MINIMAL_BELL_ON_LEADER";
 ///
 /// Note this includes the *old* default `ctrl-w` (`0x17`, `VWERASE`), which
 /// the hard-cut to `ctrl-]` retires as a latent footgun.
+///
+/// DEL (`0x7f`, `VERASE` on Linux) is absent deliberately: no parseable
+/// [`Key`] can produce it — `ctrl-?` is rejected and plain keys stop at
+/// `0x7e` — so a `0x7f` entry would be dead weight suggesting a hazard that
+/// cannot arise. The *other* erase char, `ctrl-h` (`0x08`), is parseable and
+/// lives in [`AMBIGUOUS`] instead.
 const TERMIOS_SPECIAL: &[u8] = &[
     0x03, // ctrl-C  VINTR   (SIGINT)
     0x04, // ctrl-D  VEOF
@@ -59,19 +65,28 @@ const TERMIOS_SPECIAL: &[u8] = &[
     0x17, // ctrl-W  VWERASE
     0x1a, // ctrl-Z  VSUSP   (SIGTSTP)
     0x1c, // ctrl-\  VQUIT   (SIGQUIT)
-    0x7f, // DEL     VERASE
 ];
 
 /// Control bytes that alias another commonly-typed key, so binding the leader
-/// to one is fragile across terminals: `NUL` (`ctrl-@`), `TAB` (`ctrl-i`),
-/// `LF` (`ctrl-j`), `CR` (`ctrl-m`), `ESC` (`ctrl-[`).
+/// to one is fragile across terminals. Each entry names the aliased key so
+/// the validation error can say *which* collision the user would hit:
+/// `ctrl-@` = `NUL`, `ctrl-h` = `Backspace` wherever the tty erase char is
+/// `^H` (the default on the BSDs, vs Linux's `^?`), `ctrl-i` = `TAB`,
+/// `ctrl-j` = `LF`, `ctrl-m` = `CR`, `ctrl-[` = `ESC`.
 ///
 /// The parser's `ctrl-<glyph>` range (`@`..`~`, codepoint `0x40`..`0x7e`)
 /// already excludes `ctrl-<digit>` forms, so the historical case-wrapping
 /// aliases (`ctrl-2` = `ctrl-@`, `ctrl-6` = `ctrl-^`, …) — which depend on
 /// terminal-specific digit mappings — cannot arise; users get the canonical
 /// `ctrl-@`/`ctrl-^` forms or a parse error.
-const AMBIGUOUS: &[u8] = &[0x00, 0x09, 0x0a, 0x0d, 0x1b];
+const AMBIGUOUS: &[(u8, &str)] = &[
+    (0x00, "NUL (also ctrl-Space)"),
+    (0x08, "Backspace (tty erase is ^H on the BSDs)"),
+    (0x09, "TAB"),
+    (0x0a, "LF"),
+    (0x0d, "CR (Enter)"),
+    (0x1b, "ESC"),
+];
 
 /// A logical key as expressed in config: a base glyph plus an optional Ctrl
 /// modifier. Alt/Shift are not configurable yet; the parser rejects them.
@@ -106,9 +121,70 @@ pub enum KeyError {
         "termios-special leader `{0}`: the kernel line discipline consumes it before the app (see termios(3))"
     )]
     TermiosSpecial(String),
-    /// The leader aliases another commonly-typed key (e.g. `ctrl-i` = `TAB`).
-    #[error("wrapping-ambiguous leader `{0}`: it aliases another key (e.g. ctrl-i = TAB)")]
-    Ambiguous(String),
+    /// The leader aliases another commonly-typed key; the second field
+    /// names what it aliases (e.g. `ctrl-i` aliases `TAB`).
+    #[error("wrapping-ambiguous leader `{0}`: it aliases {1}")]
+    Ambiguous(String, &'static str),
+    /// The detach key equals the leader or the forward key: command mode
+    /// checks the detach key first, so the other binding would be
+    /// unreachable. The second field names the shadowed binding.
+    #[error("conflicting session keys: the detach key `{0}` shadows {1}")]
+    ConflictingDetach(String, &'static str),
+}
+
+/// A tiny stack buffer for rendering one wire-form encoding without a heap
+/// allocation. The longest form is `\x1b[27;5;<cp>~`; parsed codepoints are
+/// ASCII (`<= 0x7e`, at most 3 digits), so 32 bytes is generous. Pushes past
+/// the end panic rather than truncate — the parse invariants make that
+/// unreachable, and a panic beats a silently wrong encoding.
+#[derive(Default)]
+struct Scratch {
+    buf: [u8; 32],
+    len: usize,
+}
+
+impl Scratch {
+    fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    fn push(&mut self, b: u8) -> &mut Self {
+        self.buf[self.len] = b;
+        self.len += 1;
+        self
+    }
+
+    fn push_str(&mut self, s: &str) -> &mut Self {
+        self.buf[self.len..self.len + s.len()].copy_from_slice(s.as_bytes());
+        self.len += s.len();
+        self
+    }
+
+    fn push_dec(&mut self, n: u32) -> &mut Self {
+        let mut digits = [0u8; 10];
+        let mut i = digits.len();
+        let mut n = n;
+        loop {
+            i -= 1;
+            // `n % 10` is a single digit; the cast cannot truncate.
+            #[allow(clippy::cast_possible_truncation)]
+            {
+                digits[i] = b'0' + (n % 10) as u8;
+            }
+            n /= 10;
+            if n == 0 {
+                break;
+            }
+        }
+        let end = self.len + (digits.len() - i);
+        self.buf[self.len..end].copy_from_slice(&digits[i..]);
+        self.len = end;
+        self
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
 }
 
 impl Key {
@@ -184,39 +260,109 @@ impl Key {
     }
 
     /// All wire forms this key can arrive as, across the plain, kitty, and
-    /// modifyOtherKeys keyboard protocols. A keystroke matches this key when
-    /// the *whole* received chunk equals any form (matching mirrors the
-    /// existing chord matcher: a chunk that is the chord plus more bytes is
-    /// not a match, so pastes never trigger command mode).
+    /// modifyOtherKeys keyboard protocols.
     ///
     /// The kitty and modifyOtherKeys modifier field is `1 + bitmask`, where
     /// Control is bit `4` — so a Ctrl-chord uses `5` (matching the shipped
-    /// `ctrl-w` encodings), and a plain key uses `1`. modifyOtherKeys only
-    /// CSI-encodes *modified* keys, so plain keys have no modifyOtherKeys
-    /// form (they arrive as [`Self::plain_byte`]); the kitty form is still
-    /// included since kitty can CSI-encode unmodified keys under "report all
-    /// keys", and it cannot false-match another key.
+    /// `ctrl-w` encodings), and a plain key uses `1`. Kitty *omits* the
+    /// modifier field entirely when it would be `1`, so a plain key needs
+    /// both kitty forms (`CSI <cp> u` and `CSI <cp> ; 1 u`) or terminals in
+    /// report-all-keys mode go unmatched. modifyOtherKeys only CSI-encodes
+    /// *modified* keys, so plain keys have no modifyOtherKeys form (they
+    /// arrive as [`Self::plain_byte`]); the kitty forms are still included
+    /// since kitty can CSI-encode unmodified keys under "report all keys",
+    /// and they cannot false-match another key.
     #[must_use]
     pub fn encodings(&self) -> Vec<Vec<u8>> {
-        let mods = 1 + u32::from(self.ctrl) * 4;
-        let cp = self.codepoint;
-        let mut out = Vec::with_capacity(3);
-        out.push(vec![self.plain_byte()]);
-        out.push(format!("\x1b[{cp};{mods}u").into_bytes());
-        if self.ctrl {
-            out.push(format!("\x1b[27;{mods};{cp}~").into_bytes());
-        }
+        let mut out = Vec::with_capacity(4);
+        self.for_each_form(|form| out.push(form.to_vec()));
         out
+    }
+
+    /// Runs `f` over every wire form, rendering each into a stack buffer —
+    /// the allocation-free path the matchers use (one call per received
+    /// chunk in the daemon's stdin hot loop; `format!`-per-form would heap-
+    /// allocate 2–3 strings a keystroke). Kept private so the test-facing
+    /// [`Self::encodings`] stays the single ordered rendering of the forms,
+    /// and `encodings()` derives from this so the two can never drift.
+    ///
+    /// Two properties the chord matcher relies on:
+    /// - No form is a prefix of another form of the same key: the bare byte
+    ///   and any CSI differ at the first byte, and the kitty forms diverge
+    ///   at the `u` vs `;` after the codepoint digits. Exact-prefix matching
+    ///   is therefore unambiguous.
+    /// - Every multi-byte form starts with a byte that cannot be a plain
+    ///   keystroke (`0x1b`), so a plain byte and a CSI never alias.
+    fn for_each_form(self, mut f: impl FnMut(&[u8])) {
+        f(&[self.plain_byte()]);
+        let mods = 1 + u32::from(self.ctrl) * 4;
+        let mut scratch = Scratch::default();
+        // Kitty without the modifier field (omitted when it would be 1).
+        // Applies to plain keys only; Ctrl-chords always carry `;5`.
+        if !self.ctrl {
+            scratch
+                .push_str("\x1b[")
+                .push_dec(self.codepoint)
+                .push(b'u');
+            f(scratch.as_bytes());
+            scratch.clear();
+        }
+        scratch
+            .push_str("\x1b[")
+            .push_dec(self.codepoint)
+            .push(b';')
+            .push_dec(mods)
+            .push(b'u');
+        f(scratch.as_bytes());
+        if self.ctrl {
+            scratch.clear();
+            scratch
+                .push_str("\x1b[27;")
+                .push_dec(mods)
+                .push(b';')
+                .push_dec(self.codepoint)
+                .push(b'~');
+            f(scratch.as_bytes());
+        }
+    }
+
+    /// The length of the longest wire form that is a prefix of `buf` — i.e.
+    /// a complete occurrence of this key at the start of `buf`, possibly
+    /// with more bytes after. The streaming chord matcher uses this to
+    /// consume a key out of a coalesced chunk.
+    fn match_prefix_len(self, buf: &[u8]) -> Option<usize> {
+        let mut best = None;
+        self.for_each_form(|form| {
+            if buf.len() >= form.len()
+                && buf[..form.len()] == *form
+                && best.is_none_or(|l: usize| form.len() > l)
+            {
+                best = Some(form.len());
+            }
+        });
+        best
+    }
+
+    /// Whether `prefix` is a *strict* prefix of some wire form — a partial
+    /// keypress, i.e. an escape sequence split across chunk boundaries.
+    fn is_form_prefix(self, prefix: &[u8]) -> bool {
+        let mut hit = false;
+        self.for_each_form(|form| {
+            hit |= prefix.len() < form.len() && form.starts_with(prefix);
+        });
+        hit
     }
 
     /// Whether a received stdin chunk is exactly this key, across all its
     /// wire forms (plain, kitty, modifyOtherKeys). A chunk that is the key
-    /// plus more bytes — a paste — is not a match, so pastes never trigger
-    /// command mode. This is the whole-chunk match the daemon's chord matcher
-    /// has always used, now derived from the key instead of hardcoded.
+    /// plus more bytes — a paste — is not a match; this whole-chunk equality
+    /// is the unit of the paste guard the streaming matcher ([`ChordMatcher`])
+    /// composes into partial-chunk matching.
     #[must_use]
     pub fn matches_chunk(&self, chunk: &[u8]) -> bool {
-        self.encodings().iter().any(|e| e.as_slice() == chunk)
+        let mut hit = false;
+        self.for_each_form(|form| hit |= form == chunk);
+        hit
     }
 
     /// The canonical config-string form, for display and round-tripping.
@@ -267,9 +413,39 @@ pub fn validate_leader(key: &Key) -> Result<(), KeyError> {
         if TERMIOS_SPECIAL.contains(&byte) {
             return Err(KeyError::TermiosSpecial(key.as_config_str()));
         }
-        if AMBIGUOUS.contains(&byte) {
-            return Err(KeyError::Ambiguous(key.as_config_str()));
+        if let Some((_, alias)) = AMBIGUOUS.iter().find(|(b, _)| *b == byte) {
+            return Err(KeyError::Ambiguous(key.as_config_str(), alias));
         }
+    }
+    Ok(())
+}
+
+/// Validates the binding *set*, catching shadowed keys [`validate_leader`]
+/// can't see (it only judges the leader in isolation). Command mode checks
+/// the detach key before the forward key, and the leader is consumed before
+/// either, so a detach key equal to the leader or the forward key makes that
+/// other binding unreachable. `forward` == `leader` is *not* a conflict — it
+/// is the shipped default (a double-press forwards).
+///
+/// Like [`validate_leader`], this runs loudly at client config load and
+/// silently at the daemon (which falls the colliding field back to default).
+///
+/// # Errors
+///
+/// Returns [`KeyError::ConflictingDetach`] when the detach key aliases the
+/// leader or the forward key.
+pub fn validate_detach_unaliased(keys: &SessionKeys) -> Result<(), KeyError> {
+    if keys.detach_key == keys.leader {
+        return Err(KeyError::ConflictingDetach(
+            keys.detach_key.as_config_str(),
+            "the leader chord",
+        ));
+    }
+    if keys.detach_key == keys.forward_key {
+        return Err(KeyError::ConflictingDetach(
+            keys.detach_key.as_config_str(),
+            "the forward key",
+        ));
     }
     Ok(())
 }
@@ -308,23 +484,25 @@ pub enum CommandMode {
     AwaitingSubcommand,
 }
 
-/// What the session-key state machine does with one stdin chunk. The daemon
-/// maps each variant to its I/O effect; the decision itself is pure, so the
-/// transitions are unit-testable without a PTY or ssh channel.
+/// A non-forward effect the chord matcher decided for received bytes. The
+/// daemon maps each variant to its I/O effect; the decision itself is pure,
+/// so the transitions are unit-testable without a PTY or ssh channel. Bytes
+/// to forward arrive as data in [`FeedOutcome::Forward`], not as an action.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyAction {
-    /// Forward the chunk verbatim to the PTY.
-    Forward,
-    /// Swallow the chunk — an unbound command-mode key that cancels command
-    /// mode (the key is dropped, not forwarded, mirroring tmux).
+    /// Swallow an unbound command-mode token — a keypress (or an escape
+    /// sequence that proved not to be a bound subcommand) drops as a unit
+    /// and cancels command mode (mirroring tmux); subsequent bytes are back
+    /// in idle mode and forward normally.
     Swallow,
     /// The leader matched: swallow it and enter command mode.
     EnterCommandMode,
     /// The detach subcommand matched: tear down the attach channel (detach,
     /// not exit — the session and its process keep running).
     Detach,
-    /// The forward subcommand matched: write a leader byte down the PTY so a
-    /// nested daemon, if any, swallows it and enters its own command mode.
+    /// The forward subcommand matched: write a leader byte down the PTY —
+    /// a nested daemon *that negotiated the same leader*, if any, swallows
+    /// it and enters its own command mode.
     ForwardLeader,
 }
 
@@ -378,56 +556,218 @@ impl SessionKeys {
         }
     }
 
-    /// Re-validates the leader at the trust boundary (the daemon). On failure
-    /// — a termios-special or ambiguous chord a buggy or malicious client
-    /// could send — returns the default keys so a bad chord never garbles the
-    /// screen. The client's load-time validation is the loud/UX gate; this is
-    /// the silent safety backstop.
+    /// Re-validates the negotiated keys at the trust boundary (the daemon),
+    /// falling back *per field*: a termios-special or ambiguous leader a
+    /// buggy or malicious client could send reverts to the default leader
+    /// without touching valid subcommand remaps, and a detach key that
+    /// shadows the leader or the forward key reverts to the default detach
+    /// key. The client's load-time validation is the loud/UX gate; this is
+    /// the silent safety backstop — bad input degrades the smallest field,
+    /// never garbling the screen.
     #[must_use]
-    pub fn validated_or_default(self) -> Self {
-        match validate_leader(&self.leader) {
-            Ok(()) => self,
-            Err(e) => {
+    pub fn validated_or_default(mut self) -> Self {
+        let default = Self::default();
+        if let Err(e) = validate_leader(&self.leader) {
+            tracing::warn!(
+                error = %e,
+                leader = self.leader.as_config_str(),
+                "rejecting negotiated session leader; falling back to the default leader",
+            );
+            // A forward that only ever *defaulted* to this rejected leader
+            // moves with it (`from_env` falls forward back to the leader when
+            // the client sent no explicit forward); an explicit forward remap
+            // is a distinct, safe field and survives.
+            if self.forward_key == self.leader {
+                self.forward_key = default.leader;
+            }
+            self.leader = default.leader;
+        }
+        if let Err(e) = validate_detach_unaliased(&self) {
+            tracing::warn!(
+                error = %e,
+                "conflicting negotiated keys; falling back to the default detach key",
+            );
+            self.detach_key = default.detach_key;
+            if let Err(e) = validate_detach_unaliased(&self) {
+                // Degenerate config (e.g. a plain `d` leader colliding with
+                // the default `d` detach): detach still fires on a second
+                // press of the leader, so leave the binding in place, but
+                // make the shadowing loud in the log.
                 tracing::warn!(
                     error = %e,
-                    leader = self.leader.as_config_str(),
-                    "rejecting negotiated session leader; falling back to default",
+                    "detach key still conflicts after fallback; keeping the shadowing binding",
                 );
-                Self::default()
             }
+        }
+        self
+    }
+}
+
+/// One decision the streaming chord matcher made for some received bytes.
+/// Outcomes arrive in stream order; the daemon maps each to its I/O effect
+/// (writes the forwarded bytes down the PTY, rings the terminal bell on the
+/// channel, tears the channel down on detach).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeedOutcome {
+    /// Bytes that are not part of any chord: write them to the PTY.
+    Forward(Vec<u8>),
+    /// A non-forward effect of a matched chord or an unbound command-mode
+    /// token.
+    Action(KeyAction),
+}
+
+/// The streaming session-key chord matcher: one per attach channel, fed each
+/// stdin chunk as it arrives off the SSH channel.
+///
+/// Whole-chunk matching (`advance` before this) silently broke the moment SSH
+/// coalesced the leader and its subcommand into one message (`\x1dd`), split
+/// a multi-byte kitty encoding across two messages, or coalesced a fast
+/// double-press in command mode. This matcher consumes a byte stream instead:
+/// it scans positionally, matches a key's wire forms as prefixes anywhere in
+/// the stream (longest form wins), and holds a trailing *strict prefix* of
+/// some form in a small buffer until the next chunk resolves it. The buffer
+/// is bounded by the longest wire form (under 16 bytes), so it cannot grow.
+///
+/// Two consequences of the streaming model:
+///
+/// - There is no paste guard at the chord layer: a leader byte mid-chunk is a
+///   chord, indistinguishable from coalesced keystrokes. Real pastes are the
+///   terminal's and the app's business (bracketed paste), not this layer's.
+/// - A chunk *ending* in a strict prefix of some form (e.g. a bare `ESC`,
+///   which prefixes every kitty form) is held until the next chunk proves or
+///   disproves it — a one-keystroke delay on such bytes, versus silently
+///   missing split multi-byte chords.
+///
+/// The matcher owns the [`CommandMode`] and the pending buffer, so a fresh
+/// attach constructs a fresh matcher and can never inherit a stale
+/// awaiting-subcommand state or half a candidate.
+pub struct ChordMatcher {
+    keys: SessionKeys,
+    mode: CommandMode,
+    /// Held strict prefix of some wire form (split across chunks). Never
+    /// longer than the key's longest form minus one byte.
+    pending: Vec<u8>,
+}
+
+impl ChordMatcher {
+    /// A fresh matcher in [`CommandMode::Idle`] acting on `keys`.
+    #[must_use]
+    pub fn new(keys: SessionKeys) -> Self {
+        Self {
+            keys,
+            mode: CommandMode::Idle,
+            pending: Vec::new(),
         }
     }
 
-    /// Advance the command-mode state machine by one stdin chunk, returning
-    /// the next state and the action to take. Pure: no I/O.
-    ///
-    /// In [`CommandMode::Idle`], a chunk matching the leader enters command
-    /// mode (the leader is swallowed); anything else forwards. In
-    /// [`CommandMode::AwaitingSubcommand`], the next chunk is the subcommand:
-    /// the detach key detaches, the forward key verbatim-forwards a leader
-    /// byte, and any other key is swallowed and cancels command mode — so a
-    /// stray leader can always be cancelled by pressing any unbound key (no
-    /// stuck state, no explicit cancel key).
+    /// The negotiated keys this matcher acts on (for host-side effects like
+    /// the bell flag and the verbatim leader byte).
     #[must_use]
-    pub fn advance(&self, mode: CommandMode, chunk: &[u8]) -> (CommandMode, KeyAction) {
-        match mode {
-            CommandMode::Idle => {
-                if self.leader.matches_chunk(chunk) {
-                    (CommandMode::AwaitingSubcommand, KeyAction::EnterCommandMode)
-                } else {
-                    (CommandMode::Idle, KeyAction::Forward)
+    pub fn keys(&self) -> &SessionKeys {
+        &self.keys
+    }
+
+    /// The current command-mode state (observability and tests).
+    #[must_use]
+    pub fn mode(&self) -> CommandMode {
+        self.mode
+    }
+
+    /// Whether `prefix` is a strict prefix of a wire form of either bound
+    /// subcommand key.
+    fn is_subcommand_form_prefix(&self, prefix: &[u8]) -> bool {
+        self.keys.detach_key.is_form_prefix(prefix) || self.keys.forward_key.is_form_prefix(prefix)
+    }
+
+    /// Feed one stdin chunk, returning the ordered decisions taken. Each
+    /// `Forward` outcome is one contiguous run of data bytes in stream order;
+    /// chord bytes themselves are consumed.
+    pub fn feed(&mut self, chunk: &[u8]) -> Vec<FeedOutcome> {
+        let mut out = Vec::new();
+        // Reassemble: any held partial candidate continues into this chunk.
+        let owned;
+        let buf: &[u8] = if self.pending.is_empty() {
+            chunk
+        } else {
+            let mut v = std::mem::take(&mut self.pending);
+            v.extend_from_slice(chunk);
+            owned = v;
+            owned.as_slice()
+        };
+
+        // `i` walks the stream; `frs` marks the start of the current run of
+        // data bytes awaiting a single `Forward` outcome.
+        let mut i = 0;
+        let mut frs = 0;
+        while i < buf.len() {
+            match self.mode {
+                CommandMode::Idle => {
+                    if let Some(len) = self.keys.leader.match_prefix_len(&buf[i..]) {
+                        if frs < i {
+                            out.push(FeedOutcome::Forward(buf[frs..i].to_vec()));
+                        }
+                        out.push(FeedOutcome::Action(KeyAction::EnterCommandMode));
+                        i += len;
+                        frs = i;
+                        self.mode = CommandMode::AwaitingSubcommand;
+                    } else if self.keys.leader.is_form_prefix(&buf[i..]) {
+                        // Trailing split candidate: flush the data run, hold
+                        // the candidate until the next chunk resolves it.
+                        if frs < i {
+                            out.push(FeedOutcome::Forward(buf[frs..i].to_vec()));
+                        }
+                        self.pending.extend_from_slice(&buf[i..]);
+                        return out;
+                    } else {
+                        i += 1;
+                    }
                 }
-            }
-            CommandMode::AwaitingSubcommand => {
-                if self.detach_key.matches_chunk(chunk) {
-                    (CommandMode::Idle, KeyAction::Detach)
-                } else if self.forward_key.matches_chunk(chunk) {
-                    (CommandMode::Idle, KeyAction::ForwardLeader)
-                } else {
-                    (CommandMode::Idle, KeyAction::Swallow)
+                CommandMode::AwaitingSubcommand => {
+                    let rest = &buf[i..];
+                    if let Some(len) = self.keys.detach_key.match_prefix_len(rest) {
+                        out.push(FeedOutcome::Action(KeyAction::Detach));
+                        self.mode = CommandMode::Idle;
+                        i += len;
+                        frs = i;
+                        continue;
+                    }
+                    if let Some(len) = self.keys.forward_key.match_prefix_len(rest) {
+                        out.push(FeedOutcome::Action(KeyAction::ForwardLeader));
+                        self.mode = CommandMode::Idle;
+                        i += len;
+                        frs = i;
+                        continue;
+                    }
+                    // No whole subcommand here; could one be split across
+                    // chunks? Walk the longest run from `i` that stays a
+                    // strict prefix of some subcommand form: `end` lands on
+                    // the first byte that breaks it.
+                    let mut end = i;
+                    while end < buf.len() && self.is_subcommand_form_prefix(&buf[i..=end]) {
+                        end += 1;
+                    }
+                    if end == buf.len() {
+                        // The remainder is a strict prefix: hold it and stay
+                        // awaiting (a split CSI completing on the next chunk).
+                        self.pending.extend_from_slice(&buf[i..]);
+                        return out;
+                    }
+                    // Not a subcommand and never going to be: swallow the
+                    // token — the longest partial candidate plus the byte
+                    // that broke it — as a unit (so a failed partial CSI
+                    // never leaks half a sequence to the PTY) and cancel
+                    // command mode, tmux-style. Bytes after resume in idle.
+                    out.push(FeedOutcome::Action(KeyAction::Swallow));
+                    i = end + 1;
+                    frs = i;
+                    self.mode = CommandMode::Idle;
                 }
             }
         }
+        if frs < buf.len() {
+            out.push(FeedOutcome::Forward(buf[frs..].to_vec()));
+        }
+        out
     }
 }
 
@@ -570,7 +910,15 @@ mod tests {
     #[test]
     fn plain_key_has_no_modifyotherkeys_form() {
         let d = Key::parse("d").unwrap();
-        assert_eq!(d.encodings(), vec![vec![0x64], b"\x1b[100;1u".to_vec(),]);
+        assert_eq!(
+            d.encodings(),
+            vec![
+                vec![0x64],
+                // Kitty omits the modifier field when it would be 1.
+                b"\x1b[100u".to_vec(),
+                b"\x1b[100;1u".to_vec(),
+            ]
+        );
     }
 
     #[test]
@@ -584,6 +932,9 @@ mod tests {
     fn validate_accepts_safe_leaders() {
         assert!(validate_leader(&Key::parse("ctrl-]").unwrap()).is_ok());
         assert!(validate_leader(&Key::parse("ctrl-^").unwrap()).is_ok());
+        // `ctrl-_` is `0x1f`, the highest control byte: the upper boundary of
+        // the accepted set, next to the rejected `ctrl-^`+1 range edge.
+        assert!(validate_leader(&Key::parse("ctrl-_").unwrap()).is_ok());
         // A plain-printable leader is a poor choice but not unsafe.
         assert!(validate_leader(&Key::parse("d").unwrap()).is_ok());
     }
@@ -604,10 +955,10 @@ mod tests {
 
     #[test]
     fn validate_rejects_ambiguous() {
-        for bad in ["ctrl-@", "ctrl-i", "ctrl-j", "ctrl-m", "ctrl-["] {
+        for bad in ["ctrl-@", "ctrl-h", "ctrl-i", "ctrl-j", "ctrl-m", "ctrl-["] {
             let err = validate_leader(&Key::parse(bad).unwrap()).unwrap_err();
             assert!(
-                matches!(err, KeyError::Ambiguous(_)),
+                matches!(err, KeyError::Ambiguous(..)),
                 "{bad} should be ambiguous, got {err:?}"
             );
         }
@@ -720,80 +1071,198 @@ mod tests {
     }
 
     #[test]
-    fn advance_idle_forwards_non_leader() {
-        let keys = SessionKeys::default();
+    fn feed_forwards_plain_data() {
+        let mut m = ChordMatcher::new(SessionKeys::default());
         assert_eq!(
-            keys.advance(CommandMode::Idle, b"hello"),
-            (CommandMode::Idle, KeyAction::Forward),
+            m.feed(b"hello"),
+            vec![FeedOutcome::Forward(b"hello".to_vec())]
         );
+        assert_eq!(m.mode(), CommandMode::Idle);
     }
 
     #[test]
-    fn advance_idle_leader_enters_command_mode() {
-        let keys = SessionKeys::default();
+    fn feed_idle_leader_enters_command_mode() {
         // Every leader encoding enters command mode.
         for chunk in [&[0x1d][..], b"\x1b[93;5u", b"\x1b[27;5;93~"] {
+            let mut m = ChordMatcher::new(SessionKeys::default());
             assert_eq!(
-                keys.advance(CommandMode::Idle, chunk),
-                (CommandMode::AwaitingSubcommand, KeyAction::EnterCommandMode),
+                m.feed(chunk),
+                vec![FeedOutcome::Action(KeyAction::EnterCommandMode)],
                 "chunk={chunk:?}",
             );
+            assert_eq!(m.mode(), CommandMode::AwaitingSubcommand);
         }
     }
 
     #[test]
-    fn advance_command_mode_detach_key_detaches() {
-        let keys = SessionKeys::default();
-        // The leader enters command mode; `d` detaches and returns to idle.
-        let (mode, _) = keys.advance(CommandMode::Idle, &[0x1d]);
-        assert_eq!(mode, CommandMode::AwaitingSubcommand);
+    fn feed_coalesced_leader_and_detach() {
+        // SSH coalescing `ctrl-]` and `d` into one message must still detach:
+        // the whole-chunk matcher model silently failed here.
+        let mut m = ChordMatcher::new(SessionKeys::default());
         assert_eq!(
-            keys.advance(mode, b"d"),
-            (CommandMode::Idle, KeyAction::Detach),
+            m.feed(b"\x1dd"),
+            vec![
+                FeedOutcome::Action(KeyAction::EnterCommandMode),
+                FeedOutcome::Action(KeyAction::Detach),
+            ],
+        );
+        assert_eq!(m.mode(), CommandMode::Idle);
+    }
+
+    #[test]
+    fn feed_data_before_leader_still_fires_chord() {
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        assert_eq!(
+            m.feed(b"ab\x1dd"),
+            vec![
+                FeedOutcome::Forward(b"ab".to_vec()),
+                FeedOutcome::Action(KeyAction::EnterCommandMode),
+                FeedOutcome::Action(KeyAction::Detach),
+            ],
         );
     }
 
     #[test]
-    fn advance_command_mode_forward_key_forwards_leader() {
-        let keys = SessionKeys::default();
+    fn feed_command_mode_detach_key_detaches() {
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        assert_eq!(
+            m.feed(&[0x1d]),
+            vec![FeedOutcome::Action(KeyAction::EnterCommandMode)]
+        );
+        assert_eq!(m.feed(b"d"), vec![FeedOutcome::Action(KeyAction::Detach)]);
+        assert_eq!(m.mode(), CommandMode::Idle);
+    }
+
+    #[test]
+    fn feed_command_mode_forward_key_forwards_leader() {
         // Default forward key is the leader itself: a double-press forwards.
-        let (mode, _) = keys.advance(CommandMode::Idle, &[0x1d]);
+        let mut m = ChordMatcher::new(SessionKeys::default());
         assert_eq!(
-            keys.advance(mode, &[0x1d]),
-            (CommandMode::Idle, KeyAction::ForwardLeader),
+            m.feed(&[0x1d]),
+            vec![FeedOutcome::Action(KeyAction::EnterCommandMode)]
         );
+        assert_eq!(
+            m.feed(&[0x1d]),
+            vec![FeedOutcome::Action(KeyAction::ForwardLeader)]
+        );
+        assert_eq!(m.mode(), CommandMode::Idle);
     }
 
     #[test]
-    fn advance_command_mode_unbound_key_swallows_and_cancels() {
-        let keys = SessionKeys::default();
-        let (mode, _) = keys.advance(CommandMode::Idle, &[0x1d]);
+    fn feed_command_mode_unbound_key_swallows_and_cancels() {
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        assert_eq!(
+            m.feed(&[0x1d]),
+            vec![FeedOutcome::Action(KeyAction::EnterCommandMode)]
+        );
         // An unbound key is swallowed (not forwarded) and exits command mode.
-        assert_eq!(
-            keys.advance(mode, b"x"),
-            (CommandMode::Idle, KeyAction::Swallow),
-        );
+        assert_eq!(m.feed(b"x"), vec![FeedOutcome::Action(KeyAction::Swallow)]);
         // After the cancel, idle resumes: a normal key forwards again.
+        assert_eq!(m.feed(b"x"), vec![FeedOutcome::Forward(b"x".to_vec())]);
+    }
+
+    #[test]
+    fn feed_command_mode_double_press_eats_nothing() {
+        // A fast `dd` arriving in one chunk detaches and forwards the second
+        // `d` — the whole-chunk matcher swallowed both bytes as "unbound".
+        let mut m = ChordMatcher::new(SessionKeys::default());
         assert_eq!(
-            keys.advance(CommandMode::Idle, b"x"),
-            (CommandMode::Idle, KeyAction::Forward),
+            m.feed(b"\x1ddd"),
+            vec![
+                FeedOutcome::Action(KeyAction::EnterCommandMode),
+                FeedOutcome::Action(KeyAction::Detach),
+                FeedOutcome::Forward(b"d".to_vec()),
+            ],
         );
     }
 
     #[test]
-    fn advance_command_mode_paste_is_unbound_swallow() {
-        let keys = SessionKeys::default();
-        let (mode, _) = keys.advance(CommandMode::Idle, &[0x1d]);
-        // A multi-byte paste in command mode matches no subcommand: swallowed,
-        // command mode cancelled (the paste is dropped, not forwarded).
+    fn feed_command_mode_paste_detach_fires_then_forwards_rest() {
+        // No paste guard at the chord layer (see the ChordMatcher docs): a
+        // pasted "detach" in command mode begins with the detach byte and is
+        // indistinguishable from coalesced keystrokes. Real pastes are
+        // bracketed-paste's business.
+        let mut m = ChordMatcher::new(SessionKeys::default());
         assert_eq!(
-            keys.advance(mode, b"detach"),
-            (CommandMode::Idle, KeyAction::Swallow),
+            m.feed(&[0x1d]),
+            vec![FeedOutcome::Action(KeyAction::EnterCommandMode)]
+        );
+        assert_eq!(
+            m.feed(b"detach"),
+            vec![
+                FeedOutcome::Action(KeyAction::Detach),
+                FeedOutcome::Forward(b"etach".to_vec()),
+            ],
         );
     }
 
     #[test]
-    fn advance_remapped_leader_uses_negotiated_keys() {
+    fn feed_split_kitty_leader_across_chunks() {
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        // A kitty form split at a chunk boundary: nothing forwards while the
+        // candidate is pending...
+        assert_eq!(m.feed(b"\x1b[9"), vec![]);
+        // ...and the chord fires when the form completes.
+        assert_eq!(
+            m.feed(b"3;5u"),
+            vec![FeedOutcome::Action(KeyAction::EnterCommandMode)]
+        );
+    }
+
+    #[test]
+    fn feed_split_detach_kitty_form_across_chunks() {
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        assert_eq!(
+            m.feed(&[0x1d]),
+            vec![FeedOutcome::Action(KeyAction::EnterCommandMode)]
+        );
+        assert_eq!(m.feed(b"\x1b[10"), vec![]);
+        assert_eq!(m.feed(b"0u"), vec![FeedOutcome::Action(KeyAction::Detach)]);
+        assert_eq!(m.mode(), CommandMode::Idle);
+    }
+
+    #[test]
+    fn feed_held_candidate_flushes_as_data_on_mismatch() {
+        // A bare ESC ends the chunk: held as a possible kitty prefix...
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        assert_eq!(m.feed(b"\x1b"), vec![]);
+        // ...but it wasn't one, so it and the next byte forward as data.
+        assert_eq!(m.feed(b"x"), vec![FeedOutcome::Forward(b"\x1bx".to_vec())]);
+        assert_eq!(m.mode(), CommandMode::Idle);
+    }
+
+    #[test]
+    fn feed_held_idle_candidate_flushes_before_a_real_leader() {
+        // ESC held idle, then the leader byte arrives: the ESC is data, the
+        // leader is the chord.
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        assert_eq!(m.feed(b"\x1b"), vec![]);
+        assert_eq!(
+            m.feed(&[0x1d]),
+            vec![
+                FeedOutcome::Forward(b"\x1b".to_vec()),
+                FeedOutcome::Action(KeyAction::EnterCommandMode),
+            ],
+        );
+    }
+
+    #[test]
+    fn feed_held_subcommand_candidate_swallows_as_a_unit_on_mismatch() {
+        // In command mode, ESC is a prefix of the bound subcommands' kitty
+        // forms, so it is held. When `[A` proves it is none of them, the
+        // whole failed token drops: no half-sequence leaks to the PTY.
+        let mut m = ChordMatcher::new(SessionKeys::default());
+        assert_eq!(
+            m.feed(&[0x1d]),
+            vec![FeedOutcome::Action(KeyAction::EnterCommandMode)]
+        );
+        assert_eq!(m.feed(b"\x1b"), vec![]);
+        assert_eq!(m.feed(b"[A"), vec![FeedOutcome::Action(KeyAction::Swallow)]);
+        assert_eq!(m.mode(), CommandMode::Idle);
+    }
+
+    #[test]
+    fn feed_remapped_leader_uses_negotiated_keys() {
         // A client that remapped leader=ctrl-^, detach=x, forward=ctrl-].
         let mut env = BTreeMap::new();
         env.insert(LEADER_ENV.to_string(), "ctrl-^".to_string());
@@ -801,25 +1270,92 @@ mod tests {
         env.insert(FORWARD_KEY_ENV.to_string(), "ctrl-]".to_string());
         let keys = SessionKeys::from_env(&env);
 
-        // The old default leader (ctrl-]) no longer enters command mode.
+        // The old default leader (ctrl-], 0x1d) no longer enters command mode.
+        let mut m = ChordMatcher::new(keys);
+        assert_eq!(m.feed(&[0x1d]), vec![FeedOutcome::Forward(vec![0x1d])]);
+        // The remapped leader (ctrl-^, 0x1e) coalesced with the remapped
+        // detach key (x) detaches.
         assert_eq!(
-            keys.advance(CommandMode::Idle, &[0x1d]),
-            (CommandMode::Idle, KeyAction::Forward),
+            m.feed(b"\x1ex"),
+            vec![
+                FeedOutcome::Action(KeyAction::EnterCommandMode),
+                FeedOutcome::Action(KeyAction::Detach),
+            ],
         );
-        // The remapped leader (ctrl-^, 0x1e) does.
+        // The remapped forward key (ctrl-]) forwards the leader.
+        let mut m = ChordMatcher::new(keys);
         assert_eq!(
-            keys.advance(CommandMode::Idle, &[0x1e]),
-            (CommandMode::AwaitingSubcommand, KeyAction::EnterCommandMode),
+            m.feed(b"\x1e\x1d"),
+            vec![
+                FeedOutcome::Action(KeyAction::EnterCommandMode),
+                FeedOutcome::Action(KeyAction::ForwardLeader),
+            ],
         );
-        // The remapped detach key (x) detaches.
-        assert_eq!(
-            keys.advance(CommandMode::AwaitingSubcommand, b"x"),
-            (CommandMode::Idle, KeyAction::Detach),
-        );
-        // The remapped forward key (ctrl-]) forwards.
-        assert_eq!(
-            keys.advance(CommandMode::AwaitingSubcommand, &[0x1d]),
-            (CommandMode::Idle, KeyAction::ForwardLeader),
-        );
+    }
+
+    #[test]
+    fn matches_chunk_accepts_plain_key_kitty_forms() {
+        // Kitty report-all-keys mode sends `d` without the modifier field.
+        let d = Key::parse("d").unwrap();
+        assert!(d.matches_chunk(b"d"));
+        assert!(d.matches_chunk(b"\x1b[100u"));
+        assert!(d.matches_chunk(b"\x1b[100;1u"));
+    }
+
+    #[test]
+    fn validate_detach_unaliased_accepts_shipped_default() {
+        // forward == leader is the shipped default: not a conflict.
+        assert!(validate_detach_unaliased(&SessionKeys::default()).is_ok());
+    }
+
+    #[test]
+    fn validate_detach_unaliased_rejects_shadowing() {
+        // detach == leader shadows the forward binding (the default forward
+        // is the leader; the leader is consumed before either).
+        let err = validate_detach_unaliased(&SessionKeys {
+            detach_key: SessionKeys::default().leader,
+            ..SessionKeys::default()
+        })
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            KeyError::ConflictingDetach(ref d, s) if d == "ctrl-]" && s == "the leader chord"
+        ));
+        // detach == forward (distinct from the leader) shadows the forward key.
+        let err = validate_detach_unaliased(&SessionKeys {
+            detach_key: Key::parse("x").unwrap(),
+            forward_key: Key::parse("x").unwrap(),
+            ..SessionKeys::default()
+        })
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            KeyError::ConflictingDetach(ref d, s) if d == "x" && s == "the forward key"
+        ));
+    }
+
+    #[test]
+    fn validated_or_default_is_field_scoped_for_a_bad_leader() {
+        // A bad leader reverts; valid subcommand remaps survive.
+        let mut env = BTreeMap::new();
+        env.insert(LEADER_ENV.to_string(), "ctrl-c".to_string());
+        env.insert(DETACH_KEY_ENV.to_string(), "x".to_string());
+        let keys = SessionKeys::from_env(&env).validated_or_default();
+        assert_eq!(keys.leader, SessionKeys::default().leader);
+        assert_eq!(keys.detach_key, Key::parse("x").unwrap());
+    }
+
+    #[test]
+    fn validated_or_default_reverts_a_shadowing_detach_key() {
+        // detach == leader reaches forward-of-leader unreachable; the detach
+        // field alone reverts.
+        let default = SessionKeys::default();
+        let keys = SessionKeys {
+            detach_key: default.leader,
+            ..default
+        };
+        let keys = keys.validated_or_default();
+        assert_eq!(keys.detach_key, default.detach_key);
+        assert_eq!(keys.leader, default.leader);
     }
 }

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -12,6 +12,7 @@ use paths::HostAbsPath;
 pub mod client;
 pub mod core;
 pub mod daemon;
+pub mod keys;
 pub mod store;
 pub mod terminal;
 pub mod wire;

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -73,7 +73,7 @@ terminal.
 
 Keys: `↑`/`↓` (or `k`/`j`) move, `/` fuzzy-filters by name, ID, and
 project path, `enter` attaches to the focused session (suspend TUI → ssh →
-resume on `ctrl-w` detach) or collapses a provider group, `d` destroys
+resume on `ctrl-]` then `d` detach) or collapses a provider group, `d` destroys
 (with confirmation — also cancels an in-flight create/upload), `r`
 renames, `n` creates a session through the full activate flow (project
 upload, loadout compose, finalize), `q` quits. The cursor's last position

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -481,9 +481,21 @@ forward = "ctrl-]"
 The leader is negotiated with the daemon per attach channel — sent as env
 vars alongside `MINIMAL_SESSION_ID` — so two clients with different configs on
 the same session each get their own chord. The daemon re-validates the leader
-as a silent backstop: a chord it rejects is logged and falls back to the
-default rather than garbling the screen. As with `[loadouts]`, every field
+as a silent backstop: a chord it rejects is logged and only that field falls
+back to the default — your valid `detach`/`forward` remaps survive — never
+garbling the screen. As with `[loadouts]`, every field
 defaults and unknown keys are rejected, so an old config keeps parsing.
+
+Two caveats on that per-channel model:
+
+- **The banner's detach hint is mint-scoped.** The orientation banner prints
+  `MINIMAL_DETACH_HINT`, seeded from the channel that minted the shell. A
+  second client attaching with a remapped chord gets a *working* chord, but
+  the banner still advertises the minting channel's; trust your config over
+  the banner in that case.
+- **Bindings must not shadow each other.** A `detach` that equals the
+  `leader` or the `forward` key makes that other binding unreachable and is
+  rejected at load; the daemon's backstop reverts just the detach field.
 
 ## Listing loadouts
 

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -455,6 +455,36 @@ follow_symlinks  = false
 A missing file is equivalent to the defaults; unknown keys are rejected so
 a typo (`[loadout]` for `[loadouts]`) fails loudly.
 
+### Session keys {#session-keys}
+
+The detach chord is configurable. The leader key (the chord that enters
+command mode) and its command-mode subcommand keys live under a
+`[session-keys]` section in the same `config.toml`:
+
+```toml
+[session-keys]
+leader = "ctrl-]"
+bell_on_leader = false
+
+[session-keys.subcommands]
+detach = "d"
+forward = "ctrl-]"
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `leader` | `ctrl-]` | The chord that enters command mode, as a logical key name (`"ctrl-]"`, `"ctrl-^"`, `"d"`, …). Rejected loudly at load if termios-special (`ctrl-c`, `ctrl-w`, `ctrl-\`, … — consumed by the line discipline before the app) or wrapping-ambiguous (`ctrl-i` = TAB, `ctrl-m` = CR, …) |
+| `bell_on_leader` | `false` | Ring the terminal bell (BEL `0x07`) on entering command mode. The terminal renders it per its own bell config; minimal picks no modality |
+| `subcommands.detach` | `d` | The command-mode key that detaches the channel |
+| `subcommands.forward` | `ctrl-]` | The command-mode key that verbatim-forwards a leader byte down the PTY (for nested sessions). Defaults to the resolved `leader`, so a double-press forwards |
+
+The leader is negotiated with the daemon per attach channel — sent as env
+vars alongside `MINIMAL_SESSION_ID` — so two clients with different configs on
+the same session each get their own chord. The daemon re-validates the leader
+as a silent backstop: a chord it rejects is logged and falls back to the
+default rather than garbling the screen. As with `[loadouts]`, every field
+defaults and unknown keys are rejected, so an old config keeps parsing.
+
 ## Listing loadouts
 
 [`min loadout list`](./cli-min.md#loadout-list-alias-ls) (alias:
@@ -701,7 +731,7 @@ attached session prints a two-line orientation banner:
 
 ```
 minimal · session api-server-4f2a · loadout default (built-in)
-detach: ctrl-w · no minimal.toml here — min init to add one
+detach: ctrl-] then d · no minimal.toml here — min init to add one
 ```
 
 The second line drops the `min init` pointer when the session workspace

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -459,7 +459,14 @@ a typo (`[loadout]` for `[loadouts]`) fails loudly.
 
 The detach chord is configurable. The leader key (the chord that enters
 command mode) and its command-mode subcommand keys live under a
-`[session-keys]` section in the same `config.toml`:
+`[session-keys]` section in the same `config.toml`.
+
+`[session-keys]` is client configuration, not a loadout: unlike everything a
+loadout composes, it is never baked into the session on activation. It is
+read fresh on every attach and negotiated per SSH channel, so each client —
+and each machine attaching to a session it didn't create — brings its own
+chord. The section is documented here only because that is where
+`config.toml` is described.
 
 ```toml
 [session-keys]
@@ -477,6 +484,13 @@ forward = "ctrl-]"
 | `bell_on_leader` | `false` | Ring the terminal bell (BEL `0x07`) on entering command mode. The terminal renders it per its own bell config; minimal picks no modality |
 | `subcommands.detach` | `d` | The command-mode key that detaches the channel |
 | `subcommands.forward` | `ctrl-]` | The command-mode key that verbatim-forwards a leader byte down the PTY (for nested sessions). Defaults to the resolved `leader`, so a double-press forwards |
+
+Key names take one of two forms: `ctrl-<glyph>`, where the glyph is a single
+ASCII character in `@`..`~` (so `ctrl-2` and `ctrl-?` are rejected), or a
+single printable ASCII glyph such as `d`. Only `ctrl-` is configurable;
+`alt-`, `shift-`, `meta-`, and `super-` are rejected. The `ctrl-` prefix is
+case-insensitive and `ctrl-` letters normalise to lowercase, since `Ctrl+a`
+and `Ctrl+A` send the same control code. Plain glyphs are case-sensitive.
 
 The leader is negotiated with the daemon per attach channel — sent as env
 vars alongside `MINIMAL_SESSION_ID` — so two clients with different configs on

--- a/docs/specs/07-spec-min-dash-tui/07-spec-min-dash-tui.md
+++ b/docs/specs/07-spec-min-dash-tui/07-spec-min-dash-tui.md
@@ -501,8 +501,8 @@ the Preview section — the same stream carries screen-change events.
 
 The initial keybind set is fixed. A future keybind configuration (e.g. via
 `dash-state.json` or a `minimal.toml` section) would let users remap keys,
-particularly important if `Ctrl-W` attach/detach (F1) conflicts with
-in-session applications.
+particularly important if the attach/detach leader chord (F1, default
+`ctrl-]`) conflicts with in-session applications.
 
 ## Security Considerations
 

--- a/docs/specs/07-spec-min-dash-tui/07-spec-min-dash-tui.md
+++ b/docs/specs/07-spec-min-dash-tui/07-spec-min-dash-tui.md
@@ -441,8 +441,9 @@ Currently `cmd_attach` shells out to `ssh` via `CommandExt::exec()`, which
 replaces the process. A TUI-native attach would: suspend the TUI (leave
 alternate screen, `disable_raw_mode`), spawn `ssh` as a child, wait for it
 to exit, then resume the TUI (re-enter alternate screen, `enable_raw_mode`,
-refresh). The user detaches with `Ctrl-W` (already handled by the daemon at
-`session_host.rs:1123`), which tears down the SSH channel; `ssh` exits; the
+refresh). The user detaches with the negotiated chord (default `ctrl-]` then
+`d`), handled per channel by the daemon's session-key matcher in
+`session_host.rs`, which tears down the SSH channel; `ssh` exits; the
 TUI resumes.
 
 Complexity: the detach chord is now configurable. The leader key (default

--- a/docs/specs/07-spec-min-dash-tui/07-spec-min-dash-tui.md
+++ b/docs/specs/07-spec-min-dash-tui/07-spec-min-dash-tui.md
@@ -445,13 +445,14 @@ refresh). The user detaches with `Ctrl-W` (already handled by the daemon at
 `session_host.rs:1123`), which tears down the SSH channel; `ssh` exits; the
 TUI resumes.
 
-Complexity: the `Ctrl-W` detach keybind may conflict with applications
-inside the session (e.g. vim's window commands). Making it configurable
-requires a settings mechanism that doesn't exist yet, and the keybind needs
-to be negotiated or accepted on both sides. The daemon currently recognizes
-three `Ctrl-W` encodings (`0x17`, kitty `CSI 119;5u`, modifyOtherKeys
-`CSI 27;5;119~` at `session_host.rs:35-40`) — a configurable chord would need
-to add the user's choice to that set.
+Complexity: the detach chord is now configurable. The leader key (default
+`ctrl-]`, `0x1d`) is negotiated per-channel at attach — the client sends it
+as env vars alongside `MINIMAL_SESSION_ID`, and the daemon re-validates it
+(termios-special chords are rejected as a safety backstop). The daemon's
+matcher derives the full encoding set (plain byte, kitty, modifyOtherKeys)
+from the negotiated key, so a remapped leader gets its CSI forms
+automatically. The old `ctrl-w` default was itself termios-special
+(`VWERASE`) and is retired; `0x17` is now an ordinary forwarded key.
 
 ### F2: Remote minimald sessions
 

--- a/scripts/e2e-attach-pty.py
+++ b/scripts/e2e-attach-pty.py
@@ -22,11 +22,12 @@ to fire `on_detach`):
   E2E_PTY_ANSWER    how to answer the session-exit prompt: `delete` (the
                     default, what the sandbox proof needs) or `keep`, which
                     leaves the session alive — a detach.
-  E2E_PTY_DETACH    set to leave via the ctrl-w detach chord once the command
-                    stream goes quiet, instead of ending it with `exit`. The
-                    session's SHELL then survives, which is what a test of
-                    re-attaching to a still-running shell needs: `exit` ends
-                    that shell, and the next attach mints a new one.
+  E2E_PTY_DETACH    set to leave via the session detach chord (the shipped
+                    default: `ctrl-]` then `d`) once the command stream goes
+                    quiet, instead of ending it with `exit`. The session's
+                    SHELL then survives, which is what a test of re-attaching
+                    to a still-running shell needs: `exit` ends that shell,
+                    and the next attach mints a new one.
 
 Prints the full captured terminal output on stdout. Exits 0 iff the attach
 process exited 0.
@@ -105,13 +106,18 @@ try:
             break  # EOF / closed
         buf.extend(chunk)
         quiet = 0 if chunk else quiet + 1
-        # The detach chord has to arrive as a WRITE OF ITS OWN: the daemon
-        # matches a *bare* ctrl-w (`b.len() == 1 && b[0] == 0x17`), so the same
-        # byte inside the command stream is not a detach — it reaches the shell,
-        # where readline eats it as delete-previous-word. Sent once the stream
-        # goes quiet, so the commands have run first.
+        # The detach chord has to arrive as a WRITE OF ITS OWN, sent once the
+        # command stream goes quiet — so the commands have run first and the
+        # chord can't be mistaken for their tail. It is the shipped default
+        # chord (leader `ctrl-]` = 0x1d, then the detach subcommand `d`), in a
+        # single coalesced chunk, which is exactly the shape the daemon's
+        # ChordMatcher accepts (sessions::keys matches chords across and within
+        # stdin chunks). An earlier era of this script sent a bare ctrl-w
+        # (0x17) here; that key retired as a detach, so a stale byte now just
+        # reaches the shell — where readline eats it as delete-previous-word
+        # and rings the bell — and the attach never ends.
         if DETACH and not detached and quiet >= 2:
-            os.write(fd, b"\x17")
+            os.write(fd, b"\x1dd")
             detached = True
         if not answered and EXIT_PROMPT in bytes(buf).lower():
             os.write(fd, PROMPT_ANSWER_KEY)  # answer the prompt like a user

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -650,7 +650,8 @@ if [ -n "$SEED_DIR" ] || [ -n "$SEEDED_MFILE" ]; then
   # lives in that process and nowhere else. The re-attach below reads it back.
   # Deliberately not `$$`: the session shell is pid 1 of its own namespace, so
   # a replacement shell would report pid 1 too and the check would be vacuous.
-  # Leaves by the ctrl-w detach chord (`E2E_PTY_DETACH`), NOT by `exit`.
+  # Leaves by the session detach chord (`E2E_PTY_DETACH`: ctrl-] then d, the
+  # shipped default), NOT by `exit`.
   # `exit` ends the session's shell, and the "re-attach" below would then land
   # on a freshly minted one — which would still report the new terminal (a new
   # shell takes `TERM` from its launch env) while proving nothing about

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -1110,7 +1110,7 @@ if [[ "$attach_out" != *"minimal · session $SESSION_NAME · loadout default (bu
   echo "--- attach output ---"; printf '%s\n' "$attach_out"
   fail
 fi
-if [[ "$attach_out" != *"detach: ctrl-w"* ]]; then
+if [[ "$attach_out" != *"detach: ctrl-] then d"* ]]; then
   echo "::error::attach output lacks the orientation banner's detach line"
   echo "--- attach output ---"; printf '%s\n' "$attach_out"
   fail


### PR DESCRIPTION
## Summary

The session detach chord is now configurable and negotiated per attach
channel, retiring the hardcoded `ctrl-w` default. `ctrl-w` is
termios-special (`VWERASE`): the kernel line discipline consumes it
before the app reads the byte, so a leaked or verbatim-forwarded leader
triggers line editing instead of reaching the app. The new default
leader is `ctrl-]` (`0x1d`), which is not termios-special and is lightly
bound by editors, tmux, and zellij.

Detach is now a two-key chord: press the leader to enter command mode,
then a subcommand. `d` detaches; a second leader verbatim-forwards a
leader byte down the PTY (a primitive for nested sessions); any unbound
key cancels command mode, mirroring tmux.

Refs gominimal/inbox#475.

## How it works

- A new `sessions::keys` module owns the key types, the reject sets
  (termios-special and wrapping-ambiguous), and the env-var contract.
- The client config gains a `[session-keys]` section. The leader is
  validated loudly at load; the daemon re-validates it as a silent
  backstop (log and fall back to default, never garble the screen).
- The daemon matcher derives the full encoding set (plain byte, kitty,
  modifyOtherKeys) from the negotiated leader, so a remapped leader gets
  its CSI forms automatically. No hardcoded key encodings remain.
- Negotiation reuses the existing per-channel env-var channel: the
  interactive attach path sends `MINIMAL_SESSION_LEADER` and friends
  alongside `MINIMAL_SESSION_ID`; exec channels send none. Two clients
  with different configs on the same session each get their own chord.

## Changes

| Area | What |
|---|---|
| `sessions::keys` (new) | `Key`, `SessionKeys`, reject sets, env-var contract, 30 unit tests |
| `sessions::client::config` | `[session-keys]` section, loud validation, `ConfigError::Validation` |
| `minimal-client::attach` | resolve session keys, send env vars with matching `SendEnv` |
| `minimal` (CLI) | `session_via_ssh` resolves keys for the interactive path; TUI threads `config_dir` |
| `minimald` | command-mode state machine, key-aware MOTD, re-validation gate, AcceptEnv doc |
| `minimal-tui` | `DashOptions.config_dir`, attach-time key resolution |
| docs, e2e | banner updated to `ctrl-] then d`, `[session-keys]` schema docs, spec F1 note |

## Breaking change

The default detach chord changes from `ctrl-w` to `ctrl-]` then `d`. The
daemon no longer intercepts `ctrl-w` (`0x17` and its CSI encodings)
anywhere. It is forwarded to the shell like any ordinary key.

## Verification

- `just fix` (fmt, clippy with `-D warnings`) is clean.
- `cargo test` on `sessions`, `minimal`, `minimald`, `minimal-client`,
  `minimal-tui` is green. 398 sessions tests, 259 minimal tests, 21
  minimal-client tests including two new attach-negotiation tests.
- Doctests pass.
- VM/daemon path: the session e2e banner assertion is updated. The full
  `just e2e` run should be confirmed on a KVM/HVF host before merge.

## Notes for reviewers

- The leader is always swallowed on match, never forwarded, so a leaked
  leader does not trigger the app `ctrl-]` binding. `ctrl-]` is not
  termios-special, so a stray leader past the deepest nesting layer is
  non-destructive.
- The daemon re-validation failure mode is load-bearing: a bad chord
  must never garble the screen. It logs and falls back to the default
  rather than rejecting the attach or writing to the channel.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace hardcoded `ctrl-w` detach with a configurable leader chord defaulting to `ctrl-]` then `d`
> - Introduces a new `[session-keys]` config section in `config.toml` allowing users to remap the session leader key, detach subcommand, forward-leader subcommand, and an optional bell-on-leader flag via [`crates/sessions/src/keys.rs`](https://github.com/gominimal/minimal/pull/1202/files#diff-2a693e0f0d603eb9ddea1dd57386c7d25bb3c7321f7818c885ed9135040fdfdd).
> - Adds a streaming `ChordMatcher` that scans stdin byte-by-byte across chunk boundaries, supporting plain, kitty, and modifyOtherKeys encodings, replacing the old single-byte `ctrl-w` check in the host mainloop.
> - Session keys are negotiated per-channel via SSH env vars (`MINIMAL_LEADER`, `MINIMAL_DETACH_KEY`, etc.) set by the client at attach time and validated server-side, with unsafe or ambiguous leaders silently falling back to defaults.
> - The MOTD detach hint is now driven by `MINIMAL_DETACH_HINT` (injected per-channel) with a fallback of `ctrl-] then d`, replacing the hardcoded `ctrl-w` string.
> - Behavioral Change: `ctrl-w` is no longer the detach key and is forwarded to the shell as a normal byte; the new default detach chord is `ctrl-]` then `d`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1ae5e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable session keys for leader, detach, forwarding, and terminal bell behavior.
  * Interactive attachments now negotiate and apply key bindings per connection.
  * Added customizable detach hints, defaulting to `Ctrl-]`, then `d`.

* **Bug Fixes**
  * Rejected unsafe or conflicting key bindings.
  * Improved handling of split, combined, stale, and renegotiated session-control input.
  * Configuration errors are reported before starting an attachment.

* **Documentation**
  * Documented session-key configuration, validation, defaults, and detach behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->