### PR TITLE
feat(op): capture upstream NOTICE/COPYRIGHT files at source extraction (#1040)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4724,6 +4724,7 @@ name = "op"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "base64 0.23.1",
  "common",
  "decode",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4738,6 +4738,7 @@ dependencies = [
  "ot",
  "rayon",
  "sandbox2",
+ "serde",
  "serde_json_lenient",
  "sha2 0.11.0",
  "shlex",

--- a/crates/lcache/src/lib.rs
+++ b/crates/lcache/src/lib.rs
@@ -243,7 +243,7 @@ impl Cache<LocalDir> {
     pub fn at_dir<P: AsRef<Path>>(p: P) -> Result<Self, std::io::Error> {
         let fs = LocalDir::with_base(p)?;
 
-        for dir in &["temp", "meta", "alog"] {
+        for dir in &["temp", "meta", "alog", "notices"] {
             match fs.mkdir(dir) {
                 Ok(()) => Ok(()),
                 Err(e) => {
@@ -296,6 +296,12 @@ impl Cache<LocalDir> {
 
         let p = self.inner().fs.path().join(subpath);
         std::fs::remove_dir_all(p).map_err(CacheErr::from)
+    }
+
+    /// Where upstream attribution files captured from extracted sources
+    /// live: `<cache>/notices/<source-sha256>.json`.
+    pub fn notices_dir(&self) -> PathBuf {
+        self.inner().fs.path().join("notices")
     }
 
     /// Allocates a temporary directory in the same filesystem as the rest of the cache.

--- a/crates/mip/src/cmd_cache.rs
+++ b/crates/mip/src/cmd_cache.rs
@@ -25,6 +25,14 @@ pub enum CacheArgs {
         #[arg(long, value_parser = parse_duration, default_value = "14d")]
         older_than: Duration,
     },
+    /// Show the upstream attribution files captured from a source archive
+    ///
+    /// Prints the `NOTICE` / `COPYRIGHT` / `COPYING` files recorded when the
+    /// archive with this sha256 was last extracted, as JSON.
+    Notices {
+        /// The archive's sha256, as declared in the build spec
+        source_sha256: String,
+    },
 }
 
 fn parse_duration(arg: &str) -> Result<std::time::Duration, anyhow::Error> {
@@ -43,7 +51,22 @@ fn parse_duration(arg: &str) -> Result<std::time::Duration, anyhow::Error> {
 }
 
 pub async fn cmd_cache(args: CacheArgs, ctx: &mut Context) -> Result<(), Error> {
-    let CacheArgs::Clean { older_than } = args;
+    let older_than = match args {
+        CacheArgs::Clean { older_than } => older_than,
+        CacheArgs::Notices { source_sha256 } => {
+            let notices = op::notices::read(&ctx.local_cache(), &source_sha256)
+                .map_err(|e| Error::Other(e.into()))?
+                .ok_or_else(|| {
+                    Error::Other(anyhow!(
+                        "no notices recorded for {source_sha256}; extract the source first"
+                    ))
+                })?;
+            let json = serde_json_lenient::to_string_pretty(&notices)
+                .map_err(|e| Error::Other(e.into()))?;
+            println!("{json}");
+            return Ok(());
+        }
+    };
 
     // Everything this project's tasks and stack need, whatever its age.
     let keep = ctx.needed_packages()?;

--- a/crates/op/Cargo.toml
+++ b/crates/op/Cargo.toml
@@ -12,6 +12,7 @@ smallvec.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+base64.workspace = true
 flate2.workspace = true
 hex.workspace = true
 futures.workspace = true

--- a/crates/op/Cargo.toml
+++ b/crates/op/Cargo.toml
@@ -19,6 +19,7 @@ globset.workspace = true
 walkdir.workspace = true
 oci-spec.workspace = true
 rayon.workspace = true
+serde.workspace = true
 serde_json_lenient.workspace = true
 sha2.workspace = true
 shlex.workspace = true

--- a/crates/op/src/lib.rs
+++ b/crates/op/src/lib.rs
@@ -42,6 +42,8 @@ pub use subsets::SubsetBuild;
 mod cache_clean;
 pub use cache_clean::{CleanCache, CleanEvent, CleanReport, StaleKind};
 
+pub mod notices;
+pub use notices::{NoticeFile, SourceNotices};
 mod sources;
 pub use sources::{SourceFetcher, SourceLoad};
 mod specs;

--- a/crates/op/src/notices.rs
+++ b/crates/op/src/notices.rs
@@ -1,0 +1,271 @@
+//! Upstream attribution files captured when a source is extracted.
+//!
+//! Some licenses require the upstream's *own* files to travel with a
+//! distribution — Apache-2.0 §4(d) for `NOTICE`, verbatim copyright notices
+//! for most permissive licenses. Only the builder ever holds the unpacked
+//! source tree, so the capture happens here, once per source, and is stored
+//! beside the cache as `<cache>/notices/<source-sha256>.json`. The
+//! attribution manifest sealed downstream already names each package's
+//! sources by sha256, which is the join key.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use lcache::{Cache, LocalDir};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Bump when the on-disk shape changes.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Top-level files that count as attribution. Matched case-insensitively on
+/// the stem, so `NOTICE`, `Notice.txt`, `COPYING.LIB`, and `COPYRIGHT.md` all
+/// qualify while `LICENSE` (covered by the canonical SPDX text) does not.
+const STEMS: &[&str] = &["NOTICE", "COPYRIGHT", "COPYING"];
+
+/// Larger files are not attribution text; skipped rather than truncated.
+const MAX_FILE_BYTES: u64 = 512 * 1024;
+
+/// Upstreams rarely ship more than a handful; a cap keeps a pathological tree
+/// from turning into a large record.
+const MAX_FILES: usize = 8;
+
+/// One captured file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoticeFile {
+    /// File name as it appears at the top of the source tree.
+    pub name: String,
+    /// Hex sha256 of the raw bytes.
+    pub sha256: String,
+    /// Contents, lossily decoded as UTF-8.
+    pub text: String,
+}
+
+/// Everything captured from one source archive.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceNotices {
+    pub schema_version: u32,
+    /// Hex sha256 of the source archive, as declared in the build spec.
+    pub source_sha256: String,
+    /// Sorted by name. Empty when the tree ships nothing qualifying, which is
+    /// recorded too so consumers can tell "scanned, none" from "never seen".
+    pub files: Vec<NoticeFile>,
+}
+
+fn qualifies(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    STEMS.iter().any(|stem| {
+        upper
+            .strip_prefix(stem)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with(['.', '-', '_']))
+    })
+}
+
+fn is_sha256_hex(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Reads the qualifying regular files directly under `dir`. Symlinks and
+/// directories are ignored — a symlink could point outside the tree.
+fn scan_dir(dir: &Path) -> io::Result<Vec<NoticeFile>> {
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if !qualifies(&name) || !entry.file_type()?.is_file() {
+            continue;
+        }
+        if entry.metadata()?.len() > MAX_FILE_BYTES {
+            continue;
+        }
+        let bytes = std::fs::read(entry.path())?;
+        files.push(NoticeFile {
+            name,
+            sha256: hex::encode(Sha256::digest(&bytes)),
+            text: String::from_utf8_lossy(&bytes).into_owned(),
+        });
+    }
+    files.sort_by(|a, b| a.name.cmp(&b.name));
+    files.truncate(MAX_FILES);
+    Ok(files)
+}
+
+/// Scans an extracted source tree rooted at `root`. When the archive kept its
+/// single top-level directory (no `strip_prefix`), that directory is the tree.
+pub fn scan(root: &Path) -> io::Result<Vec<NoticeFile>> {
+    let files = scan_dir(root)?;
+    if !files.is_empty() {
+        return Ok(files);
+    }
+    let mut entries = std::fs::read_dir(root)?.collect::<io::Result<Vec<_>>>()?;
+    match entries.pop() {
+        Some(only) if entries.is_empty() && only.file_type()?.is_dir() => scan_dir(&only.path()),
+        _ => Ok(files),
+    }
+}
+
+fn record_path(cache: &Cache<LocalDir>, source_sha256: &str) -> PathBuf {
+    cache.notices_dir().join(format!("{source_sha256}.json"))
+}
+
+/// Captures `root`'s attribution files under `source_sha256`. Idempotent:
+/// an existing record is left alone, since the same archive always yields
+/// the same tree. Returns the record's path.
+pub fn record(cache: &Cache<LocalDir>, source_sha256: &str, root: &Path) -> io::Result<PathBuf> {
+    if !is_sha256_hex(source_sha256) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("not a sha256 hex digest: {source_sha256:?}"),
+        ));
+    }
+    let path = record_path(cache, source_sha256);
+    if path.exists() {
+        return Ok(path);
+    }
+    let notices = SourceNotices {
+        schema_version: SCHEMA_VERSION,
+        source_sha256: source_sha256.to_owned(),
+        files: scan(root)?,
+    };
+    let json = serde_json_lenient::to_string_pretty(&notices).map_err(io::Error::other)?;
+    // Write-then-rename so a reader never sees a partial record.
+    let tmp = path.with_extension(format!("json.tmp-{}", std::process::id()));
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(path)
+}
+
+/// Reads a record, `None` when the source has never been extracted here.
+pub fn read(cache: &Cache<LocalDir>, source_sha256: &str) -> io::Result<Option<SourceNotices>> {
+    if !is_sha256_hex(source_sha256) {
+        return Ok(None);
+    }
+    match std::fs::read(record_path(cache, source_sha256)) {
+        Ok(bytes) => serde_json_lenient::from_slice(&bytes)
+            .map(Some)
+            .map_err(io::Error::other),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const SHA: &str = "4474de87e084953eefc1120cf905a79f72bbbf85091e30cf37c9214eafcaa9c9";
+
+    fn tree(files: &[(&str, &str)]) -> TempDir {
+        let dir = TempDir::new().unwrap();
+        for (name, body) in files {
+            std::fs::write(dir.path().join(name), body).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn stems_match_case_insensitively_with_suffixes() {
+        for name in [
+            "NOTICE",
+            "notice",
+            "Notice.txt",
+            "NOTICE.md",
+            "COPYING.LIB",
+            "COPYRIGHT-2024",
+            "copyright_notice",
+        ] {
+            assert!(qualifies(name), "{name}");
+        }
+        for name in [
+            "LICENSE",
+            "LICENSE-APACHE",
+            "NOTICES",
+            "NOTICEBOARD.txt",
+            "README",
+            "COPYINGX",
+        ] {
+            assert!(!qualifies(name), "{name}");
+        }
+    }
+
+    #[test]
+    fn scan_collects_only_qualifying_regular_files_sorted_by_name() {
+        let dir = tree(&[
+            ("NOTICE", "hello"),
+            ("copying.txt", "c"),
+            ("LICENSE", "l"),
+            ("README", "r"),
+        ]);
+        std::fs::create_dir(dir.path().join("COPYRIGHT.d")).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(dir.path().join("NOTICE"), dir.path().join("NOTICE-link"))
+            .unwrap();
+        std::fs::write(
+            dir.path().join("NOTICE.big"),
+            vec![b'x'; MAX_FILE_BYTES as usize + 1],
+        )
+        .unwrap();
+
+        let files = scan(dir.path()).unwrap();
+        let names: Vec<&str> = files.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, ["NOTICE", "copying.txt"]);
+        assert_eq!(
+            files[0].sha256,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+        assert_eq!(files[0].text, "hello");
+    }
+
+    #[test]
+    fn scan_descends_into_a_lone_top_level_directory() {
+        let dir = TempDir::new().unwrap();
+        let top = dir.path().join("pkg-1.0");
+        std::fs::create_dir(&top).unwrap();
+        std::fs::write(top.join("NOTICE"), "n").unwrap();
+        assert_eq!(scan(dir.path()).unwrap()[0].name, "NOTICE");
+
+        // Two top-level entries: the tree is `root` itself, and it has nothing.
+        std::fs::write(dir.path().join("README"), "r").unwrap();
+        assert!(scan(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn record_writes_once_and_reads_back() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = Cache::at_dir(cache_dir.path()).unwrap();
+        let src = tree(&[("NOTICE", "first")]);
+
+        let path = record(&cache, SHA, src.path()).unwrap();
+        assert_eq!(path, cache.notices_dir().join(format!("{SHA}.json")));
+        let got = read(&cache, SHA).unwrap().unwrap();
+        assert_eq!(got.schema_version, SCHEMA_VERSION);
+        assert_eq!(got.source_sha256, SHA);
+        assert_eq!(got.files.len(), 1);
+        assert_eq!(got.files[0].text, "first");
+
+        // A second extraction of the same archive does not rewrite the record.
+        std::fs::write(src.path().join("NOTICE"), "changed").unwrap();
+        record(&cache, SHA, src.path()).unwrap();
+        assert_eq!(read(&cache, SHA).unwrap().unwrap().files[0].text, "first");
+
+        // Nothing qualifying is still a record.
+        let empty = tree(&[("LICENSE", "l")]);
+        let other = "a".repeat(64);
+        record(&cache, &other, empty.path()).unwrap();
+        assert!(read(&cache, &other).unwrap().unwrap().files.is_empty());
+        assert!(read(&cache, &"b".repeat(64)).unwrap().is_none());
+    }
+
+    #[test]
+    fn record_rejects_a_key_that_is_not_a_digest() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = Cache::at_dir(cache_dir.path()).unwrap();
+        let src = tree(&[]);
+        let err = record(&cache, "../escape", src.path()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(read(&cache, "../escape").unwrap().is_none());
+    }
+}

--- a/crates/op/src/notices.rs
+++ b/crates/op/src/notices.rs
@@ -11,6 +11,7 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
+use base64::Engine as _;
 use lcache::{Cache, LocalDir};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -37,8 +38,31 @@ pub struct NoticeFile {
     pub name: String,
     /// Hex sha256 of the raw bytes.
     pub sha256: String,
-    /// Contents, lossily decoded as UTF-8.
-    pub text: String,
+    /// Contents, when they are valid UTF-8.
+    pub text: Option<String>,
+    /// Contents, base64 (standard, padded), only when they are not valid
+    /// UTF-8 — the bytes travel verbatim either way.
+    pub base64: Option<String>,
+}
+
+impl NoticeFile {
+    fn from_bytes(name: String, bytes: Vec<u8>) -> Self {
+        let sha256 = hex::encode(Sha256::digest(&bytes));
+        match String::from_utf8(bytes) {
+            Ok(text) => Self {
+                name,
+                sha256,
+                text: Some(text),
+                base64: None,
+            },
+            Err(e) => Self {
+                name,
+                sha256,
+                text: None,
+                base64: Some(base64::engine::general_purpose::STANDARD.encode(e.into_bytes())),
+            },
+        }
+    }
 }
 
 /// Everything captured from one source archive.
@@ -66,9 +90,11 @@ fn is_sha256_hex(s: &str) -> bool {
 }
 
 /// Reads the qualifying regular files directly under `dir`. Symlinks and
-/// directories are ignored — a symlink could point outside the tree.
+/// directories are ignored — a symlink could point outside the tree. The
+/// selection is made on metadata alone so no more than [`MAX_FILES`] files
+/// are ever read.
 fn scan_dir(dir: &Path) -> io::Result<Vec<NoticeFile>> {
-    let mut files = Vec::new();
+    let mut candidates = Vec::new();
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
@@ -80,16 +106,14 @@ fn scan_dir(dir: &Path) -> io::Result<Vec<NoticeFile>> {
         if entry.metadata()?.len() > MAX_FILE_BYTES {
             continue;
         }
-        let bytes = std::fs::read(entry.path())?;
-        files.push(NoticeFile {
-            name,
-            sha256: hex::encode(Sha256::digest(&bytes)),
-            text: String::from_utf8_lossy(&bytes).into_owned(),
-        });
+        candidates.push((name, entry.path()));
     }
-    files.sort_by(|a, b| a.name.cmp(&b.name));
-    files.truncate(MAX_FILES);
-    Ok(files)
+    candidates.sort();
+    candidates.truncate(MAX_FILES);
+    candidates
+        .into_iter()
+        .map(|(name, path)| Ok(NoticeFile::from_bytes(name, std::fs::read(path)?)))
+        .collect()
 }
 
 /// Scans an extracted source tree rooted at `root`. When the archive kept its
@@ -216,7 +240,38 @@ mod tests {
             files[0].sha256,
             "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         );
-        assert_eq!(files[0].text, "hello");
+        assert_eq!(files[0].text.as_deref(), Some("hello"));
+        assert_eq!(files[0].base64, None);
+    }
+
+    #[test]
+    fn scan_keeps_non_utf8_bytes_verbatim() {
+        let dir = TempDir::new().unwrap();
+        let bytes = b"Copyright \xa9 2024".to_vec();
+        std::fs::write(dir.path().join("COPYRIGHT"), &bytes).unwrap();
+        let file = scan(dir.path()).unwrap().remove(0);
+        assert_eq!(file.text, None);
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(file.base64.as_deref().unwrap())
+            .unwrap();
+        assert_eq!(decoded, bytes);
+        assert_eq!(file.sha256, hex::encode(Sha256::digest(&bytes)));
+    }
+
+    #[test]
+    fn scan_caps_the_file_count_by_name_order() {
+        let dir = TempDir::new().unwrap();
+        for i in 0..(MAX_FILES + 3) {
+            std::fs::write(dir.path().join(format!("NOTICE-{i:02}")), "x").unwrap();
+        }
+        let names: Vec<String> = scan(dir.path())
+            .unwrap()
+            .into_iter()
+            .map(|f| f.name)
+            .collect();
+        assert_eq!(names.len(), MAX_FILES);
+        assert_eq!(names[0], "NOTICE-00");
+        assert_eq!(names[MAX_FILES - 1], format!("NOTICE-{:02}", MAX_FILES - 1));
     }
 
     #[test]
@@ -244,12 +299,15 @@ mod tests {
         assert_eq!(got.schema_version, SCHEMA_VERSION);
         assert_eq!(got.source_sha256, SHA);
         assert_eq!(got.files.len(), 1);
-        assert_eq!(got.files[0].text, "first");
+        assert_eq!(got.files[0].text.as_deref(), Some("first"));
 
         // A second extraction of the same archive does not rewrite the record.
         std::fs::write(src.path().join("NOTICE"), "changed").unwrap();
         record(&cache, SHA, src.path()).unwrap();
-        assert_eq!(read(&cache, SHA).unwrap().unwrap().files[0].text, "first");
+        assert_eq!(
+            read(&cache, SHA).unwrap().unwrap().files[0].text.as_deref(),
+            Some("first")
+        );
 
         // Nothing qualifying is still a record.
         let empty = tree(&[("LICENSE", "l")]);

--- a/crates/op/src/sources.rs
+++ b/crates/op/src/sources.rs
@@ -299,6 +299,6 @@ mod tests {
         assert_eq!(record.source_sha256, SHA);
         let names: Vec<&str> = record.files.iter().map(|f| f.name.as_str()).collect();
         assert_eq!(names, ["NOTICE"]);
-        assert_eq!(record.files[0].text, "upstream notice");
+        assert_eq!(record.files[0].text.as_deref(), Some("upstream notice"));
     }
 }

--- a/crates/op/src/sources.rs
+++ b/crates/op/src/sources.rs
@@ -74,6 +74,14 @@ impl<'a, SF: SourceFetcher> Runnable for SourceLoad<'a, SF> {
             },
         });
 
+        // Attribution capture keys on the archive's declared sha256, which is
+        // what the sealed attribution manifest names per package. Local files
+        // are project-side and never appear there.
+        let source_sha256 = match &self.source.from {
+            SourceFetch::Web { sha256, .. } => Some(sha256.clone()),
+            SourceFetch::Local { .. } => None,
+        };
+
         let (cached_path, filename) = match &self.source.from {
             SourceFetch::Local {
                 full_path,
@@ -148,6 +156,7 @@ impl<'a, SF: SourceFetcher> Runnable for SourceLoad<'a, SF> {
                         self.source.strip_prefix.as_ref(),
                     )
                     .map_err(anyhow::Error::from)?;
+                    record_notices(opts, source_sha256.as_deref(), tempdir_path);
                     Ok(Materialized::TempDir(tempdir))
                 }
                 (Some(compression), Some(pending_dir)) => {
@@ -159,6 +168,7 @@ impl<'a, SF: SourceFetcher> Runnable for SourceLoad<'a, SF> {
                         self.source.strip_prefix.as_ref(),
                     )
                     .map_err(anyhow::Error::from)?;
+                    record_notices(opts, source_sha256.as_deref(), pending_dir.path());
                     Ok(Materialized::Given(pending_dir))
                 }
 
@@ -169,5 +179,126 @@ impl<'a, SF: SourceFetcher> Runnable for SourceLoad<'a, SF> {
         } else {
             Ok(Materialized::File(cached_path))
         }
+    }
+}
+
+/// Best-effort: a build never fails because attribution could not be
+/// recorded, but the miss is logged so it is not silent.
+fn record_notices(opts: &Options<'_>, source_sha256: Option<&str>, root: &std::path::Path) {
+    let Some(sha256) = source_sha256 else {
+        return;
+    };
+    if let Err(error) = crate::notices::record(&opts.cache, sha256, root) {
+        tracing::warn!(%sha256, %error, "could not record upstream notices");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Options;
+    use flate2::{Compression, write::GzEncoder};
+    use graph::{Graph, SourceFetch, SourceInput};
+    use lcache::Cache;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    const SHA: &str = "4474de87e084953eefc1120cf905a79f72bbbf85091e30cf37c9214eafcaa9c9";
+
+    /// Serves one local archive for any URL, standing in for a verified fetch.
+    #[derive(Debug)]
+    struct FixtureFetcher(PathBuf);
+
+    impl SourceFetcher for FixtureFetcher {
+        async fn download_web(
+            &self,
+            _url: &str,
+            _sha256: &str,
+            _op: &OpTracker,
+        ) -> anyhow::Result<PathBuf> {
+            Ok(self.0.clone())
+        }
+
+        async fn download_gcs(
+            &self,
+            _bucket_id: String,
+            _file: &str,
+            _sha256: &str,
+            _op: &OpTracker,
+        ) -> anyhow::Result<PathBuf> {
+            unreachable!("only web sources are fetched here")
+        }
+    }
+
+    fn tarball(dir: &Path, files: &[(&str, &[u8])]) -> PathBuf {
+        let path = dir.join("pkg-1.0.tar.gz");
+        let enc = GzEncoder::new(std::fs::File::create(&path).unwrap(), Compression::fast());
+        let mut tar = tar::Builder::new(enc);
+        for (name, body) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(name).unwrap();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            tar.append(&header, *body).unwrap();
+        }
+        tar.into_inner().unwrap().finish().unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn extracting_a_web_source_records_its_notices() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join("cache")).unwrap();
+        let cache = Cache::at_dir(tmp.path().join("cache")).unwrap();
+        let archive = tarball(
+            tmp.path(),
+            &[
+                ("pkg-1.0/NOTICE", b"upstream notice"),
+                ("pkg-1.0/LICENSE", b"apache"),
+                ("pkg-1.0/src/main.rs", b"fn main() {}"),
+            ],
+        );
+        let fetcher = FixtureFetcher(archive);
+        let graph = Graph::new();
+        let opts = Options {
+            cache: cache.clone(),
+            graph: &graph,
+            exec_base: tmp.path().to_path_buf(),
+            ot: None,
+            daemon_id: None,
+        };
+        let source = SourceInput {
+            from: SourceFetch::Web {
+                url: "https://example.invalid/pkg-1.0.tar.gz".into(),
+                sha256: SHA.into(),
+                url_pos: None,
+                sha256_pos: None,
+            },
+            extract: true,
+            strip_prefix: Some("pkg-1.0".into()),
+        };
+
+        let materialized = SourceLoad {
+            source: &source,
+            remote_fetcher: &fetcher,
+            into: None,
+        }
+        .run(&opts)
+        .await
+        .unwrap();
+
+        let Materialized::TempDir(root) = materialized else {
+            panic!("an extracted source materializes into a temp dir");
+        };
+        assert!(root.path().join("NOTICE").exists());
+
+        let record = crate::notices::read(&cache, SHA)
+            .unwrap()
+            .expect("recorded");
+        assert_eq!(record.source_sha256, SHA);
+        let names: Vec<&str> = record.files.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, ["NOTICE"]);
+        assert_eq!(record.files[0].text, "upstream notice");
     }
 }


### PR DESCRIPTION
Closes #1040 (minimal side). Follow-up in gominimal/build-servers seals the pointer into the attribution manifest.

## What

Some licenses require the upstream's own files to travel with a distribution — Apache-2.0 §4(d) for `NOTICE`, verbatim copyright notices for most permissive licenses. Only the builder holds the unpacked tree, so this captures them at extraction time:

- `op::notices` — after `extract_compressed_tar`, scan the tree root (or its lone top-level dir when no `strip_prefix`) for `NOTICE*` / `COPYRIGHT*` / `COPYING*` (case-insensitive, regular files only, ≤512 KiB, ≤8 files) and record `<cache>/notices/<source-sha256>.json` — `{schema_version, source_sha256, files:[{name, sha256, text?, base64?}]}` (`text` when valid UTF-8, `base64` otherwise — bytes travel verbatim), selection by metadata before any read, sorted, written once (write-then-rename), idempotent. "Scanned, nothing" is recorded too.
- `lcache::Cache::notices_dir()` + the dir created at `at_dir`.
- `SourceLoad` records for `Web` sources only, keyed by the declared `sha256` — the key the sealed attribution manifest already carries per package (`sources[].sha256`). Local files are project-side and never appear there. Best-effort: a failure logs a warning and never fails the build.
- `mip cache notices <sha256>` prints a record.

## Why this shape

Keying by the archive hash means one record per tarball rather than per package build, stable across rebuilds and arches, and a pure server-side join for build-servers: `sources[].sha256` → `notices/<sha256>` object → optional `notices` field on `PackageAttribution` (schema 1 → 2, additive). No output-tarball or graph changes.

## Audit backing the scope

Streamed all 86 source tarballs of the 71 Apache-2.0 packages in manifest `ff3ca2f4`: 7 ship a `NOTICE` today (bat, codex, cups, maven, otel-collector, trivy, typst), 8 more ship `COPYRIGHT`/`COPYING`. Details on #1040.

## Tests

- `op::notices`: stem matching, regular-file/symlink/size/sort rules, lone-top-dir descent, idempotent record + read-back, non-digest key rejection.
- `op::sources`: end-to-end `SourceLoad` over a generated tar.gz with `strip_prefix` records the NOTICE under the declared sha256.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added attribution notice tracking for remote source archives.
  - Added a cache command to retrieve recorded notices as formatted JSON using an archive checksum.
  - Notices are saved for extracted archives in both temporary and specified locations.
  - Added support for preserving binary notice files while displaying readable text when available.

- **Improvements**
  - Notice file selection is now deterministic and limited to a maximum number of files.
  - Notice recording failures generate warnings without interrupting builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->