### PR TITLE
fix(dash): match the Preview pane to the session PTY size

### DIFF
--- a/crates/minimal-tui/src/app.rs
+++ b/crates/minimal-tui/src/app.rs
@@ -138,6 +138,10 @@ pub enum Effect {
     Refresh,
     FetchDetail(SessionKey),
     FetchScreen(SessionKey),
+    /// Resize the session's terminal to the Preview pane's `(rows, cols)` so
+    /// the next snapshot matches the pane. Best-effort; a failure (old daemon)
+    /// is ignored and the preview keeps its clipped behavior.
+    SetScreenSize(SessionKey, u16, u16),
     Destroy(SessionKey),
     Rename(SessionKey, String),
     Create {
@@ -173,6 +177,12 @@ pub struct Model {
     pub filter: FilterState,
     pub details: HashMap<SessionKey, Detail>,
     pub screens: HashMap<SessionKey, ScreenFetch>,
+    /// The Preview pane's `(rows, cols)` from the last render, stashed by
+    /// `render_detail`. Compared against the focused session's last snapshot
+    /// size on each tick; a mismatch triggers a best-effort
+    /// `SetSessionScreenSize` so the daemon's PTY (and thus the next
+    /// snapshot) matches the pane. `None` when no session is focused.
+    pub preview_pane: Option<(u16, u16)>,
     /// The most recent bell timestamp acknowledged for a session; a bell
     /// newer than this lights the `●` indicator.
     pub bells_seen: HashMap<SessionKey, DateTime<Utc>>,
@@ -211,6 +221,7 @@ impl Model {
             filter: FilterState::default(),
             details: HashMap::new(),
             screens: HashMap::new(),
+            preview_pane: None,
             bells_seen: HashMap::new(),
             action: None,
             status: None,
@@ -405,6 +416,21 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
             // so the focused session's screen refreshes on every tick.
             let mut effects = vec![Effect::Refresh];
             if let Some(key) = model.focused() {
+                // Match the session's PTY to the Preview pane so a
+                // full-screen app renders without clipping. Only when the
+                // last snapshot's size differs from the pane — a steady
+                // state issues no resize. Best-effort: `exec_effect` ignores
+                // a failure (a daemon that predates the RPC).
+                if let Some((rows, cols)) = model.preview_pane
+                    && let Some(snap) = model
+                        .screens
+                        .get(&key)
+                        .and_then(|fetch| fetch.as_ref().ok())
+                        .and_then(|o| o.as_ref())
+                    && (snap.rows, snap.cols) != (rows, cols)
+                {
+                    effects.push(Effect::SetScreenSize(key.clone(), rows, cols));
+                }
                 effects.push(Effect::FetchScreen(key));
             }
             effects
@@ -1031,6 +1057,17 @@ async fn exec_effect(
                 .map_err(|e| format!("{e:#}"));
             Some(Msg::ScreenLoaded(key, fetch))
         }
+        Effect::SetScreenSize(key, rows, cols) => {
+            // Best-effort: a daemon that predates SetSessionScreenSize
+            // answers "request subsystem"; the preview keeps its clipped
+            // behavior and the next tick retries against the new snapshot.
+            if let Some(provider) = providers.iter_mut().find(|p| p.label == key.provider)
+                && let Err(e) = rpc::set_screen_size(provider, key.id, rows, cols).await
+            {
+                tracing::debug!(error = %e, "SetSessionScreenSize failed; preview stays clipped");
+            }
+            None
+        }
         Effect::Destroy(key) => {
             let result = match providers.iter_mut().find(|p| p.label == key.provider) {
                 Some(provider) => rpc::destroy(provider, key.id)
@@ -1495,6 +1532,54 @@ mod tests {
             effects
                 .iter()
                 .any(|e| matches!(e, Effect::FetchScreen(k) if k.id == id(1)))
+        );
+    }
+
+    /// A tick matches the session's PTY to the stashed Preview pane when the
+    /// last snapshot's size disagrees; a steady state (sizes agree) issues no
+    /// resize.
+    #[test]
+    fn tick_resizes_the_pty_when_the_pane_and_snapshot_disagree() {
+        let mut model = two_providers();
+        update(&mut model, key(KeyCode::Down));
+        let key = skey("host", 1);
+        // The pane is 20x80, but the last snapshot came from the attach
+        // terminal's 24x80: the mismatch must trigger a resize.
+        model.preview_pane = Some((20, 80));
+        model.screens.insert(
+            key.clone(),
+            Ok(Some(minimald_rpc::ScreenSnapshot {
+                rows: 24,
+                cols: 80,
+                cursor_row: None,
+                cursor_col: None,
+                lines: Vec::new(),
+            })),
+        );
+        let effects = update(&mut model, Msg::Tick);
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SetScreenSize(k, 20, 80) if *k == key)),
+            "expected a SetScreenSize effect, got {effects:?}"
+        );
+        // Once the snapshot matches the pane, the steady state is quiet.
+        model.screens.insert(
+            key.clone(),
+            Ok(Some(minimald_rpc::ScreenSnapshot {
+                rows: 20,
+                cols: 80,
+                cursor_row: None,
+                cursor_col: None,
+                lines: Vec::new(),
+            })),
+        );
+        let effects = update(&mut model, Msg::Tick);
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::SetScreenSize(..))),
+            "steady state must not resize, got {effects:?}"
         );
     }
 

