### PR TITLE
spec: add the template and its advisory linter

### DIFF
--- a/.github/workflows/spec-lint.yml
+++ b/.github/workflows/spec-lint.yml
@@ -125,8 +125,12 @@ jobs:
           # A PR that changes this workflow and no spec would otherwise prove
           # nothing: the token, the checkout and the linter would all go
           # unexercised until someone else's spec PR ran them. Lint the
-          # template instead — it is a real spec-shaped document, it lives at a
-          # known path, and it is expected to come back clean.
+          # template instead — it is a real spec-shaped document at a known
+          # path. It does not come back clean, and is not meant to: its prompts
+          # are unfilled by definition, so S006 and S007 fire on every section
+          # that is still a prompt. Those findings are the expected output of
+          # this self-test; a change in them means the template or the linter
+          # moved, which is the thing worth noticing.
           if [ ${#files[@]} -eq 0 ] && [ -f pr/docs/specs/TEMPLATE.md ] \
              && printf '%s\n' ${changed+"${changed[@]}"} \
                 | grep -qxF '.github/workflows/spec-lint.yml'; then

--- a/.github/workflows/spec-lint.yml
+++ b/.github/workflows/spec-lint.yml
@@ -1,0 +1,206 @@
+# INSTALLED FILE — the source of record is gominimal/foundry:spec/deploy/spec-lint.yml.
+#
+# Copy it verbatim into `.github/workflows/spec-lint.yml` in every repo that
+# holds specs. foundry's spec-drift.yml fails when an installed copy and this
+# file disagree.
+#
+# Only this file travels. spec_lint.py stays in foundry and is checked out at
+# run time, for the same two reasons the reviewer works that way: a PR here
+# cannot rewrite the checker that reads it, and the checker upgrades in one
+# place for every repo that installs it. A copied script would need a second
+# drift check and would be a third instance of the defect foundry has already
+# shipped twice — a value written literally in a place where the set has since
+# changed.
+name: spec-lint
+
+on:
+  pull_request:
+    paths:
+      - "docs/specs/**"
+      # Itself, so a change to this workflow is exercised by this workflow.
+      # Without it the install PR would ship a job that has never run, and the
+      # first spec PR after it would be the first execution.
+      - ".github/workflows/spec-lint.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: spec-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  spec-lint:
+    # Fork PRs get no secrets, so the App token that reads the private linter
+    # cannot be minted and there is nothing to run. Skipped, not refused: an
+    # advisory comment is not worth a red X, and the reviewer's hard refusal
+    # exists because it reaches a credentialled sandbox. This reaches a regex.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    # The only way this job reports failure. Every step below is
+    # continue-on-error, so nothing else can turn a finding — or a broken
+    # checkout — into a red check. The lint itself is sub-second; the budget is
+    # the two checkouts.
+    timeout-minutes: 10
+    steps:
+      # Every step in this job carries continue-on-error. Decision 9 is that
+      # the lint never blocks a merge, and a job that goes red when a step
+      # fails has reversed that decision no matter what the template says. The
+      # promise is a property of the job, not a flag on the script.
+      - name: Check out the tree under review
+        id: pr_tree
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The default for a pull_request event is the merge commit, a tree in
+          # no branch. Findings would anchor to line numbers the PR does not
+          # have.
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+          persist-credentials: false
+
+      - name: Mint a token for the private linter
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.AW_BOT_APP_ID }}
+          private-key: ${{ secrets.AW_BOT_PRIVATE_KEY }}
+          owner: gominimal
+          repositories: foundry
+
+      - name: Check out the linter (gominimal/foundry@main)
+        id: linter
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: gominimal/foundry
+          # A standalone copy cannot pin a foundry commit: job.workflow_sha
+          # names a commit in THIS repo. The default branch is the only pin
+          # available, so the comment records the sha it actually resolved to.
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          path: linter
+          persist-credentials: false
+          sparse-checkout: spec
+
+      - name: Lint the specs this PR touches
+        id: lint
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+
+          # Changed files come from the API, not from git: a shallow checkout of
+          # the head sha has no base to diff against, and deepening it to find
+          # one costs more than one request.
+          #
+          # Touched specs only. The format is not backfilled onto the specs that
+          # predate it, so a PR editing one spec must not be told about findings
+          # in eleven it did not write. Renames arrive as added; deletions are
+          # dropped, since a file that is gone cannot be linted.
+          mapfile -t changed < <(
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate \
+              --jq '.[] | select(.status != "removed") | .filename' 2>/dev/null || true
+          )
+
+          # A spec directory holds one spec and any number of supporting
+          # documents beside it — `architecture.md` in five of them today.
+          # Those are not specs, and linting them reports every required section
+          # as missing on a file nobody claimed was a spec. The convention that
+          # separates them is the filename: `<slug>/<slug>.md` is the spec.
+          files=()
+          for f in ${changed+"${changed[@]}"}; do
+            case "$f" in
+              docs/specs/TEMPLATE.md)
+                files+=("$f") ;;
+              docs/specs/*/*.md)
+                dir="${f%/*}"
+                [ "${f##*/}" = "${dir##*/}.md" ] && files+=("$f") ;;
+            esac
+          done
+          # A PR that changes this workflow and no spec would otherwise prove
+          # nothing: the token, the checkout and the linter would all go
+          # unexercised until someone else's spec PR ran them. Lint the
+          # template instead — it is a real spec-shaped document, it lives at a
+          # known path, and it is expected to come back clean.
+          if [ ${#files[@]} -eq 0 ] && [ -f pr/docs/specs/TEMPLATE.md ] \
+             && printf '%s\n' ${changed+"${changed[@]}"} \
+                | grep -qxF '.github/workflows/spec-lint.yml'; then
+            echo "this PR changes the workflow itself; linting the template as a self-test"
+            files=(docs/specs/TEMPLATE.md)
+          fi
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "no spec files changed"
+            echo "state=quiet" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf 'linting %d file(s):\n' "${#files[@]}"
+          printf '  %s\n' "${files[@]}"
+
+          if [ ! -f linter/spec/spec_lint.py ]; then
+            echo "::warning::the linter could not be checked out of gominimal/foundry; no comment this run"
+            echo "state=quiet" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          sha="$(git -C linter rev-parse HEAD 2>/dev/null || echo unknown)"
+
+          # --repo-root . from inside the PR tree, so `verify:` and `proof:`
+          # targets resolve and findings read `docs/specs/...` rather than
+          # `pr/docs/specs/...`.
+          ( cd pr && python3 "$GITHUB_WORKSPACE/linter/spec/spec_lint.py" \
+              --repo-root . --format markdown "${files[@]}" ) > /tmp/lint.md 2>/tmp/lint.err
+          if [ ! -s /tmp/lint.md ]; then
+            echo "::warning::the linter produced no output"
+            sed -n '1,40p' /tmp/lint.err
+            echo "state=quiet" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cat /tmp/lint.md
+
+          {
+            echo "<!-- spec-lint -->"
+            cat /tmp/lint.md
+            echo
+            echo "_Advisory, and never a merge gate. Linter: \`gominimal/foundry@${sha:0:8}\`, spec format: [How Minimal Writes Specs](https://docs.google.com/document/d/185oh7_PHVMsR2yiKOmX_pq3eUSERMRULawE8UBSZSIw/edit)._"
+          } > /tmp/comment.md
+
+          if grep -q '^No findings' /tmp/lint.md; then
+            echo "state=clean" >> "$GITHUB_OUTPUT"
+          else
+            echo "state=findings" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post the findings
+        continue-on-error: true
+        if: steps.lint.outputs.state == 'findings' || steps.lint.outputs.state == 'clean'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STATE: ${{ steps.lint.outputs.state }}
+        run: |
+          set -uo pipefail
+
+          # One comment, edited in place. A PR that pushes six times should
+          # carry one current comment, not six historical ones.
+          existing="$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+            --jq 'map(select(.body | startswith("<!-- spec-lint -->"))) | .[0].id // empty' 2>/dev/null || true)"
+
+          # A clean run never opens a comment — the absence of one is the
+          # result. It does update a comment that already exists, because the
+          # author fixed what it named and should see that.
+          if [ "$STATE" = "clean" ] && [ -z "$existing" ]; then
+            echo "clean, and no comment to update"
+            exit 0
+          fi
+
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing" \
+              -F body=@/tmp/comment.md >/dev/null && echo "updated comment $existing"
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              -F body=@/tmp/comment.md >/dev/null && echo "posted a comment"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,10 @@ proves, `nightly` ships.
   [docs/commit-conventions.md](docs/commit-conventions.md).
 - **Rust standards**:
   [docs/rust-coding-standards.md](docs/rust-coding-standards.md).
+- **Specs**: work carrying `kind:epic` gets one, at
+  `docs/specs/NN-spec-<slug>/NN-spec-<slug>.md`. Start from
+  [docs/specs/TEMPLATE.md](docs/specs/TEMPLATE.md); requirements are written as
+  EARS and the format is decided in gominimal/foundry.
 - **`.github/workflows/` is frozen** and CODEOWNER-gated. Do not edit it.
   Extend CI coverage through convention-discovered tests, `scripts/`, and the
   `justfile`, per the test-extension contract in

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -11,7 +11,7 @@ updated: <YYYY-MM-DD>
 # XXX — <feature name>
 
 <!--
-SOURCE  gominimal/foundry spec/template.md @ d7227512d2577e2396f5a097c2fe50d5ffe08f14
+SOURCE  gominimal/foundry spec/template.md @ 842b37aa97e44cccff5a0d51ea79e9e099aee111
   This file is a copy. Edit it in foundry and open a PR here; a change made
   only in this repo is lost the next time the template is updated. The SOURCE
   line is what a drift check reads to tell whether this copy is behind.
@@ -105,36 +105,67 @@ considerations section is made of.
 PROSE IS THE AUTHORING INPUT, NEVER THE REQUIREMENT. Draft the behaviour in
 English, convert it to EARS, and review the translation.
 
-VERIFICATION TIERS — T0 is the default and nothing above it is mandated.
-Escalating a requirement is a per-item call made during review.
-  T0  verify:   <command>            an example test. The default.
-  T1  property: <universal>          a proptest over generated input.
-  T2  property: + a Kani harness     exhaustive to a bound.
-  T3  proof:    <file>#<theorem>     machine-checked in Lean 4.
-  A requirement that cannot be verified yet says
-  verify: none, <reason and issue link>.
+VERIFICATION TIERS. Every requirement states its tier and how it will be
+checked, before the code exists. T0 is the default and nothing above it is
+mandated; escalating is a per-item call, and it is made here rather than
+deferred to a review, because a tier above T0 is a constraint on the code that
+has not been written yet.
+
+  tier: T0   verify:   <the repo's command for one test> <name>
+  tier: T1   + property: <the universal, in whatever notation reads clearly>
+  tier: T2   + harness:  <the Kani harness and its unwind bound>
+  tier: T3   + proof:    <file>.lean#<theorem>
+  tier: none   for a behaviour nothing can observe. See below.
+
+The tier and the fields must agree — a tier claiming more than the fields
+carry is a claim with nothing behind it, and the lint says so. A universal
+written into `property:` is what T1 asks for, so a T0 carrying one is reported
+as P012: raise it, or say in Design reasoning why it stays. `property:` at
+`none` is exempt, because nothing can watch the behaviour and there is no tier
+the universal could be evidence for.
+
+NAME THE TEST THAT WILL EXIST, not one that does. Proof lives in the test suite
+and the spec names it; T0 is "names one test", so a requirement naming none has
+no plan to be checked. The lint reports every named test it cannot find, which
+is the to-do list emptying as the code lands — not a finding to avoid by
+writing nothing. Use the repo's own command for running one test.
+
+  tier: none / verify: none, <reason and issue link> is for a behaviour that
+  genuinely cannot be observed — not for one whose code is unwritten, which is
+  true of every requirement in every spec written before its implementation.
 
 FAILURE AND EDGE BEHAVIOUR is an indented sub-bullet under the requirement it
 qualifies. Encouraged, not required.
 -->
 
 - **XXX-001** WHEN <trigger> THE SYSTEM SHALL <observable behaviour>.
-  verify: just test-one <test_name>
+  tier:     T0
+  verify:   <run one test> <test_name>
   - IF <the failure condition> THEN THE SYSTEM SHALL <defined behaviour>.
-    verify: just test-one <test_name_failure>
+    tier:   T0
+    verify: <run one test> <test_name_failure>
 
 - **XXX-002** THE SYSTEM SHALL <observable behaviour that holds universally>.
-  verify:   just test-one <test_name>
+  tier:     T1
+  verify:   <run one test> <test_name>
   property: <the universal, in whatever notation reads clearly>
 
-- **XXX-003** THE SYSTEM SHALL <a security-critical universal>.
-  verify:   just test-one <test_name>
+- **XXX-003** THE SYSTEM SHALL <a bounded universal worth exhausting>.
+  tier:     T2
+  verify:   <run one test> <test_name>
+  property: <the universal>
+  harness:  <the Kani harness, and the unwind bound it is exhaustive to>
+
+- **XXX-004** THE SYSTEM SHALL <a security-critical universal>.
+  tier:     T3
+  verify:   <run one test> <test_name>
   property: <the universal>
   proof:    proofs/<Area>/<File>.lean#<theorem_name>
 
-- **XXX-004** WHERE <an optional feature is enabled> THE SYSTEM SHALL
-  <observable behaviour>.
-  verify: none, <why not yet, and the issue link>
+- **XXX-005** WHERE <an optional feature is enabled> THE SYSTEM SHALL
+  <observable behaviour nothing can watch today>.
+  tier:     none
+  verify:   none, <why nothing can observe it, and the issue link>
 
 ## Non-goals
 
@@ -152,6 +183,7 @@ qualifies. Encouraged, not required.
      not. Same rules as above: EARS, measurable, no unmeasured adjective. -->
 
 - **XXX-N01** WHILE <load condition> THE SYSTEM SHALL <measurable bound>.
+  tier:   T0
   verify: <the benchmark or load test that measures it>
 
 ## Design reasoning

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -1,0 +1,199 @@
+---
+id: XXX
+title: <feature name>
+status: draft
+owner: <github-handle>
+epic: <org/repo#N>
+arch: <gominimal/arch link, or: none>
+updated: <YYYY-MM-DD>
+---
+
+# XXX — <feature name>
+
+<!--
+SOURCE  gominimal/foundry spec/template.md @ d7227512d2577e2396f5a097c2fe50d5ffe08f14
+  This file is a copy. Edit it in foundry and open a PR here; a change made
+  only in this repo is lost the next time the template is updated. The SOURCE
+  line is what a drift check reads to tell whether this copy is behind.
+  Delete this whole comment block when you start a spec from it.
+
+WHAT A SPEC IS FOR
+  A spec settles what a change must do, and why, before the argument happens in
+  a diff. It is the durable record of the rationale and the agreed behaviour.
+
+WHAT IT IS NOT
+  Not the work breakdown (GitHub issues). Not the coding standards (AGENTS.md).
+  Not the architecture of record (gominimal/arch). There is no architecture
+  section in a spec, and specs do not nest. The spec links; it never restates.
+
+WHEN TO WRITE ONE
+  Every epic gets one. Anything carrying kind:epic, no exceptions. The filter is
+  upstream: work that does not warrant a spec should not have been an epic.
+  Everything below that takes the fast path with no spec.
+  Net new work only. A spec for code that already exists is discretionary,
+  written when a behaviour change warrants one.
+  A merged PR makes the spec binding. No vote, no change cut-off. When the
+  implementation diverges, fix the spec in the same PR that diverged.
+
+WHERE IT LIVES
+  In the repo where the code is going to be written, at
+  docs/specs/NN-spec-<slug>/NN-spec-<slug>.md.
+
+OWNERSHIP
+  Whoever touches the code owns the spec. Own the epic, own the spec; change the
+  behaviour later and you own updating the spec that describes it. `owner` names
+  who that is today. Specs are living documents.
+
+SIZE
+  No line cap on this document. Succinctness is the goal, and complexity rather
+  than length decides when work should split. The caps that exist sit on the
+  epic and the legendary, not here. If a section has nothing true to say, delete
+  it: an empty section is worse than a missing one.
+
+WRITING
+  A requirement does not dictate implementation. Name the observable behaviour,
+  not the mechanism that produces it.
+  Every behaviour must be verifiable. If a behaviour cannot be checked against a
+  running system it is background, not a requirement — so an adjective with no
+  bound is not a requirement either: "fast" becomes "p95 under 200 ms".
+  The lint comments on the PR. It never blocks a merge.
+-->
+
+## Context
+
+<!-- ~10 lines. The problem, why now, what is true after this ships, and the
+     success criteria. Close with the first slice: the smallest increment that
+     runs end to end, so a reader has an intermediate step, not just an endpoint.
+     No solution content, no file names, no API shapes. -->
+
+<problem, why now, what is true after this ships>
+
+**Success:** <the observable condition that means this worked>
+
+**First slice:** <the smallest thing that runs end to end>
+
+## Users and stories
+
+<!-- Name the roles being targeted. Transcribe the stories from the epic rather
+     than linking to it: the epic copy is transient, because issues get edited
+     and deleted, and once a story is bound into a merged spec, changing it
+     takes a review. -->
+
+**Roles:** <who this is for, specifically>
+
+- AS A <role> I WANT <capability> SO THAT <outcome>
+
+## Requirements
+
+<!--
+ONE BULLET PER REQUIREMENT. ID is XXX-NNN, stable, never reused. The ID is the
+join key that verify: and the property link point at. If nothing consumes it,
+delete it.
+
+WRITE REQUIREMENTS AS EARS.
+
+  Ubiquitous     THE SYSTEM SHALL <observable>
+  Event-driven   WHEN <trigger> THE SYSTEM SHALL <observable>
+  State-driven   WHILE <state> THE SYSTEM SHALL <observable>
+  Optional       WHERE <feature is present> THE SYSTEM SHALL <observable>
+  Unwanted       IF <condition> THEN THE SYSTEM SHALL <observable>
+
+EARS states a property over the whole input space. That is what a property test,
+a Kani harness or a Lean proof consumes, and it is what the Security
+considerations section is made of.
+
+PROSE IS THE AUTHORING INPUT, NEVER THE REQUIREMENT. Draft the behaviour in
+English, convert it to EARS, and review the translation.
+
+VERIFICATION TIERS — T0 is the default and nothing above it is mandated.
+Escalating a requirement is a per-item call made during review.
+  T0  verify:   <command>            an example test. The default.
+  T1  property: <universal>          a proptest over generated input.
+  T2  property: + a Kani harness     exhaustive to a bound.
+  T3  proof:    <file>#<theorem>     machine-checked in Lean 4.
+  A requirement that cannot be verified yet says
+  verify: none, <reason and issue link>.
+
+FAILURE AND EDGE BEHAVIOUR is an indented sub-bullet under the requirement it
+qualifies. Encouraged, not required.
+-->
+
+- **XXX-001** WHEN <trigger> THE SYSTEM SHALL <observable behaviour>.
+  verify: just test-one <test_name>
+  - IF <the failure condition> THEN THE SYSTEM SHALL <defined behaviour>.
+    verify: just test-one <test_name_failure>
+
+- **XXX-002** THE SYSTEM SHALL <observable behaviour that holds universally>.
+  verify:   just test-one <test_name>
+  property: <the universal, in whatever notation reads clearly>
+
+- **XXX-003** THE SYSTEM SHALL <a security-critical universal>.
+  verify:   just test-one <test_name>
+  property: <the universal>
+  proof:    proofs/<Area>/<File>.lean#<theorem_name>
+
+- **XXX-004** WHERE <an optional feature is enabled> THE SYSTEM SHALL
+  <observable behaviour>.
+  verify: none, <why not yet, and the issue link>
+
+## Non-goals
+
+<!-- What this deliberately does not cover, and where each one lives instead.
+     A non-goal with no destination is an omission, not a decision. -->
+
+- <thing>: <where it lives instead>
+
+## Non-functional requirements
+
+<!-- Optional. Delete this section if nothing here belongs to this epic.
+     Performance, scalability, concurrency limits, resource ceilings. An NFR is
+     usually a property of the system rather than of one epic, so state it here
+     only when it is genuinely scoped to this work, and link it out when it is
+     not. Same rules as above: EARS, measurable, no unmeasured adjective. -->
+
+- **XXX-N01** WHILE <load condition> THE SYSTEM SHALL <measurable bound>.
+  verify: <the benchmark or load test that measures it>
+
+## Design reasoning
+
+<!-- Why this shape and not the alternatives a reviewer would reach for. This is
+     the section that survives the feature: it is the original rationale, and it
+     is what makes the spec worth reading a year later.
+     Include the generality check: would this hold for a second implementation,
+     a second provider, a second platform? If not, say so and say why that is
+     acceptable.
+     A cross-cutting decision belongs in gominimal/arch. Link it; do not restate
+     it here, or the two will drift. -->
+
+<why this shape>
+
+**Generality:** <would a second implementation fit this? what breaks if not?>
+
+## Security considerations
+
+<!-- The invariants this feature must hold, and what enforces each one. State
+     them as universals, so T1-T3 can consume them directly. A prose paragraph
+     asserting that something is safe is the least checkable text in the
+     document; an invariant with a property test is not. -->
+
+- **Invariant:** THE SYSTEM SHALL <universal that must never be violated>.
+  enforced by: <the mechanism>
+  covered by: <XXX-NNN>
+
+## Rollout
+
+<!-- Infrastructure specs only. Delete this section otherwise. -->
+
+- **Deploy:** <steps>
+- **Rollback:** <how, and how long it takes>
+- **Blast radius:** <who is affected if this is wrong>
+
+## Open questions
+
+<!-- Required. Write "None." rather than deleting the section: an empty Open
+     questions section is a claim, and a useful one.
+     [NEEDS CLARIFICATION (CRITICAL|HIGH|MEDIUM|LOW): <question>]
+     The marker is for readers and reviewers. Nothing here blocks a merge; the
+     lint comments and the review decides. -->
+
+- [NEEDS CLARIFICATION (HIGH): <question>]


### PR DESCRIPTION
The spec format was decided at the 2026-08-27 kickoff and written up in
[How Minimal Writes Specs](https://docs.google.com/document/d/185oh7_PHVMsR2yiKOmX_pq3eUSERMRULawE8UBSZSIw/edit),
which is the source of truth. This repo holds the twelve specs it governs and
had neither the template nor anything that reads it.

Two files, both copies of `gominimal/foundry:spec/`:

| File | Source |
|---|---|
| `docs/specs/TEMPLATE.md` | `spec/template.md`, plus a `SOURCE` stamp |
| `.github/workflows/spec-lint.yml` | `spec/deploy/spec-lint.yml`, byte for byte |

They land together because foundry's drift check reports both, and two separate
merges would leave its nightly run red in between.

Edit either one in foundry and open a PR here; a change made only in this repo
is lost the next time the template is updated. `spec-drift.yml` fails when a
copy and its source disagree.

## The workflow cannot fail

The format was decided as advisory: the lint comments, the review decides.
`spec_lint.py` always returns 0, and **every step in this job carries
`continue-on-error`**, so neither a finding nor a broken checkout can produce a
red check. That is deliberately a property of the job rather than a flag on the
script — the exit code is where an advisory decision quietly becomes a gate.
Nothing here joins the five required aggregators.

## What it does

On a PR touching `docs/specs/`, it comments once — edited in place on each push,
never a second comment — naming what it found and which linter found it.

It lints **only the specs the PR touches**. The twelve specs here predate the
format and are not being backfilled; a PR editing one must not be handed
findings in eleven it did not write.

Within a spec directory it lints only `<slug>/<slug>.md`. Five of the twelve
carry an `architecture.md` beside the spec, and those are supporting documents —
linting one reports every required section as missing on a file nobody claimed
was a spec.

## The checker is not copied

`spec_lint.py` stays in foundry. This job checks it out at run time under the
App token, exactly as `minimal-review.yml` does, for the same two reasons: a PR
here cannot edit the linter that reads it, and the linter upgrades in one place
for every repo that installs it.

Consequences worth stating plainly:

- **Fork PRs are skipped.** They get no secrets, so the token cannot be minted.
  Skipped rather than refused — an advisory comment is not worth a red X, and
  the reviewer's hard refusal exists because it reaches a credentialled sandbox.
  This reaches a regex.
- **A foundry outage means no comment**, not a failed check.
- The comment names the resolved sha, so a finding can always be traced to the
  linter that produced it.

## `.github/workflows/` is CODEOWNER-gated

Understood. `AGENTS.md` says to extend CI through `scripts/` and the `justfile`,
and that route was considered: the linter is not a gate, so it has nothing to
contribute to `just ci`, and a convention-discovered Rust test that shells out
to a Python advisory linter would have to pass unconditionally to keep the
promise above — a test that cannot fail, added to a suite whose value is that
its tests can.

The workflow triggers on itself, so this PR exercises it rather than shipping a
job that has never run. With no spec changed it lints `TEMPLATE.md`, which
reaches the token, the checkout and the linter.

It comes back with six findings, not clean, and that is the expected output. A
template's prompts are unfilled by definition, so `S006` reports two sections
stating nothing the template did not and `S007` reports four prompts still
unanswered. The claim that it "should come back clean" was written before those
two checks existed; it is corrected at the source in
[gominimal/foundry#78](https://github.com/gominimal/foundry/pull/78), which this
copy takes once it merges.

## The template is refreshed

The copy first opened here was stamped `d722751` and predates the `tier:` field.
Linted, it produced five `P009` — every requirement in it stating no tier. A
template that fails the check it exists to teach hands its first user five
findings none of which are theirs.

It is now taken from `gominimal/foundry@842b37a`, which brings `tier:` on every
worked requirement, the `T0`/`T1`/`T2`/`T3`/`none` ladder with `harness:` for
T2, the `tier: none` case, and `P012` — a universal written into `property:` is
what T1 asks for, so a T0 carrying one is reported rather than left as a quiet
downgrade. The escalation call is made while the spec is written, not deferred
to a review, because a tier above T0 constrains code nobody has written yet.

Delivers gominimal/foundry#30. Authored in gominimal/foundry#41.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a standardized specification template covering requirements, verification, security, rollout, and open questions.
  * Documented conventions for creating and organizing epic specifications.

* **Chores**
  * Added an advisory pull-request specification check that identifies changed specification files and reports linting results in a single editable comment.
  * Checks remain non-blocking, so findings do not prevent merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->