### PR TITLE
spec: spec-hash epoch 1 — injective, formally verified BuildSpec encoding (inbox#583)

### DIFF
--- a/docs/specs/13-spec-spec-hash-epoch1/13-spec-spec-hash-epoch1.md
+++ b/docs/specs/13-spec-spec-hash-epoch1/13-spec-spec-hash-epoch1.md
@@ -1,185 +1,166 @@
 ---
+id: EPOCH
+title: spec-hash epoch 1 — injective, formally verified BuildSpec encoding
+status: draft
+owner: bryan-minimal
 epic: gominimal/inbox#583
-arch: gominimal/arch (formal-verification path; spec-process proof tiers)
+arch: none
+updated: 2026-08-27
 ---
 
-# 13-spec-spec-hash-epoch1: injective, formally verified BuildSpec encoding
+# EPOCH — spec-hash epoch 1: injective, formally verified BuildSpec encoding
 
 ## Context
 
-The cache key is a Blake3 hash of a hand-rolled byte encoding that is not
-prefix-free: nine cargo-verified collision-witness classes exist (distinct
-specs, identical keys — a constrained cache-poisoning primitive), and the
-dual defect hashes dependency *order*, forcing spurious rebuilds on recipe
-reorder. The encoder's shape (in-band ASCII markers, conditional emission,
-platform-width integers) also makes it unverifiable — blocking the formal
-program at its flagship theorem. Epoch 1 replaces the encoding behind the
-existing `SpecEncoder` seam as the one breaking keyspace change, designed
-(reserved-tag additive evolution) so it is the last.
+The cache key is a hash of an encoding that is not prefix-free: nine
+verified collision-witness classes exist — distinct specs with identical
+keys, a constrained cache-poisoning primitive — and the dual defect hashes
+dependency order, forcing spurious rebuilds on recipe reorder. The
+encoder's shape also makes it unverifiable, blocking the formal-methods
+program at its flagship theorem. Epoch 1 replaces the encoding as the one
+breaking keyspace change, designed so it is the last.
 
-Success criteria fold in the epic: injective + well-defined encoding,
-machine-checked from day one, zero downstream format changes, one-time cold
-catalog rebuild as the whole migration.
+**Success:** no two distinct canonical specs can share a cache key, the
+property is machine-checked, and dependency reorder no longer rotates keys.
 
-**First slice** (runs end to end): the pure `encode_epoch1`/`decode` codec
-module + Kani harnesses (round-trip, all nine witness refutations, tag
-uniqueness) + epoch-1 golden pins — no call-site flip yet (minimal#1246's
-codec-first ordering).
+**First slice:** the pure encode/decode codec with machine-checked
+round-trip and all nine witness refutations, plus pinned epoch-1 digests —
+no call-site flip yet.
 
 ## Users and stories
 
-- As a **security engineer**, I want the cache key to be an injective
-  function of the spec's meaning, so that no two distinct specs share a key
-  and collision-based cache poisoning is impossible by construction.
-- As a **package author**, I want dependency identity to be
-  order-independent, so that reordering imports never forces a spurious
-  rebuild.
-- As a **verification engineer**, I want a pure bounded codec with a decoder
-  and machine-checked properties, so that injectivity is proved (Kani now,
-  Lean later) rather than asserted.
-- As a **build-infra operator**, I want the flip to change only which keys
-  exist — same 32-byte hashes, same formats — so migration is one cold
-  rebuild, not a format migration.
-- As a **release manager**, I want additive evolution after this change, so
-  that this is the last breaking keyspace change I schedule.
+**Roles:** security engineer; package author; verification engineer;
+build-infra operator; release manager.
+
+- AS A security engineer I WANT the cache key to be an injective function
+  of the spec's meaning SO THAT collision-based cache poisoning is
+  impossible by construction
+- AS A package author I WANT dependency identity to be order-independent SO
+  THAT reordering imports never forces a spurious rebuild
+- AS A verification engineer I WANT a pure bounded codec with a decoder and
+  machine-checked properties SO THAT injectivity is proved rather than
+  asserted
+- AS A build-infra operator I WANT the flip to change only which keys exist
+  SO THAT migration is one cold rebuild, not a format migration
+- AS A release manager I WANT additive evolution after this change SO THAT
+  this is the last breaking keyspace change I schedule
 
 ## Requirements
 
