### PR TITLE
fix(minimald): dispatch HVP cursor positioning via a patched vt100

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,7 +1920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2904,7 +2904,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4147,7 +4147,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "version",
- "vt100-ctt",
+ "vt100",
  "walkdir",
  "zstd",
 ]
@@ -5632,7 +5632,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6241,7 +6241,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6300,7 +6300,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7208,10 +7208,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8094,26 +8094,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "vt100-ctt"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0333bcaa031b50f85eac76cb9d62a400be0915ac2d60c3cce28656c01e7e58"
+name = "vt100"
+version = "0.16.2"
+source = "git+https://github.com/gominimal/vt100-rust.git?rev=9b8cce5a6798daf061948259ebcb073bb1ea54a6#9b8cce5a6798daf061948259ebcb073bb1ea54a6"
 dependencies = [
  "itoa",
- "log",
  "unicode-width 0.2.2",
- "vte 0.13.1",
-]
-
-[[package]]
-name = "vte"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0b683b20ef64071ff03745b14391751f6beab06a54347885459b77a3f2caa5"
-dependencies = [
- "arrayvec 0.7.8",
- "utf8parse",
- "vte_generate_state_changes",
+ "vte 0.15.0",
 ]
 
 [[package]]
@@ -8126,13 +8113,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
+name = "vte"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
- "proc-macro2",
- "quote",
+ "arrayvec 0.7.8",
+ "memchr",
 ]
 
 [[package]]
@@ -8385,7 +8372,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ members = [
     "crates/switch",
     "crates/version",
 ]
+# Local checkout of our ChrisTitusTech/vt100-rust fork (vt100-ctt); built and
+# published standalone.
+exclude = ["vt100-rust"]
 resolver = "3"
 
 package.edition = "2024"
@@ -165,7 +168,7 @@ thiserror = "2"
 unicode-width = "0.2"
 url = "2" # keep in sync with reqwest
 uuid = { version = "1.24", features = ["v4", "v7", "serde"] }
-vt100-ctt = { version = "0.17", default-features = false }
+vt100 = { version = "0.16.2" }
 zstd = "0.13"
 
 moka = { version = "0.12", default-features = false, features = ["sync"] }
@@ -228,5 +231,10 @@ stdlib = { path = "crates/stdlib" }
 # dependency of its own and stays on crates.io 0.7.3, so .ncl formatting
 # output is untouched. Drop this section once topiary publishes >0.7.3.
 [patch.crates-io]
+# upstream doy/vt100 doesn't dispatch CSI 'f' (HVP, ECMA-48's CUP alias that
+# btop uses for all cursor positioning) and merges once a year; our fork's
+# minimal-patches branch carries the fix from doy/vt100-rust#34. Drop this
+# once an upstream release includes it (gominimal/minimal#1197).
+vt100 = { git = "https://github.com/gominimal/vt100-rust.git", rev = "9b8cce5a6798daf061948259ebcb073bb1ea54a6" }
 topiary-tree-sitter-facade = { git = "https://github.com/tweag/topiary.git", rev = "838c74ab4058f82bc3c6a12380f22c10f22ac814" }
 topiary-web-tree-sitter-sys = { git = "https://github.com/tweag/topiary.git", rev = "838c74ab4058f82bc3c6a12380f22c10f22ac814" }

