### PR TITLE
ci: bring minimal-review current with foundry main

### DIFF
--- a/.github/workflows/minimal-review.yml
+++ b/.github/workflows/minimal-review.yml
@@ -40,13 +40,19 @@ env:
   # the userns backend (no /dev/kvm), where the sandbox shares the host netns.
   HOST_ALIAS: ${{ vars.MINIMAL_REVIEW_HOST_ALIAS || '100.64.255.254' }}
   BROKER_PORT: "8901"
-  REVIEW_MODEL: ${{ vars.MINIMAL_REVIEW_MODEL || 'claude-sonnet-5' }}
+  # Sonnet either way, but the id is vendor-shaped: bare through Anthropic,
+  # namespaced through OpenRouter. An explicit MINIMAL_REVIEW_MODEL wins.
+  REVIEW_MODEL: ${{ vars.MINIMAL_REVIEW_MODEL || (secrets.MINIMAL_REVIEW_KEY != '' && 'anthropic/claude-sonnet-5' || 'claude-sonnet-5') }}
   # Release channel for the Minimal CLI. `nightly` is how you pick up a fix
   # before it reaches a stable release — switch the repo variable rather than
   # editing this file, so the change is one click and shows up in the audit log.
   # unstable: `min task run` with claude-code in the task's packages needs
   # bff10a70 (#1262). Move to stable once that ships stable.
   MINIMAL_CHANNEL: ${{ vars.MINIMAL_CHANNEL || 'unstable' }}
+  # The declared task the reviewer injects and runs. Overridable because a
+  # repo may already have its own [tasks.review] — webapp does — and the
+  # injector refuses to shadow it rather than silently replacing it.
+  REVIEW_TASK: ${{ vars.MINIMAL_REVIEW_TASK || 'review' }}
   QUIET_SECONDS: ${{ vars.MINIMAL_REVIEW_QUIET_SECONDS || '90' }}
   # Backstop against an agent that loops.
   AGENT_TIMEOUT_SECONDS: "1500"
@@ -94,8 +100,7 @@ jobs:
       # One App token for both private repos this job reads: gominimal/foundry
       # (the reviewer) and gominimal/broker (credentials). This job's
       # GITHUB_TOKEN is scoped to this repo alone, so a plain cross-repo
-      # checkout gets "Repository not found". Minted first: the next step needs
-      # it.
+      # checkout gets "Repository not found". Minted first: the next step needs it.
       - name: Mint a token for the private reviewer and broker repos
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
@@ -282,6 +287,9 @@ jobs:
           echo "PR #$PR_NUMBER  head=$HEAD_SHA  base=$BASE_SHA  $(wc -l < .review/pr.diff) diff lines"
 
       - name: Install the review library and stage the generated schema
+        id: lib
+        env:
+          LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -289,8 +297,10 @@ jobs:
           # branch. A PR must never supply the code that decides whether its own
           # findings are honest and whether anything may be published.
           python3 -m venv "$RUNNER_TEMP/venv"
+          extra=""
+          [ -n "${LOGFIRE_TOKEN:-}" ] && extra="[telemetry]"
           "$RUNNER_TEMP/venv/bin/pip" install --quiet --disable-pip-version-check \
-            "$GITHUB_WORKSPACE/reviewer/review"
+            "$GITHUB_WORKSPACE/reviewer/review$extra"
 
           # STAGING — repomap, threads, prompt — shapes the agent's input and
           # cannot publish anything, so a foundry self-review may use its own.
@@ -355,6 +365,10 @@ jobs:
             -o "$GITHUB_WORKSPACE/pr/.review/threads.json" || \
             printf '[]\n' > "$GITHUB_WORKSPACE/pr/.review/threads.json"
 
+          if [ -f "$GITHUB_WORKSPACE/pr/Cargo.toml" ]; then echo "repo_map=rust" >> "$GITHUB_OUTPUT"
+          elif [ -f "$GITHUB_WORKSPACE/pr/package.json" ]; then echo "repo_map=typescript" >> "$GITHUB_OUTPUT"
+          else echo "repo_map=absent" >> "$GITHUB_OUTPUT"; fi
+
           cp "$GITHUB_WORKSPACE/pr/.review/repomap.md" \
              "$GITHUB_WORKSPACE/pr/.review/threads.json" \
              "$GITHUB_WORKSPACE/pr/.review/learnings.md" "$RUN_DIR/" 2>/dev/null || true
@@ -394,7 +408,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: gominimal/broker
-          ref: e1d3188c7ca99135a7062145a7ad448aa8a1cda6
+          ref: e6e0c29b74a4fd93258ec028325a97fc3ab639a8
           token: ${{ steps.app-token.outputs.token }}
           path: broker
           persist-credentials: false