-- **EPOCH-001** WHEN two canonically distinct specs are encoded THE SYSTEM
-  SHALL produce distinct byte strings (encoding injectivity; Blake3
-  collision resistance is the assumed axiom above it).
-  - tier: T2
-  - verify: just test-one epoch1_injectivity_bounded
-  - property: for all a, b: a != b implies encode(a) != encode(b)
-  - harness: kani_epoch1_injectivity_bounded
-  - proof: proofs/SpecHash/Epoch1.lean#encode_injective   # T3 target, stated not gated
+- **EPOCH-001** THE SYSTEM SHALL encode canonically distinct specs to
+  distinct byte strings (injectivity; collision resistance of the hash is
+  the named axiom above the encoding).
+  verify:   just test-one kani_epoch1_injectivity_bounded
+  property: for all a, b: a != b implies encode(a) != encode(b)
+  proof:    proofs/SpecHash/Epoch1.lean#encode_injective
 
-- **EPOCH-002** WHEN a spec's dependency edges are permuted THE SYSTEM SHALL
-  produce an identical encoding (edges canonically sorted by
-  (kind, index, subset); deps-as-sets).
-  - tier: T1
-  - verify: just test-one epoch1_dep_order_irrelevant
-  - property: for all s, permutations p: encode(s) == encode(p(s))
+- **EPOCH-002** WHEN a spec's dependency edges are permuted THE SYSTEM
+  SHALL produce an identical encoding.
+  verify:   just test-one epoch1_dep_order_irrelevant
+  property: for all s, permutations p: encode(s) == encode(p(s))
 
-- **EPOCH-003** WHEN any epoch-1 encoding is decoded THE SYSTEM SHALL
-  return the original spec (the decoder exists for verification; no
-  production caller is required).
-  - tier: T2
-  - verify: just test-one epoch1_roundtrip
-  - property: for all bounded specs x: decode(encode(x)) == x
-  - harness: kani_epoch1_roundtrip_bounded
+- **EPOCH-003** THE SYSTEM SHALL decode every epoch-1 encoding back to the
+  original spec.
+  verify:   just test-one kani_epoch1_roundtrip_bounded
+  property: for all bounded specs x: decode(encode(x)) == x
 
-- **EPOCH-004** WHEN each epoch-0 collision-witness pair from the defect
-  catalog is encoded under epoch 1 THE SYSTEM SHALL produce distinct
-  outputs for every pair.
-  - tier: T2
-  - verify: just test-one epoch1_refutes_epoch0_witnesses
-  - property: for all catalog pairs (a, b): encode(a) != encode(b)
-  - harness: kani_epoch1_witness_refutations
+- **EPOCH-004** THE SYSTEM SHALL encode every epoch-0 collision-witness
+  pair from the defect catalog to distinct outputs.
+  verify:   just test-one kani_epoch1_witness_refutations
+  property: for all catalog pairs (a, b): encode(a) != encode(b)
 
-- **EPOCH-005** WHEN computing any epoch-1 hash THE SYSTEM SHALL derive it
-  under the domain-separated context ("minimal.dev spec-hash epoch 1") and
-  SHALL keep `SpecHash` at 32 bytes, leaving index records, snapshots,
-  closures, provenance subjects, events, and object names byte-format
-  unchanged.
-  - tier: T0
-  - verify: just test-one epoch1_domain_separation_and_width
+- **EPOCH-005** THE SYSTEM SHALL derive epoch-1 hashes under the
+  domain-separated context and keep the hash at 32 bytes, leaving every
+  downstream record format byte-unchanged.
+  verify: just test-one epoch1_domain_separation_and_width
 
-  @EPOCH-005
-  Scenario: epoch is carried by key derivation, not by format
-    Given the same spec encoded under epoch 0 and epoch 1
-    When both hashes are computed
-    Then both are 32 bytes, the values differ, and every downstream record
-      format accepts either
+- **EPOCH-006** IF a graph contains a NaN numeric attribute THEN THE
+  SYSTEM SHALL reject it at load; WHEN encoding numbers THE SYSTEM SHALL
+  normalize negative zero to zero.
+  verify:   just test-one epoch1_number_canonicalization
+  property: for all floats f in encodable specs: not is_nan(f), one
+    representative per equality class
 
