### PR TITLE
feat(dash): show git branch, repo, and worktree per session

### DIFF
--- a/crates/minimal-tui/src/app.rs
+++ b/crates/minimal-tui/src/app.rs
@@ -1161,6 +1161,7 @@ mod tests {
             name: name.map(str::to_owned),
             project_path: Some(paths::HostAbsPath::try_new(project).unwrap()),
             status: sessions::SessionStatus::Active,
+            git: None,
             attrs: None,
         }
     }

--- a/crates/minimal-tui/src/filter.rs
+++ b/crates/minimal-tui/src/filter.rs
@@ -38,6 +38,7 @@ mod tests {
             name: name.map(str::to_owned),
             project_path: Some(paths::HostAbsPath::try_new(project).unwrap()),
             status: sessions::SessionStatus::Active,
+            git: None,
             attrs: None,
         }
     }

--- a/crates/minimal-tui/src/render.rs
+++ b/crates/minimal-tui/src/render.rs
@@ -27,13 +27,10 @@ pub fn view(model: &mut Model, frame: &mut Frame) {
     render_footer(model, frame, footer);
 }
 
-/// Truncate `s` to at most `w` display columns (appending `…` when cut), or
-/// pad it with trailing spaces to exactly `w`. Widths are terminal display
-/// widths, so CJK/emoji session names don't misalign the sidebar.
-fn pad_truncate(s: &str, w: usize) -> String {
-    let width = UnicodeWidthStr::width(s);
-    if width <= w {
-        return format!("{s}{}", " ".repeat(w - width));
+/// Truncate `s` to at most `w` display columns, appending `…` when cut.
+fn truncate(s: &str, w: usize) -> String {
+    if UnicodeWidthStr::width(s) <= w {
+        return s.to_string();
     }
     let budget = w.saturating_sub(1);
     let mut used = 0;
@@ -48,6 +45,15 @@ fn pad_truncate(s: &str, w: usize) -> String {
         })
         .collect();
     format!("{cut}…")
+}
+
+/// Truncate `s` to at most `w` display columns (appending `…` when cut), or
+/// pad it with trailing spaces to exactly `w`. Widths are terminal display
+/// widths, so CJK/emoji session names don't misalign the sidebar.
+fn pad_truncate(s: &str, w: usize) -> String {
+    let out = truncate(s, w);
+    let pad = w.saturating_sub(UnicodeWidthStr::width(out.as_str()));
+    format!("{out}{}", " ".repeat(pad))
 }
 
 fn render_sidebar(model: &mut Model, frame: &mut Frame, area: Rect) {
@@ -147,13 +153,20 @@ fn render_sidebar(model: &mut Model, frame: &mut Frame, area: Rect) {
                 let marker = if selected { "▸ " } else { "  " };
                 // Branch segment (` ⎇ feature` + two-space gutter) only
                 // when the daemon answered git info; skipping it entirely
-                // keeps the no-git layout byte-identical to before.
+                // keeps the no-git layout byte-identical to before. Cap it
+                // to whatever the row can spare after the right-aligned
+                // network/indicator block, so a long branch name truncates
+                // instead of pushing those cells off the right edge.
+                let right = format!("{net} {indicator:>2}");
+                let max_branch_width =
+                    inner_width.saturating_sub(UnicodeWidthStr::width(right.as_str()) + 2);
                 let branch = entry
                     .git
                     .as_ref()
                     .map(|g| format!(" ⎇ {}", g.branch))
+                    .filter(|_| max_branch_width > UnicodeWidthStr::width(" ⎇ "))
+                    .map(|b| truncate(&b, max_branch_width))
                     .unwrap_or_default();
-                let right = format!("{net} {indicator:>2}");
                 let right_w = UnicodeWidthStr::width(right.as_str())
                     + if branch.is_empty() {
                         0

--- a/crates/minimal-tui/src/render.rs
+++ b/crates/minimal-tui/src/render.rs
@@ -359,6 +359,9 @@ fn render_info(model: &Model, key: &SessionKey, frame: &mut Frame, area: Rect) {
             false => root,
         }
     });
+    // The branch repeats in the Info column at full fidelity, where the
+    // sidebar's tight truncation budget may have clipped it.
+    let branch = entry.and_then(|e| e.git.as_ref()).map(|g| g.branch.clone());
     let left = [
         ("project", project),
         ("user", user),
@@ -369,11 +372,14 @@ fn render_info(model: &Model, key: &SessionKey, frame: &mut Frame, area: Rect) {
         .and_then(|d| d.record.as_ref())
         .map(|r| format!("{:?}", r.network))
         .unwrap_or_else(|| "?".to_string());
-    // The Info section is four rows tall; the branch rides in the sidebar
-    // row, so only the repo root joins the right column here.
+    // The Info section is four rows tall: runtime facts first, then the
+    // git context fills the right column's spare rows.
     let mut right = vec![("net", net), ("idle", idle_text(model, key))];
     if let Some(repo) = repo {
         right.push(("repo", repo));
+    }
+    if let Some(branch) = branch {
+        right.push(("branch", branch));
     }
 
     // Left column takes half the pane; the right column starts after a
@@ -392,7 +398,9 @@ fn render_info(model: &Model, key: &SessionKey, frame: &mut Frame, area: Rect) {
             }
             if let Some((label, value)) = right.get(i) {
                 spans.push(Span::raw("  "));
-                spans.push(Span::styled(pad_truncate(label, 6), dim));
+                // Eight-wide to match the left column: the six-wide gutter
+                // left the six-char "branch" label flush against its value.
+                spans.push(Span::styled(pad_truncate(label, 8), dim));
                 spans.push(Span::raw(value.clone()));
             }
             Line::from(spans)

--- a/crates/minimal-tui/src/render.rs
+++ b/crates/minimal-tui/src/render.rs
@@ -29,6 +29,11 @@ pub fn view(model: &mut Model, frame: &mut Frame) {
 
 /// Truncate `s` to at most `w` display columns, appending `…` when cut.
 fn truncate(s: &str, w: usize) -> String {
+    // w == 0 must yield the empty string: the ellipsis alone is one column
+    // and would overflow a zero-width allocation.
+    if w == 0 {
+        return String::new();
+    }
     if UnicodeWidthStr::width(s) <= w {
         return s.to_string();
     }
@@ -777,6 +782,17 @@ mod tests {
         assert_eq!(style.fg, Some(Color::Indexed(1)));
         assert!(style.add_modifier.contains(Modifier::BOLD));
         assert!(style.add_modifier.contains(Modifier::UNDERLINED));
+    }
+
+    #[test]
+    fn truncation_respects_a_zero_width_budget() {
+        assert_eq!(truncate("abc", 0), "");
+        assert_eq!(truncate("", 0), "");
+        // Width 1 has room for the ellipsis itself when the input is cut.
+        assert_eq!(truncate("abc", 1), "…");
+        // pad_truncate inherits the zero-width guard instead of overflowing.
+        assert_eq!(pad_truncate("abc", 0), "");
+        assert_eq!(pad_truncate("", 3), "   ");
     }
 
     #[test]

--- a/crates/minimal-tui/src/render.rs
+++ b/crates/minimal-tui/src/render.rs
@@ -145,8 +145,21 @@ fn render_sidebar(model: &mut Model, frame: &mut Frame, area: Rect) {
                 // and the terminal swallows the indicator cell at the right
                 // edge (this was the "no activity indicator" bug).
                 let marker = if selected { "▸ " } else { "  " };
+                // Branch segment (` ⎇ feature` + two-space gutter) only
+                // when the daemon answered git info; skipping it entirely
+                // keeps the no-git layout byte-identical to before.
+                let branch = entry
+                    .git
+                    .as_ref()
+                    .map(|g| format!(" ⎇ {}", g.branch))
+                    .unwrap_or_default();
                 let right = format!("{net} {indicator:>2}");
-                let right_w = UnicodeWidthStr::width(right.as_str());
+                let right_w = UnicodeWidthStr::width(right.as_str())
+                    + if branch.is_empty() {
+                        0
+                    } else {
+                        UnicodeWidthStr::width(branch.as_str()) + 2
+                    };
                 let left = pad_truncate(
                     &format!("  {marker}{name}"),
                     inner_width.saturating_sub(right_w),
@@ -154,21 +167,28 @@ fn render_sidebar(model: &mut Model, frame: &mut Frame, area: Rect) {
                 let gap = inner_width
                     .saturating_sub(UnicodeWidthStr::width(left.as_str()))
                     .saturating_sub(right_w);
-                Line::from(vec![
-                    Span::styled(
-                        format!("{left}{}", " ".repeat(gap)),
-                        if selected {
-                            Style::default().add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default()
-                        },
-                    ),
-                    Span::styled(net.to_string(), Style::default().fg(Color::Gray)),
-                    Span::styled(
-                        format!(" {indicator:>2}"),
-                        Style::default().fg(Color::Yellow),
-                    ),
-                ])
+                let name_span = Span::styled(
+                    format!("{left}{}", " ".repeat(gap)),
+                    if selected {
+                        Style::default().add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                    },
+                );
+                let mut spans = vec![name_span];
+                if !branch.is_empty() {
+                    spans.push(Span::styled(branch, Style::default().fg(Color::Gray)));
+                    spans.push(Span::raw("  "));
+                }
+                spans.push(Span::styled(
+                    net.to_string(),
+                    Style::default().fg(Color::Gray),
+                ));
+                spans.push(Span::styled(
+                    format!(" {indicator:>2}"),
+                    Style::default().fg(Color::Yellow),
+                ));
+                Line::from(spans)
             }
         };
         lines.push(line);
@@ -311,6 +331,16 @@ fn render_info(model: &Model, key: &SessionKey, frame: &mut Frame, area: Rect) {
         .and_then(|a| a.title.as_ref())
         .map(|t| t.value.clone())
         .unwrap_or_else(|| "-".to_string());
+    // The repo's toplevel, tagged when the project lives in a linked
+    // worktree (its .git lives in the main repo). Absent entirely for
+    // non-repo projects so their layout doesn't shift.
+    let repo = entry.and_then(|e| e.git.as_ref()).map(|g| {
+        let root = shorten_home(&g.repo_root);
+        match g.is_worktree {
+            true => format!("{root} (worktree)"),
+            false => root,
+        }
+    });
     let left = [
         ("project", project),
         ("user", user),
@@ -321,7 +351,12 @@ fn render_info(model: &Model, key: &SessionKey, frame: &mut Frame, area: Rect) {
         .and_then(|d| d.record.as_ref())
         .map(|r| format!("{:?}", r.network))
         .unwrap_or_else(|| "?".to_string());
-    let right = [("net", net), ("idle", idle_text(model, key))];
+    // The Info section is four rows tall; the branch rides in the sidebar
+    // row, so only the repo root joins the right column here.
+    let mut right = vec![("net", net), ("idle", idle_text(model, key))];
+    if let Some(repo) = repo {
+        right.push(("repo", repo));
+    }
 
     // Left column takes half the pane; the right column starts after a
     // two-space gutter. Labels are dim in both columns.

--- a/crates/minimal-tui/tests/snapshots.rs
+++ b/crates/minimal-tui/tests/snapshots.rs
@@ -253,6 +253,40 @@ fn sidebar_and_info_show_git_context() {
     );
 }
 
+/// A branch name longer than the sidebar truncates with `…` instead of
+/// pushing the network label and activity indicator off the right edge.
+#[test]
+fn sidebar_truncates_a_long_branch() {
+    let mut model = fixed_model(vec![provider(
+        "host",
+        vec![entry_with_git(1, "api", "/src/api", false)],
+    )]);
+    let long_branch = format!("feature/{}", "x".repeat(120));
+    model.providers[0].sessions[0].git.as_mut().unwrap().branch = long_branch;
+    model.details.insert(
+        SessionKey {
+            provider: "host".to_string(),
+            id: id(1),
+        },
+        Detail {
+            record: Some(record(Some("api"), NetworkMode::OwnIp)),
+            policy: None,
+        },
+    );
+    let rendered = render(&mut model);
+    let row = rendered
+        .lines()
+        .find(|l| l.contains('⎇'))
+        .unwrap_or_else(|| panic!("branch row missing:\n{rendered}"));
+    assert!(row.contains('…'), "branch must be truncated: {row}");
+    assert!(
+        !row.contains(&"x".repeat(20)),
+        "full branch must not fit: {row}"
+    );
+    // The right-aligned cells survive truncation.
+    assert!(row.contains("OwnIp"), "network label clipped: {row}");
+}
+
 /// A session with fresh stdout renders its activity spinner in the sidebar
 /// (TestBackend text, not a stored snapshot — the glyph is what matters).
 #[test]

--- a/crates/minimal-tui/tests/snapshots.rs
+++ b/crates/minimal-tui/tests/snapshots.rs
@@ -19,8 +19,26 @@ fn entry(n: u128, name: Option<&str>, project: &str) -> minimald_rpc::ListSessio
         name: name.map(str::to_owned),
         project_path: Some(paths::HostAbsPath::try_new(project).unwrap()),
         status: sessions::SessionStatus::Active,
+        git: None,
         attrs: None,
     }
+}
+
+/// An entry backed by a git repository: branch in the sidebar row, repo
+/// root in the detail Info section.
+fn entry_with_git(
+    n: u128,
+    name: &str,
+    project: &str,
+    worktree: bool,
+) -> minimald_rpc::ListSessionsEntry {
+    let mut e = entry(n, Some(name), project);
+    e.git = Some(Box::new(minimald_rpc::GitInfo {
+        branch: "main".to_string(),
+        repo_root: project.to_string(),
+        is_worktree: worktree,
+    }));
+    e
 }
 
 fn provider(label: &str, sessions: Vec<minimald_rpc::ListSessionsEntry>) -> ProviderData {
@@ -188,6 +206,51 @@ fn detail_pane_with_policy() {
     // Focus the session.
     model.cursor = 1;
     insta::assert_snapshot!(render(&mut model));
+}
+
+/// Git info from the list RPC renders: the branch in the sidebar row
+/// (TestBackend text — the glyph is what matters) and the repo root,
+/// tagged as a worktree, in the detail Info section.
+#[test]
+fn sidebar_and_info_show_git_context() {
+    let mut model = fixed_model(vec![provider(
+        "host",
+        vec![
+            entry_with_git(1, "api-staging", "/src/api", false),
+            entry_with_git(2, "web-wt", "/src/web-wt", true),
+        ],
+    )]);
+    let rendered = render(&mut model);
+    let api_row = rendered
+        .lines()
+        .find(|l| l.contains("api-staging"))
+        .expect("session row");
+    assert!(api_row.contains('⎇'), "branch glyph missing: {api_row}");
+    assert!(api_row.contains("main"), "branch name missing: {api_row}");
+
+    // Focus the worktree session: its repo root and the worktree tag
+    // appear in the right column of the Info section.
+    model.cursor = 2;
+    let rendered = render(&mut model);
+    assert!(
+        rendered.contains("/src/web-wt (worktree)"),
+        "worktree-tagged repo root missing:\n{rendered}"
+    );
+    // A plain repo root renders without the tag.
+    model.cursor = 1;
+    let rendered = render(&mut model);
+    let info_row = rendered
+        .lines()
+        .find(|l| l.contains("repo"))
+        .expect("repo row in info section");
+    assert!(
+        info_row.contains("/src/api"),
+        "repo root missing: {info_row}"
+    );
+    assert!(
+        !info_row.contains("worktree"),
+        "plain repo must not be tagged: {info_row}"
+    );
 }
 
 /// A session with fresh stdout renders its activity spinner in the sidebar

--- a/crates/minimal-tui/tests/snapshots.rs
+++ b/crates/minimal-tui/tests/snapshots.rs
@@ -251,6 +251,35 @@ fn sidebar_and_info_show_git_context() {
         !info_row.contains("worktree"),
         "plain repo must not be tagged: {info_row}"
     );
+    // The branch repeats in the Info section at full fidelity, alongside
+    // the repo root it came from in the sidebar.
+    let branch_row = rendered
+        .lines()
+        .find(|l| l.contains("branch"))
+        .expect("branch row in info section");
+    assert!(
+        branch_row.contains("main"),
+        "branch name missing: {branch_row}"
+    );
+}
+
+/// A session with no git info renders neither a repo nor a branch row,
+/// keeping the Info column layout byte-identical to pre-git renders.
+#[test]
+fn info_section_omits_git_rows_without_git_info() {
+    let mut model = fixed_model(vec![provider(
+        "host",
+        vec![entry(1, Some("plain"), "/src/plain")],
+    )]);
+    let rendered = render(&mut model);
+    assert!(
+        !rendered.lines().any(|l| l.contains("repo")),
+        "repo row leaked into a no-git render:\n{rendered}"
+    );
+    assert!(
+        !rendered.lines().any(|l| l.contains("branch")),
+        "branch row leaked into a no-git render:\n{rendered}"
+    );
 }
 
 /// A branch name longer than the sidebar truncates with `…` instead of

--- a/crates/minimal-tui/tests/snapshots/snapshots__detail_pane_with_policy.snap
+++ b/crates/minimal-tui/tests/snapshots/snapshots__detail_pane_with_policy.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/minimal-tui/tests/snapshots.rs
-expression: render(&model)
+expression: render(&mut model)
 ---
 "┌ sessions ────────────────────┐┌ api-staging · 00000000 ──────────────────────────────────────────┐"
-"│ /                            ││ project /src/api                  net   OwnIp                    │"
-"│ ──────────────────────────── ││ user    chroma                    idle  -                        │"
+"│ /                            ││ project /src/api                  net     OwnIp                  │"
+"│ ──────────────────────────── ││ user    chroma                    idle    -                      │"
 "│ ▼ host  v0.1              ●  ││ title   -                                                        │"
 "│   ▸ api-staging     OwnIp    ││ bells   -                                                        │"
 "│                              ││ ─ Policy ─────────────────────────────────────────────────────── │"

--- a/crates/minimal-tui/tests/snapshots/snapshots__preview_section_with_screen_snapshot.snap
+++ b/crates/minimal-tui/tests/snapshots/snapshots__preview_section_with_screen_snapshot.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/minimal-tui/tests/snapshots.rs
-expression: render(&model)
+expression: render(&mut model)
 ---
 "┌ sessions ────────────────────┐┌ api-staging · 00000000 ──────────────────────────────────────────┐"
-"│ /                            ││ project /src/api                  net   ?                        │"
-"│ ──────────────────────────── ││ user    ?                         idle  -                        │"
+"│ /                            ││ project /src/api                  net     ?                      │"
+"│ ──────────────────────────── ││ user    ?                         idle    -                      │"
 "│ ▼ host  v0.1              ●  ││ title   -                                                        │"
 "│   ▸ api-staging         -    ││ bells   -                                                        │"
 "│                              ││ ─ Policy ─────────────────────────────────────────────────────── │"

--- a/crates/minimal/src/attach.rs
+++ b/crates/minimal/src/attach.rs
@@ -316,6 +316,7 @@ mod tests {
             name: None,
             project_path: Some(HostAbsPath::try_new(path).unwrap()),
             status,
+            git: None,
             attrs: None,
         }
     }
@@ -328,6 +329,7 @@ mod tests {
             name: None,
             project_path: None,
             status,
+            git: None,
             attrs: None,
         }
     }

--- a/crates/minimal/src/completion.rs
+++ b/crates/minimal/src/completion.rs
@@ -215,6 +215,7 @@ mod tests {
             name: name.map(str::to_string),
             project_path: None,
             status: Default::default(),
+            git: None,
             attrs: None,
         }
     }

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -3633,6 +3633,7 @@ mod tests {
             name: name.map(str::to_owned),
             project_path: path.map(|p| paths::HostAbsPath::try_new(p).unwrap()),
             status,
+            git: None,
             attrs: None,
         }
     }

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -51,6 +51,7 @@ fn ls_shows_shared_resource_pool() {
             name: None,
             project_path: Some(paths::HostAbsPath::try_new("/p").unwrap()),
             status: sessions::SessionStatus::Active,
+            git: None,
             attrs: None,
         }],
     };
@@ -81,6 +82,7 @@ fn ls_table_exposes_project_path_and_status() {
             name: Some("s1".to_string()),
             project_path: Some(paths::HostAbsPath::try_new("/work/proj").unwrap()),
             status: sessions::SessionStatus::Active,
+            git: None,
             attrs: None,
         }],
     };

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -147,7 +147,31 @@ pub struct ListSessionsEntry {
     /// field so an older server still deserializes cleanly.
     #[serde(default)]
     pub status: sessions::SessionStatus,
+    /// Git context for the project path, probed at list time. `None` on
+    /// responses from daemons that predate this field, and whenever the
+    /// probe fails: not a repo, no git binary, or a timeout (a VM guest
+    /// without git lands here too). Boxed so the (usually `None`) field
+    /// stays small in the enums that wrap [`ListSessionsEntry`].
+    #[serde(default)]
+    pub git: Option<Box<GitInfo>>,
     pub attrs: Option<RunningSessionAttrs>,
+}
+
+/// The git state of a session's project path, as of the last
+/// [`ListSessions`] response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GitInfo {
+    /// `git rev-parse --abbrev-ref HEAD` — the branch name, or `HEAD` when
+    /// detached.
+    pub branch: String,
+    /// `git rev-parse --show-toplevel` — the working-tree root. For a
+    /// linked worktree this is the worktree's root, not the main repo's.
+    /// On the listing daemon's own filesystem (the guest's for a VM
+    /// daemon).
+    pub repo_root: String,
+    /// The checkout is a linked worktree (or submodule): its git directory
+    /// lives outside `<toplevel>/.git`.
+    pub is_worktree: bool,
 }
 
 /// Resources shared by every session managed by a minimald instance.