@@ -402,11 +416,21 @@ jobs:
       - name: Start the credential broker and preflight it
         env:
           CLAUDE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Host-side only. The sandbox never sees this — it gets a placeholder
+          # and the broker's URL, which is the whole reason the broker exists.
+          MINIMAL_REVIEW_KEY: ${{ secrets.MINIMAL_REVIEW_KEY }}
+          # A base, not an endpoint: the broker appends the client's own
+          # `/v1/messages` to it. `/api/v1` here produced `/api/v1/v1/messages`
+          # and a 404 on every call.
+          BROKER_ANTHROPIC_UPSTREAM: ${{ secrets.MINIMAL_REVIEW_KEY != '' && 'https://openrouter.ai/api' || '' }}
           BROKER_PORT: ${{ env.BROKER_PORT }}
         run: |
           set -euo pipefail
-          if [ -z "${CLAUDE_OAUTH_TOKEN:-}" ]; then
-            echo "::error::secrets.CLAUDE_CODE_OAUTH_TOKEN is unset — the broker would start keyless"
+          # Either credential will do. This guard predated MINIMAL_REVIEW_KEY
+          # and still demanded a Claude subscription token, so an OpenRouter-only
+          # deployment — which is a supported configuration — could not start.
+          if [ -z "${CLAUDE_OAUTH_TOKEN:-}" ] && [ -z "${MINIMAL_REVIEW_KEY:-}" ]; then
+            echo "::error::neither secrets.MINIMAL_REVIEW_KEY nor secrets.CLAUDE_CODE_OAUTH_TOKEN is set — the broker would start keyless"
             exit 1
           fi
           nohup python3 "$GITHUB_WORKSPACE/broker/broker.py" > "$RUN_DIR/broker.log" 2>&1 &
@@ -420,8 +444,8 @@ jobs:
           echo "$health" | tee "$RUN_DIR/broker-health.json"
           # Fail fast: a keyless broker makes the agent retry in silence until
           # its timeout.
-          if ! echo "$health" | grep -q '"claude_oauth_loaded": true'; then
-            echo "::error::broker holds no Claude credential — aborting before minting a session"
+          if ! echo "$health" | grep -qE '"(claude_oauth_loaded|openrouter_loaded)": true'; then
+            echo "::error::broker holds no model credential — aborting before minting a session"
             exit 1
           fi
 
@@ -435,14 +459,76 @@ jobs:
             echo "::error::no minimal.toml — run 'min init' in this repo and commit the result (a pinned [upstream] is required)"
             exit 1
           fi
-          if grep -q '^\[tasks\.review\]' "$CFG"; then
-            echo "::error::$CFG already declares [tasks.review]; refusing to shadow the repo's own task"
+          if grep -q "^\[tasks\.${REVIEW_TASK}\]" "$CFG"; then
+            echo "::error::$CFG already declares [tasks.${REVIEW_TASK}]; refusing to shadow the repo's own task. Set the repo variable MINIMAL_REVIEW_TASK to a name it does not use."
             exit 1
           fi
 
+          # Strip the repo's lifecycle hooks from the copy we run under.
+          #
+          # Two reasons, and the second is the one that matters. First, they
+          # need the project allow-listed in user_policy.toml and CI has no
+          # such list, so activation just refuses — that is what stopped
+          # gominimal/webapp, whose on_activate installs deps, starts postgres
+          # and runs migrations.
+          #
+          # Second: a lifecycle hook is a script *from the branch under review*,
+          # and it runs before the reviewer does. Honouring it would execute
+          # PR-authored code in a sandbox that can reach the broker, on every
+          # PR, before anything had looked at the diff. A reviewer must not run
+          # the code it was sent to read.
+          "$RUNNER_TEMP/venv/bin/python" - "$CFG" <<'PYHOOK'
+          import re, sys, tomllib
+
+          path = sys.argv[1]
+          src = open(path).read()
+
+          # Ask the parser whether there is anything to do before editing text.
+          # The literal "[[session.lifecycle_hooks]]" can appear inside a task's
+          # own bash body, where it is a line of shell and not a table at all —
+          # stripping from there would mangle a legitimate config and then be
+          # caught below as corruption, refusing a repo for no reason.
+          try:
+              before = tomllib.loads(src)
+          except tomllib.TOMLDecodeError as exc:
+              print(f"::error::{path} is not valid TOML: {exc}")
+              sys.exit(1)
+          if not (before.get("session") or {}).get("lifecycle_hooks"):
+              print("hooks: none declared")
+              sys.exit(0)
+
+          # Tolerant of indentation: TOML permits leading whitespace before a
+          # table header, and a column-0-only pattern leaves an indented hook
+          # armed while reporting success.
+          stripped, n = re.subn(
+              r'(?ms)^[ \t]*\[\[[ \t]*session\.lifecycle_hooks[ \t]*\]\].*?(?=^[ \t]*\[|\Z)',
+              '', src)
+
+          # The regex is not enough and cannot be made enough: a hook value that
+          # is a multi-line string containing a line starting with `[` ends the
+          # match early and truncates the file. So the result is parsed, and
+          # anything short of "valid, and no hook left" stops the run. A silent
+          # miss here means PR-authored setup executes; a loud failure means a
+          # config nobody has taught this to handle, which is a person's problem
+          # and not something to guess at.
+          try:
+              doc = tomllib.loads(stripped)
+          except tomllib.TOMLDecodeError as exc:
+              print(f"::error::removing lifecycle hooks corrupted {path}: {exc}")
+              sys.exit(1)
+
+          if (doc.get("session") or {}).get("lifecycle_hooks"):
+              print("::error::a lifecycle hook survived removal — refusing to activate with "
+                    "PR-authored setup armed")
+              sys.exit(1)
+
+          open(path, "w").write(stripped)
+          print(f"hooks: removed {n} block(s), verified none remain")
+          PYHOOK
+
           cat >> "$CFG" <<TOML
 