-- **EPOCH-006** WHEN a graph containing a NaN numeric attribute is loaded
-  THE SYSTEM SHALL reject it at load, and WHEN encoding numbers THE SYSTEM
-  SHALL normalize `-0.0` to `0.0`.
-  - tier: T1
-  - verify: just test-one epoch1_number_canonicalization
-  - property: for all floats f in encodable specs: not is_nan(f) and
-    bits(normalize(f)) has one representative per equality class
+- **EPOCH-007** IF the decoder meets an unknown tag byte THEN THE SYSTEM
+  SHALL hard-error; tags 0xF0–0xFF are reserved, and a new optional field
+  SHALL reuse epoch 1 only when its absence means epoch-1 semantics.
+  verify:   just test-one epoch1_unknown_tag_rejects
+  property: for all byte strings s with an unassigned tag: decode(s) errors
 
-- **EPOCH-007** WHEN the decoder meets an unknown tag byte THE SYSTEM SHALL
-  hard-error; tags 0xF0–0xFF are reserved, and a new optional field SHALL
-  reuse epoch 1 (no epoch bump) only when its absence means epoch-1
-  semantics.
-  - tier: T1
-  - verify: just test-one epoch1_unknown_tag_rejects
-  - property: for all byte strings s with an unassigned tag: decode(s) errors
-
-- **EPOCH-008** WHEN the epoch-1 golden fixtures are hashed THE SYSTEM
-  SHALL reproduce the pinned digests, and the epoch-0 `LegacyEncoder` pin
-  SHALL remain byte-identical.
-  - tier: T0
-  - verify: just test-one epoch1_golden_pins
-
-  @EPOCH-008
-  Scenario: both epochs are pinned
-    Given the golden fixture set
-    When epoch-0 and epoch-1 digests are computed
-    Then each matches its pinned value exactly
+- **EPOCH-008** THE SYSTEM SHALL reproduce the pinned epoch-1 golden
+  digests and leave the epoch-0 pin byte-identical.
+  verify: just test-one epoch1_golden_pins
 
 ## Non-goals
 