--- a/crates/minimal-tui/src/render.rs
+++ b/crates/minimal-tui/src/render.rs
@@ -198,7 +198,7 @@ fn divider(label: &str, width: u16) -> Line<'static> {
     )
 }
 
-fn render_detail(model: &Model, frame: &mut Frame, area: Rect) {
+fn render_detail(model: &mut Model, frame: &mut Frame, area: Rect) {
     // The detail pane is one vertical stack: Info fields, a Policy section,
     // then the live Preview filling the rest. No tabs.
     let focused = model.focused();
@@ -219,6 +219,7 @@ fn render_detail(model: &Model, frame: &mut Frame, area: Rect) {
     }
 
     let Some(key) = focused else {
+        model.preview_pane = None;
         frame.render_widget(
             Paragraph::new("no session selected")
                 .style(Style::default().fg(Color::Gray))
@@ -253,6 +254,9 @@ fn render_detail(model: &Model, frame: &mut Frame, area: Rect) {
         Constraint::Min(1),
     ])
     .areas(inner);
+    // Stash the pane's size so the tick handler can match the session's
+    // PTY to it (best-effort SetSessionScreenSize).
+    model.preview_pane = Some((preview_area.height, preview_area.width));
     render_info(model, &key, frame, info_area);
     frame.render_widget(Paragraph::new(divider("Policy", inner.width)), policy_div);
     render_policy(model, &key, frame, policy_area);

--- a/crates/minimal-tui/src/rpc.rs
+++ b/crates/minimal-tui/src/rpc.rs
@@ -191,6 +191,28 @@ pub async fn fetch_screen(
     Ok(resp.ok())
 }
 
+/// Resize the session's terminal to the Preview pane's size so the next
+/// `GetSessionScreen` snapshot renders without clipping. Callers treat a
+/// failure as a no-op: a daemon that predates `SetSessionScreenSize` answers
+/// "request subsystem" and the preview keeps today's clipped behavior.
+pub async fn set_screen_size(
+    provider: &mut Provider,
+    id: SessionId,
+    rows: u16,
+    cols: u16,
+) -> Result<(), anyhow::Error> {
+    let resp = timed::<minimald_rpc::SetSessionScreenSize>(
+        &mut provider.client,
+        minimald_rpc::SetSessionScreenSizeRequest { id, rows, cols },
+    )
+    .await
+    .context("SetSessionScreenSize RPC failed")?;
+    match resp {
+        Errorable::Ok(()) => Ok(()),
+        Errorable::Err { error } => Err(anyhow::anyhow!(error)),
+    }
+}
+
 pub async fn destroy(provider: &mut Provider, id: SessionId) -> Result<(), anyhow::Error> {
     match timed::<DestroySession>(&mut provider.client, DestroySessionRequest { id })
         .await

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -242,6 +242,26 @@ impl OneshotSshRpc for GetSessionScreen {
     type Response = Errorable<ScreenSnapshot>;
 }
 
+/// An RPC to resize a session's terminal to a given size without attaching.
+/// `min dash` uses it to match the Preview pane to the session's PTY so a
+/// [`GetSessionScreen`] snapshot renders without clipping a full-screen app.
+/// A session with no live host is a no-op.
+pub struct SetSessionScreenSize;
+
+/// Request for [`SetSessionScreenSize`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SetSessionScreenSizeRequest {
+    pub id: SessionId,
+    pub rows: u16,
+    pub cols: u16,
+}
+
+impl OneshotSshRpc for SetSessionScreenSize {
+    const NAME: &'static str = constcat::concat!(RPC_SUBSYSTEM_PREFIX, "SetSessionScreenSize");
+    type Request<'a> = SetSessionScreenSizeRequest;
+    type Response = Errorable<()>;
+}
+
 /// An RPC to create a new session.
 ///
 /// Allocates the session's record and brings its actor up; the

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -9,7 +9,8 @@ use minimald_rpc::{
     GetVersionResponse, IssueClientCert, IssueClientCertRequest, ListSessions, ListSessionsEntry,
     ListSessionsResponse, OneshotSshRpc, RPC_SUBSYSTEM_PREFIX, RenameSession,
     RenameSessionResponse, ResourcePool, SessionDelta, SessionDeltaRequest, SessionDeltaResponse,
-    Shutdown, ShutdownRequest, ShutdownResponse, SubmitVerdict,
+    SetSessionScreenSize, SetSessionScreenSizeRequest, Shutdown, ShutdownRequest, ShutdownResponse,
+    SubmitVerdict,
 };
 use russh::{
     Channel as RuChannel, ChannelId,
@@ -27,6 +28,7 @@ use crate::{
     ChannelConfig,
     connection::{ConnectionError, ConnectionHandle},
     server::ServerStateHandle,
+    session_host::WinSize,
     sessions::SessionKeyPredicate,
 };
 
@@ -651,6 +653,37 @@ async fn serve_get_session_screen(
                     error: "session is not active".to_string(),
                 },
             })
+        })
+        .await
+}
+
+/// `SetSessionScreenSize` (`min dash` Preview pane): resize the session's
+/// terminal to the pane's size without attaching, so the next
+/// `GetSessionScreen` snapshot renders without clipping. Best-effort by
+/// contract: a session with no live host is a no-op, and the pixel fields are
+/// left zero (the PTY only needs rows/cols to reflow a full-screen app).
+async fn serve_set_session_screen_size(
+    s: ServerStateHandle,
+    c: RuChannel<Msg>,
+) -> Result<(), ConnectionError> {
+    SetSessionScreenSize
+        .handle_channel(c, async |req: SetSessionScreenSizeRequest| {
+            let mngr = s.sessions_manager().await;
+            let sz = WinSize {
+                rows: req.rows,
+                cols: req.cols,
+                xpixel: 0,
+                ypixel: 0,
+            };
+            match mngr
+                .set_screen_size(SessionKeyPredicate::Id(req.id), sz)
+                .await
+            {
+                Ok(()) => Ok(Errorable::Ok(())),
+                Err(e) => Ok(Errorable::Err {
+                    error: e.to_string(),
+                }),
+            }
         })
         .await
 }
