### PR TITLE
feat(minimald): fstrim after cache clean

### DIFF
--- a/crates/minimald/src/guest.rs
+++ b/crates/minimald/src/guest.rs
@@ -593,6 +593,89 @@ pub fn quiesce_state_volume(mountpoint: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+/// `struct fstrim_range` as `FITRIM` takes it: the byte range to discard and
+/// the minimum extent worth discarding. The kernel writes back `len` with the
+/// number of bytes it actually discarded, which is the only report of what a
+/// trim reclaimed.
+///
+/// `start` and `minlen` are read by the kernel through the pointer we hand it,
+/// which rustc cannot see — hence the `dead_code` waiver rather than a shape
+/// that omits them. The struct's layout *is* the contract; dropping a field
+/// would change the `FITRIM` request code below and the kernel's decode of it.
+#[repr(C)]
+#[allow(dead_code)]
+struct FstrimRange {
+    start: u64,
+    len: u64,
+    minlen: u64,
+}
+
+/// `FITRIM`, encoded as `_IOWR('X', 121, struct fstrim_range)`.
+///
+/// Computed rather than hardcoded so the derivation is auditable: the
+/// asm-generic `_IOC` layout is `dir << 30 | size << 16 | type << 8 | nr`,
+/// with `_IOWR`'s direction being read|write = 3. Every Linux target this
+/// daemon is built for (x86_64, aarch64) uses that layout; the four
+/// architectures that don't (mips, powerpc, sparc, alpha) are not targets.
+///
+/// Typed `u32` and cast at the call site: glibc's `ioctl` takes the request as
+/// `c_ulong` and musl's as `c_int`, and this daemon is built against both (the
+/// guest initramfs is static musl).
+const FITRIM: u32 =
+    (3 << 30) | ((size_of::<FstrimRange>() as u32) << 16) | ((b'X' as u32) << 8) | 121;
+
+/// Discard the free blocks of the filesystem mounted at `mountpoint`, returning
+/// the bytes the kernel reports having discarded.
+///
+/// This is the half of steady-state maintenance that reaches the *host*.
+/// Deleting files inside the guest frees ext4 blocks but writes nothing to the
+/// backing image, which is mounted without `discard`
+/// ([`mount_state_volume`]) and so is a high-water mark of every block ever
+/// written. `FITRIM` issues virtio UNMAP for the freed extents, which libkrun's
+/// virtio-blk turns into a hole-punch on the host image. Without it a sweep
+/// reclaims nothing the user can see.
+///
+/// `syncfs(2)` runs first: freshly-deleted extents are not free until the
+/// journal commits, so trimming straight after a sweep otherwise reports far
+/// less than the sweep released.
+///
+/// Safe to run on a live filesystem — `FITRIM` is the online-discard ioctl —
+/// but it takes ext4's block-group locks as it walks, so callers schedule it
+/// against idle time rather than contending with a build. The daemon's caller
+/// is the `maintenance` actor, which runs it behind the cache clean.
+///
+/// Blocking, and unbounded: the walk is proportional to the filesystem, not to
+/// what the clean freed. Callers on an async runtime owe it a blocking thread.
+pub fn trim_state_volume(mountpoint: &str) -> std::io::Result<u64> {
+    use std::os::fd::AsRawFd;
+
+    let dir = std::fs::File::open(mountpoint)?;
+    // SAFETY: `syncfs(2)` on a valid open fd; blocks until dirty pages and
+    // journal entries of the containing filesystem reach the block device, so
+    // the extents this sweep just freed are actually free before we walk them.
+    if unsafe { libc::syncfs(dir.as_raw_fd()) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    // `len: u64::MAX` asks for the whole device; the kernel clamps it to the
+    // filesystem size. `minlen: 0` takes the driver's own granularity rather
+    // than imposing one — the point here is to return as much as the backing
+    // image can reclaim, not to skip small extents.
+    let mut range = FstrimRange {
+        start: 0,
+        len: u64::MAX,
+        minlen: 0,
+    };
+    // SAFETY: `FITRIM` on a valid open fd for a mounted filesystem, with a
+    // pointer to a live, correctly-shaped `fstrim_range` the kernel both reads
+    // and writes back through.
+    if unsafe { libc::ioctl(dir.as_raw_fd(), FITRIM as _, &raw mut range) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // The kernel overwrites `len` with the bytes it discarded.
+    Ok(range.len)
+}
+
 /// Take the microVM down, by resetting it. Does not return on success: the
 /// guest resets, and libkrun's VMM exits with it. On failure it returns the
 /// `reboot(2)` error.
@@ -1197,6 +1280,17 @@ fn mount_if_absent(target: &str, source: &str, fstype: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The derivation in [`FITRIM`] must land on the number the kernel
+    /// actually decodes. `0xc018_5879` is the value every asm-generic Linux
+    /// arch has for `_IOWR('X', 121, struct fstrim_range)`; if the struct ever
+    /// changed shape the size field would move and the ioctl would be a
+    /// different, unrelated request.
+    #[test]
+    fn the_fitrim_request_code_matches_the_kernels() {
+        assert_eq!(size_of::<FstrimRange>(), 24, "three u64s, no padding");
+        assert_eq!(FITRIM, 0xc018_5879);
+    }
 
     /// Small drift is left alone: the host sends every 60s, and stepping the
     /// clock for sub-threshold noise would rewrite it on every update.

--- a/crates/minimald/src/maintenance.rs
+++ b/crates/minimald/src/maintenance.rs
@@ -1,10 +1,18 @@
 //! Housekeeping the daemon runs on its own clock, with no client asking.
 //!
-//! Today that is one job: reclaiming the local cache. A long-lived daemon
-//! accumulates build artifacts nothing reads any more, plus the sandbox, task
-//! and temp directories of executions whose process is long gone. `mip cache
-//! clean` does this on demand for a project; here the same [`op::CleanCache`]
-//! runs for the daemon, with every live session's packages held back.
+//! The job is reclaiming the local cache. A long-lived daemon accumulates
+//! build artifacts nothing reads any more, plus the sandbox, task and temp
+//! directories of executions whose process is long gone. `mip cache clean`
+//! does this on demand for a project; here the same [`op::CleanCache`] runs
+//! for the daemon, with every live session's packages held back.
+//!
+//! In the microVM there is a second half to it. Unlinking files inside the
+//! guest returns blocks to ext4 and nothing else: the data volume is mounted
+//! without `discard`, so the host's backing image only ever grows, and a clean
+//! that reclaims gigabytes inside the VM reclaims nothing the user can see on
+//! their disk. So every clean that ran is followed by an `FITRIM`
+//! ([`guest::trim_state_volume`](crate::guest::trim_state_volume)), which is
+//! what actually punches the freed extents out of the image.
 //!
 //! Cleaning is an actor, not a bare timer, because there is more than one way
 //! to ask for one: the periodic tick, and anything that wants a clean *now*.
@@ -96,13 +104,25 @@ impl Maintenance {
                     None => break,
                     Some(MaintenanceMessage::CleanNow { older_than, events, responder }) => {
                         let older_than = older_than.unwrap_or(UNUSED_FOR);
-                        responder.handle(clean(&self.state, older_than, events)).await;
+                        let report = clean(&self.state, older_than, events).await;
+                        // The trim finishes before the caller is answered: a
+                        // reply means the whole reclaim is done, on the host's
+                        // disk as well as inside the guest. Answering early
+                        // would have `mip cache clean` return while the space
+                        // it reported is still not back, which is the one
+                        // question the caller is asking.
+                        if report.is_ok() {
+                            trim_state_volume_if_mounted(&self.state).await;
+                        }
+                        responder.handle(std::future::ready(report)).await;
                         next_tick = Instant::now() + CLEAN_INTERVAL;
                     }
                 },
                 () = tokio::time::sleep_until(next_tick) => {
                     // Nobody is waiting on this one; `clean` logged the outcome.
-                    let _ = clean(&self.state, UNUSED_FOR, None).await;
+                    if clean(&self.state, UNUSED_FOR, None).await.is_ok() {
+                        trim_state_volume_if_mounted(&self.state).await;
+                    }
                     next_tick = Instant::now() + CLEAN_INTERVAL;
                 }
             }
@@ -127,9 +147,12 @@ impl MaintenanceHandle {
     /// for a caller relaying it (the `CleanCache` RPC streams it to its
     /// client).
     ///
-    /// Queues behind a clean already in progress rather than starting a second
-    /// one, so this can take as long as a full clean plus the one ahead of it,
-    /// and `events` stays silent until this request's turn comes.
+    /// Returns only once the reclaim is complete end to end — including, in
+    /// the microVM, the `FITRIM` that returns the freed blocks to the host
+    /// image. Queues behind a clean already in progress rather than starting a
+    /// second one, so this can take as long as a full clean-and-trim plus the
+    /// one ahead of it, and `events` stays silent until this request's turn
+    /// comes (the trim reports to the log, not through `events`).
     /// `NotConnected` once the actor has stopped (shutdown).
     pub(crate) async fn clean_now(
         &self,
@@ -258,6 +281,56 @@ async fn clean(
         }
     }
 }
+
+/// Hand the blocks the clean just freed back to the host image — the trim half
+/// of the module doc. No-op unless the boot path actually mounted a data volume
+/// at the state dir, which in practice means the microVM: a native daemon's
+/// state dir is a directory on the user's own filesystem, not this daemon's to
+/// discard against.
+///
+/// Every failure is logged and swallowed. A trim reclaims space; it never
+/// affects correctness, and a daemon whose housekeeping cannot punch holes
+/// still has a correct cache. `Unsupported` is the ordinary case for a
+/// filesystem or block driver without discard (a native-Linux `minimald` run
+/// with a state volume, a virtio-blk without `discard` negotiated), and would
+/// otherwise warn every [`CLEAN_INTERVAL`] forever, so it logs at debug.
+///
+/// Deliberately unbounded, unlike the shutdown quiesce's 10 s ceiling. A
+/// requesting client does wait on this — [`MaintenanceHandle::clean_now`]
+/// replies only once the trim is done — but so does it wait on the clean
+/// itself, which is equally unbounded; a reclaim takes as long as the
+/// filesystem makes it take, and a deadline here would only report success
+/// over extents still undiscarded. It shares the shutdown hazard documented on
+/// [`clean`] — a trim in flight when the `Shutdown` RPC quiesces the volume is
+/// walking a filesystem being synced and unmounted — bounded the same way, by
+/// [`MaintenanceHandle::abort`] and the ext4 journal.
+#[cfg(target_os = "linux")]
+async fn trim_state_volume_if_mounted(state: &ServerStateHandle) {
+    if !state.state_volume_mounted().await {
+        return;
+    }
+    let mountpoint = state.minimal_state_dir().await;
+    // `FITRIM` walks the whole filesystem's block groups; like the clean
+    // itself, that belongs on the blocking pool.
+    let trim = tokio::task::spawn_blocking(move || {
+        crate::guest::trim_state_volume(mountpoint.as_utf8_path().as_str())
+    });
+    match trim.await {
+        Ok(Ok(discarded)) => {
+            tracing::info!(discarded_bytes = discarded, "state volume trimmed")
+        }
+        Ok(Err(error)) if error.kind() == ErrorKind::Unsupported => {
+            tracing::debug!(%error, "state volume does not support discard; not trimming")
+        }
+        Ok(Err(error)) => tracing::warn!(%error, "state volume trim failed; space not reclaimed"),
+        Err(error) => tracing::warn!(%error, "state volume trim panicked"),
+    }
+}
+
+/// Nothing to trim off a host that has no guest data volume — `minimald` only
+/// mounts one as the microVM's pid-1, and its `FITRIM` is Linux-only.
+#[cfg(not(target_os = "linux"))]
+async fn trim_state_volume_if_mounted(_state: &ServerStateHandle) {}
 
 /// Logs what the clean removed, one line per entry, until the sender drops,
 /// mirroring each event to `relay` if a caller asked for one. Best-effort on


### PR DESCRIPTION
Fixes: #990

Borrows from @norrietaylor 's PR the fstrim bits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic filesystem trimming for the state volume after successful cache cleanup.
  - Supports both manually requested and scheduled maintenance operations.
  - Trimming synchronizes the mounted state volume and reclaims unused storage where supported.

- **Bug Fixes**
  - Maintenance responses now return only after requested trimming completes.
  - Added platform-specific handling and clearer error reporting when trimming cannot be performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->