### PR TITLE
feat: if fish is set to a known and installed shell, start it instead of bash for new sessions

### DIFF
--- a/crates/minimald/src/env.rs
+++ b/crates/minimald/src/env.rs
@@ -560,6 +560,22 @@ impl Env {
         self.sandbox.new_container().map_err(sandbox_err_to_io)
     }
 
+    /// The assembled session rootfs on the daemon's filesystem.
+    ///
+    /// Exposed so the launcher can answer "is this shell installed in
+    /// this session" before it spawns one
+    /// ([`crate::session_shell::resolve`]) — the same question
+    /// [`install_min_helpers`] answers about directories it writes into.
+    /// Only meaningful once [`Env::build`] has returned: the rootfs is
+    /// what that assembles.
+    ///
+    /// Read only by the real `SandboxLauncher` (`cfg(not(test))`), which
+    /// the mock launcher stands in for under test.
+    #[cfg_attr(test, allow(dead_code))]
+    pub(crate) fn rootfs(&self) -> std::path::PathBuf {
+        self.sandbox.rootfs()
+    }
+
     /// Builds a command to run `program` inside the given container.
     pub fn command<I, S>(
         &mut self,

--- a/crates/minimald/src/lib.rs
+++ b/crates/minimald/src/lib.rs
@@ -17,6 +17,7 @@ pub mod server;
 mod session;
 mod session_delta;
 pub mod session_host;
+mod session_shell;
 pub mod session_sop;
 mod sessions;
 mod sftp;

--- a/crates/minimald/src/session_host.rs
+++ b/crates/minimald/src/session_host.rs
@@ -2304,6 +2304,20 @@ impl SessionLauncher for SandboxLauncher {
             composition_vars,
             attach_env.connection,
         );
+        // Which shell this attach starts is decided from the composed
+        // `SHELL` (see `crate::session_shell`). Read before `env_vars`
+        // moves into the env build; the rootfs it has to be checked
+        // against doesn't exist until that build has run.
+        let requested_shell = env_vars.get("SHELL").cloned();
+        // Whether anything composed a prompt. `sandbox2` sets a
+        // bash-syntax `PS1` as the session default, which a shell that
+        // doesn't speak those escapes prints literally — so a non-bash
+        // shell gets its own (see `ShellChoice::prompt`), but only when
+        // the user hasn't asked for a specific prompt themselves.
+        let composed_prompt = env_vars.contains_key("PS1");
+        // For the log line on the fallback path, which fires after
+        // `name` has moved into `EnvArgs`.
+        let session_label = name.clone();
         // Log every item that will (or would) end up in the session,
         // tagged with its provenance. Patches and lifecycle hooks are
         // included even though the launcher can't act on them yet —
@@ -2344,30 +2358,52 @@ impl SessionLauncher for SandboxLauncher {
             container.set_session_leader();
 
             let pty = Pty::open(sz).map_err(|e| io::Error::other(format!("pty open: {e}")))?;
-            // The `bash` package installs to `/usr/bin/bash` (--prefix=/usr) and
-            // the generic rootfs has no `/bin/bash`, so exec the absolute path
-            // that exists rather than `/bin/bash` (which fails with ENOENT).
-            // `--rcfile` rather than `-l`: this build of bash has no
-            // `/etc/bash.bashrc`, so the daemon's per-attach environment hook
-            // has no shell-owned integration point to live in and must be
-            // named on the argv — and bash consults `--rcfile` only for an
-            // interactive *non-login* shell. Nothing is lost: `--noprofile`
-            // already suppressed every file `-l` would have read, so the
-            // session shell read nothing before this and still reads nothing
-            // but the daemon's own rc (a user `~/.bashrc` stays unread).
-            // `-i` is explicit rather than inferred from the pty.
+            // The shell, and the argv it needs to reach the daemon's
+            // per-attach environment hook. Every program path here is
+            // absolute (`/usr/bin/<shell>`): packages install with
+            // `--prefix=/usr` and the generic rootfs has no `/bin`, so a
+            // bare name or a `/bin/…` path would fail with ENOENT.
+            let shell = crate::session_shell::resolve(requested_shell.as_deref(), &env.rootfs());
+            if let Some(notice) = &shell.fallback {
+                tracing::warn!(
+                    session = %session_label,
+                    requested = requested_shell.as_deref().unwrap_or_default(),
+                    "{notice}",
+                );
+                // Onto the pty's *slave* — that is the shell's stdout, so
+                // the line reaches the attached terminal ahead of the
+                // first prompt. Writing to the master would feed it to
+                // the shell as input instead. Best-effort: a session that
+                // comes up must not fail over a notice, and the log above
+                // has already recorded it. CRLF because this is a raw
+                // terminal write, not a line through the shell.
+                let written = pty.dup_slave_fd().and_then(|fd| {
+                    use std::io::Write as _;
+                    std::fs::File::from(fd).write_all(format!("minimal: {notice}\r\n").as_bytes())
+                });
+                if let Err(e) = written {
+                    tracing::debug!(error = %e, "could not print the shell notice to the terminal");
+                }
+            }
             let mut command = env
-                .command(
-                    &container,
-                    "/usr/bin/bash",
-                    [
-                        "--noprofile",
-                        "--rcfile",
-                        crate::env::ATTACH_ENV_BASH_RC,
-                        "-i",
-                    ],
-                )
+                .command(&container, &shell.program, shell.args.iter().copied())
                 .map_err(|e| io::Error::other(format!("build command: {e}")))?;
+            // Name the shell that is actually running. The composed
+            // value is a path on the machine the loadout was authored on
+            // (`/opt/homebrew/bin/fish`), which resolves to nothing
+            // in-session, and on the fallback path it names a shell that
+            // isn't the one at this prompt.
+            command.env("SHELL", &shell.program);
+            // The session default `PS1` is bash's, so a shell with its
+            // own prompt grammar needs the equivalent in that grammar —
+            // handed the bash one, zsh renders `\[\033[…\]\u@\h` as
+            // literal text. Skipped when the composition set `PS1`: that
+            // is the user's own prompt, in whatever syntax they meant.
+            if let Some(prompt) = shell.prompt
+                && !composed_prompt
+            {
+                command.env("PS1", prompt);
+            }
             command.stdin(hakoniwa::Stdio::from(pty.dup_slave_fd()?));
             command.stdout(hakoniwa::Stdio::from(pty.dup_slave_fd()?));
             let tty_path = pty.slave_path().to_path_buf();
@@ -3854,6 +3890,36 @@ mod tests {
         assert_eq!(env.get("TERM").map(String::as_str), Some("xterm-256color")); // connection > composition
         assert_eq!(env.get("EDITOR").map(String::as_str), Some("hx")); // composition-only survives
         assert_eq!(env.len(), 5);
+    }
+
+    /// A composed `SHELL` reaches the layered map, which is the input
+    /// the launcher hands [`crate::session_shell::resolve`] to pick the
+    /// shell it spawns. Nothing else sets the key — the sandbox's
+    /// `/usr/bin/bash` default lives a layer below this, inside
+    /// `sandbox2`'s `command_env` — so its absence here is exactly the
+    /// "no shell was asked for" case that keeps bash the default.
+    #[test]
+    fn a_composed_shell_reaches_the_layered_env() {
+        let sv = |k: &str, v: &str| (k.to_string(), v.to_string());
+        let without = layer_session_env(
+            session_baseline_env("box-1", None),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        assert_eq!(
+            without.get("SHELL"),
+            None,
+            "nothing but a composition may name the session's shell",
+        );
+
+        let with = layer_session_env(
+            session_baseline_env("box-1", None),
+            Vec::new(),
+            vec![sv("SHELL", "/usr/bin/fish")],
+            Vec::new(),
+        );
+        assert_eq!(with.get("SHELL").map(String::as_str), Some("/usr/bin/fish"));
     }
 
     /// The per-attach environment is written in each shell's own syntax, with

--- a/crates/minimald/src/session_shell.rs
+++ b/crates/minimald/src/session_shell.rs
@@ -1,0 +1,437 @@
+//! Which shell a session's interactive attach starts, and with what argv.
+//!
+//! A session's shell used to be bash, always. It is now whatever the
+//! composition's `SHELL` names — when that names one of the shells this
+//! daemon knows how to start *and* the session actually has it installed.
+//! Anything else falls back to bash, which every session has
+//! ([`crate::env`] force-adds it to the graph's top levels).
+//!
+//! `SHELL` is **declared, not sniffed**: it comes from a loadout's or a
+//! project's `[vars]`, through the composition and the launcher's env
+//! layering. Nothing here reads the environment of the terminal the
+//! client ran in.
+//!
+//! # Why a fixed table
+//!
+//! Each shell needs its own argv, because each reaches the daemon's
+//! per-attach `TERM` refresh a different way (see
+//! [`install_attach_env_hooks`](crate::env)): bash is pointed at the
+//! daemon's rc on the command line, zsh/fish/nushell find a hook the
+//! daemon dropped at their own vendor integration point, and the POSIX
+//! tier finds it through `$ENV`. A shell outside the table has no hook
+//! to reach, so starting it would produce a session whose `TERM` goes
+//! stale on re-attach — and the set is bounded anyway by the shell
+//! packages the registry ships.
+
+use std::path::Path;
+
+/// A shell this daemon can start, as named by `SHELL`'s file name.
+struct KnownShell {
+    /// The binary's name — the file name of the `SHELL` value, and the
+    /// name it is installed under in `/usr/bin`.
+    binary: &'static str,
+    /// The package that installs it. Not always the binary's name:
+    /// nushell installs `nu`, and `sh` is a symlink the `bash` package
+    /// ships. Used to tell the user what to install.
+    package: &'static str,
+    /// Argv after the program itself.
+    args: &'static [&'static str],
+    /// A `PS1` in *this shell's* prompt syntax, for shells that cannot
+    /// read the bash-syntax one `sandbox2` sets as the session default
+    /// (`crates/sandbox2/src/config.rs`). `None` means that default is
+    /// already right — bash's own, and `sh`'s, since `sh` is bash — or
+    /// that the shell ignores `PS1` altogether, as fish and nushell do.
+    ///
+    /// Only applied when nothing composed a `PS1`: a loadout that sets
+    /// its own prompt keeps it.
+    prompt: Option<&'static str>,
+}
+
+/// Every shell the daemon will start, keyed by binary name.
+///
+/// Deliberately closed. Kept in step with the two things that bound it:
+/// the shell packages the registry ships (`bash`, `zsh`, `fish`,
+/// `nushell` — `sh` rides along as a symlink from `bash`), and the
+/// attach-env hooks `crate::env::install_attach_env_hooks` installs.
+/// Growing one without the other leaves a shell that either can't be
+/// installed or can't refresh its terminal.
+const KNOWN_SHELLS: &[KnownShell] = &[
+    KnownShell {
+        binary: "bash",
+        package: "bash",
+        // `--rcfile` rather than `-l`: this build of bash has no
+        // `/etc/bash.bashrc`, so the daemon's per-attach environment
+        // hook has no shell-owned integration point to live in and must
+        // be named on the argv — and bash consults `--rcfile` only for
+        // an interactive *non-login* shell. `--noprofile` suppresses
+        // every file `-l` would have read, so a session bash reads
+        // nothing but the daemon's own rc (a user `~/.bashrc` stays
+        // unread, as it always has). `-i` is explicit rather than
+        // inferred from the pty.
+        args: &[
+            "--noprofile",
+            "--rcfile",
+            crate::env::ATTACH_ENV_BASH_RC,
+            "-i",
+        ],
+        // The session default is already bash's own syntax.
+        prompt: None,
+    },
+    KnownShell {
+        binary: "zsh",
+        package: "zsh",
+        // The hook lives in `/etc/zsh/zshrc`, which zsh reads for an
+        // interactive shell on its own. No `--no-rcs` here: unlike bash
+        // — whose rc suppression predates this and is preserved — a user
+        // who asks for zsh is asking for their zsh, `~/.zshrc` included.
+        args: &["-i"],
+        // zsh does not speak bash's `\[…\]`/`\u@\h` prompt escapes —
+        // handed the session default it prints them literally. Same
+        // prompt, zsh's syntax. A `~/.zshrc` that sets its own `PROMPT`
+        // still wins: it runs after this.
+        prompt: Some("%F{green}%n@%m%f:%F{blue}%~%f%# "),
+    },
+    KnownShell {
+        binary: "fish",
+        package: "fish",
+        // Hook: `usr/share/fish/vendor_conf.d/`, which fish reads itself.
+        args: &["-i"],
+        // fish builds its prompt from `fish_prompt`, never `PS1`.
+        prompt: None,
+    },
+    KnownShell {
+        binary: "nu",
+        package: "nushell",
+        // Hook: `usr/share/nushell/vendor/autoload/`. No `-i`: nushell
+        // has no such flag and is interactive when given no script.
+        args: &[],
+        // nushell builds its prompt from `PROMPT_COMMAND`-shaped config
+        // of its own, never `PS1`.
+        prompt: None,
+    },
+    KnownShell {
+        binary: "sh",
+        // The `bash` package ships `/usr/bin/sh` as a symlink to bash,
+        // so this is installed in every session — bash in POSIX mode.
+        package: "bash",
+        // Hook: `$ENV`, the one startup file POSIX defines, which the
+        // launcher baseline points at a daemon-owned file.
+        args: &["-i"],
+        // This is bash, so the bash-syntax session default applies:
+        // POSIX mode changes the grammar, not the prompt escapes.
+        prompt: None,
+    },
+];
+
+/// The shell started when `SHELL` names nothing usable. Always present:
+/// `crate::env` force-adds the `bash` package to every session.
+const DEFAULT_SHELL: &str = "bash";
+
+/// Where a session's binaries live. Packages build `--prefix=/usr`, and
+/// the generic rootfs has no `/bin`, so this is the only directory worth
+/// probing — the same rule
+/// [`sandbox2::Sandbox::command`] applies when it resolves a bare
+/// program name.
+const BIN_DIR: &str = "usr/bin";
+
+/// The shell to spawn for an interactive attach.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ShellChoice {
+    /// Absolute in-sandbox path of the shell binary.
+    pub(crate) program: String,
+    /// Argv after the program.
+    pub(crate) args: &'static [&'static str],
+    /// Set when `SHELL` asked for something else and this is bash
+    /// standing in: a ready-to-print sentence saying which shell was
+    /// asked for, why it wasn't started, and how to get it. `None` on
+    /// every path where the user got what they asked for — including
+    /// the common one where they asked for nothing.
+    pub(crate) fallback: Option<String>,
+    /// A `PS1` to set for this shell, when the session default would be
+    /// unreadable in it. See [`KnownShell::prompt`]; the caller applies
+    /// it only if nothing composed a `PS1` of its own.
+    pub(crate) prompt: Option<&'static str>,
+}
+
+impl ShellChoice {
+    /// The default: bash, exactly as sessions started before `SHELL` was
+    /// consulted at all.
+    fn bash(fallback: Option<String>) -> Self {
+        let bash = KNOWN_SHELLS
+            .iter()
+            .find(|s| s.binary == DEFAULT_SHELL)
+            .expect("the default shell is in the table");
+        Self {
+            program: format!("/{BIN_DIR}/{}", bash.binary),
+            args: bash.args,
+            fallback,
+            prompt: bash.prompt,
+        }
+    }
+}
+
+/// Resolve the shell to start from the session's composed `SHELL`.
+///
+/// `requested` is the value as written — typically an absolute path from
+/// the host the loadout was authored on (`/opt/homebrew/bin/fish`,
+/// `/run/current-system/sw/bin/zsh`). Only its file name is meaningful
+/// here: the path itself describes a filesystem the sandbox has never
+/// seen. `rootfs` is the assembled session rootfs, which is what makes
+/// "is it installed" answerable.
+pub(crate) fn resolve(requested: Option<&str>, rootfs: &Path) -> ShellChoice {
+    let Some(requested) = requested.map(str::trim).filter(|s| !s.is_empty()) else {
+        return ShellChoice::bash(None);
+    };
+
+    // A `SHELL` naming a directory (`/bin/`), a bare `..`, or a NUL is
+    // not a shell; treat it the way an unknown shell is treated rather
+    // than joining it onto a path.
+    let name = Path::new(requested)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .filter(|n| !n.contains('\0'))
+        .unwrap_or_default();
+
+    let Some(shell) = KNOWN_SHELLS.iter().find(|s| s.binary == name) else {
+        return ShellChoice::bash(Some(format!(
+            "SHELL names `{requested}`, which is not a shell minimal can start \
+             (bash, zsh, fish, nu, sh) — starting bash instead.",
+        )));
+    };
+
+    // `exists` follows symlinks on purpose: `/usr/bin/sh` is one, into
+    // the same directory's `bash`.
+    if !rootfs.join(BIN_DIR).join(shell.binary).exists() {
+        return ShellChoice::bash(Some(format!(
+            "SHELL names `{requested}`, which is not installed in this session — \
+             starting bash instead. Add it with: min add --session {}",
+            shell.package,
+        )));
+    }
+
+    ShellChoice {
+        program: format!("/{BIN_DIR}/{}", shell.binary),
+        args: shell.args,
+        fallback: None,
+        prompt: shell.prompt,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A rootfs carrying `bash` (which every session has) plus whichever
+    /// other shells a case needs. `sh` is a symlink into it, the way the
+    /// `bash` package ships it.
+    fn rootfs_with(shells: &[&str]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join(BIN_DIR);
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(bin.join("bash"), "").unwrap();
+        std::os::unix::fs::symlink("bash", bin.join("sh")).unwrap();
+        for shell in shells {
+            std::fs::write(bin.join(shell), "").unwrap();
+        }
+        tmp
+    }
+
+    /// The default path, unchanged from before `SHELL` was read: bash,
+    /// with the rc that carries the per-attach `TERM` hook, and no
+    /// notice to print.
+    #[test]
+    fn no_shell_var_starts_bash() {
+        let rootfs = rootfs_with(&[]);
+        let choice = resolve(None, rootfs.path());
+        assert_eq!(choice.program, "/usr/bin/bash");
+        assert_eq!(
+            choice.args,
+            [
+                "--noprofile",
+                "--rcfile",
+                crate::env::ATTACH_ENV_BASH_RC,
+                "-i"
+            ],
+        );
+        assert_eq!(choice.fallback, None);
+    }
+
+    /// An installed shell is started, with the argv its own attach-env
+    /// hook needs.
+    #[test]
+    fn an_installed_shell_is_started() {
+        let rootfs = rootfs_with(&["fish"]);
+        let choice = resolve(Some("/usr/bin/fish"), rootfs.path());
+        assert_eq!(choice.program, "/usr/bin/fish");
+        assert_eq!(choice.args, ["-i"]);
+        assert_eq!(choice.fallback, None);
+    }
+
+    /// Only the file name is read. A loadout is authored on a host, so
+    /// its `SHELL` names a path on *that* host — `/opt/homebrew/bin` and
+    /// the Nix store are the common shapes, and neither exists in a
+    /// session.
+    #[test]
+    fn a_host_path_resolves_by_its_file_name() {
+        let rootfs = rootfs_with(&["fish"]);
+        for requested in [
+            "/opt/homebrew/bin/fish",
+            "/run/current-system/sw/bin/fish",
+            "fish",
+        ] {
+            let choice = resolve(Some(requested), rootfs.path());
+            assert_eq!(choice.program, "/usr/bin/fish", "requested: {requested}");
+            assert_eq!(choice.fallback, None, "requested: {requested}");
+        }
+    }
+
+    /// `sh` resolves through the symlink the `bash` package ships, so it
+    /// needs no package of its own — and it is bash in POSIX mode, which
+    /// reaches the attach-env through `$ENV` rather than the rc.
+    #[test]
+    fn sh_resolves_through_the_symlink() {
+        let rootfs = rootfs_with(&[]);
+        let choice = resolve(Some("/bin/sh"), rootfs.path());
+        assert_eq!(choice.program, "/usr/bin/sh");
+        assert_eq!(choice.args, ["-i"]);
+        assert_eq!(choice.fallback, None);
+    }
+
+    /// A known shell that isn't installed falls back, and the notice
+    /// names the package to install rather than leaving the user to
+    /// guess.
+    #[test]
+    fn a_known_shell_that_is_absent_falls_back_naming_its_package() {
+        let rootfs = rootfs_with(&[]);
+        let choice = resolve(Some("/usr/bin/zsh"), rootfs.path());
+        assert_eq!(choice.program, "/usr/bin/bash");
+        let notice = choice.fallback.expect("an absent shell must be reported");
+        assert!(notice.contains("/usr/bin/zsh"), "got: {notice}");
+        assert!(notice.contains("min add --session zsh"), "got: {notice}");
+    }
+
+    /// The package name is not always the binary name: nushell installs
+    /// `nu`, so `min add --session nu` would fail. The notice has to
+    /// name the package.
+    #[test]
+    fn the_notice_names_the_package_not_the_binary() {
+        let rootfs = rootfs_with(&[]);
+        let notice = resolve(Some("nu"), rootfs.path())
+            .fallback
+            .expect("an absent shell must be reported");
+        assert!(
+            notice.contains("min add --session nushell"),
+            "got: {notice}"
+        );
+    }
+
+    /// Nushell takes no interactive flag — it is interactive when given
+    /// no script, and `-i` would be a parse error.
+    #[test]
+    fn nushell_is_started_with_no_args() {
+        let rootfs = rootfs_with(&["nu"]);
+        let choice = resolve(Some("/usr/bin/nu"), rootfs.path());
+        assert_eq!(choice.program, "/usr/bin/nu");
+        assert!(choice.args.is_empty());
+    }
+
+    /// A shell outside the table falls back even when a binary of that
+    /// name is sitting in the rootfs: without an attach-env hook its
+    /// `TERM` would go stale on every re-attach.
+    #[test]
+    fn an_unknown_shell_falls_back_even_when_present() {
+        let rootfs = rootfs_with(&["elvish"]);
+        let choice = resolve(Some("/usr/bin/elvish"), rootfs.path());
+        assert_eq!(choice.program, "/usr/bin/bash");
+        let notice = choice.fallback.expect("an unknown shell must be reported");
+        assert!(notice.contains("elvish"), "got: {notice}");
+        assert!(notice.contains("bash, zsh, fish, nu, sh"), "got: {notice}");
+    }
+
+    /// Values that name no file at all take the unknown-shell path
+    /// rather than reaching the filesystem.
+    #[test]
+    fn malformed_values_fall_back() {
+        let rootfs = rootfs_with(&[]);
+        for requested in ["", "   ", "/", "/bin/", ".."] {
+            let choice = resolve(Some(requested), rootfs.path());
+            assert_eq!(
+                choice.program, "/usr/bin/bash",
+                "`{requested}` should not start anything but bash",
+            );
+        }
+    }
+
+    /// zsh cannot read the bash-syntax `PS1` that `sandbox2` sets as the
+    /// session default — handed it, zsh prints the escapes as text
+    /// (`\[\033[01;32m\]\u@\h…` on the prompt line). It gets the same
+    /// prompt in its own grammar instead.
+    #[test]
+    fn zsh_gets_a_prompt_in_its_own_syntax() {
+        let rootfs = rootfs_with(&["zsh"]);
+        let prompt = resolve(Some("/usr/bin/zsh"), rootfs.path())
+            .prompt
+            .expect("zsh cannot use the bash-syntax default");
+        assert!(
+            !prompt.contains(r"\u") && !prompt.contains(r"\["),
+            "a zsh prompt must not carry bash escapes: {prompt}",
+        );
+        assert!(prompt.contains("%n@%m"), "got: {prompt}");
+    }
+
+    /// bash and `sh` are the same binary, and the session default is
+    /// already written in their syntax — neither may be handed an
+    /// override, or a user staring at bash would see a prompt this
+    /// module invented rather than the one the sandbox sets.
+    #[test]
+    fn bash_and_sh_keep_the_session_default_prompt() {
+        let rootfs = rootfs_with(&[]);
+        for requested in [None, Some("/usr/bin/bash"), Some("/bin/sh")] {
+            assert_eq!(
+                resolve(requested, rootfs.path()).prompt,
+                None,
+                "requested: {requested:?}",
+            );
+        }
+    }
+
+    /// fish and nushell build their prompts from their own config and
+    /// never read `PS1`, so there is nothing to override.
+    #[test]
+    fn shells_that_ignore_ps1_get_no_prompt() {
+        let rootfs = rootfs_with(&["fish", "nu"]);
+        for requested in ["fish", "nu"] {
+            assert_eq!(
+                resolve(Some(requested), rootfs.path()).prompt,
+                None,
+                "requested: {requested}",
+            );
+        }
+    }
+
+    /// Every entry has to be startable and reportable: a binary the
+    /// table can't find in `/usr/bin`, or a package name that isn't the
+    /// one `min add` takes, would surface as a broken session or a
+    /// misleading notice.
+    #[test]
+    fn the_table_is_self_consistent() {
+        let names: Vec<&str> = KNOWN_SHELLS.iter().map(|s| s.binary).collect();
+        assert!(
+            names.contains(&DEFAULT_SHELL),
+            "the fallback must be listed"
+        );
+        for shell in KNOWN_SHELLS {
+            assert!(!shell.binary.is_empty());
+            assert!(!shell.package.is_empty());
+            assert!(
+                !shell.binary.contains('/'),
+                "`{}` is joined onto a path and must be one component",
+                shell.binary,
+            );
+        }
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), names.len(), "duplicate binary in the table");
+    }
+}

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -103,7 +103,10 @@ $ min session attach my-session
 
 Attach opens an interactive shell inside the session, with your tools on `PATH`
 and the session's workspace (your project files, uploaded at activation) as your
