### PR TITLE
feat(rcache,mfile): fold closure reads into auto — sealed catalog first

### DIFF
--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -624,8 +624,11 @@ pub struct CacheSettings {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum IndexSourceMode {
-    /// The upstream pin's per-commit index snapshot when it exists, falling
-    /// back to the global root index when it doesn't.
+    /// Per pinned chain link (upstream + each pinned sideload), the first
+    /// available of: the sealed per-commit *closure* (the curated, bounded
+    /// catalog), then the per-commit byte-copy snapshot, then — for the
+    /// upstream only — the global root index. Falls back to the root index
+    /// outright when there is no git upstream or no locked commit.
     Auto,
     /// The per-commit snapshot only; a missing snapshot is an error.
     Pinned,
@@ -679,6 +682,25 @@ pub enum CacheConfig {
         upstream: String,
         sideloads: Vec<String>,
     },
+    /// The `auto` chain: per pinned link, try the sealed closure first,
+    /// then the byte-copy snapshot; the upstream additionally falls back
+    /// to the root index (each hop logged — the byte-copy is the
+    /// UNCURATED copy of the root at publish time, so reading it should
+    /// leave a trace; see the 2026-08-17 dangling-index incident).
+    /// Sideload links that resolve nothing are skipped best-effort.
+    AutoChain {
+        upstream: ChainLink,
+        sideloads: Vec<ChainLink>,
+    },
+}
+
+/// One pinned chain link's candidate index objects, most-curated first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainLink {
+    /// `<repo>/<commit>.closure.shisha` — the sealed, bounded catalog.
+    pub closure: String,
+    /// `<repo>/<commit>.shisha` — the byte-copy of the root at publish.
+    pub snapshot: String,
 }
 
 /// Object key of the per-commit index snapshot for a repo + commit:
