### PR TITLE
fix: loadout name now comes exclusively from the file name stem

### DIFF
--- a/crates/minimal/src/loadouts.rs
+++ b/crates/minimal/src/loadouts.rs
@@ -907,7 +907,7 @@ on_activate = { type = "inline", value = "sleep 90", timeout = 90 }
         std::fs::create_dir_all(&loadouts).unwrap();
         std::fs::write(
             loadouts.join("default.toml"),
-            "name = \"default\"\ndescription = \"user override\"\n",
+            "description = \"user override\"\n",
         )
         .unwrap();
         let cfg = sessions::client::config::Config::default();
@@ -947,8 +947,8 @@ on_activate = { type = "inline", value = "sleep 90", timeout = 90 }
         let tmp = tempfile::tempdir().unwrap();
         let loadouts = tmp.path().join("loadouts");
         std::fs::create_dir_all(&loadouts).unwrap();
-        // Valid TOML but missing the required `name` field → parse failure.
-        std::fs::write(loadouts.join("broken.toml"), "x = 1\n").unwrap();
+        // Valid TOML, wrong schema: `packages` is a list → parse failure.
+        std::fs::write(loadouts.join("broken.toml"), "packages = 1\n").unwrap();
         let args = LoadoutListArgs {
             dir: Some(loadouts),
         };

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -62,7 +62,7 @@ fn fake_config_dir() -> tempfile::TempDir {
     .unwrap();
     std::fs::write(
         root.join("loadouts/dev.toml"),
-        "name = \"dev\"\npackages = [\"ripgrep\"]\n\n[vars]\nGITHUB_TOKEN = \"canary-secret-value\"\n",
+        "packages = [\"ripgrep\"]\n\n[vars]\nGITHUB_TOKEN = \"canary-secret-value\"\n",
     )
     .unwrap();
     dir

--- a/crates/sessions/src/client/disk.rs
+++ b/crates/sessions/src/client/disk.rs
@@ -3,14 +3,19 @@
 //! A user's loadouts live at `<config>/minimal/loadouts/<name>.toml`
 //! (where `<config>` is the platform-standard user config dir; the
 //! caller resolves that path and hands it in here). The filename
-//! stem is the loadout's identifier: it must match the loadout's
-//! declared `name` field, otherwise loading errors out — divergent
-//! references between the filename and the internal name would be a
-//! confusing source of "which one gets picked up" bugs.
+//! stem *is* the loadout's identifier — the single place a loadout is
+//! named, so a file and the loadout it defines can never disagree
+//! about which one gets picked up.
+//!
+//! A file may still carry the vestigial `name` field. It no longer
+//! names anything: [`read_loadout_file`] warns that the field isn't
+//! required and drops it, taking the name from the filename either
+//! way. That is a warning rather than an error so an older loadout
+//! keeps working untouched.
 
 use std::path::{Path, PathBuf};
 
-use crate::core::loadout::Loadout;
+use crate::core::loadout::{Loadout, LoadoutFile, LoadoutName};
 
 /// Failure loading a single loadout file.
 #[derive(Debug, thiserror::Error)]
@@ -31,25 +36,10 @@ pub enum LoadError {
         #[source]
         source: toml::de::Error,
     },
-    /// The loadout's declared `name` field disagrees with the file
-    /// stem it was loaded from.
-    #[error(
-        "loadout at `{path}` declares name `{declared_name}` but the filename \
-         stem is `{file_stem}`; rename the file or fix the `name` field"
-    )]
-    NameMismatch {
-        path: PathBuf,
-        /// The filename stem the file was found under — the
-        /// user-facing loadout identifier that must match `name`.
-        file_stem: String,
-        /// The value inside the file's `name = "..."` field, which
-        /// disagreed with `file_stem`.
-        declared_name: String,
-    },
     /// The filename stem itself isn't a valid loadout name (e.g.
     /// contains a path separator or NUL). Caught before parsing the
     /// TOML so the operator gets the concrete "your filename is bad"
