### PR TITLE
ci: regenerate minimal-review from foundry 2ff99a4b

### DIFF
--- a/.github/workflows/minimal-review.yml
+++ b/.github/workflows/minimal-review.yml
@@ -84,14 +84,14 @@ jobs:
     #
     # `issue_comment` is the one path where the trigger is not the PR. It fires
     # on issue comments too, and on a public install anyone at all can post one,
-    # so all four clauses are load-bearing: it must be a PR, the body must ask,
+    # so all four clauses have to hold: it must be a PR, the body must ask,
     # and the person asking must be one of ours. No Bot clause here — a bot's
     # comment starting a paid review is a loop nobody asked for.
     #
     # This gate is repeated in the caller, and that copy is the one that stops
     # the job from starting. This one is the backstop: the caller's file can be
     # edited by the PR under review, and this file cannot.
-    # A double-quoted scalar, not `>-`, and that is load-bearing: in a folded
+    # A double-quoted scalar, not `>-`, and the difference matters: in a folded
     # block `\n` stays two characters, so the newline clause below would test
     # for a literal backslash-n and never match. YAML unescapes it here before
     # the expression engine sees it, and expression literals have no escapes
@@ -272,9 +272,10 @@ jobs:
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
           echo "PR #$PR_NUMBER is same-repo, base $(printf '%s' "$pr" | jq -r .base.ref)"
 
-      # `ref` is load-bearing: the default checkout for a pull_request event is
-      # the MERGE commit, a tree that exists in no branch. Every finding anchor
-      # would silently point at line numbers the PR does not have.
+      # `ref` decides what gets reviewed. The default checkout for a
+      # pull_request event is the MERGE commit, a tree that exists in no
+      # branch, and every finding anchor would silently point at line numbers
+      # the PR does not have.
       - name: Check out the tree under review (PR HEAD, not the merge commit)
         if: steps.quiet.outputs.status != 'stale'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/minimal-review.yml
+++ b/.github/workflows/minimal-review.yml
@@ -91,19 +91,24 @@ jobs:
     # This gate is repeated in the caller, and that copy is the one that stops
     # the job from starting. This one is the backstop: the caller's file can be
     # edited by the PR under review, and this file cannot.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
+    # A double-quoted scalar, not `>-`, and that is load-bearing: in a folded
+    # block `\n` stays two characters, so the newline clause below would test
+    # for a literal backslash-n and never match. YAML unescapes it here before
+    # the expression engine sees it, and expression literals have no escapes
+    # of their own. The cost is that every " in the gate must be escaped.
+    if: "github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request != null &&
-       (github.event.comment.body == '/review' ||
-        startsWith(github.event.comment.body, '/review ')) &&
-       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-                github.event.comment.author_association)) ||
+      github.event.issue.pull_request != null &&
+      (github.event.comment.body == '/review' ||
+      startsWith(github.event.comment.body, '/review ') ||
+      startsWith(github.event.comment.body, '/review\n')) &&
+      contains(fromJSON('[\"OWNER\",\"MEMBER\",\"COLLABORATOR\"]'),
+      github.event.comment.author_association)) ||
       (github.event.pull_request.head.repo.full_name == github.repository &&
-       github.event.pull_request.draft != true &&
-       (github.event.pull_request.user.type == 'Bot' ||
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-                 github.event.pull_request.author_association)))
+      github.event.pull_request.draft != true &&
+      (github.event.pull_request.user.type == 'Bot' ||
+      contains(fromJSON('[\"OWNER\",\"MEMBER\",\"COLLABORATOR\"]'),
+      github.event.pull_request.author_association)))"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -834,6 +839,37 @@ jobs:
           # knows this repo's task schema.
           mip check
           cp "$CFG" "$RUN_DIR/injected-minimal.toml"
+
+          # Declare the task's own variables to the user policy, or `min` will
+          # not run it:
+          #
+          #   error: task 'review' declares 6 environment variables that your
+          #   policy does not allow, and stdin/stderr is not a terminal.
+          #
+          # It exits 1 in zero seconds, before the agent starts, so the run
+          # costs nothing and produces nothing. The gate is new — the reviewer
+          # tracks the `unstable` channel deliberately, and this is the bill
+          # for that.
+          #
+          # Read out of the config just injected rather than written by hand.
+          # The list is exactly what the task declares, so it cannot drift when
+          # the task gains a variable, and it grants nothing the task does not
+          # already ask for. A hand-kept copy would fail the same way, silently,
+          # the next time these two disagreed.
+          "$RUNNER_TEMP/venv/bin/python" - "$CFG" "$REVIEW_TASK" <<'PYPOLICY'
+          import os, pathlib, sys, tomllib
+
+          cfg, task = sys.argv[1], sys.argv[2]
+          with open(cfg, "rb") as fh:
+              declared = (tomllib.load(fh).get("tasks", {}).get(task, {})
+                          .get("env_vars") or {})
+          names = sorted(declared)
+          policy = pathlib.Path.home() / ".config" / "minimal" / "user_policy.toml"
+          policy.parent.mkdir(parents=True, exist_ok=True)
+          body = "[vars]\nallow = [" + ", ".join(f'"{n}"' for n in names) + "]\n"
+          policy.write_text(body)
+          print(f"policy: allowed {len(names)} task var(s): {', '.join(names)}")
+          PYPOLICY
 
       - name: Run the review
         id: agent


### PR DESCRIPTION
**The whole fleet has been failing since 2026-09-01 15:09 UTC.** 18 consecutive runs, zero successes, every repo.

`gominimal/minimal#1312` (`feat(task)!:` — declared breaking) reached the `unstable` channel the reviewer tracks. `min task run` now gates a task's `env_vars` on a user policy; CI has no `user_policy.toml` and no TTY to prompt on, so the task refuses before the agent starts:

```
error: task 'review' declares 6 environment variables that your policy does not allow,
and stdin/stderr is not a terminal.
```

`task exit 1 in 0s`. The run costs nothing and produces nothing, which is why it is not the broker — broker health is clean in every failing run (`ok: true`, no 4xx/5xx, upstream reachable), and a run at 15:44 against the fixed impl pushed 2.2M tokens and posted a review.

## Why this needed a separate PR

foundry#63 merged at 15:31 and fixed the implementation. **Nothing consumed it.** Every caller in the fleet still pinned a pre-fix SHA, and the two public repos carry generated copies rendered from a pre-fix impl. Fixing foundry's `main` was necessary and insufficient.

## Regenerated, not sed-ed

This is the lesson from foundry#58. That PR removed the `comment_id` input; a pin-only bump left a caller passing an input the impl no longer declares, and the result was `startup_failure` — not a bad review, no review at all. So the file is regenerated from source rather than having its pin edited.

Doing it properly also carries across changes these callers never took. See the commit message for the per-repo list.

## Not fixed here, and worth an issue

The Logfire alarm `4317c0f1` **cannot fire on this**. It watches sustained `upstream_unavailable`, which the workflow only emits on task exit **75**. This exits **1**. That is the second silent outage in a week, by a different mechanism from the first — the runs were red in GitHub for six hours and the alerting path built to catch reviewer outages stayed quiet.

Failed runs also emit `0 tokens via broker_no_usage`, which reads like a broker fault and sends the investigation the wrong way.

## Verify

`review / review` on this PR must reach `policy: allowed N task var(s)` and then actually run the agent, rather than `task exit 1 in 0s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF6NxSgMfMj1Z6ZpomE7o1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment-based review triggers for commands ending with a newline.
  * Ensured review tasks can access their declared environment variables according to the configured policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->