@@ -1154,7 +1176,42 @@ impl File {
 
         match (mode, snapshot) {
             (IndexSourceMode::Root, _) => Ok(CacheConfig::GlobalIndex),
-            (IndexSourceMode::Auto, Some(object)) => Ok(CacheConfig::CommitIndex { object }),
+            (IndexSourceMode::Auto, Some(_)) => {
+                // Pinned auto: the full per-link chain. `snapshot` above
+                // proves the upstream pin exists; rebuild both objects per
+                // link here (closure first — the curated catalog).
+                let u = self.upstream.as_ref().expect("pinned auto has an upstream");
+                let LinkConfig::Git {
+                    repo,
+                    locked_commit: Some(commit),
+                    ..
+                } = &u.link
+                else {
+                    unreachable!("snapshot presence implies a locked git upstream");
+                };
+                let sideloads = u
+                    .sideloads()
+                    .iter()
+                    .filter_map(|sl| match sl.link() {
+                        LinkConfig::Git {
+                            repo,
+                            locked_commit: Some(commit),
+                            ..
+                        } => Some(ChainLink {
+                            closure: commit_closure_object(repo, commit),
+                            snapshot: commit_index_object(repo, commit),
+                        }),
+                        _ => None,
+                    })
+                    .collect();
+                Ok(CacheConfig::AutoChain {
+                    upstream: ChainLink {
+                        closure: commit_closure_object(repo, commit),
+                        snapshot: commit_index_object(repo, commit),
+                    },
+                    sideloads,
+                })
+            }
             (IndexSourceMode::Auto, None) => Ok(CacheConfig::GlobalIndex),
             (IndexSourceMode::Pinned, Some(object)) => Ok(CacheConfig::CommitIndexOnly { object }),
             (IndexSourceMode::Pinned, None) => Err(
@@ -1830,11 +1887,16 @@ mod tests {
         .unwrap();
         let object = format!("github.com/gominimal/pkgs/{SHA}.shisha");
 
-        // Default is auto: snapshot with fallback.
+        // Default is auto: the per-link chain — sealed closure first, then
+        // the byte-copy snapshot, then (upstream only) the root.
         assert_eq!(
             pinned.cache_config(None).unwrap(),
-            CacheConfig::CommitIndex {
-                object: object.clone()
+            CacheConfig::AutoChain {
+                upstream: ChainLink {
+                    closure: format!("github.com/gominimal/pkgs/{SHA}.closure.shisha"),
+                    snapshot: object.clone(),
+                },
+                sideloads: vec![],
             }
         );
         // Override wins over the (unset) file setting.

--- a/crates/rcache/src/remote.rs
+++ b/crates/rcache/src/remote.rs
@@ -274,6 +274,20 @@ impl RemoteCache<AnyBackend> {
                 )
                 .await;
             }
+            mfile::CacheConfig::AutoChain {
+                upstream,
+                sideloads,
+            } => {
+                return Self::new_any_auto_chain(
+                    url,
+                    gcs_storage,
+                    index_dir,
+                    ot,
+                    upstream,
+                    sideloads,
+                )
+                .await;
+            }
         };
         if let IndexSource::Snapshot { object } = &source {
             tracing::debug!("cache index: per-commit snapshot {object}");
@@ -358,6 +372,116 @@ impl RemoteCache<AnyBackend> {
         tracing::debug!(
             "cache index: closure union ready, {} entries",
             rc.index.len()
+        );
+        Ok(rc)
+    }
+
+    /// The `auto` chain (mfile::CacheConfig::AutoChain): per pinned link,
+    /// first-available of sealed closure → byte-copy snapshot, with the
+    /// upstream additionally falling back to the root index. Every
+    /// downgrade WARNS: the closure is the curated catalog; the byte-copy
+    /// is an uncurated copy of the root at publish time (dangling or
+    /// non-sealed entries live there — see the 2026-08-17 incident), and
+    /// the root is the mutable global. Chosen sources log at info so
+    /// "which catalog did this client read" is answerable from any log.
+    async fn new_any_auto_chain(
+        url: AnyUrl,
+        gcs_storage: Option<Storage>,
+        index_dir: Option<PathBuf>,
+        ot: Option<OpTracker>,
+        upstream: &mfile::ChainLink,
+        sideloads: &[mfile::ChainLink],
+    ) -> Result<Self, Error<AnyRespError>> {
+        let fetch = |object: String| {
+            Self::new_any(
+                url.clone(),
+                gcs_storage.clone(),
+                index_dir.clone(),
+                ot.clone(),
+                IndexSource::Snapshot { object },
+            )
+        };
+
+        // Upstream: closure → byte-copy → root.
+        let (mut rc, upstream_source) = match fetch(upstream.closure.clone()).await {
+            Ok(rc) => (rc, "closure"),
+            Err(Error::SnapshotMissing { object }) => {
+                tracing::warn!(
+                    "auto chain: sealed closure {object} not published; \
+                     falling back to the byte-copy snapshot (the uncurated \
+                     copy of the root at publish time)"
+                );
+                match fetch(upstream.snapshot.clone()).await {
+                    Ok(rc) => (rc, "byte-copy"),
+                    Err(Error::SnapshotMissing { object }) => {
+                        tracing::warn!(
+                            "auto chain: byte-copy snapshot {object} not \
+                             published either; falling back to the root index"
+                        );
+                        (
+                            Self::new_any(
+                                url.clone(),
+                                gcs_storage.clone(),
+                                index_dir.clone(),
+                                ot.clone(),
+                                IndexSource::Root,
+                            )
+                            .await?,
+                            "root",
+                        )
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+            Err(e) => return Err(e),
+        };
+
+        // Sideloads: closure → byte-copy → skip (their specs resolve
+        // locally, exactly as an absent sideload closure does today).
+        let mut side_hits = 0usize;
+        let mut side_skipped = 0usize;
+        for link in sideloads {
+            let side = match fetch(link.closure.clone()).await {
+                Ok(s) => Some(s),
+                Err(Error::SnapshotMissing { .. }) => match fetch(link.snapshot.clone()).await {
+                    Ok(s) => {
+                        tracing::warn!(
+                            "auto chain: sideload closure {} not published; \
+                             using its byte-copy snapshot",
+                            link.closure
+                        );
+                        Some(s)
+                    }
+                    Err(Error::SnapshotMissing { .. }) => {
+                        tracing::info!(
+                            "auto chain: sideload {} publishes no index; \
+                             its specs resolve locally",
+                            link.closure
+                        );
+                        side_skipped += 1;
+                        None
+                    }
+                    Err(e) => return Err(e),
+                },
+                Err(e) => return Err(e),
+            };
+            if let Some(s) = side {
+                side_hits += 1;
+                let conflicts = rc.index.merge(s.index);
+                if conflicts > 0 {
+                    tracing::warn!(
+                        "auto chain: {conflicts} conflicting entries merging {}",
+                        link.closure
+                    );
+                }
+            }
+        }
+        tracing::info!(
+            upstream = upstream_source,
+            sideloads_merged = side_hits,
+            sideloads_skipped = side_skipped,
+            entries = rc.index.len(),
+            "cache index: auto chain ready"
         );
         Ok(rc)
     }
@@ -1072,6 +1196,97 @@ mod tests {
         // Upstream entries resolve; the sideload's specs simply miss (and
         // would build locally), exactly as they do today.
         assert_eq!(rc.sha256(&spec_a), Some([0xA1; 32]));
+        assert_eq!(rc.sha256(&SpecHash::from_bytes([0x0B; 32])), None);
+    }
+
+    #[tokio::test]
+    async fn auto_chain_prefers_the_sealed_closure() {
+        const CLOSURE: &str = "github.com/gominimal/pkgs/aaaa.closure.shisha";
+        const SNAP: &str = "github.com/gominimal/pkgs/aaaa.shisha";
+        let spec = SpecHash::from_bytes([0x0A; 32]);
+        // BOTH exist with different content: the closure must win.
+        let base = serve_objects(vec![
+            (CLOSURE.to_string(), index_bytes_for(&spec, [0xC1; 32])),
+            (SNAP.to_string(), index_bytes_for(&spec, [0xB1; 32])),
+        ]);
+        let config = mfile::CacheConfig::AutoChain {
+            upstream: mfile::ChainLink {
+                closure: CLOSURE.to_string(),
+                snapshot: SNAP.to_string(),
+            },
+            sideloads: vec![],
+        };
+        let rc = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
+            .await
+            .unwrap();
+        assert_eq!(rc.sha256(&spec), Some([0xC1; 32]));
+    }
+
+    #[tokio::test]
+    async fn auto_chain_falls_back_to_byte_copy_when_closure_missing() {
+        const CLOSURE: &str = "github.com/gominimal/pkgs/aaaa.closure.shisha";
+        const SNAP: &str = "github.com/gominimal/pkgs/aaaa.shisha";
+        let spec = SpecHash::from_bytes([0x0A; 32]);
+        let base = serve_objects(vec![(SNAP.to_string(), index_bytes_for(&spec, [0xB1; 32]))]);
+        let config = mfile::CacheConfig::AutoChain {
+            upstream: mfile::ChainLink {
+                closure: CLOSURE.to_string(),
+                snapshot: SNAP.to_string(),
+            },
+            sideloads: vec![],
+        };
+        let rc = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
+            .await
+            .unwrap();
+        assert_eq!(rc.sha256(&spec), Some([0xB1; 32]));
+    }
+
+    #[tokio::test]
+    async fn auto_chain_falls_back_to_root_when_both_missing() {
+        const CLOSURE: &str = "github.com/gominimal/pkgs/aaaa.closure.shisha";
+        const SNAP: &str = "github.com/gominimal/pkgs/aaaa.shisha";
+        let spec = SpecHash::from_bytes([0x0A; 32]);
+        // Only the ROOT index exists — pre-snapshot-era pin, exactly the
+        // 2026-08-17 incident shape (JK's July-9 pin).
+        let base = serve_index(Some(index_bytes_for(&spec, [0xD1; 32])));
+        let config = mfile::CacheConfig::AutoChain {
+            upstream: mfile::ChainLink {
+                closure: CLOSURE.to_string(),
+                snapshot: SNAP.to_string(),
+            },
+            sideloads: vec![],
+        };
+        let rc = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
+            .await
+            .unwrap();
+        assert_eq!(rc.sha256(&spec), Some([0xD1; 32]));
+    }
+
+    #[tokio::test]
+    async fn auto_chain_skips_sideload_with_no_published_index() {
+        const CLOSURE: &str = "github.com/gominimal/pkgs/aaaa.closure.shisha";
+        const SNAP: &str = "github.com/gominimal/pkgs/aaaa.shisha";
+        const SIDE_CLOSURE: &str = "github.com/acme/extra/bbbb.closure.shisha";
+        const SIDE_SNAP: &str = "github.com/acme/extra/bbbb.shisha";
+        let spec = SpecHash::from_bytes([0x0A; 32]);
+        let base = serve_objects(vec![(
+            CLOSURE.to_string(),
+            index_bytes_for(&spec, [0xC1; 32]),
+        )]);
+        let config = mfile::CacheConfig::AutoChain {
+            upstream: mfile::ChainLink {
+                closure: CLOSURE.to_string(),
+                snapshot: SNAP.to_string(),
+            },
+            sideloads: vec![mfile::ChainLink {
+                closure: SIDE_CLOSURE.to_string(),
+                snapshot: SIDE_SNAP.to_string(),
+            }],
+        };
+        let rc = RemoteCache::new_any_configured(https_url(&base), None, None, None, &config)
+            .await
+            .unwrap();
+        assert_eq!(rc.sha256(&spec), Some([0xC1; 32]));
         assert_eq!(rc.sha256(&SpecHash::from_bytes([0x0B; 32])), None);
     }
 


### PR DESCRIPTION
The #870 phase-2 fold, brought forward by yesterday's dangling-index issue: `auto` for a pinned chain now reads **sealed closure → byte-copy snapshot → (upstream only) root**, per link, with every downgrade logged at `warn` and the chosen source at `info`.

## Why now — the issue made the ordering argument concrete

The July redistribution surgery deleted artifacts but left **99 dangling records** in the root index; **every byte-copy snapshot since July 9 inherited them** (they're literal copies of the root at publish time), and a client resolving those specs got an index hit on a deleted object → hard 404 (`min add claude-code`, 2026-08-17). The **sealed closure never contained those records** — it's built by the seal path, which excludes non-redistributables by policy. Closure-first means pinned clients read the *curated, bounded* catalog (~950 records) instead of an uncurated 51k-record copy of whatever root had accumulated — and per the review decision, falling down to the byte-copy **warns**, because that's exactly where junk lives.

## What changes / what doesn't

- `IndexSourceMode::Auto` + pin → new `CacheConfig::AutoChain { upstream: ChainLink, sideloads }`; `ChainLink` carries `(closure, snapshot)` objects per pinned link. Sideloads: closure → byte-copy → skip-best-effort (unchanged semantics vs `closure` mode).
- Unpinned `auto` → root, unchanged. `pinned` / `root` / `closure` modes unchanged. `MINIMAL_INDEX_SOURCE` kill-switch kept one more release per its retire-once-settled comment.
- Chosen-source observability at `info` — the promotion flagged in the #870 evidence; after yesterday, "which catalog did this client read" must be answerable from any log.

## Validation

- **Unit matrix** (mock backend, house pattern): closure-preferred-over-both-present, byte-copy fallback, root fallback, sideload-skip — plus the updated `cache_config` mode tests. 85 tests green, clippy clean.
- **Live bucket** (same harness discipline as the #870 phase-2 evidence): closure-era pin lands on the sealed closure (dangling record invisible); a prod-proven snapshot-less pin falls through to the (purged) root; and the honest boundary — **the contaminated July-9 pin still resolves the dangling record via its byte-copy**, by construction. That boundary is what **minimal#1239** (index-hit-with-missing-object → build locally) exists for; the fold and the fallback compose to fully close the issue class.

Follow-ups: fleet pass on the next release build (Phase-1 playbook), then retire the env lever; `[cache.verify]` (signature check on the closure) stays gated on the signing-identity decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic remote-cache chaining for pinned upstream sources and sideloads.
  * Cache resolution now prefers sealed closures, then byte-copy snapshots, with root indexes as a fallback.
  * Missing sideload sources are skipped when no valid cache is available.

* **Bug Fixes**
  * Improved handling of downgrades and conflicting cache entries during resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->