### PR TITLE
feat(diagnostics): capture shutdown cause, host memory, and panic reports

### DIFF
--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -86,7 +86,7 @@ pub use capture::{Capture, CaptureError, command_capture, command_stdout, first_
 #[cfg(unix)]
 pub use disk::{DiskUsage, disk_usage};
 pub use listing::{Listing, listing};
-pub use logs::{newest_matching, newest_rotated};
+pub use logs::{newest_matching, newest_rotated, try_newest_matching};
 pub use manifest::{CollectedEntry, CollectorError, Manifest, Redaction, SkippedEntry};
 #[cfg(unix)]
 pub use system::{DiskInfo, SystemInfo, system_info};

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -86,7 +86,7 @@ pub use capture::{Capture, CaptureError, command_capture, command_stdout, first_
 #[cfg(unix)]
 pub use disk::{DiskUsage, disk_usage};
 pub use listing::{Listing, listing};
-pub use logs::newest_rotated;
+pub use logs::{newest_matching, newest_rotated};
 pub use manifest::{CollectedEntry, CollectorError, Manifest, Redaction, SkippedEntry};
 #[cfg(unix)]
 pub use system::{DiskInfo, SystemInfo, system_info};

--- a/crates/diagnostics/src/logs.rs
+++ b/crates/diagnostics/src/logs.rs
@@ -27,9 +27,25 @@ pub async fn newest_matching(
     limit: usize,
     keep: impl Fn(&str) -> bool,
 ) -> Vec<PathBuf> {
-    let Ok(mut entries) = tokio::fs::read_dir(dir).await else {
-        return Vec::new();
-    };
+    try_newest_matching(dir, limit, keep)
+        .await
+        .unwrap_or_default()
+}
+
+/// [`newest_matching`] with the directory read's failure surfaced instead of
+/// folded into an empty list.
+///
+/// For most callers "no directory" and "nothing matched" are the same
+/// finding, which is why the plain form collapses them. For a caller whose
+/// finding *turns* on the difference the collapse is a lie: a panic-report
+/// directory the OS denied us is not a host that never panicked, and saying
+/// so would rule out the exact cause the reader is looking for.
+pub async fn try_newest_matching(
+    dir: &Path,
+    limit: usize,
+    keep: impl Fn(&str) -> bool,
+) -> std::io::Result<Vec<PathBuf>> {
+    let mut entries = tokio::fs::read_dir(dir).await?;
     let mut matches: Vec<(SystemTime, PathBuf)> = Vec::new();
     while let Ok(Some(entry)) = entries.next_entry().await {
         let path = entry.path();
@@ -44,7 +60,7 @@ pub async fn newest_matching(
     }
     matches.sort_by(|(at, ap), (bt, bp)| bt.cmp(at).then_with(|| bp.cmp(ap)));
     matches.truncate(limit);
-    matches.into_iter().map(|(_, path)| path).collect()
+    Ok(matches.into_iter().map(|(_, path)| path).collect())
 }
 
 #[cfg(test)]
@@ -113,6 +129,41 @@ mod tests {
             newest_rotated(Path::new("/nonexistent/diag-log-dir"), "app.log", 5)
                 .await
                 .is_empty()
+        );
+    }
+
+    /// The fallible form is what a caller uses when "could not look" must not
+    /// read as "nothing there": it hands back the errno instead of an empty
+    /// list, and distinguishes an absent directory from an unlistable one.
+    #[tokio::test]
+    async fn try_form_reports_why_the_directory_could_not_be_read() {
+        let missing = try_newest_matching(Path::new("/nonexistent/diag-log-dir"), 5, |_| true)
+            .await
+            .expect_err("a missing directory is an error, not an empty list");
+        assert_eq!(missing.kind(), std::io::ErrorKind::NotFound);
+
+        // A non-directory stands in for the unreadable case: `read_dir` fails
+        // with something other than `NotFound` (here `ENOTDIR`), the shape a
+        // permission-denied system directory has.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let not_a_dir = tmp.path().join("regular-file");
+        std::fs::write(&not_a_dir, "").unwrap();
+        let err = try_newest_matching(&not_a_dir, 5, |_| true)
+            .await
+            .expect_err("an unlistable directory is an error");
+        assert_ne!(
+            err.kind(),
+            std::io::ErrorKind::NotFound,
+            "unreadable must stay distinguishable from absent: {err}"
+        );
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(
+            try_newest_matching(tmp.path(), 5, |_| true)
+                .await
+                .expect("a readable directory reads")
+                .is_empty(),
+            "an empty directory is an empty list, not an error"
         );
     }
 }

--- a/crates/diagnostics/src/logs.rs
+++ b/crates/diagnostics/src/logs.rs
@@ -15,17 +15,25 @@ use std::time::SystemTime;
 /// that need to distinguish "no log dir" from "no matches" check the
 /// directory first.
 pub async fn newest_rotated(dir: &Path, prefix: &str, limit: usize) -> Vec<PathBuf> {
+    newest_matching(dir, limit, |name| name.starts_with(prefix)).await
+}
+
+/// The newest `limit` files in `dir` whose names satisfy `keep`, newest
+/// first — the general form of [`newest_rotated`] for selections that are not
+/// prefix-shaped (crash reports picked out by their `.panic` extension).
+/// Same ordering and same missing-dir behavior.
+pub async fn newest_matching(
+    dir: &Path,
+    limit: usize,
+    keep: impl Fn(&str) -> bool,
+) -> Vec<PathBuf> {
     let Ok(mut entries) = tokio::fs::read_dir(dir).await else {
         return Vec::new();
     };
     let mut matches: Vec<(SystemTime, PathBuf)> = Vec::new();
     while let Ok(Some(entry)) = entries.next_entry().await {
         let path = entry.path();
-        if path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|n| n.starts_with(prefix))
-        {
+        if path.file_name().and_then(|n| n.to_str()).is_some_and(&keep) {
             let mtime = entry
                 .metadata()
                 .await

--- a/crates/diagnostics/src/power.rs
+++ b/crates/diagnostics/src/power.rs
@@ -1,13 +1,21 @@
-//! Host power-state capture: sleep/wake history, so a bundle's timeline can
-//! interleave power transitions with connection events. A silently-dying
-//! long-lived stream (#788) has suspend/resume as its most plausible mundane
-//! explanation, and ruling that in or out previously meant asking the user to
-//! run `pmset -g log` by hand.
+//! Host power-state capture: sleep/wake history, shutdown cause, and kernel
+//! panic reports, so a bundle's timeline can interleave power transitions with
+//! connection events. A silently-dying long-lived stream (#788) has
+//! suspend/resume as its most plausible mundane explanation, and ruling that
+//! in or out previously meant asking the user to run `pmset -g log` by hand.
+//!
+//! The same question one step harder is "my Mac rebooted under it" (#1222):
+//! that needs the shutdown cause and the panic report, not the sleep/wake
+//! lines, which is why the pmset capture keeps the restart events in their own
+//! bucket rather than letting a laptop's daily sleeps evict them.
 
 use std::fmt::Write as _;
+use std::path::Path;
 use std::time::Duration;
 
-use crate::bundle::{BundleSink, BundleWriter};
+use anyhow::Context as _;
+
+use crate::bundle::{BundleSink, BundleWriter, open_regular_nofollow};
 use crate::capture::command_stdout;
 use crate::manifest::Redaction;
 
@@ -22,6 +30,20 @@ const POWER_EVENTS_MAX: usize = 100;
 #[cfg(not(target_os = "macos"))]
 const JOURNAL_LINES_MAX: &str = "5000";
 
+/// Panic reports named in the capture. Only the newest is excerpted; the rest
+/// are listed so a reader can see whether this host panics repeatedly.
+const PANIC_REPORTS_LISTED: usize = 10;
+
+/// Opening lines excerpted from the newest panic report. Enough to carry the
+/// `panic(cpu N caller …)` string and the top of the backtrace — which name
+/// the panicking subsystem — and no more: a whole crash log is a dump of the
+/// user's machine state, not evidence anyone asked to share.
+const PANIC_EXCERPT_LINES: usize = 40;
+
+/// Byte ceiling on the excerpt read, applied before the line cap so a report
+/// written as one enormous line cannot pull the whole file into the bundle.
+const PANIC_EXCERPT_BYTES: u64 = 8 * 1024;
+
 /// The last [`POWER_EVENTS_MAX`] of `events` — the whole slice when it is
 /// shorter. The full pmset/journal log runs to megabytes; only the tail of the
 /// state transitions carries current signal.
@@ -29,7 +51,8 @@ fn last_events<'a>(events: &'a [&'a str]) -> &'a [&'a str] {
     &events[events.len().saturating_sub(POWER_EVENTS_MAX)..]
 }
 
-/// `<dest>/power.txt`: recent sleep/wake transitions. Best-effort — a host
+/// `<dest>/power.txt`: recent sleep/wake transitions and, on macOS, the
+/// shutdown-cause and boot events that date a restart. Best-effort — a host
 /// without the tooling records why instead of failing the collector.
 pub async fn power<W: BundleSink>(
     w: &mut BundleWriter<W>,
@@ -55,27 +78,13 @@ pub async fn power<W: BundleSink>(
             }
         }
         // The full pmset log is mostly assertion chatter; only the state-
-        // transition lines carry sleep/wake signal.
+        // transition and restart lines carry signal. The two get independent
+        // caps: a laptop sleeps many times a day, so a shared cap would evict
+        // the restart lines — the ones a "my Mac rebooted" report turns on —
+        // while they were still the newest thing that mattered.
         match command_stdout("pmset", &["-g", "log"], POWER_TIMEOUT).await {
             Ok(out) => {
-                let events: Vec<&str> = out
-                    .lines()
-                    .filter(|l| {
-                        l.contains("Entering Sleep")
-                            || l.contains("Wake from")
-                            || l.contains("DarkWake from")
-                    })
-                    .collect();
-                let tail = last_events(&events);
-                let _ = writeln!(
-                    text,
-                    "\n$ pmset -g log (sleep/wake transitions, last {} of {})",
-                    tail.len(),
-                    events.len()
-                );
-                for line in tail {
-                    let _ = writeln!(text, "{}", line.trim_end());
-                }
+                text.push_str(&pmset::sections(&out));
             }
             Err(e) => {
                 let _ = writeln!(text, "(pmset unavailable: {e})");
@@ -130,6 +139,179 @@ pub async fn power<W: BundleSink>(
     .await
 }
 
+/// Pure text handling for `pmset -g log` output.
+///
+/// Deliberately not `cfg`-gated to macOS even though only the macOS arm runs
+/// `pmset`: these filters are the #1222 regression surface, and the tests that
+/// pin them have to run on the lane that actually runs this crate's suite. The
+/// unused-on-Linux allow is the price of that coverage.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+mod pmset {
+    use std::fmt::Write as _;
+
+    use super::last_events;
+
+    /// Detail substrings marking a sleep/wake transition.
+    const SLEEP_WAKE: &[&str] = &["Entering Sleep", "Wake from", "DarkWake from"];
+
+    /// Detail substring of the line naming why the machine last went down. A
+    /// negative cause is the kernel's own verdict — panic, watchdog, power
+    /// loss — which is the fact that separates "minimal wedged the box" from
+    /// "the box died under it".
+    const SHUTDOWN_CAUSE: &str = "Shutdown Cause";
+
+    /// Event-type columns kept whole. `Boot` carries no detail substring
+    /// distinctive enough to match on, and it is the line that dates the
+    /// restart a shutdown cause explains.
+    const RESTART_EVENT_TYPES: &[&str] = &["Boot"];
+
+    /// The kept sections of a `pmset -g log` dump: restart events, then
+    /// sleep/wake transitions.
+    ///
+    /// The two are capped independently. A laptop sleeps many times a day, so
+    /// one shared cap would evict the restart lines — the ones a "my Mac
+    /// rebooted" report turns on — while they were still the newest thing that
+    /// mattered.
+    pub(super) fn sections(out: &str) -> String {
+        let restarts: Vec<&str> = out.lines().filter(|l| is_restart(l)).collect();
+        let sleep_wake: Vec<&str> = out
+            .lines()
+            .filter(|l| SLEEP_WAKE.iter().any(|m| l.contains(m)))
+            .collect();
+        let mut text = String::new();
+        push_section(&mut text, "shutdown cause / boot", &restarts);
+        push_section(&mut text, "sleep/wake transitions", &sleep_wake);
+        text
+    }
+
+    /// One labelled, tail-capped section under its echoed command banner.
+    fn push_section(text: &mut String, label: &str, events: &[&str]) {
+        let tail = last_events(events);
+        let _ = writeln!(
+            text,
+            "\n$ pmset -g log ({label}, last {} of {})",
+            tail.len(),
+            events.len()
+        );
+        for line in tail {
+            let _ = writeln!(text, "{}", line.trim_end());
+        }
+    }
+
+    /// Whether a line records the machine going down or coming back up.
+    fn is_restart(line: &str) -> bool {
+        line.contains(SHUTDOWN_CAUSE)
+            || event_type(line).is_some_and(|t| RESTART_EVENT_TYPES.contains(&t))
+    }
+
+    /// The event-type column of a log line — the field after the
+    /// `YYYY-MM-DD HH:MM:SS ±ZZZZ` timestamp. `None` for anything that does
+    /// not open a record (headers, blanks, wrapped detail lines), which is
+    /// what keeps `BootCache` assertion chatter out of the restart bucket.
+    fn event_type(line: &str) -> Option<&str> {
+        let mut fields = line.split_whitespace();
+        let date = fields.next()?;
+        let opens_a_record = date.len() == 10
+            && date.as_bytes()[4] == b'-'
+            && date.starts_with(|c: char| c.is_ascii_digit());
+        // Past the time and the zone offset sits the event type.
+        opens_a_record.then(|| fields.nth(2)).flatten()
+    }
+}
+
+/// Where the OS writes kernel panic reports; `None` on a platform with no such
+/// facility — the honest answer for Linux, whose panics go to the kernel ring
+/// buffer the [`kmsg`](crate::kmsg) collector already carries.
+const fn panic_report_dir() -> Option<&'static str> {
+    #[cfg(target_os = "macos")]
+    {
+        Some("/Library/Logs/DiagnosticReports")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+/// `<dest>/panic.txt`: the newest kernel panic reports by name, plus the
+/// opening lines of the newest.
+///
+/// A hard reboot leaves the *why* in a panic report, and "was it us?" is
+/// answered by the subsystem the panic string names. The capture carries
+/// enough to read that and no more — a whole panic log is a dump of the user's
+/// machine state, not evidence anyone offered to share.
+///
+/// Best-effort throughout: a missing directory and an empty one are both
+/// recorded as data. Where the platform has no panic reports at all, the entry
+/// is a manifest skip rather than an error.
+pub async fn panic_report<W: BundleSink>(
+    w: &mut BundleWriter<W>,
+    dest: &str,
+) -> Result<(), anyhow::Error> {
+    let path = format!("{dest}/panic.txt");
+    let Some(dir) = panic_report_dir() else {
+        w.skip(path, "kernel panic reports are a macOS facility");
+        return Ok(());
+    };
+    let text = panic_report_text(Path::new(dir)).await;
+    w.add_bytes(&path, text.as_bytes(), Redaction::None).await
+}
+
+/// The panic-report capture for `dir`. Parameterized by directory so the
+/// mechanic is exercisable without the real system location.
+async fn panic_report_text(dir: &Path) -> String {
+    let reports =
+        crate::logs::newest_matching(dir, PANIC_REPORTS_LISTED, |name| name.ends_with(".panic"))
+            .await;
+    let mut text = String::new();
+    let _ = writeln!(
+        text,
+        "$ ls -t {}/*.panic | head -{PANIC_REPORTS_LISTED}",
+        dir.display()
+    );
+    for report in &reports {
+        let _ = writeln!(text, "{}", report.display());
+    }
+    let Some(newest) = reports.first() else {
+        let _ = writeln!(text, "(no panic reports)");
+        return text;
+    };
+    let _ = writeln!(
+        text,
+        "\n=== {} (first {PANIC_EXCERPT_LINES} lines) ===",
+        newest.display()
+    );
+    match report_excerpt(newest).await {
+        Ok(excerpt) => text.push_str(&excerpt),
+        Err(e) => {
+            let _ = writeln!(text, "(unreadable: {e:#})");
+        }
+    }
+    text
+}
+
+/// The opening lines of a panic report, read no-follow and capped at both
+/// [`PANIC_EXCERPT_BYTES`] and [`PANIC_EXCERPT_LINES`]. A panic report opens
+/// with its JSON metadata header and the `panic(cpu N caller …)` string, so
+/// the front of the file is exactly the identifying part.
+async fn report_excerpt(path: &Path) -> Result<String, anyhow::Error> {
+    use tokio::io::AsyncReadExt as _;
+
+    let (file, _) = open_regular_nofollow(path).await?;
+    let mut head = Vec::new();
+    file.take(PANIC_EXCERPT_BYTES)
+        .read_to_end(&mut head)
+        .await
+        .with_context(|| format!("reading {}", path.display()))?;
+    Ok(String::from_utf8_lossy(&head)
+        .lines()
+        .take(PANIC_EXCERPT_LINES)
+        .fold(String::new(), |mut acc, line| {
+            let _ = writeln!(acc, "{}", line.trim_end());
+            acc
+        }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,5 +327,114 @@ mod tests {
 
         let few = ["a", "b", "c"];
         assert_eq!(last_events(&few).len(), 3, "fewer than the cap: all kept");
+    }
+
+    /// A `pmset -g log` dump shaped like the real thing: a restart (shutdown
+    /// cause plus the boot that followed), sleep/wake transitions around it,
+    /// and the assertion chatter that dominates the file.
+    fn pmset_dump(sleeps: usize) -> String {
+        let mut dump = String::from(
+            "2026-08-11 03:14:07 -0700 Assertions      \tPID 148(powerd) Summary BootCache\n\
+             2026-08-11 03:14:09 -0700 Summary         \tShutdown Cause: -128\n\
+             2026-08-11 03:15:44 -0700 Boot            \tOS Version: macOS 26.1\n",
+        );
+        for i in 0..sleeps {
+            let _ = writeln!(
+                dump,
+                "2026-08-11 0{}:00:00 -0700 Sleep           \t\
+                 Entering Sleep state due to 'Idle Sleep': Using AC",
+                i % 10
+            );
+            let _ = writeln!(
+                dump,
+                "2026-08-11 0{}:30:00 -0700 Wake            \tWake from Standby: due to xhci",
+                i % 10
+            );
+        }
+        dump
+    }
+
+    /// #1222: a bundle has to be able to answer "why did my Mac reboot".
+    /// The shutdown cause and the boot line that follows it are what pin
+    /// hardware-or-panic against a minimal-side hang.
+    #[test]
+    fn pmset_capture_keeps_the_shutdown_cause_and_boot() {
+        let text = pmset::sections(&pmset_dump(2));
+        assert!(
+            text.contains("Shutdown Cause: -128"),
+            "the shutdown cause is the whole point: {text}"
+        );
+        assert!(text.contains("Boot            \tOS Version"), "{text}");
+        assert!(
+            !text.contains("Summary BootCache"),
+            "assertion chatter must not ride in on the `Boot` match: {text}"
+        );
+        assert!(text.contains("Entering Sleep"), "{text}");
+        assert!(text.contains("Wake from Standby"), "{text}");
+    }
+
+    /// The restart lines get their own cap: a laptop that sleeps all day must
+    /// not push the reboot record out of the capture.
+    #[test]
+    fn frequent_sleeps_do_not_evict_the_restart_lines() {
+        let text = pmset::sections(&pmset_dump(POWER_EVENTS_MAX * 2));
+        assert!(text.contains("Shutdown Cause: -128"), "{text}");
+        assert!(
+            text.contains("(sleep/wake transitions, last 100 of 400)"),
+            "sleep/wake is capped, and says so: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn panic_capture_names_the_newest_report_and_excerpts_its_head() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let body: String = (0..PANIC_EXCERPT_LINES * 2)
+            .map(|i| format!("backtrace line {i}\n"))
+            .collect();
+        for (name, age_secs) in [("Kernel-old.panic", 600), ("Kernel-new.panic", 0)] {
+            let path = dir.path().join(name);
+            std::fs::write(&path, format!("panic(cpu 4 caller 0x0): {name}\n{body}")).unwrap();
+            std::fs::File::options()
+                .write(true)
+                .open(&path)
+                .unwrap()
+                .set_modified(std::time::SystemTime::now() - Duration::from_secs(age_secs))
+                .unwrap();
+        }
+        std::fs::write(dir.path().join("other.ips"), "not a panic").unwrap();
+
+        let text = panic_report_text(dir.path()).await;
+        assert!(text.contains("Kernel-new.panic"), "{text}");
+        assert!(text.contains("Kernel-old.panic"), "both are listed: {text}");
+        assert!(
+            !text.contains("other.ips"),
+            "only *.panic is listed: {text}"
+        );
+        assert!(
+            text.contains("panic(cpu 4 caller 0x0): Kernel-new.panic"),
+            "the newest report is the one excerpted: {text}"
+        );
+        assert!(
+            // The panic string takes the first of the capped lines, so the
+            // last backtrace line kept is two short of the cap.
+            !text.contains(&format!("backtrace line {}", PANIC_EXCERPT_LINES - 1)),
+            "the excerpt stops at the line cap: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_host_with_no_panic_reports_records_that_as_data() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let text = panic_report_text(dir.path()).await;
+        assert!(
+            text.contains("(no panic reports)"),
+            "absence is data, not an error"
+        );
+
+        let missing = panic_report_text(Path::new("/nonexistent/diag-panics")).await;
+        assert!(
+            missing.contains("(no panic reports)"),
+            "so is a missing directory"
+        );
     }
 }

--- a/crates/diagnostics/src/power.rs
+++ b/crates/diagnostics/src/power.rs
@@ -34,15 +34,17 @@ const JOURNAL_LINES_MAX: &str = "5000";
 /// are listed so a reader can see whether this host panics repeatedly.
 const PANIC_REPORTS_LISTED: usize = 10;
 
-/// Opening lines excerpted from the newest panic report. Enough to carry the
-/// `panic(cpu N caller …)` string and the top of the backtrace — which name
-/// the panicking subsystem — and no more: a whole crash log is a dump of the
-/// user's machine state, not evidence anyone asked to share.
-const PANIC_EXCERPT_LINES: usize = 40;
-
-/// Byte ceiling on the excerpt read, applied before the line cap so a report
-/// written as one enormous line cannot pull the whole file into the bundle.
+/// Bytes of the newest report's head searched for the panic string. A report
+/// carries it either as its opening line or as a field of the JSON header
+/// that precedes the backtrace, so the sentence always sits inside the first
+/// few KiB; the cap is what keeps a report written as one enormous line from
+/// being pulled into memory whole.
 const PANIC_EXCERPT_BYTES: u64 = 8 * 1024;
+
+/// Bytes kept of the panic string itself. The `panic(cpu N caller …): …`
+/// sentence names the failing subsystem in far less than this; the cap bounds
+/// a report whose string runs on.
+const PANIC_STRING_MAX_BYTES: usize = 512;
 
 /// The last [`POWER_EVENTS_MAX`] of `events` — the whole slice when it is
 /// shorter. The full pmset/journal log runs to megabytes; only the tail of the
@@ -234,16 +236,18 @@ const fn panic_report_dir() -> Option<&'static str> {
 }
 
 /// `<dest>/panic.txt`: the newest kernel panic reports by name, plus the
-/// opening lines of the newest.
+/// panic string of the newest.
 ///
 /// A hard reboot leaves the *why* in a panic report, and "was it us?" is
-/// answered by the subsystem the panic string names. The capture carries
-/// enough to read that and no more — a whole panic log is a dump of the user's
-/// machine state, not evidence anyone offered to share.
+/// answered by the subsystem the panic string names. The capture carries that
+/// sentence and no more — see [`report_panic_string`] for why the rest of a
+/// crash log does not travel.
 ///
-/// Best-effort throughout: a missing directory and an empty one are both
-/// recorded as data. Where the platform has no panic reports at all, the entry
-/// is a manifest skip rather than an error.
+/// Best-effort throughout, and every outcome is accounted for: an empty
+/// directory is recorded as data ("no panic reports"), an absent or unlistable
+/// one as a manifest skip naming the reason, and a platform with no panic
+/// reports at all as a skip too. Nothing here reports *not having looked* as
+/// an answer.
 pub async fn panic_report<W: BundleSink>(
     w: &mut BundleWriter<W>,
     dest: &str,
@@ -253,16 +257,37 @@ pub async fn panic_report<W: BundleSink>(
         w.skip(path, "kernel panic reports are a macOS facility");
         return Ok(());
     };
-    let text = panic_report_text(Path::new(dir)).await;
-    w.add_bytes(&path, text.as_bytes(), Redaction::None).await
+    match panic_report_text(Path::new(dir)).await {
+        Ok(text) => w.add_bytes(&path, text.as_bytes(), Redaction::Keys).await,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            w.skip(path, format!("no {dir} — this host keeps no panic reports"));
+            Ok(())
+        }
+        // "Nothing panicked" and "we were not allowed to look" are opposite
+        // answers to the one question this collector exists to settle, so the
+        // errno travels rather than collapsing into "(no panic reports)".
+        // Not hypothetical: `/Library/Logs/DiagnosticReports` is
+        // TCC-protected, so `min bug` from a terminal without Full Disk
+        // Access is denied here on a Mac that panicked minutes ago.
+        Err(e) => {
+            w.skip(
+                path,
+                format!("{dir} unreadable ({e}) — whether this host panicked is unknown"),
+            );
+            Ok(())
+        }
+    }
 }
 
-/// The panic-report capture for `dir`. Parameterized by directory so the
-/// mechanic is exercisable without the real system location.
-async fn panic_report_text(dir: &Path) -> String {
-    let reports =
-        crate::logs::newest_matching(dir, PANIC_REPORTS_LISTED, |name| name.ends_with(".panic"))
-            .await;
+/// The panic-report capture for `dir`, or the error that made the directory
+/// unlistable — which the caller must be able to tell from an empty one.
+/// Parameterized by directory so the mechanic is exercisable without the real
+/// system location.
+async fn panic_report_text(dir: &Path) -> std::io::Result<String> {
+    let reports = crate::logs::try_newest_matching(dir, PANIC_REPORTS_LISTED, |name| {
+        name.ends_with(".panic")
+    })
+    .await?;
     let mut text = String::new();
     let _ = writeln!(
         text,
@@ -273,28 +298,48 @@ async fn panic_report_text(dir: &Path) -> String {
         let _ = writeln!(text, "{}", report.display());
     }
     let Some(newest) = reports.first() else {
+        // Reached only when the directory *was* read: absence of reports is a
+        // fact about the host, not the shrug of a failed read.
         let _ = writeln!(text, "(no panic reports)");
-        return text;
+        return Ok(text);
     };
     let _ = writeln!(
         text,
-        "\n=== {} (first {PANIC_EXCERPT_LINES} lines) ===",
+        "\n=== {} (panic string only; report header and backtrace withheld) ===",
         newest.display()
     );
-    match report_excerpt(newest).await {
-        Ok(excerpt) => text.push_str(&excerpt),
+    match report_panic_string(newest).await {
+        Ok(Some(panic_string)) => {
+            let _ = writeln!(text, "{panic_string}");
+        }
+        Ok(None) => {
+            let _ = writeln!(
+                text,
+                "(no panic string in the first {PANIC_EXCERPT_BYTES} bytes)"
+            );
+        }
         Err(e) => {
             let _ = writeln!(text, "(unreadable: {e:#})");
         }
     }
-    text
+    Ok(text)
 }
 
-/// The opening lines of a panic report, read no-follow and capped at both
-/// [`PANIC_EXCERPT_BYTES`] and [`PANIC_EXCERPT_LINES`]. A panic report opens
-/// with its JSON metadata header and the `panic(cpu N caller …)` string, so
-/// the front of the file is exactly the identifying part.
-async fn report_excerpt(path: &Path) -> Result<String, anyhow::Error> {
+/// The panic string of the report at `path`: the one sentence naming the
+/// failing subsystem, read no-follow out of the first [`PANIC_EXCERPT_BYTES`]
+/// and capped at [`PANIC_STRING_MAX_BYTES`].
+///
+/// Deliberately *not* the head of the file. A `.panic` report is OS- and
+/// third-party-authored text whose contents this project does not control,
+/// and the parts around the panic string are the parts we have no business
+/// shipping: the metadata header carries a device-stable identifier
+/// (`crashReporterKey`, the incident id) and the hardware model, and the
+/// backtrace names every kext loaded at the time — an inventory of the user's
+/// security, VPN, and virtualization software. None of that answers "was it
+/// us?"; the panic string does. So the string alone travels, and it travels
+/// through the same fail-closed sensitive-token scrub every other flattened
+/// free-text line in a bundle goes through.
+async fn report_panic_string(path: &Path) -> Result<Option<String>, anyhow::Error> {
     use tokio::io::AsyncReadExt as _;
 
     let (file, _) = open_regular_nofollow(path).await?;
@@ -303,13 +348,52 @@ async fn report_excerpt(path: &Path) -> Result<String, anyhow::Error> {
         .read_to_end(&mut head)
         .await
         .with_context(|| format!("reading {}", path.display()))?;
-    Ok(String::from_utf8_lossy(&head)
-        .lines()
-        .take(PANIC_EXCERPT_LINES)
-        .fold(String::new(), |mut acc, line| {
-            let _ = writeln!(acc, "{}", line.trim_end());
-            acc
-        }))
+    Ok(panic_string(&String::from_utf8_lossy(&head)))
+}
+
+/// The panic string carried by a report's head, in either shape the OS
+/// writes it: a plain-text report opens with the `panic(cpu N caller …)`
+/// sentence itself, while a modern one carries it as the `panicString` field
+/// of a JSON header, where an escaped newline separates the sentence from the
+/// backtrace that follows it. Everything else in the head is dropped on the
+/// floor; what survives is truncated and scrubbed.
+fn panic_string(head: &str) -> Option<String> {
+    let raw = head.lines().find_map(|line| {
+        let line = line.trim_start();
+        if line.starts_with("panic(") {
+            return Some(line);
+        }
+        let (_, rest) = line.split_once("\"panicString\"")?;
+        let value = rest.trim_start().strip_prefix(':')?.trim_start();
+        let value = value.strip_prefix('"').unwrap_or(value);
+        // Past the first escaped newline lie the backtrace and the kext list.
+        Some(
+            value
+                .split("\\n")
+                .next()
+                .unwrap_or(value)
+                .trim_end_matches('"'),
+        )
+    })?;
+    let raw = raw.trim_end();
+    let kept = clamp_bytes(raw, PANIC_STRING_MAX_BYTES);
+    let mut out = crate::procs::scrub_flattened(kept);
+    if kept.len() < raw.len() {
+        out.push_str(" (truncated)");
+    }
+    Some(out)
+}
+
+/// `s` cut to at most `max` bytes, on a character boundary.
+fn clamp_bytes(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
 }
 
 #[cfg(test)]
@@ -385,15 +469,32 @@ mod tests {
         );
     }
 
+    /// A `.panic` report shaped like a modern one: a JSON metadata header
+    /// carrying the device-stable identifiers, the panic string, and then the
+    /// backtrace with its kext inventory.
+    fn panic_report_file(tag: &str) -> String {
+        format!(
+            "{{\"bug_type\":\"210\",\"os_version\":\"macOS 26.1\",\
+             \"incident_id\":\"1A2B3C4D-DEAD-BEEF-0000-000000000001\",\
+             \"crashReporterKey\":\"a1b2c3d4e5f60718293a4b5c6d7e8f9012345678\"}}\n\
+             {{\n\
+             \"build\" : \"Darwin Kernel Version 26.1.0\",\n\
+             \"product\" : \"MacBookPro18,3\",\n\
+             \"crashReporterKey\" : \"a1b2c3d4e5f60718293a4b5c6d7e8f9012345678\",\n\
+             \"panicString\" : \"panic(cpu 4 caller 0xfffffe001): Kernel data abort {tag}\\n\
+             Debugger message: panic\\nKernel Extensions in backtrace:\\n\
+             com.vendorvpn.tunnel(1.2)\\ncom.othervendor.security(3.4)\",\n\
+             \"panicFlags\" : \"0x0\"\n\
+             }}\n"
+        )
+    }
+
     #[tokio::test]
-    async fn panic_capture_names_the_newest_report_and_excerpts_its_head() {
+    async fn panic_capture_names_the_newest_report_and_quotes_its_panic_string() {
         let dir = tempfile::TempDir::new().unwrap();
-        let body: String = (0..PANIC_EXCERPT_LINES * 2)
-            .map(|i| format!("backtrace line {i}\n"))
-            .collect();
         for (name, age_secs) in [("Kernel-old.panic", 600), ("Kernel-new.panic", 0)] {
             let path = dir.path().join(name);
-            std::fs::write(&path, format!("panic(cpu 4 caller 0x0): {name}\n{body}")).unwrap();
+            std::fs::write(&path, panic_report_file(name)).unwrap();
             std::fs::File::options()
                 .write(true)
                 .open(&path)
@@ -403,7 +504,7 @@ mod tests {
         }
         std::fs::write(dir.path().join("other.ips"), "not a panic").unwrap();
 
-        let text = panic_report_text(dir.path()).await;
+        let text = panic_report_text(dir.path()).await.expect("readable dir");
         assert!(text.contains("Kernel-new.panic"), "{text}");
         assert!(text.contains("Kernel-old.panic"), "both are listed: {text}");
         assert!(
@@ -411,30 +512,103 @@ mod tests {
             "only *.panic is listed: {text}"
         );
         assert!(
-            text.contains("panic(cpu 4 caller 0x0): Kernel-new.panic"),
-            "the newest report is the one excerpted: {text}"
+            text.contains("panic(cpu 4 caller 0xfffffe001): Kernel data abort Kernel-new.panic"),
+            "the newest report's panic string is what the capture is for: {text}"
         );
+    }
+
+    /// The panic string is the *only* part of a third-party crash report the
+    /// bundle is entitled to. The report's metadata header identifies the
+    /// device (`crashReporterKey`, incident id) and its model, and the
+    /// backtrace is an inventory of the user's installed kexts — neither
+    /// answers "was it us?", so neither may ride along.
+    #[tokio::test]
+    async fn panic_capture_withholds_the_report_header_and_backtrace() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("Kernel-new.panic"),
+            panic_report_file("Kernel-new.panic"),
+        )
+        .unwrap();
+
+        let text = panic_report_text(dir.path()).await.expect("readable dir");
+        for leaked in [
+            "crashReporterKey",
+            "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+            "1A2B3C4D-DEAD-BEEF-0000-000000000001",
+            "MacBookPro18,3",
+            "com.vendorvpn.tunnel",
+            "com.othervendor.security",
+            "Kernel Extensions in backtrace",
+        ] {
+            assert!(
+                !text.contains(leaked),
+                "{leaked:?} is not ours to ship: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn panic_string_is_capped_and_scrubbed() {
+        let long = format!("panic(cpu 0 caller 0x1): {}", "x".repeat(4096));
+        let capped = panic_string(&long).expect("a panic string is found");
         assert!(
-            // The panic string takes the first of the capped lines, so the
-            // last backtrace line kept is two short of the cap.
-            !text.contains(&format!("backtrace line {}", PANIC_EXCERPT_LINES - 1)),
-            "the excerpt stops at the line cap: {text}"
+            capped.len() <= PANIC_STRING_MAX_BYTES + " (truncated)".len(),
+            "capped at {PANIC_STRING_MAX_BYTES} bytes: {} bytes",
+            capped.len()
+        );
+        assert!(capped.ends_with(" (truncated)"), "{capped}");
+
+        let secret = panic_string("panic(cpu 0 caller 0x1): api_key=hunter2 boom")
+            .expect("a panic string is found");
+        assert!(
+            !secret.contains("hunter2"),
+            "sensitive tokens are scrubbed fail-closed: {secret}"
+        );
+
+        // A plain-text (pre-JSON) report opens with the sentence itself.
+        assert_eq!(
+            panic_string("panic(cpu 1 caller 0x2): Kernel trap\nbacktrace 0x0\n").as_deref(),
+            Some("panic(cpu 1 caller 0x2): Kernel trap"),
+            "the backtrace stays behind"
         );
     }
 
     #[tokio::test]
     async fn a_host_with_no_panic_reports_records_that_as_data() {
         let dir = tempfile::TempDir::new().unwrap();
-        let text = panic_report_text(dir.path()).await;
+        let text = panic_report_text(dir.path()).await.expect("readable dir");
         assert!(
             text.contains("(no panic reports)"),
             "absence is data, not an error"
         );
+    }
 
-        let missing = panic_report_text(Path::new("/nonexistent/diag-panics")).await;
-        assert!(
-            missing.contains("(no panic reports)"),
-            "so is a missing directory"
+    /// #1222 turns on this distinction: on a TCC-restricted Mac the panic
+    /// directory is unreadable, and answering "(no panic reports)" there would
+    /// tell a triager the machine did not panic when nobody looked. The
+    /// unlistable directory must come back as an error so the collector can
+    /// record a skip instead.
+    #[tokio::test]
+    async fn an_unreadable_panic_directory_is_never_reported_as_no_panics() {
+        let missing = panic_report_text(Path::new("/nonexistent/diag-panics"))
+            .await
+            .expect_err("a missing directory is not an answer");
+        assert_eq!(missing.kind(), std::io::ErrorKind::NotFound);
+
+        // A non-directory stands in for the permission-denied case: the read
+        // fails with something other than `NotFound`, which is the shape a
+        // TCC-protected directory has.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let not_a_dir = tmp.path().join("DiagnosticReports");
+        std::fs::write(&not_a_dir, "").unwrap();
+        let err = panic_report_text(&not_a_dir)
+            .await
+            .expect_err("an unlistable directory is not an answer");
+        assert_ne!(
+            err.kind(),
+            std::io::ErrorKind::NotFound,
+            "unreadable stays distinguishable from absent: {err}"
         );
     }
 }

--- a/crates/diagnostics/src/system.rs
+++ b/crates/diagnostics/src/system.rs
@@ -24,6 +24,11 @@ pub struct SystemInfo {
     pub kernel: Option<String>,
     pub hostname: Option<String>,
     pub ncpu: Option<usize>,
+    /// Total physical memory. A bundle records what a session asked the VM
+    /// for; without the host's own number that figure cannot be judged
+    /// oversized, and "the machine died under a 24 GiB allocation" stays a
+    /// guess.
+    pub mem_total_bytes: Option<u64>,
     pub euid: u32,
     #[cfg(target_os = "linux")]
     pub kvm: KvmInfo,
@@ -65,12 +70,40 @@ pub async fn system_info(disk_paths: &[&Path]) -> SystemInfo {
         kernel,
         hostname,
         ncpu: std::thread::available_parallelism().map(usize::from).ok(),
+        mem_total_bytes: mem_total_bytes().await,
         // SAFETY: geteuid has no failure modes or preconditions.
         euid: unsafe { libc::geteuid() },
         #[cfg(target_os = "linux")]
         kvm: kvm_info(),
         disks: disk_paths.iter().map(|p| disk_info(p)).collect(),
     }
+}
+
+/// Total physical memory in bytes, from `hw.memsize`.
+#[cfg(target_os = "macos")]
+async fn mem_total_bytes() -> Option<u64> {
+    crate::first_stdout_line("sysctl", &["-n", "hw.memsize"], FACT_TIMEOUT)
+        .await?
+        .trim()
+        .parse()
+        .ok()
+}
+
+/// Total physical memory in bytes, from `/proc/meminfo`'s `MemTotal:` (which
+/// counts kibibytes). `None` anywhere `/proc` isn't the answer — best-effort,
+/// like every other probe here.
+#[cfg(not(target_os = "macos"))]
+async fn mem_total_bytes() -> Option<u64> {
+    tokio::fs::read_to_string("/proc/meminfo")
+        .await
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("MemTotal:"))?
+        .split_whitespace()
+        .next()?
+        .parse::<u64>()
+        .ok()
+        .map(|kib| kib * 1024)
 }
 
 fn disk_info(path: &Path) -> DiskInfo {
@@ -155,5 +188,14 @@ mod tests {
         );
         let json = serde_json_lenient::to_value(&info).unwrap();
         assert!(json["euid"].is_u64());
+        // A VM sizing recorded elsewhere in the bundle is only judgeable
+        // against the host's own memory, so the probe has to land where the
+        // platform can answer it.
+        assert!(info.mem_total_bytes.is_none_or(|bytes| bytes > 0));
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        assert!(
+            info.mem_total_bytes.is_some(),
+            "linux and macOS both report total memory"
+        );
     }
 }

--- a/crates/minimal/src/diag/mod.rs
+++ b/crates/minimal/src/diag/mod.rs
@@ -137,6 +137,11 @@ pub async fn cmd_bug(global: &GlobalArgs, args: BugArgs) -> Result<(), anyhow::E
         diagnostics::net::routes(&mut w, "host")
     );
     collect_step!(w, "host.power", diagnostics::power::power(&mut w, "host"));
+    collect_step!(
+        w,
+        "host.panic-report",
+        diagnostics::power::panic_report(&mut w, "host")
+    );
     collect_step!(w, "config", collect::config(&mut w, &paths));
     collect_step!(w, "state", collect::state(&mut w, &paths));
     // Log prefixes that matched nothing on the host come back rather than

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -343,6 +343,20 @@ async fn incident_collectors_land_and_mask_macs() {
         );
     }
 
+    // The panic-report capture is macOS-only: everywhere else the bundle
+    // still accounts for it, as a skip rather than a silent absence.
+    let manifest: serde_json_lenient::Value =
+        serde_json_lenient::from_slice(find(&files, "manifest.json").expect("manifest")).unwrap();
+    let panic_skipped = manifest["skipped"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|s| s["what"].as_str().unwrap().ends_with("panic.txt"));
+    assert!(
+        find(&files, "host/panic.txt").is_some() || panic_skipped,
+        "panic reports are either captured or recorded as skipped"
+    );
+
     // R5.1: no full MAC survives in the interfaces capture — every one is
     // masked to its OUI, so a 17-char `xx:xx:xx:xx:xx:xx` token never appears.
     let interfaces = String::from_utf8_lossy(find(&files, "host/net/interfaces.txt").unwrap());

--- a/docs/specs/10-spec-diagnostics/10-spec-diagnostics.md
+++ b/docs/specs/10-spec-diagnostics/10-spec-diagnostics.md
@@ -1066,8 +1066,14 @@ Unit 8's dual-format rework, sequenced after Unit 6.
   governed by the no-interpolated-values tracing standard; full argv is
   recorded only for marker-matched minimal-family processes — a concurrent
   unrelated process's command line is never captured (`comm` only) — and is
-  scrubbed of sensitive `key=value` tokens (R5.2, R6.2). Residual risk is
-  handled by two nets: the CLI's explicit review-before-sharing notice
+  scrubbed of sensitive `key=value` tokens (R5.2, R6.2). One free-text
+  surface is *not* ours to bound this way — the host's kernel panic report —
+  and is admitted only as a single bounded extract: the
+  `panic(cpu N caller …)` string alone, truncated and token-scrubbed. The
+  report's metadata header (device-stable `crashReporterKey`/incident id,
+  hardware model) and its backtrace (an inventory of the user's loaded kexts)
+  are withheld; the collector never copies a crash report's head verbatim.
+  Residual risk is handled by two nets: the CLI's explicit review-before-sharing notice
   (R2.9) and the team-side explorer's `audit` secret-pattern scan (Unit 8
   prior art).
 - **The collector must not be a read gadget.** Every content read on both


### PR DESCRIPTION
Part 1 of 3 in the diagnostics-collector series (#1222 sub-item 4a).

#1222 was investigated and **exonerated minimal** — the macOS panic report showed the
fault was not ours. What it did expose is that the bundle could not have told us that
on its own: `min bug` had no way to say why a machine went down. This adds shutdown
cause, host memory, and panic-report capture so the next report is answerable from the
bundle instead of requiring a live repro.

### Privacy
Panic capture is deliberately narrow. It records the `panic(cpu N caller …)` sentence
only — header identifiers, the backtrace, and the kext list are dropped — capped at
512 bytes, and run through the existing `procs::scrub_flattened` sensitive-token policy
as a fail-closed net. The manifest entry is `Redaction::Keys`, not `Redaction::None`.

### Bug found in review
An **unreadable** panic directory was being reported as "no panic reports" — the bundle
would have asserted the absence of evidence it simply could not see. Fixed: the two
cases are now distinguished, per the bundle's absence-is-explainable contract.

### Reviewer notes
- `panicString` extraction is a substring match, not a JSON parse — deliberate (no
  parser for OS-authored text of unverified shape; the byte cap bounds the read), but
  an unfamiliar report layout yields no panic string rather than a wrong one.
- Adds a clause to the spec's Security Considerations describing this bounded surface,
  since the collector introduces a free-text provenance the spec did not previously
  admit. If the team would rather not amend the spec, the doc hunk is the only part to
  revert — the code stands alone.

### Verification
`just ci`: fmt, clippy (`-D warnings`), cargo-deny, nextest 1770/1770, doctests — all
green. `just test-ignored` fails with exactly the 4 pre-existing `checkouts`/`mctx`
`InvalidPath` failures that also fail on pristine `main` in a sandbox without upstream
git checkouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