@@ -1498,6 +1531,7 @@ pub async fn handle_ssh_rpc(
         | minimald_rpc::GetSessionHooks::NAME
         | SessionDelta::NAME
         | GetSessionScreen::NAME
+        | SetSessionScreenSize::NAME
         | GetMeshStatus::NAME
         | STREAM_WORKSPACE_FILES
         | STREAM_WORKSPACE_PATCHES
@@ -1582,6 +1616,7 @@ pub async fn handle_ssh_rpc(
         minimald_rpc::GetSessionHooks::NAME => serve!(serve_get_session_hooks(s, channel)),
         SessionDelta::NAME => serve!(serve_session_delta(s, channel)),
         GetSessionScreen::NAME => serve!(serve_get_session_screen(s, channel)),
+        SetSessionScreenSize::NAME => serve!(serve_set_session_screen_size(s, channel)),
         GetMeshStatus::NAME => serve!(serve_get_mesh_status(s, channel)),
         STREAM_WORKSPACE_FILES => serve!(serve_stream_workspace_files(s, config, channel)),
         STREAM_WORKSPACE_PATCHES => serve!(serve_stream_workspace_patches(s, config, channel)),
@@ -2501,6 +2536,56 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         };
         assert_eq!((snapshot.rows, snapshot.cols), (24, 80));
+    }
+
+    #[tokio::test]
+    async fn set_session_screen_size_resizes_the_live_terminal() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        // A session with no live host is a no-op, not an error.
+        let inactive = client
+            .call::<SetSessionScreenSize>(&SetSessionScreenSizeRequest {
+                id: session_id,
+                rows: 30,
+                cols: 100,
+            })
+            .await;
+        assert!(
+            matches!(&inactive, Errorable::Ok(())),
+            "expected a no-op Ok for a hostless session, got {inactive:?}",
+        );
+
+        // Attach a shell (the mock launcher runs an echo program), then
+        // resize the PTY and poll until the next snapshot reports it. The
+        // resize goes in the loop: the host came up asynchronously with the
+        // attach, so a resize that beat it is a silent no-op and must be
+        // retried (what the TUI's tick does too).
+        let shell = client.open_shell(session_id).await;
+        shell.data_bytes(&b"hello-screen\n"[..]).await.unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            client
+                .call::<SetSessionScreenSize>(&SetSessionScreenSizeRequest {
+                    id: session_id,
+                    rows: 30,
+                    cols: 100,
+                })
+                .await
+                .unwrap();
+            let resp = client.call::<GetSessionScreen>(&session_id).await;
+            match resp {
+                Errorable::Ok(snap) if (snap.rows, snap.cols) == (30, 100) => break,
+                _ => {}
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for the resize to reach the screen snapshot",
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
     }
 
     #[tokio::test]

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -475,6 +475,10 @@ enum SessionMessage {
     /// Snapshot the running host's terminal screen for a read-only preview
     /// (`min dash`'s `GetSessionScreen`). `None` when no host is running.
     GetHostScreen(oneshot::Sender<Option<minimald_rpc::ScreenSnapshot>>),
+    /// Resize the running host's terminal to `sz` without attaching
+    /// (`min dash`'s `SetSessionScreenSize`). A session with no live host
+    /// is a no-op; the ack is sent either way.
+    SetHostScreenSize(WinSize, oneshot::Sender<()>),
     /// Compose a `Draft` session's loadout from the project config and the
     /// client's wire contribution. `None` finalizes the session (`Active`);
     /// `Some(response)` parks it in `Draft` awaiting a verdict. Refused with
@@ -876,6 +880,18 @@ impl Session {
                     } => h.get_screen().await.ok(),
                     _ => None,
                 });
