### PR TITLE
feat: preserve permissions bits when copying patch files into session

### DIFF
--- a/crates/minimal-client/src/file_upload.rs
+++ b/crates/minimal-client/src/file_upload.rs
@@ -268,9 +268,12 @@ impl<W: tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWrite for ProgressWriter<
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AddFileOptions {
     /// Override the archive-entry mode. `None` copies the source
-    /// file's mode (masked to the standard permission bits) as-is;
-    /// `Some(m)` forces `m` (e.g. `0o644` for the patches uploader
-    /// normalizing writable copies into the sandbox home).
+    /// file's mode (masked to the standard permission bits) as-is —
+    /// what both the workspace walker and the patches uploader want,
+    /// since flattening a mode strips the exec bit off whatever it is
+    /// applied to. `Some(m)` forces `m`: the hook-script uploader
+    /// stamps `0o644` because the executor runs `bash <script>`, so a
+    /// script is read rather than exec'd and never needs the bit.
     pub mode_override: Option<u32>,
 }
 
@@ -367,14 +370,21 @@ impl<W: AsyncWrite + Unpin + Send + Sync> TarZstArchive<W> {
             .metadata()
             .await
             .with_context(|| format!("statting {}", host_path.display()))?;
-        // Default mode: the source's own permission bits (masked to
-        // the standard nine + suid/sgid/sticky). Matches the
-        // `mode_override = None` docstring; otherwise an executable
-        // dropped in through `default()` would archive as 0o644 and
-        // silently lose its exec bit on unpack.
+        // Default mode: the source's own permission bits, masked to the
+        // standard nine. Matches the `mode_override = None` docstring;
+        // otherwise an executable dropped in through `default()` would
+        // archive as 0o644 and silently lose its exec bit on unpack.
+        //
+        // setuid/setgid/sticky are not emitted, because nothing on the
+        // other end honours them: the daemon's unpacker masks them off,
+        // and so does `async_tar::Archive::unpack` for the workspace
+        // stream. Sending a bit that is always discarded only makes the
+        // archive claim something the session will never have. The
+        // daemon still masks — it has to, since a peer writing raw tar
+        // bytes never runs this code.
         let default_mode = {
             use std::os::unix::fs::PermissionsExt as _;
-            metadata.permissions().mode() & 0o7777
+            metadata.permissions().mode() & 0o777
         };
         let mut header = async_tar::Header::new_gnu();
         header.set_size(metadata.len());
@@ -606,14 +616,14 @@ fn add_dir_entries_inner<'a, W: AsyncWrite + Unpin + Send + Sync + 'a>(
                     .metadata()
                     .await
                     .with_context(|| format!("statting {}", entry_path.display()))?;
-                // Preserve the source's permission bits (masked to the
-                // standard nine + suid/sgid/sticky), same as
-                // `TarZstArchive::add_file`'s default. Hardcoding 0o644
-                // here silently strips the exec bit off scripts and
-                // binaries in every workspace upload.
+                // Preserve the source's permission bits, masked to the
+                // standard nine — same rule, and same reason for the
+                // mask, as `TarZstArchive::add_file`'s default.
+                // Hardcoding 0o644 here silently strips the exec bit off
+                // scripts and binaries in every workspace upload.
                 let mode = {
                     use std::os::unix::fs::PermissionsExt as _;
-                    metadata.permissions().mode() & 0o7777
+                    metadata.permissions().mode() & 0o777
                 };
                 // Preserve the mtime too: leaving the header's zero
                 // stamp unpacks every file at the epoch, which breaks
@@ -1287,9 +1297,54 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&copied).unwrap(), "target-contents");
     }
 
