### PR TITLE
feat(containers): plumb container specs into graph, spechash gen, cache meta

### DIFF
--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -8,7 +8,7 @@
 #![allow(clippy::single_match)]
 
 use common::{SpecOrigin, Target};
-use decode::Stack;
+use decode::{Container, Stack};
 use nickel_lang_core::term::IndexMap;
 
 use generational_arena::Arena;
@@ -18,7 +18,7 @@ use std::sync::{Arc, RwLock};
 use crate::BuildSpecRef;
 use crate::builds::*;
 use crate::spec_hasher::SubsetHasher;
-use crate::{Error, SpecHash, SpecHasher};
+use crate::{ContainerHasher, Error, SpecHash, SpecHasher};
 
 /// Describes a match between a search term and a package.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -88,6 +88,13 @@ pub struct Graph {
     /// stack with a stable sort that preserves the iteration order for ties.
     pub(crate) stacks: BTreeMap<String, Stack>,
 
+    /// Container specs by name.
+    ///
+    /// Ordered by name for the same reason as [`Self::stacks`]: `iter_containers`
+    /// feeds the wire writers, so hash order would make the serialised bytes
+    /// differ run to run for the same graph.
+    pub(crate) containers: BTreeMap<String, Container>,
+
     /// Indexes build-specs by name.
     pub(crate) by_name: HashMap<String, BuildSpecRef>,
 