--- a/crates/minimald/Cargo.toml
+++ b/crates/minimald/Cargo.toml
@@ -51,7 +51,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 zstd.workspace = true
-vt100-ctt.workspace = true
+vt100.workspace = true
 walkdir.workspace = true
 
 tokio.workspace = true

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -951,11 +951,11 @@ enum Message {
 /// Renders a vt100 cell color into the string form the
 /// [`minimald_rpc::ScreenCell`] wire type uses: `"idx:<n>"` for an ANSI-256
 /// palette index, `"#rrggbb"` for truecolor, `None` for the terminal default.
-fn wire_color(color: vt100_ctt::Color) -> Option<String> {
+fn wire_color(color: vt100::Color) -> Option<String> {
     match color {
-        vt100_ctt::Color::Default => None,
-        vt100_ctt::Color::Idx(n) => Some(format!("idx:{n}")),
-        vt100_ctt::Color::Rgb(r, g, b) => Some(format!("#{r:02x}{g:02x}{b:02x}")),
+        vt100::Color::Default => None,
+        vt100::Color::Idx(n) => Some(format!("idx:{n}")),
+        vt100::Color::Rgb(r, g, b) => Some(format!("#{r:02x}{g:02x}{b:02x}")),
     }
 }
 
@@ -963,7 +963,7 @@ fn wire_color(color: vt100_ctt::Color) -> Option<String> {
 /// type. Wide-glyph continuation cells are dropped rather than emitted as
 /// spaces: consumers flatten cells into width-aware text, so a placeholder
 /// cell would add a phantom column per wide glyph and skew the row.
-fn screen_to_snapshot(screen: &vt100_ctt::Screen) -> minimald_rpc::ScreenSnapshot {
+fn screen_to_snapshot(screen: &vt100::Screen) -> minimald_rpc::ScreenSnapshot {
     use minimald_rpc::{ScreenCell, ScreenRow, ScreenSnapshot};
     let (rows, cols) = screen.size();
     let lines = (0..rows)
@@ -1014,14 +1014,14 @@ fn screen_to_snapshot(screen: &vt100_ctt::Screen) -> minimald_rpc::ScreenSnapsho
 
 /// Handles callback events from the terminal parser, transmitting them to the host.
 struct ParserEventHandler(WeakHostHandle);
-impl vt100_ctt::Callbacks for ParserEventHandler {
-    fn set_window_title(&mut self, _: &mut vt100_ctt::Screen, title: &[u8]) {
+impl vt100::Callbacks for ParserEventHandler {
+    fn set_window_title(&mut self, _: &mut vt100::Screen, title: &[u8]) {
         self.0.set_title_cb(title);
     }
-    fn audible_bell(&mut self, _: &mut vt100_ctt::Screen) {
+    fn audible_bell(&mut self, _: &mut vt100::Screen) {
         self.0.audible_bell_cb();
     }
-    fn visual_bell(&mut self, _: &mut vt100_ctt::Screen) {
+    fn visual_bell(&mut self, _: &mut vt100::Screen) {
         self.0.visual_bell_cb();
     }
 }
@@ -1241,7 +1241,7 @@ pub(crate) struct Host<P: SessionProcess, G: SessionGuard> {
     /// The last-set pty terminal size.
     sz: WinSize,
     /// In-memory representation of the terminal state.
-    parser: vt100_ctt::Parser<ParserEventHandler>,
+    parser: vt100::Parser<ParserEventHandler>,
     /// The session process.
     process: P,
     /// The master-side fd of the Pty.
@@ -2272,7 +2272,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         let (sender, receiver) = mpsc::channel(8);
         let handle = HostHandle { sender };
 
-        let parser = vt100_ctt::Parser::new_with_callbacks(
+        let parser = vt100::Parser::new_with_callbacks(
             sz.rows,
             sz.cols,
             0,
@@ -2637,7 +2637,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
     /// to a normal state on detach.
     fn unwind_codes(&self) -> Vec<u8> {
         let live = self.parser.screen();
-        let clean = vt100_ctt::Parser::new(live.size().0, live.size().1, 0)
+        let clean = vt100::Parser::new(live.size().0, live.size().1, 0)
             .screen()
             .clone();
 
@@ -2836,11 +2836,23 @@ mod tests {
     /// the flattened row keeps the terminal's display width.
     #[test]
     fn screen_snapshot_drops_wide_continuation_cells() {
-        let mut parser = vt100_ctt::Parser::new(2, 10, 0);
+        let mut parser = vt100::Parser::new(2, 10, 0);
         parser.process("abあcd".as_bytes());
         let snapshot = screen_to_snapshot(parser.screen());
         let text: String = snapshot.lines[0].cells.iter().map(|c| c.ch).collect();
         assert_eq!(text.trim_end(), "abあcd");
+    }
+
+    #[test]
+    fn hvp_positions_like_cup() {
+        // btop positions exclusively with HVP (`f`); it must behave like CUP
+        // (gominimal/minimal#1197). Guards the gominimal/vt100-rust fork's
+        // patch against being dropped.
+        let mut parser = vt100::Parser::new(5, 10, 0);
+        parser.process("\u{1b}[3;7fX\u{1b}[fY".as_bytes());
+        assert_eq!(parser.screen().cell(2, 6).unwrap().contents(), "X");
+        assert_eq!(parser.screen().cell(0, 0).unwrap().contents(), "Y");
+        assert_eq!(parser.screen().cursor_position(), (0, 1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`minimald`'s terminal model ignored `CSI Ps;Ps f` (HVP). HVP is the ECMA-48 alias of CUP (`H`), and btop uses `f` for every cursor move. The parser dropped each `f` sequence, so btop's output landed as one long append instead of positioned text. The dash Preview and re-attached sessions showed fused, wrapped frames (#1197). Real terminals accept `f`, so native btop looked correct.

No vt100-lineage crate ships the fix. Upstream doy/vt100 has two open PRs for it (#34, #36) but merges about once a year. The ChrisTitusTech fork we used (`vt100-ctt`) has the same gap and adds nothing we depend on.

This change:

- Renames the dependency from `vt100-ctt` to upstream `vt100` 0.16.2.
- Patches `vt100` against `gominimal/vt100-rust` (`minimal-patches`), which carries the fix from doy/vt100-rust#34, cherry-picked with rezigned's authorship kept.
- Adds a regression test: explicit (`ESC[3;7f`) and default (`ESC[f`) HVP must position like CUP.

The Preview keeps its truncate-only design: btop now renders legibly clipped with no PTY resize (#1225 closed).

## Changes

| File | What it does |
|---|---|
| `Cargo.toml` | Dep renamed to `vt100` 0.16.2; `[patch.crates-io]` pins the fork by rev with a drop-when comment |
| `crates/minimald/Cargo.toml` | Same rename |
| `crates/minimald/src/session_host.rs` | Import rename; new `hvp_positions_like_cup` test |
| `Cargo.lock` | `vt100-ctt` out, patched `vt100` in; `vte` 0.13.1 to 0.15.0 |

## Verification

- `just ci` green: fmt, clippy, cargo-deny (all gates, sources included), 1732 tests, doctests. The one `test-ignored` failure (`mctx tests::task_env`) also fails on clean `main` and is unrelated.
- Root cause proven end-to-end: captured btop's PTY stream (675 HVP sequences, no CR/LF, no erase) and replayed it through the parser. Strokes fused across rows before the patch and land on their intended rows after.

Refs #1197 (the detach-keybind half of that issue is unverified by this analysis and may still need work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal cursor positioning support for HVP/CUP-equivalent escape sequences.
  * Updated terminal rendering and event handling for more reliable screen conversion.
  * Preserved correct behavior for wide-character glyph rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->