### PR TITLE
fix(init): use latest pkgs for upstream in min init

### DIFF
--- a/crates/op/src/project/init.rs
+++ b/crates/op/src/project/init.rs
@@ -60,6 +60,7 @@ impl ProjectOp for InitProject {
                 (origin, link, file_path)
             }
             None => {
+                env.update_checkouts()?;
                 let rev = env.checkout_branch(DEFAULT_PKGS, DEFAULT_PKGS_BRANCH)?;
                 let origin = SpecOrigin::Repo(Repo::Git {
                     url: DEFAULT_PKGS.to_string(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing project checkouts are now updated before the default packages repository is checked out when no upstream checkout is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->