@@ -122,6 +129,7 @@ impl Graph {
             by_name: HashMap::with_capacity(2048),
             top_levels: Vec::new(),
             stacks: BTreeMap::new(),
+            containers: BTreeMap::new(),
             supply_chain: Vec::with_capacity(6),
             target: Target::host(),
             hash_cache: Arc::new(RwLock::new((
@@ -285,6 +293,21 @@ impl Graph {
     /// Returns an iterator over all stacks configured in the graph.
     pub fn iter_stacks(&self) -> impl Iterator<Item = (&String, &Stack)> {
         self.stacks.iter()
+    }
+
+    /// Returns an iterator over all containers configured in the graph.
+    pub fn iter_containers(&self) -> impl Iterator<Item = (&String, &Container)> {
+        self.containers.iter()
+    }
+
+    /// Returns the container declared under `name`, if any.
+    pub fn container<S: AsRef<str>>(&self, name: S) -> Option<&Container> {
+        self.containers.get(name.as_ref())
+    }
+
+    /// Returns the specification hash of the given container.
+    pub fn container_hash(&self, container: &Container) -> Result<SpecHash, Error> {
+        ContainerHasher::hash(self, container)
     }
 
     /// Returns a list of [BuildSpecRef] objects who's names matched the given search term.
@@ -458,6 +481,7 @@ impl Graph {
         builds: Arena<BuildSpec>,
         top_levels: Vec<BuildSpecRef>,
         stacks: BTreeMap<String, Stack>,
+        containers: BTreeMap<String, Container>,
         by_name: HashMap<String, BuildSpecRef>,
         supply_chain: Vec<SpecOrigin>,
         target: Target,
@@ -466,6 +490,7 @@ impl Graph {
             builds,
             top_levels,
             stacks,
+            containers,
             by_name,
             supply_chain,
             target,

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -29,6 +29,8 @@ pub enum Error {
     ConflictingProfile { name: String },
     /// A stack has the same name as a stack in a higher layer.
     ConflictingStack { name: String },
+    /// A container has the same name as a container in a higher layer.
+    ConflictingContainer { name: String },
     /// A package with a certain name was requested, but not found in the graph.
     NoSuchPkg { name: String },
     /// Failed to load the source code for an upstream.
@@ -69,6 +71,9 @@ impl Error {
             .unwrap(),
             Error::ConflictingStack { name } => {
                 writeln!(writer, "Error: stack '{}' already exists", name,).unwrap()
+            }
+            Error::ConflictingContainer { name } => {
+                writeln!(writer, "Error: container '{}' already exists", name,).unwrap()
             }
             Error::ConflictingPackage { from, .. } => {
                 writeln!(writer, "Error: package '{}' already exists", from.1,).unwrap()
@@ -202,7 +207,7 @@ pub use loader::{ChainLoader, LayerCache, LayerCacheDir, SourceProvider};
 pub mod wire;
 
 mod spec_hasher;
-pub use spec_hasher::SpecHasher;
+pub use spec_hasher::{ContainerHasher, SpecHasher};
 
 mod planner;
 pub use planner::Dep as PlannerDep;

--- a/crates/graph/src/loader.rs
+++ b/crates/graph/src/loader.rs
@@ -669,6 +669,22 @@ impl Graph {
             slf.stacks.insert(name, stack);
         }
 
+        // Load containers
+        for (name, container) in loader.from.containers {
+            // Verify all packages exist
+            for pkg in &container.packages {
+                if slf.by_name(pkg).is_none() {
+                    return Err(Error::NoSuchPkg { name: pkg.clone() });
+                }
+            }
+
+            if slf.containers.contains_key(&name) {
+                // Its illegal to shadow a container of the same name from upstream.
+                return Err(Error::ConflictingContainer { name });
+            }
+            slf.containers.insert(name, container);
+        }
+
         Ok(slf)
     }
 }
@@ -824,6 +840,89 @@ mod tests {
                 .map(|(name, _)| name.clone())
                 .collect::<Vec<_>>(),
             vec!["go".to_string(), "python".to_string(), "rust".to_string()],
+        );
+    }
+
+    #[test]
+    fn ingest_container() {
+        let layer = Layer::new_for_test(
+            indoc! {
+                "
+                let {build, layer, container, ..} = import \"minimal.ncl\" in
+
+                layer {
+                  builds = [
+                    build {
+                        name = \"beepboop\",
+                        build_deps = [],
+                        cmd = \"\",
+                    }
+                  ],
+                  containers = [
+                    container {
+                      name = \"container1\",
+                      packages = [\"beepboop\"],
+                    }
+                  ],
+                }
+                "
+            }
+            .to_string(),
+        )
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("spec parsing failed");
+        });
+
+        let dp = Graph::new().ingest(layer).unwrap();
+        assert_eq!(
+            dp.containers.get("container1"),
+            Some(&decode::Container {
+                name: "container1".to_string(),
+                packages: vec!["beepboop".to_string()],
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn iter_containers_yields_name_order() {
+        // The wire writers serialise containers in `iter_containers` order, so
+        // hash order would make the bytes for one graph differ between runs.
+        let layer = Layer::new_for_test(
+            indoc! {
+                "
+                let {build, layer, container, ..} = import \"minimal.ncl\" in
+
+                layer {
+                  builds = [
+                    build {
+                        name = \"beepboop\",
+                        build_deps = [],
+                        cmd = \"\",
+                    }
+                  ],
+                  containers = [
+                    container { name = \"web\", packages = [\"beepboop\"] },
+                    container { name = \"api\", packages = [\"beepboop\"] },
+                    container { name = \"jobs\", packages = [\"beepboop\"] },
+                  ],
+                }
+                "
+            }
+            .to_string(),
+        )
+        .unwrap_or_else(|e| {
+            e.report_to_stderr();
+            panic!("spec parsing failed");
+        });
+
+        let dp = Graph::new().ingest(layer).unwrap();
+        assert_eq!(
+            dp.iter_containers()
+                .map(|(name, _)| name.clone())
+                .collect::<Vec<_>>(),
+            vec!["api".to_string(), "jobs".to_string(), "web".to_string()],
         );
     }
 

--- a/crates/graph/src/spec_hasher.rs
+++ b/crates/graph/src/spec_hasher.rs
@@ -1,9 +1,10 @@
 use crate::{
-    BuildDep, BuildOutput, BuildSpec, BuildSpecRef, Graph, RuntimeDep, SourceFetch, SpecHash,
+    BuildDep, BuildOutput, BuildSpec, BuildSpecRef, Error, Graph, RuntimeDep, SourceFetch, SpecHash,
 };
 use blake3::Hasher;
 use common::{SubsetSpec, Target, target};
-use decode::AttrValue;
+use decode::{AttrValue, Container};
+use nickel_lang_core::term::IndexMap;
 use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::io::Write;
@@ -418,6 +419,174 @@ impl SubsetHasher {
     }
 }
 
+/// Computes the [SpecHash] for a container.
+///
+/// A container is a declaration *over* packages rather than a build of its own,
+/// so its hash combines two things: the packages it embeds, hashed **by
+/// content** (their [SpecHash], not their name — an image must change when what
+/// goes into it changes), and every field of the image config it declares.
+///
+/// A package's own [SpecHash] already covers its transitive runtime closure, so
+/// the closure needs no separate walk here.
+pub struct ContainerHasher;
+
+impl ContainerHasher {
+    /// Computes the [SpecHash] of `container` against the packages in `graph`.
+    ///
+    /// The [`SpecEncoder`] chosen here is the whole surface a future hash epoch
+    /// touches for containers.
+    ///
+    /// Returns [`Error::NoSuchPkg`] if a named package is not in the graph.
+    pub fn hash(graph: &Graph, container: &Container) -> Result<SpecHash, Error> {
+        let mut enc = LegacyEncoder::new();
+        Self::encode(graph, container, &mut enc)?;
+        Ok(enc.finish())
+    }
+
+    /// The encoding pass, generic over the encoder for the same reason
+    /// [`SpecHasher::encode`] is: the hash *format* is the encoder's choice.
+    fn encode<E: SpecEncoder>(
+        graph: &Graph,
+        container: &Container,
+        enc: &mut E,
+    ) -> Result<(), Error> {
+        // Destructured exhaustively on purpose: a field added to Container
+        // fails to compile here rather than silently falling out of the hash.
+        let Container {
+            name,
+            packages,
+            entrypoint,
+            cmd,
+            arch,
+            working_dir,
+            env_vars,
+            exposed_ports,
+            volumes,
+            user,
+            stop_signal,
+            labels,
+            config,
+        } = container;
+
+        enc.tag(b"container");
+        enc.bytes(name.as_bytes());
+
+        // Packages enter as a set of *content* hashes: an image must change
+        // when what goes into it changes, but not when the same packages are
+        // listed in a different order, or listed twice.
+        enc.tag(b"-packages");
+        let mut package_hashes = Vec::with_capacity(packages.len());
+        for pkg in packages {
+            let bsr = graph.by_name(pkg).ok_or_else(|| Error::NoSuchPkg {
+                name: pkg.to_string(),
+            })?;
+            package_hashes.push(graph.spec_hash(bsr));
+        }
+        package_hashes.sort_unstable();
+        package_hashes.dedup();
+        enc.index(package_hashes.len());
+        for hash in &package_hashes {
+            enc.bytes(hash.as_bytes());
+        }
+
+        enc.tag(b"-entrypoint");
+        encode_opt_argv(entrypoint.as_deref(), enc);
+        enc.tag(b"-cmd");
+        encode_opt_argv(cmd.as_deref(), enc);
+
+        enc.tag(b"-arch");
+        encode_opt_bytes(arch.as_ref().map(|a| a.as_nickel_str()), enc);
+        enc.tag(b"-working_dir");
+        encode_opt_bytes(working_dir.as_deref(), enc);
+        enc.tag(b"-user");
+        encode_opt_bytes(user.as_deref(), enc);
+        enc.tag(b"-stop_signal");
+        encode_opt_bytes(stop_signal.as_deref(), enc);
+
+        enc.tag(b"-env_vars");
+        encode_string_map(env_vars, enc);
+
+        // Both become keys of a JSON object in the image config, so both are
+        // sets: `ExposedPorts` keyed `"80/tcp"`, and `Volumes` keyed by path.
+        enc.tag(b"-exposed_ports");
+        encode_string_set(
+            exposed_ports
+                .iter()
+                .map(|p| format!("{}/{}", p.port, p.proto))
+                .collect(),
+            enc,
+        );
+
+        enc.tag(b"-volumes");
+        encode_string_set(volumes.iter().map(String::as_str).collect(), enc);
+
+        enc.tag(b"-labels");
+        encode_string_map(labels, enc);
+        enc.tag(b"-config");
+        encode_string_map(config, enc);
+
+        Ok(())
+    }
+}
+
+/// An absent optional field carries a marker rather than being skipped:
+/// skipping is what lets "unset" alias "set to the next field's value".
+fn encode_opt_bytes<E: SpecEncoder>(value: Option<&str>, enc: &mut E) {
+    match value {
+        Some(v) => {
+            enc.tag(b"some");
+            enc.bytes(v.as_bytes());
+        }
+        None => enc.tag(b"none"),
+    }
+}
+
+fn encode_opt_argv<E: SpecEncoder>(argv: Option<&[String]>, enc: &mut E) {
+    match argv {
+        Some(argv) => {
+            enc.tag(b"some");
+            enc.index(argv.len());
+            for arg in argv {
+                enc.bytes(arg.as_bytes());
+            }
+        }
+        None => enc.tag(b"none"),
+    }
+}
+
+/// Length-prefixed and sorted by key, so the declaration order of a map that
+/// becomes an unordered image-config object does not reach the hash — see
+/// [`ContainerHasher`]. Keys are unique within an [`IndexMap`], so the sort is
+/// total and needs no dedup.
+///
+/// The `k`/`v` markers are the legacy scheme's idiom for maps, matching
+/// `build_attrs_hash`'s `build_args` encoding: without them `{AB: "C"}` and
+/// `{A: "BC"}` are the same bytes.
+fn encode_string_map<E: SpecEncoder>(map: &IndexMap<String, String>, enc: &mut E) {
+    let mut entries: Vec<(&String, &String)> = map.iter().collect();
+    entries.sort_unstable_by_key(|(key, _)| *key);
+
+    enc.index(entries.len());
+    for (key, value) in entries {
+        enc.tag(b"k");
+        enc.bytes(key.as_bytes());
+        enc.tag(b"v");
+        enc.bytes(value.as_bytes());
+    }
+}
+
+/// Length-prefixed, sorted, and deduplicated: the collection describes a set in
+/// the image config, so neither order nor a repeat says anything.
+fn encode_string_set<E: SpecEncoder, S: AsRef<str> + Ord>(mut values: Vec<S>, enc: &mut E) {
+    values.sort_unstable();
+    values.dedup();
+
+    enc.index(values.len());
+    for value in &values {
+        enc.bytes(value.as_ref().as_bytes());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -688,5 +857,326 @@ mod tests {
             SpecHash::from_hex("c5c005aebf5871b30387126e5052e48206f19112fb9d2c5127c5303195726780")
                 .unwrap(),
         );
+    }
+
+    // ── Container hashing ────────────────────────────────────────────────────
+
+    /// A graph with two packages plus a container that embeds both, with every
+    /// image-config field set — the shape the golden hash below pins.
+    fn container_fixture() -> (Graph, Container) {
+        use decode::{ExposedPort, ExposedPortProto};
+
+        let mut g = Graph::new();
+        g.insert_build(BuildSpec {
+            name: "glibc".into(),
+            cmds: vec![vec!["make".into()]],
+            ..Default::default()
+        });
+        g.insert_build(BuildSpec {
+            name: "nginx".into(),
+            cmds: vec![vec!["configure".into()]],
+            ..Default::default()
+        });
+
+        let container = Container {
+            name: "web".into(),
+            packages: vec!["glibc".into(), "nginx".into()],
+            entrypoint: Some(vec!["/usr/bin/nginx".into(), "-g".into()]),
+            cmd: Some(vec!["-c".into(), "/etc/nginx/nginx.conf".into()]),
+            arch: Some(target::Arch::Amd64),
+            working_dir: Some("/srv".into()),
+            env_vars: IndexMap::from_iter([("PORT".to_string(), "8080".to_string())]),
+            exposed_ports: vec![
+                ExposedPort {
+                    proto: ExposedPortProto::Tcp,
+                    port: 80,
+                },
+                ExposedPort {
+                    proto: ExposedPortProto::Udp,
+                    port: 443,
+                },
+            ],
+            volumes: vec!["/var/lib/nginx".into()],
+            user: Some("nginx".into()),
+            stop_signal: Some("SIGQUIT".into()),
+            labels: IndexMap::from_iter([(
+                "org.opencontainers.image.title".to_string(),
+                "web".to_string(),
+            )]),
+            config: IndexMap::from_iter([("StopTimeout".to_string(), "30".to_string())]),
+        };
+        (g, container)
+    }
+
+    /// Golden hash. Built in Rust rather than Nickel, so it is stable across
+    /// architectures — see [`representative_spec`].
+    #[test]
+    fn container_hash() {
+        let (g, c) = container_fixture();
+
+        // println!("{}", ContainerHasher::hash(&g, &c).unwrap().0.to_hex());
+        assert_eq!(
+            ContainerHasher::hash(&g, &c).unwrap(),
+            SpecHash::from_hex("ddaa6e2ea3b3921d2c977bb6ff34597a762de4686503c1bb2020fd42a66f87dc")
+                .unwrap(),
+        );
+    }
+
+    /// The point of hashing packages by [SpecHash] rather than by name: an
+    /// image must change when what goes into it changes, even though the
+    /// container declaration is untouched.
+    #[test]
+    fn container_hash_tracks_package_contents() {
+        let (g, c) = container_fixture();
+        let before = ContainerHasher::hash(&g, &c).unwrap();
+
+        let mut g2 = Graph::new();
+        g2.insert_build(BuildSpec {
+            name: "glibc".into(),
+            cmds: vec![vec!["make".into()]],
+            ..Default::default()
+        });
+        g2.insert_build(BuildSpec {
+            name: "nginx".into(),
+            // The one difference: nginx builds with a different command.
+            cmds: vec![vec!["configure".into(), "--with-http_v3_module".into()]],
+            ..Default::default()
+        });
+
+        assert_ne!(
+            before,
+            ContainerHasher::hash(&g2, &c).unwrap(),
+            "a package rebuild must change the hash of the image embedding it"
+        );
+    }
+
+    /// The `k`/`v` markers and the list-length prefixes earn their keep: without
+    /// them the legacy scheme's raw concatenation hashes both of these pairs
+    /// identically.
+    #[test]
+    fn container_hash_separates_string_boundaries() {
+        let (g, base) = container_fixture();
+
+        let ab_c = Container {
+            env_vars: IndexMap::from_iter([("AB".to_string(), "C".to_string())]),
+            ..base.clone()
+        };
+        let a_bc = Container {
+            env_vars: IndexMap::from_iter([("A".to_string(), "BC".to_string())]),
+            ..base.clone()
+        };
+        assert_ne!(
+            ContainerHasher::hash(&g, &ab_c).unwrap(),
+            ContainerHasher::hash(&g, &a_bc).unwrap(),
+            "key/value boundary must be part of the hash"
+        );
+
+        // Same property across a list's element boundaries.
+        let split = Container {
+            volumes: vec!["/a".into(), "/b".into()],
+            ..base.clone()
+        };
+        let joined = Container {
+            volumes: vec!["/a/b".into()],
+            ..base
+        };
+        assert_ne!(
+            ContainerHasher::hash(&g, &split).unwrap(),
+            ContainerHasher::hash(&g, &joined).unwrap(),
+            "element boundaries must be part of the hash"
+        );
+    }
+
+    /// What the `k`/`v` markers do *not* fix, pinned so the state of play is
+    /// visible rather than folklore: they are in-band, so content containing a
+    /// marker still aliases. `Av` + `B` and `A` + `vB` both encode to `kAvvB`.
+    ///
+    /// This is inherited from the legacy scheme, not specific to containers.
+    /// **Flip this to `assert_ne!` when the injective encoder lands** — it is
+    /// the executable form of that migration's success criterion.
+    #[test]
+    fn container_hash_marker_aliasing_is_a_known_legacy_gap() {
+        let (g, base) = container_fixture();
+
+        let key_holds_marker = Container {
+            env_vars: IndexMap::from_iter([("Av".to_string(), "B".to_string())]),
+            ..base.clone()
+        };
+        let value_holds_marker = Container {
+            env_vars: IndexMap::from_iter([("A".to_string(), "vB".to_string())]),
+            ..base
+        };
+
+        assert_eq!(
+            ContainerHasher::hash(&g, &key_holds_marker).unwrap(),
+            ContainerHasher::hash(&g, &value_holds_marker).unwrap(),
+            "if this now differs, the encoder gained framing: flip to assert_ne"
+        );
+    }
+
+    /// An unset field must not hash like a set-but-empty one — the reason
+    /// optional fields carry a present/absent marker instead of being skipped.
+    #[test]
+    fn container_hash_distinguishes_absent_from_empty() {
+        let (g, base) = container_fixture();
+
+        let unset = Container {
+            user: None,
+            cmd: None,
+            ..base.clone()
+        };
+        let empty = Container {
+            user: Some(String::new()),
+            cmd: Some(Vec::new()),
+            ..base
+        };
+        assert_ne!(
+            ContainerHasher::hash(&g, &unset).unwrap(),
+            ContainerHasher::hash(&g, &empty).unwrap(),
+        );
+    }
+
+    /// Collections that become unordered image-config objects are hashed as
+    /// sets: reordering a declaration describes the same image and must reach
+    /// the same cache entry.
+    #[test]
+    fn container_hash_ignores_collection_order() {
+        use decode::{ExposedPort, ExposedPortProto};
+
+        let (g, base) = container_fixture();
+        let baseline = ContainerHasher::hash(&g, &base).unwrap();
+
+        let reordered = Container {
+            packages: vec!["nginx".into(), "glibc".into()],
+            exposed_ports: vec![
+                ExposedPort {
+                    proto: ExposedPortProto::Udp,
+                    port: 443,
+                },
+                ExposedPort {
+                    proto: ExposedPortProto::Tcp,
+                    port: 80,
+                },
+            ],
+            ..base.clone()
+        };
+        assert_eq!(
+            baseline,
+            ContainerHasher::hash(&g, &reordered).unwrap(),
+            "packages and ports are sets, not sequences"
+        );
+
+        // Maps, over more than one entry so the order can actually differ.
+        let pairs = [
+            ("A".to_string(), "1".to_string()),
+            ("B".to_string(), "2".to_string()),
+        ];
+        let reversed: Vec<_> = pairs.iter().rev().cloned().collect();
+        let declared = Container {
+            env_vars: IndexMap::from_iter(pairs.clone()),
+            labels: IndexMap::from_iter(pairs.clone()),
+            config: IndexMap::from_iter(pairs),
+            ..base.clone()
+        };
+        let declared_reversed = Container {
+            env_vars: IndexMap::from_iter(reversed.clone()),
+            labels: IndexMap::from_iter(reversed.clone()),
+            config: IndexMap::from_iter(reversed),
+            ..base.clone()
+        };
+        assert_eq!(
+            ContainerHasher::hash(&g, &declared).unwrap(),
+            ContainerHasher::hash(&g, &declared_reversed).unwrap(),
+            "env_vars, labels and config are unordered in an image config"
+        );
+
+        // But argv order is argv's whole meaning.
+        let flipped_argv = Container {
+            cmd: Some(vec!["/etc/nginx/nginx.conf".into(), "-c".into()]),
+            ..base
+        };
+        assert_ne!(
+            baseline,
+            ContainerHasher::hash(&g, &flipped_argv).unwrap(),
+            "cmd is a sequence"
+        );
+    }
+
+    /// Naming a package twice adds nothing to an image, so it must not change
+    /// the hash — the set is deduplicated, not merely sorted.
+    #[test]
+    fn container_hash_ignores_duplicate_set_entries() {
+        let (g, base) = container_fixture();
+        let baseline = ContainerHasher::hash(&g, &base).unwrap();
+
+        let with_repeats = Container {
+            packages: vec!["glibc".into(), "nginx".into(), "glibc".into()],
+            volumes: vec!["/var/lib/nginx".into(), "/var/lib/nginx".into()],
+            ..base
+        };
+        assert_eq!(baseline, ContainerHasher::hash(&g, &with_repeats).unwrap());
+    }
+
+    /// Sorting must not blur *which* values are present: a set that ignores
+    /// order still distinguishes contents.
+    #[test]
+    fn container_hash_tracks_set_membership() {
+        let (g, base) = container_fixture();
+        let baseline = ContainerHasher::hash(&g, &base).unwrap();
+
+        let dropped_package = Container {
+            packages: vec!["glibc".into()],
+            ..base.clone()
+        };
+        assert_ne!(
+            baseline,
+            ContainerHasher::hash(&g, &dropped_package).unwrap()
+        );
+
+        let extra_env = Container {
+            env_vars: IndexMap::from_iter([
+                ("PORT".to_string(), "8080".to_string()),
+                ("TZ".to_string(), "UTC".to_string()),
+            ]),
+            ..base
+        };
+        assert_ne!(baseline, ContainerHasher::hash(&g, &extra_env).unwrap());
+    }
+
+    /// A graph decoded off the wire carries whatever containers the peer sent,
+    /// with no package validation — so this is an error, not a panic.
+    #[test]
+    fn container_hash_rejects_unknown_package() {
+        let (g, base) = container_fixture();
+        let c = Container {
+            packages: vec!["glibc".into(), "not-in-this-graph".into()],
+            ..base
+        };
+
+        let err = ContainerHasher::hash(&g, &c).unwrap_err();
+        assert!(
+            matches!(err, Error::NoSuchPkg { ref name } if name == "not-in-this-graph"),
+            "got {err:?}"
+        );
+    }
+
+    /// The leading `container` tag keeps the keyspace disjoint from the build
+    /// specs' (which open with a discovery index) and subsets' (`subset`): a
+    /// container whose only content is one package must not hash like that
+    /// package.
+    #[test]
+    fn container_hash_does_not_alias_spec_hash() {
+        let mut g = Graph::new();
+        let pkg = g.insert_build(BuildSpec {
+            name: "solo".into(),
+            ..Default::default()
+        });
+        let c = Container {
+            name: "solo".into(),
+            packages: vec!["solo".into()],
+            ..Default::default()
+        };
+
+        assert_ne!(ContainerHasher::hash(&g, &c).unwrap(), g.spec_hash(&pkg));
     }
 }

--- a/crates/graph/src/wire.rs
+++ b/crates/graph/src/wire.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{BuildDep, BuildSpec, BuildSpecRef, Graph, RuntimeDep, SubsetInput};
 use common::SpecOrigin;
-use decode::Stack;
+use decode::{Container, Stack};
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -35,6 +35,7 @@ const TAG_TOP_LEVELS: u8 = 0x04;
 const TAG_PROFILE: u8 = 0x05; // profiles were removed, tag is ignored
 const TAG_STACK: u8 = 0x06;
 const TAG_SUPPLY_CHAIN: u8 = 0x07;
+const TAG_CONTAINER: u8 = 0x08;
 const TAG_FOOTER: u8 = 0xFF;
 
 /// Upper bound on a single framed record's payload length. A malformed stream
@@ -221,6 +222,12 @@ struct StackRecord {
     stack: Stack,
 }
 
+#[derive(Serialize, Deserialize)]
+struct ContainerRecord {
+    name: String,
+    container: Container,
+}
+
 // ── GraphWriter (sync) ──────────────────────────────────────────────────────
 
 /// Writes a [`Graph`] to any [`Write`] sink using the streaming wire format.
@@ -302,6 +309,15 @@ impl<W: Write> GraphWriter<W> {
                 stack: stack.clone(),
             };
             self.write_record(TAG_STACK, &serde_json_lenient::to_vec(&record)?)?;
+        }
+
+        // ── Containers ──
+        for (name, container) in graph.iter_containers() {
+            let record = ContainerRecord {
+                name: name.clone(),
+                container: container.clone(),
+            };
+            self.write_record(TAG_CONTAINER, &serde_json_lenient::to_vec(&record)?)?;
         }
 
         // ── SupplyChain ──
@@ -456,6 +472,7 @@ impl<R: Read> GraphReader<R> {
 
         let mut top_levels_raw: Vec<(usize, u64)> = Vec::new();
         let mut stacks: BTreeMap<String, Stack> = BTreeMap::new();
+        let mut containers: BTreeMap<String, Container> = BTreeMap::new();
         let mut supply_chain: Vec<SpecOrigin> = Vec::new();
 
         // ── Body ──
@@ -521,6 +538,11 @@ impl<R: Read> GraphReader<R> {
                     stacks.insert(record.name, record.stack);
                 }
 
+                TAG_CONTAINER => {
+                    let record: ContainerRecord = serde_json_lenient::from_slice(&payload)?;
+                    containers.insert(record.name, record.container);
+                }
+
                 TAG_SUPPLY_CHAIN => {
                     supply_chain = serde_json_lenient::from_slice(&payload)?;
                 }
@@ -560,7 +582,15 @@ impl<R: Read> GraphReader<R> {
         }
 
         Ok((
-            Graph::from_parts(arena, top_levels, stacks, by_name, supply_chain, target),
+            Graph::from_parts(
+                arena,
+                top_levels,
+                stacks,
+                containers,
+                by_name,
+                supply_chain,
+                target,
+            ),
             temp_dir,
         ))
     }
@@ -787,6 +817,16 @@ impl<W: AsyncWrite + Unpin> AsyncGraphWriter<W> {
                 .await?;
         }
 
+        // Containers
+        for (name, container) in graph.iter_containers() {
+            let record = ContainerRecord {
+                name: name.clone(),
+                container: container.clone(),
+            };
+            self.write_record(TAG_CONTAINER, &serde_json_lenient::to_vec(&record)?)
+                .await?;
+        }
+
         // SupplyChain
         self.write_record(
             TAG_SUPPLY_CHAIN,
@@ -922,6 +962,7 @@ impl<R: AsyncRead + Unpin> AsyncGraphReader<R> {
 
         let mut top_levels_raw: Vec<(usize, u64)> = Vec::new();
         let mut stacks: BTreeMap<String, Stack> = BTreeMap::new();
+        let mut containers: BTreeMap<String, Container> = BTreeMap::new();
         let mut supply_chain: Vec<SpecOrigin> = Vec::new();
 
         loop {
@@ -982,6 +1023,11 @@ impl<R: AsyncRead + Unpin> AsyncGraphReader<R> {
                     stacks.insert(record.name, record.stack);
                 }
 
+                TAG_CONTAINER => {
+                    let record: ContainerRecord = serde_json_lenient::from_slice(&payload)?;
+                    containers.insert(record.name, record.container);
+                }
+
                 TAG_SUPPLY_CHAIN => {
                     supply_chain = serde_json_lenient::from_slice(&payload)?;
                 }
@@ -1018,7 +1064,15 @@ impl<R: AsyncRead + Unpin> AsyncGraphReader<R> {
         }
 
         Ok((
-            Graph::from_parts(arena, top_levels, stacks, by_name, supply_chain, target),
+            Graph::from_parts(
+                arena,
+                top_levels,
+                stacks,
+                containers,
+                by_name,
+                supply_chain,
+                target,
+            ),
             temp_dir,
         ))
     }
@@ -1030,7 +1084,9 @@ impl<R: AsyncRead + Unpin> AsyncGraphReader<R> {
 mod tests {
     use super::*;
     use crate::builds::SpecTest;
-    use common::SpecOrigin;
+    use common::{SpecOrigin, target::Arch};
+    use decode::{ExposedPort, ExposedPortProto};
+    use nickel_lang_core::term::IndexMap;
     use smallvec::smallvec;
     use std::sync::Arc;
 
@@ -1786,5 +1842,340 @@ mod tests {
                 "[{label}] config.txt should be 0644"
             );
         }
+    }
+
+    // ── Container tests ──────────────────────────────────────────────────────
+
+    /// A container with every field populated, so a roundtrip proves each one
+    /// survives rather than only the handful a minimal declaration sets.
+    fn full_container(name: &str) -> Container {
+        Container {
+            name: name.to_string(),
+            packages: vec!["shared".into(), "top".into()],
+            entrypoint: Some(vec!["/bin/app".into(), "--serve".into()]),
+            cmd: Some(vec!["--port".into(), "8080".into()]),
+            arch: Some(Arch::Arm64),
+            working_dir: Some("/srv".into()),
+            env_vars: IndexMap::from_iter([
+                ("PATH".to_string(), "/bin".to_string()),
+                ("PORT".to_string(), "8080".to_string()),
+                ("RUST_LOG".to_string(), "debug".to_string()),
+            ]),
+            exposed_ports: vec![
+                ExposedPort {
+                    proto: ExposedPortProto::Tcp,
+                    port: 8080,
+                },
+                ExposedPort {
+                    proto: ExposedPortProto::Udp,
+                    port: 53,
+                },
+            ],
+            volumes: vec!["/var/lib/data".into(), "/tmp".into()],
+            user: Some("1000:1000".into()),
+            stop_signal: Some("SIGTERM".into()),
+            labels: IndexMap::from_iter([
+                (
+                    "org.opencontainers.image.title".to_string(),
+                    name.to_string(),
+                ),
+                (
+                    "org.opencontainers.image.version".to_string(),
+                    "1.2.3".to_string(),
+                ),
+            ]),
+            config: IndexMap::from_iter([("StopTimeout".to_string(), "30".to_string())]),
+        }
+    }
+
+    /// Two packages, a stack, and two containers: one fully populated and one
+    /// left at its defaults, so both the "everything set" and "nothing set"
+    /// shapes cross the wire in the same stream.
+    fn graph_with_containers() -> Graph {
+        let mut graph = Graph::new();
+        let origin = Arc::new(SpecOrigin::Inline);
+        let shared = graph.insert_build(BuildSpec {
+            name: "shared".into(),
+            from: origin.clone(),
+            ..Default::default()
+        });
+        let top = graph.insert_build(BuildSpec {
+            name: "top".into(),
+            build_deps: smallvec![BuildDep::Build(shared)],
+            from: origin,
+            ..Default::default()
+        });
+        graph.top_levels = vec![top];
+
+        graph.stacks.insert("rust".into(), Stack::default());
+        graph.containers.insert("app".into(), full_container("app"));
+        graph.containers.insert(
+            "bare".into(),
+            Container {
+                name: "bare".into(),
+                ..Default::default()
+            },
+        );
+        graph
+    }
+
+    #[test]
+    fn container_roundtrip_preserves_every_field() {
+        let graph = graph_with_containers();
+        let (restored, _td) = roundtrip(&graph);
+
+        assert_eq!(
+            restored.containers, graph.containers,
+            "container map should survive the wire format unchanged"
+        );
+
+        // Spot-check the fields whose representations are easiest to lose:
+        // the OCI exec-form argvs, the port protocols, and the arch enum.
+        let app = restored.containers.get("app").expect("app container");
+        assert_eq!(
+            app.entrypoint.as_deref(),
+            Some(&["/bin/app".to_string(), "--serve".to_string()][..])
+        );
+        assert_eq!(
+            app.cmd.as_deref(),
+            Some(&["--port".to_string(), "8080".to_string()][..])
+        );
+        assert_eq!(app.arch, Some(Arch::Arm64));
+        assert_eq!(
+            app.exposed_ports,
+            vec![
+                ExposedPort {
+                    proto: ExposedPortProto::Tcp,
+                    port: 8080
+                },
+                ExposedPort {
+                    proto: ExposedPortProto::Udp,
+                    port: 53
+                },
+            ]
+        );
+
+        // A defaulted container must come back defaulted, not filled in.
+        let bare = restored.containers.get("bare").expect("bare container");
+        assert_eq!(
+            bare,
+            &Container {
+                name: "bare".into(),
+                ..Default::default()
+            }
+        );
+    }
+
+    /// `env_vars`, `labels`, and `config` are `IndexMap`s: an image config is
+    /// order-sensitive, so the wire format must not reorder them into a plain
+    /// map's iteration order.
+    #[test]
+    fn container_map_ordering_survives_roundtrip() {
+        let graph = graph_with_containers();
+        let (restored, _td) = roundtrip(&graph);
+        let app = restored.containers.get("app").expect("app container");
+
+        assert_eq!(
+            app.env_vars.keys().collect::<Vec<_>>(),
+            vec!["PATH", "PORT", "RUST_LOG"]
+        );
+        assert_eq!(
+            app.labels.keys().collect::<Vec<_>>(),
+            vec![
+                "org.opencontainers.image.title",
+                "org.opencontainers.image.version"
+            ]
+        );
+        assert_eq!(app.config.keys().collect::<Vec<_>>(), vec!["StopTimeout"]);
+    }
+
+    /// A container names its packages by string; those names must still resolve
+    /// against the restored arena, whose indices are remapped on read.
+    #[test]
+    fn container_packages_resolve_in_restored_graph() {
+        let graph = graph_with_containers();
+        let (restored, _td) = roundtrip(&graph);
+
+        let app = restored.containers.get("app").expect("app container");
+        assert_eq!(app.packages, vec!["shared".to_string(), "top".to_string()]);
+        for pkg in &app.packages {
+            assert!(
+                restored.by_name(pkg).is_some(),
+                "container package {pkg:?} should resolve in the restored graph"
+            );
+        }
+    }
+
+    /// A graph carrying no containers writes no container records, and the
+    /// reader must not invent any.
+    #[test]
+    fn graph_without_containers_roundtrips_empty() {
+        let mut graph = Graph::new();
+        let bsr = graph.insert_build(BuildSpec {
+            name: "solo".into(),
+            from: Arc::new(SpecOrigin::Inline),
+            ..Default::default()
+        });
+        graph.top_levels = vec![bsr];
+
+        let (restored, _td) = roundtrip(&graph);
+        assert_eq!(restored.iter_containers().count(), 0);
+    }
+
+    /// Containers must survive every writer/reader pairing, and must not
+    /// disturb the positional local-file records that follow each build spec.
+    #[tokio::test]
+    async fn container_roundtrip_across_all_stream_paths() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let content = b"container-stream patch\n";
+        let fpath = tmp.path().join("patch.diff");
+        std::fs::write(&fpath, content).unwrap();
+
+        let mut graph = graph_with_containers();
+        let origin = Arc::new(SpecOrigin::Inline);
+        graph.insert_build(BuildSpec {
+            name: "with-file".into(),
+            build_deps: smallvec![BuildDep::Local {
+                full_path: fpath.clone(),
+                filename: "patch.diff".into(),
+                file_hash: blake3::hash(content),
+            }],
+            from: origin,
+            ..Default::default()
+        });
+
+        for label in ["sync", "async", "sync->async", "async->sync"] {
+            let (restored, td) = match label {
+                "sync" => roundtrip(&graph),
+                "async" => async_roundtrip(&graph).await,
+                "sync->async" => sync_write_async_read(&graph).await,
+                _ => async_write_sync_read(&graph).await,
+            };
+            assert!(td.is_some(), "[{label}] should have materialised files");
+
+            assert_eq!(
+                restored.containers, graph.containers,
+                "[{label}] container map should survive the wire format unchanged"
+            );
+
+            // The local file still lands correctly with container records in
+            // the same stream.
+            let spec = restored
+                .get(restored.by_name("with-file").unwrap())
+                .unwrap();
+            let BuildDep::Local { full_path, .. } = &spec.build_deps[0] else {
+                panic!("[{label}] expected Local dep");
+            };
+            assert_eq!(std::fs::read(full_path).unwrap(), content);
+        }
+    }
+
+    /// Both writers must frame container records identically; a divergence here
+    /// would break the cross-format paths above only for graphs with containers.
+    #[tokio::test]
+    async fn sync_and_async_container_bytes_identical() {
+        let graph = graph_with_containers();
+
+        let mut sync_buf = Vec::new();
+        GraphWriter::new(&mut sync_buf).write_graph(&graph).unwrap();
+
+        let mut async_buf = Vec::new();
+        AsyncGraphWriter::new(&mut async_buf)
+            .write_graph(&graph)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            sync_buf, async_buf,
+            "sync and async writers diverge on container records"
+        );
+    }
+
+    /// Frames `records` and appends a valid footer checksum, so a test can hand
+    /// the reader a stream the writers would never produce.
+    fn framed_stream(records: &[(u8, Vec<u8>)]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut hasher = blake3::Hasher::new();
+        for (tag, payload) in records {
+            let mut frame = vec![*tag];
+            encode_varint(payload.len() as u64, &mut frame);
+            frame.extend_from_slice(payload);
+            hasher.update(&frame);
+            buf.extend_from_slice(&frame);
+        }
+        buf.push(TAG_FOOTER);
+        encode_varint(32, &mut buf);
+        buf.extend_from_slice(hasher.finalize().as_bytes());
+        buf
+    }
+
+    /// A container record whose payload does not fit [`Container`] must surface
+    /// as a decode error, not a panic — the stream may come from the network.
+    #[tokio::test]
+    async fn malformed_container_record_is_a_clean_error() {
+        let header = serde_json_lenient::to_vec(&HeaderRecord {
+            version: STREAM_VERSION,
+            build_count: 0,
+            target: None,
+        })
+        .unwrap();
+        let stream = framed_stream(&[
+            (TAG_HEADER, header),
+            (
+                TAG_CONTAINER,
+                br#"{"name":"app","container":{"name":"app","packages":"not-an-array"}}"#.to_vec(),
+            ),
+        ]);
+
+        let err = GraphReader::new(io::Cursor::new(stream.clone()))
+            .read_graph()
+            .unwrap_err();
+        assert!(matches!(err, WireError::Json(_)), "sync: got {err:?}");
+
+        let err = AsyncGraphReader::new(io::Cursor::new(stream))
+            .read_graph()
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WireError::Json(_)), "async: got {err:?}");
+    }
+
+    /// Containers are keyed by name on both sides, so a stream is free to place
+    /// them anywhere after the header — the reader must not depend on the
+    /// writer's ordering.
+    #[test]
+    fn container_records_decode_before_build_specs() {
+        let header = serde_json_lenient::to_vec(&HeaderRecord {
+            version: STREAM_VERSION,
+            build_count: 0,
+            target: None,
+        })
+        .unwrap();
+        let container = serde_json_lenient::to_vec(&ContainerRecord {
+            name: "app".into(),
+            container: full_container("app"),
+        })
+        .unwrap();
+        let spec = serde_json_lenient::to_vec(&BuildSpecRecord {
+            arena_idx: 0,
+            arena_gen: 0,
+            spec: BuildSpec {
+                name: "shared".into(),
+                from: Arc::new(SpecOrigin::Inline),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+
+        let stream = framed_stream(&[
+            (TAG_HEADER, header),
+            (TAG_CONTAINER, container),
+            (TAG_BUILD_SPEC, spec),
+        ]);
+
+        let (restored, _td) = GraphReader::new(io::Cursor::new(stream))
+            .read_graph()
+            .unwrap();
+        assert_eq!(restored.containers.get("app"), Some(&full_container("app")));
+        assert!(restored.by_name("shared").is_some());
     }
 }

--- a/crates/lcache/src/entry_meta.rs
+++ b/crates/lcache/src/entry_meta.rs
@@ -14,12 +14,14 @@ use crate::fs::{DirEntry, FileSystem};
 pub enum MetaInner {
     Spec(String),       // name
     Subset(SubsetSpec), // (build-spec, output-names), both sorted
+    Container(String),  // name
 }
 
 impl MetaInner {
     pub fn spec_name(&self) -> Option<&String> {
         match self {
             MetaInner::Spec(sn) => Some(sn),
+            MetaInner::Container(sn) => Some(sn),
             _ => None,
         }
     }
@@ -29,6 +31,7 @@ impl Display for MetaInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MetaInner::Spec(n) => write!(f, "package {}", n),
+            MetaInner::Container(n) => write!(f, "container {}", n),
             MetaInner::Subset(s) => write!(
                 f,
                 "subset of {} with outputs [{}]",
@@ -146,7 +149,7 @@ impl EntryMeta {
                 };
 
                 match entry.inner {
-                    MetaInner::Subset(_) => {}
+                    MetaInner::Subset(_) | MetaInner::Container(_) => {}
                     MetaInner::Spec(spec_name) => {
                         if spec_name == name {
                             let p = e.path()?;


### PR DESCRIPTION
 * Accumulate container specs into `Graph`
 * Implement spec hashing for container specs
 * Add cache meta for entries which are containers
 * Add support for streaming into/out-of the graph wire representation

<!-- PR title: use a Conventional Commit subject — `type(scope): summary`,
     imperative, lower-case, no trailing period. The PR title becomes the
     squash commit subject. See docs/commit-conventions.md. -->

## Summary

<!-- What changes, and why. Link related issues (`Refs: #123` / `Closes: #123`). -->

## Testing

<!-- What you ran (`cargo test`, `cargo clippy`, harness/e2e scripts, manual
     steps) — paste the relevant output as evidence. -->

## Checklist

- [ ] Docs updated if behavior changed
- [ ] `BREAKING CHANGE:` footer present if this is a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for importing, storing, retrieving, and serializing container specifications.
  - Added stable container specification hashing, including package references, image settings, optional values, maps, and sets.
  - Added synchronous and asynchronous container read/write support.
  - Added ordered container iteration and name-based retrieval.

- **Bug Fixes**
  - Graph loading now validates referenced packages and rejects duplicate container names with a clear error.
  - Container metadata is excluded from build searches by specification name.

- **Tests**
  - Expanded coverage for container persistence, hashing, ordering, malformed data, and sync/async compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->