### PR TITLE
feat(task)!: resolve task env_vars on the client, gated on the user policy

### DIFF
--- a/crates/decode/src/stacks.rs
+++ b/crates/decode/src/stacks.rs
@@ -584,7 +584,7 @@ impl Stack {
                 .chain(self.runtime_packages.iter())
                 .cloned()
                 .collect(),
-            vars: HashMap::from_iter(
+            vars: std::collections::BTreeMap::from_iter(
                 self.build_env_vars
                     .iter()
                     .map(|(k, v)| (k.clone(), v.clone())),

--- a/crates/mctx/src/env.rs
+++ b/crates/mctx/src/env.rs
@@ -522,7 +522,7 @@ pub struct EnvArgs<'a> {
     pub home: PatchHome,
 
     /// Environment variables to set.
-    pub env_vars: Option<&'a HashMap<String, EnvVarValue>>,
+    pub env_vars: Option<&'a BTreeMap<String, EnvVarValue>>,
     /// The hostname to set, if any.
     pub hostname: Option<String>,
 

--- a/crates/mctx/src/lib.rs
+++ b/crates/mctx/src/lib.rs
@@ -1,7 +1,7 @@
 //! Top-level API for minimal tooling.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     fmt,
     path::{Path, PathBuf},
     sync::Arc,
@@ -850,7 +850,7 @@ impl Context {
         wd: Option<PathBuf>,
         state_key: Option<&String>,
         patches: Option<&'a EnvPatches>,
-        env_vars: Option<&'a HashMap<String, EnvVarValue>>,
+        env_vars: Option<&'a BTreeMap<String, EnvVarValue>>,
         packages: S,
         home: PatchHome,
     ) -> Result<env::Env<'a>, Error> {
@@ -884,7 +884,7 @@ impl Context {
         wd: Option<PathBuf>,
         state_key: Option<&String>,
         patches: Option<&'a EnvPatches>,
-        env_vars: Option<&'a HashMap<String, EnvVarValue>>,
+        env_vars: Option<&'a BTreeMap<String, EnvVarValue>>,
         packages: S,
         network_mode: sandbox2::NetworkMode,
         home: PatchHome,

--- a/crates/mfile/src/lib.rs
+++ b/crates/mfile/src/lib.rs
@@ -1417,7 +1417,7 @@ mod tests {
                         state_key: Some("test".to_string()),
                         profile: None,
                         description: None,
-                        vars: HashMap::new(),
+                        vars: BTreeMap::new(),
                         patch: EnvPatches {
                             dir: [("~/.claude".to_string(), PatchSetting::ReadWrite)].into(),
                             file: BTreeMap::new()

--- a/crates/mfile/src/tasks.rs
+++ b/crates/mfile/src/tasks.rs
@@ -1,6 +1,6 @@
 use super::{EnvPatches, EnvVarValue, StrOrList};
 use args::ArgsSpec;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// A task, defined in a `[tasks.<task_name>]` section of [File].
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
@@ -23,8 +23,14 @@ pub struct Task {
     #[serde(default)]
     pub packages: Vec<String>,
     /// Environment variables to set on the process this task launches.
+    ///
+    /// Ordered, like the patch tables next to it (#1319): these are
+    /// iterated to build a sandbox environment and to report the first
+    /// unresolvable `inherit`, so hash order would let the same
+    /// declaration name a different variable in its error from run to
+    /// run. Var names are `Ord`, so ordering by them costs nothing.
     #[serde(default, alias = "env_vars")]
-    pub vars: HashMap<String, EnvVarValue>,
+    pub vars: BTreeMap<String, EnvVarValue>,
     /// Files/directories to be patched into the sandbox this task executes in.
     #[serde(default, alias = "patches")]
     pub patch: EnvPatches,

--- a/crates/minimal-client/src/lib.rs
+++ b/crates/minimal-client/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod attach;
 pub mod file_upload;
 
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -366,25 +367,33 @@ impl Client {
         &mut self,
         command: &str,
     ) -> Result<russh::Channel<russh::client::Msg>, anyhow::Error> {
-        self.exec_channel(None, command).await
+        self.exec_channel(None, command, &BTreeMap::new()).await
     }
 
     /// Like [`Self::open_exec_channel`], but sets `MINIMAL_SESSION_ID` on the
     /// channel before the exec request, the routing contract the daemon's
     /// `min`-prefixed exec forms (`min task run <task>`, `min package build`,
     /// `min check`) are served under.
+    ///
+    /// `task_env` carries a task's `env_vars` already resolved against the
+    /// invoking shell, under
+    /// [`TASK_ENV_PREFIX`](minimald_rpc::taskenv::TASK_ENV_PREFIX). Only
+    /// `min task run` has any to send; every other caller passes an empty
+    /// map and the daemon behaves exactly as before.
     pub async fn open_session_exec_channel(
         &mut self,
         session_id: sessions::SessionId,
         command: &str,
+        task_env: &BTreeMap<String, String>,
     ) -> Result<russh::Channel<russh::client::Msg>, anyhow::Error> {
-        self.exec_channel(Some(session_id), command).await
+        self.exec_channel(Some(session_id), command, task_env).await
     }
 
     async fn exec_channel(
         &mut self,
         session_id: Option<sessions::SessionId>,
         command: &str,
+        task_env: &BTreeMap<String, String>,
     ) -> Result<russh::Channel<russh::client::Msg>, anyhow::Error> {
         let mut channel = self
             .handle
@@ -397,6 +406,16 @@ impl Client {
                 .set_env(true, "MINIMAL_SESSION_ID", id.to_string())
                 .await
                 .context("set MINIMAL_SESSION_ID env")?;
+        }
+        // Every env request must precede the exec request: the daemon folds
+        // them into the channel's pending config, which the exec dispatch
+        // then consumes.
+        for (name, value) in task_env {
+            let wire = minimald_rpc::taskenv::wire_name(name);
+            channel
+                .set_env(true, wire.as_str(), value.as_str())
+                .await
+                .with_context(|| format!("set task env {name}"))?;
         }
         channel
             .exec(true, command)

--- a/crates/minimal-client/src/lib.rs
+++ b/crates/minimal-client/src/lib.rs
@@ -7,7 +7,6 @@
 pub mod attach;
 pub mod file_upload;
 
-use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -367,7 +366,8 @@ impl Client {
         &mut self,
         command: &str,
     ) -> Result<russh::Channel<russh::client::Msg>, anyhow::Error> {
-        self.exec_channel(None, command, &BTreeMap::new()).await
+        self.exec_channel(None, command, &minimald_rpc::taskenv::TaskEnv::default())
+            .await
     }
 
     /// Like [`Self::open_exec_channel`], but sets `MINIMAL_SESSION_ID` on the
@@ -376,16 +376,19 @@ impl Client {
     /// siblings) are served under.
     ///
     /// `task_env` carries a task's `env_vars` already resolved against the
-    /// invoking shell, under
-    /// [`TASK_ENV_PREFIX`](minimald_rpc::taskenv::TASK_ENV_PREFIX). Only
+    /// invoking shell: values under
+    /// [`TASK_ENV_PREFIX`](minimald_rpc::taskenv::TASK_ENV_PREFIX), and the
+    /// names to remove under
+    /// [`TASK_ENV_DROP`](minimald_rpc::taskenv::TASK_ENV_DROP). Only
     /// [`ExecRequest::TaskRun`](minimald_rpc::exec::ExecRequest::TaskRun) has
-    /// any to send; every other caller passes an empty map and the daemon
-    /// behaves exactly as before.
+    /// any to send; every other caller passes an empty
+    /// [`TaskEnv`](minimald_rpc::taskenv::TaskEnv) and the daemon behaves
+    /// exactly as before.
     pub async fn open_session_exec_channel(
         &mut self,
         session_id: sessions::SessionId,
         command: &str,
-        task_env: &BTreeMap<String, String>,
+        task_env: &minimald_rpc::taskenv::TaskEnv,
     ) -> Result<russh::Channel<russh::client::Msg>, anyhow::Error> {
         self.exec_channel(Some(session_id), command, task_env).await
     }
@@ -394,7 +397,7 @@ impl Client {
         &mut self,
         session_id: Option<sessions::SessionId>,
         command: &str,
-        task_env: &BTreeMap<String, String>,
+        task_env: &minimald_rpc::taskenv::TaskEnv,
     ) -> Result<russh::Channel<russh::client::Msg>, anyhow::Error> {
         let mut channel = self
             .handle
@@ -411,12 +414,25 @@ impl Client {
         // Every env request must precede the exec request: the daemon folds
         // them into the channel's pending config, which the exec dispatch
         // then consumes.
-        for (name, value) in task_env {
+        for (name, value) in &task_env.set {
             let wire = minimald_rpc::taskenv::wire_name(name);
             channel
                 .set_env(true, wire.as_str(), value.as_str())
                 .await
                 .with_context(|| format!("set task env {name}"))?;
+        }
+        // Sent only when there is something to drop: an empty list and no
+        // list at all mean the same thing, and not sending one keeps the
+        // channel identical to what an older client produces.
+        if !task_env.drop.is_empty() {
+            channel
+                .set_env(
+                    true,
+                    minimald_rpc::taskenv::TASK_ENV_DROP,
+                    minimald_rpc::taskenv::encode_drops(&task_env.drop),
+                )
+                .await
+                .context("set task env drop list")?;
         }
         channel
             .exec(true, command)

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -196,8 +196,20 @@ fn resolve_task_env(
     // before the policy has spoken.
     let pairs: Vec<(&str, &sessions::core::source::Source)> =
         names.iter().map(|n| (*n, source)).collect();
-    let (verdicts, _policy) = sessions::core::compose::gate_names(&pairs, vars_policy, Some(hooks))
-        .with_context(|| format!("gating `env_vars` for task '{task_name}'"))?;
+    let (verdicts, _policy) =
+        match sessions::core::compose::gate_names(&pairs, vars_policy, Some(hooks)) {
+            Ok(out) => out,
+            // The gate stops at the first denial and names it. Reported
+            // here rather than relayed, so the operator gets the task, the
+            // variable, and the file the rule lives in.
+            Err(sessions::core::compose::ComposeError::Denied { what, .. }) => {
+                bail!(denied_task_var_message(task_name, &what, policy_path))
+            }
+            Err(e) => {
+                return Err(anyhow::Error::new(e))
+                    .with_context(|| format!("gating `env_vars` for task '{task_name}'"));
+            }
+        };
 
     let mut approved: Vec<&str> = Vec::new();
     for (name, verdict) in names.iter().zip(verdicts) {
@@ -206,7 +218,6 @@ fn resolve_task_env(
             NameVerdict::Ignored => {
                 resolved.drop.insert((*name).to_string());
             }
-            NameVerdict::Denied => bail!(denied_task_var_message(task_name, name, policy_path)),
         }
     }
 
@@ -1379,6 +1390,40 @@ mod tests {
         assert!(snippet.contains("DEPLOY_TARGET"), "{snippet}");
         let parsed: toml::Value = toml::from_str(&snippet).expect("snippet must parse");
         assert!(parsed.get("vars").is_some());
+    }
+
+    /// A denied name is reported even when an unlisted one sits beside
+    /// it. Without the short-circuit the hook answers for the unlisted
+    /// name first, and the non-interactive lane tells the operator to
+    /// allow-list that one — never mentioning the denial they would hit
+    /// on the very next run.
+    #[test]
+    fn a_denial_is_reported_even_beside_an_unlisted_name() {
+        let task = task_from_toml(
+            "[tasks.t]\nenv_vars.AWS_KEY = { inherit = true }\n\
+             env_vars.ZZ_UNLISTED = { inherit = true }\nexec = 'true'\n",
+        );
+        let policy = no_vars_policy().try_with_deny(["AWS_*"]).unwrap();
+        let hooks = RefuseAndRecord::default();
+
+        let err = resolve_task_env(
+            &task,
+            "t",
+            policy,
+            &policy_path_fixture(),
+            &project_source(),
+            &hooks,
+            |_| panic!("nothing is read out of the shell"),
+        )
+        .expect_err("the denial must fail the run");
+
+        let msg = err.to_string();
+        assert!(msg.contains("AWS_KEY"), "names the denied variable: {msg}");
+        assert!(msg.contains("[vars] deny"), "names the rule: {msg}");
+        assert!(
+            hooks.into_names().is_empty(),
+            "the hook must not be consulted once a name is denied",
+        );
     }
 
     /// An echo task's `env_vars` are read by nobody: the daemon answers it

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -80,11 +80,15 @@ fn run_alias_message(task: Option<&str>) -> String {
     )
 }
 
-/// Verify `task` is declared in the project's `minimal.toml`, walking up
-/// from `dir` like the activate config discovery does. Errors name the fix:
-/// untrimmed name → the whitespace rejection; no config → `min init`;
-/// unknown task → the declared list.
-fn check_task_declared(dir: &camino::Utf8Path, task: &str) -> Result<(), anyhow::Error> {
+/// Look up `task` in the project's `minimal.toml`, walking up from `dir`
+/// like the activate config discovery does, and return its declaration.
+/// Errors name the fix: untrimmed name → the whitespace rejection; no
+/// config → `min init`; unknown task → the declared list.
+///
+/// The declaration comes back rather than being discarded because the
+/// client needs its `env_vars` to resolve them here — see
+/// [`resolve_task_env`].
+fn declared_task(dir: &camino::Utf8Path, task: &str) -> Result<mfile::Task, anyhow::Error> {
     // Rejected before any lookup: the daemon trims the task name out of the
     // exec command string, so a name with leading/trailing whitespace can
     // never round-trip into the box — even if minimal.toml declares it.
@@ -103,10 +107,47 @@ fn check_task_declared(dir: &camino::Utf8Path, task: &str) -> Result<(), anyhow:
             name = mfile::MFILE_NAME,
         ),
     };
-    if file.task(task).is_none() {
-        bail!(unknown_task_message(&file, task));
+    match file.task(task) {
+        Some(t) => Ok(t),
+        None => bail!(unknown_task_message(&file, task)),
     }
-    Ok(())
+}
+
+/// Resolve a task's declared `env_vars` against the invoking shell, so the
+/// values reach the daemon already resolved.
+///
+/// `{ inherit = true }` means "take this from the invoking process", and
+/// the only process that can honour it is this one. The daemon runs
+/// elsewhere — on macOS, inside the microVM — so its `std::env::var` reads
+/// the daemon's own environment, which the user's `export` never reaches
+/// (#585). `[session.vars]` has always resolved here, at activation, which
+/// is exactly why the two behaved differently in the same project.
+///
+/// Literal values are carried too, not just inherited ones: the daemon
+/// applies one consistent set rather than resolving half of them itself.
+///
+/// A variable that is declared `inherit` but unset is refused here, naming
+/// the task and the variable, instead of surfacing as the daemon's
+/// `failed to spawn process` after a session has already been built.
+fn resolve_task_env(
+    task: &mfile::Task,
+    task_name: &str,
+    env: impl Fn(&str) -> Result<String, std::env::VarError>,
+) -> Result<std::collections::BTreeMap<String, String>, anyhow::Error> {
+    let mut resolved = std::collections::BTreeMap::new();
+    for (name, value) in &task.vars {
+        let value = match value {
+            mfile::EnvVarValue::Value(v) => v.clone(),
+            mfile::EnvVarValue::Inherit => env(name).map_err(|_| {
+                anyhow::anyhow!(
+                    "task '{task_name}' declares `env_vars.{name} = {{ inherit = true }}`, \
+                     but {name} is not set in this shell; export it before running the task"
+                )
+            })?,
+        };
+        resolved.insert(name.clone(), value);
+    }
+    Ok(resolved)
 }
 
 /// The whitespace rejection body: the name is debug-quoted so the offending
@@ -301,7 +342,13 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
     // The task must be declared before anything touches the daemon: a typo'd
     // name fails instantly, listing what IS declared, without a session ever
     // existing.
-    check_task_declared(&utf8_path, &args.task)?;
+    let declared = declared_task(&utf8_path, &args.task)?;
+
+    // Resolve the task's `env_vars` here, against this shell, and carry the
+    // values to the daemon on the exec channel (#585). Done alongside the
+    // declared-task check, before `ensure_daemon`, so an unset inherited
+    // variable also fails with no session built.
+    let task_env = resolve_task_env(&declared, &args.task, |k| std::env::var(k))?;
 
     crate::ensure_daemon(global)?;
 
@@ -550,7 +597,7 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
     eprintln!("Running task {} in session {session_name}...", args.task);
 
     let outcome = match client
-        .open_session_exec_channel(id, &format!("min task run {}", args.task))
+        .open_session_exec_channel(id, &format!("min task run {}", args.task), &task_env)
         .await
     {
         Ok(channel) => bridge_exec(channel).await,
@@ -635,7 +682,7 @@ mod tests {
         // The rejection fires before the minimal.toml discovery: a path
         // that has no config still yields the whitespace error, not the
         // no-config one.
-        let err = check_task_declared(camino::Utf8Path::new("/nonexistent-task-test"), "build ")
+        let err = declared_task(camino::Utf8Path::new("/nonexistent-task-test"), "build ")
             .expect_err("an untrimmed name must be rejected");
         assert!(err.to_string().contains("whitespace"), "got: {err}");
     }
@@ -668,6 +715,82 @@ mod tests {
             "got: {err}"
         );
         assert!(err.downcast_ref::<TaskExit>().is_none());
+    }
+
+    /// Build a task declaration from TOML, for the env-resolution tests.
+    fn task_from_toml(toml: &str) -> mfile::Task {
+        mfile::File::from_toml_bytes(toml.as_bytes())
+            .unwrap()
+            .task("t")
+            .expect("the fixture declares task `t`")
+    }
+
+    /// The heart of #585: `{ inherit = true }` resolves against the
+    /// *invoking shell*, not the daemon. The resolver is handed the
+    /// client's env and must read the value from it, so what travels to
+    /// the daemon is a concrete value rather than an instruction the
+    /// daemon would carry out against its own environment.
+    #[test]
+    fn inherit_resolves_against_the_supplied_client_env() {
+        let task = task_from_toml(
+            "[tasks.t]\nenv_vars.ZZ_TASK_TOKEN = { inherit = true }\nexec = 'true'\n",
+        );
+
+        let out = resolve_task_env(&task, "t", |k| {
+            assert_eq!(k, "ZZ_TASK_TOKEN");
+            Ok("task-value-123".to_string())
+        })
+        .expect("an exported variable resolves");
+
+        assert_eq!(
+            out.get("ZZ_TASK_TOKEN").map(String::as_str),
+            Some("task-value-123")
+        );
+    }
+
+    /// A declared-but-unset inherited variable fails client-side, naming
+    /// the task and the variable, rather than reaching the daemon and
+    /// surfacing as `failed to spawn process` once a session already
+    /// exists.
+    #[test]
+    fn an_unset_inherited_var_fails_client_side_naming_the_fix() {
+        let task = task_from_toml(
+            "[tasks.t]\nenv_vars.ZZ_TASK_TOKEN = { inherit = true }\nexec = 'true'\n",
+        );
+
+        let err = resolve_task_env(&task, "t", |_| Err(std::env::VarError::NotPresent))
+            .expect_err("an unset inherited variable must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("task 't'"), "names the task: {msg}");
+        assert!(msg.contains("ZZ_TASK_TOKEN"), "names the variable: {msg}");
+        assert!(msg.contains("export it"), "names the fix: {msg}");
+    }
+
+    /// Literal values are carried alongside inherited ones, so the daemon
+    /// applies one consistent set instead of resolving half of them
+    /// itself. An empty inherited value is a value, not an absence.
+    #[test]
+    fn literals_are_carried_and_empty_inherited_values_survive() {
+        let task = task_from_toml(
+            "[tasks.t]\nenv_vars.LITERAL = 'fixed'\nenv_vars.EMPTY = { inherit = true }\nexec = 'true'\n",
+        );
+
+        let out = resolve_task_env(&task, "t", |_| Ok(String::new())).expect("resolves");
+        assert_eq!(out.get("LITERAL").map(String::as_str), Some("fixed"));
+        assert_eq!(out.get("EMPTY").map(String::as_str), Some(""));
+    }
+
+    /// A task declaring no `env_vars` sends nothing, which is the signal
+    /// the daemon reads as "resolve this the old way" — so the change is
+    /// inert for every task that does not inherit.
+    #[test]
+    fn a_task_without_env_vars_resolves_to_nothing() {
+        let task = task_from_toml("[tasks.t]\nexec = 'true'\n");
+        let out = resolve_task_env(&task, "t", |_| {
+            panic!("no variable should be looked up");
+        })
+        .expect("resolves");
+        assert!(out.is_empty());
     }
 
     /// `cmd_task_run` rejects a task the project's minimal.toml does not

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -130,56 +130,139 @@ fn declared_task(dir: &camino::Utf8Path, task: &str) -> Result<mfile::Task, anyh
 /// the task and the variable, instead of surfacing as the daemon's
 /// `failed to spawn process` after a session has already been built.
 ///
-/// Every name is verified against the user's `[vars]` policy before it is
-/// resolved, in the same precedence the session composer uses: `deny`
-/// first, then `ignore`. `deny` is the user's emergency stop and fails the
-/// run naming the rule's file; `ignore` drops the variable silently. Both
-/// are checked *before* the lookup, so a denied name never has its value
-/// read out of this shell and an ignored one does not have to be set at
-/// all.
+/// # Policy
 ///
-/// An ignored name goes into [`TaskEnv::drop`] rather than simply being
+/// Every name goes through [`VarsPolicy::check`] with
+/// [`Source::Project`] provenance, and the check happens *before* the
+/// lookup. That ordering is the security property: resolving here reads
+/// the user's own shell, so a `minimal.toml` naming
+/// `env_vars.AWS_SECRET_ACCESS_KEY = { inherit = true }` would otherwise
+/// hand a hostile project a real credential. A denied or unapproved name
+/// never has its value read at all.
+///
+/// The full check applies, `allow` included — a task's `env_vars` are
+/// declared by the project, and the project is exactly what the policy
+/// exists to constrain. `[session.vars]` from the same file has always
+/// been gated this way; a task's were the inconsistency.
+///
+/// - `deny` fails the run, naming the rule's file.
+/// - `ignore` drops the name.
+/// - `allow` carries it.
+/// - anything else is referred to `hooks`, which prompts on a terminal
+///   and refuses everywhere else.
+///
+/// A dropped name goes into [`TaskEnv::drop`] rather than simply being
 /// left out. The daemon applies the resolved values by insertion, so a
 /// name it is not told about keeps whatever `minimal.toml` declared —
 /// which for an `inherit` entry means the daemon resolving it against its
 /// own environment, exactly what the user asked not to happen.
 ///
-/// The `allow` step is deliberately not applied. A task's `env_vars` are
-/// declared in the project's own `minimal.toml` and requested by name on
-/// the command line, and there is no prompt on this path — routing them
-/// through `allow` would hard-fail every scripted `min task run` until each
-/// name were allowlisted, which is the case this resolution exists to
-/// unblock. `deny` and `ignore` have no prompt leg, so they apply cleanly.
-///
 /// An echo task resolves to nothing at all, whatever it declares. The daemon
 /// answers one straight from the declaration and returns before it builds an
 /// environment (`crates/minimald/src/exec.rs`), so its `env_vars` are read by
 /// no one. Resolving them would fail a run that works today over a variable
-/// the task has no use for, and deny one over a name it never sees.
+/// the task has no use for, and gate one over a name it never sees.
 ///
+/// [`VarsPolicy::check`]: sessions::core::policy::VarsPolicy::check
+/// [`Source::Project`]: sessions::core::source::Source::Project
 /// [`TaskEnv::drop`]: minimald_rpc::taskenv::TaskEnv::drop
 fn resolve_task_env(
     task: &mfile::Task,
     task_name: &str,
-    vars_policy: &sessions::core::policy::VarsPolicy,
+    vars_policy: sessions::core::policy::VarsPolicy,
     policy_path: &std::path::Path,
+    source: &sessions::core::source::Source,
+    hooks: &dyn sessions::core::hooks::PolicyHooks,
     env: impl Fn(&str) -> Result<String, std::env::VarError>,
 ) -> Result<minimald_rpc::taskenv::TaskEnv, anyhow::Error> {
+    use sessions::core::decision::{CheckOutcome, Decision, ItemDecision};
+    use sessions::core::hooks::{HookResult, Unapproved};
+
     let mut resolved = minimald_rpc::taskenv::TaskEnv::default();
     if task.action.as_echo().is_some() {
         return Ok(resolved);
     }
-    for (name, value) in &task.vars {
-        // Deny wins over ignore, matching `VarsPolicy::check`: a
-        // would-be rejection must not be hidden behind an ignore glob.
-        if vars_policy.deny().is_match(name) {
-            bail!(denied_task_var_message(task_name, name, policy_path));
+
+    // Names in a stable order: the prompt a user answers must not depend
+    // on `HashMap` iteration order, and neither must an error naming the
+    // first denial.
+    let mut names: Vec<&String> = task.vars.keys().collect();
+    names.sort_unstable();
+
+    // Pass 1: classify. What the policy can decide alone is decided;
+    // the rest queues for the hook.
+    let mut approved: Vec<&String> = Vec::new();
+    let mut pending: Vec<&String> = Vec::new();
+    for name in names {
+        match vars_policy.check(name.as_str(), TaskVar { source }) {
+            CheckOutcome::Decided(Decision::Denied(_)) => {
+                bail!(denied_task_var_message(task_name, name, policy_path))
+            }
+            CheckOutcome::Decided(Decision::Ignored) => {
+                resolved.drop.insert(name.clone());
+            }
+            CheckOutcome::Decided(Decision::Allowed(_)) => approved.push(name),
+            CheckOutcome::NeedsApproval(_) => pending.push(name),
         }
-        if vars_policy.ignore().is_match(name) {
-            resolved.drop.insert(name.clone());
-            continue;
+    }
+
+    // Pass 2: refer what is left to the hook — a prompt on a terminal, a
+    // collect-and-refuse anywhere else.
+    if !pending.is_empty() {
+        let view: Vec<Unapproved<'_, str>> = pending
+            .iter()
+            .map(|n| Unapproved::new(n.as_str(), source))
+            .collect();
+        let (decisions, policy) = match hooks.on_var_unapproved(vars_policy.clone(), &view) {
+            HookResult::Abort => bail!(
+                "aborted: task '{task_name}' declares environment variables that \
+                 {policy_path} does not allow",
+                policy_path = policy_path.display(),
+            ),
+            HookResult::Decided {
+                decisions,
+                updated_policy,
+            } => {
+                if decisions.len() != view.len() {
+                    bail!(
+                        "policy hook returned {got} decisions for {want} variables",
+                        got = decisions.len(),
+                        want = view.len(),
+                    );
+                }
+                (decisions, updated_policy.unwrap_or(vars_policy))
+            }
+        };
+
+        // Pass 3: apply. `UseRule` re-checks against the policy the hook
+        // handed back; it cannot legally come back undecided, since the
+        // hook is the last word.
+        for (name, decision) in pending.into_iter().zip(decisions) {
+            match decision {
+                ItemDecision::AllowOnce => approved.push(name),
+                ItemDecision::IgnoreOnce => {
+                    resolved.drop.insert(name.clone());
+                }
+                ItemDecision::UseRule => match policy.check(name.as_str(), TaskVar { source }) {
+                    CheckOutcome::Decided(Decision::Denied(_)) => {
+                        bail!(denied_task_var_message(task_name, name, policy_path))
+                    }
+                    CheckOutcome::Decided(Decision::Ignored) => {
+                        resolved.drop.insert(name.clone());
+                    }
+                    CheckOutcome::Decided(Decision::Allowed(_)) => approved.push(name),
+                    CheckOutcome::NeedsApproval(_) => bail!(
+                        "policy hook left `env_vars.{name}` undecided after \
+                             asking to re-check it against the policy"
+                    ),
+                },
+            }
         }
-        let value = match value {
+    }
+
+    // Only now is anything read out of this shell.
+    for name in approved {
+        let value = match &task.vars[name] {
             mfile::EnvVarValue::Value(v) => v.clone(),
             mfile::EnvVarValue::Inherit => env(name).map_err(|_| {
                 anyhow::anyhow!(
@@ -191,6 +274,24 @@ fn resolve_task_env(
         resolved.set.insert(name.clone(), value);
     }
     Ok(resolved)
+}
+
+/// A task's declared variable, carrying the provenance
+/// [`VarsPolicy::check`] gates on. A task's `env_vars` come from the
+/// project's `minimal.toml`, so the source is always
+/// [`Source::Project`] — never `UserLoadout`, which would auto-pass the
+/// `allow` step.
+///
+/// [`VarsPolicy::check`]: sessions::core::policy::VarsPolicy::check
+/// [`Source::Project`]: sessions::core::source::Source::Project
+struct TaskVar<'a> {
+    source: &'a sessions::core::source::Source,
+}
+
+impl sessions::core::source::Provenanced for TaskVar<'_> {
+    fn source(&self) -> &sessions::core::source::Source {
+        self.source
+    }
 }
 
 /// The `[vars] deny` rejection body: names the task, the variable, and the
@@ -400,7 +501,7 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
     let declared = declared_task(&utf8_path, &args.task)?;
 
     // Read before `ensure_daemon` because the env resolution below is
-    // gated on it: a malformed policy, or a variable the policy denies,
+    // gated on it: a malformed policy, or a variable the policy refuses,
     // must fail with no session built.
     let policy_path = crate::config::user_policy_path(global);
     let user_policy = crate::config::read_user_policy(global)?;
@@ -409,13 +510,64 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
     // values to the daemon on the exec channel (#585). Done alongside the
     // declared-task check, before `ensure_daemon`, so an unset inherited
     // variable also fails with no session built.
-    let task_env = resolve_task_env(
-        &declared,
-        &args.task,
-        user_policy.vars(),
-        &policy_path,
-        |k| std::env::var(k),
-    )?;
+    //
+    // Gated against `[vars]` on the way, `allow` included. Resolving here
+    // reads the user's own shell, so the project naming a variable is the
+    // project asking for its value — the same two lanes as an activate: the
+    // interactive prompt on a real terminal, the collect-and-refuse
+    // `NoPromptHook` anywhere else.
+    let source = sessions::core::source::Source::Project {
+        path: paths::HostPath::try_new(utf8_path.clone()).context("Invalid project path")?,
+    };
+    let non_interactive = global.no_input || !crate::can_prompt_interactively();
+    let (task_env, user_policy) = if non_interactive {
+        let hooks = crate::prompt::NoPromptHook::new();
+        let task_env = resolve_task_env(
+            &declared,
+            &args.task,
+            user_policy.vars().clone(),
+            &policy_path,
+            &source,
+            &hooks,
+            |k| std::env::var(k),
+        );
+        let summary = hooks.into_summary();
+        if summary.count() > 0 {
+            let count = summary.count();
+            let snippet = summary.as_toml_snippet();
+            bail!(
+                "task '{task}' declares {count} environment variable{s} that your \
+                 policy does not allow, and stdin/stderr is not a terminal.\n\n\
+                 Add the following to {path}:\n\n{snippet}\n\
+                 Then re-run this command.",
+                task = args.task,
+                path = policy_path.display(),
+                s = if count == 1 { "" } else { "s" },
+            );
+        }
+        (task_env?, user_policy)
+    } else {
+        let hooks = crate::prompt::InteractivePrompt::new(&policy_path, user_policy.clone());
+        let task_env = resolve_task_env(
+            &declared,
+            &args.task,
+            user_policy.vars().clone(),
+            &policy_path,
+            &source,
+            &hooks,
+            |k| std::env::var(k),
+        );
+        // Persist before propagating a refusal: a rule the user chose to
+        // record is theirs whether or not this run goes on to fail.
+        let after = hooks.into_final_policy();
+        if after != user_policy {
+            match crate::prompt::save_user_policy(&policy_path, &after) {
+                Ok(()) => eprintln!("Updated {}", policy_path.display()),
+                Err(e) => eprintln!("warning: failed to update {}: {e}", policy_path.display()),
+            }
+        }
+        (task_env?, after)
+    };
 
     crate::ensure_daemon(global)?;
 
@@ -799,6 +951,84 @@ mod tests {
         std::path::PathBuf::from("/cfg/minimal/user_policy.toml")
     }
 
+    /// A policy that allows every name, for the resolution tests that are
+    /// not about gating. An empty policy would refer everything to the
+    /// hook, which is a different test.
+    fn allow_all() -> sessions::core::policy::VarsPolicy {
+        no_vars_policy().try_with_allow(["*"]).unwrap()
+    }
+
+    /// A task's `env_vars` always carry project provenance — the whole
+    /// point of the gate is that the project is what it constrains.
+    fn project_source() -> sessions::core::source::Source {
+        sessions::core::source::Source::Project {
+            path: paths::HostPath::try_new(camino::Utf8PathBuf::from("/home/dev/proj")).unwrap(),
+        }
+    }
+
+    /// A hook that answers every referred name the same way, recording
+    /// what it was asked about. Stands in for the interactive prompt.
+    struct ScriptedHook {
+        decision: sessions::core::decision::ItemDecision,
+        asked: std::cell::RefCell<Vec<String>>,
+    }
+
+    impl ScriptedHook {
+        fn new(decision: sessions::core::decision::ItemDecision) -> Self {
+            Self {
+                decision,
+                asked: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+
+        fn asked(&self) -> Vec<String> {
+            self.asked.borrow().clone()
+        }
+    }
+
+    impl sessions::core::hooks::PolicyHooks for ScriptedHook {
+        fn on_var_unapproved(
+            &self,
+            _policy: sessions::core::policy::VarsPolicy,
+            items: &[sessions::core::hooks::Unapproved<'_, str>],
+        ) -> sessions::core::hooks::HookResult<sessions::core::policy::VarsPolicy> {
+            self.asked
+                .borrow_mut()
+                .extend(items.iter().map(|i| i.item().to_string()));
+            sessions::core::hooks::HookResult::decided(vec![self.decision; items.len()])
+        }
+
+        fn on_patch_unapproved(
+            &self,
+            _policy: sessions::core::policy::PatchesPolicy,
+            _items: &[sessions::core::hooks::Unapproved<'_, camino::Utf8Path>],
+        ) -> sessions::core::hooks::HookResult<sessions::core::policy::PatchesPolicy> {
+            unreachable!("task env resolution never gates patches")
+        }
+    }
+
+    /// A hook that refuses to be asked — for the cases where the policy
+    /// must decide on its own.
+    struct NeverAsked;
+
+    impl sessions::core::hooks::PolicyHooks for NeverAsked {
+        fn on_var_unapproved(
+            &self,
+            _policy: sessions::core::policy::VarsPolicy,
+            items: &[sessions::core::hooks::Unapproved<'_, str>],
+        ) -> sessions::core::hooks::HookResult<sessions::core::policy::VarsPolicy> {
+            panic!("the policy should have decided alone, was asked about {items:?}");
+        }
+
+        fn on_patch_unapproved(
+            &self,
+            _policy: sessions::core::policy::PatchesPolicy,
+            _items: &[sessions::core::hooks::Unapproved<'_, camino::Utf8Path>],
+        ) -> sessions::core::hooks::HookResult<sessions::core::policy::PatchesPolicy> {
+            unreachable!("task env resolution never gates patches")
+        }
+    }
+
     /// Build a task declaration from TOML, for the env-resolution tests.
     fn task_from_toml(toml: &str) -> mfile::Task {
         mfile::File::from_toml_bytes(toml.as_bytes())
@@ -818,10 +1048,18 @@ mod tests {
             "[tasks.t]\nenv_vars.ZZ_TASK_TOKEN = { inherit = true }\nexec = 'true'\n",
         );
 
-        let out = resolve_task_env(&task, "t", &no_vars_policy(), &policy_path_fixture(), |k| {
-            assert_eq!(k, "ZZ_TASK_TOKEN");
-            Ok("task-value-123".to_string())
-        })
+        let out = resolve_task_env(
+            &task,
+            "t",
+            allow_all(),
+            &policy_path_fixture(),
+            &project_source(),
+            &NeverAsked,
+            |k| {
+                assert_eq!(k, "ZZ_TASK_TOKEN");
+                Ok("task-value-123".to_string())
+            },
+        )
         .expect("an exported variable resolves");
 
         assert_eq!(
@@ -844,8 +1082,10 @@ mod tests {
         let err = resolve_task_env(
             &task,
             "t",
-            &no_vars_policy(),
+            allow_all(),
             &policy_path_fixture(),
+            &project_source(),
+            &NeverAsked,
             |_| Err(std::env::VarError::NotPresent),
         )
         .expect_err("an unset inherited variable must be refused");
@@ -867,8 +1107,10 @@ mod tests {
         let out = resolve_task_env(
             &task,
             "t",
-            &no_vars_policy(),
+            allow_all(),
             &policy_path_fixture(),
+            &project_source(),
+            &NeverAsked,
             |_| Ok(String::new()),
         )
         .expect("resolves");
@@ -885,8 +1127,10 @@ mod tests {
         let out = resolve_task_env(
             &task,
             "t",
-            &no_vars_policy(),
+            no_vars_policy(),
             &policy_path_fixture(),
+            &project_source(),
+            &NeverAsked,
             |_| panic!("no variable should be looked up"),
         )
         .expect("resolves");
@@ -904,9 +1148,15 @@ mod tests {
         );
         let policy = no_vars_policy().try_with_deny(["AWS_*"]).unwrap();
 
-        let err = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |_| {
-            panic!("a denied variable must never be read out of this shell");
-        })
+        let err = resolve_task_env(
+            &task,
+            "t",
+            policy,
+            &policy_path_fixture(),
+            &project_source(),
+            &NeverAsked,
+            |_| panic!("a denied variable must never be read out of this shell"),
+        )
         .expect_err("a denied variable must fail the run");
 
         let msg = err.to_string();
@@ -935,9 +1185,15 @@ mod tests {
             .try_with_ignore(["AWS_*"])
             .unwrap();
 
-        let err = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |_| {
-            panic!("no lookup happens for a literal");
-        })
+        let err = resolve_task_env(
+            &task,
+            "t",
+            policy,
+            &policy_path_fixture(),
+            &project_source(),
+            &NeverAsked,
+            |_| panic!("no lookup happens for a literal"),
+        )
         .expect_err("deny must win over ignore");
         assert!(err.to_string().contains("[vars] deny"));
     }
@@ -951,12 +1207,24 @@ mod tests {
             "[tasks.t]\nenv_vars.NOISY_DEBUG = { inherit = true }\n\
              env_vars.KEPT = { inherit = true }\nexec = 'true'\n",
         );
-        let policy = no_vars_policy().try_with_ignore(["NOISY_*"]).unwrap();
+        let policy = no_vars_policy()
+            .try_with_ignore(["NOISY_*"])
+            .unwrap()
+            .try_with_allow(["KEPT"])
+            .unwrap();
 
-        let out = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |k| {
-            assert_eq!(k, "KEPT", "an ignored variable must not be looked up");
-            Ok("kept-value".to_string())
-        })
+        let out = resolve_task_env(
+            &task,
+            "t",
+            policy,
+            &policy_path_fixture(),
+            &project_source(),
+            &NeverAsked,
+            |k| {
+                assert_eq!(k, "KEPT", "an ignored variable must not be looked up");
+                Ok("kept-value".to_string())
+            },
+        )
         .expect("an unset but ignored variable is not an error");
 
         assert_eq!(out.set.get("KEPT").map(String::as_str), Some("kept-value"));
@@ -969,33 +1237,96 @@ mod tests {
         assert_eq!(out.drop.len(), 1);
     }
 
-    /// A name matching neither rule is carried through with no allow-list
-    /// entry and no prompt. This is the property that keeps scripted and CI
-    /// `min task run` working against a fresh install's empty policy — the
-    /// case client-side resolution exists to unblock — so the `allow` step
-    /// is deliberately not applied here.
+    /// A name the policy cannot decide is referred to the hook rather than
+    /// carried. This is the mitigation: resolution reads the user's own
+    /// shell, so a `minimal.toml` naming a credential is the project asking
+    /// for that credential's value, and the project is what the policy
+    /// exists to constrain. `[session.vars]` from the same file has always
+    /// been gated this way.
     #[test]
-    fn an_unlisted_var_needs_no_allow_entry() {
+    fn an_unlisted_var_is_referred_to_the_hook_not_carried() {
         let task = task_from_toml(
-            "[tasks.t]\nenv_vars.ZZ_TASK_TOKEN = { inherit = true }\nexec = 'true'\n",
+            "[tasks.t]\nenv_vars.AWS_SECRET_ACCESS_KEY = { inherit = true }\nexec = 'true'\n",
         );
-        // Non-empty allow set that does NOT cover the name: under the
-        // composer's origin-aware rules this would prompt, and hard-fail in
-        // CI. Here it simply resolves.
+        // A non-empty allow set that does not cover the name.
         let policy = no_vars_policy()
             .try_with_allow(["SOMETHING_ELSE_*"])
             .unwrap();
+        let hooks = ScriptedHook::new(sessions::core::decision::ItemDecision::AllowOnce);
 
-        let out = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |_| {
-            Ok("task-value-123".to_string())
-        })
-        .expect("an unlisted name resolves without an allow entry");
+        let out = resolve_task_env(
+            &task,
+            "t",
+            policy,
+            &policy_path_fixture(),
+            &project_source(),
+            &hooks,
+            |_| Ok("secret".to_string()),
+        )
+        .expect("the hook allowed it");
 
         assert_eq!(
-            out.set.get("ZZ_TASK_TOKEN").map(String::as_str),
-            Some("task-value-123")
+            hooks.asked(),
+            vec!["AWS_SECRET_ACCESS_KEY".to_string()],
+            "the unlisted name must reach the hook",
         );
-        assert!(out.drop.is_empty());
+        assert_eq!(
+            out.set.get("AWS_SECRET_ACCESS_KEY").map(String::as_str),
+            Some("secret"),
+        );
+    }
+
+    /// The value of an unapproved name is never read out of the shell.
+    /// Order matters as much as the verdict: a gate that resolved first
+    /// and asked afterwards would already have the secret in hand.
+    #[test]
+    fn an_unapproved_var_is_never_read_from_the_shell() {
+        let task = task_from_toml(
+            "[tasks.t]\nenv_vars.AWS_SECRET_ACCESS_KEY = { inherit = true }\nexec = 'true'\n",
+        );
+        let hooks = ScriptedHook::new(sessions::core::decision::ItemDecision::IgnoreOnce);
+
+        let out = resolve_task_env(
+            &task,
+            "t",
+            no_vars_policy(),
+            &policy_path_fixture(),
+            &project_source(),
+            &hooks,
+            |_| panic!("an unapproved variable must never be read out of this shell"),
+        )
+        .expect("an ignored variable is not an error");
+
+        assert_eq!(hooks.asked(), vec!["AWS_SECRET_ACCESS_KEY".to_string()]);
+        assert!(out.set.is_empty());
+        // Dropped by name, so the daemon removes the declaration rather
+        // than resolving it against its own environment.
+        assert!(out.drop.contains("AWS_SECRET_ACCESS_KEY"));
+    }
+
+    /// An empty policy — a fresh install — refers every declared name.
+    /// Nothing is carried by default, which is what makes the allow list
+    /// a real control rather than an opt-in one.
+    #[test]
+    fn an_empty_policy_refers_every_name() {
+        let task = task_from_toml(
+            "[tasks.t]\nenv_vars.A = 'literal'\nenv_vars.B = { inherit = true }\nexec = 'true'\n",
+        );
+        let hooks = ScriptedHook::new(sessions::core::decision::ItemDecision::AllowOnce);
+
+        resolve_task_env(
+            &task,
+            "t",
+            no_vars_policy(),
+            &policy_path_fixture(),
+            &project_source(),
+            &hooks,
+            |_| Ok("v".to_string()),
+        )
+        .expect("the hook allowed both");
+
+        // Sorted, so the prompt order does not depend on HashMap iteration.
+        assert_eq!(hooks.asked(), vec!["A".to_string(), "B".to_string()]);
     }
 
     /// An echo task's `env_vars` are read by nobody: the daemon answers it
@@ -1014,9 +1345,15 @@ mod tests {
         assert_eq!(task.action.as_echo(), Some("hi"));
         let policy = no_vars_policy().try_with_deny(["AWS_*"]).unwrap();
 
-        let out = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |_| {
-            panic!("an echo task looks nothing up");
-        })
+        let out = resolve_task_env(
+            &task,
+            "t",
+            policy,
+            &policy_path_fixture(),
+            &project_source(),
+            &NeverAsked,
+            |_| panic!("an echo task looks nothing up"),
+        )
         .expect("an echo task neither resolves nor denies");
 
         assert!(out.is_empty(), "nothing to send: {out:?}");

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -175,88 +175,34 @@ fn resolve_task_env(
     hooks: &dyn sessions::core::hooks::PolicyHooks,
     env: impl Fn(&str) -> Result<String, std::env::VarError>,
 ) -> Result<minimald_rpc::taskenv::TaskEnv, anyhow::Error> {
-    use sessions::core::decision::{CheckOutcome, Decision, ItemDecision};
-    use sessions::core::hooks::{HookResult, Unapproved};
+    use sessions::core::compose::NameVerdict;
 
     let mut resolved = minimald_rpc::taskenv::TaskEnv::default();
     if task.action.as_echo().is_some() {
         return Ok(resolved);
     }
 
-    // Names in a stable order: the prompt a user answers must not depend
-    // on `HashMap` iteration order, and neither must an error naming the
-    // first denial.
-    let mut names: Vec<&String> = task.vars.keys().collect();
+    // Sorted: which variable a user is prompted about first, and which
+    // denial is reported, must not depend on `HashMap` iteration order.
+    let mut names: Vec<&str> = task.vars.keys().map(String::as_str).collect();
     names.sort_unstable();
 
-    // Pass 1: classify. What the policy can decide alone is decided;
-    // the rest queues for the hook.
-    let mut approved: Vec<&String> = Vec::new();
-    let mut pending: Vec<&String> = Vec::new();
-    for name in names {
-        match vars_policy.check(name.as_str(), TaskVar { source }) {
-            CheckOutcome::Decided(Decision::Denied(_)) => {
-                bail!(denied_task_var_message(task_name, name, policy_path))
-            }
-            CheckOutcome::Decided(Decision::Ignored) => {
-                resolved.drop.insert(name.clone());
-            }
-            CheckOutcome::Decided(Decision::Allowed(_)) => approved.push(name),
-            CheckOutcome::NeedsApproval(_) => pending.push(name),
-        }
-    }
+    // The gate is `sessions`' own — the same three passes the session
+    // composer runs, called with names alone so that no value is read
+    // before the policy has spoken.
+    let pairs: Vec<(&str, &sessions::core::source::Source)> =
+        names.iter().map(|n| (*n, source)).collect();
+    let (verdicts, _policy) = sessions::core::compose::gate_names(&pairs, vars_policy, Some(hooks))
+        .with_context(|| format!("gating `env_vars` for task '{task_name}'"))?;
 
-    // Pass 2: refer what is left to the hook — a prompt on a terminal, a
-    // collect-and-refuse anywhere else.
-    if !pending.is_empty() {
-        let view: Vec<Unapproved<'_, str>> = pending
-            .iter()
-            .map(|n| Unapproved::new(n.as_str(), source))
-            .collect();
-        let (decisions, policy) = match hooks.on_var_unapproved(vars_policy.clone(), &view) {
-            HookResult::Abort => bail!(
-                "aborted: task '{task_name}' declares environment variables that \
-                 {policy_path} does not allow",
-                policy_path = policy_path.display(),
-            ),
-            HookResult::Decided {
-                decisions,
-                updated_policy,
-            } => {
-                if decisions.len() != view.len() {
-                    bail!(
-                        "policy hook returned {got} decisions for {want} variables",
-                        got = decisions.len(),
-                        want = view.len(),
-                    );
-                }
-                (decisions, updated_policy.unwrap_or(vars_policy))
+    let mut approved: Vec<&str> = Vec::new();
+    for (name, verdict) in names.iter().zip(verdicts) {
+        match verdict {
+            NameVerdict::Allowed => approved.push(name),
+            NameVerdict::Ignored => {
+                resolved.drop.insert((*name).to_string());
             }
-        };
-
-        // Pass 3: apply. `UseRule` re-checks against the policy the hook
-        // handed back; it cannot legally come back undecided, since the
-        // hook is the last word.
-        for (name, decision) in pending.into_iter().zip(decisions) {
-            match decision {
-                ItemDecision::AllowOnce => approved.push(name),
-                ItemDecision::IgnoreOnce => {
-                    resolved.drop.insert(name.clone());
-                }
-                ItemDecision::UseRule => match policy.check(name.as_str(), TaskVar { source }) {
-                    CheckOutcome::Decided(Decision::Denied(_)) => {
-                        bail!(denied_task_var_message(task_name, name, policy_path))
-                    }
-                    CheckOutcome::Decided(Decision::Ignored) => {
-                        resolved.drop.insert(name.clone());
-                    }
-                    CheckOutcome::Decided(Decision::Allowed(_)) => approved.push(name),
-                    CheckOutcome::NeedsApproval(_) => bail!(
-                        "policy hook left `env_vars.{name}` undecided after \
-                             asking to re-check it against the policy"
-                    ),
-                },
-            }
+            NameVerdict::Denied => bail!(denied_task_var_message(task_name, name, policy_path)),
         }
     }
 
@@ -271,7 +217,7 @@ fn resolve_task_env(
                 )
             })?,
         };
-        resolved.set.insert(name.clone(), value);
+        resolved.set.insert(name.to_string(), value);
     }
     Ok(resolved)
 }
@@ -339,24 +285,6 @@ fn refused_vars_snippet(names: &[String]) -> String {
     vars.insert("allow", toml_edit::value(allow));
     doc.insert("vars", toml_edit::Item::Table(vars));
     doc.to_string()
-}
-
-/// A task's declared variable, carrying the provenance
-/// [`VarsPolicy::check`] gates on. A task's `env_vars` come from the
-/// project's `minimal.toml`, so the source is always
-/// [`Source::Project`] — never `UserLoadout`, which would auto-pass the
-/// `allow` step.
-///
-/// [`VarsPolicy::check`]: sessions::core::policy::VarsPolicy::check
-/// [`Source::Project`]: sessions::core::source::Source::Project
-struct TaskVar<'a> {
-    source: &'a sessions::core::source::Source,
-}
-
-impl sessions::core::source::Provenanced for TaskVar<'_> {
-    fn source(&self) -> &sessions::core::source::Source {
-        self.source
-    }
 }
 
 /// The `[vars] deny` rejection body: names the task, the variable, and the
@@ -1422,7 +1350,15 @@ mod tests {
         )
         .expect_err("a refusing hook must fail the run");
 
-        assert!(err.to_string().contains("aborted"), "{err}");
+        // `{:#}` renders the whole anyhow chain: the gate's abort now
+        // arrives wrapped in this call site's context, so the top-level
+        // message alone would not say why the run stopped.
+        let chain = format!("{err:#}");
+        assert!(chain.contains("aborted"), "{chain}");
+        assert!(
+            chain.contains("env_vars"),
+            "names the gate that failed: {chain}"
+        );
         assert_eq!(
             hooks.into_names(),
             vec!["AWS_SECRET_ACCESS_KEY".to_string(), "OTHER".to_string()],

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -129,13 +129,38 @@ fn declared_task(dir: &camino::Utf8Path, task: &str) -> Result<mfile::Task, anyh
 /// A variable that is declared `inherit` but unset is refused here, naming
 /// the task and the variable, instead of surfacing as the daemon's
 /// `failed to spawn process` after a session has already been built.
+///
+/// Every name is verified against the user's `[vars]` policy before it is
+/// resolved, in the same precedence the session composer uses: `deny`
+/// first, then `ignore`. `deny` is the user's emergency stop and fails the
+/// run naming the rule's file; `ignore` drops the variable silently. Both
+/// are checked *before* the lookup, so a denied name never has its value
+/// read out of this shell and an ignored one does not have to be set at
+/// all.
+///
+/// The `allow` step is deliberately not applied. A task's `env_vars` are
+/// declared in the project's own `minimal.toml` and requested by name on
+/// the command line, and there is no prompt on this path — routing them
+/// through `allow` would hard-fail every scripted `min task run` until each
+/// name were allowlisted, which is the case this resolution exists to
+/// unblock. `deny` and `ignore` have no prompt leg, so they apply cleanly.
 fn resolve_task_env(
     task: &mfile::Task,
     task_name: &str,
+    vars_policy: &sessions::core::policy::VarsPolicy,
+    policy_path: &std::path::Path,
     env: impl Fn(&str) -> Result<String, std::env::VarError>,
 ) -> Result<std::collections::BTreeMap<String, String>, anyhow::Error> {
     let mut resolved = std::collections::BTreeMap::new();
     for (name, value) in &task.vars {
+        // Deny wins over ignore, matching `VarsPolicy::check`: a
+        // would-be rejection must not be hidden behind an ignore glob.
+        if vars_policy.deny().is_match(name) {
+            bail!(denied_task_var_message(task_name, name, policy_path));
+        }
+        if vars_policy.ignore().is_match(name) {
+            continue;
+        }
         let value = match value {
             mfile::EnvVarValue::Value(v) => v.clone(),
             mfile::EnvVarValue::Inherit => env(name).map_err(|_| {
@@ -148,6 +173,18 @@ fn resolve_task_env(
         resolved.insert(name.clone(), value);
     }
     Ok(resolved)
+}
+
+/// The `[vars] deny` rejection body: names the task, the variable, and the
+/// file the rule lives in, so the fix is reachable without guessing where
+/// the policy is stored. Split out for unit tests.
+fn denied_task_var_message(task_name: &str, name: &str, policy_path: &std::path::Path) -> String {
+    format!(
+        "task '{task_name}' declares `env_vars.{name}`, but {name} is denied by \
+         `[vars] deny` in {path}; remove the declaration, or the deny rule if \
+         this task should see it",
+        path = policy_path.display(),
+    )
 }
 
 /// The whitespace rejection body: the name is debug-quoted so the offending
@@ -344,11 +381,23 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
     // existing.
     let declared = declared_task(&utf8_path, &args.task)?;
 
+    // Read before `ensure_daemon` because the env resolution below is
+    // gated on it: a malformed policy, or a variable the policy denies,
+    // must fail with no session built.
+    let policy_path = crate::config::user_policy_path(global);
+    let user_policy = crate::config::read_user_policy(global)?;
+
     // Resolve the task's `env_vars` here, against this shell, and carry the
     // values to the daemon on the exec channel (#585). Done alongside the
     // declared-task check, before `ensure_daemon`, so an unset inherited
     // variable also fails with no session built.
-    let task_env = resolve_task_env(&declared, &args.task, |k| std::env::var(k))?;
+    let task_env = resolve_task_env(
+        &declared,
+        &args.task,
+        user_policy.vars(),
+        &policy_path,
+        |k| std::env::var(k),
+    )?;
 
     crate::ensure_daemon(global)?;
 
@@ -369,8 +418,6 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
     // loadout flags — the config's `default_loadouts` apply. Resolved before
     // the daemon connection so a broken loadout fails loudly client-side.
     let cfg = crate::config::read_client_config(global)?;
-    let policy_path = crate::config::user_policy_path(global);
-    let user_policy = crate::config::read_user_policy(global)?;
     let initial_policy = user_policy.clone();
     let compose_options = crate::loadouts::compose_options_from_config(&cfg);
     let selection = crate::loadouts::LoadoutSelection::from_flags(&[], false);
@@ -721,6 +768,19 @@ mod tests {
         assert!(err.downcast_ref::<TaskExit>().is_none());
     }
 
+    /// The empty `[vars]` policy — a fresh install, where nothing is
+    /// denied or ignored. The default for the resolution tests that are
+    /// not about policy.
+    fn no_vars_policy() -> sessions::core::policy::VarsPolicy {
+        sessions::core::policy::VarsPolicy::empty()
+    }
+
+    /// Stand-in for the on-disk policy path, which only ever reaches the
+    /// error message.
+    fn policy_path_fixture() -> std::path::PathBuf {
+        std::path::PathBuf::from("/cfg/minimal/user_policy.toml")
+    }
+
     /// Build a task declaration from TOML, for the env-resolution tests.
     fn task_from_toml(toml: &str) -> mfile::Task {
         mfile::File::from_toml_bytes(toml.as_bytes())
@@ -740,7 +800,7 @@ mod tests {
             "[tasks.t]\nenv_vars.ZZ_TASK_TOKEN = { inherit = true }\nexec = 'true'\n",
         );
 
-        let out = resolve_task_env(&task, "t", |k| {
+        let out = resolve_task_env(&task, "t", &no_vars_policy(), &policy_path_fixture(), |k| {
             assert_eq!(k, "ZZ_TASK_TOKEN");
             Ok("task-value-123".to_string())
         })
@@ -762,8 +822,14 @@ mod tests {
             "[tasks.t]\nenv_vars.ZZ_TASK_TOKEN = { inherit = true }\nexec = 'true'\n",
         );
 
-        let err = resolve_task_env(&task, "t", |_| Err(std::env::VarError::NotPresent))
-            .expect_err("an unset inherited variable must be refused");
+        let err = resolve_task_env(
+            &task,
+            "t",
+            &no_vars_policy(),
+            &policy_path_fixture(),
+            |_| Err(std::env::VarError::NotPresent),
+        )
+        .expect_err("an unset inherited variable must be refused");
         let msg = err.to_string();
         assert!(msg.contains("task 't'"), "names the task: {msg}");
         assert!(msg.contains("ZZ_TASK_TOKEN"), "names the variable: {msg}");
@@ -779,7 +845,14 @@ mod tests {
             "[tasks.t]\nenv_vars.LITERAL = 'fixed'\nenv_vars.EMPTY = { inherit = true }\nexec = 'true'\n",
         );
 
-        let out = resolve_task_env(&task, "t", |_| Ok(String::new())).expect("resolves");
+        let out = resolve_task_env(
+            &task,
+            "t",
+            &no_vars_policy(),
+            &policy_path_fixture(),
+            |_| Ok(String::new()),
+        )
+        .expect("resolves");
         assert_eq!(out.get("LITERAL").map(String::as_str), Some("fixed"));
         assert_eq!(out.get("EMPTY").map(String::as_str), Some(""));
     }
@@ -790,11 +863,113 @@ mod tests {
     #[test]
     fn a_task_without_env_vars_resolves_to_nothing() {
         let task = task_from_toml("[tasks.t]\nexec = 'true'\n");
-        let out = resolve_task_env(&task, "t", |_| {
-            panic!("no variable should be looked up");
-        })
+        let out = resolve_task_env(
+            &task,
+            "t",
+            &no_vars_policy(),
+            &policy_path_fixture(),
+            |_| panic!("no variable should be looked up"),
+        )
         .expect("resolves");
         assert!(out.is_empty());
+    }
+
+    /// A `deny` rule is the user's emergency stop, and it reaches a task's
+    /// `env_vars` too: the run fails naming the task, the variable, and the
+    /// file the rule lives in, rather than shipping the value into the box.
+    #[test]
+    fn a_denied_var_fails_the_run_naming_the_policy_file() {
+        let task = task_from_toml(
+            "[tasks.t]\nenv_vars.AWS_SECRET_ACCESS_KEY = { inherit = true }\nexec = 'true'\n",
+        );
+        let policy = no_vars_policy().try_with_deny(["AWS_*"]).unwrap();
+
+        let err = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |_| {
+            panic!("a denied variable must never be read out of this shell");
+        })
+        .expect_err("a denied variable must fail the run");
+
+        let msg = err.to_string();
+        assert!(msg.contains("task 't'"), "names the task: {msg}");
+        assert!(
+            msg.contains("AWS_SECRET_ACCESS_KEY"),
+            "names the variable: {msg}"
+        );
+        assert!(msg.contains("[vars] deny"), "names the rule: {msg}");
+        assert!(
+            msg.contains("/cfg/minimal/user_policy.toml"),
+            "names the policy file: {msg}"
+        );
+    }
+
+    /// `deny` is checked before the lookup, and before `ignore`: a denied
+    /// literal has no shell value to read, and a name matching both rules
+    /// resolves as denied so a would-be rejection can't be hidden behind an
+    /// ignore glob — the same precedence `VarsPolicy::check` applies.
+    #[test]
+    fn deny_beats_ignore_and_applies_to_literals() {
+        let task = task_from_toml("[tasks.t]\nenv_vars.AWS_KEY = 'literal'\nexec = 'true'\n");
+        let policy = no_vars_policy()
+            .try_with_deny(["AWS_*"])
+            .unwrap()
+            .try_with_ignore(["AWS_*"])
+            .unwrap();
+
+        let err = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |_| {
+            panic!("no lookup happens for a literal");
+        })
+        .expect_err("deny must win over ignore");
+        assert!(err.to_string().contains("[vars] deny"));
+    }
+
+    /// `ignore` drops the variable silently and lets the task run — and it
+    /// is applied before the lookup, so an ignored `inherit` need not be
+    /// set at all. The unignored siblings are unaffected.
+    #[test]
+    fn an_ignored_var_is_dropped_without_being_looked_up() {
+        let task = task_from_toml(
+            "[tasks.t]\nenv_vars.NOISY_DEBUG = { inherit = true }\n\
+             env_vars.KEPT = { inherit = true }\nexec = 'true'\n",
+        );
+        let policy = no_vars_policy().try_with_ignore(["NOISY_*"]).unwrap();
+
+        let out = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |k| {
+            assert_eq!(k, "KEPT", "an ignored variable must not be looked up");
+            Ok("kept-value".to_string())
+        })
+        .expect("an unset but ignored variable is not an error");
+
+        assert_eq!(out.get("KEPT").map(String::as_str), Some("kept-value"));
+        assert!(!out.contains_key("NOISY_DEBUG"));
+        assert_eq!(out.len(), 1);
+    }
+
+    /// A name matching neither rule is carried through with no allow-list
+    /// entry and no prompt. This is the property that keeps scripted and CI
+    /// `min task run` working against a fresh install's empty policy — the
+    /// case client-side resolution exists to unblock — so the `allow` step
+    /// is deliberately not applied here.
+    #[test]
+    fn an_unlisted_var_needs_no_allow_entry() {
+        let task = task_from_toml(
+            "[tasks.t]\nenv_vars.ZZ_TASK_TOKEN = { inherit = true }\nexec = 'true'\n",
+        );
+        // Non-empty allow set that does NOT cover the name: under the
+        // composer's origin-aware rules this would prompt, and hard-fail in
+        // CI. Here it simply resolves.
+        let policy = no_vars_policy()
+            .try_with_allow(["SOMETHING_ELSE_*"])
+            .unwrap();
+
+        let out = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |_| {
+            Ok("task-value-123".to_string())
+        })
+        .expect("an unlisted name resolves without an allow entry");
+
+        assert_eq!(
+            out.get("ZZ_TASK_TOKEN").map(String::as_str),
+            Some("task-value-123")
+        );
     }
 
     /// `cmd_task_run` rejects a task the project's minimal.toml does not

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -184,6 +184,10 @@ fn resolve_task_env(
 
     // Sorted: which variable a user is prompted about first, and which
     // denial is reported, must not depend on `HashMap` iteration order.
+    //
+    // `sort_unstable` is not in tension with wanting a fixed order — it
+    // describes what happens to *equal* elements, and these are map keys,
+    // so there are none. The order it produces is fully determined.
     let mut names: Vec<&str> = task.vars.keys().map(String::as_str).collect();
     names.sort_unstable();
 

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -138,6 +138,14 @@ fn declared_task(dir: &camino::Utf8Path, task: &str) -> Result<mfile::Task, anyh
 /// read out of this shell and an ignored one does not have to be set at
 /// all.
 ///
+/// An ignored name goes into [`TaskEnv::drop`] rather than simply being
+/// left out. The daemon applies the resolved values by insertion, so a
+/// name it is not told about keeps whatever `minimal.toml` declared —
+/// which for an `inherit` entry means the daemon resolving it against its
+/// own environment, exactly what the user asked not to happen.
+///
+/// [`TaskEnv::drop`]: minimald_rpc::taskenv::TaskEnv::drop
+///
 /// The `allow` step is deliberately not applied. A task's `env_vars` are
 /// declared in the project's own `minimal.toml` and requested by name on
 /// the command line, and there is no prompt on this path — routing them
@@ -150,8 +158,8 @@ fn resolve_task_env(
     vars_policy: &sessions::core::policy::VarsPolicy,
     policy_path: &std::path::Path,
     env: impl Fn(&str) -> Result<String, std::env::VarError>,
-) -> Result<std::collections::BTreeMap<String, String>, anyhow::Error> {
-    let mut resolved = std::collections::BTreeMap::new();
+) -> Result<minimald_rpc::taskenv::TaskEnv, anyhow::Error> {
+    let mut resolved = minimald_rpc::taskenv::TaskEnv::default();
     for (name, value) in &task.vars {
         // Deny wins over ignore, matching `VarsPolicy::check`: a
         // would-be rejection must not be hidden behind an ignore glob.
@@ -159,6 +167,7 @@ fn resolve_task_env(
             bail!(denied_task_var_message(task_name, name, policy_path));
         }
         if vars_policy.ignore().is_match(name) {
+            resolved.drop.insert(name.clone());
             continue;
         }
         let value = match value {
@@ -170,7 +179,7 @@ fn resolve_task_env(
                 )
             })?,
         };
-        resolved.insert(name.clone(), value);
+        resolved.set.insert(name.clone(), value);
     }
     Ok(resolved)
 }
@@ -807,9 +816,10 @@ mod tests {
         .expect("an exported variable resolves");
 
         assert_eq!(
-            out.get("ZZ_TASK_TOKEN").map(String::as_str),
+            out.set.get("ZZ_TASK_TOKEN").map(String::as_str),
             Some("task-value-123")
         );
+        assert!(out.drop.is_empty());
     }
 
     /// A declared-but-unset inherited variable fails client-side, naming
@@ -853,8 +863,8 @@ mod tests {
             |_| Ok(String::new()),
         )
         .expect("resolves");
-        assert_eq!(out.get("LITERAL").map(String::as_str), Some("fixed"));
-        assert_eq!(out.get("EMPTY").map(String::as_str), Some(""));
+        assert_eq!(out.set.get("LITERAL").map(String::as_str), Some("fixed"));
+        assert_eq!(out.set.get("EMPTY").map(String::as_str), Some(""));
     }
 
     /// A task declaring no `env_vars` sends nothing, which is the signal
@@ -872,6 +882,7 @@ mod tests {
         )
         .expect("resolves");
         assert!(out.is_empty());
+        assert!(out.set.is_empty() && out.drop.is_empty());
     }
 
     /// A `deny` rule is the user's emergency stop, and it reaches a task's
@@ -939,9 +950,14 @@ mod tests {
         })
         .expect("an unset but ignored variable is not an error");
 
-        assert_eq!(out.get("KEPT").map(String::as_str), Some("kept-value"));
-        assert!(!out.contains_key("NOISY_DEBUG"));
-        assert_eq!(out.len(), 1);
+        assert_eq!(out.set.get("KEPT").map(String::as_str), Some("kept-value"));
+        assert!(!out.set.contains_key("NOISY_DEBUG"));
+        assert_eq!(out.set.len(), 1);
+        // Named on the drop list, not merely absent: the daemon applies
+        // `set` by insertion, so a name it is not told about keeps the
+        // declaration `minimal.toml` made for it.
+        assert!(out.drop.contains("NOISY_DEBUG"));
+        assert_eq!(out.drop.len(), 1);
     }
 
     /// A name matching neither rule is carried through with no allow-list
@@ -967,9 +983,10 @@ mod tests {
         .expect("an unlisted name resolves without an allow entry");
 
         assert_eq!(
-            out.get("ZZ_TASK_TOKEN").map(String::as_str),
+            out.set.get("ZZ_TASK_TOKEN").map(String::as_str),
             Some("task-value-123")
         );
+        assert!(out.drop.is_empty());
     }
 
     /// `cmd_task_run` rejects a task the project's minimal.toml does not

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -1006,9 +1006,12 @@ mod tests {
     #[test]
     fn an_echo_task_resolves_to_nothing_whatever_it_declares() {
         let task = task_from_toml(
-            "[tasks.t]\naction = 'echo hi'\nenv_vars.UNSET = { inherit = true }\n\
+            "[tasks.t]\necho = 'hi'\nenv_vars.UNSET = { inherit = true }\n\
              env_vars.AWS_KEY = 'literal'\n",
         );
+        // Pinned: were the fixture to stop parsing as an echo task, every
+        // assertion below would still pass for the wrong reason.
+        assert_eq!(task.action.as_echo(), Some("hi"));
         let policy = no_vars_policy().try_with_deny(["AWS_*"]).unwrap();
 
         let out = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |_| {

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -144,14 +144,20 @@ fn declared_task(dir: &camino::Utf8Path, task: &str) -> Result<mfile::Task, anyh
 /// which for an `inherit` entry means the daemon resolving it against its
 /// own environment, exactly what the user asked not to happen.
 ///
-/// [`TaskEnv::drop`]: minimald_rpc::taskenv::TaskEnv::drop
-///
 /// The `allow` step is deliberately not applied. A task's `env_vars` are
 /// declared in the project's own `minimal.toml` and requested by name on
 /// the command line, and there is no prompt on this path — routing them
 /// through `allow` would hard-fail every scripted `min task run` until each
 /// name were allowlisted, which is the case this resolution exists to
 /// unblock. `deny` and `ignore` have no prompt leg, so they apply cleanly.
+///
+/// An echo task resolves to nothing at all, whatever it declares. The daemon
+/// answers one straight from the declaration and returns before it builds an
+/// environment (`crates/minimald/src/exec.rs`), so its `env_vars` are read by
+/// no one. Resolving them would fail a run that works today over a variable
+/// the task has no use for, and deny one over a name it never sees.
+///
+/// [`TaskEnv::drop`]: minimald_rpc::taskenv::TaskEnv::drop
 fn resolve_task_env(
     task: &mfile::Task,
     task_name: &str,
@@ -160,6 +166,9 @@ fn resolve_task_env(
     env: impl Fn(&str) -> Result<String, std::env::VarError>,
 ) -> Result<minimald_rpc::taskenv::TaskEnv, anyhow::Error> {
     let mut resolved = minimald_rpc::taskenv::TaskEnv::default();
+    if task.action.as_echo().is_some() {
+        return Ok(resolved);
+    }
     for (name, value) in &task.vars {
         // Deny wins over ignore, matching `VarsPolicy::check`: a
         // would-be rejection must not be hidden behind an ignore glob.
@@ -987,6 +996,27 @@ mod tests {
             Some("task-value-123")
         );
         assert!(out.drop.is_empty());
+    }
+
+    /// An echo task's `env_vars` are read by nobody: the daemon answers it
+    /// from the declaration and returns before it builds an environment. So
+    /// an unset `inherit` on one must not fail the run — it ran fine before
+    /// client-side resolution existed — and a denied name on one must not
+    /// either, since the task never sees it.
+    #[test]
+    fn an_echo_task_resolves_to_nothing_whatever_it_declares() {
+        let task = task_from_toml(
+            "[tasks.t]\naction = 'echo hi'\nenv_vars.UNSET = { inherit = true }\n\
+             env_vars.AWS_KEY = 'literal'\n",
+        );
+        let policy = no_vars_policy().try_with_deny(["AWS_*"]).unwrap();
+
+        let out = resolve_task_env(&task, "t", &policy, &policy_path_fixture(), |_| {
+            panic!("an echo task looks nothing up");
+        })
+        .expect("an echo task neither resolves nor denies");
+
+        assert!(out.is_empty(), "nothing to send: {out:?}");
     }
 
     /// `cmd_task_run` rejects a task the project's minimal.toml does not

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -182,14 +182,11 @@ fn resolve_task_env(
         return Ok(resolved);
     }
 
-    // Sorted: which variable a user is prompted about first, and which
-    // denial is reported, must not depend on `HashMap` iteration order.
-    //
-    // `sort_unstable` is not in tension with wanting a fixed order — it
-    // describes what happens to *equal* elements, and these are map keys,
-    // so there are none. The order it produces is fully determined.
-    let mut names: Vec<&str> = task.vars.keys().map(String::as_str).collect();
-    names.sort_unstable();
+    // Order comes off the map, which is a `BTreeMap` (#1319): which
+    // variable a user is prompted about first, and which denial is
+    // reported, are fixed by the declaration's own key order rather than
+    // by a sort here.
+    let names: Vec<&str> = task.vars.keys().map(String::as_str).collect();
 
     // The gate is `sessions`' own — the same three passes the session
     // composer runs, called with names alone so that no value is read

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -276,6 +276,71 @@ fn resolve_task_env(
     Ok(resolved)
 }
 
+/// The non-interactive lane's hook: records what the policy could not
+/// decide and then **refuses**.
+///
+/// [`NoPromptHook`](crate::prompt::NoPromptHook) cannot serve here. It
+/// fake-approves every unapproved item with `AllowOnce` so an activate's
+/// later hooks still fire and the operator's snippet lists every required
+/// edit — safe there, because that caller only ever submits a verdict and
+/// checks the summary before it does. This caller *reads values*, and an
+/// `AllowOnce` reaches the lookup: the name's value would come out of the
+/// user's shell before anyone checked the summary, which is the exact
+/// ordering the gate exists to prevent. Refusing keeps the read from
+/// happening at all; the caller formats the same snippet from `names`.
+#[derive(Default)]
+struct RefuseAndRecord {
+    names: std::cell::RefCell<Vec<String>>,
+}
+
+impl RefuseAndRecord {
+    fn into_names(self) -> Vec<String> {
+        self.names.into_inner()
+    }
+}
+
+impl sessions::core::hooks::PolicyHooks for RefuseAndRecord {
+    fn on_var_unapproved(
+        &self,
+        _policy: sessions::core::policy::VarsPolicy,
+        items: &[sessions::core::hooks::Unapproved<'_, str>],
+    ) -> sessions::core::hooks::HookResult<sessions::core::policy::VarsPolicy> {
+        let mut names = self.names.borrow_mut();
+        for item in items {
+            let name = item.item().to_owned();
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+        sessions::core::hooks::HookResult::Abort
+    }
+
+    fn on_patch_unapproved(
+        &self,
+        _policy: sessions::core::policy::PatchesPolicy,
+        _items: &[sessions::core::hooks::Unapproved<'_, camino::Utf8Path>],
+    ) -> sessions::core::hooks::HookResult<sessions::core::policy::PatchesPolicy> {
+        unreachable!("task env resolution never gates patches")
+    }
+}
+
+/// Format refused variable names as the `[vars] allow` snippet an
+/// operator can paste, mirroring
+/// [`UnapprovedSummary::as_toml_snippet`](crate::prompt::UnapprovedSummary::as_toml_snippet).
+/// Emitted through `toml_edit` so a name needing TOML escaping still
+/// produces a snippet that parses.
+fn refused_vars_snippet(names: &[String]) -> String {
+    let mut doc = toml_edit::DocumentMut::new();
+    let mut vars = toml_edit::Table::new();
+    let mut allow = toml_edit::Array::new();
+    for name in names {
+        allow.push(name.as_str());
+    }
+    vars.insert("allow", toml_edit::value(allow));
+    doc.insert("vars", toml_edit::Item::Table(vars));
+    doc.to_string()
+}
+
 /// A task's declared variable, carrying the provenance
 /// [`VarsPolicy::check`] gates on. A task's `env_vars` come from the
 /// project's `minimal.toml`, so the source is always
@@ -521,7 +586,7 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
     };
     let non_interactive = global.no_input || !crate::can_prompt_interactively();
     let (task_env, user_policy) = if non_interactive {
-        let hooks = crate::prompt::NoPromptHook::new();
+        let hooks = RefuseAndRecord::default();
         let task_env = resolve_task_env(
             &declared,
             &args.task,
@@ -531,10 +596,12 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
             &hooks,
             |k| std::env::var(k),
         );
-        let summary = hooks.into_summary();
-        if summary.count() > 0 {
-            let count = summary.count();
-            let snippet = summary.as_toml_snippet();
+        // Checked before the result: the hook refused, so `task_env` is
+        // the abort error and the names are the useful half of it.
+        let refused = hooks.into_names();
+        if !refused.is_empty() {
+            let count = refused.len();
+            let snippet = refused_vars_snippet(&refused);
             bail!(
                 "task '{task}' declares {count} environment variable{s} that your \
                  policy does not allow, and stdin/stderr is not a terminal.\n\n\
@@ -1327,6 +1394,51 @@ mod tests {
 
         // Sorted, so the prompt order does not depend on HashMap iteration.
         assert_eq!(hooks.asked(), vec!["A".to_string(), "B".to_string()]);
+    }
+
+    /// The hook the non-interactive lane actually uses must refuse, not
+    /// fake-approve. `NoPromptHook` returns `AllowOnce` for everything so
+    /// an activate's later hooks still fire — harmless there, because that
+    /// caller only submits a verdict, and fatal here, because this one
+    /// reads values: the name's secret would leave the shell before anyone
+    /// looked at the summary. Drives the real `RefuseAndRecord`, which the
+    /// hand-rolled doubles above cannot stand in for.
+    #[test]
+    fn the_non_interactive_hook_refuses_before_anything_is_read() {
+        let task = task_from_toml(
+            "[tasks.t]\nenv_vars.AWS_SECRET_ACCESS_KEY = { inherit = true }\n\
+             env_vars.OTHER = { inherit = true }\nexec = 'true'\n",
+        );
+        let hooks = RefuseAndRecord::default();
+
+        let err = resolve_task_env(
+            &task,
+            "t",
+            no_vars_policy(),
+            &policy_path_fixture(),
+            &project_source(),
+            &hooks,
+            |_| panic!("no value may be read out of the shell on the refusing path"),
+        )
+        .expect_err("a refusing hook must fail the run");
+
+        assert!(err.to_string().contains("aborted"), "{err}");
+        assert_eq!(
+            hooks.into_names(),
+            vec!["AWS_SECRET_ACCESS_KEY".to_string(), "OTHER".to_string()],
+            "the refused names are what the caller's snippet is built from",
+        );
+    }
+
+    /// The refusal snippet is the `[vars] allow` block an operator pastes,
+    /// and stays valid TOML for a name that needs escaping.
+    #[test]
+    fn the_refusal_snippet_is_pasteable_toml() {
+        let snippet = refused_vars_snippet(&["DEPLOY_TARGET".to_string()]);
+        assert!(snippet.contains("[vars]"), "{snippet}");
+        assert!(snippet.contains("DEPLOY_TARGET"), "{snippet}");
+        let parsed: toml::Value = toml::from_str(&snippet).expect("snippet must parse");
+        assert!(parsed.get("vars").is_some());
     }
 
     /// An echo task's `env_vars` are read by nobody: the daemon answers it

--- a/crates/minimald-rpc/src/lib.rs
+++ b/crates/minimald-rpc/src/lib.rs
@@ -13,6 +13,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sessions::SessionId;
 
+pub mod taskenv;
 pub mod trace;
 
 pub use sessions::{EgressPolicy, IngressPolicy, IpProto, NetworkMode, PortMapping, SessionPolicy};

--- a/crates/minimald-rpc/src/taskenv.rs
+++ b/crates/minimald-rpc/src/taskenv.rs
@@ -1,0 +1,129 @@
+//! Resolved task environment, propagated CLI → daemon over the SSH channel
+//! environment.
+//!
+//! Part of the wire contract: `min task run` resolves a task's
+//! `env_vars.X = { inherit = true }` entries against the *invoking shell*
+//! and sends each as a channel `env` request under [`TASK_ENV_PREFIX`] —
+//! the same mechanism as `MINIMAL_SESSION_ID` and
+//! [`TRACEPARENT`](crate::trace::TRACEPARENT_ENV) — and the daemon strips
+//! the prefix and applies the values verbatim instead of resolving
+//! `inherit` against its own environment.
+//!
+//! Resolution has to happen client-side because the daemon is a different
+//! process, usually on the far side of a VM boundary: its `std::env::var`
+//! reads the daemon's environment, which the user's `export` never reaches.
+//! That asymmetry is the whole of gominimal/inbox#585 — `[session.vars]`
+//! already resolved client-side at activation and worked, while a task's
+//! `env_vars` resolved daemon-side and could not.
+//!
+//! The prefix carries the variable's name and the SSH env request carries
+//! its value, both verbatim, so nothing is escaped and any string a shell
+//! can export round-trips exactly.
+
+use std::collections::BTreeMap;
+
+/// Prefix marking a channel env var as one of a task's resolved
+/// `env_vars`. Client (`set_env`) and daemon (exec dispatch) both
+/// reference this constant — the name cannot skew.
+pub const TASK_ENV_PREFIX: &str = "MINIMAL_TASK_ENV_";
+
+/// The channel env var name carrying task variable `name`.
+#[must_use]
+pub fn wire_name(name: &str) -> String {
+    format!("{TASK_ENV_PREFIX}{name}")
+}
+
+/// Extract a task's resolved env vars from a channel's env map, stripping
+/// [`TASK_ENV_PREFIX`] from each name.
+///
+/// Entries without the prefix — `MINIMAL_SESSION_ID`, `TRACEPARENT`,
+/// anything else a client sent — are ignored rather than rejected. A client
+/// that sends none yields an empty map, which is exactly the pre-#585
+/// behaviour: the daemon falls back to resolving `inherit` itself, so an
+/// older client against a newer daemon is no worse off than before.
+#[must_use]
+pub fn from_channel_env(env_vars: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    env_vars
+        .iter()
+        .filter_map(|(k, v)| Some((k.strip_prefix(TASK_ENV_PREFIX)?.to_string(), v.clone())))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A name survives the prefix round-trip, which is the whole contract:
+    /// the client prefixes, the daemon strips, and the task sees the name
+    /// its `minimal.toml` declared.
+    #[test]
+    fn wire_name_round_trips_through_from_channel_env() {
+        let mut channel = BTreeMap::new();
+        channel.insert(wire_name("ZZ_TASK_TOKEN"), "task-value-123".to_string());
+
+        let out = from_channel_env(&channel);
+        assert_eq!(
+            out.get("ZZ_TASK_TOKEN").map(String::as_str),
+            Some("task-value-123")
+        );
+        assert_eq!(out.len(), 1);
+    }
+
+    /// The channel also carries `MINIMAL_SESSION_ID` and `TRACEPARENT`;
+    /// neither is a task variable and neither may leak into the task's
+    /// environment.
+    #[test]
+    fn unprefixed_channel_vars_are_ignored() {
+        let mut channel = BTreeMap::new();
+        channel.insert("MINIMAL_SESSION_ID".to_string(), "an-id".to_string());
+        channel.insert(
+            crate::trace::TRACEPARENT_ENV.to_string(),
+            "00-aa-bb-01".to_string(),
+        );
+        channel.insert(wire_name("KEPT"), "yes".to_string());
+
+        let out = from_channel_env(&channel);
+        assert_eq!(out.len(), 1);
+        assert!(out.contains_key("KEPT"));
+    }
+
+    /// A client that sends no task env yields an empty map — the signal
+    /// the daemon reads as "resolve `inherit` yourself", preserving the
+    /// behaviour of a client that predates this field.
+    #[test]
+    fn absent_task_env_is_empty_not_an_error() {
+        let mut channel = BTreeMap::new();
+        channel.insert("MINIMAL_SESSION_ID".to_string(), "an-id".to_string());
+        assert!(from_channel_env(&channel).is_empty());
+    }
+
+    /// Values are carried verbatim: no escaping is applied on either side,
+    /// so a value holding newlines, `=`, quotes, or non-ASCII arrives
+    /// exactly as the shell exported it. A variable whose own name starts
+    /// with the prefix round-trips too, since only one prefix is stripped.
+    #[test]
+    fn values_and_prefixed_names_survive_verbatim() {
+        let gnarly = "line1\nline2 = \"quoted\" — ünicode\t\\";
+        let mut channel = BTreeMap::new();
+        channel.insert(wire_name("GNARLY"), gnarly.to_string());
+        channel.insert(wire_name("MINIMAL_TASK_ENV_X"), "inner".to_string());
+
+        let out = from_channel_env(&channel);
+        assert_eq!(out.get("GNARLY").map(String::as_str), Some(gnarly));
+        assert_eq!(
+            out.get("MINIMAL_TASK_ENV_X").map(String::as_str),
+            Some("inner")
+        );
+    }
+
+    /// An empty value is a real value, not an absence: `export X=` must
+    /// reach the task as an empty string rather than being dropped.
+    #[test]
+    fn empty_values_are_carried() {
+        let mut channel = BTreeMap::new();
+        channel.insert(wire_name("EMPTY"), String::new());
+
+        let out = from_channel_env(&channel);
+        assert_eq!(out.get("EMPTY").map(String::as_str), Some(""));
+    }
+}

--- a/crates/minimald-rpc/src/taskenv.rs
+++ b/crates/minimald-rpc/src/taskenv.rs
@@ -20,12 +20,26 @@
 //! its value, both verbatim, so nothing is escaped and any string a shell
 //! can export round-trips exactly.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Prefix marking a channel env var as one of a task's resolved
 /// `env_vars`. Client (`set_env`) and daemon (exec dispatch) both
 /// reference this constant — the name cannot skew.
 pub const TASK_ENV_PREFIX: &str = "MINIMAL_TASK_ENV_";
+
+/// Channel env var carrying the names the daemon must *remove* from the
+/// task's declarations, as a JSON array.
+///
+/// A resolved value can be sent as itself; a variable the client decided
+/// the task must not see cannot. Absence is not a signal — the daemon
+/// applies [`TASK_ENV_PREFIX`] entries by insertion, so a name the client
+/// simply omits keeps whatever `minimal.toml` declared and is resolved
+/// daemon-side. Dropping one therefore has to be said out loud.
+///
+/// Deliberately **not** under [`TASK_ENV_PREFIX`]: a name that started
+/// with it would be stripped by [`from_channel_env`] and delivered to the
+/// task as a variable called `DROP`.
+pub const TASK_ENV_DROP: &str = "MINIMAL_TASK_DROP";
 
 /// The channel env var name carrying task variable `name`.
 #[must_use]
@@ -47,6 +61,53 @@ pub fn from_channel_env(env_vars: &BTreeMap<String, String>) -> BTreeMap<String,
         .iter()
         .filter_map(|(k, v)| Some((k.strip_prefix(TASK_ENV_PREFIX)?.to_string(), v.clone())))
         .collect()
+}
+
+/// Encode the names the daemon must remove from the task's declarations,
+/// for [`TASK_ENV_DROP`]. JSON for the same reason argv words travel as
+/// JSON in [`crate::exec`]: an env var name is a TOML key and may hold
+/// anything, so no separator character is safe to assume.
+#[must_use]
+pub fn encode_drops(names: &BTreeSet<String>) -> String {
+    serde_json_lenient::to_string(names).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// The names a client asked the daemon to drop, from a channel's env map.
+///
+/// Absent, empty, or unparseable yields an empty set — a drop list is an
+/// instruction to remove something, and failing to understand one must
+/// never remove the wrong thing. An older client sends none, which leaves
+/// the task's declarations exactly as `minimal.toml` wrote them.
+#[must_use]
+pub fn drops_from_channel_env(env_vars: &BTreeMap<String, String>) -> BTreeSet<String> {
+    env_vars
+        .get(TASK_ENV_DROP)
+        .and_then(|raw| serde_json_lenient::from_str(raw).ok())
+        .unwrap_or_default()
+}
+
+/// A task's `env_vars` as the client resolved them: the values to apply,
+/// and the names to remove.
+///
+/// The two halves are disjoint by construction — a name is either resolved
+/// or dropped — and travel together because the daemon needs both to
+/// arrive at the set the task actually sees.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TaskEnv {
+    /// Values to apply over the task's own declarations.
+    pub set: BTreeMap<String, String>,
+    /// Names to remove from the task's declarations entirely.
+    pub drop: BTreeSet<String>,
+}
+
+impl TaskEnv {
+    /// `true` when there is nothing for the daemon to apply — the case for
+    /// every caller other than a task run, and for a task declaring no
+    /// `env_vars`.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty() && self.drop.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -114,6 +175,59 @@ mod tests {
             out.get("MINIMAL_TASK_ENV_X").map(String::as_str),
             Some("inner")
         );
+    }
+
+    /// The drop list round-trips, and a name on it is not also a value:
+    /// the daemon reads the two halves from different channel vars.
+    #[test]
+    fn drop_list_round_trips() {
+        let drops: BTreeSet<String> = ["NOISY_DEBUG".to_string(), "OTHER".to_string()]
+            .into_iter()
+            .collect();
+        let mut channel = BTreeMap::new();
+        channel.insert(TASK_ENV_DROP.to_string(), encode_drops(&drops));
+
+        assert_eq!(drops_from_channel_env(&channel), drops);
+        // The drop carrier is not itself a task variable.
+        assert!(from_channel_env(&channel).is_empty());
+    }
+
+    /// `TASK_ENV_DROP` must not live under `TASK_ENV_PREFIX`, or
+    /// `from_channel_env` would strip the prefix and hand the task a
+    /// variable named `DROP` holding a JSON array.
+    #[test]
+    fn the_drop_carrier_is_not_under_the_value_prefix() {
+        assert!(!TASK_ENV_DROP.starts_with(TASK_ENV_PREFIX));
+    }
+
+    /// No drop list, an empty one, and a malformed one all mean "remove
+    /// nothing". Failing to parse an instruction to delete must never
+    /// delete the wrong thing, and an older client sends none at all.
+    #[test]
+    fn an_absent_or_unparseable_drop_list_removes_nothing() {
+        let mut absent = BTreeMap::new();
+        absent.insert("MINIMAL_SESSION_ID".to_string(), "an-id".to_string());
+        assert!(drops_from_channel_env(&absent).is_empty());
+
+        let mut empty = BTreeMap::new();
+        empty.insert(TASK_ENV_DROP.to_string(), encode_drops(&BTreeSet::new()));
+        assert!(drops_from_channel_env(&empty).is_empty());
+
+        let mut junk = BTreeMap::new();
+        junk.insert(TASK_ENV_DROP.to_string(), "not json".to_string());
+        assert!(drops_from_channel_env(&junk).is_empty());
+    }
+
+    /// A name needing no escaping in JSON and one that does both survive,
+    /// so a dropped name matches the declaration it must remove exactly.
+    #[test]
+    fn drop_names_survive_verbatim() {
+        let gnarly: BTreeSet<String> = ["PLAIN".to_string(), "with \"quote\" and \\".to_string()]
+            .into_iter()
+            .collect();
+        let mut channel = BTreeMap::new();
+        channel.insert(TASK_ENV_DROP.to_string(), encode_drops(&gnarly));
+        assert_eq!(drops_from_channel_env(&channel), gnarly);
     }
 
     /// An empty value is a real value, not an absence: `export X=` must

--- a/crates/minimald/src/env.rs
+++ b/crates/minimald/src/env.rs
@@ -192,7 +192,7 @@ pub struct EnvArgs {
 
     packages: Vec<String>,
     patches: Option<EnvPatches>,
-    env_vars: Option<HashMap<String, EnvVarValue>>,
+    env_vars: Option<BTreeMap<String, EnvVarValue>>,
     ot: Option<OpTracker>,
     network_mode: NetworkMode,
     own_ip_tap: Option<sandbox2::config::OwnIpTap>,
@@ -271,7 +271,7 @@ impl EnvArgs {
 
     /// Sets environment variables to apply on top of the package-derived ones.
     #[must_use]
-    pub fn with_env_vars(mut self, env_vars: HashMap<String, EnvVarValue>) -> Self {
+    pub fn with_env_vars(mut self, env_vars: BTreeMap<String, EnvVarValue>) -> Self {
         self.env_vars = Some(env_vars);
         self
     }

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -5,7 +5,7 @@
 //! so the bridge logic can be exercised with a mock in tests without
 //! going through `tokio::process` or russh.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
 use std::io;
 use std::process::Stdio;
@@ -96,6 +96,15 @@ pub struct TaskExec {
     /// other than `min task run` — in which case resolution falls back to
     /// the daemon-side path exactly as before.
     pub env: BTreeMap<String, String>,
+    /// Names the client's `[vars] ignore` policy matched, to be removed
+    /// from the task's declarations outright.
+    ///
+    /// Omitting a name from [`Self::env`] cannot express this: the overlay
+    /// only inserts, so an omitted name keeps whatever `minimal.toml`
+    /// declared and an `inherit` among them would be resolved against the
+    /// daemon's own environment — the very indirection #585 removes. A
+    /// dropped name has to be named.
+    pub drop_env: BTreeSet<String>,
 }
 
 impl Exec for TaskExec {
@@ -187,6 +196,12 @@ async fn task_producer(
         // reaches (#585). An entry the client did not send keeps whatever
         // the task declared, so the daemon-side path still serves in-box
         // `min run` and older clients.
+        // Removals first. The two sets are disjoint, so the order is not
+        // load-bearing, but reading it in policy order — drop, then apply —
+        // matches how the client decided.
+        for name in &exec.drop_env {
+            task.vars.remove(name);
+        }
         for (name, value) in &exec.env {
             task.vars
                 .insert(name.clone(), mfile::EnvVarValue::Value(value.clone()));
@@ -999,6 +1014,7 @@ pub(crate) async fn handle_exec(
             // client that predates it — in which case the task path resolves
             // them the old way, daemon-side.
             let task_env = minimald_rpc::taskenv::from_channel_env(&config.env_vars);
+            let drop_env = minimald_rpc::taskenv::drops_from_channel_env(&config.env_vars);
             session.channel_success(id)?;
             spawn(async move {
                 let exec_task = ExecTask {
@@ -1010,6 +1026,7 @@ pub(crate) async fn handle_exec(
                         args: None,
                         task,
                         env: task_env,
+                        drop_env,
                     },
                 };
                 exec_task.run(channel).await;

--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -86,6 +86,16 @@ pub trait Process: Send + 'static {
 pub struct TaskExec {
     pub task: String,
     pub args: Option<args::ArgsSet>,
+    /// The task's `env_vars`, already resolved against the invoking shell
+    /// by the client and carried on the channel environment (see
+    /// [`minimald_rpc::taskenv`]). Applied over the task's own
+    /// declarations, so an `inherit` entry never reaches the daemon-side
+    /// `std::env::var` that cannot see the user's `export` (#585).
+    ///
+    /// Empty when the client sent none — an older `min`, or any caller
+    /// other than `min task run` — in which case resolution falls back to
+    /// the daemon-side path exactly as before.
+    pub env: BTreeMap<String, String>,
 }
 
 impl Exec for TaskExec {
@@ -166,10 +176,21 @@ async fn task_producer(
         .await
         .map_err(io::Error::other)?;
         let graph = graph_result.map_err(io::Error::other)?;
-        let (task, mut graph) = ctx
+        let (mut task, mut graph) = ctx
             .task(graph, &exec.task)
             .map_err(|e| io::Error::other(e.to_string()))?
             .ok_or_else(|| io::Error::other(format!("No such task: {}", exec.task)))?;
+        // Values the client resolved against the invoking shell win over the
+        // task's own declarations. That is what turns `{ inherit = true }`
+        // into something the daemon can apply: resolving it here would read
+        // *this* process's environment, which the user's `export` never
+        // reaches (#585). An entry the client did not send keeps whatever
+        // the task declared, so the daemon-side path still serves in-box
+        // `min run` and older clients.
+        for (name, value) in &exec.env {
+            task.vars
+                .insert(name.clone(), mfile::EnvVarValue::Value(value.clone()));
+        }
         // A task inherits its session's network isolation, through the same
         // sandbox2 `Network` seam the interactive session uses, rather than the
         // old hardcoded `HostNet` (which leaked host egress to a no-net
@@ -913,6 +934,12 @@ pub(crate) async fn handle_exec(
     }
     .to_string();
 
+    // A task's `env_vars`, resolved by the client against the invoking shell
+    // and carried on the channel environment (#585). Empty for every form
+    // but `min task run`, and empty from a client that predates it — in
+    // which case the task path resolves them the old way.
+    let task_env = minimald_rpc::taskenv::from_channel_env(&config.env_vars);
+
     let mut c = rem.split(' ');
     match c.next() {
         None => {
@@ -939,7 +966,11 @@ pub(crate) async fn handle_exec(
                     serv,
                     session: session_handle,
                     channel_id: id,
-                    exec: TaskExec { args: None, task },
+                    exec: TaskExec {
+                        args: None,
+                        task,
+                        env: task_env,
+                    },
                 };
                 exec_task.run(channel).await;
             });
@@ -969,7 +1000,11 @@ pub(crate) async fn handle_exec(
                     serv,
                     session: session_handle,
                     channel_id: id,
-                    exec: TaskExec { args: None, task },
+                    exec: TaskExec {
+                        args: None,
+                        task,
+                        env: task_env,
+                    },
                 };
                 exec_task.run(channel).await;
             });

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -1565,9 +1565,6 @@ pub enum NameVerdict {
     Allowed,
     /// Drop it silently.
     Ignored,
-    /// The policy forbids it. The caller reports; how it reports is its
-    /// own business, which is why this is a verdict and not an error.
-    Denied,
 }
 
 /// A bare name's provenance, for [`VarsPolicy::check`]. Carries no
@@ -1598,6 +1595,9 @@ impl Provenanced for NameItem<'_> {
 ///
 /// # Errors
 ///
+/// - [`ComposeError::Denied`] — a `deny` rule matched. Returned from the
+///   first denial found, before any hook is consulted, so a forbidden
+///   name is never preceded by a prompt about its neighbours.
 /// - [`ComposeError::HookRequired`] — an item needed approval and there
 ///   was no hook to ask.
 /// - [`ComposeError::Aborted`] — the hook cancelled.
@@ -1611,24 +1611,36 @@ pub fn gate_names(
     mut policy: VarsPolicy,
     hooks: Option<&dyn PolicyHooks>,
 ) -> Result<(Vec<NameVerdict>, VarsPolicy), ComposeError> {
+    // A denial ends the batch where it is found, before any hook runs.
+    // `deny` is the emergency stop: an operator who has forbidden a name
+    // should not first be prompted about its neighbours, approve one,
+    // have that rule written to `user_policy.toml`, and only then be told
+    // the composition was never going to succeed.
+    let denied = |name: &str, source: &Source| ComposeError::Denied {
+        what: name.to_owned(),
+        from: source.clone(),
+    };
     let verdict_of = |d: &Decision<NameItem<'_>>| match d {
-        Decision::Allowed(_) => NameVerdict::Allowed,
-        Decision::Ignored => NameVerdict::Ignored,
-        Decision::Denied(_) => NameVerdict::Denied,
+        Decision::Allowed(_) => Some(NameVerdict::Allowed),
+        Decision::Ignored => Some(NameVerdict::Ignored),
+        Decision::Denied(_) => None,
     };
 
-    // Pass 1: categorize. An undecided item is seeded `Denied` and
+    // Pass 1: categorize. An undecided item is seeded `Ignored` and
     // queued; pass 3 overwrites every one of them. The placeholder is
     // fail-closed on purpose — should a future edit ever leave one
-    // unwritten, the caller refuses it rather than carrying it.
+    // unwritten, the caller drops the name rather than carrying it.
     let mut verdicts: Vec<NameVerdict> = Vec::with_capacity(items.len());
     let mut unapproved: Vec<usize> = Vec::new();
     for (i, (name, source)) in items.iter().enumerate() {
         match policy.check(name, NameItem { source }) {
-            CheckOutcome::Decided(d) => verdicts.push(verdict_of(&d)),
+            CheckOutcome::Decided(d) => match verdict_of(&d) {
+                Some(v) => verdicts.push(v),
+                None => return Err(denied(name, source)),
+            },
             CheckOutcome::NeedsApproval(_) => {
                 unapproved.push(i);
-                verdicts.push(NameVerdict::Denied);
+                verdicts.push(NameVerdict::Ignored);
             }
         }
     }
@@ -1658,7 +1670,10 @@ pub fn gate_names(
                 ItemDecision::AllowOnce => NameVerdict::Allowed,
                 ItemDecision::IgnoreOnce => NameVerdict::Ignored,
                 ItemDecision::UseRule => match policy.check(name, NameItem { source }) {
-                    CheckOutcome::Decided(d) => verdict_of(&d),
+                    CheckOutcome::Decided(d) => match verdict_of(&d) {
+                        Some(v) => v,
+                        None => return Err(denied(name, source)),
+                    },
                     CheckOutcome::NeedsApproval(_) => {
                         return Err(ComposeError::use_rule_undecided(
                             HookDomain::Var,
@@ -1719,13 +1734,6 @@ pub(crate) fn gate_vars(
             // Never gated: skipped the policy entirely.
             None | Some(NameVerdict::Allowed) => allowed.push(pv),
             Some(NameVerdict::Ignored) => {}
-            Some(NameVerdict::Denied) => {
-                let what = pv.var().name().to_owned();
-                return Err(ComposeError::Denied {
-                    what,
-                    from: pv.into_parts().1,
-                });
-            }
         }
     }
 
@@ -2466,6 +2474,54 @@ mod tests {
     // =================================================================
 
     mod vars_gating {
+        /// A batch holding both a denied name and an merely-unapproved one
+        /// fails on the denial without the hook ever being consulted.
+        ///
+        /// `deny` is the emergency stop. Prompting about a neighbour first
+        /// wastes the answer — and can persist a rule to `user_policy.toml`
+        /// — for a composition that was never going to succeed. The
+        /// hook here panics if called, so the order is enforced rather
+        /// than described.
+        #[test]
+        fn a_denial_short_circuits_before_any_hook_runs() {
+            use super::super::{ComposeError, gate_names};
+            use crate::core::hooks::{HookResult, PolicyHooks, Unapproved};
+            use crate::core::policy::{PatchesPolicy, VarsPolicy};
+            use crate::core::source::Source;
+
+            struct NeverAsked;
+            impl PolicyHooks for NeverAsked {
+                fn on_var_unapproved(
+                    &self,
+                    _p: VarsPolicy,
+                    items: &[Unapproved<'_, str>],
+                ) -> HookResult<VarsPolicy> {
+                    panic!("a denial must stop the batch first; asked about {items:?}");
+                }
+                fn on_patch_unapproved(
+                    &self,
+                    _p: PatchesPolicy,
+                    _i: &[Unapproved<'_, camino::Utf8Path>],
+                ) -> HookResult<PatchesPolicy> {
+                    unreachable!()
+                }
+            }
+
+            let source = Source::Project {
+                path: paths::HostPath::try_new(camino::Utf8PathBuf::from("/p")).unwrap(),
+            };
+            let policy = VarsPolicy::empty().try_with_deny(["DENIED"]).unwrap();
+            // Sorted so the denied name is not simply first by luck.
+            let items = [("ALSO_UNLISTED", &source), ("DENIED", &source)];
+
+            let err = gate_names(&items, policy, Some(&NeverAsked))
+                .expect_err("a denied name must fail the batch");
+            assert!(
+                matches!(&err, ComposeError::Denied { what, .. } if what == "DENIED"),
+                "names the denied variable: {err:?}",
+            );
+        }
+
         use super::*;
 
         #[test]

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -1594,8 +1594,16 @@ impl Provenanced for NameItem<'_> {
 /// one defeats the gate) call this directly.
 ///
 /// `hooks` is `None` for user-only composition — all items are expected
-/// to auto-decide. Any item that reaches the `NeedsApproval` branch with
-/// no hook surfaces as [`ComposeError::HookRequired`].
+/// to auto-decide.
+///
+/// # Errors
+///
+/// - [`ComposeError::HookRequired`] — an item needed approval and there
+///   was no hook to ask.
+/// - [`ComposeError::Aborted`] — the hook cancelled.
+/// - [`ComposeError::HookContract`] — the hook returned the wrong number
+///   of decisions, or answered `UseRule` for an item the policy still
+///   cannot decide.
 ///
 /// [`VarsPolicy::check`]: crate::core::policy::VarsPolicy::check
 pub fn gate_names(
@@ -1609,13 +1617,19 @@ pub fn gate_names(
         Decision::Denied(_) => NameVerdict::Denied,
     };
 
-    // Pass 1: categorize.
-    let mut verdicts: Vec<Option<NameVerdict>> = vec![None; items.len()];
+    // Pass 1: categorize. An undecided item is seeded `Denied` and
+    // queued; pass 3 overwrites every one of them. The placeholder is
+    // fail-closed on purpose — should a future edit ever leave one
+    // unwritten, the caller refuses it rather than carrying it.
+    let mut verdicts: Vec<NameVerdict> = Vec::with_capacity(items.len());
     let mut unapproved: Vec<usize> = Vec::new();
     for (i, (name, source)) in items.iter().enumerate() {
         match policy.check(name, NameItem { source }) {
-            CheckOutcome::Decided(d) => verdicts[i] = Some(verdict_of(&d)),
-            CheckOutcome::NeedsApproval(_) => unapproved.push(i),
+            CheckOutcome::Decided(d) => verdicts.push(verdict_of(&d)),
+            CheckOutcome::NeedsApproval(_) => {
+                unapproved.push(i);
+                verdicts.push(NameVerdict::Denied);
+            }
         }
     }
 
@@ -1640,7 +1654,7 @@ pub fn gate_names(
         // Pass 3: apply.
         for (&i, decision) in unapproved.iter().zip(decisions) {
             let (name, source) = items[i];
-            verdicts[i] = Some(match decision {
+            verdicts[i] = match decision {
                 ItemDecision::AllowOnce => NameVerdict::Allowed,
                 ItemDecision::IgnoreOnce => NameVerdict::Ignored,
                 ItemDecision::UseRule => match policy.check(name, NameItem { source }) {
@@ -1652,17 +1666,11 @@ pub fn gate_names(
                         ));
                     }
                 },
-            });
+            };
         }
     }
 
-    Ok((
-        verdicts
-            .into_iter()
-            .map(|v| v.expect("every index is assigned in pass 1 or pass 3"))
-            .collect(),
-        policy,
-    ))
+    Ok((verdicts, policy))
 }
 
 /// Drive the policy pass over a batch of vars.

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -1554,6 +1554,117 @@ pub(crate) fn apply_decision<T>(
     Ok(())
 }
 
+/// What the policy decided about one name.
+///
+/// The value-free half of [`Decision`]: a caller that has not resolved
+/// its values yet — or must not, until the policy has spoken — gets a
+/// verdict it can act on without handing anything to the gate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NameVerdict {
+    /// The policy permits this name.
+    Allowed,
+    /// Drop it silently.
+    Ignored,
+    /// The policy forbids it. The caller reports; how it reports is its
+    /// own business, which is why this is a verdict and not an error.
+    Denied,
+}
+
+/// A bare name's provenance, for [`VarsPolicy::check`]. Carries no
+/// value: [`gate_names`] exists precisely so a caller need not have one.
+struct NameItem<'a> {
+    source: &'a Source,
+}
+
+impl Provenanced for NameItem<'_> {
+    fn source(&self) -> &Source {
+        self.source
+    }
+}
+
+/// Drive the policy pass over a batch of `(name, source)` pairs and
+/// return one [`NameVerdict`] per input, in order, plus the policy as
+/// the hook may have amended it.
+///
+/// This is the gate itself — classify, refer what is undecided to
+/// `hooks`, apply what comes back — with values factored out.
+/// [`gate_vars`] is this function plus the value plumbing, and callers
+/// that must decide *before* reading a value (a task's `env_vars` are
+/// resolved out of the invoking user's shell, so reading an unapproved
+/// one defeats the gate) call this directly.
+///
+/// `hooks` is `None` for user-only composition — all items are expected
+/// to auto-decide. Any item that reaches the `NeedsApproval` branch with
+/// no hook surfaces as [`ComposeError::HookRequired`].
+///
+/// [`VarsPolicy::check`]: crate::core::policy::VarsPolicy::check
+pub fn gate_names(
+    items: &[(&str, &Source)],
+    mut policy: VarsPolicy,
+    hooks: Option<&dyn PolicyHooks>,
+) -> Result<(Vec<NameVerdict>, VarsPolicy), ComposeError> {
+    let verdict_of = |d: &Decision<NameItem<'_>>| match d {
+        Decision::Allowed(_) => NameVerdict::Allowed,
+        Decision::Ignored => NameVerdict::Ignored,
+        Decision::Denied(_) => NameVerdict::Denied,
+    };
+
+    // Pass 1: categorize.
+    let mut verdicts: Vec<Option<NameVerdict>> = vec![None; items.len()];
+    let mut unapproved: Vec<usize> = Vec::new();
+    for (i, (name, source)) in items.iter().enumerate() {
+        match policy.check(name, NameItem { source }) {
+            CheckOutcome::Decided(d) => verdicts[i] = Some(verdict_of(&d)),
+            CheckOutcome::NeedsApproval(_) => unapproved.push(i),
+        }
+    }
+
+    if !unapproved.is_empty() {
+        let Some(hooks) = hooks else {
+            let i = unapproved[0];
+            return Err(ComposeError::HookRequired {
+                what: items[i].0.to_owned(),
+                from: items[i].1.clone(),
+            });
+        };
+        // Pass 2: prompt.
+        let view: Vec<Unapproved<'_, str>> = unapproved
+            .iter()
+            .map(|&i| Unapproved {
+                item: items[i].0,
+                source: items[i].1,
+            })
+            .collect();
+        let (decisions, new_policy) = prompt_var_hook(hooks, policy, &view)?;
+        policy = new_policy;
+        // Pass 3: apply.
+        for (&i, decision) in unapproved.iter().zip(decisions) {
+            let (name, source) = items[i];
+            verdicts[i] = Some(match decision {
+                ItemDecision::AllowOnce => NameVerdict::Allowed,
+                ItemDecision::IgnoreOnce => NameVerdict::Ignored,
+                ItemDecision::UseRule => match policy.check(name, NameItem { source }) {
+                    CheckOutcome::Decided(d) => verdict_of(&d),
+                    CheckOutcome::NeedsApproval(_) => {
+                        return Err(ComposeError::use_rule_undecided(
+                            HookDomain::Var,
+                            format!("variable `{name}`"),
+                        ));
+                    }
+                },
+            });
+        }
+    }
+
+    Ok((
+        verdicts
+            .into_iter()
+            .map(|v| v.expect("every index is assigned in pass 1 or pass 3"))
+            .collect(),
+        policy,
+    ))
+}
+
 /// Drive the policy pass over a batch of vars.
 ///
 /// `hooks` is `None` for user-only composition — all items are
@@ -1561,77 +1672,51 @@ pub(crate) fn apply_decision<T>(
 /// branch with no hook surfaces as [`ComposeError::HookRequired`].
 pub(crate) fn gate_vars(
     items: Vec<ProvenancedVar>,
-    mut policy: VarsPolicy,
+    policy: VarsPolicy,
     hooks: Option<&dyn PolicyHooks>,
 ) -> Result<(Vec<SessionVar>, VarsPolicy), ComposeError> {
-    let name_of = |pv: &ProvenancedVar| pv.var().name().to_owned();
-    let source_of = |pv: ProvenancedVar| pv.into_parts().1;
+    // Vars whose value doesn't pull from the user's environment
+    // (hardcoded literals, or `inherit-with-default` that fell back to
+    // the default) aren't a data-leak vector, so the allow/deny/ignore
+    // rules don't apply — they never reach the gate. The policy exists
+    // to gate user data crossing into the sandbox; there's no user data
+    // here.
+    let gated: Vec<usize> = items
+        .iter()
+        .enumerate()
+        .filter(|(_, pv)| pv.var().carries_user_data())
+        .map(|(i, _)| i)
+        .collect();
 
-    // Pass 1: categorize.
-    let mut allowed: Vec<ProvenancedVar> = Vec::new();
-    let mut unapproved: Vec<ProvenancedVar> = Vec::new();
-    for pv in items {
-        // Vars whose value doesn't pull from the user's environment
-        // (hardcoded literals, or `inherit-with-default` that fell
-        // back to the default) aren't a data-leak vector, so the
-        // allow/deny/ignore rules don't apply — send straight to
-        // `allowed` without a policy check. The policy exists to
-        // gate user data crossing into the sandbox; there's no user
-        // data here.
-        if !pv.var().carries_user_data() {
-            allowed.push(pv);
-            continue;
-        }
-        let name = pv.var().name().to_owned();
-        match policy.check(&name, pv) {
-            CheckOutcome::Decided(d) => apply_decision(d, &mut allowed, name_of, source_of)?,
-            CheckOutcome::NeedsApproval(pv) => unapproved.push(pv),
-        }
-    }
-    if !unapproved.is_empty() {
-        let Some(hooks) = hooks else {
-            // Caller wired the user-only path but produced a
-            // non-user-origin item that the policy couldn't decide.
-            let pv = unapproved.into_iter().next().expect("non-empty");
-            let what = name_of(&pv);
-            return Err(ComposeError::HookRequired {
-                what,
-                from: source_of(pv),
-            });
-        };
-        // Pass 2: prompt.
-        let view: Vec<Unapproved<'_, str>> = unapproved
+    // Scoped so the borrows of `items` end before it is consumed below.
+    let (verdicts, policy) = {
+        let pairs: Vec<(&str, &Source)> = gated
             .iter()
-            .map(|pv| Unapproved {
-                item: pv.var().name(),
-                source: pv.source(),
-            })
+            .map(|&i| (items[i].var().name(), items[i].source()))
             .collect();
-        let (decisions, new_policy) = prompt_var_hook(hooks, policy, &view)?;
-        policy = new_policy;
-        // Pass 3: apply.
-        for (pv, decision) in unapproved.into_iter().zip(decisions) {
-            match decision {
-                ItemDecision::AllowOnce => allowed.push(pv),
-                // `IgnoreOnce` is the symmetric partner of `AllowOnce`:
-                // silently drop this item for this activation without
-                // adding a policy rule. Same downstream effect as a
-                // policy `ignore` match.
-                ItemDecision::IgnoreOnce => {}
-                ItemDecision::UseRule => {
-                    let name = pv.var().name().to_owned();
-                    match policy.check(&name, pv) {
-                        CheckOutcome::Decided(d) => {
-                            apply_decision(d, &mut allowed, name_of, source_of)?;
-                        }
-                        CheckOutcome::NeedsApproval(pv) => {
-                            return Err(ComposeError::use_rule_undecided(
-                                HookDomain::Var,
-                                format!("variable `{}`", pv.var().name()),
-                            ));
-                        }
-                    }
-                }
+        gate_names(&pairs, policy, hooks)?
+    };
+
+    let mut verdict_at: Vec<Option<NameVerdict>> = vec![None; items.len()];
+    for (&i, v) in gated.iter().zip(verdicts) {
+        verdict_at[i] = Some(v);
+    }
+
+    // Walked in input order, so the emitted list keeps the order the
+    // composer built it in — an ungated literal does not jump ahead of
+    // a gated var declared before it.
+    let mut allowed: Vec<ProvenancedVar> = Vec::with_capacity(items.len());
+    for (pv, verdict) in items.into_iter().zip(&verdict_at) {
+        match verdict {
+            // Never gated: skipped the policy entirely.
+            None | Some(NameVerdict::Allowed) => allowed.push(pv),
+            Some(NameVerdict::Ignored) => {}
+            Some(NameVerdict::Denied) => {
+                let what = pv.var().name().to_owned();
+                return Err(ComposeError::Denied {
+                    what,
+                    from: pv.into_parts().1,
+                });
             }
         }
     }

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -144,7 +144,9 @@ Every name a task declares — inherited or literal — is checked against the
 - a name matching **`deny`** fails the run, naming the rule's file. The value
   is never read out of your shell.
 - a name matching **`ignore`** is dropped silently and the task runs without
-  it; an ignored variable does not have to be set.
+  it; an ignored variable does not have to be set. The name is removed from
+  the task's declarations outright, so this holds for a literal value as much
+  as an inherited one.
 - anything else is carried through. `allow` is not consulted here — a task's
   `env_vars` come from the project's own `minimal.toml` and there is no prompt
   on this path, so requiring an allow-list entry would break scripted and CI

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -166,6 +166,12 @@ through, with the same precedence — `deny`, then `ignore`, then `allow` — an
 `allow` is required for the same reason: a project you have not read should
 not be able to name a variable and receive its value.
 
+An `echo` task is the one exception, and it is not a hole: its output comes
+straight from the declaration without an environment being built, so its
+`env_vars` are read by nobody. Nothing is looked up, so there is nothing to
+gate — an `echo` task never prompts, and never fails over a variable it has
+no use for.
+
 ```toml
 # user_policy.toml
 [vars]

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -143,25 +143,37 @@ still resolve `inherit` against the daemon's environment:
 So prefer an explicit value for tasks meant to be run either of those ways.
 
 <a id="policy"></a>
-Every name a task declares — inherited or literal — is checked against the
-`[vars]` section of your `user_policy.toml` before its value is read:
+### Environment variables and your policy
 
-- a name matching **`deny`** fails the run, naming the rule's file. The value
-  is never read out of your shell.
-- a name matching **`ignore`** is dropped silently and the task runs without
-  it; an ignored variable does not have to be set. The name is removed from
-  the task's declarations outright, so this holds for a literal value as much
-  as an inherited one.
-- anything else is carried through. `allow` is not consulted here — a task's
-  `env_vars` come from the project's own `minimal.toml` and there is no prompt
-  on this path, so requiring an allow-list entry would break scripted and CI
-  runs.
+Resolving on the client means reading *your* shell. A project's
+`minimal.toml` naming `env_vars.AWS_SECRET_ACCESS_KEY = { inherit = true }` is
+that project asking for your credential, so every name a task declares —
+inherited or literal — is checked against the `[vars]` section of your
+`user_policy.toml` **before its value is read**:
+
+- a name matching **`deny`** fails the run, naming the rule's file.
+- a name matching **`ignore`** is dropped and the task runs without it. The
+  name is removed from the task's declarations outright, so this holds for a
+  literal value as much as an inherited one, and an ignored variable does not
+  have to be set.
+- a name matching **`allow`** is carried.
+- anything else is **not carried**. On a terminal you are asked, once per
+  name, and can record the answer as a rule; anywhere else the run stops and
+  prints the rules to add.
+
+This is the same gate `[session.vars]` from the same file has always passed
+through, with the same precedence — `deny`, then `ignore`, then `allow` — and
+`allow` is required for the same reason: a project you have not read should
+not be able to name a variable and receive its value.
 
 ```toml
 # user_policy.toml
 [vars]
-deny = ["AWS_*"]
+allow = ["ZZ_TASK_*", "RUST_*"]
+deny  = ["AWS_*"]
 ```
+
+A denied name:
 
 ```console
 $ min task run deploy
@@ -171,6 +183,20 @@ AWS_SECRET_ACCESS_KEY is denied by `[vars] deny` in
 if this task should see it
 ```
 
+An unlisted name in CI, where there is no one to ask:
+
+```console
+$ min task run deploy
+error: task 'deploy' declares 1 environment variable that your policy does not
+allow, and stdin/stderr is not a terminal.
+
+Add the following to ~/.config/minimal/user_policy.toml:
+
+[vars]
+allow = ["DEPLOY_TARGET"]
+
+Then re-run this command.
+```
 
 ### `interactive` - TUI apps and shells
 

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -116,6 +116,26 @@ declare the variable with the value `{ inherit = true }`:
 env_vars.TOKEN = { inherit = true }
 ```
 
+The parent process is the shell you run `min task run` in: the value is read
+on the client, at the moment you invoke the task, and carried to the session —
+the same way `[session.vars]` resolves at activation. So exporting the variable
+in your shell is enough, and the daemon's own environment is never consulted.
+
+A variable declared `inherit` but not set in that shell is an error, reported
+before the task's session is created:
+
+```console
+$ min task run deploy
+error: task 'deploy' declares `env_vars.TOKEN = { inherit = true }`, but TOKEN
+is not set in this shell; export it before running the task
+```
+
+This applies to `min task run` on the host. Running a declared task from
+*inside* a session (`min run <task>`) has no invoking client to read from, and
+an inherited variable there is still resolved against the daemon's
+environment — so prefer an explicit value for tasks meant to be run from
+inside a box.
+
 
 ### `interactive` - TUI apps and shells
 

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -136,6 +136,32 @@ an inherited variable there is still resolved against the daemon's
 environment — so prefer an explicit value for tasks meant to be run from
 inside a box.
 
+Every name a task declares — inherited or literal — is checked against the
+`[vars]` section of your `user_policy.toml` before its value is read:
+
+- a name matching **`deny`** fails the run, naming the rule's file. The value
+  is never read out of your shell.
+- a name matching **`ignore`** is dropped silently and the task runs without
+  it; an ignored variable does not have to be set.
+- anything else is carried through. `allow` is not consulted here — a task's
+  `env_vars` come from the project's own `minimal.toml` and there is no prompt
+  on this path, so requiring an allow-list entry would break scripted and CI
+  runs.
+
+```toml
+# user_policy.toml
+[vars]
+deny = ["AWS_*"]
+```
+
+```console
+$ min task run deploy
+error: task 'deploy' declares `env_vars.AWS_SECRET_ACCESS_KEY`, but
+AWS_SECRET_ACCESS_KEY is denied by `[vars] deny` in
+~/.config/minimal/user_policy.toml; remove the declaration, or the deny rule
+if this task should see it
+```
+
 
 ### `interactive` - TUI apps and shells
 

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -122,7 +122,8 @@ the same way `[session.vars]` resolves at activation. So exporting the variable
 in your shell is enough, and the daemon's own environment is never consulted.
 
 A variable declared `inherit` but not set in that shell is an error, reported
-before the task's session is created:
+before the task's session is created — unless your policy ignores the name, in
+which case it is dropped rather than looked up ([below](#policy)):
 
 ```console
 $ min task run deploy
@@ -136,6 +137,7 @@ an inherited variable there is still resolved against the daemon's
 environment — so prefer an explicit value for tasks meant to be run from
 inside a box.
 
+<a id="policy"></a>
 Every name a task declares — inherited or literal — is checked against the
 `[vars]` section of your `user_policy.toml` before its value is read:
 

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -131,11 +131,16 @@ error: task 'deploy' declares `env_vars.TOKEN = { inherit = true }`, but TOKEN
 is not set in this shell; export it before running the task
 ```
 
-This applies to `min task run` on the host. Running a declared task from
-*inside* a session (`min run <task>`) has no invoking client to read from, and
-an inherited variable there is still resolved against the daemon's
-environment — so prefer an explicit value for tasks meant to be run from
-inside a box.
+This applies to `min task run`. Two other ways of running a declared task
+still resolve `inherit` against the daemon's environment:
+
+- `min run <task>`, from *inside* a session, has no invoking client to read
+  from.
+- `min session run <session> <task>` runs against a session you already have,
+  over the attach transport, which forwards only `MINIMAL_SESSION_ID` and your
+  locale.
+
+So prefer an explicit value for tasks meant to be run either of those ways.
 
 <a id="policy"></a>
 Every name a task declares — inherited or literal — is checked against the

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -142,8 +142,7 @@ still resolve `inherit` against the daemon's environment:
 
 So prefer an explicit value for tasks meant to be run either of those ways.
 
-<a id="policy"></a>
-### Environment variables and your policy
+### Environment variables and your policy {#policy}
 
 Resolving on the client means reading *your* shell. A project's
 `minimal.toml` naming `env_vars.AWS_SECRET_ACCESS_KEY = { inherit = true }` is

--- a/docs/rust-coding-standards.md
+++ b/docs/rust-coding-standards.md
@@ -19,6 +19,7 @@ validating constructor and keeps the inner value unconstructable elsewhere.
 - `Cow<'_, str>` for sometimes-owned, sometimes-borrowed values.
 - Builder pattern for types with more than a couple of fields or any optional config. Owned style: pub fn with_x(mut self, x: T) -> Self, never &mut self -> &mut Self.
 - Cloning discipline. .clone() is fine for Arc/Rc and small Copy-ish types; cloning a String/Vec/HashMap to dodge the borrow checker means restructure or borrow instead.
+- Ordered collections when iteration order escapes. `BTreeMap`/`BTreeSet` over `HashMap`/`HashSet` for anything whose iteration reaches a sandbox, a serialized artifact, a hash, a diagnostic, or a prompt — hash order varies run to run, so the same declarations otherwise produce different output. Keys in this codebase are almost always `String` or another `Ord` newtype, so ordering costs nothing. `HashMap` stays right for pure lookup that is never iterated. Fix it at the type, not with a `sort()` at the use site: the sort has to be repeated at every consumer and silently rots when one is added. Sorting is also no defence where a *later* sort is stable and the hash order is what it faithfully preserves.
 - Captured-identifier formatting. format!("{path}") over format!("{}", path).
 - Display for users, Debug for developers. Don't reuse one for the other.
 - Generics / impl Trait over dyn Trait. Reach for dyn only for heterogeneous collections or when monomorphization causes real code bloat.


### PR DESCRIPTION
## Summary

A task declaring `env_vars.X = { inherit = true }` fails at spawn even when `X` is exported in the invoking shell:

```
$ export ZZ_TASK_TOKEN=task-value-123
$ min task run echotok
minimald: failed to spawn process: inheriting environment variable 'ZZ_TASK_TOKEN': environment variable not found
```

Both resolution sites read `std::env::var` — `crates/minimald/src/env.rs:459` and `crates/mctx/src/env.rs:666`. Reached from the task path, that is **the daemon's own environment**; on macOS the daemon is not even on the same side of the VM boundary as the shell that typed the command, so the user's `export` could never be visible to it.

`[session.vars]` uses identical syntax and works, because activation resolves it client-side before the value is shipped. The two paths diverged in the same project, in the same run — which is what made this look like a syntax problem rather than a placement one.

## Approach

Resolve a task's `env_vars` where the values actually exist.

`min task run` reads the task declaration it already loads for the declared-task check, resolves each entry against its own environment, and carries the results to the daemon as channel `env` requests under `MINIMAL_TASK_ENV_` — the same mechanism that already carries `MINIMAL_SESSION_ID` and `TRACEPARENT`. The exec dispatch strips the prefix and applies the values over the task's own declarations, so no `inherit` ever reaches the daemon-side resolver.

The prefix carries the variable's name and the SSH request carries its value, both verbatim, so nothing is escaped and any string a shell can export round-trips exactly — newlines, `=`, quotes, non-ASCII, empty.

A variable declared `inherit` but unset now fails **on the client**, naming the task and the variable:

```
error: task 'deploy' declares `env_vars.TOKEN = { inherit = true }`, but TOKEN
is not set in this shell; export it before running the task
```

rather than surfacing as a spawn failure after a session has already been built and uploaded.

## Scope and non-goals

- **Gated on the full `user_policy.toml [vars]` policy, `allow` included.** Every name a task declares goes through `VarsPolicy::check` with `Source::Project` provenance — the composer's own call, not a reimplementation, so the precedence cannot drift. `deny` fails the run naming the policy file; `ignore` removes the name from the task's declarations (a literal as much as an inherited one); `allow` carries it; anything else is referred to `PolicyHooks` — the interactive prompt on a terminal, `NoPromptHook` everywhere else, the same two lanes an activate already uses in this function.

  **The check runs before the lookup.** That ordering is the security property, not an implementation detail: a gate that resolved first and asked afterwards would already be holding the value. A test drives it with an env closure that panics if it is ever called for an unapproved name.

  Why `allow` applies, having first been argued away: client-side resolution reads *the user's own shell*. Before this PR, `env_vars.AWS_SECRET_ACCESS_KEY = { inherit = true }` resolved against the daemon's environment and got nothing; after it, the same line hands a project a real credential — the escalation is this change's own doing. The first cut skipped `allow` because routing project-declared names through it hard-fails a scripted `min task run` until each is allowlisted, but that is the mitigation working, not a defect in it. `[session.vars]` from the same `minimal.toml` has always passed the full gate under `Source::Project`; a task's `env_vars` were the inconsistency.
- **Per-project trust is not implemented.** An allowlisted name is allowed for every project, not only the one in front of you. A per-project trust concept — like the path allowlist that already gates project lifecycle hooks — would close that; left as follow-up rather than bolted on here.

  `allow` is deliberately **not** applied. A task's `env_vars` are declared in the project's own `minimal.toml` and named on the command line, and this path has no prompt — routing them through `allow` would hard-fail every scripted/CI `min task run` until each name were allowlisted, the exact case this change unblocks. `deny` and `ignore` carry no prompt leg, so they apply cleanly. An empty policy (a fresh install) is inert.

  The policy is read before `ensure_daemon`, alongside the declared-task and unset-inherit checks, so a denied variable fails with no session built. It replaces the later read that fed the loadout gating rather than adding a second one.
- **In-box `min run <task>` is unchanged.** It has no invoking client to read from, so it still resolves against the daemon. Documented in `docs/reference/tasks.md` as the remaining gap rather than left to surprise.
- **`min session run <session> <task>` is also unchanged.** Added by #1308 after this branch opened, it is a second client-side entry into `min://task/run`, but it routes through `session_via_ssh` rather than `open_session_exec_channel` and carries no resolved env. Same remaining gap as the in-box form.

## Rebased onto #1308

`main` landed #1308 (`fix(exec)!: tag exec-channel requests instead of sniffing the string`) while this was open, which rewrote the exact dispatch this change hooks into. Merged in `c5057be`:

- `minimald/src/exec.rs` — the `min task run` / `min package build` string-prefix arms this branch edited no longer exist. The resolved task env now hangs off `ExecRequest::TaskRun`, read after the empty-name guard and before the ack, feeding `TaskExec.env` exactly as before.
- `minimal/src/task.rs` — the exec command is the encoded `TaskRun` request rather than a formatted `min task run <task>` string; `task_env` rides alongside it.
- `minimal-client/src/lib.rs` — doc comment takes main's routing-contract wording and keeps the `task_env` paragraph, repointed at `ExecRequest::TaskRun`.
- `minimald-rpc/src/lib.rs` — both modules, `exec` and `taskenv`.

## Naming a dropped variable

An ignored name cannot be expressed by omission. The daemon applies the resolved values by **insertion** — it never removes — so a name it is not told about keeps whatever `minimal.toml` declared, and omission already means "an older client sent nothing, resolve it yourself". The first cut of the policy check `continue`d past an ignored name, which meant `ignore` did nothing at all: an ignored `{ inherit = true }` was still resolved daemon-side through `std::env::var` (the exact indirection this PR deletes), and an ignored literal was untouched. Caught in review, fixed in `0c6e0221`.

So the client names them. `minimald_rpc::taskenv` carries `TASK_ENV_DROP` — the matched names as a JSON array — alongside the values, paired in a `TaskEnv { set, drop }`; the daemon removes before it applies. `TASK_ENV_DROP` deliberately does **not** live under `TASK_ENV_PREFIX`: a name that started with it would be stripped by `from_channel_env` and handed to the task as a variable called `DROP`. A test pins that.

## Breaking change

`min task run` on a task whose `env_vars` name anything outside `[vars] allow` now prompts on a terminal, and fails without one. Scripted and CI callers must allowlist the names the task declares; the error prints the exact `[vars]` block to paste.

## Version skew

Inert in both directions. An older daemon accepts the env requests and ignores them; a newer daemon sees an empty set from an older client, and no drop list means remove nothing. Either way it falls back to resolving `inherit` itself — the pre-change behaviour. The additions are new channel env vars, so no wire contract is broken.

## Testing

- 5 new unit tests in `minimald-rpc::taskenv` — prefix round-trip, `MINIMAL_SESSION_ID`/`TRACEPARENT` not mistaken for task vars, absent set is empty rather than an error, verbatim values and prefixed names, empty values carried.
- 4 new unit tests in `minimal::task` — inherit resolves against the supplied client env, unset inherit fails client-side naming the fix, literals carried alongside inherited values, a task with no `env_vars` looks nothing up.
- 4 further unit tests in `minimald-rpc::taskenv` for the drop list — round-trip and non-collision with the value prefix, the carrier is not under `TASK_ENV_PREFIX`, an absent/empty/unparseable list removes nothing, names survive JSON verbatim.
- 3 unit tests in `minimal::task` for the gate — an unlisted name is referred to the hook rather than carried; an unapproved name's value is never read out of the shell (the env closure panics if called); an empty policy refers every declared name, so a fresh install carries nothing by default.
- 4 further unit tests in `minimal::task` for the policy check — a denied var fails naming the policy file and is never read out of the shell; deny beats ignore and applies to literals too; an ignored var is named on the drop list (not merely absent — the assertion that let the bug above through) and is never looked up, while its unignored siblings still resolve; and an echo task resolves to nothing whatever it declares.

Gates run on the pre-merge commit, on Linux:

| Gate | Result |
|---|---|
| `just fmt-check` | pass |
| `just clippy` (workspace, `--all-targets`, `-D warnings`) | pass |
| `cargo test --workspace` | pass — 1875 passed, 0 failed |
| `cargo test --workspace --doc` | pass — 13 passed, 0 failed |
| `cargo test --workspace -- --ignored` | 2 failures in `crates/checkouts` (`InvalidPath`), sandbox has no network; that crate depends on none of the crates touched here |
| `just deny` | not run — `cargo-deny` unavailable in that environment; no dependency was added, so the advisory/license surface is unchanged |

Re-run after the #1308 merge and the policy check, on macOS via `just test-cross` (aarch64-musl in Docker — the workspace does not build natively there):

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | pass |
| `cross clippy --workspace --exclude minvmd --all-targets -D warnings` | pass |
| `cross test --workspace --exclude minvmd` | 21 test binaries green, 0 failures, before the run was cut short by a local timeout — not a failure, but not a complete pass either. The full suite is left to CI. |

All five aggregators went green on `03bd8e24` — including `ci-macos-success` and the KVM `e2e`. That commit still had the broken `ignore`; no test caught it, which is what the strengthened assertion is for. `0c6e0221` is re-running.

For `0c6e0221`, verified locally on macOS: `cargo check` clean for `minimald-rpc`, `minimal-client`, and `minimal`'s lib; `cargo test -p minimald-rpc taskenv` — 9 passed, 0 failed; `cargo fmt --check` clean. The Linux-only test targets are left to CI.

Not run locally: `just e2e` / `just test-vm` (no hypervisor available). The daemon-side leg of this change is exercised by the session e2e in CI.

## Checklist

- [x] Docs updated if behavior changed
- [ ] `BREAKING CHANGE:` footer present if this is a breaking change

Refs: gominimal/inbox#585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task runs now apply configured allow, deny, and ignore policies to environment variables.
  * Allowed variables support literal and inherited shell values.
  * Ignored variables are removed before execution, including session-based runs.
  * Unlisted variables prompt interactively or fail clearly in non-interactive runs.
  * Session diagnostics now identify unavailable routing or proxy services.
  * Hook output is captured for improved visibility.
  * Echo tasks bypass environment resolution and policy checks.

* **Documentation**
  * Expanded guidance on environment-variable policy precedence, prompts, failures, and ignored variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



