### PR TITLE
feat: added patch source anchor for loadout root

### DIFF
--- a/.minimal/minimal.toml
+++ b/.minimal/minimal.toml
@@ -1,7 +1,7 @@
 [upstream] # Source of software & tooling
 repo = "https://github.com/gominimal/pkgs"
 branch = "main"
-locked_commit = "b1a1b1b7275d06dcd9235708a648c88e928b9462"
+locked_commit = "ff15baa9a765148b7ec28f18b1019e12adeaa4da"
 
 [stack]
 use = "rust"

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -2041,7 +2041,7 @@ async fn activate_session(
     // connection context; the client doesn't send it.
     let config = minimald_rpc::SessionConfig {
         name: Some(session_name),
-        project_path: abs_path,
+        project_path: abs_path.clone(),
         network: args.network.into(),
         policy,
         hooks_enabled: !args.no_hooks,
@@ -2072,8 +2072,7 @@ async fn activate_session(
     // touches the daemon: a mistyped path, a symlinked script, or a
     // missing loadout script directory should fail here, on this
     // machine, rather than after a session exists on the daemon.
-    let hook_scripts =
-        loadouts::stage_loadout_hook_scripts(&active, global, &utf8_path, !args.no_hooks)?;
+    let hook_scripts = loadouts::stage_loadout_hook_scripts(&active, &abs_path, !args.no_hooks)?;
 
     // Same idea for the *project's* hooks, which the daemon composes from
     // the uploaded mfile and which therefore never pass through the
@@ -2081,7 +2080,7 @@ async fn activate_session(
     // its own scripts — but the checks a staging pass would have made are
     // still worth making on this machine, before a session exists.
     if !args.no_hooks {
-        loadouts::check_project_hooks(&utf8_path)?;
+        loadouts::check_project_hooks(&abs_path)?;
     }
 
     // The daemon runs the composition's `on_activate` hooks inside

--- a/crates/minimal/src/loadouts.rs
+++ b/crates/minimal/src/loadouts.rs
@@ -99,6 +99,15 @@ fn builtin_default_loadout() -> sessions::core::loadout::Loadout {
 pub(crate) struct ActiveLoadouts {
     /// The loadouts to compose, in application order.
     pub(crate) loadouts: Vec<sessions::core::loadout::Loadout>,
+    /// The directory these loadouts were read from — whatever
+    /// `--config-dir` / `$XDG_CONFIG_HOME` resolved to for this run.
+    ///
+    /// Travels with the loadouts rather than being recomputed by each
+    /// consumer, so everything anchored at a loadout's own directory
+    /// (`<dir>/<name>/`) — its external hook scripts, and
+    /// `$LOADOUT_ROOT` in its patch sources — resolves against the
+    /// directory the files actually came from.
+    pub(crate) loadouts_dir: paths::HostAbsPath,
     /// True when the zero-config fallback used the built-in `default`
     /// loadout (as opposed to user files, including a shadowing user
     /// `default.toml`).
@@ -121,11 +130,12 @@ pub(crate) fn resolve_active_loadouts(
     cfg: &sessions::client::config::Config,
     global: &GlobalArgs,
 ) -> Result<ActiveLoadouts, anyhow::Error> {
-    let loadouts_dir = resolve_minimal_config_dir(global).join("loadouts");
+    let loadouts_dir = resolve_loadouts_dir_for_activation(global)?;
     let (names, source): (Vec<String>, &str) = match selection {
         LoadoutSelection::None => {
             return Ok(ActiveLoadouts {
                 loadouts: Vec::new(),
+                loadouts_dir,
                 builtin_default: false,
             });
         }
@@ -137,9 +147,10 @@ pub(crate) fn resolve_active_loadouts(
                 // Fall back to the built-in `default` loadout unless
                 // the user shadows it with their own `default.toml`,
                 // in which case that file is loaded instead.
-                if !loadouts_dir.join("default.toml").exists() {
+                if !loadouts_dir.as_utf8_path().join("default.toml").exists() {
                     return Ok(ActiveLoadouts {
                         loadouts: vec![builtin_default_loadout()],
+                        loadouts_dir,
                         builtin_default: true,
                     });
                 }
@@ -152,19 +163,58 @@ pub(crate) fn resolve_active_loadouts(
     let loadouts = names
         .iter()
         .map(|name| {
-            let path = loadouts_dir.join(format!("{name}.toml"));
+            let path = loadouts_dir.as_utf8_path().join(format!("{name}.toml"));
             // `LoadError`'s Display already embeds its I/O source, so flatten
             // it to a leaf before adding context; otherwise anyhow re-renders
             // the underlying error a second time from the chain.
-            sessions::client::disk::read_loadout_file(&path)
+            sessions::client::disk::read_loadout_file(path.as_std_path())
                 .map_err(|e| anyhow::anyhow!("{e}"))
                 .with_context(|| format!("{source} `{name}`"))
         })
         .collect::<Result<Vec<_>, _>>()?;
     Ok(ActiveLoadouts {
         loadouts,
+        loadouts_dir,
         builtin_default: false,
     })
+}
+
+/// The loadouts directory an activation reads from:
+/// `<config>/minimal/loadouts`, under whatever
+/// [`resolve_minimal_config_dir`] resolved for this run.
+///
+/// UTF-8 is required rather than best-effort: the directory is joined
+/// with a loadout's name to anchor that loadout's own files (hook
+/// scripts, `$LOADOUT_ROOT` patch sources), and those anchors travel
+/// through UTF-8 path types all the way to the daemon.
+///
+/// A **relative** `--config-dir` is anchored at the process working
+/// directory rather than refused. Every other consumer of the flag
+/// reads it straight off the CWD, so refusing one here would break
+/// `--config-dir some/rel/dir` for every activation — including ones
+/// that apply no loadouts at all — over an anchor those runs never use.
+/// The join is lexical (no `canonicalize`): the directory need not
+/// exist yet, and resolving symlinks here would quietly change which
+/// path a loadout's hook scripts are checked against. One consequence:
+/// a relative dir containing `..` stays unnormalized, so a loadout
+/// under it that uses `$LOADOUT_ROOT` fails expansion, which rejects
+/// `..` in any pattern.
+fn resolve_loadouts_dir_for_activation(
+    global: &GlobalArgs,
+) -> Result<paths::HostAbsPath, anyhow::Error> {
+    let dir = resolve_minimal_config_dir(global).join("loadouts");
+    let utf8 = camino::Utf8PathBuf::from_path_buf(dir)
+        .map_err(|p| anyhow::anyhow!("loadouts directory is not valid UTF-8: {}", p.display()))?;
+    match paths::HostAbsPath::try_new(utf8) {
+        Ok(abs) => Ok(abs),
+        Err(paths::Error::NotAbsolute(rel)) => {
+            let cwd = paths::HostAbsPath::from_cwd()
+                .context("resolving a relative --config-dir against the working directory")?;
+            paths::HostAbsPath::try_new(cwd.as_utf8_path().join(rel))
+                .map_err(|e| anyhow::anyhow!("loadouts directory: {e}"))
+        }
+        Err(e) => Err(anyhow::anyhow!("loadouts directory: {e}")),
+    }
 }
 
 /// Human-readable list of the active loadouts, as interpolated into the
@@ -213,8 +263,7 @@ pub(crate) fn compose_options_from_config(
 /// nothing is staged, uploaded, or run.
 pub(crate) fn stage_loadout_hook_scripts(
     active: &ActiveLoadouts,
-    global: &GlobalArgs,
-    project_root: &camino::Utf8Path,
+    project_root: &paths::HostAbsPath,
     hooks_enabled: bool,
 ) -> Result<Vec<sessions::client::hookscripts::StagedScript>, anyhow::Error> {
     use sessions::client::hookscripts::{ScriptAnchors, stage_external_scripts};
@@ -223,11 +272,6 @@ pub(crate) fn stage_loadout_hook_scripts(
     if !hooks_enabled {
         return Ok(Vec::new());
     }
-    let loadouts_dir =
-        camino::Utf8PathBuf::from_path_buf(resolve_minimal_config_dir(global).join("loadouts"))
-            .map_err(|p| {
-                anyhow::anyhow!("loadouts directory is not valid UTF-8: {}", p.display())
-            })?;
 
     let hooks: Vec<ProvenancedHook> = active
         .loadouts
@@ -243,8 +287,8 @@ pub(crate) fn stage_loadout_hook_scripts(
         .collect();
 
     let anchors = ScriptAnchors {
-        loadouts_dir,
-        project_root: project_root.to_owned(),
+        loadouts_dir: active.loadouts_dir.clone(),
+        project_root: project_root.clone(),
     };
     stage_external_scripts(&hooks, &anchors).map_err(|e| anyhow::anyhow!("{e}"))
 }
@@ -265,12 +309,12 @@ pub(crate) fn stage_loadout_hook_scripts(
 /// A project with no mfile, or one that does not parse, is not this
 /// function's problem — the activation has its own handling for both, and
 /// duplicating it here would report the same fault twice.
-pub(crate) fn check_project_hooks(project_root: &camino::Utf8Path) -> Result<(), anyhow::Error> {
+pub(crate) fn check_project_hooks(project_root: &paths::HostAbsPath) -> Result<(), anyhow::Error> {
     use sessions::client::hookscripts::{ScriptAnchors, stage_external_scripts};
     use sessions::core::lifecyclehook::{HookScript, HookScriptBody};
     use sessions::core::source::{ProvenancedHook, Source};
 
-    let Ok(mfile) = mfile::File::from_dir(project_root.as_std_path()) else {
+    let Ok(mfile) = mfile::File::from_dir(project_root.as_utf8_path().as_std_path()) else {
         return Ok(());
     };
     let Some(session) = mfile.session.as_ref() else {
@@ -312,14 +356,14 @@ pub(crate) fn check_project_hooks(project_root: &camino::Utf8Path) -> Result<(),
                 h.clone(),
                 Source::Project {
                     path: paths::HostPath::try_new(project_root.as_str())
-                        .expect("an activation's project path is a valid host path"),
+                        .expect("an absolute host path is a valid host path"),
                 },
             )
         })
         .collect();
     let anchors = ScriptAnchors {
-        loadouts_dir: project_root.to_owned(),
-        project_root: project_root.to_owned(),
+        loadouts_dir: project_root.clone(),
+        project_root: project_root.clone(),
     };
     stage_external_scripts(&provenanced, &anchors).map_err(|e| anyhow::anyhow!("{e}"))?;
     Ok(())
@@ -413,7 +457,11 @@ pub(crate) fn compose_user_contribution(
     };
 
     let mut composer = sessions::client::composer::UserComposer::new()
-        .with_orientation(sessions::core::compose::Orientation { loadouts_display });
+        .with_orientation(sessions::core::compose::Orientation { loadouts_display })
+        // Anchors `$LOADOUT_ROOT` in the loadouts' patch sources at the
+        // directory they were read from, so a loadout can patch in files
+        // shipped beside it without naming an absolute config path.
+        .with_loadouts_dir(active.loadouts_dir);
     composer
         .add_all(loadouts)
         .map_err(|e| anyhow::anyhow!("composing loadouts: {e}"))?;
@@ -609,6 +657,14 @@ impl LoadoutRow {
 mod tests {
     use super::*;
 
+    /// The directory these tests pretend their hand-built loadouts were
+    /// read from. Nothing here declares a `$LOADOUT_ROOT` patch source
+    /// or an external hook script, so the path only has to be
+    /// well-formed — it is never touched on disk.
+    fn stub_loadouts_dir() -> paths::HostAbsPath {
+        paths::HostAbsPath::try_new("/nonexistent/minimal/loadouts").unwrap()
+    }
+
     /// `LoadoutSelection::from_flags` — full truth table.
     #[test]
     fn loadout_selection_from_flags_truth_table() {
@@ -730,6 +786,7 @@ on_activate = { type = "inline", value = "echo activated" }
         let (wire, _policy) = compose_user_contribution(
             ActiveLoadouts {
                 loadouts: vec![loadout],
+                loadouts_dir: stub_loadouts_dir(),
                 builtin_default: false,
             },
             sessions::core::policy::UserPolicy::empty(),
@@ -768,6 +825,7 @@ on_activate = { type = "inline", value = "sleep 90", timeout = 90 }
         .expect("loadout parses");
         let active = ActiveLoadouts {
             loadouts: vec![loadout],
+            loadouts_dir: stub_loadouts_dir(),
             builtin_default: false,
         };
         // A tempdir with no minimal.toml: the project side contributes
@@ -845,6 +903,7 @@ on_activate = { type = "inline", value = "sleep 90", timeout = 90 }
         };
         let active = ActiveLoadouts {
             loadouts: vec![mk("helix"), mk("fish")],
+            loadouts_dir: stub_loadouts_dir(),
             builtin_default: false,
         };
         assert_eq!(loadout_display_list(&active), "helix, fish");
@@ -860,6 +919,7 @@ on_activate = { type = "inline", value = "sleep 90", timeout = 90 }
         let (wire, _policy) = compose_user_contribution(
             ActiveLoadouts {
                 loadouts: Vec::new(),
+                loadouts_dir: stub_loadouts_dir(),
                 builtin_default: true,
             },
             sessions::core::policy::UserPolicy::empty(),
@@ -928,6 +988,77 @@ on_activate = { type = "inline", value = "sleep 90", timeout = 90 }
         assert_eq!(loadout_display_list(&out), "default");
     }
 
+    /// Every resolution carries the loadouts directory it read from,
+    /// and that directory follows `--config-dir` — this is what makes
+    /// `$LOADOUT_ROOT` (and a loadout's hook scripts) resolve against
+    /// the files that are actually in play, not a platform default.
+    ///
+    /// Asserted across all three exits: the `--no-loadouts`
+    /// short-circuit, the zero-config built-in fallback, and a real
+    /// file read from disk.
+    #[test]
+    fn resolve_active_loadouts_carries_the_effective_loadouts_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loadouts = tmp.path().join("minimal/loadouts");
+        std::fs::create_dir_all(&loadouts).unwrap();
+        let expected = paths::HostAbsPath::try_new(
+            camino::Utf8PathBuf::from_path_buf(loadouts.clone()).unwrap(),
+        )
+        .unwrap();
+        let cfg = sessions::client::config::Config::default();
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(tmp.path().to_path_buf()),
+            provider: None,
+            no_input: false,
+        };
+
+        let none = resolve_active_loadouts(LoadoutSelection::None, &cfg, &global).unwrap();
+        assert_eq!(none.loadouts_dir, expected, "--no-loadouts");
+
+        let builtin = resolve_active_loadouts(LoadoutSelection::Defaults, &cfg, &global).unwrap();
+        assert!(builtin.builtin_default);
+        assert_eq!(builtin.loadouts_dir, expected, "built-in fallback");
+
+        std::fs::write(loadouts.join("dev.toml"), "description = \"d\"\n").unwrap();
+        let named = resolve_active_loadouts(
+            LoadoutSelection::Cli(vec!["dev".to_string()]),
+            &cfg,
+            &global,
+        )
+        .unwrap();
+        assert_eq!(named.loadouts_dir, expected, "--loadout dev");
+        assert_eq!(named.loadouts[0].name().as_ref(), "dev");
+    }
+
+    /// A relative `--config-dir` still resolves: it is anchored at the
+    /// working directory, the way every other consumer of the flag
+    /// reads it.
+    ///
+    /// Regression guard. `$LOADOUT_ROOT` needs an absolute anchor, but
+    /// that requirement must not leak back onto the flag — a run with
+    /// no loadouts at all (or none using the reference) has no business
+    /// failing because the config dir was spelled relatively.
+    #[test]
+    fn resolve_active_loadouts_anchors_a_relative_config_dir_at_the_cwd() {
+        let cfg = sessions::client::config::Config::default();
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(PathBuf::from("rel-cfg")),
+            provider: None,
+            no_input: false,
+        };
+        let out = resolve_active_loadouts(LoadoutSelection::None, &cfg, &global)
+            .expect("a relative --config-dir must still resolve");
+        let cwd = camino::Utf8PathBuf::from_path_buf(std::env::current_dir().unwrap()).unwrap();
+        assert_eq!(
+            out.loadouts_dir.as_utf8_path(),
+            cwd.join("rel-cfg/minimal/loadouts"),
+        );
+    }
+
     /// The built-in listing row carries the `(built-in)` tag and a
     /// zero-package contributes cell.
     #[test]
@@ -983,6 +1114,7 @@ on_activate = { type = "inline", value = "sleep 90", timeout = 90 }
             );
             let active = ActiveLoadouts {
                 loadouts: vec![loadout],
+                loadouts_dir: stub_loadouts_dir(),
                 builtin_default: false,
             };
             let (contribution, _) = compose_user_contribution(

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -307,7 +307,7 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
 
     let config = minimald_rpc::SessionConfig {
         name: Some(task_session_name(&args.task, &crate::random_hex4())),
-        project_path: abs_path,
+        project_path: abs_path.clone(),
         network: sessions::NetworkMode::HostNet,
         policy: sessions::SessionPolicy::default(),
         // Same default as an activate with no flags, matching the
@@ -334,8 +334,7 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
     }
     // Same pre-daemon staging as an activate, so a broken hook script
     // path fails here rather than after the ephemeral session exists.
-    let hook_scripts =
-        crate::loadouts::stage_loadout_hook_scripts(&active, global, &utf8_path, true)?;
+    let hook_scripts = crate::loadouts::stage_loadout_hook_scripts(&active, &abs_path, true)?;
 
     // Same first-class orientation field as an activate: a `--keep`
     // task session is attachable later, and its banner should orient

--- a/crates/sessions/src/client/composer.rs
+++ b/crates/sessions/src/client/composer.rs
@@ -2,8 +2,8 @@
 //! their policy, and emits a wire contribution to ship to the daemon.
 
 use crate::core::compose::{
-    Composable, ComposeError, ComposeOptions, Composition, Contribution, Error, StoredEnv,
-    compose_contribution, default_env,
+    Composable, ComposeError, ComposeOptions, Composition, Contribution, Error, PatchAnchors,
+    StoredEnv, compose_contribution, default_env,
 };
 use crate::core::loadout::Loadout;
 use crate::core::policy::UserPolicy;
@@ -30,6 +30,13 @@ pub struct UserComposer {
     ///
     /// [`Source::UserLoadout`]: crate::core::source::Source::UserLoadout
     seen_names: std::collections::HashSet<crate::core::loadout::LoadoutName>,
+    /// The directory the added loadouts were read from, set via
+    /// [`Self::with_loadouts_dir`]. Anchors `$LOADOUT_ROOT` in their
+    /// patch sources: loadout `dev` resolves it to `<dir>/dev`. Unset
+    /// means no loadout here can use the reference — the composer has
+    /// no way to guess which directory a loadout came from, and a wrong
+    /// guess would patch from the wrong tree.
+    loadouts_dir: Option<paths::HostAbsPath>,
     /// First-prompt orientation facts, set via
     /// [`Self::with_orientation`] and emitted on the composed
     /// [`WireContribution`] as a first-class field — control plane,
@@ -43,6 +50,7 @@ impl core::fmt::Debug for UserComposer {
         f.debug_struct("UserComposer")
             .field("contribution", &self.contribution)
             .field("seen_names", &self.seen_names)
+            .field("loadouts_dir", &self.loadouts_dir)
             .field("orientation", &self.orientation)
             .field("env", &"<closure>")
             .finish()
@@ -68,6 +76,7 @@ impl UserComposer {
         Self {
             contribution: Contribution::new(),
             seen_names: std::collections::HashSet::new(),
+            loadouts_dir: None,
             orientation: crate::core::compose::Orientation::default(),
             env: default_env(),
         }
@@ -78,6 +87,22 @@ impl UserComposer {
     #[must_use]
     pub fn with_env(mut self, env: StoredEnv) -> Self {
         self.env = env;
+        self
+    }
+
+    /// Set the directory the loadouts being added were read from, which
+    /// is what `$LOADOUT_ROOT` in their patch sources resolves against —
+    /// loadout `dev` gets `<dir>/dev`, the same directory its external
+    /// hook scripts resolve against.
+    ///
+    /// The caller sets this rather than the composer deriving it: which
+    /// directory is in play depends on how the CLI resolved its config
+    /// dir (`--config-dir`, `$XDG_CONFIG_HOME`, the platform default),
+    /// and only the caller knows that. Leaving it unset means loadouts
+    /// added here cannot use the reference at all.
+    #[must_use]
+    pub fn with_loadouts_dir(mut self, dir: paths::HostAbsPath) -> Self {
+        self.loadouts_dir = Some(dir);
         self
     }
 
@@ -156,14 +181,10 @@ impl UserComposer {
         // (this is the user's own process environment, so it's the
         // right HOME to use when the loadout doesn't declare one).
         let home_fallback = (*self.env)("HOME").ok();
-        let (composition, final_policy) = compose_contribution(
-            self.contribution,
-            &[],
-            policy,
-            None,
-            options,
-            home_fallback.as_deref(),
-        )?;
+        let anchors = PatchAnchors::home(home_fallback.as_deref())
+            .with_loadouts_dir(self.loadouts_dir.as_ref());
+        let (composition, final_policy) =
+            compose_contribution(self.contribution, &[], policy, None, options, anchors)?;
         Ok((
             composition_to_wire(composition, self.orientation),
             final_policy,

--- a/crates/sessions/src/client/handler.rs
+++ b/crates/sessions/src/client/handler.rs
@@ -20,8 +20,8 @@
 //! land at the end.
 
 use crate::core::compose::{
-    ComposeError, ComposeOptions, HookDomain, PendingPatchFile, PendingVar, SessionVar,
-    expand_patch_sources,
+    ComposeError, ComposeOptions, HookDomain, PatchAnchors, PendingPatchFile, PendingVar,
+    SessionVar, expand_patch_sources,
 };
 use crate::core::decision::{CheckOutcome, Decision, ItemDecision};
 use crate::core::enumerate::enumerate_patch_files;
@@ -437,6 +437,11 @@ fn gate_pending_patches(
     }
     let home_fallback = env("HOME").ok();
     let home_fallback = home_fallback.as_deref();
+    // No loadouts directory: nothing on this path was declared by a
+    // loadout (the daemon only sends Package / Project items), so
+    // `$LOADOUT_ROOT` here is refused rather than anchored somewhere
+    // arbitrary.
+    let anchors = PatchAnchors::home(home_fallback);
 
     let mut expanded_policy = policy.expand_with(combined_vars, home_fallback)?;
 
@@ -447,7 +452,7 @@ fn gate_pending_patches(
         pending,
         &expanded_policy,
         combined_vars,
-        home_fallback,
+        anchors,
         options.follow_symlinks,
     )?;
     if unapproved.is_empty() {
@@ -483,7 +488,7 @@ fn enumerate_and_classify_patches(
     pending: Vec<WirePendingPatch>,
     policy: &ExpandedPatchesPolicy,
     combined_vars: &[SessionVar],
-    home_fallback: Option<&str>,
+    anchors: PatchAnchors<'_>,
     follow_symlinks: bool,
 ) -> Result<(Vec<WirePatchVerdict>, Vec<PendingPatchFile>), ComposeError> {
     let mut verdicts: Vec<WirePatchVerdict> = Vec::new();
@@ -505,8 +510,7 @@ fn enumerate_and_classify_patches(
         // `follow_symlinks: None`, which resolves to the compose
         // default at expand time.
         let pp = ProvenancedPatch::new(Patch::new(p.source_pattern, dest), provenance);
-        let expanded =
-            expand_patch_sources(vec![pp], combined_vars, home_fallback, follow_symlinks)?;
+        let expanded = expand_patch_sources(vec![pp], combined_vars, anchors, follow_symlinks)?;
         // Capture the walk root before `enumerate_patch_files`
         // consumes `expanded`. Needed for the synthetic Ignored
         // verdict emitted below when the walk yields zero files.

--- a/crates/sessions/src/client/hookscripts.rs
+++ b/crates/sessions/src/client/hookscripts.rs
@@ -80,28 +80,35 @@ pub enum StageError {
 }
 
 /// Where each kind of contributor's external scripts are anchored.
+///
+/// Both anchors are [`HostAbsPath`](paths::HostAbsPath): a script is
+/// read from the user's own filesystem, and it is resolved by walking
+/// down from the anchor, so an anchor that isn't a known-absolute host
+/// path would silently resolve against the process's working
+/// directory.
 #[derive(Debug, Clone)]
 pub struct ScriptAnchors {
     /// The user's loadouts directory. A loadout named `dev` anchors its
     /// scripts at `<loadouts_dir>/dev/`.
-    pub loadouts_dir: Utf8PathBuf,
+    pub loadouts_dir: paths::HostAbsPath,
     /// The project root, for hooks declared in `minimal.toml`.
-    pub project_root: Utf8PathBuf,
+    pub project_root: paths::HostAbsPath,
 }
 
 impl ScriptAnchors {
     /// The directory `source`'s scripts resolve against, or `None` for
     /// a source that cannot declare scripts.
     #[must_use]
-    pub fn for_source(&self, source: &Source) -> Option<Utf8PathBuf> {
+    pub fn for_source(&self, source: &Source) -> Option<paths::HostAbsPath> {
         match source {
-            // Same guard as `staged_script_path`, for the same reason:
-            // the name is joined into a path that is then read from, so
-            // it has to be a component that stays put. A name this
-            // rejects has no anchor, so its scripts never stage — and
-            // the daemon would refuse to read them anyway.
-            Source::UserLoadout { name } => crate::core::lifecyclehook::safe_path_component(name)
-                .then(|| self.loadouts_dir.join(name)),
+            // `Source::loadout_dir` applies the same guard
+            // `staged_script_path` does, for the same reason: the name is
+            // joined into a path that is then read from, so it has to be a
+            // component that stays put. A name it rejects has no anchor, so
+            // its scripts never stage — and the daemon would refuse to read
+            // them anyway. It is also what `$LOADOUT_ROOT` resolves to, so a
+            // loadout's scripts and its patch sources share one directory.
+            Source::UserLoadout { .. } => source.loadout_dir(&self.loadouts_dir),
             Source::Project { .. } => Some(self.project_root.clone()),
             Source::Package { .. } => None,
         }
@@ -188,12 +195,13 @@ fn external_staged_path(source: &Source, script: &HookScript) -> Option<Utf8Path
 /// [`ConfigRelPath`](paths::ConfigRelPath), which rejects both at
 /// construction.
 fn resolve_under_anchor(
-    anchor: &Utf8Path,
+    anchor: &paths::HostAbsPath,
     rel: &Utf8Path,
     source: &Source,
 ) -> Result<Utf8PathBuf, StageError> {
     let label = source.to_string();
     let script = rel.to_owned();
+    let anchor = anchor.as_utf8_path();
 
     // Absence and unreadability are different problems, told apart here the
     // same way the per-component walk below tells them apart: "no such
@@ -275,9 +283,11 @@ mod tests {
     use crate::core::lifecyclehook::LifecycleHook;
 
     fn anchors(root: &Utf8Path) -> ScriptAnchors {
+        // `root` is a tempdir, so both joins are absolute by
+        // construction.
         ScriptAnchors {
-            loadouts_dir: root.join("loadouts"),
-            project_root: root.join("proj"),
+            loadouts_dir: paths::HostAbsPath::try_new(root.join("loadouts")).unwrap(),
+            project_root: paths::HostAbsPath::try_new(root.join("proj")).unwrap(),
         }
     }
 

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -1376,6 +1376,68 @@ impl ComposeOptions {
     }
 }
 
+/// What a batch of patterns expands against, beyond the session's
+/// resolved variables: the `HOME` fallback for the `~` prefix, and the
+/// directory the user's loadouts were read from.
+///
+/// The compose-side counterpart to
+/// [`expansion::Anchors`](crate::core::expansion::Anchors), which is
+/// per-*pattern* and already resolved. This one is per-*batch* and
+/// still holds the loadouts directory rather than one loadout's
+/// subdirectory of it, because which subdirectory applies is a property
+/// of each patch's own [`Source`] —
+/// [`expand_patch_sources`] derives it per item.
+///
+/// The two fields travel together through the whole patch pipeline
+/// (`compose_contribution` → `gate_patches` → `expand_patch_sources`),
+/// so they ride as one value rather than as a pair of positional
+/// `Option`s that are easy to transpose.
+#[derive(Clone, Copy, Debug, Default)]
+#[non_exhaustive]
+pub(crate) struct PatchAnchors<'a> {
+    /// `HOME` for the `~` / `~/…` prefix, when the session's vars don't
+    /// carry one. Explicit `$HOME` references stay strict.
+    pub(crate) home: Option<&'a str>,
+    /// Where the user's loadout files were read from. `None` — the
+    /// daemon-response path, which sees no loadouts — means no patch in
+    /// the batch can resolve `$LOADOUT_ROOT`.
+    pub(crate) loadouts_dir: Option<&'a paths::HostAbsPath>,
+}
+
+impl<'a> PatchAnchors<'a> {
+    /// Anchors carrying only a `HOME` fallback — the shape every
+    /// caller that composes no loadouts wants.
+    #[must_use]
+    pub(crate) fn home(home: Option<&'a str>) -> Self {
+        Self {
+            home,
+            loadouts_dir: None,
+        }
+    }
+
+    /// Add the directory the loadouts in this batch were read from.
+    #[must_use]
+    pub(crate) fn with_loadouts_dir(
+        mut self,
+        loadouts_dir: Option<&'a paths::HostAbsPath>,
+    ) -> Self {
+        self.loadouts_dir = loadouts_dir;
+        self
+    }
+
+    /// The directory a patch declared by `provenance` anchors
+    /// `$LOADOUT_ROOT` at — its own loadout's, or `None` for a patch no
+    /// loadout declared (and for a batch with no loadouts directory).
+    ///
+    /// Returned owned rather than folded straight into an
+    /// [`Anchors`](crate::core::expansion::Anchors): those borrow their
+    /// anchor strings, so the directory has to outlive them at the call
+    /// site.
+    fn loadout_root(self, provenance: &Source) -> Option<paths::HostAbsPath> {
+        self.loadouts_dir.and_then(|d| provenance.loadout_dir(d))
+    }
+}
+
 // =====================================================================
 // Per-domain gating
 // =====================================================================
@@ -1589,6 +1651,14 @@ pub(crate) fn gate_vars(
 /// expansion would let some patches reach the walker with their
 /// references intact, which silently matches wrong paths.
 ///
+/// `anchors` carries the batch-wide `HOME` fallback and the directory
+/// the user's loadout files were read from; each patch a loadout
+/// declared expands `$LOADOUT_ROOT` against its own subdirectory of
+/// that (see [`PatchAnchors::loadout_root`]). A patch from a
+/// non-loadout source has no such anchor, so a `$LOADOUT_ROOT`
+/// reference there is an error rather than a path pointing at someone
+/// else's tree.
+///
 /// Per-patch `follow_symlinks` is resolved here: any `Some(v)` carried
 /// on the [`ProvenancedPatch`] wins; `None` inherits
 /// `default_follow_symlinks`. The resolved bool is stamped onto the
@@ -1597,15 +1667,18 @@ pub(crate) fn gate_vars(
 pub(crate) fn expand_patch_sources(
     patches: Vec<ProvenancedPatch>,
     gated_vars: &[SessionVar],
-    home_fallback: Option<&str>,
+    anchors: PatchAnchors<'_>,
     default_follow_symlinks: bool,
 ) -> Result<Vec<ExpandedProvenancedPatch>, ComposeError> {
     patches
         .into_iter()
         .map(|pp| {
             let (patch, provenance, follow_override) = pp.into_parts();
+            let loadout_root = anchors.loadout_root(&provenance);
+            let pattern_anchors = crate::core::expansion::Anchors::home(anchors.home)
+                .with_loadout_root(loadout_root.as_ref().map(paths::HostAbsPath::as_str));
             let source =
-                crate::core::expansion::expand_source(patch.source(), gated_vars, home_fallback)?;
+                crate::core::expansion::expand_source(patch.source(), gated_vars, pattern_anchors)?;
             let follow_symlinks = follow_override.unwrap_or(default_follow_symlinks);
             Ok(ExpandedProvenancedPatch {
                 source,
@@ -1620,13 +1693,15 @@ pub(crate) fn expand_patch_sources(
 /// Drive the policy pass over a batch of patches.
 ///
 /// `hooks` is `None` for user-only composition — see [`gate_vars`].
+/// `anchors` is what the patterns expand against — see
+/// [`expand_patch_sources`].
 pub(crate) fn gate_patches(
     items: Vec<ProvenancedPatch>,
     mut policy: PatchesPolicy,
     hooks: Option<&dyn PolicyHooks>,
     options: ComposeOptions,
     gated_vars: &[SessionVar],
-    home_fallback: Option<&str>,
+    anchors: PatchAnchors<'_>,
 ) -> Result<(Vec<SessionPatch>, PatchesPolicy), ComposeError> {
     let name_of = |pf: &PatchFile| pf.user_facing().as_str().to_owned();
     let source_of = |pf: PatchFile| pf.provenance;
@@ -1645,10 +1720,10 @@ pub(crate) fn gate_patches(
     // filesystem work happens. Otherwise a costly walk could complete
     // only to be discarded by a policy-expansion error the user has
     // no IO context for.
-    let mut expanded = policy.expand_with(gated_vars, home_fallback)?;
+    let mut expanded = policy.expand_with(gated_vars, anchors.home)?;
 
     let expanded_patches =
-        expand_patch_sources(items, gated_vars, home_fallback, options.follow_symlinks)?;
+        expand_patch_sources(items, gated_vars, anchors, options.follow_symlinks)?;
     let files = enumerate_patch_files(expanded_patches)?;
 
     // Pass 1: categorize per file.
@@ -1685,7 +1760,7 @@ pub(crate) fn gate_patches(
         let (decisions, new_policy, policy_updated) = prompt_patch_hook(hooks, policy, &view)?;
         policy = new_policy;
         if policy_updated {
-            expanded = policy.expand_with(gated_vars, home_fallback)?;
+            expanded = policy.expand_with(gated_vars, anchors.home)?;
         }
         // Pass 3: apply.
         for (pf, decision) in unapproved.into_iter().zip(decisions) {
@@ -1740,6 +1815,10 @@ pub(crate) fn gate_patches(
 /// needed hook prompts (when `hooks` is `Some`), runs patch expansion
 /// against the resolved vars, and assembles the final structure.
 ///
+/// `anchors` carries the `HOME` fallback and, for `$LOADOUT_ROOT`, the
+/// directory the loadouts were read from. Only the client composes
+/// loadouts, so the daemon side leaves that unset.
+///
 /// # Errors
 ///
 /// See [`ComposeError`].
@@ -1749,7 +1828,7 @@ pub(crate) fn compose_contribution(
     policy: UserPolicy,
     hooks: Option<&dyn PolicyHooks>,
     options: ComposeOptions,
-    home_fallback: Option<&str>,
+    anchors: PatchAnchors<'_>,
 ) -> Result<(Composition, UserPolicy), ComposeError> {
     let Contribution {
         vars,
@@ -1769,9 +1848,10 @@ pub(crate) fn compose_contribution(
     check_var_mismatches(gated_vars.iter(), |v| v.var().name(), |v| v.var().value())?;
     // Patch sources and policy patterns expand against the resolved
     // vars. Explicit `$VAR` references require an explicit
-    // `SessionVar` — no env fallback. The tilde prefix (`~/...`) is
-    // the one exception: it falls back to `home_fallback` if the
-    // loadout didn't declare a `HOME` var.
+    // `SessionVar` — no env fallback. The two exceptions come from
+    // `anchors` rather than the var set: the tilde prefix (`~/...`)
+    // falls back to its `home` if the loadout didn't declare a `HOME`
+    // var, and `$LOADOUT_ROOT` resolves under its `loadouts_dir`.
     //
     // `expansion_vars` carries pre-gated vars from an outer scope
     // (e.g. the client's wire contribution as seen by the daemon)
@@ -1789,7 +1869,7 @@ pub(crate) fn compose_contribution(
         hooks,
         options,
         &combined_for_lookup,
-        home_fallback,
+        anchors,
     )?;
     check_patch_mismatches(
         gated_patches.iter(),
@@ -2158,6 +2238,137 @@ mod tests {
     }
 
     // =================================================================
+    // `$LOADOUT_ROOT` anchoring
+    // =================================================================
+
+    /// Where a patch's `$LOADOUT_ROOT` resolves is decided per patch,
+    /// from the provenance it carries — not once for the whole batch.
+    mod loadout_root_anchoring {
+        use super::*;
+
+        fn loadouts_dir() -> paths::HostAbsPath {
+            paths::HostAbsPath::try_new("/cfg/minimal/loadouts").unwrap()
+        }
+
+        fn rooted_patch(loadout: &str) -> ProvenancedPatch {
+            ProvenancedPatch::new(
+                Patch::new(
+                    "$LOADOUT_ROOT/conf.toml",
+                    PatchDest::try_new("conf.toml").unwrap(),
+                ),
+                Source::UserLoadout {
+                    name: loadout.into(),
+                },
+            )
+        }
+
+        /// Two loadouts declaring the identical pattern resolve to
+        /// their own directories — this is what makes the reference
+        /// mean "beside *me*" rather than "in the loadouts directory".
+        #[test]
+        fn each_patch_anchors_at_its_own_loadouts_subdirectory() {
+            let dir = loadouts_dir();
+            let expanded = expand_patch_sources(
+                vec![rooted_patch("dev"), rooted_patch("ops")],
+                &[],
+                PatchAnchors::default().with_loadouts_dir(Some(&dir)),
+                false,
+            )
+            .unwrap();
+            assert_eq!(
+                expanded[0].source.pattern(),
+                "/cfg/minimal/loadouts/dev/conf.toml"
+            );
+            assert_eq!(
+                expanded[1].source.pattern(),
+                "/cfg/minimal/loadouts/ops/conf.toml"
+            );
+        }
+
+        /// A project's patch has no loadout to be beside, even when a
+        /// loadouts directory is in play for the same composition.
+        #[test]
+        fn a_non_loadout_patch_has_no_anchor() {
+            let pp = ProvenancedPatch::new(
+                Patch::new(
+                    "$LOADOUT_ROOT/conf.toml",
+                    PatchDest::try_new("conf.toml").unwrap(),
+                ),
+                project_source(),
+            );
+            // let-else rather than `unwrap_err`: the Ok side isn't
+            // `Debug`, and printing an expanded patch set adds nothing
+            // to the failure message anyway.
+            let Err(err) = expand_patch_sources(
+                vec![pp],
+                &[],
+                PatchAnchors::default().with_loadouts_dir(Some(&loadouts_dir())),
+                false,
+            ) else {
+                panic!("a project patch must not resolve `$LOADOUT_ROOT`");
+            };
+            assert!(
+                matches!(
+                    err,
+                    ComposeError::Expansion(
+                        crate::core::expansion::ExpandError::LoadoutRootUnavailable { .. }
+                    )
+                ),
+                "got: {err:?}",
+            );
+        }
+
+        /// A caller that never supplied a loadouts directory — the
+        /// daemon-response path — can't anchor a loadout patch either,
+        /// rather than guessing a directory.
+        #[test]
+        fn without_a_loadouts_dir_even_a_loadout_patch_has_no_anchor() {
+            let Err(err) = expand_patch_sources(
+                vec![rooted_patch("dev")],
+                &[],
+                PatchAnchors::default(),
+                false,
+            ) else {
+                panic!("no loadouts dir means no anchor to resolve against");
+            };
+            assert!(
+                matches!(
+                    err,
+                    ComposeError::Expansion(
+                        crate::core::expansion::ExpandError::LoadoutRootUnavailable { .. }
+                    )
+                ),
+                "got: {err:?}",
+            );
+        }
+
+        /// A loadout name that isn't a path component that stays put
+        /// gets no anchor: the name is joined into a path that is then
+        /// read from. `LoadoutName` already rejects these, but wire
+        /// provenance carries an unvetted string.
+        #[test]
+        fn a_name_that_is_not_a_path_component_gets_no_anchor() {
+            let Err(err) = expand_patch_sources(
+                vec![rooted_patch("..")],
+                &[],
+                PatchAnchors::default().with_loadouts_dir(Some(&loadouts_dir())),
+                false,
+            ) else {
+                panic!("`..` must not be joined into an anchor path");
+            };
+            assert!(
+                matches!(
+                    err,
+                    ComposeError::Expansion(
+                        crate::core::expansion::ExpandError::LoadoutRootUnavailable { .. }
+                    )
+                ),
+                "got: {err:?}",
+            );
+        }
+    }
+
+    // =================================================================
     // Vars gating
     // =================================================================
 
@@ -2347,7 +2558,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap();
             assert_eq!(resolved.len(), 1);
@@ -2365,7 +2576,7 @@ mod tests {
                 Some(&PassThroughHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap();
             assert_eq!(resolved.len(), 1);
@@ -2383,7 +2594,7 @@ mod tests {
                 Some(&PassThroughHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(matches!(err, ComposeError::Denied { .. }), "got: {err:?}");
@@ -2402,7 +2613,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(matches!(err, ComposeError::Denied { .. }), "got: {err:?}");
@@ -2419,7 +2630,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap();
             assert!(resolved.is_empty());
@@ -2455,7 +2666,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap();
             resolved.sort_by_key(|sp| sp.patch().destination().as_str().to_owned());
@@ -2485,7 +2696,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .expect("missing walk root should not error");
             assert!(
@@ -2522,7 +2733,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .expect("mixed batch should not error");
             let dests: Vec<&str> = patches
@@ -2543,7 +2754,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(
@@ -2573,7 +2784,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &vars,
-                None,
+                PatchAnchors::default(),
             )
             .unwrap();
             assert_eq!(resolved.len(), 1);
@@ -2605,7 +2816,7 @@ mod tests {
                 Some(&PassThroughHook),
                 ComposeOptions::default(),
                 &vars,
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(matches!(err, ComposeError::Denied { .. }), "got: {err:?}");
@@ -2622,7 +2833,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(
@@ -2649,7 +2860,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(
@@ -2682,7 +2893,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &vars,
-                None,
+                PatchAnchors::default(),
             )
             .unwrap();
 
@@ -2730,7 +2941,7 @@ mod tests {
                 Some(&TildeDenyAddingHook),
                 ComposeOptions::default(),
                 &vars,
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(matches!(err, ComposeError::Denied { .. }), "got: {err:?}");
@@ -2768,7 +2979,7 @@ mod tests {
                 Some(&UnknownVarHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(
@@ -2811,7 +3022,7 @@ mod tests {
                     follow_symlinks: true,
                 },
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap();
             assert_eq!(resolved.len(), 1);
@@ -2846,7 +3057,7 @@ mod tests {
                     follow_symlinks: true,
                 },
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(matches!(err, ComposeError::Denied { .. }), "got: {err:?}");
@@ -2888,7 +3099,7 @@ mod tests {
                     follow_symlinks: true,
                 },
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(matches!(err, ComposeError::Denied { .. }), "got: {err:?}");
@@ -2915,7 +3126,7 @@ mod tests {
                     follow_symlinks: true,
                 },
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap();
             assert_eq!(resolved.len(), 1);
@@ -2952,7 +3163,7 @@ mod tests {
                 Some(&PanicHook),
                 ComposeOptions::default(),
                 &[],
-                None,
+                PatchAnchors::default(),
             )
             .unwrap();
             assert_eq!(resolved.len(), 1);
@@ -3819,7 +4030,7 @@ mod tests {
                 policy,
                 Some(&PanicHooks),
                 ComposeOptions::default(),
-                None,
+                PatchAnchors::default(),
             )
             .unwrap_err();
             assert!(
@@ -3862,7 +4073,7 @@ mod tests {
                 policy,
                 Some(&PanicHooks),
                 ComposeOptions::default(),
-                None,
+                PatchAnchors::default(),
             )
             .unwrap();
             assert!(

--- a/crates/sessions/src/core/expansion.rs
+++ b/crates/sessions/src/core/expansion.rs
@@ -18,11 +18,19 @@
 //!   is a hard error ([`ExpandError::UndefinedVar`]). Substitution
 //!   sources its values from the resolved-vars set the caller passes
 //!   in via [`VarLookup`].
-//!   **One narrow exception:** the *tilde prefix* (`~` / `~/...`)
-//!   accepts a `HOME` fallback from process env (threaded through
-//!   the `home_fallback` parameter), so `~/foo` works without the
-//!   loadout having to declare `HOME = { inherit = true }`. Explicit
-//!   `$HOME` and `${HOME}` references stay strict — no fallback.
+//!   **Two narrow exceptions**, both threaded in through [`Anchors`]
+//!   rather than read from the var set:
+//!   - the *tilde prefix* (`~` / `~/...`) accepts a `HOME` fallback
+//!     from process env, so `~/foo` works without the loadout having
+//!     to declare `HOME = { inherit = true }`. Explicit `$HOME` and
+//!     `${HOME}` references stay strict — no fallback.
+//!   - [`LOADOUT_ROOT`] resolves to the declaring loadout's own
+//!     directory. It is **reserved**: the name is intercepted before
+//!     the var lookup, so a loadout declaring a variable by that name
+//!     cannot shadow it here. Where no loadout declared the pattern —
+//!     a policy rule, a project's or a package's patch — referencing
+//!     it is [`ExpandError::LoadoutRootUnavailable`] rather than a
+//!     silently wrong path.
 //! - After substitution the result is **path-normalized**: redundant
 //!   slashes and `.` components are dropped. Any `..` component
 //!   produces [`ExpandError::PathTraversal`] — silent normalization
@@ -54,6 +62,59 @@ impl VarLookup for [ResolvedVar] {
         self.iter()
             .find(|v| v.name() == name)
             .map(ResolvedVar::value)
+    }
+}
+
+/// The reserved reference naming the declaring loadout's own
+/// directory — `<loadouts dir>/<loadout name>/`, beside the
+/// `<name>.toml` that declared the patch, and the same directory its
+/// external hook scripts resolve against.
+///
+/// Lets a loadout ship the files it patches in next to itself
+/// (`source = "$LOADOUT_ROOT/config.toml"`) instead of hard-coding an
+/// absolute path into the user's config directory, which breaks the
+/// moment that directory moves.
+pub const LOADOUT_ROOT: &str = "LOADOUT_ROOT";
+
+/// The substitutions that do not come from the session's resolved
+/// variables: the tilde prefix's `HOME` fallback, and the declaring
+/// loadout's [`LOADOUT_ROOT`].
+///
+/// Both are properties of *who declared the pattern* rather than of the
+/// session, so neither can be looked up in the var set. A `None` field
+/// means "this pattern has no such anchor" — referencing it is then an
+/// error, never a silent empty string.
+///
+/// `#[non_exhaustive]`: a future anchor is a new field, and callers
+/// build these through the constructors below rather than by literal —
+/// the same treatment [`ComposeOptions`](crate::core::compose::ComposeOptions)
+/// gets for the same reason.
+#[derive(Clone, Copy, Debug, Default)]
+#[non_exhaustive]
+pub struct Anchors<'a> {
+    /// `HOME` for the `~` / `~/…` prefix, when the vars don't carry one.
+    pub home: Option<&'a str>,
+    /// The declaring loadout's directory, for [`LOADOUT_ROOT`]. `None`
+    /// for anything a loadout didn't declare.
+    pub loadout_root: Option<&'a str>,
+}
+
+impl<'a> Anchors<'a> {
+    /// Anchors carrying only a `HOME` fallback — the shape every
+    /// non-loadout caller wants.
+    #[must_use]
+    pub fn home(home: Option<&'a str>) -> Self {
+        Self {
+            home,
+            loadout_root: None,
+        }
+    }
+
+    /// Add the declaring loadout's directory.
+    #[must_use]
+    pub fn with_loadout_root(mut self, loadout_root: Option<&'a str>) -> Self {
+        self.loadout_root = loadout_root;
+        self
     }
 }
 
@@ -108,6 +169,17 @@ pub enum ExpandError {
          use `$HOME/...` or an explicit path"
     )]
     UnsupportedTildeUser { pattern: String },
+
+    /// A pattern referenced [`LOADOUT_ROOT`] with no loadout to anchor
+    /// it to — a user-policy rule, or a patch a project or package
+    /// declared. There is no sensible fallback: every candidate
+    /// directory would belong to some *other* declarer, so the
+    /// reference is refused rather than resolved to the wrong tree.
+    #[error(
+        "pattern `{pattern}` references `$LOADOUT_ROOT`, which only resolves in \
+         patch sources declared by a loadout"
+    )]
+    LoadoutRootUnavailable { pattern: String },
 }
 
 /// Expand `raw` against `resolved_vars` and parse the result as a
@@ -115,9 +187,10 @@ pub enum ExpandError {
 /// to the walker. The result must be absolute so the walker has a
 /// concrete starting point.
 ///
-/// `home_fallback` applies only to the `~` / `~/…` prefix when
+/// [`Anchors::home`] applies only to the `~` / `~/…` prefix when
 /// `HOME` isn't in `resolved_vars`. Explicit `$HOME` / `${HOME}`
-/// references stay strict.
+/// references stay strict. [`Anchors::loadout_root`] backs
+/// [`LOADOUT_ROOT`]; pass `None` for a pattern no loadout declared.
 ///
 /// See [`expand_policy_pattern`] for the matcher-side variant that
 /// drops the "must be absolute" requirement — policy patterns are
@@ -135,9 +208,9 @@ pub enum ExpandError {
 pub fn expand_source(
     raw: &str,
     resolved_vars: &(impl VarLookup + ?Sized),
-    home_fallback: Option<&str>,
+    anchors: Anchors<'_>,
 ) -> Result<FileSet, ExpandError> {
-    expand_pattern(raw, resolved_vars, home_fallback, RequireAbsolute::Yes)
+    expand_pattern(raw, resolved_vars, anchors, RequireAbsolute::Yes)
 }
 
 /// Expand `raw` against `resolved_vars` and parse the result as a
@@ -149,6 +222,10 @@ pub fn expand_source(
 /// `**/*.pem` is a legitimate matcher for "any `.pem` at any depth"
 /// and doesn't need to point at a walk root.
 ///
+/// A policy rule belongs to the user, not to any one loadout, so no
+/// [`Anchors::loadout_root`] is available here: a rule referencing
+/// [`LOADOUT_ROOT`] is [`ExpandError::LoadoutRootUnavailable`].
+///
 /// # Errors
 ///
 /// See [`ExpandError`]. [`ExpandError::NotAbsolute`] cannot be
@@ -158,7 +235,12 @@ pub fn expand_policy_pattern(
     resolved_vars: &(impl VarLookup + ?Sized),
     home_fallback: Option<&str>,
 ) -> Result<FileSet, ExpandError> {
-    expand_pattern(raw, resolved_vars, home_fallback, RequireAbsolute::No)
+    expand_pattern(
+        raw,
+        resolved_vars,
+        Anchors::home(home_fallback),
+        RequireAbsolute::No,
+    )
 }
 
 /// Whether the expander enforces "result must be absolute." Kept
@@ -173,7 +255,7 @@ enum RequireAbsolute {
 fn expand_pattern(
     raw: &str,
     resolved_vars: &(impl VarLookup + ?Sized),
-    home_fallback: Option<&str>,
+    anchors: Anchors<'_>,
     require_absolute: RequireAbsolute,
 ) -> Result<FileSet, ExpandError> {
     let mut out = String::with_capacity(raw.len());
@@ -185,7 +267,7 @@ fn expand_pattern(
     if bytes.first() == Some(&b'~') && bytes.get(1).is_none_or(|&c| c == b'/') {
         let home = resolved_vars
             .lookup("HOME")
-            .or(home_fallback)
+            .or(anchors.home)
             .ok_or_else(|| ExpandError::UndefinedVar {
                 name: "HOME".into(),
             })?;
@@ -211,11 +293,23 @@ fn expand_pattern(
                 continue;
             }
             let (name, consumed) = parse_var_ref(bytes, i)?;
-            let value = resolved_vars
-                .lookup(name)
-                .ok_or_else(|| ExpandError::UndefinedVar {
-                    name: name.to_owned(),
-                })?;
+            // `LOADOUT_ROOT` is reserved: resolved from the anchors and
+            // never from the var set, so a loadout that also declares a
+            // variable by that name (for the session's env, say) can't
+            // redirect its own patch sources by accident.
+            let value = if name == LOADOUT_ROOT {
+                anchors
+                    .loadout_root
+                    .ok_or_else(|| ExpandError::LoadoutRootUnavailable {
+                        pattern: raw.to_owned(),
+                    })?
+            } else {
+                resolved_vars
+                    .lookup(name)
+                    .ok_or_else(|| ExpandError::UndefinedVar {
+                        name: name.to_owned(),
+                    })?
+            };
             escape_glob_metas(value, &mut out);
             i += consumed;
             continue;
@@ -426,8 +520,9 @@ mod tests {
 
     fn expand(raw: &str, vars: &[ResolvedVar]) -> Result<String, ExpandError> {
         // Tests default to no env fallback so existing assertions
-        // about "no resolved HOME → error" stay deterministic.
-        expand_source(raw, vars, None).map(|fs| fs.pattern().to_owned())
+        // about "no resolved HOME → error" stay deterministic, and to no
+        // loadout root so `$LOADOUT_ROOT` assertions are opt-in.
+        expand_source(raw, vars, Anchors::default()).map(|fs| fs.pattern().to_owned())
     }
 
     fn expand_with_env_home(
@@ -435,7 +530,21 @@ mod tests {
         vars: &[ResolvedVar],
         home_fallback: &str,
     ) -> Result<String, ExpandError> {
-        expand_source(raw, vars, Some(home_fallback)).map(|fs| fs.pattern().to_owned())
+        expand_source(raw, vars, Anchors::home(Some(home_fallback)))
+            .map(|fs| fs.pattern().to_owned())
+    }
+
+    fn expand_in_loadout(
+        raw: &str,
+        vars: &[ResolvedVar],
+        loadout_root: &str,
+    ) -> Result<String, ExpandError> {
+        expand_source(
+            raw,
+            vars,
+            Anchors::default().with_loadout_root(Some(loadout_root)),
+        )
+        .map(|fs| fs.pattern().to_owned())
     }
 
     // ---- happy paths ----
@@ -898,6 +1007,101 @@ mod tests {
     fn policy_pattern_still_rejects_parent_traversal() {
         let vars: [ResolvedVar; 0] = [];
         let err = expand_policy_pattern("a/../b/*.pem", vars.as_slice(), None).unwrap_err();
+        assert!(
+            matches!(err, ExpandError::PathTraversal { .. }),
+            "got: {err:?}",
+        );
+    }
+
+    // ---- $LOADOUT_ROOT ----
+
+    /// The reference resolves to the anchor the caller supplied, in
+    /// both spellings, and composes with the rest of the pattern —
+    /// including globs, which is how a loadout patches in a whole
+    /// directory it ships.
+    #[test]
+    fn loadout_root_substitutes_the_anchor() {
+        let vars: [ResolvedVar; 0] = [];
+        let root = "/home/u/.config/minimal/loadouts/dev";
+        for raw in ["$LOADOUT_ROOT/config.toml", "${LOADOUT_ROOT}/config.toml"] {
+            assert_eq!(
+                expand_in_loadout(raw, vars.as_slice(), root).unwrap(),
+                "/home/u/.config/minimal/loadouts/dev/config.toml",
+                "raw: {raw}",
+            );
+        }
+        assert_eq!(
+            expand_in_loadout("$LOADOUT_ROOT/nvim/**/*.lua", vars.as_slice(), root).unwrap(),
+            "/home/u/.config/minimal/loadouts/dev/nvim/**/*.lua",
+        );
+    }
+
+    /// The anchor is a value, not a prefix rule: it substitutes
+    /// wherever it appears, the same way `$VAR` does.
+    #[test]
+    fn loadout_root_substitutes_mid_pattern() {
+        let vars = [sv("SUB", "themes")];
+        assert_eq!(
+            expand_in_loadout("$LOADOUT_ROOT/$SUB/*.toml", vars.as_slice(), "/l/dev").unwrap(),
+            "/l/dev/themes/*.toml",
+        );
+    }
+
+    /// Glob metacharacters in the anchor are escaped like any other
+    /// substituted value. A config directory under a home named `u[1]`
+    /// would otherwise truncate the walk root at the `[` and match a
+    /// far wider tree than the loadout asked for.
+    #[test]
+    fn loadout_root_escapes_glob_metas() {
+        let vars: [ResolvedVar; 0] = [];
+        let pat =
+            expand_in_loadout("$LOADOUT_ROOT/conf", vars.as_slice(), "/home/u[1]/l/dev").unwrap();
+        assert_eq!(pat, "/home/u[[]1[]]/l/dev/conf");
+    }
+
+    /// The name is reserved: it resolves from the anchor even when a
+    /// variable of the same name is in scope, so a loadout that exports
+    /// `LOADOUT_ROOT` into its session env can't redirect its own patch
+    /// sources by accident.
+    #[test]
+    fn loadout_root_is_not_shadowed_by_a_var_of_the_same_name() {
+        let vars = [sv("LOADOUT_ROOT", "/somewhere/else")];
+        assert_eq!(
+            expand_in_loadout("$LOADOUT_ROOT/conf", vars.as_slice(), "/l/dev").unwrap(),
+            "/l/dev/conf",
+        );
+    }
+
+    /// With no loadout to anchor against — a policy rule, or a patch a
+    /// project or package declared — the reference is refused. The
+    /// alternative, falling back to the var set, would silently resolve
+    /// to whatever a loadout happened to export.
+    #[test]
+    fn loadout_root_without_an_anchor_is_an_error() {
+        let vars = [sv("LOADOUT_ROOT", "/somewhere/else")];
+        let err = expand("$LOADOUT_ROOT/conf", &vars).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ExpandError::LoadoutRootUnavailable { ref pattern } if pattern == "$LOADOUT_ROOT/conf"
+            ),
+            "got: {err:?}",
+        );
+
+        let err = expand_policy_pattern("$LOADOUT_ROOT/**", vars.as_slice(), None).unwrap_err();
+        assert!(
+            matches!(err, ExpandError::LoadoutRootUnavailable { .. }),
+            "policy rules belong to the user, not a loadout; got: {err:?}",
+        );
+    }
+
+    /// `..` is still rejected on both sides of the substitution — the
+    /// anchor is not an escape hatch out of the traversal check.
+    #[test]
+    fn loadout_root_still_rejects_parent_traversal() {
+        let vars: [ResolvedVar; 0] = [];
+        let err =
+            expand_in_loadout("$LOADOUT_ROOT/../other/x", vars.as_slice(), "/l/dev").unwrap_err();
         assert!(
             matches!(err, ExpandError::PathTraversal { .. }),
             "got: {err:?}",

--- a/crates/sessions/src/core/loadout.rs
+++ b/crates/sessions/src/core/loadout.rs
@@ -6,7 +6,10 @@
 //! `dest` paths are inside the sandbox; `source` paths are on the
 //! host. Leading `~` in `source` expands at gate time against the
 //! host home; leading `~` in `dest` expands inside the sandbox at
-//! runtime.
+//! runtime. `$LOADOUT_ROOT` in a `source` expands to this loadout's
+//! own directory — `<loadouts dir>/<name>/`, beside the file — for
+//! files shipped with the loadout rather than kept in the user's
+//! dotfiles (see [`expansion::LOADOUT_ROOT`]).
 //!
 //! ```toml
 //! packages = ["helix", "zellij"]
@@ -25,6 +28,10 @@
 //!       source = "~/dotfiles/zellij/config.kdl" },
 //!     { dest = "~/.config/zellij/layouts/",
 //!       source = { base = "~/dotfiles/zellij/layouts", patterns = ["**/*.kdl"] } },
+//!
+//!     # This loadout's own file, shipped beside it in `<name>/`.
+//!     { dest = "~/.config/helix/ignore",
+//!       source = "$LOADOUT_ROOT/helix-ignore" },
 //! ]
 //!
 //! [vars]
@@ -40,6 +47,8 @@
 //! [[lifecycle_hooks]]
 //! on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || true" }
 //! ```
+//!
+//! [`expansion::LOADOUT_ROOT`]: crate::core::expansion::LOADOUT_ROOT
 
 use std::collections::BTreeMap;
 

--- a/crates/sessions/src/core/source.rs
+++ b/crates/sessions/src/core/source.rs
@@ -32,6 +32,38 @@ pub enum Source {
     Package { name: String },
 }
 
+impl Source {
+    /// The directory a loadout's own files live in: `<loadouts_dir>/<name>/`,
+    /// beside the `<name>.toml` that declared them.
+    ///
+    /// One definition of "a loadout's directory", shared by everything
+    /// that anchors against it — external hook scripts
+    /// ([`ScriptAnchors::for_source`]) and the `$LOADOUT_ROOT` patch-source
+    /// reference ([`expand_source`]).
+    ///
+    /// `None` for every non-loadout source, and for a loadout whose name
+    /// isn't a path component that stays put — the name is joined into a
+    /// path that is then read from, so it has to be one. A
+    /// [`LoadoutName`] already rejects those, but this method is reached
+    /// from wire-shaped provenance too, where nothing has vetted the
+    /// string. That guard is also what makes the
+    /// [`sub_path_unchecked`](paths::AbsPath::sub_path_unchecked) below
+    /// sound: the name is proven to be a single non-climbing component
+    /// before it is joined.
+    ///
+    /// [`ScriptAnchors::for_source`]: crate::client::hookscripts::ScriptAnchors::for_source
+    /// [`expand_source`]: crate::core::expansion::expand_source
+    /// [`LoadoutName`]: crate::core::loadout::LoadoutName
+    #[must_use]
+    pub fn loadout_dir(&self, loadouts_dir: &paths::HostAbsPath) -> Option<paths::HostAbsPath> {
+        match self {
+            Self::UserLoadout { name } => crate::core::lifecyclehook::safe_path_component(name)
+                .then(|| loadouts_dir.sub_path_unchecked(name)),
+            Self::Project { .. } | Self::Package { .. } => None,
+        }
+    }
+}
+
 impl fmt::Display for Source {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -253,5 +285,58 @@ impl TryFrom<crate::wire::primitives::WireProvenancedHook> for ProvenancedHook {
     fn try_from(h: crate::wire::primitives::WireProvenancedHook) -> Result<Self, Self::Error> {
         let hook: crate::core::lifecyclehook::LifecycleHook = h.hook.try_into()?;
         Ok(Self::new(hook, h.source.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loadouts_dir() -> paths::HostAbsPath {
+        paths::HostAbsPath::try_new("/cfg/minimal/loadouts").unwrap()
+    }
+
+    /// A loadout's directory is its name under the loadouts directory —
+    /// the anchor both its hook scripts and its `$LOADOUT_ROOT` patch
+    /// sources resolve against.
+    #[test]
+    fn loadout_dir_is_the_name_under_the_loadouts_dir() {
+        let source = Source::UserLoadout { name: "dev".into() };
+        assert_eq!(
+            source.loadout_dir(&loadouts_dir()).map(|p| p.to_string()),
+            Some("/cfg/minimal/loadouts/dev".to_string()),
+        );
+    }
+
+    /// Nothing but a loadout has one: a project's files are anchored at
+    /// its own root, and a package cannot ship host-side files at all.
+    #[test]
+    fn non_loadout_sources_have_no_loadout_dir() {
+        let dir = loadouts_dir();
+        let project = Source::Project {
+            path: HostPath::try_new("/repo").unwrap(),
+        };
+        let package = Source::Package {
+            name: "helix".into(),
+        };
+        assert_eq!(project.loadout_dir(&dir), None);
+        assert_eq!(package.loadout_dir(&dir), None);
+    }
+
+    /// A name that wouldn't stay put as a path component gets no
+    /// directory rather than one that climbs out of the loadouts tree.
+    /// `LoadoutName` rejects these at construction; provenance arriving
+    /// from the wire has had no such check.
+    #[test]
+    fn a_name_that_escapes_gets_no_loadout_dir() {
+        let dir = loadouts_dir();
+        for name in ["..", ".", "", "a/b", "a\\b"] {
+            let source = Source::UserLoadout { name: name.into() };
+            assert_eq!(
+                source.loadout_dir(&dir),
+                None,
+                "`{name}` must not become an anchor",
+            );
+        }
     }
 }

--- a/crates/sessions/tests/client_flow1.rs
+++ b/crates/sessions/tests/client_flow1.rs
@@ -517,3 +517,163 @@ on_activate = {{ type = "inline", value = "echo activated" }}
     assert_eq!(decoded.lifecycle_hooks.len(), 1);
     assert_eq!(decoded.requested_packages.len(), 1);
 }
+
+// =====================================================================
+// `$LOADOUT_ROOT`
+// =====================================================================
+
+/// Lay out a loadouts directory holding two loadouts that ship files:
+/// `dev.toml` + `dev/`, and an `ops/` tree whose files must never be
+/// reached by `dev`'s patterns.
+fn loadouts_dir_fixture(root: &Utf8Path) {
+    fixture_tree(
+        root,
+        [
+            ("dev/config.toml", "theme = 'nord'\n"),
+            ("dev/themes/nord.toml", "# nord\n"),
+            ("dev/themes/notes.md", "noise"),
+            ("ops/config.toml", "theme = 'not-yours'\n"),
+        ],
+    );
+}
+
+/// The end the feature exists for: a loadout patches in files shipped
+/// beside it, naming neither the user's config directory nor its own
+/// name. Both a literal file and a glob resolve under `<dir>/dev/`,
+/// and nothing reaches the neighbouring `ops/` tree.
+#[test]
+fn loadout_root_resolves_to_the_directory_beside_the_loadout() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = Utf8Path::from_path(tmp.path()).unwrap();
+    loadouts_dir_fixture(root);
+    std::fs::write(
+        root.join("dev.toml").as_std_path(),
+        r#"
+[[patches]]
+dest = ".config/helix/config.toml"
+source = "$LOADOUT_ROOT/config.toml"
+
+[[patches]]
+dest = ".config/helix/themes"
+source = "${LOADOUT_ROOT}/themes/**/*.toml"
+"#,
+    )
+    .unwrap();
+
+    // Read from disk, so the loadout is named after its file the way an
+    // activation names it — that name is what picks the directory.
+    let loadout = sessions::client::disk::read_loadout_file(root.join("dev.toml").as_std_path())
+        .expect("fixture loadout loads");
+    let mut composer = UserComposer::new()
+        .with_env(pinned_env(&[]))
+        .with_loadouts_dir(paths::HostAbsPath::try_new(root.to_owned()).unwrap());
+    composer.add(loadout).unwrap();
+    let (wire, _) = composer
+        .compose(UserPolicy::empty(), ComposeOptions::default())
+        .unwrap();
+
+    let mut resolved: Vec<(&str, &str)> = wire
+        .patches
+        .iter()
+        .map(|p| {
+            (
+                p.patch.host_path.as_str(),
+                p.patch.destination.as_utf8_path().as_str(),
+            )
+        })
+        .collect();
+    resolved.sort_unstable();
+    assert_eq!(resolved.len(), 2, "got: {resolved:?}");
+    assert_paths_equivalent(resolved[0].0, root.join("dev/config.toml").as_std_path());
+    assert_paths_equivalent(
+        resolved[1].0,
+        root.join("dev/themes/nord.toml").as_std_path(),
+    );
+    assert!(
+        resolved.iter().all(|(host, _)| !host.contains("/ops/")),
+        "a loadout's root must not reach a sibling loadout's files: {resolved:?}",
+    );
+    // Destinations are what the session actually sees: the literal
+    // source lands verbatim, and the glob match lands under its `dest`
+    // directory at its path relative to the walk root — which is the
+    // loadout's own directory, not the loadouts directory above it.
+    assert_eq!(
+        resolved.iter().map(|(_, dest)| *dest).collect::<Vec<_>>(),
+        vec![
+            ".config/helix/config.toml",
+            ".config/helix/themes/nord.toml"
+        ],
+    );
+}
+
+/// The reference is reserved in patch sources: a loadout that also
+/// exports a `LOADOUT_ROOT` variable still patches from its own
+/// directory, and the variable itself reaches the session untouched.
+#[test]
+fn a_loadout_root_var_does_not_redirect_patch_sources() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = Utf8Path::from_path(tmp.path()).unwrap();
+    loadouts_dir_fixture(root);
+    let src = format!(
+        r#"
+[vars]
+LOADOUT_ROOT = "{root}/ops"
+
+[[patches]]
+dest = ".config/helix/config.toml"
+source = "$LOADOUT_ROOT/config.toml"
+"#,
+    );
+    std::fs::write(root.join("dev.toml").as_std_path(), src).unwrap();
+
+    let loadout = sessions::client::disk::read_loadout_file(root.join("dev.toml").as_std_path())
+        .expect("fixture loadout loads");
+    let mut composer = UserComposer::new()
+        .with_env(pinned_env(&[]))
+        .with_loadouts_dir(paths::HostAbsPath::try_new(root.to_owned()).unwrap());
+    composer.add(loadout).unwrap();
+    let (wire, _) = composer
+        .compose(UserPolicy::empty(), ComposeOptions::default())
+        .unwrap();
+
+    assert_eq!(wire.patches.len(), 1);
+    assert_paths_equivalent(
+        wire.patches[0].patch.host_path.as_str(),
+        root.join("dev/config.toml").as_std_path(),
+    );
+    // Reserved in patch sources, ordinary everywhere else: the var is
+    // still contributed to the session's environment.
+    assert_eq!(wire.vars.len(), 1);
+    assert_eq!(wire.vars[0].var.name, "LOADOUT_ROOT");
+    assert_eq!(wire.vars[0].var.value, format!("{root}/ops"));
+}
+
+/// A composer that was never told where its loadouts came from can't
+/// resolve the reference, and says so instead of walking some default
+/// directory.
+#[test]
+fn loadout_root_without_a_loadouts_dir_fails_the_composition() {
+    let loadout: Loadout = toml::from_str(
+        r#"name = "dev"
+
+[[patches]]
+dest = ".config/helix/config.toml"
+source = "$LOADOUT_ROOT/config.toml"
+"#,
+    )
+    .unwrap();
+    let mut composer = UserComposer::new().with_env(pinned_env(&[]));
+    composer.add(loadout).unwrap();
+    let err = composer
+        .compose(UserPolicy::empty(), ComposeOptions::default())
+        .expect_err("no loadouts dir means no anchor");
+    assert!(
+        matches!(
+            err,
+            ComposeError::Expansion(
+                sessions::core::expansion::ExpandError::LoadoutRootUnavailable { .. }
+            )
+        ),
+        "got: {err:?}",
+    );
+}

--- a/docs/concepts/loadouts.md
+++ b/docs/concepts/loadouts.md
@@ -113,6 +113,20 @@ A source that does not exist on your host is skipped with a warning rather
 than failing activation, so you can opportunistically patch a dotfile tree
 that may not be present on every machine.
 
+For files that exist only to serve one loadout, keep them beside it instead
+and name them with `$LOADOUT_ROOT` — the directory next to the loadout file,
+named after the loadout, which is also where its hook scripts live:
+
+```toml
+patches = [
+    { dest = ".config/helix/config.toml", source = "$LOADOUT_ROOT/config.toml" },
+]
+```
+
+That makes the loadout and its files one movable unit, with no absolute path
+into your config directory to keep in sync. See the
+[reference](../reference/loadouts.md#loadout_root) for the rules.
+
 ### Lifecycle hooks
 
 Hooks run inside your session, with its packages, variables, files, and

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -187,6 +187,9 @@ so list entries only make sense with per-entry dests or glob entries):
   references (including `$HOME`) resolve against the session's
   already-resolved variables (declared in `[vars]`); referencing an
   undefined name is an error. `$$` is a literal `$`.
+- `$LOADOUT_ROOT` expands to the loadout's own directory, for files you
+  ship beside the loadout itself — see
+  [`$LOADOUT_ROOT`](#loadout_root) below.
 - After expansion the path must be absolute; anchor home-relative sources
   with `~/`.
 - Glob patterns must have a literal directory prefix to walk from:
@@ -220,7 +223,53 @@ readable only by you. Two qualifications:
 Ownership is not carried and cannot be: every file in the session belongs
 to the session user, whatever it was owned by on your host.
 
-### `[[lifecycle_hooks]]` - Scripts at session transition points
+#### `$LOADOUT_ROOT` - Files shipped with the loadout {#loadout_root}
+
+Not every file a loadout patches in belongs in your dotfiles. For the ones
+that exist only to serve this loadout, keep them beside it and name them
+with `$LOADOUT_ROOT`, which expands to a directory named after the loadout
+next to its `.toml` -- the same directory its
+[external hook scripts](#lifecycle_hooks) resolve against:
+
+```
+<config>/minimal/loadouts/
+├── dev.toml
+└── dev/
+    ├── config.toml
+    └── themes/
+        └── nord.toml
+```
+
+```toml
+patches = [
+    { dest = ".config/helix/config.toml", source = "$LOADOUT_ROOT/config.toml" },
+    { dest = ".config/helix/themes/",     source = "$LOADOUT_ROOT/themes/**/*.toml" },
+]
+```
+
+It resolves against the loadouts directory actually in use, so a
+`--config-dir` or `$XDG_CONFIG_HOME` that moves your config takes the
+loadout's files with it -- which a hard-coded `~/.config/minimal/loadouts/dev/`
+would not.
+
+Details worth knowing:
+
+- The reference is **only** available in the `source` of a patch a loadout
+  declared. In a [user policy](./user-policy.md) pattern, or in a patch a
+  project declared, it fails the activation rather than resolving to some
+  other declarer's directory. `dest` is a path inside the session, so it has
+  no use for it either.
+- The name is **reserved** here: a loadout that also declares a
+  `LOADOUT_ROOT` variable still patches from its own directory. The variable
+  reaches the session normally -- only patch sources ignore it.
+- `$LOADOUT_ROOT` alone names a directory, and a patch source matches files,
+  so it patches in nothing. Write `$LOADOUT_ROOT/**/*` to take the whole
+  tree.
+- The directory is optional. A loadout that never references it does not
+  need one, and -- like any other source -- a path that isn't there is
+  skipped with a warning rather than failing the activation.
+
+### `[[lifecycle_hooks]]` - Scripts at session transition points {#lifecycle_hooks}
 
 _Optional_
 
@@ -274,6 +323,9 @@ live in `dev/`:
     ├── activate.sh
     └── teardown.sh
 ```
+
+This is the same directory [`$LOADOUT_ROOT`](#loadout_root) names, so a
+loadout's scripts and the files it patches in live together.
 
 A script must resolve to a regular file inside that directory. Symlinks are
 rejected rather than followed, at every path component — a symlink is the one

--- a/docs/reference/minimal-dot-toml.md
+++ b/docs/reference/minimal-dot-toml.md
@@ -158,7 +158,9 @@ on_activate = { type = "inline", value = "cargo check --workspace >/dev/null 2>&
   `default = "..."` for a fallback when it is unset).
 - **`patches`**: `{ source, dest }` rows copying files into the session.
   `dest` is relative to the session user's home directory; `source` resolves
-  on the host, typically inside the repo.
+  on the host, typically inside the repo. The one expansion a loadout has
+  and a project does not is `$LOADOUT_ROOT`, which names a loadout's own
+  directory; referencing it here fails the activation.
 - **`lifecycle_hooks`**: Scripts declared for session transition points
   (`on_activate`, `on_destroy`, `on_attach`, `on_detach`), run inside the
   session under POSIX `sh` — or under whatever a leading shebang names, for

--- a/docs/reference/user-policy.md
+++ b/docs/reference/user-policy.md
@@ -128,6 +128,9 @@ the session's already-resolved variables at activation:
 - A leading `~/` expands to the host home directory.
 - `$NAME` / `${NAME}` references (including `$HOME`) resolve against the
   session vars; referencing an undefined name fails the activation.
+- `$LOADOUT_ROOT` is **not** available: a policy is yours, not any one
+  loadout's, so there is no loadout for it to name. Referencing it fails the
+  activation. Write the path out, or match with a glob.
 
 Unlike loadout patch **sources**, a policy pattern need not be absolute — it is
 a matcher, not a walk seed, so a bare `**/*.pem` matches any `.pem` path at any


### PR DESCRIPTION
  ## Summary

  A loadout can now write `source = "$LOADOUT_ROOT/config.toml"` in a patch to pull
  in files shipped beside it, instead of hard-coding an absolute path like
  `~/.config/minimal/loadouts/dev/` that breaks the moment the config dir moves.

  `$LOADOUT_ROOT` resolves to `<loadouts dir>/<loadout name>/` — the same directory
  that loadout's external hook scripts already anchor at, so a loadout's scripts and
  its patch files live together. It follows the loadouts directory actually in use
  (`--config-dir`, `$XDG_CONFIG_HOME`), and is glob-escaped like any other
  substitution.

  Deliberate limits:

  - Available **only** in the `source` of a patch a loadout declared. In a user
    policy pattern, or a project's/package's patch, it fails the activation with a
    specific error rather than resolving to some other declarer's directory.
  - The name is **reserved** in patch sources: a loadout that also declares a
    `LOADOUT_ROOT` variable still patches from its own directory. The variable
    reaches the session normally.
  - No new read capability — a loadout could already name any absolute source. `..`
    is still rejected, symlink handling is unchanged, and the user policy's
    `deny`/`ignore` still gate every file the anchor produces.

  Mechanically: expansion takes an `Anchors` struct (`HOME` fallback + loadout root)
  instead of a bare `home_fallback`; the compose pipeline threads a `PatchAnchors`
  context and derives each patch's root from its own `Source`, so two loadouts
  sharing a pattern resolve to different directories. The loadouts directory is a
  realm-tagged `paths::HostAbsPath` end to end, including `ScriptAnchors`.

  Purely additive: `$LOADOUT_ROOT` is an error today, so no existing loadout can
  depend on the old behaviour.

  ## Testing

  `just fmt-check` and `just clippy` clean. `cargo test --workspace --locked` —
  1802 passed, 0 failed; 13 doctests pass. (`just test` / `deny` / `test-ignored`
  need nextest and cargo-deny, which weren't available in my environment.)

  New coverage: expansion unit tests (both spellings, mid-pattern, glob-meta
  escaping, no shadowing by a same-named var, missing anchor, `..` still rejected),
  per-provenance anchoring in compose, `Source::loadout_dir`, three `client_flow1`
  integration tests driving real files from disk through the composer to the wire
  form (asserting host paths *and* destinations), and a `minimal` test pinning the
  directory to `--config-dir`.

  ## Checklist 
  - [x] Docs updated if behavior changed
  - [x] `BREAKING CHANGE:` footer present if this is a breaking change
  Docs touched: reference/loadouts.md (new $LOADOUT_ROOT section + cross-link from the hook-scripts tree), concepts/loadouts.md, reference/user-policy.md, reference/minimal-dot-toml.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `min session run <session> <task>` for running typed session tasks.
  * Added daemon version compatibility checks during session activation and related operations.
  * Added `$LOADOUT_ROOT` support for referencing files, patches, and hooks relative to each loadout.
  * Relative configuration directories now resolve from the current working directory.

* **Bug Fixes**
  * Improved SSH attachment, terminal restoration, exit-code reporting, and proxy shutdown behavior.
  * Added safeguards against unsafe path traversal and invalid loadout references.

* **Documentation**
  * Updated loadout, patch, policy, hook, and shell behavior documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->