+            }
+            SessionMessage::SetHostScreenSize(sz, r) => {
+                // Best-effort by contract: a session with no live host has
+                // nothing to resize, and a dead host is a no-op rather than an
+                // error — the caller (the TUI's preview) ignores failures.
+                if let SessionInner::Active {
+                    host: Some((h, _)), ..
+                } = &self.inner
+                {
+                    let _ = h.set_screen_size(sz).await;
+                }
+                let _ = r.send(());
             }
             SessionMessage::ConfigureLoadout(contribution, r) => {
                 // Honour what the user chose at `min session activate`.
@@ -2295,6 +2311,19 @@ impl SessionHandle {
         // Ignore send errors - the recv will also fail.
         let _ = self.0.send(SessionMessage::GetHostScreen(send)).await;
         recv.await.ok().flatten()
+    }
+
+    /// Resizes the running session's terminal to `sz` without attaching
+    /// (`min dash`'s `SetSessionScreenSize`). A session with no live host is a
+    /// no-op; a dead actor is likewise, since the resize is best-effort.
+    pub async fn set_screen_size(&self, sz: WinSize) {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .0
+            .send(SessionMessage::SetHostScreenSize(sz, send))
+            .await;
+        let _ = recv.await;
     }
 
     /// Runs this session's `on_detach` hooks, awaiting them so a departing

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -478,7 +478,7 @@ enum SessionMessage {
     /// Resize the running host's terminal to `sz` without attaching
     /// (`min dash`'s `SetSessionScreenSize`). A session with no live host
     /// is a no-op; the ack is sent either way.
-    SetHostScreenSize(WinSize, oneshot::Sender<()>),
+    SetHostScreenSize(WinSize, oneshot::Sender<std::io::Result<()>>),
     /// Compose a `Draft` session's loadout from the project config and the
     /// client's wire contribution. `None` finalizes the session (`Active`);
     /// `Some(response)` parks it in `Draft` awaiting a verdict. Refused with
@@ -882,16 +882,15 @@ impl Session {
                 });
             }
             SessionMessage::SetHostScreenSize(sz, r) => {
-                // Best-effort by contract: a session with no live host has
-                // nothing to resize, and a dead host is a no-op rather than an
-                // error — the caller (the TUI's preview) ignores failures.
-                if let SessionInner::Active {
-                    host: Some((h, _)), ..
-                } = &self.inner
-                {
-                    let _ = h.set_screen_size(sz).await;
-                }
-                let _ = r.send(());
+                // A session with no live host has nothing to resize (a no-op);
+                // a live host reports whether its PTY accepted the resize.
+                let res = match &self.inner {
+                    SessionInner::Active {
+                        host: Some((h, _)), ..
+                    } => h.set_screen_size(sz).await,
+                    _ => Ok(()),
+                };
+                let _ = r.send(res);
             }
             SessionMessage::ConfigureLoadout(contribution, r) => {
                 // Honour what the user chose at `min session activate`.
@@ -2315,15 +2314,20 @@ impl SessionHandle {
 
     /// Resizes the running session's terminal to `sz` without attaching
     /// (`min dash`'s `SetSessionScreenSize`). A session with no live host is a
-    /// no-op; a dead actor is likewise, since the resize is best-effort.
-    pub async fn set_screen_size(&self, sz: WinSize) {
+    /// no-op; a dead actor reads as an error.
+    pub async fn set_screen_size(&self, sz: WinSize) -> std::io::Result<()> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         let _ = self
             .0
             .send(SessionMessage::SetHostScreenSize(sz, send))
             .await;
-        let _ = recv.await;
+        recv.await.unwrap_or_else(|_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "session actor is dead",
+            ))
+        })
     }
 
     /// Runs this session's `on_detach` hooks, awaiting them so a departing

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -943,6 +943,11 @@ enum Message {
     /// Answered straight off the parser — no PTY resize, no I/O relay.
     GetScreen(oneshot::Sender<minimald_rpc::ScreenSnapshot>),
 
+    /// Resize the PTY and parser screen to `sz` without attaching, so a
+    /// preview consumer (`min dash`) can match the session's terminal to its
+    /// pane. The ack is sent once the size is applied.
+    SetScreenSize(WinSize, oneshot::Sender<()>),
+
     SetTitleCallback(String),
     VisualBellCallback,
     AudibleBellCallback,
@@ -1186,6 +1191,19 @@ impl HostHandle {
         match self.sender.send(Message::GetScreen(send)).await {
             Ok(()) => recv.await.map_err(|_| ()),
             Err(SendError(Message::GetScreen(_))) => Err(()),
+            Err(e) => unreachable!("{:?}", e),
+        }
+    }
+
+    /// Resize the session's PTY and parser screen to `sz` without attaching
+    /// (the TUI's Preview pane matching its size to the session's terminal).
+    /// A dead host reads as `Err(())`, matching [`Self::get_attrs`].
+    pub async fn set_screen_size(&self, sz: WinSize) -> Result<(), ()> {
+        let (send, recv) = oneshot::channel();
+        // Ignore send errors - the recv will also fail.
+        match self.sender.send(Message::SetScreenSize(sz, send)).await {
+            Ok(()) => recv.await.map_err(|_| ()),
+            Err(SendError(Message::SetScreenSize(_, _))) => Err(()),
             Err(e) => unreachable!("{:?}", e),
         }
     }
@@ -2452,6 +2470,10 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                     }
                     Message::GetScreen(s) => {
                         let _ = s.send(self.screen_snapshot());
+                    }
+                    Message::SetScreenSize(sz, r) => {
+                        self.set_size(sz);
+                        let _ = r.send(());
                     }
                     Message::CommandInSession {
                         program,

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -946,7 +946,7 @@ enum Message {
     /// Resize the PTY and parser screen to `sz` without attaching, so a
     /// preview consumer (`min dash`) can match the session's terminal to its
     /// pane. The ack is sent once the size is applied.
-    SetScreenSize(WinSize, oneshot::Sender<()>),
+    SetScreenSize(WinSize, oneshot::Sender<io::Result<()>>),
 
     SetTitleCallback(String),
     VisualBellCallback,
@@ -1197,13 +1197,20 @@ impl HostHandle {
 
     /// Resize the session's PTY and parser screen to `sz` without attaching
     /// (the TUI's Preview pane matching its size to the session's terminal).
-    /// A dead host reads as `Err(())`, matching [`Self::get_attrs`].
-    pub async fn set_screen_size(&self, sz: WinSize) -> Result<(), ()> {
+    /// Reports a PTY resize the kernel refused; a dead host reads as
+    /// [`io::ErrorKind::BrokenPipe`], matching [`Self::get_attrs`]'s dead-host
+    /// error.
+    pub async fn set_screen_size(&self, sz: WinSize) -> io::Result<()> {
         let (send, recv) = oneshot::channel();
         // Ignore send errors - the recv will also fail.
         match self.sender.send(Message::SetScreenSize(sz, send)).await {
-            Ok(()) => recv.await.map_err(|_| ()),
-            Err(SendError(Message::SetScreenSize(_, _))) => Err(()),
+            Ok(()) => recv
+                .await
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "session host is dead"))?,
+            Err(SendError(Message::SetScreenSize(_, _))) => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "session host is dead",
+            )),
             Err(e) => unreachable!("{:?}", e),
         }
     }
