### PR TITLE
feat(decode): implement nickel/parse logic for container specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6989,7 +6989,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdlib"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "fd-lock",
  "tempfile",

--- a/crates/decode/src/attrs.rs
+++ b/crates/decode/src/attrs.rs
@@ -116,7 +116,12 @@ impl AttrValue {
             )));
         }
 
-        todo!("error for unexpected attribute value type: {:?}", rt)
+        Err(Error::unexpected_type(
+            "attribute value",
+            "a string, number, boolean, record, array, or enum",
+            &rt,
+            program,
+        ))
     }
 
     /// Returns the inner list, if this [AttrValue] is the list variant.

--- a/crates/decode/src/builds.rs
+++ b/crates/decode/src/builds.rs
@@ -448,6 +448,7 @@ impl BuildDep {
             | ObjTy::OutputData
             | ObjTy::Profile
             | ObjTy::Stack
+            | ObjTy::Container
             | ObjTy::Layer
             | ObjTy::Test => Err(Error::UnexpectedObject {
                 files: program.files(),

--- a/crates/decode/src/builds.rs
+++ b/crates/decode/src/builds.rs
@@ -1,6 +1,6 @@
 //! Build specification objects.
 
-use crate::{Error, ObjTy, attrs::AttrValue, eval_if_closure, read_ty};
+use crate::{Error, ObjTy, attrs::AttrValue, deserialize_field, eval_if_closure, read_ty};
 use crate::{StrPos, cmds_from_cmd_term, cmds_from_cmds_term};
 use common::Target;
 use nickel_lang_core::eval::value::NickelValue;
@@ -74,7 +74,7 @@ impl BuildRef {
 
                 let name =
                     if let Ok(Some(n_rt)) = record.get_value_with_ctrs(&LocIdent::new("name")) {
-                        String::deserialize(eval_if_closure(&n_rt, program)?).unwrap()
+                        deserialize_field("upstream `name`", "a string", &n_rt, program)?
                     } else {
                         return Err(Error::MissingField {
                             files: program.files(),
@@ -109,7 +109,7 @@ impl BuildRef {
 
                 let name =
                     if let Ok(Some(n_rt)) = record.get_value_with_ctrs(&LocIdent::new("name")) {
-                        String::deserialize(eval_if_closure(&n_rt, program)?).unwrap()
+                        deserialize_field("builder `name`", "a string", &n_rt, program)?
                     } else {
                         return Err(Error::MissingField {
                             files: program.files(),
@@ -178,7 +178,7 @@ impl SourceInput {
                         "file" => {
                             if let Some(rt) = field.value.as_ref() {
                                 filename = Some((
-                                    String::deserialize(eval_if_closure(rt, program)?).unwrap(),
+                                    deserialize_field("source `file`", "a string", rt, program)?,
                                     field
                                         .value
                                         .as_ref()
@@ -193,7 +193,7 @@ impl SourceInput {
                         "url" => {
                             if let Some(rt) = field.value.as_ref() {
                                 url = Some((
-                                    String::deserialize(eval_if_closure(rt, program)?).unwrap(),
+                                    deserialize_field("source `url`", "a string", rt, program)?,
                                     Some(rt.pos(program.pos_table())),
                                 ));
                             }
@@ -202,7 +202,7 @@ impl SourceInput {
                         "sha256" => {
                             if let Some(rt) = field.value.as_ref() {
                                 sha256 = Some((
-                                    String::deserialize(eval_if_closure(rt, program)?).unwrap(),
+                                    deserialize_field("source `sha256`", "a string", rt, program)?,
                                     Some(rt.pos(program.pos_table())),
                                 ));
                             }
@@ -210,17 +210,23 @@ impl SourceInput {
                         }
                         "extract" => {
                             if let Some(ext_rt) = field.value.as_ref() {
-                                extract = Some(
-                                    bool::deserialize(eval_if_closure(ext_rt, program)?).unwrap(),
-                                );
+                                extract = Some(deserialize_field(
+                                    "source `extract`",
+                                    "a boolean",
+                                    ext_rt,
+                                    program,
+                                )?);
                             }
                             Ok(())
                         }
                         "strip_prefix" => {
                             if let Some(st_rt) = field.value.as_ref() {
-                                strip_prefix = Some(
-                                    String::deserialize(eval_if_closure(st_rt, program)?).unwrap(),
-                                );
+                                strip_prefix = Some(deserialize_field(
+                                    "source `strip_prefix`",
+                                    "a string",
+                                    st_rt,
+                                    program,
+                                )?);
                             }
                             Ok(())
                         }
@@ -344,18 +350,22 @@ impl SubsetInput {
                                         outputs = Some(
                                             a.iter()
                                                 .map(|input| {
-                                                    Ok(String::deserialize(eval_if_closure(
-                                                        input, program,
-                                                    )?)
-                                                    .unwrap())
+                                                    deserialize_field(
+                                                        "subset input `outputs` entry",
+                                                        "a string",
+                                                        input,
+                                                        program,
+                                                    )
                                                 })
                                                 .collect::<Result<SmallVec<_>, Error>>()?,
                                         );
                                     } else {
-                                        todo!(
-                                            "handle outputs value being non-array {:?}",
-                                            field.value
-                                        );
+                                        return Err(Error::unexpected_type(
+                                            "subset input `outputs`",
+                                            "an array of output names",
+                                            &outputs_val,
+                                            program,
+                                        ));
                                     }
                                 }
                             }
@@ -471,11 +481,12 @@ impl BuildDep {
                     match ident_and_loc.label() {
                         "file" => {
                             file = Some((
-                                String::deserialize(eval_if_closure(
+                                deserialize_field(
+                                    "local `file`",
+                                    "a string",
                                     field.value.as_ref().unwrap(),
                                     program,
-                                )?)
-                                .unwrap(),
+                                )?,
                                 field
                                     .value
                                     .as_ref()
@@ -574,33 +585,44 @@ impl BuildOutput {
                 .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
                     match ident_and_loc.label() {
                         "glob" => {
-                            glob = Some(
-                                String::deserialize(eval_if_closure(
-                                    field.value.as_ref().unwrap(),
-                                    program,
-                                )?)
-                                .unwrap(),
-                            );
+                            glob = Some(deserialize_field(
+                                "output `glob`",
+                                "a string",
+                                field.value.as_ref().unwrap(),
+                                program,
+                            )?);
                             Ok(())
                         }
                         "allow_executable" => {
                             if let Some(rt) = field.value.as_ref() {
-                                allow_executable =
-                                    Some(bool::deserialize(eval_if_closure(rt, program)?).unwrap());
+                                allow_executable = Some(deserialize_field(
+                                    "output `allow_executable`",
+                                    "a boolean",
+                                    rt,
+                                    program,
+                                )?);
                             }
                             Ok(())
                         }
                         "allow_data" => {
                             if let Some(rt) = field.value.as_ref() {
-                                allow_data =
-                                    Some(bool::deserialize(eval_if_closure(rt, program)?).unwrap());
+                                allow_data = Some(deserialize_field(
+                                    "output `allow_data`",
+                                    "a boolean",
+                                    rt,
+                                    program,
+                                )?);
                             }
                             Ok(())
                         }
                         "allow_missing_interpreter" => {
                             if let Some(rt) = field.value.as_ref() {
-                                allow_missing_interpreter =
-                                    Some(bool::deserialize(eval_if_closure(rt, program)?).unwrap());
+                                allow_missing_interpreter = Some(deserialize_field(
+                                    "output `allow_missing_interpreter`",
+                                    "a boolean",
+                                    rt,
+                                    program,
+                                )?);
                             }
                             Ok(())
                         }
@@ -770,57 +792,54 @@ impl BuildDecl {
                 .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
                     match ident_and_loc.label() {
                         "ty" => {
-                            ty = Some(
-                                ObjTy::deserialize(eval_if_closure(
-                                    field.value.as_ref().unwrap(),
-                                    program,
-                                )?)
-                                .unwrap(),
-                            );
+                            ty = Some(deserialize_field(
+                                "builder `ty` annotation",
+                                "a known object type",
+                                field.value.as_ref().unwrap(),
+                                program,
+                            )?);
                             Ok(())
                         }
                         "name" => {
-                            name = Some(
-                                String::deserialize(eval_if_closure(
-                                    field.value.as_ref().unwrap(),
-                                    program,
-                                )?)
-                                .unwrap(),
-                            );
+                            name = Some(deserialize_field(
+                                "builder `name`",
+                                "a string",
+                                field.value.as_ref().unwrap(),
+                                program,
+                            )?);
                             Ok(())
                         }
                         "prebuilt" => {
                             if let Some(rt) = field.value.as_ref() {
-                            prebuilt = Some(
-                                bool::deserialize(eval_if_closure(
-                                    rt,
-                                    program,
-                                )?)
-                                .unwrap(),
-                            );
+                            prebuilt = Some(deserialize_field(
+                                "builder `prebuilt`",
+                                "a boolean",
+                                rt,
+                                program,
+                            )?);
                             }
                             Ok(())
                         }
                         "cmd" => {
                             if let Some(rt) = field.value.as_ref() {
-                                cmds = Some(cmds_from_cmd_term(rt, program)?);
+                                cmds = Some(cmds_from_cmd_term("builder `cmd`", rt, program)?);
                             };
                             Ok(())
                         }
                         "cmds" => {
                             if let Some(rt) = field.value.as_ref() {
-                                cmds = Some(cmds_from_cmds_term(rt, program)?);
+                                cmds = Some(cmds_from_cmds_term("builder `cmds`", rt, program)?);
                             };
                             Ok(())
                         }
                         "target" => {
                             if let Some(target_rt) = field.value.as_ref() {
-                                let target_str =
-                                    String::deserialize(eval_if_closure(
-                                        target_rt,
-                                        program,
-                                    )?)
-                                    .unwrap();
+                                let target_str: String = deserialize_field(
+                                    "builder `target`",
+                                    "a string",
+                                    target_rt,
+                                    program,
+                                )?;
                                 match target_str.parse::<Target>() {
                                     Ok(t) => {
                                         target = Some(t);
@@ -854,11 +873,15 @@ impl BuildDecl {
 
                                             Ok((
                                                 ident_and_loc.label().to_string(),
-                                                String::deserialize(eval_if_closure(
+                                                deserialize_field(
+                                                    format!(
+                                                        "builder `build_args.{}`",
+                                                        ident_and_loc.label()
+                                                    ),
+                                                    "a string",
                                                     field.value.as_ref().unwrap(),
                                                     program,
-                                                )?)
-                                                .unwrap(),
+                                                )?,
                                             ))
                                         },
                                     ).collect::<Result<IndexMap<_, _>, Error>>()?
@@ -866,7 +889,12 @@ impl BuildDecl {
                                 } else if crate::is_record(&build_args_rt) {
                                     build_args = Some(Default::default());
                                 } else {
-                                    todo!("unexpected term for build_args");
+                                    return Err(Error::unexpected_type(
+                                        "builder `build_args`",
+                                        "a record of strings",
+                                        &build_args_rt,
+                                        program,
+                                    ));
                                 }
                             }
 
@@ -890,7 +918,12 @@ impl BuildDecl {
                                         .collect::<Result<SmallVec<_>, Error>>()?,
                                 );
                             } else {
-                                todo!("handle build_deps value being non-array {:?}", field.value);
+                                return Err(Error::unexpected_type(
+                                    "builder `build_deps`",
+                                    "an array of build dependencies",
+                                    &build_deps_rt,
+                                    program,
+                                ));
                             };
                             Ok(())
                         }
@@ -910,10 +943,12 @@ impl BuildDecl {
                                                 .collect::<Result<SmallVec<_>, Error>>()?,
                                         );
                                     } else {
-                                        todo!(
-                                            "handle runtime_deps value being non-array {:?}",
-                                            field.value
-                                        );
+                                        return Err(Error::unexpected_type(
+                                            "builder `runtime_deps`",
+                                            "an array of runtime dependencies",
+                                            &runtime_deps_val,
+                                            program,
+                                        ));
                                     }
                                 }
                             }
@@ -947,7 +982,12 @@ impl BuildDecl {
                                 // Empty record - no outputs
                                 outputs = Some(Default::default());
                             } else {
-                                todo!("handle value being non-dict {:?}", field.value);
+                                return Err(Error::unexpected_type(
+                                    "builder `outputs`",
+                                    "a record of outputs",
+                                    &outputs_rt,
+                                    program,
+                                ));
                             };
                             Ok(())
                         }
@@ -994,7 +1034,12 @@ impl BuildDecl {
                                 } else if crate::is_record(&attrs_rt) {
                                     attrs = Some(Default::default());
                                 } else {
-                                    todo!("unexpected term for attrs: {:?}", attrs_rt);
+                                    return Err(Error::unexpected_type(
+                                        "builder `attrs`",
+                                        "a record of attributes",
+                                        &attrs_rt,
+                                        program,
+                                    ));
                                 }
                             }
 
@@ -1027,7 +1072,12 @@ impl BuildDecl {
                                 } else if crate::is_record(&needs_rt) {
                                     needs = Some(Default::default());
                                 } else {
-                                    todo!("unexpected term for needs: {:?}", needs_rt);
+                                    return Err(Error::unexpected_type(
+                                        "builder `needs`",
+                                        "a record of attributes",
+                                        &needs_rt,
+                                        program,
+                                    ));
                                 }
                             }
 
@@ -1056,7 +1106,12 @@ impl BuildDecl {
                                         // Empty record - no tests
                                         tests = Some(Default::default());
                                     } else {
-                                        todo!("handle value being non-dict {:?}", field.value);
+                                        return Err(Error::unexpected_type(
+                                            "builder `tests`",
+                                            "a record of tests",
+                                            &tests_rt,
+                                            program,
+                                        ));
                                     };
                                 }
                             Ok(())

--- a/crates/decode/src/container.rs
+++ b/crates/decode/src/container.rs
@@ -1,0 +1,1040 @@
+//! Decoding of container declarations, laid out at `<layer>/containers/<name>/spec.ncl`.
+
+use common::{Target, target::Arch};
+use nickel_lang_core::{
+    eval::{cache::CacheImpl, value::NickelValue},
+    program::Program,
+    term::{IndexMap, RuntimeContract},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, ObjTy, eval_if_closure, packages_array_from_term, record_data_from_val};
+
+/// The transport protocol of an [ExposedPort].
+///
+/// OCI recognises only `tcp` and `udp`, and spells them lowercase in the
+/// `ExposedPorts` keys of the image config.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Proto {
+    #[default]
+    Tcp,
+    Udp,
+}
+
+impl std::fmt::Display for Proto {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Proto::Tcp => write!(f, "tcp"),
+            Proto::Udp => write!(f, "udp"),
+        }
+    }
+}
+
+/// Word-splits the string form of an argv field into OCI exec form.
+///
+/// OCI has no shell form, so a string is split into words here and an
+/// unbalanced quote is an error rather than something a shell would see.
+/// Mirrors how `minimal.toml` outputs handle `entrypoint`/`cmd`.
+fn argv_from_term(
+    field: &'static str,
+    rt: &NickelValue,
+    program: &mut Program<CacheImpl>,
+) -> Result<Vec<String>, Error> {
+    let rt = eval_if_closure(rt, program)?;
+
+    let argv = if let Some(s) = rt.as_string() {
+        shlex::split(s.as_ref()).ok_or_else(|| {
+            Error::Other(format!(
+                "container `{field}` is not a valid shell word list: {:?}",
+                s.as_ref()
+            ))
+        })?
+    } else if let Some(a) = rt.as_array() {
+        // `CmdSpec` is an `any_of`, so its element contract does not fire on
+        // its own: without the element check here a non-string argv entry
+        // reaches `String::deserialize` and panics.
+        let pending = a.iter_pending_contracts().cloned().collect::<Vec<_>>();
+        a.iter()
+            .map(|elem| {
+                let elem = RuntimeContract::apply_all(
+                    elem.clone(),
+                    pending.iter().cloned(),
+                    elem.pos_idx(),
+                );
+                let elem = eval_if_closure(&elem, program)?;
+                String::deserialize(elem).map_err(|_| {
+                    Error::Other(format!("container `{field}` must be a list of strings"))
+                })
+            })
+            .collect::<Result<Vec<_>, Error>>()?
+    } else {
+        todo!(
+            "error for `{}` field being non-string & non-array, got {:?}",
+            field,
+            rt
+        );
+    };
+
+    if argv.is_empty() {
+        return Err(Error::Other(format!(
+            "container `{field}` must not be empty"
+        )));
+    }
+
+    Ok(argv)
+}
+
+/// A port exposed by a container image.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExposedPort {
+    /// The protocol the port speaks. Defaults to TCP, matching the OCI
+    /// bare-port form.
+    pub proto: Proto,
+    /// The port number, always within 1-65535.
+    pub port: u16,
+}
+
+impl ExposedPort {
+    /// Deserializes an exposed-port structure from the given nickel term tree.
+    pub(crate) fn from_term(
+        rt: &NickelValue,
+        program: &mut Program<CacheImpl>,
+    ) -> Result<Self, Error> {
+        let rt = eval_if_closure(rt, program)?;
+
+        let mut proto: Option<Proto> = None;
+        let mut port: Option<u16> = None;
+
+        if let Some(r) = record_data_from_val(&rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    let Some(field_rt) = field.value.as_ref() else {
+                        return Ok(());
+                    };
+                    // Field contracts are pending until applied; without this
+                    // the contracts declared in minimal.ncl never run.
+                    let field_rt = &RuntimeContract::apply_all(
+                        field_rt.clone(),
+                        field.pending_contracts.iter().cloned(),
+                        field_rt.pos_idx(),
+                    );
+
+                    match ident_and_loc.label() {
+                        "proto" => {
+                            let p_rt = eval_if_closure(field_rt, program)?;
+                            proto = Some(Proto::deserialize(p_rt).map_err(|_| {
+                                Error::Other(
+                                    "container port `proto` must be 'Tcp or 'Udp".to_string(),
+                                )
+                            })?);
+                            Ok(())
+                        }
+                        "port" => {
+                            // Deserialized as a float and range-checked here:
+                            // integer deserialization saturates rather than
+                            // failing, which would silently turn 70000 into
+                            // 65535.
+                            let n = f64::deserialize(eval_if_closure(field_rt, program)?).map_err(
+                                |_| Error::Other("container port must be a number".to_string()),
+                            )?;
+                            if n.fract() != 0.0 || !(1.0..=65535.0).contains(&n) {
+                                return Err(Error::Other(format!(
+                                    "container port must be a whole number within 1-65535, got {n}"
+                                )));
+                            }
+                            port = Some(n as u16);
+                            Ok(())
+                        }
+                        _ => Ok(()),
+                    }
+                })?;
+        } else {
+            todo!("unexpected term for exposed_ports entry: {:?}", rt);
+        }
+
+        // A bare port is TCP in the OCI `ExposedPorts` form.
+        let proto = proto.unwrap_or_default();
+        let port = match port {
+            Some(port) => port,
+            None => {
+                return Err(Error::MissingField {
+                    files: program.files(),
+                    obj: ObjTy::Container,
+                    pos: rt.pos(program.pos_table()),
+                    field: "port",
+                });
+            }
+        };
+
+        Ok(ExposedPort { proto, port })
+    }
+}
+
+/// Parses a nickel tree representing a map of `String` to `String`.
+fn string_map_from_term(
+    rt: &NickelValue,
+    program: &mut Program<CacheImpl>,
+) -> Result<IndexMap<String, String>, Error> {
+    let rt = eval_if_closure(rt, program)?;
+    if let Some(r) = record_data_from_val(&rt) {
+        r.fields
+            .iter()
+            .map(
+                |(ident_and_loc, field)| -> Result<(String, String), Error> {
+                    Ok((
+                        ident_and_loc.label().to_string(),
+                        String::deserialize(eval_if_closure(
+                            field.value.as_ref().unwrap(),
+                            program,
+                        )?)
+                        .unwrap(),
+                    ))
+                },
+            )
+            .collect::<Result<IndexMap<_, _>, Error>>()
+    } else {
+        todo!("unexpected term for string map: {:?}", rt)
+    }
+}
+
+/// A container, a declared image assembled from packages.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct Container {
+    /// The human-readable name declared on the container. Unique within a repo/layer.
+    pub name: String,
+
+    /// The names of build-specs/packages which make up the image.
+    pub packages: Vec<String>,
+
+    /// The entrypoint of the image, in OCI exec form.
+    pub entrypoint: Option<Vec<String>>,
+    /// The default command of the image, appended to the entrypoint.
+    pub cmd: Option<Vec<String>>,
+    /// The architecture the image targets.
+    ///
+    /// Must agree with the architecture the packages were built for; see
+    /// [Container::check_target].
+    pub arch: Option<Arch>,
+    /// The working directory processes in the image start in.
+    pub working_dir: Option<String>,
+
+    /// The environment variables baked into the image.
+    ///
+    /// Values are concrete: an image config carries `KEY=VALUE` strings, so
+    /// there is no host-inheriting form here.
+    pub env_vars: IndexMap<String, String>,
+
+    /// The ports the image declares it listens on.
+    pub exposed_ports: Vec<ExposedPort>,
+    /// The paths in the image which are declared as volumes.
+    pub volumes: Vec<String>,
+    /// The user processes in the image run as.
+    pub user: Option<String>,
+    /// The signal used to stop the container.
+    pub stop_signal: Option<String>,
+
+    /// Labels applied to the image.
+    pub labels: IndexMap<String, String>,
+    /// Additional image-config fields, applied verbatim.
+    pub config: IndexMap<String, String>,
+}
+
+impl Container {
+    /// Deserializes a container structure from the given nickel term tree.
+    pub fn from_term(rt: &NickelValue, program: &mut Program<CacheImpl>) -> Result<Self, Error> {
+        let rt = eval_if_closure(rt, program)?;
+
+        let mut ty: Option<ObjTy> = None;
+        let mut name: Option<String> = None;
+        let mut packages: Option<Vec<String>> = None;
+        let mut entrypoint: Option<Vec<String>> = None;
+        let mut cmd: Option<Vec<String>> = None;
+        let mut arch: Option<Arch> = None;
+        let mut working_dir: Option<String> = None;
+        let mut env_vars: Option<IndexMap<String, String>> = None;
+        let mut exposed_ports: Option<Vec<ExposedPort>> = None;
+        let mut volumes: Option<Vec<String>> = None;
+        let mut user: Option<String> = None;
+        let mut stop_signal: Option<String> = None;
+        let mut labels: Option<IndexMap<String, String>> = None;
+        let mut config: Option<IndexMap<String, String>> = None;
+
+        if let Some(r) = record_data_from_val(&rt) {
+            r.fields
+                .iter()
+                .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
+                    let Some(field_rt) = field.value.as_ref() else {
+                        return Ok(());
+                    };
+                    // Field contracts are pending until applied; without this
+                    // the contracts declared in minimal.ncl never run.
+                    let field_rt = &RuntimeContract::apply_all(
+                        field_rt.clone(),
+                        field.pending_contracts.iter().cloned(),
+                        field_rt.pos_idx(),
+                    );
+
+                    match ident_and_loc.label() {
+                        "ty" => {
+                            ty = Some(
+                                ObjTy::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
+                            );
+                            Ok(())
+                        }
+                        "name" => {
+                            name = Some(
+                                String::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
+                            );
+                            Ok(())
+                        }
+                        "packages" => {
+                            packages =
+                                Some(packages_array_from_term("packages", field_rt, program)?);
+                            Ok(())
+                        }
+                        "entrypoint" => {
+                            entrypoint = Some(argv_from_term("entrypoint", field_rt, program)?);
+                            Ok(())
+                        }
+                        "cmd" => {
+                            cmd = Some(argv_from_term("cmd", field_rt, program)?);
+                            Ok(())
+                        }
+                        "arch" => {
+                            arch = Some(
+                                Arch::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
+                            );
+                            Ok(())
+                        }
+                        "working_dir" => {
+                            working_dir = Some(
+                                String::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
+                            );
+                            Ok(())
+                        }
+                        "env_vars" => {
+                            env_vars = Some(string_map_from_term(field_rt, program)?);
+                            Ok(())
+                        }
+                        "exposed_ports" => {
+                            let ports_rt = eval_if_closure(field_rt, program)?;
+
+                            if let Some(a) = ports_rt.as_array() {
+                                // Element contracts are pending on the array.
+                                let pending =
+                                    a.iter_pending_contracts().cloned().collect::<Vec<_>>();
+                                exposed_ports = Some(
+                                    a.iter()
+                                        .map(|p| {
+                                            let p = RuntimeContract::apply_all(
+                                                p.clone(),
+                                                pending.iter().cloned(),
+                                                p.pos_idx(),
+                                            );
+                                            ExposedPort::from_term(&p, program)
+                                        })
+                                        .collect::<Result<Vec<_>, Error>>()?,
+                                );
+                            } else {
+                                todo!(
+                                    "handle exposed_ports value being non-array {:?}",
+                                    field.value
+                                );
+                            }
+
+                            Ok(())
+                        }
+                        "volumes" => {
+                            let volumes_rt = eval_if_closure(field_rt, program)?;
+
+                            if let Some(a) = volumes_rt.as_array() {
+                                // Element contracts are pending on the array.
+                                let pending =
+                                    a.iter_pending_contracts().cloned().collect::<Vec<_>>();
+                                volumes = Some(
+                                    a.iter()
+                                        .map(|v| {
+                                            let v = RuntimeContract::apply_all(
+                                                v.clone(),
+                                                pending.iter().cloned(),
+                                                v.pos_idx(),
+                                            );
+                                            Ok(String::deserialize(eval_if_closure(&v, program)?)
+                                                .unwrap())
+                                        })
+                                        .collect::<Result<Vec<_>, Error>>()?,
+                                );
+                            } else {
+                                todo!("handle volumes value being non-array {:?}", field.value);
+                            }
+
+                            Ok(())
+                        }
+                        "user" => {
+                            user = Some(
+                                String::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
+                            );
+                            Ok(())
+                        }
+                        "stop_signal" => {
+                            stop_signal = Some(
+                                String::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
+                            );
+                            Ok(())
+                        }
+                        "labels" => {
+                            labels = Some(string_map_from_term(field_rt, program)?);
+                            Ok(())
+                        }
+                        "config" => {
+                            config = Some(string_map_from_term(field_rt, program)?);
+                            Ok(())
+                        }
+                        _ => Ok(()),
+                    }
+                })?;
+        }
+
+        match ty {
+            Some(ObjTy::Container) => {} // happy path
+            None => {
+                return Err(Error::MissingTy(
+                    program.files(),
+                    rt.pos(program.pos_table()),
+                ));
+            }
+            Some(ty) => {
+                return Err(Error::UnexpectedObject {
+                    files: program.files(),
+                    got: ty,
+                    want: ObjTy::Container,
+                    pos: rt.pos(program.pos_table()),
+                });
+            }
+        };
+        let name = match name {
+            Some(name) => name,
+            None => {
+                return Err(Error::MissingField {
+                    files: program.files(),
+                    obj: ObjTy::Container,
+                    pos: rt.pos(program.pos_table()),
+                    field: "name",
+                });
+            }
+        };
+        let packages = match packages {
+            Some(packages) => packages,
+            None => {
+                return Err(Error::MissingField {
+                    files: program.files(),
+                    obj: ObjTy::Container,
+                    pos: rt.pos(program.pos_table()),
+                    field: "packages",
+                });
+            }
+        };
+        if packages.is_empty() {
+            return Err(Error::Other(format!(
+                "container {name}: `packages` must not be empty; an image with no packages has an empty rootfs"
+            )));
+        }
+
+        // `ExposedPorts` and `Volumes` are sets in the image config, so
+        // duplicates would collapse into one another on the way out.
+        let exposed_ports = exposed_ports.unwrap_or_default();
+        if let Some(dupe) = first_duplicate(exposed_ports.iter().map(|p| (p.port, p.proto))) {
+            return Err(Error::Other(format!(
+                "container {name}: port {}/{} is exposed more than once",
+                dupe.0, dupe.1
+            )));
+        }
+        let volumes = volumes.unwrap_or_default();
+        for volume in &volumes {
+            check_volume_path(&name, volume)?;
+        }
+        if let Some(dupe) = first_duplicate(volumes.iter()) {
+            return Err(Error::Other(format!(
+                "container {name}: volume `{dupe}` is declared more than once"
+            )));
+        }
+
+        Ok(Self {
+            name,
+            packages,
+            entrypoint,
+            cmd,
+            arch,
+            working_dir,
+            env_vars: env_vars.unwrap_or_default(),
+            exposed_ports,
+            volumes,
+            user,
+            stop_signal,
+            labels: labels.unwrap_or_default(),
+            config: config.unwrap_or_default(),
+        })
+    }
+
+    /// Checks that a declared `arch` agrees with the target the packages are
+    /// built for.
+    ///
+    /// A mismatch produces an image whose manifest advertises one
+    /// architecture while its binaries are built for another: it pulls
+    /// cleanly and then fails at exec time. Decoding cannot enforce this on
+    /// its own, because `arch` is also how a caller selects the target; the
+    /// code that resolves a container against a graph calls this once both
+    /// are known.
+    pub fn check_target(&self, target: &Target) -> Result<(), Error> {
+        match &self.arch {
+            Some(arch) if arch != target.arch() => Err(Error::Other(format!(
+                "container {}: declares arch {:?} but its packages are built for {:?}; \
+                 the image would fail at exec time",
+                self.name,
+                arch,
+                target.arch(),
+            ))),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Checks a volume mountpoint: a clean absolute path that is not the root.
+///
+/// The equivalent of the `AbsolutePath` contract in `minimal.ncl`, done here
+/// because a contract used inside an `Array` cannot refer to that file's
+/// bindings.
+fn check_volume_path(name: &str, path: &str) -> Result<(), Error> {
+    let invalid = |why: &str| {
+        Err(Error::Other(format!(
+            "container {name}: volume `{path}` {why}"
+        )))
+    };
+
+    if path == "/" {
+        return invalid("cannot be the root directory");
+    }
+    if !path.starts_with('/') {
+        return invalid("must be an absolute path");
+    }
+    if path.ends_with('/') || path.contains("//") {
+        return invalid("must not have a trailing or repeated `/`");
+    }
+    if path.split('/').any(|c| c == "." || c == "..") {
+        return invalid("must not contain `.` or `..` path components");
+    }
+
+    Ok(())
+}
+
+/// Returns the first item that appears more than once, if any.
+fn first_duplicate<T: std::hash::Hash + Eq + Clone, I: IntoIterator<Item = T>>(
+    items: I,
+) -> Option<T> {
+    let mut seen = std::collections::HashSet::new();
+    items.into_iter().find(|item| !seen.insert(item.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::load::*;
+    use indoc::indoc;
+
+    /// Parses a container from the fields of a `container { .. }` record,
+    /// surfacing contract violations (which are Nickel eval errors) as `Err`.
+    fn parse_body(body: &str) -> Result<Container, Error> {
+        let src =
+            format!("let {{container, ..}} = import \"minimal.ncl\" in\ncontainer {{\n{body}\n}}");
+        let (term, mut program, _origin, _target) =
+            Loader::new(src, None, &LoadOptions::for_test())?.finish()?;
+        Container::from_term(&term, &mut program)
+    }
+
+    const VALID: &str = r#"name = "web", packages = ["glibc"],"#;
+
+    /// Renders the diagnostic a user would see, so a case cannot pass by
+    /// failing for an unrelated reason.
+    fn err_text(e: &Error) -> String {
+        use codespan_reporting::term::termcolor::Buffer;
+        let mut buf = Buffer::no_color();
+        e.report_to(&mut buf);
+        String::from_utf8(buf.into_inner()).unwrap()
+    }
+
+    #[test]
+    fn rejects_invalid_fields() {
+        // (case, container body, the reason it must be rejected for)
+        let cases = [
+            // name: registry reference grammar
+            (
+                "uppercase name",
+                r#"name = "Web", packages = ["a"],"#,
+                "not a valid image name",
+            ),
+            (
+                "spaces in name",
+                r#"name = "my web app", packages = ["a"],"#,
+                "not a valid image name",
+            ),
+            (
+                "punctuation in name",
+                r#"name = "web!", packages = ["a"],"#,
+                "not a valid image name",
+            ),
+            (
+                "leading separator in name",
+                r#"name = "-web", packages = ["a"],"#,
+                "not a valid image name",
+            ),
+            // packages
+            (
+                "empty packages",
+                r#"name = "web", packages = [],"#,
+                "must not be empty",
+            ),
+            (
+                "numeric package entry",
+                r#"name = "web", packages = [1],"#,
+                "contract broken by the value of `packages`",
+            ),
+            // arch: closed enum, not a string
+            (
+                "arch as string",
+                r#"name = "web", packages = ["a"], arch = "amd64","#,
+                "contract broken",
+            ),
+            (
+                "unknown arch",
+                r#"name = "web", packages = ["a"], arch = 'X86,"#,
+                "contract broken",
+            ),
+            // working_dir: clean absolute path
+            (
+                "relative working_dir",
+                r#"name = "web", packages = ["a"], working_dir = "srv","#,
+                "must be an absolute path",
+            ),
+            (
+                "trailing slash working_dir",
+                r#"name = "web", packages = ["a"], working_dir = "/srv/","#,
+                "trailing or repeated",
+            ),
+            (
+                "dotdot working_dir",
+                r#"name = "web", packages = ["a"], working_dir = "/srv/../etc","#,
+                "`.` or `..`",
+            ),
+            (
+                "repeated slash working_dir",
+                r#"name = "web", packages = ["a"], working_dir = "/srv//x","#,
+                "trailing or repeated",
+            ),
+            // volumes
+            (
+                "root volume",
+                r#"name = "web", packages = ["a"], volumes = ["/"],"#,
+                "cannot be the root",
+            ),
+            (
+                "relative volume",
+                r#"name = "web", packages = ["a"], volumes = ["var/lib"],"#,
+                "must be an absolute path",
+            ),
+            (
+                "trailing slash volume",
+                r#"name = "web", packages = ["a"], volumes = ["/var/"],"#,
+                "trailing or repeated",
+            ),
+            (
+                "dotdot volume",
+                r#"name = "web", packages = ["a"], volumes = ["/var/../etc"],"#,
+                "`.` or `..`",
+            ),
+            (
+                "duplicate volumes",
+                r#"name = "web", packages = ["a"], volumes = ["/v", "/v"],"#,
+                "declared more than once",
+            ),
+            // ports
+            (
+                "port zero",
+                r#"name = "web", packages = ["a"], exposed_ports = [{port = 0}],"#,
+                "within 1-65535",
+            ),
+            (
+                "port too large",
+                r#"name = "web", packages = ["a"], exposed_ports = [{port = 70000}],"#,
+                "within 1-65535",
+            ),
+            (
+                "fractional port",
+                r#"name = "web", packages = ["a"], exposed_ports = [{port = 8080.5}],"#,
+                "whole number",
+            ),
+            (
+                "negative port",
+                r#"name = "web", packages = ["a"], exposed_ports = [{port = -1}],"#,
+                "within 1-65535",
+            ),
+            (
+                "unknown proto",
+                r#"name = "web", packages = ["a"], exposed_ports = [{port = 80, proto = 'Sctp}],"#,
+                "contract broken",
+            ),
+            (
+                "proto as string",
+                r#"name = "web", packages = ["a"], exposed_ports = [{port = 80, proto = "tcp"}],"#,
+                "contract broken",
+            ),
+            (
+                "duplicate exposed port",
+                r#"name = "web", packages = ["a"], exposed_ports = [{port = 80}, {port = 80, proto = 'Tcp}],"#,
+                "exposed more than once",
+            ),
+            // env var names
+            (
+                "equals in env name",
+                r#"name = "web", packages = ["a"], env_vars = {"A=B" = "1"},"#,
+                "not a valid environment variable name",
+            ),
+            (
+                "leading digit env name",
+                r#"name = "web", packages = ["a"], env_vars = {"1PORT" = "1"},"#,
+                "not a valid environment variable name",
+            ),
+            (
+                "dash in env name",
+                r#"name = "web", packages = ["a"], env_vars = {"MY-VAR" = "1"},"#,
+                "not a valid environment variable name",
+            ),
+            (
+                "empty env name",
+                r#"name = "web", packages = ["a"], env_vars = {"" = "1"},"#,
+                "not a valid environment variable name",
+            ),
+            // user
+            (
+                "empty user",
+                r#"name = "web", packages = ["a"], user = "","#,
+                "not a valid user",
+            ),
+            (
+                "space in user",
+                r#"name = "web", packages = ["a"], user = "ngin x","#,
+                "not a valid user",
+            ),
+            (
+                "triple user",
+                r#"name = "web", packages = ["a"], user = "a:b:c","#,
+                "not a valid user",
+            ),
+            // stop_signal
+            (
+                "numeric stop_signal",
+                r#"name = "web", packages = ["a"], stop_signal = "9","#,
+                "not a valid signal name",
+            ),
+            (
+                "lowercase stop_signal",
+                r#"name = "web", packages = ["a"], stop_signal = "sigterm","#,
+                "not a valid signal name",
+            ),
+            (
+                "unprefixed stop_signal",
+                r#"name = "web", packages = ["a"], stop_signal = "TERM","#,
+                "not a valid signal name",
+            ),
+            // argv
+            (
+                "empty entrypoint string",
+                r#"name = "web", packages = ["a"], entrypoint = "","#,
+                "must not be empty",
+            ),
+            (
+                "empty cmd array",
+                r#"name = "web", packages = ["a"], cmd = [],"#,
+                "must not be empty",
+            ),
+            (
+                "numeric cmd entry",
+                r#"name = "web", packages = ["a"], cmd = [1, 2],"#,
+                "contract broken by the value of `cmd`",
+            ),
+            (
+                "numeric entrypoint entry",
+                r#"name = "web", packages = ["a"], entrypoint = [1],"#,
+                "contract broken by the value of `entrypoint`",
+            ),
+            (
+                "unbalanced quote in entrypoint",
+                r#"name = "web", packages = ["a"], entrypoint = "sh -c 'echo hi","#,
+                "not a valid shell word list",
+            ),
+        ];
+
+        for (case, body, reason) in cases {
+            let err = parse_body(body)
+                .err()
+                .unwrap_or_else(|| panic!("expected `{case}` to be rejected: {body}"));
+            let text = err_text(&err);
+            assert!(
+                text.contains(reason),
+                "`{case}` was rejected, but not for `{reason}`:\n{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_valid_fields() {
+        let cases = [
+            ("root working_dir", format!(r#"{VALID} working_dir = "/","#)),
+            (
+                "nested working_dir",
+                format!(r#"{VALID} working_dir = "/srv/app","#),
+            ),
+            (
+                "dotfile path",
+                format!(r#"{VALID} working_dir = "/srv/.cache","#),
+            ),
+            ("numeric user", format!(r#"{VALID} user = "1000","#)),
+            ("uid:gid", format!(r#"{VALID} user = "1000:1000","#)),
+            ("named user", format!(r#"{VALID} user = "nobody","#)),
+            ("user:group", format!(r#"{VALID} user = "nginx:www-data","#)),
+            (
+                "realtime signal",
+                format!(r#"{VALID} stop_signal = "SIGRTMIN+3","#),
+            ),
+            (
+                "plain signal",
+                format!(r#"{VALID} stop_signal = "SIGQUIT","#),
+            ),
+            (
+                "boundary ports",
+                format!(r#"{VALID} exposed_ports = [{{port = 1}}, {{port = 65535}}],"#),
+            ),
+            (
+                "same port, different proto",
+                format!(r#"{VALID} exposed_ports = [{{port = 53}}, {{port = 53, proto = 'Udp}}],"#),
+            ),
+            (
+                "underscore env name",
+                format!(r#"{VALID} env_vars = {{_X1 = "v"}},"#),
+            ),
+            (
+                "dotted image name",
+                r#"name = "my.app_v2-beta", packages = ["a"],"#.to_string(),
+            ),
+            (
+                "pathed image name",
+                r#"name = "team/web", packages = ["a"],"#.to_string(),
+            ),
+        ];
+
+        for (case, body) in cases {
+            parse_body(&body).unwrap_or_else(|e| {
+                e.report_to_stderr();
+                panic!("expected `{case}` to be accepted: {body}");
+            });
+        }
+    }
+
+    #[test]
+    fn defaults_and_shapes() {
+        // A bare port is TCP, matching the OCI `ExposedPorts` form.
+        let c = parse_body(&format!(r#"{VALID} exposed_ports = [{{port = 8080}}],"#)).unwrap();
+        assert_eq!(
+            c.exposed_ports,
+            vec![ExposedPort {
+                proto: Proto::Tcp,
+                port: 8080
+            }]
+        );
+        assert_eq!(Proto::Tcp.to_string(), "tcp");
+        assert_eq!(Proto::Udp.to_string(), "udp");
+
+        // A string argv is word-split into exec form; quoting is honoured.
+        let c = parse_body(&format!(
+            r#"{VALID} entrypoint = "/bin/sh -c 'echo hi'", cmd = ["--flag", "x y"],"#
+        ))
+        .unwrap();
+        assert_eq!(
+            c.entrypoint,
+            Some(vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "echo hi".to_string()
+            ])
+        );
+        assert_eq!(c.cmd, Some(vec!["--flag".to_string(), "x y".to_string()]));
+    }
+
+    #[test]
+    fn check_target_rejects_mismatched_arch() {
+        use common::{Target, target::Arch};
+
+        let c = parse_body(&format!(r#"{VALID} arch = 'Arm64,"#)).unwrap();
+        assert_eq!(c.arch, Some(Arch::Arm64));
+
+        let arm = Target::new(Arch::Arm64, common::target::OS::Linux);
+        let amd = Target::new(Arch::Amd64, common::target::OS::Linux);
+        assert!(c.check_target(&arm).is_ok());
+        assert!(c.check_target(&amd).is_err());
+
+        // No declared arch: nothing to contradict.
+        let c = parse_body(VALID).unwrap();
+        assert!(c.check_target(&amd).is_ok());
+    }
+
+    #[test]
+    fn parse() {
+        let (term, mut program, _origin, _target) = Loader::new(
+            indoc! {
+                "
+                let {container, ..} = import \"minimal.ncl\" in
+                container {
+                    name = \"web\",
+
+                    packages = [\"glibc\", \"nginx\"],
+
+                    entrypoint = \"/usr/bin/nginx -g\",
+                    cmd = [\"-c\", \"/etc/nginx/nginx.conf\"],
+                    arch = 'Amd64,
+                    working_dir = \"/srv\",
+
+                    env_vars.PORT = \"8080\",
+
+                    exposed_ports = [
+                        { port = 80 },
+                        { proto = 'Udp, port = 443 },
+                    ],
+                    volumes = [\"/var/lib/nginx\"],
+                    user = \"nginx\",
+                    stop_signal = \"SIGQUIT\",
+
+                    labels.\"org.opencontainers.image.title\" = \"web\",
+                    config.Healthcheck = \"curl localhost\",
+                }
+                "
+            }
+            .to_string(),
+            None,
+            &LoadOptions::for_test(),
+        )
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("load failed");
+        })
+        .finish()
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("finish failed");
+        });
+
+        let c = Container::from_term(&term, &mut program).unwrap();
+
+        assert_eq!(
+            c,
+            Container {
+                name: "web".to_string(),
+                packages: vec!["glibc".to_string(), "nginx".to_string()],
+                entrypoint: Some(vec!["/usr/bin/nginx".to_string(), "-g".to_string()]),
+                cmd: Some(vec!["-c".to_string(), "/etc/nginx/nginx.conf".to_string()]),
+                arch: Some(Arch::Amd64),
+                working_dir: Some("/srv".to_string()),
+                env_vars: IndexMap::from_iter([("PORT".to_string(), "8080".to_string())]),
+                exposed_ports: vec![
+                    ExposedPort {
+                        proto: Proto::Tcp,
+                        port: 80
+                    },
+                    ExposedPort {
+                        proto: Proto::Udp,
+                        port: 443
+                    },
+                ],
+                volumes: vec!["/var/lib/nginx".to_string()],
+                user: Some("nginx".to_string()),
+                stop_signal: Some("SIGQUIT".to_string()),
+                labels: IndexMap::from_iter([(
+                    "org.opencontainers.image.title".to_string(),
+                    "web".to_string()
+                )]),
+                config: IndexMap::from_iter([(
+                    "Healthcheck".to_string(),
+                    "curl localhost".to_string()
+                )]),
+            }
+        )
+    }
+
+    #[test]
+    fn parse_minimal() {
+        let (term, mut program, _origin, _target) = Loader::new(
+            indoc! {
+                "
+                let {container, ..} = import \"minimal.ncl\" in
+                container {
+                    name = \"bare\",
+                    packages = [\"glibc\"],
+                }
+                "
+            }
+            .to_string(),
+            None,
+            &LoadOptions::for_test(),
+        )
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("load failed");
+        })
+        .finish()
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("finish failed");
+        });
+
+        let c = Container::from_term(&term, &mut program).unwrap();
+
+        assert_eq!(
+            c,
+            Container {
+                name: "bare".to_string(),
+                packages: vec!["glibc".to_string()],
+                ..Default::default()
+            }
+        )
+    }
+
+    #[test]
+    fn wrong_object_type() {
+        let (term, mut program, _origin, _target) = Loader::new(
+            indoc! {
+                "
+                let {stack, ..} = import \"minimal.ncl\" in
+                stack {
+                    name = \"rust\",
+                    build_cmd = \"cargo build\",
+                }
+                "
+            }
+            .to_string(),
+            None,
+            &LoadOptions::for_test(),
+        )
+        .unwrap()
+        .finish()
+        .unwrap();
+
+        assert!(matches!(
+            Container::from_term(&term, &mut program),
+            Err(Error::UnexpectedObject {
+                got: ObjTy::Stack,
+                want: ObjTy::Container,
+                ..
+            })
+        ));
+    }
+}

--- a/crates/decode/src/container.rs
+++ b/crates/decode/src/container.rs
@@ -8,24 +8,27 @@ use nickel_lang_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, ObjTy, eval_if_closure, packages_array_from_term, record_data_from_val};
+use crate::{
+    Error, ObjTy, deserialize_field, eval_if_closure, packages_array_from_term,
+    record_data_from_val,
+};
 
 /// The transport protocol of an [ExposedPort].
 ///
 /// OCI recognises only `tcp` and `udp`, and spells them lowercase in the
 /// `ExposedPorts` keys of the image config.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Proto {
+pub enum ExposedPortProto {
     #[default]
     Tcp,
     Udp,
 }
 
-impl std::fmt::Display for Proto {
+impl std::fmt::Display for ExposedPortProto {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Proto::Tcp => write!(f, "tcp"),
-            Proto::Udp => write!(f, "udp"),
+            ExposedPortProto::Tcp => write!(f, "tcp"),
+            ExposedPortProto::Udp => write!(f, "udp"),
         }
     }
 }
@@ -43,12 +46,7 @@ fn argv_from_term(
     let rt = eval_if_closure(rt, program)?;
 
     let argv = if let Some(s) = rt.as_string() {
-        shlex::split(s.as_ref()).ok_or_else(|| {
-            Error::Other(format!(
-                "container `{field}` is not a valid shell word list: {:?}",
-                s.as_ref()
-            ))
-        })?
+        crate::shell_split(&format!("container `{field}`"), s.as_ref())?
     } else if let Some(a) = rt.as_array() {
         // `CmdSpec` is an `any_of`, so its element contract does not fire on
         // its own: without the element check here a non-string argv entry
@@ -61,18 +59,21 @@ fn argv_from_term(
                     pending.iter().cloned(),
                     elem.pos_idx(),
                 );
-                let elem = eval_if_closure(&elem, program)?;
-                String::deserialize(elem).map_err(|_| {
-                    Error::Other(format!("container `{field}` must be a list of strings"))
-                })
+                deserialize_field(
+                    format!("container `{field}` entry"),
+                    "a string",
+                    &elem,
+                    program,
+                )
             })
             .collect::<Result<Vec<_>, Error>>()?
     } else {
-        todo!(
-            "error for `{}` field being non-string & non-array, got {:?}",
-            field,
-            rt
-        );
+        return Err(Error::unexpected_type(
+            format!("container `{field}`"),
+            "a string or an array of strings",
+            &rt,
+            program,
+        ));
     };
 
     if argv.is_empty() {
@@ -89,7 +90,7 @@ fn argv_from_term(
 pub struct ExposedPort {
     /// The protocol the port speaks. Defaults to TCP, matching the OCI
     /// bare-port form.
-    pub proto: Proto,
+    pub proto: ExposedPortProto,
     /// The port number, always within 1-65535.
     pub port: u16,
 }
@@ -102,7 +103,7 @@ impl ExposedPort {
     ) -> Result<Self, Error> {
         let rt = eval_if_closure(rt, program)?;
 
-        let mut proto: Option<Proto> = None;
+        let mut proto: Option<ExposedPortProto> = None;
         let mut port: Option<u16> = None;
 
         if let Some(r) = record_data_from_val(&rt) {
@@ -123,7 +124,7 @@ impl ExposedPort {
                     match ident_and_loc.label() {
                         "proto" => {
                             let p_rt = eval_if_closure(field_rt, program)?;
-                            proto = Some(Proto::deserialize(p_rt).map_err(|_| {
+                            proto = Some(ExposedPortProto::deserialize(p_rt).map_err(|_| {
                                 Error::Other(
                                     "container port `proto` must be 'Tcp or 'Udp".to_string(),
                                 )
@@ -150,7 +151,12 @@ impl ExposedPort {
                     }
                 })?;
         } else {
-            todo!("unexpected term for exposed_ports entry: {:?}", rt);
+            return Err(Error::unexpected_type(
+                "container `exposed_ports` entry",
+                "a record with `port` and optional `proto` fields",
+                &rt,
+                program,
+            ));
         }
 
         // A bare port is TCP in the OCI `ExposedPorts` form.
@@ -172,7 +178,10 @@ impl ExposedPort {
 }
 
 /// Parses a nickel tree representing a map of `String` to `String`.
+///
+/// `what` names the field being read, for the error when it is not a record.
 fn string_map_from_term(
+    what: &'static str,
     rt: &NickelValue,
     program: &mut Program<CacheImpl>,
 ) -> Result<IndexMap<String, String>, Error> {
@@ -180,21 +189,30 @@ fn string_map_from_term(
     if let Some(r) = record_data_from_val(&rt) {
         r.fields
             .iter()
+            // A field can carry an annotation and no value (`FOO | String`),
+            // which declares the name without setting anything.
+            .filter_map(|(ident_and_loc, field)| Some((ident_and_loc, field.value.as_ref()?)))
             .map(
-                |(ident_and_loc, field)| -> Result<(String, String), Error> {
+                |(ident_and_loc, value)| -> Result<(String, String), Error> {
                     Ok((
                         ident_and_loc.label().to_string(),
-                        String::deserialize(eval_if_closure(
-                            field.value.as_ref().unwrap(),
+                        deserialize_field(
+                            format!("{what} entry `{}`", ident_and_loc.label()),
+                            "a string",
+                            value,
                             program,
-                        )?)
-                        .unwrap(),
+                        )?,
                     ))
                 },
             )
             .collect::<Result<IndexMap<_, _>, Error>>()
     } else {
-        todo!("unexpected term for string map: {:?}", rt)
+        Err(Error::unexpected_type(
+            what,
+            "a record of strings",
+            &rt,
+            program,
+        ))
     }
 }
 
@@ -278,15 +296,21 @@ impl Container {
 
                     match ident_and_loc.label() {
                         "ty" => {
-                            ty = Some(
-                                ObjTy::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
-                            );
+                            ty = Some(deserialize_field(
+                                "container `ty` annotation",
+                                "a known object type",
+                                field_rt,
+                                program,
+                            )?);
                             Ok(())
                         }
                         "name" => {
-                            name = Some(
-                                String::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
-                            );
+                            name = Some(deserialize_field(
+                                "container `name`",
+                                "a string",
+                                field_rt,
+                                program,
+                            )?);
                             Ok(())
                         }
                         "packages" => {
@@ -303,19 +327,29 @@ impl Container {
                             Ok(())
                         }
                         "arch" => {
-                            arch = Some(
-                                Arch::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
-                            );
+                            arch = Some(deserialize_field(
+                                "container `arch`",
+                                "a known architecture",
+                                field_rt,
+                                program,
+                            )?);
                             Ok(())
                         }
                         "working_dir" => {
-                            working_dir = Some(
-                                String::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
-                            );
+                            working_dir = Some(deserialize_field(
+                                "container `working_dir`",
+                                "a string",
+                                field_rt,
+                                program,
+                            )?);
                             Ok(())
                         }
                         "env_vars" => {
-                            env_vars = Some(string_map_from_term(field_rt, program)?);
+                            env_vars = Some(string_map_from_term(
+                                "container `env_vars`",
+                                field_rt,
+                                program,
+                            )?);
                             Ok(())
                         }
                         "exposed_ports" => {
@@ -338,10 +372,12 @@ impl Container {
                                         .collect::<Result<Vec<_>, Error>>()?,
                                 );
                             } else {
-                                todo!(
-                                    "handle exposed_ports value being non-array {:?}",
-                                    field.value
-                                );
+                                return Err(Error::unexpected_type(
+                                    "container `exposed_ports`",
+                                    "an array of ports",
+                                    &ports_rt,
+                                    program,
+                                ));
                             }
 
                             Ok(())
@@ -361,35 +397,58 @@ impl Container {
                                                 pending.iter().cloned(),
                                                 v.pos_idx(),
                                             );
-                                            Ok(String::deserialize(eval_if_closure(&v, program)?)
-                                                .unwrap())
+                                            deserialize_field(
+                                                "container `volumes` entry",
+                                                "a string",
+                                                &v,
+                                                program,
+                                            )
                                         })
                                         .collect::<Result<Vec<_>, Error>>()?,
                                 );
                             } else {
-                                todo!("handle volumes value being non-array {:?}", field.value);
+                                return Err(Error::unexpected_type(
+                                    "container `volumes`",
+                                    "an array of strings",
+                                    &volumes_rt,
+                                    program,
+                                ));
                             }
 
                             Ok(())
                         }
                         "user" => {
-                            user = Some(
-                                String::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
-                            );
+                            user = Some(deserialize_field(
+                                "container `user`",
+                                "a string",
+                                field_rt,
+                                program,
+                            )?);
                             Ok(())
                         }
                         "stop_signal" => {
-                            stop_signal = Some(
-                                String::deserialize(eval_if_closure(field_rt, program)?).unwrap(),
-                            );
+                            stop_signal = Some(deserialize_field(
+                                "container `stop_signal`",
+                                "a string",
+                                field_rt,
+                                program,
+                            )?);
                             Ok(())
                         }
                         "labels" => {
-                            labels = Some(string_map_from_term(field_rt, program)?);
+                            labels = Some(string_map_from_term(
+                                "container `labels`",
+                                field_rt,
+                                program,
+                            )?);
                             Ok(())
                         }
                         "config" => {
-                            config = Some(string_map_from_term(field_rt, program)?);
+                            config = Some(string_map_from_term(
+                                "container `config`",
+                                field_rt,
+                                program,
+                            )?);
                             Ok(())
                         }
                         _ => Ok(()),
@@ -848,12 +907,12 @@ mod tests {
         assert_eq!(
             c.exposed_ports,
             vec![ExposedPort {
-                proto: Proto::Tcp,
+                proto: ExposedPortProto::Tcp,
                 port: 8080
             }]
         );
-        assert_eq!(Proto::Tcp.to_string(), "tcp");
-        assert_eq!(Proto::Udp.to_string(), "udp");
+        assert_eq!(ExposedPortProto::Tcp.to_string(), "tcp");
+        assert_eq!(ExposedPortProto::Udp.to_string(), "udp");
 
         // A string argv is word-split into exec form; quoting is honoured.
         let c = parse_body(&format!(
@@ -947,11 +1006,11 @@ mod tests {
                 env_vars: IndexMap::from_iter([("PORT".to_string(), "8080".to_string())]),
                 exposed_ports: vec![
                     ExposedPort {
-                        proto: Proto::Tcp,
+                        proto: ExposedPortProto::Tcp,
                         port: 80
                     },
                     ExposedPort {
-                        proto: Proto::Udp,
+                        proto: ExposedPortProto::Udp,
                         port: 443
                     },
                 ],

--- a/crates/decode/src/decl_tests.rs
+++ b/crates/decode/src/decl_tests.rs
@@ -46,19 +46,25 @@ impl Test {
                                     if let Some(tag) = rt.as_enum_tag() {
                                         is_build_test = tag.label() == "Build";
                                     } else {
-                                        todo!("class enum err: {:?}", rt)
+                                        return Err(Error::unexpected_type(
+                                            "test `class`",
+                                            "an enum tag",
+                                            &rt,
+                                            program,
+                                        ));
                                     }
                                     Ok(())
                                 }
                                 "cmd" => {
                                     if let Some(rt) = field.value.as_ref() {
-                                        cmds = Some(cmds_from_cmd_term(rt, program)?);
+                                        cmds = Some(cmds_from_cmd_term("test `cmd`", rt, program)?);
                                     };
                                     Ok(())
                                 }
                                 "cmds" => {
                                     if let Some(rt) = field.value.as_ref() {
-                                        cmds = Some(cmds_from_cmds_term(rt, program)?);
+                                        cmds =
+                                            Some(cmds_from_cmds_term("test `cmds`", rt, program)?);
                                     };
                                     Ok(())
                                 }
@@ -78,10 +84,12 @@ impl Test {
                                                         .collect::<Result<SmallVec<_>, Error>>()?,
                                                 );
                                             } else {
-                                                todo!(
-                                                    "handle test_deps value being non-array {:?}",
-                                                    field.value
-                                                );
+                                                return Err(Error::unexpected_type(
+                                                    "test `test_deps`",
+                                                    "an array of build references",
+                                                    &test_deps_val,
+                                                    program,
+                                                ));
                                             }
                                         }
                                     }

--- a/crates/decode/src/error.rs
+++ b/crates/decode/src/error.rs
@@ -2,8 +2,11 @@
 
 use crate::ObjTy;
 use nickel_lang_core::error::Error as NclError;
+use nickel_lang_core::eval::cache::CacheImpl;
+use nickel_lang_core::eval::value::NickelValue;
 use nickel_lang_core::files::Files;
 use nickel_lang_core::position::TermPos;
+use nickel_lang_core::program::Program;
 use std::fmt;
 
 /// Errors that can occur when decoding nickel layers.
@@ -33,6 +36,23 @@ pub enum Error {
         got: ObjTy,
         want: ObjTy,
         pos: TermPos,
+    },
+    /// A value in the Nickel tree had a shape the decoder cannot read there.
+    ///
+    /// Nickel's own contracts do not catch every one of these: an `any_of`
+    /// contract does not fire on its element, and some fields are read
+    /// without a contract at all. The decoder re-checks the shape itself and
+    /// reports the offending value's position with this.
+    UnexpectedType {
+        files: Files,
+        pos: TermPos,
+        /// What was being read, e.g. ``container `cmd` ``.
+        what: String,
+        /// The shape(s) accepted there, e.g. "a string or an array of strings".
+        want: &'static str,
+        /// Nickel's class for the value actually found, absent when the value
+        /// is not in evaluated form.
+        got: Option<&'static str>,
     },
     /// An object which was expected to be a build-spec was missing annotation
     /// with a unique ID (see [crate::load::Loader]).
@@ -70,6 +90,26 @@ impl Error {
     pub fn other<S: Into<String>>(msg: S) -> Self {
         Error::Other(msg.into())
     }
+
+    /// Creates an [Error::UnexpectedType] for a value read out of a Nickel
+    /// tree, taking its position and class from the value itself.
+    ///
+    /// `val` must already be evaluated (see [crate::eval_if_closure]);
+    /// an unevaluated one has no class to report.
+    pub(crate) fn unexpected_type<S: Into<String>>(
+        what: S,
+        want: &'static str,
+        val: &NickelValue,
+        program: &Program<CacheImpl>,
+    ) -> Self {
+        Error::UnexpectedType {
+            files: program.files(),
+            pos: val.pos(program.pos_table()),
+            what: what.into(),
+            want,
+            got: val.type_of(),
+        }
+    }
 }
 
 impl From<std::io::Error> for Error {
@@ -96,6 +136,20 @@ impl fmt::Display for Error {
                 f,
                 "missing field {} on object {:?} defined at {:?}",
                 field, obj, pos
+            ),
+            Error::UnexpectedType {
+                pos,
+                what,
+                want,
+                got,
+                ..
+            } => write!(
+                f,
+                "unexpected type for {} at {:?}: expected {}, got {}",
+                what,
+                pos,
+                want,
+                got.unwrap_or("an unevaluated term")
             ),
             Error::MissingID(_files, pos) => {
                 write!(f, "missing build-spec ID on object defined at {:?}", pos)
@@ -229,6 +283,34 @@ impl Error {
                     "unexpected record: found {:?} when looking for {:?}",
                     got, want
                 ));
+                let diagnostic = if let Some(pos) = pos.into_opt() {
+                    diagnostic.with_label(primary(&pos))
+                } else {
+                    diagnostic
+                };
+
+                report_with(
+                    writer,
+                    &mut files,
+                    diagnostic,
+                    nickel_lang_core::error::report::ErrorFormat::Text,
+                );
+            }
+            Error::UnexpectedType {
+                files,
+                pos,
+                what,
+                want,
+                got,
+            } => {
+                let mut files = files.clone();
+                let diagnostic = Diagnostic::error()
+                    .with_message(format!("unexpected type for {}", what))
+                    .with_note(format!(
+                        "expected {}, got {}",
+                        want,
+                        got.unwrap_or("an unevaluated term")
+                    ));
                 let diagnostic = if let Some(pos) = pos.into_opt() {
                     diagnostic.with_label(primary(&pos))
                 } else {
@@ -443,6 +525,30 @@ mod tests {
         );
         assert!(out.contains("Source"), "expected 'Source' in: {out:?}");
         assert!(out.contains("Builder"), "expected 'Builder' in: {out:?}");
+    }
+
+    #[test]
+    fn unexpected_type_contains_what_and_shapes() {
+        let e = Error::UnexpectedType {
+            files: Files::default(),
+            pos: TermPos::None,
+            what: "container `cmd`".into(),
+            want: "a string or an array of strings",
+            got: Some("Record"),
+        };
+        let out = capture(&e);
+        assert!(
+            out.contains("unexpected type for container `cmd`"),
+            "expected the headline in: {out:?}"
+        );
+        assert!(
+            out.contains("a string or an array of strings"),
+            "expected the wanted shape in: {out:?}"
+        );
+        assert!(
+            out.contains("Record"),
+            "expected the found class in: {out:?}"
+        );
     }
 
     #[test]

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -10,7 +10,7 @@ use mfile::{EnvPatches, EnvVarValue, PatchSetting, Upstream};
 use nickel_lang_core::eval::value::{NickelValue, RecordData};
 use nickel_lang_core::identifier::LocIdent;
 use nickel_lang_core::position::TermPos;
-use nickel_lang_core::term::IndexMap;
+use nickel_lang_core::term::{IndexMap, RuntimeContract};
 use nickel_lang_core::{
     eval::{Closure, cache::CacheImpl},
     program::Program,
@@ -33,6 +33,8 @@ mod decl_tests;
 pub use decl_tests::Test;
 mod stacks;
 pub use stacks::{PackageMatcherPredicate, Stack, StackMatcher};
+mod container;
+pub use container::{Container, ExposedPort, Proto};
 
 // Increment for any big change to the format of build specs / stacks, so that hash
 // keys get invalidated.
@@ -71,6 +73,7 @@ pub struct Layer {
     pub top_levels: Vec<generational_arena::Index>,
 
     pub stacks: HashMap<String, Stack>,
+    pub containers: HashMap<String, Container>,
 
     read_ids: HashMap<u64, generational_arena::Index>,
 }
@@ -172,6 +175,7 @@ impl Layer {
             read_ids: HashMap::with_capacity(512),
 
             stacks: HashMap::with_capacity(32),
+            containers: HashMap::with_capacity(32),
         };
 
         // The top-level of the nickel tree can either evaluate to:
@@ -204,6 +208,18 @@ impl Layer {
                                     .collect::<Result<Vec<_>, Error>>()?
                                     .into_iter()
                                     .map(|p| (p.name.clone(), p)),
+                            );
+                        }
+                    };
+                    if let Ok(Some(rt)) = record.get_value_with_ctrs(&LocIdent::new("containers")) {
+                        let rt = eval_if_closure(&rt, &mut program)?;
+                        if let Some(a) = rt.as_array() {
+                            layer.containers = HashMap::from_iter(
+                                a.iter()
+                                    .map(|c| layer.ingest_container(c, &mut program))
+                                    .collect::<Result<Vec<_>, Error>>()?
+                                    .into_iter()
+                                    .map(|c| (c.name.clone(), c)),
                             );
                         }
                     };
@@ -262,6 +278,14 @@ impl Layer {
         program: &mut Program<CacheImpl>,
     ) -> Result<Stack, Error> {
         Stack::from_term(rt, program)
+    }
+
+    fn ingest_container(
+        &mut self,
+        rt: &NickelValue,
+        program: &mut Program<CacheImpl>,
+    ) -> Result<Container, Error> {
+        Container::from_term(rt, program)
     }
 }
 
@@ -325,6 +349,7 @@ pub enum ObjTy {
     Upstream,
     Test,
     Stack,
+    Container,
 }
 
 pub(crate) fn read_ty(val: &NickelValue, program: &mut Program<CacheImpl>) -> Result<ObjTy, Error> {
@@ -496,14 +521,27 @@ pub(crate) fn env_vars_from_term(
 }
 
 pub(crate) fn packages_array_from_term(
+    field: &'static str,
     rt: &NickelValue,
     program: &mut Program<CacheImpl>,
 ) -> Result<Vec<String>, Error> {
     let packages_rt = eval_if_closure(rt, program)?;
 
     if let Some(a) = packages_rt.as_array() {
+        // Element contracts are pending on the array; without applying them a
+        // non-string entry reaches `String::deserialize` and panics.
+        let pending = a.iter_pending_contracts().cloned().collect::<Vec<_>>();
         a.iter()
-            .map(|input| Ok(String::deserialize(eval_if_closure(input, program)?).unwrap()))
+            .map(|input| {
+                let input = RuntimeContract::apply_all(
+                    input.clone(),
+                    pending.iter().cloned(),
+                    input.pos_idx(),
+                );
+                let input = eval_if_closure(&input, program)?;
+                String::deserialize(input)
+                    .map_err(|_| Error::Other(format!("`{field}` must be a list of package names")))
+            })
             .collect::<Result<Vec<_>, Error>>()
     } else {
         todo!("handle packages value being non-array {:?}", packages_rt);
@@ -840,7 +878,7 @@ mod tests {
         let layer = Layer::new_for_test(
             indoc! {
                 "
-                let {layer, stack, BuildSpec, ..} = import \"minimal.ncl\" in
+                let {layer, stack, container, BuildSpec, ..} = import \"minimal.ncl\" in
 
                 layer {
                   builds = [
@@ -861,6 +899,16 @@ mod tests {
                         },
 
                         build_cmd = [\"uwu\", \"build\"],
+                    }
+                  ],
+
+                  containers = [
+                    container {
+                        name = \"owo\",
+                        packages = [\"glibc\", \"nginx\"],
+
+                        entrypoint = \"/usr/bin/nginx\",
+                        exposed_ports = [{ port = 80 }],
                     }
                   ],
                 }
@@ -894,6 +942,19 @@ mod tests {
                 build_cmds: Some(vec![vec!["uwu".to_string(), "build".to_string()]]),
                 matches_project_if_any: None,
                 matches_project_priority: 0,
+            }),
+        );
+        assert_eq!(
+            layer.containers.get("owo"),
+            Some(&Container {
+                name: "owo".to_string(),
+                packages: vec!["glibc".to_string(), "nginx".to_string()],
+                entrypoint: Some(vec!["/usr/bin/nginx".to_string()]),
+                exposed_ports: vec![ExposedPort {
+                    proto: Proto::Tcp,
+                    port: 80
+                }],
+                ..Default::default()
             }),
         );
     }

--- a/crates/decode/src/lib.rs
+++ b/crates/decode/src/lib.rs
@@ -34,7 +34,7 @@ pub use decl_tests::Test;
 mod stacks;
 pub use stacks::{PackageMatcherPredicate, Stack, StackMatcher};
 mod container;
-pub use container::{Container, ExposedPort, Proto};
+pub use container::{Container, ExposedPort, ExposedPortProto};
 
 // Increment for any big change to the format of build specs / stacks, so that hash
 // keys get invalidated.
@@ -359,8 +359,7 @@ pub(crate) fn read_ty(val: &NickelValue, program: &mut Program<CacheImpl>) -> Re
         .into_opt()
         .expect("read_ty: expected non-empty record");
     if let Ok(Some(rt)) = record.get_value_with_ctrs(&LocIdent::new("ty")) {
-        let rt = eval_if_closure(&rt, program)?;
-        Ok(ObjTy::deserialize(rt).unwrap())
+        deserialize_field("`ty` annotation", "a known object type", &rt, program)
     } else {
         Err(Error::MissingTy(
             program.files(),
@@ -387,6 +386,33 @@ pub(crate) fn eval_if_closure(
     }
 }
 
+/// Word-splits the shell form of a command field into exec form.
+///
+/// There is no shell downstream to hand an unbalanced quote to, so a string
+/// that does not lex is an error rather than a silently dropped word.
+pub(crate) fn shell_split(what: &str, s: &str) -> Result<Vec<String>, Error> {
+    shlex::split(s)
+        .ok_or_else(|| Error::Other(format!("{what} is not a valid shell word list: {s:?}")))
+}
+
+/// Evaluates a field's value and deserializes it into `T`.
+///
+/// The shape of most fields is pinned by a contract in `minimal.ncl`, but not
+/// all of them are: `Dyn`-annotated fields, elements under an `any_of`, and
+/// fields read before their contract is applied all arrive here unchecked. So
+/// a failure is a wrong-shaped value rather than a decoder bug, and it is
+/// reported as one — `what` names the field and `want` its shape, as in
+/// [Error::unexpected_type].
+pub(crate) fn deserialize_field<T: serde::de::DeserializeOwned, S: Into<String>>(
+    what: S,
+    want: &'static str,
+    val: &NickelValue,
+    program: &mut Program<CacheImpl>,
+) -> Result<T, Error> {
+    let val = eval_if_closure(val, program)?;
+    T::deserialize(val.clone()).map_err(|_| Error::unexpected_type(what, want, &val, program))
+}
+
 pub(crate) fn record_data_from_val(
     val: &NickelValue,
 ) -> Option<&nickel_lang_core::term::record::RecordData> {
@@ -408,8 +434,14 @@ pub(crate) fn patches_from_term(
     let mut dirs: Option<HashMap<String, PatchSetting>> = None;
     let mut files: Option<HashMap<String, PatchSetting>> = None;
 
-    let r = record_data_from_val(&patch_rt)
-        .unwrap_or_else(|| panic!("unexpected term for patches: {:?}", patch_rt));
+    let Some(r) = record_data_from_val(&patch_rt) else {
+        return Err(Error::unexpected_type(
+            "`patches`",
+            "a record with `dir`/`dirs` and `file`/`files` fields",
+            &patch_rt,
+            program,
+        ));
+    };
 
     r.fields
         .iter()
@@ -418,8 +450,14 @@ pub(crate) fn patches_from_term(
                 "dir" | "dirs" => {
                     let dir_rt = eval_if_closure(field.value.as_ref().unwrap(), program)?;
 
-                    let r = record_data_from_val(&dir_rt)
-                        .unwrap_or_else(|| panic!("unexpected term for dir: {:?}", dir_rt));
+                    let Some(r) = record_data_from_val(&dir_rt) else {
+                        return Err(Error::unexpected_type(
+                            format!("patch `{}`", ident_and_loc.label()),
+                            "a record of patch settings",
+                            &dir_rt,
+                            program,
+                        ));
+                    };
                     if dirs.is_some() {
                         todo!("error for both 'dirs' and 'dir' set");
                     }
@@ -428,11 +466,12 @@ pub(crate) fn patches_from_term(
                             .iter()
                             .map(
                                 |(ident_and_loc, field)| -> Result<(String, PatchSetting), Error> {
-                                    let val = String::deserialize(eval_if_closure(
+                                    let val: String = deserialize_field(
+                                        format!("patch `dir.{}`", ident_and_loc.label()),
+                                        "a string",
                                         field.value.as_ref().unwrap(),
                                         program,
-                                    )?)
-                                    .unwrap();
+                                    )?;
                                     Ok((
                                         ident_and_loc.label().to_string(),
                                         match val.as_str() {
@@ -454,8 +493,14 @@ pub(crate) fn patches_from_term(
                 "file" | "files" => {
                     let file_rt = eval_if_closure(field.value.as_ref().unwrap(), program)?;
 
-                    let r = record_data_from_val(&file_rt)
-                        .unwrap_or_else(|| panic!("unexpected term for file: {:?}", file_rt));
+                    let Some(r) = record_data_from_val(&file_rt) else {
+                        return Err(Error::unexpected_type(
+                            format!("patch `{}`", ident_and_loc.label()),
+                            "a record of patch settings",
+                            &file_rt,
+                            program,
+                        ));
+                    };
                     if files.is_some() {
                         todo!("error for both 'file' and 'files' set");
                     }
@@ -464,11 +509,12 @@ pub(crate) fn patches_from_term(
                             .iter()
                             .map(
                                 |(ident_and_loc, field)| -> Result<(String, PatchSetting), Error> {
-                                    let val = String::deserialize(eval_if_closure(
+                                    let val: String = deserialize_field(
+                                        format!("patch `file.{}`", ident_and_loc.label()),
+                                        "a string",
                                         field.value.as_ref().unwrap(),
                                         program,
-                                    )?)
-                                    .unwrap();
+                                    )?;
                                     Ok((
                                         ident_and_loc.label().to_string(),
                                         match val.as_str() {
@@ -503,17 +549,19 @@ pub(crate) fn env_vars_from_term(
 ) -> Result<IndexMap<String, EnvVarValue>, Error> {
     r.fields
         .iter()
+        // A field can carry an annotation and no value (`FOO | String`), which
+        // declares the name without setting anything.
+        .filter_map(|(ident_and_loc, field)| Some((ident_and_loc, field.value.as_ref()?)))
         .map(
-            |(ident_and_loc, field)| -> Result<(String, EnvVarValue), Error> {
+            |(ident_and_loc, value)| -> Result<(String, EnvVarValue), Error> {
                 Ok((
                     ident_and_loc.label().to_string(),
-                    EnvVarValue::Value(
-                        String::deserialize(eval_if_closure(
-                            field.value.as_ref().unwrap(),
-                            program,
-                        )?)
-                        .unwrap(),
-                    ),
+                    EnvVarValue::Value(deserialize_field(
+                        format!("env var `{}`", ident_and_loc.label()),
+                        "a string",
+                        value,
+                        program,
+                    )?),
                 ))
             },
         )
@@ -544,35 +592,48 @@ pub(crate) fn packages_array_from_term(
             })
             .collect::<Result<Vec<_>, Error>>()
     } else {
-        todo!("handle packages value being non-array {:?}", packages_rt);
+        Err(Error::unexpected_type(
+            format!("`{field}`"),
+            "an array of package names",
+            &packages_rt,
+            program,
+        ))
     }
 }
 
+/// Parses a nickel tree representing a single command, in shell or exec form.
+///
+/// `what` names the field being read, for the error when it is neither.
 pub(crate) fn cmds_from_cmd_term(
+    what: &str,
     rt: &NickelValue,
     program: &mut Program<CacheImpl>,
 ) -> Result<Vec<Vec<String>>, Error> {
     let rt = eval_if_closure(rt, program)?;
     if let Some(s) = rt.as_string() {
-        Ok(vec![shlex::split(s.as_ref()).unwrap()])
+        Ok(vec![shell_split(what, s.as_ref())?])
     } else if let Some(a) = rt.as_array() {
         Ok(vec![
             a.iter()
-                .map(|rt| eval_if_closure(rt, program))
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .map(|rt| String::deserialize(rt).unwrap())
-                .collect(),
+                .map(|rt| deserialize_field(format!("{what} entry"), "a string", rt, program))
+                .collect::<Result<Vec<_>, Error>>()?,
         ])
     } else {
-        todo!(
-            "error for 'cmd' field being non-string & non-array, got {:?}",
-            rt
-        );
+        Err(Error::unexpected_type(
+            what,
+            "a string or an array of strings",
+            &rt,
+            program,
+        ))
     }
 }
 
+/// Parses a nickel tree representing a list of commands, each in shell or exec
+/// form.
+///
+/// `what` names the field being read, for the errors when it is not.
 pub(crate) fn cmds_from_cmds_term(
+    what: &str,
     rt: &NickelValue,
     program: &mut Program<CacheImpl>,
 ) -> Result<Vec<Vec<String>>, Error> {
@@ -585,24 +646,30 @@ pub(crate) fn cmds_from_cmds_term(
                 if let Some(a) = rt.as_array() {
                     Ok::<_, Error>(
                         a.iter()
-                            .map(|rt| eval_if_closure(rt, program))
-                            .collect::<Result<Vec<_>, _>>()?
-                            .into_iter()
-                            .map(|rt| String::deserialize(rt).unwrap())
-                            .collect(),
+                            .map(|rt| {
+                                deserialize_field(format!("{what} entry"), "a string", rt, program)
+                            })
+                            .collect::<Result<Vec<_>, Error>>()?,
                     )
                 } else if let Some(s) = rt.as_string() {
-                    Ok::<_, Error>(shlex::split(s.as_ref()).unwrap())
+                    Ok::<_, Error>(shell_split(&format!("{what} entry"), s.as_ref())?)
                 } else {
-                    todo!(
-                        "error for 'cmds' field being non-array & non-string, got {:?}",
-                        rt
-                    );
+                    Err(Error::unexpected_type(
+                        format!("{what} entry"),
+                        "a string or an array of strings",
+                        &rt,
+                        program,
+                    ))
                 }
             })
             .collect::<Result<Vec<_>, _>>()?)
     } else {
-        todo!("error for 'cmds' field being non-array, got {:?}", rt);
+        Err(Error::unexpected_type(
+            what,
+            "an array of commands",
+            &rt,
+            program,
+        ))
     }
 }
 
@@ -617,6 +684,98 @@ mod tests {
     use indoc::indoc;
     use mfile::EnvVarValue;
     use nickel_lang_core::term::IndexMap;
+
+    /// A field whose value is the wrong shape must decode to an error, not
+    /// abort the process. Nickel's contracts catch most of these first, but
+    /// the fields below are annotated loosely enough that the value reaches
+    /// the decoder as-is — where it used to hit a `todo!()`.
+    #[test]
+    fn wrong_shaped_field_errors_rather_than_panicking() {
+        // (offending field, what the diagnostic must name it, wanted shape)
+        let cases = [
+            (
+                "build_deps = 1",
+                "builder `build_deps`",
+                "an array of build dependencies",
+            ),
+            (
+                "runtime_deps = 1",
+                "builder `runtime_deps`",
+                "an array of runtime dependencies",
+            ),
+            (
+                "build_args = 1",
+                "builder `build_args`",
+                "a record of strings",
+            ),
+            ("attrs = 1", "builder `attrs`", "a record of attributes"),
+            ("needs = 1", "builder `needs`", "a record of attributes"),
+            ("tests = 1", "builder `tests`", "a record of tests"),
+            ("cmds = 1", "builder `cmds`", "an array of commands"),
+            (
+                "cmds = [1]",
+                "builder `cmds` entry",
+                "a string or an array of strings",
+            ),
+            // Values the contracts let through, which used to reach a
+            // `deserialize(..).unwrap()`.
+            (
+                "build_args = { a = 1 }",
+                "builder `build_args.a`",
+                "a string",
+            ),
+            ("cmds = [[1]]", "builder `cmds` entry", "a string"),
+            ("target = 1", "builder `target`", "a string"),
+            ("prebuilt = 1", "builder `prebuilt`", "a boolean"),
+        ];
+
+        for (body, what, want) in cases {
+            // `build_deps` is required, so it is in the fixture unless the
+            // case is the one supplying it.
+            let base = if body.starts_with("build_deps") {
+                "name = \"n\", cmd = \"x\""
+            } else {
+                "name = \"n\", cmd = \"x\", build_deps = []"
+            };
+            let src = format!(
+                "let {{BuildSpec, ..}} = import \"minimal.ncl\" in\n\
+                 {{ {base}, {body} }} | BuildSpec"
+            );
+            let err = crate::Layer::new_for_test(src)
+                .err()
+                .unwrap_or_else(|| panic!("expected `{body}` to be rejected"));
+
+            let Error::UnexpectedType { pos, .. } = &err else {
+                panic!("expected Error::UnexpectedType for `{body}`, got {err:?}");
+            };
+            assert!(
+                pos.into_opt().is_some(),
+                "expected `{body}` to carry the offending value's position, got {pos:?}"
+            );
+
+            let msg = err.to_string();
+            assert!(
+                msg.contains(what) && msg.contains(want) && msg.contains("Number"),
+                "unexpected message for `{body}`: {msg}"
+            );
+        }
+    }
+
+    /// An unbalanced quote in a shell-form command has no shell downstream to
+    /// receive it, and used to panic in `shlex::split(..).unwrap()`.
+    #[test]
+    fn unbalanced_quote_in_cmd_errors_rather_than_panicking() {
+        let src = "let {BuildSpec, ..} = import \"minimal.ncl\" in\n\
+                   { name = \"n\", build_deps = [], cmd = \"echo '\" } | BuildSpec"
+            .to_string();
+        let err =
+            crate::Layer::new_for_test(src).expect_err("an unbalanced quote should be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("builder `cmd`") && msg.contains("not a valid shell word list"),
+            "unexpected message: {msg}"
+        );
+    }
 
     #[test]
     fn simple_buildspec() {
@@ -951,7 +1110,7 @@ mod tests {
                 packages: vec!["glibc".to_string(), "nginx".to_string()],
                 entrypoint: Some(vec!["/usr/bin/nginx".to_string()]),
                 exposed_ports: vec![ExposedPort {
-                    proto: Proto::Tcp,
+                    proto: ExposedPortProto::Tcp,
                     port: 80
                 }],
                 ..Default::default()

--- a/crates/decode/src/load.rs
+++ b/crates/decode/src/load.rs
@@ -315,6 +315,26 @@ impl Loader {
         }
         src.push_str("\t],\n");
 
+        src.push_str("\tcontainers = [\n");
+        match std::fs::read_dir(layer_dir.as_ref().join("containers")) {
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    return Err(e.into());
+                }
+            }
+            Ok(d) => {
+                for e in d {
+                    let e = e?;
+                    if e.file_type()?.is_dir() {
+                        src.push_str("  import \"");
+                        src.push_str(e.path().to_str().unwrap());
+                        src.push_str("/spec.ncl\",\n");
+                    }
+                }
+            }
+        }
+        src.push_str("\t],\n");
+
         src.push('}');
 
         Self::new(src, args, opts)
@@ -587,6 +607,7 @@ mod tests {
         std::fs::create_dir(temp_dir.path().join("packages")).unwrap();
         std::fs::create_dir(temp_dir.path().join("profiles")).unwrap();
         std::fs::create_dir(temp_dir.path().join("stacks")).unwrap();
+        std::fs::create_dir(temp_dir.path().join("containers")).unwrap();
 
         // Create multiple packages
         for pkg_name in &["package-a", "package-b", "package-c"] {
@@ -639,6 +660,23 @@ mod tests {
         )
         .unwrap();
 
+        // Make a container called web
+        let container_dir = temp_dir.path().join("containers").join("web");
+        std::fs::create_dir(&container_dir).unwrap();
+        std::fs::write(
+            container_dir.join("spec.ncl"),
+            indoc! {
+            "
+            let {container, ..} = import \"minimal.ncl\" in
+            container {
+        		name = \"web\",
+        		packages = [\"glibc\"],
+        	}
+			"
+            },
+        )
+        .unwrap();
+
         let sr = Loader::new_with_all_pkgs(temp_dir.path(), None, &LoadOptions::for_test());
         // So we can see the actual error when the test fails
         if let Some(e) = sr.as_ref().err().iter().next() {
@@ -670,6 +708,16 @@ mod tests {
             )
             .unwrap();
             assert!(stacks_val.as_array().map(|a| a.len()).unwrap_or(0) == 1,);
+
+            // Check a field 'containers' was an array with one object
+            let containers_val = eval_if_closure(
+                &rd.get_value_with_ctrs(&LocIdent::new("containers"))
+                    .unwrap()
+                    .unwrap(),
+                &mut sr.p,
+            )
+            .unwrap();
+            assert!(containers_val.as_array().map(|a| a.len()).unwrap_or(0) == 1,);
         }
     }
 }

--- a/crates/decode/src/stacks.rs
+++ b/crates/decode/src/stacks.rs
@@ -353,13 +353,18 @@ impl Stack {
                         }
                         "build_packages" => {
                             if let Some(packages_rt) = field.value.as_ref() {
-                                build_packages = Some(packages_array_from_term(packages_rt, program)?);
+                                build_packages =
+                                    Some(packages_array_from_term("build_packages", packages_rt, program)?);
                             }
                             Ok(())
                         }
                         "runtime_packages" => {
                             if let Some(packages_rt) = field.value.as_ref() {
-                                runtime_packages = Some(packages_array_from_term(packages_rt, program)?);
+                                runtime_packages = Some(packages_array_from_term(
+                                    "runtime_packages",
+                                    packages_rt,
+                                    program,
+                                )?);
                             }
                             Ok(())
                         }
@@ -646,6 +651,31 @@ mod tests {
                 ..Default::default()
             }
         )
+    }
+
+    #[test]
+    fn non_string_package_entry_errors() {
+        // Must be an error, not a panic: the array's element contract is
+        // pending until applied.
+        for field in ["build_packages", "runtime_packages"] {
+            let src = format!(
+                "let {{stack, ..}} = import \"minimal.ncl\" in\n\
+                 stack {{ name = \"s\", build_cmd = \"x\", {field} = [1] }}"
+            );
+            let (term, mut program, _origin, _target) =
+                Loader::new(src, None, &LoadOptions::for_test())
+                    .unwrap()
+                    .finish()
+                    .unwrap();
+
+            let err = Stack::from_term(&term, &mut program)
+                .err()
+                .unwrap_or_else(|| panic!("expected `{field} = [1]` to be rejected"));
+            assert!(
+                format!("{err:?}").contains("Nickel") || matches!(err, Error::Other(_)),
+                "unexpected error for `{field}`: {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/decode/src/stacks.rs
+++ b/crates/decode/src/stacks.rs
@@ -12,7 +12,7 @@ use regex::bytes::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Error, ObjTy, cmds_from_cmd_term, env_vars_from_term, eval_if_closure,
+    Error, ObjTy, cmds_from_cmd_term, deserialize_field, env_vars_from_term, eval_if_closure,
     packages_array_from_term, record_data_from_val,
 };
 
@@ -64,15 +64,22 @@ impl PackageMatcherPredicate {
                                         |(ident_and_loc, field)| -> Result<(String, String), Error> {
                                             Ok((
                                                 ident_and_loc.label().to_string(),
-                                                String::deserialize(eval_if_closure(
+                                                deserialize_field(
+                                                    format!("stack matcher `file_regexes.{}`", ident_and_loc.label()),
+                                                    "a string",
                                                     field.value.as_ref().unwrap(),
                                                     program,
-                                                )?).unwrap(),
+                                                )?,
                                             ))
                                         },
                                     ).collect::<Result<IndexMap<_, _>, Error>>()?);
                                 } else {
-                                    todo!("unexpected term for file_regexes: {:?}", rt);
+                                    return Err(Error::unexpected_type(
+                                        "stack matcher `file_regexes`",
+                                        "a record of strings",
+                                        &rt,
+                                        program,
+                                    ));
                                 }
 
                             Ok(())
@@ -84,15 +91,22 @@ impl PackageMatcherPredicate {
                                         |(ident_and_loc, field)| -> Result<(String, String), Error> {
                                             Ok((
                                                 ident_and_loc.label().to_string(),
-                                                String::deserialize(eval_if_closure(
+                                                deserialize_field(
+                                                    format!("stack matcher `file_predicates.{}`", ident_and_loc.label()),
+                                                    "a string",
                                                     field.value.as_ref().unwrap(),
                                                     program,
-                                                )?).unwrap(),
+                                                )?,
                                             ))
                                         },
                                     ).collect::<Result<IndexMap<_, _>, Error>>()?);
                                 } else {
-                                    todo!("unexpected term for file_predicates: {:?}", rt);
+                                    return Err(Error::unexpected_type(
+                                        "stack matcher `file_predicates`",
+                                        "a record of strings",
+                                        &rt,
+                                        program,
+                                    ));
                                 }
 
                             Ok(())
@@ -113,7 +127,10 @@ impl PackageMatcherPredicate {
 }
 
 /// Parses a nickel tree representing a map of `String` to `Vec<PackageMatcherPredicate>`.
+///
+/// `what` names the field being read, for the errors when it is the wrong shape.
 fn package_map_from_term(
+    what: &'static str,
     rt: &NickelValue,
     program: &mut Program<CacheImpl>,
 ) -> Result<IndexMap<String, Vec<PackageMatcherPredicate>>, Error> {
@@ -129,10 +146,12 @@ fn package_map_from_term(
                             .map(|input| PackageMatcherPredicate::from_term(input, program))
                             .collect::<Result<Vec<_>, Error>>()?
                     } else {
-                        todo!(
-                            "handle build_package_if_any value being non-array {:?}",
-                            field.value
-                        )
+                        return Err(Error::unexpected_type(
+                            format!("{what} entry `{}`", ident_and_loc.label()),
+                            "an array of package matchers",
+                            &a_rt,
+                            program,
+                        ));
                     };
 
                     Ok((ident_and_loc.label().to_string(), pred))
@@ -140,7 +159,12 @@ fn package_map_from_term(
             )
             .collect::<Result<IndexMap<_, _>, Error>>()
     } else {
-        todo!("unexpected term for build_package_if_any: {:?}", rt)
+        Err(Error::unexpected_type(
+            what,
+            "a record of package matchers",
+            &rt,
+            program,
+        ))
     }
 }
 
@@ -241,11 +265,19 @@ impl StackMatcher {
 
                         match ident_and_loc.label() {
                             "build_package_if_any" => {
-                                build_package_matchers = package_map_from_term(&rt, program)?;
+                                build_package_matchers = package_map_from_term(
+                                    "stack `build_package_if_any`",
+                                    &rt,
+                                    program,
+                                )?;
                                 Ok(())
                             }
                             "runtime_package_if_any" => {
-                                runtime_package_matchers = package_map_from_term(&rt, program)?;
+                                runtime_package_matchers = package_map_from_term(
+                                    "stack `runtime_package_if_any`",
+                                    &rt,
+                                    program,
+                                )?;
                                 Ok(())
                             }
                             _ => Ok(()),
@@ -318,23 +350,21 @@ impl Stack {
                 .try_for_each(|(ident_and_loc, field)| -> Result<(), Error> {
                     match ident_and_loc.label() {
                         "ty" => {
-                            ty = Some(
-                                ObjTy::deserialize(eval_if_closure(
-                                    field.value.as_ref().unwrap(),
-                                    program,
-                                )?)
-                                .unwrap(),
-                            );
+                            ty = Some(deserialize_field(
+                                "stack `ty` annotation",
+                                "a known object type",
+                                field.value.as_ref().unwrap(),
+                                program,
+                            )?);
                             Ok(())
                         }
                         "name" => {
-                            name = Some(
-                                String::deserialize(eval_if_closure(
-                                    field.value.as_ref().unwrap(),
-                                    program,
-                                )?)
-                                .unwrap(),
-                            );
+                            name = Some(deserialize_field(
+                                "stack `name`",
+                                "a string",
+                                field.value.as_ref().unwrap(),
+                                program,
+                            )?);
                             Ok(())
                         }
 
@@ -345,7 +375,12 @@ impl Stack {
                                 if let Some(r) = record_data_from_val(&ev_rt) {
                                     build_env_vars = Some(env_vars_from_term(r, program)?);
                                 } else {
-                                    todo!("unexpected term for build_env_vars: {:?}", ev_rt);
+                                    return Err(Error::unexpected_type(
+                                        "stack `build_env_vars`",
+                                        "a record of strings",
+                                        &ev_rt,
+                                        program,
+                                    ));
                                 }
                             }
 
@@ -353,8 +388,11 @@ impl Stack {
                         }
                         "build_packages" => {
                             if let Some(packages_rt) = field.value.as_ref() {
-                                build_packages =
-                                    Some(packages_array_from_term("build_packages", packages_rt, program)?);
+                                build_packages = Some(packages_array_from_term(
+                                    "build_packages",
+                                    packages_rt,
+                                    program,
+                                )?);
                             }
                             Ok(())
                         }
@@ -370,7 +408,8 @@ impl Stack {
                         }
                         "build_cmd" => {
                             if let Some(rt) = field.value.as_ref() {
-                                build_cmds = Some(cmds_from_cmd_term(rt, program)?);
+                                build_cmds =
+                                    Some(cmds_from_cmd_term("stack `build_cmd`", rt, program)?);
                             };
                             Ok(())
                         }
@@ -378,20 +417,30 @@ impl Stack {
                             if let Some(rt) = field.value.as_ref() {
                                 let rt = eval_if_closure(rt, program)?;
                                 if let Some(s) = rt.as_string() {
-                                    build_cmds_cmd = Some(
-                                        shlex::split(s.as_ref()).unwrap(),
-                                    );
+                                    build_cmds_cmd = Some(crate::shell_split(
+                                        "stack `build_cmds_cmd`",
+                                        s.as_ref(),
+                                    )?);
                                 } else if let Some(a) = rt.as_array() {
                                     build_cmds_cmd = Some(
                                         a.iter()
-                                            .map(|rt| eval_if_closure(rt, program))
-                                            .collect::<Result<Vec<_>, _>>()?
-                                            .into_iter()
-                                            .map(|rt| String::deserialize(rt).unwrap())
-                                            .collect(),
+                                            .map(|rt| {
+                                                deserialize_field(
+                                                    "stack `build_cmds_cmd` entry",
+                                                    "a string",
+                                                    rt,
+                                                    program,
+                                                )
+                                            })
+                                            .collect::<Result<Vec<_>, Error>>()?,
                                     );
                                 } else {
-                                    todo!("error for 'build_cmds_cmd' field being non-string & non-array, got {:?}", rt);
+                                    return Err(Error::unexpected_type(
+                                        "stack `build_cmds_cmd`",
+                                        "a string or an array of strings",
+                                        &rt,
+                                        program,
+                                    ));
                                 }
                                 Ok(())
                             } else {
@@ -406,7 +455,8 @@ impl Stack {
                                     matches_project_if_any = Some(
                                         a.iter()
                                             .map(|m| {
-                                                let pending = a.iter_pending_contracts()
+                                                let pending = a
+                                                    .iter_pending_contracts()
                                                     .cloned()
                                                     .collect::<Vec<_>>();
                                                 let rt = RuntimeContract::apply_all(
@@ -415,18 +465,20 @@ impl Stack {
                                                     m.pos_idx(),
                                                 );
 
-                                                StackMatcher::from_term(&eval_if_closure(
-                                                    &rt,
+                                                StackMatcher::from_term(
+                                                    &eval_if_closure(&rt, program)?,
                                                     program,
-                                                )?, program)
+                                                )
                                             })
                                             .collect::<Result<Vec<_>, Error>>()?,
                                     );
                                 } else {
-                                    todo!(
-                                        "handle matches_project_if_any value being non-array {:?}",
-                                        field.value
-                                    );
+                                    return Err(Error::unexpected_type(
+                                        "stack `matches_project_if_any`",
+                                        "an array of stack matchers",
+                                        &matchers_rt,
+                                        program,
+                                    ));
                                 }
                             }
 
@@ -434,9 +486,13 @@ impl Stack {
                         }
                         "matches_project_priority" => {
                             if let Some(matchers_rt) = field.value.as_ref() {
-                                let matchers_rt =
-                                    eval_if_closure(matchers_rt, program)?;
-                                matches_project_priority = Some(i32::deserialize(matchers_rt).unwrap());
+                                let matchers_rt = eval_if_closure(matchers_rt, program)?;
+                                matches_project_priority = Some(deserialize_field(
+                                    "stack `matches_project_priority`",
+                                    "a whole number",
+                                    &matchers_rt,
+                                    program,
+                                )?);
                             }
 
                             Ok(())
@@ -651,6 +707,34 @@ mod tests {
                 ..Default::default()
             }
         )
+    }
+
+    /// A field can be annotated without being given a value
+    /// (`FOO | String`), which declares the name and sets nothing. Reading one
+    /// must skip it rather than unwrap its absent value.
+    #[test]
+    fn annotation_only_env_var_is_skipped() {
+        let src = "let {stack, ..} = import \"minimal.ncl\" in\n\
+                   stack { name = \"s\", build_cmd = \"x\",\n\
+                   build_env_vars = { SET = \"1\", DECLARED | String } }"
+            .to_string();
+        let (term, mut program, _origin, _target) =
+            Loader::new(src, None, &LoadOptions::for_test())
+                .unwrap()
+                .finish()
+                .unwrap();
+
+        let stack = Stack::from_term(&term, &mut program).expect("stack should decode");
+        assert!(
+            stack.build_env_vars.contains_key("SET"),
+            "expected the set var to survive: {:?}",
+            stack.build_env_vars
+        );
+        assert!(
+            !stack.build_env_vars.contains_key("DECLARED"),
+            "expected the annotation-only var to be skipped: {:?}",
+            stack.build_env_vars
+        );
     }
 
     #[test]

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stdlib"
-version = "0.0.19"
+version = "0.0.20"
 rust-version.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stdlib/minimal-ncl/minimal.ncl
+++ b/crates/stdlib/minimal-ncl/minimal.ncl
@@ -1,4 +1,4 @@
-let Tys = [| 'Builder, 'OutputLib, 'OutputBin, 'OutputData, 'Source, 'Local, 'Subset, 'Profile, 'Layer, 'Upstream, 'Test, 'Stack |]
+let Tys = [| 'Builder, 'OutputLib, 'OutputBin, 'OutputData, 'Source, 'Local, 'Subset, 'Profile, 'Layer, 'Upstream, 'Test, 'Stack, 'Container |]
 in
 let attrs_schema = import "attr_classes.ncl" in
 let needs_schema = import "need_classes.ncl" in
@@ -6,6 +6,81 @@ let CmdSpec = std.contract.any_of [
   String,
   Array String,
 ] in
+# Builds a contract that accepts strings matching `regex`, blaming with `msg`.
+let StringMatching = fun regex msg =>
+  std.contract.custom (fun label value =>
+    if !(std.is_string value) then
+      'Error { message = "expected a string" }
+    else if std.string.is_match regex value then
+      'Ok value
+    else
+      'Error { message = "%{msg}: got `%{value}`" }
+  ) in
+# A container image name, following the registry reference grammar: lowercase
+# alphanumerics separated by `.`, `_`, or `-`, in `/`-separated path
+# components. Registries reject uppercase, so this does too.
+let ImageName = StringMatching
+  "^[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*$"
+  "not a valid image name: use lowercase alphanumerics separated by `.`, `_`, `-`, or `/`"
+in
+# A clean absolute path: no relative form, no trailing or repeated `/`, no
+# `.`/`..` components. A bare `/` is allowed.
+let AbsolutePath =
+  std.contract.custom (fun label value =>
+    if !(std.is_string value) then
+      'Error { message = "expected a string path" }
+    else if value == "/" then
+      'Ok value
+    else if !(std.string.is_match "^(/[^/]+)+$" value) then
+      'Error {
+        message = "must be an absolute path with no trailing or repeated `/`: got `%{value}`"
+      }
+    else if std.string.is_match "(^|/)[.][.]?(/|$)" value then
+      'Error {
+        message = "must not contain `.` or `..` path components: got `%{value}`"
+      }
+    else
+      'Ok value
+  ) in
+# The user processes run as, in OCI form: `user`, `uid`, `user:group`,
+# `uid:gid`, `uid:group`, or `user:gid`.
+#
+# Prefer numeric ids. A *named* user must resolve through `/etc/passwd` inside
+# the image, which a package-assembled rootfs usually lacks, and Kubernetes
+# `runAsNonRoot` requires a numeric uid.
+let UserSpec = StringMatching
+  "^([0-9]+|[A-Za-z_][A-Za-z0-9_.-]*)(:([0-9]+|[A-Za-z_][A-Za-z0-9_.-]*))?$"
+  "not a valid user: expected `user`, `uid`, `user:group`, or `uid:gid`"
+in
+# A signal name, e.g. `SIGTERM` or `SIGRTMIN+3`.
+let StopSignal = StringMatching
+  "^SIG[A-Z0-9]+([+-][0-9]+)?$"
+  "not a valid signal name: expected the `SIGTERM` form"
+in
+# Environment variables baked into an image. Names must be POSIX portable
+# (`[A-Za-z_][A-Za-z0-9_]*`), because runtimes join these into `KEY=VALUE`
+# strings and split on the first `=`.
+let EnvVars = std.contract.custom (fun label record_value =>
+    if !(std.is_record record_value) then
+      'Error { message = "not a record" }
+    else
+      record_value
+      |> std.record.to_array
+      |> std.array.try_fold_left
+        (fun acc { field, value } =>
+          if !(std.string.is_match "^[A-Za-z_][A-Za-z0-9_]*$" field) then
+            'Error { message = "`%{field}` is not a valid environment variable name" }
+          else if !(std.is_string value) then
+            'Error { message = "environment variable `%{field}` must be a string" }
+          else
+            'Ok acc
+        )
+        null
+      |> match {
+        'Ok _ => 'Ok record_value,
+        'Error e => 'Error e,
+      }
+  ) in
 {
     BuildSpec | doc "A minimal build spec, defining inputs to the build as well as outputs which carry build artifacts downstream" = {
         ty | Tys = 'Builder,
@@ -203,6 +278,7 @@ let CmdSpec = std.contract.any_of [
         builds | Array BuildSpec,
         profiles | Array Dyn, # Profiles were removed 2026-08-06.
         stacks | Array Stack,
+        containers | Array Container,
     },
     layer | Dyn -> Layer | doc "Constructs a layer." =
         fun spec => spec | Layer,
@@ -272,4 +348,41 @@ let CmdSpec = std.contract.any_of [
         os | [| 'Linux, 'MacOS |],
         arch | [| 'Amd64, 'Arm64 |],
     },
+
+    Container | doc "A declared container image." = {
+        ty | Tys = 'Container,
+        name
+            | ImageName,
+        packages
+            | Array String,
+
+        # OCI has no shell form: a string is word-split into exec form, so an
+        # unbalanced quote is an error rather than something the shell sees.
+        entrypoint | CmdSpec | optional,
+        cmd | CmdSpec | optional,
+        # Must match the architecture the packages were built for, or the
+        # image pulls cleanly and then fails with `exec format error`.
+        arch | [| 'Amd64, 'Arm64 |] | optional,
+        working_dir | AbsolutePath | optional,
+
+        env_vars
+            | EnvVars | optional,
+
+        # Element contracts can only refer to builtins (see the note above
+        # `AbsolutePath`), so the port range, the volume paths, and the
+        # set semantics of both are checked by the decoder.
+        exposed_ports
+            | Array { port | Number, proto | [| 'Tcp, 'Udp |] | default = 'Tcp } | optional,
+        volumes
+            | Array String | optional,
+        user | UserSpec | optional,
+        stop_signal | StopSignal | optional,
+
+        labels
+            | {_ : String} | optional,
+        config
+            | {_ : String} | optional,
+    },
+    container | Dyn -> Container | doc "Constructs a container image." =
+        fun spec => spec | Container,
 }


### PR DESCRIPTION
 - New types to support field validation for containers in the embedded nickel stdlib
 - Code in `decode` to parse containers specs into a `decode::Container` struct
 - Tests for parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining and decoding container specifications in layers.
  * Added container image metadata, commands, environment variables, ports, volumes, labels, users, signals, and architecture settings.
  * Added validation for container fields, image names, duplicate definitions, and target architecture compatibility.
  * Added support for TCP and UDP exposed ports.
  * Container specifications are now included when loading projects.

* **Bug Fixes**
  * Invalid values, collection shapes, and command syntax now return clear, structured errors instead of failures.
  * Improved error messages with field-specific context.
  * Unsupported container objects are now reported as unexpected types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->