-          [tasks.review]
+          [tasks.${REVIEW_TASK}]
           description = "minimal-review: review the PR staged under .review/"
           inherit_cwd = true
           # ripgrep/ast-grep are how the reviewer verifies structurally now that
@@ -526,8 +612,13 @@ jobs:
           # it down. The task's stdout IS the data contract — it ends with
           # `cat .review/findings.json` and nothing else may print there.
           T0=$(date +%s)
-          min task run review > "$RUN_DIR/findings.json" 2> "$RUN_DIR/task-stderr.txt"
-          rc=$?
+          # `|| rc=$?`, not a bare call followed by `rc=$?`. GitHub runs this
+          # with `bash -e`, and `set -uo pipefail` above does not turn that off
+          # — so a task exiting non-zero killed the script before the next line
+          # could read the code, and every exit-75 path below was unreachable.
+          # A command on the left of `||` is a condition, which -e ignores.
+          rc=0
+          min task run "$REVIEW_TASK" > "$RUN_DIR/findings.json" 2> "$RUN_DIR/task-stderr.txt" || rc=$?
           elapsed=$(( $(date +%s) - T0 ))
           echo "elapsed_seconds=$elapsed" >> "$GITHUB_OUTPUT"
           echo "task exit $rc in ${elapsed}s"
@@ -538,7 +629,7 @@ jobs:
 
           if [ "$rc" -eq 75 ]; then
             echo "::warning::minimal-review got no usable response from upstream and produced no review for this commit. Re-run this job, or push again, once it recovers."
-            echo "status=rate_limited" >> "$GITHUB_OUTPUT"
+            echo "status=upstream_unavailable" >> "$GITHUB_OUTPUT"
             tail -n 20 "$RUN_DIR/task-stderr.txt" || true
             exit 0
           fi
@@ -552,6 +643,27 @@ jobs:
       # Model output is data. It validates against minimal-review/v1, the diff
       # and the policy, or it is dropped with a reason — nothing here repairs a
       # malformed document.
+      # Read after the run, not before: the broker's counters are cumulative and
+      # are all zero at start-up. This is the only place the token cost of a
+      # review exists — the sandbox never sees it.
+      - name: Meter the run
+        if: always()
+        run: |
+          set -uo pipefail
+          curl -fsS -m 5 "http://127.0.0.1:${BROKER_PORT}/health" \
+            > "$RUN_DIR/broker-usage.json" 2>/dev/null \
+            || echo '{}' > "$RUN_DIR/broker-usage.json"
+          python3 -c "
+          import json
+          try:
+              u = json.load(open('$RUN_DIR/broker-usage.json')).get('usage') or {}
+          except Exception:
+              u = {}
+          print('tokens: in=%s out=%s cache_read=%s requests=%s' % (
+              u.get('input_tokens'), u.get('output_tokens'),
+              u.get('cache_read_input_tokens'), u.get('requests')))
+          " || true
+
       - name: Validate the findings document
         if: steps.agent.outputs.status == 'ok'
         env:
@@ -586,7 +698,24 @@ jobs:
           policy = load_policy(os.path.join(os.environ["RUN_DIR"], "policy.toml"))
 
           with open(f"{run_dir}/findings.json", encoding="utf-8") as fh:
