### PR TITLE
fix(minimal): refuse a version-skewed daemon instead of self-destroying sessions (#1251)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,6 +4050,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "version",
 ]
 
 [[package]]

--- a/crates/minimal-client/Cargo.toml
+++ b/crates/minimal-client/Cargo.toml
@@ -22,6 +22,7 @@ serde_json_lenient.workspace = true
 sessions.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+version.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/minimal-client/src/lib.rs
+++ b/crates/minimal-client/src/lib.rs
@@ -345,7 +345,7 @@ impl Client {
             }
 
             serde_json_lenient::from_slice(&resp_buf)
-                .with_context(|| format!("decode response for {}", R::NAME))
+                .with_context(|| decode_context(R::NAME, &resp_buf))
         };
 
         tokio::time::timeout(timeout, rpc)
@@ -877,6 +877,31 @@ fn append_daemon_error(buf: &mut Vec<u8>, data: &[u8]) {
     buf.extend_from_slice(&data[..room.min(data.len())]);
 }
 
+/// How much of an undecodable reply the decode error quotes. Generous enough
+/// for any oneshot response the daemon actually sends, bounded so a
+/// pathological body can't become the whole error message.
+const DECODE_EXCERPT_MAX: usize = 1024;
+
+/// Context for a response that wouldn't decode, quoting the daemon's reply
+/// verbatim.
+///
+/// The body has to be in the message because serde's own error usually can't
+/// name the fault: every `Errorable<T>` response is `#[serde(untagged)]`, and
+/// an untagged enum discards its per-variant errors in favour of "data did
+/// not match any variant". So when a CLI meets a daemon of another build —
+/// the skew a `deny_unknown_fields` response type exists to catch — the error
+/// says only that nothing matched, and a bug report can't say which field
+/// tripped the guard (#1251). Quoting the reply makes that diagnosable
+/// without a live repro.
+fn decode_context(rpc: &str, body: &[u8]) -> String {
+    let text = String::from_utf8_lossy(body);
+    let excerpt = match text.char_indices().nth(DECODE_EXCERPT_MAX) {
+        Some((cut, _)) => format!("{}… ({} bytes total)", &text[..cut], body.len()),
+        None => text.into_owned(),
+    };
+    format!("decode response for {rpc} (daemon replied: {excerpt})")
+}
+
 /// The provider kind the CLI should talk to, given `--provider`.
 ///
 /// The native minimald and minvmd backends now occupy distinct provider dirs,
@@ -971,6 +996,45 @@ mod tests {
             super::append_daemon_error(&mut buf, &chunk);
         }
         assert_eq!(buf.len(), super::DAEMON_ERROR_MAX);
+    }
+
+    /// A daemon of another build answering `FinalizeSession` in a shape this
+    /// CLI's wire types reject must produce an error that names the offending
+    /// field. `Errorable` is untagged, so serde alone only says "no variant
+    /// matched" — the reply itself is what makes the skew diagnosable (#1251).
+    #[test]
+    fn decode_errors_quote_the_daemon_reply() {
+        use anyhow::Context as _;
+
+        let body = br#"{"activate_hooks":[],"finalized_at":"2026-08-21T00:00:00Z"}"#;
+        let err = serde_json_lenient::from_slice::<
+            minimald_rpc::Errorable<minimald_rpc::FinalizeSessionResponse>,
+        >(body)
+        .with_context(|| super::decode_context("FinalizeSession", body))
+        .unwrap_err();
+
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("finalized_at"),
+            "the reply must be quoted so the tripping field is identifiable, got: {rendered}"
+        );
+    }
+
+    /// A pathological body is quoted, but bounded — the excerpt must not
+    /// become the whole error message.
+    #[test]
+    fn decode_context_bounds_the_excerpt() {
+        let body = vec![b'x'; 8 * 1024];
+        let msg = super::decode_context("Whatever", &body);
+        assert!(
+            msg.len() < body.len(),
+            "excerpt was not bounded: {}",
+            msg.len()
+        );
+        assert!(
+            msg.contains("8192 bytes total"),
+            "missing the full size: {msg}"
+        );
     }
 
     #[test]

--- a/crates/minimal-client/src/lib.rs
+++ b/crates/minimal-client/src/lib.rs
@@ -902,12 +902,31 @@ fn decode_context(rpc: &str, body: &[u8]) -> String {
     format!("decode response for {rpc} (daemon replied: {excerpt})")
 }
 
-/// Set to a non-empty value to downgrade the version gate to a warning.
-/// Escape hatch for deliberate skew (bisecting a daemon regression against a
-/// known-good CLI); named in the gate's error so anyone who hits it finds it.
-pub const SKEW_OVERRIDE_VAR: &str = "MINIMAL_ALLOW_VERSION_SKEW";
+/// The wording, the override, and the placeholder for a daemon too old to
+/// report its build all live in the wire crate: the daemon produces the same
+/// message when it refuses a `CreateSession` whose `must_match_version` does
+/// not name it, and one definition means one sentence.
+pub use minimald_rpc::{SKEW_OVERRIDE_VAR, UNVERSIONED_DAEMON, version_skew_message};
 
-/// Refuse to drive a daemon built from a different tree than this CLI.
+/// Whether the operator asked for a skewed pair to be driven anyway.
+fn skew_override_set() -> bool {
+    std::env::var_os(SKEW_OVERRIDE_VAR).is_some_and(|v| !v.is_empty())
+}
+
+/// This CLI's build, to be asserted by an RPC that acts before it replies —
+/// today `CreateSessionRequest::must_match_version`.
+///
+/// `None` under [`SKEW_OVERRIDE_VAR`]: the daemon-side check refuses the call
+/// outright, and a refusal is not something the client could downgrade to a
+/// warning afterwards. Withholding the assertion is what keeps the override
+/// an override.
+#[must_use]
+pub fn version_assertion() -> Option<String> {
+    (!skew_override_set()).then(|| version::VERSION.to_string())
+}
+
+/// Refuse to drive a daemon built from a different tree than this CLI, given
+/// the build it just reported on a reply the caller was making anyway.
 ///
 /// The RPC surface is versioned by nothing but the two binaries agreeing, and
 /// several response types are `#[serde(deny_unknown_fields)]` on purpose (see
@@ -917,43 +936,57 @@ pub const SKEW_OVERRIDE_VAR: &str = "MINIMAL_ALLOW_VERSION_SKEW";
 /// exists on the daemon, and the activation's own cleanup then destroys it. To
 /// the operator every session is created and vanishes at once (#1251).
 ///
-/// Failing here costs one extra round trip and turns that into a diagnosis.
+/// `daemon` is `None` when the reply carried no version at all, which means a
+/// daemon older than the field — a skew by construction, reported as
+/// [`UNVERSIONED_DAEMON`] rather than waved through.
 ///
-/// Lives in this crate, not in `minimal`, because the dashboard activates
-/// sessions too: `min dash` drives the same create/upload/configure/finalize
-/// sequence from `minimal-tui`, which cannot depend on the CLI crate. One
-/// definition means one wording and one override for both front ends.
+/// Costs no round trip: every caller passes a version that came back on an RPC
+/// it had to make regardless. Lives in this crate, not in `minimal`, because
+/// the dashboard activates sessions too — `min dash` drives the same
+/// create/upload/configure/finalize sequence from `minimal-tui`, which cannot
+/// depend on the CLI crate.
+pub fn ensure_version_reported(daemon: Option<&str>) -> Result<(), anyhow::Error> {
+    if let Some(warning) = version_gate(version::VERSION, daemon, skew_override_set())? {
+        eprintln!("warning: {warning}");
+    }
+    Ok(())
+}
+
+/// The decision [`ensure_version_reported`] makes, split from the environment
+/// lookup and the printing so the override's semantics are testable without a
+/// process-global env var.
+///
+/// `Ok(None)` is a matching pair, `Ok(Some(warning))` is a skew the operator
+/// opted into, `Err` is a refusal.
+fn version_gate(
+    cli: &str,
+    daemon: Option<&str>,
+    override_set: bool,
+) -> Result<Option<String>, anyhow::Error> {
+    let daemon = daemon.unwrap_or(UNVERSIONED_DAEMON);
+    let Some(message) = version_skew_message(cli, daemon) else {
+        return Ok(None);
+    };
+    if override_set {
+        return Ok(Some(message));
+    }
+    anyhow::bail!("{message}");
+}
+
+/// [`ensure_version_reported`] for a path with no first RPC of its own to
+/// carry the assertion: spends a `GetVersion` round trip to learn the build.
+///
+/// Used by `connect_daemon` in the `minimal` crate, the generic connector that fronts
+/// the commands whose first call differs from one to the next. The
+/// activation path — the one the round trip actually showed up on — does not
+/// come through here; it asserts inside its own `CreateSession`.
 pub async fn ensure_version_match(client: &mut Client) -> Result<(), anyhow::Error> {
     use minimald_rpc::GetVersion;
     let daemon = client
         .oneshot_rpc::<GetVersion>(())
         .await
         .context("GetVersion RPC failed")?;
-
-    let Some(message) = version_skew_message(version::VERSION, &daemon.version) else {
-        return Ok(());
-    };
-    if std::env::var_os(SKEW_OVERRIDE_VAR).is_some_and(|v| !v.is_empty()) {
-        eprintln!("warning: {message}");
-        return Ok(());
-    }
-    anyhow::bail!("{message}");
-}
-
-/// The operator-facing account of a CLI/daemon version skew, or `None` when
-/// the two builds match. Split out from [`ensure_version_match`] so the
-/// wording is testable without a daemon.
-pub fn version_skew_message(cli: &str, daemon: &str) -> Option<String> {
-    (cli != daemon).then(|| {
-        format!(
-            "This CLI is minimal {cli}, but the running minimald is {daemon}. \
-             The two speak the same RPCs only when built together, so continuing \
-             would fail partway through and tear down whatever it had created. \
-             Restart the daemon on the new build: run `min stop`, then re-run this \
-             command (the daemon is started again automatically). \
-             Set {SKEW_OVERRIDE_VAR}=1 to proceed anyway."
-        )
-    })
+    ensure_version_reported(Some(&daemon.version))
 }
 
 /// The provider kind the CLI should talk to, given `--provider`.
@@ -1125,5 +1158,66 @@ mod tests {
             err.to_string().contains("SSH handshake timed out"),
             "expected a handshake-deadline error, got: {err:#}"
         );
