### PR TITLE
ci: regenerate minimal-review from foundry 867eec35

### DIFF
--- a/.github/workflows/minimal-review.yml
+++ b/.github/workflows/minimal-review.yml
@@ -773,6 +773,13 @@ jobs:
         if: always()
         run: |
           set -uo pipefail
+          # $RUN_DIR is created by the staging step, which does not run when the
+          # quiet window stands the job down, nor when an earlier step aborts.
+          # Every redirect below then fails on a missing directory — including
+          # the `|| echo '{}'` fallback — so an always() step dies and the job
+          # goes red. That is the failure guarding those steps was meant to
+          # prevent, relocated one step further on.
+          mkdir -p "$RUN_DIR"
           curl -fsS -m 5 "http://127.0.0.1:${BROKER_PORT}/health" \
             > "$RUN_DIR/broker-usage.json" 2>/dev/null \
             || echo '{}' > "$RUN_DIR/broker-usage.json"


### PR DESCRIPTION
Generated, not hand-edited: `python3 review/deploy/render-standalone.py`. One hunk, 7 lines.

This copy was rendered from foundry `71373d34`. foundry's impl moved on at `867eec35`, which added `mkdir -p "$RUN_DIR"` to the **Meter the run** step. foundry's `review-drift.yml` has failed on this since 2026-08-27 10:34.

## What the missing lines cost

`Meter the run` is `if: always()`, so it runs even when the quiet window stands the job down and the staging step that creates `$RUN_DIR` is skipped. Every redirect in it then fails on the missing directory — **including the `|| echo '{}'` fallback** — and the job goes red for the exact reason guarding the other twelve steps was meant to prevent.

Latent rather than active: it fires only on a quiet-window standdown.

## Not the cause of the current red check

Found while diagnosing [run 33125400928](https://github.com/gominimal/minimal/actions/runs/33125400928), but that failure is unrelated — a required `verification[].exit` the prompt never named, fixed in [gominimal/foundry#38](https://github.com/gominimal/foundry/pull/38). That one reaches this repo on merge without a regeneration, since this copy checks foundry out at `ref: main` rather than a pinned SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow reliability by ensuring required output directories are created before usage data is written.
  * Prevented failures when runs exit early or are stopped before staging completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->