### PR TITLE
ci: route package-cache reads through the R2 mirror in every workflow

### DIFF
--- a/.github/workflows/ci-kani.yml
+++ b/.github/workflows/ci-kani.yml
@@ -17,6 +17,12 @@ on:
     workflow_dispatch:
 
 env:
+    # Route package-cache reads through the R2 mirror. min binaries built
+    # from branches predating minimal#1234 default the reader to gs:// and
+    # bill GCS internet egress from the GHA runners (25-36 GB/day measured
+    # 2026-08-18/19, gcs_access_logs). Harmless in jobs that never read the
+    # package cache; the mutable index.shisha is edge-bypassed to live GCS.
+    MINIMAL_REMOTE_CACHE_URL: https://cache.minimal.dev/
     CARGO_TERM_COLOR: always
     # Pin EXACTLY: 0.66.0 and earlier give spurious verification failures
     # on arrays with more than 64 elements (kani#2416/#4408, fixed by the

--- a/.github/workflows/ci-linux-kvm.yml
+++ b/.github/workflows/ci-linux-kvm.yml
@@ -26,6 +26,12 @@ on:
   workflow_dispatch:
 
 env:
+  # Route package-cache reads through the R2 mirror. min binaries built
+  # from branches predating minimal#1234 default the reader to gs:// and
+  # bill GCS internet egress from the GHA runners (25-36 GB/day measured
+  # 2026-08-18/19, gcs_access_logs). Harmless in jobs that never read the
+  # package cache; the mutable index.shisha is edge-bypassed to live GCS.
+  MINIMAL_REMOTE_CACHE_URL: https://cache.minimal.dev/
   CARGO_TERM_COLOR: always
 
 # Cancel superseded runs so the e2e job isn't queued on stale commits.

--- a/.github/workflows/ci-linux-native.yml
+++ b/.github/workflows/ci-linux-native.yml
@@ -28,6 +28,12 @@ on:
   workflow_dispatch:
 
 env:
+  # Route package-cache reads through the R2 mirror. min binaries built
+  # from branches predating minimal#1234 default the reader to gs:// and
+  # bill GCS internet egress from the GHA runners (25-36 GB/day measured
+  # 2026-08-18/19, gcs_access_logs). Harmless in jobs that never read the
+  # package cache; the mutable index.shisha is edge-bypassed to live GCS.
+  MINIMAL_REMOTE_CACHE_URL: https://cache.minimal.dev/
   CARGO_TERM_COLOR: always
 
 # Cancel superseded runs on a branch; never cancel a run on main.

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -22,6 +22,12 @@ on:
     workflow_call:
 
 env:
+    # Route package-cache reads through the R2 mirror. min binaries built
+    # from branches predating minimal#1234 default the reader to gs:// and
+    # bill GCS internet egress from the GHA runners (25-36 GB/day measured
+    # 2026-08-18/19, gcs_access_logs). Harmless in jobs that never read the
+    # package cache; the mutable index.shisha is edge-bypassed to live GCS.
+    MINIMAL_REMOTE_CACHE_URL: https://cache.minimal.dev/
     CARGO_TERM_COLOR: always
 
 # Cancel a superseded run so the single runner isn't backed up by stale commits.

--- a/.github/workflows/ci-shell-installer.yml
+++ b/.github/workflows/ci-shell-installer.yml
@@ -33,6 +33,14 @@ permissions:
   # dorny/paths-filter reads the PR file list on pull_request events.
   pull-requests: read
 
+env:
+  # Route package-cache reads through the R2 mirror. min binaries built
+  # from branches predating minimal#1234 default the reader to gs:// and
+  # bill GCS internet egress from the GHA runners (25-36 GB/day measured
+  # 2026-08-18/19, gcs_access_logs). Harmless in jobs that never read the
+  # package cache; the mutable index.shisha is edge-bypassed to live GCS.
+  MINIMAL_REMOTE_CACHE_URL: https://cache.minimal.dev/
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
               # this `env` block.
               uses: gominimal/run-task@a5ed123f612b9774e3d6eaa7af45370e33aa1116 # v1
               env:
-                  MINIMAL_REMOTE_CACHE_URL: https://cache.minimal.farm/
+                  MINIMAL_REMOTE_CACHE_URL: https://cache.minimal.dev/
               with:
                   channel: unstable
                   task: build-smoke

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -19,6 +19,14 @@ concurrency:
   group: nightly-tests
   cancel-in-progress: false
 
+env:
+  # Route package-cache reads through the R2 mirror. min binaries built
+  # from branches predating minimal#1234 default the reader to gs:// and
+  # bill GCS internet egress from the GHA runners (25-36 GB/day measured
+  # 2026-08-18/19, gcs_access_logs). Harmless in jobs that never read the
+  # package cache; the mutable index.shisha is edge-bypassed to live GCS.
+  MINIMAL_REMOTE_CACHE_URL: https://cache.minimal.dev/
+
 jobs:
   advisories:
     # cargo-deny advisories, BLOCKING here — the between-PRs counterpart of

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,14 @@ on:
 permissions:
     contents: read
 
+env:
+  # Route package-cache reads through the R2 mirror. min binaries built
+  # from branches predating minimal#1234 default the reader to gs:// and
+  # bill GCS internet egress from the GHA runners (25-36 GB/day measured
+  # 2026-08-18/19, gcs_access_logs). Harmless in jobs that never read the
+  # package cache; the mutable index.shisha is edge-bypassed to live GCS.
+  MINIMAL_REMOTE_CACHE_URL: https://cache.minimal.dev/
+
 jobs:
     # Skip the build on no-op nights: a finished release stages an immutable
     # versions/<sha>/components manifest in gs://minimal-one, so if HEAD hasn't

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ on:
             - "v[0-9]*.[0-9]*.[0-9]*"
 
 env:
+    # Route package-cache reads through the R2 mirror. min binaries built
+    # from branches predating minimal#1234 default the reader to gs:// and
+    # bill GCS internet egress from the GHA runners (25-36 GB/day measured
+    # 2026-08-18/19, gcs_access_logs). Harmless in jobs that never read the
+    # package cache; the mutable index.shisha is edge-bypassed to live GCS.
+    MINIMAL_REMOTE_CACHE_URL: https://cache.minimal.dev/
     CARGO_TERM_COLOR: always
 
 # Serialize release runs so two manual dispatches can't race to cut a release


### PR DESCRIPTION
ci: route package-cache reads through the R2 mirror in every workflow

The gcs_access_logs forensics for 2026-08-18/19 show 25-36 GB/day of
billed GCS internet egress from GitHub-hosted runners, and the index
objects those readers fetch (github.com/gominimal/pkgs/b1a1b1b7....shisha
— this repo's own .minimal pin) attribute it to our CI: jobs run the
min built from the branch under test, so any PR branched before #1234
defaults the package-cache reader to gs:// and pays internet egress
for every artifact. Only one ci.yml step had the override (the
build-servers#145 canary), still pointing at the legacy hostname.

Set MINIMAL_REMOTE_CACHE_URL=https://cache.minimal.dev/ at workflow
level in the eight workflows that exercise min, and move the ci.yml
canary to the canonical hostname. Harmless where a job never reads the
package cache; the mutable index.shisha is edge-bypassed to live GCS
(infra#277), and artifacts are immutable + edge-cached (infra#429).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized package-cache access across continuous integration, testing, release, and installer workflows.
  * Updated cache routing to use the current remote cache service.
  * Preserved existing workflow execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->