-    /// `add_file` with `mode_override` honours the requested mode.
-    /// Verifies the patches uploader's normalize-to-0o644 story
-    /// (Nix-store 0o444 sources landing as writable copies).
+    /// With the default options — what the patches uploader passes —
+    /// the entry carries the source file's own permission bits. A
+    /// script patched into a session has to arrive executable, and a
+    /// `0600` source has to arrive private; both are decided here, on
+    /// the header.
+    #[tokio::test]
+    async fn tar_zst_archive_add_file_defaults_to_the_source_mode() {
+        let src = tempfile::TempDir::new().unwrap();
+        let cases = [("tool.sh", 0o755), ("secret.toml", 0o600)];
+        for (name, mode) in cases {
+            let path = src.path().join(name);
+            std::fs::write(&path, "x").unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)).unwrap();
+        }
+
+        let src_path = src.path().to_path_buf();
+        let buf = build_via_archive(async move |archive| {
+            for (name, _) in cases {
+                archive
+                    .add_file(&src_path.join(name), name, AddFileOptions::default())
+                    .await?;
+            }
+            Ok(())
+        })
+        .await;
+
+        let decoder = async_compression::tokio::bufread::ZstdDecoder::new(&buf[..]);
+        let out = tempfile::TempDir::new().unwrap();
+        async_tar::Archive::new(decoder)
+            .unpack(out.path().to_path_buf())
+            .await
+            .unwrap();
+        for (name, mode) in cases {
+            let meta = std::fs::metadata(out.path().join(name)).unwrap();
+            assert_eq!(
+                meta.permissions().mode() & 0o777,
+                mode,
+                "{name} should have kept its source mode",
+            );
+        }
+    }
+
+    /// `add_file` with `mode_override` honours the requested mode over
+    /// the source's own. Verifies the hook-script uploader's
+    /// flatten-to-0o644 story: those are read by `bash <script>`, never
+    /// exec'd, so their source mode is deliberately not carried. The
+    /// patches uploader takes the `None` branch instead — see
+    /// [`tar_zst_archive_add_file_defaults_to_the_source_mode`].
     #[tokio::test]
     async fn tar_zst_archive_add_file_honours_mode_override() {
         let src = tempfile::TempDir::new().unwrap();

--- a/crates/minimal-client/src/lib.rs
+++ b/crates/minimal-client/src/lib.rs
@@ -494,9 +494,16 @@ impl Client {
     /// share a destination with different sources, so any duplicates
     /// here are exact matches and safe to collapse.
     ///
-    /// The archive is streamed with `follow_symlinks: true` and
-    /// `mode_override: Some(0o644)` so a `/nix/store/…` link source
-    /// lands as a writable copy inside the sandbox.
+    /// The archive is streamed with `follow_symlinks: true`, so a
+    /// `/nix/store/…` link source is copied by value rather than
+    /// arriving as a link into a store the sandbox doesn't have.
+    ///
+    /// Each entry carries **the source file's own permission bits**.
+    /// The exec bit is the reason — a script patched into the session
+    /// has to still be runnable — but preservation is exact, so a
+    /// read-only source (a store path, a `0400` secret) lands read-only
+    /// and takes a `chmod` to edit in the box. The daemon masks off
+    /// setuid/setgid/sticky on unpack.
     ///
     /// [`Composition`]: sessions::core::compose::Composition
     pub async fn upload_patches(
@@ -543,9 +550,10 @@ impl Client {
                                     .add_file(
                                         host_path,
                                         dest.as_str(),
-                                        crate::file_upload::AddFileOptions {
-                                            mode_override: Some(0o644),
-                                        },
+                                        // Default options: the source's own
+                                        // mode rides the tar header. See the
+                                        // method docs.
+                                        crate::file_upload::AddFileOptions::default(),
                                     )
                                     .await
                                     .with_context(|| {

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -1151,6 +1151,12 @@ struct UnpackTarget {
 /// but the client is untrusted, so the same checks run again here —
 /// a peer writing raw tar bytes bypasses every client-side layer.
 ///
+/// Each entry's **permission bits** are reproduced on disk, masked to
+/// the standard nine. That is what carries a patched script's exec bit
+/// and a patched secret's `0600` into the session; ownership is not
+/// carried at all — every file here belongs to the daemon, and the
+/// sandbox's user namespace maps that to the session user.
+///
 /// On success, drops `target.marker` under `target.dir`. The write
 /// order matters: the marker only appears once every entry is on disk,
 /// which is what lets `FinalizeSession` treat its presence as proof
@@ -1296,6 +1302,20 @@ async fn unpack_tar_zst_into(target: UnpackTarget, c: &mut RuChannel<Msg>) -> Re
                 ));
             }
             let entry_size = entry.header().size().unwrap_or(0);
+            // The entry's permission bits, which the write below
+            // reproduces on disk: a patched script has to stay
+            // executable and a patched secret has to stay unreadable
+            // to anyone else, and neither survives a hardcoded mode.
+            //
+            // Masked to the standard nine. setuid/setgid/sticky are
+            // dropped rather than honoured — this header came off the
+            // wire, so the daemon is not in a position to trust it with
+            // a privilege bit, and `async_tar::Archive::unpack` (which
+            // unpacks the workspace tree a few functions up) applies
+            // exactly the same `& 0o777` for the same reason. A header
+            // whose mode field doesn't parse falls back to 0o644, the
+            // mode every entry landed as before this was read at all.
+            let mode = entry.header().mode().unwrap_or(0o644) & 0o777;
             // Per-entry cap: refuses forged headers that would push
             // `Vec::with_capacity` into an allocation panic or OOM
             // (allocator abort → whole daemon down) before we ever
@@ -1344,17 +1364,49 @@ async fn unpack_tar_zst_into(target: UnpackTarget, c: &mut RuChannel<Msg>) -> Re
             let dest = staging_dir.join(&entry_path);
             let path_display = entry_path.display().to_string();
             inflight.spawn(async move {
+                // `tokio::fs::OpenOptions::mode` is inherent on unix,
+                // so no `OpenOptionsExt` import is needed for it.
+                use std::os::unix::fs::PermissionsExt as _;
+                use tokio::io::AsyncWriteExt as _;
+
                 if let Some(parent) = dest.parent() {
                     tokio::fs::create_dir_all(parent)
                         .await
                         .map_err(|e| format!("creating parent dir for `{path_display}`: {e}"))?;
                 }
-                tokio::fs::write(&dest, &body)
+                // Create *with* the mode rather than writing and then
+                // widening: `.mode()` is masked by the daemon's umask,
+                // so the file is never briefly more permissive than the
+                // entry asked for. The explicit `set_permissions` below
+                // then takes it the rest of the way, since that same
+                // umask would otherwise quietly clear bits the entry
+                // does ask for.
+                let mut file = tokio::fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .mode(mode)
+                    .open(&dest)
+                    .await
+                    .map_err(|e| format!("creating `{path_display}`: {e}"))?;
+                file.write_all(&body)
                     .await
                     .map_err(|e| format!("writing `{path_display}`: {e}"))?;
+                // A `tokio::fs::File` completes its writes in the
+                // background; dropping one unflushed truncates it
+                // silently.
+                file.flush()
+                    .await
+                    .map_err(|e| format!("flushing `{path_display}`: {e}"))?;
+                // Through the handle, not the path: the mode lands on
+                // the file we just wrote rather than on whatever a
+                // concurrent unpack may have swapped in at that path.
+                file.set_permissions(std::fs::Permissions::from_mode(mode))
+                    .await
+                    .map_err(|e| format!("setting mode on `{path_display}`: {e}"))?;
                 // Explicit drop keeps the permit alive across the
-                // fs::write so the byte budget only frees up after
-                // the buffer is genuinely gone.
+                // write so the byte budget only frees up after the
+                // buffer is genuinely gone.
                 drop(body);
                 drop(permit);
                 Ok::<_, String>(())
@@ -1986,6 +2038,92 @@ mod tests {
                 .await
                 .unwrap(),
             "patches-ready marker must be written on successful unpack",
+        );
+    }
+
+    /// Build a tar+zstd archive whose entries carry the modes given,
+    /// rather than `tar_zst`'s uniform `0o644` — the shape the patches
+    /// uploader produces once it stopped flattening the source's mode.
+    async fn tar_zst_with_modes(entries: &[(&str, &[u8], u32)]) -> Vec<u8> {
+        let mut tar = async_tar::Builder::new(Vec::new());
+        for (path, contents, mode) in entries {
+            let mut header = async_tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(*mode);
+            tar.append_data(&mut header, path, *contents).await.unwrap();
+        }
+        let tar_bytes = tar.into_inner().await.unwrap();
+        let mut encoder = async_compression::tokio::write::ZstdEncoder::new(Vec::new());
+        encoder.write_all(&tar_bytes).await.unwrap();
+        encoder.shutdown().await.unwrap();
+        encoder.into_inner()
+    }
+
+    /// An entry's permission bits reach the staged file, so a patched
+    /// script stays executable and a patched secret stays private. The
+    /// `0o600` case is the one that proves the mode is applied
+    /// explicitly rather than left to the daemon's umask, which would
+    /// have produced `0o644` from the same header.
+    ///
+    /// setuid is masked off: the header arrives over the wire, so a
+    /// peer must not be able to ask the daemon to create a setuid file
+    /// in a session's tree. (`async_tar::Archive::unpack`, which
+    /// handles the workspace stream, drops it for the same reason.)
+    #[tokio::test]
+    async fn stream_workspace_patches_preserves_entry_modes() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let payload = tar_zst_with_modes(&[
+            (".local/bin/tool", b"#!/bin/sh\necho hi\n", 0o755),
+            (".config/secret.toml", b"token = 'hunter2'\n", 0o600),
+            (".local/bin/suid", b"#!/bin/sh\n", 0o4755),
+        ])
+        .await;
+
+        let channel = client
+            .open_subsystem(
+                STREAM_WORKSPACE_PATCHES,
+                &[(MINIMAL_SESSION_ID_ENV, &session_id.to_string())],
+            )
+            .await;
+        let mut stream = channel.into_stream();
+        stream.write_all(&payload).await.unwrap();
+        stream.shutdown().await.unwrap();
+        let mut trailing = Vec::new();
+        stream.read_to_end(&mut trailing).await.unwrap();
+
+        let mngr = server.state.sessions_manager().await;
+        let handle = mngr
+            .get_session(SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("session should be retrievable");
+        let paths = handle.paths().await.unwrap();
+        let patches = paths.patches.as_utf8_path();
+
+        let mode_of = async |rel: &str| {
+            tokio::fs::metadata(patches.join(rel))
+                .await
+                .unwrap_or_else(|e| panic!("staged patch `{rel}` should exist: {e}"))
+                .permissions()
+                .mode()
+                & 0o7777
+        };
+
+        assert_eq!(mode_of(".local/bin/tool").await, 0o755, "exec bit survives");
+        assert_eq!(
+            mode_of(".config/secret.toml").await,
+            0o600,
+            "a private mode is applied exactly, not widened by the umask",
+        );
+        assert_eq!(
+            mode_of(".local/bin/suid").await,
+            0o755,
+            "setuid is masked off, the rest of the mode is kept",
         );
     }
 

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -44,6 +44,13 @@ use tokio::task::JoinHandle;
 /// checked the patches-ready marker, so a missing file at this
 /// point is a bug (the marker was written but the file it should
 /// have gated on didn't land).
+///
+/// The copy is `fs::copy` specifically because it carries the source's
+/// permission bits across, which is the last link in the chain that
+/// keeps a patched script executable in the session (the unpacker set
+/// those bits on the staged file from the tar header). A hand-rolled
+/// read-then-write here would silently flatten every patch to the
+/// daemon's umask default.
 async fn materialize_patches_into_home(
     patches_dir: &DaemonAbsPath,
     home_dir: &DaemonAbsPath,
@@ -4716,5 +4723,84 @@ mod tests {
             "destroy ran a hook declared for another transition"
         );
         assert!(!record_exists(&mut client, session_id).await);
+    }
+
+    /// The staged patch's permission bits reach the session home. This
+    /// is the last hop of the chain that keeps a patched script
+    /// executable — the uploader puts the source's mode on the tar
+    /// header, the unpacker applies it to the staged file, and this
+    /// copy has to carry it the rest of the way.
+    ///
+    /// Pins the `fs::copy` in [`super::materialize_patches_into_home`]:
+    /// a hand-rolled read-then-write there would pass this test's
+    /// content assertions while silently flattening every mode.
+    #[tokio::test]
+    async fn materializing_patches_carries_their_modes_into_the_home() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        use paths::{DaemonAbsPath, HostAbsPath, SandboxRelPath};
+        use sessions::core::compose::Composition;
+        use sessions::wire::primitives::{WireResolvedPatch, WireSessionPatch, WireSource};
+        use sessions::wire::request::{COMPOSITION_SNAPSHOT_VERSION, WireComposition};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = camino::Utf8Path::from_path(tmp.path()).unwrap();
+        let patches_dir = root.join("patches");
+        let home_dir = root.join("home");
+        std::fs::create_dir_all(patches_dir.join(".local/bin").as_std_path()).unwrap();
+        std::fs::create_dir_all(home_dir.as_std_path()).unwrap();
+
+        // Two staged patches: one executable, one private. Modes are set
+        // on the staged files the way the unpacker sets them.
+        let staged = [(".local/bin/tool", 0o755), (".config/secret.toml", 0o600)];
+        for (rel, mode) in staged {
+            let path = patches_dir.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap().as_std_path()).unwrap();
+            std::fs::write(path.as_std_path(), b"x").unwrap();
+            std::fs::set_permissions(path.as_std_path(), std::fs::Permissions::from_mode(mode))
+                .unwrap();
+        }
+
+        let composition = Composition::try_from(WireComposition {
+            version: COMPOSITION_SNAPSHOT_VERSION,
+            vars: Vec::new(),
+            patches: staged
+                .iter()
+                .map(|(rel, _)| WireSessionPatch {
+                    patch: WireResolvedPatch {
+                        // The host path is not read here — the copy
+                        // sources from the staged tree, keyed by
+                        // destination — but the wire type requires one.
+                        host_path: HostAbsPath::try_new(patches_dir.join(rel)).unwrap(),
+                        destination: SandboxRelPath::try_new(*rel).unwrap(),
+                    },
+                    source: WireSource::UserLoadout {
+                        name: "dev".to_string(),
+                    },
+                })
+                .collect(),
+            packages: Vec::new(),
+            lifecycle_hooks: Vec::new(),
+            orientation: Default::default(),
+        })
+        .expect("a patch-only composition converts back");
+
+        super::materialize_patches_into_home(
+            &DaemonAbsPath::try_new(patches_dir.clone()).unwrap(),
+            &DaemonAbsPath::try_new(home_dir.clone()).unwrap(),
+            &composition,
+        )
+        .await
+        .expect("materializing staged patches");
+
+        for (rel, mode) in staged {
+            let meta = std::fs::metadata(home_dir.join(rel).as_std_path())
+                .unwrap_or_else(|e| panic!("`{rel}` should have landed in the home: {e}"));
+            assert_eq!(
+                meta.permissions().mode() & 0o7777,
+                mode,
+                "`{rel}` lost its mode on the way into the session home",
+            );
+        }
     }
 }

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -207,6 +207,19 @@ By default the walker does not follow symlinks while enumerating glob
 matches; see [`follow_symlinks`](#follow_symlinks) and the
 [client config](#client-config).
 
+**Permissions** carry across. A patched file lands with the source file's
+own permission bits, so a script stays executable and a `0600` key stays
+readable only by you. Two qualifications:
+
+- Preservation is exact, which cuts both ways: a read-only source (a
+  `0444` file, or a dotfile symlinked into a read-only store) lands
+  read-only, and editing it in the session takes a `chmod` first.
+- `setuid`, `setgid`, and the sticky bit are dropped; the nine standard
+  permission bits are what survives.
+
+Ownership is not carried and cannot be: every file in the session belongs
+to the session user, whatever it was owned by on your host.
+
 ### `[[lifecycle_hooks]]` - Scripts at session transition points
 
 _Optional_

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -84,6 +84,7 @@ SEED_DIR=""
 SEEDED_MFILE=""
 TASK_SEED_DIR="" # seeded by the `min task run` proof below; removed on teardown
 HOOK_SEED_DIR="" # seeded by the lifecycle-hooks proof below; removed on teardown
+PATCH_SRC_DIR="" # patch sources for the patch-modes proof; removed on teardown
 if [ -z "${E2E_PROJECT_DIR:-}" ]; then
   # Native: self-seed a small throwaway — never $ROOT (uploading the whole repo,
   # and scaffolding over its `.minimal/`, is the very clobber #758 prevents).
@@ -199,6 +200,7 @@ teardown() {
   [ -n "$SEEDED_MFILE" ] && rm -f "$SEEDED_MFILE"
   [ -n "$TASK_SEED_DIR" ] && rm -rf "$TASK_SEED_DIR"
   [ -n "$HOOK_SEED_DIR" ] && rm -rf "$HOOK_SEED_DIR"
+  [ -n "$PATCH_SRC_DIR" ] && rm -rf "$PATCH_SRC_DIR"
   # And the state dir — which is NOT just metadata. On a VM lane it holds the
   # provider's per-VM writable data volume
   # (`minimal/providers/local-minvmd0/data-vol.raw`), a sparse image whose HOST
@@ -859,6 +861,64 @@ LOADOUT
   rm -rf "$HOOK_SEED_DIR"; HOOK_SEED_DIR=""
   rm -f "$XDG_CONFIG_HOME/minimal/loadouts/hookdev.toml"
   echo "loadout-declared hooks proof OK (ran, ungated)"
+  echo "::endgroup::"
+
+  # -- Patch file modes ------------------------------------------------------
+  # A patch's permission bits cross three hops, and each has unit coverage of
+  # its own end only: the client stamps the source's mode on the tar header,
+  # the daemon applies it when unpacking into `<workspace>/patches/`, and the
+  # copy into the session home carries it the rest of the way. A bit dropped
+  # anywhere in there makes a patched script silently unrunnable, which is
+  # only observable from inside a real session — so it is asserted by RUNNING
+  # the patched script, not just by reading its mode back.
+  echo "::group::patch file modes"
+  PATCH_SRC_DIR="$(hook_mktemp /tmp/mnlpm.XXXXXX)"
+  # `/usr/bin/bash`, like the external-hook fixture above: it is the
+  # interpreter every lane's session is known to have.
+  printf '#!/usr/bin/bash\necho PATCHED_TOOL_OK\n' > "$PATCH_SRC_DIR/tool.sh"
+  chmod 755 "$PATCH_SRC_DIR/tool.sh"
+  printf 'token = "hunter2"\n' > "$PATCH_SRC_DIR/secret.toml"
+  chmod 600 "$PATCH_SRC_DIR/secret.toml"
+  mkdir -p "$XDG_CONFIG_HOME/minimal/loadouts"
+  {
+    printf 'description = "e2e patch modes"\n\n'
+    printf 'patches = [\n'
+    printf '  { dest = "bin/tool.sh", source = "%s/tool.sh" },\n' "$PATCH_SRC_DIR"
+    printf '  { dest = "secret.toml", source = "%s/secret.toml" },\n' "$PATCH_SRC_DIR"
+    printf ']\n'
+  } > "$XDG_CONFIG_HOME/minimal/loadouts/patchmode.toml"
+  HOOK_SEED_DIR="$(hook_mktemp /tmp/mnlpp.XXXXXX)"
+  hook_seed_preamble > "$HOOK_SEED_DIR/minimal.toml"
+  mkdir "$HOOK_SEED_DIR/.git"
+
+  pm_sid="$(cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt --loadout patchmode 2>"$WORK/patch-modes.err")" || {
+    echo "::error::activation with a patch-carrying loadout failed"
+    echo "--- stderr ---"; cat "$WORK/patch-modes.err" 2>/dev/null || true
+    fail
+  }
+  # `ls -l` rather than `stat -c %a`: portable across whatever the shell stack
+  # ships. The leading mode string is the assertion; a trailing ACL/SELinux
+  # marker would not disturb a substring match.
+  pm_out="$(mnl session exec "$pm_sid" \
+    'ls -l /home/bin/tool.sh /home/secret.toml; /home/bin/tool.sh' 2>/dev/null)"
+  if [[ "$pm_out" != *"-rwxr-xr-x"* ]]; then
+    echo "::error::patched script lost its 0755 mode: '$pm_out'"
+    echo "--- activate stderr ---"; cat "$WORK/patch-modes.err" 2>/dev/null || true
+    fail
+  fi
+  if [[ "$pm_out" != *"-rw-------"* ]]; then
+    echo "::error::patched secret did not keep its 0600 mode: '$pm_out'"
+    fail
+  fi
+  if [[ "$pm_out" != *PATCHED_TOOL_OK* ]]; then
+    echo "::error::patched script was not runnable in the session: '$pm_out'"
+    fail
+  fi
+  mnl session destroy --force "$pm_sid" >/dev/null 2>&1 || true
+  rm -rf "$HOOK_SEED_DIR"; HOOK_SEED_DIR=""
+  rm -rf "$PATCH_SRC_DIR"; PATCH_SRC_DIR=""
+  rm -f "$XDG_CONFIG_HOME/minimal/loadouts/patchmode.toml"
+  echo "patch file modes proof OK (0755 runs, 0600 stays private)"
   echo "::endgroup::"
 fi
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

  A patch copies a file from your host into the session home, and every one landed
  as `0o644` regardless of what it was: a script patched in through a loadout
  arrived non-executable, and a `0600` key arrived world-readable.

  The mode was dropped twice on the way in. The client stamped
  `mode_override: Some(0o644)` on every tar header, and the daemon's
  patches/hook-scripts unpacker wrote entry bodies with `tokio::fs::write`,
  ignoring the header's mode. The last hop was already correct —
  `materialize_patches_into_home` uses `fs::copy`, which carries permission bits —
  so only the first two needed fixing. The workspace-upload path already preserves
  modes end to end and is the precedent this follows.

  Now: the client sends the source file's own mode, and the daemon reproduces it on
  disk. Two deliberate limits, both documented in the loadout reference:

  - **setuid/setgid/sticky are dropped** (`mode & 0o777`). The header comes off the
    wire, so the daemon shouldn't honour a client-supplied privilege bit — the same
    masking `async_tar::Archive::unpack` already applies to the workspace tree.
  - **Preservation is exact**, which retires the old "normalizing writable copies"
    behaviour: a read-only source (a `0444` file, a dotfile symlinked into a
    read-only store) now lands read-only and takes a `chmod` to edit in the box.

  Ownership is not carried and can't be — every file in the session belongs to the
  session user.

  Implementation notes on the daemon write: it creates with `.mode()` so the file
  is never briefly *more* permissive than intended, then sets permissions
  explicitly on the fd so the daemon's umask can't clear bits the entry does ask
  for; the `flush` between them is required, since a `tokio::fs::File` completes
  writes in the background and dropping one unflushed truncates it silently.

  ## Testing

  `just fmt-check` and `just clippy` clean. `cargo test --workspace --locked` —
  1865 passed, 0 failed; 13 doctests pass.

  New coverage, one test per hop:

  - `stream_workspace_patches_preserves_entry_modes` drives a real upload through
    the RPC — `0o755` stays executable, `0o600` stays private (the case that proves
    the umask isn't winning), `0o4755` lands `0o755`.
  - `materializing_patches_carries_their_modes_into_the_home` pins the `fs::copy`.
  - `tar_zst_archive_add_file_defaults_to_the_source_mode` covers the client header.
  - `scripts/session-e2e.sh` gains a "patch file modes" block that patches in a
    `0755` script and a `0600` secret and asserts from inside a live session — by
    reading the modes back *and by running the patched script*, which is the only
    assertion that proves the exec bit survives all three hops.

  **Not run: `just e2e`.** The session e2e can't start a daemon in my environment —
  a global git `insteadOf` rewrite to a local mirror makes `checkouts::Repo::new`
  reject the cached clone (`vcs: invalid remote path`), which fails at the first
  step, before any of this code. The new e2e block is therefore unexecuted and
  needs a run on a normal host before merge.

  ## Checklist

  - [x] Docs updated if behavior changed
  - [x] `BREAKING CHANGE:` footer present if this is a breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File uploads, workspace transfers, and patch applications now preserve standard source permissions, including executable and private modes.
  - Patched executable files remain runnable inside sessions.
  - Setuid, setgid, sticky-bit, and ownership metadata are excluded for security.

- **Documentation**
  - Clarified permission, symlink, and ownership behavior for uploads and loadout patches.

- **Tests**
  - Added coverage validating permission preservation, security-bit masking, and executable patched scripts in sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->