### PR TITLE
fix(net): tell the client when session hostnames will not route

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -1429,9 +1429,7 @@ pub async fn cmd_ls(global: &GlobalArgs, args: LsArgs) -> Result<(), anyhow::Err
     // is exactly what will go on using hostnames that no longer resolve — and
     // stdout stays clean for the parser either way.
     warn_if_hostname_routing_down(resp.hostname_routing_unavailable.as_deref());
-    if let Some(reason) = resp.mtls_proxy_unavailable.as_deref() {
-        eprintln!("warning: the mTLS reverse proxy is not serving: {reason}");
-    }
+    warn_if_mtls_proxy_down(resp.mtls_proxy_unavailable.as_deref());
     format_ls(&mut std::io::stdout(), &args, &resp)?;
     Ok(())
 }
@@ -1445,6 +1443,17 @@ pub async fn cmd_ls(global: &GlobalArgs, args: LsArgs) -> Result<(), anyhow::Err
 fn warn_if_hostname_routing_down(reason: Option<&str>) {
     if let Some(reason) = reason {
         eprintln!("warning: session hostnames will not route: {reason}");
+    }
+}
+
+/// Tells the user the mTLS reverse proxy is not serving, and why.
+///
+/// Kept separate from [`warn_if_hostname_routing_down`] so the two faults read
+/// as what they are: hostnames failing to resolve and TLS termination being
+/// absent are different problems with different fixes.
+fn warn_if_mtls_proxy_down(reason: Option<&str>) {
+    if let Some(reason) = reason {
+        eprintln!("warning: the mTLS reverse proxy is not serving: {reason}");
     }
 }
 
@@ -2185,6 +2194,7 @@ async fn activate_session(
     // unfinalized for the daemon to reap when this connection drops.
     ensure_version_reported(created.daemon_version.as_deref())?;
     warn_if_hostname_routing_down(created.hostname_routing_unavailable.as_deref());
+    warn_if_mtls_proxy_down(created.mtls_proxy_unavailable.as_deref());
     let id = created.id;
 
     // From here the session exists on the daemon in an unfinalized state.

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -1424,8 +1424,25 @@ pub async fn cmd_ls(global: &GlobalArgs, args: LsArgs) -> Result<(), anyhow::Err
         .await
         .context("ListSessions RPC failed")?;
 
+    // On stderr, and outside `format_ls`: every output mode should carry a
+    // fault this severe — `--raw` most of all, since a script parsing bare ids
+    // is exactly what will go on using hostnames that no longer resolve — and
+    // stdout stays clean for the parser either way.
+    warn_if_hostname_routing_down(resp.hostname_routing_unavailable.as_deref());
     format_ls(&mut std::io::stdout(), &args, &resp)?;
     Ok(())
+}
+
+/// Tells the user that `<name>.local.min.internal` will not resolve, and why.
+///
+/// The daemon keeps serving without its host-side proxy, so nothing else the
+/// user sees is different: sessions activate, exec works, the list prints. The
+/// only other trace is a `warn!` in the daemon log, which is not where someone
+/// watching curl fail is looking (gominimal/inbox#560).
+fn warn_if_hostname_routing_down(reason: Option<&str>) {
+    if let Some(reason) = reason {
+        eprintln!("warning: session hostnames will not route: {reason}");
+    }
 }
 
 /// Format the session list for the given output mode. Split from
