### PR TITLE
chore(deps): update wide 1.6.0 -> 1.6.1 (1.6.0 is yanked)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8330,9 +8330,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
 dependencies = [
  "bytemuck",
  "safe_arch",


### PR DESCRIPTION
crates.io has yanked `wide` 1.6.0. This moves the lockfile to 1.6.1, the smallest available replacement.

1.6.1 satisfies `malachite-nz 0.9.2`'s `wide ^1.1.1` requirement, so the bump resolves in `Cargo.lock` alone — no manifest change, no source touched. The dependency reaches the tree as `wide <- malachite-nz <- malachite/malachite-float/malachite-q <- nickel-lang-core, nickel-lang-parser`.

```
 Cargo.lock | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

Produced with `cargo update -p wide --precise 1.6.1`. Not built locally — CI is the verification gate for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)