### PR TITLE
fix(mfile,graph,mctx): expand patch homes explicitly, drop credentials (#1204)

### DIFF
--- a/crates/graph/src/env_mapping.rs
+++ b/crates/graph/src/env_mapping.rs
@@ -1,0 +1,456 @@
+//! Typed decoding of the `env_dir_mappings` / `env_file_mappings` package
+//! attributes.
+//!
+//! Two consumers read these attributes — [`SetupForPackages`] on the
+//! task-exec path and `minimald`'s session-composition extractor — and both
+//! have to make the same security-relevant decision about each entry: a
+//! `class = 'Credential` mapping is dropped, because the secrets strategy is
+//! deferred and credentials must not reach a sandbox through package attrs.
+//!
+//! Doing that against the raw [`AttrValue`] form meant `.unwrap()` chains for
+//! the shape and a `== "Credential"` string comparison for the class, once
+//! per consumer. The string comparison in particular failed *open*: a bare
+//! nickel enum tag renders as [`AttrValue::String`] today, and if that ever
+//! changed the comparison would quietly stop matching and credential
+//! mappings would flow through unfiltered. Decoding into
+//! [`EnvFsMapping`] once, here, closes that: every entry is classified or
+//! rejected, so a rendering change is a loud decode error on *every* mapping
+//! rather than a silent unfiltering of the credential ones.
+//!
+//! The schema this mirrors is `env_dir_mappings` / `env_file_mappings` in
+//! `crates/stdlib/minimal-ncl/attr_classes.ncl`:
+//!
+//! ```text
+//! Array {
+//!     read_only | Bool,
+//!     path | String,
+//!     class | [| 'Credential, 'State |],
+//! }
+//! ```
+//!
+//! [`SetupForPackages`]: crate::SetupForPackages
+
+use crate::BuildSpec;
+use decode::AttrValue;
+
+/// Which attribute an entry was declared under, and therefore whether the
+/// path names a directory or a single file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum EnvMappingKind {
+    /// From `env_dir_mappings`: `path` is a directory root.
+    Dir,
+    /// From `env_file_mappings`: `path` is a single file.
+    File,
+}
+
+impl EnvMappingKind {
+    /// The attribute name entries of this kind are read from.
+    #[must_use]
+    pub fn attr(self) -> &'static str {
+        match self {
+            Self::Dir => "env_dir_mappings",
+            Self::File => "env_file_mappings",
+        }
+    }
+
+    /// Both kinds, in the order the attributes are read.
+    const ALL: [Self; 2] = [Self::Dir, Self::File];
+}
+
+/// What a package says a mapping contains — the nickel enum
+/// `[| 'Credential, 'State |]`.
+///
+/// Exhaustive on purpose: an entry whose class is anything else (a tag this
+/// enum does not know, a value of the wrong shape, or no class at all) is a
+/// decode error, never a mapping that flows on unclassified. The filter this
+/// feeds exists to keep credentials out of sandboxes, so "cannot tell what
+/// this is" has to fail closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum EnvMappingClass {
+    /// A credential. Dropped by both consumers until the secrets strategy
+    /// lands (see the `TODO(secrets)` notes at each drop site).
+    Credential,
+    /// Ordinary persistent state, e.g. a tool's config directory.
+    State,
+}
+
+impl EnvMappingClass {
+    /// The nickel tag this class is written as.
+    #[must_use]
+    pub fn tag(self) -> &'static str {
+        match self {
+            Self::Credential => "Credential",
+            Self::State => "State",
+        }
+    }
+}
+
+/// One decoded `env_dir_mappings` / `env_file_mappings` entry.
+///
+/// `path` is kept exactly as the package declared it — `~/`-rooted paths are
+/// not expanded here, and trailing separators are not trimmed. Both are
+/// consumer-specific concerns: expansion needs a home the graph doesn't know
+/// (see `mfile::EnvPatches::expand_home`), and the session composer's walker
+/// has its own normalization rules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvFsMapping {
+    /// Directory or file, from the attribute it was declared under.
+    pub kind: EnvMappingKind,
+    /// The path, verbatim as declared.
+    pub path: String,
+    /// The package author's declared read-only intent. Honoured by the
+    /// task-exec path (as a read-only bind mount) and only warned about on
+    /// the composition path, which is copy-based.
+    pub read_only: bool,
+    /// What the mapping contains.
+    pub class: EnvMappingClass,
+}
+
+/// Why an `env_dir_mappings` / `env_file_mappings` attribute could not be
+/// decoded.
+///
+/// Always names the package and attribute, because the fix is always an edit
+/// to some package's nickel declaration and the graph is the only layer that
+/// still knows which one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvMappingError {
+    /// The package whose attribute failed to decode.
+    pub package: String,
+    /// The attribute it was declared under.
+    pub attr: &'static str,
+    /// What was wrong with it.
+    pub kind: EnvMappingErrorKind,
+}
+
+/// The specific way an entry departed from the schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnvMappingErrorKind {
+    /// The attribute's value was neither a list of entries nor a single
+    /// entry record.
+    NotEntries,
+    /// An element of the list was not a record.
+    EntryNotARecord,
+    /// A required field was absent.
+    MissingField(&'static str),
+    /// A field was present with the wrong type.
+    WrongType {
+        /// The field name.
+        field: &'static str,
+        /// The type the schema calls for.
+        expected: &'static str,
+    },
+    /// The `class` field held a tag this build of minimal does not know.
+    UnknownClass(String),
+}
+
+impl std::fmt::Display for EnvMappingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "package `{}`: `{}`: ", self.package, self.attr)?;
+        match &self.kind {
+            EnvMappingErrorKind::NotEntries => {
+                write!(f, "expected a list of mapping records")
+            }
+            EnvMappingErrorKind::EntryNotARecord => {
+                write!(f, "expected each entry to be a record")
+            }
+            EnvMappingErrorKind::MissingField(field) => {
+                write!(f, "an entry is missing the required `{field}` field")
+            }
+            EnvMappingErrorKind::WrongType { field, expected } => {
+                write!(f, "an entry's `{field}` field is not {expected}")
+            }
+            EnvMappingErrorKind::UnknownClass(tag) => write!(
+                f,
+                "an entry's `class` is `{tag}`, which is not one of {}",
+                [EnvMappingClass::Credential, EnvMappingClass::State]
+                    .map(|c| format!("'{}", c.tag()))
+                    .join(", "),
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EnvMappingError {}
+
+impl From<EnvMappingError> for std::io::Error {
+    fn from(e: EnvMappingError) -> Self {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+    }
+}
+
+impl EnvFsMapping {
+    /// Decodes every `env_dir_mappings` and `env_file_mappings` entry a build
+    /// spec declares, in attribute order (dirs then files). A spec that
+    /// declares neither yields an empty vec.
+    pub fn decode_all(spec: &BuildSpec) -> Result<Vec<Self>, EnvMappingError> {
+        let mut out = Vec::new();
+        for kind in EnvMappingKind::ALL {
+            if let Some(v) = spec.attrs.get(kind.attr()) {
+                out.extend(Self::decode_attr(&spec.name, kind, v)?);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Decodes one attribute's value into its entries.
+    ///
+    /// Both wire shapes the schema can produce are accepted: a list of
+    /// records, and — for a package that declared a single mapping without
+    /// wrapping it in a list — a bare record.
+    pub fn decode_attr(
+        package: &str,
+        kind: EnvMappingKind,
+        value: &AttrValue,
+    ) -> Result<Vec<Self>, EnvMappingError> {
+        let err = |k| EnvMappingError {
+            package: package.to_string(),
+            attr: kind.attr(),
+            kind: k,
+        };
+        let entries: Vec<&AttrValue> = match value {
+            AttrValue::List(l) => l.iter().collect(),
+            AttrValue::Map(_) => vec![value],
+            _ => return Err(err(EnvMappingErrorKind::NotEntries)),
+        };
+        entries
+            .into_iter()
+            .map(|entry| Self::decode_entry(kind, entry).map_err(err))
+            .collect()
+    }
+
+    /// Decodes a single entry record.
+    fn decode_entry(kind: EnvMappingKind, entry: &AttrValue) -> Result<Self, EnvMappingErrorKind> {
+        let entry = entry.as_map().ok_or(EnvMappingErrorKind::EntryNotARecord)?;
+        let field = |name: &'static str| {
+            entry
+                .get(name)
+                .ok_or(EnvMappingErrorKind::MissingField(name))
+        };
+        let path = field("path")?
+            .as_string()
+            .ok_or(EnvMappingErrorKind::WrongType {
+                field: "path",
+                expected: "a string",
+            })?
+            .clone();
+        let read_only = *field("read_only")?
+            .as_bool()
+            .ok_or(EnvMappingErrorKind::WrongType {
+                field: "read_only",
+                expected: "a boolean",
+            })?;
+        Ok(Self {
+            kind,
+            path,
+            read_only,
+            class: EnvMappingClass::decode(field("class")?)?,
+        })
+    }
+}
+
+impl EnvMappingClass {
+    /// Decodes the `class` field of one entry.
+    ///
+    /// A bare nickel enum tag arrives as [`AttrValue::String`]; a tag
+    /// carrying an argument would arrive as [`AttrValue::EnumVariant`]. Both
+    /// are accepted so the decode does not hinge on which of the two
+    /// `decode`'s conversion happens to pick, and anything else — including a
+    /// tag this build does not know — is an error rather than a mapping that
+    /// slips past the credential filter unclassified.
+    fn decode(value: &AttrValue) -> Result<Self, EnvMappingErrorKind> {
+        let tag = match value {
+            AttrValue::String(s, _) => s.as_str(),
+            AttrValue::EnumVariant(tag, _) => tag.as_str(),
+            _ => {
+                return Err(EnvMappingErrorKind::WrongType {
+                    field: "class",
+                    expected: "an enum tag",
+                });
+            }
+        };
+        match tag {
+            t if t == Self::Credential.tag() => Ok(Self::Credential),
+            t if t == Self::State.tag() => Ok(Self::State),
+            other => Err(EnvMappingErrorKind::UnknownClass(other.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nickel_lang_core::term::IndexMap;
+
+    fn entry(fields: &[(&str, AttrValue)]) -> AttrValue {
+        AttrValue::Map(IndexMap::from_iter(
+            fields.iter().map(|(k, v)| (k.to_string(), v.clone())),
+        ))
+    }
+
+    fn tag(t: &str) -> AttrValue {
+        AttrValue::String(t.to_string(), None)
+    }
+
+    fn well_formed(class: &str) -> AttrValue {
+        entry(&[
+            ("path", tag("~/.claude.json")),
+            ("read_only", AttrValue::Bool(false)),
+            ("class", tag(class)),
+        ])
+    }
+
+    /// The happy path: both classes decode, `path` is kept verbatim (no `~/`
+    /// expansion, no trailing-slash trimming) and the kind comes from the
+    /// attribute the entry was declared under.
+    #[test]
+    fn decodes_both_classes_keeping_the_path_verbatim() {
+        let value = AttrValue::List(vec![well_formed("State"), well_formed("Credential")]);
+
+        let got = EnvFsMapping::decode_attr("claude-code", EnvMappingKind::File, &value).unwrap();
+
+        assert_eq!(
+            got,
+            vec![
+                EnvFsMapping {
+                    kind: EnvMappingKind::File,
+                    path: "~/.claude.json".to_string(),
+                    read_only: false,
+                    class: EnvMappingClass::State,
+                },
+                EnvFsMapping {
+                    kind: EnvMappingKind::File,
+                    path: "~/.claude.json".to_string(),
+                    read_only: false,
+                    class: EnvMappingClass::Credential,
+                },
+            ]
+        );
+    }
+
+    /// This is the whole point of the type. A class the decoder does not
+    /// recognise is an error naming the package, not an entry that sails past
+    /// the credential filter because it failed a `== "Credential"` string
+    /// test. The same holds if the class is missing entirely, or arrives with
+    /// a shape the decoder doesn't expect — which is exactly what a change to
+    /// `decode::AttrValue`'s enum-tag rendering would look like from here.
+    #[test]
+    fn an_unclassifiable_entry_is_an_error_not_a_pass_through() {
+        let cases = [
+            (
+                well_formed("Secret"),
+                EnvMappingErrorKind::UnknownClass("Secret".to_string()),
+            ),
+            (
+                entry(&[
+                    ("path", tag("~/.claude.json")),
+                    ("read_only", AttrValue::Bool(false)),
+                ]),
+                EnvMappingErrorKind::MissingField("class"),
+            ),
+            (
+                entry(&[
+                    ("path", tag("~/.claude.json")),
+                    ("read_only", AttrValue::Bool(false)),
+                    ("class", AttrValue::Bool(true)),
+                ]),
+                EnvMappingErrorKind::WrongType {
+                    field: "class",
+                    expected: "an enum tag",
+                },
+            ),
+        ];
+
+        for (value, want) in cases {
+            let err = EnvFsMapping::decode_attr(
+                "claude-code",
+                EnvMappingKind::File,
+                &AttrValue::List(vec![value]),
+            )
+            .expect_err("an unclassifiable entry must not decode");
+            assert_eq!(err.kind, want);
+            assert_eq!(err.package, "claude-code");
+            assert_eq!(err.attr, "env_file_mappings");
+            assert!(
+                err.to_string().contains("claude-code"),
+                "the error must name the package to go and edit, got {err}"
+            );
+        }
+    }
+
+    /// A tag rendered as an enum *variant* rather than a string decodes the
+    /// same way, so the filter does not hinge on which of the two forms
+    /// `decode`'s conversion produces.
+    #[test]
+    fn a_tag_decodes_from_either_attr_value_rendering() {
+        let variant = entry(&[
+            ("path", tag("~/.claude.json")),
+            ("read_only", AttrValue::Bool(true)),
+            (
+                "class",
+                AttrValue::EnumVariant("Credential".to_string(), Box::new(AttrValue::Bool(true))),
+            ),
+        ]);
+
+        let got = EnvFsMapping::decode_attr(
+            "claude-code",
+            EnvMappingKind::File,
+            &AttrValue::List(vec![variant]),
+        )
+        .unwrap();
+
+        assert_eq!(got[0].class, EnvMappingClass::Credential);
+        assert!(got[0].read_only);
+    }
+
+    /// The shape errors the old code met with `.unwrap()` — a panic in the
+    /// daemon — are ordinary errors naming the offending field.
+    #[test]
+    fn malformed_shapes_are_errors_rather_than_panics() {
+        let cases = [
+            (AttrValue::Bool(true), EnvMappingErrorKind::NotEntries),
+            (
+                AttrValue::List(vec![AttrValue::Bool(true)]),
+                EnvMappingErrorKind::EntryNotARecord,
+            ),
+            (
+                AttrValue::List(vec![entry(&[
+                    ("read_only", AttrValue::Bool(false)),
+                    ("class", tag("State")),
+                ])]),
+                EnvMappingErrorKind::MissingField("path"),
+            ),
+            (
+                AttrValue::List(vec![entry(&[
+                    ("path", tag("~/.claude")),
+                    ("read_only", tag("yes")),
+                    ("class", tag("State")),
+                ])]),
+                EnvMappingErrorKind::WrongType {
+                    field: "read_only",
+                    expected: "a boolean",
+                },
+            ),
+        ];
+
+        for (value, want) in cases {
+            assert_eq!(
+                EnvFsMapping::decode_attr("b1", EnvMappingKind::Dir, &value)
+                    .expect_err("malformed input must not decode")
+                    .kind,
+                want
+            );
+        }
+    }
+
+    /// A package that declares one mapping as a bare record, rather than a
+    /// one-element list, decodes too — the session-composition extractor
+    /// accepted that shape before this type existed and still must.
+    #[test]
+    fn a_bare_record_decodes_as_a_single_entry() {
+        let got =
+            EnvFsMapping::decode_attr("b1", EnvMappingKind::Dir, &well_formed("State")).unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].kind, EnvMappingKind::Dir);
+    }
+}

--- a/crates/graph/src/env_setup.rs
+++ b/crates/graph/src/env_setup.rs
@@ -3,6 +3,7 @@ use std::{
     path::PathBuf,
 };
 
+use crate::env_mapping::{EnvFsMapping, EnvMappingClass, EnvMappingKind};
 use crate::{BuildSpecRef, Graph};
 use decode::AttrValue;
 use mfile::EnvPatches;
@@ -30,64 +31,6 @@ pub struct SetupForPackages {
     pub fs_mapping_packages: HashMap<String, String>,
 }
 
-/// The string form of the nickel enum tag `'Credential` as it appears after
-/// `decode`'s AttrValue conversion. Compared as a plain string at runtime, so
-/// if `decode::AttrValue`'s enum-tag rendering ever changes (angle-brackets,
-/// hash prefix, etc.) the checks here and in `minimald`'s session-composition
-/// extractor silently stop matching, and credential mappings flow through
-/// unfiltered.
-///
-/// The regression guards are `fs_mappings_drop_credential_class` in this
-/// module and `credential_class_fs_mappings_are_filtered_out` in
-/// `minimald::sessions::composables`; if the rendering changes, both fail and
-/// this constant is where to update.
-// TODO(schema-stability): keep in sync with `decode::AttrValue::EnumTag`
-// rendering.
-pub const CREDENTIAL_CLASS_TAG: &str = "Credential";
-
-/// Reads one `env_dir_mappings` / `env_file_mappings` entry into its declared
-/// path and patch setting, dropping `class = 'Credential` entries.
-///
-/// TODO(secrets): credential-class mappings are dropped rather than routed
-/// through a separate secrets channel, matching what the session-composition
-/// path already does in `minimald`'s `extract_fs_mappings`. Until the secrets
-/// strategy lands they simply aren't seen by the sandbox — which is also what
-/// keeps a task running inside the guest from trying to mount host
-/// credentials that aren't there (#1204).
-fn read_mapping(
-    package: &str,
-    attr: &'static str,
-    entry: &AttrValue,
-) -> Option<(String, mfile::PatchSetting)> {
-    use mfile::PatchSetting;
-
-    let entry = entry.as_map().unwrap();
-    let path = entry.get("path").unwrap().as_string().unwrap().clone();
-    if entry
-        .get("class")
-        .and_then(|c| c.as_string())
-        .map(String::as_str)
-        == Some(CREDENTIAL_CLASS_TAG)
-    {
-        tracing::warn!(
-            package = %package,
-            attr = %attr,
-            path = %path,
-            "dropping Credential-class fs mapping; the secrets strategy is deferred, so \
-             credentials do not reach the sandbox through package attributes",
-        );
-        return None;
-    }
-    Some((
-        path,
-        if *entry.get("read_only").unwrap().as_bool().unwrap() {
-            PatchSetting::ReadOnly
-        } else {
-            PatchSetting::ReadWrite
-        },
-    ))
-}
-
 impl SetupForPackages {
     /// Computes environment settings that need to be applied to an environment containing the
     /// given packages.
@@ -108,25 +51,36 @@ impl SetupForPackages {
 
         for dep in i.into_iter() {
             let b = g.get(dep).unwrap();
-            if let Some(dirs) = b.attrs.get("env_dir_mappings") {
-                for mapping in dirs.as_list().unwrap() {
-                    if let Some((path, setting)) =
-                        read_mapping(&b.name, "env_dir_mappings", mapping)
-                    {
-                        fs_mapping_packages.insert(path.clone(), b.name.clone());
-                        patch.dir.insert(path, setting);
-                    }
+            for mapping in EnvFsMapping::decode_all(b)? {
+                // TODO(secrets): credential-class mappings are dropped rather
+                // than routed through a separate secrets channel, matching
+                // what the session-composition path already does in
+                // `minimald`'s `extract_fs_mappings`. Until the secrets
+                // strategy lands they simply aren't seen by the sandbox —
+                // which is also what keeps a task running inside the guest
+                // from trying to mount host credentials that aren't there
+                // (#1204).
+                if mapping.class == EnvMappingClass::Credential {
+                    tracing::warn!(
+                        package = %b.name,
+                        attr = %mapping.kind.attr(),
+                        path = %mapping.path,
+                        "dropping Credential-class fs mapping; the secrets strategy is \
+                         deferred, so credentials do not reach the sandbox through package \
+                         attributes",
+                    );
+                    continue;
                 }
-            }
-            if let Some(files) = b.attrs.get("env_file_mappings") {
-                for mapping in files.as_list().unwrap() {
-                    if let Some((path, setting)) =
-                        read_mapping(&b.name, "env_file_mappings", mapping)
-                    {
-                        fs_mapping_packages.insert(path.clone(), b.name.clone());
-                        patch.file.insert(path, setting);
-                    }
-                }
+                let setting = if mapping.read_only {
+                    mfile::PatchSetting::ReadOnly
+                } else {
+                    mfile::PatchSetting::ReadWrite
+                };
+                fs_mapping_packages.insert(mapping.path.clone(), b.name.clone());
+                match mapping.kind {
+                    EnvMappingKind::Dir => patch.dir.insert(mapping.path, setting),
+                    EnvMappingKind::File => patch.file.insert(mapping.path, setting),
+                };
             }
             if let Some(wiring) = b.attrs.get("env_state_wiring") {
                 let mut apply_wiring = |entry: &AttrValue| -> Result<(), std::io::Error> {
@@ -239,6 +193,51 @@ mod tests {
                 )]),
             }
         )
+    }
+
+    /// An entry the typed decode can't classify stops the whole setup with
+    /// an error naming the package, rather than reaching the sandbox as an
+    /// unclassified — and therefore unfiltered — mapping. This is what the
+    /// old `class` string comparison could not do: it answered "not
+    /// `Credential`" for anything it didn't recognise and let the mapping
+    /// through.
+    #[test]
+    fn an_unclassifiable_mapping_fails_the_whole_setup() {
+        let layer = Layer::new_for_test(
+            indoc! {
+                "
+            let {BuildSpec, ..} = import \"minimal.ncl\" in
+
+            let
+                b1 = {
+                    name = \"b1\",
+                    build_deps = [],
+                    cmd = \"\",
+                    attrs = {
+                        env_file_mappings = [{ read_only = false, path = \"~/.claude.json\" }],
+                    },
+                } | BuildSpec,
+            in
+            [b1]
+            "
+            }
+            .to_string(),
+        )
+        // Nickel's own `class | [| 'Credential, 'State |]` contract does not
+        // catch this: a record contract's undefined field is lazy, so an
+        // entry that simply omits `class` evaluates cleanly and arrives here
+        // unclassified. That is precisely the case the old string comparison
+        // waved through.
+        .expect("nickel accepts an entry that omits `class`");
+        let g = Graph::new().ingest(layer).unwrap();
+
+        let err = SetupForPackages::build(&g, [g.by_name("b1").unwrap()])
+            .expect_err("an entry with no class must not decode");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("b1") && err.to_string().contains("class"),
+            "the error must name the package and the offending field, got {err}"
+        );
     }
 
     #[test]

--- a/crates/graph/src/env_setup.rs
+++ b/crates/graph/src/env_setup.rs
@@ -21,6 +21,71 @@ pub struct SetupForPackages {
     pub needs_internet: bool,
     /// The filesystem mappings accumulated from `env_file_mappings` and `env_dir_mappings` attrs.
     pub fs_mappings: EnvPatches,
+    /// Which package contributed each entry of `fs_mappings`, keyed by the
+    /// path exactly as the package declared it (`~/`-rooted paths are not
+    /// expanded here). Last writer wins, matching `fs_mappings` itself.
+    ///
+    /// Consumed when a mapping can't be honoured, so the error can name the
+    /// package to go and look at rather than only the path it landed on.
+    pub fs_mapping_packages: HashMap<String, String>,
+}
+
+/// The string form of the nickel enum tag `'Credential` as it appears after
+/// `decode`'s AttrValue conversion. Compared as a plain string at runtime, so
+/// if `decode::AttrValue`'s enum-tag rendering ever changes (angle-brackets,
+/// hash prefix, etc.) the checks here and in `minimald`'s session-composition
+/// extractor silently stop matching, and credential mappings flow through
+/// unfiltered.
+///
+/// The regression guards are `fs_mappings_drop_credential_class` in this
+/// module and `credential_class_fs_mappings_are_filtered_out` in
+/// `minimald::sessions::composables`; if the rendering changes, both fail and
+/// this constant is where to update.
+// TODO(schema-stability): keep in sync with `decode::AttrValue::EnumTag`
+// rendering.
+pub const CREDENTIAL_CLASS_TAG: &str = "Credential";
+
+/// Reads one `env_dir_mappings` / `env_file_mappings` entry into its declared
+/// path and patch setting, dropping `class = 'Credential` entries.
+///
+/// TODO(secrets): credential-class mappings are dropped rather than routed
+/// through a separate secrets channel, matching what the session-composition
+/// path already does in `minimald`'s `extract_fs_mappings`. Until the secrets
+/// strategy lands they simply aren't seen by the sandbox — which is also what
+/// keeps a task running inside the guest from trying to mount host
+/// credentials that aren't there (#1204).
+fn read_mapping(
+    package: &str,
+    attr: &'static str,
+    entry: &AttrValue,
+) -> Option<(String, mfile::PatchSetting)> {
+    use mfile::PatchSetting;
+
+    let entry = entry.as_map().unwrap();
+    let path = entry.get("path").unwrap().as_string().unwrap().clone();
+    if entry
+        .get("class")
+        .and_then(|c| c.as_string())
+        .map(String::as_str)
+        == Some(CREDENTIAL_CLASS_TAG)
+    {
+        tracing::warn!(
+            package = %package,
+            attr = %attr,
+            path = %path,
+            "dropping Credential-class fs mapping; the secrets strategy is deferred, so \
+             credentials do not reach the sandbox through package attributes",
+        );
+        return None;
+    }
+    Some((
+        path,
+        if *entry.get("read_only").unwrap().as_bool().unwrap() {
+            PatchSetting::ReadOnly
+        } else {
+            PatchSetting::ReadWrite
+        },
+    ))
 }
 
 impl SetupForPackages {
@@ -36,37 +101,31 @@ impl SetupForPackages {
         i: I,
     ) -> Result<SetupForPackages, std::io::Error> {
         let mut patch = EnvPatches::default();
+        let mut fs_mapping_packages: HashMap<String, String> = Default::default();
         let (mut needs_dns, mut needs_internet) = (false, false);
         let mut env_vars: HashMap<String, String> = Default::default();
         let mut state_dirs = HashSet::default();
 
-        use mfile::PatchSetting;
         for dep in i.into_iter() {
             let b = g.get(dep).unwrap();
             if let Some(dirs) = b.attrs.get("env_dir_mappings") {
                 for mapping in dirs.as_list().unwrap() {
-                    let mapping = mapping.as_map().unwrap();
-                    patch.dir.insert(
-                        mapping.get("path").unwrap().as_string().unwrap().clone(),
-                        if *mapping.get("read_only").unwrap().as_bool().unwrap() {
-                            PatchSetting::ReadOnly
-                        } else {
-                            PatchSetting::ReadWrite
-                        },
-                    );
+                    if let Some((path, setting)) =
+                        read_mapping(&b.name, "env_dir_mappings", mapping)
+                    {
+                        fs_mapping_packages.insert(path.clone(), b.name.clone());
+                        patch.dir.insert(path, setting);
+                    }
                 }
             }
-            if let Some(dirs) = b.attrs.get("env_file_mappings") {
-                for mapping in dirs.as_list().unwrap() {
-                    let mapping = mapping.as_map().unwrap();
-                    patch.file.insert(
-                        mapping.get("path").unwrap().as_string().unwrap().clone(),
-                        if *mapping.get("read_only").unwrap().as_bool().unwrap() {
-                            PatchSetting::ReadOnly
-                        } else {
-                            PatchSetting::ReadWrite
-                        },
-                    );
+            if let Some(files) = b.attrs.get("env_file_mappings") {
+                for mapping in files.as_list().unwrap() {
+                    if let Some((path, setting)) =
+                        read_mapping(&b.name, "env_file_mappings", mapping)
+                    {
+                        fs_mapping_packages.insert(path.clone(), b.name.clone());
+                        patch.file.insert(path, setting);
+                    }
                 }
             }
             if let Some(wiring) = b.attrs.get("env_state_wiring") {
@@ -102,6 +161,7 @@ impl SetupForPackages {
         Ok(SetupForPackages {
             env_vars,
             fs_mappings: patch,
+            fs_mapping_packages,
             state_dirs,
             needs_dns,
             needs_internet,
@@ -116,8 +176,14 @@ mod tests {
     use indoc::indoc;
     use mfile::PatchSetting;
 
+    /// `class = 'Credential` mappings are dropped here, matching what the
+    /// session-composition path (`minimald`'s `extract_fs_mappings`) already
+    /// did; `class = 'State` ones survive and remember the package that
+    /// declared them. Regression guard for #1204, where a credential file a
+    /// package declared as `~/.claude.json` reached a guest task's sandbox
+    /// and was created at `/` on a read-only rootfs.
     #[test]
-    fn fs_mappings() {
+    fn fs_mappings_drop_credential_class() {
         let layer = Layer::new_for_test(
             indoc! {
                 "
@@ -165,11 +231,12 @@ mod tests {
                 state_dirs: Default::default(),
                 fs_mappings: EnvPatches {
                     dir: HashMap::from_iter([("~/.claude".to_string(), PatchSetting::ReadWrite)]),
-                    file: HashMap::from_iter([(
-                        "~/.claude.json".to_string(),
-                        PatchSetting::ReadWrite
-                    )])
+                    file: HashMap::new(),
                 },
+                fs_mapping_packages: HashMap::from_iter([(
+                    "~/.claude".to_string(),
+                    "b1".to_string()
+                )]),
             }
         )
     }
@@ -222,6 +289,7 @@ mod tests {
                 needs_internet: true,
                 state_dirs: Default::default(),
                 fs_mappings: Default::default(),
+                fs_mapping_packages: Default::default(),
             }
         )
     }
@@ -270,6 +338,7 @@ mod tests {
                 needs_internet: false,
                 state_dirs: HashSet::from_iter(["gocache".to_string(), "gomodcache".to_string()]),
                 fs_mappings: Default::default(),
+                fs_mapping_packages: Default::default(),
             }
         )
     }

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -181,7 +181,7 @@ pub use builds::{
 };
 
 mod env_setup;
-pub use env_setup::SetupForPackages;
+pub use env_setup::{CREDENTIAL_CLASS_TAG, SetupForPackages};
 
 // Re-exported so downstream crates can inspect the `Stack` a
 // `Graph::stack(name)` lookup returns without pulling in `decode`

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -180,8 +180,13 @@ pub use builds::{
     SubsetInput,
 };
 
+mod env_mapping;
+pub use env_mapping::{
+    EnvFsMapping, EnvMappingClass, EnvMappingError, EnvMappingErrorKind, EnvMappingKind,
+};
+
 mod env_setup;
-pub use env_setup::{CREDENTIAL_CLASS_TAG, SetupForPackages};
+pub use env_setup::SetupForPackages;
 
 // Re-exported so downstream crates can inspect the `Stack` a
 // `Graph::stack(name)` lookup returns without pulling in `decode`

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -363,6 +363,11 @@ impl EnvChannel<'_> {
                     Some(&task.patch),
                     Some(&task.vars),
                     task.packages.clone(),
+                    // A nested `min task` inside a bound-dir sandbox: paths
+                    // are mirrored one-for-one and sandbox2 gave this process
+                    // the outer environment's `HOME`, so the ambient home is
+                    // the outer home, which is the one `~/` meant all along.
+                    PatchHome::Ambient,
                 )
                 .await?;
 
@@ -512,6 +517,9 @@ pub struct EnvArgs<'a> {
     pub cwd: PathBuf,
     /// Any additional pinhole bind mounts / file mappings.
     pub patches: Option<&'a EnvPatches>,
+    /// The home directory `~/`-rooted patch paths expand against, and that
+    /// the sandbox reports as `$HOME`.
+    pub home: PatchHome,
 
     /// Environment variables to set.
     pub env_vars: Option<&'a HashMap<String, EnvVarValue>>,
@@ -570,6 +578,52 @@ fn declared_by(packages: &HashMap<String, String>, declared: &str, task: &str) -
     }
 }
 
+/// The home directory this environment's `~/`-rooted patch paths expand
+/// against, and that its sandbox reports as `$HOME`.
+///
+/// A patch path such as `~/.claude.json` has to name a real directory on the
+/// filesystem the sandbox is assembled on. Reading the *ambient* home is
+/// right in exactly one of the two situations this type distinguishes, so the
+/// choice is made at the call site rather than silently deep in the
+/// conversion: `minimald` is pid 1 inside the guest with `HOME=/`, and
+/// expanding against that put package-declared files at the root of a
+/// read-only rootfs, failing with `EROFS` (#1204).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum PatchHome {
+    /// The home of the process building the environment (`$HOME`).
+    ///
+    /// The right answer for `mip` run by a developer: the sandbox mirrors
+    /// host paths one-for-one (`WdSetup::BoundDir`), so the home a package
+    /// means by `~` *is* the invoking user's, and sandbox2 synthesizes the
+    /// same home into the sandbox's passwd. An unset `HOME` leaves no home at
+    /// all, which is an error for a `~/`-rooted mapping and fine for anything
+    /// else.
+    #[default]
+    Ambient,
+    /// The home directory of the `minimald` session this environment belongs
+    /// to, in the daemon's filesystem view.
+    ///
+    /// [`Daemon`]-realm because that is the filesystem the daemon assembles
+    /// the sandbox on, and because it is the realm the session already tracks
+    /// its home in (`SessionPaths::home`, `minimald::env::EnvArgs::home`) —
+    /// so it arrives here without a conversion that could launder the realm.
+    ///
+    /// [`Daemon`]: paths::Daemon
+    Session(paths::DaemonAbsPath),
+}
+
+impl PatchHome {
+    /// The directory to expand `~/` against, or `None` when there is no home
+    /// to be had (an [`Ambient`](Self::Ambient) home with `HOME` unset).
+    #[must_use]
+    pub fn resolve(&self) -> Option<PathBuf> {
+        match self {
+            Self::Ambient => std::env::home_dir(),
+            Self::Session(home) => Some(home.as_utf8_path().as_std_path().to_path_buf()),
+        }
+    }
+}
+
 /// A successfully-configured runtime environment.
 pub struct Env<'a> {
     sandbox: sandbox2::Sandbox<EnvChannel<'a>>,
@@ -622,14 +676,14 @@ impl<'a> Env<'a> {
             );
         }
 
-        // `~/`-rooted patch paths expand against this environment's home. It
-        // is the ambient one here: the sandbox mirrors host paths one-for-one
-        // (`WdSetup::BoundDir`) and sandbox2 synthesizes the same home into
-        // the sandbox's passwd. A home that can't hold the file — notably `/`,
-        // which is what `minimald` sees as pid 1 in the guest — is refused
-        // with the package named, rather than landing the file at the root of
-        // a read-only rootfs (#1204).
-        let home = std::env::home_dir();
+        // `~/`-rooted patch paths expand against the home the caller named
+        // (see [`PatchHome`]), and the same home goes on to the sandbox as
+        // `$HOME` so a mapped-in `~/.claude.json` lands where the process
+        // will look for it. A home that can't hold the file — notably `/`,
+        // which is what `minimald` sees as pid 1 in the guest with no session
+        // to borrow a home from — is refused with the package named, rather
+        // than landing the file at the root of a read-only rootfs (#1204).
+        let home = args.home.resolve();
         let fs_mappings = patch.to_fs_mappings(home.as_deref()).map_err(|e| {
             Error::Other(anyhow::anyhow!(
                 "{e} (declared by {})",
@@ -652,6 +706,7 @@ impl<'a> Env<'a> {
 
         let mut config = sandbox2::config::Config::new(args.name)
             .with_wd(args.cwd.clone(), false, fs_mappings)
+            .with_home(home.clone())
             .with_rootfs(
                 args.transitives
                     .keys()
@@ -898,6 +953,35 @@ mod tests {
     use sandbox2::Channel;
     use std::io::{BufRead, BufReader};
     use tempfile::tempdir;
+
+    /// The guest case (#1204). A task running in a `minimald` session
+    /// expands `~/` against the session's own home — a real, writable
+    /// directory — where the daemon's ambient home is `/` (it is pid 1 in the
+    /// guest) and expanding against that produced `/.claude.json` on a
+    /// read-only rootfs. Both halves are asserted here: the session home
+    /// resolves and expands, and `/` is still refused for the case where
+    /// there is no session home to borrow.
+    #[test]
+    fn a_session_home_expands_where_the_ambient_one_is_refused() {
+        let patches = EnvPatches {
+            file: [("~/.claude.json".to_string(), mfile::PatchSetting::ReadWrite)].into(),
+            ..Default::default()
+        };
+
+        let session = PatchHome::Session(
+            paths::DaemonAbsPath::try_new("/var/lib/minimal/sessions/s1/home").unwrap(),
+        );
+        let home = session.resolve().expect("a session always has a home");
+        assert_eq!(
+            patches.to_fs_mappings(Some(&home)).unwrap()[0].host_path,
+            "/var/lib/minimal/sessions/s1/home/.claude.json",
+        );
+
+        assert!(
+            patches.to_fs_mappings(Some(Path::new("/"))).is_err(),
+            "a pid-1 daemon with no session home to offer must still refuse `/`"
+        );
+    }
 
     /// A patch path a package declared is attributed to that package; one
     /// that only the task's own `patch` table names falls back to the task.

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -560,6 +560,16 @@ pub fn interpolate_task_strings(
     .map_err(Error::Other)
 }
 
+/// Names whoever put a patch path into the environment: the package that
+/// declared it, or — for a path that arrived through the task's own `patch`
+/// table rather than a package attribute — the task itself.
+fn declared_by(packages: &HashMap<String, String>, declared: &str, task: &str) -> String {
+    match packages.get(declared) {
+        Some(p) => format!("package `{p}`"),
+        None => format!("task `{task}`"),
+    }
+}
+
 /// A successfully-configured runtime environment.
 pub struct Env<'a> {
     sandbox: sandbox2::Sandbox<EnvChannel<'a>>,
@@ -581,6 +591,7 @@ impl<'a> Env<'a> {
 
         let SetupForPackages {
             fs_mappings: mut patch,
+            fs_mapping_packages,
             needs_dns,
             needs_internet,
             state_dirs,
@@ -611,8 +622,36 @@ impl<'a> Env<'a> {
             );
         }
 
+        // `~/`-rooted patch paths expand against this environment's home. It
+        // is the ambient one here: the sandbox mirrors host paths one-for-one
+        // (`WdSetup::BoundDir`) and sandbox2 synthesizes the same home into
+        // the sandbox's passwd. A home that can't hold the file — notably `/`,
+        // which is what `minimald` sees as pid 1 in the guest — is refused
+        // with the package named, rather than landing the file at the root of
+        // a read-only rootfs (#1204).
+        let home = std::env::home_dir();
+        let fs_mappings = patch.to_fs_mappings(home.as_deref()).map_err(|e| {
+            Error::Other(anyhow::anyhow!(
+                "{e} (declared by {})",
+                declared_by(&fs_mapping_packages, &e.declared, args.name)
+            ))
+        })?;
+        // Expanded path → the declaration behind it. sandbox2 only ever sees
+        // the expanded form, so its "create mapped file" failures name a path
+        // nobody wrote down; this puts the package and its `~/`-rooted
+        // declaration back into the message.
+        let declarations: HashMap<String, &String> = fs_mapping_packages
+            .keys()
+            .filter_map(|declared| {
+                Some((
+                    EnvPatches::expand_home(declared, home.as_deref()).ok()?,
+                    declared,
+                ))
+            })
+            .collect();
+
         let mut config = sandbox2::config::Config::new(args.name)
-            .with_wd(args.cwd.clone(), false, patch.into())
+            .with_wd(args.cwd.clone(), false, fs_mappings)
             .with_rootfs(
                 args.transitives
                     .keys()
@@ -660,7 +699,23 @@ impl<'a> Env<'a> {
                     daemon_id,
                 },
             )
-            .await?;
+            .await
+            .map_err(|e| {
+                // Sandbox setup creates every mapped file it doesn't find. If
+                // that failed on a path we mapped in, say whose declaration it
+                // was — "create mapped file /.claude.json: EROFS" on its own
+                // sends nobody anywhere useful (#1204).
+                let sandbox2::Error::IO(_, path, _) = &e else {
+                    return e.into();
+                };
+                match path.to_str().and_then(|p| declarations.get(p)) {
+                    Some(declared) => Error::Other(anyhow::anyhow!(
+                        "{e}; mapped in by {}, which declares it as `{declared}`",
+                        declared_by(&fs_mapping_packages, declared, args.name)
+                    )),
+                    None => e.into(),
+                }
+            })?;
         for want_dir in state_dirs {
             std::fs::create_dir_all(args.state_base_dir.join(&want_dir)).map_err(|e| {
                 Error::IO("creating state dir", args.state_base_dir.join(want_dir), e)
@@ -843,6 +898,25 @@ mod tests {
     use sandbox2::Channel;
     use std::io::{BufRead, BufReader};
     use tempfile::tempdir;
+
+    /// A patch path a package declared is attributed to that package; one
+    /// that only the task's own `patch` table names falls back to the task.
+    /// The attribution is what makes a failure to map `~/.claude.json`
+    /// actionable — the path alone doesn't say who asked for it (#1204).
+    #[test]
+    fn declared_by_names_the_package_then_the_task() {
+        let packages =
+            HashMap::from_iter([("~/.claude.json".to_string(), "claude-code".to_string())]);
+        assert_eq!(
+            declared_by(&packages, "~/.claude.json", "test"),
+            "package `claude-code`"
+        );
+        assert_eq!(
+            declared_by(&packages, "~/.npmrc", "test"),
+            "task `test`",
+            "a path no package declared came from the task's own patch table"
+        );
+    }
 
     /// Helper: build a Context and Graph from the fakerepo test data,
     /// matching the pattern used in lib.rs tests.

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -33,7 +33,7 @@ pub use mfile_search_strategy::MFileSearchStrategy;
 mod project_setup;
 pub use project_setup::ProjectSetup;
 
-pub use env::{Env, interpolate_task_strings};
+pub use env::{Env, PatchHome, interpolate_task_strings};
 use tokio::sync::Semaphore;
 use toml_edit::{Array, DocumentMut, Item, TableLike, Value};
 
@@ -852,6 +852,7 @@ impl Context {
         patches: Option<&'a EnvPatches>,
         env_vars: Option<&'a HashMap<String, EnvVarValue>>,
         packages: S,
+        home: PatchHome,
     ) -> Result<env::Env<'a>, Error> {
         self.make_env_with_network(
             name,
@@ -862,6 +863,7 @@ impl Context {
             env_vars,
             packages,
             sandbox2::NetworkMode::HostNet,
+            home,
         )
         .await
     }
@@ -870,6 +872,10 @@ impl Context {
     /// [`sandbox2::NetworkMode`], so callers (e.g. the minimald task-exec path)
     /// can give a task the same network isolation as its session rather than
     /// always `HostNet`.
+    ///
+    /// `home` is the directory `~/`-rooted patch paths expand against; see
+    /// [`PatchHome`] for why every caller states it rather than letting
+    /// the conversion read the ambient one.
     #[allow(clippy::too_many_arguments)]
     pub async fn make_env_with_network<'a, S: PackageSelection>(
         &'a mut self,
@@ -881,6 +887,7 @@ impl Context {
         env_vars: Option<&'a HashMap<String, EnvVarValue>>,
         packages: S,
         network_mode: sandbox2::NetworkMode,
+        home: PatchHome,
     ) -> Result<env::Env<'a>, Error> {
         let mfile = self.minimal_file();
 
@@ -951,6 +958,7 @@ impl Context {
                 transitives: transitive_deps,
                 cwd: wd,
                 patches,
+                home,
                 env_vars,
                 hostname: Some(name.to_string()),
                 override_network_mode: Some(network_mode),
@@ -1441,6 +1449,7 @@ mod tests {
                     Some(&task_smoketest.patch),
                     Some(&task_smoketest.vars),
                     task_smoketest.packages,
+                    PatchHome::Ambient,
                 )
                 .await
                 .unwrap();
@@ -1616,6 +1625,7 @@ mod tests {
                     Some(&task.patch),
                     Some(&task.vars),
                     task.packages.clone(),
+                    PatchHome::Ambient,
                 )
                 .await
                 .unwrap();

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -303,8 +303,9 @@ impl EnvPatches {
     /// usable home is an error here rather than a write into `/`.
     ///
     /// Mappings come back in a deterministic order — directories then files,
-    /// each sorted by declared path — so a caller reporting the first
-    /// failure names the same entry every run.
+    /// each sorted by declared path — so the sandbox applies them the same
+    /// way every run and a caller reporting the first failure names the same
+    /// entry every run.
     pub fn to_fs_mappings(
         &self,
         home: Option<&Path>,
@@ -340,17 +341,39 @@ impl EnvPatches {
         };
         let home = match home {
             None => HomeUnusable::Unset,
-            Some(h) => match h.to_str() {
-                Some(s) if h.is_absolute() && s != "/" => {
-                    return Ok(format!("{}/{stripped}", s.trim_end_matches('/')));
-                }
-                _ => HomeUnusable::NotAHome(h.to_path_buf()),
+            Some(h) => match Self::usable_home(h) {
+                // UTF-8 by construction — `usable_home` only returns a path
+                // it has already round-tripped through `to_str`.
+                Some(h) => return Ok(format!("{}/{stripped}", h.to_str().unwrap())),
+                None => HomeUnusable::NotAHome(h.to_path_buf()),
             },
         };
         Err(PatchHomeError {
             declared: path.to_string(),
             home,
         })
+    }
+
+    /// Normalizes `home` and hands it back only if it is somewhere a
+    /// patched-in file could actually live: absolute, valid UTF-8, and naming
+    /// at least one directory below `/`.
+    ///
+    /// The test is on normalized [`Component`]s rather than the literal
+    /// string. `/`, `//` and `/.` all denote the filesystem root, so a
+    /// string-exact `home != "/"` check passes the latter two straight
+    /// through and reconstitutes the very `/.claude.json` this guard exists
+    /// to prevent (#1204). Normalizing also collapses duplicate separators
+    /// and trailing `/` and `/.` segments, so `/home/dev/`, `/home//dev` and
+    /// `/home/dev/.` all expand identically.
+    fn usable_home(home: &Path) -> Option<PathBuf> {
+        if !home.is_absolute() {
+            return None;
+        }
+        let normalized: PathBuf = home.components().collect();
+        let names_a_directory = normalized
+            .components()
+            .any(|c| matches!(c, Component::Normal(_)));
+        (names_a_directory && normalized.to_str().is_some()).then_some(normalized)
     }
 }
 
@@ -1600,6 +1623,67 @@ mod tests {
         assert!(
             err.to_string().contains("~/.claude.json"),
             "the error must name the unexpanded path, got {err}"
+        );
+    }
+
+    /// Every spelling of the filesystem root is refused, not just the literal
+    /// `"/"`. A string-exact guard let `//` and `/.` through — both are
+    /// absolute, both compare unequal to `"/"`, and both then expanded
+    /// `~/.claude.json` right back to `/.claude.json`, reproducing #1204 with
+    /// a `HOME` a shell or a `WORKDIR /` image could plausibly set.
+    #[test]
+    fn to_fs_mappings_refuses_every_spelling_of_root() {
+        let patches = EnvPatches {
+            file: [("~/.claude.json".to_string(), PatchSetting::ReadWrite)].into(),
+            ..Default::default()
+        };
+
+        for home in ["//", "/.", "///", "/./."] {
+            assert_eq!(
+                patches
+                    .to_fs_mappings(Some(Path::new(home)))
+                    .unwrap_err()
+                    .home,
+                HomeUnusable::NotAHome(PathBuf::from(home)),
+                "`HOME={home}` names the filesystem root and must be refused"
+            );
+        }
+    }
+
+    /// A home that does name a directory expands the same however it is
+    /// spelled: trailing separators, doubled separators and `.` segments are
+    /// normalized away rather than passed into the mapping.
+    #[test]
+    fn to_fs_mappings_normalizes_the_home_it_expands_against() {
+        let patches = EnvPatches {
+            file: [("~/.claude.json".to_string(), PatchSetting::ReadWrite)].into(),
+            ..Default::default()
+        };
+
+        for home in ["/home/dev", "/home/dev/", "/home//dev", "/home/./dev/."] {
+            let mappings = patches.to_fs_mappings(Some(Path::new(home))).unwrap();
+            assert_eq!(
+                mappings[0].host_path, "/home/dev/.claude.json",
+                "`HOME={home}` should expand like `/home/dev`"
+            );
+        }
+    }
+
+    /// A relative `HOME` is no home either — expanding against it would make
+    /// the mapping depend on whatever directory the daemon happens to be in.
+    #[test]
+    fn to_fs_mappings_refuses_a_relative_home() {
+        let patches = EnvPatches {
+            file: [("~/.claude.json".to_string(), PatchSetting::ReadWrite)].into(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            patches
+                .to_fs_mappings(Some(Path::new("home/dev")))
+                .unwrap_err()
+                .home,
+            HomeUnusable::NotAHome(PathBuf::from("home/dev")),
         );
     }
 

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -1,7 +1,7 @@
 //! Finding & reading the `minimal.toml` file.
 
 use std::collections::{BTreeMap, HashMap};
-use std::env::{self, home_dir};
+use std::env;
 use std::ffi::{OsStr, OsString};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Component, Path, PathBuf};
@@ -239,6 +239,50 @@ pub struct EnvPatches {
     pub file: HashMap<String, PatchSetting>,
 }
 
+/// Why a `~/`-rooted patch path had no home directory to expand against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HomeUnusable {
+    /// No home directory is known at all — `HOME` is unset.
+    Unset,
+    /// A home is known but is no place to put a patched-in file: a relative
+    /// path, one that isn't valid UTF-8, or `/`, which is what a daemon
+    /// running as pid 1 inside the guest reports.
+    NotAHome(PathBuf),
+}
+
+/// A patch path rooted at `~/` whose home could not be resolved.
+///
+/// Carries the declaration verbatim — still `~/`-rooted — so the caller can
+/// name the offending entry, and the package that contributed it, back to
+/// the user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatchHomeError {
+    /// The path exactly as it was declared.
+    pub declared: String,
+    /// What was wrong with the home it would have expanded against.
+    pub home: HomeUnusable,
+}
+
+impl std::fmt::Display for PatchHomeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "cannot map `{}` into the environment: ", self.declared)?;
+        match &self.home {
+            HomeUnusable::Unset => write!(
+                f,
+                "`HOME` is unset, so there is no home directory to expand `~/` against"
+            ),
+            HomeUnusable::NotAHome(home) => write!(
+                f,
+                "the home directory is `{}`, which is not somewhere a file can be patched in \
+                 (a daemon running as pid 1 sees `HOME=/`)",
+                home.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PatchHomeError {}
+
 impl EnvPatches {
     /// Combines the given [EnvPatches] into `self`. If keys conflict, `other` takes precedence.
     pub fn union(&mut self, other: &Self) {
@@ -247,46 +291,66 @@ impl EnvPatches {
         self.file
             .extend(other.file.iter().map(|(k, v)| (k.clone(), v.clone())));
     }
-}
 
-impl From<EnvPatches> for Vec<common::FsMapping> {
-    fn from(val: EnvPatches) -> Self {
-        let h = home_dir().unwrap();
-        let map_path = |path: String| {
-            if let Some(stripped) = path.strip_prefix("~/") {
-                h.join(stripped).to_str().unwrap().to_string()
-            } else {
-                path
+    /// Lowers these patches into sandbox filesystem mappings, expanding
+    /// `~/`-rooted paths against `home`.
+    ///
+    /// `home` is the home directory of the environment being built, which is
+    /// not necessarily the running process's: `minimald` is pid 1 inside the
+    /// guest with `HOME=/`, and expanding against that put package-declared
+    /// files such as `~/.claude.json` at the root of a read-only rootfs,
+    /// where creating them fails with `EROFS` (#1204). A `~/` path with no
+    /// usable home is an error here rather than a write into `/`.
+    ///
+    /// Mappings come back in a deterministic order — directories then files,
+    /// each sorted by declared path — so a caller reporting the first
+    /// failure names the same entry every run.
+    pub fn to_fs_mappings(
+        &self,
+        home: Option<&Path>,
+    ) -> Result<Vec<common::FsMapping>, PatchHomeError> {
+        let mut mappings = Vec::with_capacity(self.dir.len() + self.file.len());
+        for (is_file, entries) in [(false, &self.dir), (true, &self.file)] {
+            let mut entries: Vec<_> = entries.iter().collect();
+            entries.sort_by_key(|(path, _)| *path);
+            for (path, settings) in entries {
+                mappings.push(common::FsMapping {
+                    host_path: Self::expand_home(path, home)?,
+                    sandbox_path: None, // use host
+                    create_if_missing: true,
+                    is_file,
+                    read_only: matches!(settings, PatchSetting::ReadOnly),
+                });
             }
-        };
+        }
+        Ok(mappings)
+    }
 
-        val.dir
-            .into_iter()
-            .map(|(path, settings)| common::FsMapping {
-                host_path: map_path(path),
-                sandbox_path: None, // use host
-                create_if_missing: true,
-                is_file: false,
-                read_only: match settings {
-                    PatchSetting::ReadOnly => true,
-                    PatchSetting::ReadWrite => false,
-                },
-            })
-            .chain(
-                val.file
-                    .into_iter()
-                    .map(|(path, settings)| common::FsMapping {
-                        host_path: map_path(path),
-                        sandbox_path: None, // use host
-                        create_if_missing: true,
-                        is_file: true,
-                        read_only: match settings {
-                            PatchSetting::ReadOnly => true,
-                            PatchSetting::ReadWrite => false,
-                        },
-                    }),
-            )
-            .collect()
+    /// Resolves one declared patch path against `home`: `~/`-rooted paths are
+    /// expanded, anything else is returned as-is.
+    ///
+    /// Exposed alongside [`to_fs_mappings`](Self::to_fs_mappings) so a caller
+    /// holding the declarations can map an expanded path back to the entry it
+    /// came from — the sandbox only ever sees the expanded form, and an error
+    /// about `/home/dev/.claude.json` is only actionable once it can be tied
+    /// to the `~/.claude.json` some package declared.
+    pub fn expand_home(path: &str, home: Option<&Path>) -> Result<String, PatchHomeError> {
+        let Some(stripped) = path.strip_prefix("~/") else {
+            return Ok(path.to_string());
+        };
+        let home = match home {
+            None => HomeUnusable::Unset,
+            Some(h) => match h.to_str() {
+                Some(s) if h.is_absolute() && s != "/" => {
+                    return Ok(format!("{}/{stripped}", s.trim_end_matches('/')));
+                }
+                _ => HomeUnusable::NotAHome(h.to_path_buf()),
+            },
+        };
+        Err(PatchHomeError {
+            declared: path.to_string(),
+            home,
+        })
     }
 }
 
@@ -1476,6 +1540,96 @@ mod tests {
                 .into(),
                 file: HashMap::new()
             }
+        );
+    }
+
+    /// `~/` expands against the home the caller passes, not the ambient
+    /// process's, and absolute paths are left alone. Directories come before
+    /// files, each sorted by declared path.
+    #[test]
+    fn to_fs_mappings_expands_against_the_given_home() {
+        let patches = EnvPatches {
+            dir: [("~/.claude".to_string(), PatchSetting::ReadWrite)].into(),
+            file: [
+                ("~/.claude.json".to_string(), PatchSetting::ReadOnly),
+                ("/etc/hosts".to_string(), PatchSetting::ReadOnly),
+            ]
+            .into(),
+        };
+
+        let mappings = patches
+            .to_fs_mappings(Some(Path::new("/home/dev")))
+            .expect("a real home expands");
+
+        assert_eq!(
+            mappings
+                .iter()
+                .map(|m| (m.host_path.as_str(), m.is_file, m.read_only))
+                .collect::<Vec<_>>(),
+            vec![
+                ("/home/dev/.claude", false, false),
+                ("/etc/hosts", true, true),
+                ("/home/dev/.claude.json", true, true),
+            ]
+        );
+    }
+
+    /// Regression guard for #1204: `minimald` runs as pid 1 inside the guest
+    /// with `HOME=/`, and expanding a package-declared `~/.claude.json`
+    /// against that used to produce `/.claude.json` — a create against the
+    /// guest's read-only rootfs, failing with `EROFS`. Refuse it instead, and
+    /// name the path as declared so the caller can point at the package.
+    #[test]
+    fn to_fs_mappings_refuses_a_root_home() {
+        let patches = EnvPatches {
+            file: [("~/.claude.json".to_string(), PatchSetting::ReadWrite)].into(),
+            ..Default::default()
+        };
+
+        let err = patches
+            .to_fs_mappings(Some(Path::new("/")))
+            .expect_err("`/` is not a home directory");
+
+        assert_eq!(
+            err,
+            PatchHomeError {
+                declared: "~/.claude.json".to_string(),
+                home: HomeUnusable::NotAHome(PathBuf::from("/")),
+            }
+        );
+        assert!(
+            err.to_string().contains("~/.claude.json"),
+            "the error must name the unexpanded path, got {err}"
+        );
+    }
+
+    /// An unset `HOME` is an error too, where it used to panic on
+    /// `home_dir().unwrap()`. Paths that never mention `~/` still resolve —
+    /// no home is needed for those.
+    #[test]
+    fn to_fs_mappings_without_a_home() {
+        let tilde = EnvPatches {
+            dir: [("~/.cache".to_string(), PatchSetting::ReadWrite)].into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            tilde.to_fs_mappings(None).unwrap_err(),
+            PatchHomeError {
+                declared: "~/.cache".to_string(),
+                home: HomeUnusable::Unset,
+            }
+        );
+
+        let absolute = EnvPatches {
+            dir: [("/var/cache".to_string(), PatchSetting::ReadWrite)].into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            absolute
+                .to_fs_mappings(None)
+                .expect("absolute paths need no home")
+                .len(),
+            1
         );
     }
 

--- a/crates/minimald/src/env.rs
+++ b/crates/minimald/src/env.rs
@@ -1159,6 +1159,12 @@ impl SessionChannel {
                     Some(&task.patch),
                     Some(&task.vars),
                     task.packages.clone(),
+                    // The session's own home, not the daemon's. `minimald` is
+                    // pid 1 with `HOME=/` inside the guest, so the ambient
+                    // home would expand a package's `~/.claude.json` onto the
+                    // read-only rootfs (#1204); the session has a real,
+                    // writable home and this channel already holds it.
+                    mctx::PatchHome::Session(self.home.clone()),
                 )
                 .await?;
 

--- a/crates/minimald/src/env.rs
+++ b/crates/minimald/src/env.rs
@@ -439,6 +439,7 @@ impl Env {
         let (legacy_state_dirs, mut pkg_env_vars) = if args.include_package_attr_wiring {
             let SetupForPackages {
                 fs_mappings: _,
+                fs_mapping_packages: _,
                 needs_dns: _,
                 needs_internet: _,
                 state_dirs,

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -187,6 +187,11 @@ async fn task_producer(
             // so any future mode also takes the safe HostNet default.
             _ => sandbox2::NetworkMode::HostNet,
         };
+        // A task's `~/` resolves against the session's home, the same
+        // directory the interactive session sees at `/home`. The daemon's own
+        // ambient home is `/` inside the guest, and expanding against that
+        // dropped package-declared files onto the read-only rootfs (#1204).
+        let session_home = session.paths().await?.home;
         let mut env = ctx
             .make_env_with_network(
                 &exec.task,
@@ -197,6 +202,7 @@ async fn task_producer(
                 Some(&task.vars),
                 task.packages.clone(),
                 network_mode,
+                mctx::PatchHome::Session(session_home),
             )
             .await
             .map_err(|e| io::Error::other(e.to_string()))?;

--- a/crates/minimald/src/sessions/composables.rs
+++ b/crates/minimald/src/sessions/composables.rs
@@ -20,11 +20,13 @@
 
 use std::sync::Arc;
 
-// The string form of the nickel enum tag `'Credential`, shared with the
-// package-attribute path in `graph` so both filters key off one definition.
-// That constant carries the schema-stability note; the regression guard on
-// this side is `credential_class_fs_mappings_are_filtered_out` below.
-use graph::CREDENTIAL_CLASS_TAG;
+// The env-mapping attrs are decoded into `graph`'s typed representation
+// rather than read out of `AttrValue` here, so this path and the
+// package-attribute path in `graph::SetupForPackages` classify an entry
+// through one definition instead of two string comparisons. The regression
+// guard on this side is `credential_class_fs_mappings_are_filtered_out`
+// below.
+use graph::{EnvFsMapping, EnvMappingClass, EnvMappingKind};
 use paths::DaemonAbsPath;
 use sessions::{
     SessionId,
@@ -36,8 +38,8 @@ use sessions::{
 /// The runtime-env attrs a package can declare on
 /// `BuildSpec.attrs`. See
 /// [`extract_package_attrs`] for the extraction rules — in
-/// particular, `class = 'Credential` mappings are silently dropped
-/// pending the future secrets strategy.
+/// particular, `class = 'Credential` mappings are dropped (with a
+/// warn naming the package) pending the future secrets strategy.
 #[derive(Debug)]
 struct PackageAttrs {
     state_wiring: Vec<mfile::StateWiring>,
@@ -52,13 +54,14 @@ struct PackageAttrs {
 /// into domain-typed pieces for [`mfile::PackageComposable`].
 ///
 /// Credential-class mappings are dropped (see `TODO(secrets)`);
-/// `read_only` is ignored (minimal is copy-based). Malformed
-/// entries are silently skipped — the nickel schema is the
-/// authority on shape.
+/// `read_only` is ignored (minimal is copy-based). An entry that
+/// doesn't decode is an error, not a skip: this extractor feeds a
+/// credential filter, so an entry nobody can classify must never
+/// reach the session.
 fn extract_package_attrs(b: &graph::BuildSpec) -> Result<PackageAttrs, std::io::Error> {
     Ok(PackageAttrs {
         state_wiring: extract_state_wiring(b)?,
-        fs_mappings: extract_fs_mappings(b),
+        fs_mappings: extract_fs_mappings(b)?,
     })
 }
 
@@ -102,7 +105,9 @@ fn extract_state_wiring(b: &graph::BuildSpec) -> Result<Vec<mfile::StateWiring>,
         .collect()
 }
 
-fn extract_fs_mappings(b: &graph::BuildSpec) -> Vec<mfile::PackageFsMapping> {
+fn extract_fs_mappings(
+    b: &graph::BuildSpec,
+) -> Result<Vec<mfile::PackageFsMapping>, std::io::Error> {
     // TODO(secrets): `class = 'Credential` mappings are filtered
     // out here rather than routed through a separate secrets
     // channel. When the secrets strategy lands, teach this
@@ -113,78 +118,57 @@ fn extract_fs_mappings(b: &graph::BuildSpec) -> Vec<mfile::PackageFsMapping> {
     // [`mfile::PackageComposable::contribute`]; here we just tag the
     // variant so that logic can distinguish them from single-file
     // mappings.
-    ["env_dir_mappings", "env_file_mappings"]
-        .iter()
-        .flat_map(|attr| {
-            let is_dir = *attr == "env_dir_mappings";
-            b.attrs
-                .get(*attr)
-                .into_iter()
-                .flat_map(|v| attr_entries(v).into_iter())
-                .filter_map(move |entry| {
-                    let m = entry.as_map()?;
-                    // Normalize the path: trim trailing slashes so a
-                    // package declaration like `~/.claude/` gives the
-                    // same mapping as `~/.claude`, and reject the
-                    // pathological cases (empty, or a bare `/`) so a
-                    // walker rooted at filesystem root can never
-                    // reach the client.
-                    let path = m.get("path")?.as_string()?.trim_end_matches('/').to_owned();
-                    if path.is_empty() {
-                        tracing::warn!(
-                            package = %b.name,
-                            attr = %attr,
-                            "dropping fs mapping with empty or root path; the walker \
-                             would otherwise be rooted at the filesystem root",
-                        );
-                        return None;
-                    }
-                    // The two filters differ in what they do with the entry:
-                    // - Credential-class drops the entry entirely (with a
-                    //   warn naming the package + path).
-                    // - read_only=true keeps the entry (the mapping still
-                    //   reaches the sandbox) but warns that the flag was
-                    //   ignored, since minimal is copy-based and there's
-                    //   no read-only enforcement to apply.
-                    // Both warn so an operator reading daemon logs sees
-                    // exactly which package's mapping had its declared
-                    // intent altered.
-                    //
-                    // Missing/malformed `class` still returns silently —
-                    // that's a nickel-schema violation on the package side
-                    // and the extractor isn't the right layer to surface
-                    // it.
-                    if m.get("class")
-                        .and_then(|c| c.as_string())
-                        .map(String::as_str)
-                        == Some(CREDENTIAL_CLASS_TAG)
-                    {
-                        tracing::warn!(
-                            package = %b.name,
-                            path = %path,
-                            "dropping Credential-class fs mapping from session composition; \
-                             the secrets strategy is deferred, so credentials do not reach the \
-                             session sandbox via the composition path",
-                        );
-                        return None;
-                    }
-                    if m.get("read_only").and_then(|c| c.as_bool()).copied() == Some(true) {
-                        tracing::warn!(
-                            package = %b.name,
-                            path = %path,
-                            "ignoring `read_only = true` on fs mapping; minimal is copy-based \
-                             and the resulting sandbox file is writable regardless of the \
-                             package author's declared intent",
-                        );
-                    }
-                    Some(if is_dir {
-                        mfile::PackageFsMapping::Dir { path }
-                    } else {
-                        mfile::PackageFsMapping::File { path }
-                    })
-                })
-        })
-        .collect()
+    let mut out = Vec::new();
+    for mapping in EnvFsMapping::decode_all(b)? {
+        // Normalize the path: trim trailing slashes so a package
+        // declaration like `~/.claude/` gives the same mapping as
+        // `~/.claude`, and reject the pathological cases (empty, or
+        // a bare `/`) so a walker rooted at filesystem root can
+        // never reach the client.
+        let path = mapping.path.trim_end_matches('/').to_owned();
+        if path.is_empty() {
+            tracing::warn!(
+                package = %b.name,
+                attr = %mapping.kind.attr(),
+                "dropping fs mapping with empty or root path; the walker \
+                 would otherwise be rooted at the filesystem root",
+            );
+            continue;
+        }
+        // The two filters differ in what they do with the entry:
+        // - Credential-class drops the entry entirely (with a warn
+        //   naming the package + path).
+        // - read_only=true keeps the entry (the mapping still
+        //   reaches the sandbox) but warns that the flag was
+        //   ignored, since minimal is copy-based and there's no
+        //   read-only enforcement to apply.
+        // Both warn so an operator reading daemon logs sees exactly
+        // which package's mapping had its declared intent altered.
+        if mapping.class == EnvMappingClass::Credential {
+            tracing::warn!(
+                package = %b.name,
+                path = %path,
+                "dropping Credential-class fs mapping from session composition; \
+                 the secrets strategy is deferred, so credentials do not reach the \
+                 session sandbox via the composition path",
+            );
+            continue;
+        }
+        if mapping.read_only {
+            tracing::warn!(
+                package = %b.name,
+                path = %path,
+                "ignoring `read_only = true` on fs mapping; minimal is copy-based \
+                 and the resulting sandbox file is writable regardless of the \
+                 package author's declared intent",
+            );
+        }
+        out.push(match mapping.kind {
+            EnvMappingKind::Dir => mfile::PackageFsMapping::Dir { path },
+            EnvMappingKind::File => mfile::PackageFsMapping::File { path },
+        });
+    }
+    Ok(out)
 }
 
 /// Normalize the list-or-single-map wire shape into a slice of
@@ -725,6 +709,51 @@ mod tests {
             vec![mfile::PackageFsMapping::Dir {
                 path: "~/.claude".to_string(),
             }],
+        );
+    }
+
+    /// The other half of the credential filter: an entry this build
+    /// cannot classify fails the whole extraction rather than
+    /// reaching the composer as an ordinary mapping.
+    ///
+    /// This is the hazard the shared typed decode exists to close.
+    /// While both extractors compared `class` to the string
+    /// `"Credential"`, anything that didn't match — an entry with no
+    /// class, or a `decode::AttrValue` that rendered enum tags some
+    /// other way — was treated as "not a credential" and staged into
+    /// the session. Now it is an error naming the package to go and
+    /// fix.
+    #[test]
+    fn an_unclassifiable_fs_mapping_fails_extraction() {
+        let layer = Layer::new_for_test(
+            indoc! {
+                "
+                let {BuildSpec, ..} = import \"minimal.ncl\" in
+                {
+                    name = \"claude-code\",
+                    build_deps = [],
+                    cmd = \"\",
+                    attrs = {
+                        env_file_mappings = [{ read_only = false, path = \"~/.claude.json\" }],
+                    },
+                } | BuildSpec
+                "
+            }
+            .to_string(),
+        )
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("spec parsing failed");
+        });
+        let g = graph::Graph::new().ingest(layer).unwrap();
+        let bs = g.get(g.by_name("claude-code").unwrap()).unwrap();
+
+        let err = extract_package_attrs(bs)
+            .expect_err("an entry with no class must not reach the composer");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("claude-code") && err.to_string().contains("class"),
+            "the error must name the package and the offending field, got {err}"
         );
     }
 

--- a/crates/minimald/src/sessions/composables.rs
+++ b/crates/minimald/src/sessions/composables.rs
@@ -20,6 +20,11 @@
 
 use std::sync::Arc;
 
+// The string form of the nickel enum tag `'Credential`, shared with the
+// package-attribute path in `graph` so both filters key off one definition.
+// That constant carries the schema-stability note; the regression guard on
+// this side is `credential_class_fs_mappings_are_filtered_out` below.
+use graph::CREDENTIAL_CLASS_TAG;
 use paths::DaemonAbsPath;
 use sessions::{
     SessionId,
@@ -96,23 +101,6 @@ fn extract_state_wiring(b: &graph::BuildSpec) -> Result<Vec<mfile::StateWiring>,
         })
         .collect()
 }
-
-/// The string form of the nickel enum tag `'Credential` as it
-/// appears after `decode`'s AttrValue conversion. Compared as a
-/// plain string at runtime in [`extract_fs_mappings`], so if
-/// `decode::AttrValue::EnumTag` ever changes its rendering
-/// (angle-brackets, hash prefix, etc.) the check here silently
-/// stops matching — credential mappings would then flow through
-/// unfiltered.
-///
-/// The actual regression guard is the
-/// `credential_class_fs_mappings_are_filtered_out` test in this
-/// module, which asserts a `'Credential`-tagged mapping is dropped.
-/// If `decode`'s enum-tag rendering changes, that test will fail
-/// and this constant is where to update.
-// TODO(schema-stability): keep in sync with `decode::AttrValue::EnumTag`
-// rendering.
-const CREDENTIAL_CLASS_TAG: &str = "Credential";
 
 fn extract_fs_mappings(b: &graph::BuildSpec) -> Vec<mfile::PackageFsMapping> {
     // TODO(secrets): `class = 'Credential` mappings are filtered

--- a/crates/mip/src/cmd_run.rs
+++ b/crates/mip/src/cmd_run.rs
@@ -256,6 +256,9 @@ pub async fn run_task(
             Some(&task.patch),
             Some(&task.vars),
             task.packages.clone(),
+            // `mip` runs on the user's own host, where the sandbox mirrors
+            // host paths, so `~` means the invoking user's home.
+            mctx::PatchHome::Ambient,
         )
         .await?;
 

--- a/crates/sandbox2/src/config.rs
+++ b/crates/sandbox2/src/config.rs
@@ -203,6 +203,16 @@ pub struct Config {
     pub hostname: Option<String>,
     /// The username to set in the environment, if any. Defaults to `build`.
     pub username: Option<String>,
+    /// The home directory to give the sandboxed process — both `$HOME` and
+    /// the synthesized passwd entry — under the [`WdSetup::BoundDir`] layout.
+    /// The other two layouts own their home outright (`/state/home` for
+    /// `Isolated`, `/home` for `Session`) and ignore this.
+    ///
+    /// `None` falls back to the ambient `$HOME` of the process building the
+    /// sandbox, which is the right answer for `mip` on a developer's host and
+    /// the wrong one under `minimald`, where the daemon is pid 1 in the guest
+    /// with `HOME=/` and has a real session home to offer instead (#1204).
+    pub home: Option<PathBuf>,
 
     /// Globally/initially-set environment variables.
     pub env_vars: HashMap<String, String>,
@@ -234,6 +244,30 @@ pub struct Invocation {
 }
 
 impl Config {
+    /// The home directory a command in this sandbox sees, as an absolute path
+    /// inside the sandbox. One definition, used for both `$HOME` and the
+    /// synthesized passwd entry so the two can never disagree.
+    ///
+    /// `Isolated` and `Session` own their home outright. `BoundDir` mirrors
+    /// host paths one-for-one, so its home is a host path too: the
+    /// caller-supplied [`Config::home`] when there is one, else the ambient
+    /// `$HOME`. `/state/home` is the last resort for a process with no `$HOME`
+    /// at all.
+    #[must_use]
+    pub fn sandbox_home(&self) -> String {
+        match &self.wd {
+            WdSetup::Isolated { .. } => "/state/home".to_string(),
+            WdSetup::Session { .. } => format!("/{}", crate::SESSION_HOME),
+            WdSetup::BoundDir { .. } => self
+                .home
+                .as_deref()
+                .and_then(Path::to_str)
+                .map(String::from)
+                .or_else(|| std::env::var("HOME").ok())
+                .unwrap_or_else(|| "/state/home".to_string()),
+        }
+    }
+
     /// The working directory a command in this sandbox starts in, as an
     /// absolute path inside the sandbox — `/workbench` for a session (unless
     /// the name is overridden), `/build` for a task.
@@ -303,14 +337,7 @@ impl Config {
         set("XDG_CACHE_HOME", "/state/cache");
         set("XDG_RUNTIME_DIR", "/run");
 
-        match &self.wd {
-            WdSetup::Isolated { .. } => set("HOME", "/state/home"),
-            WdSetup::Session { .. } => set("HOME", "/home"),
-            WdSetup::BoundDir { .. } => match std::env::var("HOME") {
-                Ok(h) => set("HOME", &h),
-                Err(_) => set("HOME", "/state/home"),
-            },
-        }
+        set("HOME", &self.sandbox_home());
 
         if let WdSetup::Isolated { .. } = self.wd {
             set("OUTPUT_DIR", "/build/output");
@@ -358,6 +385,7 @@ impl Config {
             env_vars: HashMap::with_capacity(12),
             hostname: None,
             username: None,
+            home: None,
             keep_dirs: false,
             rootfs: BTreeSet::new(),
             state_dir: None,
@@ -479,6 +507,13 @@ impl Config {
     /// Configures the username to use in the sandbox.
     pub fn with_username<S: Into<String>>(mut self, username: S) -> Self {
         self.username = Some(username.into());
+        self
+    }
+    /// Configures the home directory to give the sandboxed process under the
+    /// [`WdSetup::BoundDir`] layout, in place of the ambient `$HOME`. See
+    /// [`Config::home`]; `None` restores the ambient fallback.
+    pub fn with_home<P: Into<PathBuf>>(mut self, home: Option<P>) -> Self {
+        self.home = home.map(Into::into);
         self
     }
 
@@ -635,13 +670,7 @@ impl Config {
             common::synth_dns_config(&sd)
                 .map_err(|e| Error::IO("synthesizing DNS configuration", sd.clone(), e))?;
         }
-        let home = match &self.wd {
-            WdSetup::Isolated { .. } => "/state/home".to_string(),
-            WdSetup::BoundDir { .. } => std::env::home_dir()
-                .and_then(|p| p.to_str().map(String::from))
-                .unwrap_or_else(|| "/state/home".to_string()),
-            WdSetup::Session { .. } => "/home".to_string(),
-        };
+        let home = self.sandbox_home();
         match &self.username {
             Some(n) => common::synth_user_group_config(&sd, n, &home),
             None => common::synth_user_group_config(&sd, "build", &home),
@@ -710,5 +739,33 @@ mod tests {
         assert_eq!(env.get("SOURCE_DATE_EPOCH").map(String::as_str), Some("0"));
         assert_eq!(env.get("LC_ALL").map(String::as_str), Some("en_US.utf8"));
         assert_eq!(env.get("PS1"), None);
+    }
+
+    /// A bound-dir sandbox mirrors host paths, so its home is a host path —
+    /// the caller's when one is given. `minimald` gives the session's home
+    /// here because its own ambient `$HOME` is `/` in the guest, which is not
+    /// a directory anything can be patched into (#1204).
+    #[test]
+    fn a_bound_dir_sandbox_takes_the_home_it_is_given() {
+        let config = Config::new("test")
+            .with_wd("/workbench", false, Vec::new())
+            .with_home(Some("/var/lib/minimal/sessions/s1/home"));
+
+        assert_eq!(config.sandbox_home(), "/var/lib/minimal/sessions/s1/home");
+        assert_eq!(
+            config.command_env().get("HOME").map(String::as_str),
+            Some("/var/lib/minimal/sessions/s1/home"),
+        );
+    }
+
+    /// The other two layouts own their home outright, so an override is
+    /// ignored rather than silently relocating a session's `/home`.
+    #[test]
+    fn only_the_bound_dir_layout_takes_a_home_override() {
+        let session = session_config().with_home(Some("/elsewhere"));
+        assert_eq!(session.sandbox_home(), "/home");
+
+        let build = Config::new("test").with_home(Some("/elsewhere"));
+        assert_eq!(build.sandbox_home(), "/state/home");
     }
 }


### PR DESCRIPTION
Closes #1204.

Two defects on the sandbox environment path.

**1. `~` was expanded against the ambient home.** `impl From<EnvPatches> for
Vec<common::FsMapping>` called `home_dir().unwrap()`. In the guest `minimald` runs as
pid 1 with `HOME=/`, so `~/.claude.json` became `/.claude.json` on a read-only ext4
root — EROFS at session create. Homes are now expanded **explicitly** from a
caller-supplied value, and a `/`-rooted home is refused up front rather than silently
producing junk paths at the filesystem root.

**2. The session and task-exec paths disagreed about credentials.**
`composables.rs` dropped `class = 'Credential` mappings while `graph/src/env_setup.rs`
kept them. The two paths now agree.

### Reviewer notes — please read before merging
- **This converts the symptom, it does not fully fix the guest case.** The only
  production caller still passes an ambient home (`std::env::home_dir()` in
  `crates/mctx/src/env.rs`), because `EnvArgs` has no `home` field to plumb one
  through. In the guest, a surviving `~/`-rooted State-class mapping now hard-errors
  with a clear pre-flight refusal instead of EROFS-at-create. Better, but the mapping
  still does not work; plumbing a real home to `minimald/src/exec.rs` is follow-up.
- **Dropping `class = 'Credential` is a functional removal on host runs too**, not just
  in the guest. A `mip run` task that previously received `~/.claude.json` (or an
  upstream package's `~/.aws/credentials`) now runs without it, signalled only by a
  `tracing::warn!`. Expect "not logged in" from tools with no error from minimal itself.
  Deliberate, documented under `TODO(secrets)`, and consistent with the session path —
  but it wants a release note.
- The `/`-home guard is string-exact (`s != "/"`), so `HOME=//` and `HOME=/.` slip past
  it and reproduce the original `/.claude.json`. Improbable, but comparing normalized
  components would be robust.
- `HOME=/` on a *writable* root (minimald as root in a container) regresses from
  "works" to "errors". Arguably correct — dotfiles at `/` are junk — but it is the one
  configuration that gets stricter.
- The renamed test `fs_mappings_drop_credential_class` **tightens** its assertion to the
  new narrower behaviour; it is not a weakened gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand `~/` patch homes explicitly via `EnvPatches::to_fs_mappings` and drop `Credential`-class fs mappings
> - Replaces the implicit `From<EnvPatches> for Vec<FsMapping>` with `EnvPatches::to_fs_mappings(&self, home: Option<&Path>)`, which requires the caller to pass a home directory and returns a structured `PatchHomeError` when `~/` cannot expand to a usable home (e.g. `/` or unset) instead of panicking or mapping to `/`
> - `env_setup::read_mapping` filters out fs mappings with `class = 'Credential` (`CREDENTIAL_CLASS_TAG`) and logs a warning per dropped entry; `SetupForPackages::build` now skips these entries
> - Adds `SetupForPackages::fs_mapping_packages: HashMap<String, String>` to record which package declared each surviving mapping; `mctx::env` uses it to attribute sandbox file-creation IO errors back to the declaring package or task and the original `~/` path
> - `graph::CREDENTIAL_CLASS_TAG` is now a public re-export so `minimald` and other crates import it instead of redefining
> - Risk: `From<EnvPatches> for Vec<FsMapping>` is removed; any out-of-tree caller relying on that impl will fail to compile. `~/` paths now error instead of silently mapping to `/` when home is unusable — check `env.rs` build sites in [crates/mctx/src/env.rs](https://github.com/gominimal/minimal/pull/1262/files#diff-b7da06c3b65c0833a934029f47dea9d800eba35146808b4f255d22c88f753995) and [crates/minimald/src/env.rs](https://github.com/gominimal/minimal/pull/1262/files#diff-ece548260b2c5052569423263e9b54827b352ed496728bed2f1bf4c52c251dc1)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80b867a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Filesystem mappings now retain package information for clearer diagnostics.
  - `~/` paths resolve against the configured ambient or session home directory.
  - Environment setup errors identify the package or task associated with failed mappings.
  - Environment and patch mappings now use stable ordering for consistent results.

- **Bug Fixes**
  - Credential-related filesystem mappings are filtered with warnings.
  - Invalid or unclassifiable mappings now produce clearer errors.
  - Home-directory paths are validated more reliably, while valid absolute paths continue to work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->