-              doc = ReviewDocument.parse_v0_or_v1(json.load(fh))
+              # The gate comes from the default branch while this workflow
+              # comes from the PR head, so the workflow can be newer than the
+              # library it calls. That is not a transient state to code around
+              # once — it is permanent, and every gate-API change passes
+              # through it on the way in. Ask what the installed gate accepts
+              # rather than assuming, so a PR that adds a parameter still gets
+              # reviewed by the older gate instead of dying on a TypeError.
+              import inspect
+
+              raw = json.load(fh)
+              accepted = inspect.signature(ReviewDocument.parse_v0_or_v1).parameters
+              host_known = {
+                  "pr": int(os.environ["PR_NUMBER"]),
+                  "head_sha": os.environ["HEAD_SHA"],
+              }
+              doc = ReviewDocument.parse_v0_or_v1(
+                  raw, **{k: v for k, v in host_known.items() if k in accepted}
+              )
           with open(f"{run_dir}/pr.diff", encoding="utf-8") as fh:
               diff = fh.read()
 
@@ -640,6 +769,8 @@ jobs:
           ELAPSED: ${{ steps.agent.outputs.elapsed_seconds }}
           AGENT_STATUS: ${{ steps.agent.outputs.status }}
           POST_OUTCOME: ${{ steps.post.outcome }}
+          UPSTREAM: ${{ secrets.MINIMAL_REVIEW_KEY != '' && 'openrouter' || 'anthropic' }}
+          REPO_MAP: ${{ steps.lib.outputs.repo_map }}
         run: |
           set -euo pipefail
           mkdir -p "$RUN_DIR"
@@ -651,9 +782,12 @@ jobs:
             --arg run "$GITHUB_RUN_ID" \
             --arg astatus "${AGENT_STATUS:-none}" \
             --arg posted "${POST_OUTCOME:-skipped}" \
+            --arg upstream "${UPSTREAM:-anthropic}" \
+            --arg repomap "${REPO_MAP:-absent}" \
             '{pr: $pr, head_sha: $head, base_sha: $base, agent_seconds: $elapsed,
               host_alias: $alias, backend: $kvm, run_id: $run,
-              agent_status: $astatus, posted: $posted}' \
+              agent_status: $astatus, posted: $posted,
+              upstream: $upstream, repo_map: $repomap}' \
             > "$RUN_DIR/run.json"
 
           # The audit record must say what actually happened.
@@ -661,7 +795,7 @@ jobs:
             success) headline="review posted to PR #${PR_NUMBER:-?}"; detail="The review below was posted." ;;
             failure) headline="posting FAILED for PR #${PR_NUMBER:-?}"; detail="The review below was rendered but not posted — see the failing step." ;;
             *)       case "${AGENT_STATUS:-none}" in
-                       rate_limited) headline="rate-limited — no review for PR #${PR_NUMBER:-?}"; detail="No review was produced; nothing was posted." ;;
+                       upstream_unavailable) headline="upstream unavailable — no review for PR #${PR_NUMBER:-?}"; detail="Upstream returned nothing usable — quota, gateway or overload. No review was produced and nothing was posted." ;;
                        *)            headline="no review posted to PR #${PR_NUMBER:-?}"; detail="Nothing was posted." ;;
                      esac ;;
           esac
@@ -681,6 +815,24 @@ jobs:
               echo "No rendered payload — see the failing step above and the run artifact."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Always: a review that died still has a cost, a duration and a reason,
+      # and those are the rows that turn "it broke twice this week" into a
+      # distribution. Exits 0 whatever happens — instrumentation must not be
+      # able to fail a run that has otherwise finished.
+      - name: Emit telemetry
+        if: always()
+        env:
+          LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+        run: |
+          set -uo pipefail
+          "$RUNNER_TEMP/venv/bin/python" -m contract.emit \
+            --run        "$RUN_DIR/run.json" \
+            --findings   "$RUN_DIR/findings.json" \
+            --validation "$RUN_DIR/validation.txt" \
+            --usage      "$RUN_DIR/broker-usage.json" \
+            --repo       "$GITHUB_REPOSITORY" \
+            --outcome    "${{ job.status }}" || true
 
       - name: Upload the run artifact
         if: always()

--- a/.github/workflows/minimal-review.yml
+++ b/.github/workflows/minimal-review.yml
@@ -358,6 +358,14 @@ jobs:
             --policy "$RUN_DIR/policy.toml" \
             -o "$GITHUB_WORKSPACE/pr/.review/review-prompt.md"
 