@@ -2472,8 +2479,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                         let _ = s.send(self.screen_snapshot());
                     }
                     Message::SetScreenSize(sz, r) => {
-                        self.set_size(sz);
-                        let _ = r.send(());
+                        let _ = r.send(self.set_size(sz));
                     }
                     Message::CommandInSession {
                         program,
@@ -2561,10 +2567,10 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                         };
                     }
                     StdinMsg::TerminalUpdate(sz) => {
-                        self.set_size(WinSize::from(&sz));
+                        self.set_size_best_effort(WinSize::from(&sz));
                     },
                     StdinMsg::WindowChange{ col_width, row_height, pix_height, pix_width } => {
-                        self.set_size(WinSize {
+                        self.set_size_best_effort(WinSize {
                             rows: row_height as u16,
                             cols: col_width as u16,
                             xpixel: pix_width as u16,
@@ -2638,20 +2644,29 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             let _ = old_join_hnd.await;
         }
 
-        self.set_size(sz);
+        self.set_size_best_effort(sz);
 
         // After the binding is installed and sized, so a hook writing to
         // the terminal reaches the client that just attached.
         self.run_hooks_for(crate::hooks::HookEvent::Attach).await;
     }
-    fn set_size(&mut self, sz: WinSize) {
-        // If the terminal size changed, reconfigure the pty.
+    fn set_size(&mut self, sz: WinSize) -> io::Result<()> {
+        // If the terminal size changed, reconfigure the pty. The parser and
+        // `self.sz` only follow a resize the PTY actually accepted, so a
+        // refused resize cannot desync the snapshot from the terminal.
         if sz != self.sz {
-            if let Err(e) = set_winsize(self.master.as_raw_fd(), sz) {
-                tracing::warn!(error = %e, "set_winsize failed, ignoring");
-            }
+            set_winsize(self.master.as_raw_fd(), sz)?;
             self.parser.screen_mut().set_size(sz.rows, sz.cols);
             self.sz = sz;
+        }
+        Ok(())
+    }
+
+    /// Best-effort resize for callers with no result channel (interactive
+    /// stdin resize events): log and drop a `set_winsize` failure.
+    fn set_size_best_effort(&mut self, sz: WinSize) {
+        if let Err(e) = self.set_size(sz) {
+            tracing::warn!(error = %e, "set_winsize failed, ignoring");
         }
     }
 

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     session::{Session, SessionConfig, SessionHandle},
-    session_host::HostAttrs,
+    session_host::{HostAttrs, WinSize},
     store::{RecordPredicate, SessionRecordHandle, Store, StoreHandle},
 };
 use common::SpecHash;
@@ -130,6 +130,11 @@ enum ManagerMessage {
         SessionKeyPredicate,
         Responder<Option<minimald_rpc::ScreenSnapshot>>,
     ),
+    /// Resize a running session's terminal (`min dash`'s
+    /// `SetSessionScreenSize`). Read-only against the `running` map — like
+    /// [`GetScreen`](Self::GetScreen) it never starts an actor, and a
+    /// session with no live host is a no-op.
+    SetScreenSize(SessionKeyPredicate, WinSize, Responder<()>),
     /// Read a session's persisted composition snapshot. Read-only
     /// against the store — like [`GetRecord`](Self::GetRecord) and
     /// unlike [`GetSession`](Self::GetSession), it never starts an
@@ -486,6 +491,25 @@ impl Manager {
                         Some(h) => h.get_screen().await,
                         None => None,
                     })
+                })
+                .await;
+            }
+            ManagerMessage::SetScreenSize(pred, sz, r) => {
+                r.handle(async {
+                    let id = match pred {
+                        SessionKeyPredicate::Id(id) => id,
+                        SessionKeyPredicate::Name(name) => {
+                            match self.store.find(RecordPredicate::Name(name)).await? {
+                                Some(handle) => handle.record().await?.id,
+                                None => return Ok(()),
+                            }
+                        }
+                    };
+                    // A session with no live host has nothing to resize.
+                    if let Some(h) = self.running.get(&id) {
+                        h.set_screen_size(sz).await;
+                    }
+                    Ok::<(), SessionsError>(())
                 })
                 .await;
             }
