### PR TITLE
ci(macos): never run the self-hosted e2e for fork pull requests

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -210,7 +210,30 @@ jobs:
         # RUN_MACOS_CI is the kill-switch repo variable for taking the mini
         # offline; a skipped e2e reads as `skipped`, which the aggregator
         # treats as pass.
-        if: ${{ vars.RUN_MACOS_CI != 'false' && (github.event_name != 'pull_request' || needs.changes.outputs.macos == 'true') }}
+        #
+        # FORK GUARD — the head-repo check is load-bearing SECURITY, not a
+        # filter. This repo is PUBLIC and this job runs on a self-hosted
+        # runner: a physical Mac mini on a home network, reused across jobs
+        # rather than torn down. Without this condition, anyone can open a PR
+        # from a fork and execute arbitrary code on that machine — GitHub's own
+        # docs say not to pair self-hosted runners with public repos for
+        # exactly this reason. `permissions: contents: read` and using no
+        # secrets limit what a run can STEAL; they do nothing about what it can
+        # RUN, or what it can leave behind on a persistent host.
+        #
+        # Deliberately expressed here rather than relying on the repo's
+        # "require approval for fork PRs" setting: that setting exempts anyone
+        # with a previously-merged PR, is invisible in review, and silently
+        # reverts to the org default. This line is versioned, reviewable, and
+        # fails closed.
+        #
+        # Fork PRs get `skipped`, which the ci-macos-success aggregator counts
+        # as pass, so this does not wedge the required check.
+        if: >-
+            ${{ vars.RUN_MACOS_CI != 'false'
+            && (github.event_name != 'pull_request'
+                || (needs.changes.outputs.macos == 'true'
+                    && github.event.pull_request.head.repo.full_name == github.repository)) }}
         needs: [changes, artifacts, unit]
         runs-on: [self-hosted, macOS, ARM64]
         timeout-minutes: 30


### PR DESCRIPTION
**The one live external exposure in the estate.** This repo is **public** and the `e2e` job runs on `[self-hosted, macOS, ARM64]` — a physical Mac mini, reused across jobs rather than torn down. On a `pull_request` trigger, anyone can open a PR from a fork and **execute arbitrary code on that machine**. GitHub's own guidance is not to pair self-hosted runners with public repos for exactly this reason.

Existing hardening limits what a run could **steal** (`permissions: contents: read`, no secrets). It does nothing about what a run can **execute**, or leave behind on a persistent host.

### The guard
```
github.event.pull_request.head.repo.full_name == github.repository
```
Expressed **in the workflow**, not via the repo's *"require approval for fork PRs"* setting — that setting exempts anyone with a previously-merged PR, is invisible in review, and silently reverts to the org default. This line is versioned, reviewable, and fails closed.

### Behaviour is otherwise unchanged
| trigger | before | after |
|---|---|---|
| push to main | runs | runs |
| `workflow_call` (nightly tier) | runs | runs |
| same-repo PR touching macOS | runs | runs |
| same-repo PR, no macOS changes | skipped | skipped |
| **fork PR** | **runs on your Mac mini** | **skipped** |
| `RUN_MACOS_CI=false` | skipped | skipped |

Fork PRs get `skipped`, which `ci-macos-success` counts as pass — the required check still goes green rather than wedging. That aggregator design is what makes this safe to add.

### Provenance
Found by karkinos (`github/actions-self-hosted-runner-public-repo`). It also flags `nightly.yml` and `release.yml`, but **neither triggers on `pull_request`**, so neither has a fork-controlled execution path — `ci-macos.yml` was the live one.

**No fork PR has ever run this workflow** (checked run history), so this closes a hole rather than answering an incident.

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>