-    /// message instead of a downstream "name mismatch" one.
+    /// message instead of a downstream one about the contents.
     #[error("loadout file `{path}` has an invalid stem: {source}")]
     InvalidStem {
         path: PathBuf,
@@ -65,8 +55,8 @@ pub enum LoadError {
 #[non_exhaustive]
 pub struct LoadoutEntry {
     /// The filename stem (without `.toml`). This is what the user
-    /// interacts with as the loadout identifier — [`read_loadout_file`]
-    /// enforces that it matches the loadout's internal `name` field.
+    /// interacts with as the loadout identifier, and what
+    /// [`read_loadout_file`] names the parsed loadout after.
     pub file_stem: String,
     /// Path to the loadout file. Absolute when `list_loadouts`
     /// canonicalized the input directory (its normal path); may be
@@ -101,9 +91,14 @@ pub enum ListError {
     },
 }
 
-/// Parse a single loadout file. The file stem must be a valid
-/// [`LoadoutName`] (rejects path separators, NUL, empty) and must
-/// match the loadout's declared `name` field.
+/// Parse a single loadout file and name it after its filename stem,
+/// which must be a valid [`LoadoutName`] (rejects path separators,
+/// NUL, empty).
+///
+/// A `name` field inside the file is vestigial: it is warned about
+/// and discarded, whether or not it agrees with the filename. Loading
+/// continues either way — a stale `name` costs the user a warning,
+/// not a broken session.
 ///
 /// # Errors
 ///
@@ -111,41 +106,78 @@ pub enum ListError {
 pub fn read_loadout_file(path: &Path) -> Result<Loadout, LoadError> {
     // Validate the stem *before* reading the file so an operator
     // renaming to `~/foo/bar.toml` gets the specific "your filename
-    // is bad" message instead of a confusing name-mismatch error
-    // downstream.
+    // is bad" message instead of a downstream one about the contents.
     let file_stem_str = path
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or_default();
     let file_stem =
-        crate::core::loadout::LoadoutName::try_new(file_stem_str).map_err(|source| {
-            LoadError::InvalidStem {
-                path: path.to_path_buf(),
-                source,
-            }
+        LoadoutName::try_new(file_stem_str).map_err(|source| LoadError::InvalidStem {
+            path: path.to_path_buf(),
+            source,
         })?;
 
     let contents = std::fs::read_to_string(path).map_err(|source| LoadError::Io {
         path: path.to_path_buf(),
         source,
     })?;
-    let loadout: Loadout = toml::from_str(&contents).map_err(|source| LoadError::Parse {
+    let file: LoadoutFile = toml::from_str(&contents).map_err(|source| LoadError::Parse {
         path: path.to_path_buf(),
         source,
     })?;
-    if loadout.name() != &file_stem {
-        return Err(LoadError::NameMismatch {
-            path: path.to_path_buf(),
-            file_stem: file_stem.into_inner(),
-            declared_name: loadout.name().as_ref().to_string(),
-        });
+
+    match DeclaredName::classify(file.declared_name(), &file_stem) {
+        DeclaredName::Absent => {}
+        DeclaredName::Redundant => tracing::warn!(
+            path = %path.display(),
+            loadout = %file_stem,
+            "loadout `{file_stem}` declares a `name` field; a loadout is now named \
+             after its file, so the field is no longer required and can be deleted",
+        ),
+        DeclaredName::Mismatched(declared) => tracing::warn!(
+            path = %path.display(),
+            loadout = %file_stem,
+            declared_name = %declared,
+            "loadout `{file_stem}` declares the name `{declared}`, which does not match \
+             its filename; a loadout is now named after its file, so the field is no \
+             longer required — using `{file_stem}` and ignoring the declared name",
+        ),
     }
-    Ok(loadout)
+
+    Ok(file.into_loadout(file_stem))
+}
+
+/// How a loadout file's declared `name` field stands relative to the
+/// filename it was read from — the classification behind
+/// [`read_loadout_file`]'s warnings. The field carries no authority in
+/// any of these cases; only what to tell the user differs.
+#[derive(Debug, PartialEq, Eq)]
+enum DeclaredName<'a> {
+    /// No `name` field: the current, expected shape of a loadout file.
+    Absent,
+    /// A `name` field agreeing with the filename — harmless, but no
+    /// longer required.
+    Redundant,
+    /// A `name` field disagreeing with the filename. The filename
+    /// wins; the declared name it carries is discarded.
+    Mismatched(&'a LoadoutName),
+}
+
+impl<'a> DeclaredName<'a> {
+    /// Classify `declared` (a file's `name` field, if any) against the
+    /// `file_stem` the loadout is actually named after.
+    fn classify(declared: Option<&'a LoadoutName>, file_stem: &LoadoutName) -> Self {
+        match declared {
+            None => Self::Absent,
+            Some(name) if name == file_stem => Self::Redundant,
+            Some(name) => Self::Mismatched(name),
+        }
+    }
 }
 
 /// Enumerate every `*.toml` file in `dir` and try to parse each as a
-/// [`Loadout`]. Returns one [`LoadoutEntry`] per file, sorted by
-/// stem; parse and name-mismatch failures are folded into the
+/// [`Loadout`], named after its file. Returns one [`LoadoutEntry`]
+/// per file, sorted by stem; parse failures are folded into the
 /// entry's `loadout` field so the caller can surface them in the
 /// listing rather than aborting the whole scan.
 ///
@@ -230,34 +262,65 @@ mod tests {
         path
     }
 
-    /// A well-formed loadout file loads and its name field matches
-    /// the file stem.
+    /// A loadout file with no `name` field — the current shape —
+    /// takes its name from the filename.
     #[test]
-    fn read_loadout_file_ok() {
+    fn read_loadout_file_names_from_file_stem() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(dir.path(), "dev.toml", r#"name = "dev""#);
+        let path = write_file(dir.path(), "dev.toml", r#"packages = ["helix"]"#);
         let loadout = read_loadout_file(&path).expect("valid loadout should load");
         assert_eq!(loadout.name().as_ref(), "dev");
     }
 
-    /// A loadout whose declared `name` disagrees with its filename
-    /// stem is rejected with a descriptive error.
+    /// A file still declaring the `name` it is filed under loads
+    /// unchanged: the field is redundant, not wrong, so it costs a
+    /// warning and nothing else.
     #[test]
-    fn read_loadout_file_name_mismatch_errors() {
+    fn read_loadout_file_redundant_name_still_loads() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(dir.path(), "dev.toml", r#"name = "other""#);
-        let err = read_loadout_file(&path).expect_err("mismatched name should error");
-        match err {
-            LoadError::NameMismatch {
-                file_stem,
-                declared_name,
-                ..
-            } => {
-                assert_eq!(file_stem, "dev");
-                assert_eq!(declared_name, "other");
-            }
-            other => panic!("expected NameMismatch, got {other:?}"),
-        }
+        let path = write_file(
+            dir.path(),
+            "dev.toml",
+            "name = \"dev\"\npackages = [\"helix\"]\n",
+        );
+        let loadout = read_loadout_file(&path).expect("a redundant name is not an error");
+        assert_eq!(loadout.name().as_ref(), "dev");
+        assert_eq!(loadout.packages(), &["helix"]);
+    }
+
+    /// A loadout whose declared `name` disagrees with its filename
+    /// still loads — under the filename. The declared name is
+    /// discarded (the user is warned), so the loadout is reachable by
+    /// exactly the name it is filed under.
+    #[test]
+    fn read_loadout_file_mismatched_name_is_discarded() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            dir.path(),
+            "dev.toml",
+            "name = \"other\"\npackages = [\"helix\"]\n",
+        );
+        let loadout = read_loadout_file(&path).expect("a mismatched name is not an error");
+        assert_eq!(loadout.name().as_ref(), "dev");
+        assert_eq!(loadout.packages(), &["helix"]);
+    }
+
+    /// The warning classification behind those two paths, exercised
+    /// directly: absent, agreeing, and disagreeing `name` fields.
+    #[test]
+    fn declared_name_classification() {
+        let stem = LoadoutName::try_new("dev").unwrap();
+        let same = LoadoutName::try_new("dev").unwrap();
+        let other = LoadoutName::try_new("other").unwrap();
+        assert_eq!(DeclaredName::classify(None, &stem), DeclaredName::Absent);
+        assert_eq!(
+            DeclaredName::classify(Some(&same), &stem),
+            DeclaredName::Redundant
+        );
+        assert_eq!(
+            DeclaredName::classify(Some(&other), &stem),
+            DeclaredName::Mismatched(&other)
+        );
     }
 
     /// Malformed TOML is reported as a `Parse` error, not swallowed.
@@ -275,14 +338,15 @@ mod tests {
     #[test]
     fn list_loadouts_enumerates_and_sorts() {
         let dir = TempDir::new().unwrap();
-        write_file(dir.path(), "beta.toml", r#"name = "beta""#);
-        write_file(dir.path(), "alpha.toml", r#"name = "alpha""#);
+        write_file(dir.path(), "beta.toml", r#"packages = ["zellij"]"#);
+        write_file(dir.path(), "alpha.toml", r#"packages = ["helix"]"#);
         write_file(dir.path(), "readme.txt", "not a loadout");
         std::fs::create_dir(dir.path().join("nested")).unwrap();
         // Malformed but present — should show up as an entry with
         // a `Parse` error, not skip the file entirely.
         write_file(dir.path(), "broken.toml", "= bad =");
-        // Name-mismatch — also surfaces as an entry with an error.
+        // A stale `name` field is no longer a failure: the entry
+        // parses and is listed under its filename.
         write_file(dir.path(), "renamed.toml", r#"name = "different""#);
 
         let entries = list_loadouts(dir.path()).expect("should list");
@@ -292,10 +356,15 @@ mod tests {
         assert!(entries[0].loadout.is_ok());
         assert!(entries[1].loadout.is_ok());
         assert!(matches!(entries[2].loadout, Err(LoadError::Parse { .. })));
-        assert!(matches!(
-            entries[3].loadout,
-            Err(LoadError::NameMismatch { .. })
-        ));
+        assert_eq!(
+            entries[3]
+                .loadout
+                .as_ref()
+                .expect("renamed")
+                .name()
+                .as_ref(),
+            "renamed"
+        );
     }
 
     /// A missing directory returns `NotFound`, not a generic I/O error.

--- a/crates/sessions/src/core/loadout.rs
+++ b/crates/sessions/src/core/loadout.rs
@@ -50,9 +50,9 @@ use crate::core::primitives::{LenientVarEntry, Patch, Patches, StrictVarName, Va
 /// separators and NUL bytes.
 ///
 /// Names appear in user-facing contexts (selection menus, error
-/// messages) and may be used as filesystem-key fragments by the loader,
-/// so they're constrained at construction time rather than at point of
-/// use.
+/// messages) and are the filename stems the loader reads loadouts
+/// from, so they're constrained at construction time rather than at
+/// point of use.
 #[nutype(
     sanitize(trim),
     validate(not_empty, predicate = |s: &str| !s.contains(['/', '\\', '\0'])),
@@ -63,10 +63,25 @@ use crate::core::primitives::{LenientVarEntry, Patch, Patches, StrictVarName, Va
 )]
 pub struct LoadoutName(String);
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct Loadout {
-    /// Identifier — user-facing, used in selection and error messages.
-    name: LoadoutName,
+/// A loadout file's contents, with its identity not yet resolved.
+///
+/// A loadout is named after the file it lives in, never after
+/// anything written inside it: [`read_loadout_file`] pairs the parsed
+/// contents with the filename stem via [`LoadoutFile::into_loadout`].
+///
+/// The `name` key is still accepted so files written when it *was* the
+/// identifier keep parsing. It is exposed through
+/// [`LoadoutFile::declared_name`] only so the loader can warn that the
+/// field is no longer required; it never becomes the identifier, and a
+/// declared name that disagrees with the filename is discarded.
+///
+/// [`read_loadout_file`]: crate::client::disk::read_loadout_file
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct LoadoutFile {
+    /// The vestigial `name` field. See the type docs: read for
+    /// warnings, never for identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    name: Option<LoadoutName>,
     /// Free-form description, shown alongside the name in user-facing
     /// contexts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -95,6 +110,61 @@ pub struct Loadout {
     follow_symlinks: Option<bool>,
 }
 
+impl LoadoutFile {
+    /// The `name` field declared inside the file, if it still carries
+    /// one. Not the loadout's identity — see the type docs.
+    #[must_use]
+    pub fn declared_name(&self) -> Option<&LoadoutName> {
+        self.name.as_ref()
+    }
+
+    /// Resolve identity: pair these contents with `name`, the stem of
+    /// the file they were read from. Any declared `name` is discarded.
+    #[must_use]
+    pub fn into_loadout(self, name: LoadoutName) -> Loadout {
+        Loadout { name, file: self }
+    }
+}
+
+/// A loadout: a file's contents plus the identity taken from its
+/// filename.
+#[derive(Clone, Debug)]
+pub struct Loadout {
+    /// Identifier — user-facing, used in selection and error messages.
+    /// Assigned by the loader from the filename stem, so it is
+    /// authoritative over any `name` the file itself declared.
+    name: LoadoutName,
+    /// Everything the file declared.
+    file: LoadoutFile,
+}
+
+/// Serializing a [`Loadout`] emits the resolved name in the `name`
+/// field, so the output round-trips back through [`Loadout`]'s own
+/// [`Deserialize`](serde::Deserialize) impl.
+impl serde::Serialize for Loadout {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut file = self.file.clone();
+        file.name = Some(self.name.clone());
+        file.serialize(serializer)
+    }
+}
+
+/// Deserializing a [`Loadout`] *does* require a `name` field: this is
+/// the path for loadouts defined in-repo (the `min` CLI's built-in
+/// `default`) and in tests, where there is no file to take a name
+/// from. Loadouts read from disk go through [`LoadoutFile`] instead
+/// and are named after their file.
+impl<'de> serde::Deserialize<'de> for Loadout {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let file = LoadoutFile::deserialize(deserializer)?;
+        let name = file
+            .name
+            .clone()
+            .ok_or_else(|| serde::de::Error::missing_field("name"))?;
+        Ok(file.into_loadout(name))
+    }
+}
+
 impl Loadout {
     /// Construct a loadout with a pre-validated name. Build it up via
     /// the additive `with_*` methods:
@@ -111,25 +181,14 @@ impl Loadout {
     /// ```
     #[must_use]
     pub fn new(name: LoadoutName) -> Self {
-        Self {
-            name,
-            description: None,
-            packages: Vec::new(),
-            vars: BTreeMap::new(),
-            vars_lenient: Vec::new(),
-            patches: Patches::empty(),
-            lifecycle_hooks: Vec::new(),
-            follow_symlinks: None,
-        }
+        LoadoutFile::default().into_loadout(name)
     }
 
     /// Set a free-form description.
     #[must_use]
-    pub fn with_description(self, description: impl Into<String>) -> Self {
-        Self {
-            description: Some(description.into()),
-            ..self
-        }
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.file.description = Some(description.into());
+        self
     }
 
     /// The loadout's identifier.
@@ -141,14 +200,14 @@ impl Loadout {
     /// The loadout's free-form description, if any.
     #[must_use]
     pub fn description(&self) -> Option<&str> {
-        self.description.as_deref()
+        self.file.description.as_deref()
     }
 
     /// Append a package dependency.
     #[must_use]
     pub fn with_package(self, package: impl Into<String>) -> Self {
         let mut new = self;
-        new.packages.push(package.into());
+        new.file.packages.push(package.into());
         new
     }
 
@@ -158,7 +217,7 @@ impl Loadout {
     #[must_use]
     pub fn with_var(self, name: StrictVarName, value: VarValue) -> Self {
         let mut new = self;
-        new.vars.insert(name, value);
+        new.file.vars.insert(name, value);
         new
     }
 
@@ -166,14 +225,14 @@ impl Loadout {
     #[must_use]
     pub fn with_var_lenient(self, entry: LenientVarEntry) -> Self {
         let mut new = self;
-        new.vars_lenient.push(entry);
+        new.file.vars_lenient.push(entry);
         new
     }
 
     /// Append a patch.
     #[must_use]
     pub fn with_patch(mut self, patch: Patch) -> Self {
-        self.patches.push(patch);
+        self.file.patches.push(patch);
         self
     }
 
@@ -181,7 +240,7 @@ impl Loadout {
     #[must_use]
     pub fn with_lifecycle_hook(self, hook: LifecycleHook) -> Self {
         let mut new = self;
-        new.lifecycle_hooks.push(hook);
+        new.file.lifecycle_hooks.push(hook);
         new
     }
 
@@ -196,7 +255,7 @@ impl Loadout {
     /// never saw the original command line.
     #[must_use]
     pub fn without_lifecycle_hooks(mut self) -> Self {
-        self.lifecycle_hooks.clear();
+        self.file.lifecycle_hooks.clear();
         self
     }
 
@@ -204,7 +263,7 @@ impl Loadout {
     /// this loadout's patches.
     #[must_use]
     pub fn with_follow_symlinks(mut self, v: bool) -> Self {
-        self.follow_symlinks = Some(v);
+        self.file.follow_symlinks = Some(v);
         self
     }
 
@@ -215,25 +274,25 @@ impl Loadout {
     /// [`ComposeOptions::follow_symlinks`]: crate::core::compose::ComposeOptions::follow_symlinks
     #[must_use]
     pub fn follow_symlinks(&self) -> Option<bool> {
-        self.follow_symlinks
+        self.file.follow_symlinks
     }
 
     /// Packages this loadout requires.
     #[must_use]
     pub fn packages(&self) -> &[String] {
-        &self.packages
+        &self.file.packages
     }
 
     /// Variables with POSIX-shaped names (raw wire-form accessor).
     #[must_use]
     pub fn vars(&self) -> &BTreeMap<StrictVarName, VarValue> {
-        &self.vars
+        &self.file.vars
     }
 
     /// Variables with Linux-permissive names (raw wire-form accessor).
     #[must_use]
     pub fn vars_lenient(&self) -> &[LenientVarEntry] {
-        &self.vars_lenient
+        &self.file.vars_lenient
     }
 
     /// Iterate over every variable this loadout declares — strict and
@@ -249,10 +308,12 @@ impl Loadout {
     /// the underlying [`BTreeMap`]), then lenient (in declaration order).
     pub fn all_vars(&self) -> impl Iterator<Item = (VarName, &VarValue)> {
         let strict = self
+            .file
             .vars
             .iter()
             .map(|(n, v)| (VarName::Strict(n.clone()), v));
         let lenient = self
+            .file
             .vars_lenient
             .iter()
             .map(|e| (VarName::Lenient(e.name().clone()), e.value()));
@@ -262,13 +323,13 @@ impl Loadout {
     /// Patches contributed by this loadout.
     #[must_use]
     pub fn patches(&self) -> &Patches {
-        &self.patches
+        &self.file.patches
     }
 
     /// Lifecycle hooks attached to this loadout.
     #[must_use]
     pub fn lifecycle_hooks(&self) -> &[LifecycleHook] {
-        &self.lifecycle_hooks
+        &self.file.lifecycle_hooks
     }
 }
 
@@ -312,7 +373,7 @@ impl crate::core::compose::Composable for Loadout {
         // shouldn't fail activation just because the host doesn't
         // set them.
         let mut contribution = crate::core::compose::Contribution::new();
-        for (name, value) in self.vars {
+        for (name, value) in self.file.vars {
             if let Some(resolved) =
                 resolve_var_declaration(&loadout_name, name.as_ref(), value, env)?
             {
@@ -327,7 +388,7 @@ impl crate::core::compose::Composable for Loadout {
                 ));
             }
         }
-        for entry in self.vars_lenient {
+        for entry in self.file.vars_lenient {
             let (name, value) = entry.into_parts();
             if let Some(resolved) =
                 resolve_var_declaration(&loadout_name, name.as_ref(), value, env)?
@@ -350,11 +411,11 @@ impl crate::core::compose::Composable for Loadout {
         // helper's var loop is a no-op.
         let mut rest = crate::core::compose::contribute_primitives(
             &source,
-            self.packages,
+            self.file.packages,
             std::collections::BTreeMap::new(),
             Vec::new(),
-            self.patches,
-            self.lifecycle_hooks,
+            self.file.patches,
+            self.file.lifecycle_hooks,
             env,
         )?;
         contribution.merge(std::mem::take(&mut rest)).ok();
@@ -364,7 +425,7 @@ impl crate::core::compose::Composable for Loadout {
         // inherit `ComposeOptions::follow_symlinks` at expand time.
         // `Some(v)` overrides the default for this loadout's patches
         // specifically.
-        if let Some(follow) = self.follow_symlinks {
+        if let Some(follow) = self.file.follow_symlinks {
             contribution.set_follow_symlinks_on_patches(Some(follow));
         }
         Ok(contribution)
@@ -543,6 +604,37 @@ mod tests {
         let collected: Vec<_> = l.all_vars().collect();
         assert!(matches!(collected[0].0, VarName::Strict(_)));
         assert!(matches!(collected[1].0, VarName::Lenient(_)));
+    }
+
+    /// A loadout file carries no identity of its own: it parses
+    /// without a `name` field, and takes the name it is given.
+    #[test]
+    fn loadout_file_takes_the_name_it_is_given() {
+        let file: LoadoutFile = toml::from_str(r#"packages = ["helix"]"#).unwrap();
+        assert_eq!(file.declared_name(), None);
+        let l = file.into_loadout(LoadoutName::try_new("dev").unwrap());
+        assert_eq!(l.name().as_ref(), "dev");
+        assert_eq!(l.packages(), &["helix"]);
+    }
+
+    /// A file that still declares a `name` parses — the field is
+    /// readable so the loader can warn about it — but the name it
+    /// declares loses to the one `into_loadout` assigns.
+    #[test]
+    fn declared_name_is_readable_but_never_wins() {
+        let file: LoadoutFile = toml::from_str(r#"name = "stale""#).unwrap();
+        assert_eq!(file.declared_name().unwrap().as_ref(), "stale");
+        let l = file.into_loadout(LoadoutName::try_new("dev").unwrap());
+        assert_eq!(l.name().as_ref(), "dev");
+    }
+
+    /// `Loadout`'s own `Deserialize` — the in-repo path, with no file
+    /// to be named after — still requires the `name` field.
+    #[test]
+    fn loadout_deserialize_requires_a_name() {
+        let err = toml::from_str::<Loadout>(r#"packages = ["helix"]"#)
+            .expect_err("a nameless Loadout has no identity");
+        assert!(err.to_string().contains("name"), "got: {err}");
     }
 
     #[test]

--- a/docs/concepts/loadouts.md
+++ b/docs/concepts/loadouts.md
@@ -56,9 +56,9 @@ directories. The global `--config-dir` flag overrides the base directory when
 you need a non-default location.
 
 The filename stem is the loadout's identifier. A file named `dev.toml`
-defines the loadout `dev`, and its `name` field inside the file must match
-that stem. The directory is not created for you: make it and drop
-`<name>.toml` files in to get started.
+defines the loadout `dev` — nothing inside the file names it, so renaming
+the file renames the loadout. The directory is not created for you: make it
+and drop `<name>.toml` files in to get started.
 
 ## What a loadout carries
 
@@ -140,7 +140,6 @@ Putting the pieces together, a loadout that sets up the helix editor and the
 zellij multiplexer with your dotfiles looks like this:
 
 ```toml
-name        = "dev"
 description = "helix + zellij with my dotfiles"
 packages    = ["helix", "zellij"]
 
@@ -238,7 +237,7 @@ loadouts directory other than the default.
 ## Where to go next
 
 - The [loadout reference](../reference/loadouts.md) has the full TOML schema
-  for every field (`name`, `packages`, `[vars]`, `patches`,
+  for every field (`description`, `packages`, `[vars]`, `patches`,
   `[[lifecycle_hooks]]`, and the rest), the client config keys, and the exact
   composition and conflict rules.
 - [Sessions](./sessions.md) explains the session model that loadouts layer

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -33,11 +33,14 @@ consistency with Minimal's state and cache dirs. The global
 
 The filename stem **is** the loadout's identifier:
 
-- It must match the `name` field declared inside the file, or loading fails
-  with a `NameMismatch` error naming both the file stem and the declared
-  `name`.
+- Nothing inside the file names it, so renaming the file renames the
+  loadout.
 - Names are trimmed and must be non-empty, with no `/`, `\`, or NUL
   characters.
+- A file that still carries the old `name` field loads anyway, with a
+  warning that the field is no longer required. If the declared name
+  disagrees with the filename, the warning says so and the filename wins;
+  the declared name is discarded.
 
 The directory is not created automatically; create it and drop
 `<name>.toml` files there to get started.
@@ -48,7 +51,6 @@ A loadout that brings in the helix editor and zellij multiplexer, wired up
 with the user's dotfiles:
 
 ```toml
-name        = "dev"
 description = "helix + zellij with my dotfiles"
 packages    = ["helix", "zellij"]
 
@@ -81,11 +83,16 @@ Saved as `<config>/minimal/loadouts/dev.toml`, this is applied with
 
 ### `name` - The loadout's identifier
 
-_Required_
+_Not a field. Comes from the filename_
 
-Must match the filename stem. Shown in selection and error messages.
+A loadout is identified by its filename stem — `dev.toml` is the loadout
+`dev` — which is what selection and error messages show.
+
+The field itself is obsolete. A file that still declares one loads with a
+warning that it is no longer required, and the filename is used regardless:
 
 ```toml
+# Delete this line; the file is already named `dev.toml`.
 name = "dev"
 ```
 

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -764,7 +764,6 @@ exit' E2E_PTY_ANSWER=keep python3 "$ROOT/scripts/e2e-attach-pty.py" - \
   echo "::group::lifecycle hooks: loadout-declared"
   mkdir -p "$XDG_CONFIG_HOME/minimal/loadouts"
   cat > "$XDG_CONFIG_HOME/minimal/loadouts/hookdev.toml" <<'LOADOUT'
-name = "hookdev"
 description = "e2e loadout hooks"
 
 [[lifecycle_hooks]]


### PR DESCRIPTION
fixes https://github.com/gominimal/inbox/issues/476

Summary

A loadout is now identified solely by its filename. The name field inside the file is accepted, warned about, and discarded — matching the filename or not, loading continues either way, so existing loadouts keep working. Previously a disagreement was a hard LoadError::NameMismatch.

Internals: LoadoutFile holds a file's contents unnamed; into_loadout(stem) pairs it with the filename, so Loadout still carries a non-optional name and no caller changed. Docs and fixtures drop name = ....

Testing

cargo test --workspace green (sessions 404 → 407 tests), just clippy and cargo fmt --check clean. Manually verified via min loadout list: both warnings fire, and a file declaring something-else lists as its filename.

Checklist

- [x] Docs updated if behavior changed
- [x] BREAKING CHANGE: footer present if this is a breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Loadout names are now determined by their TOML filenames.
  - The in-file `name` field is optional and no longer overrides the filename.
  - Legacy or mismatched names are accepted with warnings.

- **Bug Fixes**
  - Improved validation and error reporting for malformed loadout files.
  - Loadout listings now handle legacy name discrepancies without failing.

- **Documentation**
  - Updated loadout examples and schema references to reflect filename-based naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->