### PR TITLE
fix(minimald): scaffold the default mfile before composing

### DIFF
--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1183,8 +1183,17 @@ impl Session {
         // later never reaches the sandbox. Propagated, not logged — an
         // activation that hands back a session id must hand back a usable
         // session, and a box with no blueprint can't run anything.
-        self.scaffold_mfile_if_missing(&workspace_path)
-            .map_err(|e| std::io::Error::other(format!("scaffolding a default mfile: {e}")))?;
+        //
+        // Fenced: the scaffold resolves the default package repo over the
+        // network and runs inline on the session actor, so an unfenced call
+        // would pin a worker for the whole fetch. Flavor-guarded because
+        // `block_in_place` panics on a current-thread runtime.
+        let scaffold = || self.scaffold_mfile_if_missing(&workspace_path);
+        match tokio::runtime::Handle::current().runtime_flavor() {
+            tokio::runtime::RuntimeFlavor::MultiThread => tokio::task::block_in_place(scaffold),
+            _ => scaffold(),
+        }
+        .map_err(|e| std::io::Error::other(format!("scaffolding a default mfile: {e}")))?;
 
         // Phase 1+2: resolve the project and drive the composer. Kept fully
         // synchronous — its non-`Send` intermediaries must not cross an

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1177,13 +1177,14 @@ impl Session {
         let object = self.record.object().await?;
         let workspace_path = object.workspace_path();
 
-        // Deliberately no scaffold here: composing is not the moment to
-        // fabricate a project. `scaffold_default_mfile` resolves the default
-        // package repo's branch head over the network, and the default's
-        // packages reach the sandbox through the launcher's context (built
-        // from the workspace mfile) rather than through the composition —
-        // so paying for it here would buy nothing. A bare workspace composes
-        // to an empty loadout, and the scaffold lands at context-build time.
+        // Scaffold before composing, not after: the launcher's package set is
+        // its baseline unioned with the composition's packages (see the note
+        // on `SessionInner::Active::composition`), so a default written any
+        // later never reaches the sandbox. Propagated, not logged — an
+        // activation that hands back a session id must hand back a usable
+        // session, and a box with no blueprint can't run anything.
+        self.scaffold_mfile_if_missing(&workspace_path)
+            .map_err(|e| std::io::Error::other(format!("scaffolding a default mfile: {e}")))?;
 
         // Phase 1+2: resolve the project and drive the composer. Kept fully
         // synchronous — its non-`Send` intermediaries must not cross an
@@ -2367,6 +2368,10 @@ impl Session {
     /// session's workspace if it has none, so [`mctx::Context::new`] can
     /// succeed and the session gets a usable set of packages. A workspace
     /// that already holds an uploaded `minimal.toml` is left alone.
+    ///
+    /// Runs from [`Self::configure_loadout`], ahead of the composition that
+    /// decides the launcher's packages; [`Self::build_context`] repeats it as
+    /// an idempotent backstop for sessions brought up from disk.
     fn scaffold_mfile_if_missing(&self, wsp: &DaemonAbsPath) -> Result<(), String> {
         if wsp.as_utf8_path().join(mfile::MFILE_NAME).exists() {
             return Ok(());
@@ -2374,16 +2379,45 @@ impl Session {
         match mfile::File::from_dir(wsp.as_utf8_path()) {
             Ok(_) => Ok(()), // it exists
             Err(mfile::Error::NotFound) => {
-                let config = self.workspace_config(wsp)?;
-
-                use op::ProjectOp as _;
-                let mut env = mctx::ProjectSetup::for_init(config).map_err(|e| e.to_string())?;
-                let plan = op::InitProject.run(&mut env).map_err(|e| e.to_string())?;
-
-                std::fs::write(&plan.toml_path, &plan.content).map_err(|e| e.to_string())
+                let (toml_path, content) = self.default_mfile_plan(wsp)?;
+                std::fs::write(&toml_path, &content).map_err(|e| e.to_string())
             }
             Err(e) => Err(e.to_string()),
         }
+    }
+
+    /// The default `minimal.toml` [`Self::scaffold_mfile_if_missing`] writes:
+    /// `op::InitProject` detects the workspace's stack against the default
+    /// package repo, whose branch head it resolves over the network.
+    #[cfg(not(any(test, feature = "test-support")))]
+    fn default_mfile_plan(
+        &self,
+        wsp: &DaemonAbsPath,
+    ) -> Result<(std::path::PathBuf, String), String> {
+        let config = self.workspace_config(wsp)?;
+
+        use op::ProjectOp as _;
+        let mut env = mctx::ProjectSetup::for_init(config).map_err(|e| e.to_string())?;
+        let plan = op::InitProject.run(&mut env).map_err(|e| e.to_string())?;
+
+        Ok((plan.toml_path, plan.content))
+    }
+
+    /// Under test, stand in for `op::InitProject`'s network round-trip: tests
+    /// run offline, and what they need from the scaffold is that it lands
+    /// before the composition — not what stack detection would have picked.
+    /// Same two packages `op::InitProject` falls back to when nothing matches.
+    #[cfg(any(test, feature = "test-support"))]
+    fn default_mfile_plan(
+        &self,
+        wsp: &DaemonAbsPath,
+    ) -> Result<(std::path::PathBuf, String), String> {
+        Ok((
+            wsp.as_utf8_path()
+                .join(mfile::MFILE_NAME)
+                .into_std_path_buf(),
+            "[session]\npackages = [\"base\", \"vim\"]\n".to_string(),
+        ))
     }
 
     /// Do the actual context construction: run [`mctx::Context::new`] against
@@ -2391,7 +2425,9 @@ impl Session {
     /// [`Self::context`].
     ///
     /// The workspace mfile it parses is either the client's uploaded one or
-    /// a default scaffolded here on the way past.
+    /// the default [`Self::configure_loadout`] scaffolded. The scaffold is
+    /// repeated here as a backstop — it early-returns when the mfile exists,
+    /// so it only fires for a session whose compose predates it.
     ///
     /// [`Config`]: mctx::Config
     async fn build_context(&self, scaffold_if_missing: bool) -> Result<mctx::Context, String> {

--- a/crates/minimald/src/sessions.rs
+++ b/crates/minimald/src/sessions.rs
@@ -1802,13 +1802,14 @@ pub(crate) mod tests {
     }
 
     /// Configuring a loadout against a workspace with no `minimal.toml`
-    /// still succeeds — the parse fails silently (debug log), the
-    /// graph resolve is short-circuited (no `Context` to resolve
-    /// against), no project contribution lands, and the
-    /// empty-contribution fast path completes as before. Guards the
-    /// DM1 / empty-workspace path against regressions.
+    /// scaffolds a default one *before* composing, so the packages that
+    /// default declares land in the composition — and from there in the
+    /// launcher's package set, which is its baseline unioned with the
+    /// composition's packages and nothing else. Scaffolding after the
+    /// compose (as `build_context` alone used to) left a session running
+    /// without the packages its own workspace mfile declared.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn configure_loadout_with_missing_mfile_still_succeeds() {
+    async fn configure_loadout_scaffolds_missing_mfile_into_composition() {
         let (_state, _cache, mngr) = manager().await;
         // No `seed_workspace_mfile`: the workspace stays empty, mirroring
         // an activation against a directory with no `minimal.toml`.
@@ -1818,7 +1819,16 @@ pub(crate) mod tests {
             .configure_loadout(WireContribution::default())
             .await
             .expect("configuring against a missing mfile should still succeed");
-        assert!(response.is_none());
+        assert!(response.is_none(), "the scaffolded default gates nothing");
+
+        let comp = peek_composition(&mngr, id).await;
+        let package_names: std::collections::BTreeSet<&str> =
+            comp.packages().iter().map(|p| p.package()).collect();
+        assert!(
+            package_names.contains("vim"),
+            "the scaffolded mfile's packages should reach the composition, \
+             got {package_names:?}"
+        );
     }
 
     /// A `[session]` block that contributes a package is picked up

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -85,6 +85,7 @@ SEEDED_MFILE=""
 TASK_SEED_DIR="" # seeded by the `min task run` proof below; removed on teardown
 HOOK_SEED_DIR="" # seeded by the lifecycle-hooks proof below; removed on teardown
 PATCH_SRC_DIR="" # patch sources for the patch-modes proof; removed on teardown
+SKIP_SEED_DIR="" # seeded by the skip-lane scaffold proof below; removed on teardown
 if [ -z "${E2E_PROJECT_DIR:-}" ]; then
   # Native: self-seed a small throwaway — never $ROOT (uploading the whole repo,
   # and scaffolding over its `.minimal/`, is the very clobber #758 prevents).
@@ -201,6 +202,7 @@ teardown() {
   [ -n "$TASK_SEED_DIR" ] && rm -rf "$TASK_SEED_DIR"
   [ -n "$HOOK_SEED_DIR" ] && rm -rf "$HOOK_SEED_DIR"
   [ -n "$PATCH_SRC_DIR" ] && rm -rf "$PATCH_SRC_DIR"
+  [ -n "$SKIP_SEED_DIR" ] && rm -rf "$SKIP_SEED_DIR"
   # And the state dir — which is NOT just metadata. On a VM lane it holds the
   # provider's per-VM writable data volume
   # (`minimal/providers/local-minvmd0/data-vol.raw`), a sparse image whose HOST
@@ -1054,6 +1056,63 @@ exit' python3 "$ROOT/scripts/e2e-attach-pty.py" - \
   echo "shell fallback proof OK (bash started, notice names the package)"
   echo "::endgroup::"
 fi
+# ---------------------------------------------------------------------------
+# Skip-lane scaffold proof (every lane). Every other seed here deliberately
+# becomes a VCS root so the headless upload gate ships it; this one does the
+# opposite. A non-VCS, non-empty directory with no `minimal.toml` (and no
+# explicit `--sync`) is the one shape where the gate SKIPS the upload, so the
+# session's blueprint is not the user's — it is the one the daemon scaffolds
+# into the workspace. Its packages must reach the box: they used to be decided
+# by a composition that ran before the scaffold, so the session came up
+# without the packages its own `/workbench/minimal.toml` declared
+# (gominimal/inbox#601). Mints its own session; nothing here touches $sid.
+echo "::group::skip-lane scaffold (no VCS root, no minimal.toml: the daemon writes the blueprint)"
+SKIP_SEED_DIR="$(mktemp -d /tmp/mnlsc.XXXXXX)"
+# Non-empty (an empty dir skips the upload for a different reason), and
+# deliberately WITHOUT a `.git` marker or a `minimal.toml` — both would take
+# the activation off the skip lane. /tmp has no mfile above it, so the
+# client's walk up finds none either.
+printf 'skip-lane seed\n' > "$SKIP_SEED_DIR/README"
+# `--no-prompt` plus stdin from /dev/null: headless, which is what turns the
+# non-VCS upload confirmation into a silent skip.
+skip_activate_out="$(cd "$SKIP_SEED_DIR" \
+  && mnl session activate . --name e2e-scaffold --no-prompt </dev/null 2>"$WORK/skip-activate.err")" || {
+  echo "::error::'min session activate' from a non-VCS dir with no minimal.toml failed"
+  echo "--- stdout ---"; printf '%s\n' "$skip_activate_out"
+  echo "--- stderr ---"; cat "$WORK/skip-activate.err" 2>/dev/null || true
+  fail
+}
+skip_sid="$(printf '%s\n' "$skip_activate_out" | tail -n1 | tr -d '\r')"
+# One exec: the blueprint the daemon wrote, then whether the box carries what
+# it declares. `vim` is the discriminator — the scaffold always declares it and
+# it is in none of the launcher's baseline packages (base/coreutils/socat), so
+# its presence can only have come from the scaffolded mfile.
+skip_probe="$(mnl session exec "$skip_sid" \
+  'cat /workbench/minimal.toml; command -v vim >/dev/null 2>&1 && echo VIM_PRESENT || echo VIM_ABSENT' \
+  2>"$WORK/skip-exec.err")" || {
+  echo "::error::'min session exec' against the skip-lane session failed"
+  echo "--- stdout ---"; printf '%s\n' "$skip_probe"
+  echo "--- stderr ---"; cat "$WORK/skip-exec.err" 2>/dev/null || true
+  fail
+}
+# Glob, never `| grep -q` — same SIGPIPE-under-pipefail reasoning as the
+# sandbox proof's markers.
+if [[ "$skip_probe" != *'"vim"'* ]]; then
+  echo "::error::the daemon-scaffolded /workbench/minimal.toml does not declare vim; the assertion below would prove nothing"
+  echo "--- probe ---"; printf '%s\n' "$skip_probe"
+  fail
+fi
+if [[ "$skip_probe" != *VIM_PRESENT* ]]; then
+  echo "::error::the session lacks a package its own scaffolded /workbench/minimal.toml declares (gominimal/inbox#601)"
+  echo "--- probe ---"; printf '%s\n' "$skip_probe"
+  echo "--- activate stderr ---"; cat "$WORK/skip-activate.err" 2>/dev/null || true
+  fail
+fi
+mnl session destroy --force "$skip_sid" >/dev/null 2>&1 || true
+rm -rf "$SKIP_SEED_DIR"; SKIP_SEED_DIR=""
+echo "skip-lane scaffold proof OK (scaffolded blueprint's packages reached the box)"
+echo "::endgroup::"
+
 # ---------------------------------------------------------------------------
 # Session-sandbox proof (every lane). Everything above proves the lifecycle;
 # this forks a real sandbox and proves the in-sandbox `min add`. A session is


### PR DESCRIPTION
## Summary

A session activated on the **skip lane** (non-VCS, non-empty dir, no `minimal.toml`, headless — so the workspace upload is skipped) came up without the packages its own daemon-scaffolded `/workbench/minimal.toml` declared.

The launcher's package set is `BASELINE_PACKAGES ∪ composition.packages()` (`session_host.rs`), and nothing else reads the mfile — the mctx context supplies only the *graph*, never the package set. The scaffold ran later, from `build_context`, so on the skip lane the compose saw an empty workspace, produced an empty composition, and the default's packages never reached the sandbox.

This moves `scaffold_mfile_if_missing` into `configure_loadout`, ahead of `run_compose`. `build_context` keeps its call as an idempotent backstop for sessions brought up from disk.

**A scaffold failure now fails the activation rather than being swallowed.** That is deliberate: an activation that returns a session id must return a usable session (decision `D-usable-id`, gominimal/inbox#581). Today such a session fails later, at the first `exec`, with a confusing internal error naming a package server.

The comment that declined to scaffold at compose time justified itself with a claim that was false — that the default's packages reach the sandbox through the launcher's context — and named a symbol that does not exist (`scaffold_default_mfile`; the real function is `Session::scaffold_mfile_if_missing`). It is replaced, and the accurate note on `SessionInner::Active::composition` is now the single source of truth.

`Closes: gominimal/inbox#601`

### Reviewer note — the `test-support` seam

`configure_loadout_with_missing_mfile_still_succeeds` blessed the old behaviour and would now have driven `op::InitProject` into a real `git fetch` of the default package repo during `cargo test`. The hazard was wider than that one test: `minimal/tests/cli.rs::create_session_at` and `test_harness::create_configured_session` also configure loadouts against empty workspaces, and they build `minimald` *without* `cfg(test)`.

So the `op::InitProject` call sits behind a `cfg(not(any(test, feature = "test-support")))` seam whose test twin returns the same fallback packages `init` generates. Only the network round-trip is stubbed — the scaffold's policy (skip when an mfile exists, the `from_dir` match, the disk write) and the *ordering*, which is the thing under test, stay real.

Verified this does not ship: `cargo tree -e features,no-dev -p minimald --workspace` does not enable `test-support`, and every production build path (`cargo build -p minimald`, the initramfs `zigbuild`) excludes dev-dependencies. The real path is covered by the new e2e case.

## Testing

- `cargo nextest list --workspace` confirms `configure_loadout_scaffolds_missing_mfile_into_composition` is present and runs.
- The new unit test is a genuine regression guard: with the `scaffold_mfile_if_missing` call removed it fails; with it, it passes.
- `shellcheck scripts/session-e2e.sh` → exit 0; `bash -n` → syntax OK.
- New e2e case (`scripts/session-e2e.sh`): activates from a non-VCS, non-empty dir with no `minimal.toml`, then asserts the box carries what the daemon-written blueprint declares. `vim` is the discriminator — the scaffold always declares it and it is in none of the launcher's baseline packages, so its presence can only have come from the scaffolded mfile. Mints its own session; nothing touches `$sid`. No workflow edits (`.github/workflows/` untouched).

**Not verified locally, deliberately flagged:** the full `just test` could not be completed on the authoring host — the linker was OOM-killed and the box ran out of disk mid-run. That host also has 14 pre-existing failures on clean `main` caused by a sandbox-wide git URL rewrite (`url.http://…/git/.insteadof https://github.com/`), which makes any test asserting a remote URL round-trip fail. CI is the real gate here.

**Risk worth watching in CI:** the daemon-scaffolded mfile pins `[upstream]` at the *current head* of `gominimal/pkgs@main`, not at this repo's own `locked_commit` like every other seed in the script. If head has drifted from the pin, `base`/`vim` may miss the warm cache and build from source on every lane. The case is self-contained and easy to gate or re-point if that proves expensive.

## Checklist

- [x] Docs updated if behavior changed — the two contradictory in-source comments are reconciled
- [ ] `BREAKING CHANGE:` footer present if this is a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sessions created without a `minimal.toml` now automatically receive a default configuration containing `vim`.
  - The default configuration is applied during session setup, including in non-version-controlled, non-empty directories.

- **Bug Fixes**
  - Improved handling of configuration scaffolding errors during session creation.

- **Tests**
  - Added coverage verifying default configuration creation, package composition, installation, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->