### PR TITLE
fix(minimald): return from exec when the child exits, not when its pipes close

### DIFF
--- a/crates/minimald/src/exec.rs
+++ b/crates/minimald/src/exec.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
 use std::io;
 use std::process::Stdio;
+use std::time::Duration;
 
 use futures::{
     StreamExt,
@@ -724,24 +725,51 @@ where
 }
 
 /// Drives one [`Process`] to completion: pumps `r → child stdin` and
-/// `child stdout/stderr → w/e` concurrently until both output streams
-/// hit EOF, then reaps the child and returns the SSH-encoded exit code.
+/// `child stdout/stderr → w/e` concurrently, and returns the
+/// SSH-encoded exit code once **the child exits** — not once its pipes
+/// close (gominimal/inbox#566).
 ///
-/// EOF on both stdout and stderr is the exit signal. When the child
-/// exits (or is killed), the kernel closes its stdio fds, which surfaces
-/// as EOF on our read side — so once both are drained the subsequent
-/// `process.wait()` resolves promptly. The one case this misses is a
-/// child that forks a grandchild and lets it inherit stdout/stderr;
-/// then the pipes stay open past the child's own exit and we drain
-/// until the grandchild exits too. That matches the existing semantics
-/// (drain everything before returning) and is fine for `min run` and
-/// `sh -c` usage.
+/// The two are usually the same event: when the child exits the kernel
+/// closes its stdio fds and our read side sees EOF. They come apart
+/// when the child forks a grandchild that inherits stdout/stderr and
+/// outlives it — `sh -c 'sleep 20 & echo STARTED'`. The write ends stay
+/// open, so waiting for EOF would hold the caller for as long as the
+/// grandchild lives. Note that the direct child here is the `nsenter`
+/// shim, which itself blocks in `Child::wait` on the session shell, so
+/// "the child exited" already means "the user's command finished";
+/// pipelines and foreground jobs are waited on by that shell and are
+/// unaffected.
 ///
-/// Polling the three I/O sources in a single `select!` lets a slow
-/// consumer on one side apply backpressure without starving the others.
-/// On an SSH-channel write failure we also `start_kill` the child: with
-/// no one reading its output the pipe buffer would fill, the child
-/// would block on write, and EOF (and `wait`) would never resolve.
+/// So the loop ends on the *first* of: both output streams at EOF, the
+/// child exiting, or an SSH-channel write failing. On child exit we
+/// then, in order:
+///
+/// 1. **Drain what is already buffered** ([`drain_ready`]): everything
+///    the child wrote before exiting is sitting in the pipe and still
+///    belongs to the caller. Reads stop the moment a pipe would block,
+///    so this costs nothing when there is no grandchild.
+/// 2. **Return the exit code.**
+/// 3. **Hand any still-open read end to a detached drain-and-discard
+///    task** ([`spawn_pipe_drain`]). Dropping it instead would leave
+///    the grandchild writing into a pipe with no reader — EPIPE, and
+///    SIGPIPE, which kills a detached service on its first log line.
+///
+/// The trade is that a grandchild's output after we return is silently
+/// discarded; `nohup cmd >/dev/null 2>&1 &` is the way to detach
+/// cleanly (documented in `docs/reference/cli-min.md`).
+///
+/// Polling the I/O sources in a single `select!` lets a slow consumer
+/// on one side apply backpressure without starving the others, which is
+/// why the branches stay unbiased rather than ranking `process.wait()`
+/// last. The cost is that `wait` can win a race against readable
+/// output; step 1 is what makes that harmless. Nothing is lost to the
+/// branches `select!` cancels either way: `read` is cancel-safe, and
+/// the SSH writes live in branch *handlers*, which run after the
+/// `select!` has already resolved.
+///
+/// On an SSH-channel write failure we stop and `start_kill` the child:
+/// with no one reading its output the pipe buffer would fill, the child
+/// would block on write, and `wait` would never resolve.
 ///
 /// `stdin_open` is threaded by `&mut` so once the SSH client closes
 /// stdin (EOF or read error), every subsequent child in the sequence
@@ -773,8 +801,16 @@ where
 
     let mut stdout_open = true;
     let mut stderr_open = true;
