### PR TITLE
build: use line-tables-only debug info for dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,13 @@ opt-level = 1
 lto = false
 codegen-units = 16
 
+# Keep debug info lean for third-party dependencies. Full DWARF on every
+# transitive rlib bloats `target/debug` into the tens of GB (this workspace
+# alone accumulated ~160GB of deps). Line tables are enough for backtraces and
+# gdb line numbers; workspace crates keep full debug info for local debugging.
+[profile.dev.package."*"]
+debug = "line-tables-only"
+
 [workspace.dependencies]
 anyhow = "1.0"
 arbitrary = "1"


### PR DESCRIPTION
## Summary

The dev profile embeds full DWARF debug info in every transitive rlib. On this 31-crate workspace that accumulated ~160GB in `target/debug/deps` (2,445 rlibs for 551 distinct crates, with each copy carrying full DWARF).

This sets `debug = "line-tables-only"` for third-party dependencies in the dev profile. Line tables are enough for backtraces and gdb line numbers; workspace crates keep full debug info for local debugging.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Add `[profile.dev.package."*"]` with `debug = "line-tables-only"` |

## Verification

- Built `mfile` (workspace crate) with the new profile; inspected rlib sections:
  - Deps (`serde`, `tracing`, `toml_edit`): `.debug_line` present, all other `.debug_*` sections absent
  - Workspace crates (`sessions`, `common`, `mfile`): full `.debug_*` sections intact
- Backtraces and gdb line numbers still work with line tables; only variable-level inspection of third-party code is lost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved development build configuration to reduce debug information generated by third-party dependencies.
  * Preserved full debugging details for the application’s own workspace components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->