+    }
+
+    /// The gate's three outcomes, off a version a reply already carried:
+    /// matching builds cost nothing, a differing build is refused with the
+    /// skew message, and the override downgrades that refusal to a warning
+    /// the caller prints.
+    #[test]
+    fn the_gate_passes_a_match_refuses_a_skew_and_warns_under_the_override() {
+        if let Some(warning) =
+            super::version_gate("0.6.0", Some("0.6.0"), false).expect("a matching pair must pass")
+        {
+            panic!("a matching pair must not warn: {warning}");
+        }
+
+        let err = super::version_gate("0.6.0", Some("0.5.0"), false)
+            .expect_err("a differing build must be refused")
+            .to_string();
+        assert!(err.contains("0.6.0") && err.contains("0.5.0"), "got: {err}");
+        assert!(err.contains("min stop"), "missing the recovery: {err}");
+        assert!(
+            err.contains(super::SKEW_OVERRIDE_VAR),
+            "missing the override: {err}"
+        );
+
+        let warning = super::version_gate("0.6.0", Some("0.5.0"), true)
+            .expect("the override must let the operator proceed")
+            .expect("the override still warns");
+        assert_eq!(warning, err);
+    }
+
+    /// A reply carrying no version at all comes from a daemon built before the
+    /// piggybacked handshake existed, which makes it a different build by
+    /// construction. It must be refused, and named — not waved through as an
+    /// unknown.
+    #[test]
+    fn a_reply_without_a_version_is_a_skew_not_an_unknown() {
+        let err = super::version_gate("0.6.0", None, false)
+            .expect_err("an unversioned daemon must be refused")
+            .to_string();
+        assert!(
+            err.contains(super::UNVERSIONED_DAEMON),
+            "the daemon must be named, got: {err}"
+        );
+        assert!(err.contains("min stop"), "missing the recovery: {err}");
+
+        super::version_gate("0.6.0", None, true)
+            .expect("the override must let the operator proceed")
+            .expect("the override still warns");
+    }
+
+    /// The assertion this CLI puts on a `CreateSession` is its own build —
+    /// except under the override, where it must be withheld entirely: the
+    /// daemon-side check refuses the call outright, and a refusal is not
+    /// something the client could downgrade to a warning after the fact.
+    #[test]
+    fn the_override_withholds_the_assertion_rather_than_softening_it() {
+        // `version_assertion` reads the process environment, so exercise the
+        // decision it encodes rather than racing other tests over an env var.
+        let assertion = |override_set: bool| (!override_set).then(|| version::VERSION.to_string());
+        assert_eq!(assertion(false).as_deref(), Some(version::VERSION));
+        assert_eq!(assertion(true), None);
     }
 }

--- a/crates/minimal-client/src/lib.rs
+++ b/crates/minimal-client/src/lib.rs
@@ -902,6 +902,60 @@ fn decode_context(rpc: &str, body: &[u8]) -> String {
     format!("decode response for {rpc} (daemon replied: {excerpt})")
 }
 
+/// Set to a non-empty value to downgrade the version gate to a warning.
+/// Escape hatch for deliberate skew (bisecting a daemon regression against a
+/// known-good CLI); named in the gate's error so anyone who hits it finds it.
+pub const SKEW_OVERRIDE_VAR: &str = "MINIMAL_ALLOW_VERSION_SKEW";
+
+/// Refuse to drive a daemon built from a different tree than this CLI.
+///
+/// The RPC surface is versioned by nothing but the two binaries agreeing, and
+/// several response types are `#[serde(deny_unknown_fields)]` on purpose (see
+/// `FinalizeSessionResponse` in `minimald-rpc` for why that guard is
+/// load-bearing). A skewed pair therefore doesn't fail at connect time — it
+/// fails *mid-activation*, at `FinalizeSession`, after the session already
+/// exists on the daemon, and the activation's own cleanup then destroys it. To
+/// the operator every session is created and vanishes at once (#1251).
+///
+/// Failing here costs one extra round trip and turns that into a diagnosis.
+///
+/// Lives in this crate, not in `minimal`, because the dashboard activates
+/// sessions too: `min dash` drives the same create/upload/configure/finalize
+/// sequence from `minimal-tui`, which cannot depend on the CLI crate. One
+/// definition means one wording and one override for both front ends.
+pub async fn ensure_version_match(client: &mut Client) -> Result<(), anyhow::Error> {
+    use minimald_rpc::GetVersion;
+    let daemon = client
+        .oneshot_rpc::<GetVersion>(())
+        .await
+        .context("GetVersion RPC failed")?;
+
+    let Some(message) = version_skew_message(version::VERSION, &daemon.version) else {
+        return Ok(());
+    };
+    if std::env::var_os(SKEW_OVERRIDE_VAR).is_some_and(|v| !v.is_empty()) {
+        eprintln!("warning: {message}");
+        return Ok(());
+    }
+    anyhow::bail!("{message}");
+}
+
+/// The operator-facing account of a CLI/daemon version skew, or `None` when
+/// the two builds match. Split out from [`ensure_version_match`] so the
+/// wording is testable without a daemon.
+pub fn version_skew_message(cli: &str, daemon: &str) -> Option<String> {
+    (cli != daemon).then(|| {
+        format!(
+            "This CLI is minimal {cli}, but the running minimald is {daemon}. \
+             The two speak the same RPCs only when built together, so continuing \
+             would fail partway through and tear down whatever it had created. \
+             Restart the daemon on the new build: run `min stop`, then re-run this \
+             command (the daemon is started again automatically). \
+             Set {SKEW_OVERRIDE_VAR}=1 to proceed anyway."
+        )
+    })
+}
+
 /// The provider kind the CLI should talk to, given `--provider`.
 ///
 /// The native minimald and minvmd backends now occupy distinct provider dirs,