+    // Set when a write to the SSH channel fails. The channel is gone,
+    // so there is nothing left to relay and the child has to be killed
+    // rather than left to block on a pipe nobody drains.
+    let mut ssh_write_failed = false;
+    // `Some` once the child has been reaped; also the loop's exit
+    // signal, since anything still holding the pipes open past this
+    // point is a grandchild we do not wait for.
+    let mut child_exit: Option<io::Result<Option<i32>>> = None;
 
-    while stdout_open || stderr_open {
+    while (stdout_open || stderr_open) && !ssh_write_failed && child_exit.is_none() {
         tokio::select! {
             // Gated on `child_stdin.is_some()`: if the current child's
             // stdin pipe broke mid-step (write failure below) we stop
@@ -826,8 +862,7 @@ where
                                 %channel_id, error = %err,
                                 "exec: failed to forward child stdout to ssh channel; killing child",
                             );
-                            stdout_open = false;
-                            let _ = process.start_kill();
+                            ssh_write_failed = true;
                         }
                     }
                 }
@@ -848,16 +883,74 @@ where
                                 %channel_id, error = %err,
                                 "exec: failed to forward child stderr to ssh channel; killing child",
                             );
-                            stderr_open = false;
-                            let _ = process.start_kill();
+                            ssh_write_failed = true;
                         }
                     }
                 }
             }
+            // Lowest-value branch but deliberately unbiased: `select!`
+            // picks at random among ready branches, so this can win a
+            // race with pending output. That is what the post-loop
+            // `drain_ready` covers. Nothing here touches `process`, so
+            // the `&mut process` this future holds is uncontended.
+            status = process.wait() => child_exit = Some(status),
         }
     }
 
