### PR TITLE
fix(exec)!: tag exec-channel requests instead of sniffing the string

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ The CLI reference overview is [docs/reference/cli.md](docs/reference/cli.md).
 | `minimal-client` | SSH client transport to `minimald` over the UDS bridge, shared by `min` and the TUI. |
 | `minimal-tui` | `min dash`: the session-manager TUI (ratatui/crossterm, Elm-style loop). |
 | `minimald` | The session daemon: an SSH server hosting sessions and task/sandbox executions. |
-| `minimald-rpc` | Wire contract for `minimald`'s oneshot SSH RPCs. |
+| `minimald-rpc` | Wire contract for `minimald`'s oneshot SSH RPCs and the exec channel's request vocabulary. |
 | `minvmd` | Host daemon that boots Linux microVMs via libkrun and bridges host UDS to in-VM vsock. |
 | `mip` | The Minimal package/build CLI. |
 | `mlog` | JSON file-log layer both `minimald` and `minvmd` write through; one definition of the on-disk log format. |

--- a/crates/minimal-client/src/attach.rs
+++ b/crates/minimal-client/src/attach.rs
@@ -52,7 +52,12 @@ pub fn host_key_opts(known_hosts: &Path) -> [String; 2] {
 /// Build the `ssh` command that attaches to session `id` via the daemon
 /// socket at `sock`.
 ///
-/// The interactive path (`command: None`) forces a PTY with `-tt` — the
+/// `wire` is an already-encoded [`minimald_rpc::exec`] request, or `None` for
+/// the interactive shell. Callers name their own form — [`remote_command`] for
+/// a user's argv, [`minimald_rpc::exec::ExecRequest::TaskRun`] for a task — so
+/// this function never has to guess what a caller meant.
+///
+/// The interactive path (`wire: None`) forces a PTY with `-tt` — the
 /// daemon's shell_request handler mints the PTY-backed session shell, and
 /// ssh handles termios/PTY management. The caller decides how to run the
 /// command: `min session attach` `exec()`s it, `min dash` spawns it as a
@@ -60,7 +65,7 @@ pub fn host_key_opts(known_hosts: &Path) -> [String; 2] {
 pub fn attach_command(
     sock: &Path,
     id: sessions::SessionId,
-    command: &[String],
+    wire: Option<&str>,
 ) -> Result<std::process::Command, anyhow::Error> {
     // ProxyCommand points at our own `proxy` subcommand so we don't
     // depend on socat or nc being installed.
@@ -113,7 +118,7 @@ pub fn attach_command(
     // remote PTY, yet the interactive shell reading it never sees an EOF from a
     // redirected local stdin (`< /dev/null`, a pipe), so the command blocks
     // forever (#953). Callers must guarantee a terminal on stdin.
-    if command.is_empty() {
+    if wire.is_none() {
         ssh.arg("-tt");
     }
 
@@ -130,11 +135,43 @@ pub fn attach_command(
 
     // If a command was provided, pass it to ssh (non-interactive exec).
     // Otherwise, ssh opens an interactive shell via shell_request.
-    for cmd in command.iter() {
-        ssh.arg(cmd);
+    if let Some(wire) = wire {
+        ssh.arg(wire);
     }
 
     Ok(ssh)
+}
+
+/// The single command string to hand `ssh`, or `None` for the interactive
+/// shell.
+///
+/// ssh has no argv on the wire: it joins its trailing arguments with single
+/// spaces and the far side runs the result through a shell — so an argv passed
+/// through word by word is re-split by that shell, and every quote the *local*
+/// shell already removed is gone for good. `min session exec s sh -c 'echo A B'`
+/// arrived as `sh -c echo A B`, where `A` became `sh`'s `$0` and vanished from
+/// the output (gominimal/inbox#558 — fully qualified because the bare `#NNN`
+/// refs elsewhere in this tree point at this repo, and that one does not).
+///
+/// So the request is tagged instead ([`minimald_rpc::exec`]), and the arity
+/// picks the tag:
+///
+/// * One argument is a shell command, carried as-is — the `ssh host '...'` form
+///   the session e2e and the docs use (`min session exec s 'echo $PWD'`), where
+///   pipes, globs and `$PWD` are the point and must reach the session's shell.
+/// * Several arguments are an argv, carried as data. No shell reassembles them,
+///   so a word keeps its spaces and its metacharacters stay literal.
+///
+/// Arity is a default, not a limitation: both forms are nameable on the wire,
+/// so an explicit `--shell` / `--argv` flag could select one without changing
+/// the protocol.
+pub fn remote_command(command: &[String]) -> Option<String> {
+    use minimald_rpc::exec::ExecRequest;
+    match command {
+        [] => None,
+        [one] => Some(ExecRequest::Shell(one.clone()).encode()),
+        words => Some(ExecRequest::Argv(words.to_vec()).encode()),
+    }
 }
 
 #[cfg(test)]
@@ -145,7 +182,7 @@ mod tests {
     #[test]
     fn attach_command_targets_the_provider_alias() {
         let sock = PathBuf::from("/tmp/x/providers/local-minimald0/ssh.sock");
-        let cmd = attach_command(&sock, sessions::SessionId::nil(), &[]).unwrap();
+        let cmd = attach_command(&sock, sessions::SessionId::nil(), None).unwrap();
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
@@ -161,22 +198,74 @@ mod tests {
     #[test]
     fn attach_command_with_exec_has_no_forced_pty() {
         let sock = PathBuf::from("/tmp/x/providers/local-minvmd0/ssh.sock");
-        let cmd = attach_command(
-            &sock,
-            sessions::SessionId::nil(),
-            &["min".to_string(), "run".to_string(), "test".to_string()],
-        )
-        .unwrap();
+        let wire = remote_command(&["min".to_string(), "run".to_string(), "test".to_string()]);
+        let cmd = attach_command(&sock, sessions::SessionId::nil(), wire.as_deref()).unwrap();
         let args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
         assert!(!args.iter().any(|a| a == "-tt"));
+        // One trailing argument, not three: ssh would join a word-per-arg argv
+        // with spaces and let the far shell re-split it.
         assert_eq!(
-            args.into_iter().rev().take(3).rev().collect::<Vec<_>>(),
-            vec!["min".to_string(), "run".to_string(), "test".to_string()]
+            args.last().map(String::as_str),
+            Some(r#"min://argv ["min","run","test"]"#)
         );
     }
+
+    /// No command is the interactive shell: ssh gets no trailing argument at
+    /// all, and the daemon opens the session shell via `shell_request`.
+    #[test]
+    fn no_command_is_the_interactive_shell() {
+        assert_eq!(remote_command(&[]), None);
+    }
+
+    /// The `ssh host '...'` form the e2e and docs use: a lone argument is a
+    /// shell command, so `$PWD`, pipes and `;` still mean what they say when
+    /// the session's shell sees them.
+    #[test]
+    fn a_lone_argument_is_carried_as_a_shell_command() {
+        let wire = remote_command(&["echo EXEC_OK $PWD".to_string()]).unwrap();
+        assert_eq!(
+            minimald_rpc::exec::ExecRequest::parse(&wire),
+            Ok(minimald_rpc::exec::ExecRequest::Shell(
+                "echo EXEC_OK $PWD".to_string()
+            ))
+        );
+    }
+
+    /// The bug: `min session exec s sh -c 'echo A B C'`. ssh's join let the far
+    /// shell re-split the `-c` argument, so `A` was eaten as `sh`'s `$0` and
+    /// only `B C` printed. Carried as an argv, the words arrive as data and
+    /// `echo A B C` stays one argument.
+    #[test]
+    fn a_multi_word_argv_survives_as_data() {
+        let wire = remote_command(&["sh".to_string(), "-c".to_string(), "echo A B C".to_string()])
+            .unwrap();
+        assert_eq!(
+            minimald_rpc::exec::ExecRequest::parse(&wire),
+            Ok(minimald_rpc::exec::ExecRequest::Argv(vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "echo A B C".to_string(),
+            ]))
+        );
+    }
+
+    /// A session command that merely looks like one of the daemon's own is the
+    /// session's: nothing about `min ...` is special on the wire any more, so
+    /// the session's `min` binary is reachable (gominimal/inbox#558).
+    #[test]
+    fn a_min_command_still_belongs_to_the_session() {
+        let wire = remote_command(&["min --version".to_string()]).unwrap();
+        assert_eq!(
+            minimald_rpc::exec::ExecRequest::parse(&wire),
+            Ok(minimald_rpc::exec::ExecRequest::Shell(
+                "min --version".to_string()
+            ))
+        );
+    }
+
     /// A VM-backed provider dir carries the guest's recorded host key, so
     /// attach must verify against it rather than waive the check.
     #[test]

--- a/crates/minimal-client/src/lib.rs
+++ b/crates/minimal-client/src/lib.rs
@@ -370,9 +370,9 @@ impl Client {
     }
 
     /// Like [`Self::open_exec_channel`], but sets `MINIMAL_SESSION_ID` on the
-    /// channel before the exec request, the routing contract the daemon's
-    /// `min`-prefixed exec forms (`min task run <task>`, `min package build`,
-    /// `min check`) are served under.
+    /// channel before the exec request, the routing contract the daemon's own
+    /// exec forms ([`minimald_rpc::exec::ExecRequest::TaskRun`] and its
+    /// siblings) are served under.
     pub async fn open_session_exec_channel(
         &mut self,
         session_id: sessions::SessionId,

--- a/crates/minimal-tui/src/app.rs
+++ b/crates/minimal-tui/src/app.rs
@@ -1074,7 +1074,7 @@ fn attach_and_resume(
     id: SessionId,
     model: &mut Model,
 ) {
-    let result = minimal_client::attach::attach_command(sock, id, &[]).and_then(|mut cmd| {
+    let result = minimal_client::attach::attach_command(sock, id, None).and_then(|mut cmd| {
         terminal.suspend();
         let status = cmd.status();
         // A failed resume leaves the TUI unusable; report it over the

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -199,6 +199,12 @@ pub enum SessionCommand {
     Attach(AttachArgs),
     /// Execute a command in an existing session
     Exec(ExecArgs),
+    /// Run a declared task in an existing session
+    ///
+    /// The task runs in the named session's context, serviced by the daemon —
+    /// the counterpart to `min task run <task>`, which composes a task session
+    /// of its own instead of reusing one you already have.
+    Run(SessionRunArgs),
     /// Destroy (terminate) a session
     Destroy(DestroyArgs),
     /// Rename an existing session
@@ -261,8 +267,22 @@ pub struct ExecArgs {
     #[arg(add = completion::session_completer())]
     pub session: String,
     /// Command to execute in the session context
+    ///
+    /// A single argument is a shell command, run by the session's shell with
+    /// its pipes, globs and `$VAR` intact: `min session exec s 'echo $PWD'`.
+    /// Several arguments are an argv, quoted so the session sees exactly the
+    /// words you typed: `min session exec s sh -c 'echo A B'`.
     #[arg(trailing_var_arg = true, required = true, num_args = 1..)]
     pub command: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct SessionRunArgs {
+    /// Session identifier (UUID or session name).
+    #[arg(add = completion::session_completer())]
+    pub session: String,
+    /// Name of a task declared in the session project's minimal.toml
+    pub task: String,
 }
 
 #[derive(Debug, Args)]
@@ -792,6 +812,7 @@ async fn run_command(cli: Cli) -> Result<(), anyhow::Error> {
             SessionCommand::Activate(args) => cmd_activate(&cli.global_args, args).await,
             SessionCommand::Attach(args) => cmd_attach(&cli.global_args, args).await,
             SessionCommand::Exec(args) => cmd_exec(&cli.global_args, args).await,
+            SessionCommand::Run(args) => cmd_session_run(&cli.global_args, args).await,
             SessionCommand::Destroy(args) => cmd_destroy(&cli.global_args, args).await,
             SessionCommand::Rename(args) => cmd_rename(&cli.global_args, args).await,
             SessionCommand::Policy(args) => cmd_session_policy(&cli.global_args, args).await,
@@ -962,7 +983,7 @@ async fn cmd_bare(global: &GlobalArgs) -> Result<(), anyhow::Error> {
                 session_name = ?entry.name,
                 "found session"
             );
-            session_via_ssh(&sock, entry.id, vec![]).await
+            session_via_ssh(&sock, entry.id, None).await
         }
         // Two ways to land on create-and-attach: no sessions exist at all
         // (first run), or the ambiguity picker's `+ Create a new session`
@@ -2466,7 +2487,7 @@ pub async fn cmd_attach(global: &GlobalArgs, args: AttachArgs) -> Result<(), any
         "found session"
     );
 
-    session_via_ssh(&sock, id, vec![]).await
+    session_via_ssh(&sock, id, None).await
 }
 
 /// Executes a command in an existing session.
@@ -2493,7 +2514,48 @@ pub async fn cmd_exec(global: &GlobalArgs, args: ExecArgs) -> Result<(), anyhow:
         "found session"
     );
 
-    session_via_ssh(&sock, r.id, args.command).await
+    session_via_ssh(
+        &sock,
+        r.id,
+        minimal_client::attach::remote_command(&args.command),
+    )
+    .await
+}
+
+/// Runs a task declared by the session's project, in that session.
+///
+/// The daemon services this itself rather than handing it to the session's
+/// shell, so the task composes against the session's context. Named on the wire
+/// as [`minimald_rpc::exec::ExecRequest::TaskRun`]; nothing is inferred from the
+/// text, which is what lets a task share a name with a program on `PATH`.
+pub async fn cmd_session_run(
+    global: &GlobalArgs,
+    args: SessionRunArgs,
+) -> Result<(), anyhow::Error> {
+    ensure_daemon(global)?;
+
+    let sock = client::resolve_socket_path(global.minimal_dir.as_deref(), global.use_minvmd())
+        .context("Failed to resolve daemon socket path")?;
+
+    let mut client = client::Client::connect(&sock)
+        .await
+        .context("Failed to connect to minimald")?;
+    // Gated by hand for the same reason as `cmd_exec`: this hands off into a
+    // live session, which is not something to drive on a skewed pair.
+    let r = resolve_session_version_gated(&mut client, &args.session).await?;
+    tracing::info!(
+        session_id = %r.id,
+        session_name = ?r.name,
+        task = %args.task,
+        "found session"
+    );
+
+    session_via_ssh(
+        &sock,
+        r.id,
+        Some(minimald_rpc::exec::ExecRequest::TaskRun(args.task).encode()),
+    )
+    .await
 }
 
 /// Resolve a session to attach to when the user supplied no explicit session
@@ -2604,17 +2666,17 @@ fn ensure_interactive_attach_tty(stdin_is_tty: bool) -> Result<(), anyhow::Error
 async fn session_via_ssh(
     sock: &std::path::Path,
     id: sessions::SessionId,
-    command: Vec<String>,
+    wire: Option<String>,
 ) -> Result<(), anyhow::Error> {
     // The command itself lives in minimal-client, shared with the dash TUI's
     // suspend-attach-resume flow.
-    let mut ssh = minimal_client::attach::attach_command(sock, id, &command)?;
+    let mut ssh = minimal_client::attach::attach_command(sock, id, wire.as_deref())?;
 
     // `-tt` over a *non-terminal* stdin is a trap: ssh still forces the
     // remote PTY, yet the interactive shell reading it never sees an EOF from a
     // redirected local stdin (`< /dev/null`, a pipe), so the command blocks
     // forever (#953). Fail fast instead of hanging.
-    if command.is_empty() {
+    if wire.is_none() {
         ensure_interactive_attach_tty(std::io::stdin().is_terminal())?;
 
         // The interactive path waits on ssh rather than `exec()`ing it, so this
@@ -3949,6 +4011,7 @@ mod tests {
                 "lib.rs::cmd_attach = gated",
                 "lib.rs::cmd_bare = gated",
                 "lib.rs::cmd_exec = gated",
+                "lib.rs::cmd_session_run = gated",
                 "lib.rs::cmd_session_setup_zed = gated",
                 "lib.rs::cmd_ssh_forward = gated",
                 "lib.rs::cmd_version = ungated",
@@ -4671,6 +4734,40 @@ mod tests {
                 "1 file differs from activation (may include committed work):".to_string(),
                 "  A scratch.txt".to_string(),
             ]
+        );
+    }
+
+    /// `min session run <session> <task>` names both the session to run in and
+    /// the task to run, in that order — the session-scoped counterpart to
+    /// `min task run <task>`, which composes a session of its own.
+    #[test]
+    fn session_run_takes_a_session_then_a_task() {
+        let cli = Cli::try_parse_from(["min", "session", "run", "web", "build"]).unwrap();
+        let Some(Command::Session(SessionArgs {
+            command: SessionCommand::Run(a),
+        })) = cli.command
+        else {
+            panic!("expected a session run command");
+        };
+        assert_eq!(a.session, "web");
+        assert_eq!(a.task, "build");
+
+        // Both operands are required: a lone session names no task.
+        assert!(Cli::try_parse_from(["min", "session", "run", "web"]).is_err());
+        assert!(Cli::try_parse_from(["min", "session", "run"]).is_err());
+    }
+
+    /// The task reaches the daemon as a named form, so a task whose name
+    /// collides with a program on the session's `PATH` is still a task —
+    /// nothing is inferred from the text (gominimal/inbox#558).
+    #[test]
+    fn session_run_encodes_a_task_form_not_a_command() {
+        let wire = minimald_rpc::exec::ExecRequest::TaskRun("check".to_string()).encode();
+        assert_eq!(
+            minimald_rpc::exec::ExecRequest::parse(&wire),
+            Ok(minimald_rpc::exec::ExecRequest::TaskRun(
+                "check".to_string()
+            ))
         );
     }
 

--- a/crates/minimal/src/main.rs
+++ b/crates/minimal/src/main.rs
@@ -127,8 +127,8 @@ impl std::io::Write for DashLog {
 /// Whether the command's stdout is a data contract that tracing must not
 /// pollute, so its logs go to stderr instead. The `completions` handlers emit a
 /// shell shim on stdout, `session exec` carries only the exec'd
-/// command's output, and `task run` streams the task's stdout — a log line
-/// in any of them would be read as content. A bare `min` (no subcommand) is
+/// command's output, and `task run` / `session run` stream the task's stdout —
+/// a log line in any of them would be read as content. A bare `min` (no subcommand) is
 /// one too: its non-TTY twin promises an empty stdout to pipelines, and its
 /// interactive activate path prints only the session id there.
 fn stdout_is_data_contract(command: &Option<minimal::Command>) -> bool {
@@ -138,7 +138,8 @@ fn stdout_is_data_contract(command: &Option<minimal::Command>) -> bool {
             minimal::Command::CompleteSessionStr(_)
                 | minimal::Command::Completions(_)
                 | minimal::Command::Session(minimal::SessionArgs {
-                    command: minimal::SessionCommand::Exec(ExecArgs { .. }),
+                    command: minimal::SessionCommand::Exec(ExecArgs { .. })
+                        | minimal::SessionCommand::Run(_),
                 })
                 | minimal::Command::Task(minimal::TaskArgs {
                     command: minimal::TaskCommand::Run(_),
@@ -157,6 +158,19 @@ mod tests {
     #[test]
     fn bare_min_is_a_stdout_contract() {
         assert!(stdout_is_data_contract(&None));
+    }
+
+    /// `min session run` streams the task's stdout over the exec channel, so
+    /// tracing must route to stderr like the other stdout contracts.
+    #[test]
+    fn session_run_is_a_stdout_contract() {
+        let cmd = Some(Command::Session(minimal::SessionArgs {
+            command: minimal::SessionCommand::Run(minimal::SessionRunArgs {
+                session: "web".to_string(),
+                task: "build".to_string(),
+            }),
+        }));
+        assert!(stdout_is_data_contract(&cmd));
     }
 
     /// `min task run` streams the task's stdout, so tracing must route to

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -550,7 +550,10 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
     eprintln!("Running task {} in session {session_name}...", args.task);
 
     let outcome = match client
-        .open_session_exec_channel(id, &format!("min task run {}", args.task))
+        .open_session_exec_channel(
+            id,
+            &minimald_rpc::exec::ExecRequest::TaskRun(args.task.clone()).encode(),
+        )
         .await
     {
         Ok(channel) => bridge_exec(channel).await,

--- a/crates/minimald-rpc/Cargo.toml
+++ b/crates/minimald-rpc/Cargo.toml
@@ -13,8 +13,6 @@ hex.workspace = true
 paths.workspace = true
 rand.workspace = true
 serde.workspace = true
+serde_json_lenient.workspace = true
 
 sessions.workspace = true
-
-[dev-dependencies]
-serde_json_lenient.workspace = true

--- a/crates/minimald-rpc/src/exec.rs
+++ b/crates/minimald-rpc/src/exec.rs
@@ -1,0 +1,296 @@
+//! The exec-channel command vocabulary.
+//!
+//! SSH's `exec` request carries exactly one string (RFC 4254 §5.2), so every
+//! form a client can ask for has to fit in it. This module is that encoding,
+//! defined once and shared: clients build the string here, the daemon parses it
+//! here, and neither can drift from the other.
+//!
+//! # Why the requests are tagged
+//!
+//! The daemon used to decide what a request meant by *looking at* the string —
+//! anything starting with `min ` was one of its own commands, everything else
+//! was a shell command for the session. That conflated three different things
+//! in one untagged string, and both failure modes were real:
+//!
+//! * A session command was stolen. `min --version` names the session's own
+//!   `min` binary, but the daemon claimed the prefix and refused it, so the
+//!   binary was simply unreachable through exec.
+//! * An argv could not be sent at all. ssh has no argv on the wire — it joins
+//!   its trailing arguments with single spaces and the far side reshells the
+//!   result — so `sh -c 'echo A B C'` arrived as `sh -c echo A B C` and `A`
+//!   became `sh`'s `$0` (gominimal/inbox#558). Quoting the words on the client
+//!   fixed the splitting but broke the `min ` sniffing, because both read the
+//!   same bytes.
+//!
+//! Tagging separates them. A request reaches the daemon only by naming a form
+//! explicitly, [`ExecRequest::Argv`] carries its words as data rather than as a
+//! line for some shell to re-split, and — the rule that makes the hijack
+//! impossible — **anything untagged belongs to the session**.
+//!
+//! # The forms
+//!
+//! ```text
+//! min://shell <command>          run <command> with the session's shell
+//! min://argv ["a","b"]           exec this argv in the session, no shell
+//! min://task/run <task>          daemon-serviced: run a declared task
+//! min://package/build [args]     daemon-serviced: build packages
+//! min://check [args]             daemon-serviced: lint the session's config
+//! <anything else>                a shell command for the session
+//! ```
+//!
+//! `git-receive-pack min://<session>` is not part of this vocabulary: the git
+//! remote helper speaks the pack protocol and the daemon routes it before it
+//! gets here.
+
+use std::fmt;
+
+/// Prefix marking a request as one this vocabulary defines. A command that does
+/// not start with it is a shell command for the session, never a daemon one.
+pub const EXEC_SCHEME: &str = "min://";
+
+/// What a client asked the daemon to run on an exec channel.
+///
+/// Build one with the constructors below and render it with
+/// [`ExecRequest::encode`]; recover it with [`ExecRequest::parse`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecRequest {
+    /// A command line for the session's shell, with its pipes, globs and
+    /// `$VAR` intact. The `ssh host '<cmd>'` form.
+    Shell(String),
+    /// An argv to exec directly in the session. No shell stands between these
+    /// words and the process, so nothing can re-split them.
+    ///
+    /// Never empty — [`ExecRequest::parse`] rejects an empty argv rather than
+    /// handing the daemon a program-less request.
+    Argv(Vec<String>),
+    /// Run a task the session's project declares.
+    TaskRun(String),
+    /// Build packages against the session.
+    PackageBuild(String),
+    /// Lint the session's `minimal.toml`, packages, profiles and stacks.
+    Check(String),
+}
+
+/// Tag for [`ExecRequest::Shell`].
+const SHELL: &str = "shell";
+/// Tag for [`ExecRequest::Argv`].
+const ARGV: &str = "argv";
+/// Tag for [`ExecRequest::TaskRun`].
+const TASK_RUN: &str = "task/run";
+/// Tag for [`ExecRequest::PackageBuild`].
+const PACKAGE_BUILD: &str = "package/build";
+/// Tag for [`ExecRequest::Check`].
+const CHECK: &str = "check";
+
+/// Every tag, for the error message that lists what the daemon accepts.
+const TAGS: [&str; 5] = [SHELL, ARGV, TASK_RUN, PACKAGE_BUILD, CHECK];
+
+impl ExecRequest {
+    /// The wire string for this request.
+    pub fn encode(&self) -> String {
+        match self {
+            Self::Shell(cmd) => format!("{EXEC_SCHEME}{SHELL} {cmd}"),
+            Self::Argv(words) => {
+                // JSON rather than a separator byte: argv strings reach `ssh`
+                // as process arguments, so the one delimiter that could never
+                // collide with the payload — NUL — is exactly the one that
+                // cannot survive `execve`. JSON has no such hole, and it keeps
+                // the daemon's `exec request` log line readable.
+                let json = serde_json_lenient::to_string(words)
+                    .expect("a Vec<String> always serializes to JSON");
+                format!("{EXEC_SCHEME}{ARGV} {json}")
+            }
+            Self::TaskRun(task) => format!("{EXEC_SCHEME}{TASK_RUN} {task}"),
+            Self::PackageBuild(args) => format!("{EXEC_SCHEME}{PACKAGE_BUILD} {args}"),
+            Self::Check(args) => format!("{EXEC_SCHEME}{CHECK} {args}"),
+        }
+    }
+
+    /// Recover a request from its wire string.
+    ///
+    /// An untagged command is a [`ExecRequest::Shell`] for the session: the
+    /// daemon's own forms are reachable only by naming them, so no session
+    /// command can be mistaken for one.
+    ///
+    /// # Errors
+    ///
+    /// [`ExecParseError`] when the scheme is present but the tag is unknown,
+    /// or when an `argv` payload is not a JSON array of strings — both are a
+    /// client asking for something this daemon does not serve, which is worth
+    /// refusing rather than silently running in a shell.
+    pub fn parse(command: &str) -> Result<Self, ExecParseError> {
+        let Some(rest) = command.strip_prefix(EXEC_SCHEME) else {
+            return Ok(Self::Shell(command.to_string()));
+        };
+
+        // The tag runs to the first space; everything after it is the payload,
+        // verbatim. Splitting once (not on every space) is what lets a task
+        // name or a shell command keep its own spaces.
+        let (tag, payload) = match rest.split_once(' ') {
+            Some((tag, payload)) => (tag, payload),
+            None => (rest, ""),
+        };
+
+        match tag {
+            SHELL => Ok(Self::Shell(payload.to_string())),
+            ARGV => {
+                let words: Vec<String> = serde_json_lenient::from_str(payload)
+                    .map_err(|e| ExecParseError::Argv(e.to_string()))?;
+                if words.is_empty() {
+                    return Err(ExecParseError::EmptyArgv);
+                }
+                Ok(Self::Argv(words))
+            }
+            TASK_RUN => Ok(Self::TaskRun(payload.to_string())),
+            PACKAGE_BUILD => Ok(Self::PackageBuild(payload.to_string())),
+            CHECK => Ok(Self::Check(payload.to_string())),
+            unknown => Err(ExecParseError::UnknownTag(unknown.to_string())),
+        }
+    }
+}
+
+/// Why an exec request naming the [`EXEC_SCHEME`] could not be understood.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecParseError {
+    /// The scheme was present but the tag after it is not one this daemon
+    /// serves — typically a newer client against an older daemon.
+    UnknownTag(String),
+    /// The `argv` payload was not a JSON array of strings.
+    Argv(String),
+    /// The `argv` payload was a well-formed but empty array, which names no
+    /// program to run.
+    EmptyArgv,
+}
+
+impl fmt::Display for ExecParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownTag(tag) => write!(
+                f,
+                "unknown exec form '{EXEC_SCHEME}{tag}'; this daemon serves {}",
+                TAGS.map(|t| format!("{EXEC_SCHEME}{t}")).join(", "),
+            ),
+            Self::Argv(e) => write!(
+                f,
+                "the {EXEC_SCHEME}{ARGV} payload is not a JSON array of strings: {e}"
+            ),
+            Self::EmptyArgv => write!(f, "the {EXEC_SCHEME}{ARGV} payload names no program"),
+        }
+    }
+}
+
+impl std::error::Error for ExecParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every form survives the round trip it exists for.
+    #[test]
+    fn each_form_round_trips() {
+        for req in [
+            ExecRequest::Shell("echo EXEC_OK $PWD".to_string()),
+            ExecRequest::Argv(vec!["sh".into(), "-c".into(), "echo A B C".into()]),
+            ExecRequest::TaskRun("build".to_string()),
+            ExecRequest::PackageBuild("--verbose pkg".to_string()),
+            ExecRequest::Check(String::new()),
+        ] {
+            assert_eq!(ExecRequest::parse(&req.encode()), Ok(req));
+        }
+    }
+
+    /// The bug this vocabulary exists for: the words arrive as data, so the
+    /// spaces inside `echo A B C` are part of one argument and no shell gets a
+    /// chance to re-split them.
+    #[test]
+    fn an_argv_keeps_words_that_contain_spaces_whole() {
+        let req = ExecRequest::Argv(vec!["sh".into(), "-c".into(), "echo A B C".into()]);
+        let ExecRequest::Argv(back) = ExecRequest::parse(&req.encode()).unwrap() else {
+            panic!("argv must parse back as an argv");
+        };
+        assert_eq!(back[2], "echo A B C");
+    }
+
+    /// The hijack that used to make a session's own `min` unreachable: an
+    /// untagged command belongs to the session, however it happens to start.
+    #[test]
+    fn an_untagged_command_is_always_the_sessions() {
+        for cmd in [
+            "min --version",
+            "min run build",
+            "min check",
+            "echo hi",
+            "git status",
+        ] {
+            assert_eq!(
+                ExecRequest::parse(cmd),
+                Ok(ExecRequest::Shell(cmd.to_string())),
+                "{cmd} must reach the session",
+            );
+        }
+    }
+
+    /// A payload keeps its own spaces: the tag is split off once, not on every
+    /// space, so a shell command and a multi-word arg list arrive intact.
+    #[test]
+    fn the_payload_keeps_its_spaces() {
+        assert_eq!(
+            ExecRequest::parse("min://shell echo a  b; echo c"),
+            Ok(ExecRequest::Shell("echo a  b; echo c".to_string()))
+        );
+        assert_eq!(
+            ExecRequest::parse("min://package/build --verbose a b"),
+            Ok(ExecRequest::PackageBuild("--verbose a b".to_string()))
+        );
+    }
+
+    /// A tag with no payload at all — `min://check` — is the no-args form, not
+    /// a parse error.
+    #[test]
+    fn a_bare_tag_is_the_empty_payload() {
+        assert_eq!(
+            ExecRequest::parse("min://check"),
+            Ok(ExecRequest::Check(String::new()))
+        );
+    }
+
+    /// A newer client's form against an older daemon is refused by name, so the
+    /// error can say which form was asked for.
+    #[test]
+    fn an_unknown_tag_is_refused_rather_than_shelled() {
+        let err = ExecRequest::parse("min://teleport now").unwrap_err();
+        assert_eq!(err, ExecParseError::UnknownTag("teleport".to_string()));
+        assert!(err.to_string().contains("min://teleport"), "{err}");
+        // The message lists what this daemon does serve.
+        assert!(err.to_string().contains("min://task/run"), "{err}");
+    }
+
+    /// A malformed or program-less argv is refused rather than guessed at.
+    #[test]
+    fn a_broken_argv_payload_is_refused() {
+        assert!(matches!(
+            ExecRequest::parse("min://argv not-json"),
+            Err(ExecParseError::Argv(_))
+        ));
+        assert_eq!(
+            ExecRequest::parse("min://argv []"),
+            Err(ExecParseError::EmptyArgv)
+        );
+    }
+
+    /// Quotes, backslashes and newlines in an argument are payload, not syntax:
+    /// JSON carries them and the daemon gets the byte-exact word back.
+    #[test]
+    fn awkward_characters_survive_an_argv() {
+        let nasty = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "it's \"quoted\"\\ and\nnewlined".to_string(),
+        ];
+        let req = ExecRequest::Argv(nasty.clone());
+        assert_eq!(
+            ExecRequest::parse(&req.encode()),
+            Ok(ExecRequest::Argv(nasty))
+        );
+    }
+}

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -13,6 +13,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sessions::SessionId;
 
+pub mod exec;
 pub mod trace;
 
 pub use sessions::{EgressPolicy, IngressPolicy, IpProto, NetworkMode, PortMapping, SessionPolicy};

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -842,14 +842,16 @@ where
 ///
 /// Accepted forms are:
 ///  * `git-receive-pack min://<session ID>` - handles a git receive-pack, routing
-///    with the trailing session ID
-///  * `min task run <task>` (canonical) or `min run <task>` (legacy alias) -
-///    runs a task, routed via a `MINIMAL_SESSION_ID` env var that must be set
-///    on the channel by the client
-///  * `min package build <args>` - builds package(s), routed via a
-///    `MINIMAL_SESSION_ID` env var that must be set on the channel by the client
-///  * `min check <args>` - lints the session's `minimal.toml`, packages,
-///    profiles, and stacks, routed the same way as `min package build`
+///    with the trailing session ID. Matched before the vocabulary below, and
+///    not part of it: git speaks the pack protocol, not exec requests.
+///  * a [`minimald_rpc::exec::ExecRequest`], which is where the rest of the
+///    vocabulary is defined. The daemon-serviced forms — `min://task/run`,
+///    `min://package/build` and `min://check` — are each routed via a
+///    `MINIMAL_SESSION_ID` env var that must be set on the channel by the
+///    client. `min://shell` and `min://argv` are handed to the session.
+///  * anything else: a shell command for the session. Nothing about a
+///    command's text routes it, so a session command can never be mistaken
+///    for one of the daemon's own (gominimal/inbox#558).
 pub(crate) async fn handle_exec(
     argv: &[u8],
     serv: ServerStateHandle,

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -484,15 +484,41 @@ impl Exec for TokioExec {
     }
 }
 
+/// What to run inside the session, and whether a shell stands between the
+/// client's words and the process.
+#[derive(Debug, Clone)]
+pub enum SessionProgram {
+    /// A command line for the session's shell. The client wrote a shell
+    /// command, so quoting, globs, pipes and redirections are part of what it
+    /// means — matching what `ssh host '...'` does everywhere else.
+    Shell(String),
+    /// An argv to exec directly. Nothing re-splits these words, which is the
+    /// whole point: a shell in the middle would undo the quoting the client
+    /// already resolved. Guaranteed non-empty by
+    /// [`minimald_rpc::exec::ExecRequest::parse`].
+    Argv(Vec<String>),
+}
+
+impl SessionProgram {
+    /// The program and arguments to hand the session, resolving a shell
+    /// command into an explicit `bash -c` argv.
+    fn argv(self) -> (String, Vec<String>) {
+        match self {
+            Self::Shell(cmd) => (SESSION_SHELL.to_string(), vec!["-c".to_string(), cmd]),
+            Self::Argv(mut words) => {
+                // Non-empty by construction; `remove(0)` cannot panic.
+                let program = words.remove(0);
+                (program, words)
+            }
+        }
+    }
+}
+
 /// An [`Exec`] that runs a command *inside* the session's sandbox, joining the
 /// namespaces of the running session process.
-///
-/// `argv` is handed to the session's shell rather than split here, matching
-/// what `ssh host '...'` does everywhere else: the client wrote a shell command,
-/// and quoting, globs, pipes and redirections are part of what it means.
 #[derive(Debug, Clone)]
 pub struct SessionExec {
-    pub argv: String,
+    pub program: SessionProgram,
     /// The SSH username, needed only if the session has no host running and one
     /// has to be launched to service this request.
     pub conn_username: String,
@@ -515,9 +541,8 @@ impl Exec for SessionExec {
                 .ensure_host(self.conn_username)
                 .await
                 .map_err(|e| io::Error::other(format!("{e}")))?;
-            let command = host
-                .command_in_session(SESSION_SHELL, ["-c", &self.argv])
-                .await?;
+            let (program, args) = self.program.argv();
+            let command = host.command_in_session(&program, &args).await?;
 
             let mut command = Command::from(command);
             command
@@ -896,43 +921,57 @@ pub(crate) async fn handle_exec(
     // refused below.
     tracing::info!(%session_id, command = %argv, "exec request");
 
-    let rem = match argv.strip_prefix("min ") {
-        Some(c) => c,
-        // Not one of the daemon's own commands, so it is a command for the
-        // session: run it in the sandbox, the way `ssh host '<cmd>'` runs it on
-        // the host it names.
-        None => {
+    // Parsed, never sniffed. The vocabulary in `minimald_rpc::exec` is the only
+    // way to ask for one of the daemon's own forms, so a session command can no
+    // longer be mistaken for one — `min --version` names the session's `min`
+    // and reaches it, where the old `strip_prefix("min ")` claimed and refused
+    // it (gominimal/inbox#558).
+    let request = match minimald_rpc::exec::ExecRequest::parse(&argv) {
+        Ok(request) => request,
+        Err(e) => {
+            tracing::warn!(%session_id, error = %e, "execution request rejected");
+            // Accept-then-report, as the bad-flag path does: a bare
+            // `channel_failure` would reach the client as an opaque "exec
+            // request failed" with none of the detail the error carries.
+            session.channel_success(id)?;
+            spawn(async move {
+                reject_unsupported_exec(channel, e.to_string()).await;
+            });
+            return Ok(());
+        }
+    };
+
+    use minimald_rpc::exec::ExecRequest;
+    match request {
+        ExecRequest::Shell(_) | ExecRequest::Argv(_) => {
+            let program = match request {
+                ExecRequest::Shell(cmd) => SessionProgram::Shell(cmd),
+                ExecRequest::Argv(words) => SessionProgram::Argv(words),
+                _ => unreachable!("the match arm admits only Shell and Argv"),
+            };
             let span = exec_span(&config, session_id, &argv);
             session.channel_success(id)?;
             spawn(
-                run_in_session(serv, conn, session_handle, id, channel, argv, conn_username)
-                    .instrument(span),
+                run_in_session(
+                    serv,
+                    conn,
+                    session_handle,
+                    id,
+                    channel,
+                    program,
+                    conn_username,
+                )
+                .instrument(span),
             );
-            return Ok(());
         }
-    }
-    .to_string();
-
-    let mut c = rem.split(' ');
-    match c.next() {
-        None => {
-            tracing::warn!(%session_id, "execution request rejected: expected `min <sub command>`");
-            session.channel_failure(id)?;
-            return Ok(());
-        }
-        Some("run") => {
-            // `min run` with no task name would leave `strip_prefix("run ")`
-            // as `None` (and a trailing-space `min run ` as empty) — reject
-            // both before acking, rather than panicking on `.unwrap()`.
-            let task = rem.strip_prefix("run ").unwrap_or("").trim();
+        ExecRequest::TaskRun(task) => {
+            let task = task.trim().to_string();
             if task.is_empty() {
-                tracing::warn!(%session_id, "execution request rejected: expected `min run <task name>`");
+                tracing::warn!(%session_id, "execution request rejected: task/run names no task");
                 session.channel_failure(id)?;
                 return Ok(());
             }
-            let task = task.to_string();
             session.channel_success(id)?;
-
             spawn(async move {
                 let exec_task = ExecTask {
                     conn,
@@ -944,87 +983,36 @@ pub(crate) async fn handle_exec(
                 exec_task.run(channel).await;
             });
         }
-        Some("task") => {
-            // `min task run <task>` is the canonical spelling of the legacy
-            // bare `min run <task>`; `run` is its only sub-command. A bare
-            // `min task`, an unknown sub-command, or a prefix match like
-            // `min task runx` is refused before acking.
-            let rest = rem.strip_prefix("task").unwrap_or("").trim();
-            let task = rest
-                .strip_prefix("run")
-                .filter(|task| task.is_empty() || task.starts_with(' '))
-                .map(str::trim)
-                .unwrap_or("");
-            if task.is_empty() {
-                tracing::warn!(%session_id, "execution request rejected: expected `min task run <task name>`");
-                session.channel_failure(id)?;
-                return Ok(());
-            }
-            let task = task.to_string();
+        ExecRequest::PackageBuild(args) => {
             session.channel_success(id)?;
-
-            spawn(async move {
-                let exec_task = ExecTask {
-                    conn,
-                    serv,
-                    session: session_handle,
-                    channel_id: id,
-                    exec: TaskExec { args: None, task },
-                };
-                exec_task.run(channel).await;
-            });
-        }
-        Some("package") => {
-            // `build` is the only `package` sub-command serviced here; a
-            // bare `min package`, an unknown sub-command, or a prefix match
-            // like `min package buildx` is refused before acking.
-            let rest = rem.strip_prefix("package").unwrap_or("").trim();
-            let Some(build_args) = rest
-                .strip_prefix("build")
-                .filter(|args| args.is_empty() || args.starts_with(' '))
-            else {
-                tracing::warn!(%session_id, "execution request rejected: expected `min package build [args...]`");
-                session.channel_failure(id)?;
-                return Ok(());
-            };
-            session.channel_success(id)?;
-            // Everything after the sub-command is the build's args
-            // (`--verbose` / `--rebuild` / package names).
-            let build_args = build_args.trim().to_string();
+            let build_args = args.trim().to_string();
             spawn(async move {
                 run_build_exec(session_handle, id, channel, build_args).await;
             });
         }
-        Some("check") => {
+        ExecRequest::Check(args) => {
             session.channel_success(id)?;
-            let check_args = rem.strip_prefix("check").unwrap_or("").trim().to_string();
+            let check_args = args.trim().to_string();
             spawn(async move {
                 run_check_exec(session_handle, id, channel, check_args).await;
             });
         }
-        Some(other) => {
-            tracing::warn!(%session_id, "execution request rejected: unexpected min sub-command `{other}`");
-            session.channel_success(id)?;
-            spawn(async move {
-                reject_unsupported_exec(channel, argv).await;
-            });
-        }
-    };
+    }
 
     Ok(())
 }
 
-/// Accepts the channel and reports an exec request that is not one of the
-/// accepted forms on the SSH stderr stream, then exits non-zero. A bare
-/// `channel_failure` would reach the client only as an opaque "exec request
-/// failed", so — mirroring the accept-then-report shape `run_check_exec` uses
-/// for a bad flag — this names the rejected command and lists what the daemon
-/// runs. The command is still refused; nothing is spawned.
-async fn reject_unsupported_exec(channel: Channel<Msg>, rejected: String) {
+/// Accepts the channel and reports an exec request the daemon cannot serve on
+/// the SSH stderr stream, then exits non-zero. A bare `channel_failure` would
+/// reach the client only as an opaque "exec request failed", so — mirroring the
+/// accept-then-report shape `run_check_exec` uses for a bad flag — this relays
+/// the parse error, which already names the form asked for and lists the ones
+/// this daemon serves. The command is still refused; nothing is spawned.
+async fn reject_unsupported_exec(channel: Channel<Msg>, reason: String) {
     let (_rs, ws) = channel.split();
     let mut e = ws.make_writer_ext(Some(1));
     let _ = e
-        .write_all(unsupported_command_message(&rejected).as_bytes())
+        .write_all(unsupported_command_message(&reason).as_bytes())
         .await;
     let _ = e.flush().await;
     let _ = ws.eof().await;
@@ -1032,13 +1020,11 @@ async fn reject_unsupported_exec(channel: Channel<Msg>, rejected: String) {
     let _ = ws.close().await; // needed to release the remote
 }
 
-/// The stderr copy for an exec request that is not an accepted form: names the
-/// rejected command and lists the forms the daemon services.
-fn unsupported_command_message(rejected: &str) -> String {
-    format!(
-        "minimald: unsupported command '{rejected}'; accepted: \
-         min run <task>, min package build [args...], min check [args...]\n"
-    )
+/// The stderr copy for an exec request the daemon cannot serve. The reason
+/// comes from [`minimald_rpc::exec::ExecParseError`], which already names the
+/// form that was asked for and the ones this daemon serves.
+fn unsupported_command_message(reason: &str) -> String {
+    format!("minimald: {reason}\n")
 }
 
 /// The tracing span an in-session exec runs under, mirroring the `rpc` span in
@@ -1089,7 +1075,7 @@ async fn run_in_session(
     session: SessionHandle,
     channel_id: ChannelId,
     channel: Channel<Msg>,
-    argv: String,
+    program: SessionProgram,
     conn_username: String,
 ) {
     let exec_task = ExecTask {
@@ -1098,7 +1084,7 @@ async fn run_in_session(
         session,
         channel_id,
         exec: SessionExec {
-            argv,
+            program,
             conn_username,
         },
     };
@@ -1834,6 +1820,8 @@ mod tests {
         //! and `handle_exec` request routing.
         use sessions::SessionId;
 
+        use minimald_rpc::exec::ExecRequest;
+
         use crate::MINIMAL_SESSION_ID_ENV;
         use crate::test_harness::{
             TestClient, TestServer, create_configured_session, create_session_req,
@@ -1971,11 +1959,11 @@ mod tests {
                 .exec(
                     &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
                     false,
-                    "min run echo_ok",
+                    &ExecRequest::TaskRun("echo_ok".to_string()).encode(),
                     &[],
                 )
                 .await
-                .expect("min run echo_ok should be accepted");
+                .expect("a task/run request should be accepted");
 
             assert_eq!(out.stdout, b"MINIMALD_SESSION_OK\n");
             assert_eq!(out.exit_status, Some(0));
@@ -2003,26 +1991,47 @@ mod tests {
                 .exec(
                     &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
                     false,
-                    "min task run some_task",
+                    &ExecRequest::TaskRun("some_task".to_string()).encode(),
                     &[],
                 )
                 .await;
             assert!(
                 accepted.is_ok(),
-                "`min task run <task>` must be accepted, got {accepted:?}",
+                "a task/run request naming a task must be accepted, got {accepted:?}",
             );
 
-            let rejected = client
+            // A task/run naming no task is refused before anything spawns, and
+            // there is nothing useful to stream, so it is a channel failure.
+            let empty = client
                 .exec(
                     &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
                     false,
-                    "min task runx",
+                    &ExecRequest::TaskRun(String::new()).encode(),
                     &[],
                 )
                 .await;
             assert!(
-                rejected.is_err(),
-                "`min task runx` is not `min task run <task>` and must be refused, got {rejected:?}",
+                empty.is_err(),
+                "a task/run naming no task must be refused, got {empty:?}",
+            );
+
+            // A near-miss tag is a form this daemon does not serve. It is not
+            // silently downgraded to a session shell command: the scheme was
+            // named, so the client asked for something specific.
+            let unknown = client
+                .exec(
+                    &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
+                    false,
+                    "min://task/runx some_task",
+                    &[],
+                )
+                .await
+                .expect("an unknown form is reported over the channel, not a channel failure");
+            assert_ne!(unknown.exit_status, Some(0));
+            assert!(
+                String::from_utf8_lossy(&unknown.stderr).contains("min://task/runx"),
+                "the refusal should name the form asked for, got {:?}",
+                String::from_utf8_lossy(&unknown.stderr),
             );
         }
 
@@ -2046,11 +2055,11 @@ mod tests {
                 .exec(
                     &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
                     false,
-                    "min check",
+                    &ExecRequest::Check(String::new()).encode(),
                     &[],
                 )
                 .await
-                .expect("min check should be accepted");
+                .expect("a check request should be accepted");
 
             assert_eq!(out.exit_status, Some(0));
             assert_eq!(
@@ -2080,7 +2089,7 @@ mod tests {
                 .exec(
                     &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
                     false,
-                    "min check --packags",
+                    &ExecRequest::Check("--packags".to_string()).encode(),
                     &[],
                 )
                 .await
@@ -2099,13 +2108,23 @@ mod tests {
             );
         }
 
-        /// `min check` takes its flags after the sub-command, so a prefix match
-        /// like `min checkx` must not be serviced as `min check`. A `min`
-        /// sub-command the daemon doesn't know is refused outright rather than
-        /// handed to the session — and refusing it means never running it, on
-        /// the daemon's filesystem least of all.
+        /// A command that merely *looks* like one of the daemon's own belongs
+        /// to the session, and reaches it.
+        ///
+        /// This is the contract that replaced prefix-sniffing: the daemon used
+        /// to claim every command starting with `min ` and refuse the ones it
+        /// did not recognise, which made a session's own `min` binary
+        /// unreachable through exec (gominimal/inbox#558). Now only the
+        /// `min://` scheme addresses the daemon, so `min checkx` is just a
+        /// command — routed to the session, and never run on the daemon's own
+        /// filesystem.
+        ///
+        /// The marker file pins the second half: had it run here, it would
+        /// exist. This harness launches a mock host with no sandbox to join, so
+        /// the command fails rather than running in-session; where it was
+        /// *sent* is what matters and what can be proved without a real sandbox.
         #[tokio::test]
-        async fn a_check_lookalike_is_not_serviced_as_check() {
+        async fn a_min_lookalike_goes_to_the_session_not_the_daemon() {
             let server = TestServer::new().await;
             let mut client = server.connect().await;
             let session_id = fresh_session(&mut client).await;
@@ -2131,12 +2150,80 @@ mod tests {
             assert_ne!(
                 out.exit_status,
                 Some(0),
-                "`min checkx` is not `min check` and must not succeed; stdout was {:?}",
+                "the mock harness has no sandbox to run in, so this cannot succeed; stdout was {:?}",
                 String::from_utf8_lossy(&out.stdout),
             );
+            // Routed, not refused: the old daemon answered this with an
+            // "unsupported command" refusal instead of handing it over.
+            let stderr = String::from_utf8_lossy(&out.stderr);
             assert!(
-                String::from_utf8_lossy(&out.stderr).contains("min checkx"),
-                "the refusal should name the rejected command, got {:?}",
+                !stderr.contains("unsupported"),
+                "a `min` lookalike must be routed to the session, not refused, got {stderr:?}",
+            );
+        }
+
+        /// An argv reaches the session as words, not as a line for some shell
+        /// to re-split — the fix for gominimal/inbox#558. The mock harness has
+        /// no sandbox, so what is provable here is that the form is accepted
+        /// and routed to the session rather than refused or run on the daemon.
+        #[tokio::test]
+        async fn an_argv_form_is_accepted_and_routed_to_the_session() {
+            let server = TestServer::new().await;
+            let mut client = server.connect().await;
+            let session_id = fresh_session(&mut client).await;
+            let session_str = session_id.to_string();
+            let marker = daemon_marker("argv");
+            let _ = std::fs::remove_file(&marker);
+
+            let out = client
+                .exec(
+                    &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
+                    false,
+                    &ExecRequest::Argv(vec![
+                        "sh".to_string(),
+                        "-c".to_string(),
+                        format!("printf pwned > {}", marker.display()),
+                    ])
+                    .encode(),
+                    &[],
+                )
+                .await
+                .expect("an argv request is serviced over the channel");
+
+            assert!(
+                !marker.exists(),
+                "an argv exec ran on the daemon's filesystem, creating {}",
+                marker.display(),
+            );
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            assert!(
+                !stderr.contains("unsupported"),
+                "the argv form must be routed to the session, not refused, got {stderr:?}",
+            );
+        }
+
+        /// An argv naming no program is refused rather than guessed at.
+        #[tokio::test]
+        async fn an_empty_argv_is_refused() {
+            let server = TestServer::new().await;
+            let mut client = server.connect().await;
+            let session_id = fresh_session(&mut client).await;
+            let session_str = session_id.to_string();
+
+            let out = client
+                .exec(
+                    &[(MINIMAL_SESSION_ID_ENV, session_str.as_str())],
+                    false,
+                    "min://argv []",
+                    &[],
+                )
+                .await
+                .expect("the refusal is reported over the channel");
+
+            assert_ne!(out.exit_status, Some(0));
+            assert!(
+                String::from_utf8_lossy(&out.stderr).contains("names no program"),
+                "got {:?}",
                 String::from_utf8_lossy(&out.stderr),
             );
         }

--- a/crates/minvmd/tests/minimald_session_integration.rs
+++ b/crates/minvmd/tests/minimald_session_integration.rs
@@ -188,9 +188,15 @@ async fn minimald_exec_over_bridge() {
 
     let (stdout, exit) = result.unwrap_or_else(|e| panic!("minimald_session_integration: {e}"));
     eprintln!("minimald_session_integration: exec stdout={stdout:?} exit={exit:?}");
-    assert!(
-        stdout.trim() == sentinel,
-        "expected stdout {sentinel:?}, got {stdout:?}"
+    // Exact, not trimmed: the task's output is the whole of stdout, and the
+    // in-process twin (`minimald::exec` `exec_runs_echo_task`) asserts the same
+    // bytes. A trimming compare would swallow anything that leaked in
+    // alongside it — including the leading blank line the old
+    // argv-through-a-shell bug produced (gominimal/inbox#558).
+    assert_eq!(
+        stdout,
+        format!("{sentinel}\n"),
+        "expected stdout {sentinel:?} and nothing else, got {stdout:?}"
     );
     assert_eq!(exit, Some(0), "expected exit status 0, got {exit:?}");
 }

--- a/crates/minvmd/tests/minimald_session_integration.rs
+++ b/crates/minvmd/tests/minimald_session_integration.rs
@@ -7,7 +7,7 @@
 //! `minimald_exec_over_bridge` drives a real russh client over a `UnixStream`
 //! to the bridge UDS: it authenticates, creates a session (`CreateSession` RPC
 //! over an SSH subsystem), uploads a task-only `minimal.toml` into the session
-//! workspace over SFTP, runs `min run echo_ok` in that session, and asserts the
+//! workspace over SFTP, runs the `echo_ok` task in that session, and asserts the
 //! stdout + exit status that come back — proving the full path host UDS →
 //! libkrun bridge → guest vsock → minimald SSH (`run_on_vsock`, direct, no socat
 //! relay) → session task exec. The `echo` task is serviced without a package
@@ -167,16 +167,18 @@ async fn minimald_exec_over_bridge() {
     let guest = Guest::boot();
     let sentinel = "MINIMALD_SESSION_OK";
     // A task-only `minimal.toml` uploaded into the session workspace over
-    // SFTP. `min run echo_ok` is serviced straight from this declaration —
-    // no `[upstream]`, package graph, or sandbox — so the guest needs no
-    // network and nothing baked into the rootfs beyond minimald itself.
+    // SFTP. The task is named on the wire as a `min://task/run` request and is
+    // serviced straight from this declaration — no `[upstream]`, package graph,
+    // or sandbox — so the guest needs no network and nothing baked into the
+    // rootfs beyond minimald itself.
     let mfile = format!("[tasks.echo_ok]\necho = \"{sentinel}\"\n");
 
     // Retry the whole session to absorb the post-READY startup race.
     tokio::time::sleep(Duration::from_millis(500)).await;
     let mut result = Err("not attempted".to_string());
     for attempt in 1..=6 {
-        result = run_session_exec(&guest.sock_path, Some(&mfile), "min run echo_ok").await;
+        let task = minimald_rpc::exec::ExecRequest::TaskRun("echo_ok".to_string()).encode();
+        result = run_session_exec(&guest.sock_path, Some(&mfile), &task).await;
         if result.is_ok() {
             break;
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,8 +63,9 @@ sessions is a **provider**.
   `minimald` over a UNIX domain socket.
 - **minimald** is the session daemon: an SSH server that hosts sessions and
   task/sandbox executions within them. On Linux it runs natively on the host.
-  Oneshot RPCs (create session, list, exec, sftp, …) share a wire contract
-  defined in the **minimald-rpc** crate.
+  Oneshot RPCs (create session, list, sftp, …) share a wire contract defined
+  in the **minimald-rpc** crate, which also defines the tagged vocabulary the
+  streaming exec channel speaks.
 - **minvmd** is the microVM host daemon for platforms (macOS) or setups where
   `minimald` cannot run natively: it boots a Linux microVM via libkrun
   (Hypervisor.framework on macOS, KVM on Linux), supervises its lifecycle, and
@@ -206,7 +207,7 @@ Notable crates, in roughly the order the build pipeline drives them:
 | `mfile` | build | Finding and reading the `minimal.toml` file. |
 | `minimal` | session | The `min` session CLI, which pairs with and talks to `minimald`. |
 | `minimald` | session | The session daemon: an SSH server hosting sessions and task/sandbox executions. |
-| `minimald-rpc` | session | Wire contract for `minimald`'s oneshot SSH RPCs. |
+| `minimald-rpc` | session | Wire contract for `minimald`'s oneshot SSH RPCs and for the exec channel's request vocabulary. |
 | `minvmd` | session | Host daemon that boots Linux microVMs via libkrun and bridges host UDS to in-VM vsock. |
 | `mip` | build | The Minimal package/build CLI. |
 | `op` | build | Complex operations over the graph and packages (builds, cache object construction). |

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -232,9 +232,10 @@ test run, a linter) that executes in a freshly composed sandbox built from the
 packages that task needs. If a needed package is not present, Minimal builds it
 or fetches it from a remote cache first. Loadouts contribute to the session's
 interactive shell only, never to tasks, so your personal tooling cannot
-influence a task's deterministic execution. Running `min session exec <session> min run
-<task>` is the non-interactive way to trigger a declared task against a
-session.
+influence a task's deterministic execution. Running `min task run <task>` is
+the non-interactive way to trigger a declared task; `min session run <session>
+<task>` runs one against a session you already have, rather than composing a
+task session of its own.
 
 The through-line: a **session** is the durable, named environment a provider
 hosts; a **sandbox** is the isolated execution context composed from a package

--- a/docs/guide/tasks.md
+++ b/docs/guide/tasks.md
@@ -6,7 +6,7 @@ description: Define named tasks in minimal.toml that run commands in sandboxed e
 
 Tasks define commands that run in a [sandbox](../concepts/sandboxing.md) with exactly your declared dependencies. Every developer on your team runs the same task in the same environment.
 
-A task is a **one-shot** command that runs in its own fresh sandbox and exits, driven by the `mip` CLI (Linux-only; inside a session, `min task run <name>` runs the same tasks on any platform; the bare `min run <name>` is a legacy alias). That makes it different from an interactive [dev session](./dev-shell.md), which is a long-lived environment you attach to with `min`. Reach for a task to run builds, tests, linters, and deploys; reach for a session for interactive development.
+A task is a **one-shot** command that runs in its own fresh sandbox and exits, driven by the `mip` CLI (Linux-only; inside a session, `min task run <name>` runs the same tasks on any platform; from the host, `min session run <session> <name>` runs one against a session you already have; the bare `min run <name>` is a legacy alias). That makes it different from an interactive [dev session](./dev-shell.md), which is a long-lived environment you attach to with `min`. Reach for a task to run builds, tests, linters, and deploys; reach for a session for interactive development.
 
 ## Defining a task
 

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -110,6 +110,58 @@ Attaches to an existing session, identified by UUID or session name. When
 working directory (or the only existing session) and opens an interactive
 picker if the choice is ambiguous (`--no-input` errors instead).
 
+### `session exec`
+
+```
+min session exec <SESSION> <COMMAND>...
+```
+
+Runs a command in an existing session, non-interactively, relaying its
+stdout, stderr and exit code.
+
+How `COMMAND` is read depends on how many arguments you give it:
+
+- **One argument is a shell command**, run by the session's shell with its
+  pipes, globs and `$VAR` intact — the `ssh host '<cmd>'` form.
+
+  ```
+  min session exec web 'echo $PWD'
+  ```
+
+- **Several arguments are an argv**, carried as data. No shell reassembles
+  them, so a word keeps its spaces and its metacharacters stay literal.
+
+  ```
+  min session exec web sh -c 'echo A B C'
+  ```
+
+The argv form matters because ssh has no argv on the wire — it joins its
+trailing arguments with single spaces and the far side reshells the result.
+Passing words through one by one would let the session's shell re-split them,
+which is how `sh -c 'echo A B C'` once lost its first word to `sh`'s `$0`.
+
+Nothing about a command's *text* routes it: a command is the session's however
+it happens to start, so the session's own `min` binary is reachable here. The
+daemon's own operations are named explicitly instead — see `session run`.
+
+### `session run`
+
+```
+min session run <SESSION> <TASK>
+```
+
+Runs a task declared in the session project's `minimal.toml`, in that session,
+relaying its output and exit code.
+
+This is the session-scoped counterpart to
+[`min task run <task>`](../guide/tasks.md), which composes a task session of
+its own. Use `session run` when you want the task to run against a session you
+already have.
+
+Because the task is named as a task rather than inferred from a command string,
+a task may share a name with a daemon subcommand or with a program on the
+session's `PATH`.
+
 ### `session destroy`
 
 ```
@@ -295,7 +347,8 @@ session arguments completable — `min session attach <TAB>` lists live session
 names, and `min session attach 019<TAB>` lists session IDs, neither of which
 exists at the time a static script would be written. Every argument documented
 as "UUID or session name" completes this way: `session attach`,
-`session destroy`, `session rename`, and `session policy`.
+`session exec`, `session run`, `session destroy`, `session rename`, and
+`session policy`.
 
 Session completion is best-effort by design. It never starts a daemon — with
 none running there is nothing to list, and booting a VM on a keystroke would be

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -339,6 +339,32 @@ if [ "$rc" -ne 7 ]; then
   echo "::error::'min session exec \"exit 7\"' exited $rc (expected the command's 7)"
   fail
 fi
+# A multi-word argv must reach the session with the quoting the local shell
+# already removed. ssh has no argv on the wire — it joins its trailing
+# arguments with spaces and the far side reshells the result — so passing them
+# through word by word let `sh -c` take LINE1 as its `$0`, so it never printed.
+# The client now sends a `min://argv` request carrying the words as data
+# (gominimal/inbox#558).
+argv_out="$(mnl session exec "$sid" sh -c 'echo LINE1; echo LINE2' 2>"$WORK/exec-argv.err")" || {
+  echo "::error::'min session exec $sid sh -c ...' failed"
+  echo "--- stderr ---"; cat "$WORK/exec-argv.err" 2>/dev/null || true
+  fail
+}
+if [ "$argv_out" != "$(printf 'LINE1\nLINE2')" ]; then
+  echo "::error::multi-word argv lost its quoting: expected 'LINE1/LINE2', got '$argv_out'"
+  fail
+fi
+# A command that merely looks like one of the daemon's own belongs to the
+# session. The daemon used to claim every string starting with `min ` and refuse
+# what it did not recognise, which made the session's own `min` unreachable
+# through exec; only the `min://` scheme addresses the daemon now.
+lookalike_err="$WORK/exec-lookalike.err"
+mnl session exec "$sid" 'min --version' >"$WORK/exec-lookalike.out" 2>"$lookalike_err"
+if grep -q "unsupported command" "$lookalike_err"; then
+  echo "::error::the daemon hijacked a session command instead of routing it"
+  echo "--- stderr ---"; cat "$lookalike_err"
+  fail
+fi
 echo "session exec proof OK"
 echo "::endgroup::"
 
@@ -421,6 +447,31 @@ if [ -n "$SEED_DIR" ] || [ -n "$SEEDED_MFILE" ]; then
     mnl ls 2>&1 || true
     fail
   fi
+  # `min session run <session> <task>` runs a declared task against a session
+  # that already exists, rather than composing one of its own. It reaches the
+  # daemon as a named `min://task/run` form, so nothing about the task's name
+  # is inferred from the text — the routing a bare string used to decide by
+  # prefix-sniffing (gominimal/inbox#558).
+  sr_out="$(mnl session run "$kept" e2e-echo 2>"$WORK/session-run.err")"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "::error::'min session run $kept e2e-echo' exited $rc (expected 0)"
+    echo "--- stderr ---"; cat "$WORK/session-run.err" 2>/dev/null || true
+    fail
+  fi
+  if [[ "$sr_out" != *TASK_RUN_E2E_OK* ]]; then
+    echo "::error::'min session run' did not stream the task's output, got '$sr_out'"
+    fail
+  fi
+  # The task's exit code is the client's, as it is for `min task run`.
+  mnl session run "$kept" e2e-fail >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" -ne 7 ]; then
+    echo "::error::'min session run $kept e2e-fail' exited $rc (expected 7)"
+    fail
+  fi
+  echo "session run proof OK (task in an existing session, exit relay 7 → 7)"
+
   # The destroy dirty gate: the kept session's task process has exited, so
   # no host is running and its at-risk state is unknowable — the gate must
   # refuse a headless (no TTY) destroy without --force, naming the escape


### PR DESCRIPTION
ssh's exec request carries one string (RFC 4254 §5.2), and the daemon decided what it meant by looking at it: anything starting with `min ` was one of its own commands, everything else was a shell command for the session. That conflated three intents in one untagged string, and both failure modes were real.

An argv could not be sent. ssh joins its trailing arguments with single spaces and the far side reshells the result, so
`min session exec s sh -c 'echo A B C'` arrived as `sh -c echo A B C` and `A` became sh's $0 — it never printed. Quoting the words on the client fixed the splitting but broke the sniffing, because both read the same bytes.

A session command was stolen. `min --version` names the session's own `min`, but the daemon claimed the prefix and refused it, so that binary was simply unreachable through exec.

Requests are now tagged, in a vocabulary both sides share (`minimald-rpc::exec`): min://shell, min://argv, min://task/run, min://package/build and min://check. Argv words travel as JSON — NUL, the one delimiter that could never collide with the payload, is exactly the one execve cannot carry — and are exec'd with no shell in between. Anything untagged belongs to the session, which is the rule that makes the hijack impossible.

Adds `min session run <session> <task>`, which names the task form explicitly and restores running a declared task against a session you already have. A task may now share a name with a daemon subcommand or a program on PATH.

BREAKING CHANGE: the exec-channel wire contract changed, so a client and daemon must be built together — the existing version gate already refuses a skewed pair. `min session exec <s> 'min check'` and `min session exec <s> min run <task>` no longer route to the daemon; they run in the session. The daemon forms are reached by `min session run` and `min task run`.

Fixes: gominimal/inbox#558


Claude-Session: https://claude.ai/code/session_01Si8R82wVqVvvWiKVJAmEJX

<!-- PR title: use a Conventional Commit subject — `type(scope): summary`,
     imperative, lower-case, no trailing period. The PR title becomes the
     squash commit subject. See docs/commit-conventions.md. -->

## Summary

<!-- What changes, and why. Link related issues (`Refs: #123` / `Closes: #123`). -->

## Testing

<!-- What you ran (`cargo test`, `cargo clippy`, harness/e2e scripts, manual
     steps) — paste the relevant output as evidence. -->

## Checklist

- [x] Docs updated if behavior changed
- [ ] `BREAKING CHANGE:` footer present if this is a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `min session run` to execute named tasks in existing sessions.
  - Enhanced `min session exec` with shell commands and literal argument execution.
  - Improved handling of commands containing spaces and special characters.
  - Commands resembling daemon commands now run correctly within sessions.

- **Bug Fixes**
  - Improved task output and exit-code reporting.
  - Invalid execution requests now provide clear errors and exit status.

- **Documentation**
  - Updated CLI, session, task, and architecture documentation for new commands and execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->