### PR TITLE
docs: state where `{ inherit = true }` diverges by surface

### DIFF
--- a/crates/mfile/src/project_composable.rs
+++ b/crates/mfile/src/project_composable.rs
@@ -2,14 +2,27 @@
 //!
 //! [`ProjectComposable`] pairs a project's [`Session`] block with its
 //! project path, tagging every primitive it produces with
-//! [`Source::Project`]. Mirrors [`Loadout`]'s materialization
-//! exactly — the only difference is provenance and the absence of a
-//! per-block name.
+//! [`Source::Project`]. It mirrors [`Loadout`]'s materialization for
+//! packages, patches, and lifecycle hooks — but **not** for vars.
+//!
+//! A project routes its vars through the shared
+//! [`contribute_primitives`] / [`ResolvedVar::resolve_with`] path, so
+//! a bare `{ inherit = true }` that the environment does not carry is
+//! a hard error and fails activation. [`Loadout`] resolves its own
+//! vars through a private `resolve_var_declaration` that warns and
+//! drops that same case instead. Both behaviours are deliberate — a
+//! project declares what every contributor needs, a loadout declares
+//! one developer's preferences — but they are *not* the same
+//! behaviour, and this module is the strict half. The user-facing
+//! statement of the split is "Where `{ inherit = true }` differs" in
+//! `docs/reference/minimal-dot-toml.md`.
 //!
 //! [`Session`]: crate::Session
 //! [`Composable`]: sessions::core::compose::Composable
 //! [`Source::Project`]: sessions::core::source::Source::Project
 //! [`Loadout`]: sessions::core::loadout::Loadout
+//! [`contribute_primitives`]: sessions::core::compose::contribute_primitives
+//! [`ResolvedVar::resolve_with`]: sessions::core::primitives::ResolvedVar::resolve_with
 
 use paths::HostPath;
 use sessions::core::compose::{Composable, Contribution, Error, contribute_primitives};