-working directory. Exiting the shell detaches: the session keeps running in the
+working directory. That shell is bash unless a loadout asks for another one it
+has installed — set `SHELL` in `[vars]` to be dropped into zsh, fish, nushell,
+or POSIX `sh` instead ([reference](../reference/loadouts.md#session-shell)).
+Exiting the shell detaches: the session keeps running in the
 background, and `min session attach` rejoins it later. Changes you make inside stay in
 the session's workspace; bring them back to the host by pushing them out with
 `git push min://<session>`.

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -164,7 +164,7 @@ name  = "weird-thing"
 value = "x"
 ```
 
-### `patches` - Files copied from the host into the session
+### `patches` - Files copied from the host into the session {#patches}
 
 _Optional_
 
@@ -463,8 +463,10 @@ file means an empty policy; a fresh install activates fine without it.
 
 ## Vars in the attach shell
 
-The interactive shell minted by [`min session attach`](./cli-min.md#session-attach) is
-`bash --noprofile --rcfile <daemon rc> -i`. It sources **none** of your
+The interactive shell minted by [`min session attach`](./cli-min.md#session-attach)
+is bash unless a loadout says otherwise — see
+[`SHELL`](#session-shell) below. bash is started as
+`bash --noprofile --rcfile <daemon rc> -i`: it sources **none** of your
 startup files (not `/etc/profile`, `~/.bash_profile`, or `~/.bashrc`), so
 rc-file patches cannot influence it — the only rc it reads is the daemon's
 own, which installs the [attached terminal](#attached-terminal) hook and
@@ -499,6 +501,60 @@ i.e. through `[vars]`:
   Replacing `PROMPT_COMMAND` costs you nothing but the banner: the
   [attached terminal's](#attached-terminal) `TERM` is refreshed by a hook
   the daemon installs, not by this variable.
+
+### `SHELL` - Which shell an attach starts {#session-shell}
+
+Set `SHELL` in `[vars]` to be dropped into that shell instead of bash:
+
+```toml
+packages = ["fish"]
+
+[vars]
+SHELL = "/usr/bin/fish"
+```
+
+Only the file name is read, so a value carried over from your host
+(`/opt/homebrew/bin/fish`, a Nix store path) still works — the path
+itself names a filesystem the session does not have. Five shells are
+supported, each because the session can install it *and* the daemon ships
+it an [attached terminal](#attached-terminal) hook:
+
+| `SHELL` | Package to install |
+|---|---|
+| `bash` | `bash` (always present) |
+| `sh` | `bash` — it ships `sh` as a POSIX-mode symlink, so this needs nothing |
+| `zsh` | `zsh` |
+| `fish` | `fish` |
+| `nu` | `nushell` |
+
+Anything else starts bash and prints one line saying why. A shell from
+that table which the session hasn't installed is named along with the
+package that would supply it; a `SHELL` naming anything else is told
+which five shells there are to choose from. Nothing fails either way.
+
+This is the loadout's `SHELL`, not the `$SHELL` of the terminal you ran
+`min` from: a session is a declared environment, and the shell it hands
+you is part of the declaration.
+
+Three things worth knowing:
+
+- **bash is unchanged**, rc suppression included. Every other shell reads
+  its own startup files from the session home — which is where
+  [patches](#patches) land, so a patched-in `config.fish` or `.zshrc`
+  applies. That asymmetry is deliberate: bash's behaviour predates this
+  and stays as it was.
+- **The shell is chosen once**, at the attach that mints the session
+  shell, and that shell outlives later attaches. Changing `SHELL`
+  afterwards takes a new session.
+- **The stock prompt follows where it can.** The session default `PS1`
+  is written in bash's syntax, so zsh is given the same prompt in zsh's
+  syntax instead of printing `\u@\h` at you; fish and nushell build
+  their prompts from their own config and ignore `PS1` entirely. A `PS1`
+  you set in `[vars]` always wins, in whatever syntax you wrote it.
+- **The banner does not follow.** The orientation banner rides
+  `PROMPT_COMMAND`, which is bash's; a fish or nushell session simply
+  doesn't print it. `TERM` refresh *does* work in all five — that is what
+  the daemon's hooks are for.
 
 ### The attached terminal {#attached-terminal}
 

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -971,6 +971,88 @@ LOADOUT
   rm -f "$XDG_CONFIG_HOME/minimal/loadouts/patchmode.toml"
   echo "patch file modes proof OK (0755 runs, 0600 stays private)"
   echo "::endgroup::"
+
+  # -- The session shell -----------------------------------------------------
+  # A loadout's `SHELL` picks the shell the attach mints, when the session has
+  # it installed. Only an interactive attach can show this: `min session exec`
+  # runs `bash -c` through nsenter and never touches the session shell, so it
+  # would pass no matter what got spawned. Both cases below need no extra
+  # package — `sh` is a symlink the `bash` package ships, and `zsh` is the
+  # not-installed case precisely because nothing pulls it in.
+  #
+  # `$0` is the assertion, not `$SHELL`: it is the shell's own argv[0], so it
+  # reports the process that is actually running rather than a variable the
+  # daemon also sets. Wrapped in `printf` so the marker appears only in the
+  # OUTPUT — the pty echoes what we type, and a bare `echo` of the marker would
+  # match its own echo.
+  echo "::group::session shell from a loadout's SHELL"
+  mkdir -p "$XDG_CONFIG_HOME/minimal/loadouts"
+  printf 'description = "e2e session shell"\n\n[vars]\nSHELL = "/usr/bin/sh"\n' \
+    > "$XDG_CONFIG_HOME/minimal/loadouts/shelldev.toml"
+  # Not installed in this session, so this one must fall back to bash and say
+  # so on the terminal.
+  printf 'description = "e2e missing shell"\n\n[vars]\nSHELL = "/usr/bin/zsh"\n' \
+    > "$XDG_CONFIG_HOME/minimal/loadouts/shellmissing.toml"
+  HOOK_SEED_DIR="$(hook_mktemp /tmp/mnlsh.XXXXXX)"
+  hook_seed_preamble > "$HOOK_SEED_DIR/minimal.toml"
+  mkdir "$HOOK_SEED_DIR/.git"
+
+  sh_sid="$(cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt --loadout shelldev 2>"$WORK/shell-sh.err")" || {
+    echo "::error::activation with a SHELL-carrying loadout failed"
+    echo "--- stderr ---"; cat "$WORK/shell-sh.err" 2>/dev/null || true
+    fail
+  }
+  # shellcheck disable=SC2086 # E2E_MINIMAL_ARGS must word-split.
+  # shellcheck disable=SC2016 # `$0` must reach the SESSION's shell unexpanded.
+  sh_out="$(E2E_PTY_COMMANDS='printf "SESSION_SHELL_IS[%s]\n" "$0"
+exit' python3 "$ROOT/scripts/e2e-attach-pty.py" - \
+    min ${E2E_MINIMAL_ARGS:-} session attach "$sh_sid" \
+    2>"$WORK/shell-sh-attach.err")" || {
+    echo "::error::pty attach for the session-shell proof failed"
+    echo "--- transcript ---"; printf '%s\n' "$sh_out"
+    echo "--- stderr ---"; cat "$WORK/shell-sh-attach.err" 2>/dev/null || true
+    fail
+  }
+  if [[ "$sh_out" != *"SESSION_SHELL_IS[/usr/bin/sh]"* ]]; then
+    echo "::error::loadout SHELL=/usr/bin/sh did not become the session shell"
+    echo "--- transcript ---"; printf '%s\n' "$sh_out"
+    fail
+  fi
+  echo "declared shell OK (SHELL=/usr/bin/sh started sh, not bash)"
+
+  # The fallback: a shell that isn't installed leaves bash running AND tells
+  # the user why, on the terminal, before the first prompt.
+  miss_sid="$(cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt --loadout shellmissing 2>"$WORK/shell-missing.err")" || {
+    echo "::error::activation with an uninstalled SHELL failed"
+    echo "--- stderr ---"; cat "$WORK/shell-missing.err" 2>/dev/null || true
+    fail
+  }
+  # shellcheck disable=SC2086 # E2E_MINIMAL_ARGS must word-split.
+  # shellcheck disable=SC2016 # `$0` must reach the SESSION's shell unexpanded.
+  miss_out="$(E2E_PTY_COMMANDS='printf "SESSION_SHELL_IS[%s]\n" "$0"
+exit' python3 "$ROOT/scripts/e2e-attach-pty.py" - \
+    min ${E2E_MINIMAL_ARGS:-} session attach "$miss_sid" \
+    2>"$WORK/shell-missing-attach.err")" || {
+    echo "::error::pty attach for the shell-fallback proof failed"
+    echo "--- transcript ---"; printf '%s\n' "$miss_out"
+    echo "--- stderr ---"; cat "$WORK/shell-missing-attach.err" 2>/dev/null || true
+    fail
+  }
+  if [[ "$miss_out" != *"SESSION_SHELL_IS[/usr/bin/bash]"* ]]; then
+    echo "::error::an uninstalled SHELL did not fall back to bash"
+    echo "--- transcript ---"; printf '%s\n' "$miss_out"
+    fail
+  fi
+  if [[ "$miss_out" != *"min add --session zsh"* ]]; then
+    echo "::error::the fallback notice did not reach the terminal"
+    echo "--- transcript ---"; printf '%s\n' "$miss_out"
+    fail
+  fi
+  rm -rf "$HOOK_SEED_DIR"; HOOK_SEED_DIR=""
+  rm -f "$XDG_CONFIG_HOME/minimal/loadouts/shelldev.toml"
+  rm -f "$XDG_CONFIG_HOME/minimal/loadouts/shellmissing.toml"
+  echo "shell fallback proof OK (bash started, notice names the package)"
+  echo "::endgroup::"
 fi
 # ---------------------------------------------------------------------------
 # Session-sandbox proof (every lane). Everything above proves the lifecycle;


### PR DESCRIPTION
## Summary

  Attaching to a session always dropped you into bash. The only way to land
  somewhere else was a `PROMPT_COMMAND` that `exec`s another shell — a hack that
  fires per prompt, is a composed var the MOTD recipe's `unset` can eat, and runs
  after bash has already started.

  Setting `SHELL` in a loadout's `[vars]` now picks the shell the attach mints:

  ```toml
  packages = ["fish"]

  [vars]
  SHELL = "/usr/bin/fish"
```

  Five shells, each because the registry ships a package for it and the daemon
  already installs it an attach-env TERM hook: bash, sh, zsh, fish, nu.
  Only the file name of SHELL is read, so a value carried over from the host
  (/opt/homebrew/bin/fish, a Nix store path) resolves fine. Anything else — not
  installed, or not in the table — starts bash and prints one line saying so,
  naming the package to add. Nothing fails.

  The daemon was most of the way here already: it installs per-shell hooks for
  exactly these shells and publishes the attach-env in POSIX/fish/JSON form, with
  the reason in the code ("a session's shell is whatever the user runs, not only
  the bash the daemon spawns"). Only the spawn was still hardcoded.

  SHELL is declared, not sniffed — nothing reads the $SHELL of the terminal you
  ran min from. No client or wire change.

  Three things the docs now state plainly: bash keeps its existing rc suppression
  while other shells read their own startup files from the session home (where
  patches land — deliberate); the shell is chosen once, at the attach that mints
  it; and the orientation banner rides PROMPT_COMMAND, so a non-bash session
  doesn't print it (TERM refresh works in all five).

  Testing

  just fmt-check and just clippy clean. cargo test --workspace --locked --no-fail-fast — 1862 passed, 14 failed; all 14 are pre-existing
  vcs: invalid remote path failures in mctx/minimald env::tests from a
  poisoned checkout cache in my environment, confirmed by a control run with my
  changes stashed. 13 doctests pass.

  New coverage: 10 resolver unit tests over a fake rootfs (default bash with
  today's exact argv; installed shell + its argv; host paths resolved by file name;
  sh through the symlink the bash package ships; absent shell falls back with a
  notice naming the package — nushell, not nu; a present-but-unknown shell
  still falls back; malformed values; table self-consistency), plus a
  layer_session_env case pinning that a composed SHELL reaches the map.

  Not run: just e2e. A daemon won't start in my environment — a global git
  insteadOf rewrite makes checkouts::Repo::new reject the cached clone, the
  same root cause as the 14 unit failures. The two new e2e blocks (a SHELL=/usr/bin/sh
  loadout asserting $0 through a real pty attach, and an uninstalled zsh
  asserting bash + the notice) are bash -n-valid but unexecuted and need a run on
  a normal host before merge.

  Checklist

  - [x] Docs updated if behavior changed
  - [x] BREAKING CHANGE: footer present if this is a breaking change

  Docs touched: `reference/loadouts.md` (new `SHELL` section + the attach-shell opener) and `concepts/sessions.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive sessions now launch the shell selected through `SHELL`.
  * Supported shells include bash, sh, zsh, fish, and nushell, with shell-specific prompts and startup behavior.
  * Invalid or unavailable shells fall back to bash with installation guidance.
  * Improved session command handling, including task execution within existing sessions and reliable argument and exit-code forwarding.

* **Documentation**
  * Updated session and loadout guides with shell selection, requirements, fallback behavior, and prompt details.

* **Tests**
  * Expanded coverage for shell selection, fallback behavior, prompts, command routing, and task execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->