-    match process.wait().await {
+    // Nobody is reading the child's output any more, so it would wedge
+    // on a full pipe and never be reapable. Kill, then fall through to
+    // the `wait` below.
+    if ssh_write_failed {
+        let _ = process.start_kill();
+    }
+
+    // The child is gone but a grandchild may still hold the write ends.
+    // Everything the child itself wrote is already in the pipe buffer
+    // and still belongs to the caller — take it before returning.
+    if child_exit.is_some() {
+        let relayed = drain_ready(
+            &channel_id,
+            &mut child_stdout,
+            &mut stdout_open,
+            w,
+            &mut stdout_buf,
+            "stdout",
+        )
+        .await;
+        // A dead SSH channel takes stderr with it; skip the second
+        // drain rather than log the same failure twice. Neither flag is
+        // cleared — a pipe we stopped reading is exactly the one the
+        // background drain below has to keep alive.
+        if relayed {
+            drain_ready(
+                &channel_id,
+                &mut child_stderr,
+                &mut stderr_open,
+                e,
+                &mut stderr_buf,
+                "stderr",
+            )
+            .await;
+        }
+    }
+
+    // Let anything still attached see EOF on its stdin; `*stdin_open`
+    // is untouched, so the next child in the sequence still reads `r`.
+    drop(child_stdin);
+
+    // Hand off before returning: an orphan writing into a pipe whose
+    // read end we dropped takes SIGPIPE and dies. See `spawn_pipe_drain`.
+    spawn_pipe_drain(
+        channel_id.to_string(),
+        stdout_open.then_some(child_stdout),
+        stderr_open.then_some(child_stderr),
+    );
+
+    let status = match child_exit {
+        Some(status) => status,
+        None => process.wait().await,
+    };
+    match status {
         Ok(code) => code.unwrap_or(1) as u32,
         Err(err) => {
             tracing::warn!(
@@ -867,6 +960,128 @@ where
             1
         }
     }
+}
+
+/// How long [`drain_ready`] waits for a pipe to produce something after
+/// the child has been reaped, before concluding that whatever still
+/// holds the write end is a grandchild whose output we do not owe the
+/// caller.
+///
+/// Only paid when a grandchild really is holding the pipe: in the
+/// ordinary case EOF is already pending and the read returns at once.
+const DRAIN_GRACE: Duration = Duration::from_millis(100);
+
+/// Relays whatever `src` already has buffered to `sink`, stopping once
+/// `src` goes quiet for [`DRAIN_GRACE`].
+///
+/// Called once the child has been reaped, when a grandchild may be
+/// holding the write end open: the bytes the child wrote before exiting
+/// are still owed to the caller, but there is nothing beyond them worth
+/// waiting for.
+///
+/// The stopping condition is a short timeout rather than a single
+/// `now_or_never` poll, and that distinction is load-bearing. Tokio
+/// learns a pipe is readable from a reactor turn, so a lone poll issued
+/// on the turn where `wait()` resolved can report "would block" for a
+/// pipe that already holds the child's output — silently truncating the
+/// common `min session exec echo hi` case. Waiting for readiness
+/// instead of guessing at it costs nothing when EOF is already pending
+/// (the overwhelmingly common shape) and at most one [`DRAIN_GRACE`]
+/// when a grandchild really is holding the write end open.
+///
+/// Sets `*open = false` on EOF or a read error. Returns `false` if a
+/// write to the SSH channel failed, so the caller can stop relaying.
+async fn drain_ready<S, W>(
+    channel_id: &impl Display,
+    src: &mut S,
+    open: &mut bool,
+    sink: &mut W,
+    buf: &mut [u8],
+    stream_name: &'static str,
+) -> bool
+where
+    S: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    // Bound the drain: a grandchild writing faster than we relay could
+    // otherwise keep every read succeeding forever and reintroduce the
+    // very hang this function exists to end. 64 rounds of an 8 KiB
+    // buffer is many times a pipe's capacity, so a real backlog always
+    // fits.
+    const MAX_ROUNDS: usize = 64;
+
+    for _ in 0..MAX_ROUNDS {
+        if !*open {
+            return true;
+        }
+        // An elapsed timeout means the pipe went quiet: whatever is
+        // still holding the write end is not the child we just reaped,
+        // so its output is not ours to relay. `read` is cancel-safe, so
+        // losing the race here drops no bytes.
+        let Ok(read_res) = tokio::time::timeout(DRAIN_GRACE, src.read(buf)).await else {
+            return true;
+        };
+        match read_res {
+            Ok(0) => *open = false,
+            Err(err) => {
+                tracing::warn!(
+                    %channel_id, error = %err, stream = stream_name,
+                    "exec: failed to read child output while draining; treating as eof",
+                );
+                *open = false;
+            }
+            Ok(n) => {
+                if let Err(err) = sink.write_all(&buf[..n]).await {
+                    tracing::warn!(
+                        %channel_id, error = %err, stream = stream_name,
+                        "exec: failed to forward drained child output to ssh channel",
+                    );
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Reads and discards a grandchild's inherited stdio for as long as it
+/// holds the write end open.
+///
+/// Handed the read ends of an exited child's stdout/stderr once
+/// [`bridge_one`] has stopped relaying. Simply dropping them would
+/// point the orphan's next write at a pipe with no reader: EPIPE, and
+/// SIGPIPE, whose default disposition kills the process — turning a
+/// visible hang into a backgrounded service that dies on its first log
+/// line. Draining costs two fds and one task for the orphan's life,
+/// which is what the blocking bridge held anyway.
+///
+/// Does nothing (and spawns nothing) when both handles are `None`, the
+/// case for every child that closes its pipes on exit.
+fn spawn_pipe_drain<O, E>(channel_id: String, stdout: Option<O>, stderr: Option<E>)
+where
+    O: AsyncRead + Unpin + Send + 'static,
+    E: AsyncRead + Unpin + Send + 'static,
+{
+    if stdout.is_none() && stderr.is_none() {
+        return;
+    }
+    tracing::debug!(
+        %channel_id,
+        "exec: child exited with its stdio still held open; draining in the background",
+    );
+    spawn(async move {
+        async fn discard<S: AsyncRead + Unpin>(src: Option<S>) {
+            let Some(mut src) = src else { return };
+            let mut buf = [0u8; 8 * 1024];
+            while let Ok(n) = src.read(&mut buf).await {
+                if n == 0 {
+                    break;
+                }
+            }
+        }
+        tokio::join!(discard(stdout), discard(stderr));
+        tracing::debug!(%channel_id, "exec: background stdio drain finished");
+    });
 }
 
 /// Handles a request to run a program on an SSH channel.
@@ -1719,6 +1934,83 @@ mod tests {
         // maps to exit status 1.
         assert_eq!(exit, 1);
         assert!(ctrl.was_killed());
+    }
+
+    /// A grandchild that inherited the child's stdout keeps the pipe
+    /// open past the child's own exit — `sh -c 'sleep 20 & echo
+    /// STARTED'`. The bridge must return on the *child's* exit, relay
+    /// what the child wrote before exiting, and keep reading the orphan's
+    /// pipe rather than dropping it (gominimal/inbox#566).
+    ///
+    /// Every other test here drops the stdout writer *before* signalling
+    /// exit, which is why none of them caught this: holding it is the
+    /// whole point.
+    #[tokio::test]
+    async fn bridge_returns_on_child_exit_with_stdout_still_held_open() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let (
+            process,
+            MockEndpoints {
+                stdin_reader: _stdin_reader,
+                mut stdout_writer,
+                stderr_writer,
+                ctrl,
+            },
+        ) = build_mock();
+        // Only stdout models the inherited fd; stderr EOFs as usual.
+        drop(stderr_writer);
+
+        // SSH stdin closed: bridge sees EOF immediately.
+        let (closed_stdin_w, mut bridge_stdin) = duplex(64);
+        drop(closed_stdin_w);
+        let (mut client_stdout, mut bridge_stdout) = duplex(1024 * 1024);
+        let (_unused_stderr_peer, mut bridge_stderr) = duplex(64 * 1024);
+
+        let bridge_task = tokio::spawn(async move {
+            bridge(
+                "test",
+                process,
+                &mut bridge_stdin,
+                &mut bridge_stdout,
+                &mut bridge_stderr,
+            )
+            .await
+        });
+
+        // What the child printed before exiting, then the exit — with
+        // the writer still held, standing in for the backgrounded
+        // grandchild's copy of the fd.
+        stdout_writer.write_all(b"STARTED\n").await.unwrap();
+        ctrl.signal_exit(0).await;
+
+        let exit = timeout(Duration::from_secs(10), bridge_task)
+            .await
+            .expect("bridge must return on child exit, not wait out the orphan")
+            .unwrap();
+        assert_eq!(exit, 0);
+        assert!(!ctrl.was_killed());
+
+        // The orphan lives on. Its next write must not hit a closed read
+        // end — that is EPIPE, and SIGPIPE kills a real process — and
+        // more than a pipeful must still move, proving something is
+        // actually draining rather than merely holding the fd.
+        let orphan_output = vec![b'x'; 256 * 1024];
+        timeout(
+            Duration::from_secs(10),
+            stdout_writer.write_all(&orphan_output),
+        )
+        .await
+        .expect("the daemon must keep draining the orphan's pipe, not stall on a full one")
+        .expect("dropping the read end would break the orphan's pipe (EPIPE/SIGPIPE)");
+
+        // Pre-exit output is still relayed in full; post-exit output is
+        // discarded, so the client sees exactly the former.
+        drop(stdout_writer);
+        let mut out = Vec::new();
+        client_stdout.read_to_end(&mut out).await.unwrap();
+        assert_eq!(out, b"STARTED\n");
     }
 
     /// A two-process sequence: the first child exits non-zero, so the

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -148,9 +148,10 @@ daemon's own operations are named explicitly instead — see `session run`.
 
 `session exec` returns when `COMMAND` itself exits, and relays output up to
 that point. A process the command backgrounds keeps running in the session,
-but anything it writes *after* the command has exited is not relayed — it is
-read and discarded, so the process is never killed by a broken pipe, but you
-will not see it.
+but what it writes *after* the command has exited is not yours to rely on: a
+short drain catches whatever was already in flight, and past that its output
+is read and discarded. Nothing it writes is ever lost to a broken pipe — the
+process is not killed — but you will not see it.
 
 ```
 min session exec web 'sleep 20 & echo STARTED'   # returns immediately

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -144,6 +144,31 @@ Nothing about a command's *text* routes it: a command is the session's however
 it happens to start, so the session's own `min` binary is reachable here. The
 daemon's own operations are named explicitly instead — see `session run`.
 
+#### Backgrounding a command
+
+`session exec` returns when `COMMAND` itself exits, and relays output up to
+that point. A process the command backgrounds keeps running in the session,
+but anything it writes *after* the command has exited is not relayed — it is
+read and discarded, so the process is never killed by a broken pipe, but you
+will not see it.
+
+```
+min session exec web 'sleep 20 & echo STARTED'   # returns immediately
+```
+
+So background a long-running process with its output redirected somewhere you
+can retrieve it, rather than expecting it on the wire:
+
+```
+min session exec web 'nohup ./server >server.log 2>&1 &'
+min session exec web 'tail -n 50 server.log'
+```
+
+`nohup ... >/dev/null 2>&1 &` is the fully detached form: it hands the process
+its own stdout and stderr and drops the ones it inherited, so nothing about it
+depends on the exec channel at all. The same applies to `session run` and
+`task run`, which relay over the same channel.
+
 ### `session run`
 
 ```


### PR DESCRIPTION
Closes gominimal/inbox#566.

## The bug

`bridge_one` ended its I/O loop only when both child stdout and stderr hit EOF, then reaped the child. A grandchild that inherited those fds holds the write ends open past the child's own exit, so the loop ran for as long as the grandchild lived:

```console
$ min session exec web 'sleep 20 & echo STARTED'
STARTED
# ...blocks for 20s
```

The trigger is **fd inheritance, not backgrounding** — `nohup sleep 20 >/dev/null 2>&1 &` already returned instantly, because the redirects mean nothing inherits the pipes.

## The fix

`process.wait()` becomes a fourth `select!` branch, so the loop ends on the first of: both streams at EOF, the child exiting, or an SSH-channel write failing.

On child exit we drain what is already buffered, return the exit code, and hand any still-open read end to a **detached drain-and-discard task**. That last part is load-bearing rather than tidy: dropping the read end would point the orphan's next write at a pipe with no reader, and SIGPIPE would kill the backgrounded service on its first log line. That converts a visible 20s hang into a silent death, in exactly the use case people background things for.

### The drain's stopping condition

The drain stops when the pipe stays quiet for 100 ms, rather than after a single `now_or_never` poll. This distinction decides whether the fix is correct at all:

tokio learns a pipe is readable from a reactor turn. A lone `now_or_never` issued on the turn where `wait()` resolved can report "would block" for a pipe that already holds the child's output — which would silently truncate `min session exec echo hi`, the most common command there is. A mock-based test can't catch it either: `duplex` makes writes readable without a reactor turn, so the race structurally cannot reproduce there.

The grace is only ever paid when a grandchild really is holding the write end. With no grandchild, EOF is already pending and the read returns at once. Measured by raising the constant to 2500 ms:

| Test | 100 ms grace | 2500 ms grace |
|---|---|---|
| `end_to_end::exec_runs_echo_task` (real process) | 0.094 s | 0.094 s |
| `bridge_returns_on_child_exit_with_stdout_still_held_open` | 0.105 s | 2.505 s |

The ordinary path never touches it.

## Why the race in `select!` is harmless

The branches stay unbiased, so `wait` can win against readable output; the post-loop drain is what makes that safe. Nothing is lost to cancellation either way — `read` is cancel-safe, and the SSH writes live in branch *handlers*, which run after the `select!` has already resolved.

To make `wait` a branch at all, the two SSH-write-failure handlers no longer call `process.start_kill()` inline (that would contend with the `&mut process` `wait` holds across the `select!`); they set a flag and the kill happens after the loop, where `process` is free. The child is still killed for the same reason as before.

## Scope

The daemon's direct child is the `nsenter` shim, which itself blocks in `Child::wait` on the session shell (`crates/minimald/src/nsenter.rs`), so "the child exited" already means "the user's command finished". Pipelines and foreground jobs are waited on by that shell and are unaffected. `min task run` and `min session run` share `bridge_one` through `ExecTask::run` and get the same fix.

The trade — a grandchild's output written after we return is discarded — is now documented in `docs/reference/cli-min.md` under a new "Backgrounding a command" subsection, along with the `nohup cmd >/dev/null 2>&1 &` detach idiom.

## Test

`bridge_returns_on_child_exit_with_stdout_still_held_open` signals exit while still holding the stdout writer, then writes 256 KiB through it — proving both that the bridge returned and that the orphan's writes still land somewhere rather than taking EPIPE. Every pre-existing test drops the writers before signalling exit, which is precisely why none of them caught this.

## Note on the issue text

The issue also described an argv re-evaluation defect. That one is already fixed on `main` by 8c517227 (`fix(exec)!: tag exec-channel requests instead of sniffing the string`); nothing here re-addresses it.

## Verification

`cargo clippy -p minimald --all-targets` clean, `cargo fmt --check` clean, all 14 `exec::` tests pass locally. Leaving the full matrix to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Commands now return promptly when the underlying process exits, even if inherited output streams remain open.
  - Output produced before exit is preserved, while lingering output is safely discarded in the background.
  - SSH write failures now terminate the associated command instead of leaving it running.

- **Documentation**
  - Added guidance and examples for running commands in the background with `session exec`.
  - Documented output-discard behavior after command completion and clarified applicability to `session run` and `task run`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->