@@ -1298,5 +1322,47 @@ mod tests {
         assert_eq!(round_trip(&resp), resp);
         let json = serde_json_lenient::to_string(&resp).unwrap();
         assert!(json.contains(r#""kind":"pending""#), "got: {json}");
+    }
+
+    /// Back-compat both directions: a daemon that predates `git` omits the
+    /// field and decodes to `None`; an extra field in the payload is
+    /// accepted (no `deny_unknown_fields`), so a new daemon still serves
+    /// old clients.
+    #[test]
+    fn list_sessions_entry_decodes_with_and_without_git() {
+        let bare = r#"{
+            "id": "00000000-0000-0000-0000-000000000001",
+            "name": "api",
+            "project_path": "/src/api",
+            "status": "active",
+            "attrs": null
+        }"#;
+        let without: ListSessionsEntry =
+            serde_json_lenient::from_str(bare).expect("pre-git payload");
+        assert_eq!(without.git, None);
+
+        let with_git = serde_json_lenient::json!({
+            "id": "00000000-0000-0000-0000-000000000001",
+            "name": "api",
+            "project_path": "/src/api",
+            "status": "active",
+            "git": {
+                "branch": "main",
+                "repo_root": "/src/api",
+                "is_worktree": true
+            },
+            "attrs": null
+        });
+        let with: ListSessionsEntry =
+            serde_json_lenient::from_value(with_git).expect("post-git payload");
+        assert_eq!(
+            with.git,
+            Some(Box::new(GitInfo {
+                branch: "main".to_string(),
+                repo_root: "/src/api".to_string(),
+                is_worktree: true,
+            }))
+        );
+        assert_eq!(round_trip(&with), with);
     }
 }

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -116,18 +116,25 @@ async fn serve_list_sessions(
                 .await
                 .map_err(|e| ConnectionError::Internal(e.to_string()))?;
             let mngr = s.sessions_manager().await;
+            let infos = mngr
+                .list()
+                .await
+                .map_err(|e| ConnectionError::Internal(e.to_string()))?;
             Ok(ListSessionsResponse {
                 resource_pool,
-                sessions: mngr
-                    .list()
-                    .await
-                    .map_err(|e| ConnectionError::Internal(e.to_string()))?
-                    .into_iter()
-                    .map(|i| ListSessionsEntry {
+                // The git probes run in parallel across sessions: each is
+                // one small process under a deadline, and serializing them
+                // would multiply the latency of every list call.
+                sessions: futures::future::join_all(infos.into_iter().map(|i| async move {
+                    let git = probe_git_info(i.project_path.as_utf8_path().as_std_path())
+                        .await
+                        .map(Box::new);
+                    ListSessionsEntry {
                         id: i.id,
                         name: i.name,
                         project_path: Some(i.project_path),
                         status: i.status,
+                        git,
                         attrs: i.attrs.map(|a| minimald_rpc::RunningSessionAttrs {
                             last_stdout: a.stdout_last.map(|i| i.into()),
                             last_stdin: a.stdin_last.map(|i| i.into()),
@@ -144,11 +151,61 @@ async fn serve_list_sessions(
                                 last: t.into(),
                             }),
                         }),
-                    })
-                    .collect(),
+                    }
+                }))
+                .await,
             })
         })
         .await
