### PR TITLE
feat(mctx): default cache reads to the R2 mirror (cache.minimal.dev)

### DIFF
--- a/crates/mctx/src/config.rs
+++ b/crates/mctx/src/config.rs
@@ -42,6 +42,18 @@ impl std::error::Error for ConfigError {
 /// bucket. A bare name (no scheme) is treated as a GCS bucket.
 pub const DEFAULT_REMOTE_CACHE_BUCKET: &str = "minimal-staging-cache";
 
+/// Default *read* location: the R2 mirror on the product domain. Cache
+/// reads are immutable, content-addressed, and sha256-verified
+/// client-side, and R2 charges no egress — where the same reads from
+/// the GCS bucket are billed internet egress for every consumer
+/// outside GCP. Writers never use this (writes require the `gs://`
+/// bucket above). An explicitly configured location or the
+/// `MINIMAL_REMOTE_CACHE_URL` env var both take precedence: in-cloud
+/// readers (res-servers) pin `gs://` explicitly for free same-region
+/// reads, and pointing the env var at `gs://minimal-staging-cache` is
+/// the escape hatch back to direct GCS.
+pub const DEFAULT_REMOTE_CACHE_READ_URL: &str = "https://cache.minimal.dev/";
+
 /// Parses a remote-cache location string into (a) the resolved [`AnyUrl`] a
 /// reader fetches from and (b) the GCS bucket name a *writer* would use
 /// (`None` for an HTTPS mirror — you can't write to a read mirror). Accepted:
@@ -180,6 +192,7 @@ impl ConfigBuilder {
     /// Constructs a config object using the given builder.
     pub fn build(self) -> Result<Config, ConfigError> {
         // The one configured cache location (default: the shared GCS bucket).
+        let explicitly_configured = self.remote_cache_url.is_some();
         let remote_cache_url = self
             .remote_cache_url
             .unwrap_or_else(|| DEFAULT_REMOTE_CACHE_BUCKET.to_string());
@@ -187,13 +200,28 @@ impl ConfigBuilder {
         // when it's an HTTPS mirror -> writes error, since you can't write to a
         // read mirror). This also validates the configured value.
         let (_, remote_cache_write_bucket) = parse_remote_cache_url(&remote_cache_url)?;
-        // Reads honour the `MINIMAL_REMOTE_CACHE_URL` env override (for read-only
-        // consumers pointing at an R2 mirror to avoid GCS egress); otherwise the
-        // configured location.
-        let read_raw = std::env::var("MINIMAL_REMOTE_CACHE_URL")
+        // Read-side resolution, in precedence order: the
+        // `MINIMAL_REMOTE_CACHE_URL` env override, then an explicitly
+        // configured location, then the R2 mirror default. Only callers
+        // that configured nothing get the mirror — an explicit
+        // `with_remote_cache_url` (e.g. res-servers pinning `gs://` for
+        // free same-region reads) is honoured for reads AND writes.
+        let env_override = std::env::var("MINIMAL_REMOTE_CACHE_URL")
             .ok()
-            .filter(|s| !s.trim().is_empty())
-            .unwrap_or_else(|| remote_cache_url.clone());
+            .filter(|s| !s.trim().is_empty());
+        let (read_raw, read_source) = match (env_override, explicitly_configured) {
+            (Some(url), _) => (url, "env-override"),
+            (None, true) => (remote_cache_url.clone(), "configured"),
+            (None, false) => (
+                DEFAULT_REMOTE_CACHE_READ_URL.to_string(),
+                "default-r2-mirror",
+            ),
+        };
+        // One line of visibility: which source reads use. Selection was
+        // previously silent, which made "is this client actually on the
+        // mirror?" unanswerable from logs (it took GCS access-log
+        // forensics to attribute egress).
+        tracing::info!(url = %read_raw, source = read_source, "remote cache read location");
         let (remote_cache_read, _) = parse_remote_cache_url(&read_raw)?;
 
         Ok(Config {
@@ -415,6 +443,29 @@ mod tests {
             cfg.remote_cache_write_bucket(),
             Some(DEFAULT_REMOTE_CACHE_BUCKET)
         );
+    }
+
+    #[test]
+    fn default_reader_is_the_r2_mirror_writer_stays_gcs() {
+        // The R2-default flip: an unconfigured builder reads from the
+        // mirror but still derives its write bucket from the GCS
+        // default — the read default must never leak into the writer.
+        let cfg = ConfigBuilder::new().build().unwrap();
+        assert_eq!(
+            cfg.remote_cache_write_bucket(),
+            Some(DEFAULT_REMOTE_CACHE_BUCKET)
+        );
+        // Same env guard as the sibling tests.
+        if std::env::var("MINIMAL_REMOTE_CACHE_URL")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .is_none()
+        {
+            assert!(
+                matches!(cfg.remote_cache_url(), AnyUrl::Https(_)),
+                "unconfigured reader should default to the R2 mirror"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
**DRAFT until [infra#422](https://github.com/gominimal/infra/pull/422) is deployed and verified** — the cache.minimal.dev custom domain + index.shisha bypass route must be live before this default can ship. I'll mark ready-for-review with the verification transcript once the domain passes the three-curl parity check (artifact bytes ≡ .farm ≡ GCS, fresh index, 404 passthrough).

## What flips

Read-side default only. Precedence after this change: `MINIMAL_REMOTE_CACHE_URL` env override → explicitly configured location → **`https://cache.minimal.dev/`**. Ends the per-repo whack-a-mole (webapp#380, pkgs#613, build-servers#239 — all become harmless no-ops) and covers every laptop and future consumer with zero wiring.

## What deliberately does NOT change

- **Writes**: still derive from the configured `gs://` bucket; an HTTPS mirror remains read-only. The read default cannot leak into the writer (new test pins this).
- **In-cloud readers**: res-servers pin `gs://` explicitly (buildbot sends `remote_cache_gcs_bucket` unconditionally — verified at the single call site), keeping free same-region GCS reads.
- **Escape hatch**: `MINIMAL_REMOTE_CACHE_URL=gs://minimal-staging-cache` returns any client to direct GCS.

## Also in here

The chosen read location + source is now logged at `info` — selection was previously silent, which made "is this client actually on the mirror?" unanswerable from logs (this month's egress attribution took GCS access-log forensics; that gap dies here).

## Safety case

Same objects, byte-identical (R2 is Sippy-fed from authoritative GCS; verified); every artifact is sha256-verified client-side regardless of source; the mutable root `index.shisha` is served fresh from GCS by the edge Worker on both hostnames; per-commit snapshots (the default read path since #912/#995) are immutable. The env-var version of this exact routing has run in webapp CI since July 8 and is canaried by dogfood (#667).

Local validation: `cargo check -p mctx` clean; clippy findings identical to baseline (10 pre-existing); mctx's test target doesn't compile on macOS at baseline either (pre-existing, unrelated) — Linux CI is authoritative for the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default remote cache reads to the R2 mirror (cache.minimal.dev) in `mctx`
> - `ConfigBuilder.build` now selects the read URL by precedence: env override (`MINIMAL_REMOTE_CACHE_URL`) > explicitly configured value > new `DEFAULT_REMOTE_CACHE_READ_URL` constant pointing at `https://cache.minimal.dev/`.
> - Write bucket derivation is unchanged — it continues to come from the explicitly configured location via `parse_remote_cache_url`.
> - An `info` log is emitted at build time indicating the selected read URL and which precedence level chose it.
> - Behavioral Change: unconfigured builds now read from the R2 mirror instead of the GCS default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d502ef2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved remote cache configuration by using a faster default read source.
  * Preserved existing cache write behavior while separating read and write locations.
  * Added clearer logging to indicate the selected cache source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->