--- a/crates/minimal-tui/src/rpc.rs
+++ b/crates/minimal-tui/src/rpc.rs
@@ -87,6 +87,11 @@ pub async fn discover(minimal_dir: Option<&Path>) -> Vec<Provider> {
         if !sock.exists() {
             continue;
         }
+        // Deliberately not version-gated: the dashboard is read-only until the
+        // user acts, it renders each provider's version in the sidebar, and a
+        // skewed daemon is precisely when an operator needs to see (and be able
+        // to destroy) the sessions on it. The one multi-step mutation the TUI
+        // drives, `activate`, gates on its own connection instead.
         match Client::connect(&sock).await {
             Ok(client) => providers.push(Provider {
                 label,
@@ -112,6 +117,8 @@ pub async fn connect_missing(providers: &mut Vec<Provider>, minimal_dir: Option<
         if !sock.exists() {
             continue;
         }
+        // Deliberately not version-gated, for the same reason as `discover`:
+        // a provider that reappears mid-run must still be listable.
         match tokio::time::timeout(CONNECT_TIMEOUT, Client::connect(&sock)).await {
             Ok(Ok(client)) => {
                 tracing::info!(provider = label, "provider connected");
@@ -249,6 +256,11 @@ pub async fn activate(
     contribution: sessions::wire::request::WireContribution,
 ) -> Result<SessionId, anyhow::Error> {
     let mut client = Client::connect(sock).await?;
+    // The dashboard's own copy of the create/upload/configure/finalize
+    // sequence, so it needs the same gate `min session activate` gets: on a
+    // skewed pair `FinalizeSession` fails after the record exists, and the
+    // abort below then destroys the session the user just created (#1251).
+    minimal_client::ensure_version_match(&mut client).await?;
     let id = match client
         .oneshot_rpc::<CreateSession>(CreateSessionRequest {
             config: SessionConfig {
@@ -456,5 +468,44 @@ mod tests {
         std::fs::write(dir.path().join(mfile::MFILE_NAME), "not valid toml = =").unwrap();
         let path = camino::Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
         assert!(resolve_upload_root(&path).is_err());
+    }
+}
+
+#[cfg(test)]
+mod version_gate_tests {
+    /// The dashboard opens three daemon connections, and #1251's gate reached
+    /// none of them. Only `activate` runs a multi-step mutation, so only it is
+    /// gated; the two discovery connections stay open on purpose and must say
+    /// so, since a reader who finds an ungated connect has no other way to tell
+    /// an audited decision from an oversight.
+    #[test]
+    fn only_the_activation_path_is_version_gated() {
+        // Concatenated so this scanner does not match itself.
+        const NEEDLE: &str = concat!("Client", "::connect(");
+        let src = include_str!("rpc.rs");
+
+        let mut gated = 0;
+        let mut explained = 0;
+        for (i, line) in src.lines().enumerate() {
+            if !line.contains(NEEDLE) {
+                continue;
+            }
+            // The classification is always within a few lines of the connect:
+            // the gate call just after it, or the rationale comment just before.
+            let window: Vec<&str> = src.lines().skip(i.saturating_sub(8)).take(20).collect();
+            let text = window.join("\n");
+            if text.contains("ensure_version_match") {
+                gated += 1;
+            } else if text.contains("not version-gated") {
+                explained += 1;
+            } else {
+                panic!("unclassified daemon connection at rpc.rs:{}", i + 1);
+            }
+        }
+        assert_eq!(
+            (gated, explained),
+            (1, 2),
+            "the connection inventory changed"
+        );
     }
 }

--- a/crates/minimal-tui/src/rpc.rs
+++ b/crates/minimal-tui/src/rpc.rs
@@ -260,8 +260,11 @@ pub async fn activate(
     // sequence, so it needs the same gate `min session activate` gets: on a
     // skewed pair `FinalizeSession` fails after the record exists, and the
     // abort below then destroys the session the user just created (#1251).
-    minimal_client::ensure_version_match(&mut client).await?;
-    let id = match client
+    // The gate is the `must_match_version` on the create below and the version
+    // the reply echoes back — not a `GetVersion` ahead of them. Activation is
+    // the one path where an extra round trip is felt, and the create can carry
+    // the check for free.
+    let created = match client
         .oneshot_rpc::<CreateSession>(CreateSessionRequest {
             config: SessionConfig {
                 name,
@@ -274,13 +277,23 @@ pub async fn activate(
                 hooks_enabled: true,
                 attrs: Default::default(),
             },
+            // A daemon of another build refuses this before it allocates
+            // anything; `None` under the skew override, which is how an
+            // operator still gets through.
+            must_match_version: minimal_client::version_assertion(),
         })
         .await
         .context("CreateSession RPC failed")?
     {
-        Errorable::Ok(resp) => resp.id,
+        Errorable::Ok(resp) => resp,
         Errorable::Err { error } => return Err(anyhow::anyhow!(error)),
     };
+    // A daemon that predates the field ignored the assertion and echoes no
+    // version; that silence is itself the skew. Refuse now — before the
+    // upload and the finalize — leaving an unfinalized record the daemon
+    // reaps when this connection drops.
+    minimal_client::ensure_version_reported(created.daemon_version.as_deref())?;
+    let id = created.id;
 
     let flow = async {
         // The upload-root walk and VCS-root stat are blocking filesystem
@@ -478,34 +491,126 @@ mod version_gate_tests {
     /// gated; the two discovery connections stay open on purpose and must say
     /// so, since a reader who finds an ungated connect has no other way to tell
     /// an audited decision from an oversight.
+    ///
+    /// Asserted as an inventory rather than a count, so adding, removing, or
+    /// reclassifying a connection fails here and forces the same judgement.
     #[test]
     fn only_the_activation_path_is_version_gated() {
+        assert_eq!(
+            connect_site_inventory(),
+            [
+                "activate = gated",
+                "connect_missing = ungated (explained)",
+                "discover = ungated (explained)",
+            ]
+        );
+    }
+
+    /// The dashboard's activation must not spend a round trip on the version
+    /// either. Its gate is the assertion on the `CreateSession` it was already
+    /// sending plus the build the reply echoes back — never a `GetVersion`
+    /// ahead of them.
+    ///
+    /// `refresh` still calls `GetVersion`, and must: the sidebar renders each
+    /// provider's build. That is a display fetch on the idle loop, not a gate
+    /// on the create path.
+    #[test]
+    fn the_dashboard_activation_makes_no_version_round_trip() {
+        let body = function_code("activate").expect("rpc.rs no longer defines activate");
+        for round_trip in ["GetVersion", "ensure_version_match"] {
+            assert!(
+                !body.contains(round_trip),
+                "activate reintroduced a version round trip ({round_trip})"
+            );
+        }
+        assert!(
+            body.contains("must_match_version"),
+            "activate no longer asserts its build on the create"
+        );
+        assert!(
+            body.contains("ensure_version_reported"),
+            "activate no longer checks the build the create echoed back"
+        );
+        assert!(
+            function_code("refresh").is_some_and(|f| f.contains("GetVersion")),
+            "the sidebar still needs each provider's version"
+        );
+    }
+
+    /// Every free-function declaration in this file, as `(line index, name)`.
+    fn fn_decls(lines: &[&str]) -> Vec<(usize, String)> {
+        lines
+            .iter()
+            .enumerate()
+            .filter_map(|(i, l)| {
+                let t = l.trim_start();
+                let t = t.strip_prefix("pub ").unwrap_or(t);
+                let t = t.strip_prefix("async ").unwrap_or(t);
+                t.strip_prefix("fn ")
+                    .map(|rest| (i, rest.split(['(', '<']).next().unwrap_or("").to_string()))
+            })
+            .collect()
+    }
+
+    /// The named function's code, comments dropped — the rationale prose names
+    /// the very mechanisms the scanners look for.
+    fn function_code(name: &str) -> Option<String> {
+        let src = include_str!("rpc.rs");
+        let lines: Vec<&str> = src.lines().collect();
+        let decls = fn_decls(&lines);
+        let at = decls.iter().position(|(_, n)| n == name)?;
+        let to = decls.get(at + 1).map_or(lines.len(), |(d, _)| *d);
+        Some(
+            lines[decls[at].0..to]
+                .iter()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .copied()
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    }
+
+    /// Attributes every direct `Client` connection in this file to the
+    /// function that opens it, and reports how it is classified: gated by the
+    /// assertion it carries on its own first RPC, or deliberately ungated with
+    /// a comment saying why. An unclassified connection fails the test.
+    fn connect_site_inventory() -> Vec<String> {
         // Concatenated so this scanner does not match itself.
         const NEEDLE: &str = concat!("Client", "::connect(");
         let src = include_str!("rpc.rs");
+        let lines: Vec<&str> = src.lines().collect();
+        let decls = fn_decls(&lines);
 
-        let mut gated = 0;
-        let mut explained = 0;
-        for (i, line) in src.lines().enumerate() {
+        let mut sites = Vec::new();
+        for (i, line) in lines.iter().enumerate() {
             if !line.contains(NEEDLE) {
                 continue;
             }
-            // The classification is always within a few lines of the connect:
-            // the gate call just after it, or the rationale comment just before.
-            let window: Vec<&str> = src.lines().skip(i.saturating_sub(8)).take(20).collect();
-            let text = window.join("\n");
-            if text.contains("ensure_version_match") {
-                gated += 1;
-            } else if text.contains("not version-gated") {
-                explained += 1;
-            } else {
-                panic!("unclassified daemon connection at rpc.rs:{}", i + 1);
-            }
+            let (start, name) = decls
+                .iter()
+                .rev()
+                .find(|(d, _)| *d < i)
+                .cloned()
+                .unwrap_or((0, "<top level>".to_string()));
+            let end = decls
+                .iter()
+                .find(|(d, _)| *d > start)
+                .map_or(lines.len(), |(d, _)| *d);
+            let body = &lines[start..end];
+            let gated = body.iter().any(|l| {
+                l.contains("must_match_version")
+                    || l.contains("ensure_version_reported")
+                    || l.contains("ensure_version_match")
+            });
+            let explained = body.iter().any(|l| l.contains("not version-gated"));
+            let label = match (gated, explained) {
+                (true, _) => "gated",
+                (false, true) => "ungated (explained)",
+                (false, false) => panic!("unclassified daemon connection in {name}"),
+            };
+            sites.push(format!("{name} = {label}"));
         }
-        assert_eq!(
-            (gated, explained),
-            (1, 2),
-            "the connection inventory changed"
-        );
+        sites.sort();
+        sites
     }
 }

--- a/crates/minimal/src/diag/net.rs
+++ b/crates/minimal/src/diag/net.rs
@@ -111,6 +111,9 @@ pub async fn probe_socket(sock_path: &Path) -> (SocketProbe, Option<crate::clien
     }
 
     let t = Instant::now();
+    // Deliberately not version-gated: a support bundle has to describe the
+    // daemon that is actually running, and a skew is one of the faults it is
+    // collected to reveal — refusing to probe would erase the evidence.
     let mut client = match crate::client::Client::connect(sock_path).await {
         Ok(client) => {
             probe.handshake = Stage::run(t, Ok(()));

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -941,6 +941,10 @@ async fn cmd_bare(global: &GlobalArgs) -> Result<(), anyhow::Error> {
     let mut client = client::Client::connect(&sock)
         .await
         .context("Failed to connect to minimald")?;
+    // Connects directly rather than through `connect_daemon` (it needs `sock`
+    // for the attach hand-off), so the gate is applied by hand — this path can
+    // end in an activation just as `min session activate` does.
+    ensure_version_match(&mut client).await?;
 
     match resolve_smart_attach(&mut client, global).await? {
         SmartAttach::Attach(entry) => {
@@ -1104,14 +1108,76 @@ fn display_with_home_tilde(path: &camino::Utf8Path, home: Option<&camino::Utf8Pa
     }
 }
 
-/// Connect to the daemon, resolving the socket path from global args.
+/// Connect to the daemon, resolving the socket path from global args, and
+/// refuse to proceed against a daemon of a different build
+/// ([`ensure_version_match`]).
 pub async fn connect_daemon(global: &GlobalArgs) -> Result<client::Client, anyhow::Error> {
+    let mut client = connect_daemon_unchecked(global).await?;
+    ensure_version_match(&mut client).await?;
+    Ok(client)
+}
+
+/// [`connect_daemon`] without the version gate.
+///
+/// For the commands that must keep working *because* the pair is skewed —
+/// `min stop` is the recovery the gate's own message prescribes, so gating it
+/// would leave the operator with no way out.
+async fn connect_daemon_unchecked(global: &GlobalArgs) -> Result<client::Client, anyhow::Error> {
     let sock = client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd())
         .context("Failed to resolve daemon socket path")?;
 
     client::Client::connect(&sock)
         .await
         .context("Failed to connect to minimald")
+}
+
+/// Set to a non-empty value to downgrade the version gate to a warning.
+/// Escape hatch for deliberate skew (bisecting a daemon regression against a
+/// known-good CLI); named in the gate's error so anyone who hits it finds it.
+const SKEW_OVERRIDE_VAR: &str = "MINIMAL_ALLOW_VERSION_SKEW";
+
+/// Refuse to drive a daemon built from a different tree than this CLI.
+///
+/// The RPC surface is versioned by nothing but the two binaries agreeing, and
+/// several response types are `#[serde(deny_unknown_fields)]` on purpose (see
+/// `FinalizeSessionResponse` in `minimald-rpc` for why that guard is
+/// load-bearing). A skewed pair therefore doesn't fail at connect time — it
+/// fails *mid-activation*, at `FinalizeSession`, after the session already
+/// exists on the daemon, and the activation's own cleanup then destroys it. To
+/// the operator every session is created and vanishes at once (#1251).
+///
+/// Failing here costs one extra round trip and turns that into a diagnosis.
+async fn ensure_version_match(client: &mut client::Client) -> Result<(), anyhow::Error> {
+    use minimald_rpc::GetVersion;
+    let daemon = client
+        .oneshot_rpc::<GetVersion>(())
+        .await
+        .context("GetVersion RPC failed")?;
+
+    let Some(message) = version_skew_message(version::VERSION, &daemon.version) else {
+        return Ok(());
+    };
+    if std::env::var_os(SKEW_OVERRIDE_VAR).is_some_and(|v| !v.is_empty()) {
+        eprintln!("warning: {message}");
+        return Ok(());
+    }
+    bail!("{message}");
+}
+
+/// The operator-facing account of a CLI/daemon version skew, or `None` when
+/// the two builds match. Split out from [`ensure_version_match`] so the
+/// wording is testable without a daemon.
+fn version_skew_message(cli: &str, daemon: &str) -> Option<String> {
+    (cli != daemon).then(|| {
+        format!(
+            "This CLI is minimal {cli}, but the running minimald is {daemon}. \
+             The two speak the same RPCs only when built together, so continuing \
+             would fail partway through and tear down whatever it had created. \
+             Restart the daemon on the new build: run `min stop`, then re-run this \
+             command (the daemon is started again automatically). \
+             Set {SKEW_OVERRIDE_VAR}=1 to proceed anyway."
+        )
+    })
 }
 
 /// A session reference parsed from a CLI string: either a UUID or a name.
@@ -3148,7 +3214,9 @@ pub async fn cmd_stop(global: &GlobalArgs, args: StopArgs) -> Result<(), anyhow:
     // Racy by nature: the daemon may go down between the probe and this connect
     // (or `--provider` may point the probe and the client at different backends),
     // so a connect failure is still a real error, not something to swallow.
-    let mut client = connect_daemon(global).await?;
+    // Unchecked: stopping a version-skewed daemon is exactly what the version
+    // gate tells the operator to do, so this command must never be gated by it.
+    let mut client = connect_daemon_unchecked(global).await?;
 
     use minimald_rpc::{Shutdown, ShutdownRequest};
     let resp = client
@@ -3721,6 +3789,33 @@ mod tests {
         // A signalled child reports no code of its own; the shell's 128 + n.
         // 9 is SIGKILL, in the low bits where wait(2) puts the signal.
         assert_eq!(exit_code_of(std::process::ExitStatus::from_raw(9)), 137);
+    }
+
+    /// A CLI upgraded past its daemon must be refused up front, naming both
+    /// builds and the recovery. Before #1251 the skew surfaced only at
+    /// `FinalizeSession`, by which point the activation's cleanup had already
+    /// destroyed the session it had just created.
+    #[test]
+    fn version_skew_is_reported_with_both_builds_and_a_recovery() {
+        let msg = version_skew_message("0.6.0", "0.5.0-dev.12.g86ce5c3a")
+            .expect("differing builds are a skew");
+        assert!(msg.contains("0.6.0"), "missing the CLI version: {msg}");
+        assert!(
+            msg.contains("0.5.0-dev.12.g86ce5c3a"),
+            "missing the daemon version: {msg}"
+        );
+        assert!(msg.contains("min stop"), "missing the recovery: {msg}");
+        assert!(
+            msg.contains(SKEW_OVERRIDE_VAR),
+            "missing the override: {msg}"
+        );
+    }
+
+    /// Matching builds are the overwhelmingly common case and must cost the
+    /// operator nothing.
+    #[test]
+    fn matching_versions_are_not_a_skew() {
+        assert!(version_skew_message(version::VERSION, version::VERSION).is_none());
     }
 
     /// The `Cli` command tree must stay well-formed: a malformed clap

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -21,6 +21,10 @@ pub mod config;
 pub mod diag;
 pub mod dirs;
 use minimal_client::file_upload;
+// The version gate lives in `minimal-client`, next to the transport it guards,
+// so the dashboard's activation path (`minimal-tui`, which cannot depend on
+// this crate) gates on the same wording and the same override.
+use minimal_client::ensure_version_match;
 pub mod git_remote;
 pub mod loadouts;
 pub mod prompt;
@@ -1131,55 +1135,6 @@ async fn connect_daemon_unchecked(global: &GlobalArgs) -> Result<client::Client,
         .context("Failed to connect to minimald")
 }
 
-/// Set to a non-empty value to downgrade the version gate to a warning.
-/// Escape hatch for deliberate skew (bisecting a daemon regression against a
-/// known-good CLI); named in the gate's error so anyone who hits it finds it.
-const SKEW_OVERRIDE_VAR: &str = "MINIMAL_ALLOW_VERSION_SKEW";
-
-/// Refuse to drive a daemon built from a different tree than this CLI.
-///
-/// The RPC surface is versioned by nothing but the two binaries agreeing, and
-/// several response types are `#[serde(deny_unknown_fields)]` on purpose (see
-/// `FinalizeSessionResponse` in `minimald-rpc` for why that guard is
-/// load-bearing). A skewed pair therefore doesn't fail at connect time — it
-/// fails *mid-activation*, at `FinalizeSession`, after the session already
-/// exists on the daemon, and the activation's own cleanup then destroys it. To
-/// the operator every session is created and vanishes at once (#1251).
-///
-/// Failing here costs one extra round trip and turns that into a diagnosis.
-async fn ensure_version_match(client: &mut client::Client) -> Result<(), anyhow::Error> {
-    use minimald_rpc::GetVersion;
-    let daemon = client
-        .oneshot_rpc::<GetVersion>(())
-        .await
-        .context("GetVersion RPC failed")?;
-
-    let Some(message) = version_skew_message(version::VERSION, &daemon.version) else {
-        return Ok(());
-    };
-    if std::env::var_os(SKEW_OVERRIDE_VAR).is_some_and(|v| !v.is_empty()) {
-        eprintln!("warning: {message}");
-        return Ok(());
-    }
-    bail!("{message}");
-}
-
-/// The operator-facing account of a CLI/daemon version skew, or `None` when
-/// the two builds match. Split out from [`ensure_version_match`] so the
-/// wording is testable without a daemon.
-fn version_skew_message(cli: &str, daemon: &str) -> Option<String> {
-    (cli != daemon).then(|| {
-        format!(
-            "This CLI is minimal {cli}, but the running minimald is {daemon}. \
-             The two speak the same RPCs only when built together, so continuing \
-             would fail partway through and tear down whatever it had created. \
-             Restart the daemon on the new build: run `min stop`, then re-run this \
-             command (the daemon is started again automatically). \
-             Set {SKEW_OVERRIDE_VAR}=1 to proceed anyway."
-        )
-    })
-}
-
 /// A session reference parsed from a CLI string: either a UUID or a name.
 /// Used to build the typed request enums both `GetSessionRecord` and
 /// `GetSessionPolicy` expect.
@@ -1782,6 +1737,9 @@ fn arm_activation_interrupt(
             return;
         }
         eprintln!("\nAborting activation; cleaning up session {session_id}…");
+        // Deliberately not version-gated: this is the cleanup half of an
+        // activation the gate already cleared, and a cleanup that refuses to
+        // run is the orphaned session #1251 is about.
         if let Ok(sock) = sock
             && let Ok(mut client) = client::Client::connect(&sock).await
         {
@@ -2367,6 +2325,10 @@ pub async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), any
     let mut client = client::Client::connect(&sock)
         .await
         .context("Failed to connect to minimald")?;
+    // Connects directly rather than through `connect_daemon` (it needs `sock`
+    // for the ssh hand-off), so the gate is applied by hand — with no session
+    // named, this path creates one, and a skewed activation is #1251 exactly.
+    ensure_version_match(&mut client).await?;
 
     let (id, name) = match args.session {
         Some(ref s) => {
@@ -2404,6 +2366,10 @@ pub async fn cmd_exec(global: &GlobalArgs, args: ExecArgs) -> Result<(), anyhow:
     let mut client = client::Client::connect(&sock)
         .await
         .context("Failed to connect to minimald")?;
+    // Gated by hand for the same reason as `cmd_attach`: this hands off into a
+    // live session (the daemon mints the exec channel and runs the attach
+    // hooks around it), which is not something to drive on a skewed pair.
+    ensure_version_match(&mut client).await?;
 
     let r = resolve_session(&mut client, &args.session).await?;
     tracing::info!(
@@ -2632,6 +2598,10 @@ pub async fn cmd_session_setup_zed(
     let mut daemon_client = client::Client::connect(&sock)
         .await
         .context("Failed to connect to minimald")?;
+    // Gated: the record read here is baked into Zed's settings.json and
+    // outlives the command, so it must not be sourced from a daemon the
+    // operator is about to restart onto another build.
+    ensure_version_match(&mut daemon_client).await?;
     let record = resolve_session(&mut daemon_client, &args.session).await?;
 
     // Pin the socket explicitly rather than leaning on `min proxy`'s own
@@ -3390,6 +3360,10 @@ pub async fn cmd_ssh_forward(
     let mut daemon_client = client::Client::connect(&sock)
         .await
         .context("Failed to connect to minimald")?;
+    // Gated: like `cmd_attach`, this hands off into a live session — the
+    // forward's server-side auth gate is keyed on wire types both builds have
+    // to agree on.
+    ensure_version_match(&mut daemon_client).await?;
 
     let record = resolve_session(&mut daemon_client, &args.session).await?;
 
@@ -3734,6 +3708,9 @@ pub async fn cmd_version(global: &GlobalArgs) -> Result<(), anyhow::Error> {
         }
     };
 
+    // Deliberately not version-gated: reporting the two versions is how an
+    // operator sees a skew at all, so this must answer on a skewed pair rather
+    // than refuse — and the gate's own check is this very RPC.
     let mut client = match client::Client::connect(&sock).await {
         Ok(c) => c,
         Err(e) => {
@@ -3797,7 +3774,7 @@ mod tests {
     /// destroyed the session it had just created.
     #[test]
     fn version_skew_is_reported_with_both_builds_and_a_recovery() {
-        let msg = version_skew_message("0.6.0", "0.5.0-dev.12.g86ce5c3a")
+        let msg = client::version_skew_message("0.6.0", "0.5.0-dev.12.g86ce5c3a")
             .expect("differing builds are a skew");
         assert!(msg.contains("0.6.0"), "missing the CLI version: {msg}");
         assert!(
@@ -3806,16 +3783,120 @@ mod tests {
         );
         assert!(msg.contains("min stop"), "missing the recovery: {msg}");
         assert!(
-            msg.contains(SKEW_OVERRIDE_VAR),
+            msg.contains(client::SKEW_OVERRIDE_VAR),
             "missing the override: {msg}"
         );
+    }
+
+    /// Every direct daemon connection in this crate is either version-gated or
+    /// deliberately not, and this test is where that decision is recorded.
+    ///
+    /// #1251 shipped the gate but wired it to two call sites; the rest reached
+    /// activations and live-session hand-offs ungated. A new connection is easy
+    /// to add and easy to forget, so the inventory is asserted rather than
+    /// documented: adding, removing, or un-gating one fails here and forces the
+    /// same judgement — can this path leave daemon state half-built (gate it),
+    /// or must it work *because* the pair is skewed (leave it, with a comment
+    /// saying why)?
+    #[test]
+    fn every_daemon_connection_is_classified() {
+        assert_eq!(
+            connect_site_inventory(env!("CARGO_MANIFEST_DIR")),
+            [
+                "diag/net.rs::probe_socket = ungated",
+                "lib.rs::arm_activation_interrupt = ungated",
+                "lib.rs::cmd_attach = gated",
+                "lib.rs::cmd_bare = gated",
+                "lib.rs::cmd_exec = gated",
+                "lib.rs::cmd_session_setup_zed = gated",
+                "lib.rs::cmd_ssh_forward = gated",
+                "lib.rs::cmd_version = ungated",
+                "lib.rs::connect_daemon_unchecked = ungated",
+                "task.rs::arm_task_run_interrupt = ungated",
+            ]
+        );
+    }
+
+    /// Attributes every direct `Client` connection under `<crate>/src` to the
+    /// function that opens it, and reports whether that function also applies
+    /// the version gate. Source-level on purpose: the alternative is a live
+    /// daemon per call site.
+    fn connect_site_inventory(manifest_dir: &str) -> Vec<String> {
+        // Built by concatenation so this scanner does not match itself.
+        const NEEDLE: &str = concat!("Client", "::connect(");
+        let src = std::path::Path::new(manifest_dir).join("src");
+
+        let mut files = Vec::new();
+        let mut stack = vec![src.clone()];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("crate src must be readable") {
+                let path = entry.expect("readable dir entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    files.push(path);
+                }
+            }
+        }
+        files.sort();
+
+        let is_fn_decl = |line: &str| {
+            let t = line.trim_start();
+            let t = t
+                .strip_prefix("pub(crate) ")
+                .or_else(|| t.strip_prefix("pub "))
+                .unwrap_or(t);
+            let t = t.strip_prefix("async ").unwrap_or(t);
+            t.strip_prefix("fn ")
+                .map(|rest| rest.split(['(', '<']).next().unwrap_or("").to_string())
+        };
+
+        let mut sites = Vec::new();
+        for path in files {
+            let text = std::fs::read_to_string(&path).expect("source file must be readable");
+            let lines: Vec<&str> = text.lines().collect();
+            let decls: Vec<(usize, String)> = lines
+                .iter()
+                .enumerate()
+                .filter_map(|(i, l)| is_fn_decl(l).map(|n| (i, n)))
+                .collect();
+            let rel = path
+                .strip_prefix(&src)
+                .expect("scanned under src")
+                .to_string_lossy()
+                .into_owned();
+            for (i, line) in lines.iter().enumerate() {
+                if !line.contains(NEEDLE) {
+                    continue;
+                }
+                let (start, name) = decls
+                    .iter()
+                    .rev()
+                    .find(|(d, _)| *d < i)
+                    .cloned()
+                    .unwrap_or((0, "<top level>".to_string()));
+                let end = decls
+                    .iter()
+                    .find(|(d, _)| *d > start)
+                    .map_or(lines.len(), |(d, _)| *d);
+                let gated = lines[start..end]
+                    .iter()
+                    .any(|l| l.contains("ensure_version_match"));
+                sites.push(format!(
+                    "{rel}::{name} = {}",
+                    if gated { "gated" } else { "ungated" }
+                ));
+            }
+        }
+        sites.sort();
+        sites
     }
 
     /// Matching builds are the overwhelmingly common case and must cost the
     /// operator nothing.
     #[test]
     fn matching_versions_are_not_a_skew() {
-        assert!(version_skew_message(version::VERSION, version::VERSION).is_none());
+        assert!(client::version_skew_message(version::VERSION, version::VERSION).is_none());
     }
 
     /// The `Cli` command tree must stay well-formed: a malformed clap

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -24,7 +24,10 @@ use minimal_client::file_upload;
 // The version gate lives in `minimal-client`, next to the transport it guards,
 // so the dashboard's activation path (`minimal-tui`, which cannot depend on
 // this crate) gates on the same wording and the same override.
-use minimal_client::ensure_version_match;
+// `ensure_version_reported` asserts a build a reply already carried;
+// `ensure_version_match` is the round-trip form, for paths with no first RPC
+// of their own to carry it.
+use minimal_client::{ensure_version_match, ensure_version_reported, version_assertion};
 pub mod git_remote;
 pub mod loadouts;
 pub mod prompt;
@@ -947,10 +950,12 @@ async fn cmd_bare(global: &GlobalArgs) -> Result<(), anyhow::Error> {
         .context("Failed to connect to minimald")?;
     // Connects directly rather than through `connect_daemon` (it needs `sock`
     // for the attach hand-off), so the gate is applied by hand — this path can
-    // end in an activation just as `min session activate` does.
-    ensure_version_match(&mut client).await?;
+    // end in an activation just as `min session activate` does. It rides on the
+    // `ListSessions` this path had to send anyway; nothing here spends a round
+    // trip on the version alone.
+    let listed = list_sessions_version_gated(&mut client).await?;
 
-    match resolve_smart_attach(&mut client, global).await? {
+    match resolve_smart_attach(&listed.sessions, global)? {
         SmartAttach::Attach(entry) => {
             tracing::info!(
                 session_id = %entry.id,
@@ -1115,18 +1120,29 @@ fn display_with_home_tilde(path: &camino::Utf8Path, home: Option<&camino::Utf8Pa
 /// Connect to the daemon, resolving the socket path from global args, and
 /// refuse to proceed against a daemon of a different build
 /// ([`ensure_version_match`]).
+///
+/// Costs a `GetVersion` round trip, which is why the paths that care — the
+/// activation, and the attach/exec hand-offs — do not come through here: they
+/// fold the assertion into the RPC they were already sending. This stays the
+/// safe default for the rest, whose first call differs from one command to the
+/// next and none of which is hot.
 pub async fn connect_daemon(global: &GlobalArgs) -> Result<client::Client, anyhow::Error> {
     let mut client = connect_daemon_unchecked(global).await?;
     ensure_version_match(&mut client).await?;
     Ok(client)
 }
 
-/// [`connect_daemon`] without the version gate.
+/// [`connect_daemon`] without the `GetVersion` gate.
 ///
-/// For the commands that must keep working *because* the pair is skewed —
-/// `min stop` is the recovery the gate's own message prescribes, so gating it
-/// would leave the operator with no way out.
-async fn connect_daemon_unchecked(global: &GlobalArgs) -> Result<client::Client, anyhow::Error> {
+/// Two kinds of caller. The commands that must keep working *because* the pair
+/// is skewed — `min stop` is the recovery the gate's own message prescribes, so
+/// gating it would leave the operator with no way out. And the activation path,
+/// which *is* gated, just not from here: its `CreateSession` carries the
+/// assertion itself, so routing it through [`connect_daemon`] would only add
+/// the round trip this connector exists to skip.
+pub(crate) async fn connect_daemon_unchecked(
+    global: &GlobalArgs,
+) -> Result<client::Client, anyhow::Error> {
     let sock = client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd())
         .context("Failed to resolve daemon socket path")?;
 
@@ -1190,16 +1206,64 @@ async fn resolve_session(
     client: &mut client::Client,
     session: &str,
 ) -> Result<sessions::Record, anyhow::Error> {
+    let resp = get_session_record(client, session).await?;
+    named_record(resp.record, session)
+}
+
+/// [`resolve_session`] for the paths that must refuse a version-skewed daemon:
+/// the same lookup, with the build it reports asserted before the record is
+/// used for anything.
+///
+/// The lookup is the first RPC `min session attach`, `min session exec`,
+/// `min session setup-zed`, and `min ssh-forward` make, so the gate rides on
+/// its reply rather than on a `GetVersion` sent ahead of it — an activation
+/// must not pay a round trip for a check the calls it already makes can carry
+/// (#1251). Ordered so the skew is reported ahead of a "no session found":
+/// against the wrong daemon, the name is the less useful of the two answers.
+async fn resolve_session_version_gated(
+    client: &mut client::Client,
+    session: &str,
+) -> Result<sessions::Record, anyhow::Error> {
+    let resp = get_session_record(client, session).await?;
+    ensure_version_reported(resp.daemon_version.as_deref())?;
+    named_record(resp.record, session)
+}
+
+/// The `GetSessionRecord` round trip both resolvers share.
+async fn get_session_record(
+    client: &mut client::Client,
+    session: &str,
+) -> Result<minimald_rpc::GetSessionRecordResponse, anyhow::Error> {
     use minimald_rpc::{GetSessionRecord, GetSessionRecordRequest};
     let lookup: GetSessionRecordRequest = SessionLookup::parse(session).into();
-    let resp = client
+    client
         .oneshot_rpc::<GetSessionRecord>(lookup)
         .await
-        .context("GetSessionRecord RPC failed")?;
-    match resp.record {
-        Some(r) => Ok(r),
-        None => bail!("No session found matching '{session}'"),
-    }
+        .context("GetSessionRecord RPC failed")
+}
+
+/// Unwrap a looked-up record, naming what was asked for when nothing matched.
+fn named_record(
+    record: Option<sessions::Record>,
+    session: &str,
+) -> Result<sessions::Record, anyhow::Error> {
+    record.ok_or_else(|| anyhow::anyhow!("No session found matching '{session}'"))
+}
+
+/// `ListSessions` with the daemon's build asserted off the same reply, for the
+/// paths that go on to attach or activate. See
+/// [`resolve_session_version_gated`] for why the gate rides here rather than on
+/// a `GetVersion` of its own.
+async fn list_sessions_version_gated(
+    client: &mut client::Client,
+) -> Result<minimald_rpc::ListSessionsResponse, anyhow::Error> {
+    use minimald_rpc::ListSessions;
+    let resp = client
+        .oneshot_rpc::<ListSessions>(())
+        .await
+        .context("ListSessions RPC failed")?;
+    ensure_version_reported(resp.daemon_version.as_deref())?;
+    Ok(resp)
 }
 
 /// Bidirectionally pipe stdio to a daemon UDS socket.
@@ -1999,7 +2063,11 @@ async fn activate_session(
             file_upload::is_empty_or_home(root.as_std_path(), std::env::home_dir().as_deref())
         });
 
-    let mut client = connect_daemon(global).await?;
+    // Deliberately not `connect_daemon`: this path's version gate travels on
+    // the `CreateSession` below rather than on a `GetVersion` sent ahead of it.
+    // Activation is the hot path #1251's gate landed on, and it must not pay a
+    // round trip for a check its own first RPC can make.
+    let mut client = connect_daemon_unchecked(global).await?;
 
     use minimald_rpc::{
         ConfigureLoadout, ConfigureLoadoutRequest, CreateSession, CreateSessionRequest,
@@ -2015,6 +2083,11 @@ async fn activate_session(
         let resp = client
             .oneshot_rpc::<CreateSession>(CreateSessionRequest {
                 config: config.clone(),
+                // The version gate: a daemon of another build refuses this
+                // call outright, before it has allocated anything to tear
+                // down. `None` under the skew override, which is what lets an
+                // operator proceed.
+                must_match_version: version_assertion(),
             })
             .await
             .context("CreateSession RPC failed")?;
@@ -2030,6 +2103,13 @@ async fn activate_session(
             }
         }
     };
+    // The other half of the gate: a daemon old enough to predate
+    // `must_match_version` ignored the assertion instead of answering it, and
+    // says so by echoing no version at all. Being older than the field is
+    // itself proof of a skew, so refuse here — still before the upload, the
+    // loadout, and the finalize that #1251 died at, and with the session left
+    // unfinalized for the daemon to reap when this connection drops.
+    ensure_version_reported(created.daemon_version.as_deref())?;
     let id = created.id;
 
     // From here the session exists on the daemon in an unfinalized state.
@@ -2328,14 +2408,17 @@ pub async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), any
     // Connects directly rather than through `connect_daemon` (it needs `sock`
     // for the ssh hand-off), so the gate is applied by hand — with no session
     // named, this path creates one, and a skewed activation is #1251 exactly.
-    ensure_version_match(&mut client).await?;
-
+    // Both arms below gate on the build the daemon reports on the lookup they
+    // were already making, so the gate costs no round trip of its own.
     let (id, name) = match args.session {
         Some(ref s) => {
-            let r = resolve_session(&mut client, s).await?;
+            let r = resolve_session_version_gated(&mut client, s).await?;
             (r.id, r.name)
         }
-        None => match resolve_smart_attach(&mut client, global).await? {
+        None => match resolve_smart_attach(
+            &list_sessions_version_gated(&mut client).await?.sessions,
+            global,
+        )? {
             SmartAttach::Attach(entry) => (entry.id, entry.name),
             SmartAttach::CreateForCwd => return activate_new_for_attach(global).await,
             SmartAttach::NoSessions => {
@@ -2368,10 +2451,9 @@ pub async fn cmd_exec(global: &GlobalArgs, args: ExecArgs) -> Result<(), anyhow:
         .context("Failed to connect to minimald")?;
     // Gated by hand for the same reason as `cmd_attach`: this hands off into a
     // live session (the daemon mints the exec channel and runs the attach
-    // hooks around it), which is not something to drive on a skewed pair.
-    ensure_version_match(&mut client).await?;
-
-    let r = resolve_session(&mut client, &args.session).await?;
+    // hooks around it), which is not something to drive on a skewed pair. The
+    // gate rides on the lookup's reply — no `GetVersion` ahead of it.
+    let r = resolve_session_version_gated(&mut client, &args.session).await?;
     tracing::info!(
         session_id = %r.id,
         session_name = ?r.name,
@@ -2382,24 +2464,22 @@ pub async fn cmd_exec(global: &GlobalArgs, args: ExecArgs) -> Result<(), anyhow:
 }
 
 /// Resolve a session to attach to when the user supplied no explicit session
-/// reference. Lists sessions, matches against the current working directory,
-/// and either attaches directly (unambiguous), opens the interactive picker
-/// (ambiguous), or errors (ambiguous but non-interactive).
+/// reference. Matches an already-fetched session list against the current
+/// working directory, and either attaches directly (unambiguous), opens the
+/// interactive picker (ambiguous), or errors (ambiguous but non-interactive).
+///
+/// Takes the list rather than fetching it so its two callers can assert the
+/// daemon's build off the `ListSessions` reply — before the picker blocks on a
+/// human, not after.
 ///
 /// Returns [`SmartAttach::NoSessions`] when no sessions exist at all, which
 /// `min session attach` reports as an error pointing at `min session activate`.
-async fn resolve_smart_attach(
-    client: &mut client::Client,
+fn resolve_smart_attach(
+    sessions: &[minimald_rpc::ListSessionsEntry],
     global: &GlobalArgs,
 ) -> Result<SmartAttach, anyhow::Error> {
-    use minimald_rpc::ListSessions;
-
-    let resp = client
-        .oneshot_rpc::<ListSessions>(())
-        .await
-        .context("ListSessions RPC failed")?;
     let cwd = attach::cwd_host_path(global)?;
-    match attach::resolve_for_attach(&resp.sessions, &cwd) {
+    match attach::resolve_for_attach(sessions, &cwd) {
         attach::SmartResolve::NoSessions => Ok(SmartAttach::NoSessions),
         attach::SmartResolve::Attach(entry) => {
             // Unambiguous auto-resolve: the operator never chose this session,
@@ -2600,9 +2680,9 @@ pub async fn cmd_session_setup_zed(
         .context("Failed to connect to minimald")?;
     // Gated: the record read here is baked into Zed's settings.json and
     // outlives the command, so it must not be sourced from a daemon the
-    // operator is about to restart onto another build.
-    ensure_version_match(&mut daemon_client).await?;
-    let record = resolve_session(&mut daemon_client, &args.session).await?;
+    // operator is about to restart onto another build. The daemon names its
+    // build on the lookup's own reply.
+    let record = resolve_session_version_gated(&mut daemon_client, &args.session).await?;
 
     // Pin the socket explicitly rather than leaning on `min proxy`'s own
     // resolution: Zed launches the ProxyCommand from its own environment, which
@@ -3362,10 +3442,8 @@ pub async fn cmd_ssh_forward(
         .context("Failed to connect to minimald")?;
     // Gated: like `cmd_attach`, this hands off into a live session — the
     // forward's server-side auth gate is keyed on wire types both builds have
-    // to agree on.
-    ensure_version_match(&mut daemon_client).await?;
-
-    let record = resolve_session(&mut daemon_client, &args.session).await?;
+    // to agree on. Asserted off the lookup this command already makes.
+    let record = resolve_session_version_gated(&mut daemon_client, &args.session).await?;
 
     // Validate the forward spec format: local:remote_host:remote_port.
     // We accept either `local_port:host:port` (3 components, last two joined by
@@ -3817,15 +3895,100 @@ mod tests {
         );
     }
 
-    /// Attributes every direct `Client` connection under `<crate>/src` to the
-    /// function that opens it, and reports whether that function also applies
-    /// the version gate. Source-level on purpose: the alternative is a live
-    /// daemon per call site.
-    fn connect_site_inventory(manifest_dir: &str) -> Vec<String> {
-        // Built by concatenation so this scanner does not match itself.
-        const NEEDLE: &str = concat!("Client", "::connect(");
-        let src = std::path::Path::new(manifest_dir).join("src");
+    /// Every `CreateSession` this crate sends states, in the request itself,
+    /// whether it asserts the daemon's build.
+    ///
+    /// The struct field makes omitting the decision a compile error; this
+    /// makes answering it "no" a visible one. Both session-creating paths
+    /// assert — they are the ones #1251 is about — and the inventory is what
+    /// stops a third from quietly passing `None`.
+    #[test]
+    fn every_create_session_asserts_the_daemon_build() {
+        assert_eq!(
+            create_site_inventory(env!("CARGO_MANIFEST_DIR")),
+            [
+                "lib.rs::activate_session = asserts",
+                "task.rs::cmd_task_run = asserts",
+            ]
+        );
+    }
 
+    /// The activation path must not spend a round trip on the version.
+    ///
+    /// That was the cost of #1251's first fix: a `GetVersion` ahead of the
+    /// create, on the one path where an extra RTT is felt. The check now rides
+    /// on the `CreateSession` the path was already sending, so the marks of
+    /// the old mechanism — `GetVersion`, `ensure_version_match`, or the
+    /// `connect_daemon` that issues it — must be absent from both creators,
+    /// and the marks of the new one present.
+    #[test]
+    fn the_activation_path_makes_no_version_round_trip() {
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        for (file, func) in [
+            ("src/lib.rs", "activate_session"),
+            ("src/task.rs", "cmd_task_run"),
+        ] {
+            let text = std::fs::read_to_string(manifest.join(file)).expect("readable source");
+            let body = function_body(&text, func)
+                .unwrap_or_else(|| panic!("{file} no longer defines {func}"));
+            for round_trip in ["GetVersion", "ensure_version_match", "connect_daemon("] {
+                assert!(
+                    !body.contains(round_trip),
+                    "{func} reintroduced a version round trip ({round_trip})"
+                );
+            }
+            assert!(
+                body.contains("must_match_version"),
+                "{func} no longer asserts its build on the create"
+            );
+            assert!(
+                body.contains("ensure_version_reported"),
+                "{func} no longer checks the build the create echoed back"
+            );
+        }
+    }
+
+    /// The code of the named free function, from its `fn` line to the next
+    /// one, with comment lines dropped — the prose here talks *about* the
+    /// mechanisms the caller is scanning for, and a rationale comment naming
+    /// `GetVersion` must not read as a call to it.
+    fn function_body(text: &str, name: &str) -> Option<String> {
+        let lines: Vec<&str> = text.lines().collect();
+        let decls = fn_decl_lines(&lines);
+        let start = decls.iter().position(|(_, n)| n == name)?;
+        let from = decls[start].0;
+        let to = decls.get(start + 1).map_or(lines.len(), |(d, _)| *d);
+        Some(
+            lines[from..to]
+                .iter()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .copied()
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    }
+
+    /// Every free-function declaration in `lines`, as `(line index, name)`.
+    fn fn_decl_lines(lines: &[&str]) -> Vec<(usize, String)> {
+        lines
+            .iter()
+            .enumerate()
+            .filter_map(|(i, l)| {
+                let t = l.trim_start();
+                let t = t
+                    .strip_prefix("pub(crate) ")
+                    .or_else(|| t.strip_prefix("pub "))
+                    .unwrap_or(t);
+                let t = t.strip_prefix("async ").unwrap_or(t);
+                t.strip_prefix("fn ")
+                    .map(|rest| (i, rest.split(['(', '<']).next().unwrap_or("").to_string()))
+            })
+            .collect()
+    }
+
+    /// Every `.rs` file under `<crate>/src`, sorted.
+    fn crate_sources(manifest_dir: &str) -> (std::path::PathBuf, Vec<std::path::PathBuf>) {
+        let src = std::path::Path::new(manifest_dir).join("src");
         let mut files = Vec::new();
         let mut stack = vec![src.clone()];
         while let Some(dir) = stack.pop() {
@@ -3839,34 +4002,31 @@ mod tests {
             }
         }
         files.sort();
+        (src, files)
+    }
 
-        let is_fn_decl = |line: &str| {
-            let t = line.trim_start();
-            let t = t
-                .strip_prefix("pub(crate) ")
-                .or_else(|| t.strip_prefix("pub "))
-                .unwrap_or(t);
-            let t = t.strip_prefix("async ").unwrap_or(t);
-            t.strip_prefix("fn ")
-                .map(|rest| rest.split(['(', '<']).next().unwrap_or("").to_string())
-        };
-
+    /// Attributes every line matching `needle` under `<crate>/src` to the
+    /// function containing it, labelling that function by whether its body
+    /// carries one of `markers`.
+    fn source_inventory(
+        manifest_dir: &str,
+        needle: &str,
+        markers: &[&str],
+        labels: (&str, &str),
+    ) -> Vec<String> {
+        let (src, files) = crate_sources(manifest_dir);
         let mut sites = Vec::new();
         for path in files {
             let text = std::fs::read_to_string(&path).expect("source file must be readable");
             let lines: Vec<&str> = text.lines().collect();
-            let decls: Vec<(usize, String)> = lines
-                .iter()
-                .enumerate()
-                .filter_map(|(i, l)| is_fn_decl(l).map(|n| (i, n)))
-                .collect();
+            let decls = fn_decl_lines(&lines);
             let rel = path
                 .strip_prefix(&src)
                 .expect("scanned under src")
                 .to_string_lossy()
                 .into_owned();
             for (i, line) in lines.iter().enumerate() {
-                if !line.contains(NEEDLE) {
+                if !line.contains(needle) {
                     continue;
                 }
                 let (start, name) = decls
@@ -3879,17 +4039,61 @@ mod tests {
                     .iter()
                     .find(|(d, _)| *d > start)
                     .map_or(lines.len(), |(d, _)| *d);
-                let gated = lines[start..end]
+                let marked = lines[start..end]
                     .iter()
-                    .any(|l| l.contains("ensure_version_match"));
+                    .any(|l| markers.iter().any(|m| l.contains(m)));
                 sites.push(format!(
                     "{rel}::{name} = {}",
-                    if gated { "gated" } else { "ungated" }
+                    if marked { labels.0 } else { labels.1 }
                 ));
             }
         }
         sites.sort();
         sites
+    }
+
+    /// Attributes every `CreateSessionRequest` construction under
+    /// `<crate>/src` to its function, and reports whether it asserts this
+    /// build.
+    fn create_site_inventory(manifest_dir: &str) -> Vec<String> {
+        // Built by concatenation so this scanner does not match itself.
+        const NEEDLE: &str = concat!("CreateSession", "Request {");
+        source_inventory(
+            manifest_dir,
+            NEEDLE,
+            &[
+                "must_match_version: version_assertion()",
+                "must_match_version: minimal_client::version_assertion()",
+            ],
+            ("asserts", "asserts nothing"),
+        )
+    }
+
+    /// Attributes every direct `Client` connection under `<crate>/src` to the
+    /// function that opens it, and reports whether that function also applies
+    /// the version gate. Source-level on purpose: the alternative is a live
+    /// daemon per call site.
+    ///
+    /// A path counts as gated whichever way it gets its answer: the
+    /// `GetVersion` round trip (`ensure_version_match`), a build a reply it was
+    /// already making carried (`ensure_version_reported`, directly or through a
+    /// `*_version_gated` lookup helper), or the assertion it puts on its own
+    /// `CreateSession`. What the inventory records is that the decision was
+    /// made, not which mechanism made it.
+    fn connect_site_inventory(manifest_dir: &str) -> Vec<String> {
+        // Built by concatenation so this scanner does not match itself.
+        const NEEDLE: &str = concat!("Client", "::connect(");
+        source_inventory(
+            manifest_dir,
+            NEEDLE,
+            &[
+                "ensure_version_match",
+                "ensure_version_reported",
+                "_version_gated(",
+                "must_match_version",
+            ],
+            ("gated", "ungated"),
+        )
     }
 
     /// Matching builds are the overwhelmingly common case and must cost the

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -355,7 +355,10 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
         std::env::home_dir().as_deref(),
     );
 
-    let mut client = crate::connect_daemon(global).await?;
+    // Not `connect_daemon`: like `min session activate`, this creates a session
+    // and the version gate rides on that `CreateSession` rather than on a
+    // `GetVersion` ahead of it.
+    let mut client = crate::connect_daemon_unchecked(global).await?;
 
     use minimald_rpc::{
         ConfigureLoadout, ConfigureLoadoutRequest, CreateSession, CreateSessionRequest,
@@ -368,6 +371,9 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
         let resp = client
             .oneshot_rpc::<CreateSession>(CreateSessionRequest {
                 config: config.clone(),
+                // Refused by a daemon of another build before it allocates
+                // anything; `None` under the skew override.
+                must_match_version: minimal_client::version_assertion(),
             })
             .await
             .context("CreateSession RPC failed")?;
@@ -383,6 +389,10 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
             }
         }
     };
+    // A daemon too old to know the field ignored it and echoes no version;
+    // that silence is the skew. Caught here, before the upload and the
+    // finalize, with the record still unfinalized and reapable.
+    minimal_client::ensure_version_reported(created.daemon_version.as_deref())?;
     let id = created.id;
     let session_name = config
         .name

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -191,6 +191,9 @@ fn arm_task_run_interrupt(
         // without that race a second interrupt would be silently swallowed.
         const CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
         let destroy = async {
+            // Deliberately not version-gated: this is the recovery half of a
+            // task run, and a cleanup blocked by a skew is exactly the orphaned
+            // session the gate exists to prevent.
             if let Ok(sock) = sock
                 && let Ok(mut client) = crate::client::Client::connect(&sock).await
             {

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -42,6 +42,7 @@ async fn version_succeeds_without_daemon() {
 #[test]
 fn ls_shows_shared_resource_pool() {
     let resp = ListSessionsResponse {
+        daemon_version: None,
         resource_pool: Some(ResourcePool {
             cpu_cores: 8,
             memory_bytes: 16 * 1024 * 1024 * 1024,
@@ -76,6 +77,7 @@ fn ls_shows_shared_resource_pool() {
 #[test]
 fn ls_table_exposes_project_path_and_status() {
     let resp = ListSessionsResponse {
+        daemon_version: None,
         resource_pool: None,
         sessions: vec![minimald_rpc::ListSessionsEntry {
             id: SessionId::nil(),
@@ -740,7 +742,10 @@ async fn create_pending_session(daemon: &common::TestDaemon, name: &str) -> Sess
         CreateSessionRequest,
     };
     let id = client
-        .call::<CreateSession>(&CreateSessionRequest { config })
+        .call::<CreateSession>(&CreateSessionRequest {
+            config,
+            must_match_version: None,
+        })
         .await
         .unwrap()
         .id;
@@ -791,7 +796,10 @@ async fn create_session_at(
         FinalizeSession, FinalizeSessionRequest,
     };
     let id = match client
-        .call::<CreateSession>(&CreateSessionRequest { config })
+        .call::<CreateSession>(&CreateSessionRequest {
+            config,
+            must_match_version: None,
+        })
         .await
     {
         minimald_rpc::Errorable::Ok(r) => r.id,

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -99,6 +99,43 @@ impl OneshotSshRpc for GetVersion {
     type Response = GetVersionResponse;
 }
 
+/// Set to a non-empty value to downgrade the version gate to a warning.
+/// Escape hatch for deliberate skew (bisecting a daemon regression against a
+/// known-good CLI); named in [`version_skew_message`] so anyone who hits the
+/// gate finds it.
+pub const SKEW_OVERRIDE_VAR: &str = "MINIMAL_ALLOW_VERSION_SKEW";
+
+/// How [`version_skew_message`] names a daemon whose reply carried no
+/// `daemon_version` at all.
+///
+/// Every RPC that the gated paths piggyback on reports the daemon's build
+/// (see [`CreateSessionResponse::daemon_version`]). A reply without one comes
+/// from a daemon built before that field existed — which is itself proof that
+/// it is not this build, so it is a skew, not an unknown.
+pub const UNVERSIONED_DAEMON: &str = "an older build that does not report its version";
+
+/// The operator-facing account of a CLI/daemon version skew, or `None` when
+/// the two builds match.
+///
+/// Lives in the wire crate because *both* ends produce it: the client when a
+/// reply reports a build it did not expect, and the daemon when it refuses a
+/// create whose [`CreateSessionRequest::must_match_version`] does not name it.
+/// One definition means the operator reads the same sentence whichever side
+/// caught the skew.
+#[must_use]
+pub fn version_skew_message(cli: &str, daemon: &str) -> Option<String> {
+    (cli != daemon).then(|| {
+        format!(
+            "This CLI is minimal {cli}, but the running minimald is {daemon}. \
+             The two speak the same RPCs only when built together, so continuing \
+             would fail partway through and tear down whatever it had created. \
+             Restart the daemon on the new build: run `min stop`, then re-run this \
+             command (the daemon is started again automatically). \
+             Set {SKEW_OVERRIDE_VAR}=1 to proceed anyway."
+        )
+    })
+}
+
 /// An RPC to list sessions managed by this minimald.
 pub struct ListSessions;
 
@@ -189,6 +226,12 @@ pub struct ListSessionsResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_pool: Option<ResourcePool>,
     pub sessions: Vec<ListSessionsEntry>,
+    /// The build this daemon runs, so a client can assert the pair matches
+    /// without spending a round trip on [`GetVersion`]. `None` from a daemon
+    /// that predates the field — see [`UNVERSIONED_DAEMON`] for why that is a
+    /// skew rather than an unknown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_version: Option<String>,
 }
 
 impl OneshotSshRpc for ListSessions {
@@ -217,6 +260,12 @@ pub enum GetSessionRecordRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetSessionRecordResponse {
     pub record: Option<sessions::Record>,
+    /// The build this daemon runs, so a client can assert the pair matches
+    /// without spending a round trip on [`GetVersion`]. `None` from a daemon
+    /// that predates the field — see [`UNVERSIONED_DAEMON`] for why that is a
+    /// skew rather than an unknown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_version: Option<String>,
 }
 
 impl OneshotSshRpc for GetSessionRecord {
@@ -328,6 +377,25 @@ fn default_hooks_enabled() -> bool {
 pub struct CreateSessionRequest {
     /// Out-of-band session config.
     pub config: SessionConfig,
+    /// The build the caller expects the daemon to be. When set, the daemon
+    /// compares it against its own version and fails the RPC with
+    /// [`version_skew_message`] *before allocating anything*, so a skewed pair
+    /// cannot leave a half-built session behind (#1251). `None` asserts
+    /// nothing and behaves exactly as this RPC always has — which is what a
+    /// client sends when the operator set [`SKEW_OVERRIDE_VAR`], since a
+    /// daemon-side refusal is not something a client-side override could
+    /// downgrade to a warning.
+    ///
+    /// Carried here rather than checked by a preceding [`GetVersion`] because
+    /// this is the first RPC of the activation path, and that path must not
+    /// pay a round trip for a check the create can make itself.
+    ///
+    /// A daemon that predates this field ignores it —
+    /// [`CreateSessionRequest`] is not `deny_unknown_fields`, deliberately, so
+    /// that older clients keep working — and is caught instead by the
+    /// [`CreateSessionResponse::daemon_version`] it fails to echo.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub must_match_version: Option<String>,
 }
 
 /// The response for a [`CreateSession`] RPC: the allocated session.
@@ -339,6 +407,12 @@ pub struct CreateSessionRequest {
 pub struct CreateSessionResponse {
     /// Daemon-assigned session id.
     pub id: SessionId,
+    /// The build this daemon runs, so a client can assert the pair matches
+    /// without spending a round trip on [`GetVersion`]. `None` from a daemon
+    /// that predates the field — see [`UNVERSIONED_DAEMON`] for why that is a
+    /// skew rather than an unknown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_version: Option<String>,
 }
 
 impl OneshotSshRpc for CreateSession {
@@ -1219,8 +1293,59 @@ mod tests {
                     .into_iter()
                     .collect(),
             },
+            must_match_version: Some("0.6.0".into()),
         };
         assert_eq!(round_trip(&req), req);
+    }
+
+    /// A client that predates `must_match_version` sends no such field, and
+    /// the daemon must read that as "assert nothing" rather than fail to
+    /// decode the request. `CreateSessionRequest` is deliberately *not*
+    /// `deny_unknown_fields`, which is the same property read the other way:
+    /// a daemon that predates the field ignores it instead of rejecting the
+    /// create outright.
+    #[test]
+    fn create_session_request_predating_must_match_version_asserts_nothing() {
+        let json = r#"{"config":{
+            "name": "s",
+            "project_path": "/p",
+            "network": "host_net",
+            "attrs": {}
+        }}"#;
+        let req: CreateSessionRequest =
+            serde_json_lenient::from_str(json).expect("legacy request must load");
+        assert!(req.must_match_version.is_none());
+
+        // And the forward direction: an old daemon's serde ignores the new
+        // field rather than refusing the request.
+        let with_field = r#"{"config":{
+            "name": "s",
+            "project_path": "/p",
+            "network": "host_net",
+            "attrs": {}
+        },"must_match_version":"0.6.0"}"#;
+        let req: CreateSessionRequest =
+            serde_json_lenient::from_str(with_field).expect("the new field must decode");
+        assert_eq!(req.must_match_version.as_deref(), Some("0.6.0"));
+    }
+
+    /// The skew wording names both builds, the recovery, and the override —
+    /// and says nothing at all when the two builds agree.
+    #[test]
+    fn version_skew_message_names_both_builds_the_recovery_and_the_override() {
+        assert!(version_skew_message("0.6.0", "0.6.0").is_none());
+        let msg = version_skew_message("0.6.0", "0.5.0-dev.12.g86ce5c3a")
+            .expect("differing builds are a skew");
+        assert!(msg.contains("0.6.0"), "missing the CLI version: {msg}");
+        assert!(
+            msg.contains("0.5.0-dev.12.g86ce5c3a"),
+            "missing the daemon version: {msg}"
+        );
+        assert!(msg.contains("min stop"), "missing the recovery: {msg}");
+        assert!(
+            msg.contains(SKEW_OVERRIDE_VAR),
+            "missing the override: {msg}"
+        );
     }
 
     /// A `SessionConfig` from a client that predates `hooks_enabled`
@@ -1242,8 +1367,31 @@ mod tests {
     fn create_session_response_round_trips() {
         let resp = CreateSessionResponse {
             id: SessionId::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
+            daemon_version: Some("0.6.0".into()),
         };
         assert_eq!(round_trip(&resp), resp);
+    }
+
+    /// The reply a daemon that predates `daemon_version` sends must still
+    /// decode — with `None`, which is what tells the client it is talking to
+    /// a build older than the handshake and therefore a skewed one.
+    #[test]
+    fn create_session_response_predating_daemon_version_decodes_as_absent() {
+        let resp: Errorable<CreateSessionResponse> =
+            serde_json_lenient::from_str(r#"{"id":"00000000-0000-0000-0000-000000000001"}"#)
+                .expect("a legacy reply must decode");
+        assert!(resp.unwrap().daemon_version.is_none());
+    }
+
+    /// Same for the two read RPCs the attach/exec paths gate on.
+    #[test]
+    fn read_responses_predating_daemon_version_decode_as_absent() {
+        let listed: ListSessionsResponse =
+            serde_json_lenient::from_str(r#"{"sessions":[]}"#).expect("deserialize");
+        assert!(listed.daemon_version.is_none());
+        let record: GetSessionRecordResponse =
+            serde_json_lenient::from_str(r#"{"record":null}"#).expect("deserialize");
+        assert!(record.daemon_version.is_none());
     }
 
     #[test]

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -30,6 +30,11 @@ use crate::{
     sessions::SessionKeyPredicate,
 };
 
+/// This daemon's build, reported on every reply a version-gated client path
+/// piggybacks its check on. One name for it so the assertion in
+/// `serve_create_session` and the versions echoed to clients cannot drift.
+const OWN_VERSION: &str = version::VERSION;
+
 /// Server-side serving glue for [`OneshotSshRpc`]s.
 ///
 /// The wire contract (names, request/response schemas) lives in the
@@ -121,6 +126,7 @@ async fn serve_list_sessions(
                 .await
                 .map_err(|e| ConnectionError::Internal(e.to_string()))?;
             Ok(ListSessionsResponse {
+                daemon_version: Some(OWN_VERSION.to_string()),
                 resource_pool,
                 // The git probes run in parallel across sessions: each is
                 // one small process under a deadline, and serializing them
@@ -233,6 +239,7 @@ async fn serve_get_session_record(
         .handle_channel(c, async |req| {
             let mngr = s.sessions_manager().await;
             Ok(GetSessionRecordResponse {
+                daemon_version: Some(OWN_VERSION.to_string()),
                 record: mngr
                     .get_record(match req {
                         GetSessionRecordRequest::Id(id) => SessionKeyPredicate::Id(id),
@@ -261,6 +268,18 @@ async fn serve_create_session(
 ) -> Result<(), ConnectionError> {
     CreateSession
         .handle_channel(c, async |req| {
+            // The version gate, made by the RPC the activation path was
+            // already sending rather than by a `GetVersion` ahead of it
+            // (#1251). Checked here, before the manager allocates anything,
+            // because the failure this closes is precisely a session that
+            // exists and then gets torn down by its own caller's cleanup:
+            // refusing after `create_session` would reproduce it.
+            if let Some(asserted) = req.must_match_version.as_deref()
+                && let Some(message) = minimald_rpc::version_skew_message(asserted, OWN_VERSION)
+            {
+                return Ok(Errorable::Err { error: message });
+            }
+
             let mngr = s.sessions_manager().await;
             // Read the name off the config before it is handed to the
             // manager: the success record below needs it, and the reply
@@ -279,7 +298,10 @@ async fn serve_create_session(
                         session_name = session_name.as_deref().unwrap_or(ANONYMOUS_SESSION),
                         "session created"
                     );
-                    Errorable::Ok(minimald_rpc::CreateSessionResponse { id })
+                    Errorable::Ok(minimald_rpc::CreateSessionResponse {
+                        id,
+                        daemon_version: Some(OWN_VERSION.to_string()),
+                    })
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Errorable::Err {
                     error: "A session with that name already exists".to_string(),
@@ -2477,6 +2499,91 @@ mod tests {
         );
     }
 
+    /// The version gate, made by the RPC the activation path already sends
+    /// rather than by a `GetVersion` ahead of it (#1251).
+    ///
+    /// A matching assertion is invisible; a differing one fails the call with
+    /// the skew message *and leaves nothing behind* — which is the whole
+    /// point, since the failure this closes is a session that exists and is
+    /// then destroyed by its own caller's cleanup. An absent assertion (an
+    /// older client) behaves exactly as this RPC always did.
+    #[tokio::test]
+    async fn create_session_refuses_a_version_skew_before_allocating_anything() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        let mut skewed = req("skewed", "/uwu");
+        skewed.must_match_version = Some("0.0.0-not-this-build".to_string());
+        let refused = client.call::<CreateSession>(&skewed).await;
+        let error = refused.err().expect("a skewed create must be refused");
+        assert!(
+            error.contains("0.0.0-not-this-build") && error.contains(OWN_VERSION),
+            "the refusal must name both builds, got: {error}"
+        );
+        assert!(error.contains("min stop"), "missing the recovery: {error}");
+        assert!(
+            error.contains(minimald_rpc::SKEW_OVERRIDE_VAR),
+            "missing the override: {error}"
+        );
+        assert!(
+            client.call::<ListSessions>(&()).await.sessions.is_empty(),
+            "a refused create must not have allocated a session"
+        );
+
+        // The matching assertion goes through, and the reply names the build
+        // that honoured it — the half of the handshake that catches a daemon
+        // too old to have looked at `must_match_version` at all.
+        let mut matching = req("matching", "/uwu");
+        matching.must_match_version = Some(OWN_VERSION.to_string());
+        let created = client
+            .call::<CreateSession>(&matching)
+            .await
+            .ok()
+            .expect("a matching assertion must be accepted");
+        assert_eq!(created.daemon_version.as_deref(), Some(OWN_VERSION));
+
+        // And a client that asserts nothing — an older one, or one running
+        // under the skew override — is unaffected.
+        let created = client
+            .call::<CreateSession>(&req("unasserted", "/uwu"))
+            .await
+            .ok()
+            .expect("an unasserted create must behave as it always has");
+        assert_eq!(created.daemon_version.as_deref(), Some(OWN_VERSION));
+    }
+
+    /// The two read RPCs the attach / exec / setup-zed / ssh-forward paths
+    /// gate on must report the daemon's build, or those paths have nothing to
+    /// assert against and would have to spend a `GetVersion` to find out.
+    #[tokio::test]
+    async fn the_read_rpcs_report_the_daemon_build() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+
+        let id = client
+            .call::<CreateSession>(&req("my session", "/uwu"))
+            .await
+            .unwrap()
+            .id;
+
+        assert_eq!(
+            client
+                .call::<ListSessions>(&())
+                .await
+                .daemon_version
+                .as_deref(),
+            Some(OWN_VERSION)
+        );
+        assert_eq!(
+            client
+                .call::<GetSessionRecord>(&GetSessionRecordRequest::Id(id))
+                .await
+                .daemon_version
+                .as_deref(),
+            Some(OWN_VERSION)
+        );
+    }
+
     #[tokio::test]
     async fn get_session_policy_returns_the_policy_configured_at_launch() {
         // R2.6: GetSessionPolicy reads the live per-session policy from the
@@ -2500,6 +2607,7 @@ mod tests {
                     hooks_enabled: true,
                     attrs: Default::default(),
                 },
+                must_match_version: None,
             })
             .await
             .unwrap()
@@ -2700,6 +2808,7 @@ mod tests {
                     hooks_enabled: true,
                     attrs: Default::default(),
                 },
+                must_match_version: None,
             })
             .await;
         assert_eq!(

--- a/crates/minimald/src/test_harness.rs
+++ b/crates/minimald/src/test_harness.rs
@@ -442,6 +442,9 @@ pub fn create_session_req(name: &str, project: &str) -> minimald_rpc::CreateSess
             hooks_enabled: true,
             attrs: Default::default(),
         },
+        // No assertion: the harness's client *is* this daemon's build, and
+        // the version gate has its own tests.
+        must_match_version: None,
     }
 }
 

--- a/crates/minvmd/examples/exec.rs
+++ b/crates/minvmd/examples/exec.rs
@@ -174,6 +174,9 @@ async fn run_session_exec(
                 hooks_enabled: true,
                 attrs: Default::default(),
             },
+            // The guest daemon is built from this same tree by the harness, so
+            // there is no skew to assert against; the gate has its own tests.
+            must_match_version: None,
         };
         let body =
             serde_json_lenient::to_vec(&req).map_err(|e| format!("serialize request: {e}"))?;

--- a/crates/minvmd/tests/minimald_session_integration.rs
+++ b/crates/minvmd/tests/minimald_session_integration.rs
@@ -270,6 +270,9 @@ async fn run_session_exec(
                 hooks_enabled: true,
                 attrs: Default::default(),
             },
+            // The guest daemon is built from this same tree by the harness, so
+            // there is no skew to assert against; the gate has its own tests.
+            must_match_version: None,
         };
         let body =
             serde_json_lenient::to_vec(&req).map_err(|e| format!("serialize request: {e}"))?;


### PR DESCRIPTION
Closes #1251.

A CLI talking to a daemon from another build would fail partway through an
activation and tear down whatever it had already created. There was no version
check, and the failure was undiagnosable: every oneshot response is wrapped in an
`#[serde(untagged)]` `Errorable<T>`, and an untagged enum discards its per-variant
errors in favour of "data did not match any variant" — so a `deny_unknown_fields`
guard doing its job produced an error that could not name the offending field.

**`deny_unknown_fields` is not relaxed.** Two changes instead:

1. **A version gate.** `ensure_version_match` compares CLI and daemon versions and
   refuses with a message naming both builds and prescribing the recovery
   (`min stop`, then re-run). `MINIMAL_ALLOW_VERSION_SKEW=1` overrides with a warning.
2. **Decode errors quote the daemon's reply** verbatim, bounded to 1 KiB, so a bug
   report can name the field that tripped the guard without a live repro.

### Every daemon connection is now classified

`min stop` and the Ctrl-C cleanup paths are deliberately **ungated** — a cleanup that
refuses to run *is* the orphaned session, and `min stop` is the recovery the gate's
own message prescribes. Gated: `cmd_attach`, `cmd_exec`, `cmd_session_setup_zed`,
`cmd_ssh_forward`, and the dash `activate` path. Every ungated site carries a one-line
reason so the next reader does not have to redo the audit.

Gating the TUI required moving `ensure_version_match` / `version_skew_message` /
`SKEW_OVERRIDE_VAR` into `minimal-client` (the crate both front ends share), since
`minimal-tui` cannot depend on `minimal`. The message text and override semantics are
byte-for-byte unchanged.

### Tests
`every_daemon_connection_is_classified` and `only_the_activation_path_is_version_gated`
scan the sources at test time and assert the full gated/ungated inventory — a new
`Client::connect` fails the build until someone repeats this judgement. Both were
observed failing on a wrong classification before being made to pass.

### For reviewers
- `cmd_session_setup_zed` is the judgement call: read-only against the daemon, but it
  bakes daemon-sourced identity into persistent editor config. Gated on those grounds;
  a strict "multi-step mutation" reading would leave it ungated.
- `completion.rs` already routed through `connect_daemon`, so shell completions now
  fall silent against a skewed daemon. Pre-existing, untouched here.
- The source-scanning tests are an unusual shape for this tree and will need updating
  whenever a connection is legitimately added. That is the point, but it is a
  maintenance cost worth an explicit yes/no.
- `just e2e` / `just test-vm` not run (no KVM in the dev sandbox). `cmd_attach`,
  `cmd_exec`, and dash activate each now pay one extra `GetVersion` round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daemon and CLI version compatibility checks across session activation, attach, exec, and related workflows.
  * Added clear version-skew errors, including support for legacy or unversioned daemons.
  * Daemon responses now report their version to improve compatibility diagnostics.
  * Added an override option for recovery and diagnostic operations.

* **Bug Fixes**
  * Improved undecodable response errors with a bounded excerpt of the original reply.
  * Prevented incompatible daemons from proceeding with session creation or activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->