@@ -143,11 +156,13 @@ mod tests {
 
     /// A var with `{ inherit = true }` whose env lookup returns
     /// [`NotPresent`] surfaces the [`ResolutionFailure`] as a
-    /// composition [`Error`], mirroring [`Loadout::contribute`].
-    /// This is expected: daemon-side pending routing lives in the
-    /// composer, not the trait impl. Documents the current failure
-    /// mode so a future PR that adds pending routing has a test to
-    /// flip.
+    /// composition [`Error`]. This is where a project **diverges from**
+    /// [`Loadout::contribute`], which warns and drops the same input;
+    /// the strictness is the project surface's documented contract, not
+    /// an accident of this impl. Daemon-side pending routing lives in
+    /// the composer, not the trait impl, so the error surfaces to the
+    /// user as `ComposeError::VarResolution` after the client re-resolves
+    /// the pending var against its own env.
     ///
     /// [`NotPresent`]: std::env::VarError::NotPresent
     /// [`ResolutionFailure`]: sessions::core::primitives::VarError::ResolutionFailure
@@ -166,8 +181,8 @@ mod tests {
 
         let env = |_: &str| Err(std::env::VarError::NotPresent);
         let err = comp.contribute(&env).expect_err("inherit lookup fails");
-        // Error propagates as the composer's Var domain, matching
-        // Loadout's behavior for the same input.
+        // Error propagates as the composer's Var domain. Loadout
+        // returns Ok here for the same input — see the doc comment.
         assert!(matches!(err, Error::Var { .. }));
     }
 

--- a/crates/sessions/docs/COMPOSITION.md
+++ b/crates/sessions/docs/COMPOSITION.md
@@ -104,6 +104,21 @@ a new session to retry.
 The user's loadouts are added to a `UserComposer` via
 `UserComposer::add`. Each `Loadout::contribute(env)` call resolves
 `VarValue::Inherit*` and tags items with `Source::UserLoadout`.
+
+Loadout var resolution is deliberately **not** the shared
+`ResolvedVar::resolve_with` path. `Loadout::contribute` runs its own
+`resolve_var_declaration`, which differs on one branch: a bare
+`VarValue::Inherit` whose lookup returns `VarError::NotPresent` is
+`warn!`ed and dropped (`Ok(None)`) instead of erroring, so a loadout
+that opportunistically inherits `COLORTERM` doesn't fail activation on
+a host that doesn't set it. Every other branch — `NotUnicode`,
+`InheritWithDefault`, `Specified` — matches `resolve_with`. Phase 3's
+project and package vars go through `resolve_with` itself and so
+**do** hard-fail on an unset bare `Inherit`; the divergence is
+intentional and user-visible, and is documented for end users under
+"Where `{ inherit = true }` differs" in
+`docs/reference/minimal-dot-toml.md`.
+
 `UserComposer::compose(policy)` runs the **shared client-side gate
 pipeline** (described below). User-origin items auto-pass the
 `allow` step but still hit `deny` and `ignore`; vars whose value
@@ -183,7 +198,10 @@ project vars still land but package contributions are empty.
 The client receives the `ContributionResponse` and runs
 `client::handler::handle_response` over the pending batch: resolves
 any `Inherit`/`InheritWithDefault` vars against the client env
-(`ResolvedVar::resolve_with`), expands patch sources against the
+(`ResolvedVar::resolve_with` — so a bare `Inherit` the client env
+does not carry aborts the whole activation with
+`ComposeError::VarResolution`, unlike the Phase 1 loadout path that
+drops it with a warning), expands patch sources against the
 already-gated vars from Phase 1 plus anything approved in this
 batch, applies the user policy, and prompts via local `PolicyHooks`
 when the policy can't decide. Result: one `ContributionVerdict`,

--- a/crates/sessions/src/core/compose.rs
+++ b/crates/sessions/src/core/compose.rs
@@ -606,10 +606,24 @@ pub trait Composable {
 /// against a single [`Source`], resolving each var against `env`.
 ///
 /// Shared by [`crate::core::loadout::Loadout`]'s and every project /
-/// package composable's `contribute` — the only per-source
-/// difference is the [`Source`] tag stamped on every produced item,
-/// so lifting the loop bodies into one helper prevents the impls
-/// from drifting when a new primitive lands.
+/// package composable's `contribute`, so lifting the loop bodies into
+/// one helper prevents the impls from drifting when a new primitive
+/// lands. For packages, patches, and hooks the only per-source
+/// difference is the [`Source`] tag stamped on every produced item.
+///
+/// **Vars are the exception.** [`Loadout::contribute`] passes empty
+/// maps for both var arguments and resolves its own vars through a
+/// private `resolve_var_declaration`, because a loadout treats a bare
+/// [`VarValue::Inherit`] the host hasn't set as a warn-and-drop.
+/// Everything that *does* route vars through here — project and
+/// package composables — gets [`ResolvedVar::resolve_with`]'s strict
+/// rule instead, where that same case is a hard error. Don't read
+/// this helper as the single definition of var semantics; it is the
+/// strict one of two.
+///
+/// [`Loadout::contribute`]: crate::core::loadout::Loadout::contribute
+/// [`VarValue::Inherit`]: crate::core::primitives::VarValue::Inherit
+/// [`ResolvedVar::resolve_with`]: crate::core::primitives::ResolvedVar::resolve_with
 ///
 /// Positional args over a named struct because wrapping five fields
 /// in a `Primitives`-shaped struct at every callsite (only to

--- a/docs/guide/dev-shell.md
+++ b/docs/guide/dev-shell.md
@@ -73,6 +73,14 @@ AWS_PROFILE = { inherit = true }
 
 A string value like `EDITOR = "nano"` defines a fixed variable. Using `{ inherit = true }` passes through the value from your host environment, which is useful for credentials or configuration that varies per developer.
 
+Inheriting this way is required, not opportunistic. If `AWS_PROFILE` is not set in your host environment, activation fails rather than starting the session without it:
+
+```
+error: Composition gating failed: could not resolve pending var `AWS_PROFILE`: environment variable not found
+```
+
+Since `minimal.toml` is checked in, that applies to everyone on the project — write `{ inherit = true, default = "..." }` instead when the variable is genuinely optional. A loadout's `[vars]` takes the opposite view of the same spelling and only warns; see [Where `{ inherit = true }` differs](../reference/minimal-dot-toml.md#inherit-divergence).
+
 ### Run setup on activation
 
 To run setup steps when a session comes up, declare lifecycle hooks in the `[session]` block:

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -122,7 +122,7 @@ Names are not checked at activation: an unknown package composes cleanly
 and fails later, when the session first spawns, with
 `no such package: <name>`.
 
-### `[vars]` - Environment variables
+### `[vars]` - Environment variables {#vars}
 
 _Optional_
 
@@ -149,6 +149,15 @@ MUXER = { inherit = true }               # inherit from the host env
   when the host does not have the variable set.
 
 `inherit = false` is rejected; omit the variable instead.
+
+The warn-and-drop rule is a loadout relaxation, not a property of the
+spelling. The same `{ inherit = true }` in a project's
+[`[session.vars]`](./minimal-dot-toml.md#session) is **required**: an unset
+host variable there fails activation instead of being dropped. A project is
+declaring what every contributor needs, where a loadout is declaring what one
+developer would like. See
+[Where `{ inherit = true }` differs](./minimal-dot-toml.md#inherit-divergence)
+for the rule on every surface that accepts the form.
 
 ### `[[vars_lenient]]` - Environment variables with non-POSIX names {#vars_lenient}
 

--- a/docs/reference/minimal-dot-toml.md
+++ b/docs/reference/minimal-dot-toml.md
@@ -145,6 +145,9 @@ RUST_LOG         = "info"
 CARGO_TERM_COLOR = "always"
 # Inherit from the developer's environment if set, else the default.
 DATABASE_URL     = { inherit = true, default = "postgres://localhost/dev" }
+# Inherit with no fallback: a developer who has not set this cannot
+# activate a session on this project.
+GITHUB_TOKEN     = { inherit = true }
 
 # Declared to warm the compile cache when a session comes up.
 [[session.lifecycle_hooks]]
@@ -154,8 +157,20 @@ on_activate = { type = "inline", value = "cargo check --workspace >/dev/null 2>&
 - **`packages`**: Packages brought into every session on this project,
   alongside whatever the developer's loadouts contribute.
 - **`vars`**: Environment variables. A string sets a fixed value;
-  `{ inherit = true }` passes the developer's own value through (add
-  `default = "..."` for a fallback when it is unset).
+  `{ inherit = true }` passes the developer's own value through. Here that
+  inheritance is **required**: if the developer's environment does not have
+  the variable set, activation fails rather than proceeding without it.
+
+  ```console
+  $ min session activate
+  error: Composition gating failed: could not resolve pending var
+  `GITHUB_TOKEN`: environment variable not found
+  ```
+
+  Adding `default = "..."` supplies a fallback and makes the variable
+  optional again. A loadout spells the bare form the same way but treats it
+  as optional — see
+  [Where `{ inherit = true }` differs](#inherit-divergence).
 - **`patches`**: `{ source, dest }` rows copying files into the session.
   `dest` is relative to the session user's home directory; `source` resolves
   on the host, typically inside the repo. The one expansion a loadout has
@@ -171,7 +186,29 @@ on_activate = { type = "inline", value = "cargo check --workspace >/dev/null 2>&
 
 The field shapes and composition semantics (conflicts, policy gating) are the
 same as loadouts; see the [loadout reference](./loadouts.md) for the exact
-rules.
+rules. Variable *resolution* is the exception: a bare `{ inherit = true }`
+that the host has not set fails activation here, where a loadout drops it
+with a warning, so the loadout page's rule for that one case does not carry
+over.
+
+#### Where `{ inherit = true }` differs {#inherit-divergence}
+
+Three surfaces accept `{ inherit = true }`, spelled identically on each.
+They agree that a variable the host *has* set is passed through, and they
+disagree about everything else:
+
+| Surface | Host variable unset | `default = "..."` |
+|---|---|---|
+| This file's `[session.vars]` (and `[[session.vars_lenient]]`) | Activation fails: `could not resolve pending var <NAME>` | Supported; the default is used |
+| A loadout's [`[vars]`](./loadouts.md#vars) and [`[[vars_lenient]]`](./loadouts.md#vars_lenient) | Dropped, with a warning on the terminal; activation continues | Supported; the default is used |
+| A task's [`env_vars`](./tasks.md#env_vars) | The run fails before the session is built | Rejected when the file is parsed — a task's `inherit` takes no `default` |
+
+Two things narrow the task row. An `echo` task never builds an environment,
+so it never reads — or fails over — an `env_vars` declaration. And
+`min run <task>` from inside a session, along with
+`min session run <session> <task>`, resolves `inherit` against the daemon's
+environment rather than your shell. Both are covered in
+[Tasks](./tasks.md#env_vars).
 
 
 

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -95,7 +95,7 @@ state_key = "dev" # Cache build artifacts under 'dev'
 ```
 
 
-### `env_vars` - Environment variables to set
+### `env_vars` - Environment variables to set {#env_vars}
 
 _Optional. `env_vars` is an alias of the canonical `vars` key; both parse_
 


### PR DESCRIPTION
Closes gominimal/inbox#567.

Documentation and comments only. **Zero behavior change, zero test changes.**

## The problem

The same three tokens mean different things depending on where they are written, and the docs never said so. Worse, the `[session]` section of `minimal-dot-toml.md` affirmatively claimed parity with loadouts and sent the reader to the page carrying the *opposite* rule.

The actual split, unchanged by this PR:

| Surface | Bare `{ inherit = true }`, host unset | `default` available? |
|---|---|---|
| `[session.vars]` / `[[session.vars_lenient]]` | **Hard error**, activation fails | yes |
| loadout `[vars]` / `[[vars_lenient]]` | Warns and drops the var | yes |
| task `env_vars` | **Hard error**, different message | **no** |

The project path routes vars through `contribute_primitives` → `ResolvedVar::resolve_with` (strict); `Loadout::contribute` passes empty var maps to that same helper and resolves them itself through a private `resolve_var_declaration` (warn-and-drop). A task's `env_vars` is a different type entirely — `mfile::EnvVarValue` has only `Value`/`Inherit`, and its deserializer rejects extra fields, so there is no `default` to fall back on.

## Changes

- **`docs/reference/minimal-dot-toml.md`** — the epicenter. Corrected the parity sentence; rewrote the `vars` bullet to state the hard-fail and show the real error text; added a `#### Where { inherit = true } differs` section with the cross-surface table and its narrowings (echo tasks; in-session `min run` / `min session run` resolving against the daemon env). Added a `GITHUB_TOKEN = { inherit = true }` example that demonstrates the trap.
- **`docs/reference/loadouts.md`** — frames warn-and-drop as a loadout *relaxation*, not a property of the spelling, and links to the new section.
- **`docs/guide/dev-shell.md`**, **`crates/sessions/docs/COMPOSITION.md`** — pointers to the same section.
- **`docs/reference/tasks.md`** — anchor only; the page already stated its own rule correctly and was the model for the new prose.
- **`crates/mfile/src/project_composable.rs`** — corrected three comments asserting project/loadout parity.
- **`crates/sessions/src/core/compose.rs`** — corrected a fourth: `contribute_primitives`'s own doc claimed "the only per-source difference is the `Source` tag stamped on every produced item", which is false precisely because `Loadout` routes vars around it. Left uncorrected, that would reintroduce the defect one call site away from the code the issue is about.

Explicit `{#vars}` and `{#env_vars}` anchors were added so the new cross-page links don't depend on derived slugs — the repo already has three stale links of that kind (`user-policy.md:30`, `cli-min.md:98,198` → `loadouts.md#lifecycle_hooks---scripts-at-session-transition-points`), left alone here as out of scope.

## Two corrections to the issue report

1. The report praises the strict path for a `--no-prompt` error carrying a paste-ready `user_policy.toml` snippet. **It doesn't attach to this error.** That snippet comes from `NoPromptHook`/`UnapprovedSummary` and fires only for policy-*undecided* items; var resolution fails before classification, so an unset `[session.vars]` inherit yields a bare `Composition gating failed:` line with no snippet. The polished message the reporter had in mind is the *task* path. The new docs quote the message that actually appears.
2. The report omits a fourth surface pair: `[[session.vars_lenient]]` vs a loadout's `[[vars_lenient]]` (non-POSIX names). The identical strict/lenient split applies, and it's covered in the new table.

## Verification

`just fmt-check`, `just clippy` (`-D warnings`), and `just doctest` clean. `cargo doc --no-deps -p mfile -p sessions` emits only pre-existing warnings at lines this PR didn't author; all new intra-doc links resolve. `just test` on the branch matches the `origin/main` baseline with an identical failure-name set (14, all environmental git-URL-rewrite failures in this sandbox). `docs/reference/manifest.json` needs no change — all three reference pages touched are already listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)