+}
+
+/// Per-probe deadline for the `git rev-parse` calls
+/// [`serve_list_sessions`] runs: a list response must stay fast even when
+/// a session's project sits on a wedged filesystem.
+const GIT_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Probes the git context of `path` for [`minimald_rpc::GitInfo`]: one
+/// `rev-parse` invocation answers the branch, the toplevel, and the git
+/// directory. `--absolute-git-dir` (not `--git-dir`) keeps the worktree
+/// comparison exact — the relative form prints `.git` when `path` is the
+/// toplevel. Anything but a clean success — not a repo, no git binary, a
+/// timeout — yields `None`.
+async fn probe_git_info(path: &std::path::Path) -> Option<minimald_rpc::GitInfo> {
+    let out = tokio::time::timeout(
+        GIT_PROBE_TIMEOUT,
+        tokio::process::Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args([
+                "rev-parse",
+                "--abbrev-ref",
+                "HEAD",
+                "--show-toplevel",
+                "--absolute-git-dir",
+            ])
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(out.stdout).ok()?;
+    let mut lines = text.lines();
+    let (branch, toplevel, git_dir) = match (lines.next(), lines.next(), lines.next(), lines.next())
+    {
+        (Some(branch), Some(toplevel), Some(git_dir), None) => (branch, toplevel, git_dir),
+        _ => return None,
+    };
+    Some(minimald_rpc::GitInfo {
+        branch: branch.to_string(),
+        repo_root: toplevel.to_string(),
+        is_worktree: git_dir != format!("{toplevel}/.git"),
+    })
 }
 
 fn detect_resource_pool() -> Option<ResourcePool> {
@@ -2413,6 +2470,8 @@ mod tests {
                 // A freshly-created session that hasn't been configured yet
                 // sits in `Pending` until `ConfigureLoadout` promotes it.
                 status: sessions::SessionStatus::Pending,
+                // /uwu is not a git repository, so the probe yields nothing.
+                git: None,
                 attrs: None,
             }]
         );