@@ -863,6 +887,23 @@ impl ManagerHandle {
         let _ = self
             .sender
             .send(ManagerMessage::GetScreen(pred, send))
+            .await;
+        recv.await.expect("corresponding sessions manager is dead")
+    }
+
+    /// Resizes a running session's terminal to `sz` without attaching
+    /// (`min dash`'s `SetSessionScreenSize`). Never starts an actor; a
+    /// session with no live host is a no-op.
+    pub async fn set_screen_size(
+        &self,
+        pred: SessionKeyPredicate,
+        sz: WinSize,
+    ) -> Result<(), SessionsError> {
+        let (send, recv) = Responder::channel();
+        // Ignore send errors - the recv will also fail.
+        let _ = self
+            .sender
+            .send(ManagerMessage::SetScreenSize(pred, sz, send))
             .await;
         recv.await.expect("corresponding sessions manager is dead")
     }

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -507,7 +507,7 @@ impl Manager {
                     };
                     // A session with no live host has nothing to resize.
                     if let Some(h) = self.running.get(&id) {
-                        h.set_screen_size(sz).await;
+                        h.set_screen_size(sz).await?;
                     }
                     Ok::<(), SessionsError>(())
                 })


### PR DESCRIPTION
## Summary

The `min dash` Preview pane shows a `GetSessionScreen` snapshot of the session's PTY, sized for the last attach terminal. In a narrower dash terminal, a full-screen app (btop and similar) renders clipped on the right and looks broken.

