### PR TITLE
spec: session/task SBOM + CycloneDX Blueprint (inbox#582)

### DIFF
--- a/docs/specs/12-spec-sbom-blueprint/12-spec-sbom-blueprint.md
+++ b/docs/specs/12-spec-sbom-blueprint/12-spec-sbom-blueprint.md
@@ -5,7 +5,7 @@ status: draft
 owner: bryan-minimal
 epic: gominimal/inbox#582
 arch: none
-updated: 2026-08-27
+updated: 2026-09-03
 ---
 
 # SBOM — session/task SBOM + CycloneDX Blueprint
@@ -23,8 +23,17 @@ agent sessions want the posture story reviewable before granting it.
 documents whose component digests chain to the signed catalog closure, and
 whose regeneration is byte-identical.
 
-**First slice:** a fixture composition emits validated CycloneDX 1.5 and
-minimal-valid SPDX 2.3 documents, byte-stable across regenerations.
+A document for an environment is a **composition**, not a re-derivation:
+the per-package document sealed at publish is the unit, and an environment's
+document is an envelope of composition-level facts over references to those
+units, resolved through the environment's pin. Packages the cache does not
+carry — built locally, or non-redistributable by policy — are the ordinary
+case, not the exception, and appear as declared gaps.
+
+**First slice:** publish emits a per-package document for one catalog
+package, sealed beside its artifact; a fixture composition then emits
+validated CycloneDX 1.5 and minimal-valid SPDX 2.3 over it, byte-stable
+across regenerations.
 
 ## Users and stories
 
@@ -42,7 +51,8 @@ developer running agent sessions; build-infra operator; auditor.
   before granting it
 - AS A build-infra operator I WANT the same model emitted per-package at
   publish time SO THAT catalog artifacts ship supply-chain documents without
-  a second implementation
+  a second implementation, and every environment document composes from them
+  rather than re-deriving component detail
 - AS AN auditor I WANT deterministic regeneration SO THAT two parties can
   independently produce and compare the same document
 
@@ -52,16 +62,25 @@ developer running agent sessions; build-infra operator; auditor.
   emitted twice THE SYSTEM SHALL produce byte-identical documents, deriving
   serials, namespaces, and timestamps from content and pin, never from wall
   clock or randomness.
+  tier:     T1
   verify:   just test-one sbom_regeneration_deterministic
   property: for all pin, inputs: emit(pin, inputs) == emit(pin, inputs)
+  - IF the cache's contents differ between two emissions under the same pin
+    THEN THE SYSTEM SHALL still produce byte-identical documents, the
+    composition being a function of the pin and its closure rather than of
+    what the cache happens to hold.
+    tier:   T0
+    verify: just test-one sbom_determinism_independent_of_cache_state
 
 - **SBOM-002** WHEN a document is emitted as CycloneDX THE SYSTEM SHALL
   produce output that validates against the vendored CycloneDX 1.5 schema.
+  tier:     T1
   verify:   just test-one sbom_cdx_schema_conformance
   property: for all compositions c: cdx_schema_valid(emit_cdx(c))
 
 - **SBOM-003** WHEN a document is emitted as SPDX THE SYSTEM SHALL produce
   minimal-valid SPDX 2.3.
+  tier:     T1
   verify:   just test-one sbom_spdx_validity
   property: for all compositions c: spdx_valid(emit_spdx(c))
 
@@ -69,12 +88,14 @@ developer running agent sessions; build-infra operator; auditor.
   artifact digest resolvable through the signed closure object, or an
   explicit digest gap of `built-locally` or `non-redistributable` — never
   neither and never both.
+  tier:     T1
   verify:   just test-one sbom_digest_or_gap_total
   property: for all components k: has_sha256(k) xor has_digest_gap(k)
 
 - **SBOM-005** THE SYSTEM SHALL include every package present in the
   environment as a component, with launcher-injected packages carrying
   `minimal:added-by=launcher`.
+  tier:     T1
   verify:   just test-one sbom_launcher_packages_present
   property: for all environments e: components(emit(e)) superset packages(e)
 
@@ -82,6 +103,7 @@ developer running agent sessions; build-infra operator; auditor.
   SYSTEM SHALL validate against the vendored draft schema and SHALL emit
   axes the session model cannot declare as schema-TODO properties, never as
   fabricated values.
+  tier:     T1
   verify:   just test-one blueprint_schema_conformance
   property: for all compositions c: bp_schema_valid(emit_bp(c)) and
     fabricated_axes(emit_bp(c)) is empty
@@ -89,14 +111,45 @@ developer running agent sessions; build-infra operator; auditor.
 - **SBOM-007** WHEN a session SBOM is emitted under a pin whose commit
   carries a sealed attribution manifest THE SYSTEM SHALL emit component
   licenses equal to the manifest's license entries for that pin.
+  tier:     T0
   verify: just test-one sbom_licenses_match_attribution
 
 - **SBOM-008** THE SYSTEM SHALL record environment-variable assets by name
   and provenance only, and SHALL never embed variable values in any
   document.
+  tier:     T1
   verify:   just test-one blueprint_env_values_never_embedded
   property: for all compositions c, vars v: values(v) intersect
     bytes(emit(c)) is empty
+
+- **SBOM-009** WHEN emitting a document for an environment whose components
+  are published under its pin THE SYSTEM SHALL compose component detail by
+  reference to the per-package documents resolved through that pin's
+  closure, rather than re-deriving it from recipe metadata.
+  tier:     T0
+  verify:   just test-one sbom_composes_from_per_package_documents
+
+- **SBOM-010** THE SYSTEM SHALL derive composition-level facts — launcher
+  injection, posture axes, and environment assets — from the environment's
+  own declaration, never from a component document, which cannot carry
+  them.
+  tier:     T1
+  verify:   just test-one sbom_envelope_facts_are_environment_derived
+  property: for all environments e: envelope(emit(e)) == declared_facts(e)
+
+- **SBOM-011** IF a component has no per-package document resolvable
+  through the pinned closure THEN THE SYSTEM SHALL emit that component
+  carrying its declared digest gap, never omitting it.
+  tier:     T1
+  verify:   just test-one sbom_unresolvable_component_becomes_a_gap
+  property: for all environments e: components(emit(e)) superset packages(e)
+
+- **SBOM-012** IF the pinned index or a referenced per-package document
+  cannot be fetched THEN THE SYSTEM SHALL fail naming the pin, the
+  unresolved object, and the remediation, never emitting a document whose
+  component set is silently incomplete.
+  tier:     T0
+  verify:   just test-one sbom_unfetchable_reference_fails_loudly
 
 ## Non-goals
 
@@ -106,6 +159,9 @@ developer running agent sessions; build-infra operator; auditor.
 - Converging legacy `mfile::Task` onto sessions primitives: minimal#700 D6
 - Network-zone enforcement: the sessions/sandbox spec (zones are declared
   and caveated here)
+- Signing composed environment documents: they are derivations over signed
+  per-package inputs and carry those bundles by reference — signing policy
+  lives with the attestation cutover, gominimal/build-servers#86
 
 ## Design reasoning
 
@@ -119,7 +175,7 @@ model crate serves both the CLI and build-infra per-package emission — the
 second consumer is why the model takes no CLI or daemon dependencies. A
 content-derived catalog pin replaces random serials and wall-clock so
 documents chain to a Sigstore-verifiable object and regeneration is
-reproducible. Decisions and alternatives live in minimal#700 (D1–D11).
+reproducible. Decisions and alternatives live in minimal#700 (D1-D11).
 
 **Generality:** a second document format fits behind the serializer seam
 (SPDX proves it in the first slice); a second consumer (build infra) is a
@@ -146,6 +202,11 @@ the spec that defines the sandbox.
   explicit gap rather than an omission or a guess.
   enforced by: the digest-or-gap total mapping over the signed closure
   covered by: SBOM-004
+- **Invariant:** THE SYSTEM SHALL never emit a document whose component set
+  is incomplete without saying so.
+  enforced by: unresolvable components become declared gaps; unfetchable
+  references abort the emission
+  covered by: SBOM-011, SBOM-012
 
 ## Open questions
 
@@ -156,6 +217,14 @@ the spec that defines the sandbox.
 - [NEEDS CLARIFICATION (CRITICAL): D11 — Sandbox-Spec vocabulary conflicts;
   answers change every emitted document's vocabulary; settle before golden
   fixtures land.]
+- [NEEDS CLARIFICATION (HIGH): is a composed environment document signed in
+  its own right, or a verifiable derivation over signed per-package inputs
+  it references? Recommendation on record: a derivation — it needs no
+  per-environment signing infrastructure and stays valid as inputs are
+  re-signed. Decide with the attestation cutover, build-servers#86.]
+- [NEEDS CLARIFICATION (HIGH): which existing emitter does the model crate
+  subsume — `minimal-supply-chain::sbom`, `pkgmgr-rs`'s `commands::sbom`,
+  or `attest-sbom`? Answering it late means a fourth implementation.]
 - [NEEDS CLARIFICATION (LOW): SPDX `created` timestamp source (proposal:
   pinned commit's committer timestamp); both answers satisfy SBOM-001;
   settle in first-slice review.]

--- a/docs/specs/12-spec-sbom-blueprint/12-spec-sbom-blueprint.md
+++ b/docs/specs/12-spec-sbom-blueprint/12-spec-sbom-blueprint.md
@@ -1,168 +1,161 @@
 ---
+id: SBOM
+title: session/task SBOM + CycloneDX Blueprint
+status: draft
+owner: bryan-minimal
 epic: gominimal/inbox#582
-arch: gominimal/arch (CycloneDX Blueprints design synthesis; SBOM/Blueprint implementation plan)
+arch: none
+updated: 2026-08-27
 ---
 
-# 12-spec-sbom-blueprint: session/task SBOM + CycloneDX Blueprint
+# SBOM — session/task SBOM + CycloneDX Blueprint
 
 ## Context
 
-Minimal owns, in-process, the complete declared story of a session or task —
-composition, closure, pins — but cannot export it in the formats the world
-consumes. Security scanners want an SBOM; compliance wants supply-chain
-documents whose digests are evidence rather than assertion; build infra wants
-per-package SBOMs at publish chained to the signed per-commit closure
-(build-servers#86/#185); developers granting agent sessions want the posture
-story (what crosses the sandbox boundary) reviewable before granting it.
+Minimal owns the complete declared story of a session or task — composition,
+closure, pins — but cannot export it in the formats the world consumes.
+Security scanners want an SBOM; compliance wants documents whose digests are
+evidence rather than assertion; build infrastructure wants per-package SBOMs
+at publish chained to the signed per-commit closure; developers granting
+agent sessions want the posture story reviewable before granting it.
 
-Success criteria fold in the epic's outcome: one lean model (`crates/sbom`,
-serde-only deps) serving two consumers — the `min sbom` CLI and build-infra
-per-package emission — with CycloneDX 1.5 + minimal-valid SPDX 2.3 behind one
-serializer seam, and a CycloneDX 2.0 draft Blueprint posture format.
+**Success:** a session or task+loadout yields schema-valid supply-chain
+documents whose component digests chain to the signed catalog closure, and
+whose regeneration is byte-identical.
 
-**First slice** (runs end to end): `crates/sbom` + neutral IR + both
-serializers + `SerialPolicy::ContentDerived` + `CatalogPin` + golden fixtures
-and schema-conformance tests — platform-neutral, no CLI/daemon changes
-(minimal#700 PR-1).
+**First slice:** a fixture composition emits validated CycloneDX 1.5 and
+minimal-valid SPDX 2.3 documents, byte-stable across regenerations.
 
 ## Users and stories
 
-- As a **security engineer**, I want a CycloneDX SBOM of any task or session,
-  so that existing scanners and policy tooling can evaluate what Minimal
-  environments contain.
-- As a **compliance reviewer / downstream consumer**, I want component digests
-  that verifiably chain to the signed per-commit catalog closure, so that the
-  document is evidence, not assertion.
-- As a **developer running agent sessions**, I want a Blueprint of a session's
-  declared posture (env inherits, patches, hooks, zones), so that I can review
-  what an agent environment may do before granting it.
-- As a **build-infra operator**, I want the same model emitted per-package at
-  publish time, so that catalog artifacts ship supply-chain documents without
-  a second implementation.
-- As an **auditor**, I want deterministic regeneration, so that two parties
-  can independently produce and compare the same document.
+**Roles:** security engineer; compliance reviewer / downstream consumer;
+developer running agent sessions; build-infra operator; auditor.
+
+- AS A security engineer I WANT a CycloneDX SBOM of any task or session SO
+  THAT existing scanners and policy tooling can evaluate what Minimal
+  environments contain
+- AS A compliance reviewer I WANT component digests that verifiably chain to
+  the signed per-commit catalog closure SO THAT the document is evidence,
+  not assertion
+- AS A developer running agent sessions I WANT a Blueprint of a session's
+  declared posture SO THAT I can review what an agent environment may do
+  before granting it
+- AS A build-infra operator I WANT the same model emitted per-package at
+  publish time SO THAT catalog artifacts ship supply-chain documents without
+  a second implementation
+- AS AN auditor I WANT deterministic regeneration SO THAT two parties can
+  independently produce and compare the same document
 
 ## Requirements
 
-- **SBOM-001** WHEN `min sbom` is invoked twice with the same `CatalogPin`
-  and identical declared inputs THE SYSTEM SHALL emit byte-identical
-  documents, deriving serials, namespaces, and timestamps from content and
-  pin, never from wall clock or randomness.
-  - tier: T1
-  - verify: just test-one sbom_regeneration_deterministic
-  - property: for all pin, inputs: emit(pin, inputs) == emit(pin, inputs)
+- **SBOM-001** WHEN the same catalog pin and identical declared inputs are
+  emitted twice THE SYSTEM SHALL produce byte-identical documents, deriving
+  serials, namespaces, and timestamps from content and pin, never from wall
+  clock or randomness.
+  verify:   just test-one sbom_regeneration_deterministic
+  property: for all pin, inputs: emit(pin, inputs) == emit(pin, inputs)
 
-- **SBOM-002** WHEN a document is emitted with `--format cdx` THE SYSTEM
-  SHALL produce output that validates against the vendored CycloneDX 1.5
-  schema.
-  - tier: T1
-  - verify: just test-one sbom_cdx_schema_conformance
-  - property: for all compositions c: cdx_schema_valid(emit_cdx(c))
+- **SBOM-002** WHEN a document is emitted as CycloneDX THE SYSTEM SHALL
+  produce output that validates against the vendored CycloneDX 1.5 schema.
+  verify:   just test-one sbom_cdx_schema_conformance
+  property: for all compositions c: cdx_schema_valid(emit_cdx(c))
 
-- **SBOM-003** WHEN a document is emitted with `--format spdx` THE SYSTEM
-  SHALL produce minimal-valid SPDX 2.3.
-  - tier: T1
-  - verify: just test-one sbom_spdx_validity
-  - property: for all compositions c: spdx_valid(emit_spdx(c))
+- **SBOM-003** WHEN a document is emitted as SPDX THE SYSTEM SHALL produce
+  minimal-valid SPDX 2.3.
+  verify:   just test-one sbom_spdx_validity
+  property: for all compositions c: spdx_valid(emit_spdx(c))
 
-- **SBOM-004** WHEN emitting any component THE SYSTEM SHALL attach either an
-  `artifact_sha256` resolvable through the signed closure object, or an
-  explicit `digest_gap` of `built-locally` or `non-redistributable` — never
+- **SBOM-004** THE SYSTEM SHALL attach to every component either an
+  artifact digest resolvable through the signed closure object, or an
+  explicit digest gap of `built-locally` or `non-redistributable` — never
   neither and never both.
-  - tier: T1
-  - verify: just test-one sbom_digest_or_gap_total
-  - property: for all components k: has_sha256(k) xor has_digest_gap(k)
+  verify:   just test-one sbom_digest_or_gap_total
+  property: for all components k: has_sha256(k) xor has_digest_gap(k)
 
-- **SBOM-005** WHEN the environment contains launcher-injected packages THE
-  SYSTEM SHALL include them as components carrying
-  `minimal:added-by=launcher` — an SBOM SHALL never omit a package present
-  in the environment.
-  - tier: T1
-  - verify: just test-one sbom_launcher_packages_present
-  - property: for all environments e: components(emit(e)) superset packages(e)
+- **SBOM-005** THE SYSTEM SHALL include every package present in the
+  environment as a component, with launcher-injected packages carrying
+  `minimal:added-by=launcher`.
+  verify:   just test-one sbom_launcher_packages_present
+  property: for all environments e: components(emit(e)) superset packages(e)
 
-- **SBOM-006** WHEN a document is emitted with `--format cdx-blueprint` THE
-  SYSTEM SHALL produce output validating against the vendored CycloneDX 2.0
-  draft schema, and SHALL emit axes the session model cannot declare as
-  schema-TODO properties, never as fabricated values.
-  - tier: T1
-  - verify: just test-one blueprint_schema_conformance
-  - property: for all compositions c: bp_schema_valid(emit_bp(c)) and
-    fabricated_axes(emit_bp(c)) == empty
+- **SBOM-006** WHEN a document is emitted as a CycloneDX 2.0 Blueprint THE
+  SYSTEM SHALL validate against the vendored draft schema and SHALL emit
+  axes the session model cannot declare as schema-TODO properties, never as
+  fabricated values.
+  verify:   just test-one blueprint_schema_conformance
+  property: for all compositions c: bp_schema_valid(emit_bp(c)) and
+    fabricated_axes(emit_bp(c)) is empty
 
-- **SBOM-007** licenses cross-check with the sealed attribution manifest
-  - tier: T0
-  - verify: just test-one sbom_licenses_match_attribution
+- **SBOM-007** WHEN a session SBOM is emitted under a pin whose commit
+  carries a sealed attribution manifest THE SYSTEM SHALL emit component
+  licenses equal to the manifest's license entries for that pin.
+  verify: just test-one sbom_licenses_match_attribution
 
-  @SBOM-007
-  Scenario: session SBOM and attribution manifest agree on licenses
-    Given a pinned commit with a sealed attribution manifest
-    When a session SBOM is emitted under the same CatalogPin
-    Then each component's licenses equal the manifest's license_spdx entries
-
-- **SBOM-008** WHEN emitting environment-variable assets THE SYSTEM SHALL
-  record variable names and provenance (inherited vs specified) and SHALL
-  never embed variable values.
-  - tier: T1
-  - verify: just test-one blueprint_env_values_never_embedded
-  - property: for all compositions c, vars v: values(v) intersect
-    bytes(emit(c)) == empty
+- **SBOM-008** THE SYSTEM SHALL record environment-variable assets by name
+  and provenance only, and SHALL never embed variable values in any
+  document.
+  verify:   just test-one blueprint_env_values_never_embedded
+  property: for all compositions c, vars v: values(v) intersect
+    bytes(emit(c)) is empty
 
 ## Non-goals
 
-Live-session/observed mode (declared-spec only; observed capture is its own
-subsystem — minimal#700 slice 6, gated on D2). Full SPDX profile depth.
-Usage/link-tier axis (model field reserved). Converging legacy `mfile::Task`
-onto sessions primitives (D6). Network-zone enforcement (declared and
-caveated in v1).
+- Live-session/observed mode: minimal#700 slice 6 (declared-spec only here)
+- Full SPDX profile depth: minimal#700 D10 (minimal-valid only here)
+- Usage/link-tier axis: model field reserved, minimal#700 refs
+- Converging legacy `mfile::Task` onto sessions primitives: minimal#700 D6
+- Network-zone enforcement: the sessions/sandbox spec (zones are declared
+  and caveated here)
 
 ## Design reasoning
 
-The artifact minimal emits for build/workflow story is CycloneDX
-**formulation** (schema-stable since 1.5), while "Blueprint" — the 2.0 draft
-threat-modeling schema — carries the posture story; the naming distinction is
-deliberate to avoid a semantic clash in a public CLI (see the arch design
-synthesis). Declared-spec-first because minimal persists no execution ledger
-today: the declared model is cheap and honest, observed capture is a real
-subsystem. One lean crate serves both the CLI and build-infra emission —
-the second consumer is why `crates/sbom` takes no clap/daemon/rcache deps.
-`CatalogPin = {repo, commit, closure_object}` replaces uuid-v4 + wall-clock
-serials so documents chain to a Sigstore-verifiable object (minimal#995,
-build-servers#86) and regeneration is reproducible. Decisions and
-alternatives live in minimal#700 (D1–D11) and gominimal/arch.
+The build/workflow story minimal emits is CycloneDX **formulation**
+(schema-stable since 1.5); "Blueprint" — the 2.0 draft threat-modeling
+schema — carries the posture story. The naming distinction is deliberate to
+avoid a semantic clash in a public CLI. Declared-spec-first because minimal
+persists no execution ledger today: the declared model is cheap and honest;
+observed capture is a real subsystem deferred to its own slice. One lean
+model crate serves both the CLI and build-infra per-package emission — the
+second consumer is why the model takes no CLI or daemon dependencies. A
+content-derived catalog pin replaces random serials and wall-clock so
+documents chain to a Sigstore-verifiable object and regeneration is
+reproducible. Decisions and alternatives live in minimal#700 (D1–D11).
+
+**Generality:** a second document format fits behind the serializer seam
+(SPDX proves it in the first slice); a second consumer (build infra) is a
+design input, not an afterthought. What does not generalize: posture
+vocabulary is bound to the Sandbox Spec — a second sandbox model would need
+its own axis mapping, which is acceptable because the vocabulary follows
+the spec that defines the sandbox.
 
 ## Security considerations
 
-- The honesty invariants are universals and carry the security weight:
-  an SBOM SHALL never omit present packages (SBOM-005) and a Blueprint SHALL
-  never fabricate posture (SBOM-006) — a flattering document is worse than
-  none.
-- Environment-variable VALUES never enter any document (SBOM-008): inherited
-  secrets stay host-side; documents carry names and provenance only.
-- Digest trust chains to the signed per-commit closure; verification is
-  consumer-side via the existing Sigstore path (build-servers#86). A document
-  without a verifiable pin is an assertion, and `digest_gap` says so
-  explicitly rather than pretending.
-- Blueprint documents map a session's attack surface by design; they contain
-  no secrets by SBOM-008, but distribution defaults should treat them like
-  configuration, not like public marketing.
+- **Invariant:** THE SYSTEM SHALL include every package present in the
+  environment in its SBOM.
+  enforced by: closure-walk emission with launcher-injection tagging, never
+  filtering
+  covered by: SBOM-005
+- **Invariant:** THE SYSTEM SHALL emit no fabricated posture values.
+  enforced by: schema-TODO properties for undeclarable axes
+  covered by: SBOM-006
+- **Invariant:** THE SYSTEM SHALL embed no environment-variable values in
+  any document.
+  enforced by: name+provenance asset model; values never enter the IR
+  covered by: SBOM-008
+- **Invariant:** THE SYSTEM SHALL represent every unverifiable digest as an
+  explicit gap rather than an omission or a guess.
+  enforced by: the digest-or-gap total mapping over the signed closure
+  covered by: SBOM-004
 
 ## Open questions
 
-- **CRITICAL:** D4 — `--format cdx-blueprint` naming vs "blueprint" already
-  meaning minimal.toml in user-facing docs. At least one plausible answer
-  renames the CLI surface (observable behaviour). Recommendation on record
-  (keep crate name, user-facing flag `cdx-blueprint`); needs the decision
-  before the format flag ships (minimal#700, decide-before-slice-4).
-- **CRITICAL:** D11 — Sandbox-Spec vocabulary conflicts (`network.type`,
-  `file_imports/exports`, `machine.*`). Plausible answers change every
-  emitted document's vocabulary; must settle before golden fixtures land or
-  renames churn every checked-in BOM.
-- SPDX `created` timestamp source (proposal: pinned commit's committer
-  timestamp). Both candidate answers satisfy SBOM-001's content-derived
-  rule; bytes differ but no requirement changes — non-critical, settle in
-  PR-1 review.
-
-## Rollout
-
-N/A. (CLI + library work; no infrastructure deployment.)
+- [NEEDS CLARIFICATION (CRITICAL): D4 — `--format cdx-blueprint` naming vs
+  "blueprint" already meaning minimal.toml in user docs; renames the CLI
+  surface. Recommendation on record in minimal#700; decide before the
+  format flag ships.]
+- [NEEDS CLARIFICATION (CRITICAL): D11 — Sandbox-Spec vocabulary conflicts;
+  answers change every emitted document's vocabulary; settle before golden
+  fixtures land.]
+- [NEEDS CLARIFICATION (LOW): SPDX `created` timestamp source (proposal:
+  pinned commit's committer timestamp); both answers satisfy SBOM-001;
+  settle in first-slice review.]

--- a/docs/specs/12-spec-sbom-blueprint/12-spec-sbom-blueprint.md
+++ b/docs/specs/12-spec-sbom-blueprint/12-spec-sbom-blueprint.md
@@ -23,6 +23,10 @@ agent sessions want the posture story reviewable before granting it.
 documents whose component digests chain to the signed catalog closure, and
 whose regeneration is byte-identical.
 
+A **catalog pin** is the triple {repo, commit, closure object} the epic
+defines; every document is emitted under one, and "the pin" below always means
+it.
+
 A document for an environment is a **composition**, not a re-derivation:
 the per-package document sealed at publish is the unit, and an environment's
 document is an envelope of composition-level facts over references to those
@@ -49,10 +53,9 @@ developer running agent sessions; build-infra operator; auditor.
 - AS A developer running agent sessions I WANT a Blueprint of a session's
   declared posture SO THAT I can review what an agent environment may do
   before granting it
-- AS A build-infra operator I WANT the same model emitted per-package at
-  publish time SO THAT catalog artifacts ship supply-chain documents without
-  a second implementation, and every environment document composes from them
-  rather than re-deriving component detail
+- AS A build-infra operator I WANT the same SBOM model emitted per-package at
+  publish time SO THAT catalog artifacts ship with supply-chain documents
+  without a second implementation
 - AS AN auditor I WANT deterministic regeneration SO THAT two parties can
   independently produce and compare the same document
 
@@ -122,12 +125,13 @@ developer running agent sessions; build-infra operator; auditor.
   property: for all compositions c, vars v: values(v) intersect
     bytes(emit(c)) is empty
 
-- **SBOM-009** WHEN emitting a document for an environment whose components
-  are published under its pin THE SYSTEM SHALL compose component detail by
-  reference to the per-package documents resolved through that pin's
-  closure, rather than re-deriving it from recipe metadata.
+- **SBOM-009** WHEN a component has a per-package document sealed under the
+  environment's pin THE SYSTEM SHALL emit that component's detail equal to
+  that document. The per-package document is the interface build
+  infrastructure emits and this command reads, so its content is part of the
+  contract rather than an implementation choice.
   tier:     T0
-  verify:   just test-one sbom_composes_from_per_package_documents
+  verify:   just test-one sbom_component_detail_equals_sealed_document
 
 - **SBOM-010** THE SYSTEM SHALL derive composition-level facts — launcher
   injection, posture axes, and environment assets — from the environment's
@@ -148,8 +152,10 @@ developer running agent sessions; build-infra operator; auditor.
   cannot be fetched THEN THE SYSTEM SHALL fail naming the pin, the
   unresolved object, and the remediation, never emitting a document whose
   component set is silently incomplete.
-  tier:     T0
+  tier:     T1
   verify:   just test-one sbom_unfetchable_reference_fails_loudly
+  property: for all emissions e: emitted(e) implies every component of e
+    resolved or carries a declared gap
 
 ## Non-goals
 
@@ -176,6 +182,27 @@ second consumer is why the model takes no CLI or daemon dependencies. A
 content-derived catalog pin replaces random serials and wall-clock so
 documents chain to a Sigstore-verifiable object and regeneration is
 reproducible. Decisions and alternatives live in minimal#700 (D1-D11).
+
+SBOM-009 through SBOM-012 answer a review question on the spec PR rather than
+an acceptance criterion: the epic predates the choice between eager
+whole-environment emission and composition, and its criteria do not reach it.
+Composition by reference rather than eager whole-environment emission: the
+per-package document is the unit publish already has the inputs for, one
+document serves every environment containing that package, and a composed
+document inherits corrected component data — a revised patch ledger, a new
+advisory disposition — without regenerating anything. The cost is that
+resolution can miss, which is why SBOM-011 and SBOM-012 are requirements
+rather than error handling: a document that silently drops a component is
+worse than one that refuses to emit. Non-redistributable packages and
+locally-built ones are permanently outside the cache by design, so the gap
+arm is the ordinary path, not a failure mode.
+
+Three CycloneDX emitters already exist in the org — `minimal-supply-chain`'s
+`sbom.rs`, `pkgmgr-rs`'s `pkgmgr sbom` built on it, and the older
+`attest-sbom` crate — all deriving from recipe metadata rather than from a
+built artifact. The model crate here subsumes rather than joins them; which of
+the three it replaces is an open question below, and leaving it unanswered is
+how a fourth implementation gets written.
 
 **Generality:** a second document format fits behind the serializer seam
 (SPDX proves it in the first slice); a second consumer (build infra) is a

--- a/docs/specs/12-spec-sbom-blueprint/12-spec-sbom-blueprint.md
+++ b/docs/specs/12-spec-sbom-blueprint/12-spec-sbom-blueprint.md
@@ -1,0 +1,168 @@
+---
+epic: gominimal/inbox#582
+arch: gominimal/arch (CycloneDX Blueprints design synthesis; SBOM/Blueprint implementation plan)
+---
+
+# 12-spec-sbom-blueprint: session/task SBOM + CycloneDX Blueprint
+
+## Context
+
+Minimal owns, in-process, the complete declared story of a session or task —
+composition, closure, pins — but cannot export it in the formats the world
+consumes. Security scanners want an SBOM; compliance wants supply-chain
+documents whose digests are evidence rather than assertion; build infra wants
+per-package SBOMs at publish chained to the signed per-commit closure
+(build-servers#86/#185); developers granting agent sessions want the posture
+story (what crosses the sandbox boundary) reviewable before granting it.
+
+Success criteria fold in the epic's outcome: one lean model (`crates/sbom`,
+serde-only deps) serving two consumers — the `min sbom` CLI and build-infra
+per-package emission — with CycloneDX 1.5 + minimal-valid SPDX 2.3 behind one
+serializer seam, and a CycloneDX 2.0 draft Blueprint posture format.
+
+**First slice** (runs end to end): `crates/sbom` + neutral IR + both
+serializers + `SerialPolicy::ContentDerived` + `CatalogPin` + golden fixtures
+and schema-conformance tests — platform-neutral, no CLI/daemon changes
+(minimal#700 PR-1).
+
+## Users and stories
+
+- As a **security engineer**, I want a CycloneDX SBOM of any task or session,
+  so that existing scanners and policy tooling can evaluate what Minimal
+  environments contain.
+- As a **compliance reviewer / downstream consumer**, I want component digests
+  that verifiably chain to the signed per-commit catalog closure, so that the
+  document is evidence, not assertion.
+- As a **developer running agent sessions**, I want a Blueprint of a session's
+  declared posture (env inherits, patches, hooks, zones), so that I can review
+  what an agent environment may do before granting it.
+- As a **build-infra operator**, I want the same model emitted per-package at
+  publish time, so that catalog artifacts ship supply-chain documents without
+  a second implementation.
+- As an **auditor**, I want deterministic regeneration, so that two parties
+  can independently produce and compare the same document.
+
+## Requirements
+
+- **SBOM-001** WHEN `min sbom` is invoked twice with the same `CatalogPin`
+  and identical declared inputs THE SYSTEM SHALL emit byte-identical
+  documents, deriving serials, namespaces, and timestamps from content and
+  pin, never from wall clock or randomness.
+  - tier: T1
+  - verify: just test-one sbom_regeneration_deterministic
+  - property: for all pin, inputs: emit(pin, inputs) == emit(pin, inputs)
+
+- **SBOM-002** WHEN a document is emitted with `--format cdx` THE SYSTEM
+  SHALL produce output that validates against the vendored CycloneDX 1.5
+  schema.
+  - tier: T1
+  - verify: just test-one sbom_cdx_schema_conformance
+  - property: for all compositions c: cdx_schema_valid(emit_cdx(c))
+
+- **SBOM-003** WHEN a document is emitted with `--format spdx` THE SYSTEM
+  SHALL produce minimal-valid SPDX 2.3.
+  - tier: T1
+  - verify: just test-one sbom_spdx_validity
+  - property: for all compositions c: spdx_valid(emit_spdx(c))
+
+- **SBOM-004** WHEN emitting any component THE SYSTEM SHALL attach either an
+  `artifact_sha256` resolvable through the signed closure object, or an
+  explicit `digest_gap` of `built-locally` or `non-redistributable` — never
+  neither and never both.
+  - tier: T1
+  - verify: just test-one sbom_digest_or_gap_total
+  - property: for all components k: has_sha256(k) xor has_digest_gap(k)
+
+- **SBOM-005** WHEN the environment contains launcher-injected packages THE
+  SYSTEM SHALL include them as components carrying
+  `minimal:added-by=launcher` — an SBOM SHALL never omit a package present
+  in the environment.
+  - tier: T1
+  - verify: just test-one sbom_launcher_packages_present
+  - property: for all environments e: components(emit(e)) superset packages(e)
+
+- **SBOM-006** WHEN a document is emitted with `--format cdx-blueprint` THE
+  SYSTEM SHALL produce output validating against the vendored CycloneDX 2.0
+  draft schema, and SHALL emit axes the session model cannot declare as
+  schema-TODO properties, never as fabricated values.
+  - tier: T1
+  - verify: just test-one blueprint_schema_conformance
+  - property: for all compositions c: bp_schema_valid(emit_bp(c)) and
+    fabricated_axes(emit_bp(c)) == empty
+
+- **SBOM-007** licenses cross-check with the sealed attribution manifest
+  - tier: T0
+  - verify: just test-one sbom_licenses_match_attribution
+
+  @SBOM-007
+  Scenario: session SBOM and attribution manifest agree on licenses
+    Given a pinned commit with a sealed attribution manifest
+    When a session SBOM is emitted under the same CatalogPin
+    Then each component's licenses equal the manifest's license_spdx entries
+
+- **SBOM-008** WHEN emitting environment-variable assets THE SYSTEM SHALL
+  record variable names and provenance (inherited vs specified) and SHALL
+  never embed variable values.
+  - tier: T1
+  - verify: just test-one blueprint_env_values_never_embedded
+  - property: for all compositions c, vars v: values(v) intersect
+    bytes(emit(c)) == empty
+
+## Non-goals
+
+Live-session/observed mode (declared-spec only; observed capture is its own
+subsystem — minimal#700 slice 6, gated on D2). Full SPDX profile depth.
+Usage/link-tier axis (model field reserved). Converging legacy `mfile::Task`
+onto sessions primitives (D6). Network-zone enforcement (declared and
+caveated in v1).
+
+## Design reasoning
+
+The artifact minimal emits for build/workflow story is CycloneDX
+**formulation** (schema-stable since 1.5), while "Blueprint" — the 2.0 draft
+threat-modeling schema — carries the posture story; the naming distinction is
+deliberate to avoid a semantic clash in a public CLI (see the arch design
+synthesis). Declared-spec-first because minimal persists no execution ledger
+today: the declared model is cheap and honest, observed capture is a real
+subsystem. One lean crate serves both the CLI and build-infra emission —
+the second consumer is why `crates/sbom` takes no clap/daemon/rcache deps.
+`CatalogPin = {repo, commit, closure_object}` replaces uuid-v4 + wall-clock
+serials so documents chain to a Sigstore-verifiable object (minimal#995,
+build-servers#86) and regeneration is reproducible. Decisions and
+alternatives live in minimal#700 (D1–D11) and gominimal/arch.
+
+## Security considerations
+
+- The honesty invariants are universals and carry the security weight:
+  an SBOM SHALL never omit present packages (SBOM-005) and a Blueprint SHALL
+  never fabricate posture (SBOM-006) — a flattering document is worse than
+  none.
+- Environment-variable VALUES never enter any document (SBOM-008): inherited
+  secrets stay host-side; documents carry names and provenance only.
+- Digest trust chains to the signed per-commit closure; verification is
+  consumer-side via the existing Sigstore path (build-servers#86). A document
+  without a verifiable pin is an assertion, and `digest_gap` says so
+  explicitly rather than pretending.
+- Blueprint documents map a session's attack surface by design; they contain
+  no secrets by SBOM-008, but distribution defaults should treat them like
+  configuration, not like public marketing.
+
+## Open questions
+
+- **CRITICAL:** D4 — `--format cdx-blueprint` naming vs "blueprint" already
+  meaning minimal.toml in user-facing docs. At least one plausible answer
+  renames the CLI surface (observable behaviour). Recommendation on record
+  (keep crate name, user-facing flag `cdx-blueprint`); needs the decision
+  before the format flag ships (minimal#700, decide-before-slice-4).
+- **CRITICAL:** D11 — Sandbox-Spec vocabulary conflicts (`network.type`,
+  `file_imports/exports`, `machine.*`). Plausible answers change every
+  emitted document's vocabulary; must settle before golden fixtures land or
+  renames churn every checked-in BOM.
+- SPDX `created` timestamp source (proposal: pinned commit's committer
+  timestamp). Both candidate answers satisfy SBOM-001's content-derived
+  rule; bytes differ but no requirement changes — non-critical, settle in
+  PR-1 review.
+
+## Rollout
+
+N/A. (CLI + library work; no infrastructure deployment.)


### PR DESCRIPTION
Spec for gominimal/inbox#582, drafted with the `spec-author` skill (spec-kit plugin) per the arch#10 process — the process's first full dogfood run.

- 12 requirements, all with `tier:` lines and `verify:` pointers in the repo's one-test form (`cargo nextest run -p <crate> <test>`): 10 at T1 (EARS + property — determinism, schema conformance in both formats, digest-or-gap totality, launcher marking, no-fabrication, env-values-never-embedded across every serializer, environment-derived envelope facts, unreferenced-component-carries-its-gap, unfetchable-reference-fails-loudly) and 2 at T0 (attribution cross-check; per-package document projection), plus a T0 sub-clause under SBOM-001 for cache independence. SBOM-009..012 came from review (composition by reference), not from the epic; the Design reasoning says so.
- Lives at `docs/specs/19-spec-sbom-blueprint/` (renumbered from 12 to clear the collision with the other open `12-` specs).
- User stories transcribed from the epic, each naming its role.
- **Two CRITICAL open questions (D4 naming, D11 vocabulary)** — under the process, the spec lint blocks merge until they're resolved, which is correct: both have recommendations on record in minimal#700 and are quick to settle. This PR stays draft until then.
- Rollout N/A (CLI+library, not infra).

Self-lint (per the skill): every requirement has a stable repo-unique ID (SBOM- prefix scan came back empty), is verifiable, carries `verify:`, and matches its recorded tier's syntax; `spec-lint` reports only the two advisory Q002 notes for the CRITICAL open questions below. Binding = merged PR with multiple approvals; author presentation to follow per Review.

Process findings from the dogfood, for the arch#10 thread: minimal's existing `docs/specs/` numbering has a collision (two 07- specs) — the skill's next-NN rule assumes uniqueness; and the 11 pre-existing specs follow an earlier local format, so ratifying arch#10 should state whether they backfill (the process says no wholesale backfill — presumably they stay as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Software Bill of Materials (SBOM) and CycloneDX Blueprint specification.
  * Linked the specification to its architecture documentation and finalized its status.
  * Clarified requirements for deterministic session, task, and package documents, including package composition, licenses, digests, environment data, security controls, and unavailable objects.
  * Specified that environment-variable values are excluded from intermediate SBOM data.
  * Proposed the `min box sbom <box>` command and documented related architecture decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