+          # Keep a copy of what the agent was actually handed. The artifact
+          # collects $RUN_DIR, and the prompt is staged under pr/.review/, so
+          # "what did the agent read" was unanswerable after the fact. A run
+          # where the agent replied conversationally instead of reviewing cost a
+          # control experiment to diagnose, for want of this one file.
+          cp "$GITHUB_WORKSPACE/pr/.review/review-prompt.md" "$RUN_DIR/review-prompt.md"
+          echo "prompt: $(wc -c < "$RUN_DIR/review-prompt.md") bytes, sha256 $(sha256sum "$RUN_DIR/review-prompt.md" | cut -c1-16)"
+
           # Repo map: what exists in this codebase and what it is for. Every
           # workspace crate with its //! intent line, plus the public surface of
           # the crates this PR touches. ~17% of human review comments here are
@@ -597,7 +605,7 @@ jobs:
           # carries the findings and stderr is the only other channel out.
           # Push the logs through it rather than expecting to read them later.
           {
-            echo "--- agent-log (tail) ---"; tail -c 2000 .review/agent-log.txt 2>/dev/null
+            echo "--- agent-log (tail) ---"; tail -c 8000 .review/agent-log.txt 2>/dev/null
             echo "--- agent-err (tail) ---"; tail -c 2000 .review/agent-err.txt 2>/dev/null
             echo "--- build attempts ---"; tail -c 2000 .review/build-attempts.log 2>/dev/null
           } >&2
@@ -613,6 +621,19 @@ jobs:
               exit 75
             fi
             echo 'review: agent produced no .review/findings.json' >&2
+            # What the SANDBOX saw, so "it refused" and "it never got the
+            # inputs" stop looking identical in the log.
+            #
+            # Every expansion here is escaped. This heredoc is unquoted, so an
+            # unescaped $( ) runs on the runner at inject time and bakes the
+            # host's numbers into the task as a constant — which reports a
+            # 7386-byte prompt even when the box received nothing, i.e. it
+            # asserts exactly the fact this line exists to establish.
+            prompt_bytes=missing
+            diff_lines=missing
+            [ -f .review/review-prompt.md ] && prompt_bytes="\$(wc -c < .review/review-prompt.md)"
+            [ -f .review/pr.diff ] && diff_lines="\$(wc -l < .review/pr.diff)"
+            echo "review: inputs prompt=\${prompt_bytes} bytes, diff=\${diff_lines} lines" >&2
             tail -n 40 .review/agent-err.txt >&2
             exit 65
           fi

--- a/.github/workflows/minimal-review.yml
+++ b/.github/workflows/minimal-review.yml
@@ -1,3 +1,10 @@
+# GENERATED FILE — DO NOT EDIT.
+#
+# Rendered from gominimal/foundry:.github/workflows/minimal-review-impl.yml
+# by review/deploy/render-standalone.py. Edit the implementation there; this
+# copy exists only because a public repo cannot call a reusable workflow in a
+# private one. foundry's review-drift.yml fails when the two disagree.
+#
 name: minimal-review
 
 # The reviewer posts an advisory review and can do nothing else. Four
@@ -22,13 +29,12 @@ on:
         description: "PR number to review"
         required: true
         type: string
-
 permissions:
   contents: read
   pull-requests: write
 
-# Debounce `synchronize` bursts: a push that lands three commits in ten seconds
-# should produce one review of the final head, not three of intermediate trees.
+# Debounce `synchronize` bursts: three commits in ten seconds should produce one
+# review of the final head, not three of intermediate trees.
 concurrency:
   group: minimal-review-${{ github.event.pull_request.number || github.event.inputs.pr }}
   cancel-in-progress: true
@@ -75,8 +81,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      # Wait before spending anything, so a burst of pushes cancels this run
-      # before the agent starts rather than halfway through it.
+      # A fork PR must never reach a credential. The job-level `if` above
+      # already refuses one, but that `if` lives in a file the PR under review
+      # can edit, so this re-checks before anything is minted.
+      - name: Refuse fork PRs
+        env:
+          CALLER: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "pull_request" ] && [ "$HEAD_REPO" != "$CALLER" ]; then
+            echo "::error::fork PR from $HEAD_REPO reached the reviewer; refusing before any credential is minted."
+            exit 1
+          fi
+          echo "caller: $CALLER ($EVENT)"
+
       - name: Quiet window
         id: quiet
         if: github.event_name == 'pull_request'
@@ -118,6 +138,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: gominimal/foundry
+          # Standalone: job.workflow_sha would name a commit in THIS repo, not
+          # in foundry. The default branch is the only available pin, so this
+          # copy carries the version skew the gate's forward-compat shim absorbs.
           ref: main
           token: ${{ steps.app-token.outputs.token }}
           path: reviewer

--- a/.github/workflows/minimal-review.yml
+++ b/.github/workflows/minimal-review.yml
@@ -122,6 +122,7 @@ jobs:
       # GITHUB_TOKEN is scoped to this repo alone, so a plain cross-repo
       # checkout gets "Repository not found". Minted first: the next step needs it.
       - name: Mint a token for the private reviewer and broker repos