This change makes the TUI resize the session PTY to the pane size:

- New oneshot RPC `SetSessionScreenSize` in `minimald-rpc`, carried through the daemon's actor chain (manager, session, host). `Host::set_size` is already a no-op when the size is unchanged, so steady state costs nothing.
- The TUI stashes the Preview pane's `(rows, cols)` at render time. On each tick, if the last snapshot's size disagrees with the pane, it issues the resize before fetching the next snapshot.
- The resize is best-effort. A daemon that predates this change answers "request subsystem" and the preview keeps its clipped behavior, so the wire change stays back-compat in both directions.

## Changes

| File | What it does |
|---|---|
| `crates/minimald-rpc/src/lib.rs` | New `SetSessionScreenSize` RPC type and request struct |
| `crates/minimald/src/session_host.rs` | `Message::SetScreenSize` arm; `HostHandle::set_screen_size` |
| `crates/minimald/src/session.rs` | `SetHostScreenSize` arm; `SessionHandle::set_screen_size` |
| `crates/minimald/src/sessions.rs` | Manager message, handler, public `set_screen_size` |
| `crates/minimald/src/rpc.rs` | Dispatch registration and `serve_set_session_screen_size` |
| `crates/minimal-tui/src/rpc.rs` | `set_screen_size` RPC client |
| `crates/minimal-tui/src/app.rs` | `preview_pane` on the model, `Effect::SetScreenSize`, tick mismatch detection, `exec_effect` arm |
| `crates/minimal-tui/src/render.rs` | Stash the pane size during `render_detail` |

## Verification

- `just ci` green: fmt, clippy, cargo-deny, 1728 tests, doctests. The one `test-ignored` failure (`mctx tests::task_env`) also fails on clean `main` and is unrelated.
- New daemon integration test: `set_session_screen_size_resizes_the_live_terminal` (resize reaches the screen snapshot; hostless session is a no-op).
- New TUI unit test: `tick_resizes_the_pty_when_the_pane_and_snapshot_disagree` (resize only on mismatch).

Fixes #1197


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal sessions now automatically resize to match the Preview pane.
  * Preview dimensions update as the interface layout changes.
  * Resizing works for active sessions and safely handles unavailable sessions or hosts.

* **Bug Fixes**
  * Prevented mismatches between the displayed terminal preview and the session’s actual terminal size.
  * Resize failures are handled gracefully without interrupting normal screen updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->