### PR TITLE
fix(min): name the directory when a session cannot be composed

### DIFF
--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -2069,6 +2069,20 @@ fn project_lifecycle_hook_count(root: &camino::Utf8Path) -> usize {
     }
 }
 
+/// The user-facing text for a session that could not be composed, by
+/// either route: a refused `ConfigureLoadout` or failed gating of what it
+/// sent back. The underlying error names an internal step the caller never
+/// asked for, so the directory leads and that text follows as the only
+/// diagnostic there is. Shared with `min task run` (`crate::task`), which
+/// creates a session through the same two steps.
+pub(crate) fn composition_failure_message(project_dir: &camino::Utf8Path, error: &str) -> String {
+    format!(
+        "Cannot start a session for {project_dir}: composing a session environment from \
+         that directory's project configuration failed, so no session was activated. Fix \
+         the configuration there, then re-run.\n\ncause: {error}"
+    )
+}
+
 /// Create a new session via the `CreateSession` RPC.
 pub async fn cmd_activate(global: &GlobalArgs, args: ActivateArgs) -> Result<(), anyhow::Error> {
     activate_session(global, args, true).await
@@ -2432,8 +2446,10 @@ async fn activate_session(
         .context("ConfigureLoadout RPC failed")?;
     let configured = match configured {
         minimald_rpc::Errorable::Ok(r) => r,
+        // Bails before the `println!("{id}")` below: a session that cannot
+        // compose never puts an id on stdout for a script to capture.
         minimald_rpc::Errorable::Err { error } => {
-            bail!("ConfigureLoadout failed: {error}");
+            bail!(composition_failure_message(&utf8_path, &error));
         }
     };
     // The daemon may finalize immediately (`Ready`) or ask the
@@ -2464,7 +2480,11 @@ async fn activate_session(
                 Ok((verdict, _final_policy)) => verdict,
                 Err(e) => {
                     send_abort(&mut client, session_id).await;
-                    bail!("Composition gating failed: {e}");
+                    // The route an activation actually reaches today: the
+                    // daemon routes project config back for gating, so a
+                    // project it cannot compose surfaces here rather than as
+                    // the `Errorable::Err` above.
+                    bail!(composition_failure_message(&utf8_path, &e.to_string()));
                 }
             };
             let summary = hooks.into_summary();
@@ -5210,6 +5230,65 @@ mod tests {
         std::fs::write(dir.path().join(mfile::MFILE_NAME), "not valid toml = =").unwrap();
         let path = camino::Utf8Path::from_path(dir.path()).expect("temp path is UTF-8");
         assert!(resolve_upload_root(path).is_err());
+    }
+
+    /// A refused composition is reported in the user's terms — the
+    /// directory the activation ran from — with the daemon's own text kept
+    /// as subordinate detail rather than as the headline (#581).
+    ///
+    /// The daemon error below is the one from the report: it names an
+    /// internal package server the caller never asked for and cannot reach.
+    #[test]
+    fn composition_failure_leads_with_the_directory_not_the_daemon_step() {
+        let daemon_error = "init of minimal context: other: git command 'fetch' failed \
+                            (exit status: 128): fatal: unable to access \
+                            'http://:8898/pkgs-local.git/': Failed to connect to server";
+        let msg =
+            composition_failure_message(camino::Utf8Path::new("/home/dev/myproject"), daemon_error);
+
+        let headline = msg.lines().next().expect("a first line");
+        assert!(
+            headline.contains("/home/dev/myproject"),
+            "the headline must name the directory: {msg}"
+        );
+        assert!(
+            !headline.contains("pkgs-local.git") && !headline.contains("ConfigureLoadout"),
+            "the headline must not lead with the internal step: {msg}"
+        );
+        assert!(
+            msg.contains(daemon_error),
+            "the daemon's error is the only diagnostic and must survive: {msg}"
+        );
+    }
+
+    /// Both session-creating paths report an uncomposable session through
+    /// the one helper, for both of the ways it can fail: the refused
+    /// `ConfigureLoadout` and the gating of what that RPC sent back.
+    /// Asserted rather than documented — the wording was already duplicated
+    /// across these two functions once, and re-typing either bail is one
+    /// copy-paste away.
+    #[test]
+    fn both_creators_share_the_composition_failure_message() {
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        for (file, func) in [
+            ("src/lib.rs", "activate_session"),
+            ("src/task.rs", "cmd_task_run"),
+        ] {
+            let text = std::fs::read_to_string(manifest.join(file)).expect("readable source");
+            let body = function_body(&text, func)
+                .unwrap_or_else(|| panic!("{file} no longer defines {func}"));
+            assert_eq!(
+                body.matches("composition_failure_message").count(),
+                2,
+                "{func} must route both composition failures through the shared message"
+            );
+            for bare in ["ConfigureLoadout failed", "Composition gating failed"] {
+                assert!(
+                    !body.contains(bare),
+                    "{func} still names the internal step instead of the directory ({bare})"
+                );
+            }
+        }
     }
 
     /// A project outside a VCS root that declares lifecycle hooks must be

--- a/crates/minimal/src/lib.rs
+++ b/crates/minimal/src/lib.rs
@@ -1730,6 +1730,7 @@ async fn drive_pending_to_active(
     policy: sessions::core::policy::UserPolicy,
     options: sessions::core::compose::ComposeOptions,
     hooks: &dyn sessions::core::hooks::PolicyHooks,
+    project_dir: &camino::Utf8Path,
 ) -> Result<
     (
         sessions::SessionId,
@@ -1743,7 +1744,13 @@ async fn drive_pending_to_active(
         Ok(v) => v,
         Err(e) => {
             send_abort(client, session_id).await;
-            bail!("Composition gating failed: {e}");
+            // Declining at the prompt is not a broken project: only a
+            // genuine compose failure gets the directory-led message.
+            use sessions::core::compose::ComposeError;
+            match e {
+                ComposeError::Aborted | ComposeError::Denied { .. } => bail!("{e}"),
+                _ => bail!(composition_failure_message(project_dir, &e.to_string())),
+            }
         }
     };
     // Extract the approved-patch destinations before submit consumes
@@ -2518,6 +2525,7 @@ async fn activate_session(
                 user_policy,
                 compose_options,
                 &hooks,
+                &utf8_path,
             )
             .await;
             if let Ok((_, _, ref approved)) = result {
@@ -5261,26 +5269,28 @@ mod tests {
         );
     }
 
-    /// Both session-creating paths report an uncomposable session through
-    /// the one helper, for both of the ways it can fail: the refused
-    /// `ConfigureLoadout` and the gating of what that RPC sent back.
-    /// Asserted rather than documented — the wording was already duplicated
-    /// across these two functions once, and re-typing either bail is one
-    /// copy-paste away.
+    /// Every site that reports an uncomposable session goes through the one
+    /// helper: the refused `ConfigureLoadout` and the headless gating bail in
+    /// each creator, plus the interactive gating bail they share via
+    /// [`drive_pending_to_active`]. Asserted rather than documented — the
+    /// wording was already duplicated across the creators once, and the
+    /// interactive site was missed the first time precisely because it lives
+    /// in a third function.
     #[test]
     fn both_creators_share_the_composition_failure_message() {
         let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-        for (file, func) in [
-            ("src/lib.rs", "activate_session"),
-            ("src/task.rs", "cmd_task_run"),
+        for (file, func, uses) in [
+            ("src/lib.rs", "activate_session", 2),
+            ("src/task.rs", "cmd_task_run", 2),
+            ("src/lib.rs", "drive_pending_to_active", 1),
         ] {
             let text = std::fs::read_to_string(manifest.join(file)).expect("readable source");
             let body = function_body(&text, func)
                 .unwrap_or_else(|| panic!("{file} no longer defines {func}"));
             assert_eq!(
                 body.matches("composition_failure_message").count(),
-                2,
-                "{func} must route both composition failures through the shared message"
+                uses,
+                "{func} must route its composition failures through the shared message"
             );
             for bare in ["ConfigureLoadout failed", "Composition gating failed"] {
                 assert!(

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -735,8 +735,10 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
         .context("ConfigureLoadout RPC failed")?;
     let configured = match configured {
         minimald_rpc::Errorable::Ok(r) => r,
+        // Same failure, same wording as an activate: the user knows the
+        // directory, not the daemon-side step that broke.
         minimald_rpc::Errorable::Err { error } => {
-            bail!("ConfigureLoadout failed: {error}");
+            bail!(crate::composition_failure_message(&utf8_path, &error));
         }
     };
 
@@ -754,7 +756,10 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
                     Ok((verdict, _final_policy)) => verdict,
                     Err(e) => {
                         crate::send_abort(&mut client, session_id).await;
-                        bail!("Composition gating failed: {e}");
+                        bail!(crate::composition_failure_message(
+                            &utf8_path,
+                            &e.to_string()
+                        ));
                     }
                 };
             let summary = hooks.into_summary();

--- a/crates/minimal/src/task.rs
+++ b/crates/minimal/src/task.rs
@@ -786,6 +786,7 @@ pub async fn cmd_task_run(global: &GlobalArgs, args: TaskRunArgs) -> Result<(), 
                 user_policy,
                 compose_options,
                 &hooks,
+                &utf8_path,
             )
             .await;
             if let Ok((_, _, ref approved)) = result {

--- a/crates/minimal/tests/cli.rs
+++ b/crates/minimal/tests/cli.rs
@@ -425,6 +425,65 @@ async fn activate_uses_repo_dir_when_no_positional_path() {
     assert_eq!(hello, b"hello world");
 }
 
+/// `min session activate` puts a session id on stdout only for a session
+/// that can actually run `exec`. When the daemon refuses to compose one,
+/// the activation must fail with stdout untouched — otherwise a script's
+/// `id=$(min session activate)` captures an id whose every `min session
+/// exec` then fails — and the error must name the directory the user ran
+/// from rather than the daemon-side step that broke (#581).
+///
+/// Driven through the compiled binary, not `cmd_activate`: the contract
+/// under test is what reaches the process's stdout. The composition is
+/// broken by a project var inheriting a name no environment defines — the
+/// daemon routes it back for gating and resolving it fails, which is the
+/// way an activation actually reaches a composition failure today.
+#[tokio::test]
+async fn activate_prints_no_session_id_when_composition_fails() {
+    let (_daemon, args) = setup().await;
+    let minimal_dir = args.minimal_dir.clone().expect("setup points at a tempdir");
+
+    // `.git` marks a VCS root so the upload gate doesn't prompt; the
+    // var name is unique enough that no environment defines it.
+    let project = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir(project.path().join(".git")).unwrap();
+    std::fs::write(
+        project.path().join("minimal.toml"),
+        "[session.vars]\nMIN_UNRESOLVABLE_INHERIT_581 = { inherit = true }\n",
+    )
+    .unwrap();
+    let project_canon = project.path().canonicalize().unwrap();
+
+    // An empty config dir keeps the developer's own loadouts and policy
+    // out of the run.
+    let config_dir = tempfile::TempDir::new().unwrap();
+    let out = tokio::process::Command::new(env!("CARGO_BIN_EXE_min"))
+        .args(["--minimal-dir".as_ref(), minimal_dir.as_os_str()])
+        .args(["--config-dir".as_ref(), config_dir.path().as_os_str()])
+        .arg("--no-input")
+        .args(["session", "activate"])
+        .arg(&project_canon)
+        .args(["--name", "composition-failure", "--sync", "tarball"])
+        .arg("--no-prompt")
+        .output()
+        .await
+        .expect("the min binary should be invocable");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "activation must fail: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "a session that cannot compose must put nothing on stdout, got: {stdout}"
+    );
+    assert!(
+        stderr.contains(project_canon.to_str().unwrap()),
+        "the error must name the directory the activation ran from: {stderr}"
+    );
+}
+
 /// `min session attach` with no session argument and `--no-input` errors cleanly when
 /// no sessions exist, rather than hanging or shelling out to ssh. The error
 /// surfaces before any ssh exec, so it is deterministic in a test environment.


### PR DESCRIPTION
## Summary

An activation that fails to compose reported the daemon's own error verbatim:

```
ConfigureLoadout failed: init of minimal context: other: git command 'fetch' failed
(exit status: 128): fatal: unable to access 'http://…/pkgs-local.git/': Failed to connect
```

That names an internal package server the caller never asked for and cannot act on. The one thing they *do* know is the directory they ran from. Now:

```
error: Cannot start a session for /tmp/myproject: composing a session environment from that
directory's project configuration failed, so no session was activated. Fix the configuration
there, then re-run.

cause: <original daemon error, in full>
```

`utf8_path` is the path used — it is literally the directory the activation ran from (positional, `-C/--repo-dir`, or cwd) and is always present, where `upload_root` is `Option` and is *derived* (a walk up to the nearest mfile), so it can name a directory the user never typed.

`Refs: gominimal/inbox#581` — this is §1 (decision `D-usable-id`) partial; the daemon half is #1339.

### Reviewer note — scope, one step past the obvious fix

The `Errorable::Err` branch is not the one users actually reach. **The daemon routes a project it cannot compose back to the client as *pending items* rather than failing the RPC** (`resolve_project_ctx_and_graph` even downgrades graph-resolution failure to a `warn!`). Two independent broken-project fixtures — an unresolvable `{ inherit = true }` var, and a patch with a non-absolute source — both came back `Pending` and then died at the *other* bail, `Composition gating failed: …`.

Fixing only `Errorable::Err` would have left the visible message unchanged, so both bails route through one helper. `task.rs` carried its own copy of *both* strings; those now share the helper too, with a source-inventory test to stop them drifting apart again — they had already drifted once.

## Testing

`just test` on this branch, on a host whose clean-`main` baseline was captured first for comparison:

```
1947 tests run: 1933 passed (1 leaky), 14 failed, 12 skipped
```

The 14 failures are **identical to the clean `main` baseline** (`diff` of the sorted failure sets is empty) — they are environmental: the authoring sandbox rewrites every `github.com` URL to a local git proxy (`url.http://…/git/.insteadof https://github.com/`), so any test asserting a remote URL round-trips fails. Root cause confirmed as `Other(vcs: invalid remote path)` at `minimald/src/env.rs`.

The three new tests, run directly:

```
PASS minimal tests::composition_failure_leads_with_the_directory_not_the_daemon_step
PASS minimal tests::both_creators_share_the_composition_failure_message
PASS minimal::cli activate_prints_no_session_id_when_composition_fails
Summary: 3 tests run: 3 passed
```

`activate_prints_no_session_id_when_composition_fails` spawns the compiled `min` binary against an in-process `TestServer` and asserts exit non-zero, **stdout empty**, and stderr naming the project directory — so `id=$(min session activate)` cannot capture an id whose every `min session exec` then fails. That stdout half cannot be asserted from the existing `cmd_activate` tests, which do not capture stdout.

No e2e case added: the failure-path e2e needs the daemon change in #1339, so it belongs there rather than here.

## Checklist

- [x] Docs updated if behavior changed — user-facing error text only
- [ ] `BREAKING CHANGE:` footer present if this is a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activation failure messages to identify the relevant project directory.
  * Preserved the underlying daemon error for clearer troubleshooting.
  * Standardized error reporting across activation and session-composition failures.
  * Prevented session IDs from being emitted when activation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->