+        if: steps.quiet.outputs.status != 'stale'
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
@@ -135,6 +136,7 @@ jobs:
       # it is reviewed by, and the reviewer upgrades in one place for every repo
       # that installs it.
       - name: Check out the reviewer (gominimal/foundry@main)
+        if: steps.quiet.outputs.status != 'stale'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: gominimal/foundry
@@ -153,23 +155,32 @@ jobs:
       # broker. Dispatch requires write access, but "trusted to trigger" is not
       # "meant to review anything".
       - name: Refuse a fork PR on dispatch
+        id: dispatch_pr
         if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.inputs.pr }}
         run: |
           set -euo pipefail
-          head_repo="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.repo.full_name // ""')"
+          pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          head_repo="$(printf '%s' "$pr" | jq -r '.head.repo.full_name // ""')"
           if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
             echo "::error::PR #$PR_NUMBER has its head in '${head_repo:-<deleted>}', not $GITHUB_REPOSITORY. Fork review is out of scope."
             exit 1
           fi
-          echo "PR #$PR_NUMBER is same-repo"
+          # The same response carries the base. Without this the dispatch path
+          # falls back to the default branch, so a PR targeting a release branch
+          # or stacked on another PR gets a diff containing commits it never
+          # introduced — and every anchor lands on code it did not change.
+          printf '%s' "$pr" | jq -r '"base_ref=" + .base.ref' >> "$GITHUB_OUTPUT"
+          printf '%s' "$pr" | jq -r '"base_sha=" + .base.sha' >> "$GITHUB_OUTPUT"
+          echo "PR #$PR_NUMBER is same-repo, base $(printf '%s' "$pr" | jq -r .base.ref)"
 
       # `ref` is load-bearing: the default checkout for a pull_request event is
       # the MERGE commit, a tree that exists in no branch. Every finding anchor
       # would silently point at line numbers the PR does not have.
       - name: Check out the tree under review (PR HEAD, not the merge commit)
+        if: steps.quiet.outputs.status != 'stale'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.inputs.pr) }}
@@ -178,6 +189,7 @@ jobs:
           persist-credentials: false
 
       - name: Choose which reviewer to run
+        if: steps.quiet.outputs.status != 'stale'
         run: |
           set -euo pipefail
           # foundry reviews itself with its own PR's staging code, because a
@@ -194,14 +206,15 @@ jobs:
           echo "reviewer: $REVIEWER"
 
       - name: Resolve the PR and stage the reviewer's inputs
+        if: steps.quiet.outputs.status != 'stale'
         id: pr
         working-directory: pr
         env:
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           INPUT_PR_NUMBER: ${{ github.event.inputs.pr }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref || steps.dispatch_pr.outputs.base_ref }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha || steps.dispatch_pr.outputs.base_sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -236,14 +249,18 @@ jobs:
           BASE_SHA="$(git merge-base "$BASE_TIP" HEAD)"
 
           # The policy sets the confidence floor and the inline cap — it governs
-          # the gate, so it cannot come from the branch being gated. Taken from
-          # the merge base: still this repo's own committed policy, but the
-          # version that was already reviewed and merged, so a PR cannot raise
-          # min_confidence or set max_inline_findings to 0 and silence itself.
+          # the gate, so it cannot come from the branch being gated. Taken from the
+          # base branch TIP, not the merge base. Both keep the anti-tamper
+          # property — neither is PR-controlled — but the merge base is the
+          # newest commit the branch already shares, so a PR cut before the
+          # policy was added or last tightened keeps reading the old version, or
+          # none at all and the permissive built-in defaults, for its whole life.
+          # Silently, and for reasons unrelated to anything it changed.
           # A policy change takes effect for the PRs after it, not for itself.
           # Absent is fine — every reader falls back to the built-in defaults.
-          if git show "$BASE_SHA:.minimal/review/policy.toml" > "$RUN_DIR/policy.toml" 2>/dev/null; then
-            echo "policy: from base ${BASE_SHA:0:12}"
+          POLICY_SHA="$(git rev-parse "$BASE_TIP")"
+          if git show "$POLICY_SHA:.minimal/review/policy.toml" > "$RUN_DIR/policy.toml" 2>/dev/null; then
+            echo "policy: from base tip ${POLICY_SHA:0:12}"
           else
             rm -f "$RUN_DIR/policy.toml"
             echo "policy: none at base; using built-in defaults"
@@ -283,15 +300,37 @@ jobs:
           # Findings already dismissed. Always from the default branch, never
           # $REVIEWER: a PR must not choose what its own reviewer stays silent
           # about. Absent is a valid empty state.
