### PR TITLE
fix: set TERM per attach

### DIFF
--- a/crates/minimald/src/env.rs
+++ b/crates/minimald/src/env.rs
@@ -50,6 +50,120 @@ use tokio::task::{JoinHandle, spawn_blocking};
 /// The min helper script installed at `/usr/bin/min` inside the sandbox.
 const MIN_SCRIPT: &str = include_str!("env_min_helper.sh");
 
+/// Marks a hook file as ours, so a rootfs that already carries one (zsh's
+/// global rc is a file its own package may ship) is appended to once rather
+/// than repeatedly.
+const ATTACH_ENV_HOOK_MARKER: &str = "minimal: per-attach environment";
+
+/// Directory and file name of the bash rc the session shell is started with
+/// (`--rcfile`). Not a shell-owned integration point like the others — this
+/// build of bash has no `/etc/bash.bashrc` — so the daemon names it on the
+/// shell's own argv; see [`install_attach_env_hooks`].
+const ATTACH_ENV_BASH_RC_DIR: &str = "usr/share/minimal";
+const ATTACH_ENV_BASH_RC_NAME: &str = "attach-env.bash";
+
+/// In-sandbox absolute path of that rc, for the shell's argv.
+///
+/// Read only by the real launcher (`cfg(not(test))`); the mock launcher runs
+/// its own program, so tolerate it being unread under `test`.
+#[cfg_attr(test, allow(dead_code))]
+pub(crate) const ATTACH_ENV_BASH_RC: &str =
+    constcat::concat!("/", ATTACH_ENV_BASH_RC_DIR, "/", ATTACH_ENV_BASH_RC_NAME);
+
+/// File name of the POSIX fallback, installed beside the bash rc.
+const ATTACH_ENV_POSIX_NAME: &str = "attach-env-posix.sh";
+
+/// In-sandbox absolute path of the POSIX fallback, named by `$ENV`.
+///
+/// `$ENV` is the one hook POSIX defines: an interactive shell expands it and
+/// sources that file at startup. dash, the BusyBox and BSD ashes, ksh, and
+/// mksh all honour it (bash only in POSIX mode, which is why bash has its own
+/// rc instead).
+///
+/// It buys startup, not refresh: POSIX has no per-prompt or per-command hook,
+/// and none can be synthesized — `PS1` expansion cannot mutate the shell's own
+/// environment, since a command substitution runs in a subshell and
+/// `${var:=word}` assigns only when the variable is unset. So a POSIX shell
+/// gets the terminal that was current when it started, and a long-lived one
+/// re-syncs by sourcing `$MINIMAL_ATTACH_ENV` itself. Documented in
+/// `docs/reference/loadouts.md`.
+pub(crate) const ATTACH_ENV_POSIX: &str =
+    constcat::concat!("/", ATTACH_ENV_BASH_RC_DIR, "/", ATTACH_ENV_POSIX_NAME);
+
+/// POSIX shells: no function, no hook, no trap — just read the published
+/// file, if it is there. Sourced once, at shell startup, via `$ENV`.
+///
+/// Deliberately silent and side-effect free: `$ENV` is read by every
+/// interactive POSIX shell in the session (and by some ksh builds for
+/// non-interactive ones too), so anything that printed or failed here would
+/// surface in places that have nothing to do with a terminal.
+const ATTACH_ENV_HOOK_POSIX: &str = constcat::concat!(
+    "# ",
+    ATTACH_ENV_HOOK_MARKER,
+    "\n[ -r ",
+    crate::session_host::ATTACH_ENV_SH,
+    " ] && . ",
+    crate::session_host::ATTACH_ENV_SH,
+    "\n: \n",
+);
+
+/// bash: a `DEBUG` trap rather than `PROMPT_COMMAND`.
+///
+/// `PROMPT_COMMAND` is an environment variable, so a composed one replaces
+/// ours and the MOTD recipe this project documented for years ends in
+/// `unset PROMPT_COMMAND` — either would silently stop the refresh. A trap is
+/// shell state, not environment, so nothing a loadout sets can reach it.
+const ATTACH_ENV_HOOK_BASH: &str = constcat::concat!(
+    "# ",
+    ATTACH_ENV_HOOK_MARKER,
+    "\n__minimal_attach_env() {\n    [ -r ",
+    crate::session_host::ATTACH_ENV_SH,
+    " ] && . ",
+    crate::session_host::ATTACH_ENV_SH,
+    "\n    return 0\n}\ntrap '__minimal_attach_env' DEBUG\n",
+);
+
+/// zsh: `precmd`, its per-prompt hook. Installed into the global rc, so it
+/// runs before any user `~/.zshrc`, which cannot unset a hook it never saw.
+const ATTACH_ENV_HOOK_ZSH: &str = constcat::concat!(
+    "# ",
+    ATTACH_ENV_HOOK_MARKER,
+    "\nautoload -Uz add-zsh-hook\n__minimal_attach_env() {\n    [ -r ",
+    crate::session_host::ATTACH_ENV_SH,
+    " ] && . ",
+    crate::session_host::ATTACH_ENV_SH,
+    "\n}\nadd-zsh-hook precmd __minimal_attach_env\nadd-zsh-hook preexec __minimal_attach_env\n",
+);
+
+/// fish: its own syntax, from `vendor_conf.d` — the directory fish reserves
+/// for exactly this kind of integration.
+const ATTACH_ENV_HOOK_FISH: &str = constcat::concat!(
+    "# ",
+    ATTACH_ENV_HOOK_MARKER,
+    "\nfunction __minimal_attach_env --on-event fish_prompt\n    test -r ",
+    crate::session_host::ATTACH_ENV_FISH,
+    "\n    and source ",
+    crate::session_host::ATTACH_ENV_FISH,
+    "\nend\nfunction __minimal_attach_env_preexec --on-event fish_preexec\n    test -r ",
+    crate::session_host::ATTACH_ENV_FISH,
+    "\n    and source ",
+    crate::session_host::ATTACH_ENV_FISH,
+    "\nend\n",
+);
+
+/// nushell: the JSON form, from a vendor autoload dir. Nu cannot `source` a
+/// path it does not know at parse time, and a literal path that is missing is
+/// a parse error rather than a skipped file, so it reads data instead.
+const ATTACH_ENV_HOOK_NU: &str = constcat::concat!(
+    "# ",
+    ATTACH_ENV_HOOK_MARKER,
+    "\n$env.config.hooks.pre_prompt ++= [{||\n    let p = \"",
+    crate::session_host::ATTACH_ENV_JSON,
+    "\"\n    if ($p | path exists) { load-env (open $p) }\n}]\n$env.config.hooks.pre_execution ++= [{||\n    let p = \"",
+    crate::session_host::ATTACH_ENV_JSON,
+    "\"\n    if ($p | path exists) { load-env (open $p) }\n}]\n",
+);
+
 /// Where the session's workspace appears *inside* the sandbox. The daemon sees
 /// the same directory at [`SessionChannel::working`], so this is the prefix
 /// that translates a path typed in the sandbox into one the daemon can write.
@@ -497,13 +611,84 @@ fn sandbox_err_to_io(e: sandbox2::Error) -> std::io::Error {
     std::io::Error::other(e.to_string())
 }
 
-/// Installs the `min` helper script and the `etc` directory into a rootfs.
+/// Installs the `min` helper script and the `etc` directory into a rootfs,
+/// along with the per-attach environment hooks ([`install_attach_env_hooks`]).
 fn install_min_helpers(rootfs: &Path) -> std::io::Result<()> {
     let usr_bin = rootfs.join("usr").join("bin");
     std::fs::create_dir_all(&usr_bin)?;
     std::fs::write(usr_bin.join("min"), MIN_SCRIPT)?;
     std::fs::set_permissions(usr_bin.join("min"), Permissions::from_mode(0o0755))?;
     std::fs::create_dir_all(rootfs.join("etc"))?;
+    install_attach_env_hooks(rootfs)?;
+    Ok(())
+}
+
+/// Installs the shell hooks that re-read the per-attach environment (`TERM`)
+/// into a rootfs.
+///
+/// These live in the *rootfs*, at each shell's own vendor/system integration
+/// point, for two reasons. They are outside the session home, which is where
+/// loadout patches land — so nothing a loadout does can collide with them or
+/// remove them. And they are installed by the daemon for every session, so no
+/// loadout or project author has to know the mechanism exists, which a
+/// composed `PROMPT_COMMAND` recipe would have required.
+///
+/// One file per shell because there is no shell-agnostic hook: each names its
+/// own events. Each installs *two* — one at the prompt and one before a
+/// command runs — because they answer different questions. The prompt hook
+/// keeps a shell that is sitting idle current; the pre-execution hook is what
+/// makes the very first command typed at a prompt drawn *before* the attach
+/// see the new terminal, rather than the value that was in force when that
+/// prompt was drawn. bash needs only the `DEBUG` trap, which already fires
+/// before every command. bash is missing here on purpose — this build has no
+/// `/etc/bash.bashrc`, so the session shell is pointed at
+/// [`ATTACH_ENV_BASH_RC`] with `--rcfile` instead (which also keeps the
+/// session from reading a user `~/.bashrc` it never read before).
+///
+/// Every hook hard-codes the file path rather than reading
+/// `$MINIMAL_ATTACH_ENV`: the variable is a convenience for anyone scripting
+/// against this, and a session whose composition happened to set it must not
+/// be able to break the refresh.
+fn install_attach_env_hooks(rootfs: &Path) -> std::io::Result<()> {
+    // (integration dir, file name, contents)
+    let hooks: [(&Path, &str, &str); 5] = [
+        (
+            Path::new(ATTACH_ENV_BASH_RC_DIR),
+            ATTACH_ENV_BASH_RC_NAME,
+            ATTACH_ENV_HOOK_BASH,
+        ),
+        (
+            Path::new(ATTACH_ENV_BASH_RC_DIR),
+            ATTACH_ENV_POSIX_NAME,
+            ATTACH_ENV_HOOK_POSIX,
+        ),
+        (Path::new("etc/zsh"), "zshrc", ATTACH_ENV_HOOK_ZSH),
+        (
+            Path::new("usr/share/fish/vendor_conf.d"),
+            "00-minimal-attach-env.fish",
+            ATTACH_ENV_HOOK_FISH,
+        ),
+        (
+            Path::new("usr/share/nushell/vendor/autoload"),
+            "00-minimal-attach-env.nu",
+            ATTACH_ENV_HOOK_NU,
+        ),
+    ];
+
+    for (dir, name, body) in hooks {
+        let dir = rootfs.join(dir);
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join(name);
+        // zsh's global rc is a file its own package may ship, so append rather
+        // than overwrite; the others are namespaced files nothing else owns.
+        // Appending is safe on a fresh rootfs and idempotent per launch, since
+        // each session composes its rootfs anew.
+        let existing = std::fs::read_to_string(&path).unwrap_or_default();
+        if existing.contains(ATTACH_ENV_HOOK_MARKER) {
+            continue;
+        }
+        std::fs::write(&path, format!("{existing}{body}"))?;
+    }
     Ok(())
 }
 
