### PR TITLE
feat: lifecycle hooks

### DIFF
--- a/.minimal/minimal.toml
+++ b/.minimal/minimal.toml
@@ -66,7 +66,7 @@ type = "oci-image"
 packages = ["libkrun"]
 
 [session]
-packages = ["just", "protobuf"]
+packages = ["just", "protobuf", "shellcheck", "python"]
 
 [tasks.vim]
 profile = "demo"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,11 @@ mac-buildable (see the comments in `.github/workflows/ci-macos.yml`).
   Homebrew (`brew install slp/krun/libkrun`) for the VM recipes (`just up`,
   `just test-vm`, `just e2e`); `jq`, `zstd`, and `cpio` (`brew install jq zstd
   cpio`) for the `artifacts`/`initramfs` scripts those recipes run.
+- **python3**, on any host running `just e2e` / `just e2e-native`: the session
+  e2e drives its interactive attaches through a real pty
+  ([scripts/e2e-attach-pty.py](scripts/e2e-attach-pty.py)), because only a tty
+  can answer the session-exit prompt. Stdlib only — no packages to install —
+  but the interpreter must be on `PATH`.
 
 ## justfile recipes
 

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -1944,4 +1944,34 @@ mod tests {
             IndexSourceMode::Closure
         );
     }
+
+    /// The demo project under `crates/sessions/example_project` must
+    /// stay parseable as a real `File`, hooks and all.
+    ///
+    /// It is documentation people copy from, and nothing else reads it,
+    /// so without this it can rot silently. Lifecycle hooks make that
+    /// sharper: `LifecycleHookBuilder` and `HookScriptRepr` both deny
+    /// unknown fields, so a misspelled key there is a hard parse error
+    /// rather than a quietly-ignored line.
+    #[test]
+    fn example_project_parses_with_its_lifecycle_hooks() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../sessions/example_project/minimal.toml"
+        );
+        let src = std::fs::read_to_string(path).expect("example project is readable");
+        let file: File = toml::from_str(&src).expect("example project must parse as an mfile");
+
+        let session = file
+            .session
+            .expect("the example declares a [session] block");
+        assert_eq!(session.lifecycle_hooks.len(), 1);
+        let hook = &session.lifecycle_hooks[0];
+        // All four transitions, so each can be exercised from the demo.
+        assert!(hook.on_activate().is_some());
+        assert!(hook.on_attach().is_some());
+        assert!(hook.on_detach().is_some());
+        assert!(hook.on_destroy().is_some());
+        assert!(hook.description().is_some());
+    }
 }

--- a/crates/mfile/src/package_composable.rs
+++ b/crates/mfile/src/package_composable.rs
@@ -28,13 +28,13 @@
 //! route them through a separate path. `read_only` is discarded
 //! (no meaning under copy semantics). `class = 'State` entries
 //! flow through unchanged as regular patches, gate-able via
-//! [`PatchPolicy`].
+//! [`PatchesPolicy`].
 //!
 //! [`Composable`]: sessions::core::compose::Composable
 //! [`Source::Package`]: sessions::core::source::Source::Package
 //! [`ProjectComposable`]: crate::ProjectComposable
 //! [`Patch`]: sessions::core::primitives::Patch
-//! [`PatchPolicy`]: sessions::core::policy::PatchPolicy
+//! [`PatchesPolicy`]: sessions::core::policy::PatchesPolicy
 
 use sessions::core::compose::{Composable, Contribution, Error};
 use sessions::core::primitives::{Patch, PatchDest, ResolvedVar, VarValue};

--- a/crates/mfile/src/project_composable.rs
+++ b/crates/mfile/src/project_composable.rs
@@ -63,10 +63,10 @@ impl Composable for ProjectComposable {
             path: self.project_path,
         };
         // Session transition scripts declared in a project `[session]`
-        // block are accepted and composed like any other primitive; the
-        // feature is gated off for this release purely at the output and
-        // execution layers (see `crates/minimald/src/session_host.rs`),
-        // not by dropping them here.
+        // block are composed like any other primitive. Unlike a
+        // loadout's, they face the user's `[hooks]` policy before they
+        // will run — a project is not the user, and a hook is arbitrary
+        // code. That gate is the composer's; nothing is dropped here.
         contribute_primitives(
             &source,
             self.session.packages,

--- a/crates/minimal-client/src/lib.rs
+++ b/crates/minimal-client/src/lib.rs
@@ -540,6 +540,80 @@ impl Client {
         result
     }
 
+    /// Stream a zstd-compressed tarball of external lifecycle-hook
+    /// scripts to the daemon's `WorkspaceHookScriptsTarZst` subsystem,
+    /// which unpacks each entry under `<workspace>/hooks/<staged>`.
+    ///
+    /// `scripts` comes from
+    /// [`stage_external_scripts`](sessions::client::hookscripts::stage_external_scripts),
+    /// which has already resolved every path against its anchor and
+    /// refused anything symlinked or outside it. An empty list is a
+    /// no-op — no channel is opened, and no hooks-ready marker is
+    /// written, which is what lets `FinalizeSession` skip its marker
+    /// check for an all-inline composition.
+    ///
+    /// A separate stream from
+    /// [`upload_patches`](Self::upload_patches) rather than extra
+    /// entries in that archive: patch destinations are arbitrary
+    /// home-relative paths, so any prefix reserved inside the patch
+    /// archive is one a user could legitimately claim, and the whole
+    /// patch tree is copied into the sandbox home at finalize — which
+    /// is not where scripts belong.
+    pub async fn upload_hook_scripts(
+        &mut self,
+        session_id: sessions::SessionId,
+        scripts: &[sessions::client::hookscripts::StagedScript],
+    ) -> Result<(), anyhow::Error> {
+        if scripts.is_empty() {
+            return Ok(());
+        }
+        self.stream_upload(
+            session_id,
+            constcat::concat!(
+                minimald_rpc::RPC_SUBSYSTEM_PREFIX,
+                "WorkspaceHookScriptsTarZst"
+            ),
+            "hook script",
+            async |writer| {
+                crate::file_upload::stream_via_pipe(writer, async |tx| {
+                    let mut archive = crate::file_upload::TarZstArchive::new(tx);
+                    // Always finalize, even on a build error:
+                    // `async_tar::Builder` panics from `Drop` if
+                    // dropped unfinished, and `?` here is not an
+                    // unwind. Same pattern as `upload_patches`.
+                    let build_result: Result<(), anyhow::Error> = async {
+                        for s in scripts {
+                            archive
+                                .add_file(
+                                    s.host_path.as_std_path(),
+                                    s.staged.as_str(),
+                                    crate::file_upload::AddFileOptions {
+                                        // 0644: the executor runs
+                                        // `bash <script>`, which
+                                        // reads rather than execs.
+                                        mode_override: Some(0o644),
+                                    },
+                                )
+                                .await
+                                .with_context(|| {
+                                    format!("adding hook script {} → {}", s.host_path, s.staged,)
+                                })?;
+                        }
+                        Ok(())
+                    }
+                    .await;
+                    let finish_result = archive.finish().await;
+                    match (build_result, finish_result) {
+                        (Err(build), _) => Err(build),
+                        (Ok(()), r) => r,
+                    }
+                })
+                .await
+            },
+        )
+        .await
+    }
+
     /// Common plumbing behind [`Self::upload_workspace_files`] and
     /// [`Self::upload_patches`]: open a channel, set the session-id
     /// env var, request a subsystem, drive `stream` over the

--- a/crates/minimal-tui/src/rpc.rs
+++ b/crates/minimal-tui/src/rpc.rs
@@ -238,6 +238,9 @@ pub async fn rename(
 /// root isn't a VCS checkout — the CLI asks for confirmation there (#770),
 /// and a TUI form pre-filled with the current directory must not stream a
 /// home directory to the daemon on three Enters.
+///
+/// Loadout hooks that name an external script are dropped on the way — see
+/// [`without_external_hook_scripts`].
 pub async fn activate(
     sock: &Path,
     name: Option<String>,
@@ -253,6 +256,10 @@ pub async fn activate(
                 project_path: project_path.clone(),
                 network,
                 policy: SessionPolicy::default(),
+                // Same default as an activate with no flags: the dashboard
+                // has no `--no-hooks` of its own, and a session created here
+                // is attachable later like any other.
+                hooks_enabled: true,
                 attrs: Default::default(),
             },
         })
@@ -285,6 +292,14 @@ pub async fn activate(
             .upload_workspace_files_quiet(id, upload_root.as_std_path())
             .await
             .context("uploading project files")?;
+        // Drop hooks whose scripts live in a file. The dashboard has no
+        // hook-script upload — that staging lives in the `minimal` crate,
+        // which sits above this one — and the daemon refuses to finalize a
+        // session whose composition names a staged script that never
+        // arrived. Sending them would fail every dashboard activation for a
+        // user whose loadout happens to use an external hook. Inline hooks
+        // carry their body in the composition and are kept.
+        let contribution = without_external_hook_scripts(contribution);
         let configured = client
             .oneshot_rpc::<minimald_rpc::ConfigureLoadout>(minimald_rpc::ConfigureLoadoutRequest {
                 session_id: id,
@@ -347,6 +362,46 @@ fn resolve_upload_root(dir: &camino::Utf8Path) -> Result<camino::Utf8PathBuf, an
     }
 }
 
+/// Strip hooks whose scripts are files rather than inline bodies.
+///
+/// The daemon gates `FinalizeSession` on a marker the hook-script upload
+/// writes, and the dashboard has no such upload — the staging that produces
+/// it lives in the `minimal` crate, above this one. A composition naming a
+/// script that never arrives cannot finalize, so a user whose loadout uses
+/// an external hook could not create a session from the dashboard at all.
+///
+/// Dropping is the conservative half of that trade: an inline hook still
+/// runs, and an external one silently does not rather than failing the
+/// activation. A hook left with no scripts at all is removed entirely,
+/// since an empty one is not constructible.
+fn without_external_hook_scripts(
+    mut contribution: sessions::wire::request::WireContribution,
+) -> sessions::wire::request::WireContribution {
+    use sessions::wire::primitives::WireHookScript;
+    let is_inline =
+        |s: &Option<WireHookScript>| !matches!(s, Some(WireHookScript::External { .. }));
+    for ph in &mut contribution.lifecycle_hooks {
+        let h = &mut ph.hook;
+        for slot in [
+            &mut h.on_activate,
+            &mut h.on_destroy,
+            &mut h.on_attach,
+            &mut h.on_detach,
+        ] {
+            if !is_inline(slot) {
+                *slot = None;
+            }
+        }
+    }
+    contribution.lifecycle_hooks.retain(|ph| {
+        let h = &ph.hook;
+        h.on_activate.is_some()
+            || h.on_destroy.is_some()
+            || h.on_attach.is_some()
+            || h.on_detach.is_some()
+    });
+    contribution
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/minimal-tui/tests/snapshots.rs
+++ b/crates/minimal-tui/tests/snapshots.rs
@@ -55,6 +55,7 @@ fn record(name: Option<&str>, network: NetworkMode) -> sessions::Record {
         network,
         policy: sessions::SessionPolicy::default(),
         status: sessions::SessionStatus::Active,
+        hooks_enabled: true,
         attrs: Default::default(),
     }
 }

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -219,6 +219,9 @@ pub enum SessionCommand {
     #[command(name = "setup-zed", verbatim_doc_comment)]
     #[command(hide = true)]
     SetupZed(SetupZedArgs),
+    /// List the lifecycle hooks composed into a session, and where each
+    /// was declared
+    Hooks(HooksArgs),
 }
 
 #[derive(Debug, Args)]
@@ -232,6 +235,17 @@ pub struct SetupZedArgs {
     /// Print the connection entry as JSON instead of editing any file
     #[arg(long)]
     pub print: bool,
+}
+
+/// Args for `min session hooks`.
+#[derive(Debug, Args)]
+pub struct HooksArgs {
+    /// Session identifier (UUID or session name)
+    #[arg(add = completion::session_completer())]
+    pub session: String,
+    /// Emit the raw JSON the daemon returned instead of a table
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]
@@ -472,6 +486,15 @@ pub struct ActivateArgs {
     /// `default_loadouts`). Conflicts with `--loadout`.
     #[arg(long, conflicts_with = "loadout")]
     pub no_loadouts: bool,
+    /// Run none of the session's lifecycle hooks, from either the
+    /// loadouts or the project's `minimal.toml`.
+    ///
+    /// The choice is recorded on the session, so it also applies to the
+    /// attach, detach, and destroy transitions later in its life — not
+    /// just to this activation. Use it to bring up a session whose
+    /// project declares hooks you have not reviewed.
+    #[arg(long)]
+    pub no_hooks: bool,
     /// Fail instead of prompting when the daemon returns items the
     /// user policy can't auto-decide. Useful for CI and other
     /// non-interactive contexts — the error message includes a
@@ -766,6 +789,7 @@ async fn run_command(cli: Cli) -> Result<(), anyhow::Error> {
             SessionCommand::Rename(args) => cmd_rename(&cli.global_args, args).await,
             SessionCommand::Policy(args) => cmd_session_policy(&cli.global_args, args).await,
             SessionCommand::SetupZed(args) => cmd_session_setup_zed(&cli.global_args, args).await,
+            SessionCommand::Hooks(args) => cmd_session_hooks(&cli.global_args, args).await,
         },
         Some(Command::Loadout(LoadoutArgs {
             command: LoadoutCommand::List(args),
@@ -954,6 +978,7 @@ fn bare_activate_args() -> ActivateArgs {
         ingress: Vec::new(),
         loadout: Vec::new(),
         no_loadouts: false,
+        no_hooks: false,
         no_prompt: false,
         attach: true,
     }
@@ -1126,6 +1151,15 @@ impl From<SessionLookup> for minimald_rpc::GetSessionPolicyRequest {
     }
 }
 
+impl From<SessionLookup> for minimald_rpc::GetSessionHooksRequest {
+    fn from(l: SessionLookup) -> Self {
+        match l {
+            SessionLookup::Id(id) => Self::Id(id),
+            SessionLookup::Name(n) => Self::Name(n),
+        }
+    }
+}
+
 /// Resolve a session by UUID or name, returning its record.
 ///
 /// Used by commands that need the full record before proceeding (destroy,
@@ -1235,8 +1269,10 @@ pub async fn cmd_dash(global: &GlobalArgs) -> Result<(), anyhow::Error> {
     let compose_options = loadouts::compose_options_from_config(&cfg);
     let active =
         loadouts::resolve_active_loadouts(loadouts::LoadoutSelection::Defaults, &cfg, global)?;
+    // `true`: the dashboard has no `--no-hooks`, matching the `hooks_enabled`
+    // the TUI sends on `CreateSession`.
     let (contribution, _user_policy) =
-        loadouts::compose_user_contribution(active, user_policy, compose_options)?;
+        loadouts::compose_user_contribution(active, user_policy, compose_options, true)?;
     minimal_tui::run(minimal_tui::DashOptions {
         minimal_dir: global.minimal_dir.clone(),
         contribution,
@@ -1581,19 +1617,31 @@ async fn best_effort_destroy(client: &mut client::Client, session_id: sessions::
     }
 }
 
-/// Upload the composition's patches (if any) and finalize the
-/// session. The session is `Materializing` at entry; `Active` on
-/// success. On upload/finalize failure the session is left in
-/// `Materializing` — the caller is responsible for destroying it.
+/// Upload the composition's patches and external hook scripts (if
+/// any) and finalize the session. The session is `Materializing` at
+/// entry; `Active` on success. On upload/finalize failure the session
+/// is left in `Materializing` — the caller is responsible for
+/// destroying it.
+///
+/// Both uploads precede `FinalizeSession`, which gates on each
+/// upload's ready-marker: a session must not become attachable while
+/// either its patches or its hook scripts are still missing from the
+/// daemon.
 async fn upload_and_finalize(
     client: &mut client::Client,
     session_id: sessions::SessionId,
     patches: &[(std::path::PathBuf, paths::SandboxRelPath)],
+    hook_scripts: &[sessions::client::hookscripts::StagedScript],
 ) -> Result<(), anyhow::Error> {
     client
         .upload_patches(session_id, patches)
         .await
         .context("Failed to upload composition patches")?;
+
+    client
+        .upload_hook_scripts(session_id, hook_scripts)
+        .await
+        .context("Failed to upload lifecycle hook scripts")?;
 
     use minimald_rpc::{FinalizeSession, FinalizeSessionRequest};
     let resp = client
@@ -1601,7 +1649,18 @@ async fn upload_and_finalize(
         .await
         .context("FinalizeSession RPC failed")?;
     match resp {
-        minimald_rpc::Errorable::Ok(_) => Ok(()),
+        minimald_rpc::Errorable::Ok(ok) => {
+            // An activate hook runs headlessly, so without this the only
+            // trace of it is the daemon log. Say what ran — the user
+            // agreed to let this code execute, and is owed the receipt.
+            for hook in &ok.activate_hooks {
+                match hook.description.as_deref() {
+                    Some(d) => eprintln!("Ran activation hook from {}: {d}", hook.declared_by),
+                    None => eprintln!("Ran activation hook from {}", hook.declared_by),
+                }
+            }
+            Ok(())
+        }
         minimald_rpc::Errorable::Err { error } => {
             bail!("FinalizeSession failed: {error}");
         }
@@ -1817,6 +1876,7 @@ async fn activate_session(
         project_path: abs_path,
         network: args.network.into(),
         policy,
+        hooks_enabled: !args.no_hooks,
         attrs: Default::default(),
     };
 
@@ -1840,8 +1900,24 @@ async fn activate_session(
     // from it in the launcher baseline). The banner's other dynamic
     // clause — blueprint presence — is a session-filesystem fact,
     // tested by the templates in-shell when they print.
+    // Resolve the loadouts' external hook scripts before anything
+    // touches the daemon: a mistyped path, a symlinked script, or a
+    // missing loadout script directory should fail here, on this
+    // machine, rather than after a session exists on the daemon.
+    let hook_scripts =
+        loadouts::stage_loadout_hook_scripts(&active, global, &utf8_path, !args.no_hooks)?;
+
+    // Same idea for the *project's* hooks, which the daemon composes from
+    // the uploaded mfile and which therefore never pass through the
+    // staging above. Nothing here is uploaded — the project tree carries
+    // its own scripts — but the checks a staging pass would have made are
+    // still worth making on this machine, before a session exists.
+    if !args.no_hooks {
+        loadouts::check_project_hooks(&utf8_path)?;
+    }
+
     let (contribution, user_policy) =
-        loadouts::compose_user_contribution(active, user_policy, compose_options)?;
+        loadouts::compose_user_contribution(active, user_policy, compose_options, !args.no_hooks)?;
 
     // `--sync` defaults to tarball; `sync_explicit` records whether the
     // user actually typed the flag, which distinguishes a deliberate
@@ -2116,7 +2192,7 @@ async fn activate_session(
     // are exact matches (same source), so collapsing is safe.
     collected_patches.sort_by(|a, b| a.1.as_str().cmp(b.1.as_str()));
     collected_patches.dedup_by(|a, b| a.1.as_str() == b.1.as_str());
-    if let Err(e) = upload_and_finalize(&mut client, id, &collected_patches).await {
+    if let Err(e) = upload_and_finalize(&mut client, id, &collected_patches, &hook_scripts).await {
         // Best-effort teardown: the session is stuck in
         // Materializing on the daemon. Destroy it so the operator's
         // `min ls` doesn't fill with half-finalized sessions.
@@ -2291,6 +2367,7 @@ async fn activate_new_for_attach(global: &GlobalArgs) -> Result<(), anyhow::Erro
             ingress: Vec::new(),
             loadout: Vec::new(),
             no_loadouts: false,
+            no_hooks: false,
             no_prompt: false,
             attach: true,
         },
@@ -2481,6 +2558,105 @@ pub async fn cmd_session_setup_zed(
     );
 
     Ok(())
+}
+
+/// `min session hooks`: list the lifecycle hooks composed into a
+/// session, with the loadout or project that declared each.
+///
+/// Shows what will actually run, not what was asked for: the daemon
+/// answers from the composition, which holds only the hooks that
+/// survived the user-policy gate. A session activated with `--no-hooks`,
+/// or one whose project was never allow-listed, lists nothing.
+///
+/// Rows are in setup order — project first, then loadouts in the order
+/// they were applied. Teardown runs the reverse.
+async fn cmd_session_hooks(global: &GlobalArgs, args: HooksArgs) -> Result<(), anyhow::Error> {
+    ensure_daemon(global)?;
+    let mut client = connect_daemon(global).await?;
+
+    use minimald_rpc::{GetSessionHooks, GetSessionHooksRequest};
+    let lookup: GetSessionHooksRequest = SessionLookup::parse(&args.session).into();
+    let resp = client
+        .oneshot_rpc::<GetSessionHooks>(lookup)
+        .await
+        .context("GetSessionHooks RPC failed")?;
+
+    let hooks = match resp {
+        minimald_rpc::Errorable::Ok(hooks) => hooks,
+        minimald_rpc::Errorable::Err { error } => bail!("{error}"),
+    };
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json_lenient::to_string(&hooks).context("Failed to serialize hooks")?
+        );
+        return Ok(());
+    }
+
+    if hooks.is_empty() {
+        println!("No lifecycle hooks are composed into this session.");
+        return Ok(());
+    }
+
+    // One row per *script*, not per hook: a hook may declare up to four,
+    // and "when does this run" is the question the listing exists to
+    // answer.
+    for provenanced in &hooks {
+        let hook = &provenanced.hook;
+        let source = render_hook_source(&provenanced.source);
+        for (event, script) in [
+            ("on_activate", hook.on_activate.as_ref()),
+            ("on_destroy", hook.on_destroy.as_ref()),
+            ("on_attach", hook.on_attach.as_ref()),
+            ("on_detach", hook.on_detach.as_ref()),
+        ] {
+            let Some(script) = script else { continue };
+            let (kind, body, timeout) = render_hook_script(script);
+            print!("{event:<12} {kind:<9} {timeout:>4}s  {source}");
+            match hook.description.as_deref() {
+                Some(d) => println!("  — {d}"),
+                None => println!(),
+            }
+            println!("             {body}");
+        }
+    }
+    Ok(())
+}
+
+/// Human-readable origin for a hook row.
+fn render_hook_source(source: &sessions::wire::primitives::WireSource) -> String {
+    use sessions::wire::primitives::WireSource;
+    match source {
+        WireSource::UserLoadout { name } => format!("loadout {name}"),
+        WireSource::Project { path } => format!("project {path}"),
+        WireSource::Package { name } => format!("package {name}"),
+    }
+}
+
+/// `(kind, one-line body, timeout seconds)` for a hook script.
+///
+/// An inline body is collapsed to its first line so a multi-line script
+/// cannot break the row alignment; the full text is available via
+/// `--json`.
+fn render_hook_script(
+    script: &sessions::wire::primitives::WireHookScript,
+) -> (&'static str, String, u64) {
+    use sessions::wire::primitives::WireHookScript;
+    match script {
+        WireHookScript::Inline { body, timeout_secs } => {
+            let first = body.lines().next().unwrap_or("").trim();
+            let shown = if body.lines().count() > 1 {
+                format!("{first} …")
+            } else {
+                first.to_string()
+            };
+            ("inline", shown, *timeout_secs)
+        }
+        WireHookScript::External { path, timeout_secs } => {
+            ("external", path.as_str().to_string(), *timeout_secs)
+        }
+    }
 }
 
 /// The local mesh-enrolment record path. `--minimal-dir` still wins for

--- a/crates/minimal/src/loadouts.rs
+++ b/crates/minimal/src/loadouts.rs
@@ -196,6 +196,134 @@ pub(crate) fn compose_options_from_config(
         .with_follow_symlinks(cfg.loadouts.follow_symlinks)
 }
 
+/// Resolve and validate every external hook script the active loadouts
+/// declare, ready to upload.
+///
+/// Run before the daemon connection is opened so a mistyped script path
+/// fails on this machine, naming the file, instead of surfacing after a
+/// session already exists on the daemon.
+///
+/// Only *loadout* scripts are staged here. A project's external scripts
+/// live in the project tree, which the daemon already has from the
+/// workspace upload, so it resolves those itself —
+/// [`check_project_hooks`] validates them without staging them.
+///
+/// Returns an empty list when hooks are disabled — `--no-hooks` means
+/// nothing is staged, uploaded, or run.
+pub(crate) fn stage_loadout_hook_scripts(
+    active: &ActiveLoadouts,
+    global: &GlobalArgs,
+    project_root: &camino::Utf8Path,
+    hooks_enabled: bool,
+) -> Result<Vec<sessions::client::hookscripts::StagedScript>, anyhow::Error> {
+    use sessions::client::hookscripts::{ScriptAnchors, stage_external_scripts};
+    use sessions::core::source::{ProvenancedHook, Source};
+
+    if !hooks_enabled {
+        return Ok(Vec::new());
+    }
+    let loadouts_dir =
+        camino::Utf8PathBuf::from_path_buf(resolve_minimal_config_dir(global).join("loadouts"))
+            .map_err(|p| {
+                anyhow::anyhow!("loadouts directory is not valid UTF-8: {}", p.display())
+            })?;
+
+    let hooks: Vec<ProvenancedHook> = active
+        .loadouts
+        .iter()
+        .flat_map(|l| {
+            let source = Source::UserLoadout {
+                name: l.name().as_ref().to_owned(),
+            };
+            l.lifecycle_hooks()
+                .iter()
+                .map(move |h| ProvenancedHook::new(h.clone(), source.clone()))
+        })
+        .collect();
+
+    let anchors = ScriptAnchors {
+        loadouts_dir,
+        project_root: project_root.to_owned(),
+    };
+    stage_external_scripts(&hooks, &anchors).map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+/// Validate the hooks a project declares, before a session exists.
+///
+/// The daemon composes these from the uploaded mfile, so nothing here is
+/// staged or sent — but every reason a hook would fail later is knowable
+/// now, on the machine that owns the file:
+///
+/// - an **external** script that is missing, is not a regular file, or
+///   traverses a symlink. The daemon would surface this only when the
+///   hook ran, which for `on_destroy` is at teardown, long after the
+///   mistake.
+/// - an **inline** script that is empty, which can only ever be a typo:
+///   it declares a transition and then does nothing at it.
+///
+/// A project with no mfile, or one that does not parse, is not this
+/// function's problem — the activation has its own handling for both, and
+/// duplicating it here would report the same fault twice.
+pub(crate) fn check_project_hooks(project_root: &camino::Utf8Path) -> Result<(), anyhow::Error> {
+    use sessions::client::hookscripts::{ScriptAnchors, stage_external_scripts};
+    use sessions::core::lifecyclehook::{HookScript, HookScriptBody};
+    use sessions::core::source::{ProvenancedHook, Source};
+
+    let Ok(mfile) = mfile::File::from_dir(project_root.as_std_path()) else {
+        return Ok(());
+    };
+    let Some(session) = mfile.session.as_ref() else {
+        return Ok(());
+    };
+    let hooks = &session.lifecycle_hooks;
+    if hooks.is_empty() {
+        return Ok(());
+    }
+
+    for hook in hooks {
+        let scripts = [
+            ("on_activate", hook.on_activate()),
+            ("on_destroy", hook.on_destroy()),
+            ("on_attach", hook.on_attach()),
+            ("on_detach", hook.on_detach()),
+        ];
+        for (event, script) in scripts {
+            let Some(HookScriptBody::Inline(body)) = script.map(HookScript::body) else {
+                continue;
+            };
+            if body.trim().is_empty() {
+                anyhow::bail!(
+                    "the project's `{event}` lifecycle hook has an empty inline script \
+                     (in {}/minimal.toml)",
+                    project_root,
+                );
+            }
+        }
+    }
+
+    // Resolved against the project root, the same anchor the daemon uses.
+    // The loadouts dir is irrelevant here and is never consulted, since
+    // every hook is tagged `Project`.
+    let provenanced: Vec<ProvenancedHook> = hooks
+        .iter()
+        .map(|h| {
+            ProvenancedHook::new(
+                h.clone(),
+                Source::Project {
+                    path: paths::HostPath::try_new(project_root.as_str())
+                        .expect("an activation's project path is a valid host path"),
+                },
+            )
+        })
+        .collect();
+    let anchors = ScriptAnchors {
+        loadouts_dir: project_root.to_owned(),
+        project_root: project_root.to_owned(),
+    };
+    stage_external_scripts(&provenanced, &anchors).map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(())
+}
+
 /// Compose the resolved [`ActiveLoadouts`] into a
 /// [`sessions::wire::request::WireContribution`] under the user's
 /// [`UserPolicy`] loaded from `user_policy.toml`. User-origin items
@@ -217,6 +345,7 @@ pub(crate) fn compose_user_contribution(
     active: ActiveLoadouts,
     policy: sessions::core::policy::UserPolicy,
     options: sessions::core::compose::ComposeOptions,
+    hooks_enabled: bool,
 ) -> Result<
     (
         sessions::wire::request::WireContribution,
@@ -225,16 +354,21 @@ pub(crate) fn compose_user_contribution(
     anyhow::Error,
 > {
     let loadouts_display = loadout_display_list(&active);
-    // Session transition scripts declared in a loadout are not available
-    // in this release, so they are silently excluded here — before the
-    // loadouts reach the composer — rather than after composition. This
-    // keeps a declared hook from participating in composition at all.
-    // Drop the `without_lifecycle_hooks` map when the feature ships.
-    let loadouts: Vec<_> = active
-        .loadouts
-        .into_iter()
-        .map(sessions::core::loadout::Loadout::without_lifecycle_hooks)
-        .collect();
+    // `--no-hooks` strips the loadouts' transition scripts here, before
+    // they reach the composer, rather than filtering them out after
+    // composition: a hook the user opted out of then never participates
+    // in composition, never rides the wire, and has no script staged for
+    // it. The daemon applies the same flag to the project's hooks, and
+    // the session record carries it for the later transitions.
+    let loadouts: Vec<_> = if hooks_enabled {
+        active.loadouts
+    } else {
+        active
+            .loadouts
+            .into_iter()
+            .map(sessions::core::loadout::Loadout::without_lifecycle_hooks)
+            .collect()
+    };
 
     let mut composer = sessions::client::composer::UserComposer::new()
         .with_orientation(sessions::core::compose::Orientation { loadouts_display });
@@ -525,13 +659,16 @@ mod tests {
         );
     }
 
-    /// A loadout that declares a session transition script still composes
-    /// cleanly: the hook is excluded before composition (see
-    /// [`compose_user_contribution`]), so it neither errors nor lands in
-    /// the wire contribution, while the loadout's other items compose
-    /// normally.
+    /// A loadout that declares a session transition script contributes
+    /// it, alongside its other items.
+    ///
+    /// This inverts what the test asserted while hooks were gated off:
+    /// the hook used to be stripped unconditionally before composition,
+    /// and now rides the contribution unless `--no-hooks` is given (see
+    /// [`no_hooks_strips_loadout_hooks_from_the_contribution`] for the
+    /// opt-out direction).
     #[test]
-    fn loadout_lifecycle_hook_is_excluded_without_affecting_composition() {
+    fn loadout_lifecycle_hook_composes_alongside_other_items() {
         let loadout: sessions::core::loadout::Loadout = toml::from_str(
             r#"
 name = "dev"
@@ -555,13 +692,15 @@ on_activate = { type = "inline", value = "echo activated" }
             },
             sessions::core::policy::UserPolicy::empty(),
             sessions::core::compose::ComposeOptions::default(),
+            true,
         )
-        .expect("composition succeeds despite the declared hook");
+        .expect("composition succeeds with the declared hook");
 
-        // The declared hook is silently excluded...
-        assert!(
-            wire.lifecycle_hooks.is_empty(),
-            "declared lifecycle hook must be excluded from the contribution"
+        // The declared hook rides the contribution...
+        assert_eq!(
+            wire.lifecycle_hooks.len(),
+            1,
+            "declared lifecycle hook must reach the contribution"
         );
         // ...while the loadout's other items compose normally.
         assert_eq!(wire.requested_packages.len(), 1);
@@ -648,6 +787,7 @@ on_activate = { type = "inline", value = "echo activated" }
             },
             sessions::core::policy::UserPolicy::empty(),
             sessions::core::compose::ComposeOptions::default(),
+            true,
         )
         .expect("empty composition succeeds");
         assert_eq!(wire.orientation.loadouts_display, "default (built-in)");
@@ -743,5 +883,42 @@ on_activate = { type = "inline", value = "echo activated" }
             no_input: false,
         };
         assert!(cmd_loadout_list(args, &global).is_err());
+    }
+
+    /// A loadout carrying a hook contributes it when hooks are on and
+    /// contributes nothing when `--no-hooks` turns them off.
+    ///
+    /// The off case is the one that matters: the hook must be absent
+    /// from the *wire contribution*, not merely skipped at run time, so
+    /// that a hook the user opted out of is never shipped to the daemon
+    /// and never has a script staged for it.
+    #[test]
+    fn no_hooks_strips_loadout_hooks_from_the_contribution() {
+        use sessions::core::lifecyclehook::{HookScript, LifecycleHook};
+        use sessions::core::loadout::{Loadout, LoadoutName};
+
+        let build = |hooks_enabled: bool| {
+            let loadout = Loadout::new(LoadoutName::try_new("dev").unwrap()).with_lifecycle_hook(
+                LifecycleHook::builder()
+                    .with_on_activate(HookScript::inline("echo hi"))
+                    .build()
+                    .unwrap(),
+            );
+            let active = ActiveLoadouts {
+                loadouts: vec![loadout],
+                builtin_default: false,
+            };
+            let (contribution, _) = compose_user_contribution(
+                active,
+                sessions::core::policy::UserPolicy::empty(),
+                sessions::core::compose::ComposeOptions::default(),
+                hooks_enabled,
+            )
+            .expect("composing a hook-only loadout");
+            contribution.lifecycle_hooks.len()
+        };
+
+        assert_eq!(build(true), 1, "hooks on: the loadout's hook composes in");
+        assert_eq!(build(false), 0, "--no-hooks: nothing reaches the wire");
     }
 }

--- a/crates/minimal/src/prompt.rs
+++ b/crates/minimal/src/prompt.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 
 use sessions::core::decision::ItemDecision;
 use sessions::core::hooks::{HookResult, PolicyHooks, Unapproved};
-use sessions::core::policy::{PatchPolicy, VarNameGlobs, VarsPolicy};
+use sessions::core::policy::{HooksPolicy, PatchesPolicy, VarNameGlobs, VarsPolicy};
 use sessions::core::source::Source;
 
 /// One choice a user makes at a prompt. Names carry both intent
@@ -174,7 +174,9 @@ pub struct InteractivePrompt {
     /// cell. Extracted by [`Self::into_final_policy`].
     vars_policy: RefCell<VarsPolicy>,
     /// Same shape as `vars_policy`, for the patches side.
-    patches_policy: RefCell<PatchPolicy>,
+    patches_policy: RefCell<PatchesPolicy>,
+    /// Same shape again, for the lifecycle-hooks side.
+    hooks_policy: RefCell<HooksPolicy>,
 }
 
 impl InteractivePrompt {
@@ -184,12 +186,13 @@ impl InteractivePrompt {
     /// composer.
     #[must_use]
     pub fn new(policy_path: &Path, initial: sessions::core::policy::UserPolicy) -> Self {
-        let (vars, patches) = initial.into_parts();
+        let (vars, patches, hooks) = initial.into_parts();
         Self {
             prompter: Box::new(InquirePrompter),
             can_persist: is_writable(policy_path),
             vars_policy: RefCell::new(vars),
             patches_policy: RefCell::new(patches),
+            hooks_policy: RefCell::new(hooks),
         }
     }
 
@@ -204,6 +207,7 @@ impl InteractivePrompt {
         sessions::core::policy::UserPolicy::empty()
             .with_vars(self.vars_policy.into_inner())
             .with_patches(self.patches_policy.into_inner())
+            .with_hooks(self.hooks_policy.into_inner())
     }
 
     /// Test seam: injectable prompter + explicit `can_persist`.
@@ -214,7 +218,8 @@ impl InteractivePrompt {
             prompter,
             can_persist,
             vars_policy: RefCell::new(VarsPolicy::empty()),
-            patches_policy: RefCell::new(PatchPolicy::empty()),
+            patches_policy: RefCell::new(PatchesPolicy::empty()),
+            hooks_policy: RefCell::new(HooksPolicy::empty()),
         }
     }
 
@@ -340,9 +345,9 @@ impl PolicyHooks for InteractivePrompt {
 
     fn on_patch_unapproved(
         &self,
-        _policy: PatchPolicy,
+        _policy: PatchesPolicy,
         items: &[Unapproved<'_, camino::Utf8Path>],
-    ) -> HookResult<PatchPolicy> {
+    ) -> HookResult<PatchesPolicy> {
         let choices = self.choices();
         let mut decisions = Vec::with_capacity(items.len());
         let mut policy_touched = false;
@@ -361,6 +366,42 @@ impl PolicyHooks for InteractivePrompt {
             match apply_patch_choice(&mut policy, path.as_str(), choice, &mut policy_touched) {
                 PatchStep::Decision(d) => decisions.push(d),
                 PatchStep::Abort => return HookResult::Abort,
+            }
+        }
+        if policy_touched {
+            HookResult::decided_with_policy(decisions, policy.clone())
+        } else {
+            HookResult::decided(decisions)
+        }
+    }
+
+    fn on_hook_unapproved(
+        &self,
+        _policy: HooksPolicy,
+        items: &[Unapproved<'_, camino::Utf8Path>],
+    ) -> HookResult<HooksPolicy> {
+        let choices = self.choices();
+        let mut decisions = Vec::with_capacity(items.len());
+        let mut policy_touched = false;
+        let mut policy = self.hooks_policy.borrow_mut();
+        for item in items {
+            let root = item.item();
+            // Worded to say what approval actually grants. The other
+            // two domains move data; this one runs code, and a prompt
+            // that read like "wants to use lifecycle hooks" would
+            // understate what the user is agreeing to.
+            let msg = format!(
+                "The project at `{}` wants to run its own scripts inside the session \
+                 (lifecycle hooks). This executes arbitrary code from that project.",
+                root.as_str()
+            );
+            let choice = match self.prompter.ask(&msg, choices) {
+                Ok(c) => c,
+                Err(_) => return HookResult::Abort,
+            };
+            match apply_hook_choice(&mut policy, root.as_str(), choice, &mut policy_touched) {
+                HookStep::Decision(d) => decisions.push(d),
+                HookStep::Abort => return HookResult::Abort,
             }
         }
         if policy_touched {
@@ -468,7 +509,7 @@ fn apply_var_choice(
 /// absolute path the walker produced. Fancier pattern editing
 /// (glob-ification, `~/` conversion) is a future feature.
 fn apply_patch_choice(
-    policy: &mut PatchPolicy,
+    policy: &mut PatchesPolicy,
     path: &str,
     choice: UserChoice,
     touched: &mut bool,
@@ -491,6 +532,86 @@ fn apply_patch_choice(
             *policy = append_patch_pattern(policy.clone(), PatchBucket::Deny, path);
             *touched = true;
             PatchStep::Abort
+        }
+    }
+}
+
+/// Outcome of applying a hooks-side [`UserChoice`]. Same shape as
+/// [`VarStep`] and [`PatchStep`].
+enum HookStep {
+    Decision(ItemDecision),
+    Abort,
+}
+
+/// Apply one [`UserChoice`] to the hooks policy for a project root.
+///
+/// The permanent variants record the project root verbatim, so
+/// approving once covers every hook that project declares now and
+/// later. That is the intended grain: the user is trusting the
+/// project, not auditing individual scripts, and a per-script rule
+/// would silently lapse the moment the project added another.
+fn apply_hook_choice(
+    policy: &mut HooksPolicy,
+    root: &str,
+    choice: UserChoice,
+    touched: &mut bool,
+) -> HookStep {
+    match choice {
+        UserChoice::AllowOnce => HookStep::Decision(ItemDecision::AllowOnce),
+        UserChoice::IgnoreOnce => HookStep::Decision(ItemDecision::IgnoreOnce),
+        UserChoice::AllowPermanent => {
+            *policy = append_hook_pattern(policy.clone(), HookBucket::Allow, root);
+            *touched = true;
+            HookStep::Decision(ItemDecision::UseRule)
+        }
+        UserChoice::IgnorePermanent => {
+            *policy = append_hook_pattern(policy.clone(), HookBucket::Ignore, root);
+            *touched = true;
+            HookStep::Decision(ItemDecision::UseRule)
+        }
+        UserChoice::Abort => HookStep::Abort,
+        UserChoice::DenyPermanent => {
+            *policy = append_hook_pattern(policy.clone(), HookBucket::Deny, root);
+            *touched = true;
+            HookStep::Abort
+        }
+    }
+}
+
+enum HookBucket {
+    Allow,
+    Deny,
+    Ignore,
+}
+
+/// Append `root` as a pattern into the requested hooks-policy bucket.
+fn append_hook_pattern(policy: HooksPolicy, bucket: HookBucket, root: &str) -> HooksPolicy {
+    // Stored as a literal, not as the pattern it would otherwise be
+    // read as. The user picked one project at the prompt; a raw path
+    // containing glob metacharacters would either match its siblings
+    // too — approving code execution nobody was asked about — or match
+    // nothing, leaving a rule that silently never fires. See
+    // [`literal_policy_pattern`].
+    let root = sessions::core::expansion::literal_policy_pattern(root);
+    let extend = |existing: &[String]| -> Vec<String> {
+        existing
+            .iter()
+            .cloned()
+            .chain(std::iter::once(root.clone()))
+            .collect()
+    };
+    match bucket {
+        HookBucket::Allow => {
+            let p = extend(policy.allow());
+            policy.with_allow(p)
+        }
+        HookBucket::Deny => {
+            let p = extend(policy.deny());
+            policy.with_deny(p)
+        }
+        HookBucket::Ignore => {
+            let p = extend(policy.ignore());
+            policy.with_ignore(p)
         }
     }
 }
@@ -538,7 +659,12 @@ fn append_var_pattern(policy: &mut VarsPolicy, bucket: VarBucket, name: &str) ->
     }
 }
 
-fn append_patch_pattern(policy: PatchPolicy, bucket: PatchBucket, path: &str) -> PatchPolicy {
+fn append_patch_pattern(policy: PatchesPolicy, bucket: PatchBucket, path: &str) -> PatchesPolicy {
+    // Same literal-not-pattern reasoning as `append_hook_pattern`. A
+    // patch moves data rather than running it, so the stakes are lower
+    // — but a rule that silently never matches is the same bug either
+    // way, and the user picked one file.
+    let path = &sessions::core::expansion::literal_policy_pattern(path);
     match bucket {
         PatchBucket::Allow => {
             let patterns: Vec<String> = policy
@@ -595,6 +721,7 @@ pub struct NoPromptHook {
 pub struct UnapprovedSummary {
     vars: Vec<String>,
     patches: Vec<String>,
+    hooks: Vec<String>,
 }
 
 impl UnapprovedSummary {
@@ -626,6 +753,15 @@ impl UnapprovedSummary {
             patches.insert("allow", toml_edit::value(allow));
             doc.insert("patches", toml_edit::Item::Table(patches));
         }
+        if !self.hooks.is_empty() {
+            let mut hooks = toml_edit::Table::new();
+            let mut allow = toml_edit::Array::new();
+            for root in &self.hooks {
+                allow.push(root.as_str());
+            }
+            hooks.insert("allow", toml_edit::value(allow));
+            doc.insert("hooks", toml_edit::Item::Table(hooks));
+        }
         doc.to_string()
     }
 
@@ -633,7 +769,7 @@ impl UnapprovedSummary {
     /// would require approval").
     #[must_use]
     pub fn count(&self) -> usize {
-        self.vars.len() + self.patches.len()
+        self.vars.len() + self.patches.len() + self.hooks.len()
     }
 }
 
@@ -694,12 +830,28 @@ impl PolicyHooks for NoPromptHook {
 
     fn on_patch_unapproved(
         &self,
-        _policy: PatchPolicy,
+        _policy: PatchesPolicy,
         items: &[Unapproved<'_, camino::Utf8Path>],
-    ) -> HookResult<PatchPolicy> {
+    ) -> HookResult<PatchesPolicy> {
         let mut seen = self.seen.borrow_mut();
         for item in items {
             insert_unique(&mut seen.patches, item.item().as_str().to_owned());
+        }
+        HookResult::decided(vec![ItemDecision::AllowOnce; items.len()])
+    }
+
+    /// Records each project whose hooks would need approval and
+    /// fake-approves, exactly as the other two domains do — the caller
+    /// checks `into_summary().count()` and aborts before any verdict
+    /// reaches the daemon, so this never grants execution.
+    fn on_hook_unapproved(
+        &self,
+        _policy: HooksPolicy,
+        items: &[Unapproved<'_, camino::Utf8Path>],
+    ) -> HookResult<HooksPolicy> {
+        let mut seen = self.seen.borrow_mut();
+        for item in items {
+            insert_unique(&mut seen.hooks, item.item().as_str().to_owned());
         }
         HookResult::decided(vec![ItemDecision::AllowOnce; items.len()])
     }
@@ -817,8 +969,8 @@ impl Drop for RemoveOnDrop<'_> {
     }
 }
 
-/// Upsert the six rule arrays (`vars.allow/deny/ignore`,
-/// `patches.allow/deny/ignore`) from `policy` into `doc`, replacing
+/// Upsert the nine rule arrays (`vars`, `patches`, and `hooks`, each
+/// with `allow`/`deny`/`ignore`) from `policy` into `doc`, replacing
 /// each in place while leaving surrounding structure, comments, and
 /// unrelated keys intact. Empty arrays are removed rather than
 /// written as `[]` so a minimal policy doesn't render bloated
@@ -837,12 +989,18 @@ fn merge_policy_into_document(
     upsert_string_array(doc, "patches", "deny", patches.deny());
     upsert_string_array(doc, "patches", "ignore", patches.ignore());
 
-    // Drop `[vars]` / `[patches]` sections that end up empty. Keeps
-    // the file minimal after a rule the user hand-added gets emptied
-    // by some future policy operation (defensive — today's flow only
-    // appends, never removes).
+    let hooks = policy.hooks();
+    upsert_string_array(doc, "hooks", "allow", hooks.allow());
+    upsert_string_array(doc, "hooks", "deny", hooks.deny());
+    upsert_string_array(doc, "hooks", "ignore", hooks.ignore());
+
+    // Drop sections that end up empty. Keeps the file minimal after a
+    // rule the user hand-added gets emptied by some future policy
+    // operation (defensive — today's flow only appends, never
+    // removes).
     remove_empty_section(doc, "vars");
     remove_empty_section(doc, "patches");
+    remove_empty_section(doc, "hooks");
 }
 
 fn upsert_string_array(
@@ -951,6 +1109,37 @@ mod tests {
 
     fn scripted(answers: Vec<UserChoice>, can_persist: bool) -> InteractivePrompt {
         InteractivePrompt::with_prompter(Box::new(ScriptedPrompter::new(answers)), can_persist)
+    }
+
+    /// "Allow permanent" on a project whose path contains glob
+    /// metacharacters must store something that means *that* project.
+    /// Stored raw, `/tmp/build*` would grant every sibling `build…`
+    /// project the right to run code in the user's sessions — an
+    /// approval nobody was asked for. Asserted here as well as on the
+    /// expander so the escaping cannot be dropped at the call site.
+    #[test]
+    fn allowing_a_project_with_glob_chars_stores_a_literal_not_a_pattern() {
+        let policy = append_hook_pattern(HooksPolicy::empty(), HookBucket::Allow, "/tmp/build*");
+        let stored = policy.allow();
+        assert_eq!(stored.len(), 1);
+        assert_ne!(
+            stored[0], "/tmp/build*",
+            "the raw path would be read back as a wildcard",
+        );
+
+        // What matters is the behaviour after expansion, not the spelling.
+        let vars: [sessions::core::primitives::ResolvedVar; 0] = [];
+        let fs =
+            sessions::core::expansion::expand_policy_pattern(&stored[0], vars.as_slice(), None)
+                .expect("the stored entry should expand");
+        assert!(
+            fs.is_match("/tmp/build*"),
+            "should match the project itself"
+        );
+        assert!(
+            !fs.is_match("/tmp/build-someone-elses-project"),
+            "should not reach another project",
+        );
     }
 
     // ---- UserChoice option filtering ----
@@ -1096,7 +1285,7 @@ mod tests {
         let source = package_source("go");
         let path = camino::Utf8Path::new("/home/u/.config/go/env");
         let items = [Unapproved::new(path, &source)];
-        let out = hook.on_patch_unapproved(PatchPolicy::empty(), &items);
+        let out = hook.on_patch_unapproved(PatchesPolicy::empty(), &items);
         match out {
             HookResult::Decided {
                 decisions,
@@ -1166,11 +1355,79 @@ mod tests {
         let path = camino::Utf8Path::new("/etc/foo");
         let patch_items = [Unapproved::new(path, &source)];
         let _ =
-            hook.on_patch_unapproved(sessions::core::policy::PatchPolicy::empty(), &patch_items);
+            hook.on_patch_unapproved(sessions::core::policy::PatchesPolicy::empty(), &patch_items);
 
         let summary = hook.into_summary();
         assert_eq!(summary.vars, vec!["DIAGRAM", "GOCACHE", "LOG_LEVEL"]);
         assert_eq!(summary.patches, vec!["/etc/foo"]);
+    }
+
+    /// `--no-prompt` records the projects whose hooks would need
+    /// approval and renders them into the `[hooks]` section of the
+    /// pasteable snippet.
+    ///
+    /// Without this the snippet would tell an operator how to unblock
+    /// the vars and patches but stay silent about the hooks, so the
+    /// activation would fail again on the next run for a reason the
+    /// error never mentioned.
+    #[test]
+    fn no_prompt_hook_collects_projects_and_renders_hooks_section() {
+        let hook = NoPromptHook::new();
+        let source = project_source();
+        let root = camino::Utf8Path::new("/repo");
+
+        let items = [Unapproved::new(root, &source)];
+        let _ = hook.on_hook_unapproved(HooksPolicy::empty(), &items);
+        // A second batch naming the same project must not duplicate.
+        let _ = hook.on_hook_unapproved(HooksPolicy::empty(), &items);
+
+        let summary = hook.into_summary();
+        assert_eq!(summary.hooks, vec!["/repo"]);
+        assert_eq!(summary.count(), 1);
+
+        let snippet = summary.as_toml_snippet();
+        assert!(snippet.contains("[hooks]"), "got: {snippet}");
+        assert!(snippet.contains("\"/repo\""), "got: {snippet}");
+        // The snippet must parse — it is meant to be pasted verbatim.
+        let parsed: sessions::core::policy::UserPolicy =
+            toml::from_str(&snippet).expect("snippet must be valid user_policy.toml");
+        assert_eq!(parsed.hooks().allow(), &["/repo".to_string()]);
+    }
+
+    /// A project the user permanently allows lands in the hooks
+    /// policy's `allow` list, so the next activation of that project
+    /// runs its hooks without asking again.
+    #[test]
+    fn allow_permanent_appends_project_to_hooks_allow() {
+        let mut policy = HooksPolicy::empty();
+        let mut touched = false;
+        let step = apply_hook_choice(
+            &mut policy,
+            "/repo",
+            UserChoice::AllowPermanent,
+            &mut touched,
+        );
+        assert!(matches!(step, HookStep::Decision(ItemDecision::UseRule)));
+        assert!(touched);
+        assert_eq!(policy.allow(), &["/repo".to_string()]);
+        assert!(policy.deny().is_empty());
+    }
+
+    /// A permanent denial records the rule *and* aborts, matching the
+    /// patch domain: the user is saying "never" and "not now" at once.
+    #[test]
+    fn deny_permanent_records_rule_and_aborts() {
+        let mut policy = HooksPolicy::empty();
+        let mut touched = false;
+        let step = apply_hook_choice(
+            &mut policy,
+            "/repo",
+            UserChoice::DenyPermanent,
+            &mut touched,
+        );
+        assert!(matches!(step, HookStep::Abort));
+        assert!(touched);
+        assert_eq!(policy.deny(), &["/repo".to_string()]);
     }
 
     /// The TOML snippet builder groups by domain, quotes correctly,

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -307,6 +307,11 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
         project_path: abs_path,
         network: sessions::NetworkMode::HostNet,
         policy: sessions::SessionPolicy::default(),
+        // Same default as an activate with no flags, matching the
+        // loadout handling below. `min task run` has no `--no-hooks` of
+        // its own; a `--keep` session is attachable later, so its hooks
+        // should behave like any other session's.
+        hooks_enabled: true,
         attrs: Default::default(),
     };
 
@@ -324,11 +329,16 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
         let names: Vec<&str> = active.loadouts.iter().map(|l| l.name().as_ref()).collect();
         eprintln!("Applying loadouts: {}", names.join(", "));
     }
+    // Same pre-daemon staging as an activate, so a broken hook script
+    // path fails here rather than after the ephemeral session exists.
+    let hook_scripts =
+        crate::loadouts::stage_loadout_hook_scripts(&active, global, &utf8_path, true)?;
+
     // Same first-class orientation field as an activate: a `--keep`
     // task session is attachable later, and its banner should orient
     // too.
     let (contribution, user_policy) =
-        crate::loadouts::compose_user_contribution(active, user_policy, compose_options)?;
+        crate::loadouts::compose_user_contribution(active, user_policy, compose_options, true)?;
 
     // Upload per the normal activate rules: tarball sync (the default), the
     // same empty/`$HOME` and non-VCS-root gates, no `--sync` escape hatch.
@@ -502,7 +512,9 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
 
     collected_patches.sort_by(|a, b| a.1.as_str().cmp(b.1.as_str()));
     collected_patches.dedup_by(|a, b| a.1.as_str() == b.1.as_str());
-    if let Err(e) = crate::upload_and_finalize(&mut client, id, &collected_patches).await {
+    if let Err(e) =
+        crate::upload_and_finalize(&mut client, id, &collected_patches, &hook_scripts).await
+    {
         crate::best_effort_destroy(&mut client, id).await;
         return Err(e);
     }

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -265,6 +265,7 @@ async fn activate_creates_session() {
         ingress: vec![],
         loadout: vec![],
         no_loadouts: false,
+        no_hooks: false,
         no_prompt: false,
         attach: false,
     };
@@ -307,6 +308,7 @@ async fn activate_uploads_project_files() {
         ingress: vec![],
         loadout: vec![],
         no_loadouts: false,
+        no_hooks: false,
         no_prompt: false,
         attach: false,
     };
@@ -388,6 +390,7 @@ async fn activate_uses_repo_dir_when_no_positional_path() {
         ingress: vec![],
         loadout: vec![],
         no_loadouts: false,
+        no_hooks: false,
         no_prompt: false,
         attach: false,
     };
@@ -726,6 +729,7 @@ async fn create_pending_session(daemon: &common::TestDaemon, name: &str) -> Sess
         project_path: paths::HostAbsPath::try_new(project_path).unwrap(),
         network: sessions::NetworkMode::NoNet,
         policy: Default::default(),
+        hooks_enabled: true,
         attrs: Default::default(),
     };
 
@@ -776,6 +780,7 @@ async fn create_session_at(
         project_path,
         network: sessions::NetworkMode::NoNet,
         policy: Default::default(),
+        hooks_enabled: true,
         attrs: Default::default(),
     };
 

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -279,9 +279,24 @@ pub struct SessionConfig {
     /// Per-session networking policy (egress + ingress).
     #[serde(default)]
     pub policy: SessionPolicy,
+    /// Whether the session runs the lifecycle hooks composed into it.
+    /// Cleared by `min session activate --no-hooks`, and persisted onto
+    /// the session record so the later attach/detach/destroy
+    /// transitions — which run from processes that never saw the
+    /// activating command — honour the same choice. Defaults to `true`
+    /// so a client that predates the field gets hooks, not silence.
+    #[serde(default = "default_hooks_enabled")]
+    pub hooks_enabled: bool,
     /// Free-form attributes (typed by the caller).
     #[serde(default)]
     pub attrs: std::collections::BTreeMap<String, String>,
+}
+
+/// Serde default for [`SessionConfig::hooks_enabled`]. See
+/// [`sessions::Record::hooks_enabled`] for why this cannot be a bare
+/// `#[serde(default)]`.
+fn default_hooks_enabled() -> bool {
+    true
 }
 
 /// The request for a [`CreateSession`] RPC.
@@ -392,9 +407,36 @@ pub struct FinalizeSessionRequest {
     pub session_id: SessionId,
 }
 
-/// The response for a [`FinalizeSession`] RPC — a unit-shaped ack.
+/// The response for a [`FinalizeSession`] RPC.
+///
+/// Carries what the session's `on_activate` hooks did, so the client can
+/// report it: a hook that ran is otherwise invisible to the user, since
+/// activation is headless and its output goes to the daemon log. A
+/// *failing* activate hook fails the whole RPC instead, so anything
+/// listed here succeeded.
+/// `deny_unknown_fields` is load-bearing, not tidiness. [`Errorable`] is
+/// `#[serde(untagged)]`, so it tries `Ok(S)` first and takes it if it
+/// parses — and a struct whose every field is optional parses from *any*
+/// object, including `{"error": "..."}`. Without this, every failed
+/// finalize would decode as a successful one with no hooks.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct FinalizeSessionResponse {
+    /// One entry per `on_activate` hook that ran, in the order they ran.
+    /// Serde-defaulted so a daemon that predates the field still answers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub activate_hooks: Vec<RanHook>,
+}
+
+/// One hook that ran, as reported back to the client.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FinalizeSessionResponse;
+pub struct RanHook {
+    /// Where it was declared, e.g. ``user loadout `dev` ``.
+    pub declared_by: String,
+    /// The hook's own description, when it has one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
 
 impl OneshotSshRpc for FinalizeSession {
     const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "FinalizeSession");
@@ -594,6 +636,33 @@ impl OneshotSshRpc for GetSessionPolicy {
     const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "GetSessionPolicy");
     type Request<'a> = GetSessionPolicyRequest;
     type Response = Errorable<SessionPolicy>;
+}
+
+/// An RPC to list the lifecycle hooks composed into a session, and where
+/// each was declared.
+///
+/// Served from the session's persisted composition snapshot rather than
+/// live state, so it answers after a daemon restart and for a session
+/// nobody is attached to. The snapshot holds only the hooks that
+/// survived the user-policy gate, so what this returns is what will
+/// actually run — not what the loadouts and project asked for.
+pub struct GetSessionHooks;
+
+/// Request for the [`GetSessionHooks`] RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GetSessionHooksRequest {
+    Name(String),
+    Id(SessionId),
+}
+
+impl OneshotSshRpc for GetSessionHooks {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "GetSessionHooks");
+    type Request<'a> = GetSessionHooksRequest;
+    /// Each hook paired with the loadout or project that declared it, in
+    /// setup order (project first, then loadouts). Teardown order is the
+    /// reverse; the caller renders whichever it needs.
+    type Response = Errorable<Vec<sessions::wire::primitives::WireProvenancedHook>>;
 }
 
 /// An RPC for a process inside a PTask to request a dynamic ingress port
@@ -890,6 +959,45 @@ mod tests {
     use super::*;
     use sessions::wire::request::{ContributionResponse, WireContribution};
 
+    /// A failed finalize must decode as an error, not as a success with
+    /// nothing in it.
+    ///
+    /// [`Errorable`] is `#[serde(untagged)]`, so it takes `Ok(S)` if `S`
+    /// parses at all — and a response whose fields are all optional
+    /// parses from any object, an error payload included. Adding
+    /// `activate_hooks` reopened exactly that hole, and the symptom is
+    /// silent: every activation, including a failing one, reads as
+    /// successful. `deny_unknown_fields` is what closes it, and this is
+    /// what keeps it closed.
+    #[test]
+    fn a_finalize_error_does_not_decode_as_a_successful_finalize() {
+        let err: Errorable<FinalizeSessionResponse> =
+            serde_json_lenient::from_str(r#"{"error":"activation hook failed"}"#)
+                .expect("an error payload must decode");
+        match err {
+            Errorable::Err { error } => assert!(error.contains("activation hook failed")),
+            Errorable::Ok(ok) => {
+                panic!("an error decoded as success: {ok:?}")
+            }
+        }
+
+        // The success shapes still decode: with hooks, and without.
+        let bare: Errorable<FinalizeSessionResponse> =
+            serde_json_lenient::from_str("{}").expect("an empty success must decode");
+        assert_eq!(bare, Errorable::Ok(FinalizeSessionResponse::default()));
+        let with_hooks: Errorable<FinalizeSessionResponse> = serde_json_lenient::from_str(
+            r#"{"activate_hooks":[{"declared_by":"user loadout `dev`"}]}"#,
+        )
+        .expect("a populated success must decode");
+        match with_hooks {
+            Errorable::Ok(ok) => {
+                assert_eq!(ok.activate_hooks.len(), 1);
+                assert_eq!(ok.activate_hooks[0].declared_by, "user loadout `dev`");
+            }
+            Errorable::Err { error } => panic!("a success decoded as an error: {error}"),
+        }
+    }
+
     /// An empty request body must decode with the documented defaults so a
     /// bare `{}` probe (or an older client) still gets a full bundle.
     #[test]
@@ -1079,12 +1187,31 @@ mod tests {
                 project_path: paths::HostAbsPath::try_new("/home/u/proj").unwrap(),
                 network: NetworkMode::OwnIp,
                 policy: SessionPolicy::default(),
+                // The non-default (`--no-hooks`): `true` is the serde
+                // default, so a fixture using it would round-trip green
+                // even if the field never reached the wire.
+                hooks_enabled: false,
                 attrs: [("color".to_string(), "blue".to_string())]
                     .into_iter()
                     .collect(),
             },
         };
         assert_eq!(round_trip(&req), req);
+    }
+
+    /// A `SessionConfig` from a client that predates `hooks_enabled`
+    /// deserializes with hooks **on**. A bare `#[serde(default)]` would
+    /// give `false` and silently disable hooks for every older client.
+    #[test]
+    fn session_config_predating_hooks_enabled_defaults_to_on() {
+        let json = r#"{
+            "name": "s",
+            "project_path": "/p",
+            "network": "host_net",
+            "attrs": {}
+        }"#;
+        let c: SessionConfig = serde_json_lenient::from_str(json).expect("legacy config must load");
+        assert!(c.hooks_enabled);
     }
 
     #[test]

--- a/crates/minimald/src/hooks.rs
+++ b/crates/minimald/src/hooks.rs
@@ -1,0 +1,1415 @@
+//! Running a session's lifecycle hooks.
+//!
+//! A hook is a script a loadout or a project asked to run at one
+//! of a session's transitions. It executes **inside the running
+//! session's sandbox**, by joining the session process's namespaces
+//! (see [`crate::nsenter`]) — not in a freshly-built one. That
+//! distinction matters: a new sandbox would share the rootfs and the
+//! persistent home/workspace mounts, but get its own `/tmp`, its own
+//! `/dev`, and its own network namespace. On an own-IP session the
+//! fresh netns has no tap relayed to the switch, so a hook that fetches
+//! anything would fail there and succeed on a host-net session — the
+//! same declaration behaving differently for reasons nobody connected
+//! to hooks. Joining the live session avoids all of it.
+//!
+//! # Delivering the script
+//!
+//! Scripts are piped to their interpreter on stdin rather than
+//! referenced by path. The staged-scripts directory lives beside the
+//! session's workspace on the *daemon* filesystem and is not mounted
+//! into the sandbox, so a path would not resolve there; and reading the
+//! bytes daemon-side collapses inline and external hooks onto one code
+//! path. It also settles stdin: the script occupies it, so a hook cannot
+//! read the user's keystrokes out of an attached terminal.
+//!
+//! Which interpreter is [`Interpreter`]'s decision: POSIX `sh` by
+//! default, or whatever a leading shebang names. Because the script
+//! arrives on stdin, no kernel ever sees that shebang — this module
+//! reads it and runs what it names.
+//!
+//! # What this module does not do
+//!
+//! Decide *when* hooks fire. Wiring the four transitions is the
+//! caller's job; this module runs a set of hooks for one event and
+//! reports what happened.
+
+use std::collections::BTreeMap;
+use std::process::Stdio;
+use std::time::Duration;
+
+use paths::DaemonAbsPath;
+use sessions::SessionId;
+use sessions::core::compose::Composition;
+use sessions::core::lifecyclehook::{HookScript, HookScriptBody, staged_script_path};
+use sessions::core::source::{Provenanced, ProvenancedHook, Source};
+
+/// The transition a hook is running for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HookEvent {
+    Activate,
+    Destroy,
+    Attach,
+    Detach,
+}
+
+impl HookEvent {
+    /// The name as declared in configuration, and as reported to the
+    /// hook in `MINIMAL_HOOK_EVENT`.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Activate => "on_activate",
+            Self::Destroy => "on_destroy",
+            Self::Attach => "on_attach",
+            Self::Detach => "on_detach",
+        }
+    }
+
+    /// Teardown events run in reverse composition order, so the project
+    /// tears down after every loadout that layered on top of it. They are
+    /// also the events that run under a total budget — see
+    /// [`run_hooks`].
+    pub(crate) fn is_teardown(self) -> bool {
+        matches!(self, Self::Destroy | Self::Detach)
+    }
+
+    /// This event's script on `hook`, if it declares one.
+    pub(crate) fn script_of(
+        self,
+        hook: &sessions::core::lifecyclehook::LifecycleHook,
+    ) -> Option<&HookScript> {
+        match self {
+            Self::Activate => hook.on_activate(),
+            Self::Destroy => hook.on_destroy(),
+            Self::Attach => hook.on_attach(),
+            Self::Detach => hook.on_detach(),
+        }
+    }
+}
+
+/// Builds commands that run inside a session's sandbox.
+///
+/// Exists so the runner can be exercised without a real sandbox: the
+/// production implementation joins namespaces via the session host,
+/// while tests substitute one that returns a plain host command. That
+/// leaves only the `setns` step untested here — everything else (script
+/// delivery, stdio, timeouts, ordering, metadata) runs against the same
+/// code path either way.
+pub(crate) trait SessionCommands {
+    /// A command that will run `program` with `args` inside the
+    /// session, with `extra_env` layered over the session's own
+    /// variables.
+    fn command(
+        &self,
+        program: &str,
+        args: &[&str],
+        extra_env: BTreeMap<String, String>,
+    ) -> impl std::future::Future<Output = std::io::Result<std::process::Command>> + Send;
+}
+
+/// A [`SessionCommands`] owning everything needed to build an
+/// injection, so it can outlive a borrow of the host.
+///
+/// The host uses this rather than its own handle: a hook run happens
+/// inside the host's message loop, so a round-trip through the handle
+/// would deadlock against itself. Owning the data also keeps a `&Host`
+/// off the stack across an await — a `Host` holds a non-`Sync`
+/// `dyn NetGuard`, which would make the whole session future non-`Send`.
+pub(crate) struct InjectedCommands {
+    pub(crate) leader_pid: u32,
+    pub(crate) cwd: String,
+    pub(crate) vars: BTreeMap<String, String>,
+}
+
+impl SessionCommands for InjectedCommands {
+    async fn command(
+        &self,
+        program: &str,
+        args: &[&str],
+        extra_env: BTreeMap<String, String>,
+    ) -> std::io::Result<std::process::Command> {
+        let mut vars = self.vars.clone();
+        vars.extend(extra_env);
+        crate::nsenter::Injection::new(self.leader_pid, program, args)
+            .with_cwd(self.cwd.clone())
+            .with_env(vars)
+            .command()
+            .map_err(std::io::Error::other)
+    }
+}
+
+impl SessionCommands for crate::session_host::HostHandle {
+    fn command(
+        &self,
+        program: &str,
+        args: &[&str],
+        extra_env: BTreeMap<String, String>,
+    ) -> impl std::future::Future<Output = std::io::Result<std::process::Command>> + Send {
+        let args: Vec<String> = args.iter().map(|a| (*a).to_string()).collect();
+        let program = program.to_string();
+        async move { self.command_in_session_env(program, args, extra_env).await }
+    }
+}
+
+/// How a hook's output is routed.
+pub(crate) enum HookOutput {
+    /// Open this terminal fresh for each hook and write to it, so the
+    /// hook's stdout really is a tty (`[ -t 1 ]`, `tput`, size queries).
+    ///
+    /// A path rather than a retained descriptor: while any slave fd for
+    /// a PTY stays open its master never sees EOF, so holding one for
+    /// the session's lifetime would stop the host from ever observing
+    /// the shell exit. Each descriptor opened here lives only as long
+    /// as the hook that writes to it.
+    Tty(std::path::PathBuf),
+    /// Capture and return it. Activate and destroy hooks have no
+    /// terminal to write to.
+    Capture,
+}
+
+/// What a hook did.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct HookOutcome {
+    /// The transition it ran for.
+    pub(crate) event: &'static str,
+    /// Human-readable source, e.g. ``user loadout `dev` `` (from `Source`'s `Display`).
+    pub(crate) declared_by: String,
+    /// The hook's own description, when it has one.
+    pub(crate) description: Option<String>,
+    pub(crate) status: HookStatus,
+    /// Tail of captured output; always empty for
+    /// [`HookOutput::Tty`], which wrote straight to the terminal.
+    pub(crate) output: String,
+}
+
+impl HookOutcome {
+    /// Whether this outcome should be treated as a failure by callers
+    /// that gate on hooks (only `on_activate` does).
+    pub(crate) fn failed(&self) -> bool {
+        !matches!(self.status, HookStatus::Ok)
+    }
+}
+
+/// The terminal state of one hook run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum HookStatus {
+    /// Exited zero.
+    Ok,
+    /// Exited non-zero, or was killed by a signal (`code` absent).
+    Failed { code: Option<i32> },
+    /// Exceeded the time it was given and was killed.
+    ///
+    /// `after` is what it actually got, which is not always what it
+    /// asked for: on a budgeted run (teardown — see [`run_hooks`]) a
+    /// hook is cut to whatever the budget has left. `budgeted` says
+    /// which happened, because otherwise a hook declaring 60s and
+    /// reported as timing out after 4s reads as a broken timeout rather
+    /// than as a teardown that had already spent its time.
+    TimedOut { after: Duration, budgeted: bool },
+    /// Never ran: the command could not be built or spawned, or its
+    /// script could not be read.
+    NotRun { reason: String },
+}
+
+/// How long output tails are kept in an outcome. Enough to see a
+/// compiler error or a stack trace without letting a chatty hook push
+/// megabytes into a log line or an RPC response.
+const OUTPUT_TAIL_BYTES: usize = 4096;
+
+/// Run every hook in `composition` that declares a script for `event`.
+///
+/// Setup events run in composition order (project first, then loadouts
+/// in selection order); teardown events run in reverse, so the project
+/// tears down last. Hooks that declare nothing for this event are
+/// skipped silently.
+///
+/// Never returns an error: a hook that could not run produces a
+/// [`HookStatus::NotRun`] outcome rather than aborting the batch, so a
+/// caller always gets one outcome per hook that declared a script and
+/// decides for itself what is fatal. Only `on_activate` treats a
+/// failure as fatal, and that decision belongs to its trigger, not
+/// here.
+/// `budget`, when set, is a deadline across the **whole** run rather
+/// than per hook. Each script still gets at most its own timeout, but
+/// never more than what is left; once the budget is spent the remaining
+/// hooks are reported [`HookStatus::NotRun`] without being started.
+///
+/// Teardown passes one. A per-script cap alone bounds nothing in
+/// aggregate — nothing limits how many hooks a composition may carry,
+/// so N of them at [`MAX_HOOK_TIMEOUT`] each would hold a destroy open
+/// for N×5 minutes, which is the exact failure that cap exists to
+/// prevent. Setup passes `None`: `on_activate` and `on_attach` run
+/// under a command the user is watching and can interrupt, and
+/// truncating them would silently half-configure a session instead of
+/// failing it.
+///
+/// [`MAX_HOOK_TIMEOUT`]: sessions::core::lifecyclehook::MAX_HOOK_TIMEOUT
+pub(crate) async fn run_hooks<C: SessionCommands>(
+    commands: &C,
+    ctx: &HookContext<'_>,
+    event: HookEvent,
+    mut output: HookOutput,
+    budget: Option<Duration>,
+) -> Vec<HookOutcome> {
+    let ordered: Vec<&ProvenancedHook> = if event.is_teardown() {
+        ctx.composition.lifecycle_hooks_teardown().collect()
+    } else {
+        ctx.composition.lifecycle_hooks().iter().collect()
+    };
+    // Only hooks that declare something for this event are numbered, so
+    // MINIMAL_HOOK_INDEX/COUNT describe the run that actually happens
+    // rather than the whole composition.
+    let running: Vec<&ProvenancedHook> = ordered
+        .into_iter()
+        .filter(|ph| event.script_of(ph.hook()).is_some())
+        .collect();
+
+    let deadline = budget.map(|b| tokio::time::Instant::now() + b);
+    let mut outcomes = Vec::with_capacity(running.len());
+    for (index, ph) in running.iter().enumerate() {
+        let script = event
+            .script_of(ph.hook())
+            .expect("filtered to hooks with a script for this event");
+        // A hook gets the smaller of its own timeout and what remains of
+        // the run's budget, so the last hook cannot extend past it.
+        let allowed = match deadline {
+            None => script.timeout(),
+            Some(d) => {
+                let left = d.saturating_duration_since(tokio::time::Instant::now());
+                if left.is_zero() {
+                    outcomes.push(not_run_over_budget(event, ph, budget));
+                    continue;
+                }
+                script.timeout().min(left)
+            }
+        };
+        outcomes.push(
+            run_one(
+                commands,
+                ctx,
+                event,
+                ph,
+                script,
+                allowed,
+                index,
+                running.len(),
+                &mut output,
+            )
+            .await,
+        );
+    }
+    outcomes
+}
+
+/// The outcome for a hook the run had no time left to start. Reported
+/// rather than skipped silently: a hook that did not run is something
+/// the operator has to be able to see, and it names the budget so the
+/// reason is not mistaken for the hook's own failure.
+fn not_run_over_budget(
+    event: HookEvent,
+    ph: &ProvenancedHook,
+    budget: Option<Duration>,
+) -> HookOutcome {
+    HookOutcome {
+        event: event.as_str(),
+        declared_by: ph.source().to_string(),
+        description: ph.hook().description().map(str::to_owned),
+        status: HookStatus::NotRun {
+            reason: format!(
+                "the {} budget of {}s was spent by earlier hooks",
+                event.as_str(),
+                budget.unwrap_or_default().as_secs(),
+            ),
+        },
+        output: String::new(),
+    }
+}
+
+/// What a hook body is fed to, and with which arguments.
+///
+/// Hooks are POSIX shell by default: the contract is `sh`, not any one
+/// shell's extensions, so a hook that works in one session keeps working in
+/// a session whose `sh` is a leaner one. A script that wants something else
+/// says so in a shebang, which is the spelling every hook author already
+/// knows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Interpreter {
+    program: String,
+    args: Vec<String>,
+}
+
+impl Interpreter {
+    /// POSIX `sh` reading the script from standard input. `-s` is the POSIX
+    /// spelling of "commands come from stdin"; passing no operands would
+    /// mean the same thing, but saying it leaves nothing to infer.
+    fn posix_shell() -> Self {
+        Self {
+            program: "sh".to_string(),
+            args: vec!["-s".to_string()],
+        }
+    }
+
+    /// The interpreter `body` asks for in a shebang, or POSIX `sh` when it
+    /// asks for nothing.
+    ///
+    /// The body still reaches the interpreter on stdin rather than as a
+    /// file, so this reads the shebang and runs what it names instead of
+    /// letting the kernel do it — a hook has no path inside the session to
+    /// be exec'd from. It is parsed exactly as the kernel would, so a hook
+    /// behaves the same here as the same file would anywhere else:
+    ///
+    /// - The interpreter is the first whitespace-delimited word. A path
+    ///   containing spaces therefore cannot be named — there is no quoting
+    ///   in a shebang line, on any system. Point one at `env` instead.
+    /// - Everything after it is **one** argument, not one per word
+    ///   (`execve(2)`). This is why `#!/usr/bin/env -S python3 -u` works:
+    ///   `env` receives `-S python3 -u` whole and splits it itself, which
+    ///   is what `-S` is for. Splitting here instead would hand `env` a
+    ///   `-S` with only `python3` attached and leave `-u` to be misread as
+    ///   an option to `env`.
+    ///
+    /// The one thing the kernel does that this cannot: resolve a relative
+    /// interpreter path, which it would take against the *daemon's* working
+    /// directory rather than the session's. Name an absolute path, or a
+    /// bare command for `env` to find on the session's `PATH`.
+    ///
+    /// The shebang line is left in the body. Every interpreter this can name
+    /// treats `#` as a comment, and keeping it means a hook's line numbers
+    /// match what its author wrote.
+    fn for_script(body: &[u8]) -> Self {
+        let Some(rest) = body.strip_prefix(b"#!") else {
+            return Self::posix_shell();
+        };
+        let line = rest.split(|b| *b == b'\n').next().unwrap_or_default();
+        // A shebang naming a non-UTF-8 path is not something to guess at.
+        let Ok(line) = std::str::from_utf8(line) else {
+            return Self::posix_shell();
+        };
+        // `trim` rather than `trim_start`: it also takes the `\r` a CRLF
+        // checkout leaves on the line, which is otherwise part of the last
+        // argument (or of the interpreter's own path, when it is alone).
+        let line = line.trim();
+        let (program, arg) = match line.split_once(char::is_whitespace) {
+            Some((program, arg)) => (program, arg.trim()),
+            None => (line, ""),
+        };
+        if program.is_empty() {
+            // `#!` with nothing after it names no interpreter.
+            return Self::posix_shell();
+        }
+        Self {
+            program: program.to_string(),
+            args: if arg.is_empty() {
+                Vec::new()
+            } else {
+                vec![arg.to_string()]
+            },
+        }
+    }
+
+    /// The program to run.
+    fn program(&self) -> &str {
+        &self.program
+    }
+
+    /// Its arguments, in the shape [`SessionCommands::command`] takes.
+    fn args(&self) -> Vec<&str> {
+        self.args.iter().map(String::as_str).collect()
+    }
+}
+
+/// Everything a hook run needs to know about the session it belongs to.
+pub(crate) struct HookContext<'a> {
+    pub(crate) session_id: SessionId,
+    pub(crate) session_name: &'a str,
+    pub(crate) composition: &'a Composition,
+    /// Where the client's uploaded external scripts were staged.
+    pub(crate) hooks_dir: DaemonAbsPath,
+    /// The session's workspace, where a project's own scripts live when
+    /// the project tree was uploaded.
+    pub(crate) workspace: DaemonAbsPath,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_one<C: SessionCommands>(
+    commands: &C,
+    ctx: &HookContext<'_>,
+    event: HookEvent,
+    ph: &ProvenancedHook,
+    script: &HookScript,
+    // How long this run may take — the script's own timeout, or less
+    // when a budgeted run has less than that left. See `run_hooks`.
+    timeout: Duration,
+    index: usize,
+    count: usize,
+    output: &mut HookOutput,
+) -> HookOutcome {
+    let declared_by = ph.source().to_string();
+    let description = ph.hook().description().map(str::to_owned);
+    let outcome = |status| HookOutcome {
+        event: event.as_str(),
+        declared_by: declared_by.clone(),
+        description: description.clone(),
+        status,
+        output: String::new(),
+    };
+
+    let body = match read_script(ctx, ph.source(), script) {
+        Ok(b) => b,
+        Err(reason) => return outcome(HookStatus::NotRun { reason }),
+    };
+
+    let env = metadata_env(ctx, event, ph.source(), index, count);
+    // The interpreter reads the script from stdin. Nothing is passed as an
+    // argument beyond what the shebang asked for, so a script's `$1..` are
+    // empty rather than accidentally inheriting anything.
+    let interpreter = Interpreter::for_script(&body);
+    let built = match commands
+        .command(interpreter.program(), &interpreter.args(), env)
+        .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return outcome(HookStatus::NotRun {
+                reason: format!("building the command for `{}`: {e}", interpreter.program()),
+            });
+        }
+    };
+
+    let mut cmd = tokio::process::Command::from(built);
+    cmd.stdin(Stdio::piped());
+    let capturing = match output {
+        HookOutput::Capture => {
+            cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+            true
+        }
+        HookOutput::Tty(path) => {
+            // Opened per hook and dropped with the child, so no slave
+            // descriptor outlives the run that needed it.
+            let open = |p: &std::path::Path| std::fs::OpenOptions::new().write(true).open(p);
+            let (out, err) = match (open(path), open(path)) {
+                (Ok(o), Ok(e)) => (o, e),
+                _ => {
+                    return outcome(HookStatus::NotRun {
+                        reason: format!("opening the session terminal `{}` failed", path.display()),
+                    });
+                }
+            };
+            cmd.stdout(Stdio::from(out)).stderr(Stdio::from(err));
+            false
+        }
+    };
+    cmd.kill_on_drop(true);
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            // Naming the interpreter matters most here: a shebang for
+            // something the session doesn't have is an ordinary mistake, and
+            // a bare ENOENT would look like the hook itself was missing.
+            return outcome(HookStatus::NotRun {
+                reason: format!("spawning `{}`: {e}", interpreter.program()),
+            });
+        }
+    };
+
+    // Write the script, then close stdin — an interpreter reads to EOF
+    // before it runs anything, so a hook that never terminates cannot be
+    // blamed on a stdin left open.
+    //
+    // Bounded by the same deadline as the run itself: an interpreter that
+    // never reads its stdin leaves this blocked once the body outgrows the
+    // pipe buffer, and an unbounded block here would sit *before* the
+    // timeout below and defeat it — including the teardown budget, whose
+    // whole job is that a hook cannot hold a session open.
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt as _;
+        let written = tokio::time::timeout(timeout, stdin.write_all(&body)).await;
+        let failed = match written {
+            Ok(Ok(())) => None,
+            Ok(Err(e)) => Some(format!("writing the script to stdin: {e}")),
+            Err(_elapsed) => Some(format!(
+                "the interpreter did not read its script within {}s",
+                timeout.as_secs(),
+            )),
+        };
+        if let Some(reason) = failed {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            return outcome(HookStatus::NotRun { reason });
+        }
+        drop(stdin);
+    }
+
+    let waited = if capturing {
+        tokio::time::timeout(timeout, child.wait_with_output()).await
+    } else {
+        tokio::time::timeout(timeout, async {
+            child.wait().await.map(|status| std::process::Output {
+                status,
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            })
+        })
+        .await
+    };
+
+    match waited {
+        Ok(Ok(out)) => {
+            let mut o = outcome(if out.status.success() {
+                HookStatus::Ok
+            } else {
+                HookStatus::Failed {
+                    code: out.status.code(),
+                }
+            });
+            o.output = tail_of(&out.stdout, &out.stderr);
+            o
+        }
+        Ok(Err(e)) => outcome(HookStatus::NotRun {
+            reason: format!("waiting: {e}"),
+        }),
+        Err(_elapsed) => {
+            // `wait_with_output`/`wait` took ownership, so the kill goes
+            // through `kill_on_drop`: the child is dropped when the
+            // timed-out future is, which signals it. That reaches the
+            // interpreter — the shim relays it via `PR_SET_PDEATHSIG` —
+            // but not anything the interpreter itself backgrounded: no
+            // process group is set, so a `foo &` outlives the timeout.
+            // Those are bounded by the session instead, whose PID
+            // namespace takes them when its shell exits.
+            outcome(HookStatus::TimedOut {
+                after: timeout,
+                // Cut short by the run's budget rather than by its own
+                // declaration, when the two differ.
+                budgeted: timeout < script.timeout(),
+            })
+        }
+    }
+}
+
+/// Whether `p` stays inside the directory it is joined to: relative,
+/// with no `..` component. The twin of `rpc::safe_relative_path`, which
+/// guards the *write* side (unpacking an uploaded archive); this guards
+/// the read.
+fn contained_relative_path(p: &std::path::Path) -> bool {
+    !p.is_absolute()
+        && !p
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+}
+
+/// The script bytes to feed the interpreter ([`Interpreter::for_script`]
+/// reads its shebang out of these).
+///
+/// Inline hooks carry their body in the composition. External hooks are
+/// read from the staged-scripts directory; a project's script may
+/// instead be in the uploaded workspace tree, which is checked as a
+/// fallback because that upload makes staging unnecessary.
+fn read_script(
+    ctx: &HookContext<'_>,
+    source: &Source,
+    script: &HookScript,
+) -> Result<Vec<u8>, String> {
+    match script.body() {
+        HookScriptBody::Inline(body) => Ok(body.clone().into_bytes()),
+        HookScriptBody::External(rel) => {
+            let staged = staged_script_path(source, rel)
+                .ok_or_else(|| "this source cannot declare hook scripts".to_string())?;
+            // Both joins below are made with a path derived from wire
+            // data, so neither is allowed to climb out of the directory
+            // it is anchored to. `staged_script_path` and
+            // `ConfigRelPath` each refuse the components that would let
+            // it; this is the check at the point of use, where the
+            // consequence actually lands — reading a file the session
+            // was never given.
+            if !contained_relative_path(staged.as_std_path())
+                || !contained_relative_path(rel.as_utf8_path().as_std_path())
+            {
+                return Err(format!(
+                    "hook script path `{staged}` escapes the session's staged-hooks directory"
+                ));
+            }
+            let staged_path = ctx.hooks_dir.as_utf8_path().join(&staged);
+            match std::fs::read(staged_path.as_std_path()) {
+                Ok(b) => return Ok(b),
+                Err(e) if e.kind() != std::io::ErrorKind::NotFound => {
+                    return Err(format!("reading `{staged_path}`: {e}"));
+                }
+                Err(_) => {}
+            }
+            // Not staged. For a project, the script may have arrived
+            // with the workspace tree instead.
+            if matches!(source, Source::Project { .. }) {
+                let in_tree = ctx.workspace.as_utf8_path().join(rel.as_utf8_path());
+                return std::fs::read(in_tree.as_std_path()).map_err(|e| {
+                    format!(
+                        "script not staged, and reading `{in_tree}` from the workspace \
+                         failed: {e}"
+                    )
+                });
+            }
+            Err(format!(
+                "no staged script at `{staged_path}` (was the hook-script upload skipped?)"
+            ))
+        }
+    }
+}
+
+/// The metadata a hook gets on top of the session's own environment.
+fn metadata_env(
+    ctx: &HookContext<'_>,
+    event: HookEvent,
+    source: &Source,
+    index: usize,
+    count: usize,
+) -> BTreeMap<String, String> {
+    // Split into kind and name because a hook author wants to branch on
+    // one and print the other; `Source`'s `Display` gives a single
+    // prose string, which is right for a log line but not for `[ "$K" =
+    // project ]`. The catch-all exists because `Source` is
+    // `#[non_exhaustive]`: a variant added later should degrade to a
+    // usable value rather than fail to compile a crate that only needs
+    // a label for it.
+    let (kind, name) = match source {
+        Source::UserLoadout { name } => ("loadout", name.clone()),
+        Source::Project { path } => ("project", path.as_utf8_path().to_string()),
+        Source::Package { name } => ("package", name.clone()),
+        other => ("other", other.to_string()),
+    };
+    BTreeMap::from([
+        ("MINIMAL_SESSION_ID".to_string(), ctx.session_id.to_string()),
+        (
+            "MINIMAL_SESSION_NAME".to_string(),
+            ctx.session_name.to_string(),
+        ),
+        ("MINIMAL_HOOK_EVENT".to_string(), event.as_str().to_string()),
+        ("MINIMAL_HOOK_SOURCE_KIND".to_string(), kind.to_string()),
+        ("MINIMAL_HOOK_SOURCE_NAME".to_string(), name),
+        // 1-based: these are for a human reading a log line, not an
+        // array index.
+        ("MINIMAL_HOOK_INDEX".to_string(), (index + 1).to_string()),
+        ("MINIMAL_HOOK_COUNT".to_string(), count.to_string()),
+    ])
+}
+
+/// Last [`OUTPUT_TAIL_BYTES`] of the two streams, stderr after stdout.
+fn tail_of(stdout: &[u8], stderr: &[u8]) -> String {
+    let mut joined = String::from_utf8_lossy(stdout).into_owned();
+    if !stderr.is_empty() {
+        if !joined.is_empty() && !joined.ends_with('\n') {
+            joined.push('\n');
+        }
+        joined.push_str(&String::from_utf8_lossy(stderr));
+    }
+    if joined.len() <= OUTPUT_TAIL_BYTES {
+        return joined;
+    }
+    // Cut on a char boundary so the tail stays valid UTF-8.
+    let start = joined
+        .char_indices()
+        .rev()
+        .map(|(i, _)| i)
+        .find(|i| joined.len() - i >= OUTPUT_TAIL_BYTES)
+        .unwrap_or(0);
+    joined[start..].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sessions::core::lifecyclehook::LifecycleHook;
+
+    /// A [`SessionCommands`] that runs the command on the host instead
+    /// of inside a sandbox. Exercises everything but the namespace
+    /// join.
+    struct HostCommands;
+
+    impl SessionCommands for HostCommands {
+        fn command(
+            &self,
+            program: &str,
+            args: &[&str],
+            extra_env: BTreeMap<String, String>,
+        ) -> impl std::future::Future<Output = std::io::Result<std::process::Command>> + Send
+        {
+            let mut cmd = std::process::Command::new(program);
+            cmd.args(args);
+            cmd.env_clear();
+            cmd.envs(extra_env);
+            async move { Ok(cmd) }
+        }
+    }
+
+    /// A [`SessionCommands`] that always refuses, standing in for a
+    /// session whose shell has exited.
+    struct DeadSession;
+
+    impl SessionCommands for DeadSession {
+        async fn command(
+            &self,
+            _program: &str,
+            _args: &[&str],
+            _extra_env: BTreeMap<String, String>,
+        ) -> std::io::Result<std::process::Command> {
+            Err(std::io::Error::other("no session leader"))
+        }
+    }
+
+    fn loadout(name: &str) -> Source {
+        Source::UserLoadout {
+            name: name.to_string(),
+        }
+    }
+
+    fn project() -> Source {
+        Source::Project {
+            path: paths::HostPath::try_new("/repo").unwrap(),
+        }
+    }
+
+    /// Compose `hooks` (in order) into a `Composition`.
+    ///
+    /// Built through the public snapshot conversion rather than a
+    /// test-only constructor: `Composition`'s own builders are
+    /// crate-private to `sessions`, and going through the wire form
+    /// exercises the same path a daemon restart takes.
+    fn composition_of(hooks: Vec<ProvenancedHook>) -> Composition {
+        use sessions::wire::primitives::WireProvenancedHook;
+        use sessions::wire::request::{COMPOSITION_SNAPSHOT_VERSION, WireComposition};
+        let wire = WireComposition {
+            version: COMPOSITION_SNAPSHOT_VERSION,
+            vars: Vec::new(),
+            patches: Vec::new(),
+            packages: Vec::new(),
+            lifecycle_hooks: hooks.into_iter().map(WireProvenancedHook::from).collect(),
+            orientation: Default::default(),
+        };
+        Composition::try_from(wire).expect("hooks with at least one script convert back")
+    }
+
+    fn ctx<'a>(composition: &'a Composition, dir: &camino::Utf8Path) -> HookContext<'a> {
+        HookContext {
+            session_id: SessionId::nil(),
+            session_name: "test",
+            composition,
+            hooks_dir: DaemonAbsPath::try_new(dir.join("hooks")).unwrap(),
+            workspace: DaemonAbsPath::try_new(dir.join("tree")).unwrap(),
+        }
+    }
+
+    fn inline_hook(event: HookEvent, body: &str, source: Source) -> ProvenancedHook {
+        let script = HookScript::inline(body);
+        let b = LifecycleHook::builder();
+        let b = match event {
+            HookEvent::Activate => b.with_on_activate(script),
+            HookEvent::Destroy => b.with_on_destroy(script),
+            HookEvent::Attach => b.with_on_attach(script),
+            HookEvent::Detach => b.with_on_detach(script),
+        };
+        ProvenancedHook::new(b.build().unwrap(), source)
+    }
+
+    /// The last guard before the daemon reads a file for a hook.
+    ///
+    /// Currently unreachable: `staged_script_path` refuses a loadout
+    /// name that isn't a plain path component, and `ConfigRelPath`
+    /// refuses `..` in the script path, so nothing upstream can hand
+    /// this an escaping path today. Tested directly for that reason —
+    /// it is the backstop if either of those ever loosens, and a
+    /// backstop nothing exercises is one nobody notices breaking.
+    #[test]
+    fn contained_relative_path_rejects_anything_that_could_climb_out() {
+        use std::path::Path;
+        for bad in [
+            "/etc/shadow",
+            "../etc/shadow",
+            "loadout/../../../etc/shadow",
+            "a/b/..",
+            "..",
+        ] {
+            assert!(
+                !contained_relative_path(Path::new(bad)),
+                "{bad:?} should be refused",
+            );
+        }
+        for good in [
+            "loadout/dev/activate.sh",
+            "project/scripts/setup.sh",
+            "a",
+            "./a/b",
+        ] {
+            assert!(
+                contained_relative_path(Path::new(good)),
+                "{good:?} should be allowed",
+            );
+        }
+    }
+
+    /// The default is POSIX `sh`, reading the script from stdin.
+    #[test]
+    fn a_script_without_a_shebang_runs_under_posix_sh() {
+        let i = Interpreter::for_script(b"echo hello\n");
+        assert_eq!(i.program(), "sh");
+        assert_eq!(i.args(), vec!["-s"]);
+        assert_eq!(i, Interpreter::for_script(b""));
+    }
+
+    /// A shebang names the interpreter, and everything after it is a
+    /// single argument — `execve(2)`'s rule, not one-arg-per-word. The
+    /// `env -S` case is the one that would break under word splitting:
+    /// `env` needs `-S python3 -u` whole to split it itself.
+    #[test]
+    fn a_shebang_names_the_interpreter_and_one_argument() {
+        let cases: [(&[u8], &str, Vec<&str>); 5] = [
+            (b"#!/bin/fish\necho hi\n", "/bin/fish", vec![]),
+            (
+                b"#!/usr/bin/env python3\nprint(1)\n",
+                "/usr/bin/env",
+                vec!["python3"],
+            ),
+            (
+                b"#!/usr/bin/env -S python3 -u\nprint(1)\n",
+                "/usr/bin/env",
+                vec!["-S python3 -u"],
+            ),
+            (b"#!/bin/sh -e\ntrue\n", "/bin/sh", vec!["-e"]),
+            // No trailing newline: the shebang is the whole body.
+            (b"#!/bin/fish", "/bin/fish", vec![]),
+        ];
+        for (body, program, args) in cases {
+            let i = Interpreter::for_script(body);
+            assert_eq!(
+                i.program(),
+                program,
+                "body: {:?}",
+                String::from_utf8_lossy(body)
+            );
+            assert_eq!(i.args(), args, "body: {:?}", String::from_utf8_lossy(body));
+        }
+    }
+
+    /// Surrounding whitespace — including the `\r` a CRLF-checkout leaves on
+    /// the line — is not part of the interpreter's path.
+    #[test]
+    fn a_shebang_tolerates_padding_and_crlf() {
+        let i = Interpreter::for_script(b"#!  /usr/bin/env  fish  \r\nls\n");
+        assert_eq!(i.program(), "/usr/bin/env");
+        assert_eq!(i.args(), vec!["fish"]);
+    }
+
+    /// A `#!` that names nothing, or names something unreadable, falls back
+    /// to the default rather than failing the hook: a script whose first
+    /// line is odd is still a script.
+    #[test]
+    fn an_unusable_shebang_falls_back_to_posix_sh() {
+        for body in [
+            &b"#!\necho hi\n"[..],
+            &b"#!   \n"[..],
+            &b"#!/bin/\xff\n"[..],
+        ] {
+            assert_eq!(
+                Interpreter::for_script(body),
+                Interpreter::for_script(b"echo hi"),
+                "body: {:?}",
+                String::from_utf8_lossy(body),
+            );
+        }
+    }
+
+    /// A `#!` has to lead the file to be a shebang; one further down is just
+    /// a comment.
+    #[test]
+    fn a_shebang_below_the_first_line_is_only_a_comment() {
+        let i = Interpreter::for_script(b"echo hi\n#!/bin/fish\n");
+        assert_eq!(i.program(), "sh");
+    }
+
+    /// End to end: a shebang'd script is really fed to the interpreter it
+    /// names. `cat` copies stdin to stdout, so seeing the script's own text
+    /// come back proves both halves — the program was chosen from the
+    /// shebang, and the body reached it.
+    #[tokio::test]
+    async fn a_shebang_script_is_run_by_the_interpreter_it_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        // Not a shell script: under `sh` this would be a syntax error.
+        let body = "#!/bin/cat\n<<< not shell >>>\n";
+        let comp = composition_of(vec![inline_hook(HookEvent::Activate, body, loadout("dev"))]);
+
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        assert_eq!(outcomes[0].status, HookStatus::Ok, "{:?}", outcomes[0]);
+        assert!(
+            outcomes[0].output.contains("<<< not shell >>>"),
+            "the script did not reach `cat`: {:?}",
+            outcomes[0],
+        );
+        // The shebang rides along in the body, so `cat` echoes it too.
+        assert!(
+            outcomes[0].output.contains("#!/bin/cat"),
+            "{:?}",
+            outcomes[0]
+        );
+    }
+
+    /// A shebang naming something the session doesn't have fails the hook
+    /// with the interpreter in the message — the common mistake, and one a
+    /// bare ENOENT would misattribute to the hook script itself.
+    #[tokio::test]
+    async fn a_missing_interpreter_is_reported_by_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let comp = composition_of(vec![inline_hook(
+            HookEvent::Activate,
+            "#!/definitely/not/an/interpreter\ntrue\n",
+            loadout("dev"),
+        )]);
+
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        let HookStatus::NotRun { reason } = &outcomes[0].status else {
+            panic!("expected NotRun, got {:?}", outcomes[0].status);
+        };
+        assert!(
+            reason.contains("/definitely/not/an/interpreter"),
+            "the failure should name the interpreter: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn inline_hook_runs_and_reports_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let comp = composition_of(vec![inline_hook(
+            HookEvent::Activate,
+            "echo hello",
+            loadout("dev"),
+        )]);
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].status, HookStatus::Ok);
+        assert!(!outcomes[0].failed());
+        assert!(outcomes[0].output.contains("hello"), "{:?}", outcomes[0]);
+        assert_eq!(outcomes[0].declared_by, "user loadout `dev`");
+    }
+
+    /// A non-zero exit is reported with its code rather than swallowed.
+    #[tokio::test]
+    async fn failing_hook_reports_its_exit_code() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let comp = composition_of(vec![inline_hook(
+            HookEvent::Activate,
+            "echo oops >&2; exit 3",
+            loadout("dev"),
+        )]);
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        assert_eq!(outcomes[0].status, HookStatus::Failed { code: Some(3) });
+        assert!(outcomes[0].failed());
+        assert!(outcomes[0].output.contains("oops"));
+    }
+
+    /// A hook that outlives its timeout is killed and reported as timed
+    /// out, not left running.
+    #[tokio::test]
+    async fn hook_exceeding_its_timeout_is_killed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let script = HookScript::inline("sleep 30")
+            .with_timeout(Duration::from_secs(1))
+            .unwrap();
+        let hook = LifecycleHook::builder()
+            .with_on_activate(script)
+            .build()
+            .unwrap();
+        let comp = composition_of(vec![ProvenancedHook::new(hook, loadout("dev"))]);
+
+        let started = std::time::Instant::now();
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        // Its own declared timeout, on an unbudgeted run — so not
+        // `budgeted`, which is what distinguishes this from a teardown
+        // that ran out of time.
+        assert!(
+            matches!(
+                outcomes[0].status,
+                HookStatus::TimedOut {
+                    budgeted: false,
+                    ..
+                }
+            ),
+            "{:?}",
+            outcomes[0],
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(20),
+            "the runner must not wait out the script it killed",
+        );
+    }
+
+    /// Setup runs project-first; teardown runs the exact reverse.
+    #[tokio::test]
+    async fn teardown_runs_in_reverse_of_setup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+
+        let setup = composition_of(vec![
+            inline_hook(HookEvent::Activate, "true", project()),
+            inline_hook(HookEvent::Activate, "true", loadout("dev")),
+        ]);
+        let order: Vec<String> = run_hooks(
+            &HostCommands,
+            &ctx(&setup, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await
+        .into_iter()
+        .map(|o| o.declared_by)
+        .collect();
+        assert_eq!(order, vec!["project `/repo`", "user loadout `dev`"]);
+
+        let teardown = composition_of(vec![
+            inline_hook(HookEvent::Destroy, "true", project()),
+            inline_hook(HookEvent::Destroy, "true", loadout("dev")),
+        ]);
+        let order: Vec<String> = run_hooks(
+            &HostCommands,
+            &ctx(&teardown, dir),
+            HookEvent::Destroy,
+            HookOutput::Capture,
+            None,
+        )
+        .await
+        .into_iter()
+        .map(|o| o.declared_by)
+        .collect();
+        assert_eq!(order, vec!["user loadout `dev`", "project `/repo`"]);
+    }
+
+    /// Hooks that declare nothing for the event in flight are skipped,
+    /// and the index/count reported to those that do run describes only
+    /// the actual run.
+    #[tokio::test]
+    async fn only_hooks_declaring_this_event_run_and_are_numbered() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let comp = composition_of(vec![
+            inline_hook(HookEvent::Detach, "true", loadout("other")),
+            inline_hook(
+                HookEvent::Activate,
+                "echo $MINIMAL_HOOK_INDEX/$MINIMAL_HOOK_COUNT",
+                loadout("dev"),
+            ),
+        ]);
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        assert_eq!(outcomes.len(), 1, "the detach-only hook must not run");
+        assert!(outcomes[0].output.contains("1/1"), "{:?}", outcomes[0]);
+    }
+
+    /// The metadata block reaches the script.
+    #[tokio::test]
+    async fn hook_receives_its_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let comp = composition_of(vec![inline_hook(
+            HookEvent::Attach,
+            "echo $MINIMAL_HOOK_EVENT $MINIMAL_HOOK_SOURCE_KIND $MINIMAL_HOOK_SOURCE_NAME",
+            loadout("dev"),
+        )]);
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Attach,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        assert!(
+            outcomes[0].output.contains("on_attach loadout dev"),
+            "{:?}",
+            outcomes[0],
+        );
+    }
+
+    /// An external script is read from the staged directory at the path
+    /// the client derived.
+    #[tokio::test]
+    async fn external_script_is_read_from_the_staged_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let staged = dir.join("hooks").join("loadout").join("dev");
+        std::fs::create_dir_all(staged.as_std_path()).unwrap();
+        std::fs::write(staged.join("a.sh").as_std_path(), "echo from-staged\n").unwrap();
+
+        let hook = LifecycleHook::builder()
+            .with_on_activate(HookScript::try_external("a.sh").unwrap())
+            .build()
+            .unwrap();
+        let comp = composition_of(vec![ProvenancedHook::new(hook, loadout("dev"))]);
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        assert_eq!(outcomes[0].status, HookStatus::Ok, "{:?}", outcomes[0]);
+        assert!(outcomes[0].output.contains("from-staged"));
+    }
+
+    /// A project's external script that was never staged falls back to
+    /// the uploaded workspace tree.
+    #[tokio::test]
+    async fn project_script_falls_back_to_the_workspace_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let tree = dir.join("tree").join("scripts");
+        std::fs::create_dir_all(tree.as_std_path()).unwrap();
+        std::fs::write(tree.join("s.sh").as_std_path(), "echo from-tree\n").unwrap();
+
+        let hook = LifecycleHook::builder()
+            .with_on_activate(HookScript::try_external("scripts/s.sh").unwrap())
+            .build()
+            .unwrap();
+        let comp = composition_of(vec![ProvenancedHook::new(hook, project())]);
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        assert_eq!(outcomes[0].status, HookStatus::Ok, "{:?}", outcomes[0]);
+        assert!(outcomes[0].output.contains("from-tree"));
+    }
+
+    /// A missing external script is reported as not-run, naming the
+    /// path it looked for, rather than failing silently or panicking.
+    #[tokio::test]
+    async fn missing_external_script_reports_not_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let hook = LifecycleHook::builder()
+            .with_on_activate(HookScript::try_external("nope.sh").unwrap())
+            .build()
+            .unwrap();
+        let comp = composition_of(vec![ProvenancedHook::new(hook, loadout("dev"))]);
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        assert!(
+            matches!(&outcomes[0].status, HookStatus::NotRun { reason } if reason.contains("nope.sh")),
+            "{:?}",
+            outcomes[0],
+        );
+        assert!(outcomes[0].failed());
+    }
+
+    /// A session with no shell to join yields a not-run outcome per
+    /// hook — the batch still reports, so a caller can say what was
+    /// skipped instead of appearing to have run them.
+    #[tokio::test]
+    async fn dead_session_reports_not_run_per_hook() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let comp = composition_of(vec![inline_hook(
+            HookEvent::Destroy,
+            "true",
+            loadout("dev"),
+        )]);
+        let outcomes = run_hooks(
+            &DeadSession,
+            &ctx(&comp, dir),
+            HookEvent::Destroy,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(outcomes[0].status, HookStatus::NotRun { .. }));
+    }
+
+    /// A teardown's hooks share one budget. Per-hook timeouts alone
+    /// bound nothing in aggregate — nothing caps how many hooks a
+    /// composition carries — so three hooks that would each burn their
+    /// own timeout must still finish within the total, and the ones
+    /// that never got to start must say so.
+    #[tokio::test]
+    async fn a_teardown_budget_is_shared_across_all_of_its_hooks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let slow = || {
+            let script = HookScript::inline("sleep 30")
+                .with_timeout(Duration::from_secs(10))
+                .unwrap();
+            ProvenancedHook::new(
+                LifecycleHook::builder()
+                    .with_on_destroy(script)
+                    .build()
+                    .unwrap(),
+                loadout("dev"),
+            )
+        };
+        let comp = composition_of(vec![slow(), slow(), slow()]);
+
+        let started = std::time::Instant::now();
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Destroy,
+            HookOutput::Capture,
+            Some(Duration::from_secs(2)),
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(outcomes.len(), 3, "every hook is accounted for");
+        // Unbudgeted this would be 3 × 10s; the budget caps the whole run.
+        assert!(
+            elapsed < Duration::from_secs(8),
+            "the budget did not bound the run: took {elapsed:?}",
+        );
+        // The first burns the budget — and says the budget cut it
+        // short, not its own 10s timeout, which it never reached.
+        assert!(
+            matches!(
+                outcomes[0].status,
+                HookStatus::TimedOut { budgeted: true, .. }
+            ),
+            "{:?}",
+            outcomes[0],
+        );
+        let over_budget = outcomes[1..]
+            .iter()
+            .filter(
+                |o| matches!(&o.status, HookStatus::NotRun { reason } if reason.contains("budget")),
+            )
+            .count();
+        assert!(
+            over_budget >= 1,
+            "a hook the budget left no time for should report why: {:?}",
+            &outcomes[1..],
+        );
+    }
+
+    /// Without a budget the per-hook timeouts are the only bound, which
+    /// is what setup transitions want: an `on_activate` that takes its
+    /// full timeout is slow, not truncated.
+    #[tokio::test]
+    async fn an_unbudgeted_run_lets_every_hook_have_its_own_timeout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let quick = |body: &str| {
+            ProvenancedHook::new(
+                LifecycleHook::builder()
+                    .with_on_activate(HookScript::inline(body))
+                    .build()
+                    .unwrap(),
+                loadout("dev"),
+            )
+        };
+        let comp = composition_of(vec![quick("echo one"), quick("echo two")]);
+
+        let outcomes = run_hooks(
+            &HostCommands,
+            &ctx(&comp, dir),
+            HookEvent::Activate,
+            HookOutput::Capture,
+            None,
+        )
+        .await;
+
+        assert_eq!(outcomes.len(), 2);
+        assert!(
+            outcomes.iter().all(|o| o.status == HookStatus::Ok),
+            "{outcomes:?}",
+        );
+    }
+
+    /// A composition with no hooks for the event produces no outcomes
+    /// and does nothing.
+    #[tokio::test]
+    async fn no_hooks_is_a_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let comp = composition_of(Vec::new());
+        assert!(
+            run_hooks(
+                &DeadSession,
+                &ctx(&comp, dir),
+                HookEvent::Activate,
+                HookOutput::Capture,
+                None,
+            )
+            .await
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn output_tail_keeps_the_end_and_stays_utf8() {
+        let long = "é".repeat(OUTPUT_TAIL_BYTES);
+        let tail = tail_of(long.as_bytes(), b"");
+        assert!(tail.len() <= OUTPUT_TAIL_BYTES + 2);
+        assert!(long.ends_with(&tail));
+    }
+}

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -7,6 +7,7 @@ pub mod env;
 mod exec;
 #[cfg(target_os = "linux")]
 pub mod guest;
+mod hooks;
 mod maintenance;
 #[cfg(target_os = "linux")]
 pub mod net;

--- a/crates/minimald/src/main.rs
+++ b/crates/minimald/src/main.rs
@@ -515,6 +515,32 @@ async fn async_main() -> Result<(), MainError> {
         return spawn_detached(&cli);
     }
 
+    // Pin the path this daemon re-execs itself from as the `__nsenter` shim,
+    // now, while the file is certainly still there. Resolved per-spawn instead,
+    // `current_exe()` reads `/proc/self/exe`, which the kernel reports as a
+    // dangling `<path> (deleted)` once the binary has been replaced — so every
+    // lifecycle hook and in-session exec fails with `ENOENT` after any rebuild
+    // of a running daemon. `just min` rebuilds `-p minimald` on every
+    // invocation, so a dev daemon meets that the first time its source changes.
+    // The path resolved here keeps naming whatever now lives at it.
+    //
+    // Not in the microVM: pid-1's own path is the initramfs `/init`, which is
+    // unreachable after the rootfs switch, so the guest stages a runnable copy
+    // and registers *that* (#1175). Registration is first-wins, so claiming it
+    // here would lock the guest's out.
+    if !is_minimal_microvm() {
+        match std::env::current_exe() {
+            Ok(exe) => minimald::nsenter::set_shim_exe(exe),
+            // Non-fatal: without a registration each injection falls back to
+            // resolving `current_exe()` itself, which is the prior behaviour.
+            Err(e) => tracing::warn!(
+                error = %e,
+                "could not resolve this daemon's executable to register as the nsenter shim; \
+                 in-session exec will re-resolve it per spawn",
+            ),
+        }
+    }
+
     // Handle setup specific to operating in a micro-vm.
     use minimald::guest;
     // Before anything forks from us and inherits the limits. Best effort: the

--- a/crates/minimald/src/nsenter.rs
+++ b/crates/minimald/src/nsenter.rs
@@ -219,6 +219,21 @@ pub enum NsenterError {
         source: std::io::Error,
     },
 
+    /// The shim path resolved to something that is no longer on disk. The
+    /// usual cause is a daemon whose own binary was replaced or deleted while
+    /// it was running: `current_exe()` reads `/proc/self/exe`, which the
+    /// kernel then reports as a dangling `<path> (deleted)`.
+    ///
+    /// Checked before the spawn because the `ENOENT` it would otherwise
+    /// produce names the *injected* program, sending whoever reads it looking
+    /// for a missing `bash` inside the session instead of a missing daemon
+    /// outside it.
+    #[error(
+        "the daemon's own executable is gone from {path:?} — it was replaced or deleted while \
+         the daemon was running (a rebuild, typically); restart minimald"
+    )]
+    ShimMissing { path: PathBuf },
+
     /// `setns(2)` failed. `EPERM` on an otherwise sound setup means one of: the
     /// caller is multi-threaded (which the user namespace forbids), the set
     /// includes a namespace the sandbox never unshared (see
@@ -413,6 +428,12 @@ impl Injection {
                 std::env::current_exe().map_err(|source| NsenterError::CurrentExe { source })?
             }
         };
+        // See [`NsenterError::ShimMissing`]: a path that has gone away since it
+        // was resolved is worth its own error, because the spawn's `ENOENT`
+        // blames the injected program for the daemon's problem.
+        if !shim.exists() {
+            return Err(NsenterError::ShimMissing { path: shim });
+        }
 
         let mut cmd = Command::new(shim);
         cmd.arg(SUBCOMMAND).arg("--pidfd").arg(PIDFD_FD.to_string());
@@ -631,8 +652,14 @@ mod tests {
     /// The production path: no shim is named per injection (only tests do
     /// that), so this resolution order is what keeps #1175 fixed. One test,
     /// because [`SHIM_EXE`] is process-wide and set once.
+    ///
+    /// Both stand-in shims are real files: a path that doesn't exist is now
+    /// [`NsenterError::ShimMissing`], which would mask the ordering under test.
     #[test]
     fn the_registered_shim_overrides_current_exe_and_yields_to_an_explicit_one() {
+        let registered_exe = tempfile::NamedTempFile::new().expect("a temp file to stand in");
+        let explicit_exe = tempfile::NamedTempFile::new().expect("a temp file to stand in");
+
         // A plain child shares all our namespaces, so nothing is joined and no
         // privilege is needed.
         let mut sleep = Command::new("/bin/sleep")
@@ -643,10 +670,10 @@ mod tests {
         let injection = || Injection::new(target, "/bin/true", Vec::<&str>::new());
 
         let unregistered = injection().command().map(|c| c.get_program().to_owned());
-        set_shim_exe("/run/minimald");
+        set_shim_exe(registered_exe.path());
         let registered = injection().command().map(|c| c.get_program().to_owned());
         let explicit = injection()
-            .with_shim("/usr/bin/minimald")
+            .with_shim(explicit_exe.path())
             .command()
             .map(|c| c.get_program().to_owned());
 
@@ -658,15 +685,42 @@ mod tests {
             "with nothing registered the daemon re-execs itself",
         );
         assert_eq!(
-            registered.expect("building the command"),
-            OsStr::new("/run/minimald"),
+            PathBuf::from(registered.expect("building the command")),
+            registered_exe.path(),
             "the registered shim replaces current_exe()",
         );
         assert_eq!(
-            explicit.expect("building the command"),
-            OsStr::new("/usr/bin/minimald"),
+            PathBuf::from(explicit.expect("building the command")),
+            explicit_exe.path(),
             "a per-injection shim still wins over the registration",
         );
+    }
+
+    /// A shim path that has gone away — the shape `current_exe()` takes after
+    /// the daemon's binary is replaced under it, which any rebuild of a running
+    /// daemon does — is reported as the daemon's problem. Spawning it instead
+    /// yields an `ENOENT` naming the injected program, which reads as a broken
+    /// session rather than a stale daemon.
+    #[test]
+    fn a_shim_that_is_no_longer_on_disk_is_named_as_the_failure() {
+        let missing = tempfile::NamedTempFile::new().expect("a temp file to stand in");
+        let path = missing.path().to_path_buf();
+        drop(missing); // Now a path that resolved a moment ago and no longer does.
+
+        let mut sleep = Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawning /bin/sleep");
+        let built = Injection::new(sleep.id(), "/bin/true", Vec::<&str>::new())
+            .with_shim(&path)
+            .command();
+
+        let _ = sleep.kill();
+        let _ = sleep.wait();
+        let Err(NsenterError::ShimMissing { path: reported }) = built else {
+            panic!("expected ShimMissing, got {:?}", built.map(|_| "a command"));
+        };
+        assert_eq!(reported, path);
     }
 
     #[test]

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -347,7 +347,7 @@ async fn serve_finalize_session(
                 });
             };
             Ok(match h.finalize().await {
-                Ok(()) => Errorable::Ok(FinalizeSessionResponse),
+                Ok(activate_hooks) => Errorable::Ok(FinalizeSessionResponse { activate_hooks }),
                 Err(e) => Errorable::Err {
                     error: e.to_string(),
                 },
@@ -550,6 +550,59 @@ async fn serve_get_session_policy(
                 // session record, not a hardcoded default.
                 Some(record) => Ok(Errorable::Ok(record.policy)),
             }
+        })
+        .await
+}
+
+/// `GetSessionHooks`: the lifecycle hooks composed into a session, each
+/// with the loadout or project that declared it.
+///
+/// Read from the persisted composition snapshot, so it answers for a
+/// session with no running host and survives a daemon restart. A session
+/// whose snapshot is missing (activated before snapshots existed, or
+/// reaped mid-write) reports an empty list rather than failing: "no
+/// hooks recorded" is the honest answer, and there is nothing to run.
+async fn serve_get_session_hooks(
+    s: ServerStateHandle,
+    c: RuChannel<Msg>,
+) -> Result<(), ConnectionError> {
+    minimald_rpc::GetSessionHooks
+        .handle_channel(c, async |req| {
+            let mngr = s.sessions_manager().await;
+            let predicate = match req {
+                minimald_rpc::GetSessionHooksRequest::Id(id) => SessionKeyPredicate::Id(id),
+                minimald_rpc::GetSessionHooksRequest::Name(name) => SessionKeyPredicate::Name(name),
+            };
+            // The record first, only to tell "no such session" from "a
+            // session with nothing recorded" — both of which the
+            // composition read answers with `None`.
+            if mngr
+                .get_record(predicate.clone())
+                .await
+                .map_err(|e| ConnectionError::Internal(e.to_string()))?
+                .is_none()
+            {
+                return Ok(Errorable::Err {
+                    error: "no session found".to_string(),
+                });
+            }
+            // Read-only: `get_composition` goes to the store rather than
+            // the actor, so listing a stopped session's hooks does not
+            // start it. Reporting on a session is not a reason to run one.
+            let composition = mngr
+                .get_composition(predicate)
+                .await
+                .map_err(|e| ConnectionError::Internal(e.to_string()))?;
+            let hooks = composition
+                .map(|c| {
+                    c.lifecycle_hooks()
+                        .iter()
+                        .cloned()
+                        .map(Into::into)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            Ok(Errorable::Ok(hooks))
         })
         .await
 }
@@ -782,6 +835,23 @@ pub(crate) const STREAM_WORKSPACE_PATCHES: &str =
 /// marker exists" note in `finalize_session_handler`.
 pub(crate) const PATCHES_READY_MARKER: &str = ".patches_ready";
 
+pub(crate) const STREAM_WORKSPACE_HOOK_SCRIPTS: &str =
+    constcat::concat!(RPC_SUBSYSTEM_PREFIX, "WorkspaceHookScriptsTarZst");
+
+/// Marker file the hook-script unpacker drops after a successful
+/// atomic swap. `FinalizeSession` requires it before promoting a
+/// session whose composition declares external hook scripts, so a
+/// client that skipped the upload can't leave an `Active` session
+/// whose hooks reference files that were never staged.
+pub(crate) const HOOKS_READY_MARKER: &str = ".hooks_ready";
+
+/// Per-entry size cap on incoming hook scripts. A lifecycle hook is a
+/// shell script; a megabyte is already far past anything reasonable,
+/// and the cap exists to stop a forged tar header from driving
+/// `Vec::with_capacity` into an allocation failure, not to constrain
+/// legitimate use.
+const MAX_HOOK_SCRIPT_BYTES: u64 = 1024 * 1024;
+
 /// Per-entry size cap on incoming patch archives. Legitimate patch files are
 /// dotfiles (KB to a few MB); this ceiling is generous but bounded so a peer
 /// forging a tar header can't push `Vec::with_capacity` into an allocation
@@ -965,43 +1035,67 @@ async fn served(fut: impl Future<Output = Result<(), ConnectionError>>) {
     }
 }
 
-/// Unpacks the composition-patches tarball streamed over `c`.
+/// What distinguishes one tar-upload stream from another.
 ///
-/// The unpack is **atomic**: entries land in a `<patches_dir>.tmp`
-/// staging dir first, then get swapped into place via rename once
-/// the stream ends cleanly. A mid-stream failure leaves the tmp
-/// tree behind (removed on the next successful run) but never
-/// pollutes `patches/`.
+/// Everything else about unpacking — validation, staging, the atomic
+/// swap, the marker — is identical across streams and lives in
+/// [`unpack_tar_zst_into`]. Adding a stream means describing it here,
+/// not writing a second unpacker: the entry guards are security
+/// checks, and a second copy is a second place for a fix to miss.
+struct UnpackTarget {
+    /// Live directory the staged tree is swapped into.
+    dir: std::path::PathBuf,
+    /// Marker filename dropped after a successful swap. Preconditions
+    /// in `FinalizeSession` read it, so it is written last.
+    marker: &'static str,
+    /// Ceiling on a single entry's *declared* size. Guards against a
+    /// forged header driving `Vec::with_capacity` into an allocation
+    /// failure, not against legitimate volume.
+    max_entry_bytes: u64,
+    /// Serializes the swap against another upload on the same stream
+    /// and session.
+    lock: Arc<tokio::sync::Mutex<()>>,
+    /// Noun for error messages — "patch", "hook script".
+    label: &'static str,
+}
+
+/// Unpack a zstd-compressed tarball streamed over `c` into
+/// `target.dir`.
 ///
-/// Every archive entry's path is validated against traversal —
-/// `SandboxRelPath::try_new` already rejects absolute paths and
-/// `..` components on the client side, but the client is untrusted
-/// so we re-check the wire form here. Absolute + traversal paths
-/// are dropped with an error before any file is written.
+/// The unpack is **atomic**: entries land in a per-upload staging dir
+/// first, then swap into place once the stream ends cleanly. A
+/// mid-stream failure leaves the staging tree behind (removed on the
+/// next run) but never pollutes the live directory.
 ///
-/// On success, drops [`PATCHES_READY_MARKER`] under the patches
-/// dir. `FinalizeSession` uses that marker as its precondition
-/// for the `Materializing → Active` transition, so this write
-/// order matters: marker only appears once every patch is on disk.
-#[tracing::instrument(level = "debug", skip_all)]
-async fn unpack_workspace_patches(
-    s: &ServerStateHandle,
-    config: &ChannelConfig,
-    c: &mut RuChannel<Msg>,
-) -> Result<(), String> {
+/// Every entry is validated before a byte reaches disk. The client
+/// already rejects absolute and `..` paths at the wire-schema level,
+/// but the client is untrusted, so the same checks run again here —
+/// a peer writing raw tar bytes bypasses every client-side layer.
+///
+/// On success, drops `target.marker` under `target.dir`. The write
+/// order matters: the marker only appears once every entry is on disk,
+/// which is what lets `FinalizeSession` treat its presence as proof
+/// the upload completed.
+#[tracing::instrument(level = "debug", skip_all, fields(stream = target.label))]
+async fn unpack_tar_zst_into(target: UnpackTarget, c: &mut RuChannel<Msg>) -> Result<(), String> {
     use std::path::Path as StdPath;
 
-    let (session_handle, paths) = upload_session_handle(s, config).await?;
-    let patches_dir = paths.patches.as_utf8_path().as_std_path().to_path_buf();
+    let UnpackTarget {
+        dir,
+        marker,
+        max_entry_bytes,
+        lock,
+        label,
+    } = target;
 
     // Per-upload unique staging path so two concurrent uploads for
     // the same session never share a staging tree. The nanosecond
-    // clock is fine as a discriminator — the per-session upload
-    // lock below serializes the swap, so we don't need a strong
-    // guarantee against collisions, only against name reuse across
-    // the two in-flight tasks.
+    // clock is fine as a discriminator — the swap lock below
+    // serializes the install, so we don't need a strong guarantee
+    // against collisions, only against name reuse across the two
+    // in-flight tasks.
     let staging_dir = {
-        let mut d = patches_dir.clone();
+        let mut d = dir.clone();
         let suffix = format!(
             ".upload.{}.tmp",
             std::time::SystemTime::now()
@@ -1016,7 +1110,7 @@ async fn unpack_workspace_patches(
                 n.push(&suffix);
                 n
             })
-            .unwrap_or_else(|| format!("patches{suffix}").into());
+            .unwrap_or_else(|| format!("upload{suffix}").into());
         d.set_file_name(name);
         d
     };
@@ -1027,7 +1121,7 @@ async fn unpack_workspace_patches(
     let _ = tokio::fs::remove_dir_all(&staging_dir).await;
     tokio::fs::create_dir_all(&staging_dir)
         .await
-        .map_err(|e| format!("creating patch staging dir: {e}"))?;
+        .map_err(|e| format!("creating {label} staging dir: {e}"))?;
 
     // Zstd decode + tar walk + per-entry unpack. Tar itself is a
     // stream format so decoding entries is sequential, but writing
@@ -1049,7 +1143,7 @@ async fn unpack_workspace_patches(
     use tokio::io::AsyncReadExt as _;
     let mut entries = archive
         .entries()
-        .map_err(|e| format!("reading patch tar entries: {e}"))?;
+        .map_err(|e| format!("reading {label} tar entries: {e}"))?;
     let write_concurrency = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(4);
@@ -1070,62 +1164,56 @@ async fn unpack_workspace_patches(
     // racing the next upload's `remove_dir_all` at the top of this
     // function and burning blocking-pool slots for results nobody
     // reads.
-    //
-    // `unpack_loop` returns Err on any per-entry problem;
-    // `abort_and_drain` afterward cancels stragglers regardless of
-    // outcome so no writes outlive this function.
     let mut inflight: tokio::task::JoinSet<Result<(), String>> = tokio::task::JoinSet::new();
     let loop_result: Result<(), String> = async {
         while let Some(entry) = entries.next().await {
-            let mut entry = entry.map_err(|e| format!("reading patch tar entry: {e}"))?;
+            let mut entry = entry.map_err(|e| format!("reading {label} tar entry: {e}"))?;
             let entry_path = entry
                 .path()
                 .map_err(|e| format!("decoding entry path: {e}"))?
                 .into_owned();
             if !safe_relative_path(&entry_path) {
                 return Err(format!(
-                    "patch archive entry rejected: `{}` contains an absolute path or a `..` component",
+                    "{label} archive entry rejected: `{}` contains an absolute path or a \
+                     `..` component",
                     entry_path.display()
                 ));
             }
-            // Reject a patch destination that would clobber the
-            // patches-ready marker. Marker + user patch would
-            // otherwise race, and `materialize_patches_into_home`
-            // would silently copy the emptied marker into the
-            // sandbox home, zeroing whatever the user had there.
-            if entry_path == StdPath::new(PATCHES_READY_MARKER) {
+            // Reject an entry that would clobber the ready marker.
+            // Marker + uploaded file would otherwise race, and for
+            // patches `materialize_patches_into_home` would silently
+            // copy the emptied marker into the sandbox home, zeroing
+            // whatever the user had there.
+            if entry_path == StdPath::new(marker) {
                 return Err(format!(
-                    "patch archive entry rejected: `{}` collides with the daemon's \
-                     patches-ready marker filename",
+                    "{label} archive entry rejected: `{}` collides with the daemon's \
+                     ready-marker filename",
                     entry_path.display()
                 ));
             }
-            // Patches are individual files copied verbatim into the
-            // sandbox home. The client's uploader
-            // (`Client::upload_patches` → `TarZstArchive::add_file`)
-            // only ever emits `EntryType::Regular` — symlink sources
-            // are read through (their target's bytes get archived as
-            // a regular file, dropping the link relation on the
-            // client side, on purpose) and directory sources fan
-            // out into per-file Regular entries. Every non-Regular
-            // entry type is out of scope: we do not create
-            // directories, symlinks, hardlinks, or device nodes in
-            // the sandbox home from a patch archive. Blindly running
-            // `tokio::fs::write` for any of those would silently
-            // land an empty file at that path — a directory entry
-            // would then break `create_dir_all(parent)` for its
-            // children, and a symlink entry would drop the link
-            // target on the floor. Fail loudly instead.
+            // Only regular files are unpacked. The client's uploader
+            // (`TarZstArchive::add_file`) only ever emits
+            // `EntryType::Regular` — symlink sources are read through
+            // (their target's bytes get archived as a regular file,
+            // dropping the link relation on purpose) and directory
+            // sources fan out into per-file Regular entries. Every
+            // other entry type is out of scope: we do not create
+            // directories, symlinks, hardlinks, or device nodes from
+            // an uploaded archive. Blindly running `tokio::fs::write`
+            // for any of those would silently land an empty file at
+            // that path — a directory entry would then break
+            // `create_dir_all(parent)` for its children, and a
+            // symlink entry would drop the link target on the floor.
+            // Fail loudly instead.
             let entry_type = entry.header().entry_type();
             if !matches!(
                 entry_type,
                 async_tar::EntryType::Regular | async_tar::EntryType::Continuous
             ) {
                 return Err(format!(
-                    "patch archive entry rejected: `{}` is {:?}; only regular files are \
-                     supported",
+                    "{label} archive entry rejected: `{}` is {entry_type:?}; only regular \
+                     files are supported",
                     entry_path.display(),
-                    entry_type,
                 ));
             }
             let entry_size = entry.header().size().unwrap_or(0);
@@ -1133,10 +1221,10 @@ async fn unpack_workspace_patches(
             // `Vec::with_capacity` into an allocation panic or OOM
             // (allocator abort → whole daemon down) before we ever
             // reserve budget.
-            if entry_size > MAX_PATCH_ENTRY_BYTES {
+            if entry_size > max_entry_bytes {
                 return Err(format!(
-                    "patch archive entry rejected: `{}` declares {entry_size} bytes, \
-                     exceeds the {MAX_PATCH_ENTRY_BYTES}-byte per-entry cap",
+                    "{label} archive entry rejected: `{}` declares {entry_size} bytes, \
+                     exceeds the {max_entry_bytes}-byte per-entry cap",
                     entry_path.display()
                 ));
             }
@@ -1150,7 +1238,7 @@ async fn unpack_workspace_patches(
                     Some(Ok(Ok(()))) => {}
                     Some(Ok(Err(e))) => return Err(e),
                     Some(Err(join_err)) => {
-                        return Err(format!("write task panicked: {join_err}"))
+                        return Err(format!("write task panicked: {join_err}"));
                     }
                     None => break,
                 }
@@ -1178,9 +1266,9 @@ async fn unpack_workspace_patches(
             let path_display = entry_path.display().to_string();
             inflight.spawn(async move {
                 if let Some(parent) = dest.parent() {
-                    tokio::fs::create_dir_all(parent).await.map_err(|e| {
-                        format!("creating parent dir for `{path_display}`: {e}")
-                    })?;
+                    tokio::fs::create_dir_all(parent)
+                        .await
+                        .map_err(|e| format!("creating parent dir for `{path_display}`: {e}"))?;
                 }
                 tokio::fs::write(&dest, &body)
                     .await
@@ -1216,25 +1304,18 @@ async fn unpack_workspace_patches(
     }
     loop_result?;
 
-    // Serialize the swap + marker-write against any other
-    // in-flight `WorkspacePatchesTarZst` upload for this same
-    // session. Two concurrent uploads would otherwise race on
-    // `patches_dir` — one's `RENAME_EXCHANGE` could observe an
-    // unexpected mid-swap state, or the marker could get written
-    // pointing at the wrong upload's contents. The staging phase
-    // above ran without the lock (all writes went to a per-upload
-    // unique dir), so we only pay the serialization cost across
-    // the seconds-of-work install step, not the minutes-of-work
-    // unpack.
-    let _swap_guard = session_handle
-        .patches_upload_lock()
-        .await
-        .map_err(|e| format!("session is gone: {e}"))?
-        .lock_owned()
-        .await;
+    // Serialize the swap + marker-write against any other in-flight
+    // upload on this stream for this session. Two concurrent uploads
+    // would otherwise race on the live dir — one's `RENAME_EXCHANGE`
+    // could observe an unexpected mid-swap state, or the marker could
+    // get written pointing at the wrong upload's contents. The staging
+    // phase above ran without the lock (all writes went to a per-upload
+    // unique dir), so we only pay the serialization cost across the
+    // seconds-of-work install step, not the minutes-of-work unpack.
+    let _swap_guard = lock.lock_owned().await;
 
     // Install the new tree. Two shapes depending on whether a
-    // prior `patches/` exists:
+    // prior tree exists:
     //
     // 1. **Prior tree present** — `renameat2(RENAME_EXCHANGE)` swaps
     //    the staging tree and the live tree atomically. At every
@@ -1242,12 +1323,11 @@ async fn unpack_workspace_patches(
     //    trees, and each carries a valid marker (the old one from
     //    the prior successful unpack, the new one written below).
     //    A `FinalizeSession` racing the swap can't observe a gap
-    //    where `patches/` doesn't exist or where the marker is
-    //    absent, only "old contents + old marker" or "new contents
-    //    + new marker."  We swap the trees first (contents on
-    //    disk), then delete the old contents that ended up under
-    //    `staging_dir` after the swap, then write the new marker
-    //    over the old one.
+    //    where the dir doesn't exist or where the marker is absent,
+    //    only "old contents + old marker" or "new contents + new
+    //    marker." We swap the trees first (contents on disk), then
+    //    delete the old contents that ended up under `staging_dir`
+    //    after the swap, then write the new marker over the old one.
     // 2. **First install** — no prior tree, so `RENAME_EXCHANGE`
     //    fails with `ENOENT`. Plain `rename` is atomic in this
     //    case (nothing to displace), so we fall through to it.
@@ -1259,20 +1339,16 @@ async fn unpack_workspace_patches(
     // where the nix item is configured out.
     let swap_result = tokio::task::spawn_blocking({
         let staging_dir = staging_dir.clone();
-        let patches_dir = patches_dir.clone();
+        let dir = dir.clone();
         move || {
-            common::renameat2::renameat2_cwd(
-                &staging_dir,
-                &patches_dir,
-                common::renameat2::RENAME_EXCHANGE,
-            )
+            common::renameat2::renameat2_cwd(&staging_dir, &dir, common::renameat2::RENAME_EXCHANGE)
         }
     })
     .await
     .map_err(|e| format!("atomic-swap task panicked: {e}"))?;
     match swap_result {
         Ok(()) => {
-            // `staging_dir` now holds the previous `patches/` tree
+            // `staging_dir` now holds the previous tree
             // (post-exchange). Drop it — a partial cleanup here is
             // fine; the next unpack's leading `remove_dir_all`
             // covers it.
@@ -1282,26 +1358,98 @@ async fn unpack_workspace_patches(
             // No prior tree — the `RENAME_EXCHANGE` requires both
             // sides to exist. Plain rename is atomic when the
             // destination doesn't exist yet.
-            tokio::fs::rename(&staging_dir, &patches_dir)
+            tokio::fs::rename(&staging_dir, &dir)
                 .await
-                .map_err(|e| format!("swapping patches dir into place: {e}"))?;
+                .map_err(|e| format!("swapping {label} dir into place: {e}"))?;
         }
         Err(e) => {
-            return Err(format!("atomic-swap of patches dir failed: {e}"));
+            return Err(format!("atomic-swap of {label} dir failed: {e}"));
         }
     }
 
-    // Marker last, so `patches/`'s newly-swapped contents can never
-    // coexist with a stale marker. If we crash between the swap and
-    // this write, the next upload's swap replaces the whole tree
-    // and rewrites the marker — FinalizeSession is what fails safe,
-    // not this handler.
-    let marker = patches_dir.join(StdPath::new(PATCHES_READY_MARKER));
-    tokio::fs::write(&marker, b"")
+    // Marker last, so the newly-swapped contents can never coexist
+    // with a stale marker. If we crash between the swap and this
+    // write, the next upload's swap replaces the whole tree and
+    // rewrites the marker — FinalizeSession is what fails safe, not
+    // this handler.
+    let marker_path = dir.join(StdPath::new(marker));
+    tokio::fs::write(&marker_path, b"")
         .await
-        .map_err(|e| format!("writing patches-ready marker: {e}"))?;
+        .map_err(|e| format!("writing {label}-ready marker: {e}"))?;
 
     Ok(())
+}
+
+/// Unpacks the composition-patches tarball streamed over `c` into
+/// `<workspace>/patches/`, keyed by each patch's sandbox-home-relative
+/// destination. See [`unpack_tar_zst_into`] for the mechanics.
+async fn unpack_workspace_patches(
+    s: &ServerStateHandle,
+    config: &ChannelConfig,
+    c: &mut RuChannel<Msg>,
+) -> Result<(), String> {
+    let (session_handle, paths) = upload_session_handle(s, config).await?;
+    let lock = session_handle
+        .patches_upload_lock()
+        .await
+        .map_err(|e| format!("session is gone: {e}"))?;
+    unpack_tar_zst_into(
+        UnpackTarget {
+            dir: paths.patches.as_utf8_path().as_std_path().to_path_buf(),
+            marker: PATCHES_READY_MARKER,
+            max_entry_bytes: MAX_PATCH_ENTRY_BYTES,
+            lock,
+            label: "patch",
+        },
+        c,
+    )
+    .await
+}
+
+/// Unpacks the external-hook-scripts tarball streamed over `c` into
+/// `<workspace>/hooks/`.
+///
+/// Entry paths are the staged paths
+/// [`staged_script_path`](sessions::core::lifecyclehook::staged_script_path)
+/// produced on the client; the daemon re-derives the same paths from
+/// the composition when it goes looking for a script, so nothing here
+/// needs a manifest.
+async fn unpack_workspace_hook_scripts(
+    s: &ServerStateHandle,
+    config: &ChannelConfig,
+    c: &mut RuChannel<Msg>,
+) -> Result<(), String> {
+    let (session_handle, paths) = upload_session_handle(s, config).await?;
+    let lock = session_handle
+        .hook_scripts_upload_lock()
+        .await
+        .map_err(|e| format!("session is gone: {e}"))?;
+    unpack_tar_zst_into(
+        UnpackTarget {
+            dir: paths.hooks.as_utf8_path().as_std_path().to_path_buf(),
+            marker: HOOKS_READY_MARKER,
+            max_entry_bytes: MAX_HOOK_SCRIPT_BYTES,
+            lock,
+            label: "hook script",
+        },
+        c,
+    )
+    .await
+}
+async fn serve_stream_workspace_hook_scripts(
+    s: ServerStateHandle,
+    config: ChannelConfig,
+    mut c: RuChannel<Msg>,
+) -> Result<(), ConnectionError> {
+    let outcome = match unpack_workspace_hook_scripts(&s, &config, &mut c).await {
+        Ok(()) => Ok(()),
+        Err(msg) => {
+            let _ = c.extended_data_bytes(1, msg.clone()).await;
+            Err(ConnectionError::Internal(msg))
+        }
+    };
+    let _ = c.close().await;
+    outcome
 }
 
 /// Returns true if `p` is a relative path with no `..` components.
@@ -1347,11 +1495,13 @@ pub async fn handle_ssh_rpc(
         | Shutdown::NAME
         | AbortSession::NAME
         | GetSessionPolicy::NAME
+        | minimald_rpc::GetSessionHooks::NAME
         | SessionDelta::NAME
         | GetSessionScreen::NAME
         | GetMeshStatus::NAME
         | STREAM_WORKSPACE_FILES
         | STREAM_WORKSPACE_PATCHES
+        | STREAM_WORKSPACE_HOOK_SCRIPTS
         | minimald_rpc::DIAG_BUNDLE_SUBSYSTEM
         | minimald_rpc::CLEAN_CACHE_SUBSYSTEM
         | IssueClientCert::NAME => {
@@ -1429,11 +1579,15 @@ pub async fn handle_ssh_rpc(
         Shutdown::NAME => serve!(serve_shutdown(s, channel)),
         AbortSession::NAME => serve!(serve_abort_session(s, channel)),
         GetSessionPolicy::NAME => serve!(serve_get_session_policy(s, channel)),
+        minimald_rpc::GetSessionHooks::NAME => serve!(serve_get_session_hooks(s, channel)),
         SessionDelta::NAME => serve!(serve_session_delta(s, channel)),
         GetSessionScreen::NAME => serve!(serve_get_session_screen(s, channel)),
         GetMeshStatus::NAME => serve!(serve_get_mesh_status(s, channel)),
         STREAM_WORKSPACE_FILES => serve!(serve_stream_workspace_files(s, config, channel)),
         STREAM_WORKSPACE_PATCHES => serve!(serve_stream_workspace_patches(s, config, channel)),
+        STREAM_WORKSPACE_HOOK_SCRIPTS => {
+            serve!(serve_stream_workspace_hook_scripts(s, config, channel))
+        }
         minimald_rpc::DIAG_BUNDLE_SUBSYSTEM => {
             serve!(crate::diag::serve_stream_diag_bundle(s, config, channel))
         }
@@ -1756,6 +1910,344 @@ mod tests {
         );
     }
 
+    /// Build a tar+zstd archive with full control over each entry's
+    /// type and declared size, so tests can produce the malformed
+    /// shapes a hostile peer would hand-craft — `tar_zst` can only
+    /// build well-formed regular-file entries.
+    ///
+    /// `declared_size` overrides the header's size field without
+    /// changing the body, which is how the forged-header case is
+    /// reproduced.
+    async fn tar_zst_raw(entries: &[(&str, &[u8], async_tar::EntryType, Option<u64>)]) -> Vec<u8> {
+        let mut tar = async_tar::Builder::new(Vec::new());
+        for (path, contents, entry_type, declared_size) in entries {
+            let mut header = async_tar::Header::new_gnu();
+            header.set_size(declared_size.unwrap_or(contents.len() as u64));
+            header.set_mode(0o644);
+            header.set_entry_type(*entry_type);
+            tar.append_data(&mut header, path, *contents).await.unwrap();
+        }
+        let tar_bytes = tar.into_inner().await.unwrap();
+        let mut encoder = async_compression::tokio::write::ZstdEncoder::new(Vec::new());
+        encoder.write_all(&tar_bytes).await.unwrap();
+        encoder.shutdown().await.unwrap();
+        encoder.into_inner()
+    }
+
+    /// Build a tar+zstd archive whose entry name is written straight
+    /// into the header's raw name field, bypassing the path validation
+    /// `Builder::append_data` performs.
+    ///
+    /// This is the only way to produce the archive shape the daemon's
+    /// traversal guard exists for: `async_tar`'s builder refuses to
+    /// *construct* a `..` entry, so a well-behaved client cannot make
+    /// one — but a hostile peer writing tar bytes by hand can, and that
+    /// is the case the guard has to catch.
+    async fn tar_zst_forged_name(name: &[u8], contents: &[u8]) -> Vec<u8> {
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        // Raw name write: `set_path` would reject or normalize this.
+        {
+            let gnu = header.as_gnu_mut().expect("new_gnu produces a GNU header");
+            gnu.name[..name.len()].copy_from_slice(name);
+        }
+        header.set_cksum();
+
+        let mut tar = async_tar::Builder::new(Vec::new());
+        tar.append(&header, contents).await.unwrap();
+        let tar_bytes = tar.into_inner().await.unwrap();
+
+        let mut encoder = async_compression::tokio::write::ZstdEncoder::new(Vec::new());
+        encoder.write_all(&tar_bytes).await.unwrap();
+        encoder.shutdown().await.unwrap();
+        encoder.into_inner()
+    }
+
+    /// Push `payload` through `subsystem` for `session_id` and return
+    /// whatever the daemon relayed on stderr — empty on success. Keeps
+    /// the channel (rather than `into_stream`) so extended data stays
+    /// readable, which is how a rejection is signalled.
+    async fn upload_and_collect_stderr(
+        client: &mut TestClient,
+        subsystem: &str,
+        session_id: SessionId,
+        payload: &[u8],
+    ) -> String {
+        use russh::ChannelMsg;
+        let mut channel = client
+            .open_subsystem(
+                subsystem,
+                &[(MINIMAL_SESSION_ID_ENV, &session_id.to_string())],
+            )
+            .await;
+        channel.data(payload).await.unwrap();
+        channel.eof().await.unwrap();
+        let mut stderr = Vec::new();
+        while let Some(msg) = channel.wait().await {
+            if let ChannelMsg::ExtendedData { data, ext: 1 } = msg {
+                stderr.extend_from_slice(&data);
+            }
+        }
+        String::from_utf8_lossy(&stderr).into_owned()
+    }
+
+    /// Resolve a session's staged-patches and staged-hooks dirs.
+    async fn staged_dirs(
+        server: &TestServer,
+        session_id: SessionId,
+    ) -> (camino::Utf8PathBuf, camino::Utf8PathBuf) {
+        let mngr = server.state.sessions_manager().await;
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("session should be retrievable");
+        let paths = handle.paths().await.unwrap();
+        (
+            paths.patches.as_utf8_path().to_owned(),
+            paths.hooks.as_utf8_path().to_owned(),
+        )
+    }
+
+    /// A `..` entry is refused end-to-end, not merely by the
+    /// `safe_relative_path` unit above: the guard has to actually be
+    /// wired into the unpack loop, before any byte reaches disk.
+    #[tokio::test]
+    async fn stream_workspace_patches_rejects_traversal_end_to_end() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let payload = tar_zst_forged_name(b"../escape.toml", b"pwned\n").await;
+        let stderr =
+            upload_and_collect_stderr(&mut client, STREAM_WORKSPACE_PATCHES, session_id, &payload)
+                .await;
+
+        assert!(
+            stderr.contains("`..`") || stderr.contains("absolute path"),
+            "expected a traversal rejection, got: {stderr:?}",
+        );
+        let (patches, _) = staged_dirs(&server, session_id).await;
+        assert!(
+            !tokio::fs::try_exists(patches.join(PATCHES_READY_MARKER))
+                .await
+                .unwrap_or(false),
+            "a rejected upload must not leave a ready marker",
+        );
+    }
+
+    /// An entry named exactly like the ready marker is refused: it
+    /// would otherwise be copied into the sandbox home by
+    /// `materialize_patches_into_home`, zeroing whatever the user had
+    /// at that path.
+    #[tokio::test]
+    async fn stream_workspace_patches_rejects_marker_collision() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let payload = tar_zst(&[(PATCHES_READY_MARKER, b"")]).await;
+        let stderr =
+            upload_and_collect_stderr(&mut client, STREAM_WORKSPACE_PATCHES, session_id, &payload)
+                .await;
+
+        assert!(
+            stderr.contains("ready-marker"),
+            "expected a marker-collision rejection, got: {stderr:?}",
+        );
+    }
+
+    /// Only regular files are unpacked. A directory entry would
+    /// otherwise be written as an empty *file*, which then breaks
+    /// `create_dir_all` for anything nested beneath it.
+    #[tokio::test]
+    async fn stream_workspace_patches_rejects_non_regular_entry() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let payload = tar_zst_raw(&[("adir", b"", async_tar::EntryType::Directory, None)]).await;
+        let stderr =
+            upload_and_collect_stderr(&mut client, STREAM_WORKSPACE_PATCHES, session_id, &payload)
+                .await;
+
+        assert!(
+            stderr.contains("only regular files"),
+            "expected a non-regular-entry rejection, got: {stderr:?}",
+        );
+    }
+
+    /// A forged header declaring more bytes than the per-entry cap is
+    /// refused on the header alone, before the body is read — the
+    /// check that stops `Vec::with_capacity` being driven into an
+    /// allocation failure.
+    #[tokio::test]
+    async fn stream_workspace_patches_rejects_oversize_declared_entry() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let payload = tar_zst_raw(&[(
+            "big.toml",
+            b"small body",
+            async_tar::EntryType::Regular,
+            Some(MAX_PATCH_ENTRY_BYTES + 1),
+        )])
+        .await;
+        let stderr =
+            upload_and_collect_stderr(&mut client, STREAM_WORKSPACE_PATCHES, session_id, &payload)
+                .await;
+
+        assert!(
+            stderr.contains("per-entry cap"),
+            "expected an oversize rejection, got: {stderr:?}",
+        );
+    }
+
+    /// A second upload replaces the first tree wholesale rather than
+    /// merging into it, and the marker survives. Exercises both swap
+    /// branches: the first upload takes the plain-rename path (no
+    /// prior tree), the second takes `RENAME_EXCHANGE`.
+    #[tokio::test]
+    async fn stream_workspace_patches_second_upload_replaces_the_tree() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let first = tar_zst(&[("only-in-first.toml", b"a\n")]).await;
+        assert_eq!(
+            upload_and_collect_stderr(&mut client, STREAM_WORKSPACE_PATCHES, session_id, &first)
+                .await,
+            "",
+        );
+        let second = tar_zst(&[("only-in-second.toml", b"b\n")]).await;
+        assert_eq!(
+            upload_and_collect_stderr(&mut client, STREAM_WORKSPACE_PATCHES, session_id, &second)
+                .await,
+            "",
+        );
+
+        let (patches, _) = staged_dirs(&server, session_id).await;
+        assert!(
+            tokio::fs::try_exists(patches.join("only-in-second.toml"))
+                .await
+                .unwrap(),
+            "the second upload's contents must be present",
+        );
+        assert!(
+            !tokio::fs::try_exists(patches.join("only-in-first.toml"))
+                .await
+                .unwrap(),
+            "the first upload's contents must be gone, not merged",
+        );
+        assert!(
+            tokio::fs::try_exists(patches.join(PATCHES_READY_MARKER))
+                .await
+                .unwrap(),
+            "the marker must survive the swap",
+        );
+    }
+
+    // -- hook scripts ---------------------------------------------------
+
+    /// The hook-script stream unpacks under `<workspace>/hooks/` at the
+    /// staged path the client derived, and drops its own ready marker.
+    #[tokio::test]
+    async fn stream_workspace_hook_scripts_unpacks_and_writes_marker() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let payload = tar_zst(&[
+            ("loadout/dev/activate.sh", b"echo hi\n"),
+            ("project/scripts/setup.sh", b"echo setup\n"),
+        ])
+        .await;
+        let stderr = upload_and_collect_stderr(
+            &mut client,
+            STREAM_WORKSPACE_HOOK_SCRIPTS,
+            session_id,
+            &payload,
+        )
+        .await;
+        assert_eq!(stderr, "", "upload should succeed");
+
+        let (_, hooks) = staged_dirs(&server, session_id).await;
+        assert_eq!(
+            tokio::fs::read(hooks.join("loadout/dev/activate.sh"))
+                .await
+                .unwrap(),
+            b"echo hi\n",
+        );
+        assert_eq!(
+            tokio::fs::read(hooks.join("project/scripts/setup.sh"))
+                .await
+                .unwrap(),
+            b"echo setup\n",
+        );
+        assert!(
+            tokio::fs::try_exists(hooks.join(HOOKS_READY_MARKER))
+                .await
+                .unwrap(),
+            "hooks-ready marker must be written on successful unpack",
+        );
+    }
+
+    /// The hook-script stream enforces the same entry guards as the
+    /// patch stream. Parameterized over the malformed shapes so the two
+    /// paths can't drift in what they refuse.
+    #[tokio::test]
+    async fn stream_workspace_hook_scripts_rejects_malformed_entries() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let cases: Vec<(&str, Vec<u8>)> = vec![
+            (
+                "`..`",
+                tar_zst_forged_name(b"../escape.sh", b"pwned\n").await,
+            ),
+            ("ready-marker", tar_zst(&[(HOOKS_READY_MARKER, b"")]).await),
+            (
+                "only regular files",
+                tar_zst_raw(&[("adir", b"", async_tar::EntryType::Directory, None)]).await,
+            ),
+            (
+                "per-entry cap",
+                tar_zst_raw(&[(
+                    "big.sh",
+                    b"small",
+                    async_tar::EntryType::Regular,
+                    Some(MAX_HOOK_SCRIPT_BYTES + 1),
+                )])
+                .await,
+            ),
+        ];
+        for (needle, payload) in cases {
+            let stderr = upload_and_collect_stderr(
+                &mut client,
+                STREAM_WORKSPACE_HOOK_SCRIPTS,
+                session_id,
+                &payload,
+            )
+            .await;
+            assert!(
+                stderr.contains(needle),
+                "expected a rejection mentioning {needle:?}, got: {stderr:?}",
+            );
+        }
+
+        let (_, hooks) = staged_dirs(&server, session_id).await;
+        assert!(
+            !tokio::fs::try_exists(hooks.join(HOOKS_READY_MARKER))
+                .await
+                .unwrap_or(false),
+            "no rejected upload may leave a ready marker",
+        );
+    }
+
     /// Unit test on the daemon-side traversal guard — the piece
     /// covering a malicious peer that hand-crafts a raw tar with
     /// `..` entries (the client's own `async_tar` builder refuses
@@ -1946,6 +2438,7 @@ mod tests {
                     project_path: HostAbsPath::try_new("/uwu").unwrap(),
                     network: NetworkMode::OwnIp,
                     policy: SessionPolicy::new(Some(egress.clone()), None),
+                    hooks_enabled: true,
                     attrs: Default::default(),
                 },
             })
@@ -2051,6 +2544,7 @@ mod tests {
                     project_path: HostAbsPath::try_new("/uwu").unwrap(),
                     network: NetworkMode::HostNet,
                     policy: SessionPolicy::new(Some(egress), None),
+                    hooks_enabled: true,
                     attrs: Default::default(),
                 },
             })
@@ -2138,6 +2632,7 @@ mod tests {
                 session_id: SessionId::nil(),
                 vars: vec![],
                 patches: vec![],
+                lifecycle_hooks: vec![],
             })
             .await;
         match resp {

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -71,6 +71,130 @@ async fn materialize_patches_into_home(
     Ok(())
 }
 
+/// Run the session's hooks for `event` and log what each one did.
+///
+/// Returns an empty list when there is nothing to run *or nothing to
+/// run it in*: a session with no composition, or with no live host,
+/// has no namespaces to join. That is not an error — a session that
+/// was never attached, whose shell has exited, or that came up from
+/// disk after a daemon restart genuinely has no sandbox for a hook to
+/// enter, and teardown must proceed regardless.
+async fn run_session_hooks(
+    inner: &SessionInner,
+    record: &SessionRecordHandle,
+    event: crate::hooks::HookEvent,
+) -> Vec<crate::hooks::HookOutcome> {
+    use sessions::store::SessionObject as _;
+
+    let SessionInner::Active {
+        composition: Some(composition),
+        host: Some((handle, _)),
+        ..
+    } = inner
+    else {
+        return Vec::new();
+    };
+    let object = match record.object().await {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::warn!(
+                event = event.as_str(),
+                error = %e,
+                "reading the session record failed; skipping lifecycle hooks",
+            );
+            return Vec::new();
+        }
+    };
+    let name = registry_name(object.record());
+    let ctx = crate::hooks::HookContext {
+        session_id: *record.id(),
+        session_name: &name,
+        composition,
+        hooks_dir: object.hooks_path(),
+        workspace: object.workspace_path(),
+    };
+    // Teardown runs under one budget across all of its hooks; setup runs
+    // unbounded (see [`crate::hooks::run_hooks`]). Every event reaching
+    // this function is headless, and the two teardown ones are the pair
+    // that must not be able to hold a session open.
+    let budget = event.is_teardown().then_some(TEARDOWN_HOOK_BUDGET);
+    let outcomes = crate::hooks::run_hooks(
+        handle,
+        &ctx,
+        event,
+        crate::hooks::HookOutput::Capture,
+        budget,
+    )
+    .await;
+    log_hook_outcomes(&name, &outcomes);
+    outcomes
+}
+
+/// Emit one record per hook run. Failures are warnings so an operator
+/// sees them without turning on debug logging; the captured tail rides
+/// along because a hook's own output is usually the only explanation
+/// of why it failed.
+fn log_hook_outcomes(session: &str, outcomes: &[crate::hooks::HookOutcome]) {
+    for o in outcomes {
+        if o.failed() {
+            tracing::warn!(
+                session,
+                event = o.event,
+                declared_by = %o.declared_by,
+                status = ?o.status,
+                output = %o.output,
+                "lifecycle hook failed",
+            );
+        } else {
+            tracing::info!(
+                session,
+                event = o.event,
+                declared_by = %o.declared_by,
+                "lifecycle hook ran",
+            );
+        }
+    }
+}
+
+/// True when `composition` has a hook whose external script can only
+/// reach the daemon through the hook-script upload — and which therefore
+/// must not be finalized until that upload lands.
+///
+/// Two exclusions, and both are the difference between a session that
+/// activates and one that cannot:
+///
+/// - **Inline** hooks carry their body in the composition, so a session
+///   whose hooks are all inline uploads nothing and must not wait on a
+///   marker that will never appear.
+/// - **Project** hooks name a path inside the project, and the project
+///   tree is uploaded wholesale by the activation that precedes this.
+///   Their scripts arrive with it, which is why the client stages only
+///   *loadout* scripts and why [`crate::hooks::read_script`] falls back
+///   to the workspace for a project source. Gating on the marker here
+///   would demand an upload that is never sent, and no project could
+///   ever declare an external hook script.
+fn composition_needs_staged_scripts(composition: &Composition) -> bool {
+    use sessions::core::lifecyclehook::{HookScript, HookScriptBody};
+    use sessions::core::source::{Provenanced, Source};
+    composition
+        .lifecycle_hooks()
+        .iter()
+        .filter(|ph| !matches!(ph.source(), Source::Project { .. }))
+        .any(|ph| {
+            let hook = ph.hook();
+            [
+                hook.on_activate(),
+                hook.on_destroy(),
+                hook.on_attach(),
+                hook.on_detach(),
+            ]
+            .into_iter()
+            .flatten()
+            .map(HookScript::body)
+            .any(|b| matches!(b, HookScriptBody::External(_)))
+        })
+}
+
 /// Load the persisted composition snapshot for an `Active` session
 /// brought up from disk after a daemon restart. Returns `None` (with
 /// a warning log) when the sidecar is missing or corrupt. The
@@ -190,6 +314,12 @@ pub struct SessionPaths {
     /// may not exist yet — it's created on the first successful
     /// upload.
     pub patches: DaemonAbsPath,
+    /// Where the daemon stages client-uploaded external lifecycle-hook
+    /// scripts (`WorkspaceHookScriptsTarZst` unpacks under this dir,
+    /// keyed by the script's staged path). Like `patches`, it may not
+    /// exist yet — a session whose hooks are all inline never uploads
+    /// anything here.
+    pub hooks: DaemonAbsPath,
 }
 
 /// Everything a [`Session`] actor needs at spawn time. Every session actor
@@ -267,6 +397,48 @@ type LaunchedHost = (
     JoinHandle<Result<i32, std::io::Error>>,
 );
 
+/// Where in the session lifecycle a host launch is happening, which decides
+/// whether the launch has to wait for an `Active` record.
+///
+/// Only [`Session::finalize`]'s launch is `Activating`. Every other
+/// launch happens after the session is attachable and keeps the status gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LaunchPhase {
+    /// A launch against a session that is already `Active`: an attach, or an
+    /// exec's [`Session::ensure_host`]. Both check the record's status
+    /// themselves before getting here; the gate in [`Session::context`] is
+    /// their backstop.
+    Attached,
+    /// The pre-activation launch inside [`Session::finalize`]. It runs while
+    /// the record is still `Materializing` by construction — promoting to
+    /// `Active` is what finalize does *after* the activation hooks this host
+    /// exists to run — so it cannot take the `Active` gate without
+    /// deadlocking against itself.
+    Activating,
+}
+
+/// How long *all* of a teardown transition's hooks get, together.
+///
+/// A hook's own timeout is capped at
+/// [`MAX_HOOK_TIMEOUT`](sessions::core::lifecyclehook::MAX_HOOK_TIMEOUT)
+/// to keep one from holding a session open, but nothing bounds how many
+/// hooks a composition may carry — so without a total, N of them at the
+/// cap would hold a destroy for N×5 minutes and defeat the point. This
+/// is that total. Wide enough that an honest teardown never meets it;
+/// the hooks are a courtesy, and the destroy is the contract.
+const TEARDOWN_HOOK_BUDGET: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// How long a teardown transition will wait for the sandbox it needs to
+/// run its hooks in.
+///
+/// Nothing else about a host launch is time-bounded, because every other
+/// caller is a user waiting on their own attach. A teardown is not: the
+/// hooks are a courtesy and the destroy is the contract, so the launch
+/// gets a deadline and the session is torn down either way. Generous
+/// enough to cover a cold cache on a loaded box — this is a backstop
+/// against a wedge, not a performance budget.
+const HOOK_LAUNCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// The PTY size a host minted with nothing attached starts at. A client that
 /// attaches later resizes it; until then only an unattached shell sees it.
 const UNATTACHED_WIN_SIZE: WinSize = WinSize {
@@ -327,7 +499,11 @@ enum SessionMessage {
     /// patches-ready marker under `<workspace>/patches/`. Idempotent
     /// on an already-`Active` session; refused with `InvalidInput`
     /// on `Pending` (configure the loadout first).
-    Finalize(oneshot::Sender<Result<(), std::io::Error>>),
+    Finalize(oneshot::Sender<Result<Vec<minimald_rpc::RanHook>, std::io::Error>>),
+    /// Run this session's `on_detach` hooks, sent by a binding that has
+    /// left a session which outlives it. Answered when they have run (or
+    /// been skipped), so a departing binding can await them.
+    RunDetachHooks(oneshot::Sender<()>),
     /// Abort a `Draft` session: delete its record and stop the actor.
     /// Refused with `InvalidInput` on an `Active` session (use `Destroy`).
     Abort(oneshot::Sender<Result<(), std::io::Error>>),
@@ -346,9 +522,16 @@ enum SessionMessage {
     /// record.
     Destroy(oneshot::Sender<Result<(), std::io::Error>>),
     GetRecord(oneshot::Sender<Record>),
+    /// Hand back the session's composition, if it has one. Sourced from
+    /// the persisted snapshot: `Session::run` loads it at spawn, so this
+    /// answers for an actor brought up from disk after a restart.
+    GetComposition(oneshot::Sender<Option<Arc<Composition>>>),
     /// Hand back an `Arc` clone of this session's patches-upload lock, see
     /// [`Session::patches_upload_lock`].
     GetPatchesUploadLock(oneshot::Sender<Arc<Mutex<()>>>),
+    /// Hand back an `Arc` clone of this session's hook-scripts-upload lock,
+    /// see [`Session::hook_scripts_upload_lock`].
+    GetHookScriptsUploadLock(oneshot::Sender<Arc<Mutex<()>>>),
     /// Kick off a background package build as a session side-op. Replies with
     /// the receiver end of the build's event stream.
     StartBuild {
@@ -417,6 +600,13 @@ pub struct Session {
     /// tree and step on each other.
     patches_upload_lock: Arc<Mutex<()>>,
 
+    /// The same, for `WorkspaceHookScriptsTarZst` uploads and the
+    /// `<workspace>/hooks/` tree. A separate lock from the patches one:
+    /// the two uploads target different trees and run back-to-back, so
+    /// sharing a lock would serialize them against each other for no
+    /// reason.
+    hook_scripts_upload_lock: Arc<Mutex<()>>,
+
     /// A non-owning handle to the [`Manager`](crate::sessions::Manager), used to
     /// build the [`SessionControl`] handed to each [`Binding`] so a shell-exit
     /// "delete" tears this session down through the manager (record removal and
@@ -460,6 +650,7 @@ impl Session {
             tracker: OpTracker::new_root(),
             inner,
             patches_upload_lock: Arc::new(Mutex::new(())),
+            hook_scripts_upload_lock: Arc::new(Mutex::new(())),
             manager,
             weak_self,
             #[cfg(target_os = "linux")]
@@ -687,7 +878,21 @@ impl Session {
                 });
             }
             SessionMessage::ConfigureLoadout(contribution, r) => {
-                let _ = r.send(self.configure_loadout(contribution).await);
+                // Honour what the user chose at `min session activate`.
+                let hooks_enabled = match self.record.record().await {
+                    Ok(rec) => rec.hooks_enabled,
+                    // Unreadable record: compose without hooks. Failing
+                    // closed is the only safe default for a domain whose
+                    // approval grants code execution.
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "reading hooks_enabled failed; composing without lifecycle hooks",
+                        );
+                        false
+                    }
+                };
+                let _ = r.send(self.configure_loadout(contribution, hooks_enabled).await);
             }
             SessionMessage::SubmitVerdict(msg) => {
                 let (verdict, r) = *msg;
@@ -737,7 +942,20 @@ impl Session {
                 let _ = r.send(());
                 return ControlFlow::Break(Teardown::ManagerInitiated);
             }
+            SessionMessage::RunDetachHooks(r) => {
+                self.run_hooks_headless(crate::hooks::HookEvent::Detach)
+                    .await;
+                let _ = r.send(());
+            }
             SessionMessage::Destroy(r) => {
+                // Before `stop_running`: a destroy hook runs *inside* the
+                // session, so the sandbox it joins has to still exist — or
+                // be minted, which is what this does when the session's
+                // shell has already gone. Failures are logged, never
+                // propagated: a session must stay destroyable whatever its
+                // hooks do.
+                self.run_hooks_headless(crate::hooks::HookEvent::Destroy)
+                    .await;
                 self.stop_running(false).await;
                 // Withdraw the hostname before the fallible record delete, so
                 // a delete failure leaves a stale on-disk record (repairable
@@ -751,6 +969,9 @@ impl Session {
             SessionMessage::GetPatchesUploadLock(r) => {
                 let _ = r.send(Arc::clone(&self.patches_upload_lock));
             }
+            SessionMessage::GetHookScriptsUploadLock(r) => {
+                let _ = r.send(Arc::clone(&self.hook_scripts_upload_lock));
+            }
             SessionMessage::StartBuild {
                 rebuild,
                 pkgs,
@@ -763,6 +984,9 @@ impl Session {
             }
             SessionMessage::StartMaterialize { opts, reply } => {
                 let _ = reply.send(self.start_materialize(opts).await);
+            }
+            SessionMessage::GetComposition(r) => {
+                let _ = r.send(self.composition());
             }
             SessionMessage::GetRecord(r) => {
                 let _ = r.send(self.record.record().await.unwrap());
@@ -794,9 +1018,14 @@ impl Session {
     /// but a fresh stash starts numbering from 0 again). The client must
     /// `AbortSession` and create a new session to retry rather than
     /// silently strand its outstanding verdict submission.
+    /// `hooks_enabled` is passed rather than read from the record
+    /// because the two callers disagree: the `ConfigureLoadout` RPC
+    /// honours what the user chose at activation, while the attach
+    /// shortcut always composes with hooks off (see its call site).
     async fn configure_loadout(
         &mut self,
         contribution: WireContribution,
+        hooks_enabled: bool,
     ) -> Result<Option<ContributionResponse>, std::io::Error> {
         match &self.inner {
             SessionInner::Active { .. } => {
@@ -828,7 +1057,19 @@ impl Session {
         // Phase 1+2: resolve the project and drive the composer. Kept fully
         // synchronous — its non-`Send` intermediaries must not cross an
         // `.await`.
-        let outcome = composables::run_compose(&self.daemon_ctx, &workspace_path, contribution)?;
+        // A session activated with `--no-hooks` drops the project's
+        // hooks here, the same way the client already dropped its
+        // loadouts' before sending. Both ends honour the flag, so the
+        // composition — and the snapshot persisted from it — records
+        // that the session has no hooks at all, rather than carrying
+        // hooks that every later transition has to remember to skip.
+        let outcome = composables::run_compose(
+            &self.daemon_ctx,
+            &workspace_path,
+            &self.record.record().await?.project_path,
+            contribution,
+            hooks_enabled,
+        )?;
 
         match outcome {
             // The composition is complete: promote the record
@@ -949,12 +1190,13 @@ impl Session {
     /// with `WrongState`; refuses `Materializing` sessions without
     /// a patches-ready marker with a "patches upload never
     /// finished" fault.
-    async fn finalize(&mut self) -> Result<(), std::io::Error> {
+    async fn finalize(&mut self) -> Result<Vec<minimald_rpc::RanHook>, std::io::Error> {
         let record = self.record.record().await?;
         match record.status {
             SessionStatus::Active => {
-                // Already finalized — retry is a no-op.
-                Ok(())
+                // Already finalized — retry is a no-op, and its hooks ran
+                // on the finalize that did the work.
+                Ok(Vec::new())
             }
             SessionStatus::Materializing => {
                 // Guard against a `Materializing` record whose
@@ -1035,6 +1277,41 @@ impl Session {
                     }
                 }
 
+                // Same precondition for hook scripts that arrive by
+                // upload. Without it, a client that skipped that upload
+                // would produce an `Active` session whose hooks name
+                // files that were never staged — and the first symptom
+                // would be an activation hook failing at some later
+                // point, far from the cause. Which hooks those are is
+                // narrower than "any external script": see
+                // [`composition_needs_staged_scripts`].
+                let needs_staged_scripts = matches!(
+                    &self.inner,
+                    SessionInner::Active {
+                        composition: Some(c),
+                        ..
+                    } if composition_needs_staged_scripts(c)
+                );
+                if needs_staged_scripts {
+                    let marker = paths_obj
+                        .hooks_path()
+                        .as_utf8_path()
+                        .join(crate::rpc::HOOKS_READY_MARKER);
+                    let marker_present = tokio::fs::try_exists(&marker).await.map_err(|e| {
+                        std::io::Error::new(
+                            e.kind(),
+                            format!("checking hooks-ready marker at {}: {e}", marker.as_str()),
+                        )
+                    })?;
+                    if !marker_present {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "hook-script upload never completed; cannot finalize \
+                             (upload hook scripts, then retry FinalizeSession)",
+                        ));
+                    }
+                }
+
                 // Materialize the composition's patches into the
                 // session's home dir. Done here — once — rather
                 // than on every attach so the sandbox home is
@@ -1053,12 +1330,66 @@ impl Session {
                     materialize_patches_into_home(&patches_dir, &home, comp).await?;
                 }
 
+                // Activate hooks run here — after the patches are in the
+                // sandbox home, before the session becomes attachable —
+                // so setup work and its failures land at
+                // `min session activate` rather than at some later
+                // attach.
+                //
+                // A hook runs *inside* the session, which means a shell
+                // has to exist for its namespaces to be joined. Nothing
+                // launches one this early, so this does, and keeps it:
+                // the next attach reuses it, and whatever the hooks put
+                // in `/tmp` survives into the session instead of dying
+                // with a throwaway sandbox. Gated on there actually
+                // being activate hooks, so a session without them pays
+                // nothing and comes up exactly as before.
+                let mut ran: Vec<minimald_rpc::RanHook> = Vec::new();
+                if self.has_hooks_for(crate::hooks::HookEvent::Activate) {
+                    self.launch_host_for_hooks(LaunchPhase::Activating).await?;
+                    let outcomes = run_session_hooks(
+                        &self.inner,
+                        &self.record,
+                        crate::hooks::HookEvent::Activate,
+                    )
+                    .await;
+                    // Unlike every other transition, an activate failure
+                    // aborts: a development environment whose setup
+                    // script failed is not the environment the user
+                    // asked for, and handing back a quietly-wrong
+                    // session is worse than refusing.
+                    if let Some(failed) = outcomes.iter().find(|o| o.failed()) {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            format!(
+                                "activation hook from {} failed ({:?}); the session was not \
+                                 activated{}",
+                                failed.declared_by,
+                                failed.status,
+                                if failed.output.is_empty() {
+                                    String::new()
+                                } else {
+                                    format!(":\n{}", failed.output)
+                                },
+                            ),
+                        ));
+                    }
+                    // Nothing failed, so every outcome here is a hook that
+                    // ran. Reported back so the client can say what it did
+                    // — an activate hook is headless, and without this the
+                    // only trace is the daemon log.
+                    ran.extend(outcomes.iter().map(|o| minimald_rpc::RanHook {
+                        declared_by: o.declared_by.clone(),
+                        description: o.description.clone(),
+                    }));
+                }
+
                 let mut record = record;
                 record.status = SessionStatus::Active;
                 self.record.write(record.clone()).await?;
                 #[cfg(target_os = "linux")]
                 self.register_hostname(&record);
-                Ok(())
+                Ok(ran)
             }
             SessionStatus::Pending => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -1246,7 +1577,16 @@ impl Session {
         // reachable for `DestroySession`) and refuse the attach with
         // an actionable error naming the required explicit flow.
         if let SessionInner::Draft { pending: None } = &self.inner {
-            self.configure_loadout(WireContribution::default())
+            // Hooks are forced off on this path regardless of the
+            // record. The shortcut composes with no client in the loop,
+            // and a project hook needs a client-side policy decision it
+            // has no way to obtain — composing with hooks on would
+            // return `Pending`, which this path cannot resolve, and
+            // every attach to a hook-declaring project would fail.
+            // A session that wants its project's hooks has to come up
+            // through `min session activate`, where the user is present
+            // to answer for them.
+            self.configure_loadout(WireContribution::default(), false)
                 .await
                 .map_err(AttachError::LoadoutFailed)?;
             let has_patches = matches!(
@@ -1324,12 +1664,14 @@ impl Session {
 
     /// Launches a host for this session.
     ///
-    /// The one path both callers take: [`Self::attach`], which has a client
+    /// The one path all callers take: [`Self::attach`], which has a client
     /// channel and passes it in as `progress` so the sandbox coming up is
-    /// rendered on the client's terminal, and [`Self::ensure_host`], which has
-    /// no channel at all. The channel goes in and comes back out because
-    /// progress rendering borrows it for the duration; storing the result is
-    /// left to the caller, since attach only keeps a host it could bind to.
+    /// rendered on the client's terminal, [`Self::ensure_host`], which has
+    /// no channel at all, and [`Self::launch_host_for_hooks`], which
+    /// runs before the session is `Active` (hence `phase`). The channel goes
+    /// in and comes back out because progress rendering borrows it for the
+    /// duration; storing the result is left to the caller, since attach only
+    /// keeps a host it could bind to.
     async fn launch_host(
         &mut self,
         session_hnd: SessionHandle,
@@ -1337,11 +1679,12 @@ impl Session {
         sz: WinSize,
         attach_env: session_host::AttachEnv,
         progress: Option<ChannelProgress>,
+        phase: LaunchPhase,
     ) -> Result<(Option<Channel<Msg>>, LaunchedHost), AttachError> {
         let record = self.record.record().await.unwrap();
         let paths = self.paths().await;
         let launcher = self
-            .session_launcher(session_hnd, &record, attach_env)
+            .session_launcher(session_hnd, &record, attach_env, phase)
             .await?;
         // Where the shell-exit prompt's save-then-delete lane archives the
         // changed files. Daemon-side and session-independent; created on
@@ -1361,6 +1704,10 @@ impl Session {
             // Mint a handle to this session ID in the sessions actor/manager.
             Some(SessionControl::new(self.manager.clone(), record.id)),
             archives_dir,
+            record.id,
+            // The host runs attach and detach itself: it owns the terminal
+            // they write to and the process whose namespaces they join.
+            self.composition(),
         ));
 
         let (channel, spawned) = match progress {
@@ -1418,6 +1765,7 @@ impl Session {
                 UNATTACHED_WIN_SIZE,
                 session_host::AttachEnv::default(),
                 None,
+                LaunchPhase::Attached,
             )
             .await?;
 
@@ -1439,7 +1787,14 @@ impl Session {
     ) -> Result<(), AttachError> {
         let progress = ChannelProgress::new(channel, self.tracker.clone(), (sz.cols, sz.rows));
         let (channel, launched) = self
-            .launch_host(session_hnd, conn_username, sz, attach_env, Some(progress))
+            .launch_host(
+                session_hnd,
+                conn_username,
+                sz,
+                attach_env,
+                Some(progress),
+                LaunchPhase::Attached,
+            )
             .await?;
         let channel = channel.expect("progress hands back the channel it was given");
 
@@ -1454,6 +1809,144 @@ impl Session {
         })?;
         let SessionInner::Active { host, .. } = &mut self.inner else {
             unreachable!("mint_session_host is only reachable from the Active state");
+        };
+        *host = Some(launched);
+        Ok(())
+    }
+
+    /// True when this session's composition declares at least one script for
+    /// `event`. Gates the headless host launches ([`Self::finalize`]'s and
+    /// [`Self::run_detach_hooks`]'s): without it, a transition would pay for
+    /// a sandbox no hook is going to use.
+    fn has_hooks_for(&self, event: crate::hooks::HookEvent) -> bool {
+        let SessionInner::Active {
+            composition: Some(c),
+            ..
+        } = &self.inner
+        else {
+            return false;
+        };
+        c.lifecycle_hooks()
+            .iter()
+            .any(|ph| event.script_of(ph.hook()).is_some())
+    }
+
+    /// Runs this session's hooks for `event` headlessly, minting a host
+    /// first when none is running.
+    ///
+    /// The launch is what makes this reliable. A hook runs *inside* the
+    /// session, so it needs a process whose namespaces it can join, and
+    /// neither teardown transition is guaranteed one: the host slot outlives
+    /// the host process, so a session whose shell has exited still holds a
+    /// handle to a host that can no longer run anything, and a session that
+    /// was never attached may have no host at all. Minting here — the same
+    /// launch [`Self::finalize`] does for activation — covers both, and a
+    /// session whose shell is still up (the ctrl-w detach, a destroy from a
+    /// second terminal) reuses it rather than starting a second one.
+    ///
+    /// Best effort, and *bounded*: a teardown that cannot run its hooks
+    /// still happens, so every failure is logged, none is propagated, and
+    /// nothing here may block indefinitely — see [`HOOK_LAUNCH_TIMEOUT`].
+    /// Activation is the exception and keeps its own path in
+    /// [`Self::finalize`] — a failed activate hook aborts the activation
+    /// rather than being logged past.
+    async fn run_hooks_headless(&mut self, event: crate::hooks::HookEvent) {
+        if !self.has_hooks_for(event) {
+            return;
+        }
+        // `Attached`, not `Activating`: both transitions only happen once the
+        // session is `Active`, so neither has reason to skip the status gate.
+        // A session torn down before it activated (an aborted finalize leaves
+        // it `Materializing`) is refused here and skips its hooks — teardown
+        // for setup that never completed.
+        //
+        // Timed out rather than simply awaited: this runs on the destroy
+        // path, and building a sandbox reaches the filesystem, the package
+        // cache, and (for an own-IP session) the network switch. A session
+        // must always be destroyable, so a launch that wedges has to cost
+        // its hooks rather than the whole teardown.
+        match tokio::time::timeout(
+            HOOK_LAUNCH_TIMEOUT,
+            self.launch_host_for_hooks(LaunchPhase::Attached),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    event = event.as_str(),
+                    error = %e,
+                    "launching the session to run its hooks failed; skipping them",
+                );
+                return;
+            }
+            Err(_elapsed) => {
+                tracing::warn!(
+                    event = event.as_str(),
+                    timeout_secs = HOOK_LAUNCH_TIMEOUT.as_secs(),
+                    "launching the session to run its hooks timed out; skipping them",
+                );
+                return;
+            }
+        }
+        run_session_hooks(&self.inner, &self.record, event).await;
+    }
+
+    /// Launch the session host so lifecycle hooks have namespaces to
+    /// join, and keep it as the session's host.
+    ///
+    /// Headless: there is no client channel, no PTY negotiated, and no
+    /// forwarded locale — neither the activating RPC nor a departing
+    /// binding is an attach. The window size is a placeholder the first
+    /// real attach replaces.
+    ///
+    /// A host that is still *running* (an attach raced the finalize; a
+    /// ctrl-w detach left the shell up) is left alone. A dead one is
+    /// replaced rather than reused: the slot outlives the process, so a
+    /// session whose shell exited still holds a handle to a host that can no
+    /// longer run anything — which is exactly the state a detach hook meets
+    /// on the shell-exit path. Mirrors [`Self::ensure_host`]'s liveness
+    /// check for the same reason.
+    async fn launch_host_for_hooks(&mut self, phase: LaunchPhase) -> Result<(), std::io::Error> {
+        if matches!(
+            &self.inner,
+            SessionInner::Active { host: Some((h, _)), .. } if h.is_alive()
+        ) {
+            return Ok(());
+        }
+        let session_hnd = self.weak_self.upgrade().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "session actor is shutting down; cannot run lifecycle hooks",
+            )
+        })?;
+        let username = self
+            .record
+            .record()
+            .await?
+            .username
+            .unwrap_or_else(|| "user".to_string());
+        let launched = self
+            .launch_host(
+                session_hnd,
+                username,
+                WinSize {
+                    rows: 24,
+                    cols: 80,
+                    xpixel: 0,
+                    ypixel: 0,
+                },
+                session_host::AttachEnv::default(),
+                None,
+                phase,
+            )
+            .await
+            .map_err(|e| {
+                std::io::Error::other(format!("launching the session to run its hooks: {e}"))
+            })?
+            .1;
+        let SessionInner::Active { host, .. } = &mut self.inner else {
+            unreachable!("a headless hook launch only reaches here from the Active state");
         };
         *host = Some(launched);
         Ok(())
@@ -1477,6 +1970,7 @@ impl Session {
         session: SessionHandle,
         record: &Record,
         attach_env: session_host::AttachEnv,
+        phase: LaunchPhase,
     ) -> Result<session_host::SandboxLauncher, AttachError> {
         // R2.1: reject a policy that is incompatible with the network mode
         // (e.g. egress on a non-`OwnIp` PTask) before launching the host.
@@ -1489,10 +1983,18 @@ impl Session {
         // ingress configured on any other mode.
         let ingress = record.policy.ingress.clone();
         Ok(session_host::SandboxLauncher {
-            ctx: self
-                .context(true)
-                .await
-                .map_err(AttachError::ContextCreationFailed)?,
+            ctx: match phase {
+                LaunchPhase::Attached => self.context(true).await,
+                // The activation launch runs inside `finalize`, before the
+                // record is promoted, so the status gate in `context` would
+                // reject it — see [`LaunchPhase::Activating`]. Everything
+                // that gate protects has already been established by the
+                // time finalize gets here: the session is composed (checked
+                // before any of this runs) and its patches are materialized
+                // into the home dir.
+                LaunchPhase::Activating => self.build_context(true).await,
+            }
+            .map_err(AttachError::ContextCreationFailed)?,
             attach_env,
             network_mode,
             net_switch: Arc::clone(&self.net_switch),
@@ -1513,6 +2015,7 @@ impl Session {
         _session: SessionHandle,
         record: &Record,
         _attach_env: session_host::AttachEnv,
+        _phase: LaunchPhase,
     ) -> Result<session_host::MockLauncher, AttachError> {
         // Mirror the production R2.1 gate so test launches reject a
         // policy/network-mode mismatch the same way production does.
@@ -1536,6 +2039,13 @@ impl Session {
     /// session would execute against an unpopulated home dir —
     /// the exact lifecycle escape the `Materializing` state was
     /// added to prevent.
+    ///
+    /// The one caller that legitimately runs before the promotion —
+    /// [`Session::finalize`]'s activation-hook launch — reaches
+    /// [`Self::build_context`] directly instead, via
+    /// [`LaunchPhase::Activating`]. It materializes the home dir first, so
+    /// it satisfies the invariant this gate protects without being able to
+    /// satisfy the gate itself.
     async fn context(&mut self, scaffold_if_missing: bool) -> Result<mctx::Context, String> {
         if matches!(&self.inner, SessionInner::Draft { .. }) {
             return Err("session is pending composition".to_string());
@@ -1623,6 +2133,7 @@ impl Session {
             cache: obj.cache_path(),
             home: obj.home_path(),
             patches: obj.patches_path(),
+            hooks: obj.hooks_path(),
         }
     }
 }
@@ -1638,6 +2149,16 @@ impl SessionHandle {
         WeakSessionHandle(self.0.downgrade())
     }
 
+    /// The session's composition, if it has one. See
+    /// [`SessionMessage::GetComposition`].
+    pub async fn composition(&self) -> Result<Option<Arc<Composition>>, std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        let _ = self.0.send(SessionMessage::GetComposition(send)).await;
+        recv.await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
+        })
+    }
+
     /// Handle to the per-session patches-upload lock, owned by the session
     /// actor.
     ///
@@ -1650,6 +2171,21 @@ impl SessionHandle {
         let _ = self
             .0
             .send(SessionMessage::GetPatchesUploadLock(send))
+            .await;
+        recv.await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
+        })
+    }
+
+    /// Handle to the per-session hook-scripts-upload lock, owned by the
+    /// session actor. Serializes `WorkspaceHookScriptsTarZst` RPCs the
+    /// same way [`Self::patches_upload_lock`] serializes patch uploads.
+    pub async fn hook_scripts_upload_lock(&self) -> Result<Arc<Mutex<()>>, std::io::Error> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .0
+            .send(SessionMessage::GetHookScriptsUploadLock(send))
             .await;
         recv.await.map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::NotConnected, "session actor is gone")
@@ -1761,6 +2297,17 @@ impl SessionHandle {
         recv.await.ok().flatten()
     }
 
+    /// Runs this session's `on_detach` hooks, awaiting them so a departing
+    /// binding doesn't race its own teardown. A dead actor means there is
+    /// no session to run them against, which is not an error worth raising
+    /// on a path whose whole job is leaving.
+    pub async fn run_detach_hooks(&self) {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self.0.send(SessionMessage::RunDetachHooks(send)).await;
+        let _ = recv.await;
+    }
+
     /// Returns a minimal context initialized on this sessions' worktree.
     pub async fn context(&self) -> Result<mctx::Context, String> {
         let (send, recv) = oneshot::channel();
@@ -1857,7 +2404,7 @@ impl SessionHandle {
     /// `WorkspacePatchesTarZst` upload. Idempotent on already-Active
     /// sessions. See [`Session::finalize`] for the state-machine
     /// contract.
-    pub(crate) async fn finalize(&self) -> Result<(), std::io::Error> {
+    pub(crate) async fn finalize(&self) -> Result<Vec<minimald_rpc::RanHook>, std::io::Error> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(SessionMessage::Finalize(send)).await;
@@ -3037,5 +3584,538 @@ mod tests {
             again.same_host(&host),
             "a second exec request minted a second host instead of reusing the first"
         );
+    }
+
+    // ---- lifecycle hooks -------------------------------------------------
+    //
+    // Hooks run inside the session, which under test means the host-side
+    // command `session_host::Host::command_in_session` builds for the mock
+    // launcher. What these cover is the wiring above that: which transitions
+    // run hooks, when they run relative to teardown, and whether a session
+    // with no live host gets one minted first.
+
+    /// A hook body that records having run by creating `marker`. A redirect
+    /// rather than `touch(1)`: a hook gets only the session's own
+    /// environment, so nothing here should depend on inheriting a PATH.
+    fn marker_body(marker: &std::path::Path) -> String {
+        format!("echo ran > {}", marker.display())
+    }
+
+    /// An inline hook script. The timeout is generous because a loaded box
+    /// slowing a hook down should not read as a hook that didn't fire.
+    fn inline(body: String) -> sessions::wire::primitives::WireHookScript {
+        sessions::wire::primitives::WireHookScript::Inline {
+            body,
+            timeout_secs: 60,
+        }
+    }
+
+    /// Creates an `Active` session whose composition carries `hook`.
+    ///
+    /// The hook is delivered through the client contribution, the way a
+    /// loadout's are — no policy gate applies to those — so these tests
+    /// drive the actor's hook wiring without also driving the project-hook
+    /// approval flow. Provenance doesn't change how a hook is run.
+    /// A client contribution carrying one hook, sourced from a loadout —
+    /// no policy gate applies to those, so a test drives the actor's hook
+    /// wiring without also driving the project-approval flow.
+    fn contribution_with_hook(
+        hook: sessions::wire::primitives::WireLifecycleHook,
+    ) -> sessions::wire::request::WireContribution {
+        sessions::wire::request::WireContribution {
+            lifecycle_hooks: vec![sessions::wire::primitives::WireProvenancedHook {
+                hook,
+                source: sessions::wire::primitives::WireSource::UserLoadout {
+                    name: "test".to_string(),
+                },
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// The session's on-disk status, or `None` once it is gone.
+    async fn record_status(
+        client: &mut TestClient,
+        id: SessionId,
+    ) -> Option<sessions::SessionStatus> {
+        client
+            .call::<GetSessionRecord>(&GetSessionRecordRequest::Id(id))
+            .await
+            .record
+            .map(|r| r.status)
+    }
+
+    async fn session_with_hook(
+        client: &mut TestClient,
+        name: &str,
+        hook: sessions::wire::primitives::WireLifecycleHook,
+    ) -> SessionId {
+        use crate::test_harness::{create_session_req, unwrap_ready};
+        use minimald_rpc::{
+            ConfigureLoadout, ConfigureLoadoutRequest, CreateSession, Errorable, FinalizeSession,
+            FinalizeSessionRequest,
+        };
+
+        let id = client
+            .call::<CreateSession>(&create_session_req(name, "/uwu"))
+            .await
+            .unwrap()
+            .id;
+        unwrap_ready(
+            client
+                .call::<ConfigureLoadout>(&ConfigureLoadoutRequest {
+                    session_id: id,
+                    contribution: sessions::wire::request::WireContribution {
+                        lifecycle_hooks: vec![sessions::wire::primitives::WireProvenancedHook {
+                            hook,
+                            source: sessions::wire::primitives::WireSource::UserLoadout {
+                                name: "test".to_string(),
+                            },
+                        }],
+                        ..Default::default()
+                    },
+                })
+                .await
+                .unwrap(),
+        );
+        match client
+            .call::<FinalizeSession>(&FinalizeSessionRequest { session_id: id })
+            .await
+        {
+            Errorable::Ok(_) => id,
+            Errorable::Err { error } => panic!("FinalizeSession failed: {error}"),
+        }
+    }
+
+    /// Destroys `id` through the RPC surface a client uses.
+    async fn destroy_session(client: &mut TestClient, id: SessionId) {
+        use minimald_rpc::{DestroySession, DestroySessionRequest, Errorable};
+        match client
+            .call::<DestroySession>(&DestroySessionRequest { id })
+            .await
+        {
+            Errorable::Ok(_) => {}
+            Errorable::Err { error } => panic!("DestroySession failed: {error}"),
+        }
+    }
+
+    /// Waits for `marker` to appear, so a test can observe a hook that runs
+    /// off the path it is driving (a detach is reported by the departing
+    /// binding, not by the RPC the test called).
+    async fn await_marker(marker: &std::path::Path) -> bool {
+        for _ in 0..100 {
+            if marker.exists() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        false
+    }
+
+    /// The finalize gate waits only for scripts that actually arrive by
+    /// upload.
+    ///
+    /// The client stages *loadout* scripts; a project's ride along with
+    /// the project tree, which the activation already uploads. Counting
+    /// a project's external script here would demand an upload nobody
+    /// sends — and no project could declare one at all, because the
+    /// session would fail to finalize every time.
+    #[test]
+    fn only_uploaded_hook_scripts_gate_the_finalize() {
+        use super::{Composition, composition_needs_staged_scripts};
+        use sessions::core::lifecyclehook::{HookScript, LifecycleHook};
+        use sessions::core::source::{ProvenancedHook, Source};
+        use sessions::wire::primitives::WireProvenancedHook;
+        use sessions::wire::request::{COMPOSITION_SNAPSHOT_VERSION, WireComposition};
+
+        let composition_of = |hook: ProvenancedHook| {
+            Composition::try_from(WireComposition {
+                version: COMPOSITION_SNAPSHOT_VERSION,
+                vars: Vec::new(),
+                patches: Vec::new(),
+                packages: Vec::new(),
+                lifecycle_hooks: vec![WireProvenancedHook::from(hook)],
+                orientation: Default::default(),
+            })
+            .expect("a hook with a script converts back")
+        };
+        let with_activate = |script: HookScript, source: Source| {
+            composition_of(ProvenancedHook::new(
+                LifecycleHook::builder()
+                    .with_on_activate(script)
+                    .build()
+                    .unwrap(),
+                source,
+            ))
+        };
+        let external = || HookScript::try_external("scripts/setup.sh").unwrap();
+        let project = || Source::Project {
+            path: paths::HostPath::try_new("/home/dev/proj").unwrap(),
+        };
+        let loadout = || Source::UserLoadout {
+            name: "dev".to_string(),
+        };
+
+        assert!(
+            !composition_needs_staged_scripts(&with_activate(external(), project())),
+            "a project's script arrives with the project tree, not the hook-script upload",
+        );
+        assert!(
+            composition_needs_staged_scripts(&with_activate(external(), loadout())),
+            "a loadout's script only ever arrives by upload",
+        );
+        // An inline hook uploads nothing, whoever declared it.
+        assert!(!composition_needs_staged_scripts(&with_activate(
+            HookScript::inline("true"),
+            loadout()
+        )));
+    }
+
+    /// Activation runs `on_activate`, and the session it hands back is
+    /// attachable.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn activation_runs_its_activate_hooks() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("activated");
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = session_with_hook(
+            &mut client,
+            "activate-hooks",
+            sessions::wire::primitives::WireLifecycleHook {
+                on_activate: Some(inline(marker_body(&marker))),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert!(marker.exists(), "on_activate did not run");
+        assert_eq!(
+            record_status(&mut client, session_id).await,
+            Some(sessions::SessionStatus::Active),
+            "a session whose activate hook succeeded should be attachable",
+        );
+    }
+
+    /// A failing `on_activate` fails the *activation*: the session does
+    /// not become attachable, and the error names the hook's source and
+    /// what it printed. Unlike every other transition, this one is a gate
+    /// — a development environment whose setup script failed is not the
+    /// environment that was asked for.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_failing_activate_hook_blocks_the_session() {
+        use crate::test_harness::create_session_req;
+        use minimald_rpc::{
+            ConfigureLoadout, ConfigureLoadoutRequest, CreateSession, Errorable, FinalizeSession,
+            FinalizeSessionRequest,
+        };
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let id = client
+            .call::<CreateSession>(&create_session_req("activate-fails", "/uwu"))
+            .await
+            .unwrap()
+            .id;
+        crate::test_harness::unwrap_ready(
+            client
+                .call::<ConfigureLoadout>(&ConfigureLoadoutRequest {
+                    session_id: id,
+                    contribution: contribution_with_hook(
+                        sessions::wire::primitives::WireLifecycleHook {
+                            on_activate: Some(inline(
+                                "echo ACTIVATE_SAID_NO >&2; exit 3".to_string(),
+                            )),
+                            ..Default::default()
+                        },
+                    ),
+                })
+                .await
+                .unwrap(),
+        );
+
+        let error = match client
+            .call::<FinalizeSession>(&FinalizeSessionRequest { session_id: id })
+            .await
+        {
+            Errorable::Err { error } => error,
+            Errorable::Ok(_) => panic!("finalize should have failed on the activate hook"),
+        };
+        assert!(
+            error.contains("ACTIVATE_SAID_NO"),
+            "the error should carry what the hook printed: {error}",
+        );
+        assert!(
+            error.contains("test"),
+            "the error should name where the hook was declared: {error}",
+        );
+        // The gate that matters: not attachable.
+        assert_ne!(
+            record_status(&mut client, id).await,
+            Some(sessions::SessionStatus::Active),
+            "a session whose activate hook failed must not be attachable",
+        );
+    }
+
+    // `on_attach` has no unit test here, deliberately. It is the one
+    // transition that runs in the user's shell rather than headlessly, so
+    // it goes through `Host::hook_plan`, which resolves the sandbox's
+    // session leader out of `/proc` — and the mock launcher's program is a
+    // plain childless `/bin/sh`, so there is no leader to find. Faking one
+    // would need a second test seam in `InjectedCommands` and would then
+    // prove only that the call happens, not the property the transition
+    // exists for: that the hook's output reaches the attached terminal.
+    // The session e2e asserts exactly that, against a real sandbox and a
+    // real pty ("lifecycle hooks: the four transitions").
+    //
+    /// Destroy runs the session's `on_destroy` hooks in the ordinary case:
+    /// a session with a live host, which the hooks join rather than
+    /// replace. `DestroySession` answers only once they have run, so the
+    /// marker is there by the time the call returns — no polling.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn destroy_runs_its_destroy_hooks_against_a_live_host() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("destroyed");
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = session_with_hook(
+            &mut client,
+            "destroy-hooks",
+            sessions::wire::primitives::WireLifecycleHook {
+                on_destroy: Some(inline(marker_body(&marker))),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        // Bring a host up and leave it running, so destroy meets the state
+        // it has always handled: a session with somewhere to run.
+        let manager = server.state.sessions_manager().await;
+        let handle = manager
+            .get_session(crate::sessions::SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("the session should be retrievable");
+        let host = handle
+            .ensure_host("tester".to_string())
+            .await
+            .expect("an Active session should be able to launch a host");
+        assert!(host.is_alive());
+        drop(handle);
+
+        destroy_session(&mut client, session_id).await;
+
+        assert!(marker.exists(), "destroy did not run its on_destroy hook");
+        assert!(
+            !record_exists(&mut client, session_id).await,
+            "the session record should be gone after a destroy"
+        );
+    }
+
+    /// The regression this exists for: a session whose shell has exited
+    /// still holds a *handle* to a host that can no longer run anything, so
+    /// destroy has to mint one rather than reuse the corpse. Before the fix
+    /// the hook came back `NotRun { "session host stopped ..." }` and the
+    /// session was destroyed silently.
+    ///
+    /// Drives the reported flow exactly: attach, exit the shell, keep the
+    /// session at the prompt, then destroy.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn destroy_runs_its_hooks_after_the_session_shell_has_exited() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("destroyed");
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = session_with_hook(
+            &mut client,
+            "destroy-after-exit",
+            sessions::wire::primitives::WireLifecycleHook {
+                on_destroy: Some(inline(marker_body(&marker))),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        // Exit the shell and answer the prompt with the default (keep), the
+        // way the reported repro does. This is what leaves the stale handle.
+        let mut channel = client.open_shell(session_id).await;
+        channel
+            .data_bytes(format!("{}\n", crate::session_host::MOCK_EXIT_LINE).into_bytes())
+            .await
+            .unwrap();
+        let mut prompt_out = Vec::new();
+        let mut answered = false;
+        while let Ok(msg) = tokio::time::timeout(Duration::from_secs(10), channel.wait()).await {
+            match msg {
+                Some(ChannelMsg::Data { data }) => {
+                    prompt_out.extend_from_slice(&data);
+                    if !answered
+                        && String::from_utf8_lossy(&prompt_out)
+                            .contains(crate::session_host::SHELL_EXIT_PROMPT)
+                    {
+                        channel.data_bytes(b"\r".to_vec()).await.unwrap();
+                        answered = true;
+                    }
+                }
+                Some(_) => {}
+                None => break,
+            }
+        }
+        assert!(answered, "expected the session-exit prompt to render");
+        assert!(
+            record_exists(&mut client, session_id).await,
+            "keeping at the prompt must leave the session alive"
+        );
+
+        destroy_session(&mut client, session_id).await;
+
+        assert!(
+            marker.exists(),
+            "destroy skipped its hooks for a session whose shell had exited"
+        );
+    }
+
+    /// A session that was never attached has no host at all — the same hole
+    /// from the other side. Nothing here declares an `on_activate`, so
+    /// finalize mints nothing and destroy is the first transition that needs
+    /// a sandbox.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn destroy_runs_its_hooks_for_a_session_that_was_never_attached() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("destroyed");
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = session_with_hook(
+            &mut client,
+            "destroy-never-attached",
+            sessions::wire::primitives::WireLifecycleHook {
+                on_destroy: Some(inline(marker_body(&marker))),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        destroy_session(&mut client, session_id).await;
+
+        assert!(
+            marker.exists(),
+            "destroy skipped its hooks for a session that never had a host"
+        );
+    }
+
+    /// A destroy hook that fails is reported, not obeyed: the session is
+    /// still torn down and its record still deleted. A session that a bad
+    /// hook could pin would be unremovable.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_failing_destroy_hook_still_destroys_the_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("destroyed");
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = session_with_hook(
+            &mut client,
+            "destroy-hook-fails",
+            sessions::wire::primitives::WireLifecycleHook {
+                on_destroy: Some(inline(format!("{}; exit 3", marker_body(&marker)))),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        destroy_session(&mut client, session_id).await;
+
+        assert!(marker.exists(), "the hook should still have run");
+        assert!(
+            !record_exists(&mut client, session_id).await,
+            "a failing destroy hook must not keep the session alive"
+        );
+    }
+
+    /// Leaving a session that outlives the binding runs its `on_detach`
+    /// hooks — including on the shell-exit path, where the shell that would
+    /// once have run them is exactly what has gone away.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn detach_runs_its_detach_hooks_after_the_shell_exits() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("detached");
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = session_with_hook(
+            &mut client,
+            "detach-hooks",
+            sessions::wire::primitives::WireLifecycleHook {
+                on_detach: Some(inline(marker_body(&marker))),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let mut channel = client.open_shell(session_id).await;
+        channel
+            .data_bytes(format!("{}\n", crate::session_host::MOCK_EXIT_LINE).into_bytes())
+            .await
+            .unwrap();
+        let mut prompt_out = Vec::new();
+        let mut answered = false;
+        while let Ok(msg) = tokio::time::timeout(Duration::from_secs(10), channel.wait()).await {
+            match msg {
+                Some(ChannelMsg::Data { data }) => {
+                    prompt_out.extend_from_slice(&data);
+                    if !answered
+                        && String::from_utf8_lossy(&prompt_out)
+                            .contains(crate::session_host::SHELL_EXIT_PROMPT)
+                    {
+                        channel.data_bytes(b"\r".to_vec()).await.unwrap();
+                        answered = true;
+                    }
+                }
+                Some(_) => {}
+                None => break,
+            }
+        }
+        assert!(answered, "expected the session-exit prompt to render");
+
+        // Reported by the departing binding rather than by anything this
+        // test called, so it lands shortly after the channel closes.
+        assert!(
+            await_marker(&marker).await,
+            "keeping the session at the exit prompt did not run its detach hooks"
+        );
+    }
+
+    /// A session that declares nothing for a transition runs nothing — and
+    /// in particular is not made to pay for a sandbox launch on the way out.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_session_with_no_destroy_hook_runs_nothing_on_destroy() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("should-not-exist");
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        // Declares an `on_attach` only: the composition carries a hook, but
+        // not one destroy should reach for.
+        let session_id = session_with_hook(
+            &mut client,
+            "no-destroy-hook",
+            sessions::wire::primitives::WireLifecycleHook {
+                on_attach: Some(inline(marker_body(&marker))),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        destroy_session(&mut client, session_id).await;
+
+        assert!(
+            !marker.exists(),
+            "destroy ran a hook declared for another transition"
+        );
+        assert!(!record_exists(&mut client, session_id).await);
     }
 }

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -94,6 +94,18 @@ impl From<&RequestedPty> for WinSize {
 pub struct Pty {
     master: OwnedFd,
     slave: OwnedFd,
+    /// Filesystem path of the slave side (`/dev/pts/N`), captured at
+    /// open.
+    ///
+    /// Exists so a caller that needs the terminal *later* — a lifecycle
+    /// hook wanting a real tty for `[ -t 1 ]` and `tput` — can open a
+    /// short-lived descriptor and close it again, instead of retaining
+    /// a spare slave fd for the session's lifetime. Retaining one is
+    /// precisely the leak the `set_cloexec` comment below warns about:
+    /// while any slave fd stays open the master never sees EOF, so the
+    /// host never observes the shell exiting and the session is never
+    /// reaped.
+    slave_path: std::path::PathBuf,
 }
 
 impl Pty {
@@ -138,7 +150,39 @@ impl Pty {
         set_cloexec(master.as_raw_fd())?;
         set_cloexec(slave.as_raw_fd())?;
 
-        Ok(Self { master, slave })
+        // `ptsname_r`, not `ptsname`: the latter returns a pointer to a
+        // static buffer, which is not safe to call from a daemon that
+        // opens PTYs from more than one task.
+        let slave_path = {
+            let mut buf = [0 as libc::c_char; 128];
+            // SAFETY: `master` is a live PTY master fd; `buf` is a valid
+            // writable array of the length passed alongside it.
+            let ret = unsafe { libc::ptsname_r(master.as_raw_fd(), buf.as_mut_ptr(), buf.len()) };
+            if ret != 0 {
+                return Err(io::Error::from_raw_os_error(ret));
+            }
+            // SAFETY: on success `ptsname_r` wrote a NUL-terminated
+            // string into `buf`.
+            let cstr = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) };
+            std::path::PathBuf::from(
+                std::str::from_utf8(cstr.to_bytes())
+                    .map_err(|_| io::Error::other("pty slave path is not valid UTF-8"))?,
+            )
+        };
+
+        Ok(Self {
+            master,
+            slave,
+            slave_path,
+        })
+    }
+
+    /// Path of the slave side, for opening a short-lived terminal
+    /// descriptor after the pair has been wired to a process. See
+    /// [`Pty::slave_path`](Self::slave_path) on the struct for why this
+    /// is a path rather than a retained descriptor.
+    pub fn slave_path(&self) -> &std::path::Path {
+        &self.slave_path
     }
 
     /// Returns the raw file descriptor for the master side.
@@ -242,36 +286,40 @@ fn log_session_contents(
             "session content (patch: materialized into session home at FinalizeSession)",
         );
     }
-    // Session transition scripts are gated off for this release. A hook
-    // declared in a project `[session]` block is still accepted and
-    // composed into the session — it is disabled here, at the output
-    // layer, by suppressing the content-logging loop below (and it is
-    // never executed, as exec is deferred), rather than being refused at
-    // compose time. Restore the loop when the feature ships. (Hooks from
-    // loadouts are excluded earlier, before client-side composition — see
-    // `crates/minimal/src/loadouts.rs`.)
-    //
-    // for h in comp.lifecycle_hooks() {
-    //     let src = sessions::core::source::Provenanced::source(h);
-    //     let hook = h.hook();
-    //     [
-    //         ("on_activate", hook.on_activate()),
-    //         ("on_destroy", hook.on_destroy()),
-    //         ("on_failure", hook.on_failure()),
-    //     ]
-    //     .into_iter()
-    //     .filter_map(|(event, script)| script.map(|s| (event, s)))
-    //     .for_each(|(event, script)| {
-    //         let kind = match script {
-    //             sessions::core::lifecyclehook::HookScript::Inline(_) => "inline",
-    //             sessions::core::lifecyclehook::HookScript::External(_) => "external",
-    //         };
-    //         tracing::info!(
-    //             session = session_name,
-    //             ...
-    //         );
-    //     });
-    // }
+    // Hooks are logged in setup order (project first, then loadouts —
+    // see `Composition::lifecycle_hooks`), so the log reads in the
+    // order the transitions will fire. Execution is still deferred, so
+    // this records intent rather than an outcome; an operator
+    // inspecting a session should be able to see which scripts it
+    // carries and where each came from before any of them runs.
+    for h in comp.lifecycle_hooks() {
+        let src = sessions::core::source::Provenanced::source(h);
+        let hook = h.hook();
+        [
+            ("on_activate", hook.on_activate()),
+            ("on_destroy", hook.on_destroy()),
+            ("on_attach", hook.on_attach()),
+            ("on_detach", hook.on_detach()),
+        ]
+        .into_iter()
+        .filter_map(|(event, script)| script.map(|s| (event, s)))
+        .for_each(|(event, script)| {
+            let kind = match script.body() {
+                sessions::core::lifecyclehook::HookScriptBody::Inline(_) => "inline",
+                sessions::core::lifecyclehook::HookScriptBody::External(_) => "external",
+            };
+            tracing::info!(
+                session = session_name,
+                domain = "lifecycle_hook",
+                event,
+                kind,
+                timeout_secs = script.timeout().as_secs(),
+                description = hook.description().unwrap_or_default(),
+                source = ?src,
+                "session content (lifecycle hook: composed, not yet executed)",
+            );
+        });
+    }
 }
 
 /// Duplicate `fd` into a new close-on-exec `OwnedFd` via
@@ -334,6 +382,7 @@ enum BindingMsg {
 /// Messages from the binding (user terminal) to the shell process / host.
 enum StdinMsg {
     Bytes(bytes::Bytes),
+    /// A binding left its mainloop for a reason that counts as a detach.
     TerminalUpdate(RequestedPty),
     WindowChange {
         col_width: u32,
@@ -510,16 +559,52 @@ impl Binding {
 
         tracing::info!(reason = ?exit_reason, "binding leaving mainloop");
 
-        if exit_reason == MainloopExitReason::ProcessExited {
-            Self::shell_exit_prompt(
-                self.delta.as_ref(),
-                self.control.as_ref(),
-                &self.archives_dir,
-                &self.name,
-                rs.make_reader(),
-                &mut w,
-            )
-            .await;
+        // Whether the session outlives this binding, and so should run its
+        // `on_detach` hooks. `HostGone` leaves no session to detach from,
+        // and a shell exit resolved as "delete" flows into destruction,
+        // which runs its own hooks instead.
+        let session_outlives_us = match exit_reason {
+            MainloopExitReason::HostGone => false,
+            MainloopExitReason::ProcessExited => {
+                Self::shell_exit_prompt(
+                    self.delta.as_ref(),
+                    self.control.as_ref(),
+                    &self.archives_dir,
+                    &self.name,
+                    rs.make_reader(),
+                    &mut w,
+                )
+                .await
+                    == ExitDisposition::Kept
+            }
+            MainloopExitReason::Detach => true,
+            // NOT on supercede, however much it looks like a departure.
+            // `Host::attach` sends the teardown and then awaits this
+            // binding's join handle — from inside the host's own message
+            // loop — so anything here that needs the host deadlocks:
+            // `detached()` reaches the session actor, which reaches back
+            // into the host to build the hook's command, which is blocked
+            // waiting for us. The session is also still attached, just by
+            // someone else, so firing `on_detach` immediately before the
+            // new binding's `on_attach` would misdescribe what happened.
+            MainloopExitReason::Superceded => false,
+            // Not on daemon shutdown. Asking for detach hooks reaches the
+            // sessions manager, which brings a session's actor *up* from
+            // disk on demand and would mint a fresh sandbox to run them in
+            // — the opposite of what shutdown is doing, and a race against
+            // the teardown already in flight. The session is being
+            // suspended, not left: `on_detach` waits for the next real
+            // departure.
+            MainloopExitReason::Shutdown => false,
+        };
+
+        // Asked of the session actor rather than run here: a detach hook is
+        // not the departing shell's to run — on the shell-exit path that
+        // shell is already gone, which is what ended the sandbox — so the
+        // actor mints a host for it exactly as activation does. Awaited, so
+        // the hooks are not racing this binding's teardown.
+        if session_outlives_us && let Some(control) = self.control.as_ref() {
+            control.detached().await;
         }
 
         let _ = ws.eof().await;
@@ -577,7 +662,8 @@ impl Binding {
         name: &str,
         mut r: R,
         mut w: W,
-    ) where
+    ) -> ExitDisposition
+    where
         R: tokio::io::AsyncRead + Unpin,
         W: tokio::io::AsyncWrite + Unpin,
     {
@@ -700,18 +786,36 @@ impl Binding {
             match control {
                 Some(control) => {
                     let _ = w.write_all(b"\r\nDeleting session...\r\n").await;
-                    if let Err(e) = control.destroy().await {
-                        tracing::warn!(error = %e, "session delete failed");
-                        let _ = w
-                            .write_all(format!("Failed to delete session: {e}\r\n").as_bytes())
-                            .await;
+                    match control.destroy().await {
+                        // Destroyed: its own hooks have run, and there is no
+                        // session left to detach from.
+                        Ok(()) => return ExitDisposition::Destroyed,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "session delete failed");
+                            let _ = w
+                                .write_all(format!("Failed to delete session: {e}\r\n").as_bytes())
+                                .await;
+                        }
                     }
                 }
                 // No manager wired (test harness): degrade to a detach.
                 None => tracing::warn!("delete selected but no session control available"),
             }
         }
+        // Every remaining path leaves the session standing: keep, cancel, a
+        // failed delete, or a delete with nothing wired to carry it out.
+        ExitDisposition::Kept
     }
+}
+
+/// What the shell-exit prompt settled on, which decides whether the session
+/// is still there to run `on_detach`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExitDisposition {
+    /// The session survives the shell that exited.
+    Kept,
+    /// The session was torn down, running its `on_destroy` hooks on the way.
+    Destroyed,
 }
 
 /// A handle to a launched session process.
@@ -807,6 +911,9 @@ pub(crate) struct Launched<P, G> {
     /// down explicitly via [`sandbox2::NetGuard::teardown`] at session end.
     /// `None` for `HostNet`/`NoNet` and for the mock launcher.
     net_guard: Option<Box<dyn sandbox2::NetGuard>>,
+    /// Path of the session PTY's slave side, so hooks can open the
+    /// terminal briefly rather than the host retaining a descriptor.
+    tty_path: std::path::PathBuf,
 }
 
 /// Actor messages to a [`Host`].
@@ -825,6 +932,10 @@ enum Message {
     CommandInSession {
         program: std::ffi::OsString,
         args: Vec<std::ffi::OsString>,
+        /// Layered over the session's own variables, replacing on a
+        /// shared key. Empty for callers that want the session
+        /// environment verbatim.
+        extra_env: std::collections::BTreeMap<String, String>,
         reply: oneshot::Sender<Result<std::process::Command, crate::nsenter::NsenterError>>,
     },
 
@@ -1019,6 +1130,28 @@ impl HostHandle {
         I: IntoIterator<Item = S>,
         S: AsRef<std::ffi::OsStr>,
     {
+        self.command_in_session_env(program, args, std::collections::BTreeMap::new())
+            .await
+    }
+
+    /// [`Self::command_in_session`], with `extra_env` layered over the
+    /// session's own variables.
+    ///
+    /// Separate rather than an extra parameter on the common form
+    /// because [`crate::nsenter::Injection::with_env`] *replaces* the
+    /// environment outright — merging has to happen host-side, where
+    /// the session's variables live, and every caller that doesn't need
+    /// it should keep saying so by not passing anything.
+    pub async fn command_in_session_env<I, S>(
+        &self,
+        program: impl AsRef<std::ffi::OsStr>,
+        args: I,
+        extra_env: std::collections::BTreeMap<String, String>,
+    ) -> io::Result<std::process::Command>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
         let (reply, recv) = oneshot::channel();
         let message = Message::CommandInSession {
             program: program.as_ref().to_os_string(),
@@ -1026,6 +1159,7 @@ impl HostHandle {
                 .into_iter()
                 .map(|a| a.as_ref().to_os_string())
                 .collect(),
+            extra_env,
             reply,
         };
         let dead = || io::Error::other("session host stopped before the command could be built");
@@ -1135,6 +1269,20 @@ pub(crate) struct Host<P: SessionProcess, G: SessionGuard> {
     // thus the sandbox files) is dropped. `None` for `HostNet`/`NoNet` and tests.
     net_guard: Option<Box<dyn sandbox2::NetGuard>>,
 
+    /// Path of the session PTY's slave side. Attach and detach hooks
+    /// open it briefly so their stdout is a real terminal; the host
+    /// never holds a descriptor on it, because one open slave fd stops
+    /// the master from ever seeing EOF.
+    tty_path: std::path::PathBuf,
+    /// The composed hooks, so the attach and detach transitions can run
+    /// them. `None` for a host spawned without one (tests, and a
+    /// restart-orphaned actor).
+    composition: Option<Arc<sessions::core::compose::Composition>>,
+    /// Identity and paths a hook run needs.
+    session_id: sessions::SessionId,
+    hooks_dir: paths::DaemonAbsPath,
+    workspace_dir: paths::DaemonAbsPath,
+
     // Destroy capability handed to each binding this host spawns, so a
     // shell-exit "delete" can tear the whole session down. `None` for hosts
     // built without a manager (the test harness).
@@ -1166,6 +1314,51 @@ pub(crate) struct Host<P: SessionProcess, G: SessionGuard> {
     // down before the sandbox files backing its rootfs are removed. Also read,
     // via `SessionGuard`, for the session's current environment.
     guard: G,
+}
+
+/// An owned snapshot of everything a hook run needs.
+///
+/// Owned rather than borrowed because a `Host` holds a non-`Sync`
+/// `dyn NetGuard`: keeping a `&Host` alive across an await would make
+/// the whole session future non-`Send`.
+struct HookPlan {
+    event: crate::hooks::HookEvent,
+    commands: crate::hooks::InjectedCommands,
+    composition: Arc<sessions::core::compose::Composition>,
+    session_id: sessions::SessionId,
+    session_name: String,
+    hooks_dir: paths::DaemonAbsPath,
+    workspace: paths::DaemonAbsPath,
+    output: crate::hooks::HookOutput,
+}
+
+/// Run a snapshotted plan, warning on any hook that failed.
+///
+/// Never fatal: an attach must not be refused, and a detach must not be
+/// blocked, because a hook misbehaved.
+async fn run_hook_plan(plan: HookPlan) {
+    let ctx = crate::hooks::HookContext {
+        session_id: plan.session_id,
+        session_name: &plan.session_name,
+        composition: &plan.composition,
+        hooks_dir: plan.hooks_dir,
+        workspace: plan.workspace,
+    };
+    // No budget: the only event still routed through the host is
+    // `on_attach`, which runs on the user's terminal under a command
+    // they can interrupt. Teardown is budgeted where it runs, on the
+    // session actor.
+    for o in crate::hooks::run_hooks(&plan.commands, &ctx, plan.event, plan.output, None).await {
+        if o.failed() {
+            tracing::warn!(
+                session = plan.session_name,
+                event = o.event,
+                declared_by = %o.declared_by,
+                status = ?o.status,
+                "lifecycle hook failed",
+            );
+        }
+    }
 }
 
 /// A launched session process backed by a sandboxed [`hakoniwa::Child`].
@@ -1388,6 +1581,70 @@ pub(crate) struct SandboxLauncher {
 struct PhaseOneAttachGuard {
     switch: std::sync::Arc<tokio::sync::Mutex<crate::net::SwitchClient>>,
     armed: bool,
+}
+
+/// Reaps a freshly-spawned sandbox process if the launch is abandoned
+/// before the process is handed off to a [`Launched`].
+///
+/// A [`hakoniwa::Child`] does not terminate when dropped, so anything
+/// that lets one go without killing it orphans the sandbox — a process
+/// still holding the session's rootfs after the session it belonged to
+/// is gone. The `Err` arms between the spawn and the handoff reap
+/// explicitly; this is what catches the third way out, a **cancelled**
+/// launch future. There is a real caller: a teardown transition bounds
+/// its launch with a timeout (`session::HOOK_LAUNCH_TIMEOUT`) and drops
+/// this future when it expires, which without the guard would strand a
+/// sandbox the destroy then tries to delete out from under.
+///
+/// Reaping is synchronous (`kill` + `wait` are not async), so unlike
+/// [`PhaseOneAttachGuard`] this needs no runtime to do its work in
+/// `Drop`.
+#[cfg(not(test))]
+struct SpawnedProcessGuard {
+    /// `None` once the process has been handed off — see
+    /// [`Self::release`].
+    process: Option<hakoniwa::Child>,
+}
+
+#[cfg(not(test))]
+impl SpawnedProcessGuard {
+    fn new(process: hakoniwa::Child) -> Self {
+        Self {
+            process: Some(process),
+        }
+    }
+
+    /// Borrow the guarded process, for the post-spawn wiring that still
+    /// needs it while the guard stays responsible for it.
+    fn get_mut(&mut self) -> &mut hakoniwa::Child {
+        self.process
+            .as_mut()
+            .expect("the process is taken only by `release`, which consumes the guard")
+    }
+
+    /// Hand the process off, disarming the guard.
+    fn release(mut self) -> hakoniwa::Child {
+        self.process
+            .take()
+            .expect("the process is taken only here, and this consumes the guard")
+    }
+}
+
+#[cfg(not(test))]
+impl Drop for SpawnedProcessGuard {
+    fn drop(&mut self) {
+        let Some(mut process) = self.process.take() else {
+            return;
+        };
+        // `kill` and `wait` are independent: a process that already
+        // exited fails the kill with `ESRCH` but still needs reaping.
+        if let Err(e) = process.kill() {
+            tracing::warn!(error = %e, "killing sandbox process after an abandoned launch");
+        }
+        if let Err(e) = process.wait() {
+            tracing::warn!(error = %e, "reaping sandbox process after an abandoned launch");
+        }
+    }
 }
 
 #[cfg(not(test))]
@@ -1627,6 +1884,7 @@ impl SessionLauncher for SandboxLauncher {
                 .map_err(|e| io::Error::other(format!("build command: {e}")))?;
             command.stdin(hakoniwa::Stdio::from(pty.dup_slave_fd()?));
             command.stdout(hakoniwa::Stdio::from(pty.dup_slave_fd()?));
+            let tty_path = pty.slave_path().to_path_buf();
             let (master, slave) = pty.into_fds();
             command.stderr(hakoniwa::Stdio::from(slave));
 
@@ -1636,30 +1894,23 @@ impl SessionLauncher for SandboxLauncher {
             // `command`/`container` no longer borrow `env`, so it can be moved
             // into the host to keep its backing files alive.
             drop(container);
-            Ok::<_, io::Error>((env, master, process))
+            Ok::<_, io::Error>((env, master, process, tty_path))
         }
         .await;
 
-        let (env, master, mut process) = match build_and_spawn {
+        let (env, master, process, tty_path) = match build_and_spawn {
             // `attach_guard` (if armed) rolls the phase-1 attach back on this
-            // `Err` return when it drops.
+            // `Err` return when it drops. Nothing spawned, so there is no
+            // process to reap on this arm.
             Ok(parts) => parts,
             Err(e) => return Err(e),
         };
 
-        // Reap a sandbox process whose own-IP attach failed. A `hakoniwa::Child`
-        // does not terminate when dropped — it would orphan the sandbox process —
-        // so kill and reap it explicitly. `kill` and `wait` are independent: when
-        // `kill` fails with `ESRCH` because the process already exited during the
-        // attach window, the child still needs reaping, so `wait` runs regardless.
-        let reap = |process: &mut hakoniwa::Child| {
-            if let Err(kill_err) = process.kill() {
-                tracing::warn!(error = %kill_err, "killing sandbox process after OwnIp attach failure");
-            }
-            if let Err(wait_err) = process.wait() {
-                tracing::warn!(error = %wait_err, "reaping sandbox process after OwnIp attach failure");
-            }
-        };
+        // From here the process exists, so every way out of this function
+        // has to account for it — including the one no `return` covers, a
+        // cancelled future. `SpawnedProcessGuard` owns it until the
+        // handoff at the bottom; an `Err` return or a drop reaps it.
+        let mut process = SpawnedProcessGuard::new(process);
 
         // Phase 2 (post-spawn): wire the freshly-unshared netns onto the switch.
         // Native (DM2): hakoniwa already built + configured the tap in-namespace
@@ -1675,8 +1926,7 @@ impl SessionLauncher for SandboxLauncher {
                 // `Drop`, so it never closes it); a missing fd means the in-VM
                 // RustSlirp setup did not run — `attach_guard` rolls the phase-1
                 // attach back on the `Err` return.
-                let Some(raw) = process.rustslirp_tapfd else {
-                    reap(&mut process);
+                let Some(raw) = process.get_mut().rustslirp_tapfd else {
                     return Err(io::Error::other(
                         "own-IP sandbox produced no in-namespace tap fd",
                     ));
@@ -1704,12 +1954,10 @@ impl SessionLauncher for SandboxLauncher {
                         }
                         Some(Box::new(guard) as Box<dyn sandbox2::NetGuard>)
                     }
-                    // `complete_local_own_ip_attach` leaves rollback to
-                    // `attach_guard` (this `Err` return), so only reap the process.
-                    Err(e) => {
-                        reap(&mut process);
-                        return Err(io::Error::other(e));
-                    }
+                    // `complete_local_own_ip_attach` leaves the switch
+                    // rollback to `attach_guard` and the process to
+                    // `process`, both on this `Err` return.
+                    Err(e) => return Err(io::Error::other(e)),
                 }
             } else if matches!(network_mode, NetworkMode::OwnIp) {
                 let network = crate::net::gvproxy_network::GvproxyNetwork::new(
@@ -1717,12 +1965,9 @@ impl SessionLauncher for SandboxLauncher {
                     session_name,
                     ingress,
                 );
-                match network.attach(process.id()).await {
+                match network.attach(process.get_mut().id()).await {
                     Ok(guard) => Some(guard),
-                    Err(e) => {
-                        reap(&mut process);
-                        return Err(io::Error::other(e));
-                    }
+                    Err(e) => return Err(io::Error::other(e)),
                 }
             } else {
                 None
@@ -1730,9 +1975,10 @@ impl SessionLauncher for SandboxLauncher {
 
         Ok(Launched {
             master,
-            process: SandboxProcess(process),
+            process: SandboxProcess(process.release()),
             guard: env,
             net_guard,
+            tty_path,
         })
     }
 }
@@ -1799,6 +2045,7 @@ impl SessionLauncher for MockLauncher {
         command.arg("-c").arg(&script);
         command.stdin(std::process::Stdio::from(pty.dup_slave_fd()?));
         command.stdout(std::process::Stdio::from(pty.dup_slave_fd()?));
+        let tty_path = pty.slave_path().to_path_buf();
         let (master, slave) = pty.into_fds();
         command.stderr(std::process::Stdio::from(slave));
 
@@ -1809,6 +2056,7 @@ impl SessionLauncher for MockLauncher {
             process: MockProcess(process),
             guard: (),
             net_guard: None,
+            tty_path,
         })
     }
 }
@@ -1844,20 +2092,104 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
     ///
     /// Fails if the shell's PID cannot be resolved or pinned; see
     /// [`Self::session_leader_pid`].
+    #[cfg(not(test))]
     pub(crate) fn command_in_session<I, S>(
         &self,
         program: impl AsRef<std::ffi::OsStr>,
         args: I,
+        extra_env: std::collections::BTreeMap<String, String>,
     ) -> Result<std::process::Command, crate::nsenter::NsenterError>
     where
         I: IntoIterator<Item = S>,
         S: AsRef<std::ffi::OsStr>,
     {
         let environment = self.guard.command_environment();
+        // `with_env` replaces rather than extends, so the merge happens
+        // here: session variables first, `extra_env` layered over them.
+        let mut vars = environment.vars;
+        vars.extend(extra_env);
         crate::nsenter::Injection::new(self.session_leader_pid()?, program, args)
             .with_cwd(environment.cwd)
-            .with_env(environment.vars)
+            .with_env(vars)
             .command()
+    }
+
+    /// Under test, build a plain host-side command instead of injecting into
+    /// a sandbox — the same swap [`MockLauncher`] makes for the launcher and
+    /// `()` makes for the guard.
+    ///
+    /// [`MockLauncher`]'s program is an un-sandboxed `/bin/sh` with no
+    /// children, so there is no container supervisor to resolve and
+    /// [`Self::session_leader_pid`] cannot succeed; a test reaching this
+    /// would only ever see `NoSessionLeader`. Running host-side instead
+    /// keeps everything above the injection under test — the session
+    /// environment, the script piping, output capture, outcome reporting,
+    /// and the actor wiring that decides *when* hooks run — while
+    /// [`crate::nsenter`]'s own tests cover the injection itself.
+    #[cfg(test)]
+    pub(crate) fn command_in_session<I, S>(
+        &self,
+        program: impl AsRef<std::ffi::OsStr>,
+        args: I,
+        extra_env: std::collections::BTreeMap<String, String>,
+    ) -> Result<std::process::Command, crate::nsenter::NsenterError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        let environment = self.guard.command_environment();
+        let mut vars = environment.vars;
+        vars.extend(extra_env);
+        let mut cmd = std::process::Command::new(program);
+        cmd.args(args);
+        cmd.env_clear();
+        cmd.envs(vars);
+        // The mock guard reports no cwd, and an empty one would make every
+        // spawn fail; a real sandbox path wouldn't resolve host-side anyway,
+        // so only set what exists here.
+        if !environment.cwd.is_empty() && std::path::Path::new(&environment.cwd).is_dir() {
+            cmd.current_dir(&environment.cwd);
+        }
+        Ok(cmd)
+    }
+
+    /// Snapshot what a hook run needs, or `None` when there is nothing
+    /// to run or nothing to run it in.
+    fn hook_plan(&self, event: crate::hooks::HookEvent) -> Option<HookPlan> {
+        let composition = self.composition.clone()?;
+        let leader_pid = match self.session_leader_pid() {
+            Ok(pid) => pid,
+            Err(e) => {
+                tracing::debug!(
+                    event = event.as_str(),
+                    error = %e,
+                    "no session leader; skipping lifecycle hooks",
+                );
+                return None;
+            }
+        };
+        let environment = self.guard.command_environment();
+        Some(HookPlan {
+            event,
+            commands: crate::hooks::InjectedCommands {
+                leader_pid,
+                cwd: environment.cwd,
+                vars: environment.vars,
+            },
+            composition,
+            session_id: self.session_id,
+            session_name: self.session_name.clone(),
+            hooks_dir: self.hooks_dir.clone(),
+            workspace: self.workspace_dir.clone(),
+            output: crate::hooks::HookOutput::Tty(self.tty_path.clone()),
+        })
+    }
+
+    /// Snapshot a plan and run it, if there is anything to run.
+    async fn run_hooks_for(&mut self, event: crate::hooks::HookEvent) {
+        if let Some(plan) = self.hook_plan(event) {
+            run_hook_plan(plan).await;
+        }
     }
 
     /// Spawns a session host from the given launcher, wiring it to `channel` if
@@ -1876,6 +2208,8 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         channel: Option<Channel<Msg>>,
         control: Option<SessionControl>,
         archives_dir: std::path::PathBuf,
+        session_id: sessions::SessionId,
+        composition: Option<Arc<sessions::core::compose::Composition>>,
     ) -> Result<(HostHandle, JoinHandle<Result<i32, std::io::Error>>), std::io::Error>
     where
         L: SessionLauncher<Process = P, Guard = G>,
@@ -1889,6 +2223,8 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             channel,
             control,
             archives_dir,
+            session_id,
+            composition,
         )
         .await?;
         let task = tokio::spawn(host.mainloop());
@@ -1908,6 +2244,8 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         channel: Option<Channel<Msg>>,
         control: Option<SessionControl>,
         archives_dir: std::path::PathBuf,
+        session_id: sessions::SessionId,
+        composition: Option<Arc<sessions::core::compose::Composition>>,
     ) -> Result<(Self, HostHandle), std::io::Error>
     where
         L: SessionLauncher<Process = P, Guard = G>,
@@ -1915,6 +2253,9 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         // Baseline the workspace before the process launches, so nothing the
         // session writes can leak into the "since activation" reference point.
         let workspace_root = paths.working.as_utf8_path().as_std_path().to_path_buf();
+        // Kept before `launch` consumes `paths`.
+        let hooks_dir = paths.hooks.clone();
+        let workspace_dir = paths.working.clone();
         let delta = DeltaSource::arm(workspace_root.clone()).await;
 
         // The launcher consumes `name`; the bindings need it too, to name the
@@ -1925,6 +2266,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             process,
             guard,
             net_guard,
+            tty_path,
         } = launcher.launch(name, username, paths, sz).await?;
 
         let (sender, receiver) = mpsc::channel(8);
@@ -1958,6 +2300,11 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             stdout_buf: vec![0u8; 8 * 1024],
             stdin_buf: None,
             net_guard,
+            tty_path,
+            composition,
+            session_id,
+            hooks_dir,
+            workspace_dir,
             control,
             delta,
             workspace_root,
@@ -2109,9 +2456,10 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                     Message::CommandInSession {
                         program,
                         args,
+                        extra_env,
                         reply,
                     } => {
-                        let _ = reply.send(self.command_in_session(program, args));
+                        let _ = reply.send(self.command_in_session(program, args, extra_env));
                     }
                     Message::GetAtRisk(s) => {
                         // Computed on a spawned task: the git commands and
@@ -2269,6 +2617,10 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         }
 
         self.set_size(sz);
+
+        // After the binding is installed and sized, so a hook writing to
+        // the terminal reaches the client that just attached.
+        self.run_hooks_for(crate::hooks::HookEvent::Attach).await;
     }
     fn set_size(&mut self, sz: WinSize) {
         // If the terminal size changed, reconfigure the pty.
@@ -2564,11 +2916,14 @@ mod tests {
                 cache: DaemonAbsPath::root(),
                 home: DaemonAbsPath::root(),
                 patches: DaemonAbsPath::root(),
+                hooks: DaemonAbsPath::root(),
             },
             DEFAULT_SIZE,
             None,
             None,
             std::env::temp_dir(),
+            sessions::SessionId::nil(),
+            None,
         )
         .await
         .expect("failed to build host");
@@ -2632,11 +2987,14 @@ mod tests {
                 cache: DaemonAbsPath::root(),
                 home: DaemonAbsPath::root(),
                 patches: DaemonAbsPath::root(),
+                hooks: DaemonAbsPath::root(),
             },
             DEFAULT_SIZE,
             None,
             None,
             std::env::temp_dir(),
+            sessions::SessionId::nil(),
+            None,
         )
         .await
         .expect("failed to build host");
@@ -2702,6 +3060,7 @@ mod tests {
             command.arg("-c").arg(&script);
             command.stdin(std::process::Stdio::from(pty.dup_slave_fd()?));
             command.stdout(std::process::Stdio::from(pty.dup_slave_fd()?));
+            let tty_path = pty.slave_path().to_path_buf();
             let (master, slave) = pty.into_fds();
             command.stderr(std::process::Stdio::from(slave));
             let process = command.spawn()?;
@@ -2709,6 +3068,7 @@ mod tests {
                 master,
                 process: MockProcess(process),
                 guard: (),
+                tty_path,
                 net_guard: Some(Box::new(RecordingNetGuard {
                     torn_down: self.torn_down,
                 })),
@@ -2722,6 +3082,7 @@ mod tests {
             cache: DaemonAbsPath::root(),
             home: DaemonAbsPath::root(),
             patches: DaemonAbsPath::root(),
+            hooks: DaemonAbsPath::root(),
         }
     }
 
@@ -2742,6 +3103,8 @@ mod tests {
             None,
             None,
             std::env::temp_dir(),
+            sessions::SessionId::nil(),
+            None,
         )
         .await
         .expect("failed to build host");
@@ -2790,6 +3153,8 @@ mod tests {
             None,
             None,
             std::env::temp_dir(),
+            sessions::SessionId::nil(),
+            None,
         )
         .await
         .expect("failed to build host");

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -77,6 +77,7 @@ fn build_record(
         network: config.network,
         policy: config.policy,
         status,
+        hooks_enabled: config.hooks_enabled,
         attrs: config.attrs,
     };
     record
@@ -129,6 +130,20 @@ enum ManagerMessage {
         SessionKeyPredicate,
         Responder<Option<minimald_rpc::ScreenSnapshot>>,
     ),
+    /// Read a session's persisted composition snapshot. Read-only
+    /// against the store — like [`GetRecord`](Self::GetRecord) and
+    /// unlike [`GetSession`](Self::GetSession), it never starts an
+    /// actor, so inspecting a stopped session leaves it stopped.
+    GetComposition(
+        SessionKeyPredicate,
+        Responder<Option<sessions::core::compose::Composition>>,
+    ),
+    /// How many session actors are live. Test-only, and the only way
+    /// to observe the read-only-ness of [`GetRecord`](Self::GetRecord)
+    /// and [`GetComposition`](Self::GetComposition) — "did that query
+    /// start an actor?" is otherwise invisible from outside.
+    #[cfg(test)]
+    RunningCount(Responder<usize>),
     CreateSession(Box<CreateSessionMsg>),
     DeleteSession(SessionId, Responder<()>),
     Shutdown(bool, Responder<Result<(), ()>>),
@@ -434,6 +449,20 @@ impl Manager {
                 })
                 .await;
             }
+            #[cfg(test)]
+            ManagerMessage::RunningCount(r) => {
+                let n = self.running.len();
+                r.handle(async move { Ok::<_, SessionsError>(n) }).await;
+            }
+            ManagerMessage::GetComposition(pred, r) => {
+                r.handle(async {
+                    Ok::<_, SessionsError>(match self.store.find(pred.into()).await? {
+                        Some(handle) => handle.load_composition().await?,
+                        None => None,
+                    })
+                })
+                .await;
+            }
             // Get the session actor for the predicate, starting it
             // if the session is known but not running.
             ManagerMessage::GetSession(pred, r) => {
@@ -495,8 +524,39 @@ impl Manager {
                                     format!("no session with ID `{}`", id.as_ref()),
                                 )
                             })?;
-                    match self.running.remove(&id) {
-                        // A live actor owns its full teardown.
+                    // Teardown belongs to the actor, so an idle session gets
+                    // one brought up rather than having its record deleted
+                    // out from under it. That used to be a fair shortcut —
+                    // "nothing to undo" — but a session's `on_destroy` hooks
+                    // now run on this path, and skipping the actor skipped
+                    // them silently for any session whose actor had been
+                    // reaped (every session, after a daemon restart).
+                    //
+                    // Spawning is cheap: the actor reads its record and
+                    // composition, and only mints a sandbox if there are
+                    // destroy hooks to run in one.
+                    let actor = match self.running.remove(&id) {
+                        Some(hnd) => Some(hnd),
+                        None => match Session::run(self.session_config(handle.clone())).await {
+                            Ok(hnd) => Some(hnd),
+                            // A record the actor refuses to come up on — a
+                            // restart-orphaned `Materializing` one is the
+                            // known case — must still be destroyable, so
+                            // fall through to deleting it directly. A
+                            // session that cannot be torn down is worse
+                            // than one torn down without its hooks.
+                            Err(e) => {
+                                tracing::warn!(
+                                    session_id = %id,
+                                    error = %e,
+                                    "could not start the session to run its destroy hooks; \
+                                     removing its record without them",
+                                );
+                                None
+                            }
+                        },
+                    };
+                    match actor {
                         Some(hnd) => {
                             hnd.destroy().await?;
                             // Belt-and-braces: a dead actor (self-terminated
@@ -510,8 +570,6 @@ impl Manager {
                                 return Err(e);
                             }
                         }
-                        // Never spawned: no host or hostname registration to
-                        // undo, so just remove the on-disk record.
                         None => handle.delete().await?,
                     }
                     Ok(())
@@ -630,6 +688,29 @@ impl SessionControl {
             )),
         }
     }
+
+    /// Reports that a binding has left a session that outlives it, so the
+    /// session runs its `on_detach` hooks.
+    ///
+    /// Returns nothing: leaving is not a fallible operation from the
+    /// departing side, and every way this can come up empty — the manager
+    /// already shut down, the session already gone — means there is nothing
+    /// left to run hooks against. Those are logged where they can be
+    /// explained, not raised here.
+    pub async fn detached(&self) {
+        let Some(mngr) = self.manager.upgrade() else {
+            return;
+        };
+        match mngr.get_session(SessionKeyPredicate::Id(self.id)).await {
+            Ok(Some(session)) => session.run_detach_hooks().await,
+            Ok(None) => {}
+            Err(e) => tracing::warn!(
+                error = %e,
+                session = %self.id,
+                "could not reach the session to run its detach hooks",
+            ),
+        }
+    }
 }
 
 impl ManagerHandle {
@@ -657,6 +738,37 @@ impl ManagerHandle {
         let (send, recv) = Responder::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self.sender.send(ManagerMessage::List(send)).await;
+        recv.await.expect("corresponding sessions manager is dead")
+    }
+
+    /// How many session actors are live. See
+    /// [`ManagerMessage::RunningCount`].
+    #[cfg(test)]
+    pub(crate) async fn running_count(&self) -> usize {
+        let (send, recv) = Responder::channel();
+        let _ = self.sender.send(ManagerMessage::RunningCount(send)).await;
+        recv.await
+            .expect("corresponding sessions manager is dead")
+            .expect("counting live actors cannot fail")
+    }
+
+    /// Reads a session's persisted composition snapshot.
+    ///
+    /// Read-only: unlike [`Self::get_session`] this never brings the
+    /// session's actor up, so a query about a stopped session does not
+    /// start it. `None` for an unknown session and for one with no
+    /// snapshot — the two are indistinguishable here on purpose, since
+    /// both mean "nothing recorded to report".
+    pub async fn get_composition(
+        &self,
+        pred: SessionKeyPredicate,
+    ) -> Result<Option<sessions::core::compose::Composition>, SessionsError> {
+        let (send, recv) = Responder::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .sender
+            .send(ManagerMessage::GetComposition(pred, send))
+            .await;
         recv.await.expect("corresponding sessions manager is dead")
     }
 
@@ -801,8 +913,11 @@ pub(crate) mod tests {
     use std::io::ErrorKind;
     use tempfile::TempDir;
 
-    fn daemon_dir(tmp: &TempDir) -> DaemonAbsPath {
-        DaemonAbsPath::try_new(tmp.path().to_str().unwrap()).unwrap()
+    /// A stand-in for the client-side project path a session record
+    /// carries — the identity the composer stamps onto the project's
+    /// contributions, distinct from the daemon workspace it reads.
+    fn declared_path() -> paths::HostAbsPath {
+        paths::HostAbsPath::try_new("/home/dev/myproject").unwrap()
     }
 
     /// Resolves the session's live actor and peeks its held
@@ -908,6 +1023,7 @@ pub(crate) mod tests {
                 })
                 .collect(),
             patches: vec![],
+            lifecycle_hooks: vec![],
         }
     }
 
@@ -917,6 +1033,7 @@ pub(crate) mod tests {
             project_path: HostAbsPath::try_new("/proj").unwrap(),
             network: sessions::NetworkMode::default(),
             policy: Default::default(),
+            hooks_enabled: true,
             attrs: Default::default(),
         }
     }
@@ -940,10 +1057,20 @@ pub(crate) mod tests {
         mngr: &ManagerHandle,
         config: minimald_rpc::SessionConfig,
     ) -> SessionId {
+        create_active_session_contributing(mngr, config, WireContribution::default()).await
+    }
+
+    /// [`create_active_session_with`] carrying a client contribution —
+    /// the way a test gets lifecycle hooks into a session's composition.
+    async fn create_active_session_contributing(
+        mngr: &ManagerHandle,
+        config: minimald_rpc::SessionConfig,
+        contribution: WireContribution,
+    ) -> SessionId {
         let id = mngr.create_session(config, None).await.unwrap();
         let handle = session(mngr, id).await;
         let response = handle
-            .configure_loadout(WireContribution::default())
+            .configure_loadout(contribution)
             .await
             .expect("configuring an empty loadout should succeed");
         assert!(response.is_none(), "an empty loadout should finalize");
@@ -957,26 +1084,40 @@ pub(crate) mod tests {
     async fn manager() -> (TempDir, TempDir, ManagerHandle) {
         let state = TempDir::new().unwrap();
         let cache = TempDir::new().unwrap();
+        let mngr = manager_over(state.path(), cache.path()).await;
+        (state, cache, mngr)
+    }
+
+    /// A manager rooted at existing state and cache directories, so a
+    /// test can stand a second one up over the first's store — the way
+    /// a daemon restart sees a session it never started.
+    async fn manager_over(state: &std::path::Path, cache: &std::path::Path) -> ManagerHandle {
+        let state = state.to_path_buf();
+        let cache = cache.to_path_buf();
         // These tests never start an `OwnIp` launch (they use the mock
         // launcher), so the switch is never spawned; a placeholder binary path
         // is sufficient.
         let switch = Arc::new(Mutex::new(crate::net::SwitchClient::new(
             "/nonexistent/gvproxy",
-            state.path().join("gvproxy"),
+            state.join("gvproxy"),
         )));
         // Tests use per-TempDir cache/state dirs so they don't pollute the
         // shared daemon paths a real invocation would touch.
         let mctx_config = mctx::ConfigBuilder::new()
-            .with_cache_dir(cache.path())
-            .with_state_dir(state.path())
+            .with_cache_dir(&cache)
+            .with_state_dir(&state)
             .with_daemon_id("test".to_string())
             .build()
             .unwrap();
         let daemon_ctx = Arc::new(mctx::DaemonContext::init(mctx_config).unwrap());
-        let mngr = Manager::init(daemon_dir(&state), daemon_dir(&cache), daemon_ctx, switch)
+        Manager::init(daemon_abs(&state), daemon_abs(&cache), daemon_ctx, switch)
             .await
-            .unwrap();
-        (state, cache, mngr)
+            .unwrap()
+    }
+
+    /// A [`DaemonAbsPath`] for a test directory.
+    fn daemon_abs(p: &std::path::Path) -> DaemonAbsPath {
+        DaemonAbsPath::try_new(p.to_str().unwrap()).unwrap()
     }
 
     /// Destroying a known-but-not-running session removes its record so it no
@@ -1000,7 +1141,107 @@ pub(crate) mod tests {
         let _ = create_active_session(&mngr).await;
     }
 
-    /// Destroying a session that has been brought up (its actor is running, but
+    /// Destroying a session whose actor is not running must still go
+    /// through that actor, because teardown is the actor's job — and now
+    /// includes running the session's `on_destroy` hooks.
+    ///
+    /// The shortcut this replaced ("never spawned, so nothing to undo —
+    /// just remove the record") predated hooks and skipped them in
+    /// silence for every session whose actor had been reaped, which after
+    /// a daemon restart is all of them. Asserted through the live-actor
+    /// count: the destroy has to bring one up.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn destroying_an_idle_session_goes_through_its_actor() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("destroyed");
+
+        let (state, cache, mngr) = manager().await;
+        // A destroy hook is the discriminator: both the actor path and the
+        // old shortcut delete the record, so only the hook's side effect
+        // tells them apart.
+        let id = create_active_session_contributing(
+            &mngr,
+            sample_config(),
+            WireContribution {
+                lifecycle_hooks: vec![sessions::wire::primitives::WireProvenancedHook {
+                    hook: sessions::wire::primitives::WireLifecycleHook {
+                        on_destroy: Some(sessions::wire::primitives::WireHookScript::Inline {
+                            body: format!("echo ran > {}", marker.display()),
+                            timeout_secs: 60,
+                        }),
+                        ..Default::default()
+                    },
+                    source: sessions::wire::primitives::WireSource::UserLoadout {
+                        name: "test".to_string(),
+                    },
+                }],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        // A second manager over the same store knows the session from disk
+        // and has never run it — a daemon restart's view, and the state the
+        // old shortcut applied to.
+        let restarted = manager_over(state.path(), cache.path()).await;
+        assert_eq!(restarted.running_count().await, 0);
+
+        restarted.delete_session(id).await.unwrap();
+
+        assert!(
+            marker.exists(),
+            "destroying an idle session skipped its on_destroy hook",
+        );
+        assert!(
+            restarted
+                .get_record(SessionKeyPredicate::Id(id))
+                .await
+                .unwrap()
+                .is_none(),
+            "the record should be gone after destroy"
+        );
+    }
+
+    /// Reading a session's composition must not resurrect it.
+    ///
+    /// `min session hooks` is a report, and a report has no business
+    /// starting what it reports on — `get_session` would, since it
+    /// brings an actor up from disk on demand. Asserted against the
+    /// live-actor count because that is the only place the difference
+    /// shows.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reading_a_composition_does_not_start_the_session() {
+        let (state, cache, mngr) = manager().await;
+        let id = create_active_session(&mngr).await;
+
+        // A second manager over the same store: it knows the session
+        // from disk and has never run it, which is the state a daemon
+        // restart leaves and the one where "did this start an actor?"
+        // is answerable.
+        let restarted = manager_over(state.path(), cache.path()).await;
+        assert_eq!(
+            restarted.running_count().await,
+            0,
+            "a fresh manager should not have started anything",
+        );
+
+        // The read answers for the session...
+        let composition = restarted
+            .get_composition(SessionKeyPredicate::Id(id))
+            .await
+            .expect("reading the snapshot should succeed");
+        assert!(
+            composition.is_some(),
+            "an Active session should have a persisted composition",
+        );
+        // ...without bringing it up. `get_session` here would.
+        assert_eq!(
+            restarted.running_count().await,
+            0,
+            "reading the composition started the session's actor",
+        );
+    }
+
     /// no host is attached) tears the actor down and removes the record.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn destroy_tears_down_a_running_session() {
@@ -1215,6 +1456,7 @@ pub(crate) mod tests {
                 session_id: id,
                 vars: vec![],
                 patches: vec![],
+                lifecycle_hooks: vec![],
             })
             .await
             .expect("actor reply should succeed");
@@ -1275,6 +1517,7 @@ pub(crate) mod tests {
                 })
                 .collect(),
             patches: vec![],
+            lifecycle_hooks: vec![],
         };
         let step = handle
             .submit_verdict(verdict)
@@ -1663,8 +1906,14 @@ pub(crate) mod tests {
                 name: "test".into(),
             },
         });
-        let (project, packages) =
-            build_composables(&path, &ProjectResolution::NoMFile, &contribution).unwrap();
+        let (project, packages) = build_composables(
+            &path,
+            &declared_path(),
+            &ProjectResolution::NoMFile,
+            &contribution,
+            true,
+        )
+        .unwrap();
         assert!(project.is_none(), "NoMFile → no ProjectComposable");
         assert!(packages.is_empty(), "NoMFile → no PackageComposables");
     }
@@ -1706,8 +1955,10 @@ pub(crate) mod tests {
         let path = DaemonAbsPath::try_new(project.path().to_str().unwrap()).unwrap();
         let (project_composable, packages) = build_composables(
             &path,
+            &declared_path(),
             &ProjectResolution::MFileOnly(ctx),
             &WireContribution::default(),
+            true,
         )
         .unwrap();
         assert!(
@@ -1718,6 +1969,33 @@ pub(crate) mod tests {
             packages.is_empty(),
             "MFileOnly → no PackageComposables (no graph to walk)",
         );
+
+        // Provenance names the project as the *user* knows it, not the
+        // per-session workspace the mfile was read out of. The hooks
+        // policy matches projects by this path and every error message
+        // quotes it, so a per-session value would be unmatchable and
+        // unrecognizable — see `build_composables`.
+        use sessions::core::compose::Composable as _;
+        let contribution = project_composable
+            .unwrap()
+            .contribute(&|_| Err(std::env::VarError::NotPresent))
+            .expect("the fixture's [session] block contributes cleanly");
+        let sources: Vec<_> = contribution
+            .packages()
+            .iter()
+            .map(sessions::core::source::Provenanced::source)
+            .collect();
+        assert!(!sources.is_empty(), "fixture should contribute a package");
+        for source in sources {
+            let sessions::core::source::Source::Project { path } = source else {
+                panic!("project material should carry Source::Project, got {source:?}");
+            };
+            assert_eq!(
+                path.as_utf8_path().as_str(),
+                declared_path().as_utf8_path().as_str(),
+                "provenance should name the declared project path, not the workspace",
+            );
+        }
     }
 
     /// [`run_composer`] with an empty client contribution and no

--- a/crates/minimald/src/sessions/composables.rs
+++ b/crates/minimald/src/sessions/composables.rs
@@ -356,8 +356,10 @@ fn fold_stack_vars_into_session<'a, I>(
 /// lands.
 pub(crate) fn build_composables(
     project_path: &DaemonAbsPath,
+    declared_path: &paths::HostAbsPath,
     resolution: &ProjectResolution,
     contribution: &WireContribution,
+    hooks_enabled: bool,
 ) -> Result<
     (
         Option<mfile::ProjectComposable>,
@@ -449,15 +451,26 @@ pub(crate) fn build_composables(
         if let Some(gstack) = graph_stack {
             fold_stack_vars_into_session(&mut effective, &gstack.name, &gstack.build_env_vars);
         }
+        // `--no-hooks`: drop the project's transition scripts before
+        // they reach the composer. Cleared here, ahead of the
+        // is-empty recheck below, so a `[session]` block whose only
+        // material was hooks collapses to no composable at all
+        // rather than an empty one.
+        if !hooks_enabled {
+            effective.lifecycle_hooks.clear();
+        }
         // Post-fold recheck: every stack var could theoretically
         // fail both strict and lenient validation, leaving
         // `effective` empty despite the pre-check. Rare, but the
         // recheck is cheap.
         (!effective.is_empty()).then(|| {
-            mfile::ProjectComposable::new(
-                paths::AbsPath::<paths::Host>::new_unchecked(project_path.as_utf8_path()).into(),
-                effective,
-            )
+            // The *declared* path, not the workspace this mfile was
+            // read from. Provenance is identity, and the workspace is
+            // per-session (`.../sessions/<id>/tree`) — stamping that
+            // would give the same project a different identity on every
+            // activation, which the hooks policy matches against and
+            // every error message quotes back at the user.
+            mfile::ProjectComposable::new(declared_path.clone().into(), effective)
         })
     };
 
@@ -551,14 +564,26 @@ pub(crate) fn build_composables(
 /// callers on an async runtime should wrap it in a blocking-safe
 /// helper. Kept free of `.await`s so its non-`Send` intermediaries
 /// ([`mctx::Context`], nickel-`Rc`-carrying errors) never cross one.
+/// `project_path` is where the mfile is *read* from — the session's
+/// daemon-side workspace. `declared_path` is where the project lives on
+/// the user's machine, taken from the session record: the two are
+/// different filesystems, and only the second is a stable identity for
+/// the project (see [`build_composables`]).
 pub(crate) fn run_compose(
     daemon_ctx: &Arc<mctx::DaemonContext>,
     project_path: &DaemonAbsPath,
+    declared_path: &paths::HostAbsPath,
     contribution: WireContribution,
+    hooks_enabled: bool,
 ) -> Result<ComposeOutcome, std::io::Error> {
     let resolution = resolve_project_ctx_and_graph(daemon_ctx, project_path)?;
-    let (project_composable, package_composables) =
-        build_composables(project_path, &resolution, &contribution)?;
+    let (project_composable, package_composables) = build_composables(
+        project_path,
+        declared_path,
+        &resolution,
+        &contribution,
+        hooks_enabled,
+    )?;
     run_composer(contribution, project_composable, package_composables)
 }
 

--- a/crates/minimald/src/store.rs
+++ b/crates/minimald/src/store.rs
@@ -343,6 +343,7 @@ mod tests {
             project_path: HostAbsPath::try_new("/home/alice/proj").unwrap(),
             network: NetworkMode::default(),
             policy: Default::default(),
+            hooks_enabled: true,
             status: SessionStatus::default(),
             attrs: Default::default(),
         }

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -413,6 +413,7 @@ pub fn create_session_req(name: &str, project: &str) -> minimald_rpc::CreateSess
             project_path: paths::HostAbsPath::try_new(project).unwrap(),
             network: sessions::NetworkMode::default(),
             policy: Default::default(),
+            hooks_enabled: true,
             attrs: Default::default(),
         },
     }

--- a/crates/minvmd/examples/exec.rs
+++ b/crates/minvmd/examples/exec.rs
@@ -171,6 +171,7 @@ async fn run_session_exec(
                     .map_err(|e| format!("project_path: {e}"))?,
                 network: sessions::NetworkMode::default(),
                 policy: Default::default(),
+                hooks_enabled: true,
                 attrs: Default::default(),
             },
         };
@@ -281,7 +282,7 @@ async fn run_session_exec(
         let resp: Errorable<FinalizeSessionResponse> = serde_json_lenient::from_slice(&resp_buf)
             .map_err(|e| format!("decode response: {e}"))?;
         match resp {
-            Errorable::Ok(FinalizeSessionResponse) => {}
+            Errorable::Ok(_) => {}
             Errorable::Err { error } => return Err(format!("FinalizeSession failed: {error}")),
         }
     }

--- a/crates/minvmd/tests/minimald_session_integration.rs
+++ b/crates/minvmd/tests/minimald_session_integration.rs
@@ -264,6 +264,10 @@ async fn run_session_exec(
                     .map_err(|e| format!("project_path: {e}"))?,
                 network: sessions::NetworkMode::default(),
                 policy: Default::default(),
+                // The serde default, and what every non-`--no-hooks`
+                // activation sends. This session only runs an exec, so
+                // it declares no hooks either way.
+                hooks_enabled: true,
                 attrs: Default::default(),
             },
         };

--- a/crates/sessions/docs/COMPOSITION.md
+++ b/crates/sessions/docs/COMPOSITION.md
@@ -478,7 +478,7 @@ Below, in numbered prose:
    batch plus the composer's `HOME` env lookup as tilde fallback).
    Walk the filesystem under each expanded root and fan out to one
    `PatchFile` per matching file. Expand `~` and `$VAR` in
-   `PatchPolicy` patterns the same way, against a temporary copy
+   `PatchesPolicy` patterns the same way, against a temporary copy
    (the raw policy is preserved for round-trip).
 3. **Pass 1 — Categorize.** Each item runs through `Policy::check`,
    which steps through:
@@ -605,7 +605,7 @@ overload:
   in Phase 3 each file gets its own `WirePatchVerdict` so a Denied
   doesn't abort, it just rejects that file.
 - **Hook gets narrow policy by value.** The gate hands the hook an
-  owned `VarsPolicy` or `PatchPolicy` — never `&mut UserPolicy`. To
+  owned `VarsPolicy` or `PatchesPolicy` — never `&mut UserPolicy`. To
   add a rule, the hook returns the modified copy in
   `HookResult::Decided.updated_policy`; the gate installs it before
   Pass 3.
@@ -619,7 +619,7 @@ overload:
   malicious client can't submit `"../../etc/foo"` to escape the
   sandbox home.
 - **Source `~` is expanded at gate time; dest has no `~` to expand.**
-  Patch source `FileSet` patterns and `PatchPolicy` patterns expand
+  Patch source `FileSet` patterns and `PatchesPolicy` patterns expand
   `~` against a resolved `HOME` — a session var named `HOME` first,
   else the client-side fallback (`UserComposer`'s `env("HOME")` in
   Phase 1, `handle_response`'s `env("HOME")` in Phase 3). The

--- a/crates/sessions/example_project/minimal.toml
+++ b/crates/sessions/example_project/minimal.toml
@@ -46,6 +46,18 @@
 #   GOCACHE       — no prompt. Package `env_state_wiring` values
 #   GOMODCACHE      are `Specified` (the package attr declares the
 #                   literal), so `carries_user_data` is false.
+#   hooks         — prompts once, for the project as a whole. A
+#                   project's lifecycle hooks are arbitrary code it
+#                   asked to run inside your session, so the gate
+#                   asks before any of them run, and the answer is
+#                   per-project rather than per-script. Approve
+#                   permanently and it lands in `[hooks] allow` in
+#                   `user_policy.toml`; decline and the session
+#                   still comes up, just without them. Loadout
+#                   hooks are not gated — those are your own files.
+#
+# `min session activate --no-hooks` skips the question and the
+# hooks entirely, for the run where you just want the box.
 #
 # `claude-code` also contributes a patch source that resolves to
 # `~/.claude`. If you don't have that directory the client emits a
@@ -96,3 +108,41 @@ LANG = { inherit = true, default = "C.UTF-8" }
 # fires. Export `TZ=America/New_York` in your shell and re-run to
 # force the env-hit path.
 TZ = { inherit = true, default = "UTC" }
+
+# One hook covering all four transitions, so each can be observed
+# without arranging anything. Scripts run under POSIX `sh` unless they
+# open with a shebang, and every command here is a shell builtin or a
+# coreutil the baseline already carries — so nothing depends on a
+# package being installed or has a failure mode of its own.
+#
+# The two transitions with nowhere to print (`on_activate`,
+# `on_detach`) leave a marker file in `/home` instead, which you can
+# see from inside the session; the two that do print, print.
+#
+# WHERE THE OUTPUT GOES differs by transition, and it is the part
+# that surprises people:
+#
+#   on_attach              — your terminal. It runs on the PTY you
+#                            are attached to, printing just after
+#                            the session binds, so you see it
+#                            directly.
+#   the other three        — the daemon log, not your terminal.
+#                            There is no PTY to write to at any of
+#                            them: activate and destroy have none,
+#                            and a detach is the terminal leaving.
+#                            Look for `lifecycle hook ran` records.
+#
+# A script can also read `$MINIMAL_HOOK_EVENT`, one of the metadata
+# variables the runner sets alongside the session's own
+# environment — see `MINIMAL_HOOK_SOURCE_KIND`,
+# `MINIMAL_HOOK_SOURCE_NAME`, `MINIMAL_HOOK_INDEX`, and
+# `MINIMAL_HOOK_COUNT` for the rest.
+#
+# `min session hooks <session>` lists these back, showing where
+# each was declared and what will actually run.
+[[session.lifecycle_hooks]]
+description = "print at each transition"
+on_activate = { type = "inline", value = "touch /home/alpha.txt" }
+on_attach   = { type = "inline", value = "echo \"beta\"" }
+on_detach   = { type = "inline", value = "touch /home/gamma.txt" }
+on_destroy  = { type = "inline", value = "echo \"omega\"" }

--- a/crates/sessions/src/client/handler.rs
+++ b/crates/sessions/src/client/handler.rs
@@ -8,8 +8,12 @@
 //! `~/${PROJECT_ROOT}` can reference a `PROJECT_ROOT` approved
 //! moments earlier in the same response.
 //!
-//! Lifecycle hooks are pass-through — no per-hook policy exists, so
-//! rejecting a hook means aborting the session.
+//! Lifecycle hooks are gated last, against the hooks policy, by the
+//! project root that declared them: a hook is arbitrary code, so a
+//! project must be allow-listed before any of its hooks run. Hooks are
+//! decided per project rather than per script — a project's hooks are
+//! approved as a set — so the prompt fires once per project no matter
+//! how many scripts it declares.
 //!
 //! Per-domain verdicts are correlated by `id`, not slice position:
 //! auto-decided items come out in input order but hook-routed items
@@ -22,11 +26,13 @@ use crate::core::compose::{
 use crate::core::decision::{CheckOutcome, Decision, ItemDecision};
 use crate::core::enumerate::enumerate_patch_files;
 use crate::core::hooks::{PolicyHooks, Unapproved};
-use crate::core::policy::{ExpandedPatchPolicy, PatchPolicy, UserPolicy, VarsPolicy};
+use crate::core::policy::{
+    ExpandedPatchesPolicy, HooksPolicy, PatchesPolicy, UserPolicy, VarsPolicy,
+};
 use crate::core::primitives::{Patch, PatchDest};
 use crate::core::source::{Provenanced, ProvenancedPatch, Source};
-use crate::wire::policy::{WirePatchVerdict, WireVarVerdict};
-use crate::wire::primitives::{WirePendingPatch, WirePendingVar};
+use crate::wire::policy::{WireHookVerdict, WirePatchVerdict, WireVarVerdict};
+use crate::wire::primitives::{WirePendingHook, WirePendingPatch, WirePendingVar};
 use crate::wire::request::{ContributionResponse, ContributionVerdict};
 
 /// Gate the daemon's pending items against `policy`, prompting via
@@ -54,7 +60,7 @@ pub fn handle_response(
     env: &dyn Fn(&str) -> Result<String, std::env::VarError>,
 ) -> Result<(ContributionVerdict, UserPolicy), ComposeError> {
     let session_id = response.session_id;
-    let (vars_policy, patches_policy) = policy.into_parts();
+    let (vars_policy, patches_policy, hooks_policy) = policy.into_parts();
 
     let (var_out, vars_policy) = gate_pending_vars(response.vars, vars_policy, hooks, env)?;
 
@@ -70,18 +76,165 @@ pub fn handle_response(
         env,
     )?;
 
+    // Hooks gate last so its policy patterns can expand against the
+    // same resolved var set the patch gate used.
+    let (hook_verdicts, hooks_policy) = gate_pending_hooks(
+        response.lifecycle_hooks,
+        hooks_policy,
+        hooks,
+        &combined_vars,
+        env,
+    )?;
+
     let final_policy = UserPolicy::empty()
         .with_vars(vars_policy)
-        .with_patches(patches_policy);
+        .with_patches(patches_policy)
+        .with_hooks(hooks_policy);
 
     Ok((
         ContributionVerdict {
             session_id,
             vars: var_out.verdicts,
             patches: patch_verdicts,
+            lifecycle_hooks: hook_verdicts,
         },
         final_policy,
     ))
+}
+
+// =====================================================================
+// Lifecycle hooks
+// =====================================================================
+
+/// One project whose hooks still need a decision: the root path the
+/// prompt shows, the original [`Source`] (kept rather than rebuilt from
+/// the path, so a re-check after the prompt matches on exactly what the
+/// policy saw the first time), and the ids waiting on that decision.
+type UndecidedProject = (
+    camino::Utf8PathBuf,
+    Source,
+    Vec<crate::wire::primitives::PendingId>,
+);
+
+/// Gate the daemon's pending lifecycle hooks against the hooks policy.
+///
+/// Decisions are made **per project**, not per hook: a project's hooks
+/// are approved or refused as a set, so a project declaring five hooks
+/// prompts once rather than five times, and can't end up half-approved.
+/// Every hook from one project therefore receives that project's single
+/// decision.
+fn gate_pending_hooks(
+    pending: Vec<WirePendingHook>,
+    policy: HooksPolicy,
+    hooks: &dyn PolicyHooks,
+    combined_vars: &[SessionVar],
+    env: &dyn Fn(&str) -> Result<String, std::env::VarError>,
+) -> Result<(Vec<WireHookVerdict>, HooksPolicy), ComposeError> {
+    if pending.is_empty() {
+        return Ok((Vec::new(), policy));
+    }
+    let home_fallback = env("HOME").ok();
+    let expanded = policy.expand_with(combined_vars, home_fallback.as_deref())?;
+
+    // Pass 1: classify each hook. `Provenanced` is what the policy
+    // reads, so a lightweight (id, source) pair stands in for the hook
+    // itself here — the daemon holds the hook and only needs a verdict.
+    let mut verdicts: Vec<WireHookVerdict> = Vec::with_capacity(pending.len());
+    // Distinct projects still needing a decision, in first-seen order.
+    let mut unapproved: Vec<UndecidedProject> = Vec::new();
+    for p in pending {
+        let source: Source = p.source.into();
+        match expanded.check(HookRef {
+            id: p.id,
+            source: source.clone(),
+        }) {
+            CheckOutcome::Decided(Decision::Allowed(h)) => {
+                verdicts.push(WireHookVerdict::Approved { id: h.id });
+            }
+            CheckOutcome::Decided(Decision::Denied(h)) => {
+                verdicts.push(WireHookVerdict::Denied { id: h.id });
+            }
+            CheckOutcome::Decided(Decision::Ignored) => {
+                verdicts.push(WireHookVerdict::Ignored { id: p.id });
+            }
+            CheckOutcome::NeedsApproval(h) => {
+                // Only `Source::Project` reaches here — the other two
+                // variants are always decided — so the path is present.
+                let root = match &h.source {
+                    Source::Project { path } => path.as_utf8_path().to_owned(),
+                    other => {
+                        return Err(ComposeError::InvalidWireItem {
+                            what: "lifecycle hook needing approval from a non-project source",
+                            context: format!("{other:?}"),
+                        });
+                    }
+                };
+                match unapproved.iter_mut().find(|(p, _, _)| *p == root) {
+                    Some((_, _, ids)) => ids.push(h.id),
+                    None => unapproved.push((root, h.source, vec![h.id])),
+                }
+            }
+        }
+    }
+    if unapproved.is_empty() {
+        return Ok((verdicts, policy));
+    }
+
+    // Pass 2: prompt once per project.
+    let view: Vec<Unapproved<'_, camino::Utf8Path>> = unapproved
+        .iter()
+        .map(|(root, source, _)| Unapproved {
+            item: root.as_path(),
+            source,
+        })
+        .collect();
+    let (decisions, policy) = crate::core::compose::prompt_hook_hook(hooks, policy, &view)?;
+
+    // Pass 3: apply one decision to every hook from that project.
+    let expanded = policy.expand_with(combined_vars, home_fallback.as_deref())?;
+    for ((root, source, ids), decision) in unapproved.into_iter().zip(decisions) {
+        for id in ids {
+            let verdict = match decision {
+                ItemDecision::AllowOnce => WireHookVerdict::Approved { id },
+                ItemDecision::IgnoreOnce => WireHookVerdict::Ignored { id },
+                ItemDecision::UseRule => match expanded.check(HookRef {
+                    id,
+                    source: source.clone(),
+                }) {
+                    CheckOutcome::Decided(Decision::Allowed(h)) => {
+                        WireHookVerdict::Approved { id: h.id }
+                    }
+                    CheckOutcome::Decided(Decision::Denied(h)) => {
+                        WireHookVerdict::Denied { id: h.id }
+                    }
+                    CheckOutcome::Decided(Decision::Ignored) => WireHookVerdict::Ignored { id },
+                    CheckOutcome::NeedsApproval(_) => {
+                        return Err(ComposeError::use_rule_undecided(
+                            HookDomain::Hook,
+                            format!("lifecycle hooks from project `{root}`"),
+                        ));
+                    }
+                },
+            };
+            verdicts.push(verdict);
+        }
+    }
+    Ok((verdicts, policy))
+}
+
+/// The minimum a hook needs to face the policy: its correlation id and
+/// the source that declared it. The hook body stays on the daemon, so
+/// the client never has to ship one back — only a decision.
+#[derive(Clone, Debug)]
+struct HookRef {
+    id: crate::wire::primitives::PendingId,
+    source: Source,
+}
+
+impl Provenanced for HookRef {
+    fn source(&self) -> &Source {
+        &self.source
+    }
 }
 
 // =====================================================================
@@ -273,12 +426,12 @@ fn classify_var(policy: &VarsPolicy, pending: PendingVar) -> VarClassification {
 
 fn gate_pending_patches(
     pending: Vec<WirePendingPatch>,
-    policy: PatchPolicy,
+    policy: PatchesPolicy,
     hooks: &dyn PolicyHooks,
     options: ComposeOptions,
     combined_vars: &[SessionVar],
     env: &dyn Fn(&str) -> Result<String, std::env::VarError>,
-) -> Result<(Vec<WirePatchVerdict>, PatchPolicy), ComposeError> {
+) -> Result<(Vec<WirePatchVerdict>, PatchesPolicy), ComposeError> {
     if pending.is_empty() {
         return Ok((Vec::new(), policy));
     }
@@ -328,7 +481,7 @@ fn gate_pending_patches(
 /// that need the hook.
 fn enumerate_and_classify_patches(
     pending: Vec<WirePendingPatch>,
-    policy: &ExpandedPatchPolicy,
+    policy: &ExpandedPatchesPolicy,
     combined_vars: &[SessionVar],
     home_fallback: Option<&str>,
     follow_symlinks: bool,
@@ -403,7 +556,7 @@ fn enumerate_and_classify_patches(
 
 /// Apply a hook's `ItemDecision` to a single pending patch file.
 fn apply_patch_decision(
-    policy: &ExpandedPatchPolicy,
+    policy: &ExpandedPatchesPolicy,
     pending: PendingPatchFile,
     decision: ItemDecision,
 ) -> Result<WirePatchVerdict, ComposeError> {
@@ -436,7 +589,7 @@ enum PatchClassification {
 }
 
 fn classify_patch_file(
-    policy: &ExpandedPatchPolicy,
+    policy: &ExpandedPatchesPolicy,
     pending: PendingPatchFile,
 ) -> PatchClassification {
     let (id, pf) = pending.into_parts();

--- a/crates/sessions/src/client/hookscripts.rs
+++ b/crates/sessions/src/client/hookscripts.rs
@@ -1,0 +1,525 @@
+//! Resolving and validating external lifecycle-hook scripts on the
+//! client, before they are uploaded to the daemon.
+//!
+//! An external script is declared as a relative path. What it is
+//! relative *to* depends on who declared it, and that can't be settled
+//! when the file is parsed — the same [`LifecycleHook`] type is
+//! deserialized from a loadout and from a project's `minimal.toml`. So
+//! the anchor is resolved here, from the hook's recorded
+//! [`Source`], at the point the script is staged:
+//!
+//! | Source | Anchor |
+//! |---|---|
+//! | [`Source::UserLoadout`] | `<config>/minimal/loadouts/<name>/` |
+//! | [`Source::Project`] | the project root |
+//!
+//! Validation runs on the client so a mistyped path fails locally and
+//! immediately, naming the file, rather than surfacing partway through
+//! an activation that has already created a session on the daemon.
+//!
+//! [`LifecycleHook`]: crate::core::lifecyclehook::LifecycleHook
+//! [`Source::UserLoadout`]: crate::core::source::Source::UserLoadout
+//! [`Source::Project`]: crate::core::source::Source::Project
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::core::lifecyclehook::{HookScript, HookScriptBody, staged_script_path};
+use crate::core::source::{Provenanced, ProvenancedHook, Source};
+
+/// Why an external hook script couldn't be staged.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StageError {
+    /// The declaring source has no anchor on this machine — a loadout
+    /// whose script directory is missing, or a project path that isn't
+    /// present.
+    #[error("hook script `{script}` from {declared_by}: no such directory `{anchor}`")]
+    MissingAnchor {
+        script: Utf8PathBuf,
+        declared_by: String,
+        anchor: Utf8PathBuf,
+    },
+
+    /// A component of the path is a symlink. Rejected rather than
+    /// followed: a symlink is the one way a path that passes every
+    /// other check can still resolve outside its anchor.
+    #[error(
+        "hook script `{script}` from {declared_by}: `{component}` is a symlink, which is not allowed"
+    )]
+    SymlinkComponent {
+        script: Utf8PathBuf,
+        declared_by: String,
+        component: Utf8PathBuf,
+    },
+
+    /// The path doesn't exist under its anchor.
+    #[error("hook script `{script}` from {declared_by}: no such file `{resolved}`")]
+    NotFound {
+        script: Utf8PathBuf,
+        declared_by: String,
+        resolved: Utf8PathBuf,
+    },
+
+    /// The path exists but isn't a regular file.
+    #[error("hook script `{script}` from {declared_by}: `{resolved}` is not a regular file")]
+    NotAFile {
+        script: Utf8PathBuf,
+        declared_by: String,
+        resolved: Utf8PathBuf,
+    },
+
+    /// Stat failed for a reason other than absence.
+    #[error("hook script `{script}` from {declared_by}: reading `{resolved}`: {source_err}")]
+    Io {
+        script: Utf8PathBuf,
+        declared_by: String,
+        resolved: Utf8PathBuf,
+        #[source]
+        source_err: std::io::Error,
+    },
+}
+
+/// Where each kind of contributor's external scripts are anchored.
+#[derive(Debug, Clone)]
+pub struct ScriptAnchors {
+    /// The user's loadouts directory. A loadout named `dev` anchors its
+    /// scripts at `<loadouts_dir>/dev/`.
+    pub loadouts_dir: Utf8PathBuf,
+    /// The project root, for hooks declared in `minimal.toml`.
+    pub project_root: Utf8PathBuf,
+}
+
+impl ScriptAnchors {
+    /// The directory `source`'s scripts resolve against, or `None` for
+    /// a source that cannot declare scripts.
+    #[must_use]
+    pub fn for_source(&self, source: &Source) -> Option<Utf8PathBuf> {
+        match source {
+            // Same guard as `staged_script_path`, for the same reason:
+            // the name is joined into a path that is then read from, so
+            // it has to be a component that stays put. A name this
+            // rejects has no anchor, so its scripts never stage — and
+            // the daemon would refuse to read them anyway.
+            Source::UserLoadout { name } => crate::core::lifecyclehook::safe_path_component(name)
+                .then(|| self.loadouts_dir.join(name)),
+            Source::Project { .. } => Some(self.project_root.clone()),
+            Source::Package { .. } => None,
+        }
+    }
+}
+
+/// One external script resolved on the host and ready to upload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagedScript {
+    /// Absolute host path to read the script from.
+    pub host_path: Utf8PathBuf,
+    /// Path within the session's staged-hooks directory, from
+    /// [`staged_script_path`]. The daemon reconstructs this same value
+    /// from the hook's source, so the two sides agree without a
+    /// manifest.
+    pub staged: Utf8PathBuf,
+}
+
+/// Resolve and validate every external script the given hooks declare.
+///
+/// Inline scripts are skipped — their bodies travel inside the
+/// composition and need no file. Duplicates are collapsed: two hooks
+/// naming the same script from the same source upload once.
+///
+/// # Errors
+///
+/// Returns the first [`StageError`]. Failing on the first is
+/// deliberate: a broken script path is a typo to fix, and reporting
+/// them one at a time keeps the message pointed at a single file.
+pub fn stage_external_scripts(
+    hooks: &[ProvenancedHook],
+    anchors: &ScriptAnchors,
+) -> Result<Vec<StagedScript>, StageError> {
+    let mut out: Vec<StagedScript> = Vec::new();
+    for ph in hooks {
+        let source = ph.source();
+        let Some(anchor) = anchors.for_source(source) else {
+            // A package can't declare hooks and the gate denies any
+            // that appear, so there is nothing to resolve.
+            continue;
+        };
+        let hook = ph.hook();
+        for script in [
+            hook.on_activate(),
+            hook.on_destroy(),
+            hook.on_attach(),
+            hook.on_detach(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let Some(staged) = external_staged_path(source, script) else {
+                continue;
+            };
+            let HookScriptBody::External(rel) = script.body() else {
+                continue;
+            };
+            let host_path = resolve_under_anchor(&anchor, rel.as_utf8_path(), source)?;
+            let candidate = StagedScript { host_path, staged };
+            if !out.contains(&candidate) {
+                out.push(candidate);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// The staged path for `script`, or `None` when it is inline (or from a
+/// source that can't stage).
+fn external_staged_path(source: &Source, script: &HookScript) -> Option<Utf8PathBuf> {
+    match script.body() {
+        HookScriptBody::Inline(_) => None,
+        HookScriptBody::External(rel) => staged_script_path(source, rel),
+    }
+}
+
+/// Resolve `rel` under `anchor`, rejecting a symlink at any component.
+///
+/// Each component is stat'd with `symlink_metadata` as the path is
+/// walked. Canonicalizing instead would *follow* symlinks — it can tell
+/// you where a path ends up, but not that it took a link to get there,
+/// which is exactly the thing being refused. `..` and absolute paths
+/// are already impossible here: `rel` comes from a
+/// [`ConfigRelPath`](paths::ConfigRelPath), which rejects both at
+/// construction.
+fn resolve_under_anchor(
+    anchor: &Utf8Path,
+    rel: &Utf8Path,
+    source: &Source,
+) -> Result<Utf8PathBuf, StageError> {
+    let label = source.to_string();
+    let script = rel.to_owned();
+
+    // Absence and unreadability are different problems, told apart here the
+    // same way the per-component walk below tells them apart: "no such
+    // directory" sends you to create it, an I/O error sends you to look at
+    // permissions or the filesystem.
+    match std::fs::symlink_metadata(anchor.as_std_path()) {
+        Ok(m) if m.is_dir() => {}
+        Ok(_) => {
+            return Err(StageError::MissingAnchor {
+                script,
+                declared_by: label,
+                anchor: anchor.to_owned(),
+            });
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(StageError::MissingAnchor {
+                script,
+                declared_by: label,
+                anchor: anchor.to_owned(),
+            });
+        }
+        Err(e) => {
+            return Err(StageError::Io {
+                script,
+                declared_by: label,
+                resolved: anchor.to_owned(),
+                source_err: e,
+            });
+        }
+    }
+
+    let mut current = anchor.to_owned();
+    let mut components = rel.components().peekable();
+    while let Some(component) = components.next() {
+        current = current.join(component.as_str());
+        let is_last = components.peek().is_none();
+        let meta = match std::fs::symlink_metadata(current.as_std_path()) {
+            Ok(m) => m,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(StageError::NotFound {
+                    script,
+                    declared_by: label,
+                    resolved: current,
+                });
+            }
+            Err(e) => {
+                return Err(StageError::Io {
+                    script,
+                    declared_by: label,
+                    resolved: current,
+                    source_err: e,
+                });
+            }
+        };
+        // Checked on every component, including the last: a symlinked
+        // leaf is just as capable of pointing outside the anchor as a
+        // symlinked directory partway down.
+        if meta.file_type().is_symlink() {
+            return Err(StageError::SymlinkComponent {
+                script,
+                declared_by: label,
+                component: current,
+            });
+        }
+        if is_last && !meta.is_file() {
+            return Err(StageError::NotAFile {
+                script,
+                declared_by: label,
+                resolved: current,
+            });
+        }
+    }
+    Ok(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::lifecyclehook::LifecycleHook;
+
+    fn anchors(root: &Utf8Path) -> ScriptAnchors {
+        ScriptAnchors {
+            loadouts_dir: root.join("loadouts"),
+            project_root: root.join("proj"),
+        }
+    }
+
+    fn loadout_source() -> Source {
+        Source::UserLoadout { name: "dev".into() }
+    }
+
+    fn project_source(root: &Utf8Path) -> Source {
+        Source::Project {
+            path: paths::HostPath::try_new(root.join("proj")).unwrap(),
+        }
+    }
+
+    fn hook_with_activate(script: HookScript, source: Source) -> ProvenancedHook {
+        let h = LifecycleHook::builder()
+            .with_on_activate(script)
+            .build()
+            .unwrap();
+        ProvenancedHook::new(h, source)
+    }
+
+    /// Create `<root>/loadouts/dev/` and return it.
+    fn make_loadout_dir(root: &Utf8Path) -> Utf8PathBuf {
+        let d = root.join("loadouts").join("dev");
+        std::fs::create_dir_all(d.as_std_path()).unwrap();
+        d
+    }
+
+    #[test]
+    fn inline_scripts_need_no_staging() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        make_loadout_dir(root);
+        let hooks = vec![hook_with_activate(
+            HookScript::inline("echo hi"),
+            loadout_source(),
+        )];
+        assert!(
+            stage_external_scripts(&hooks, &anchors(root))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn loadout_script_resolves_under_its_own_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        let dir = make_loadout_dir(root);
+        std::fs::write(dir.join("activate.sh").as_std_path(), "echo hi\n").unwrap();
+
+        let hooks = vec![hook_with_activate(
+            HookScript::try_external("activate.sh").unwrap(),
+            loadout_source(),
+        )];
+        let staged = stage_external_scripts(&hooks, &anchors(root)).unwrap();
+        assert_eq!(staged.len(), 1);
+        assert_eq!(staged[0].host_path, dir.join("activate.sh"));
+        assert_eq!(
+            staged[0].staged,
+            Utf8PathBuf::from("loadout/dev/activate.sh")
+        );
+    }
+
+    #[test]
+    fn project_script_resolves_under_the_project_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        let proj = root.join("proj").join("scripts");
+        std::fs::create_dir_all(proj.as_std_path()).unwrap();
+        std::fs::write(proj.join("setup.sh").as_std_path(), "echo hi\n").unwrap();
+
+        let hooks = vec![hook_with_activate(
+            HookScript::try_external("scripts/setup.sh").unwrap(),
+            project_source(root),
+        )];
+        let staged = stage_external_scripts(&hooks, &anchors(root)).unwrap();
+        assert_eq!(staged.len(), 1);
+        assert_eq!(
+            staged[0].staged,
+            Utf8PathBuf::from("project/scripts/setup.sh")
+        );
+    }
+
+    /// A symlinked leaf is refused even though it resolves to a real
+    /// file inside the anchor — following it is what's disallowed, not
+    /// where it happens to land.
+    #[test]
+    fn symlinked_script_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        let dir = make_loadout_dir(root);
+        std::fs::write(dir.join("real.sh").as_std_path(), "echo hi\n").unwrap();
+        std::os::unix::fs::symlink(
+            dir.join("real.sh").as_std_path(),
+            dir.join("link.sh").as_std_path(),
+        )
+        .unwrap();
+
+        let hooks = vec![hook_with_activate(
+            HookScript::try_external("link.sh").unwrap(),
+            loadout_source(),
+        )];
+        let err = stage_external_scripts(&hooks, &anchors(root)).unwrap_err();
+        assert!(
+            matches!(err, StageError::SymlinkComponent { .. }),
+            "got: {err:?}",
+        );
+    }
+
+    /// A symlinked *directory* partway down is refused too — this is
+    /// the escape a leaf-only check would miss.
+    #[test]
+    fn symlinked_intermediate_directory_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        let dir = make_loadout_dir(root);
+        let outside = root.join("outside");
+        std::fs::create_dir_all(outside.as_std_path()).unwrap();
+        std::fs::write(outside.join("evil.sh").as_std_path(), "echo pwned\n").unwrap();
+        std::os::unix::fs::symlink(outside.as_std_path(), dir.join("sub").as_std_path()).unwrap();
+
+        let hooks = vec![hook_with_activate(
+            HookScript::try_external("sub/evil.sh").unwrap(),
+            loadout_source(),
+        )];
+        let err = stage_external_scripts(&hooks, &anchors(root)).unwrap_err();
+        assert!(
+            matches!(err, StageError::SymlinkComponent { .. }),
+            "got: {err:?}",
+        );
+    }
+
+    #[test]
+    fn missing_script_is_reported_with_its_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        make_loadout_dir(root);
+        let hooks = vec![hook_with_activate(
+            HookScript::try_external("nope.sh").unwrap(),
+            loadout_source(),
+        )];
+        let err = stage_external_scripts(&hooks, &anchors(root)).unwrap_err();
+        assert!(matches!(err, StageError::NotFound { .. }), "got: {err:?}");
+        assert!(err.to_string().contains("nope.sh"), "got: {err}");
+    }
+
+    #[test]
+    fn directory_in_place_of_a_script_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        let dir = make_loadout_dir(root);
+        std::fs::create_dir_all(dir.join("adir").as_std_path()).unwrap();
+        let hooks = vec![hook_with_activate(
+            HookScript::try_external("adir").unwrap(),
+            loadout_source(),
+        )];
+        let err = stage_external_scripts(&hooks, &anchors(root)).unwrap_err();
+        assert!(matches!(err, StageError::NotAFile { .. }), "got: {err:?}");
+    }
+
+    /// A loadout that declares an external script but has no script
+    /// directory gets a message naming the directory it should create,
+    /// not a bare "file not found".
+    #[test]
+    fn missing_loadout_script_directory_is_named() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        let hooks = vec![hook_with_activate(
+            HookScript::try_external("activate.sh").unwrap(),
+            loadout_source(),
+        )];
+        let err = stage_external_scripts(&hooks, &anchors(root)).unwrap_err();
+        assert!(
+            matches!(err, StageError::MissingAnchor { .. }),
+            "got: {err:?}",
+        );
+        assert!(err.to_string().contains("loadouts/dev"), "got: {err}");
+    }
+
+    /// Two hooks naming the same script upload it once.
+    #[test]
+    fn duplicate_scripts_collapse() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        let dir = make_loadout_dir(root);
+        std::fs::write(dir.join("a.sh").as_std_path(), "echo hi\n").unwrap();
+
+        let hooks = vec![
+            hook_with_activate(HookScript::try_external("a.sh").unwrap(), loadout_source()),
+            hook_with_activate(HookScript::try_external("a.sh").unwrap(), loadout_source()),
+        ];
+        assert_eq!(
+            stage_external_scripts(&hooks, &anchors(root))
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    /// Every transition's script is staged, not just `on_activate`.
+    #[test]
+    fn all_four_transitions_are_staged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        let dir = make_loadout_dir(root);
+        for f in ["a.sh", "d.sh", "at.sh", "dt.sh"] {
+            std::fs::write(dir.join(f).as_std_path(), "echo hi\n").unwrap();
+        }
+        let hook = LifecycleHook::builder()
+            .with_on_activate(HookScript::try_external("a.sh").unwrap())
+            .with_on_destroy(HookScript::try_external("d.sh").unwrap())
+            .with_on_attach(HookScript::try_external("at.sh").unwrap())
+            .with_on_detach(HookScript::try_external("dt.sh").unwrap())
+            .build()
+            .unwrap();
+        let hooks = vec![ProvenancedHook::new(hook, loadout_source())];
+        assert_eq!(
+            stage_external_scripts(&hooks, &anchors(root))
+                .unwrap()
+                .len(),
+            4
+        );
+    }
+
+    /// A package-sourced hook stages nothing rather than erroring —
+    /// the policy gate already denies it, so this path just has nothing
+    /// to do.
+    #[test]
+    fn package_sourced_hooks_stage_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        let hooks = vec![hook_with_activate(
+            HookScript::try_external("a.sh").unwrap(),
+            Source::Package {
+                name: "helix".into(),
+            },
+        )];
+        assert!(
+            stage_external_scripts(&hooks, &anchors(root))
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/crates/sessions/src/client/mod.rs
+++ b/crates/sessions/src/client/mod.rs
@@ -2,3 +2,4 @@ pub mod composer;
 pub mod config;
 pub mod disk;
 pub mod handler;
+pub mod hookscripts;

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -16,15 +16,14 @@ use std::collections::BTreeMap;
 use crate::core::decision::{CheckOutcome, Decision, ItemDecision};
 use crate::core::enumerate::{ExpandedProvenancedPatch, PatchFile, enumerate_patch_files};
 use crate::core::hooks::{HookResult, PolicyHooks, Unapproved};
-use crate::core::policy::{PatchPolicy, UserPolicy, VarsPolicy};
+use crate::core::policy::{PatchesPolicy, UserPolicy, VarsPolicy};
 use crate::core::primitives::{ResolvedPatch, ResolvedVar, VarError};
 use crate::core::source::{
     Provenanced, ProvenancedHook, ProvenancedPackage, ProvenancedPatch, ProvenancedVar, Source,
 };
 use crate::wire::policy::{WirePatchVerdict, WireVarVerdict};
 use crate::wire::primitives::{
-    PendingId, WirePendingPatch, WirePendingVar, WireProvenancedHook, WireSessionPatch,
-    WireSessionVar,
+    PendingId, WirePendingHook, WirePendingPatch, WirePendingVar, WireSessionPatch, WireSessionVar,
 };
 
 /// Errors produced while a [`Composable`] materializes its
@@ -167,7 +166,7 @@ impl fmt::Display for Conflict {
                 for (source, src) in disagreeing_sources {
                     write!(f, "\n  - {src:?} (from {source})")?;
                 }
-                // PatchPolicy matches against *source* paths, not
+                // PatchesPolicy matches against *source* paths, not
                 // destinations — the hint must steer the user to a
                 // pattern that matches the sources shown above, not
                 // the destination.
@@ -766,6 +765,7 @@ pub enum ComposeError {
 pub(crate) enum HookDomain {
     Var,
     Patch,
+    Hook,
 }
 
 impl ComposeError {
@@ -777,6 +777,9 @@ impl ComposeError {
         let kind = match domain {
             HookDomain::Var => "UseRule returned for a var the policy still cannot decide",
             HookDomain::Patch => "UseRule returned for a patch file the policy still cannot decide",
+            HookDomain::Hook => {
+                "UseRule returned for a project whose hooks the policy still cannot decide"
+            }
         };
         Self::HookContract {
             kind,
@@ -794,6 +797,7 @@ impl ComposeError {
         let kind = match domain {
             HookDomain::Var => "var-domain hook returned the wrong number of decisions",
             HookDomain::Patch => "patch-domain hook returned the wrong number of decisions",
+            HookDomain::Hook => "lifecycle-hook-domain hook returned the wrong number of decisions",
         };
         Self::HookContract {
             kind,
@@ -1144,10 +1148,34 @@ impl Composition {
     }
 
     /// The lifecycle hooks contributed to the session, each paired
-    /// with its source. Pass-through; no policy gate.
+    /// with its source, in **setup order**: the project's hooks first,
+    /// then each loadout's in the order the loadouts were selected.
+    ///
+    /// This is the order the setup transitions (`on_activate`,
+    /// `on_attach`) run in, and it is a contract, not an accident of
+    /// assembly: the daemon builds its own contribution first and
+    /// appends the client's via
+    /// [`extend_from_wire`](Self::extend_from_wire), which is what puts
+    /// the project ahead of the loadouts. A project maintainer relies on
+    /// setting up before any developer's personal hooks do.
+    /// [`lifecycle_hooks_teardown`](Self::lifecycle_hooks_teardown) is
+    /// the matching reverse order.
     #[must_use]
     pub fn lifecycle_hooks(&self) -> &[ProvenancedHook] {
         &self.lifecycle_hooks
+    }
+
+    /// The lifecycle hooks in **teardown order** — the exact reverse of
+    /// [`lifecycle_hooks`](Self::lifecycle_hooks), so the project tears
+    /// down last, after every loadout that layered on top of it.
+    ///
+    /// The transitions that use this are `on_detach` and `on_destroy`.
+    /// Exposed as its own accessor rather than left to each caller to
+    /// `.rev()`: a caller that forgets would silently tear down in setup
+    /// order, which no test of a single-contributor session would catch.
+    #[must_use]
+    pub fn lifecycle_hooks_teardown(&self) -> impl DoubleEndedIterator<Item = &ProvenancedHook> {
+        self.lifecycle_hooks.iter().rev()
     }
 
     /// Consume the [`Composition`] and return the underlying vectors
@@ -1387,9 +1415,9 @@ pub(crate) fn prompt_var_hook(
 /// the resolved vars.
 pub(crate) fn prompt_patch_hook(
     hooks: &dyn PolicyHooks,
-    policy: PatchPolicy,
+    policy: PatchesPolicy,
     view: &[Unapproved<'_, camino::Utf8Path>],
-) -> Result<(Vec<ItemDecision>, PatchPolicy, bool), ComposeError> {
+) -> Result<(Vec<ItemDecision>, PatchesPolicy, bool), ComposeError> {
     match hooks.on_patch_unapproved(policy.clone(), view) {
         HookResult::Abort => Err(ComposeError::Aborted),
         HookResult::Decided {
@@ -1408,6 +1436,32 @@ pub(crate) fn prompt_patch_hook(
                 None => (policy, false),
             };
             Ok((decisions, policy, updated))
+        }
+    }
+}
+
+/// Invoke the lifecycle-hook-domain hook on a batch of projects whose
+/// hooks the policy couldn't decide. Same shape as
+/// [`prompt_var_hook`]; one decision per **project**, not per script.
+pub(crate) fn prompt_hook_hook(
+    hooks: &dyn PolicyHooks,
+    policy: crate::core::policy::HooksPolicy,
+    view: &[Unapproved<'_, camino::Utf8Path>],
+) -> Result<(Vec<ItemDecision>, crate::core::policy::HooksPolicy), ComposeError> {
+    match hooks.on_hook_unapproved(policy.clone(), view) {
+        HookResult::Abort => Err(ComposeError::Aborted),
+        HookResult::Decided {
+            decisions,
+            updated_policy,
+        } => {
+            if decisions.len() != view.len() {
+                return Err(ComposeError::hook_decision_count_mismatch(
+                    HookDomain::Hook,
+                    view.len(),
+                    decisions.len(),
+                ));
+            }
+            Ok((decisions, updated_policy.unwrap_or(policy)))
         }
     }
 }
@@ -1568,12 +1622,12 @@ pub(crate) fn expand_patch_sources(
 /// `hooks` is `None` for user-only composition — see [`gate_vars`].
 pub(crate) fn gate_patches(
     items: Vec<ProvenancedPatch>,
-    mut policy: PatchPolicy,
+    mut policy: PatchesPolicy,
     hooks: Option<&dyn PolicyHooks>,
     options: ComposeOptions,
     gated_vars: &[SessionVar],
     home_fallback: Option<&str>,
-) -> Result<(Vec<SessionPatch>, PatchPolicy), ComposeError> {
+) -> Result<(Vec<SessionPatch>, PatchesPolicy), ComposeError> {
     let name_of = |pf: &PatchFile| pf.user_facing().as_str().to_owned();
     let source_of = |pf: PatchFile| pf.provenance;
 
@@ -1703,7 +1757,11 @@ pub(crate) fn compose_contribution(
         packages,
         lifecycle_hooks,
     } = contribution;
-    let (vars_policy, patches_policy) = policy.into_parts();
+    // The hooks policy passes straight through: this is the *loadout*
+    // composition, and a loadout's hooks are the user's own files. Only
+    // project-declared hooks face the gate, on the daemon-response path
+    // in `client::handler`.
+    let (vars_policy, patches_policy, hooks_policy) = policy.into_parts();
     let (gated_vars, vars_policy) = gate_vars(vars, vars_policy, hooks)?;
     // Conflict detection runs post-gate so that the user's `ignore`
     // policy can drop offending contributors before they're compared.
@@ -1741,7 +1799,8 @@ pub(crate) fn compose_contribution(
     check_patch_prefix_collisions(gated_patches.iter(), |p| p.patch().destination())?;
     let final_policy = UserPolicy::empty()
         .with_vars(vars_policy)
-        .with_patches(patches_policy);
+        .with_patches(patches_policy)
+        .with_hooks(hooks_policy);
     let composition = Composition {
         vars: gated_vars,
         patches: gated_patches,
@@ -1766,6 +1825,7 @@ pub(crate) struct PendingTransform {
     pub(crate) wire: WirePending,
     pub(crate) pending_vars: BTreeMap<PendingId, ProvenancedVar>,
     pub(crate) pending_patches: BTreeMap<PendingId, ProvenancedPatch>,
+    pub(crate) pending_hooks: BTreeMap<PendingId, ProvenancedHook>,
 }
 
 /// Wire-shaped pending payload — the subset of [`PendingTransform`]
@@ -1774,7 +1834,7 @@ pub(crate) struct PendingTransform {
 pub(crate) struct WirePending {
     pub(crate) vars: Vec<WirePendingVar>,
     pub(crate) patches: Vec<WirePendingPatch>,
-    pub(crate) lifecycle_hooks: Vec<WireProvenancedHook>,
+    pub(crate) lifecycle_hooks: Vec<WirePendingHook>,
 }
 
 /// Convert daemon-collected vars, patches, and lifecycle hooks into
@@ -1830,8 +1890,21 @@ pub(crate) fn contribution_to_pending(
         pending_patches.insert(id, pp);
     }
 
-    let wire_hooks: Vec<WireProvenancedHook> =
-        lifecycle_hooks.into_iter().map(Into::into).collect();
+    // Hooks are stashed by id like vars and patches, rather than
+    // shipped as a pass-through list. The daemon must be able to drop
+    // the ones the client refuses, and it can only do that if each hook
+    // has an id the verdict can name.
+    let mut pending_hooks: BTreeMap<PendingId, ProvenancedHook> = BTreeMap::new();
+    let mut wire_hooks: Vec<WirePendingHook> = Vec::with_capacity(lifecycle_hooks.len());
+    for (i, ph) in lifecycle_hooks.into_iter().enumerate() {
+        let id = PendingId::new(u32::try_from(i).expect("pending hook index fits in u32"));
+        wire_hooks.push(WirePendingHook {
+            id,
+            hook: ph.hook().clone().into(),
+            source: ph.source().clone().into(),
+        });
+        pending_hooks.insert(id, ph);
+    }
 
     PendingTransform {
         wire: WirePending {
@@ -1841,6 +1914,7 @@ pub(crate) fn contribution_to_pending(
         },
         pending_vars,
         pending_patches,
+        pending_hooks,
     }
 }
 
@@ -2025,9 +2099,9 @@ mod tests {
 
         fn on_patch_unapproved(
             &self,
-            _policy: PatchPolicy,
+            _policy: PatchesPolicy,
             _items: &[Unapproved<'_, camino::Utf8Path>],
-        ) -> HookResult<PatchPolicy> {
+        ) -> HookResult<PatchesPolicy> {
             panic!("patch hook not expected in these tests")
         }
     }
@@ -2046,9 +2120,9 @@ mod tests {
         }
         fn on_patch_unapproved(
             &self,
-            _: PatchPolicy,
+            _: PatchesPolicy,
             _: &[Unapproved<'_, camino::Utf8Path>],
-        ) -> HookResult<PatchPolicy> {
+        ) -> HookResult<PatchesPolicy> {
             panic!("patch hook should not have been invoked")
         }
     }
@@ -2066,9 +2140,9 @@ mod tests {
         }
         fn on_patch_unapproved(
             &self,
-            _: PatchPolicy,
+            _: PatchesPolicy,
             items: &[Unapproved<'_, camino::Utf8Path>],
-        ) -> HookResult<PatchPolicy> {
+        ) -> HookResult<PatchesPolicy> {
             HookResult::decided(vec![ItemDecision::AllowOnce; items.len()])
         }
     }
@@ -2266,7 +2340,7 @@ mod tests {
         fn user_origin_single_file_short_circuits() {
             let (_tmp, patch) = single_file_patch("hello.txt", "config/hello.txt");
             let pp = ProvenancedPatch::new(patch, user_source());
-            let policy = PatchPolicy::empty();
+            let policy = PatchesPolicy::empty();
             let (resolved, _) = gate_patches(
                 vec![pp],
                 policy,
@@ -2284,7 +2358,7 @@ mod tests {
         fn project_origin_goes_through_prompt() {
             let (_tmp, patch) = single_file_patch("conf.toml", "etc/conf.toml");
             let pp = ProvenancedPatch::new(patch, project_source());
-            let policy = PatchPolicy::empty();
+            let policy = PatchesPolicy::empty();
             let (resolved, _) = gate_patches(
                 vec![pp],
                 policy,
@@ -2302,7 +2376,7 @@ mod tests {
         fn deny_via_policy_errors() {
             let (_tmp, patch) = single_file_patch("secret.pem", "config/x");
             let pp = ProvenancedPatch::new(patch, project_source());
-            let policy = PatchPolicy::empty().with_deny(["/**/*.pem"]);
+            let policy = PatchesPolicy::empty().with_deny(["/**/*.pem"]);
             let err = gate_patches(
                 vec![pp],
                 policy,
@@ -2321,7 +2395,7 @@ mod tests {
         fn user_loadout_honors_deny() {
             let (_tmp, patch) = single_file_patch("secret.pem", "config/x");
             let pp = ProvenancedPatch::new(patch, user_source());
-            let policy = PatchPolicy::empty().with_deny(["/**/*.pem"]);
+            let policy = PatchesPolicy::empty().with_deny(["/**/*.pem"]);
             let err = gate_patches(
                 vec![pp],
                 policy,
@@ -2338,7 +2412,7 @@ mod tests {
         fn user_loadout_still_honors_ignore() {
             let (_tmp, patch) = single_file_patch("trash.bak", "config/x");
             let pp = ProvenancedPatch::new(patch, user_source());
-            let policy = PatchPolicy::empty().with_ignore(["/**/*.bak"]);
+            let policy = PatchesPolicy::empty().with_ignore(["/**/*.bak"]);
             let (resolved, _) = gate_patches(
                 vec![pp],
                 policy,
@@ -2374,7 +2448,7 @@ mod tests {
             let pattern = format!("{root}/**/*.lua");
             let patch = Patch::new(pattern, PatchDest::try_new("nvim").unwrap());
             let pp = ProvenancedPatch::new(patch, user_source());
-            let policy = PatchPolicy::empty();
+            let policy = PatchesPolicy::empty();
             let (mut resolved, _) = gate_patches(
                 vec![pp],
                 policy,
@@ -2404,7 +2478,7 @@ mod tests {
                 PatchDest::try_new("x").unwrap(),
             );
             let pp = ProvenancedPatch::new(patch, user_source());
-            let policy = PatchPolicy::empty();
+            let policy = PatchesPolicy::empty();
             let (patches, _policy) = gate_patches(
                 vec![pp],
                 policy,
@@ -2441,7 +2515,7 @@ mod tests {
                 ),
                 user_source(),
             );
-            let policy = PatchPolicy::empty();
+            let policy = PatchesPolicy::empty();
             let (patches, _) = gate_patches(
                 vec![present, missing],
                 policy,
@@ -2462,7 +2536,7 @@ mod tests {
         fn tilde_pattern_with_missing_home_var_errors() {
             let patch = Patch::new("~/dotfiles/conf", PatchDest::try_new("conf").unwrap());
             let pp = ProvenancedPatch::new(patch, user_source());
-            let policy = PatchPolicy::empty();
+            let policy = PatchesPolicy::empty();
             let err = gate_patches(
                 vec![pp],
                 policy,
@@ -2491,7 +2565,7 @@ mod tests {
 
             let patch = Patch::new("~/dotfiles/conf", PatchDest::try_new("conf").unwrap());
             let pp = ProvenancedPatch::new(patch, user_source());
-            let policy = PatchPolicy::empty();
+            let policy = PatchesPolicy::empty();
             let vars = [home_var(root.as_str())];
             let (resolved, _) = gate_patches(
                 vec![pp],
@@ -2522,7 +2596,7 @@ mod tests {
             );
             let pp = ProvenancedPatch::new(patch, project_source());
 
-            let policy = PatchPolicy::empty().with_deny(["~/.ssh/**"]);
+            let policy = PatchesPolicy::empty().with_deny(["~/.ssh/**"]);
             let vars = [home_var(root.as_str())];
 
             let err = gate_patches(
@@ -2541,7 +2615,7 @@ mod tests {
         fn policy_tilde_pattern_without_home_var_errors() {
             let (_tmp, patch) = single_file_patch("conf.toml", "conf");
             let pp = ProvenancedPatch::new(patch, user_source());
-            let policy = PatchPolicy::empty().with_deny(["~/.ssh/**"]);
+            let policy = PatchesPolicy::empty().with_deny(["~/.ssh/**"]);
             let err = gate_patches(
                 vec![pp],
                 policy,
@@ -2568,7 +2642,7 @@ mod tests {
         fn user_prefixed_tilde_is_rejected() {
             let (_tmp, patch) = single_file_patch("conf.toml", "conf");
             let pp = ProvenancedPatch::new(patch, user_source());
-            let policy = PatchPolicy::empty().with_deny(["~someuser/.ssh/**"]);
+            let policy = PatchesPolicy::empty().with_deny(["~someuser/.ssh/**"]);
             let err = gate_patches(
                 vec![pp],
                 policy,
@@ -2599,7 +2673,7 @@ mod tests {
             let patch = Patch::new(file.as_str(), PatchDest::try_new("hello.txt").unwrap());
             let pp = ProvenancedPatch::new(patch, user_source());
 
-            let policy = PatchPolicy::empty().with_allow(["~/.config/**"]);
+            let policy = PatchesPolicy::empty().with_allow(["~/.config/**"]);
             let vars = [home_var(root.as_str())];
 
             let (_resolved, policy_out) = gate_patches(
@@ -2628,9 +2702,9 @@ mod tests {
                 }
                 fn on_patch_unapproved(
                     &self,
-                    policy: PatchPolicy,
+                    policy: PatchesPolicy,
                     items: &[Unapproved<'_, camino::Utf8Path>],
-                ) -> HookResult<PatchPolicy> {
+                ) -> HookResult<PatchesPolicy> {
                     let updated = policy.with_deny(["~/*.pem"]);
                     HookResult::decided_with_policy(
                         vec![ItemDecision::UseRule; items.len()],
@@ -2647,7 +2721,7 @@ mod tests {
             let patch = Patch::new(file.as_str(), PatchDest::try_new("secret.pem").unwrap());
             let pp = ProvenancedPatch::new(patch, project_source());
 
-            let policy = PatchPolicy::empty();
+            let policy = PatchesPolicy::empty();
             let vars = [home_var(root.as_str())];
 
             let err = gate_patches(
@@ -2675,9 +2749,9 @@ mod tests {
                 }
                 fn on_patch_unapproved(
                     &self,
-                    policy: PatchPolicy,
+                    policy: PatchesPolicy,
                     items: &[Unapproved<'_, camino::Utf8Path>],
-                ) -> HookResult<PatchPolicy> {
+                ) -> HookResult<PatchesPolicy> {
                     let updated = policy.with_deny(["$NOT_RESOLVED/*"]);
                     HookResult::decided_with_policy(
                         vec![ItemDecision::UseRule; items.len()],
@@ -2687,7 +2761,7 @@ mod tests {
             }
             let (_tmp, patch) = single_file_patch("conf.toml", "conf");
             let pp = ProvenancedPatch::new(patch, project_source());
-            let policy = PatchPolicy::empty();
+            let policy = PatchesPolicy::empty();
             let err = gate_patches(
                 vec![pp],
                 policy,
@@ -2728,7 +2802,7 @@ mod tests {
                 PatchDest::try_new("etc").unwrap(),
             );
             let pp = ProvenancedPatch::new(patch, user_source());
-            let policy = PatchPolicy::empty();
+            let policy = PatchesPolicy::empty();
             let (resolved, _) = gate_patches(
                 vec![pp],
                 policy,
@@ -2763,7 +2837,7 @@ mod tests {
                 PatchDest::try_new("etc").unwrap(),
             );
             let pp = ProvenancedPatch::new(patch, project_source());
-            let policy = PatchPolicy::empty().with_deny([format!("{denied_dir}/**")]);
+            let policy = PatchesPolicy::empty().with_deny([format!("{denied_dir}/**")]);
             let err = gate_patches(
                 vec![pp],
                 policy,
@@ -2790,7 +2864,7 @@ mod tests {
                 PatchDest::try_new("etc").unwrap(),
             );
             let pp = ProvenancedPatch::new(patch, project_source());
-            let policy = PatchPolicy::empty().with_allow([format!("{root}/**")]);
+            let policy = PatchesPolicy::empty().with_allow([format!("{root}/**")]);
             let (resolved, _) = gate_patches(
                 vec![pp],
                 policy,
@@ -2829,7 +2903,7 @@ mod tests {
             );
             let pp = ProvenancedPatch::new(patch, project_source());
 
-            let policy = PatchPolicy::empty().with_allow([format!("{link}/**")]);
+            let policy = PatchesPolicy::empty().with_allow([format!("{link}/**")]);
             let (resolved, _) = gate_patches(
                 vec![pp],
                 policy,
@@ -3269,7 +3343,7 @@ mod tests {
 
         fn hook(body: &str, source: Source) -> ProvenancedHook {
             let lh = LifecycleHook::builder()
-                .with_on_activate(HookScript::Inline(body.into()))
+                .with_on_activate(HookScript::inline(body))
                 .build()
                 .expect("at least one callback set");
             ProvenancedHook::new(lh, source)
@@ -3474,6 +3548,80 @@ mod tests {
             assert_eq!(left.lifecycle_hooks.len(), 2);
         }
 
+        // ---------------- hook ordering contract ----------------
+
+        /// The composed hook list is project-first, loadouts-after, and
+        /// the teardown view is its exact reverse.
+        ///
+        /// This is the property project maintainers depend on — set up
+        /// before any developer's personal hooks, tear down after them —
+        /// and it falls out of *how* a composition is assembled (daemon
+        /// pass-through first, client contribution appended), so nothing
+        /// but a test stops a future refactor of that assembly from
+        /// silently inverting it.
+        #[test]
+        fn hooks_compose_project_first_and_tear_down_in_reverse() {
+            use crate::wire::request::WireContribution;
+
+            // Daemon side: the project's hooks are installed first.
+            let mut composition = Composition::from_daemon_passthrough(
+                Vec::new(),
+                vec![hook("project", project_source())],
+            );
+            // Client side: the loadouts' hooks arrive already gated and
+            // are appended.
+            composition
+                .extend_from_wire(WireContribution {
+                    lifecycle_hooks: vec![hook("loadout", user_source()).into()],
+                    ..Default::default()
+                })
+                .expect("appending a gated contribution");
+
+            let setup: Vec<&Source> = composition
+                .lifecycle_hooks()
+                .iter()
+                .map(Provenanced::source)
+                .collect();
+            assert_eq!(
+                setup,
+                vec![&project_source(), &user_source()],
+                "setup order must be project, then loadouts",
+            );
+
+            let teardown: Vec<&Source> = composition
+                .lifecycle_hooks_teardown()
+                .map(Provenanced::source)
+                .collect();
+            assert_eq!(
+                teardown,
+                vec![&user_source(), &project_source()],
+                "teardown order must be the exact reverse of setup",
+            );
+        }
+
+        /// The teardown view is a pure reordering: same hooks, same
+        /// count, nothing dropped. Guards against a future
+        /// implementation that filters while reversing.
+        #[test]
+        fn teardown_view_is_a_pure_reversal() {
+            let mut composition = Composition::from_daemon_passthrough(
+                Vec::new(),
+                vec![
+                    hook("a", project_source()),
+                    hook("b", user_source()),
+                    hook("c", user_source()),
+                ],
+            );
+            // Touch `composition` mutably so the borrow shape matches
+            // real use, then compare the two views.
+            let forward: Vec<_> = composition.lifecycle_hooks().to_vec();
+            let mut reversed: Vec<_> = composition.lifecycle_hooks_teardown().cloned().collect();
+            assert_eq!(reversed.len(), forward.len());
+            reversed.reverse();
+            assert_eq!(reversed, forward);
+            let _ = &mut composition;
+        }
+
         // ---------------- package-supplied fs / user-data filter ----------------
 
         /// A package may not supply patches, nor vars that carry user
@@ -3594,9 +3742,9 @@ mod tests {
             }
             fn on_patch_unapproved(
                 &self,
-                _: PatchPolicy,
+                _: PatchesPolicy,
                 _: &[crate::core::hooks::Unapproved<'_, camino::Utf8Path>],
-            ) -> crate::core::hooks::HookResult<PatchPolicy> {
+            ) -> crate::core::hooks::HookResult<PatchesPolicy> {
                 panic!("hook should not have been invoked")
             }
         }

--- a/crates/sessions/src/core/expansion.rs
+++ b/crates/sessions/src/core/expansion.rs
@@ -362,6 +362,38 @@ fn validate_strict_var_name(name: &str) -> Result<(), &'static str> {
 /// a `$VAR` is substituted *inside* it, the value's commas would
 /// otherwise split into extra alternatives. Bracket-escaping `,`
 /// preserves the value's intent regardless of context.
+/// Turn a literal path into a policy pattern that matches exactly it.
+///
+/// Policy entries are patterns: they go through variable expansion and
+/// then become globs. Anything storing a path a user *chose* — the
+/// prompt writing an approved project into `[hooks] allow`, say — has
+/// to say so, or the path is reinterpreted. Both directions bite:
+/// `/tmp/build*` stored raw matches every sibling `build…` project, and
+/// `/home/d/proj[1]` stored raw matches nothing at all, including
+/// itself. The first is a consent bypass and the second is a rule that
+/// silently never fires.
+///
+/// Escapes both layers this passes through — `$` for the expander,
+/// glob metacharacters for globset. A leading `~` is *not* escapable
+/// (the expander has no syntax for it), which is harmless for the
+/// callers there are: they store absolute paths, so the character
+/// cannot lead.
+#[must_use]
+pub fn literal_policy_pattern(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    // Split on the expander's one mid-path metacharacter and escape the
+    // runs between: `$` doubles to `$$`, everything else is glob-escaped
+    // wholesale. The remaining thing the expander reads — a leading `~` —
+    // is positional and cannot appear in a run.
+    for (i, run) in path.split('$').enumerate() {
+        if i > 0 {
+            out.push_str("$$");
+        }
+        escape_glob_metas(run, &mut out);
+    }
+    out
+}
+
 fn escape_glob_metas(value: &str, out: &mut String) {
     for c in value.chars() {
         match c {
@@ -802,6 +834,62 @@ mod tests {
         let vars = [sv("HOME", "/home/u")];
         let fs = expand_policy_pattern("~/.ssh/**", vars.as_slice(), None).unwrap();
         assert_eq!(fs.pattern(), "/home/u/.ssh/**");
+    }
+
+    /// A path stored through [`literal_policy_pattern`] matches
+    /// exactly itself — and, critically, nothing else. The unescaped
+    /// forms of these fail in both directions: `/tmp/build*` matches
+    /// every sibling, and `/home/d/proj[1]` matches nothing at all.
+    #[test]
+    fn a_literal_policy_pattern_matches_itself_and_only_itself() {
+        let vars: [ResolvedVar; 0] = [];
+        let cases: [(&str, &str); 5] = [
+            // Wildcards: the over-match direction.
+            ("/tmp/build*", "/tmp/build-someone-elses-project"),
+            ("/tmp/proj?", "/tmp/projX"),
+            // Brackets and braces: the matches-nothing direction.
+            ("/home/d/proj[1]", "/home/d/proj1"),
+            ("/home/d/{a,b}", "/home/d/a"),
+            // The expander's own metacharacter, before globbing runs.
+            ("/home/d/$HOME/proj", "/home/d//home/u/proj"),
+        ];
+        for (literal, sibling) in cases {
+            let fs = expand_policy_pattern(&literal_policy_pattern(literal), vars.as_slice(), None)
+                .unwrap_or_else(|e| panic!("{literal:?} should expand: {e:?}"));
+            assert!(
+                fs.is_match(literal),
+                "{literal:?} should match itself (stored as {:?})",
+                fs.pattern(),
+            );
+            assert!(
+                !fs.is_match(sibling),
+                "{literal:?} should not match {sibling:?} (stored as {:?})",
+                fs.pattern(),
+            );
+        }
+    }
+
+    /// What storing the path raw would do, pinned so the reason for
+    /// [`literal_policy_pattern`] is visible rather than folklore: one
+    /// project's approval reaches another project entirely.
+    #[test]
+    fn an_unescaped_path_is_read_as_a_pattern_and_over_matches() {
+        let vars: [ResolvedVar; 0] = [];
+        let fs = expand_policy_pattern("/tmp/build*", vars.as_slice(), None).unwrap();
+        assert!(
+            fs.is_match("/tmp/build-someone-elses-project"),
+            "this is the behaviour `literal_policy_pattern` exists to prevent",
+        );
+    }
+
+    /// An ordinary path is stored unchanged, so escaping costs nothing
+    /// in readability for the paths people actually have.
+    #[test]
+    fn a_literal_policy_pattern_leaves_an_ordinary_path_alone() {
+        assert_eq!(
+            literal_policy_pattern("/home/dev/my-project"),
+            "/home/dev/my-project",
+        );
     }
 
     /// Substitution and `..` normalization still apply — dropping

--- a/crates/sessions/src/core/hooks.rs
+++ b/crates/sessions/src/core/hooks.rs
@@ -5,7 +5,7 @@
 //! per item (and, optionally, a mutated policy snapshot).
 
 use crate::core::decision::ItemDecision;
-use crate::core::policy::{PatchPolicy, VarsPolicy};
+use crate::core::policy::{HooksPolicy, PatchesPolicy, VarsPolicy};
 use crate::core::source::Source;
 
 /// One item the policy could not decide, borrowed from the gate
@@ -93,7 +93,7 @@ impl<P> HookResult<P> {
 /// decide on its own.
 ///
 /// Hooks receive an owned copy of the *narrow* domain policy
-/// (`VarsPolicy` / `PatchPolicy`); they cannot mutate the gate's
+/// (`VarsPolicy` / `PatchesPolicy`); they cannot mutate the gate's
 /// state directly. To add rules, return a modified policy snapshot in
 /// [`HookResult::Decided::updated_policy`] — wider mutations to the
 /// full [`UserPolicy`](crate::core::policy::UserPolicy) are not
@@ -120,7 +120,37 @@ pub trait PolicyHooks {
 
     fn on_patch_unapproved(
         &self,
-        policy: PatchPolicy,
+        policy: PatchesPolicy,
         items: &[Unapproved<'_, camino::Utf8Path>],
-    ) -> HookResult<PatchPolicy>;
+    ) -> HookResult<PatchesPolicy>;
+
+    /// Decide whether a project's lifecycle hooks may run.
+    ///
+    /// Each item's borrowed value is the **project root path**, not a
+    /// script — one entry per project awaiting a decision, deduplicated
+    /// by the gate, because a project's hooks are allowed or refused as
+    /// a set rather than one script at a time. Approving here grants
+    /// arbitrary code execution inside the session, so an implementation
+    /// that prompts should say so plainly.
+    ///
+    /// The `~`-form guidance for patch policies applies here too:
+    /// return added rules in `~`-form and let the gate expand them.
+    ///
+    /// # Default
+    ///
+    /// Aborts. Approving a hook grants arbitrary code execution, so an
+    /// implementation that hasn't considered this domain must not be
+    /// able to grant it by omission. Aborting fails closed *and*
+    /// loudly: the activation stops with a visible error rather than
+    /// quietly composing a session whose hooks were dropped. Every
+    /// implementation that can actually ask the user should override
+    /// this; the default exists for test doubles and for
+    /// var/patch-only consumers.
+    fn on_hook_unapproved(
+        &self,
+        _policy: HooksPolicy,
+        _items: &[Unapproved<'_, camino::Utf8Path>],
+    ) -> HookResult<HooksPolicy> {
+        HookResult::Abort
+    }
 }

--- a/crates/sessions/src/core/lifecyclehook.rs
+++ b/crates/sessions/src/core/lifecyclehook.rs
@@ -1,88 +1,277 @@
-//! Lifecycle hooks: scripts run on activation, destruction, or failure of a host resource.
+//! Lifecycle hooks: scripts run at a session's state transitions.
 //!
-//! A [`LifecycleHook`] groups up to three scripts (one per transition point) and
-//! guarantees that at least one is present — an empty hook is a no-op and is
-//! rejected at construction time. Build hooks programmatically through
-//! [`LifecycleHook::builder`] or deserialize them from configuration; both paths
-//! enforce the same invariant.
+//! A [`LifecycleHook`] groups up to four scripts (one per transition point)
+//! and guarantees that at least one is present — an empty hook is a no-op and
+//! is rejected at construction time. Build hooks programmatically through
+//! [`LifecycleHook::builder`] or deserialize them from configuration; both
+//! paths enforce the same invariant.
+//!
+//! Each script carries its own [`timeout`](HookScript::timeout), defaulting to
+//! [`DEFAULT_HOOK_TIMEOUT`] and capped at [`MAX_HOOK_TIMEOUT`]. The cap is a
+//! denial-of-service bound: a hook is arbitrary code contributed by a project,
+//! so an unbounded timeout would let one hold a session open (or block its
+//! teardown) indefinitely.
+
+use std::time::Duration;
 
 use camino::Utf8PathBuf;
 use paths::ConfigRelPath;
 
-/// Errors produced when constructing a [`LifecycleHook`].
+/// Timeout applied to a hook script that doesn't declare one.
+pub const DEFAULT_HOOK_TIMEOUT: Duration = Duration::from_mins(1);
+
+/// Hard ceiling on a hook script's declared timeout. Rejected at
+/// deserialization rather than clamped, so a declaration that can't be
+/// honored fails loudly where it is written instead of behaving differently
+/// from what it says.
+pub const MAX_HOOK_TIMEOUT: Duration = Duration::from_mins(5);
+
+/// Errors produced when constructing a [`LifecycleHook`] or a
+/// [`HookScript`].
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// No hook script was provided.
     ///
     /// Returned by [`LifecycleHookBuilder::build`] (and therefore by
-    /// deserialization) when none of `on_activate`, `on_destroy`, or
-    /// `on_failure` is set.
-    #[error("At least one of on_activate, on_destroy, or on_failure must be specified")]
+    /// deserialization) when none of `on_activate`, `on_destroy`,
+    /// `on_attach`, or `on_detach` is set.
+    #[error(
+        "at least one of on_activate, on_destroy, on_attach, or on_detach \
+         must be specified"
+    )]
     EmptyLifecycleHook,
+
+    /// The removed `on_failure` transition was declared.
+    ///
+    /// Named explicitly rather than folded into an unknown-field error: the
+    /// key parsed silently before this variant existed, so a hook file
+    /// carrying it would otherwise lose a script without saying so.
+    #[error("`on_failure` is no longer a lifecycle transition; use `on_destroy` instead")]
+    OnFailureRemoved,
+
+    /// A script declared a timeout above [`MAX_HOOK_TIMEOUT`].
+    #[error(
+        "hook timeout of {got}s exceeds the maximum of {}s",
+        MAX_HOOK_TIMEOUT.as_secs()
+    )]
+    TimeoutTooLarge {
+        /// The declared timeout, in seconds.
+        got: u64,
+    },
+
+    /// A script declared a zero timeout, which would kill it before it
+    /// could run.
+    #[error("hook timeout must be greater than zero")]
+    TimeoutZero,
+
+    /// An external script's path failed [`ConfigRelPath`]'s validation —
+    /// it was absolute, or contained a `..` component.
+    #[error("external hook script path: {0}")]
+    Path(#[from] paths::Error),
 }
 
-/// A script executed by a lifecycle hook.
+/// Which flavor of script a [`HookScript`] carries. The `type` field of
+/// the wire form.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookScriptType {
+    /// Script body stored inline.
+    Inline,
+    /// Path to a script file on disk, relative to the config directory.
+    External,
+}
+
+/// The body of a lifecycle hook script: either the script itself or a
+/// path to it.
 ///
-/// Either the script body provided directly ([`Inline`](Self::Inline)) or a
-/// path to a script file on disk ([`External`](Self::External)).
-///
-/// External scripts are [`ConfigRelPath`]s — anchored to the directory of the
-/// `minimal.toml` they were decoded from. Absolute paths are rejected at
-/// deserialization. To run an arbitrary host path, the executor binds the
-/// `ConfigRelPath` against the known config directory.
-///
-/// Serialized with adjacent tagging — the wire form is a table with `type` and
-/// `value` keys:
-///
-/// ```toml
-/// on_activate = { type = "inline",   value = "echo hi"   }
-/// on_failure  = { type = "external", value = "./run.sh"  }
-/// ```
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type", content = "value", rename_all = "lowercase")]
-pub enum HookScript {
+/// External scripts are [`ConfigRelPath`]s — anchored at stage time to the
+/// directory that owns the file they were decoded from (a loadout's script
+/// directory, or the project root). Absolute paths and `..` components are
+/// rejected at deserialization.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HookScriptBody {
     /// Script body stored inline.
     Inline(String),
-    /// Path to a script file on disk, relative to the config directory.
+    /// Path to a script file on disk, relative to its anchor.
     External(ConfigRelPath),
 }
 
-impl HookScript {
-    /// Construct an [`Inline`](Self::Inline) script.
-    #[must_use]
-    pub fn inline(s: impl Into<String>) -> Self {
-        Self::Inline(s.into())
-    }
-
-    /// Construct an [`External`](Self::External) script.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`paths::Error::IsAbsolute`] if `p` is an absolute path;
-    /// external script paths are anchored to the config directory.
-    pub fn try_external(p: impl Into<Utf8PathBuf>) -> Result<Self, paths::Error> {
-        Ok(Self::External(ConfigRelPath::try_new(p)?))
-    }
-}
-
-/// Scripts run at lifecycle transition points of a host resource.
+/// A script executed at one lifecycle transition, plus the timeout it runs
+/// under.
 ///
-/// At least one of `on_activate`, `on_destroy`, or `on_failure` must
-/// be set; the empty case is rejected by both the builder and
-/// `serde` deserialization.
+/// Serialized as a table with `type`, `value`, and an optional `timeout` in
+/// whole seconds:
+///
+/// ```toml
+/// on_activate = { type = "inline",   value = "echo hi"  }
+/// on_destroy  = { type = "external", value = "./run.sh", timeout = 120 }
+/// ```
+///
+/// The three keys sit at one level, so this is a struct with a `type`
+/// discriminator rather than an adjacently-tagged enum: serde's adjacent
+/// tagging recognizes exactly the tag and content keys and silently skips
+/// anything beside them, which would make `timeout` parse cleanly and do
+/// nothing. [`HookScriptRepr`] therefore validates the whole table and
+/// rejects unknown keys.
 ///
 /// # Example
 ///
 /// ```
-/// use sessions::core::lifecyclehook::{HookScript, LifecycleHook};
+/// use sessions::core::lifecyclehook::{HookScript, HookScriptBody, DEFAULT_HOOK_TIMEOUT};
+///
+/// let s: HookScript = toml::from_str("type = \"inline\"\nvalue = \"echo hi\"\n").unwrap();
+/// assert!(matches!(s.body(), HookScriptBody::Inline(b) if b == "echo hi"));
+/// assert_eq!(s.timeout(), DEFAULT_HOOK_TIMEOUT);
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "HookScriptRepr", into = "HookScriptRepr")]
+pub struct HookScript {
+    body: HookScriptBody,
+    timeout: Duration,
+}
+
+impl HookScript {
+    /// Construct an inline script with the default timeout.
+    #[must_use]
+    pub fn inline(s: impl Into<String>) -> Self {
+        Self {
+            body: HookScriptBody::Inline(s.into()),
+            timeout: DEFAULT_HOOK_TIMEOUT,
+        }
+    }
+
+    /// Construct an external script with the default timeout.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Path`] if `p` is absolute or contains a `..`
+    /// component; external script paths are anchored to a config directory.
+    pub fn try_external(p: impl Into<Utf8PathBuf>) -> Result<Self, Error> {
+        Ok(Self {
+            body: HookScriptBody::External(ConfigRelPath::try_new(p)?),
+            timeout: DEFAULT_HOOK_TIMEOUT,
+        })
+    }
+
+    /// Override the timeout.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TimeoutZero`] for a zero timeout, or
+    /// [`Error::TimeoutTooLarge`] above [`MAX_HOOK_TIMEOUT`].
+    pub fn with_timeout(self, timeout: Duration) -> Result<Self, Error> {
+        validate_timeout(timeout)?;
+        Ok(Self { timeout, ..self })
+    }
+
+    /// The script body.
+    #[must_use]
+    pub fn body(&self) -> &HookScriptBody {
+        &self.body
+    }
+
+    /// How long the script may run before it is killed.
+    #[must_use]
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    /// Consume the script and return `(body, timeout)`.
+    #[must_use]
+    pub fn into_parts(self) -> (HookScriptBody, Duration) {
+        (self.body, self.timeout)
+    }
+}
+
+/// Reject a timeout outside `(0, MAX_HOOK_TIMEOUT]`.
+fn validate_timeout(timeout: Duration) -> Result<(), Error> {
+    if timeout.is_zero() {
+        return Err(Error::TimeoutZero);
+    }
+    if timeout > MAX_HOOK_TIMEOUT {
+        return Err(Error::TimeoutTooLarge {
+            got: timeout.as_secs(),
+        });
+    }
+    Ok(())
+}
+
+/// The on-the-wire (and on-disk) shape of a [`HookScript`].
+///
+/// `deny_unknown_fields` is deliberate: the whole reason this type exists
+/// rather than an adjacently-tagged enum is that a misplaced key used to be
+/// skipped in silence. A typo like `timout = 120` must be an error, not a
+/// script that quietly runs with the default.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HookScriptRepr {
+    /// Which flavor of script `value` holds.
+    #[serde(rename = "type")]
+    pub script_type: HookScriptType,
+    /// The inline body, or the relative path to the script file.
+    pub value: String,
+    /// Timeout in whole seconds. Absent means [`DEFAULT_HOOK_TIMEOUT`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<u64>,
+}
+
+impl TryFrom<HookScriptRepr> for HookScript {
+    type Error = Error;
+
+    fn try_from(repr: HookScriptRepr) -> Result<Self, Self::Error> {
+        let timeout = repr
+            .timeout
+            .map_or(DEFAULT_HOOK_TIMEOUT, Duration::from_secs);
+        validate_timeout(timeout)?;
+        let body = match repr.script_type {
+            HookScriptType::Inline => HookScriptBody::Inline(repr.value),
+            HookScriptType::External => {
+                HookScriptBody::External(ConfigRelPath::try_new(repr.value)?)
+            }
+        };
+        Ok(Self { body, timeout })
+    }
+}
+
+impl From<HookScript> for HookScriptRepr {
+    fn from(s: HookScript) -> Self {
+        let (script_type, value) = match s.body {
+            HookScriptBody::Inline(body) => (HookScriptType::Inline, body),
+            HookScriptBody::External(path) => (HookScriptType::External, path.as_str().to_owned()),
+        };
+        // Only emit `timeout` when it differs from the default, so a
+        // round-trip of an undeclared timeout stays undeclared.
+        let timeout = (s.timeout != DEFAULT_HOOK_TIMEOUT).then_some(s.timeout.as_secs());
+        Self {
+            script_type,
+            value,
+            timeout,
+        }
+    }
+}
+
+/// Scripts run at a session's lifecycle transition points.
+///
+/// At least one of `on_activate`, `on_destroy`, `on_attach`, or
+/// `on_detach` must be set; the empty case is rejected by both the builder
+/// and `serde` deserialization.
+///
+/// # Example
+///
+/// ```
+/// use sessions::core::lifecyclehook::{HookScriptBody, LifecycleHook};
 ///
 /// let src = r#"
 /// on_activate = { type = "inline", value = "echo hello" }
-/// on_failure  = { type = "external", value = "./cleanup.sh" }
+/// on_detach   = { type = "external", value = "./cleanup.sh", timeout = 120 }
 /// "#;
 /// let hook: LifecycleHook = toml::from_str(src).unwrap();
-/// assert!(matches!(hook.on_activate(), Some(HookScript::Inline(_))));
+/// assert!(matches!(
+///     hook.on_activate().map(|s| s.body()),
+///     Some(HookScriptBody::Inline(_)),
+/// ));
+/// assert_eq!(hook.on_detach().unwrap().timeout().as_secs(), 120);
 /// assert!(toml::from_str::<LifecycleHook>("").is_err());
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -91,7 +280,8 @@ pub struct LifecycleHook {
     description: Option<String>,
     on_activate: Option<HookScript>,
     on_destroy: Option<HookScript>,
-    on_failure: Option<HookScript>,
+    on_attach: Option<HookScript>,
+    on_detach: Option<HookScript>,
 }
 
 impl LifecycleHook {
@@ -101,31 +291,45 @@ impl LifecycleHook {
         LifecycleHookBuilder::default()
     }
 
-    /// The script to run on activation, if any.
+    /// The hook's free-form description, if any.
+    #[must_use]
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    /// The script to run on session activation, if any.
     #[must_use]
     pub fn on_activate(&self) -> Option<&HookScript> {
         self.on_activate.as_ref()
     }
 
-    /// The script to run on destruction, if any.
+    /// The script to run on session destruction, if any.
     #[must_use]
     pub fn on_destroy(&self) -> Option<&HookScript> {
         self.on_destroy.as_ref()
     }
 
-    /// The script to run when activation fails, if any.
+    /// The script to run when a client attaches, if any.
     #[must_use]
-    pub fn on_failure(&self) -> Option<&HookScript> {
-        self.on_failure.as_ref()
+    pub fn on_attach(&self) -> Option<&HookScript> {
+        self.on_attach.as_ref()
+    }
+
+    /// The script to run when a client detaches, if any.
+    #[must_use]
+    pub fn on_detach(&self) -> Option<&HookScript> {
+        self.on_detach.as_ref()
     }
 
     /// Consume the [`LifecycleHook`] and return
-    /// `(description, on_activate, on_destroy, on_failure)`.
+    /// `(description, on_activate, on_destroy, on_attach, on_detach)`.
     #[must_use]
+    #[allow(clippy::type_complexity)]
     pub fn into_parts(
         self,
     ) -> (
         Option<String>,
+        Option<HookScript>,
         Option<HookScript>,
         Option<HookScript>,
         Option<HookScript>,
@@ -134,7 +338,8 @@ impl LifecycleHook {
             self.description,
             self.on_activate,
             self.on_destroy,
-            self.on_failure,
+            self.on_attach,
+            self.on_detach,
         )
     }
 }
@@ -148,9 +353,11 @@ impl TryFrom<LifecycleHookBuilder> for LifecycleHook {
 
 /// Builder for [`LifecycleHook`].
 ///
-/// Doubles as the on-the-wire deserialization shape for `LifecycleHook` — every
-/// field is optional, and validation runs at [`build`](Self::build) time.
+/// Doubles as the on-the-wire deserialization shape for `LifecycleHook` —
+/// every field is optional, and validation runs at [`build`](Self::build)
+/// time.
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LifecycleHookBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
@@ -159,24 +366,32 @@ pub struct LifecycleHookBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     on_destroy: Option<HookScript>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    on_attach: Option<HookScript>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    on_detach: Option<HookScript>,
+    /// Accepts the removed `on_failure` key purely so [`build`](Self::build)
+    /// can reject it by name. Never serialized; `deny_unknown_fields` would
+    /// otherwise produce a generic unknown-field error that doesn't say what
+    /// to migrate to.
+    #[serde(default, skip_serializing)]
     on_failure: Option<HookScript>,
 }
 
 impl LifecycleHookBuilder {
+    /// Sets the free-form description.
+    #[must_use]
+    pub fn with_description(self, description: impl Into<String>) -> Self {
+        Self {
+            description: Some(description.into()),
+            ..self
+        }
+    }
+
     /// Sets the script to run on activation.
     #[must_use]
     pub fn with_on_activate(self, on_activate: HookScript) -> Self {
         Self {
             on_activate: Some(on_activate),
-            ..self
-        }
-    }
-
-    /// Sets the script to run when activation fails.
-    #[must_use]
-    pub fn with_on_failure(self, on_failure: HookScript) -> Self {
-        Self {
-            on_failure: Some(on_failure),
             ..self
         }
     }
@@ -190,21 +405,51 @@ impl LifecycleHookBuilder {
         }
     }
 
+    /// Sets the script to run on attach.
+    #[must_use]
+    pub fn with_on_attach(self, on_attach: HookScript) -> Self {
+        Self {
+            on_attach: Some(on_attach),
+            ..self
+        }
+    }
+
+    /// Sets the script to run on detach.
+    #[must_use]
+    pub fn with_on_detach(self, on_detach: HookScript) -> Self {
+        Self {
+            on_detach: Some(on_detach),
+            ..self
+        }
+    }
+
     /// Consumes the builder and produces a [`LifecycleHook`].
     ///
     /// # Errors
     ///
-    /// Returns [`Error::EmptyLifecycleHook`] if none of `on_activate`,
-    /// `on_destroy`, or `on_failure` has been set.
+    /// - [`Error::OnFailureRemoved`] if the removed `on_failure` key was set.
+    /// - [`Error::EmptyLifecycleHook`] if none of the four transitions has
+    ///   been set.
     pub fn build(self) -> Result<LifecycleHook, Error> {
-        if self.on_activate.is_none() && self.on_destroy.is_none() && self.on_failure.is_none() {
+        // Checked before the emptiness test: a hook whose only script is an
+        // `on_failure` should say that `on_failure` is gone, not that it is
+        // empty.
+        if self.on_failure.is_some() {
+            return Err(Error::OnFailureRemoved);
+        }
+        if self.on_activate.is_none()
+            && self.on_destroy.is_none()
+            && self.on_attach.is_none()
+            && self.on_detach.is_none()
+        {
             return Err(Error::EmptyLifecycleHook);
         }
         Ok(LifecycleHook {
             description: self.description,
             on_activate: self.on_activate,
             on_destroy: self.on_destroy,
-            on_failure: self.on_failure,
+            on_attach: self.on_attach,
+            on_detach: self.on_detach,
         })
     }
 }
@@ -215,9 +460,82 @@ impl From<LifecycleHook> for LifecycleHookBuilder {
             description: value.description,
             on_activate: value.on_activate,
             on_destroy: value.on_destroy,
-            on_failure: value.on_failure,
+            on_attach: value.on_attach,
+            on_detach: value.on_detach,
+            on_failure: None,
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// External script staging
+// ---------------------------------------------------------------------------
+
+/// Where an external hook script lands in the session's staged-hooks
+/// directory, relative to that directory's root.
+///
+/// The client uploads scripts under these paths and the daemon resolves
+/// them back from the same inputs, so the scheme is the contract
+/// between the two and lives here rather than on either side. It is
+/// derived purely from `(source, script path)` — there is no manifest
+/// to keep in sync, and no id to allocate.
+///
+/// The layout mirrors where the script was declared, which keeps a
+/// staged tree readable when someone goes looking:
+///
+/// ```text
+/// hooks/loadout/dev/activate.sh     ← loadout `dev`, "activate.sh"
+/// hooks/project/scripts/setup.sh    ← the project, "scripts/setup.sh"
+/// ```
+///
+/// The script path is a [`ConfigRelPath`], which rejects absolute paths
+/// and `..`. There is one project per session, so `project` needs no
+/// discriminator.
+///
+/// The loadout name is validated **here** rather than trusted from the
+/// [`Source`](crate::core::source::Source). A `Source` built on this
+/// machine carries a name that came from a
+/// [`LoadoutName`](crate::core::loadout::LoadoutName), but a `Source`
+/// decoded from the wire carries whatever the peer sent — and the
+/// daemon derives a path to *read* from exactly this function. A name
+/// that is not a single ordinary path component would let that read
+/// climb out of the staged-hooks directory, so it is refused rather
+/// than interpolated. See [`safe_path_component`].
+///
+/// Returns `None` for [`Source::Package`](crate::core::source::Source::Package)
+/// (packages cannot declare hooks, and the policy gate denies any that
+/// appear, so there is nothing to stage) and for a loadout whose name is
+/// unusable as a path component.
+#[must_use]
+pub fn staged_script_path(
+    source: &crate::core::source::Source,
+    script: &ConfigRelPath,
+) -> Option<Utf8PathBuf> {
+    use crate::core::source::Source;
+    let prefix = match source {
+        Source::UserLoadout { name } => {
+            if !safe_path_component(name) {
+                return None;
+            }
+            Utf8PathBuf::from("loadout").join(name)
+        }
+        Source::Project { .. } => Utf8PathBuf::from("project"),
+        Source::Package { .. } => return None,
+    };
+    Some(prefix.join(script.as_utf8_path()))
+}
+
+/// Whether `s` is usable as a single path component that stays put:
+/// non-empty, no separators or NUL, and not a relative-directory name.
+///
+/// [`LoadoutName`](crate::core::loadout::LoadoutName) enforces all of
+/// this except the `.`/`..` cases — a name is a display string first and
+/// a path fragment second, and neither dot form contains a separator.
+/// Both are excluded here because this fragment is joined into a path
+/// the daemon then reads from.
+#[must_use]
+pub fn safe_path_component(s: &str) -> bool {
+    !s.is_empty() && s != "." && s != ".." && !s.contains(['/', '\\', '\0'])
 }
 
 // ---------------------------------------------------------------------------
@@ -226,27 +544,66 @@ impl From<LifecycleHook> for LifecycleHookBuilder {
 
 impl From<crate::wire::primitives::WireHookScript> for HookScript {
     fn from(s: crate::wire::primitives::WireHookScript) -> Self {
-        match s {
-            crate::wire::primitives::WireHookScript::Inline { body } => Self::Inline(body),
-            crate::wire::primitives::WireHookScript::External { path } => Self::External(path),
-        }
+        use crate::wire::primitives::WireHookScript as W;
+        // The wire form is produced by a peer, so its timeout is clamped
+        // rather than rejected: a skewed or hostile peer must not be able to
+        // fault a composition load, but it must not be able to exceed the cap
+        // either.
+        let (body, timeout_secs) = match s {
+            W::Inline {
+                body,
+                timeout_secs: t,
+            } => (HookScriptBody::Inline(body), t),
+            W::External {
+                path,
+                timeout_secs: t,
+            } => (HookScriptBody::External(path), t),
+        };
+        let timeout = Duration::from_secs(t_clamped(timeout_secs));
+        Self { body, timeout }
     }
 }
 
-/// Fallible because the wire form may have all three callbacks
-/// absent, which the builder rejects.
+/// Clamp a peer-supplied timeout into `[1, MAX_HOOK_TIMEOUT]` seconds.
+fn t_clamped(secs: u64) -> u64 {
+    secs.clamp(1, MAX_HOOK_TIMEOUT.as_secs())
+}
+
+/// Fallible because the wire form may have all four callbacks absent, which
+/// the builder rejects.
 impl TryFrom<crate::wire::primitives::WireLifecycleHook> for LifecycleHook {
     type Error = Error;
     fn try_from(h: crate::wire::primitives::WireLifecycleHook) -> Result<Self, Self::Error> {
         let mut builder = Self::builder();
+        // Read before `description` moves out of `h`.
+        let discarded_on_failure = h.on_failure.is_some();
+        if let Some(d) = h.description.clone() {
+            builder = builder.with_description(d);
+        }
         if let Some(s) = h.on_activate {
             builder = builder.with_on_activate(s.into());
         }
         if let Some(s) = h.on_destroy {
             builder = builder.with_on_destroy(s.into());
         }
-        if let Some(s) = h.on_failure {
-            builder = builder.with_on_failure(s.into());
+        if let Some(s) = h.on_attach {
+            builder = builder.with_on_attach(s.into());
+        }
+        if let Some(s) = h.on_detach {
+            builder = builder.with_on_detach(s.into());
+        }
+        // `on_failure` was removed before hooks ever executed, so nothing
+        // is losing behaviour here — but a v1 snapshot can still carry
+        // one, and dropping a script the author wrote without saying so
+        // is the failure mode the config-side `OnFailureRemoved` error
+        // exists to prevent. Warn rather than reject: this is a load
+        // path, and a session must still come up.
+        if discarded_on_failure {
+            tracing::warn!(
+                description = h.description.as_deref().unwrap_or("<none>"),
+                "discarding an `on_failure` script from an older composition \
+                 snapshot; it has never executed — use `on_destroy`",
+            );
         }
         builder.build()
     }
@@ -255,6 +612,50 @@ impl TryFrom<crate::wire::primitives::WireLifecycleHook> for LifecycleHook {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A `Source` decoded from the wire carries whatever the peer sent,
+    /// so a loadout name that is not a plain path component must not
+    /// reach the staged path — the daemon joins that path onto the
+    /// session's hooks directory and reads it, so a `..` there reads a
+    /// file outside the session.
+    #[test]
+    fn a_loadout_name_that_is_not_a_path_component_stages_nothing() {
+        use crate::core::source::Source;
+        let script = ConfigRelPath::try_new("x.sh").unwrap();
+        for hostile in [
+            "../../../../etc",
+            "..",
+            ".",
+            "",
+            "a/b",
+            r"a\b",
+            "a\0b",
+            "loadout/../..",
+        ] {
+            let source = Source::UserLoadout {
+                name: hostile.to_string(),
+            };
+            assert_eq!(
+                staged_script_path(&source, &script),
+                None,
+                "loadout name {hostile:?} produced a staged path",
+            );
+        }
+    }
+
+    /// The ordinary case still stages where the layout says it does.
+    #[test]
+    fn a_well_formed_loadout_stages_under_its_own_name() {
+        use crate::core::source::Source;
+        let script = ConfigRelPath::try_new("scripts/activate.sh").unwrap();
+        let source = Source::UserLoadout {
+            name: "dev".to_string(),
+        };
+        assert_eq!(
+            staged_script_path(&source, &script),
+            Some(Utf8PathBuf::from("loadout/dev/scripts/activate.sh")),
+        );
+    }
 
     #[test]
     fn builder_rejects_all_none() {
@@ -267,28 +668,61 @@ mod tests {
     #[test]
     fn builder_accepts_only_on_activate() {
         let hook = LifecycleHook::builder()
-            .with_on_activate(HookScript::Inline("a".into()))
+            .with_on_activate(HookScript::inline("a"))
             .build()
             .unwrap();
         assert!(hook.on_activate().is_some());
         assert!(hook.on_destroy().is_none());
-        assert!(hook.on_failure().is_none());
+        assert!(hook.on_attach().is_none());
+        assert!(hook.on_detach().is_none());
+    }
+
+    /// Each of the four transitions on its own satisfies the
+    /// at-least-one invariant.
+    #[test]
+    fn builder_accepts_any_single_transition() {
+        let cases: [fn(LifecycleHookBuilder, HookScript) -> LifecycleHookBuilder; 4] = [
+            LifecycleHookBuilder::with_on_activate,
+            LifecycleHookBuilder::with_on_destroy,
+            LifecycleHookBuilder::with_on_attach,
+            LifecycleHookBuilder::with_on_detach,
+        ];
+        for set in cases {
+            assert!(
+                set(LifecycleHook::builder(), HookScript::inline("x"))
+                    .build()
+                    .is_ok()
+            );
+        }
     }
 
     #[test]
-    fn toml_deserializes_full_hook() {
+    fn toml_deserializes_all_four_transitions() {
         let src = r#"
+            description = "everything"
             on_activate = { type = "inline",   value = "echo activated" }
             on_destroy  = { type = "external", value = "./teardown.sh" }
-            on_failure  = { type = "inline",   value = "echo failed" }
+            on_attach   = { type = "inline",   value = "echo attached" }
+            on_detach   = { type = "external", value = "./detach.sh" }
         "#;
         let hook: LifecycleHook = toml::from_str(src).unwrap();
-        assert!(matches!(hook.on_activate(), Some(HookScript::Inline(s)) if s == "echo activated"));
+        assert_eq!(hook.description(), Some("everything"));
         assert!(matches!(
-            hook.on_destroy(),
-            Some(HookScript::External(p)) if p.as_str() == "./teardown.sh"
+            hook.on_activate().map(HookScript::body),
+            Some(HookScriptBody::Inline(s)) if s == "echo activated",
         ));
-        assert!(matches!(hook.on_failure(), Some(HookScript::Inline(s)) if s == "echo failed"));
+        assert!(matches!(
+            hook.on_destroy().map(HookScript::body),
+            Some(HookScriptBody::External(p)) if p.as_str() == "./teardown.sh",
+        ));
+        assert!(matches!(
+            hook.on_attach().map(HookScript::body),
+            Some(HookScriptBody::Inline(s)) if s == "echo attached",
+        ));
+        assert!(matches!(
+            hook.on_detach().map(HookScript::body),
+            Some(HookScriptBody::External(p)) if p.as_str() == "./detach.sh",
+        ));
     }
 
     #[test]
@@ -299,7 +733,6 @@ mod tests {
         let hook: LifecycleHook = toml::from_str(src).unwrap();
         assert!(hook.on_activate().is_some());
         assert!(hook.on_destroy().is_none());
-        assert!(hook.on_failure().is_none());
     }
 
     #[test]
@@ -311,37 +744,157 @@ mod tests {
         );
     }
 
+    // -- timeouts ------------------------------------------------------
+
+    /// The regression test for the reason [`HookScript`] is a struct
+    /// rather than an adjacently-tagged enum: under adjacent tagging
+    /// `timeout` is classified as an unrecognized field and silently
+    /// skipped, so this hook would have run with the 60s default while
+    /// claiming 120.
+    #[test]
+    fn timeout_is_not_silently_dropped() {
+        let src = r#"on_activate = { type = "inline", value = "x", timeout = 120 }"#;
+        let hook: LifecycleHook = toml::from_str(src).unwrap();
+        assert_eq!(
+            hook.on_activate().unwrap().timeout(),
+            Duration::from_mins(2),
+        );
+    }
+
+    #[test]
+    fn timeout_defaults_when_absent() {
+        let src = r#"on_activate = { type = "inline", value = "x" }"#;
+        let hook: LifecycleHook = toml::from_str(src).unwrap();
+        assert_eq!(hook.on_activate().unwrap().timeout(), DEFAULT_HOOK_TIMEOUT);
+    }
+
+    #[test]
+    fn timeout_above_cap_is_rejected() {
+        let over = MAX_HOOK_TIMEOUT.as_secs() + 1;
+        let src = format!(r#"on_activate = {{ type = "inline", value = "x", timeout = {over} }}"#);
+        let err = toml::from_str::<LifecycleHook>(&src).unwrap_err();
+        assert!(
+            err.to_string().contains("maximum"),
+            "expected cap error, got: {err}",
+        );
+    }
+
+    #[test]
+    fn timeout_at_cap_is_accepted() {
+        let at = MAX_HOOK_TIMEOUT.as_secs();
+        let src = format!(r#"on_activate = {{ type = "inline", value = "x", timeout = {at} }}"#);
+        let hook: LifecycleHook = toml::from_str(&src).unwrap();
+        assert_eq!(hook.on_activate().unwrap().timeout(), MAX_HOOK_TIMEOUT);
+    }
+
+    #[test]
+    fn zero_timeout_is_rejected() {
+        let src = r#"on_activate = { type = "inline", value = "x", timeout = 0 }"#;
+        let err = toml::from_str::<LifecycleHook>(src).unwrap_err();
+        assert!(
+            err.to_string().contains("greater than zero"),
+            "expected zero-timeout error, got: {err}",
+        );
+    }
+
+    /// A misspelled key inside a script table is an error rather than a
+    /// silently-ignored no-op — the same failure mode that made `timeout`
+    /// unusable under adjacent tagging.
+    #[test]
+    fn unknown_key_in_script_table_is_rejected() {
+        let src = r#"on_activate = { type = "inline", value = "x", timout = 120 }"#;
+        let err = toml::from_str::<LifecycleHook>(src).unwrap_err();
+        assert!(
+            err.to_string().contains("timout") || err.to_string().contains("unknown field"),
+            "expected unknown-field error, got: {err}",
+        );
+    }
+
+    #[test]
+    fn unknown_key_in_hook_table_is_rejected() {
+        let src = r#"
+            on_activate = { type = "inline", value = "x" }
+            on_activte  = { type = "inline", value = "typo" }
+        "#;
+        assert!(toml::from_str::<LifecycleHook>(src).is_err());
+    }
+
+    // -- on_failure migration ------------------------------------------
+
+    #[test]
+    fn on_failure_is_rejected_by_name() {
+        let src = r#"
+            on_activate = { type = "inline", value = "x" }
+            on_failure  = { type = "inline", value = "old" }
+        "#;
+        let err = toml::from_str::<LifecycleHook>(src).unwrap_err();
+        assert!(
+            err.to_string().contains("on_destroy"),
+            "error should name the replacement, got: {err}",
+        );
+    }
+
+    /// A hook whose *only* script is the removed `on_failure` reports the
+    /// removal, not emptiness — the emptiness error would send the author
+    /// looking for a missing script rather than a renamed one.
+    #[test]
+    fn lone_on_failure_reports_removal_not_emptiness() {
+        let src = r#"on_failure = { type = "inline", value = "old" }"#;
+        let err = toml::from_str::<LifecycleHook>(src).unwrap_err();
+        assert!(
+            err.to_string().contains("on_destroy"),
+            "expected removal error, got: {err}",
+        );
+    }
+
+    // -- round trips ---------------------------------------------------
+
     #[test]
     fn serde_round_trip_through_toml() {
         let original = LifecycleHook::builder()
-            .with_on_activate(HookScript::Inline("echo hi".into()))
-            .with_on_failure(HookScript::External(
-                ConfigRelPath::try_new("./fail.sh").unwrap(),
-            ))
+            .with_description("d")
+            .with_on_activate(HookScript::inline("echo hi"))
+            .with_on_detach(
+                HookScript::try_external("./fail.sh")
+                    .unwrap()
+                    .with_timeout(Duration::from_mins(2))
+                    .unwrap(),
+            )
             .build()
             .unwrap();
 
         let serialized = toml::to_string(&original).unwrap();
         let parsed: LifecycleHook = toml::from_str(&serialized).unwrap();
-
-        assert!(matches!(parsed.on_activate(), Some(HookScript::Inline(s)) if s == "echo hi"));
-        assert!(matches!(
-            parsed.on_failure(),
-            Some(HookScript::External(p)) if p.as_str() == "./fail.sh"
-        ));
-        assert!(parsed.on_destroy().is_none());
+        assert_eq!(parsed, original);
+        assert_eq!(
+            parsed.on_detach().unwrap().timeout(),
+            Duration::from_mins(2),
+        );
     }
 
     #[test]
     fn hook_script_try_external_helper() {
         let s = HookScript::try_external("./run.sh").unwrap();
-        assert!(matches!(s, HookScript::External(ref p) if p.as_str() == "./run.sh"));
+        assert!(matches!(s.body(), HookScriptBody::External(p) if p.as_str() == "./run.sh"));
+        assert_eq!(s.timeout(), DEFAULT_HOOK_TIMEOUT);
     }
 
     #[test]
     fn hook_script_try_external_rejects_absolute() {
         let err = HookScript::try_external("/abs").unwrap_err();
-        assert!(matches!(err, paths::Error::IsAbsolute(_)), "got: {err:?}");
+        assert!(
+            matches!(err, Error::Path(paths::Error::IsAbsolute(_))),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn hook_script_try_external_rejects_parent_dir() {
+        let err = HookScript::try_external("../escape.sh").unwrap_err();
+        assert!(
+            matches!(err, Error::Path(paths::Error::ContainsParentDir(_))),
+            "got: {err:?}",
+        );
     }
 
     #[test]
@@ -358,7 +911,9 @@ mod tests {
         };
         let s = toml::to_string(&original).unwrap();
         let parsed: Wrap = toml::from_str(&s).unwrap();
-        assert!(matches!(parsed.hook, HookScript::External(ref p) if p.as_str() == "./run.sh"),);
+        assert!(
+            matches!(parsed.hook.body(), HookScriptBody::External(p) if p.as_str() == "./run.sh"),
+        );
     }
 
     #[test]
@@ -374,14 +929,48 @@ mod tests {
     }
 
     #[test]
+    fn external_rejects_parent_dir_at_deserialize() {
+        let src = r#"
+            on_activate = { type = "external", value = "../etc/hook.sh" }
+        "#;
+        assert!(toml::from_str::<LifecycleHook>(src).is_err());
+    }
+
+    #[test]
     fn serde_omits_unset_fields() {
         let hook = LifecycleHook::builder()
-            .with_on_activate(HookScript::Inline("x".into()))
+            .with_on_activate(HookScript::inline("x"))
             .build()
             .unwrap();
         let serialized = toml::to_string(&hook).unwrap();
         assert!(serialized.contains("on_activate"));
         assert!(!serialized.contains("on_destroy"));
+        assert!(!serialized.contains("on_attach"));
+        assert!(!serialized.contains("on_detach"));
         assert!(!serialized.contains("on_failure"));
+        // A default timeout stays undeclared rather than materializing on
+        // round-trip.
+        assert!(!serialized.contains("timeout"));
+    }
+
+    /// A peer-supplied timeout above the cap is clamped rather than
+    /// faulting the conversion: the wire path must not let a skewed or
+    /// hostile peer fail a composition load, nor exceed the bound.
+    #[test]
+    fn wire_timeout_is_clamped_not_rejected() {
+        use crate::wire::primitives::WireHookScript;
+        let s: HookScript = WireHookScript::Inline {
+            body: "x".into(),
+            timeout_secs: u64::MAX,
+        }
+        .into();
+        assert_eq!(s.timeout(), MAX_HOOK_TIMEOUT);
+
+        let s: HookScript = WireHookScript::Inline {
+            body: "x".into(),
+            timeout_secs: 0,
+        }
+        .into();
+        assert_eq!(s.timeout(), Duration::from_secs(1));
     }
 }

--- a/crates/sessions/src/core/loadout.rs
+++ b/crates/sessions/src/core/loadout.rs
@@ -186,9 +186,14 @@ impl Loadout {
     }
 
     /// Drop every lifecycle hook from this loadout, returning the
-    /// hookless loadout. Used to exclude session transition scripts
-    /// before composition while the feature is gated off for a release,
-    /// so a declared hook cannot participate in composition at all.
+    /// hookless loadout.
+    ///
+    /// Backs `min session activate --no-hooks`: the client applies this
+    /// before composing, so a hook the user opted out of never reaches
+    /// the composer, never rides the wire, and has no script staged for
+    /// it. The session record carries the same flag, because the
+    /// attach, detach, and destroy transitions fire from processes that
+    /// never saw the original command line.
     #[must_use]
     pub fn without_lifecycle_hooks(mut self) -> Self {
         self.lifecycle_hooks.clear();

--- a/crates/sessions/src/core/policy.rs
+++ b/crates/sessions/src/core/policy.rs
@@ -1,8 +1,8 @@
-//! Policy types: per-domain `VarsPolicy` and `PatchPolicy`, plus the
+//! Policy types: per-domain `VarsPolicy` and `PatchesPolicy`, plus the
 //! top-level `UserPolicy` that bundles them.
 //!
 //! [`UserPolicy`] bundles the per-domain policies — [`VarsPolicy`] for
-//! environment variables and [`PatchPolicy`] for file patches. Both
+//! environment variables and [`PatchesPolicy`] for file patches. Both
 //! gate every declaration regardless of origin; user-origin
 //! declarations from a [`Loadout`] don't need to be explicitly
 //! `allow`-listed (they auto-pass that check), but `ignore` and
@@ -354,7 +354,7 @@ impl VarsPolicy {
 }
 
 // =====================================================================
-// PatchPolicy
+// PatchesPolicy
 // =====================================================================
 
 /// Policy gating which patches are honored, checked per source file
@@ -377,7 +377,7 @@ impl VarsPolicy {
 ///
 /// [`Loadout`]: crate::core::loadout::Loadout
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct PatchPolicy {
+pub struct PatchesPolicy {
     #[serde(
         default,
         skip_serializing_if = "Vec::is_empty",
@@ -416,7 +416,7 @@ where
     })
 }
 
-impl PatchPolicy {
+impl PatchesPolicy {
     /// Construct an empty policy. Build it up with [`Self::with_allow`],
     /// [`Self::with_deny`], and [`Self::with_ignore`].
     #[must_use]
@@ -486,7 +486,7 @@ impl PatchPolicy {
     }
 
     /// Expand the raw patterns against `resolved_vars` and produce an
-    /// [`ExpandedPatchPolicy`] suitable for matching.
+    /// [`ExpandedPatchesPolicy`] suitable for matching.
     ///
     /// Every pattern is run through
     /// [`crate::core::expansion::expand_source`]; the first failure stops
@@ -500,7 +500,7 @@ impl PatchPolicy {
         &self,
         resolved_vars: &(impl crate::core::expansion::VarLookup + ?Sized),
         home_fallback: Option<&str>,
-    ) -> Result<ExpandedPatchPolicy, crate::core::expansion::ExpandError> {
+    ) -> Result<ExpandedPatchesPolicy, crate::core::expansion::ExpandError> {
         let expand_one =
             |raws: &[String]| -> Result<Vec<FileSet>, crate::core::expansion::ExpandError> {
                 // Policy patterns are matchers, not walk seeds — they
@@ -521,7 +521,206 @@ impl PatchPolicy {
         let allow = expand_one(&self.allow)?;
         let deny = expand_one(&self.deny)?;
         let ignore = expand_one(&self.ignore)?;
-        Ok(ExpandedPatchPolicy::from_expanded(allow, deny, ignore))
+        Ok(ExpandedPatchesPolicy::from_expanded(allow, deny, ignore))
+    }
+}
+
+// =====================================================================
+// HooksPolicy
+// =====================================================================
+
+/// The user's policy for which **projects** may run lifecycle hooks in
+/// their sessions, matched by project root path.
+///
+/// A lifecycle hook is arbitrary code a project asks to execute inside
+/// the session, so unlike vars and patches — where the risk is a
+/// project pulling the user's data *in* — the risk here is execution
+/// itself. A project must therefore be allow-listed by path before any
+/// hook it declares will run.
+///
+/// Only project-declared hooks are gated. A hook from a
+/// [`Loadout`](crate::core::loadout::Loadout) is the user's own file,
+/// already under their control, and passes without a rule. A hook
+/// tagged [`Source::Package`] is refused outright: packages have no
+/// legitimate way to contribute one, so its presence means either a bug
+/// or an attempt to smuggle execution past this gate.
+///
+/// Precedence mirrors the other domains: `deny` first (the emergency
+/// stop, so an overlapping deny+ignore resolves as denied), then
+/// `ignore` (silent skip, no prompt), then `allow`. A project matching
+/// none of the three routes to a prompt. Patterns may contain `~/` or
+/// `$VAR` and are expanded at gate time, exactly like
+/// [`PatchesPolicy`]'s, while the stored form stays raw so the policy
+/// round-trips losslessly.
+///
+/// ```toml
+/// [hooks]
+/// allow  = ["~/work/**"]
+/// deny   = ["~/downloads/**"]
+/// ignore = ["~/scratch/**"]
+/// ```
+///
+/// [`Source::Package`]: crate::core::source::Source::Package
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct HooksPolicy {
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_one_or_many"
+    )]
+    allow: Vec<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_one_or_many"
+    )]
+    deny: Vec<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_one_or_many"
+    )]
+    ignore: Vec<String>,
+}
+
+impl HooksPolicy {
+    /// Construct an empty policy — no project may run hooks without
+    /// being prompted for.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Replace the `allow` set with raw project-root patterns.
+    #[must_use]
+    pub fn with_allow<I, S>(self, patterns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            allow: patterns.into_iter().map(Into::into).collect(),
+            ..self
+        }
+    }
+
+    /// Replace the `deny` set with raw project-root patterns.
+    #[must_use]
+    pub fn with_deny<I, S>(self, patterns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            deny: patterns.into_iter().map(Into::into).collect(),
+            ..self
+        }
+    }
+
+    /// Replace the `ignore` set with raw project-root patterns.
+    #[must_use]
+    pub fn with_ignore<I, S>(self, patterns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            ignore: patterns.into_iter().map(Into::into).collect(),
+            ..self
+        }
+    }
+
+    /// Raw project-root patterns whose hooks may run.
+    #[must_use]
+    pub fn allow(&self) -> &[String] {
+        &self.allow
+    }
+
+    /// Raw project-root patterns whose hooks are refused outright.
+    #[must_use]
+    pub fn deny(&self) -> &[String] {
+        &self.deny
+    }
+
+    /// Raw project-root patterns whose hooks are dropped silently,
+    /// without a prompt.
+    #[must_use]
+    pub fn ignore(&self) -> &[String] {
+        &self.ignore
+    }
+
+    /// Expand the raw patterns against `resolved_vars` into a matcher.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`crate::core::expansion::ExpandError`]
+    /// produced by any pattern.
+    pub fn expand_with(
+        &self,
+        resolved_vars: &(impl crate::core::expansion::VarLookup + ?Sized),
+        home_fallback: Option<&str>,
+    ) -> Result<ExpandedHooksPolicy, crate::core::expansion::ExpandError> {
+        let expand_one =
+            |raws: &[String]| -> Result<Vec<FileSet>, crate::core::expansion::ExpandError> {
+                raws.iter()
+                    .map(|r| {
+                        crate::core::expansion::expand_policy_pattern(
+                            r,
+                            resolved_vars,
+                            home_fallback,
+                        )
+                    })
+                    .collect()
+            };
+        Ok(ExpandedHooksPolicy {
+            allow: expand_one(&self.allow)?,
+            deny: expand_one(&self.deny)?,
+            ignore: expand_one(&self.ignore)?,
+        })
+    }
+}
+
+/// A [`HooksPolicy`] with its patterns expanded into concrete globs,
+/// ready to match project roots. Produced by
+/// [`HooksPolicy::expand_with`].
+#[derive(Clone, Debug)]
+pub struct ExpandedHooksPolicy {
+    allow: Vec<FileSet>,
+    deny: Vec<FileSet>,
+    ignore: Vec<FileSet>,
+}
+
+impl ExpandedHooksPolicy {
+    /// Categorize one hook against this policy, by the source that
+    /// declared it.
+    ///
+    /// - [`Source::UserLoadout`] → allowed. The user's own file.
+    /// - [`Source::Package`] → denied. Packages cannot declare hooks;
+    ///   one appearing here is a bug or an attempt to bypass the gate,
+    ///   and either way must not execute.
+    /// - [`Source::Project`] → matched by project root: `deny`, then
+    ///   `ignore`, then `allow`, else a prompt.
+    ///
+    /// [`Source::UserLoadout`]: crate::core::source::Source::UserLoadout
+    /// [`Source::Package`]: crate::core::source::Source::Package
+    /// [`Source::Project`]: crate::core::source::Source::Project
+    #[must_use]
+    pub fn check<T: Provenanced>(&self, item: T) -> CheckOutcome<T> {
+        let path = match item.source() {
+            Source::UserLoadout { .. } => return CheckOutcome::Decided(Decision::Allowed(item)),
+            Source::Package { .. } => return CheckOutcome::Decided(Decision::Denied(item)),
+            Source::Project { path } => path.as_utf8_path().to_owned(),
+        };
+        if filesets_match(&self.deny, &path) {
+            return CheckOutcome::Decided(Decision::Denied(item));
+        }
+        if filesets_match(&self.ignore, &path) {
+            return CheckOutcome::Decided(Decision::Ignored);
+        }
+        if filesets_match(&self.allow, &path) {
+            return CheckOutcome::Decided(Decision::Allowed(item));
+        }
+        CheckOutcome::NeedsApproval(item)
     }
 }
 
@@ -535,8 +734,10 @@ impl PatchPolicy {
 pub struct UserPolicy {
     #[serde(default, skip_serializing_if = "vars_policy_is_default")]
     vars: VarsPolicy,
-    #[serde(default, skip_serializing_if = "patch_policy_is_default")]
-    patches: PatchPolicy,
+    #[serde(default, skip_serializing_if = "patches_policy_is_default")]
+    patches: PatchesPolicy,
+    #[serde(default, skip_serializing_if = "hooks_policy_is_default")]
+    hooks: HooksPolicy,
 }
 
 impl UserPolicy {
@@ -565,7 +766,7 @@ impl UserPolicy {
 
     /// Replace the patches policy.
     #[must_use]
-    pub fn with_patches(self, patches: PatchPolicy) -> Self {
+    pub fn with_patches(self, patches: PatchesPolicy) -> Self {
         Self { patches, ..self }
     }
 
@@ -577,8 +778,20 @@ impl UserPolicy {
 
     /// The patches policy in effect.
     #[must_use]
-    pub fn patches(&self) -> &PatchPolicy {
+    pub fn patches(&self) -> &PatchesPolicy {
         &self.patches
+    }
+
+    /// Replace the lifecycle-hooks policy.
+    #[must_use]
+    pub fn with_hooks(self, hooks: HooksPolicy) -> Self {
+        Self { hooks, ..self }
+    }
+
+    /// The lifecycle-hooks policy in effect.
+    #[must_use]
+    pub fn hooks(&self) -> &HooksPolicy {
+        &self.hooks
     }
 
     /// Consume the policy and return the underlying narrow policies.
@@ -587,8 +800,8 @@ impl UserPolicy {
     /// policy into the corresponding per-domain gate and rebuilds a
     /// `UserPolicy` from the (possibly updated) results.
     #[must_use]
-    pub fn into_parts(self) -> (VarsPolicy, PatchPolicy) {
-        (self.vars, self.patches)
+    pub fn into_parts(self) -> (VarsPolicy, PatchesPolicy, HooksPolicy) {
+        (self.vars, self.patches, self.hooks)
     }
 }
 
@@ -596,33 +809,37 @@ fn vars_policy_is_default(p: &VarsPolicy) -> bool {
     p == &VarsPolicy::default()
 }
 
-fn patch_policy_is_default(p: &PatchPolicy) -> bool {
-    p == &PatchPolicy::default()
+fn patches_policy_is_default(p: &PatchesPolicy) -> bool {
+    p == &PatchesPolicy::default()
+}
+
+fn hooks_policy_is_default(p: &HooksPolicy) -> bool {
+    p == &HooksPolicy::default()
 }
 
 // =====================================================================
-// ExpandedPatchPolicy
+// ExpandedPatchesPolicy
 // =====================================================================
 
-/// A [`PatchPolicy`] with all `~/` and `$VAR` references expanded into
+/// A [`PatchesPolicy`] with all `~/` and `$VAR` references expanded into
 /// concrete glob patterns against a set of resolved session vars.
 ///
-/// Produced from a raw [`PatchPolicy`] via
-/// [`PatchPolicy::expand_with`] at the patch gate's main entry point;
+/// Produced from a raw [`PatchesPolicy`] via
+/// [`PatchesPolicy::expand_with`] at the patch gate's main entry point;
 /// the gate matches against this form, not the raw policy. The raw
 /// policy is preserved separately so it can round-trip through
 /// serialization unchanged.
 #[derive(Clone, Debug)]
-pub struct ExpandedPatchPolicy {
+pub struct ExpandedPatchesPolicy {
     allow: Vec<FileSet>,
     deny: Vec<FileSet>,
     ignore: Vec<FileSet>,
 }
 
-impl ExpandedPatchPolicy {
-    /// Construct an `ExpandedPatchPolicy` from already-expanded
+impl ExpandedPatchesPolicy {
+    /// Construct an `ExpandedPatchesPolicy` from already-expanded
     /// lists. Crate-internal so external callers must go through
-    /// [`PatchPolicy::expand_with`] and can't bypass expansion.
+    /// [`PatchesPolicy::expand_with`] and can't bypass expansion.
     pub(crate) fn from_expanded(
         allow: Vec<FileSet>,
         deny: Vec<FileSet>,
@@ -721,7 +938,7 @@ impl ExpandedPatchPolicy {
 }
 
 /// Path-level decision used internally by
-/// [`ExpandedPatchPolicy::decide`]. The public-facing outcome
+/// [`ExpandedPatchesPolicy::decide`]. The public-facing outcome
 /// ([`CheckOutcome`]) carries the item; this type doesn't, so it can
 /// be computed for the same item against multiple paths and combined.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -983,7 +1200,7 @@ mod tests {
     }
 
     // =================================================================
-    // PatchPolicy tests
+    // PatchesPolicy tests
     // =================================================================
 
     #[test]
@@ -993,7 +1210,7 @@ mod tests {
             deny = ["~/.ssh/**", "**/*.pem"]
             ignore = ["**/.DS_Store"]
         "#;
-        let policy: PatchPolicy = toml::from_str(src).unwrap();
+        let policy: PatchesPolicy = toml::from_str(src).unwrap();
         assert_eq!(patterns(policy.allow()), ["~/.config/**", "/etc/xdg/**"]);
         assert_eq!(patterns(policy.deny()), ["~/.ssh/**", "**/*.pem"]);
         assert_eq!(patterns(policy.ignore()), ["**/.DS_Store"]);
@@ -1001,7 +1218,7 @@ mod tests {
 
     #[test]
     fn patch_policy_defaults_when_omitted() {
-        let policy: PatchPolicy = toml::from_str("").unwrap();
+        let policy: PatchesPolicy = toml::from_str("").unwrap();
         assert!(policy.allow().is_empty());
         assert!(policy.deny().is_empty());
         assert!(policy.ignore().is_empty());
@@ -1009,13 +1226,13 @@ mod tests {
 
     #[test]
     fn patch_policy_accepts_bare_string_for_each_field() {
-        let policy: PatchPolicy = toml::from_str(r#"deny = "~/.ssh/**""#).unwrap();
+        let policy: PatchesPolicy = toml::from_str(r#"deny = "~/.ssh/**""#).unwrap();
         assert_eq!(patterns(policy.deny()), ["~/.ssh/**"]);
     }
 
     #[test]
     fn patch_policy_builder_methods() {
-        let p = PatchPolicy::empty()
+        let p = PatchesPolicy::empty()
             .with_allow(["~/.config/**"])
             .with_deny(["~/.ssh/**", "**/*.pem"])
             .with_ignore(["**/.DS_Store"]);
@@ -1030,20 +1247,20 @@ mod tests {
         // glob is held verbatim and only fails at expansion-time, after
         // var substitution gets a chance to fix it. This documents that
         // shift.
-        let p = PatchPolicy::empty().with_allow(["[bad"]);
+        let p = PatchesPolicy::empty().with_allow(["[bad"]);
         assert_eq!(patterns(p.allow()), ["[bad"]);
     }
 
     #[test]
     fn patch_policy_skips_empty_fields_on_serialize() {
-        let p = PatchPolicy::empty().with_allow(["A"]);
+        let p = PatchesPolicy::empty().with_allow(["A"]);
         let s = toml::to_string(&p).unwrap();
         assert!(s.contains("allow"), "expected allow, got: {s}");
         assert!(!s.contains("deny"), "expected no deny, got: {s}");
         assert!(!s.contains("ignore"), "expected no ignore, got: {s}");
     }
 
-    // ---- PatchPolicy::expand_with ----
+    // ---- PatchesPolicy::expand_with ----
 
     /// Build a `ResolvedVar` with the given name + value.
     fn sv(name: &str, value: &str) -> crate::core::primitives::ResolvedVar {
@@ -1059,7 +1276,7 @@ mod tests {
     /// `HOME` get the same substituted prefix.
     #[test]
     fn expand_with_substitutes_all_three_lists() {
-        let policy = PatchPolicy::empty()
+        let policy = PatchesPolicy::empty()
             .with_allow(["~/cfg/**"])
             .with_deny(["$HOME/.ssh/**"])
             .with_ignore(["~/.DS_Store"]);
@@ -1078,7 +1295,7 @@ mod tests {
     /// failure.
     #[test]
     fn expand_with_propagates_first_undefined_var() {
-        let policy = PatchPolicy::empty()
+        let policy = PatchesPolicy::empty()
             .with_allow(["/etc/**"])
             .with_deny(["$NOPE/*"]);
         let vars: [crate::core::primitives::ResolvedVar; 0] = [];
@@ -1099,7 +1316,7 @@ mod tests {
     /// resolved-vars set at all.
     #[test]
     fn expand_with_empty_vars_works_when_no_expansion_needed() {
-        let policy = PatchPolicy::empty()
+        let policy = PatchesPolicy::empty()
             .with_allow(["/etc/xdg/**"])
             .with_deny(["/**/*.pem"])
             .with_ignore(["/**/.DS_Store"]);
@@ -1114,7 +1331,7 @@ mod tests {
     /// Deny wins when a path matches both `deny` and `ignore`. Same
     /// invariant as [`vars_policy_check_deny_wins_over_ignore_on_overlap`],
     /// on the patch-side gate. Goes through
-    /// [`ExpandedPatchPolicy::check`] with a `link` of `None` so only
+    /// [`ExpandedPatchesPolicy::check`] with a `link` of `None` so only
     /// the single-path `decide` codepath is exercised.
     #[test]
     fn patch_policy_check_deny_wins_over_ignore_on_overlap() {
@@ -1126,7 +1343,7 @@ mod tests {
                 &self.source
             }
         }
-        let policy = PatchPolicy::empty()
+        let policy = PatchesPolicy::empty()
             .with_deny(["/etc/secret/**"])
             .with_ignore(["/etc/secret/**"]);
         let vars: [crate::core::primitives::ResolvedVar; 0] = [];
@@ -1157,7 +1374,7 @@ mod tests {
                 &self.source
             }
         }
-        let policy = PatchPolicy::empty().with_deny(["**/*.pem"]);
+        let policy = PatchesPolicy::empty().with_deny(["**/*.pem"]);
         let vars: [crate::core::primitives::ResolvedVar; 0] = [];
         let expanded = policy
             .expand_with(vars.as_slice(), None)
@@ -1212,7 +1429,7 @@ mod tests {
         "#;
         let p: UserPolicy = toml::from_str(src).unwrap();
         assert_eq!(p.vars().allow().raw_patterns(), &["X"]);
-        assert_eq!(p.patches(), &PatchPolicy::default());
+        assert_eq!(p.patches(), &PatchesPolicy::default());
     }
 
     #[test]

--- a/crates/sessions/src/core/primitives.rs
+++ b/crates/sessions/src/core/primitives.rs
@@ -47,7 +47,7 @@
 //!   construction or matching time.
 //! - **The composer** (see [`crate::core::compose`]) expands leading
 //!   `~` in patch *source* patterns and in
-//!   [`PatchPolicy`](crate::core::policy::PatchPolicy) patterns at the
+//!   [`PatchesPolicy`](crate::core::policy::PatchesPolicy) patterns at the
 //!   start of the patch gate, against the composer's `HOME` env lookup.
 //!   Patterns retain their `~` form in returned policies for
 //!   round-trippability.

--- a/crates/sessions/src/core/source.rs
+++ b/crates/sessions/src/core/source.rs
@@ -17,8 +17,8 @@ use crate::core::primitives::{Patch, ResolvedVar};
 ///
 /// `Source` is what makes the origin-aware allow step possible
 /// ([`VarsPolicy::check`](crate::core::policy::VarsPolicy::check) /
-/// [`PatchPolicy::check`](crate::core::policy::PatchPolicy::check) inspect
-/// this) and what error messages name when an item is rejected.
+/// [`ExpandedPatchesPolicy::check`](crate::core::policy::ExpandedPatchesPolicy::check)
+/// inspect this) and what error messages name when an item is rejected.
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Source {

--- a/crates/sessions/src/daemon/composer.rs
+++ b/crates/sessions/src/daemon/composer.rs
@@ -24,8 +24,6 @@ use crate::wire::request::{ContributionResponse, ContributionVerdict, WireContri
 pub struct PendingComposeState {
     /// Daemon-collected packages (no per-item wire verdict).
     pub daemon_packages: Vec<ProvenancedPackage>,
-    /// Daemon-collected lifecycle hooks (no per-item wire verdict).
-    pub daemon_lifecycle_hooks: Vec<ProvenancedHook>,
     /// Daemon-collected vars keyed by the [`PendingId`] shipped on
     /// the wire response. Supplies source provenance the verdict
     /// omits.
@@ -33,6 +31,12 @@ pub struct PendingComposeState {
     /// Daemon-collected patches keyed by [`PendingId`]. Supplies
     /// destination and source provenance the verdict omits.
     pub pending_patches: BTreeMap<PendingId, ProvenancedPatch>,
+    /// Daemon-collected lifecycle hooks keyed by [`PendingId`]. The
+    /// hook itself lives here rather than being reconstructed from the
+    /// verdict, so an approval carries back only a decision — the
+    /// client cannot substitute a different script for the one it was
+    /// shown.
+    pub pending_hooks: BTreeMap<PendingId, ProvenancedHook>,
     /// Client's already-gated wire contribution, untouched.
     pub client_contribution: WireContribution,
 }
@@ -170,31 +174,34 @@ impl SessionComposer {
             lifecycle_hooks,
         } = contribution;
 
-        // All-decided fast path: only items the client must gate are
-        // vars and patches. Packages and lifecycle hooks have no
-        // per-item verdict in the wire schema, so a daemon
-        // contribution carrying only those (or carrying nothing)
-        // assembles directly into the Composition.
+        // All-decided fast path: packages are the only domain with no
+        // per-item verdict, so a daemon contribution carrying nothing
+        // else assembles directly into the Composition.
+        //
+        // Lifecycle hooks must be counted here. They used to ride the
+        // response for information only, which meant a project whose
+        // sole contribution was hooks took this path and never faced
+        // the gate — precisely the case the hooks policy exists to
+        // catch.
         tracing::info!(
             daemon_vars = vars.len(),
             daemon_patches = patches.len(),
             daemon_packages = packages.len(),
+            daemon_hooks = lifecycle_hooks.len(),
             "compose: daemon-side contribution collected",
         );
-        if vars.is_empty() && patches.is_empty() {
-            let mut composition = Composition::from_daemon_passthrough(packages, lifecycle_hooks);
+        if vars.is_empty() && patches.is_empty() && lifecycle_hooks.is_empty() {
+            let mut composition = Composition::from_daemon_passthrough(packages, Vec::new());
             composition.extend_from_wire(client)?;
             return Ok(ComposeOutcome::Ready(composition));
         }
 
-        // Daemon-collected vars or patches: route them back to the
-        // client for gating. Lifecycle hooks ride in the response
-        // for audit; a separate copy is retained on the stash for
-        // Phase 4 to install. Packages aren't on the wire at all —
-        // they only live on the stash. Vars and patches are stashed
-        // by `PendingId` so `resume_from_verdict` can reattach
-        // provenance to whatever the client approves.
-        let transform = contribution_to_pending(vars, patches, lifecycle_hooks.clone());
+        // Daemon-collected vars, patches, or hooks: route them back to
+        // the client for gating. Packages aren't on the wire at all —
+        // they only live on the stash. Every gated domain is stashed by
+        // `PendingId` so `resume_from_verdict` can reattach provenance
+        // to whatever the client approves.
+        let transform = contribution_to_pending(vars, patches, lifecycle_hooks);
         let response = ContributionResponse {
             session_id,
             vars: transform.wire.vars,
@@ -205,9 +212,9 @@ impl SessionComposer {
             response,
             state: PendingComposeState {
                 daemon_packages: packages,
-                daemon_lifecycle_hooks: lifecycle_hooks,
                 pending_vars: transform.pending_vars,
                 pending_patches: transform.pending_patches,
+                pending_hooks: transform.pending_hooks,
                 client_contribution: client,
             },
         })
@@ -240,20 +247,86 @@ pub fn resume_from_verdict(
 ) -> Result<Composition, ComposeError> {
     let PendingComposeState {
         daemon_packages,
-        daemon_lifecycle_hooks,
         pending_vars,
         pending_patches,
+        pending_hooks,
         client_contribution,
     } = state;
 
-    let mut composition =
-        Composition::from_daemon_passthrough(daemon_packages, daemon_lifecycle_hooks);
+    let accepted_hooks = apply_hook_verdicts(pending_hooks, verdict.lifecycle_hooks)?;
+    let mut composition = Composition::from_daemon_passthrough(daemon_packages, accepted_hooks);
 
     let accepted_vars = apply_var_verdicts(pending_vars, verdict.vars)?;
     let accepted_patches = apply_patch_verdicts(&pending_patches, verdict.patches)?;
     composition.extend_with(accepted_vars, accepted_patches)?;
     composition.extend_from_wire(client_contribution)?;
     Ok(composition)
+}
+
+/// Walk the hook verdict, keeping the hooks the client approved.
+///
+/// A hook the verdict never mentions is **dropped**, not kept: the
+/// stash is the daemon's, and silence from the client must fail closed.
+/// That is what makes a verdict from a client predating this gate safe
+/// — it simply carries no hook decisions, so no project hook runs.
+///
+/// A `Denied` verdict aborts the whole resume, matching vars and
+/// patches: a project-declared item the user explicitly refused can't
+/// be silently dropped, because the resulting session would differ from
+/// what the project declared without anyone being told.
+///
+/// # Errors
+///
+/// - [`ComposeError::InvalidWireItem`] if a verdict names a
+///   [`PendingId`] that isn't in the stash.
+/// - [`ComposeError::Denied`] if any hook was refused.
+fn apply_hook_verdicts(
+    mut pending_hooks: BTreeMap<PendingId, ProvenancedHook>,
+    hook_verdicts: Vec<crate::wire::policy::WireHookVerdict>,
+) -> Result<Vec<ProvenancedHook>, ComposeError> {
+    use crate::wire::policy::WireHookVerdict as V;
+
+    let mut accepted = Vec::new();
+    for v in hook_verdicts {
+        let (id, approved) = match v {
+            V::Approved { id } => (id, true),
+            V::Denied { id } => {
+                let from = pending_hooks.get(&id).map(|h| h.source().clone());
+                return Err(match from {
+                    Some(from) => ComposeError::Denied {
+                        what: "lifecycle hook".to_string(),
+                        from,
+                    },
+                    None => ComposeError::InvalidWireItem {
+                        what: "hook verdict for an unknown pending id",
+                        context: format!("id {}", id.get()),
+                    },
+                });
+            }
+            V::Ignored { id } => (id, false),
+        };
+        let hook = pending_hooks
+            .remove(&id)
+            .ok_or_else(|| ComposeError::InvalidWireItem {
+                what: "hook verdict for an unknown pending id",
+                context: format!("id {}", id.get()),
+            })?;
+        if approved {
+            accepted.push(hook);
+        }
+    }
+    // Anything still in the stash went unaddressed. Log it rather than
+    // failing: an older client legitimately sends no hook verdicts at
+    // all, and refusing the whole activation for that would break it
+    // against a newer daemon for no security gain — the hooks are
+    // already dropped.
+    if !pending_hooks.is_empty() {
+        tracing::info!(
+            dropped = pending_hooks.len(),
+            "compose: lifecycle hooks with no client verdict were dropped",
+        );
+    }
+    Ok(accepted)
 }
 
 /// Walk the var verdict, draining `pending_vars` as items are
@@ -556,21 +629,24 @@ mod tests {
                 // Stash is empty (no packages or hooks collected); the
                 // client's wire contribution is the default we passed.
                 assert!(state.daemon_packages.is_empty());
-                assert!(state.daemon_lifecycle_hooks.is_empty());
+                assert!(state.pending_hooks.is_empty());
                 assert_eq!(state.client_contribution, WireContribution::default());
             }
             ComposeOutcome::Ready(_) => panic!("expected Pending, got Ready"),
         }
     }
 
-    /// A daemon contribution carrying packages and lifecycle hooks
-    /// (but no vars or patches) takes the all-decided fast path —
-    /// neither domain has a per-item verdict slot, so they pass
-    /// through verbatim into the assembled [`Composition`].
-    /// Regression guard for branching on `vars + patches` (not
-    /// `Contribution::is_empty()`).
+    /// A daemon contribution carrying packages **and lifecycle hooks**
+    /// does *not* take the all-decided fast path: hooks now carry a
+    /// per-item verdict, so the client must gate them.
+    ///
+    /// This inverts the previous contract, deliberately. When hooks
+    /// were pass-through, a project whose only contribution was hooks
+    /// composed straight to `Ready` and never faced the policy — the
+    /// exact hole the hooks gate exists to close. Packages still have
+    /// no verdict and would take the fast path on their own.
     #[test]
-    fn daemon_collected_packages_and_hooks_route_to_ready() {
+    fn daemon_collected_hooks_route_to_pending_not_ready() {
         use crate::core::compose::{Composable, Contribution, Error};
         use crate::core::lifecyclehook::{HookScript, LifecycleHook};
         use crate::core::source::ProvenancedHook;
@@ -600,18 +676,60 @@ mod tests {
         let mut composer = SessionComposer::new(WireContribution::default());
         composer.add(ProjectPkgAndHook).unwrap();
 
+        match composer
+            .compose(nil_id(), ComposeOptions::default())
+            .unwrap()
+        {
+            ComposeOutcome::Pending { response, state } => {
+                // The hook is on the wire with an id the verdict can
+                // name, and stashed daemon-side under that same id.
+                assert_eq!(response.vars.len(), 0);
+                assert_eq!(response.patches.len(), 0);
+                assert_eq!(response.lifecycle_hooks.len(), 1);
+                let id = response.lifecycle_hooks[0].id;
+                assert!(state.pending_hooks.contains_key(&id));
+                // The package needs no verdict, so it waits on the
+                // stash rather than riding the response.
+                assert_eq!(state.daemon_packages.len(), 1);
+                assert_eq!(state.daemon_packages[0].package(), "ripgrep");
+            }
+            ComposeOutcome::Ready(_) => {
+                panic!("hooks must force a client gate, not compose straight to Ready")
+            }
+        }
+    }
+
+    /// Packages alone still take the fast path — adding the hooks
+    /// check to that branch must not have made every package-bearing
+    /// project pay for a round-trip.
+    #[test]
+    fn daemon_collected_packages_alone_still_route_to_ready() {
+        use crate::core::compose::{Composable, Contribution, Error};
+
+        struct ProjectPkgOnly;
+        impl Composable for ProjectPkgOnly {
+            fn contribute(
+                self,
+                _env: &dyn Fn(&str) -> Result<String, std::env::VarError>,
+            ) -> Result<Contribution, Error> {
+                let src = Source::Project {
+                    path: paths::HostPath::try_new("/proj").unwrap(),
+                };
+                let mut c = Contribution::new();
+                c.push_package(ProvenancedPackage::new("ripgrep", src));
+                Ok(c)
+            }
+        }
+
+        let mut composer = SessionComposer::new(WireContribution::default());
+        composer.add(ProjectPkgOnly).unwrap();
         let res = unwrap_ready(
             composer
                 .compose(nil_id(), ComposeOptions::default())
                 .unwrap(),
         );
-        // Vars and patches are untouched; pkg and hook passed
-        // through onto the Composition.
-        assert!(res.vars().is_empty());
-        assert!(res.patches().is_empty());
         assert_eq!(res.packages().len(), 1);
-        assert_eq!(res.packages()[0].package(), "ripgrep");
-        assert_eq!(res.lifecycle_hooks().len(), 1);
+        assert!(res.lifecycle_hooks().is_empty());
     }
 
     // ============================================================
@@ -639,7 +757,7 @@ mod tests {
         pending_vars.insert(PendingId::new(0), pv);
         let state = PendingComposeState {
             daemon_packages: Vec::new(),
-            daemon_lifecycle_hooks: Vec::new(),
+            pending_hooks: BTreeMap::new(),
             pending_vars,
             pending_patches: BTreeMap::new(),
             client_contribution: WireContribution::default(),
@@ -664,6 +782,7 @@ mod tests {
                 },
             }],
             patches: vec![],
+            lifecycle_hooks: vec![],
         };
         let comp = resume_from_verdict(state, verdict).unwrap();
         assert_eq!(comp.vars().len(), 1);
@@ -683,6 +802,7 @@ mod tests {
                 name: "PROJECT_VAR".into(),
             }],
             patches: vec![],
+            lifecycle_hooks: vec![],
         };
         let comp = resume_from_verdict(state, verdict).unwrap();
         assert!(comp.vars().is_empty());
@@ -699,6 +819,7 @@ mod tests {
                 name: "PROJECT_VAR".into(),
             }],
             patches: vec![],
+            lifecycle_hooks: vec![],
         };
         let err = resume_from_verdict(state, verdict).unwrap_err();
         match err {
@@ -726,6 +847,7 @@ mod tests {
                 },
             }],
             patches: vec![],
+            lifecycle_hooks: vec![],
         };
         let err = resume_from_verdict(state, verdict).unwrap_err();
         assert!(
@@ -744,6 +866,7 @@ mod tests {
             session_id: id,
             vars: vec![],
             patches: vec![],
+            lifecycle_hooks: vec![],
         };
         let err = resume_from_verdict(state, verdict).unwrap_err();
         assert!(
@@ -760,7 +883,7 @@ mod tests {
     fn resume_from_verdict_empty_inputs_yields_empty_composition() {
         let state = PendingComposeState {
             daemon_packages: Vec::new(),
-            daemon_lifecycle_hooks: Vec::new(),
+            pending_hooks: BTreeMap::new(),
             pending_vars: BTreeMap::new(),
             pending_patches: BTreeMap::new(),
             client_contribution: WireContribution::default(),
@@ -769,6 +892,7 @@ mod tests {
             session_id: SessionId::nil(),
             vars: vec![],
             patches: vec![],
+            lifecycle_hooks: vec![],
         };
         let comp = resume_from_verdict(state, verdict).unwrap();
         assert!(comp.vars().is_empty());
@@ -777,11 +901,9 @@ mod tests {
         assert!(comp.lifecycle_hooks().is_empty());
     }
 
-    /// Daemon-stashed packages and lifecycle hooks pass through the
-    /// resume into the assembled `Composition` (they have no
-    /// per-item verdict and are never on the wire round-trip).
-    #[test]
-    fn resume_from_verdict_passes_through_packages_and_hooks() {
+    /// Build a `PendingComposeState` holding one package and one
+    /// project-declared hook, both from `/proj`.
+    fn state_with_one_package_and_hook() -> PendingComposeState {
         use crate::core::lifecyclehook::{HookScript, LifecycleHook};
         let src = Source::Project {
             path: paths::HostPath::try_new("/proj").unwrap(),
@@ -790,22 +912,107 @@ mod tests {
             .with_on_activate(HookScript::inline("echo hi"))
             .build()
             .unwrap();
-        let state = PendingComposeState {
+        PendingComposeState {
             daemon_packages: vec![ProvenancedPackage::new("ripgrep", src.clone())],
-            daemon_lifecycle_hooks: vec![ProvenancedHook::new(hook, src)],
             pending_vars: BTreeMap::new(),
             pending_patches: BTreeMap::new(),
+            pending_hooks: [(PendingId::new(0), ProvenancedHook::new(hook, src))]
+                .into_iter()
+                .collect(),
             client_contribution: WireContribution::default(),
-        };
+        }
+    }
+
+    /// Packages pass through the resume (no per-item verdict); an
+    /// **approved** hook composes in.
+    #[test]
+    fn resume_from_verdict_passes_packages_and_keeps_approved_hooks() {
+        use crate::wire::policy::WireHookVerdict;
         let verdict = ContributionVerdict {
             session_id: SessionId::nil(),
             vars: vec![],
             patches: vec![],
+            lifecycle_hooks: vec![WireHookVerdict::Approved {
+                id: PendingId::new(0),
+            }],
         };
-        let comp = resume_from_verdict(state, verdict).unwrap();
+        let comp = resume_from_verdict(state_with_one_package_and_hook(), verdict).unwrap();
         assert_eq!(comp.packages().len(), 1);
         assert_eq!(comp.packages()[0].package(), "ripgrep");
         assert_eq!(comp.lifecycle_hooks().len(), 1);
+    }
+
+    /// A hook the verdict never mentions is dropped rather than kept.
+    ///
+    /// This is the compatibility contract for a client that predates
+    /// the hooks gate: its verdict carries no hook decisions at all, so
+    /// silence must mean "do not run", never "run unchecked". Packages
+    /// are unaffected — they were never gated.
+    #[test]
+    fn resume_from_verdict_drops_hooks_with_no_verdict() {
+        let verdict = ContributionVerdict {
+            session_id: SessionId::nil(),
+            vars: vec![],
+            patches: vec![],
+            lifecycle_hooks: vec![],
+        };
+        let comp = resume_from_verdict(state_with_one_package_and_hook(), verdict).unwrap();
+        assert_eq!(comp.packages().len(), 1);
+        assert!(
+            comp.lifecycle_hooks().is_empty(),
+            "a hook with no verdict must not run",
+        );
+    }
+
+    /// An `Ignored` hook is dropped without failing the activation,
+    /// while a `Denied` one aborts the whole resume — the same split
+    /// the var and patch domains use.
+    #[test]
+    fn resume_from_verdict_ignores_or_denies_hooks() {
+        use crate::wire::policy::WireHookVerdict;
+        let ignored = ContributionVerdict {
+            session_id: SessionId::nil(),
+            vars: vec![],
+            patches: vec![],
+            lifecycle_hooks: vec![WireHookVerdict::Ignored {
+                id: PendingId::new(0),
+            }],
+        };
+        let comp = resume_from_verdict(state_with_one_package_and_hook(), ignored).unwrap();
+        assert!(comp.lifecycle_hooks().is_empty());
+
+        let denied = ContributionVerdict {
+            session_id: SessionId::nil(),
+            vars: vec![],
+            patches: vec![],
+            lifecycle_hooks: vec![WireHookVerdict::Denied {
+                id: PendingId::new(0),
+            }],
+        };
+        let err = resume_from_verdict(state_with_one_package_and_hook(), denied)
+            .expect_err("a denied hook must abort the resume");
+        assert!(matches!(err, ComposeError::Denied { .. }), "got: {err:?}");
+    }
+
+    /// A verdict naming an id the daemon never issued is a protocol
+    /// fault, not something to silently skip.
+    #[test]
+    fn resume_from_verdict_rejects_unknown_hook_id() {
+        use crate::wire::policy::WireHookVerdict;
+        let verdict = ContributionVerdict {
+            session_id: SessionId::nil(),
+            vars: vec![],
+            patches: vec![],
+            lifecycle_hooks: vec![WireHookVerdict::Approved {
+                id: PendingId::new(99),
+            }],
+        };
+        let err = resume_from_verdict(state_with_one_package_and_hook(), verdict)
+            .expect_err("unknown pending id must fault");
+        assert!(
+            matches!(err, ComposeError::InvalidWireItem { .. }),
+            "got: {err:?}",
+        );
     }
 
     /// The client's stashed wire contribution merges in on top of
@@ -825,7 +1032,7 @@ mod tests {
         };
         let state = PendingComposeState {
             daemon_packages: Vec::new(),
-            daemon_lifecycle_hooks: Vec::new(),
+            pending_hooks: BTreeMap::new(),
             pending_vars: BTreeMap::new(),
             pending_patches: BTreeMap::new(),
             client_contribution: client,
@@ -834,6 +1041,7 @@ mod tests {
             session_id: SessionId::nil(),
             vars: vec![],
             patches: vec![],
+            lifecycle_hooks: vec![],
         };
         let comp = resume_from_verdict(state, verdict).unwrap();
         assert_eq!(comp.vars().len(), 1);

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -319,6 +319,14 @@ pub enum SessionStatus {
     Active,
 }
 
+/// Default for [`Record::hooks_enabled`] (and for the matching field on
+/// `minimald_rpc::SessionConfig`): hooks are on unless the user opted
+/// out. A bare `#[serde(default)]` would give `false`, silently
+/// disabling hooks on every record written before the field existed.
+fn hooks_enabled_default() -> bool {
+    true
+}
+
 /// Deserialize a session name, collapsing an empty string to `None`.
 ///
 /// An empty-string name could reach storage before the rename/activate
@@ -370,6 +378,19 @@ pub struct Record {
     /// always finalized at create time.
     #[serde(default)]
     pub status: SessionStatus,
+
+    /// Whether this session runs the lifecycle hooks composed into it.
+    /// Cleared by `min session activate --no-hooks`.
+    ///
+    /// Persisted on the record rather than applied only to the
+    /// composition because the attach, detach, and destroy transitions
+    /// fire from processes that never saw the activating command line —
+    /// a later `min session attach` has no other way to know the user
+    /// opted out. Defaults to `true` for records that predate the field;
+    /// hooks have never executed, so no existing session gains
+    /// behaviour from that default.
+    #[serde(default = "hooks_enabled_default")]
+    pub hooks_enabled: bool,
 
     /// Free-form attributes.
     pub attrs: BTreeMap<String, String>,
@@ -487,8 +508,43 @@ mod tests {
             network,
             policy,
             status: SessionStatus::default(),
+            hooks_enabled: true,
             attrs: BTreeMap::new(),
         }
+    }
+
+    /// A record written before `hooks_enabled` existed loads with hooks
+    /// **on**. A bare `#[serde(default)]` would yield `false` and
+    /// silently disable hooks for every pre-existing session — the kind
+    /// of regression that looks like "hooks just don't work" rather
+    /// than an error.
+    #[test]
+    fn record_predating_hooks_enabled_defaults_to_on() {
+        let json = r#"{
+            "id": "00000000-0000-0000-0000-000000000001",
+            "name": null,
+            "username": null,
+            "project_path": "/p",
+            "attrs": {}
+        }"#;
+        let r: Record = serde_json_lenient::from_str(json).expect("legacy record must still load");
+        assert!(r.hooks_enabled);
+    }
+
+    /// An explicit `false` survives deserialization rather than being
+    /// overwritten by the default.
+    #[test]
+    fn record_honours_explicit_hooks_disabled() {
+        let json = r#"{
+            "id": "00000000-0000-0000-0000-000000000001",
+            "name": null,
+            "username": null,
+            "project_path": "/p",
+            "hooks_enabled": false,
+            "attrs": {}
+        }"#;
+        let r: Record = serde_json_lenient::from_str(json).expect("record must load");
+        assert!(!r.hooks_enabled);
     }
 
     #[test]

--- a/crates/sessions/src/store.rs
+++ b/crates/sessions/src/store.rs
@@ -28,6 +28,17 @@ pub trait SessionObject: Sized + Send + Clone + 'static + std::fmt::Debug {
     /// materialize into the sandbox home. Each entry is stored
     /// under the patch's sandbox-home-relative destination path.
     fn patches_path(&self) -> DaemonAbsPath;
+    /// Directory the daemon stages the client-uploaded external
+    /// lifecycle-hook scripts into. Each entry is stored under the
+    /// path [`staged_script_path`] derives from its hook's source, so
+    /// the daemon can find a script again from the composition alone.
+    ///
+    /// Deliberately not under [`patches_path`](Self::patches_path):
+    /// the whole patch tree is copied into the sandbox home when the
+    /// session finalizes, and hook scripts are not dotfiles.
+    ///
+    /// [`staged_script_path`]: crate::core::lifecyclehook::staged_script_path
+    fn hooks_path(&self) -> DaemonAbsPath;
 }
 
 /// Describes the primary key a [`Loader`] uses to reference
@@ -228,6 +239,9 @@ impl SessionObject for DiskSession {
     }
     fn patches_path(&self) -> DaemonAbsPath {
         sub_path!(self.root_path(), "patches")
+    }
+    fn hooks_path(&self) -> DaemonAbsPath {
+        sub_path!(self.root_path(), "hooks")
     }
 }
 
@@ -1036,6 +1050,10 @@ mod tests {
                 None,
             ),
             status: SessionStatus::default(),
+            // Deliberately the non-default (`--no-hooks`): `true` is the
+            // serde default, so a fixture using it would round-trip
+            // green even if the field were dropped on write.
+            hooks_enabled: false,
             attrs: [("color".to_string(), "blue".to_string())]
                 .into_iter()
                 .collect(),
@@ -1061,6 +1079,11 @@ mod tests {
         // is the authoritative source the GetSessionPolicy RPC reads back.
         assert_eq!(got.record().network, input.network);
         assert_eq!(got.record().policy, input.policy);
+        // Likewise `--no-hooks`: the attach, detach, and destroy
+        // transitions read this back off disk, long after the flag that
+        // set it is gone.
+        assert_eq!(got.record().hooks_enabled, input.hooks_enabled);
+        assert!(!got.record().hooks_enabled);
 
         // Check find_by_id as well.
         assert_eq!(

--- a/crates/sessions/src/wire/policy.rs
+++ b/crates/sessions/src/wire/policy.rs
@@ -90,6 +90,34 @@ pub enum WirePatchVerdict {
     },
 }
 
+/// The client's decision about one pending lifecycle hook.
+///
+/// Unlike a var or patch verdict this carries no value back: the daemon
+/// already holds the hook, and the client is answering only "may this
+/// run". `Denied` aborts the activation, matching the other domains —
+/// a project-declared hook the user explicitly refused must not leave a
+/// session that silently differs from what the project asked for.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WireHookVerdict {
+    /// User policy or prompt approved this hook; it composes in.
+    Approved {
+        /// Matches the corresponding `WirePendingHook::id`.
+        id: PendingId,
+    },
+    /// User policy or prompt refused this hook.
+    Denied {
+        /// Matches the corresponding `WirePendingHook::id`.
+        id: PendingId,
+    },
+    /// User policy's `ignore` rule matched; drop it without failing
+    /// the activation.
+    Ignored {
+        /// Matches the corresponding `WirePendingHook::id`.
+        id: PendingId,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sessions/src/wire/primitives.rs
+++ b/crates/sessions/src/wire/primitives.rs
@@ -141,8 +141,19 @@ pub struct WireSessionPatch {
     pub source: WireSource,
 }
 
+/// Timeout a peer that predates the `timeout_secs` field is assumed to
+/// have meant. Matches
+/// [`DEFAULT_HOOK_TIMEOUT`](crate::core::lifecyclehook::DEFAULT_HOOK_TIMEOUT).
+fn default_hook_timeout_secs() -> u64 {
+    crate::core::lifecyclehook::DEFAULT_HOOK_TIMEOUT.as_secs()
+}
+
 /// A lifecycle hook script. Mirrors
 /// [`crate::core::lifecyclehook::HookScript`].
+///
+/// `timeout_secs` is serde-defaulted so payloads from peers that predate
+/// the field deserialize cleanly. The domain conversion clamps it into
+/// range rather than rejecting, so a skewed peer can't fault a load.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum WireHookScript {
@@ -150,26 +161,53 @@ pub enum WireHookScript {
     Inline {
         /// Script body.
         body: String,
+        /// Timeout in whole seconds.
+        #[serde(default = "default_hook_timeout_secs")]
+        timeout_secs: u64,
     },
-    /// Path to a script file, resolved against the config dir at
-    /// apply time.
+    /// Path to a script file, resolved against its anchor at apply time.
     External {
         /// Config-relative path to the script.
         path: paths::ConfigRelPath,
+        /// Timeout in whole seconds.
+        #[serde(default = "default_hook_timeout_secs")]
+        timeout_secs: u64,
     },
 }
 
 /// A lifecycle hook. Mirrors
 /// [`crate::core::lifecyclehook::LifecycleHook`].
+///
+/// Every field is serde-defaulted and skipped when unset, so this shape
+/// tolerates version skew in both directions: a peer that predates
+/// `description` / `on_attach` / `on_detach` simply omits them, and the
+/// removed `on_failure` sent by an older peer is ignored rather than
+/// faulting the message (unknown fields are not denied here — leniency is
+/// deliberate on the wire, unlike the config-file form).
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct WireLifecycleHook {
+    /// Free-form description, carried so `min session hooks` can label
+    /// each hook with what its author called it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Run on session activation, if set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_activate: Option<WireHookScript>,
     /// Run on session destruction, if set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_destroy: Option<WireHookScript>,
-    /// Run on session failure, if set.
+    /// Run when a client attaches, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_attach: Option<WireHookScript>,
+    /// Run when a client detaches, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_detach: Option<WireHookScript>,
+    /// The removed `on_failure` transition, captured only so a v1
+    /// snapshot carrying one can be reported rather than silently
+    /// losing a script. Never written (it is skipped when unset, and
+    /// nothing sets it) and never converted into a
+    /// [`LifecycleHook`](crate::core::lifecyclehook::LifecycleHook) —
+    /// see that conversion for where the warning is logged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_failure: Option<WireHookScript>,
 }
@@ -242,6 +280,22 @@ pub struct WirePendingVar {
     /// this field existed (backward-compatible).
     #[serde(default)]
     pub carries_user_data: bool,
+}
+
+/// Daemon → Client: a lifecycle hook from the project that the client
+/// must run through the user's hooks policy before it may execute.
+///
+/// Carries the hook itself so the client can show the user what it is
+/// being asked to approve — a prompt that named only the project would
+/// be asking for consent to code the user cannot see.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WirePendingHook {
+    /// Correlation id; the client echoes it back on the verdict.
+    pub id: PendingId,
+    /// The hook awaiting a decision.
+    pub hook: WireLifecycleHook,
+    /// Where it came from — the project root the policy matches.
+    pub source: WireSource,
 }
 
 /// Daemon → Client: a patch from a package or the project that the
@@ -325,20 +379,27 @@ impl From<crate::core::compose::SessionPatch> for WireSessionPatch {
 
 impl From<crate::core::lifecyclehook::HookScript> for WireHookScript {
     fn from(s: crate::core::lifecyclehook::HookScript) -> Self {
-        match s {
-            crate::core::lifecyclehook::HookScript::Inline(body) => Self::Inline { body },
-            crate::core::lifecyclehook::HookScript::External(path) => Self::External { path },
+        use crate::core::lifecyclehook::HookScriptBody;
+        let (body, timeout) = s.into_parts();
+        let timeout_secs = timeout.as_secs();
+        match body {
+            HookScriptBody::Inline(body) => Self::Inline { body, timeout_secs },
+            HookScriptBody::External(path) => Self::External { path, timeout_secs },
         }
     }
 }
 
 impl From<crate::core::lifecyclehook::LifecycleHook> for WireLifecycleHook {
     fn from(h: crate::core::lifecyclehook::LifecycleHook) -> Self {
-        let (_description, on_activate, on_destroy, on_failure) = h.into_parts();
+        let (description, on_activate, on_destroy, on_attach, on_detach) = h.into_parts();
         Self {
+            description,
             on_activate: on_activate.map(Into::into),
             on_destroy: on_destroy.map(Into::into),
-            on_failure: on_failure.map(Into::into),
+            on_attach: on_attach.map(Into::into),
+            // Never emitted: the domain type has no such transition.
+            on_failure: None,
+            on_detach: on_detach.map(Into::into),
         }
     }
 }
@@ -484,9 +545,11 @@ mod tests {
         let cases = [
             WireHookScript::Inline {
                 body: "echo hi".into(),
+                timeout_secs: 60,
             },
             WireHookScript::External {
                 path: paths::ConfigRelPath::try_new("hooks/run.sh").unwrap(),
+                timeout_secs: 120,
             },
         ];
         for s in cases {
@@ -494,18 +557,52 @@ mod tests {
         }
     }
 
+    /// A payload from a peer that predates `timeout_secs` deserializes to
+    /// the default rather than failing or landing on zero.
+    #[test]
+    fn hook_script_timeout_defaults_when_absent() {
+        let raw = serde_json_lenient::json!({ "kind": "inline", "body": "echo hi" });
+        let s: WireHookScript = serde_json_lenient::from_value(raw).expect("deserialize");
+        assert_eq!(
+            s,
+            WireHookScript::Inline {
+                body: "echo hi".into(),
+                timeout_secs: default_hook_timeout_secs(),
+            },
+        );
+    }
+
     #[test]
     fn lifecycle_hook_round_trips_with_optional_fields() {
         let h = WireLifecycleHook {
+            description: Some("warm caches".into()),
             on_activate: Some(WireHookScript::Inline {
                 body: "echo activated".into(),
+                timeout_secs: 60,
             }),
             on_destroy: None,
-            on_failure: Some(WireHookScript::External {
-                path: paths::ConfigRelPath::try_new("fail.sh").unwrap(),
+            on_attach: None,
+            on_detach: Some(WireHookScript::External {
+                path: paths::ConfigRelPath::try_new("detach.sh").unwrap(),
+                timeout_secs: 30,
             }),
+            on_failure: None,
         };
         assert_eq!(round_trip(&h), h);
+    }
+
+    /// A message from a peer that still sends the removed `on_failure`
+    /// deserializes cleanly, dropping the field. Wire-level leniency is
+    /// deliberate: version skew must not fault a session.
+    #[test]
+    fn lifecycle_hook_ignores_legacy_on_failure() {
+        let raw = serde_json_lenient::json!({
+            "on_activate": { "kind": "inline", "body": "x" },
+            "on_failure":  { "kind": "inline", "body": "old" },
+        });
+        let h: WireLifecycleHook = serde_json_lenient::from_value(raw).expect("deserialize");
+        assert!(h.on_activate.is_some());
+        assert!(h.description.is_none());
     }
 
     #[test]
@@ -522,12 +619,28 @@ mod tests {
             hook: WireLifecycleHook {
                 on_activate: Some(WireHookScript::Inline {
                     body: "echo hi".into(),
+                    timeout_secs: 60,
                 }),
                 ..Default::default()
             },
             source: user_source(),
         };
         assert_eq!(round_trip(&h), h);
+    }
+
+    /// The domain → wire → domain trip preserves a non-default timeout.
+    /// Guards the seam that made `timeout` unusable under adjacent
+    /// tagging: a value that survives TOML but is dropped on the wire is
+    /// equally broken.
+    #[test]
+    fn timeout_survives_domain_wire_round_trip() {
+        use crate::core::lifecyclehook::HookScript;
+        let original = HookScript::inline("x")
+            .with_timeout(std::time::Duration::from_mins(2))
+            .unwrap();
+        let wire: WireHookScript = original.clone().into();
+        let back: HookScript = round_trip(&wire).into();
+        assert_eq!(back, original);
     }
 
     #[test]

--- a/crates/sessions/src/wire/request.rs
+++ b/crates/sessions/src/wire/request.rs
@@ -10,16 +10,26 @@
 //! 3. Client → daemon: [`ContributionVerdict`] with per-item decisions.
 
 use super::errors::WireError;
-use super::policy::{WirePatchVerdict, WireVarVerdict};
+use super::policy::{WireHookVerdict, WirePatchVerdict, WireVarVerdict};
 use super::primitives::{
-    WireOrientation, WirePackageRef, WirePendingPatch, WirePendingVar, WireProvenancedHook,
-    WireSessionPatch, WireSessionVar,
+    WireOrientation, WirePackageRef, WirePendingHook, WirePendingPatch, WirePendingVar,
+    WireProvenancedHook, WireSessionPatch, WireSessionVar,
 };
 use crate::SessionId;
 
 /// Snapshot format version for [`WireComposition`]. Bumped when the
 /// on-disk shape changes in a way older daemons can't tolerate.
-const COMPOSITION_SNAPSHOT_VERSION: u32 = 1;
+///
+/// - **1** — lifecycle hooks carried `on_failure` and no `description`
+///   or per-script `timeout`.
+/// - **2** — hooks carry `description`, `on_attach`, `on_detach`, and a
+///   per-script `timeout_secs`; `on_failure` is gone.
+pub const COMPOSITION_SNAPSHOT_VERSION: u32 = 2;
+
+/// Version assumed for a sidecar with no `version` field. Those were
+/// written before the field existed, which is by definition version 1 —
+/// so this must not track [`COMPOSITION_SNAPSHOT_VERSION`].
+const LEGACY_COMPOSITION_SNAPSHOT_VERSION: u32 = 1;
 
 /// The client's composed contribution, wire-shaped: var values
 /// resolved, patch sources expanded to concrete files, every item
@@ -50,13 +60,13 @@ pub struct WireContribution {
 /// same wire primitives used for the live RPC flow
 /// ([`WireContribution`], [`ContributionResponse`]). A `version` field
 /// gates the on-disk shape so a future format can evolve without
-/// ambiguity; the current and only version is
-/// [`COMPOSITION_SNAPSHOT_VERSION`] (1).
+/// ambiguity; the current one is [`COMPOSITION_SNAPSHOT_VERSION`].
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WireComposition {
     /// Snapshot format version. Defaults to
-    /// [`COMPOSITION_SNAPSHOT_VERSION`] so sidecars written by daemons
-    /// that predate the field deserialize cleanly.
+    /// [`LEGACY_COMPOSITION_SNAPSHOT_VERSION`] — a sidecar without the
+    /// field was written before it existed, which is version 1 by
+    /// definition, not whatever the current writer emits.
     #[serde(default = "default_composition_version")]
     pub version: u32,
     /// Variables that survived the policy gate.
@@ -76,7 +86,7 @@ pub struct WireComposition {
 }
 
 fn default_composition_version() -> u32 {
-    COMPOSITION_SNAPSHOT_VERSION
+    LEGACY_COMPOSITION_SNAPSHOT_VERSION
 }
 
 impl From<&crate::core::compose::Composition> for WireComposition {
@@ -110,8 +120,10 @@ pub struct ContributionResponse {
     pub vars: Vec<WirePendingVar>,
     /// Pending patches awaiting policy + prompt.
     pub patches: Vec<WirePendingPatch>,
-    /// Lifecycle hooks (no policy applies; pass through to client).
-    pub lifecycle_hooks: Vec<WireProvenancedHook>,
+    /// Lifecycle hooks awaiting the hooks-policy gate. Project-declared
+    /// hooks only — a loadout's are the user's own and never reach the
+    /// daemon-side pending set.
+    pub lifecycle_hooks: Vec<WirePendingHook>,
 }
 
 /// Client → Daemon: per-item verdicts on the [`ContributionResponse`]'s
@@ -124,6 +136,12 @@ pub struct ContributionVerdict {
     pub vars: Vec<WireVarVerdict>,
     /// One verdict per pending patch.
     pub patches: Vec<WirePatchVerdict>,
+    /// One verdict per pending lifecycle hook. Serde-defaulted so a
+    /// verdict from a client that predates the hooks gate deserializes;
+    /// the daemon treats a hook with no verdict as refused, so an old
+    /// client can never accidentally approve one by omission.
+    #[serde(default)]
+    pub lifecycle_hooks: Vec<WireHookVerdict>,
 }
 
 /// Daemon's reply to a `SubmitVerdict`: composition finalized (the
@@ -217,8 +235,26 @@ mod tests {
                 id: PendingId::new(2),
                 host_path: paths::HostAbsPath::try_new("/etc/secret").unwrap(),
             }],
+            lifecycle_hooks: vec![WireHookVerdict::Approved {
+                id: PendingId::new(3),
+            }],
         };
         assert_eq!(round_trip(&v), v);
+    }
+
+    /// A verdict from a client that predates the hooks gate carries no
+    /// `lifecycle_hooks` key at all. It must deserialize to an empty
+    /// list — which the daemon treats as "approve nothing" — rather
+    /// than failing the message.
+    #[test]
+    fn contribution_verdict_without_hook_field_deserializes_empty() {
+        let json = format!(
+            r#"{{"session_id":"{}","vars":[],"patches":[]}}"#,
+            session_id()
+        );
+        let v: ContributionVerdict =
+            serde_json_lenient::from_str(&json).expect("legacy verdict must load");
+        assert!(v.lifecycle_hooks.is_empty());
     }
 
     #[test]
@@ -270,12 +306,49 @@ mod tests {
 
     #[test]
     fn composition_snapshot_defaults_version_to_one() {
-        // A sidecar written without the `version` field (e.g. by a
-        // hypothetical future writer that omits it) should default to
-        // version 1, not 0.
+        // A sidecar written without the `version` field predates the
+        // field, so it is version 1 — not 0, and not whatever the
+        // current writer emits.
         let json = r#"{"vars":[],"patches":[],"packages":[],"lifecycle_hooks":[]}"#;
         let c: WireComposition = serde_json_lenient::from_str(json).unwrap();
-        assert_eq!(c.version, COMPOSITION_SNAPSHOT_VERSION);
+        assert_eq!(c.version, LEGACY_COMPOSITION_SNAPSHOT_VERSION);
+        assert_ne!(c.version, COMPOSITION_SNAPSHOT_VERSION);
+    }
+
+    /// A v1 sidecar — `on_failure` present, no `description` or
+    /// `timeout_secs` — still loads. Its `on_failure` is dropped and the
+    /// remaining scripts take the default timeout.
+    #[test]
+    fn v1_snapshot_with_on_failure_still_loads() {
+        let json = r#"{
+            "version": 1,
+            "vars": [], "patches": [], "packages": [],
+            "lifecycle_hooks": [{
+                "hook": {
+                    "on_activate": {"kind": "inline", "body": "echo hi"},
+                    "on_failure":  {"kind": "inline", "body": "old"}
+                },
+                "source": {"kind": "user_loadout", "name": "dev"}
+            }]
+        }"#;
+        let c: WireComposition =
+            serde_json_lenient::from_str(json).expect("v1 snapshot must still load");
+        assert_eq!(c.version, 1);
+        let hook = &c.lifecycle_hooks[0].hook;
+        assert!(hook.on_activate.is_some());
+        assert!(hook.description.is_none());
+    }
+
+    /// The writer stamps the current version, so a freshly written
+    /// snapshot is distinguishable on read from a legacy one that
+    /// omitted the field entirely.
+    #[test]
+    fn written_snapshot_carries_current_version() {
+        let composition =
+            crate::core::compose::Composition::from_daemon_passthrough(Vec::new(), Vec::new());
+        let wire = WireComposition::from(&composition);
+        assert_eq!(wire.version, COMPOSITION_SNAPSHOT_VERSION);
+        assert_ne!(wire.version, LEGACY_COMPOSITION_SNAPSHOT_VERSION);
     }
 
     /// Payloads written before the `orientation` field existed

--- a/crates/sessions/tests/client_flow1.rs
+++ b/crates/sessions/tests/client_flow1.rs
@@ -11,7 +11,7 @@ use camino::Utf8Path;
 use sessions::client::composer::UserComposer;
 use sessions::core::compose::{ComposeError, ComposeOptions, StoredEnv};
 use sessions::core::loadout::Loadout;
-use sessions::core::policy::{PatchPolicy, UserPolicy, VarsPolicy};
+use sessions::core::policy::{PatchesPolicy, UserPolicy, VarsPolicy};
 use sessions::core::source::Source;
 use sessions::wire::primitives::WireSource;
 
@@ -348,7 +348,7 @@ _TMP = { inherit = true }
     assert_eq!(names, ["EDITOR"]);
 }
 
-/// `PatchPolicy::ignore` drops a matching user-origin patch file. The
+/// `PatchesPolicy::ignore` drops a matching user-origin patch file. The
 /// patch-side analogue of [`ignore_filters_user_var`].
 ///
 /// Both the source pattern and the deny pattern use `**` — the source
@@ -380,7 +380,7 @@ source = "{root}/dotfiles/helix/themes/**/*"
     );
     let loadout: Loadout = toml::from_str(&src).unwrap();
 
-    let patch_policy = PatchPolicy::empty().with_ignore(["/**/*.bak"]);
+    let patch_policy = PatchesPolicy::empty().with_ignore(["/**/*.bak"]);
     let policy = UserPolicy::empty().with_patches(patch_policy);
     let mut composer = UserComposer::new().with_env(pinned_env(&[]));
     composer.add(loadout).unwrap();
@@ -417,7 +417,7 @@ source = "{root}/dotfiles/secrets/id_rsa"
     );
     let loadout: Loadout = toml::from_str(&src).unwrap();
 
-    let patch_policy = PatchPolicy::empty().with_deny(["/**/id_rsa"]);
+    let patch_policy = PatchesPolicy::empty().with_deny(["/**/id_rsa"]);
     let policy = UserPolicy::empty().with_patches(patch_policy);
 
     let mut composer = UserComposer::new().with_env(pinned_env(&[]));

--- a/crates/sessions/tests/client_flow2.rs
+++ b/crates/sessions/tests/client_flow2.rs
@@ -13,7 +13,7 @@ use sessions::client::handler::handle_response;
 use sessions::core::compose::{ComposeError, ComposeOptions, SessionVar};
 use sessions::core::decision::ItemDecision;
 use sessions::core::hooks::{HookResult, PolicyHooks, Unapproved};
-use sessions::core::policy::{PatchPolicy, UserPolicy, VarsPolicy};
+use sessions::core::policy::{PatchesPolicy, UserPolicy, VarsPolicy};
 use sessions::wire::policy::{WirePatchVerdict, WireVarVerdict};
 use sessions::wire::primitives::{
     PendingId, WirePendingPatch, WirePendingVar, WireResolvedVar, WireSessionVar, WireSource,
@@ -91,9 +91,9 @@ impl PolicyHooks for PassThroughHooks {
     }
     fn on_patch_unapproved(
         &self,
-        _: PatchPolicy,
+        _: PatchesPolicy,
         items: &[Unapproved<'_, camino::Utf8Path>],
-    ) -> HookResult<PatchPolicy> {
+    ) -> HookResult<PatchesPolicy> {
         HookResult::decided(vec![ItemDecision::AllowOnce; items.len()])
     }
 }
@@ -109,9 +109,9 @@ impl PolicyHooks for AbortHooks {
     }
     fn on_patch_unapproved(
         &self,
-        _: PatchPolicy,
+        _: PatchesPolicy,
         _: &[Unapproved<'_, camino::Utf8Path>],
-    ) -> HookResult<PatchPolicy> {
+    ) -> HookResult<PatchesPolicy> {
         HookResult::abort()
     }
 }
@@ -128,10 +128,20 @@ impl PolicyHooks for PanicHooks {
     }
     fn on_patch_unapproved(
         &self,
-        _: PatchPolicy,
+        _: PatchesPolicy,
         _: &[Unapproved<'_, camino::Utf8Path>],
-    ) -> HookResult<PatchPolicy> {
+    ) -> HookResult<PatchesPolicy> {
         panic!("patch hook should not have been invoked")
+    }
+    // Overridden rather than left to the trait's fail-closed default:
+    // the default aborts, which a test asserting "no prompt happened"
+    // could not distinguish from a policy that decided on its own.
+    fn on_hook_unapproved(
+        &self,
+        _: sessions::core::policy::HooksPolicy,
+        _: &[Unapproved<'_, camino::Utf8Path>],
+    ) -> HookResult<sessions::core::policy::HooksPolicy> {
+        panic!("lifecycle-hook prompt should not have been invoked")
     }
 }
 
@@ -477,7 +487,8 @@ fn patch_source_uses_gated_vars() {
         root.join("helix").as_str(),
         "dev",
     )];
-    let policy = UserPolicy::empty().with_patches(PatchPolicy::empty().with_allow(["/**/*.toml"]));
+    let policy =
+        UserPolicy::empty().with_patches(PatchesPolicy::empty().with_allow(["/**/*.toml"]));
 
     let (verdict, _) = handle_response(
         response,
@@ -532,7 +543,7 @@ fn patch_source_uses_batch_approved_vars() {
                 .try_with_allow(["HELIX_CONFIG"])
                 .unwrap(),
         )
-        .with_patches(PatchPolicy::empty().with_allow(["/**/*.toml"]));
+        .with_patches(PatchesPolicy::empty().with_allow(["/**/*.toml"]));
 
     let (verdict, _) = handle_response(
         response,
@@ -633,7 +644,7 @@ fn multi_file_patch_yields_per_file_verdicts() {
         lifecycle_hooks: vec![],
     };
     let policy = UserPolicy::empty().with_patches(
-        PatchPolicy::empty()
+        PatchesPolicy::empty()
             .with_allow(["/**/*.toml"])
             .with_deny(["/**/*.bak"]),
     );
@@ -678,29 +689,39 @@ fn multi_file_patch_yields_per_file_verdicts() {
     );
 }
 
-/// Lifecycle hooks in the response are silently dropped — the
-/// verdict has no hook field. This test asserts the handler doesn't
-/// fail or otherwise observe them, since there's no per-hook policy.
-#[test]
-fn lifecycle_hooks_are_dropped() {
-    use sessions::wire::primitives::{WireHookScript, WireLifecycleHook, WireProvenancedHook};
-
-    let response = ContributionResponse {
+/// Build a one-hook response from `source`.
+fn hook_response(source: WireSource) -> ContributionResponse {
+    use sessions::wire::primitives::{
+        PendingId, WireHookScript, WireLifecycleHook, WirePendingHook,
+    };
+    ContributionResponse {
         session_id: session_id(),
         vars: vec![],
         patches: vec![],
-        lifecycle_hooks: vec![WireProvenancedHook {
+        lifecycle_hooks: vec![WirePendingHook {
+            id: PendingId::new(0),
             hook: WireLifecycleHook {
                 on_activate: Some(WireHookScript::Inline {
                     body: "echo hi".into(),
+                    timeout_secs: 60,
                 }),
                 ..Default::default()
             },
-            source: package_source("helix"),
+            source,
         }],
-    };
+    }
+}
+
+/// A hook tagged as coming from a **package** is denied outright,
+/// without consulting the prompt (`PanicHooks` would fire if it were
+/// consulted). Packages have no legitimate way to declare a hook, so
+/// one appearing here is a bug or a bypass attempt and must not run.
+#[test]
+fn package_declared_hook_is_denied_without_prompting() {
+    use sessions::wire::policy::WireHookVerdict;
+
     let (verdict, _) = handle_response(
-        response,
+        hook_response(package_source("helix")),
         &[],
         UserPolicy::empty(),
         &PanicHooks,
@@ -710,6 +731,117 @@ fn lifecycle_hooks_are_dropped() {
     .unwrap();
     assert!(verdict.vars.is_empty());
     assert!(verdict.patches.is_empty());
+    assert!(
+        matches!(
+            verdict.lifecycle_hooks.as_slice(),
+            [WireHookVerdict::Denied { .. }]
+        ),
+        "got: {:?}",
+        verdict.lifecycle_hooks,
+    );
+}
+
+/// A project-declared hook with an empty policy has no rule to decide
+/// it, so it routes to the prompt rather than being auto-approved.
+/// `PanicHooks` panics when consulted, which is exactly the signal
+/// that the gate reached the prompt.
+#[test]
+#[should_panic(expected = "lifecycle-hook prompt should not have been invoked")]
+fn project_declared_hook_with_no_rule_reaches_the_prompt() {
+    let _ = handle_response(
+        hook_response(project_source()),
+        &[],
+        UserPolicy::empty(),
+        &PanicHooks,
+        ComposeOptions::default(),
+        &pinned_env(&[]),
+    );
+}
+
+/// An `allow` rule matching the project root approves its hooks
+/// without prompting.
+#[test]
+fn project_hook_allowed_by_policy_skips_the_prompt() {
+    use sessions::core::policy::HooksPolicy;
+    use sessions::wire::policy::WireHookVerdict;
+
+    let policy = UserPolicy::empty().with_hooks(HooksPolicy::empty().with_allow(["/repo"]));
+    let (verdict, _) = handle_response(
+        hook_response(project_source()),
+        &[],
+        policy,
+        &PanicHooks,
+        ComposeOptions::default(),
+        &pinned_env(&[]),
+    )
+    .unwrap();
+    assert!(
+        matches!(
+            verdict.lifecycle_hooks.as_slice(),
+            [WireHookVerdict::Approved { .. }]
+        ),
+        "got: {:?}",
+        verdict.lifecycle_hooks,
+    );
+}
+
+/// A `deny` rule refuses the project's hooks without prompting, and
+/// beats an overlapping `allow` — the same emergency-stop precedence
+/// the other two domains use.
+#[test]
+fn project_hook_denied_by_policy_beats_allow() {
+    use sessions::core::policy::HooksPolicy;
+    use sessions::wire::policy::WireHookVerdict;
+
+    let policy = UserPolicy::empty().with_hooks(
+        HooksPolicy::empty()
+            .with_allow(["/repo"])
+            .with_deny(["/repo"]),
+    );
+    let (verdict, _) = handle_response(
+        hook_response(project_source()),
+        &[],
+        policy,
+        &PanicHooks,
+        ComposeOptions::default(),
+        &pinned_env(&[]),
+    )
+    .unwrap();
+    assert!(
+        matches!(
+            verdict.lifecycle_hooks.as_slice(),
+            [WireHookVerdict::Denied { .. }]
+        ),
+        "got: {:?}",
+        verdict.lifecycle_hooks,
+    );
+}
+
+/// An `ignore` rule drops the project's hooks silently — no prompt,
+/// and no denial that would abort the activation.
+#[test]
+fn project_hook_ignored_by_policy_is_dropped_quietly() {
+    use sessions::core::policy::HooksPolicy;
+    use sessions::wire::policy::WireHookVerdict;
+
+    let policy = UserPolicy::empty().with_hooks(HooksPolicy::empty().with_ignore(["/repo"]));
+    let (verdict, _) = handle_response(
+        hook_response(project_source()),
+        &[],
+        policy,
+        &PanicHooks,
+        ComposeOptions::default(),
+        &pinned_env(&[]),
+    )
+    .unwrap();
+    assert!(
+        matches!(
+            verdict.lifecycle_hooks.as_slice(),
+            [WireHookVerdict::Ignored { .. }]
+        ),
+        "got: {:?}",
+        verdict.lifecycle_hooks,
+    );
 }
 
 /// Patch-side parity for `policy_ignore_per_item`: a file matched
@@ -734,7 +866,7 @@ fn patch_policy_ignore_produces_ignored_verdict() {
         lifecycle_hooks: vec![],
     };
     let policy = UserPolicy::empty().with_patches(
-        PatchPolicy::empty()
+        PatchesPolicy::empty()
             .with_ignore(["/**/draft.toml"])
             .with_allow(["/**/*.toml"]),
     );
@@ -778,9 +910,9 @@ fn unapproved_vars_batched_into_one_hook_call() {
         }
         fn on_patch_unapproved(
             &self,
-            _: PatchPolicy,
+            _: PatchesPolicy,
             _: &[Unapproved<'_, camino::Utf8Path>],
-        ) -> HookResult<PatchPolicy> {
+        ) -> HookResult<PatchesPolicy> {
             panic!("patch hook not expected")
         }
     }
@@ -853,9 +985,9 @@ fn hook_use_rule_with_updated_policy_approves() {
         }
         fn on_patch_unapproved(
             &self,
-            _: PatchPolicy,
+            _: PatchesPolicy,
             _: &[Unapproved<'_, camino::Utf8Path>],
-        ) -> HookResult<PatchPolicy> {
+        ) -> HookResult<PatchesPolicy> {
             panic!("not expected")
         }
     }
@@ -900,9 +1032,9 @@ fn hook_use_rule_without_decision_errors_as_hook_contract() {
         }
         fn on_patch_unapproved(
             &self,
-            _: PatchPolicy,
+            _: PatchesPolicy,
             _: &[Unapproved<'_, camino::Utf8Path>],
-        ) -> HookResult<PatchPolicy> {
+        ) -> HookResult<PatchesPolicy> {
             panic!("not expected")
         }
     }
@@ -950,9 +1082,9 @@ fn hook_wrong_decision_count_errors_as_hook_contract() {
         }
         fn on_patch_unapproved(
             &self,
-            _: PatchPolicy,
+            _: PatchesPolicy,
             _: &[Unapproved<'_, camino::Utf8Path>],
-        ) -> HookResult<PatchPolicy> {
+        ) -> HookResult<PatchesPolicy> {
             panic!("not expected")
         }
     }
@@ -1047,9 +1179,9 @@ fn unapproved_files_batched_into_one_hook_call() {
         }
         fn on_patch_unapproved(
             &self,
-            _: PatchPolicy,
+            _: PatchesPolicy,
             items: &[Unapproved<'_, camino::Utf8Path>],
-        ) -> HookResult<PatchPolicy> {
+        ) -> HookResult<PatchesPolicy> {
             *self.calls.borrow_mut() += 1;
             self.batch_sizes.borrow_mut().push(items.len());
             HookResult::decided(vec![ItemDecision::AllowOnce; items.len()])

--- a/docs/concepts/loadouts.md
+++ b/docs/concepts/loadouts.md
@@ -115,14 +115,17 @@ that may not be present on every machine.
 
 ### Lifecycle hooks
 
-> **Coming soon.** Lifecycle hooks are not yet live: a hook declared in a
-> loadout is accepted, but the current release excludes it from composition
-> and nothing executes it. The declaration format below is what we expect to ship.
+Hooks run inside your session, with its packages, variables, files, and
+network. Your own loadouts' hooks run without ceremony; a *project's* hooks
+require you to allow-list that project in your
+[user policy](../reference/user-policy.md) first, because a hook is arbitrary
+code the project asked to run on your machine. `min session activate
+--no-hooks` turns them off for a session entirely.
 
 Hooks are scripts declared to run at session transition points: `on_activate`
-when the session comes up, `on_destroy` when it is torn down, and `on_failure`
-when activation fails. Declare them to warm a cache, fetch grammars, or clean
-up after a failed start:
+when the session comes up, `on_destroy` when it is torn down, `on_attach`
+when you connect to it, and `on_detach` when you disconnect. Declare them to
+warm a cache, fetch grammars, or clean up when you step away:
 
 ```toml
 [[lifecycle_hooks]]

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -91,6 +91,7 @@ the current directory).
 | `--sync <MODE>` | | How to load project files into the session: `tarball` (default: stream a tarball of your project and unpack it) or `none` (do not populate the worktree) |
 | `--loadout <NAME>` | | Apply the named loadout from `<config>/minimal/loadouts/<NAME>.toml`. Repeatable; if given, config-file `default_loadouts` are ignored |
 | `--no-loadouts` | | Apply no loadouts at all (also skips the config's `default_loadouts`). Conflicts with `--loadout` |
+| `--no-hooks` | | Run none of the session's [lifecycle hooks](./loadouts.md#lifecycle_hooks---scripts-at-session-transition-points), from either the loadouts or the project's `minimal.toml`. Recorded on the session, so it applies to the later attach, detach, and destroy transitions too |
 | `--no-prompt` | | Fail instead of prompting when the daemon surfaces items user policy can't auto-decide; implied when stdin/stderr isn't a TTY |
 | `--attach` | | Automatically attach after creation |
 
@@ -131,6 +132,29 @@ min session policy <SESSION>
 Prints the effective networking policy for `SESSION` (a UUID or session
 name) as JSON — an object with `egress` and `ingress` fields, each null
 when unset. Resolved from the daemon.
+
+### `session hooks`
+
+```
+min session hooks <SESSION> [--json]
+```
+
+Lists the [lifecycle hooks](./loadouts.md#lifecycle_hooks---scripts-at-session-transition-points)
+composed into `SESSION` (a UUID or session name), one row per script, with
+the transition it runs on, whether it is inline or external, its timeout, and
+the loadout or project that declared it.
+
+This shows what will actually run, not what was asked for: the daemon answers
+from the session's composition, which holds only the hooks that survived your
+[user policy](./user-policy.md). A session activated with `--no-hooks`, or one
+whose project you never allow-listed, lists nothing.
+
+Rows are in setup order — the project first, then loadouts in the order they
+were applied; teardown runs the reverse. Inline bodies are collapsed to their
+first line; `--json` emits the full records.
+
+Answered from the persisted composition, so it works after a daemon restart
+and for a session nobody is attached to.
 
 ### `stop`
 

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -201,22 +201,105 @@ matches; see [`follow_symlinks`](#follow_symlinks) and the
 
 _Optional_
 
-Each hook groups up to three scripts (`on_activate`, `on_destroy`, and
-`on_failure`), and at least one must be present. An optional `description`
-labels the hook. Scripts are either inline or a path to a file:
+Each hook groups up to four scripts — `on_activate` when the session is
+created, `on_destroy` when it is destroyed, `on_attach` when you connect,
+and `on_detach` when you disconnect — and at least one must be present. An
+optional `description` labels the hook. Scripts are either inline or a path
+to a file:
 
 ```toml
 [[lifecycle_hooks]]
 description = "warm caches"
 on_activate = { type = "inline",   value = "cargo fetch || true" }
-on_failure  = { type = "external", value = "./cleanup.sh" }
+on_detach   = { type = "external", value = "./cleanup.sh", timeout = 120 }
 ```
 
-External script paths must be relative (absolute paths are rejected at
-parse time) and are anchored to the configuration directory the file was
-loaded from. Hooks from multiple contributors concatenate in declaration
-order. Note: in the current release hooks are composed and recorded with
-the session, but executing them is not yet wired up.
+Each script may set a `timeout` in whole seconds, defaulting to 60 and
+capped at 300; a script that exceeds the cap is rejected when the file is
+parsed.
+
+Scripts run under POSIX `sh` unless they open with a shebang, in which case
+they run under what it names — so a hook can be written in whatever you
+already think in:
+
+```toml
+[[lifecycle_hooks]]
+on_activate = { type = "inline", value = "#!/usr/bin/env fish\nset -gx ...\n" }
+on_detach   = { type = "external", value = "./teardown.py" }   # #!/usr/bin/env python3
+```
+
+The interpreter must be present *in the session*, and it is handed the
+script on standard input rather than as a file. That covers every shell and
+scripting language in common use; it does not cover one that insists on a
+file argument (`awk -f`). The shebang is parsed the way the kernel parses
+one — the interpreter is the first word, everything after it is a single
+argument (so `#!/usr/bin/env -S python3 -u` works, `-S` and all), and there
+is no quoting, so an interpreter path cannot contain spaces. Give an
+absolute path or a bare command for `env` to find: a relative path would
+resolve against the daemon, not the session. Default to POSIX `sh` where you
+can — it is the one interpreter a session is guaranteed to have.
+
+External script paths must be relative (absolute paths and `..` components
+are rejected at parse time). A loadout's scripts are anchored at a directory
+beside the loadout file, named after the loadout — so `dev.toml`'s scripts
+live in `dev/`:
+
+```
+<config>/minimal/loadouts/
+├── dev.toml
+└── dev/
+    ├── activate.sh
+    └── teardown.sh
+```
+
+A script must resolve to a regular file inside that directory. Symlinks are
+rejected rather than followed, at every path component — a symlink is the one
+way a path that passes every other check could still reach outside the
+anchor. All of this is checked on your machine before a session is created,
+so a mistyped path fails immediately and names the file.
+
+Hooks from multiple contributors concatenate in declaration order, and run in
+that order for the setup transitions (`on_activate`, `on_attach`) and in
+reverse for the teardown ones (`on_destroy`, `on_detach`) — so a project sets
+up before your loadouts and tears down after them.
+
+They execute inside the running session, sharing its packages, variables,
+files, and network. `on_attach` runs on the terminal you are attached to, so
+its output reaches you and `[ -t 1 ]` is true. The other three have no
+terminal and their output is captured into the daemon log — `on_detach`
+included, because the shell it would have run on is often the very thing
+that just went away (leaving a session by exiting its shell is a detach).
+
+On top of the session's own variables, each hook is given a few describing
+the run it is part of:
+
+| Variable | Value |
+|---|---|
+| `MINIMAL_SESSION_ID` | The session's id. |
+| `MINIMAL_SESSION_NAME` | Its display name. |
+| `MINIMAL_HOOK_EVENT` | The transition: `on_activate`, `on_destroy`, `on_attach`, or `on_detach`. |
+| `MINIMAL_HOOK_SOURCE_KIND` | `loadout` or `project` — for branching. |
+| `MINIMAL_HOOK_SOURCE_NAME` | The loadout's name, or the project's path as you refer to it on your own machine (not the daemon's copy of the tree). |
+| `MINIMAL_HOOK_INDEX` / `MINIMAL_HOOK_COUNT` | Position within this transition's run, 1-based — for logging, e.g. `[2/3]`. |
+
+Each teardown transition runs all of its hooks under a **single shared time
+budget** rather than giving each one its own timeout — `on_detach` and
+`on_destroy` get a budget each, not one between them. A session has to stay
+destroyable, and per-script caps alone would let enough hooks add up to hold
+one open. A hook that runs into the end of the budget is cut short and says
+so, and one the budget leaves no room for at all is reported as not run —
+either way the log distinguishes it from a hook that exhausted its own
+`timeout`, and teardown continues.
+
+A failing `on_activate` **fails the activation** — the session does not become
+attachable, and the error names the hook and what it printed. The other three
+never block their transition: a failing attach, detach, or destroy hook is
+logged and the session carries on. A session must always be attachable and
+always destroyable.
+
+`on_failure` was an earlier spelling that never executed; it has been
+removed. A hook file that still declares it is rejected with an error
+pointing at `on_destroy`.
 
 ### `follow_symlinks` - Symlink handling for patch sources {#follow_symlinks}
 
@@ -338,8 +421,8 @@ configuration. Merge semantics across all contributors:
   `ignore` list to drop all contributors of that variable.
 - **Patches** with the same destination and different sources are likewise
   a conflict.
-- **Lifecycle hooks** concatenate in declaration order (execution is not
-  yet wired up in the current release).
+- **Lifecycle hooks** concatenate in declaration order; setup transitions
+  run in that order and teardown transitions in reverse.
 
 Two loadouts with the same name cannot be applied together.
 

--- a/docs/reference/minimal-dot-toml.md
+++ b/docs/reference/minimal-dot-toml.md
@@ -160,8 +160,12 @@ on_activate = { type = "inline", value = "cargo check --workspace >/dev/null 2>&
   `dest` is relative to the session user's home directory; `source` resolves
   on the host, typically inside the repo.
 - **`lifecycle_hooks`**: Scripts declared for session transition points
-  (`on_activate`, `on_destroy`, `on_failure`). Composed and recorded today;
-  execution is not yet wired up in the current release.
+  (`on_activate`, `on_destroy`, `on_attach`, `on_detach`), run inside the
+  session under POSIX `sh` — or under whatever a leading shebang names, for
+  a hook you would rather write in fish or Python. A project's hooks require
+  the developer to allow-list the project in their
+  [user policy](./user-policy.md) before they will run — a hook is arbitrary
+  code, so the developer must opt in.
 
 The field shapes and composition semantics (conflicts, policy gating) are the
 same as loadouts; see the [loadout reference](./loadouts.md) for the exact

--- a/docs/reference/user-policy.md
+++ b/docs/reference/user-policy.md
@@ -17,18 +17,27 @@ choice on every activation. The allow list does not apply to values specified in
 loadouts, only the ignore and deny lists do.
 
 The policy is enforced **only on the client**, inside `min`, never on the
-daemon (see [Sessions](../concepts/sessions.md)). It gates two domains:
+daemon (see [Sessions](../concepts/sessions.md)). It gates three domains:
 
 - **Variables** — matched by variable **name**.
 - **Patches** — matched by the **source file paths** a patch enumerates on
   the host (the patch's `dest` is never matched).
+- **Lifecycle hooks** — matched by the **project root path** that declared
+  them.
 
-Packages and lifecycle hooks are not gated by the user policy as they do not request user data.
+The first two exist to stop a project pulling *your data* into a session. The
+third exists for a different reason: a [lifecycle
+hook](./loadouts.md#lifecycle_hooks---scripts-at-session-transition-points) is
+arbitrary code the project asks to run inside your session, so the risk is
+execution rather than disclosure. A project must be allow-listed before any
+hook it declares will run. Hooks declared in your own loadouts are not gated —
+they are your files already.
 
 Packages are effectively out of scope. A package cannot supply file
 patches, nor environment variables that carry host data (values inherited from
-your shell); Because packages cannot transfer host data into a session, the policy's protective
-purpose does not apply to them.
+your shell), nor lifecycle hooks; because packages cannot transfer host data
+into a session or ask to execute code, the policy's protective purpose does not
+apply to them.
 
 ## Where the policy lives
 
@@ -64,12 +73,13 @@ ignore = ["**/.DS_Store"]
 
 ## Schema
 
-The file has two optional sections, `[vars]` and `[patches]`. Each holds three
-optional keys — `allow`, `deny`, and `ignore` — and each key is a list of glob
-patterns. Every key defaults to empty, so any section or key may be omitted; an
-empty file is a valid empty policy.
+The file has three optional sections, `[vars]`, `[patches]`, and `[hooks]`.
+Each holds three optional keys — `allow`, `deny`, and `ignore` — and each key
+is a list of glob patterns. Every key defaults to empty, so any section or key
+may be omitted; an empty file is a valid empty policy.
 
-Each of the six lists accepts either a single bare string or a list of strings:
+Each of the nine lists accepts either a single bare string or a list of
+strings:
 
 ```toml
 [vars]
@@ -135,10 +145,43 @@ deny   = ["~/.ssh/**", "**/*.pem"]
 ignore = ["**/.DS_Store"]
 ```
 
+### `[hooks]` — Lifecycle-script rules
+
+Patterns match the **project root path** that declared the hook — as you refer
+to that project on your own machine, not the daemon's copy of it. The script's
+own contents and any file it names are never matched: this section decides
+*whose* code may run, not which code.
+
+| Key | Matches project roots whose… |
+|-----|------------------------------|
+| `allow` | hooks may run |
+| `deny` | hooks may never run, and whose presence fails the activation |
+| `ignore` | hooks are silently dropped without prompting |
+
+Only the project is arbitrated here. Your loadouts' hooks are your own files
+and run without consulting this section; packages cannot declare hooks at all,
+and any that appear are denied outright.
+
+Patterns expand the same way patch patterns do (`~/`, `$NAME`, `${NAME}`).
+They are globs, so a path containing glob metacharacters must be escaped to
+match itself — the prompt does that for you when you choose a permanent rule,
+which is why a hand-written entry is best kept to a plain path.
+
+A project matching nothing in this section is **undecided**, not allowed: it
+reaches the prompt, and under `--no-prompt` it fails the activation with a
+snippet naming the project. Silence is never consent — a hook is arbitrary
+code from someone else.
+
+```toml
+[hooks]
+allow = ["~/work/**"]
+deny  = ["/tmp/**"]
+```
+
 ## How a contribution is decided
 
-Every variable and every patch source is categorized against the relevant
-section in a fixed precedence:
+Every variable, every patch source, and every project that declares lifecycle
+hooks is categorized against the relevant section in a fixed precedence:
 
 1. **`deny`** — if it matches, the composition fails. Deny takes precedence
    over every other rule, including `ignore`: an item matched by both `deny`

--- a/docs/specs/11-spec-lifecycle-hooks/11-spec-lifecycle-hooks.md
+++ b/docs/specs/11-spec-lifecycle-hooks/11-spec-lifecycle-hooks.md
@@ -1,0 +1,413 @@
+---
+id: spec-lifecycle-hooks
+title: "Lifecycle hooks: user- and project-defined scripts at session transitions"
+kind: spec
+status: shipped
+tracking-issue:
+supersedes:
+---
+
+# Lifecycle hooks: user- and project-defined scripts at session transitions
+
+## Context
+
+Lifecycle hooks are a feature of session composables (loadouts, projects) that
+lets a user define arbitrary code to execute at a session's state transitions.
+Hooks execute inside the session's sandbox.
+
+This document is the as-shipped design. It began as a pre-implementation spec
+and has been reconciled against the implementation: where building it revealed
+the original design to be wrong or impossible, the text describes what shipped
+and says why it differs. Those points are marked **Changed from the original
+design**, and are the parts worth reading if you have seen the earlier draft.
+
+## User stories
+
+As a user I want to be able to…
+
+- Perform arbitrary actions to set up my development environment when it is
+  created
+- Perform arbitrary actions to set up my development environment when I
+  connect to it
+- Perform arbitrary actions to tear down my development environment when I
+  disconnect from it
+- Perform arbitrary actions to tear down my development environment when I
+  destroy it
+- Disable lifecycle hooks entirely on a session-by-session basis
+- List all lifecycle hooks associated with my session and determine where they
+  were defined
+
+As a project maintainer I want to be able to…
+
+- Do everything a user might want for environment set-up and tear-down,
+  consistently between developers
+- Have project-level hooks take precedence over user-level ones (first to set
+  up, last to tear down)
+
+As a lifecycle hook author I want to be able to…
+
+- Have access to all packages, variables, and files composed into the sandbox
+- Have access to additional metadata provided by minimal with additional
+  context
+- Define hooks in a shell, or in another interpreter of my choosing
+- Define hooks inline in a loadout or project (`minimal.toml`) file
+- Have write access to the sandbox filesystem
+- Have `on_attach` output reach the terminal I am attached to
+
+## Solution
+
+### Declaration
+
+Hooks are declared in loadouts and in projects (`minimal.toml`). Each may
+declare any number. A lifecycle hook consists of an optional string
+description and a set of optional hook scripts, one per transition. A hook
+must define at least one script to be valid; an empty one is a fatal error at
+deserialization.
+
+A hook script is either an inline script body or a path to a script file.
+Both are strings, so a `type` field labels which. Loadout script paths resolve
+against a directory in the user's loadouts directory named after the loadout;
+project script paths resolve against the project root. Paths may not traverse
+symlinks and may not contain `..`.
+
+Each hook script takes an optional `timeout`, defaulting to 60 seconds.
+
+#### Transitions
+
+| Transition | Fires when |
+|---|---|
+| `on_activate` | the session is created |
+| `on_destroy` | the session is destroyed |
+| `on_attach` | a client attaches |
+| `on_detach` | a client detaches |
+
+```toml
+[[lifecycle_hooks]]
+on_activate = { type = "external", value = "activate.sh" }
+on_destroy  = { type = "external", value = "teardown.sh" }
+on_attach   = { type = "external", value = "attach.sh" }
+on_detach   = { type = "external", value = "detach.sh" }
+
+[[lifecycle_hooks]]
+description = "warm the tree-sitter grammar cache"
+on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || true", timeout = 120 }
+```
+
+In a `minimal.toml` the section is prefixed with `session.`.
+
+`on_failure` was an earlier spelling that never executed. It is rejected by
+name at parse time with an error pointing at `on_destroy`, rather than being
+silently dropped — the hook deserializer otherwise ignores unrecognized keys,
+which would lose the script without saying so. A composition snapshot that
+still carries one loads, discards it, and logs a warning.
+
+### Interpreter
+
+**Changed from the original design.** The original specified bash. Hook
+bodies run under POSIX `sh` unless they open with a shebang, in which case
+they run under what it names.
+
+The contract is `sh`, not any one shell's extensions, so a hook that works in
+one session keeps working in a session whose `sh` is leaner. A hook wanting
+more says so the way every hook author already knows:
+
+```toml
+on_activate = { type = "inline", value = "#!/usr/bin/env fish\nset -gx ...\n" }
+```
+
+The shebang is parsed exactly as `execve(2)` parses one — the interpreter is
+the first word, everything after it is a **single** argument. That is what
+makes `#!/usr/bin/env -S python3 -u` work: `env` receives `-S python3 -u`
+whole and splits it itself. Splitting per-word here would hand `env` a `-S`
+with only `python3` attached.
+
+Two consequences of reading the shebang ourselves rather than letting a kernel
+do it (see *Execution*):
+
+- The interpreter must accept a program on standard input. Every shell and
+  scripting language in common use does; one that insists on a file argument
+  (`awk -f`) cannot be driven this way.
+- A relative interpreter path would resolve against the *daemon's* working
+  directory, not the session's. Name an absolute path, or a bare command for
+  `env` to find on the session's `PATH`.
+
+There is no quoting in a shebang line on any system, so an interpreter path
+cannot contain spaces.
+
+### External scripts
+
+A script path resolves against an anchor determined by where the hook was
+declared: a loadout named `dev` anchors at a `dev` directory beside
+`dev.toml`; a project anchors at the project root. The anchor cannot be
+decided when the file is parsed, because the same hook type is deserialized
+from both kinds of file — it is decided from the hook's recorded source.
+
+Validation runs on the client, before the session is created, so a mistyped
+path fails locally and immediately rather than partway through an activation.
+A script must resolve to a regular file underneath its anchor, must not climb
+out of it, and must not traverse a symlink at any component. Symlinks are
+rejected rather than followed, so canonicalizing the path is not sufficient —
+each component is checked as it is walked.
+
+Transport depends on origin:
+
+- **Inline** scripts need none; their bodies travel inside the composition.
+- **Project** scripts travel with the project tree, which activation uploads
+  into the session workspace, and the daemon resolves them there.
+- **Loadout** scripts are uploaded during activation, in a stream alongside
+  the patch upload.
+
+That upload is a separate archive stream rather than extra entries in the
+patch stream. Patch destinations are arbitrary paths under the session home,
+so any prefix reserved inside the patch archive is one a user could
+legitimately claim; and the daemon copies the entire staged patch tree into
+the home directory at finalize, where hook scripts do not belong. The stream
+reuses the existing archive builder and the existing atomic unpack-and-swap,
+landing scripts in a `hooks` directory beside `patches` in the session
+workspace.
+
+The daemon's finalize gate waits for that upload only for hooks that actually
+arrive by it. A project's external script is **not** counted: it comes with
+the project tree, so gating on a marker that is never sent would mean no
+project could declare an external hook script at all.
+
+### Client-side pre-flight
+
+**Changed from the original design.** The original routed these checks
+through `mip check`. `mip` is legacy, so the checks run on the client at
+activation instead — the same "fail on this machine, before a session exists"
+property, without a command nobody runs.
+
+Before the daemon is contacted, activation validates:
+
+- every **loadout** external script, as part of staging it;
+- every **project** external script, against the project root — validated but
+  not staged, since the project tree carries it;
+- every **inline** script is non-empty, which can only ever be a typo: it
+  declares a transition and then does nothing at it.
+
+Without this a bad project hook surfaces only when it runs, which for
+`on_destroy` is at teardown, long after the mistake.
+
+### Composition and ordering
+
+The hooks the client composes from loadouts and the hooks the daemon composes
+from the project meet in one composition. The daemon composes the project
+first and appends the client's contribution, so the composed list is ordered
+project-first, loadouts-after. That ordering is a guaranteed property,
+documented and covered by tests in both directions.
+
+Setup hooks run in that order; teardown hooks run in reverse. Project
+maintainers get the precedence the design calls for: project hooks set up
+first and tear down last. Among loadouts, hooks run in selection order.
+
+### Execution
+
+Hooks run as processes inside the session's sandbox, joining the session
+process's namespaces — not a freshly built sandbox. A new sandbox would share
+the rootfs and the persistent home and workspace mounts but get its own
+`/tmp`, its own `/dev`, and its own network namespace; on an own-IP session
+that fresh netns has no tap relayed to the switch, so a hook that fetches
+anything would fail there and succeed on a host-net session.
+
+**Changed from the original design.** The original wrote inline scripts into
+the sandbox as executable files. Scripts are instead **piped to the
+interpreter on standard input**. The staged-scripts directory is on the daemon
+filesystem and is not mounted into the sandbox, so a path would not resolve
+there; reading the bytes daemon-side collapses inline and external onto one
+code path; and it avoids materialising user-controlled executables inside the
+session. It also settles standard input: the script occupies it, so a hook
+cannot read the user's keystrokes out of an attached terminal. The cost is
+that no kernel sees the shebang, so minimal parses it (see *Interpreter*).
+
+`on_attach` runs on the same pseudo-terminal as the user's shell; its output
+reaches the attached client the way the shell's does. The other three have no
+terminal, and their output is captured and logged.
+
+Every hook receives the session's composed environment plus:
+
+| Variable | Value |
+|---|---|
+| `MINIMAL_SESSION_ID` | The session's id |
+| `MINIMAL_SESSION_NAME` | Its display name |
+| `MINIMAL_HOOK_EVENT` | The transition: `on_activate`, `on_destroy`, `on_attach`, `on_detach` |
+| `MINIMAL_HOOK_SOURCE_KIND` | `loadout` or `project`, for branching |
+| `MINIMAL_HOOK_SOURCE_NAME` | The loadout's name, or the project's path **as the client refers to it** |
+| `MINIMAL_HOOK_INDEX` / `MINIMAL_HOOK_COUNT` | Position within this transition's run, 1-based |
+
+### Trigger points
+
+**`on_activate`** runs when a session is finalized, after its patches are
+materialized into the sandbox home and before the session is marked
+attachable. The sandbox has not been built at that point — the daemon builds
+it lazily on first attach — so finalization builds it. That is the same
+cache-backed package resolution the first attach would perform, so the attach
+that follows is not slower for it. Setup work, and its failures, land at
+`min session activate`. The finalize response carries one entry per hook that
+ran, so the client can report it: an activate hook is headless, and without
+that the only trace is the daemon log.
+
+**`on_attach`** runs when a channel is bound to a session host, after the
+binding is installed so its output reaches the client. This covers the attach
+that creates the host and every later re-attach.
+
+**`on_destroy`** runs when a session is destroyed, before its host is stopped,
+since the sandbox must still exist for a hook to run in it. A session whose
+actor is not running has one started for the purpose — teardown is the actor's
+job, and taking the shortcut of deleting the record directly skips the hooks
+silently for every session whose actor has been reaped, which after a daemon
+restart is all of them.
+
+**`on_detach`** — **changed from the original design in three ways.**
+
+*It is headless.* The original had detach hooks run on the user's terminal.
+That is not achievable on the dominant path: leaving a session by exiting its
+shell means the shell's exit is precisely what ended the sandbox, so by the
+time a detach is observable there is no terminal and no namespace left to run
+in. Detach hooks run headlessly like activate and destroy, and the actor mints
+a host for them when none is live. `on_attach` still runs on the terminal.
+
+*Exiting the shell and keeping the session is a detach.* The original said a
+binding that ends because the shell exited "flows into destruction instead."
+That path offers Keep or Delete; Keep leaves the session alive, which is a
+detach by any reading. Delete flows into destruction and runs `on_destroy`.
+
+*Daemon shutdown does not fire it.* The original said it should. Asking for
+detach hooks reaches the sessions manager, which brings a session's actor up
+from disk on demand and would mint a sandbox to run them in — the opposite of
+what shutdown is doing. The session is being suspended, not left.
+
+A binding displaced by a second connection does not fire detach either: that
+is a replacement, not a departure. It is also unsafe to try — the attach that
+displaces it awaits the old binding's teardown from inside the host's own
+message loop, so a detach hook there deadlocks against the host it needs.
+
+### Failure handling
+
+Every hook runs under a timeout. Without one, a hook that hangs would wedge an
+attach or make a session impossible to destroy. The timeout bounds the write
+of the script to the interpreter as well as the wait for it, since an
+interpreter that never reads its input would otherwise block before the
+timeout applied.
+
+A hook killed by its timeout takes the interpreter with it. Anything the
+interpreter itself backgrounded survives, bounded instead by the session,
+whose PID namespace takes it when the shell exits.
+
+An activate hook that fails or times out **fails the activation**. The session
+does not become attachable, and the error names the hook's source and what it
+printed. A development environment whose setup script failed is not the
+environment the user asked for.
+
+Attach, detach, and destroy hooks never block their transition. A failing
+attach hook warns and the attach proceeds; a failing detach or destroy hook is
+logged and teardown proceeds. A session must always be destroyable.
+
+**Added since the original design.** Each teardown transition runs all of its
+hooks under a single shared time budget — `on_detach` and `on_destroy` get a
+budget each, not one between them. A per-script cap bounds nothing in
+aggregate, because nothing limits how many hooks a composition may carry: N
+hooks at the cap would hold a destroy open for N × the cap, which is the exact
+failure the cap exists to prevent. A hook that runs into the end of the budget
+is cut short and says so; one the budget leaves no room for is reported as not
+run. The log distinguishes both from a hook that exhausted its own `timeout`.
+The launch of a sandbox for a teardown hook is bounded the same way.
+
+### Disabling and listing
+
+Hooks are disabled per session with `min session activate --no-hooks`. The
+flag is persisted on the session record, not only applied to the composition,
+because attach, detach, and destroy fire from processes that never saw the
+original command. The client also omits hooks from what it composes and
+uploads, so such a session has no scripts staged for it at all.
+
+`min session hooks <session>` lists every hook composed into a session: the
+transition, the description, whether it is inline or external, and the loadout
+or project that declared it. It is served from the daemon's persisted
+composition snapshot, so it works after a daemon restart and without an
+attached session, and it reads that snapshot from the store rather than
+through the session's actor — a report has no business starting the thing it
+reports on.
+
+### User policy
+
+A project's hooks are arbitrary code from someone else, so a project must be
+allow-listed by path in `user_policy.toml` before any hook it declares will
+run. A loadout's hooks are the user's own file and are not gated. Packages
+cannot declare hooks; any that appear are denied outright.
+
+Silence is not consent: a project matching no rule is undecided, reaches the
+prompt, and under `--no-prompt` fails the activation with a snippet naming the
+project.
+
+The path matched is the project **as the client refers to it**, not the
+daemon's per-session copy of the tree. A per-session path would be different
+on every activation, making a permanent allow rule unmatchable and
+`--no-prompt` unusable.
+
+Policy patterns are globs, so the prompt escapes the path before storing it.
+Stored raw, a path containing glob metacharacters would either match its
+siblings — approving code execution nobody was asked about — or match nothing
+at all, leaving a rule that silently never fires.
+
+## Testing
+
+Schema and path validation are unit-tested in the crate owning the types:
+TOML round-trips for all four transitions, rejection of hooks with no scripts,
+and each path rule.
+
+Composition tests cover the ordering guarantee in both directions and confirm
+that a session activated with hooks disabled composes none.
+
+Daemon tests cover the activate, detach, and destroy trigger points against a
+mock sandbox: that hooks dispatch at the right moment, that a failing activate
+hook prevents a session from becoming attachable, that teardown hooks run for
+a session whose actor is idle, and that the teardown budget bounds a run in
+aggregate. The upload path is covered like the patch upload it mirrors.
+
+`on_attach` has no daemon-level test. It is the one transition that runs in
+the user's shell, so it resolves the sandbox's session leader from `/proc`,
+and the mock launcher's program is a childless shell with no leader to find.
+Faking one would prove the call happens but not the property the transition
+exists for.
+
+The session end-to-end harness is the only layer that exercises the real
+namespace injection, and it covers: all four transitions in one session
+lifecycle; shebang dispatch to a non-default interpreter; an external script
+through the upload and staging path; loadout-declared hooks; the three
+refusals (un-allow-listed project, failing activate, `--no-hooks`); and
+survival across a daemon restart. `on_attach` is asserted from the attached
+terminal's transcript, driven through a real pty.
+
+On VM lanes the daemon runs inside the guest and logs to a guest tmpfs, so the
+assertions that read a hook's captured output are native-lane only. What runs
+everywhere: that a failing teardown hook still tears the session down, and
+that `on_detach` ran — read back through the session rather than from a log.
+
+## Threat model
+
+| Threat | Mitigation | Notes |
+|---|---|---|
+| A malicious project provides a hook that exfiltrates sensitive data | The project must be allow-listed in the user policy before any hook runs | Shared responsibility between minimal and users |
+| A malicious project infiltrates user data into a session for a hook to exfiltrate | Files and variables carrying user data must themselves be allow-listed before entering the session | Shared responsibility between minimal and users |
+| A malicious project denies service with a very large timeout and an infinite loop | Hard cap of 300 seconds on any hook's declared timeout, plus a per-transition teardown budget bounding all of a transition's hooks together | |
+| A malicious project steals compute by running it in a hook | Allow-listing, plus the timeout cap and teardown budget | |
+| A hook script path escapes its anchor to read a file outside the session | Path validation refuses `..` and absolute paths at construction, refuses a symlink at any component when staged, and re-checks containment on the daemon before reading | The daemon check is defence in depth: it is currently unreachable, and tested directly for that reason |
+
+Lifecycle hooks fundamentally provide arbitrary code execution. Beyond the
+above, the best that can be done is to make the user aware that a project
+wants to run code, and to let them decline until they have reviewed it.
+
+## Known gaps
+
+- A project's external hook script is not uploaded when the project tree is
+  not (`--sync none`). The client-side pre-flight catches a *missing* script,
+  but a present one that never reaches the daemon fails when the hook runs.
+- The persisted composition snapshot is not version-gated on read: a snapshot
+  claiming a version newer than this daemon understands is parsed rather than
+  refused.
+- A composition snapshot written before the provenance fix carries the daemon's
+  per-session workspace path as the project's identity. Script resolution
+  ignores that path, so the visible effect is limited to
+  `MINIMAL_HOOK_SOURCE_NAME` and hook diagnostics for sessions created before
+  the fix.

--- a/scripts/e2e-attach-pty.py
+++ b/scripts/e2e-attach-pty.py
@@ -12,6 +12,17 @@ Usage: e2e-attach-pty.py <add_tool> <argv...>
   <add_tool>  package to `min add` (also its binary + `--version` subject)
   <argv...>   the command to spawn under the pty, e.g. `min --provider local-minvmd session attach <sid>`
 
+Two environment variables retarget it for callers that want a pty and a
+transcript but not the sandbox proof's command stream (the lifecycle-hooks
+proof drives an attach to observe `on_attach` on the terminal, then leaves
+to fire `on_detach`):
+
+  E2E_PTY_COMMANDS  newline-separated lines to type instead of the default
+                    `min add` stream. `<add_tool>` is then unused; pass `-`.
+  E2E_PTY_ANSWER    how to answer the session-exit prompt: `delete` (the
+                    default, what the sandbox proof needs) or `keep`, which
+                    leaves the session alive — a detach.
+
 Prints the full captured terminal output on stdout. Exits 0 iff the attach
 process exited 0.
 """
@@ -29,19 +40,29 @@ if not attach_argv:
     sys.stderr.write("e2e-attach-pty: missing attach argv\n")
     sys.exit(2)
 
-# Built so the absence marker `TOOL_ABSENT_BEFORE` appears ONLY as executed
-# output, never as echoed input (the pty echoes what we type).
-commands = [
-    f"if command -v {add_tool} >/dev/null 2>&1; then "
-    f"printf 'TOOL_%s_BEFORE\\n' PRESENT; else printf 'TOOL_%s_BEFORE\\n' ABSENT; fi",
-    f"min add {add_tool}",
-    "hash -r",
-    f"{add_tool} --version",
-    "exit",
-]
+if os.environ.get("E2E_PTY_COMMANDS") is not None:
+    commands = os.environ["E2E_PTY_COMMANDS"].split("\n")
+else:
+    # Built so the absence marker `TOOL_ABSENT_BEFORE` appears ONLY as executed
+    # output, never as echoed input (the pty echoes what we type).
+    commands = [
+        f"if command -v {add_tool} >/dev/null 2>&1; then "
+        f"printf 'TOOL_%s_BEFORE\\n' PRESENT; else printf 'TOOL_%s_BEFORE\\n' ABSENT; fi",
+        f"min add {add_tool}",
+        "hash -r",
+        f"{add_tool} --version",
+        "exit",
+    ]
 
 EXIT_PROMPT = b"would you like to do with this session"  # SHELL_EXIT_PROMPT, lowercased
-DELETE_KEY = b"\x1b[B\r"  # Down arrow -> "Delete", Enter to confirm
+# The prompt's first option is "Exit, leaving the session ... in place" — so a
+# bare Enter keeps the session (a detach), and Down+Enter selects "Delete".
+PROMPT_KEYS = {"delete": b"\x1b[B\r", "keep": b"\r"}
+answer = os.environ.get("E2E_PTY_ANSWER", "delete")
+if answer not in PROMPT_KEYS:
+    sys.stderr.write(f"e2e-attach-pty: unknown E2E_PTY_ANSWER {answer!r}\n")
+    sys.exit(2)
+PROMPT_ANSWER_KEY = PROMPT_KEYS[answer]
 DEADLINE = time.monotonic() + 240  # overall safety cap
 
 pid, fd = pty.fork()
@@ -76,7 +97,7 @@ try:
             break  # EOF / closed
         buf.extend(chunk)
         if not answered and EXIT_PROMPT in bytes(buf).lower():
-            os.write(fd, DELETE_KEY)  # answer the prompt like a user
+            os.write(fd, PROMPT_ANSWER_KEY)  # answer the prompt like a user
             answered = True
 finally:
     # Don't let a hung attach wedge the lane.

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -83,6 +83,7 @@ ADD_TOOL_MARKER="jq-1"
 SEED_DIR=""
 SEEDED_MFILE=""
 TASK_SEED_DIR="" # seeded by the `min task run` proof below; removed on teardown
+HOOK_SEED_DIR="" # seeded by the lifecycle-hooks proof below; removed on teardown
 if [ -z "${E2E_PROJECT_DIR:-}" ]; then
   # Native: self-seed a small throwaway — never $ROOT (uploading the whole repo,
   # and scaffolding over its `.minimal/`, is the very clobber #758 prevents).
@@ -197,6 +198,7 @@ teardown() {
   [ -n "$SEED_DIR" ] && rm -rf "$SEED_DIR"
   [ -n "$SEEDED_MFILE" ] && rm -f "$SEEDED_MFILE"
   [ -n "$TASK_SEED_DIR" ] && rm -rf "$TASK_SEED_DIR"
+  [ -n "$HOOK_SEED_DIR" ] && rm -rf "$HOOK_SEED_DIR"
   # And the state dir — which is NOT just metadata. On a VM lane it holds the
   # provider's per-VM writable data volume
   # (`minimal/providers/local-minvmd0/data-vol.raw`), a sparse image whose HOST
@@ -455,6 +457,343 @@ if [ -n "$SEED_DIR" ] || [ -n "$SEEDED_MFILE" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Lifecycle-hooks proofs. These are the only coverage of hook execution that
+# goes through the real nsenter injection: the unit tests substitute a
+# host-side command builder for it, so a break in the injection, in the
+# script upload, or in the client/daemon round trip would not show up there.
+#
+# Seeded projects of their own, like the task-run proof, because the shared
+# seed declares no hooks.
+if [ -n "$SEED_DIR" ] || [ -n "$SEEDED_MFILE" ]; then
+  # Every fixture below is a project, and a project's hooks only run once the
+  # user has allow-listed it. Written up front so nothing has to be answered
+  # interactively — and note this is only writable in advance because the
+  # policy stores the project path as the CLIENT knows it. A daemon that
+  # stamped its own per-session workspace copy would make this unmatchable,
+  # which is what `hooks_gate_refuses_without_an_allow_entry` below pins from
+  # the other side.
+  hook_allow() {
+    mkdir -p "$XDG_CONFIG_HOME/minimal"
+    printf '[hooks]\nallow = ["%s"]\n' "$1" > "$XDG_CONFIG_HOME/minimal/user_policy.toml"
+  }
+  # `mktemp -d`, then resolve it. macOS's /tmp is a symlink to /private/tmp,
+  # and `min session activate .` reports the project by its RESOLVED path —
+  # so an allow entry written against the unresolved one names a project the
+  # daemon never sees, and the activation fails the gate on that lane only.
+  # Every hooks fixture goes through here so the path in the policy and the
+  # path in the record are the same string on every host.
+  hook_mktemp() {
+    local dir
+    dir="$(mktemp -d "$1")" || return 1
+    (cd "$dir" && pwd -P)
+  }
+  # The `[upstream]` stanza every fixture needs, plus the shell stack.
+  hook_seed_preamble() {
+    awk '
+      /^\[upstream\]/            { grab = 1; print; next }
+      grab && (/^$/ || /^\[/)    { exit }
+      grab                       { print }
+    ' "$ROOT/.minimal/minimal.toml"
+    printf '\n[stack]\nuse = "shell"\n'
+  }
+  # Grep the daemon's file log. The only way to observe a hook whose session
+  # is gone by the time you could look (`on_destroy`), and the reason those
+  # fixtures exit non-zero: RUST_LOG is `warn` here, so the INFO "hook ran"
+  # record is not emitted, but the WARN "hook failed" record is — and it
+  # carries the hook's captured output, which is the evidence.
+  hook_log_has() {
+    find "$XDG_STATE_HOME/minimal/logs" -name 'minimald.log.*' -type f \
+      -exec grep -l -- "$1" {} + 2>/dev/null | head -n1
+  }
+  # Whether that log is on THIS host. On a VM lane minimald runs inside the
+  # guest and writes to a guest tmpfs (`/run/minimal`), which no host path
+  # reaches — the host's log dir holds only `minvmd.log`. So the assertions
+  # that read a hook's captured output are native-only.
+  #
+  # What is NOT skipped anywhere: that the destroy still completed. That half
+  # of the contract ("a failing teardown hook must not block the teardown")
+  # is asserted off `min ls` on every lane, and `on_detach` — the other
+  # headless teardown hook — is proved on every lane too, by a marker read
+  # back through the session rather than out of a log.
+  hook_log_readable() { [ -z "$E2E_VM" ]; }
+
+  # -- A. The four transitions, one session ---------------------------------
+  # One fixture and one activation covering activate → attach → detach →
+  # destroy. Separate activations would be separate package installs for no
+  # extra coverage.
+  echo "::group::lifecycle hooks: the four transitions"
+  HOOK_SEED_DIR="$(hook_mktemp /tmp/mnlh.XXXXXX)"
+  # shellcheck disable=SC2016 # `$MINIMAL_HOOK_EVENT` and `$0` must reach the
+  # TOML *unexpanded*: they are for the hook's own shell to expand inside the
+  # session, and expanding them here would write this script's values instead
+  # — which is exactly what these assertions are checking did not happen.
+  {
+    hook_seed_preamble
+    # No shebang on the first hook: proves the POSIX-`sh` default.
+    # `$MINIMAL_HOOK_EVENT` proves the metadata env reaches the hook.
+    printf '\n[[session.lifecycle_hooks]]\n'
+    printf 'description = "e2e transition markers"\n'
+    printf 'on_activate = { type = "inline", value = "echo HOOK_OK $MINIMAL_HOOK_EVENT > /home/hook-activate" }\n'
+    printf 'on_attach   = { type = "inline", value = "echo HOOK_ATTACH_OK" }\n'
+    printf 'on_detach   = { type = "inline", value = "echo HOOK_OK $MINIMAL_HOOK_EVENT > /home/hook-detach" }\n'
+    # Non-zero on purpose: makes the daemon log the run at WARN *with its
+    # output*, which is the only evidence that outlives the session — and
+    # asserts the contract that a failing teardown hook still tears down.
+    printf 'on_destroy  = { type = "inline", value = "echo HOOK_DESTROY_OK; exit 3" }\n'
+    # A second hook, dispatched by shebang rather than the default, writing
+    # the interpreter it actually ran under.
+    printf '\n[[session.lifecycle_hooks]]\n'
+    printf 'description = "e2e shebang dispatch"\n'
+    printf 'on_activate = { type = "inline", value = "#!/usr/bin/bash\\necho $0 > /home/hook-shebang\\n" }\n'
+  } > "$HOOK_SEED_DIR/minimal.toml"
+  mkdir "$HOOK_SEED_DIR/.git"
+  hook_allow "$HOOK_SEED_DIR"
+
+  hook_sid="$(cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt 2>"$WORK/hooks-activate.err")" || {
+    echo "::error::'min session activate' with project hooks failed"
+    echo "--- stderr ---"; cat "$WORK/hooks-activate.err" 2>/dev/null || true
+    fail
+  }
+
+  # on_activate. Read back from INSIDE the session, so this asserts the hook
+  # ran in the session's namespaces rather than anywhere on the host.
+  hook_out="$(mnl session exec "$hook_sid" 'cat /home/hook-activate' 2>"$WORK/hooks-read.err")" || {
+    echo "::error::could not read the activate hook's marker from the session"
+    echo "--- stderr ---"; cat "$WORK/hooks-read.err" 2>/dev/null || true
+    fail
+  }
+  if [[ "$hook_out" != *"HOOK_OK on_activate"* ]]; then
+    echo "::error::on_activate hook did not run in the session (marker: '$hook_out')"
+    echo "--- activate stderr ---"; cat "$WORK/hooks-activate.err" 2>/dev/null || true
+    fail
+  fi
+
+  # Shebang dispatch: the second hook ran under the interpreter it named, not
+  # the default. Resolved against the SESSION's filesystem, which is the part
+  # no unit test can reach.
+  sheb_out="$(mnl session exec "$hook_sid" 'cat /home/hook-shebang' 2>/dev/null)"
+  if [[ "$sheb_out" != *bash* ]]; then
+    echo "::error::shebang hook did not run under the interpreter it named (\$0: '$sheb_out')"
+    fail
+  fi
+  echo "on_activate + shebang dispatch OK"
+
+  # on_attach and on_detach, over a REAL pty — `on_attach` writes to the
+  # terminal you are attached to, and a detach is by definition something a
+  # non-interactive caller cannot perform. Answer the exit prompt with `keep`
+  # (Enter, the first option) so leaving the shell is a detach rather than a
+  # destroy.
+  # shellcheck disable=SC2086 # E2E_MINIMAL_ARGS must word-split.
+  attach_out="$(E2E_PTY_COMMANDS='cat /home/hook-activate
+exit' E2E_PTY_ANSWER=keep python3 "$ROOT/scripts/e2e-attach-pty.py" - \
+    min ${E2E_MINIMAL_ARGS:-} session attach "$hook_sid" \
+    2>"$WORK/hooks-attach.err")" || {
+    echo "::error::pty attach for the hooks proof failed"
+    echo "--- transcript ---"; printf '%s\n' "$attach_out"
+    echo "--- stderr ---"; cat "$WORK/hooks-attach.err" 2>/dev/null || true
+    fail
+  }
+  # `on_attach` runs on the attached terminal, so its output is in the
+  # transcript. Glob, not grep — same SIGPIPE-under-pipefail reasoning as the
+  # sandbox proof's marker checks.
+  if [[ "$attach_out" != *HOOK_ATTACH_OK* ]]; then
+    echo "::error::on_attach hook output did not reach the attached terminal"
+    echo "--- transcript ---"; printf '%s\n' "$attach_out"
+    fail
+  fi
+  # Keeping at the exit prompt is a detach, and the session must survive it.
+  if ! mnl ls --raw 2>/dev/null | grep -q -- "$hook_sid"; then
+    echo "::error::session gone after answering the exit prompt with 'keep'"
+    fail
+  fi
+  # `on_detach` is headless (the terminal it would have used is the thing
+  # that just left), so its marker is read back the same way as activate's.
+  # Reported by the departing binding rather than by anything we called, so
+  # it lands shortly after the attach returns.
+  detached=""
+  for _ in $(seq 1 40); do
+    if mnl session exec "$hook_sid" 'cat /home/hook-detach' 2>/dev/null | grep -q HOOK_OK; then
+      detached=1; break
+    fi
+    sleep 0.25
+  done
+  if [ -z "$detached" ]; then
+    echo "::error::on_detach hook did not run after the attach ended"
+    echo "--- transcript ---"; printf '%s\n' "$attach_out"
+    fail
+  fi
+  echo "on_attach (on the terminal) + on_detach (headless, after leaving) OK"
+
+  # on_destroy. The session's filesystem goes with it, so the evidence is the
+  # daemon log — and the failing hook must not have blocked the teardown.
+  mnl session destroy --force "$hook_sid" >/dev/null 2>&1 \
+    || { echo "::error::could not destroy the hooks session $hook_sid"; fail; }
+  if hook_log_readable; then
+    destroy_log=""
+    for _ in $(seq 1 40); do
+      destroy_log="$(hook_log_has HOOK_DESTROY_OK)"
+      [ -n "$destroy_log" ] && break
+      sleep 0.25
+    done
+    if [ -z "$destroy_log" ]; then
+      echo "::error::on_destroy hook left no record in the daemon log"
+      echo "--- log dir ---"; ls -la "$XDG_STATE_HOME/minimal/logs" 2>/dev/null || true
+      fail
+    fi
+    echo "on_destroy OK (ran, output captured, and a non-zero exit still destroyed)"
+  else
+    echo "on_destroy: output check skipped (guest-side daemon log)"
+  fi
+  # Lane-agnostic half: a failing teardown hook must not keep the session.
+  if mnl ls --raw 2>/dev/null | grep -q -- "$hook_sid"; then
+    echo "::error::a failing on_destroy hook blocked the teardown"
+    fail
+  fi
+  rm -rf "$HOOK_SEED_DIR"; HOOK_SEED_DIR=""
+  echo "::endgroup::"
+
+  # -- B. External hook scripts ---------------------------------------------
+  # The longest untested chain in the feature: the client resolves the path
+  # against its anchor, refuses a symlink at any component, tars it up; the
+  # daemon unpacks it under the session's hooks dir with its own per-entry
+  # validation; and at run time the daemon re-derives the same staged path
+  # from the hook's source and reads it. Every piece has unit coverage;
+  # nothing covered the wire between them.
+  echo "::group::lifecycle hooks: external scripts"
+  HOOK_SEED_DIR="$(hook_mktemp /tmp/mnlx.XXXXXX)"
+  {
+    hook_seed_preamble
+    printf '\n[[session.lifecycle_hooks]]\n'
+    printf 'description = "e2e external script"\n'
+    printf 'on_activate = { type = "external", value = "hooks/setup.sh" }\n'
+  } > "$HOOK_SEED_DIR/minimal.toml"
+  mkdir "$HOOK_SEED_DIR/.git" "$HOOK_SEED_DIR/hooks"
+  printf '#!/usr/bin/bash\necho HOOK_EXTERNAL_OK > /home/hook-external\n' \
+    > "$HOOK_SEED_DIR/hooks/setup.sh"
+  chmod +x "$HOOK_SEED_DIR/hooks/setup.sh"
+  hook_allow "$HOOK_SEED_DIR"
+
+  ext_sid="$(cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt 2>"$WORK/hooks-ext.err")" || {
+    echo "::error::activation with an external hook script failed"
+    echo "--- stderr ---"; cat "$WORK/hooks-ext.err" 2>/dev/null || true
+    fail
+  }
+  ext_out="$(mnl session exec "$ext_sid" 'cat /home/hook-external' 2>/dev/null)"
+  if [[ "$ext_out" != *HOOK_EXTERNAL_OK* ]]; then
+    echo "::error::external hook script did not run (marker: '$ext_out')"
+    echo "--- activate stderr ---"; cat "$WORK/hooks-ext.err" 2>/dev/null || true
+    fail
+  fi
+  mnl session destroy --force "$ext_sid" >/dev/null 2>&1 || true
+  rm -rf "$HOOK_SEED_DIR"; HOOK_SEED_DIR=""
+  echo "external hook script proof OK (staged, uploaded, resolved, ran)"
+  echo "::endgroup::"
+
+  # -- C. The refusals ------------------------------------------------------
+  # Three ways hooks must NOT run, each spanning the client/daemon boundary.
+  echo "::group::lifecycle hooks: refusals"
+  HOOK_SEED_DIR="$(hook_mktemp /tmp/mnlr.XXXXXX)"
+  {
+    hook_seed_preamble
+    printf '\n[[session.lifecycle_hooks]]\n'
+    printf 'description = "e2e refusal fixture"\n'
+    printf 'on_activate = { type = "inline", value = "echo HOOK_REFUSAL_MARKER > /home/hook-refusal; exit 9" }\n'
+  } > "$HOOK_SEED_DIR/minimal.toml"
+  mkdir "$HOOK_SEED_DIR/.git"
+
+  # C1: no allow entry + --no-prompt. The consent boundary for arbitrary code
+  # execution: it must refuse, and the error must carry a snippet the user
+  # can act on. Asserting the snippet's CONTENT is what catches a regression
+  # to an unmatchable project path.
+  rm -f "$XDG_CONFIG_HOME/minimal/user_policy.toml"
+  if (cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt >/dev/null 2>"$WORK/hooks-gate.err"); then
+    echo "::error::activation with un-allow-listed project hooks should have refused"
+    fail
+  fi
+  if ! grep -q "hooks" "$WORK/hooks-gate.err" || ! grep -qF -- "$HOOK_SEED_DIR" "$WORK/hooks-gate.err"; then
+    echo "::error::the hooks refusal does not name the project in an actionable snippet"
+    echo "--- stderr ---"; cat "$WORK/hooks-gate.err" 2>/dev/null || true
+    fail
+  fi
+  echo "gate refuses an un-allow-listed project, naming it OK"
+
+  # C2: a failing on_activate fails the ACTIVATION — the session must not
+  # come up, and the error must name the hook and what it printed.
+  hook_allow "$HOOK_SEED_DIR"
+  if (cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt >/dev/null 2>"$WORK/hooks-failact.err"); then
+    echo "::error::activation should have failed on a failing on_activate hook"
+    fail
+  fi
+  if ! grep -qi "hook" "$WORK/hooks-failact.err"; then
+    echo "::error::the failed-activation error does not mention the hook"
+    echo "--- stderr ---"; cat "$WORK/hooks-failact.err" 2>/dev/null || true
+    fail
+  fi
+  echo "a failing on_activate aborts the activation OK"
+
+  # C3: --no-hooks. Both ends honour it (the client strips its loadouts'
+  # before sending, the daemon strips the project's), so the same fixture
+  # that just failed the activation must now come up clean.
+  nohooks_sid="$(cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt --no-hooks 2>"$WORK/hooks-nohooks.err")" || {
+    echo "::error::'--no-hooks' activation failed"
+    echo "--- stderr ---"; cat "$WORK/hooks-nohooks.err" 2>/dev/null || true
+    fail
+  }
+  if mnl session exec "$nohooks_sid" 'cat /home/hook-refusal' >/dev/null 2>&1; then
+    echo "::error::'--no-hooks' session ran its project's on_activate hook anyway"
+    fail
+  fi
+  # And the composition records that it has none, rather than carrying hooks
+  # every later transition has to remember to skip.
+  nohooks_list="$(mnl session hooks "$nohooks_sid" 2>/dev/null)"
+  if [[ "$nohooks_list" != *"No lifecycle hooks"* ]]; then
+    echo "::error::'--no-hooks' session still lists composed hooks: $nohooks_list"
+    fail
+  fi
+  mnl session destroy --force "$nohooks_sid" >/dev/null 2>&1 || true
+  echo "--no-hooks suppresses execution and composition OK"
+  rm -rf "$HOOK_SEED_DIR"; HOOK_SEED_DIR=""
+  rm -f "$XDG_CONFIG_HOME/minimal/user_policy.toml"
+  echo "::endgroup::"
+
+  # -- Loadout-declared hooks ------------------------------------------------
+  # A different path from everything above: composed on the CLIENT, ungated
+  # (they are the user's own file, not a project's), and staged under a
+  # different prefix. XDG_CONFIG_HOME is hermetic here, so the loadout only
+  # exists for this block.
+  echo "::group::lifecycle hooks: loadout-declared"
+  mkdir -p "$XDG_CONFIG_HOME/minimal/loadouts"
+  cat > "$XDG_CONFIG_HOME/minimal/loadouts/hookdev.toml" <<'LOADOUT'
+name = "hookdev"
+description = "e2e loadout hooks"
+
+[[lifecycle_hooks]]
+on_activate = { type = "inline", value = "echo HOOK_LOADOUT_OK > /home/hook-loadout" }
+LOADOUT
+  HOOK_SEED_DIR="$(hook_mktemp /tmp/mnll.XXXXXX)"
+  hook_seed_preamble > "$HOOK_SEED_DIR/minimal.toml"
+  mkdir "$HOOK_SEED_DIR/.git"
+
+  # No `[hooks] allow` written: a loadout's hooks face no policy gate, and
+  # --no-prompt proves it — a gate would fail the activation here.
+  lo_sid="$(cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt --loadout hookdev 2>"$WORK/hooks-loadout.err")" || {
+    echo "::error::activation with a loadout-declared hook failed"
+    echo "--- stderr ---"; cat "$WORK/hooks-loadout.err" 2>/dev/null || true
+    fail
+  }
+  lo_out="$(mnl session exec "$lo_sid" 'cat /home/hook-loadout' 2>/dev/null)"
+  if [[ "$lo_out" != *HOOK_LOADOUT_OK* ]]; then
+    echo "::error::loadout-declared hook did not run (marker: '$lo_out')"
+    echo "--- activate stderr ---"; cat "$WORK/hooks-loadout.err" 2>/dev/null || true
+    fail
+  fi
+  mnl session destroy --force "$lo_sid" >/dev/null 2>&1 || true
+  rm -rf "$HOOK_SEED_DIR"; HOOK_SEED_DIR=""
+  rm -f "$XDG_CONFIG_HOME/minimal/loadouts/hookdev.toml"
+  echo "loadout-declared hooks proof OK (ran, ungated)"
+  echo "::endgroup::"
+fi
+# ---------------------------------------------------------------------------
 # Session-sandbox proof (every lane). Everything above proves the lifecycle;
 # this forks a real sandbox and proves the in-sandbox `min add`. A session is
 # interactive by design, so we drive it like a real user through a REAL pty
@@ -536,6 +875,33 @@ if mnl ls --raw 2>/dev/null | grep -Fqx "$sid"; then
   fail
 fi
 
+# ---------------------------------------------------------------------------
+# Lifecycle hooks across a daemon restart. Staged around the stop/respawn
+# proof below rather than as its own block, because the restart is the point:
+# a session's hooks live in a composition snapshot on disk, and a daemon that
+# has never composed this session has to reconstruct them from it. Activated
+# here, asserted after the respawn.
+HOOK_RESTART_SID=""
+if [ -n "$SEED_DIR" ] || [ -n "$SEEDED_MFILE" ]; then
+  HOOK_SEED_DIR="$(hook_mktemp /tmp/mnlp2.XXXXXX)"
+  {
+    hook_seed_preamble
+    printf '\n[[session.lifecycle_hooks]]\n'
+    printf 'description = "e2e restart survivor"\n'
+    # Non-zero for the same reason as the transitions fixture: the WARN
+    # record is what carries the output past the session's own lifetime.
+    printf 'on_destroy = { type = "inline", value = "echo HOOK_RESTART_OK; exit 3" }\n'
+  } > "$HOOK_SEED_DIR/minimal.toml"
+  mkdir "$HOOK_SEED_DIR/.git"
+  hook_allow "$HOOK_SEED_DIR"
+  HOOK_RESTART_SID="$(cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt 2>"$WORK/hooks-restart.err")" || {
+    echo "::error::activation for the hooks-restart proof failed"
+    echo "--- stderr ---"; cat "$WORK/hooks-restart.err" 2>/dev/null || true
+    fail
+  }
+  rm -f "$XDG_CONFIG_HOME/minimal/user_policy.toml"
+fi
+
 # Shut the daemon down; it must not survive.
 # Keep stderr: discarding it leaves a failing stop indistinguishable from every
 # other one, and this assertion's error text is the whole diagnosis.
@@ -569,5 +935,43 @@ fi
 # half of #730.
 mnl ls >/dev/null 2>&1 \
   || { echo "::error::'minimal ls' after 'minimal stop' did not restart the daemon"; fail; }
+
+# The hooks staged before the stop must have survived it. This daemon never
+# composed that session — it is reading the snapshot off disk — so both halves
+# are worth asserting: that it can still SAY what the hooks are, and that it
+# can still RUN one.
+if [ -n "$HOOK_RESTART_SID" ]; then
+  echo "::group::lifecycle hooks: survive a daemon restart"
+  restart_list="$(mnl session hooks "$HOOK_RESTART_SID" 2>"$WORK/hooks-restart-list.err")"
+  if [[ "$restart_list" != *on_destroy* ]]; then
+    echo "::error::hooks did not survive the daemon restart: $restart_list"
+    echo "--- stderr ---"; cat "$WORK/hooks-restart-list.err" 2>/dev/null || true
+    fail
+  fi
+  mnl session destroy --force "$HOOK_RESTART_SID" >/dev/null 2>&1 \
+    || { echo "::error::could not destroy the hooks-restart session"; fail; }
+  # Same lane split as the transitions block: the hook's output is only
+  # readable where the daemon logs to this host. The listing above already
+  # proved the snapshot survived on every lane.
+  if hook_log_readable; then
+    restart_log=""
+    for _ in $(seq 1 40); do
+      restart_log="$(hook_log_has HOOK_RESTART_OK)"
+      [ -n "$restart_log" ] && break
+      sleep 0.25
+    done
+    if [ -z "$restart_log" ]; then
+      echo "::error::on_destroy did not run for a session composed by a previous daemon"
+      fail
+    fi
+  fi
+  if mnl ls --raw 2>/dev/null | grep -q -- "$HOOK_RESTART_SID"; then
+    echo "::error::the hooks-restart session survived its destroy"
+    fail
+  fi
+  rm -rf "$HOOK_SEED_DIR"; HOOK_SEED_DIR=""
+  echo "hooks survive a daemon restart OK (listed, and still executable)"
+  echo "::endgroup::"
+fi
 
 echo "session e2e OK"


### PR DESCRIPTION
Resolves https://github.com/gominimal/inbox/issues/201

## Summary

Sessions can now run scripts at their four transition points — `on_activate`,
`on_attach`, `on_detach`, `on_destroy` — declared either in a loadout or in a
project's `[session]` block. Hooks execute **inside the running session** by
joining its namespaces, so they see the same packages, variables, files, and
network the user does.

- **Declaration.** Inline bodies or external script paths, each with its own
  `timeout` (default 60s, capped at 300s — a hook is arbitrary code, so an
  unbounded one could hold a session open). Hooks concatenate in contributor
  order and run in reverse for teardown, so a project sets up before your
  loadouts and tears down after them.
- **Interpreter.** POSIX `sh` by default, or whatever a leading shebang names,
  parsed exactly as `execve(2)` would — so a hook can be fish or Python without
  behaving differently here than anywhere else.
- **Consent.** A *project's* hooks are arbitrary code from someone else, so
  they run only once the user allow-lists the project in their
  `[hooks]` policy; a loadout's are the user's own file and are ungated. A
  package cannot declare hooks at all, and the gate denies any that appear.
- **Failure semantics.** A failing `on_activate` fails the activation — a
  development environment whose setup script failed is not the environment
  that was asked for. The other three never block their transition: a session
  must always be attachable and always destroyable. Teardown additionally runs
  under one shared time budget across all its hooks.
- **Introspection.** `min session hooks <session>` lists what a session
  carries and where each hook came from, read from the persisted composition
  snapshot so it answers for stopped sessions and survives a daemon restart.
- **Opt-out.** `min session activate --no-hooks` drops them at composition
  time, so the session records that it has none rather than carrying hooks
  every later transition has to remember to skip.

Also lands the e2e coverage for the above, which found three bugs that unit
tests structurally could not: a project's external hook script could never
activate (the finalize gate demanded an upload the client does not send for
project-sourced scripts), `on_destroy` was silently skipped for any session
whose actor was idle (every session, after a daemon restart), and "Allow
permanent" stored the project path as a glob pattern, so a path containing
metacharacters either matched nothing or matched its siblings.

The session e2e's pty driver moved from Python to socat — see the dependency
note in the checklist below.

## Testing

`just e2e-native` — the full session e2e against a host-native daemon,
including the new hooks blocks and the rewritten pty driver:

```
::group::lifecycle hooks: the four transitions
on_activate + shebang dispatch OK
on_attach (on the terminal) + on_detach (headless, after leaving) OK
on_destroy OK (ran, output captured, and a non-zero exit still destroyed)
::group::lifecycle hooks: external scripts
external hook script proof OK (staged, uploaded, resolved, ran)
::group::lifecycle hooks: refusals
gate refuses an un-allow-listed project, naming it OK
a failing on_activate aborts the activation OK
--no-hooks suppresses execution and composition OK
::group::lifecycle hooks: loadout-declared
loadout-declared hooks proof OK (ran, ungated)
::group::sandbox proof (interactive attach via pty: min add jq + run)
sandbox proof: in-sandbox 'min add jq' + run OK, orientation banner rendered (3041ms)
::group::lifecycle hooks: survive a daemon restart
hooks survive a daemon restart OK (listed, and still executable)
session e2e OK
```

Unit and integration tests across the touched crates:

```
$ cargo test -p minimald -p sessions -p minimal -p mfile
total passed: 980   (0 failed)
```

Static gates:

```
$ just clippy       # clean
$ just fmt-check    # clean
$ just lint-shell   # 27 script(s) passed shellcheck
```

Each regression test was confirmed to fail against the pre-fix behaviour
before being kept — e.g. reverting the destroy fix yields *"destroying an idle
session skipped its on_destroy hook"*.

**Not run:** `just e2e` (the VM lane). This box has no `/dev/kvm`, so the
VM-backed path is unverified locally; the e2e is lane-agnostic and the native
lane exercises the identical script.

## Checklist

- [x] Docs updated if behavior changed

  `docs/reference/loadouts.md` (hook semantics, interpreter/shebang rules,
  metadata variables, teardown budget), `docs/reference/minimal-dot-toml.md`,
  `docs/reference/user-policy.md`, `docs/reference/cli-min.md`,
  `docs/concepts/loadouts.md`, and `AGENTS.md`.

- [x] `BREAKING CHANGE:` footer present if this is a breaking change

  Not breaking. `on_failure` — an earlier spelling that never executed — is
  rejected by name with an error pointing at `on_destroy`, rather than being
  silently ignored.

### Reviewer notes

- ~~**New host dependency: `socat`.** The e2e drives its interactive attaches
  through a real pty, because only a tty can answer the session-exit prompt.
  That driver was Python (an undeclared assumption that happens to hold on
  hosted runners); it is now `scripts/e2e-attach-pty.sh`. socat is present on
  stock Linux but **not** stock macOS — the self-hosted Apple Silicon runner
  needs `brew install socat` before the macOS lane will pass. Documented in
  AGENTS.md; I could not add an install step because `.github/workflows/` is
  frozen.~~
- `crates/sessions/src/core/policy.rs` gains `HooksPolicy` as a near-copy of
  `PatchesPolicy`. Left deliberately un-unified — the two are incidentally the
  same shape today and are expected to diverge.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add lifecycle hooks (on_activate, on_destroy, on_attach, on_detach) to sessions
> - Introduces four lifecycle hook transitions that run scripts inside the session at activation, destruction, attach, and detach; hooks are declared in loadout or project `minimal.toml` files and composed alongside vars and patches.
> - Adds a user-level `[hooks]` policy (allow/deny/ignore) that gates project-declared hooks; interactive mode prompts for approval and persists decisions to `user_policy.toml`; packages cannot declare hooks.
> - External hook scripts (file-backed, not inline) are validated and staged locally by the client then uploaded to the daemon via a new `WorkspaceHookScriptsTarZst` SSH subsystem before finalization.
> - `min activate --no-hooks` disables all hooks for a session; the choice persists across attach, detach, and destroy transitions.
> - Adds `min session hooks` CLI subcommand to list composed hooks for a running or idle session, with `--json` output support.
> - On-activate hook failures abort activation with a detailed error; detach/destroy hooks run best-effort under a shared 120s teardown budget and are skipped (with a warning) if a host cannot be started within 60s.
> - Risk: sessions with external hook scripts now require a hook-script upload step before `FinalizeSession` will succeed; missing the upload returns an `InvalidInput` error instructing the client to upload scripts first.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfd3e6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle hooks for activation, attachment, detachment, and destruction, including ordering, timeouts, output handling, and failure reporting.
  * Added `session hooks` to view configured hooks in table or JSON format.
  * Added policy-based hook approval, denial, and ignore controls.
  * Added `session activate --no-hooks`, persisted across later transitions.
  * Added safe staging and execution of external hook scripts.

* **Documentation**
  * Updated lifecycle hook configuration, policy, timeout, security, and migration guidance.
  * Added example configurations and end-to-end coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->