### PR TITLE
feat(diagnostics): capture the terminal a bundle was collected on (#950)

### DIFF
--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -18,6 +18,7 @@
 //! - [`kmsg`] — the kernel ring buffer, read without `dmesg`
 //! - [`disk`] — filesystem capacity probes
 //! - [`system`] — host identity/capability probe (OS, kernel, KVM, disks)
+//! - [`terminal`] — the tty state and window size of the invoking terminal
 //!
 //! The split with the app crates is mechanics vs. policy: the *how* lives
 //! here; the *what* — which paths, which log prefixes, which env names are
@@ -41,6 +42,8 @@ pub mod procs;
 pub mod redact;
 #[cfg(unix)]
 pub mod system;
+#[cfg(unix)]
+pub mod terminal;
 
 /// Per-collector deadline. Generous enough for a slow disk, small enough that
 /// one wedged collector cannot stall a whole bundle — and a wedged host is
@@ -90,3 +93,5 @@ pub use logs::{newest_matching, newest_rotated, try_newest_matching};
 pub use manifest::{CollectedEntry, CollectorError, Manifest, Redaction, SkippedEntry};
 #[cfg(unix)]
 pub use system::{DiskInfo, SystemInfo, system_info};
+#[cfg(unix)]
+pub use terminal::{StreamInfo, TerminalInfo, WinSize, terminal_info};

--- a/crates/diagnostics/src/terminal.rs
+++ b/crates/diagnostics/src/terminal.rs
@@ -1,0 +1,173 @@
+//! The terminal a bundle's producer was invoked on: whether each standard
+//! stream is a tty, and what that terminal says about itself.
+//!
+//! Sessions are interactive by design, so "the TUI is garbled", "lines wrap
+//! wrong", "resize does nothing" (#950) are all claims about a terminal no
+//! bundle described. Two facts answer most of them. Whether the streams are
+//! ttys separates "ran under a pipe, a script, or CI" from a real terminal —
+//! the precondition `min attach` and the interactive prompts gate on, so a
+//! refused attach or a prompt nobody saw is explained by this field alone.
+//! The window size explains the rendering: a zero or stale `TIOCGWINSZ` is
+//! the classic wrong-wrapping cause, and a size the user's window plainly is
+//! not says the resize never reached the pty.
+//!
+//! The caveat the capture cannot escape is that it describes the terminal the
+//! *bundle* ran on, which is the terminal that rendered wrong only when the
+//! user reports from the same window. Recording it beside the other host
+//! facts is what makes that judgeable instead of unasked.
+
+use std::ffi::CStr;
+use std::os::fd::RawFd;
+
+use serde::Serialize;
+
+/// The three standard streams' terminal facts. Best-effort like every probe:
+/// what cannot be read is `None`, never an error.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct TerminalInfo {
+    pub stdin: StreamInfo,
+    pub stdout: StreamInfo,
+    pub stderr: StreamInfo,
+}
+
+/// One stream's terminal facts. `device` and `size` are `None` whenever the
+/// stream is not a tty: there is nothing to ask a pipe.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct StreamInfo {
+    pub tty: bool,
+    /// The tty device behind the stream (`/dev/ttys004`, `/dev/pts/3`), which
+    /// tells a console apart from a pty — and tells two streams pointing at
+    /// different terminals apart from the usual case where all three share
+    /// one.
+    pub device: Option<String>,
+    pub size: Option<WinSize>,
+}
+
+/// A terminal's `TIOCGWINSZ` dimensions, reported exactly as the kernel gives
+/// them. Zeroes are kept rather than folded into `None`: "the terminal claims
+/// it has no rows" is the finding, not a failed read.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+pub struct WinSize {
+    pub rows: u16,
+    pub cols: u16,
+    pub xpixel: u16,
+    pub ypixel: u16,
+}
+
+/// Gathers [`TerminalInfo`] for stdin, stdout, and stderr.
+pub fn terminal_info() -> TerminalInfo {
+    TerminalInfo {
+        stdin: stream_info(libc::STDIN_FILENO),
+        stdout: stream_info(libc::STDOUT_FILENO),
+        stderr: stream_info(libc::STDERR_FILENO),
+    }
+}
+
+/// Probes one descriptor. A closed or non-tty fd answers `tty: false` and
+/// nothing else — the probe never fails.
+fn stream_info(fd: RawFd) -> StreamInfo {
+    // SAFETY: isatty only inspects the descriptor; an invalid one is EBADF.
+    let tty = unsafe { libc::isatty(fd) } == 1;
+    StreamInfo {
+        tty,
+        device: tty.then(|| device_name(fd)).flatten(),
+        size: tty.then(|| win_size(fd)).flatten(),
+    }
+}
+
+/// The tty device path behind `fd`, `None` when it cannot be resolved.
+fn device_name(fd: RawFd) -> Option<String> {
+    // SAFETY: ttyname returns a pointer into a static buffer valid until the
+    // next ttyname call on this thread; it is copied into an owned String
+    // before this thread can make another.
+    let name = unsafe { libc::ttyname(fd) };
+    if name.is_null() {
+        return None;
+    }
+    // SAFETY: a non-null ttyname result is a NUL-terminated C string.
+    unsafe { CStr::from_ptr(name) }
+        .to_str()
+        .ok()
+        .map(str::to_owned)
+}
+
+/// The window size `fd`'s terminal reports, `None` when the ioctl fails.
+fn win_size(fd: RawFd) -> Option<WinSize> {
+    // SAFETY: an all-zero winsize is a valid value to hand the ioctl, which
+    // overwrites it wholesale; the fields are only read when it succeeded.
+    let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+    // SAFETY: `ws` is a valid winsize and TIOCGWINSZ writes exactly one.
+    (unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) } == 0).then_some(WinSize {
+        rows: ws.ws_row,
+        cols: ws.ws_col,
+        xpixel: ws.ws_xpixel,
+        ypixel: ws.ws_ypixel,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+
+    use super::*;
+
+    /// A pty pair sized `rows`x`cols`, so the probe can be pointed at a real
+    /// terminal instead of whatever the test runner left on fd 0.
+    fn open_pty(rows: u16, cols: u16) -> (OwnedFd, OwnedFd) {
+        let (mut master, mut slave): (RawFd, RawFd) = (-1, -1);
+        let ws = libc::winsize {
+            ws_row: rows,
+            ws_col: cols,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+        // SAFETY: valid out-pointers for both fds and the initial size, NULL
+        // for the optional name/termios parameters.
+        let ret = unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &ws,
+            )
+        };
+        assert_eq!(ret, 0, "openpty: {}", std::io::Error::last_os_error());
+        // SAFETY: openpty succeeded, so both fds are open and owned by nobody.
+        unsafe { (OwnedFd::from_raw_fd(master), OwnedFd::from_raw_fd(slave)) }
+    }
+
+    #[test]
+    fn a_tty_reports_its_device_and_the_size_it_was_opened_with() {
+        let (_master, slave) = open_pty(24, 80);
+        let info = stream_info(slave.as_raw_fd());
+
+        assert!(info.tty);
+        let size = info.size.expect("a pty answers TIOCGWINSZ");
+        assert_eq!((size.rows, size.cols), (24, 80));
+        assert!(
+            info.device.is_some_and(|d| d.starts_with("/dev/")),
+            "a pty slave names its device"
+        );
+    }
+
+    #[test]
+    fn a_pipe_is_not_a_tty_and_has_nothing_to_report() {
+        let (reader, _writer) = std::io::pipe().expect("pipe");
+        let info = stream_info(reader.as_raw_fd());
+
+        assert!(!info.tty);
+        assert!(info.device.is_none() && info.size.is_none());
+    }
+
+    #[test]
+    fn every_standard_stream_is_described() {
+        let json = serde_json_lenient::to_value(terminal_info()).unwrap();
+        for stream in ["stdin", "stdout", "stderr"] {
+            assert!(json[stream]["tty"].is_boolean(), "{stream} unprobed");
+        }
+    }
+}