@@ -1504,6 +1689,98 @@ impl tokio::io::AsyncWrite for StreamWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every session rootfs carries the per-attach environment hook for every
+    /// shell we support, at that shell's own vendor/system integration point
+    /// — installed by the daemon, so no loadout or project author has to know
+    /// the mechanism exists, and outside the session home, so no loadout
+    /// patch can collide with one.
+    #[test]
+    fn every_session_rootfs_carries_the_attach_env_hooks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = tmp.path();
+        install_min_helpers(rootfs).unwrap();
+
+        // (path in the rootfs, a fragment only that shell's hook contains)
+        // Two hooks per shell, and the pre-execution one is the load-bearing
+        // half: the first command typed at a prompt drawn *before* the attach
+        // must already see the new terminal, which a prompt-only hook cannot
+        // do (that prompt already fired). bash's `DEBUG` trap covers both.
+        let expected = [
+            (
+                "usr/share/minimal/attach-env.bash",
+                "trap '__minimal_attach_env' DEBUG",
+            ),
+            ("etc/zsh/zshrc", "add-zsh-hook precmd __minimal_attach_env"),
+            ("etc/zsh/zshrc", "add-zsh-hook preexec __minimal_attach_env"),
+            (
+                "usr/share/fish/vendor_conf.d/00-minimal-attach-env.fish",
+                "--on-event fish_prompt",
+            ),
+            (
+                "usr/share/fish/vendor_conf.d/00-minimal-attach-env.fish",
+                "--on-event fish_preexec",
+            ),
+            (
+                "usr/share/nushell/vendor/autoload/00-minimal-attach-env.nu",
+                "$env.config.hooks.pre_prompt",
+            ),
+            (
+                "usr/share/nushell/vendor/autoload/00-minimal-attach-env.nu",
+                "$env.config.hooks.pre_execution",
+            ),
+            // The POSIX tier sources the file outright: `$ENV` fires once, at
+            // startup, and POSIX has no hook to refresh from afterwards.
+            (
+                "usr/share/minimal/attach-env-posix.sh",
+                "/home/.local/state/minimal/attach-env.sh",
+            ),
+        ];
+        for (rel, fragment) in expected {
+            let body = std::fs::read_to_string(rootfs.join(rel))
+                .unwrap_or_else(|e| panic!("{rel} should be installed: {e}"));
+            assert!(body.contains(fragment), "{rel} is missing its hook: {body}");
+            // Each reads the published file by absolute path rather than
+            // through `$MINIMAL_ATTACH_ENV`, so a composed variable of that
+            // name cannot redirect or break the refresh.
+            assert!(
+                body.contains(crate::session_host::ATTACH_ENV_SH)
+                    || body.contains(crate::session_host::ATTACH_ENV_FISH)
+                    || body.contains(crate::session_host::ATTACH_ENV_JSON),
+                "{rel} should hard-code the published path: {body}"
+            );
+            assert!(
+                !body.contains("$MINIMAL_ATTACH_ENV"),
+                "{rel} must not depend on a composed variable: {body}"
+            );
+        }
+    }
+
+    /// A rootfs whose own packages ship a global zsh rc keeps it: the hook is
+    /// appended, and appending is idempotent across launches.
+    #[test]
+    fn installing_hooks_appends_to_a_shipped_zshrc_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = tmp.path();
+        std::fs::create_dir_all(rootfs.join("etc/zsh")).unwrap();
+        std::fs::write(
+            rootfs.join("etc/zsh/zshrc"),
+            "# shipped by the zsh package\n",
+        )
+        .unwrap();
+
+        install_min_helpers(rootfs).unwrap();
+        install_min_helpers(rootfs).unwrap();
+
+        let body = std::fs::read_to_string(rootfs.join("etc/zsh/zshrc")).unwrap();
+        assert!(body.contains("# shipped by the zsh package"), "{body}");
+        assert_eq!(
+            body.matches("add-zsh-hook precmd __minimal_attach_env")
+                .count(),
+            1,
+            "the hook should be appended exactly once: {body}"
+        );
+    }
     use camino::Utf8PathBuf;
     use mctx::ConfigBuilder;
     use std::io::{BufRead, BufReader};

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -651,6 +651,34 @@ pub struct Session {
     /// we spawns (e.g. build [`SideOp`]s) so they can reach back into
     /// the session.
     weak_self: WeakSessionHandle,
+
+    /// What brought the currently held host up, which decides whether an
+    /// interactive attach may respawn it. See [`HostOrigin`].
+    host_origin: HostOrigin,
+}
+
+/// Why a session host was launched.
+///
+/// The sandbox and the interactive shell are one spawn — the shell *is* the
+/// sandbox's session leader — so a launch that only wanted the sandbox still
+/// creates the shell a user may later attach to, and that shell's `environ`
+/// is fixed for its lifetime. This records which case a live host is in, so
+/// an attach can tell "the shell was made for a terminal" from "the shell was
+/// made for a hook, and no terminal has ever described itself to it".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostOrigin {
+    /// Minted by an attach, from a client with a PTY. Its environment already
+    /// describes a terminal.
+    Interactive,
+    /// Minted by [`Session::launch_host_for_hooks`] to run lifecycle hooks.
+    /// Nothing of the user's runs in it: activation hooks have completed by
+    /// the time an attach can arrive, so the shell is safe to replace.
+    Hooks,
+    /// Minted by [`Session::ensure_host`] to serve an exec. The command is
+    /// live inside that sandbox, so replacing the shell would kill it — this
+    /// one is never respawned, and the attaching terminal's facts reach it
+    /// through the per-attach environment instead.
+    Exec,
 }
 
 impl Session {
@@ -686,6 +714,10 @@ impl Session {
             hook_scripts_upload_lock: Arc::new(Mutex::new(())),
             manager,
             weak_self,
+            // No host yet; the first launch sets this. `Interactive` is the
+            // conservative default — it is the one value that never licenses
+            // a respawn.
+            host_origin: HostOrigin::Interactive,
             #[cfg(target_os = "linux")]
             hostnames,
         }
@@ -1577,10 +1609,25 @@ impl Session {
         let attach_env = {
             let inherited = inherited_session_env(&config.env_vars);
             let mut connection = Vec::new();
-            if let Some(pty) = config.pty.as_ref()
-                && !pty.term.is_empty()
-            {
-                connection.push(("TERM".to_string(), pty.term.clone()));
+            match config.pty.as_ref().map(|pty| pty.term.as_str()) {
+                Some(term) if !term.is_empty() => {
+                    tracing::info!(term, "attach carries a terminal");
+                    connection.push(("TERM".to_string(), term.to_string()));
+                }
+                // The client had nothing to say about its terminal — OpenSSH
+                // sends an empty pty-req term string when its own `TERM` is
+                // unset. The session keeps whatever the last attach published,
+                // which is right (an absent value is not an assertion that
+                // there is no terminal) but indistinguishable from "nothing
+                // changed" unless it is said out loud. Logged because the
+                // silence here has already cost one debugging session: the
+                // symptom is a session whose `TERM` never follows the client,
+                // and this line is the difference between reading it off and
+                // guessing at it.
+                _ => tracing::info!(
+                    "attach carries no terminal (client sent an empty pty-req term); \
+                     keeping the last published TERM"
+                ),
             }
             session_host::AttachEnv {
                 inherited,
@@ -1671,6 +1718,31 @@ impl Session {
             }
         }
 
+        // A host minted to run hooks has an environment that describes no
+        // terminal, because there was none — and the shell's `environ` cannot
+        // be revised in place. Nothing of the user's is running in it (the
+        // activation hooks it was launched for have completed by the time an
+        // attach can arrive), so replace it with one minted for the terminal
+        // that is actually here. An `Exec`-minted host is deliberately not
+        // replaced: a command is live inside that sandbox, and killing it to
+        // improve `TERM` is a bad trade. That case rides on the per-attach
+        // environment the host republishes instead.
+        let respawn_for_terminal =
+            self.host_origin == HostOrigin::Hooks && !attach_env.connection.is_empty();
+        if respawn_for_terminal
+            && let SessionInner::Active {
+                host: slot @ Some(_),
+                ..
+            } = &mut self.inner
+        {
+            tracing::info!(
+                "replacing the hook-launched session shell with one minted for the attaching terminal"
+            );
+            let (handle, join) = slot.take().expect("matched on Some");
+            let _ = handle.kill(false).await;
+            let _ = join.await;
+        }
+
         let host = match &mut self.inner {
             // Awaiting a verdict: a client is mid create flow, and composing
             // over it here would discard the items it is still gating.
@@ -1683,7 +1755,10 @@ impl Session {
                     .await
             }
             Some((h, _)) => {
-                match h.attach(channel, sz).await {
+                // Every attach carries the connection facts, not just the one
+                // that mints the shell: `TERM` describes whichever terminal is
+                // on the other end of *this* channel.
+                match h.attach(channel, sz, attach_env.connection_env()).await {
                     Ok(()) => Ok(()),
                     Err((channel, sz)) => {
                         // session host is dead
@@ -1716,6 +1791,11 @@ impl Session {
     ) -> Result<(Option<Channel<Msg>>, LaunchedHost), AttachError> {
         let record = self.record.record().await.unwrap();
         let paths = self.paths().await;
+        // Kept before the launcher consumes `attach_env`: the launch folds
+        // these into the shell's environment, and the host keeps them so it
+        // can layer them onto everything it later runs in the session and
+        // republish them for the shell to re-read.
+        let connection_env = attach_env.connection_env();
         let launcher = self
             .session_launcher(session_hnd, &record, attach_env, phase)
             .await?;
@@ -1755,6 +1835,7 @@ impl Session {
             // The host runs attach and detach itself: it owns the terminal
             // they write to and the process whose namespaces they join.
             self.composition(),
+            connection_env,
         ));
 
         let (channel, spawned) = match progress {
@@ -1859,6 +1940,13 @@ impl Session {
             SessionInner::Active { .. } => None,
         };
         if let Some(host) = running {
+            // Same claim as the launch below, for a host this call did not
+            // mint: an exec is about to run in this sandbox, so a later
+            // attach must not replace the shell out from under it. Without
+            // this, a host minted for lifecycle hooks stays `Hooks` through
+            // every exec that reuses it, and the first interactive attach
+            // would respawn it — killing a command that is still running.
+            self.host_origin = HostOrigin::Exec;
             return Ok(host);
         }
 
@@ -1878,6 +1966,9 @@ impl Session {
             unreachable!("ensure_host returns early on a Draft session");
         };
         *slot = Some(launched);
+        // Minted for an exec: a command is about to run in this sandbox, so a
+        // later attach must not replace it. See [`HostOrigin::Exec`].
+        self.host_origin = HostOrigin::Exec;
         Ok(host)
     }
 
@@ -1906,15 +1997,26 @@ impl Session {
         // the host died in the window between launch and attach; surface it as
         // a spawn failure rather than leaving a dead, channel-less host — which
         // is why the host is stored only once it is bound.
-        launched.0.attach(channel, sz).await.map_err(|_| {
-            AttachError::SpawnFailed(std::io::Error::other(
-                "session host exited before its channel could attach",
-            ))
-        })?;
+        //
+        // The launch already folded this attach's connection facts into the
+        // shell's environment, so nothing new is passed here: the host holds
+        // them, and an empty map means "no revision", not "no terminal".
+        launched
+            .0
+            .attach(channel, sz, session_host::ConnectionEnv::new())
+            .await
+            .map_err(|_| {
+                AttachError::SpawnFailed(std::io::Error::other(
+                    "session host exited before its channel could attach",
+                ))
+            })?;
         let SessionInner::Active { host, .. } = &mut self.inner else {
             unreachable!("mint_session_host is only reachable from the Active state");
         };
         *host = Some(launched);
+        // Minted by an attach: its environment describes the terminal that is
+        // here, so nothing may replace it out from under that client.
+        self.host_origin = HostOrigin::Interactive;
         Ok(())
     }
 
@@ -2053,6 +2155,10 @@ impl Session {
             unreachable!("a headless hook launch only reaches here from the Active state");
         };
         *host = Some(launched);
+        // Minted for hooks, with no terminal to describe: an interactive
+        // attach may replace this shell rather than inherit its blank `TERM`.
+        // See [`HostOrigin::Hooks`].
+        self.host_origin = HostOrigin::Hooks;
         Ok(())
     }
 
@@ -4032,6 +4138,149 @@ mod tests {
             record_status(&mut client, session_id).await,
             Some(sessions::SessionStatus::Active),
             "a session whose activate hook succeeded should be attachable",
+        );
+    }
+
+    /// The POSIX form of the per-attach environment the host republishes into
+    /// the session's home. Empty when nothing has been published yet.
+    async fn published_attach_env(server: &TestServer, session_id: SessionId) -> String {
+        let paths = session_paths(server, session_id).await;
+        let path = paths
+            .home
+            .sub_path_unchecked(".local/state/minimal/attach-env.sh");
+        tokio::fs::read_to_string(path.as_str())
+            .await
+            .unwrap_or_default()
+    }
+
+    /// An attach publishes the terminal it arrived from, so the session shell
+    /// can pick it up at its next prompt.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn attach_publishes_the_terminal_it_arrived_from() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        let mut channel = client
+            .open_shell_with_term(session_id, "xterm-256color")
+            .await;
+        await_echo(&mut channel).await;
+
+        let published = published_attach_env(&server, session_id).await;
+        assert!(
+            published.contains("export TERM='xterm-256color'"),
+            "the attaching terminal should be published; got: {published:?}"
+        );
+    }
+
+    /// `TERM` is a per-attach fact, not a per-shell one: a client attaching
+    /// from a different terminal than the one that minted the shell gets its
+    /// own terminal described, not the previous client's.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reattaching_from_another_terminal_republishes_term() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        let mut first = client.open_shell_with_term(session_id, "xterm").await;
+        await_echo(&mut first).await;
+        assert!(
+            published_attach_env(&server, session_id)
+                .await
+                .contains("export TERM='xterm'")
+        );
+
+        // Same session, same shell — a different terminal.
+        let mut second = client.open_shell_with_term(session_id, "wezterm").await;
+        await_echo(&mut second).await;
+
+        let published = published_attach_env(&server, session_id).await;
+        assert!(
+            published.contains("export TERM='wezterm'"),
+            "a re-attach must republish, not keep the minting terminal's TERM; \
+             got: {published:?}"
+        );
+    }
+
+    /// A client that says nothing about its terminal — OpenSSH sends an empty
+    /// pty-req term string when its own `TERM` is unset — leaves the last
+    /// published value standing rather than clearing it. An absent value is
+    /// not an assertion that there is no terminal, and a session that had a
+    /// good `TERM` must not lose it to a client that could not describe one.
+    ///
+    /// This is the case `Session::attach` logs, because on the wire it looks
+    /// exactly like "nothing changed".
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn an_attach_with_no_terminal_keeps_the_last_published_one() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = create_session(&mut client).await;
+
+        let mut first = client.open_shell_with_term(session_id, "wezterm").await;
+        await_echo(&mut first).await;
+        assert!(
+            published_attach_env(&server, session_id)
+                .await
+                .contains("export TERM='wezterm'")
+        );
+
+        // Same session, a client with no terminal to declare.
+        let mut second = client.open_shell_with_term(session_id, "").await;
+        await_echo(&mut second).await;
+
+        let published = published_attach_env(&server, session_id).await;
+        assert!(
+            published.contains("export TERM='wezterm'"),
+            "an attach with no terminal must not clear the last one; got: {published:?}"
+        );
+    }
+
+    /// Regression: a session shell minted headlessly — by the activation
+    /// hooks, with no terminal anywhere in the picture — used to keep that
+    /// terminal-less environment for the session's whole life, because
+    /// `TERM` was applied only when the shell was *minted* and every later
+    /// attach reused the shell. A session whose loadout declared an
+    /// `on_activate` hook therefore ran with no `TERM` at all, and `less`
+    /// in it fell back to ncurses' generic `unknown` entry
+    /// (`'unknown': I need something more specific.`).
+    ///
+    /// The attaching terminal must win over a shell that was minted without
+    /// one.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_hook_launched_shell_takes_the_attaching_terminals_term() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("activated");
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = session_with_hook(
+            &mut client,
+            "hook-then-attach",
+            sessions::wire::primitives::WireLifecycleHook {
+                on_activate: Some(inline(marker_body(&marker))),
+                ..Default::default()
+            },
+        )
+        .await;
+        assert!(
+            marker.exists(),
+            "the activate hook should have brought a host up headlessly"
+        );
+        assert!(
+            published_attach_env(&server, session_id).await.is_empty(),
+            "a headless launch has no terminal to describe"
+        );
+
+        let mut channel = client
+            .open_shell_with_term(session_id, "xterm-256color")
+            .await;
+        await_echo(&mut channel).await;
+
+        let published = published_attach_env(&server, session_id).await;
+        assert!(
+            published.contains("export TERM='xterm-256color'"),
+            "a hook-launched shell must still take the attaching terminal's \
+             TERM; got: {published:?}"
         );
     }
 

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -974,7 +974,10 @@ pub(crate) struct Launched<P, G> {
 /// Actor messages to a [`Host`].
 enum Message {
     Kill(bool),
-    Attach(Channel<Msg>, WinSize),
+    /// Bind a client channel to this host. The [`ConnectionEnv`] rides along
+    /// on every attach — not just the one that minted the host — because it
+    /// describes the terminal on the other end of *this* channel.
+    Attach(Channel<Msg>, WinSize, ConnectionEnv),
     GetAttrs(oneshot::Sender<HostAttrs>),
     /// Compute the workspace's at-risk report (VCS-exact when the tree is a
     /// git repository, the changed-since-activation delta otherwise) and
@@ -1139,14 +1142,24 @@ impl HostHandle {
             Err(_e) => Err(()), // closed
         }
     }
+    /// Binds `c` to this host, carrying the attaching terminal's facts.
+    ///
+    /// `connection` is applied on every attach, so a client attaching from a
+    /// different terminal than the one that minted the shell updates `TERM`
+    /// for everything the session spawns from here on. An empty map leaves the
+    /// last known facts in place rather than clearing them: a client whose own
+    /// `TERM` is unset (OpenSSH then sends an empty pty-req term string) has
+    /// nothing to say about the terminal, which is not the same as saying
+    /// there isn't one.
     pub async fn attach(
         &self,
         c: Channel<Msg>,
         sz: WinSize,
+        connection: ConnectionEnv,
     ) -> Result<(), (Channel<Msg>, WinSize)> {
-        match self.sender.send(Message::Attach(c, sz)).await {
+        match self.sender.send(Message::Attach(c, sz, connection)).await {
             Ok(()) => Ok(()),
-            Err(SendError(Message::Attach(c, sz))) => Err((c, sz)),
+            Err(SendError(Message::Attach(c, sz, _))) => Err((c, sz)),
             Err(e) => unreachable!("{:?}", e),
         }
     }
@@ -1358,6 +1371,17 @@ pub(crate) struct Host<P: SessionProcess, G: SessionGuard> {
     // prompt's save-then-delete lane can name its archive.
     session_name: String,
 
+    /// The attached terminal's facts as of the latest attach, layered over the
+    /// session's own environment for everything this host runs in the sandbox
+    /// (`command_in_session`) and republished into the session's home so the
+    /// already-running shell can pick them up at its next prompt.
+    connection_env: ConnectionEnv,
+
+    /// Daemon-side path of the session's home directory — the same directory
+    /// the sandbox mounts at [`SESSION_HOME_ROOT`]. Held so the per-attach
+    /// environment files can be written without entering the sandbox.
+    home_dir: paths::DaemonAbsPath,
+
     // Daemon-side directory the save-then-delete lane archives into, handed
     // to each binding alongside `delta`.
     archives_dir: std::path::PathBuf,
@@ -1386,6 +1410,97 @@ struct HookPlan {
     workspace: paths::DaemonAbsPath,
     output: crate::hooks::HookOutput,
 }
+
+/// Writes the session's per-attach environment files: `env` rendered into
+/// [`ATTACH_ENV_SH_REL`], [`ATTACH_ENV_FISH_REL`], and [`ATTACH_ENV_JSON_REL`]
+/// under the session's `home` directory.
+///
+/// This is how a fact about the *current* terminal reaches a shell that was
+/// spawned for a previous one — a process's `environ` cannot be rewritten from
+/// outside, so the value is published to a file the shell re-reads, at every
+/// prompt and before every command, through the hooks `crate::env` installs
+/// into the session rootfs. Written from the daemon's side of the session home
+/// rather than through the sandbox: it is the same directory, and it works
+/// before the session has anything running to inject into.
+///
+/// Best-effort. A failure here costs a stale `TERM` in the shell, which must
+/// never be allowed to refuse an attach.
+async fn write_connection_env(home: paths::DaemonAbsPath, env: ConnectionEnv) {
+    // Nothing to say: leave whatever the last attach published in place. An
+    // attach that carries no facts is a client that couldn't describe its
+    // terminal, not a client asserting there is no terminal.
+    if env.is_empty() {
+        return;
+    }
+
+    let dir = home.sub_path_unchecked(ATTACH_ENV_DIR_REL);
+    if let Err(e) = tokio::fs::create_dir_all(dir.as_str()).await {
+        tracing::warn!(error = %e, dir = %dir, "creating the per-attach env dir");
+        return;
+    }
+
+    let mut sh = String::from("# Written by minimald on attach; edits are lost.\n");
+    let mut fish = sh.clone();
+    for (k, v) in &env {
+        // Single quotes are the only quoting both shells read literally. POSIX
+        // has no escape inside them, so a quote is closed, escaped, and
+        // reopened; fish does take a backslash escape.
+        sh.push_str(&format!("export {k}='{}'\n", v.replace('\'', r"'\''")));
+        fish.push_str(&format!(
+            "set -gx {k} '{}'\n",
+            v.replace('\\', r"\\").replace('\'', r"\'")
+        ));
+    }
+
+    // The data form. Serialized rather than hand-rendered so the escaping is
+    // the serializer's problem; a failure here is not fatal to the others.
+    let json = match serde_json_lenient::to_string_pretty(&env) {
+        Ok(j) => Some(j),
+        Err(e) => {
+            tracing::warn!(error = %e, "rendering the per-attach env as JSON");
+            None
+        }
+    };
+
+    let files = [
+        (ATTACH_ENV_SH_REL, Some(sh)),
+        (ATTACH_ENV_FISH_REL, Some(fish)),
+        (ATTACH_ENV_JSON_REL, json),
+    ];
+    for (rel, body) in files {
+        let Some(body) = body else { continue };
+        let path = home.sub_path_unchecked(rel);
+
+        // Write a sibling and rename over the destination, rather than
+        // truncating in place. A shell reads these files constantly — bash's
+        // `DEBUG` trap sources one before every command — so an in-place
+        // rewrite has a window where a reader sees a truncated file, and half
+        // an `export TERM='xterm-256co` is a syntax error on the user's
+        // terminal. `rename(2)` is atomic within a directory, and the sibling
+        // is in the same one by construction.
+        let tmp = home.sub_path_unchecked(&format!(
+            "{rel}.{}.{}.tmp",
+            std::process::id(),
+            ATTACH_ENV_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        if let Err(e) = tokio::fs::write(tmp.as_str(), body).await {
+            tracing::warn!(error = %e, path = %tmp, "writing the per-attach env file");
+            // Nothing was published, so nothing is half-written — but the
+            // sibling may exist and must not accumulate.
+            let _ = tokio::fs::remove_file(tmp.as_str()).await;
+            continue;
+        }
+        if let Err(e) = tokio::fs::rename(tmp.as_str(), path.as_str()).await {
+            tracing::warn!(error = %e, path = %path, "publishing the per-attach env file");
+            let _ = tokio::fs::remove_file(tmp.as_str()).await;
+        }
+    }
+}
+
+/// Distinguishes the temporary files [`write_connection_env`] renames into
+/// place, so two attaches publishing at once cannot pick the same sibling and
+/// clobber each other's half-written file.
+static ATTACH_ENV_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Run a snapshotted plan, warning on any hook that failed.
 ///
@@ -1502,13 +1617,17 @@ impl SessionProcess for SandboxProcess {
 const BASELINE_PACKAGES: &[&str] = &["base", "coreutils", "socat"];
 
 /// Environment folded into a session shell at the launching attach, over and
-/// above the composition. Both halves are captured from the SSH channel that
-/// mints the shell (see [`crate::session::Session::attach`]); a re-attach to an
-/// already-running shell does not revisit them.
+/// above the composition. Both halves are captured from the SSH channel the
+/// attach arrives on (see [`crate::session::Session::attach`]).
 ///
 /// The two halves sit on opposite sides of the composition in precedence:
 /// `inherited` are defaults the composition may override, `connection` are
 /// authoritative facts that override the composition.
+///
+/// `inherited` is a launch-time fact: it describes the client that *created*
+/// the shell and cannot be revised without respawning it. `connection` is a
+/// per-attach fact — see [`ConnectionEnv`] — carried on every attach, not just
+/// the one that mints the host.
 ///
 /// The fields are read only by the real [`SandboxLauncher`] (`cfg(not(test))`);
 /// the mock launcher ignores them, so tolerate them being unread under `test`.
@@ -1528,12 +1647,86 @@ pub(crate) struct AttachEnv {
     pub(crate) connection: Vec<(String, String)>,
 }
 
+impl AttachEnv {
+    /// The connection half as a map, for merging into a session environment.
+    pub(crate) fn connection_env(&self) -> ConnectionEnv {
+        self.connection.iter().cloned().collect()
+    }
+}
+
+/// The facts that describe *the terminal currently attached*, as opposed to
+/// the session's own composed environment: `TERM` today.
+///
+/// Kept apart from [`AttachEnv`] because its lifetime is different. A session
+/// shell is spawned once and lives across many attaches, so its `environ` is
+/// frozen at launch — but `TERM` describes whichever terminal is on the other
+/// end *now*, and a client attaching from a different terminal than the one
+/// that minted the shell brings a different one. The host therefore keeps the
+/// latest and republishes it on every attach ([`Host::publish_connection_env`])
+/// rather than treating it as a launch-time constant.
+pub(crate) type ConnectionEnv = std::collections::BTreeMap<String, String>;
+
+/// Where the session home lives inside the sandbox.
+///
+/// Derived from the same `sandbox2` constant the sandbox mounts it from
+/// (`crate::env::HOME_ROOT` is the same value; this module cannot use that one
+/// because `env` is `cfg(not(test))` and these paths are asserted under test).
+const SESSION_HOME_ROOT: &str = constcat::concat!("/", sandbox2::SESSION_HOME);
+
+/// Session-home-relative directory holding the per-attach environment files.
+const ATTACH_ENV_DIR_REL: &str = ".local/state/minimal";
+
+/// POSIX-shell form of the per-attach environment, sourced by the baseline
+/// [`BASELINE_PROMPT_COMMAND`] at every prompt.
+const ATTACH_ENV_SH_REL: &str = constcat::concat!(ATTACH_ENV_DIR_REL, "/attach-env.sh");
+
+/// fish form of the same file, read by the fish hook the daemon installs into
+/// the rootfs (`crate::env`). Written alongside the POSIX form because a
+/// session's shell is whatever the user runs, not only the bash the daemon
+/// spawns.
+const ATTACH_ENV_FISH_REL: &str = constcat::concat!(ATTACH_ENV_DIR_REL, "/attach-env.fish");
+
+/// The same facts as data rather than as a script, for a shell that would
+/// rather read them than evaluate them — nushell, today.
+///
+/// Nu cannot use either script form. `source` takes a *parse-time constant*
+/// path, so it can't be pointed at `$env.MINIMAL_ATTACH_ENV_JSON`; and a
+/// literal path that doesn't exist yet is a hard parse error, which would
+/// break the shell outright on a session that has published nothing. Its
+/// `load-env (open …)` reads this file instead, under a `path exists` guard.
+/// JSON also sidesteps a third set of quoting rules — the escaping is the
+/// serializer's problem, not this module's.
+///
+/// Every key here becomes an environment variable, so the file carries no
+/// metadata (not even the "generated" banner the script forms have).
+const ATTACH_ENV_JSON_REL: &str = constcat::concat!(ATTACH_ENV_DIR_REL, "/attach-env.json");
+
+/// In-sandbox absolute path of the POSIX per-attach environment file.
+pub(crate) const ATTACH_ENV_SH: &str = constcat::concat!(SESSION_HOME_ROOT, "/", ATTACH_ENV_SH_REL);
+
+/// In-sandbox absolute path of the fish per-attach environment file.
+pub(crate) const ATTACH_ENV_FISH: &str =
+    constcat::concat!(SESSION_HOME_ROOT, "/", ATTACH_ENV_FISH_REL);
+
+/// In-sandbox absolute path of the JSON per-attach environment file.
+pub(crate) const ATTACH_ENV_JSON: &str =
+    constcat::concat!(SESSION_HOME_ROOT, "/", ATTACH_ENV_JSON_REL);
+
+/// The baseline shell's per-prompt wiring, in two halves.
+///
 /// Trigger half of the launcher-baseline orientation banner: evaluates the
 /// [`BASELINE_MOTD`] payload at the first interactive prompt, then unsets
 /// both vars so the banner prints exactly once and never for
 /// non-interactive commands. Identical to the MOTD recipe the built-in
 /// `default` loadout ships and `docs/reference/loadouts.md` ("Vars in the
 /// attach shell") documents.
+///
+/// It carries nothing but the banner. The per-attach environment is refreshed
+/// by the shell hooks the daemon installs into the rootfs (`crate::env`),
+/// deliberately not from here: this variable is composed, so a loadout
+/// setting its own `PROMPT_COMMAND` would replace the refresh, and the MOTD
+/// recipe above would `unset` it — neither of which a session's `TERM` may
+/// depend on.
 const BASELINE_PROMPT_COMMAND: &str = r#"eval "$MINIMAL_MOTD"; unset PROMPT_COMMAND MINIMAL_MOTD"#;
 
 /// Absolute workspace root inside a session sandbox, `/workbench` by
@@ -1592,6 +1785,25 @@ fn session_baseline_env(
             BASELINE_PROMPT_COMMAND.to_string(),
         ),
         ("MINIMAL_MOTD".to_string(), BASELINE_MOTD.to_string()),
+        // Where the host republishes the attached terminal's facts. Named
+        // rather than hard-coded into the prompt command so a loadout that
+        // replaces `PROMPT_COMMAND` (or starts another shell) can still find
+        // the file; the fish form is offered for the same reason.
+        ("MINIMAL_ATTACH_ENV".to_string(), ATTACH_ENV_SH.to_string()),
+        (
+            "MINIMAL_ATTACH_ENV_FISH".to_string(),
+            ATTACH_ENV_FISH.to_string(),
+        ),
+        (
+            "MINIMAL_ATTACH_ENV_JSON".to_string(),
+            ATTACH_ENV_JSON.to_string(),
+        ),
+        // The POSIX fallback tier. `$ENV` is the only startup hook a plain
+        // `sh`, dash, ash, or ksh offers, and unlike the other four shells
+        // there is nothing in the rootfs they read on their own — so this one
+        // has to travel as a variable. It names a daemon-owned file; the file
+        // is what does the work.
+        ("ENV".to_string(), crate::env::ATTACH_ENV_POSIX.to_string()),
     ];
     if let Some(display) = loadouts_display {
         env.push(("MINIMAL_LOADOUTS".to_string(), display.to_string()));
@@ -1958,8 +2170,26 @@ impl SessionLauncher for SandboxLauncher {
             // The `bash` package installs to `/usr/bin/bash` (--prefix=/usr) and
             // the generic rootfs has no `/bin/bash`, so exec the absolute path
             // that exists rather than `/bin/bash` (which fails with ENOENT).
+            // `--rcfile` rather than `-l`: this build of bash has no
+            // `/etc/bash.bashrc`, so the daemon's per-attach environment hook
+            // has no shell-owned integration point to live in and must be
+            // named on the argv — and bash consults `--rcfile` only for an
+            // interactive *non-login* shell. Nothing is lost: `--noprofile`
+            // already suppressed every file `-l` would have read, so the
+            // session shell read nothing before this and still reads nothing
+            // but the daemon's own rc (a user `~/.bashrc` stays unread).
+            // `-i` is explicit rather than inferred from the pty.
             let mut command = env
-                .command(&container, "/usr/bin/bash", ["--noprofile", "-l"])
+                .command(
+                    &container,
+                    "/usr/bin/bash",
+                    [
+                        "--noprofile",
+                        "--rcfile",
+                        crate::env::ATTACH_ENV_BASH_RC,
+                        "-i",
+                    ],
+                )
                 .map_err(|e| io::Error::other(format!("build command: {e}")))?;
             command.stdin(hakoniwa::Stdio::from(pty.dup_slave_fd()?));
             command.stdout(hakoniwa::Stdio::from(pty.dup_slave_fd()?));
@@ -2184,8 +2414,13 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
     {
         let environment = self.guard.command_environment();
         // `with_env` replaces rather than extends, so the merge happens
-        // here: session variables first, `extra_env` layered over them.
+        // here: session variables first, then the attached terminal's facts,
+        // then `extra_env`. The connection layer sits above the session's own
+        // variables for the same reason it does at launch — `TERM` describes
+        // the terminal, and the session's copy of it is only ever as fresh as
+        // the attach that spawned the shell.
         let mut vars = environment.vars;
+        vars.extend(self.connection_env.clone());
         vars.extend(extra_env);
         crate::nsenter::Injection::new(self.session_leader_pid()?, program, args)
             .with_cwd(environment.cwd)
@@ -2218,6 +2453,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
     {
         let environment = self.guard.command_environment();
         let mut vars = environment.vars;
+        vars.extend(self.connection_env.clone());
         vars.extend(extra_env);
         let mut cmd = std::process::Command::new(program);
         cmd.args(args);
@@ -2290,6 +2526,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         archives_dir: std::path::PathBuf,
         session_id: sessions::SessionId,
         composition: Option<Arc<sessions::core::compose::Composition>>,
+        connection_env: ConnectionEnv,
     ) -> Result<(HostHandle, JoinHandle<Result<i32, std::io::Error>>), std::io::Error>
     where
         L: SessionLauncher<Process = P, Guard = G>,
@@ -2306,6 +2543,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             archives_dir,
             session_id,
             composition,
+            connection_env,
         )
         .await?;
         let task = tokio::spawn(host.mainloop());
@@ -2328,6 +2566,7 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         archives_dir: std::path::PathBuf,
         session_id: sessions::SessionId,
         composition: Option<Arc<sessions::core::compose::Composition>>,
+        connection_env: ConnectionEnv,
     ) -> Result<(Self, HostHandle), std::io::Error>
     where
         L: SessionLauncher<Process = P, Guard = G>,
@@ -2341,6 +2580,9 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         // Kept before `launch` consumes `paths`.
         let hooks_dir = paths.hooks.clone();
         let workspace_dir = paths.working.clone();
+        // Kept for `write_connection_env`, which rewrites the per-attach env
+        // (TERM included) into the session's home on every reattach.
+        let home_dir = paths.home.clone();
 
         // The launcher consumes `name`; the bindings need it too, to name the
         // archives the shell-exit prompt's save-then-delete lane writes.
@@ -2394,11 +2636,22 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
             workspace_root,
             session_name,
             archives_dir,
+            connection_env,
+            home_dir,
             guard,
         };
 
         if let Some(channel) = channel {
-            host.attach(channel, sz, true).await;
+            // The launch already folded these facts into the shell's
+            // environment, so pass an empty map rather than re-applying them:
+            // `attach` treats empty as "nothing new to say" and publishes what
+            // the host already holds.
+            host.attach(channel, sz, true, ConnectionEnv::new()).await;
+        } else {
+            // No client to bind, so nothing calls `attach` — publish anyway,
+            // so a host minted headlessly still has the files in place before
+            // anything in the session looks for them.
+            host.publish_connection_env().await;
         }
 
         Ok((host, handle))
@@ -2594,8 +2847,8 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
                         // `mainloop` reap via `wait()` and return.
                         return Err(());
                     }
-                    Message::Attach(channel, sz) => {
-                        self.attach(channel, sz, false).await;
+                    Message::Attach(channel, sz, connection) => {
+                        self.attach(channel, sz, false, connection).await;
                     }
                     Message::SetTitleCallback(title) => {
                         self.attrs.title = Some((title, SystemTime::now()));
@@ -2757,7 +3010,22 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         Ok(())
     }
 
-    async fn attach(&mut self, channel: Channel<Msg>, sz: WinSize, skip_flush: bool) {
+    async fn attach(
+        &mut self,
+        channel: Channel<Msg>,
+        sz: WinSize,
+        skip_flush: bool,
+        connection: ConnectionEnv,
+    ) {
+        // Before anything the client can see: the facts describe the terminal
+        // that is arriving, and the shell's first prompt after this should
+        // already read them. Empty means the client had nothing to say (see
+        // [`HostHandle::attach`]), so the previous facts stand.
+        if !connection.is_empty() {
+            self.connection_env = connection;
+        }
+        self.publish_connection_env().await;
+
         if !skip_flush {
             self.parser.screen_mut().set_size(sz.rows, sz.cols);
             let _ = channel
@@ -2790,6 +3058,17 @@ impl<P: SessionProcess, G: SessionGuard> Host<P, G> {
         // the terminal reaches the client that just attached.
         self.run_hooks_for(crate::hooks::HookEvent::Attach).await;
     }
+    /// Rewrites the session's per-attach environment files from
+    /// [`Self::connection_env`].
+    ///
+    /// Takes `&mut self` rather than `&self` deliberately: a `Host` holds a
+    /// non-`Sync` `dyn NetGuard`, so a `&Host` held across the write's await
+    /// would make the whole session future non-`Send` (the same constraint
+    /// [`HookPlan`] snapshots around).
+    async fn publish_connection_env(&mut self) {
+        write_connection_env(self.home_dir.clone(), self.connection_env.clone()).await;
+    }
+
     fn set_size(&mut self, sz: WinSize) {
         // If the terminal size changed, reconfigure the pty.
         if sz != self.sz {
@@ -2901,6 +3180,58 @@ mod tests {
         assert_eq!(env.len(), 5);
     }
 
+    /// The per-attach environment is written in each shell's own syntax, with
+    /// values quoted so a terminal name carrying shell metacharacters is
+    /// data rather than code, plus a JSON form for shells that read data
+    /// instead of evaluating a script. An empty map writes nothing at all: an
+    /// attach that carries no facts leaves the last known ones standing.
+    #[tokio::test]
+    async fn write_connection_env_renders_every_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = DaemonAbsPath::try_new(
+            camino::Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap(),
+        )
+        .unwrap();
+        let sh = home.sub_path_unchecked(ATTACH_ENV_SH_REL);
+        let fish = home.sub_path_unchecked(ATTACH_ENV_FISH_REL);
+        let json = home.sub_path_unchecked(ATTACH_ENV_JSON_REL);
+
+        write_connection_env(home.clone(), ConnectionEnv::new()).await;
+        for path in [&sh, &json] {
+            assert!(
+                !std::fs::exists(path.as_str()).unwrap(),
+                "an empty attach has nothing to publish"
+            );
+        }
+
+        let env: ConnectionEnv = [
+            ("TERM".to_string(), "xterm-256color".to_string()),
+            ("ODD".to_string(), "it's \\ odd".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        write_connection_env(home, env).await;
+
+        let sh = std::fs::read_to_string(sh.as_str()).unwrap();
+        assert!(sh.contains("export TERM='xterm-256color'"), "{sh}");
+        // POSIX has no escape inside single quotes: close, escape, reopen.
+        assert!(sh.contains(r"export ODD='it'\''s \ odd'"), "{sh}");
+
+        let fish = std::fs::read_to_string(fish.as_str()).unwrap();
+        assert!(fish.contains("set -gx TERM 'xterm-256color'"), "{fish}");
+        // fish does take a backslash escape, and escapes the backslash too.
+        assert!(fish.contains(r"set -gx ODD 'it\'s \\ odd'"), "{fish}");
+
+        // The JSON form round-trips the values themselves rather than a
+        // rendering of them, and carries nothing but the variables — every
+        // key in it becomes one, so a "generated by" banner would too.
+        let json = std::fs::read_to_string(json.as_str()).unwrap();
+        let back: ConnectionEnv = serde_json_lenient::from_str(&json).expect("{json}");
+        assert_eq!(back.get("TERM").map(String::as_str), Some("xterm-256color"));
+        assert_eq!(back.get("ODD").map(String::as_str), Some("it's \\ odd"));
+        assert_eq!(back.len(), 2, "{json}");
+    }
+
     /// The launcher baseline seeds the session's identity plus the
     /// once-only orientation banner pair: the session name verbatim in
     /// `MINIMAL_SESSION_NAME`, the self-unsetting `PROMPT_COMMAND`
@@ -2932,6 +3263,36 @@ mod tests {
         let pc = env.get("PROMPT_COMMAND").expect("baseline PROMPT_COMMAND");
         assert!(pc.contains(r#"eval "$MINIMAL_MOTD""#));
         assert!(pc.contains("unset PROMPT_COMMAND MINIMAL_MOTD"));
+        // The banner and the per-attach environment are deliberately not
+        // wired together: this variable is composed, so a loadout could
+        // replace it (and the MOTD recipe unsets it outright). The refresh
+        // lives in the shell hooks `crate::env` installs into the rootfs.
+        assert!(
+            !pc.contains("MINIMAL_ATTACH_ENV"),
+            "the refresh must not ride on a composed variable: {pc}"
+        );
+
+        // The paths are still named in the environment, for anything
+        // scripting against them; the hooks themselves do not read these.
+        assert_eq!(
+            env.get("MINIMAL_ATTACH_ENV").map(String::as_str),
+            Some("/home/.local/state/minimal/attach-env.sh")
+        );
+        assert_eq!(
+            env.get("MINIMAL_ATTACH_ENV_FISH").map(String::as_str),
+            Some("/home/.local/state/minimal/attach-env.fish")
+        );
+        assert_eq!(
+            env.get("MINIMAL_ATTACH_ENV_JSON").map(String::as_str),
+            Some("/home/.local/state/minimal/attach-env.json")
+        );
+        // The POSIX tier's only startup hook. Unlike the other shells' hooks
+        // this one has to be a variable, because a plain `sh` reads nothing
+        // else — so the baseline names the daemon-owned file.
+        assert_eq!(
+            env.get("ENV").map(String::as_str),
+            Some("/usr/share/minimal/attach-env-posix.sh")
+        );
 
         let motd = env.get("MINIMAL_MOTD").expect("baseline MINIMAL_MOTD");
         assert!(motd.starts_with("[ -t 1 ]"), "banner must be TTY-gated");
@@ -3093,6 +3454,7 @@ mod tests {
             std::env::temp_dir(),
             sessions::SessionId::nil(),
             None,
+            ConnectionEnv::new(),
         )
         .await
         .expect("failed to build host");
@@ -3165,6 +3527,7 @@ mod tests {
             std::env::temp_dir(),
             sessions::SessionId::nil(),
             None,
+            ConnectionEnv::new(),
         )
         .await
         .expect("failed to build host");
@@ -3276,6 +3639,7 @@ mod tests {
             std::env::temp_dir(),
             sessions::SessionId::nil(),
             None,
+            ConnectionEnv::new(),
         )
         .await
         .expect("failed to build host");
@@ -3327,6 +3691,7 @@ mod tests {
             std::env::temp_dir(),
             sessions::SessionId::nil(),
             None,
+            ConnectionEnv::new(),
         )
         .await
         .expect("failed to build host");

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -299,13 +299,25 @@ impl TestClient {
         &mut self,
         session_id: SessionId,
     ) -> russh::Channel<russh::client::Msg> {
+        self.open_shell_with_term(session_id, "xterm").await
+    }
+
+    /// [`Self::open_shell`], naming the terminal type the PTY request
+    /// carries. `TERM` is a per-connection fact the daemon applies on every
+    /// attach, so a test that cares which terminal is on the other end — or
+    /// that re-attaches from a different one — has to be able to say.
+    pub async fn open_shell_with_term(
+        &mut self,
+        session_id: SessionId,
+        term: &str,
+    ) -> russh::Channel<russh::client::Msg> {
         let channel = self.handle.channel_open_session().await.unwrap();
         channel
             .set_env(true, crate::MINIMAL_SESSION_ID_ENV, session_id.to_string())
             .await
             .unwrap();
         channel
-            .request_pty(true, "xterm", 80, 24, 0, 0, &[])
+            .request_pty(true, term, 80, 24, 0, 0, &[])
             .await
             .unwrap();
         channel.request_shell(true).await.unwrap();

--- a/crates/sessions/src/core/loadout.rs
+++ b/crates/sessions/src/core/loadout.rs
@@ -30,8 +30,10 @@
 //! [vars]
 //! EDITOR    = "hx"
 //! VISUAL    = "hx"
-//! TERM      = { inherit = true, default = "xterm-256color" }
 //! COLORTERM = { inherit = true }
+//! # `TERM` is deliberately absent: the daemon sets it from the terminal
+//! # each attach arrives on and keeps it current, above anything composed
+//! # here (`docs/reference/loadouts.md`, "The attached terminal").
 //!
 //! # Warm helix's tree-sitter grammar cache the first time the session
 //! # comes up. Best-effort; failures don't tank activation.

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -141,7 +141,10 @@ MUXER = { inherit = true }               # inherit from the host env
 - `{ inherit = true }` passes the variable through from the environment of
   the `min` process on the host. If the host does not have it set, the
   variable is dropped from the session (with a warning) rather than failing
-  activation, so opportunistically inheriting things like `TERM` is safe.
+  activation, so opportunistically inheriting things like `COLORTERM` is
+  safe. `TERM` is not worth inheriting: the daemon sets it from the terminal
+  you attach from and keeps it current, above anything a loadout composes —
+  see [The attached terminal](#attached-terminal).
 - `{ inherit = true, default = "..." }` inherits, falling back to `default`
   when the host does not have the variable set.
 
@@ -443,10 +446,12 @@ file means an empty policy; a fresh install activates fine without it.
 ## Vars in the attach shell
 
 The interactive shell minted by [`min session attach`](./cli-min.md#session-attach) is
-`bash --noprofile -l`, a login shell that sources **no** startup files
-(not `/etc/profile`, `~/.bash_profile`, or `~/.bashrc`), so rc-file
-patches cannot influence it. Interactive setup travels through the
-environment instead, i.e. through `[vars]`:
+`bash --noprofile --rcfile <daemon rc> -i`. It sources **none** of your
+startup files (not `/etc/profile`, `~/.bash_profile`, or `~/.bashrc`), so
+rc-file patches cannot influence it — the only rc it reads is the daemon's
+own, which installs the [attached terminal](#attached-terminal) hook and
+nothing else. Interactive setup travels through the environment instead,
+i.e. through `[vars]`:
 
 - **Prompt**: the session launcher seeds a baseline environment
   (a stock `PS1`, plus the [orientation banner](#orientation-banner)
@@ -458,20 +463,110 @@ environment instead, i.e. through `[vars]`:
   to the launcher's defaults.
 - **Banner / MOTD**: bash evaluates `PROMPT_COMMAND` from the
   environment before the first interactive prompt, so a once-only banner
-  can ship as a payload var plus a self-unsetting trigger:
+  can ship as a payload var plus a trigger that clears its own payload:
 
   ```toml
   [vars]
-  PROMPT_COMMAND = 'eval "$MINIMAL_MOTD"; unset PROMPT_COMMAND MINIMAL_MOTD'
+  PROMPT_COMMAND = 'if [ -n "${MINIMAL_MOTD:-}" ]; then eval "$MINIMAL_MOTD"; unset MINIMAL_MOTD; fi; if [ -r "${MINIMAL_ATTACH_ENV:-}" ]; then . "$MINIMAL_ATTACH_ENV"; fi'
   MINIMAL_MOTD   = '''
   [ -t 1 ] && printf '%s\n' '' '  Welcome to the dev session.' ''
   '''
   ```
 
-  The trigger unsets both variables, so the banner prints exactly once
+  The trigger clears `MINIMAL_MOTD`, so the banner prints exactly once
   and never runs for non-interactive commands; the `[ -t 1 ]` guard keeps
   redirected output clean. Multi-line literal values survive composition
   intact.
+
+  Replacing `PROMPT_COMMAND` costs you nothing but the banner: the
+  [attached terminal's](#attached-terminal) `TERM` is refreshed by a hook
+  the daemon installs, not by this variable.
+
+### The attached terminal {#attached-terminal}
+
+A session shell is spawned once and outlives the terminals that attach to
+it, so `TERM` — a fact about *the terminal currently attached* — cannot
+live in its environment alone. The shell may have been minted for a
+different terminal, or for no terminal at all: a lifecycle hook or an exec
+brings the sandbox up the same way an attach does.
+
+**Nothing is required of a loadout or a project for this to work.** The
+daemon publishes the current terminal's facts on every attach, and installs
+the hook that re-reads them into every session rootfs, for every shell it
+supports. This is deliberately not carried by a `[vars]` entry: an
+environment variable is composed, so a loadout could replace it — and the
+MOTD recipe above unsets `PROMPT_COMMAND` outright — which would leave the
+session's `TERM` depending on whether an author knew to preserve it.
+
+The published files, rewritten on each attach (edits to them are lost):
+
+| Var | File | Read by |
+|---|---|---|
+| `MINIMAL_ATTACH_ENV` | `~/.local/state/minimal/attach-env.sh` | bash, zsh — POSIX `export TERM='…'` |
+| `MINIMAL_ATTACH_ENV_FISH` | `~/.local/state/minimal/attach-env.fish` | fish — `set -gx TERM '…'` |
+| `MINIMAL_ATTACH_ENV_JSON` | `~/.local/state/minimal/attach-env.json` | nushell — data, not a script |
+
+`ENV` is also set, to a daemon-owned file that sources the POSIX form at
+shell startup — see [Other POSIX shells](#attached-terminal-posix).
+
+The variables are there for anything you want to script against. The hooks
+themselves do not read them: each hard-codes the path, so a composition
+that happens to set a variable of that name cannot redirect the refresh.
+
+The hooks live at each shell's own vendor/system integration point, inside
+the rootfs rather than the session home — so a loadout patch cannot collide
+with one:
+
+| Shell | Hook location | At the prompt | Before a command |
+|---|---|---|---|
+| bash | the rc the session shell is started with (`--rcfile`) | — | `DEBUG` trap |
+| zsh | `/etc/zsh/zshrc` | `precmd` | `preexec` |
+| fish | `/usr/share/fish/vendor_conf.d/` | `fish_prompt` event | `fish_preexec` event |
+| nushell | `/usr/share/nushell/vendor/autoload/` | `pre_prompt` | `pre_execution` |
+
+Two hooks, because they answer different questions. The prompt one keeps a
+shell that is sitting idle current. The pre-execution one matters when you
+re-attach: the prompt on your screen was drawn *before* you detached, and
+it has already fired its prompt hook — so without a hook that runs before
+the command, the first thing you type at that restored prompt would still
+see the terminal you had last time, and only the *next* prompt would catch
+up. bash's `DEBUG` trap covers both cases on its own.
+
+bash uses a trap rather than `PROMPT_COMMAND` for the same reason the
+mechanism is not a var at all: `PROMPT_COMMAND` is composed, and the MOTD
+recipe unsets it. A trap is shell state, which nothing in a composition can
+reach.
+
+#### Other POSIX shells {#attached-terminal-posix}
+
+A plain `sh`, dash, the BusyBox or BSD ashes, ksh and mksh get a weaker
+guarantee, and the limit is POSIX's rather than ours. The one hook POSIX
+defines is `$ENV`: an interactive shell expands it and sources that file at
+**startup**. The daemon points `ENV` at a file of its own
+(`/usr/share/minimal/attach-env-posix.sh`) which sources the published
+POSIX form, so any such shell starts with the terminal that is current at
+that moment — including one started from a parent whose own value was
+stale.
+
+What these shells cannot do is *refresh*. POSIX has no per-prompt or
+per-command hook, and none can be built: `PS1` expansion cannot change the
+shell's own environment, because a command substitution runs in a subshell
+and `${var:=word}` assigns only when the variable is unset. So a `sh` you
+left running across a re-attach keeps the terminal it started with. Two
+ways out, either of which is a one-liner:
+
+```sh
+. "$MINIMAL_ATTACH_ENV"   # re-sync this shell
+exec sh                   # or just start a new one
+```
+
+ksh93 is the exception in this family — its `PS1.get` discipline function
+is a genuine per-prompt hook — but the daemon does not install one, so ksh93
+behaves like the rest here.
+
+Anything the daemon itself runs inside the session — an exec, a lifecycle
+hook — gets the current terminal's facts applied directly, above the
+composed vars, without any of this.
 
 ### Orientation banner {#orientation-banner}
 
@@ -509,4 +604,6 @@ cannot collide with either.
 Because the trigger lives in the baseline layer, a loadout that sets its
 own `PROMPT_COMMAND` replaces the banner cleanly — and can interpolate
 the same `$MINIMAL_*` vars in its own MOTD, as the built-in `default`
-loadout does for its orientation lines.
+loadout does for its orientation lines. It carries no obligation beyond
+the banner — the [attached terminal's](#attached-terminal) `TERM` is kept
+current by a daemon-installed shell hook that no composition can reach.

--- a/scripts/e2e-attach-pty.py
+++ b/scripts/e2e-attach-pty.py
@@ -22,6 +22,11 @@ to fire `on_detach`):
   E2E_PTY_ANSWER    how to answer the session-exit prompt: `delete` (the
                     default, what the sandbox proof needs) or `keep`, which
                     leaves the session alive — a detach.
+  E2E_PTY_DETACH    set to leave via the ctrl-w detach chord once the command
+                    stream goes quiet, instead of ending it with `exit`. The
+                    session's SHELL then survives, which is what a test of
+                    re-attaching to a still-running shell needs: `exit` ends
+                    that shell, and the next attach mints a new one.
 
 Prints the full captured terminal output on stdout. Exits 0 iff the attach
 process exited 0.
@@ -59,6 +64,7 @@ EXIT_PROMPT = b"would you like to do with this session"  # SHELL_EXIT_PROMPT, lo
 # bare Enter keeps the session (a detach), and Down+Enter selects "Delete".
 PROMPT_KEYS = {"delete": b"\x1b[B\r", "keep": b"\r"}
 answer = os.environ.get("E2E_PTY_ANSWER", "delete")
+DETACH = os.environ.get("E2E_PTY_DETACH") is not None
 if answer not in PROMPT_KEYS:
     sys.stderr.write(f"e2e-attach-pty: unknown E2E_PTY_ANSWER {answer!r}\n")
     sys.exit(2)
@@ -91,11 +97,22 @@ try:
     time.sleep(1.5)
     os.write(fd, ("\n".join(commands) + "\n").encode())
 
+    quiet = 0
+    detached = False
     while time.monotonic() < DEADLINE:
         chunk = drain_ready(1.0)
         if chunk is None:
             break  # EOF / closed
         buf.extend(chunk)
+        quiet = 0 if chunk else quiet + 1
+        # The detach chord has to arrive as a WRITE OF ITS OWN: the daemon
+        # matches a *bare* ctrl-w (`b.len() == 1 && b[0] == 0x17`), so the same
+        # byte inside the command stream is not a detach — it reaches the shell,
+        # where readline eats it as delete-previous-word. Sent once the stream
+        # goes quiet, so the commands have run first.
+        if DETACH and not detached and quiet >= 2:
+            os.write(fd, b"\x17")
+            detached = True
         if not answered and EXIT_PROMPT in bytes(buf).lower():
             os.write(fd, PROMPT_ANSWER_KEY)  # answer the prompt like a user
             answered = True

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -583,9 +583,31 @@ if [ -n "$SEED_DIR" ] || [ -n "$SEEDED_MFILE" ]; then
   # non-interactive caller cannot perform. Answer the exit prompt with `keep`
   # (Enter, the first option) so leaving the shell is a detach rather than a
   # destroy.
+  #
+  # This attach also proves `TERM`, and this is the only place in the lane
+  # that can: the session's shell was minted HEADLESSLY, by the activation
+  # hooks above, with no terminal in the picture — the exact shape that used
+  # to leave a session with no `TERM` at all for its whole life (every later
+  # attach reused that shell), so `less` in it fell back to ncurses' generic
+  # `unknown` entry. A pinned `TERM` on the driver makes the assertion below
+  # exact whatever the lane's own terminal is; the unit tests cover the
+  # decision, but only a real sandbox proves the value reaches a real bash.
   # shellcheck disable=SC2086 # E2E_MINIMAL_ARGS must word-split.
+  # Leave a mark IN the shell — a plain shell variable, never exported, so it
+  # lives in that process and nowhere else. The re-attach below reads it back.
+  # Deliberately not `$$`: the session shell is pid 1 of its own namespace, so
+  # a replacement shell would report pid 1 too and the check would be vacuous.
+  # Leaves by the ctrl-w detach chord (`E2E_PTY_DETACH`), NOT by `exit`.
+  # `exit` ends the session's shell, and the "re-attach" below would then land
+  # on a freshly minted one — which would still report the new terminal (a new
+  # shell takes `TERM` from its launch env) while proving nothing about
+  # re-attaching. Detaching leaves the shell running, which is what the mark
+  # above is read back out of.
+  # shellcheck disable=SC2016 # `$TERM` must reach the SESSION's shell unexpanded.
   attach_out="$(E2E_PTY_COMMANDS='cat /home/hook-activate
-exit' E2E_PTY_ANSWER=keep python3 "$ROOT/scripts/e2e-attach-pty.py" - \
+echo TERM_INSHELL=$TERM
+__e2e_same_shell=yes' \
+    E2E_PTY_DETACH=1 TERM=xterm-256color python3 "$ROOT/scripts/e2e-attach-pty.py" - \
     min ${E2E_MINIMAL_ARGS:-} session attach "$hook_sid" \
     2>"$WORK/hooks-attach.err")" || {
     echo "::error::pty attach for the hooks proof failed"
@@ -598,6 +620,16 @@ exit' E2E_PTY_ANSWER=keep python3 "$ROOT/scripts/e2e-attach-pty.py" - \
   # sandbox proof's marker checks.
   if [[ "$attach_out" != *HOOK_ATTACH_OK* ]]; then
     echo "::error::on_attach hook output did not reach the attached terminal"
+    echo "--- transcript ---"; printf '%s\n' "$attach_out"
+    fail
+  fi
+  # The attaching terminal must be what the shell reports, even though this
+  # shell was minted for hooks rather than for a terminal. Matching the FULL
+  # `TERM_INSHELL=<value>` is what makes this real: the pty echoes the typed
+  # `echo TERM_INSHELL=$TERM` verbatim (the shell expands it only on the
+  # output side), so an empty or stale `TERM` cannot satisfy it.
+  if [[ "$attach_out" != *"TERM_INSHELL=xterm-256color"* ]]; then
+    echo "::error::the attached terminal's TERM did not reach the session shell"
     echo "--- transcript ---"; printf '%s\n' "$attach_out"
     fail
   fi
@@ -623,6 +655,43 @@ exit' E2E_PTY_ANSWER=keep python3 "$ROOT/scripts/e2e-attach-pty.py" - \
     fail
   fi
   echo "on_attach (on the terminal) + on_detach (headless, after leaving) OK"
+  echo "TERM reached the hook-launched shell from the attaching terminal OK"
+
+  # Re-attach to the SAME (still-running) shell from a terminal that calls
+  # itself something else. `TERM` is a per-attach fact, so the shell must now
+  # report the new one: the value is not fixed when the shell is minted, and
+  # the daemon-installed hook re-reads it. This is the case a user hits by
+  # attaching from a second machine or emulator.
+  #
+  # The in-shell mark is asserted alongside it, because `TERM` alone cannot
+  # tell the two explanations apart: a daemon that *replaced* the shell would
+  # also report the new terminal, while silently destroying everything the
+  # session was running. Only the original process still holds that variable.
+  # shellcheck disable=SC2086 # E2E_MINIMAL_ARGS must word-split.
+  # shellcheck disable=SC2016 # `$TERM` must reach the SESSION's shell unexpanded.
+  reattach_out="$(E2E_PTY_COMMANDS='echo TERM_INSHELL=$TERM
+echo SHELLMARK=[$__e2e_same_shell]
+exit' E2E_PTY_ANSWER=keep TERM=vt220 python3 "$ROOT/scripts/e2e-attach-pty.py" - \
+    min ${E2E_MINIMAL_ARGS:-} session attach "$hook_sid" \
+    2>"$WORK/hooks-reattach.err")" || {
+    echo "::error::pty re-attach for the TERM proof failed"
+    echo "--- transcript ---"; printf '%s\n' "$reattach_out"
+    echo "--- stderr ---"; cat "$WORK/hooks-reattach.err" 2>/dev/null || true
+    fail
+  }
+  if [[ "$reattach_out" != *"TERM_INSHELL=vt220"* ]]; then
+    echo "::error::re-attaching from a different terminal did not update TERM"
+    echo "--- transcript ---"; printf '%s\n' "$reattach_out"
+    fail
+  fi
+  # `SHELLMARK=[yes]` can only come from the shell that ran the assignment;
+  # a replacement prints `SHELLMARK=[]`, which is why the brackets are there.
+  if [[ "$reattach_out" != *"SHELLMARK=[yes]"* ]]; then
+    echo "::error::the re-attach did not land on the same shell (its state was gone)"
+    echo "--- transcript ---"; printf '%s\n' "$reattach_out"
+    fail
+  fi
+  echo "re-attach from a different terminal updated TERM in the same shell OK"
 
   # on_destroy. The session's filesystem goes with it, so the evidence is the
   # daemon log — and the failing hook must not have blocked the teardown.


### PR DESCRIPTION
### Problem

A session shell could come up with no `TERM` and keep it for the session's
whole life. In that shell, anything that pages dies before printing:

$ git branch
'unknown': I need something more specific.

(`less` substitutes the literal `unknown` for an unset `TERM`; ncurses
rejects that entry as generic.)

### Cause

`TERM` was a **mint-time** fact. `Session::attach` read it from the PTY
request but only passed it to `mint_session_host` — the live-host branch
dropped it. And two launches have no PTY to read it from: `ensure_host`
(execs) and `launch_host_for_hooks` (lifecycle hooks). So a session whose
loadout declared an `on_activate` hook got a terminal-less shell, and every
later attach silently reused it.

### Fix

`TERM` is now a per-attach fact:

1. **Carried on every attach**, not just the minting one, and layered over
   the session env for everything the daemon runs in the sandbox.
2. **Published on each attach** to `~/.local/state/minimal/attach-env.{sh,fish,json}`,
   since a running process's `environ` can't be rewritten from outside.
3. **Hook-minted shells are replaced** on the first interactive attach.
   `Exec`-minted ones are not — a command is live in that sandbox.

The refresh hooks are installed **by the daemon into every session rootfs**,
at each shell's own vendor/system integration point — no loadout or project
author participates, and nothing composed can weaken them:

| Shell | At the prompt | Before a command |
|---|---|---|
| bash | — | `DEBUG` trap |
| zsh | `precmd` | `preexec` |
| fish | `fish_prompt` | `fish_preexec` |
| nushell | `pre_prompt` | `pre_execution` |

The pre-execution half is load-bearing: after a re-attach, the prompt on
screen was drawn *before* you detached and has already fired, so without it
the first command you type still sees the old terminal.

POSIX shells (sh, dash, ash, busybox, ksh) get `$ENV` pointing at a
daemon-owned file — correct at startup, no refresh, because POSIX has no
hook for one.

Note: the session shell is now `bash --noprofile --rcfile <daemon rc> -i`
rather than `-l`; `--rcfile` is only honored for non-login shells, and
`--noprofile` already suppressed everything `-l` would have read.

### Testing

- 5 tests in `minimald`, each verified non-vacuous by reverting the fix.
- `session-e2e.sh` asserts `TERM` in a hook-launched shell and after a
  re-attach from a different terminal; reverted, it fails with `dumb`.
- Each generated hook exercised against its real shell (bash, zsh, fish,
  nushell) in the stale-prompt scenario; `$ENV` via `bash --posix`.
- `just ci` green except two `mctx` `test-ignored` tests, which fail
  identically at the base commit (nested-sandbox limitation).
  `just e2e-native` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal environment details now refresh automatically when attaching or reattaching to sessions.
  * Added shell-specific environment hooks for Bash, POSIX shells, Zsh, Fish, and Nushell.
  * Interactive terminal sessions can replace hook-launched shells when appropriate.

* **Bug Fixes**
  * Improved preservation and updating of terminal settings across session attachments.
  * Ensured existing shells remain active when reattaching with updated terminal settings.

* **Documentation**
  * Clarified terminal environment handling, refresh behavior, and shell startup support.
  * Updated loadout guidance to avoid inheriting `TERM`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->