@@ -2164,6 +2181,7 @@ async fn activate_session(
     // loadout, and the finalize that #1251 died at, and with the session left
     // unfinalized for the daemon to reap when this connection drops.
     ensure_version_reported(created.daemon_version.as_deref())?;
+    warn_if_hostname_routing_down(created.hostname_routing_unavailable.as_deref());
     let id = created.id;
 
     // From here the session exists on the daemon in an unfinalized state.

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -1429,6 +1429,9 @@ pub async fn cmd_ls(global: &GlobalArgs, args: LsArgs) -> Result<(), anyhow::Err
     // is exactly what will go on using hostnames that no longer resolve — and
     // stdout stays clean for the parser either way.
     warn_if_hostname_routing_down(resp.hostname_routing_unavailable.as_deref());
+    if let Some(reason) = resp.mtls_proxy_unavailable.as_deref() {
+        eprintln!("warning: the mTLS reverse proxy is not serving: {reason}");
+    }
     format_ls(&mut std::io::stdout(), &args, &resp)?;
     Ok(())
 }

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -43,6 +43,7 @@ async fn version_succeeds_without_daemon() {
 fn ls_shows_shared_resource_pool() {
     let resp = ListSessionsResponse {
         daemon_version: None,
+        hostname_routing_unavailable: None,
         resource_pool: Some(ResourcePool {
             cpu_cores: 8,
             memory_bytes: 16 * 1024 * 1024 * 1024,
@@ -78,6 +79,7 @@ fn ls_shows_shared_resource_pool() {
 fn ls_table_exposes_project_path_and_status() {
     let resp = ListSessionsResponse {
         daemon_version: None,
+        hostname_routing_unavailable: None,
         resource_pool: None,
         sessions: vec![minimald_rpc::ListSessionsEntry {
             id: SessionId::nil(),

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -44,6 +44,7 @@ fn ls_shows_shared_resource_pool() {
     let resp = ListSessionsResponse {
         daemon_version: None,
         hostname_routing_unavailable: None,
+        mtls_proxy_unavailable: None,
         resource_pool: Some(ResourcePool {
             cpu_cores: 8,
             memory_bytes: 16 * 1024 * 1024 * 1024,
@@ -80,6 +81,7 @@ fn ls_table_exposes_project_path_and_status() {
     let resp = ListSessionsResponse {
         daemon_version: None,
         hostname_routing_unavailable: None,
+        mtls_proxy_unavailable: None,
         resource_pool: None,
         sessions: vec![minimald_rpc::ListSessionsEntry {
             id: SessionId::nil(),

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -243,6 +243,18 @@ pub struct ListSessionsResponse {
     /// daemon log, and the user is at a terminal watching curl fail.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hostname_routing_unavailable: Option<String>,
+    /// Why the mTLS reverse proxy (`:7655`) is not serving, when it is not.
+    ///
+    /// Separate from [`Self::hostname_routing_unavailable`] because they are
+    /// different services with different consumers: losing `:7654` costs every
+    /// session its hostname, losing `:7655` costs whatever terminates TLS
+    /// against it. Reporting them through one field would tell a user their
+    /// hostnames are broken when they are not.
+    ///
+    /// Always `None` from a daemon built without the `networking-proxy`
+    /// feature, which is the default — there is no proxy to be unavailable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mtls_proxy_unavailable: Option<String>,
 }
 
 impl OneshotSshRpc for ListSessions {
@@ -1398,11 +1410,11 @@ mod tests {
     /// client that read it that way would warn on every session it lists.
     #[test]
     fn responses_predating_hostname_routing_field_decode_as_absent() {
-        let list: ListSessionsResponse = serde_json_lenient::from_str(
-            r#"{"sessions":[],"daemon_version":"0.5.0"}"#,
-        )
-        .expect("a pre-field ListSessions reply must still decode");
+        let list: ListSessionsResponse =
+            serde_json_lenient::from_str(r#"{"sessions":[],"daemon_version":"0.5.0"}"#)
+                .expect("a pre-field ListSessions reply must still decode");
         assert!(list.hostname_routing_unavailable.is_none());
+        assert!(list.mtls_proxy_unavailable.is_none());
 
         let create: Errorable<CreateSessionResponse> = serde_json_lenient::from_str(
             r#"{"id":"00000000-0000-0000-0000-000000000001","daemon_version":"0.5.0"}"#,
@@ -1422,6 +1434,7 @@ mod tests {
         let resp = ListSessionsResponse {
             daemon_version: Some("0.6.0".into()),
             hostname_routing_unavailable: None,
+            mtls_proxy_unavailable: None,
             resource_pool: None,
             sessions: vec![],
         };
@@ -1430,14 +1443,17 @@ mod tests {
             !json.contains("hostname_routing_unavailable"),
             "healthy reply should omit the field, got {json}"
         );
+        assert!(
+            !json.contains("mtls_proxy_unavailable"),
+            "healthy reply should omit the mTLS field too, got {json}"
+        );
 
         let down = ListSessionsResponse {
             hostname_routing_unavailable: Some("port 7654 is held".into()),
             ..resp
         };
         let json = serde_json_lenient::to_string(&down).expect("serializes");
-        let back: ListSessionsResponse =
-            serde_json_lenient::from_str(&json).expect("round trips");
+        let back: ListSessionsResponse = serde_json_lenient::from_str(&json).expect("round trips");
         assert_eq!(
             back.hostname_routing_unavailable.as_deref(),
             Some("port 7654 is held")

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -233,6 +233,16 @@ pub struct ListSessionsResponse {
     /// skew rather than an unknown.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daemon_version: Option<String>,
+    /// Why `<name>.local.min.internal` hostnames will not route, when they
+    /// will not. `None` means the daemon brought its host-side proxy up, or
+    /// predates this field.
+    ///
+    /// The daemon keeps serving when the proxy fails to come up — sessions
+    /// still activate and exec still works — so nothing else in this response
+    /// betrays the loss. Without this the only trace is a `warn!` in the
+    /// daemon log, and the user is at a terminal watching curl fail.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname_routing_unavailable: Option<String>,
 }
 
 impl OneshotSshRpc for ListSessions {
@@ -414,6 +424,14 @@ pub struct CreateSessionResponse {
     /// skew rather than an unknown.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daemon_version: Option<String>,
+    /// Why `<name>.local.min.internal` hostnames will not route, when they
+    /// will not — see [`ListSessionsResponse::hostname_routing_unavailable`].
+    ///
+    /// Carried on the activation reply as well as the list because activation
+    /// is where a user is about to rely on it, and the session comes up
+    /// looking healthy either way.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname_routing_unavailable: Option<String>,
 }
 
 impl OneshotSshRpc for CreateSession {
@@ -1369,8 +1387,61 @@ mod tests {
         let resp = CreateSessionResponse {
             id: SessionId::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
             daemon_version: Some("0.6.0".into()),
+            hostname_routing_unavailable: None,
         };
         assert_eq!(round_trip(&resp), resp);
+    }
+
+    /// A daemon that predates `hostname_routing_unavailable` must still decode,
+    /// with the field absent. Absent has to mean "said nothing", not "reported
+    /// a fault": an older daemon is not evidence that routing is down, and a
+    /// client that read it that way would warn on every session it lists.
+    #[test]
+    fn responses_predating_hostname_routing_field_decode_as_absent() {
+        let list: ListSessionsResponse = serde_json_lenient::from_str(
+            r#"{"sessions":[],"daemon_version":"0.5.0"}"#,
+        )
+        .expect("a pre-field ListSessions reply must still decode");
+        assert!(list.hostname_routing_unavailable.is_none());
+
+        let create: Errorable<CreateSessionResponse> = serde_json_lenient::from_str(
+            r#"{"id":"00000000-0000-0000-0000-000000000001","daemon_version":"0.5.0"}"#,
+        )
+        .expect("a pre-field CreateSession reply must still decode");
+        match create {
+            Errorable::Ok(c) => assert!(c.hostname_routing_unavailable.is_none()),
+            Errorable::Err { error } => panic!("expected Ok, got {error}"),
+        }
+    }
+
+    /// The field is omitted from the wire when there is nothing wrong, so the
+    /// healthy path costs no bytes and an older client sees exactly what it
+    /// saw before.
+    #[test]
+    fn hostname_routing_field_is_omitted_when_healthy() {
+        let resp = ListSessionsResponse {
+            daemon_version: Some("0.6.0".into()),
+            hostname_routing_unavailable: None,
+            resource_pool: None,
+            sessions: vec![],
+        };
+        let json = serde_json_lenient::to_string(&resp).expect("serializes");
+        assert!(
+            !json.contains("hostname_routing_unavailable"),
+            "healthy reply should omit the field, got {json}"
+        );
+
+        let down = ListSessionsResponse {
+            hostname_routing_unavailable: Some("port 7654 is held".into()),
+            ..resp
+        };
+        let json = serde_json_lenient::to_string(&down).expect("serializes");
+        let back: ListSessionsResponse =
+            serde_json_lenient::from_str(&json).expect("round trips");
+        assert_eq!(
+            back.hostname_routing_unavailable.as_deref(),
+            Some("port 7654 is held")
+        );
     }
 
     /// The reply a daemon that predates `daemon_version` sends must still

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -444,6 +444,15 @@ pub struct CreateSessionResponse {
     /// looking healthy either way.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hostname_routing_unavailable: Option<String>,
+    /// Why the mTLS reverse proxy is not serving, when it is not — see
+    /// [`ListSessionsResponse::mtls_proxy_unavailable`].
+    ///
+    /// Here for the same reason as the field above it: both proxies are
+    /// daemon-wide rather than session-scoped, so the thing that decides
+    /// whether activation should mention them is whether the person
+    /// activating is about to depend on one, and that is not ours to know.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mtls_proxy_unavailable: Option<String>,
 }
 
 impl OneshotSshRpc for CreateSession {
@@ -1400,6 +1409,7 @@ mod tests {
             id: SessionId::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
             daemon_version: Some("0.6.0".into()),
             hostname_routing_unavailable: None,
+            mtls_proxy_unavailable: None,
         };
         assert_eq!(round_trip(&resp), resp);
     }
@@ -1421,7 +1431,10 @@ mod tests {
         )
         .expect("a pre-field CreateSession reply must still decode");
         match create {
-            Errorable::Ok(c) => assert!(c.hostname_routing_unavailable.is_none()),
+            Errorable::Ok(c) => {
+                assert!(c.hostname_routing_unavailable.is_none());
+                assert!(c.mtls_proxy_unavailable.is_none());
+            }
             Errorable::Err { error } => panic!("expected Ok, got {error}"),
         }
     }

--- a/crates/minimald/src/net/proxy.rs
+++ b/crates/minimald/src/net/proxy.rs
@@ -148,9 +148,12 @@ fn split_authority(authority: &str) -> (&str, Option<u16>) {
 /// supersedes the former systemd-resolved probe (R3.4).
 ///
 /// The returned listener is the caller's to either serve (via [`serve`]) or
-/// drop. The success event therefore reports the address as `reachable` rather
-/// than `listening`: binding proves the address is free, but a caller that drops
-/// the listener (the current startup check does) is not yet accepting requests.
+/// drop. The success event reports the address as `reachable` rather than
+/// `listening` because binding only proves the address was free — a caller that
+/// drops the listener is not accepting requests. The daemon startup path does
+/// serve it (see `server::start_host_proxies`); this said otherwise, and reading
+/// it as a bind-and-drop probe is what made gominimal/inbox#560 look like a
+/// false alarm on macOS.
 pub async fn bind_listener(addr: SocketAddr) -> Option<TcpListener> {
     match TcpListener::bind(addr).await {
         Ok(listener) => {

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -128,6 +128,7 @@ async fn serve_list_sessions(
             Ok(ListSessionsResponse {
                 daemon_version: Some(OWN_VERSION.to_string()),
                 hostname_routing_unavailable: s.proxy_unavailable().await,
+                mtls_proxy_unavailable: s.mtls_unavailable().await,
                 resource_pool,
                 // The git probes run in parallel across sessions: each is
                 // one small process under a deadline, and serializing them

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -127,6 +127,7 @@ async fn serve_list_sessions(
                 .map_err(|e| ConnectionError::Internal(e.to_string()))?;
             Ok(ListSessionsResponse {
                 daemon_version: Some(OWN_VERSION.to_string()),
+                hostname_routing_unavailable: s.proxy_unavailable().await,
                 resource_pool,
                 // The git probes run in parallel across sessions: each is
                 // one small process under a deadline, and serializing them
@@ -301,6 +302,7 @@ async fn serve_create_session(
                     Errorable::Ok(minimald_rpc::CreateSessionResponse {
                         id,
                         daemon_version: Some(OWN_VERSION.to_string()),
+                        hostname_routing_unavailable: s.proxy_unavailable().await,
                     })
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Errorable::Err {

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -304,6 +304,7 @@ async fn serve_create_session(
                         id,
                         daemon_version: Some(OWN_VERSION.to_string()),
                         hostname_routing_unavailable: s.proxy_unavailable().await,
+                        mtls_proxy_unavailable: s.mtls_unavailable().await,
                     })
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Errorable::Err {

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -158,6 +158,16 @@ pub struct ServerState {
     /// Memoized SSH host key, after first successful load.
     host_key: Option<PrivateKey>,
 
+    /// Why the host-side egress proxy is not reachable, if it is not. Set by
+    /// [`start_host_proxies`] and read by the `ListSessions` RPC.
+    ///
+    /// Both failure paths land here, because they produce the same symptom
+    /// from different places: on DM2 the bind itself fails, and on DM1 the
+    /// bind succeeds inside the guest but publishing it on the host loopback
+    /// does not. A fix that surfaced only the first would stay silent on
+    /// macOS, which is the platform the failure was reported from.
+    proxy_unavailable: Option<String>,
+
     /// The daemon's TLS certificate authority, used by the HTTPS proxy and the
     /// `IssueClientCert` RPC. Generated once on daemon startup and held for the
     /// daemon's lifetime; clients must call `minimal login` again after a
@@ -245,6 +255,7 @@ impl ServerState {
             shutdown: CancellationToken::new(),
             log_release,
             host_key: None,
+            proxy_unavailable: None,
             #[cfg(feature = "networking-proxy")]
             cert_authority,
             #[cfg(feature = "networking-wg")]
@@ -297,6 +308,16 @@ impl ServerStateHandle {
     /// Returns a handle to the sessions manager.
     pub async fn sessions_manager(&self) -> sessions::ManagerHandle {
         self.0.lock().await.sessions.clone()
+    }
+
+    /// Records why hostname routing is unavailable, so a client can be told.
+    pub(crate) async fn set_proxy_unavailable(&self, reason: String) {
+        self.0.lock().await.proxy_unavailable = Some(reason);
+    }
+
+    /// Why hostname routing is unavailable, or `None` if the proxy is up.
+    pub(crate) async fn proxy_unavailable(&self) -> Option<String> {
+        self.0.lock().await.proxy_unavailable.clone()
     }
 
     /// Returns the daemon-scoped mctx state.
@@ -718,9 +739,12 @@ async fn start_host_proxies(state: &ServerStateHandle, in_microvm: bool) {
         Ipv4Addr::LOCALHOST.into()
     };
 
-    // B5 egress/DNS proxy (:7654), always.
+    // B5 egress/DNS proxy (:7654), always. Both ways this can fail end with
+    // `<name>.local.min.internal` not routing, so both are recorded on the
+    // state where `ListSessions` can reach them — a daemon that keeps serving
+    // without its proxy looks identical to a healthy one otherwise.
     let egress_addr = SocketAddr::new(bind_base, proxy::EGRESS_PROXY_PORT);
-    if proxy::bind_listener(egress_addr)
+    let bound = proxy::bind_listener(egress_addr)
         .await
         .map(|listener| {
             let router = Router::new(registry.clone());
@@ -730,15 +754,29 @@ async fn start_host_proxies(state: &ServerStateHandle, in_microvm: bool) {
                 }
             })
         })
-        .is_some()
-        && in_microvm
-    {
-        // Only publish a port whose listener actually bound.
-        expose_proxy_on_host(
+        .is_some();
+
+    if !bound {
+        // DM2: something else on the host holds the port.
+        state
+            .set_proxy_unavailable(format!(
+                "the daemon could not bind {egress_addr}; another process is \
+                 holding it. Check with: lsof -nP -iTCP:{} -sTCP:LISTEN",
+                proxy::EGRESS_PROXY_PORT
+            ))
+            .await;
+    } else if in_microvm {
+        // DM1: the guest bind cannot collide with a host process, so the
+        // failure moves to the publish instead. Only publish a port whose
+        // listener actually bound.
+        if let Some(reason) = expose_proxy_on_host(
             crate::net::DEFAULT_SUBNET.daemon_ip(),
             proxy::EGRESS_PROXY_PORT,
         )
-        .await;
+        .await
+        {
+            state.set_proxy_unavailable(reason).await;
+        }
     }
 
     // B8 mTLS reverse proxy (:7655), under the networking-proxy feature.
@@ -762,7 +800,7 @@ async fn start_host_proxies(state: &ServerStateHandle, in_microvm: bool) {
                     .is_some()
                     && in_microvm
                 {
-                    expose_proxy_on_host(
+                    let _ = expose_proxy_on_host(
                         crate::net::DEFAULT_SUBNET.daemon_ip(),
                         proxy::HTTPS_PROXY_PORT,
                     )
@@ -791,11 +829,15 @@ const HOST_EXPOSE_PUBLISH_TIMEOUT: std::time::Duration = std::time::Duration::fr
 
 /// Publishes a guest-side proxy bound on `daemon_ip:port` onto the macOS host's
 /// loopback (`127.0.0.1:port`) via the host gvproxy forwarder, reached over the
-/// vsock shuttle (DM1). Best-effort: warns and returns on failure, since the
-/// host gvproxy may be absent. Capped at [`HOST_EXPOSE_PUBLISH_TIMEOUT`] so it
-/// never stalls [`Server::run`]'s SSH accept loop.
+/// vsock shuttle (DM1). Best-effort in that it never fails the daemon, since
+/// the host gvproxy may be absent. Capped at [`HOST_EXPOSE_PUBLISH_TIMEOUT`] so
+/// it never stalls [`Server::run`]'s SSH accept loop.
+///
+/// Returns `Some(reason)` when the publish did not happen, so the caller can
+/// tell a client rather than leaving the loss in the daemon log — on DM1 this
+/// is the path a host process holding the port actually breaks.
 #[cfg(target_os = "linux")]
-async fn expose_proxy_on_host(daemon_ip: std::net::Ipv4Addr, port: u16) {
+async fn expose_proxy_on_host(daemon_ip: std::net::Ipv4Addr, port: u16) -> Option<String> {
     use crate::net::policy::{ControlChannel, ExposeRequest, post_json};
 
     let control = ControlChannel::Vsock {
@@ -813,17 +855,29 @@ async fn expose_proxy_on_host(daemon_ip: std::net::Ipv4Addr, port: u16) {
     )
     .await
     {
-        Ok(Ok(_)) => {}
-        Ok(Err(error)) => tracing::warn!(
-            %port,
-            %error,
-            "could not publish host-side proxy on the host loopback via gvproxy forwarder"
-        ),
-        Err(_) => tracing::warn!(
-            %port,
-            timeout = ?HOST_EXPOSE_PUBLISH_TIMEOUT,
-            "host-side proxy publish did not complete in time; continuing (best-effort)"
-        ),
+        Ok(Ok(_)) => None,
+        Ok(Err(error)) => {
+            tracing::warn!(
+                %port,
+                %error,
+                "could not publish host-side proxy on the host loopback via gvproxy forwarder"
+            );
+            Some(format!(
+                "the daemon could not publish port {port} on the host loopback \
+                 via the gvproxy forwarder: {error}"
+            ))
+        }
+        Err(_) => {
+            tracing::warn!(
+                %port,
+                timeout = ?HOST_EXPOSE_PUBLISH_TIMEOUT,
+                "host-side proxy publish did not complete in time; continuing (best-effort)"
+            );
+            Some(format!(
+                "publishing port {port} on the host loopback did not complete within \
+                 {HOST_EXPOSE_PUBLISH_TIMEOUT:?}"
+            ))
+        }
     }
 }
 

--- a/crates/minimald/src/server.rs
+++ b/crates/minimald/src/server.rs
@@ -168,6 +168,12 @@ pub struct ServerState {
     /// macOS, which is the platform the failure was reported from.
     proxy_unavailable: Option<String>,
 
+    /// Why the mTLS reverse proxy is not serving, if it is not. Kept apart
+    /// from [`Self::proxy_unavailable`] so a client is not told its hostnames
+    /// are broken when only TLS termination is. Never set without the
+    /// `networking-proxy` feature, where there is no such proxy to lose.
+    mtls_unavailable: Option<String>,
+
     /// The daemon's TLS certificate authority, used by the HTTPS proxy and the
     /// `IssueClientCert` RPC. Generated once on daemon startup and held for the
     /// daemon's lifetime; clients must call `minimal login` again after a
@@ -256,6 +262,7 @@ impl ServerState {
             log_release,
             host_key: None,
             proxy_unavailable: None,
+            mtls_unavailable: None,
             #[cfg(feature = "networking-proxy")]
             cert_authority,
             #[cfg(feature = "networking-wg")]
@@ -318,6 +325,17 @@ impl ServerStateHandle {
     /// Why hostname routing is unavailable, or `None` if the proxy is up.
     pub(crate) async fn proxy_unavailable(&self) -> Option<String> {
         self.0.lock().await.proxy_unavailable.clone()
+    }
+
+    /// Records why the mTLS reverse proxy is not serving.
+    #[cfg_attr(not(feature = "networking-proxy"), expect(dead_code))]
+    pub(crate) async fn set_mtls_unavailable(&self, reason: String) {
+        self.0.lock().await.mtls_unavailable = Some(reason);
+    }
+
+    /// Why the mTLS reverse proxy is not serving, or `None` if it is.
+    pub(crate) async fn mtls_unavailable(&self) -> Option<String> {
+        self.0.lock().await.mtls_unavailable.clone()
     }
 
     /// Returns the daemon-scoped mctx state.
@@ -782,10 +800,15 @@ async fn start_host_proxies(state: &ServerStateHandle, in_microvm: bool) {
     // B8 mTLS reverse proxy (:7655), under the networking-proxy feature.
     #[cfg(feature = "networking-proxy")]
     {
+        // Three ways this ends with nothing serving on :7655, and all three
+        // were silent: the TLS config failing to build, the bind failing, and
+        // the publish failing. The daemon carries on in every case, so only a
+        // reported reason distinguishes "no mTLS proxy configured" from "the
+        // mTLS proxy is broken".
         let https_addr = SocketAddr::new(bind_base, proxy::HTTPS_PROXY_PORT);
         match state.cert_authority().await.build_server_config() {
             Ok(tls_config) => {
-                if proxy::bind_listener(https_addr)
+                let bound = proxy::bind_listener(https_addr)
                     .await
                     .map(|listener| {
                         let router = Router::new(registry.clone());
@@ -797,18 +820,34 @@ async fn start_host_proxies(state: &ServerStateHandle, in_microvm: bool) {
                             }
                         })
                     })
-                    .is_some()
-                    && in_microvm
-                {
-                    let _ = expose_proxy_on_host(
+                    .is_some();
+
+                if !bound {
+                    state
+                        .set_mtls_unavailable(format!(
+                            "the daemon could not bind {https_addr}; another process is \
+                             holding it. Check with: lsof -nP -iTCP:{} -sTCP:LISTEN",
+                            proxy::HTTPS_PROXY_PORT
+                        ))
+                        .await;
+                } else if in_microvm
+                    && let Some(reason) = expose_proxy_on_host(
                         crate::net::DEFAULT_SUBNET.daemon_ip(),
                         proxy::HTTPS_PROXY_PORT,
                     )
-                    .await;
+                    .await
+                {
+                    state.set_mtls_unavailable(reason).await;
                 }
             }
             Err(error) => {
                 tracing::warn!(%error, "could not build TLS config for the mTLS reverse proxy");
+                state
+                    .set_mtls_unavailable(format!(
+                        "the daemon could not build a TLS config for the mTLS reverse \
+                         proxy: {error}"
+                    ))
+                    .await;
             }
         }
     }


### PR DESCRIPTION
Fixes [gominimal/inbox#560](https://github.com/gominimal/inbox/issues/560).

## The problem

A daemon whose host-side egress proxy never came up **keeps serving**. Sessions activate, exec works, `min ls` prints a table — and `<name>.local.min.internal` resolves for nobody. The only trace is a `warn!` in the daemon log, which is not where someone watching `curl` fail is looking.

That is why the documented first move for this failure is `lsof -nP -iTCP:7654 -sTCP:LISTEN` — a diagnostic the user performs because the daemon kept one to itself. The `remedy` string already exists in the warning; it just never reaches anyone.

## Both failure paths, because they live on different platforms

This is the part worth reviewing carefully. The issue as filed described one site; there are two, and the report came from the platform the obvious fix would have missed.

| Mode | Bind | How a host process holding 7654 breaks it |
|---|---|---|
| **DM2** / native Linux | binds host loopback directly | `bind_listener` fails, `start_host_proxies` skips |
| **DM1** / microVM (macOS) | binds `0.0.0.0` *inside the guest* | bind succeeds — nothing on the host can collide — then `expose_proxy_on_host` fails to publish |

`expose_proxy_on_host` was best-effort on **both** its error and timeout branches. A fix that surfaced only `bind_listener` would have left macOS exactly as silent as before, while looking like a fix.

## What changed

- `expose_proxy_on_host` returns the reason it gave up instead of only logging it.
- `ServerState` carries `proxy_unavailable`; both paths set it.
- `ListSessions` and `CreateSession` report it — **list** because that is where a user goes when a hostname does not resolve, **activate** because that is the moment before they rely on it.
- The warning is emitted to stderr from the command, not through `format_ls`. So `--raw` sees it too — a script parsing bare ids is exactly what will go on using hostnames that no longer resolve — and stdout stays clean for the parser, and `format_ls` stays pure for its tests.

## Wire compatibility

Both fields use `#[serde(default, skip_serializing_if = "Option::is_none")]`, matching `daemon_version` and `resource_pool` beside them. An older daemon still decodes; a healthy reply puts nothing new on the wire.

One subtlety with a test on it: **absent must mean "said nothing", not "reported a fault"**. An older daemon is not evidence that routing is down, and a client reading it that way would warn on every session it listed. Two tests cover this — one that pre-field payloads decode with the field absent, one that a healthy reply omits it entirely.

## Also here

`bind_listener`'s doc comment said *"a caller that drops the listener (the current startup check does)"*. The startup path serves it (`server.rs:722-732`). Reading that sentence as a bind-and-drop probe is what made this look like a false alarm on macOS in the first place, so it is worth not leaving in place.

## Verification

`minimald` does not build on macOS (`procfs`), so this was checked on Linux in a Minimal session:

| | |
|---|---|
| `cargo check -p minimald` | clean |
| `cargo clippy -p minimald -p minimald-rpc -p minimal` | clean |
| `cargo test -p minimald-rpc` | 36 passed |
| `cargo test -p minimal` | 219 passed |

## Not covered

The `:7655` mTLS proxy uses the same `bind_listener` and `expose_proxy_on_host`, so it inherits the same silence. Left alone deliberately: it is behind the non-default `networking-proxy` feature and nothing ships with it on ([inbox#590](https://github.com/gominimal/inbox/issues/590)). If that feature is ever enabled by default, this should extend to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LJPq7h3kHDD5cQpg1u6E9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear diagnostics when hostname routing or the mTLS proxy is unavailable.
  * Session listings and activation now report routing and proxy availability issues.
  * Warnings appear across all listing formats while keeping standard output machine-readable.
  * The daemon continues starting when proxy services fail, while exposing actionable failure details.
* **Documentation**
  * Clarified proxy binding and reachability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->