@@ -2454,6 +2513,100 @@ mod tests {
         // The configured ingress was `None`, and the read reflects that rather
         // than the old hardcoded `Some(IngressPolicy::default())`.
         assert_eq!(policy.ingress, None);
+    }
+
+    /// `ListSessions` answers each session's git context: branch and
+    /// toplevel for a plain repo, the worktree flag for a linked
+    /// worktree, and `None` for a non-repo project. Follows
+    /// `session_delta`'s fixture; skipped where no git binary exists.
+    #[tokio::test]
+    async fn list_sessions_reports_git_info_per_session() {
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            eprintln!("skipping: no git binary in this environment");
+            return;
+        }
+
+        let repo = tempfile::tempdir().unwrap();
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(repo.path())
+                .args([
+                    "-c",
+                    "user.name=t",
+                    "-c",
+                    "user.email=t@example.invalid",
+                    "-c",
+                    "commit.gpgsign=false",
+                ])
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "-b", "main"]);
+        git(&["commit", "--allow-empty", "-m", "initial"]);
+        let wt_parent = tempfile::tempdir().unwrap();
+        let wt_path = wt_parent.path().join("wt");
+        git(&[
+            "worktree",
+            "add",
+            "-b",
+            "feature",
+            wt_path.to_str().unwrap(),
+        ]);
+        let plain = tempfile::tempdir().unwrap();
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        for (name, path) in [
+            ("repo-s", repo.path()),
+            ("wt-s", wt_path.as_path()),
+            ("plain-s", plain.path()),
+        ] {
+            crate::test_harness::create_configured_session(
+                &mut client,
+                name,
+                path.to_str().unwrap(),
+            )
+            .await;
+        }
+
+        let list = client.call::<ListSessions>(&()).await;
+        let by_name = |n: &str| {
+            list.sessions
+                .iter()
+                .find(|s| s.name.as_deref() == Some(n))
+                .unwrap_or_else(|| panic!("session {n} missing from list"))
+        };
+
+        // `--show-toplevel` canonicalizes; tempdir paths may pass through
+        // symlinks (/var → /private/var on macOS).
+        let repo_root = std::fs::canonicalize(repo.path()).unwrap();
+        let repo_s = by_name("repo-s")
+            .git
+            .clone()
+            .expect("repo-s must have git info");
+        assert_eq!(repo_s.branch, "main");
+        assert_eq!(std::fs::canonicalize(&repo_s.repo_root).unwrap(), repo_root,);
+        assert!(!repo_s.is_worktree);
+
+        let wt_s = by_name("wt-s")
+            .git
+            .clone()
+            .expect("wt-s must have git info");
+        assert_eq!(wt_s.branch, "feature");
+        assert!(wt_s.is_worktree, "linked worktree must be flagged");
+
+        assert_eq!(by_name("plain-s").git, None, "non-repo must probe to None");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The dash lists sessions with no sense of what checkout each serves. Dogfooding feedback asked for the branch, repo, and worktree per session.