-          if [ -f "$GITHUB_WORKSPACE/reviewer/review/learnings/minimal.md" ]; then
-            cp "$GITHUB_WORKSPACE/reviewer/review/learnings/minimal.md" .review/learnings.md
+          # Derived from the repo, not a hardcoded name. Every other repo-scoped
+          # read in this file keys off $GITHUB_REPOSITORY; this one named
+          # `minimal.md` literally, so in a workflow explicitly meant to be
+          # installed everywhere, each repo would load minimal's dismissals
+          # instead of its own — silently defeating the one mechanism that stops
+          # the reviewer repeating a finding a team already rejected.
+          LEARNINGS="$GITHUB_WORKSPACE/reviewer/review/learnings/${GITHUB_REPOSITORY##*/}.md"
+          if [ -f "$LEARNINGS" ]; then
+            cp "$LEARNINGS" .review/learnings.md
+            echo "learnings: $(wc -l < .review/learnings.md) lines from ${GITHUB_REPOSITORY##*/}.md"
           else
             printf '# Dismissed findings\n\n_None recorded yet._\n' > .review/learnings.md
+            echo "learnings: none recorded for ${GITHUB_REPOSITORY##*/}"
           fi
 
           # No-build shims; the task prepends this directory to PATH.
           mkdir -p .review/nobuild
-          for tool in cargo rustc cargo-clippy cargo-nextest; do
+          # The union, not the language this repo happens to be. A Rust-only
+          # blocklist on an Astro/Node repo left `pnpm build` wide open — the
+          # guard read as enforcement while enforcing nothing. Deriving the list
+          # from the detected repo map would work too, and would be one more
+          # thing to get wrong per language; the reviewer must not build
+          # anything, so the union states that directly.
+          # `node` is deliberately absent. It is an interpreter, not a build
+          # driver — npm/pnpm/yarn/npx already stop `pnpm build` — and shimming
+          # it risks breaking the agent's own runtime if claude-code launches
+          # through `#!/usr/bin/env node`. Blocking the reviewer is a worse
+          # outcome than a build already stopped three other ways.
+          for tool in cargo rustc cargo-clippy cargo-nextest \
+                      npm pnpm yarn npx \
+                      go make cmake; do
             cat > ".review/nobuild/$tool" <<'STUB'
           #!/bin/sh
           echo "$(date -u +%H:%M:%S) $(basename "$0") $*" >> "$PWD/.review/build-attempts.log"
@@ -310,6 +349,7 @@ jobs:
           echo "PR #$PR_NUMBER  head=$HEAD_SHA  base=$BASE_SHA  $(wc -l < .review/pr.diff) diff lines"
 
       - name: Install the review library and stage the generated schema
+        if: steps.quiet.outputs.status != 'stale'
         id: lib
         env:
           LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
@@ -405,6 +445,7 @@ jobs:
              "$GITHUB_WORKSPACE/pr/.review/learnings.md" "$RUN_DIR/" 2>/dev/null || true
 
       - name: Install Minimal
+        if: steps.quiet.outputs.status != 'stale'
         run: |
           set -euo pipefail
           curl -fsSL "https://go.minimal.dev/${MINIMAL_CHANNEL}" | sh
@@ -417,9 +458,11 @@ jobs:
       # package build dies with write("/proc/self/uid_map") => Operation not
       # permitted. Same line gominimal/minimal's own ci-linux-native.yml uses.
       - name: Enable unprivileged user namespaces
+        if: steps.quiet.outputs.status != 'stale'
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Report the isolation backend
+        if: steps.quiet.outputs.status != 'stale'
         run: |
           set -euo pipefail
           command -v min >/dev/null || { echo "::error::min is not on PATH after install"; exit 1; }
@@ -436,15 +479,17 @@ jobs:
       # an OAuth Bearer upstream, so no credential material reaches the sandbox:
       # the box gets a placeholder token and a base URL pointing back here.
       - name: Check out the credential broker (gominimal/broker)
+        if: steps.quiet.outputs.status != 'stale'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: gominimal/broker
-          ref: e6e0c29b74a4fd93258ec028325a97fc3ab639a8
+          ref: d4b53da036ed5fc8ab51accadfdea0d79d5fa055
           token: ${{ steps.app-token.outputs.token }}
           path: broker
           persist-credentials: false
 
       - name: Start the credential broker and preflight it
+        if: steps.quiet.outputs.status != 'stale'
         env:
           CLAUDE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Host-side only. The sandbox never sees this — it gets a placeholder
@@ -475,12 +520,16 @@ jobs:
           echo "$health" | tee "$RUN_DIR/broker-health.json"
           # Fail fast: a keyless broker makes the agent retry in silence until
           # its timeout.