--- a/crates/diagnostics/src/terminal.rs
+++ b/crates/diagnostics/src/terminal.rs
@@ -79,16 +79,27 @@ fn stream_info(fd: RawFd) -> StreamInfo {
 }
 
 /// The tty device path behind `fd`, `None` when it cannot be resolved.
+///
+/// `ttyname_r`, not `ttyname`: the latter answers out of a buffer that glibc
+/// and musl both make a *process-wide* static, so two threads probing at once
+/// can each be handed the other's device. Collectors run sequentially today,
+/// but a probe that is only correct because of its caller's scheduling is a
+/// trap for the next one. The `_r` form writes into a caller-owned buffer and
+/// is safe unconditionally.
 fn device_name(fd: RawFd) -> Option<String> {
-    // SAFETY: ttyname returns a pointer into a static buffer valid until the
-    // next ttyname call on this thread; it is copied into an owned String
-    // before this thread can make another.
-    let name = unsafe { libc::ttyname(fd) };
-    if name.is_null() {
+    // POSIX puts TTY_NAME_MAX at 32; 256 is headroom for any /dev/pts/N a
+    // kernel cares to invent. ERANGE (too small) reads as "unresolved", which
+    // is what every other failure here does too.
+    let mut buf = [0 as libc::c_char; 256];
+    // SAFETY: `buf` is a valid writable buffer of exactly the length passed;
+    // on success ttyname_r writes a NUL-terminated string within it.
+    let rc = unsafe { libc::ttyname_r(fd, buf.as_mut_ptr(), buf.len()) };
+    if rc != 0 {
         return None;
     }
-    // SAFETY: a non-null ttyname result is a NUL-terminated C string.
-    unsafe { CStr::from_ptr(name) }
+    // SAFETY: ttyname_r reported success, so `buf` holds a NUL-terminated
+    // string no longer than itself.
+    unsafe { CStr::from_ptr(buf.as_ptr()) }
         .to_str()
         .ok()
         .map(str::to_owned)
@@ -161,6 +172,36 @@ mod tests {
 
         assert!(!info.tty);
         assert!(info.device.is_none() && info.size.is_none());
+    }
+
+    /// The device lookup is reentrant. `ttyname` would answer all of these
+    /// threads out of one process-wide buffer, so a probe could return a
+    /// terminal it never looked at; `ttyname_r` gives each caller its own.
+    #[test]
+    fn concurrent_device_lookups_do_not_collide() {
+        // Held open for the whole test: /dev/pts numbers are recycled on
+        // close, so only simultaneously-live ptys are guaranteed to differ.
+        let ptys: Vec<(OwnedFd, OwnedFd)> = (0..8).map(|_| open_pty(24, 80)).collect();
+        let probe =
+            |slave: &OwnedFd| device_name(slave.as_raw_fd()).expect("a pty names its device");
+
+        // The uncontended answers, taken one at a time.
+        let expected: Vec<String> = ptys.iter().map(|(_, slave)| probe(slave)).collect();
+
+        let concurrent: Vec<String> = std::thread::scope(|s| {
+            let handles: Vec<_> = ptys
+                .iter()
+                .map(|(_, slave)| s.spawn(move || probe(slave)))
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        // Contention changes nothing. Under `ttyname` these would smear into
+        // whichever name the shared static held when each thread read it.
+        assert_eq!(
+            concurrent, expected,
+            "a probe returned another pty's device"
+        );
     }
 
     #[test]

--- a/crates/minimal/src/diag/collect.rs
+++ b/crates/minimal/src/diag/collect.rs
@@ -45,6 +45,17 @@ pub async fn system(w: &mut BundleWriter, paths: &DiagPaths) -> Result<(), anyho
         .await
 }
 
+// ── host/terminal.json ───────────────────────────────────────────────────────
+
+/// The terminal `min bug` itself ran on. Interactive rendering complaints
+/// (#950) cannot be judged without it, and it costs three ioctls.
+pub async fn terminal(w: &mut BundleWriter) -> Result<(), anyhow::Error> {
+    let info = diagnostics::terminal_info();
+    let json = serde_json_lenient::to_vec_pretty(&info).context("serializing terminal info")?;
+    w.add_bytes("host/terminal.json", &json, Redaction::None)
+        .await
+}
+
 // ── host/env.json ────────────────────────────────────────────────────────────
 
 pub async fn env(w: &mut BundleWriter) -> Result<(), anyhow::Error> {

--- a/crates/minimal/src/diag/mod.rs
+++ b/crates/minimal/src/diag/mod.rs
@@ -107,6 +107,7 @@ pub async fn cmd_bug(global: &GlobalArgs, args: BugArgs) -> Result<(), anyhow::E
     // ── Host-side collectors: independent, each failure becomes a
     // manifest error rather than aborting the run.
     collect_step!(w, "host.system", collect::system(&mut w, &paths));
+    collect_step!(w, "host.terminal", collect::terminal(&mut w));
     collect_step!(w, "host.env", collect::env(&mut w));
     collect_step!(w, "host.dirs", dirs_report(&mut w, global));
     // Incident collectors: the wedged-system captures. The mechanics live in

--- a/crates/minimal/src/diag/redact.rs
+++ b/crates/minimal/src/diag/redact.rs
@@ -7,7 +7,22 @@
 
 /// Env vars whose *values* are safe and useful to include verbatim. Everything
 /// else is reported by name only.
-const ENV_VALUE_ALLOWLIST_EXACT: &[&str] = &["RUST_LOG", "HOME", "SHELL", "TERM", "PATH"];
+///
+/// `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, and `COLORTERM` join `TERM` because
+/// a rendering complaint (#950) is answered by the emulator, not the termcap
+/// name: Terminal.app, iTerm2, and Ghostty disagree about wide glyphs and
+/// truecolor while all reporting `xterm-256color`. Each names a program, never
+/// the user or their work.
+const ENV_VALUE_ALLOWLIST_EXACT: &[&str] = &[
+    "RUST_LOG",
+    "HOME",
+    "SHELL",
+    "TERM",
+    "TERM_PROGRAM",
+    "TERM_PROGRAM_VERSION",
+    "COLORTERM",
+    "PATH",
+];
 const ENV_VALUE_ALLOWLIST_PREFIXES: &[&str] = &["XDG_", "MINIMAL_", "MINVMD_", "MINIMALD_"];
 
 /// Returns true when the named env var's value may be captured verbatim.
@@ -35,6 +50,10 @@ mod tests {
             "MINIMALD_DETACHED",
             "HOME",
             "PATH",
+            "TERM",
+            "TERM_PROGRAM",
+            "TERM_PROGRAM_VERSION",
+            "COLORTERM",
         ] {
             assert!(is_env_value_allowlisted(name), "{name} should be allowed");
         }
@@ -48,6 +67,15 @@ mod tests {
             "MINVMD_PASSWORD",
             "MINIMALIST_THING",
         ] {
+            assert!(!is_env_value_allowlisted(name), "{name} must not be");
+        }
+    }
+
+    /// The terminal-identity names are an exact-match widening, not a `TERM`
+    /// prefix: a var that merely starts with the same letters stays masked.
+    #[test]
+    fn terminal_identity_is_allowlisted_by_name_not_by_prefix() {
+        for name in ["TERMINAL_EMULATOR", "TERM_SESSION_ID", "TERM_TOKEN"] {
             assert!(!is_env_value_allowlisted(name), "{name} must not be");
         }
     }

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -127,6 +127,43 @@ async fn bug_without_daemon_still_produces_a_bundle() {
     );
 }
 
+/// R2.3a: the bundle describes the terminal `min bug` ran on. A rendering
+/// complaint is unjudgeable without it (#950), so the entry is unconditional
+/// — under `cargo test` the streams are pipes, and "not a terminal" is
+/// exactly the finding that separates a CI run from a real session.
+#[tokio::test]
+async fn the_invoking_terminal_is_described() {
+    let state = tempfile::TempDir::new().unwrap();
+    let config = tempfile::TempDir::new().unwrap();
+    let out_dir = tempfile::TempDir::new().unwrap();
+    let out = out_dir.path().join("diag.tar.zst");
+    cmd_bug(&global_args(state.path(), config.path()), bug_args(&out))
+        .await
+        .unwrap();
+
+    let files = unpack(&out).await;
+    let terminal: serde_json_lenient::Value =
+        serde_json_lenient::from_slice(find(&files, "host/terminal.json").expect("terminal.json"))
+            .unwrap();
+
+    for name in ["stdin", "stdout", "stderr"] {
+        let stream = &terminal[name];
+        let tty = stream["tty"].as_bool().expect("tty is probed as a bool");
+        if tty {
+            let size = &stream["size"];
+            assert!(
+                size["rows"].is_u64() && size["cols"].is_u64(),
+                "a terminal reports the size that explains its wrapping: {stream}"
+            );
+        } else {
+            assert!(
+                stream["size"].is_null() && stream["device"].is_null(),
+                "a pipe has no size or device to report: {stream}"
+            );
+        }
+    }
+}
+
 #[tokio::test]
 async fn planted_secrets_never_reach_the_bundle() {
     let state = tempfile::TempDir::new().unwrap();

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -127,7 +127,7 @@ async fn bug_without_daemon_still_produces_a_bundle() {
     );
 }
 
-/// R2.3a: the bundle describes the terminal `min bug` ran on. A rendering
+/// R2.10: the bundle describes the terminal `min bug` ran on. A rendering
 /// complaint is unjudgeable without it (#950), so the entry is unconditional
 /// — under `cargo test` the streams are pipes, and "not a terminal" is
 /// exactly the finding that separates a CI run from a real session.
@@ -150,10 +150,14 @@ async fn the_invoking_terminal_is_described() {
         let stream = &terminal[name];
         let tty = stream["tty"].as_bool().expect("tty is probed as a bool");
         if tty {
+            // A terminal reports the size that explains its wrapping — but a
+            // failed `TIOCGWINSZ` is a null size, not a broken bundle, and the
+            // probe is specified best-effort. Demand well-formedness, not
+            // presence.
             let size = &stream["size"];
             assert!(
-                size["rows"].is_u64() && size["cols"].is_u64(),
-                "a terminal reports the size that explains its wrapping: {stream}"
+                size.is_null() || (size["rows"].is_u64() && size["cols"].is_u64()),
+                "a terminal's size is either absent or complete: {stream}"
             );
         } else {
             assert!(

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -207,13 +207,21 @@ system facts, log tails, redacted config, and state listings, plus a
 broken install still yields a valid archive that explains what is
 missing.
 
+Because sessions are interactive, the bundle also records the terminal
+`bug` itself ran on (`host/terminal.json`): whether stdin, stdout, and
+stderr are ttys — the same condition `attach` gates on, so a run under a
+pipe or CI is distinguishable from a real terminal — and, for each that
+is, its device and its `TIOCGWINSZ` rows/columns, which is what makes a
+garbled TUI or wrong wrapping diagnosable.
+
 Diagnosing a wedged system must not change it: `bug` mutates no state and
 never starts a daemon; it works even when none are running.
 
 Secret-shaped values (env vars, tokens) are redacted before they enter
 the archive: only a small allowlist of env names (`RUST_LOG`, `HOME`,
-`SHELL`, `TERM`, `PATH`, and the `XDG_*` / `MINIMAL_*` / `MINVMD_*` /
-`MINIMALD_*` prefixes) have values captured verbatim (a sensitive-shaped
+`SHELL`, `TERM`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `COLORTERM`,
+`PATH`, and the `XDG_*` / `MINIMAL_*` / `MINVMD_*` / `MINIMALD_*`
+prefixes) have values captured verbatim (a sensitive-shaped
 name always loses to the allowlist), and every other env var is reported
 by name only. Session and project file contents are never included, only
 name/size listings. Review the archive before sharing.

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -211,8 +211,9 @@ Because sessions are interactive, the bundle also records the terminal
 `bug` itself ran on (`host/terminal.json`): whether stdin, stdout, and
 stderr are ttys — the same condition `attach` gates on, so a run under a
 pipe or CI is distinguishable from a real terminal — and, for each that
-is, its device and its `TIOCGWINSZ` rows/columns, which is what makes a
-garbled TUI or wrong wrapping diagnosable.
+is, its device and its `TIOCGWINSZ` geometry (rows, columns, and the
+`xpixel`/`ypixel` size emulators report), which is what makes a garbled
+TUI or wrong wrapping diagnosable.
 
 Diagnosing a wedged system must not change it: `bug` mutates no state and
 never starts a daemon; it works even when none are running.

--- a/docs/specs/10-spec-diagnostics/10-spec-diagnostics.md
+++ b/docs/specs/10-spec-diagnostics/10-spec-diagnostics.md
@@ -346,14 +346,20 @@ paths, and the archive layout.
   in the manifest, per R1.3.)
 - **R2.4**: `host/env.json` shall enumerate via `std::env::vars_os` (never
   `vars` — panics on non-UTF-8), record allowlisted values verbatim
-  (`RUST_LOG`, `HOME`, `SHELL`, `TERM`, `PATH`; prefixes `XDG_`, `MINIMAL_`,
+  (`RUST_LOG`, `HOME`, `SHELL`, `TERM`, `TERM_PROGRAM`,
+  `TERM_PROGRAM_VERSION`, `COLORTERM`, `PATH`; prefixes `XDG_`, `MINIMAL_`,
   `MINVMD_`, `MINIMALD_`), and mask everything else to `<redacted:len=N>`.
   The allowlist grants candidacy, not exemption: an allowlisted name that
   trips the R1.5 sensitive-key policy (e.g. `MINIMAL_TOKEN`,
   `MINIMALD_SECRET`) is masked regardless. `HOME` and `PATH` are recorded
   deliberately — install-layout questions dominate field triage — and their
   user-identifying paths are covered by the review-before-sharing notice
-  (R2.9).
+  (R2.9). The three terminal names beyond `TERM` are matched **exactly, not
+  as a `TERM` prefix**: each names an emulator program, whereas
+  `TERM_SESSION_ID` and any `TERM`-prefixed token would not. Locale (`LANG`,
+  `LC_*`) is deliberately **not** allowlisted — it carries weakly
+  identifying country/language signal, and unmasking it is a policy call for
+  a human rather than a consequence of a collector change.
 - **R2.5**: Config files (`config.toml`, `user_policy.toml`, loadouts) shall
   be bundled through the TOML redaction walker; unparseable TOML is withheld
   with a manifest note, never shipped raw. Every content read — config
@@ -376,6 +382,23 @@ paths, and the archive layout.
   `min dirs` unchanged).
 - **R2.9**: The final output shall print the archive path, entry and error
   counts, and a review-before-sharing notice.
+- **R2.10**: `host/terminal.json` shall record the terminal the bundle's
+  producer was invoked on (`diagnostics::terminal_info`): for each of stdin,
+  stdout, and stderr, whether it is a tty, and for those that are, the tty
+  device path and the `TIOCGWINSZ` geometry (`rows`, `cols`, `xpixel`,
+  `ypixel`). Sessions are interactive, so the tty flag is the same
+  precondition `attach` and the prompts gate on — it separates a pipe, a
+  script, or CI from a real terminal — and the geometry is what makes a
+  garbled TUI or wrong wrapping judgeable. The entry is unconditional: "not
+  a terminal" is a finding, not an absence. Every field is best-effort per
+  R2.3's discipline — a stream that is not a tty reports `null` device and
+  size, and a tty whose ioctl fails reports a `null` size rather than an
+  error. Device lookup shall use `ttyname_r`; `ttyname` answers from a
+  process-wide static buffer on both glibc and musl and is unsafe to reach
+  concurrently. The capture describes the terminal the *bundle* ran on,
+  which is the one that rendered wrong only when the user reports from the
+  same window; that caveat is inherent and is why the field sits beside the
+  other host facts rather than being presented as the incident's terminal.
 
 **Proof Artifacts:**
 
@@ -387,6 +410,11 @@ paths, and the archive layout.
    archive — covers R2.4, R2.5.
 3. **CLI:** `min bug` on a dev box; inspect manifest counts and `host/`
    entries — covers R2.3, R2.7-R2.9.
+4. **Test:** `the_invoking_terminal_is_described` — `host/terminal.json` is
+   present and every standard stream is probed; a tty carries a well-formed
+   size, a pipe carries neither device nor size. Paired with the `diagnostics`
+   unit tests, which point the probe at a real pty of known dimensions and at
+   a pipe — covers R2.10.
 
 ---
 
@@ -1105,6 +1133,7 @@ Unit 8's dual-format rework, sequenced after Unit 6.
 | 2 | R2.1, R2.2, R2.6 | Test | `bug_without_daemon_still_produces_a_bundle` (Linux lane) |
 | 2 | R2.4, R2.5 | Test | planted secret → `<redacted:len=N>`, never verbatim |
 | 2 | R2.3, R2.7-R2.9 | CLI | `min bug` on dev box; manifest counts, `host/` entries |
+| 2 | R2.10 | Test | `the_invoking_terminal_is_described`; `cargo test -p diagnostics terminal` — pty of known size, pipe reports nothing |
 | 3 | R3.2-R3.4 | CLI (gate) | idle attach + `minvmd stop` → clean ext4 journal; `boot.log` in provider dir, `minimald.log*` on volume next boot |
 | 3 | R3.4 | Test | release runs exactly once, before quiesce returns |
 | 3 | R3.6 | Test | size-threshold rotation + retention pruning |


### PR DESCRIPTION
Closes: #950

## Summary

Terminal-dependent bugs were unreproducible from a bundle because the bundle never said
what terminal `min` was running on. This adds `host/terminal.json`: per standard stream,
whether it is a tty, and for those that are, the tty device and the `TIOCGWINSZ` geometry
(`rows`, `cols`, `xpixel`, `ypixel`). The tty flag is the same precondition `attach` and
the interactive prompts gate on, so a refused attach or a prompt nobody saw is explained
by this field alone.

The env allowlist widens to `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, and `COLORTERM`: a
rendering complaint is answered by the emulator, not the termcap name — Terminal.app,
iTerm2, and Ghostty disagree about wide glyphs and truecolor while all reporting
`xterm-256color`.

The diagnostics spec is extended with **R2.10** for `host/terminal.json`, and R2.4 is
corrected — its allowlist had already drifted from the code.

### Redaction policy — what this deliberately does NOT do

`LANG` and `LC_*` are **not** unmasked. Locale can carry country/language signal that is
weakly identifying, and unmasking it is a policy decision for a human, not a collector
change. There is a test asserting `LANG` stays masked, alongside `USER` and the token
names.

The widening is by **exact name, not prefix** — a second test asserts `TERMINAL_EMULATOR`,
`TERM_SESSION_ID`, and `TERM_TOKEN` stay masked, so nothing leaks in on a `TERM` prefix
match. Both policies are now written into R2.4 rather than living only in the code.

### Review notes — all four resolved in `29b4ac6d`

The first round of self-review raised four items. Each was valid; each is fixed:

- **`ttyname(3)` is not per-thread.** Its `SAFETY` comment claimed a per-thread buffer;
  on glibc and musl it is a **process-wide static**, so two concurrent probes could each
  be handed the other's device. Now uses `ttyname_r`, which writes into a caller-owned
  buffer. Added `concurrent_device_lookups_do_not_collide`, which probes eight
  simultaneously-live ptys from eight threads and asserts the answers match the
  uncontended ones. (This is also the concurrency risk CodeRabbit flagged.)
- **Cited requirement `R2.3a` did not exist.** The spec is the authority for bundle
  contents and had never been extended for `host/terminal.json`. Added **R2.10** — appended
  rather than inserted as `R2.3a`, because the spec states IDs are referenced by the
  planner and must not be renumbered after approval — with its proof artifact and
  traceability row. The test now cites R2.10.
- **`cli-min.md` under-described the field set.** It said "device and its `TIOCGWINSZ`
  rows/columns"; `WinSize` also serializes `xpixel`/`ypixel`. Now describes the full
  geometry.
- **`the_invoking_terminal_is_described` was too strict.** It asserted rows/cols are
  present whenever `tty` is true, so a tty whose `TIOCGWINSZ` fails would fail the assert
  rather than be tolerated. The probe is specified best-effort, so it now demands the size
  be well-formed *when present* rather than present at all.

## Testing

`cargo test -p diagnostics -p minimal --test bug --lib` on Linux x86_64:

```
     Running unittests src/lib.rs (diagnostics)
test result: ok. 64 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running unittests src/lib.rs (minimal)
test result: ok. 165 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running tests/bug.rs
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Covering directly: `the_invoking_terminal_is_described`,
`a_tty_reports_its_device_and_the_size_it_was_opened_with`,
`a_pipe_is_not_a_tty_and_has_nothing_to_report`, `every_standard_stream_is_described`,
`concurrent_device_lookups_do_not_collide`, and the redaction pair asserting the exact-match
allowlist and that `LANG` stays masked.

Also clean: `cargo fmt --check`, `cargo clippy -p diagnostics -p minimal --all-targets`.

Not run: the VM/e2e recipes — this change touches no daemon or VM path.

## Checklist

- [x] Docs updated if behavior changed — `docs/reference/cli-min.md` and the diagnostics
      spec (R2.10 added, R2.4 corrected)
- [x] `BREAKING CHANGE:` footer present if this is a breaking change — n/a, additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