- The daemon's `serve_list_sessions` now probes each session's project path with one `git rev-parse --abbrev-ref HEAD --show-toplevel --absolute-git-dir` invocation via `tokio::process`, under a 1 s deadline, in parallel across sessions. `--absolute-git-dir` keeps the worktree comparison exact (the relative form prints `.git` at the toplevel); anything but a clean success (not a repo, no git, timeout) yields `None`.
- New wire field `#[serde(default)] git: Option<Box<GitInfo>>` on `ListSessionsEntry`. Back-compat both directions: old daemons omit the field and clients show nothing, new daemons are tolerated by old clients (plain serde, no `deny_unknown_fields`). Boxed so the mostly-`None` field stays small in the CLI's picker enums (clippy `large_enum_variant`).
- The TUI renders ` ⎇ <branch>` in the sidebar row; the detail Info column gains the repo toplevel, tagged `(worktree)` for linked worktrees, plus the branch at full fidelity where the sidebar may have clipped it. Both git rows come from the same field, so they appear and disappear together; non-repo sessions never gain or lose rows. Right-column labels widen to eight columns so the six-char `branch` label keeps the same two-space gutter as its siblings, and the two stored insta snapshots shift by that much.

**VM caveat:** the guest daemon probes git inside the guest. Guests without git yield `None` and the dash shows nothing, per the degraded-behavior contract.