-          if ! echo "$health" | grep -qE '"(claude_oauth_loaded|openrouter_loaded)": true'; then
+          # jq, not grep: the pattern required a literal space after the colon,
+          # so a broker emitting the same document compactly would abort a run
+          # holding a perfectly good credential.
+          if ! printf '%s' "$health" | jq -e '[.. | objects | (.claude_oauth_loaded, .openrouter_loaded)] | any(. == true)' > /dev/null 2>&1; then
             echo "::error::broker holds no model credential — aborting before minting a session"
             exit 1
           fi
 
       - name: Inject the review task (runtime only — never committed)
+        if: steps.quiet.outputs.status != 'stale'
         working-directory: pr
         run: |
           set -euo pipefail
@@ -576,11 +625,16 @@ jobs:
           env_vars.ANTHROPIC_MODEL = "${REVIEW_MODEL}"
           bash = '''
           set -eu
-          command -v claude >/dev/null 2>&1 || { echo 'review: no claude on PATH' >&2; exit 66; }
-
           # The stack puts cargo on PATH whatever this task's packages say, so
           # no-build is enforced by these shims, which refuse and log attempts.
           export PATH="\$PWD/.review/nobuild:\$PATH"
+
+          # Probe AFTER the shims are armed, not before. Probing first tests an
+          # environment the agent never runs in: if a shim shadows something
+          # claude needs to start, the check passes and the agent then dies at
+          # exit 127 with nothing explaining why. Fail here, where it can say so.
+          command -v claude >/dev/null 2>&1 || { echo 'review: no claude on PATH (shims armed — one may be shadowing its launcher)' >&2; exit 66; }
+          claude --version >/dev/null 2>&1 || { echo 'review: claude is on PATH but will not start under the no-build shims' >&2; exit 66; }
 
           # Preflight the path the AGENT will use, not the one the host can
           # reach. The host-side /health check passes on 127.0.0.1 whatever the


### PR DESCRIPTION
`minimal-review.yml` is copy-pasted into five repos and hand-maintained. Fixes have been landing in [gominimal/foundry](https://github.com/gominimal/foundry)'s copy only. This is the furthest behind of the five — **16 fixes**, several load-bearing.

Regenerated from foundry `main` plus the install-only delta (App-token mint and the two cross-repo checkouts) rather than hand-patched, so the diff is exactly the drift and nothing else. The three private installs got the same treatment and are byte-identical to this file.

### What was missing, and what it cost

| | Fix | Consequence today |
|---|---|---|
| 1 | Lifecycle-hook strip | Every review dies the day this repo adds a `[[session.lifecycle_hooks]]` — the failure that killed every `webapp` review |
| 2 | `rc=0; … \|\| rc=$?` | The bare `rc=$?` never ran. Steps are `bash -e {0}` and `set -uo pipefail` does not clear `-e`, so **every exit-75/65/66/67 diagnostic path here is dead code** |
| 3–5 | Meter / emit / `[telemetry]` extra | No telemetry at all. Granting `LOGFIRE_TOKEN` would have produced nothing |
| 6–7 | `repo_map` output, `upstream`+`repomap` in run.json | `run.json` has 9 keys instead of 11 |
| 8–10 | `MINIMAL_REVIEW_TASK` knob | `[tasks.review]` is hardcoded at three sites. The day this repo declares its own `review` task the reviewer dies **with no override available** |
| 11–13 | OpenRouter support + either-credential guard | `MINIMAL_REVIEW_KEY` appears zero times; this repo is Claude-only at both the guard and the health check |
| 14 | Broker pin `e1d3188c` → `e6e0c29b` | Two commits behind, missing "route /anthropic to OpenRouter when MINIMAL_REVIEW_KEY is set" |
| 15 | `upstream_unavailable` rename | Reports a 502 under a label reading "rate limited" |
| 16 | Gate forward-compat shim | The shim exists *precisely because* the workflow comes from the PR while the gate comes from `foundry@main`. This is the one copy without it, so it dies first on a `TypeError` the next time the gate's signature changes — and it never passes `pr`/`head_sha`, so its gate cannot cross-check the document's claimed PR against the real one |

### Verification

Generated file diffs against the three private installs at zero lines. Against this repo's current copy: 24 hunks, all of them the fixes above. YAML parses; both heredocs balanced.

Nothing here is repo-specific — all per-repo config is already repository or organization variables (`MINIMAL_REVIEW_TASK`, `MINIMAL_REVIEW_MODEL`, `MINIMAL_CHANNEL`, `MINIMAL_REVIEW_HOST_ALIAS`).

### Follow-up

Copy-pasting an 800-line workflow into five repos is the actual defect; this PR only makes the copies agree today. The structural fix — one `on: workflow_call` implementation with thin pinned callers — is in progress in foundry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)