-Changing `SpecHash`'s size or algorithm. Migrating historical epoch-0
-artifacts (immutable history stays valid for old pins). wire.rs varint work
-(minimal#1109 set 2). The slots feature (this spec only guarantees the name
-axis is sound). Landing the Lean proof (EPOCH-001's `proof:` line is the
-stated T3 target; Kani holds the property until it lands).
+- Changing the hash's size or algorithm: minimal#1246 interaction inventory
+- Migrating historical epoch-0 artifacts: immutable history stays valid for
+  old pins (minimal#1246 decision 4)
+- Wire varint work: minimal#1109 set 2
+- The slots feature: its own design (this spec only guarantees the name
+  axis is sound)
+- Landing the Lean proof: the formal-verification roadmap (EPOCH-001's
+  proof line is the stated target; Kani holds the property until it lands)
 
 ## Design reasoning
 
 Fixed-width byte-tagged TLV over varints because injectivity is then
-structural (every payload length-prefixed, every list count-prefixed,
-u32-LE indices) and the codec stays in Kani/Lean's sweet spot: pure, no
-unsafe, no trait objects, no unbounded recursion (the spec walk stays
+structural — every payload length-prefixed, every list count-prefixed,
+fixed-width indices — and the codec stays in the provers' sweet spot: pure,
+no unsafe, no trait objects, no unbounded recursion (the spec walk stays
 outside). Domain separation carries the epoch so versioning costs zero
 preimage bytes and no downstream format learns anything. No conditional
 emission because absence must be inexpressible by adjacent content — the
-root cause of five of the nine witness classes. Deps-as-sets is the
-long-standing maintainer position and makes the well-definedness half of
-the biconditional provable as a clean bottom-up fold. One-time cold rebuild
-over dual-hash machinery: dual-publish complexity is how one breaking
-change becomes three. Full alternatives and the decision ledger live in
-minimal#1246; the audit rationale in the arch formal-verification path.
+root cause of five of the nine witness classes. Deps-as-sets makes the
+well-definedness half of the biconditional provable as a clean bottom-up
+fold. One-time cold rebuild over dual-hash machinery: dual-publish
+complexity is how one breaking change becomes three. The decision ledger
+lives in minimal#1246; the audit rationale in the formal-verification path.
+
+**Generality:** a second epoch is additive by construction (reserved tags,
+new derive-key context); a second hash algorithm is out of scope by
+decision and would be a new epoch. The codec's proofs bind to this
+encoding, not to the traversal — a second traversal source reuses them.
 
 ## Security considerations
 
-- The central claim is security-load-bearing and machine-checked:
-  encoding injectivity (EPOCH-001/004) removes the cache-poisoning-by-
-  collision primitive; the theorem is conditional on the named axiom
-  (Blake3 collision resistance) and the trust boundary is explicit.
-- Strict decoding (EPOCH-007) is the anti-smuggling invariant: unknown
-  structure can never be silently absorbed into a hash preimage.
-- The verification lane is advisory in CI (per the #1217 convention) but
-  the witness-refutation suite (EPOCH-004) is a required check: a change
-  that reintroduces any catalogued collision class must not merge.
-- Epoch-0 keys remain trusted for pinned history only; nothing re-signs or
-  re-blesses old artifacts under new keys.
-
-## Open questions
-
-- **CRITICAL:** D1 — are `tests` hashed? At least one plausible answer
-  changes which spec edits rotate keys (observable behaviour).
-  Recommendation on record (out of the hash, plus a write-guard assertion
-  that test execution cannot touch the output tree); decider: maintainers,
-  in minimal#1246.
-- **CRITICAL:** D5 confirmation — reserved-tag additive evolution means a
-  future optional field with absent≠epoch-1 semantics forces an epoch bump;
-  plausible alternative (strict epoch-per-change) changes EPOCH-007's
-  contract. Recommendation on record (reserved-tag additive); decider:
-  maintainers, in minimal#1246.
-- D4 migration shape (accepted-recommendation: one-time cold catalog
-  rebuild) — both plausible answers satisfy every requirement above;
-  rollout-only, non-critical, settle at flip time with build-infra.
+- **Invariant:** THE SYSTEM SHALL never assign two distinct canonical
+  specs the same cache key.
+  enforced by: prefix-free TLV encoding; machine-checked bounded
+  injectivity and witness refutations
+  covered by: EPOCH-001, EPOCH-004
+- **Invariant:** THE SYSTEM SHALL never silently absorb unknown structure
+  into a hash preimage.
+  enforced by: strict decoding, unknown tag = hard error
+  covered by: EPOCH-007
+- **Invariant:** THE SYSTEM SHALL keep epoch-0 keys trusted for pinned
+  history only, never re-blessing old artifacts under new keys.
+  enforced by: epoch selection at the single call site; no migration path
+  covered by: EPOCH-005
 
 ## Rollout
 
-The epoch flip is config-plumbed at one call site and ships in a release;
-the catalog rebuilds cold under epoch-1 keys on the first pkgs CI cycle at
-that release (a world rebuild — schedule it deliberately, see
-build-servers#271/#272 for the operational lessons). Old pins continue
-reading epoch-0 objects; no artifact migration. Test plan: the full
-verification suite above plus one staged catalog rebuild on the staging
-cache before the release carrying the flip.
+- **Deploy:** the flip is config-plumbed at one call site and ships in a
+  release; the catalog rebuilds cold under epoch-1 keys on the first pkgs
+  CI cycle at that release — a full world rebuild, scheduled deliberately
+  with build-infra (see build-servers#271/#272 operational lessons). Staged
+  catalog rebuild on the staging cache precedes the release.
+- **Rollback:** flip the config back to epoch 0 — epoch-0 objects and
+  snapshots remain valid throughout; rollback is minutes, not a rebuild.
+- **Blast radius:** catalog consumers during the one cold rebuild window
+  (cache misses, not wrong data); nothing else — all record formats are
+  byte-unchanged.
+
+## Open questions
+
+- [NEEDS CLARIFICATION (CRITICAL): decision 1 — are `tests` hashed?
+  Changes which spec edits rotate keys. Recommendation on record (out of
+  the hash, plus a write-guard assertion that test execution cannot touch
+  the output tree); decider: maintainers, minimal#1246.]
+- [NEEDS CLARIFICATION (CRITICAL): decision 5 confirmation — reserved-tag
+  additive evolution vs strict epoch-per-change changes EPOCH-007's
+  contract. Recommendation on record (reserved-tag additive); decider:
+  maintainers, minimal#1246.]
+- [NEEDS CLARIFICATION (LOW): decision 4 migration shape — one-time cold
+  rebuild (recommended) vs dual-hash; rollout-only, every requirement holds
+  under both; settle at flip time with build-infra.]

--- a/docs/specs/13-spec-spec-hash-epoch1/13-spec-spec-hash-epoch1.md
+++ b/docs/specs/13-spec-spec-hash-epoch1/13-spec-spec-hash-epoch1.md
@@ -1,0 +1,185 @@
+---
+epic: gominimal/inbox#583
+arch: gominimal/arch (formal-verification path; spec-process proof tiers)
+---
+
+# 13-spec-spec-hash-epoch1: injective, formally verified BuildSpec encoding
+
+## Context
+
+The cache key is a Blake3 hash of a hand-rolled byte encoding that is not
+prefix-free: nine cargo-verified collision-witness classes exist (distinct
+specs, identical keys — a constrained cache-poisoning primitive), and the
+dual defect hashes dependency *order*, forcing spurious rebuilds on recipe
+reorder. The encoder's shape (in-band ASCII markers, conditional emission,
+platform-width integers) also makes it unverifiable — blocking the formal
+program at its flagship theorem. Epoch 1 replaces the encoding behind the
+existing `SpecEncoder` seam as the one breaking keyspace change, designed
+(reserved-tag additive evolution) so it is the last.
+
+Success criteria fold in the epic: injective + well-defined encoding,
+machine-checked from day one, zero downstream format changes, one-time cold
+catalog rebuild as the whole migration.
+
+**First slice** (runs end to end): the pure `encode_epoch1`/`decode` codec
+module + Kani harnesses (round-trip, all nine witness refutations, tag
+uniqueness) + epoch-1 golden pins — no call-site flip yet (minimal#1246's
+codec-first ordering).
+
+## Users and stories
+
+- As a **security engineer**, I want the cache key to be an injective
+  function of the spec's meaning, so that no two distinct specs share a key
+  and collision-based cache poisoning is impossible by construction.
+- As a **package author**, I want dependency identity to be
+  order-independent, so that reordering imports never forces a spurious
+  rebuild.
+- As a **verification engineer**, I want a pure bounded codec with a decoder
+  and machine-checked properties, so that injectivity is proved (Kani now,
+  Lean later) rather than asserted.
+- As a **build-infra operator**, I want the flip to change only which keys
+  exist — same 32-byte hashes, same formats — so migration is one cold
+  rebuild, not a format migration.
+- As a **release manager**, I want additive evolution after this change, so
+  that this is the last breaking keyspace change I schedule.
+
+## Requirements
+
+- **EPOCH-001** WHEN two canonically distinct specs are encoded THE SYSTEM
+  SHALL produce distinct byte strings (encoding injectivity; Blake3
+  collision resistance is the assumed axiom above it).
+  - tier: T2
+  - verify: just test-one epoch1_injectivity_bounded
+  - property: for all a, b: a != b implies encode(a) != encode(b)
+  - harness: kani_epoch1_injectivity_bounded
+  - proof: proofs/SpecHash/Epoch1.lean#encode_injective   # T3 target, stated not gated
+
+- **EPOCH-002** WHEN a spec's dependency edges are permuted THE SYSTEM SHALL
+  produce an identical encoding (edges canonically sorted by
+  (kind, index, subset); deps-as-sets).
+  - tier: T1
+  - verify: just test-one epoch1_dep_order_irrelevant
+  - property: for all s, permutations p: encode(s) == encode(p(s))
+
+- **EPOCH-003** WHEN any epoch-1 encoding is decoded THE SYSTEM SHALL
+  return the original spec (the decoder exists for verification; no
+  production caller is required).
+  - tier: T2
+  - verify: just test-one epoch1_roundtrip
+  - property: for all bounded specs x: decode(encode(x)) == x
+  - harness: kani_epoch1_roundtrip_bounded
+
+- **EPOCH-004** WHEN each epoch-0 collision-witness pair from the defect
+  catalog is encoded under epoch 1 THE SYSTEM SHALL produce distinct
+  outputs for every pair.
+  - tier: T2
+  - verify: just test-one epoch1_refutes_epoch0_witnesses
+  - property: for all catalog pairs (a, b): encode(a) != encode(b)
+  - harness: kani_epoch1_witness_refutations
+
+- **EPOCH-005** WHEN computing any epoch-1 hash THE SYSTEM SHALL derive it
+  under the domain-separated context ("minimal.dev spec-hash epoch 1") and
+  SHALL keep `SpecHash` at 32 bytes, leaving index records, snapshots,
+  closures, provenance subjects, events, and object names byte-format
+  unchanged.
+  - tier: T0
+  - verify: just test-one epoch1_domain_separation_and_width
+
+  @EPOCH-005
+  Scenario: epoch is carried by key derivation, not by format
+    Given the same spec encoded under epoch 0 and epoch 1
+    When both hashes are computed
+    Then both are 32 bytes, the values differ, and every downstream record
+      format accepts either
+
+- **EPOCH-006** WHEN a graph containing a NaN numeric attribute is loaded
+  THE SYSTEM SHALL reject it at load, and WHEN encoding numbers THE SYSTEM
+  SHALL normalize `-0.0` to `0.0`.
+  - tier: T1
+  - verify: just test-one epoch1_number_canonicalization
+  - property: for all floats f in encodable specs: not is_nan(f) and
+    bits(normalize(f)) has one representative per equality class
+
+- **EPOCH-007** WHEN the decoder meets an unknown tag byte THE SYSTEM SHALL
+  hard-error; tags 0xF0–0xFF are reserved, and a new optional field SHALL
+  reuse epoch 1 (no epoch bump) only when its absence means epoch-1
+  semantics.
+  - tier: T1
+  - verify: just test-one epoch1_unknown_tag_rejects
+  - property: for all byte strings s with an unassigned tag: decode(s) errors
+
+- **EPOCH-008** WHEN the epoch-1 golden fixtures are hashed THE SYSTEM
+  SHALL reproduce the pinned digests, and the epoch-0 `LegacyEncoder` pin
+  SHALL remain byte-identical.
+  - tier: T0
+  - verify: just test-one epoch1_golden_pins
+
+  @EPOCH-008
+  Scenario: both epochs are pinned
+    Given the golden fixture set
+    When epoch-0 and epoch-1 digests are computed
+    Then each matches its pinned value exactly
+
+## Non-goals
+
+Changing `SpecHash`'s size or algorithm. Migrating historical epoch-0
+artifacts (immutable history stays valid for old pins). wire.rs varint work
+(minimal#1109 set 2). The slots feature (this spec only guarantees the name
+axis is sound). Landing the Lean proof (EPOCH-001's `proof:` line is the
+stated T3 target; Kani holds the property until it lands).
+
+## Design reasoning
+
+Fixed-width byte-tagged TLV over varints because injectivity is then
+structural (every payload length-prefixed, every list count-prefixed,
+u32-LE indices) and the codec stays in Kani/Lean's sweet spot: pure, no
+unsafe, no trait objects, no unbounded recursion (the spec walk stays
+outside). Domain separation carries the epoch so versioning costs zero
+preimage bytes and no downstream format learns anything. No conditional
+emission because absence must be inexpressible by adjacent content — the
+root cause of five of the nine witness classes. Deps-as-sets is the
+long-standing maintainer position and makes the well-definedness half of
+the biconditional provable as a clean bottom-up fold. One-time cold rebuild
+over dual-hash machinery: dual-publish complexity is how one breaking
+change becomes three. Full alternatives and the decision ledger live in
+minimal#1246; the audit rationale in the arch formal-verification path.
+
+## Security considerations
+
+- The central claim is security-load-bearing and machine-checked:
+  encoding injectivity (EPOCH-001/004) removes the cache-poisoning-by-
+  collision primitive; the theorem is conditional on the named axiom
+  (Blake3 collision resistance) and the trust boundary is explicit.
+- Strict decoding (EPOCH-007) is the anti-smuggling invariant: unknown
+  structure can never be silently absorbed into a hash preimage.
+- The verification lane is advisory in CI (per the #1217 convention) but
+  the witness-refutation suite (EPOCH-004) is a required check: a change
+  that reintroduces any catalogued collision class must not merge.
+- Epoch-0 keys remain trusted for pinned history only; nothing re-signs or
+  re-blesses old artifacts under new keys.
+
+## Open questions
+
+- **CRITICAL:** D1 — are `tests` hashed? At least one plausible answer
+  changes which spec edits rotate keys (observable behaviour).
+  Recommendation on record (out of the hash, plus a write-guard assertion
+  that test execution cannot touch the output tree); decider: maintainers,
+  in minimal#1246.
+- **CRITICAL:** D5 confirmation — reserved-tag additive evolution means a
+  future optional field with absent≠epoch-1 semantics forces an epoch bump;
+  plausible alternative (strict epoch-per-change) changes EPOCH-007's
+  contract. Recommendation on record (reserved-tag additive); decider:
+  maintainers, in minimal#1246.
+- D4 migration shape (accepted-recommendation: one-time cold catalog
+  rebuild) — both plausible answers satisfy every requirement above;
+  rollout-only, non-critical, settle at flip time with build-infra.
+
+## Rollout
+
+The epoch flip is config-plumbed at one call site and ships in a release;
+the catalog rebuilds cold under epoch-1 keys on the first pkgs CI cycle at
+that release (a world rebuild — schedule it deliberately, see
+build-servers#271/#272 for the operational lessons). Old pins continue
+reading epoch-0 objects; no artifact migration. Test plan: the full
+verification suite above plus one staged catalog rebuild on the staging
+cache before the release carrying the flip.


### PR DESCRIPTION
> **2026-09-17:** now `docs/specs/20-spec-spec-hash-epoch1/` (renumbered by Norrie). Bound to architecture.md **D3.1** (the keyspace contract); every requirement carries a `tier:` (EPOCH-001 T3 target with its Kani harness as today's evidence; 003/004 T2; 002/006/007/009 T1; 005/008 T0); verify pointers in the repo's one-test form. **New EPOCH-009**: epoch selection is data — the sealed index declares its epoch and consumers follow their pinned index — which D3.1 fixes and the original criteria (and this spec's first draft) stated as "config-plumbed at one call site"; that is now the producing side only. The decision-5 CRITICAL is resolved by D3.1; decision 1 (`tests` hashed?) remains the one open question. Epic inbox#583 updated to match.

Spec for gominimal/inbox#583, drafted with `spec-author` 0.3.0 — second full dogfood, and the first spec to climb the proof-tier ladder past T1.

- 8 requirements with recorded `tier:` lines: **three at T2 with named Kani harnesses** (bounded injectivity, round-trip, the nine epoch-0 collision-witness refutations), one carrying the **T3 `proof:` line** as the stated Lean/Aeneas target (held by Kani until it lands, per the roadmap), three at T1, two at T0 scenarios (domain-separation/width, golden pins for both epochs).
- Security section names the axiom explicitly (Blake3 collision resistance) — the theorem is conditional and says so.
- **Two CRITICAL open questions** (D1 tests-in-hash, D5 forward-compat confirmation — both with recommendations on record in minimal#1246, deciders: maintainers) — per the process the lint blocks merge until they resolve; draft until then. D4 (migration shape) assessed non-critical: rollout-only, every requirement holds under both answers.
- Rollout section present (this one IS infra-touching: the flip is a scheduled world rebuild — operational lessons referenced).
- NN note: 12 is reserved by open PR #1304, so this takes 13 — 'reserved-by-open-PR' is a numbering case the skill will learn next.

Implementation tracker of record: minimal#1246 (encoding proposal, defect catalog, decision ledger, interaction inventory). Epic: inbox#583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