## Changes

| File | What it does |
|---|---|
| `crates/minimald-rpc/src/lib.rs` | `GitInfo` wire type, `git` field, round-trip and back-compat tests |
| `crates/minimald/src/rpc.rs` | `probe_git_info` plus parallel probing in `serve_list_sessions`; integration test with a repo, a linked worktree, and a non-repo fixture |
| `crates/minimal-tui/src/render.rs` | Sidebar branch segment, Info-column repo root and branch, eight-column label gutter, zero-width guard in `truncate` |
| `crates/minimal-tui/tests/snapshots.rs` | `sidebar_and_info_show_git_context` render test plus the no-git-omission case; two stored snapshots realigned to the wider gutter |
| `crates/minimal{,-tui}/...` | `git: None` in existing `ListSessionsEntry` literals |

## Verification

- `just ci` green: fmt, clippy, cargo-deny, 1729 tests, doctests. The one `test-ignored` failure (`mctx tests::task_env`) also fails on clean `main` and is unrelated.
- New daemon integration test `list_sessions_reports_git_info_per_session` builds a real repo plus a `git worktree add` fixture and asserts branch, toplevel, and the worktree flag over the wire.
- Added since: fmt, clippy, and the full `minimal-tui` suite green (40 lib tests including `truncation_respects_a_zero_width_budget`, 13 snapshot tests including `info_section_omits_git_rows_without_git_info`).

Fixes #1200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session listings now show the current Git branch when available.
  * Session details display the repository root and identify linked worktrees.
  * Git metadata includes branch, repository location, and worktree status.
* **Improvements**
  * Long branch names are truncated while preserving network and activity indicators.
  * Sessions without Git information retain their existing layout.
  * Git details are omitted for non-repositories or unavailable metadata, keeping loading responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
