### PR TITLE
feat: support loadout.toml in per-loadout directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ exit
 
 The project's `minimal.toml` describes what every contributor's session
 needs; a **loadout** carries what *you* want on top: your editor, terminal
-multiplexer, shell config, and dotfiles. Loadouts are single TOML files under
-`~/.config/minimal/loadouts/`:
+multiplexer, shell config, and dotfiles. Loadouts live under
+`~/.config/minimal/loadouts/`, either as `<name>.toml` or — to keep one under
+version control, alongside the files it ships — as `<name>/loadout.toml`:
 
 ```toml
 # ~/.config/minimal/loadouts/dev.toml
@@ -177,7 +178,9 @@ on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || 
 
 Apply one with `min session activate --loadout dev --attach .`, or list it in
 `default_loadouts` under `[loadouts]` in `~/.config/minimal/config.toml` to have it join every
-session automatically. `min loadout list` shows what's available. The full
+session automatically. `min loadout list` shows what's available, in either
+layout — so `git clone <repo> ~/.config/minimal/loadouts/dev` is enough to
+pick up a loadout someone else published. The full
 schema (file patches, lifecycle hooks, environment-variable inheritance,
 composition rules) is in the
 [loadouts reference](docs/reference/loadouts.md).

--- a/crates/minimal/src/diag/collect.rs
+++ b/crates/minimal/src/diag/collect.rs
@@ -80,14 +80,55 @@ pub async fn config(w: &mut BundleWriter, paths: &DiagPaths) -> Result<(), anyho
     )
     .await;
 
+    // Both loadout layouts: `<name>.toml` and `<name>/loadout.toml`. Only
+    // the definition file either way — the rest of a loadout's directory
+    // ($LOADOUT_ROOT assets, hook scripts) is the user's own content and
+    // has never been collected.
     match tokio::fs::read_dir(paths.config.join("loadouts")).await {
         Ok(mut entries) => loop {
             match entries.next_entry().await {
                 Ok(Some(entry)) => {
                     let path = entry.path();
-                    if path.extension().is_some_and(|e| e == "toml")
-                        && let Some(name) = path.file_name().and_then(|n| n.to_str())
-                    {
+                    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                        continue;
+                    };
+                    // `DirEntry::file_type` does not follow symlinks, and
+                    // that is the point: descending into a symlinked
+                    // `<name>/` would read a `loadout.toml` from wherever
+                    // it pointed, and `open_regular_nofollow` could not
+                    // stop it — `O_NOFOLLOW` guards only the final
+                    // component. A symlinked directory is therefore not a
+                    // directory here, matching the daemon-side refusal of
+                    // a symlinked hook anchor.
+                    let is_dir = match entry.file_type().await {
+                        Ok(ft) => ft.is_dir(),
+                        Err(e) => {
+                            w.skip(
+                                format!("config/loadouts/{name}"),
+                                format!("unreadable: {e}"),
+                            );
+                            continue;
+                        }
+                    };
+                    if is_dir {
+                        let file = path.join(sessions::client::disk::LOADOUT_FILE_NAME);
+                        // Existence only. Whether this is a *safe* file to
+                        // read is `add_redacted_toml`'s call, and it makes
+                        // it independently — a symlinked `loadout.toml` is
+                        // refused at open and the refusal recorded, the
+                        // same way a symlinked `<name>.toml` is below.
+                        if tokio::fs::metadata(&file).await.is_ok_and(|m| m.is_file()) {
+                            add_redacted_toml(
+                                w,
+                                &file,
+                                &format!(
+                                    "config/loadouts/{name}/{}.redacted",
+                                    sessions::client::disk::LOADOUT_FILE_NAME
+                                ),
+                            )
+                            .await;
+                        }
+                    } else if path.extension().is_some_and(|e| e == "toml") {
                         add_redacted_toml(w, &path, &format!("config/loadouts/{name}.redacted"))
                             .await;
                     }

--- a/crates/minimal/src/loadouts.rs
+++ b/crates/minimal/src/loadouts.rs
@@ -110,7 +110,7 @@ pub(crate) struct ActiveLoadouts {
     pub(crate) loadouts_dir: paths::HostAbsPath,
     /// True when the zero-config fallback used the built-in `default`
     /// loadout (as opposed to user files, including a shadowing user
-    /// `default.toml`).
+    /// `default` loadout of their own).
     pub(crate) builtin_default: bool,
 }
 
@@ -123,8 +123,8 @@ pub(crate) struct ActiveLoadouts {
 ///
 /// With no flags and an empty `default_loadouts`, falls back to the
 /// built-in [`builtin_default_loadout`] so a zero-config box is
-/// oriented rather than bare; a user `default.toml` on disk shadows
-/// the built-in.
+/// oriented rather than bare; a user `default` loadout on disk — in
+/// either layout — shadows the built-in.
 pub(crate) fn resolve_active_loadouts(
     selection: LoadoutSelection,
     cfg: &sessions::client::config::Config,
@@ -145,9 +145,16 @@ pub(crate) fn resolve_active_loadouts(
             if configured.is_empty() {
                 // Zero-config: no flags and no configured defaults.
                 // Fall back to the built-in `default` loadout unless
-                // the user shadows it with their own `default.toml`,
+                // the user shadows it with their own — in either
+                // layout, `default.toml` or `default/loadout.toml` —
                 // in which case that file is loaded instead.
-                if !loadouts_dir.as_utf8_path().join("default.toml").exists() {
+                //
+                // Probed through the resolver rather than a bare
+                // `exists()` so both layouts are found by one rule,
+                // and so a `default` that exists but is broken
+                // (malformed TOML, both layouts at once) is reported
+                // as the error it is instead of being read as absence.
+                if !user_default_exists(&loadouts_dir)? {
                     return Ok(ActiveLoadouts {
                         loadouts: vec![builtin_default_loadout()],
                         loadouts_dir,
@@ -163,11 +170,30 @@ pub(crate) fn resolve_active_loadouts(
     let loadouts = names
         .iter()
         .map(|name| {
-            let path = loadouts_dir.as_utf8_path().join(format!("{name}.toml"));
+            // Validate before the name reaches a path join. Without
+            // this, `--loadout ../../evil` would be interpolated
+            // straight into a filename and read an arbitrary `.toml`
+            // off disk — the post-read stem check does not catch it,
+            // since `file_stem("../../evil.toml")` is just `evil`.
+            //
+            // `LoadoutName`'s own error is the nutype-generated
+            // "failed the predicate test", which tells the user
+            // nothing about what a loadout name may contain — so the
+            // rule is spelled out here instead.
+            let name = sessions::core::loadout::LoadoutName::try_new(name)
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "`{name}` is not a loadout name: names are the file or directory \
+                         a loadout is filed under, so they cannot be empty, be `.` or \
+                         `..`, or contain `/`, `\\`, or NUL"
+                    )
+                })
+                .with_context(|| format!("{source} `{name}`"))?;
             // `LoadError`'s Display already embeds its I/O source, so flatten
             // it to a leaf before adding context; otherwise anyhow re-renders
             // the underlying error a second time from the chain.
-            sessions::client::disk::read_loadout_file(path.as_std_path())
+            sessions::client::disk::load_loadout(loadouts_dir.as_utf8_path().as_std_path(), &name)
+                .map(|(loadout, _layout)| loadout)
                 .map_err(|e| anyhow::anyhow!("{e}"))
                 .with_context(|| format!("{source} `{name}`"))
         })
@@ -177,6 +203,26 @@ pub(crate) fn resolve_active_loadouts(
         loadouts_dir,
         builtin_default: false,
     })
+}
+
+/// Whether the user has a `default` loadout of their own on disk, in
+/// either layout — the probe behind the zero-config fallback in
+/// [`resolve_active_loadouts`].
+///
+/// Absence is the normal answer here, so [`LoadError::NotFound`] maps
+/// to `Ok(false)`. Every other error means the file is *there* and
+/// unusable, which the user wants told rather than silently replaced
+/// by the built-in.
+///
+/// [`LoadError::NotFound`]: sessions::client::disk::LoadError::NotFound
+fn user_default_exists(loadouts_dir: &paths::HostAbsPath) -> Result<bool, anyhow::Error> {
+    let name = sessions::core::loadout::LoadoutName::try_new(BUILTIN_DEFAULT_NAME)
+        .expect("the built-in default's name is a valid loadout name");
+    match sessions::client::disk::load_loadout(loadouts_dir.as_utf8_path().as_std_path(), &name) {
+        Ok(_) => Ok(true),
+        Err(sessions::client::disk::LoadError::NotFound { .. }) => Ok(false),
+        Err(e) => Err(anyhow::anyhow!("{e}")).context("default_loadouts `default`"),
+    }
 }
 
 /// The loadouts directory an activation reads from:
@@ -484,10 +530,12 @@ fn resolve_loadouts_dir(args: &LoadoutListArgs, global: &GlobalArgs) -> PathBuf 
     resolve_minimal_config_dir(global).join("loadouts")
 }
 
-/// List loadouts discovered in the loadouts directory. One row per
-/// parseable `.toml` file; files that fail to parse are reported on
-/// stderr and make the command exit non-zero, leaving the table of
-/// valid loadouts intact. Loadouts named in
+/// List loadouts discovered in the loadouts directory, in both
+/// layouts (`<name>.toml` and `<name>/loadout.toml`). One row per
+/// parseable loadout; ones that fail to load — a parse error, or a
+/// name defined in both layouts at once — are reported on stderr and
+/// make the command exit non-zero, leaving the table of valid
+/// loadouts intact. Loadouts named in
 /// `[loadouts].default_loadouts` in the client config are marked
 /// with a leading `*`.
 pub fn cmd_loadout_list(args: LoadoutListArgs, global: &GlobalArgs) -> Result<(), anyhow::Error> {
@@ -499,7 +547,8 @@ pub fn cmd_loadout_list(args: LoadoutListArgs, global: &GlobalArgs) -> Result<()
         // orients the user. Note where to add their own and continue.
         Err(sessions::client::disk::ListError::NotFound { path }) => {
             eprintln!(
-                "No loadouts directory at {} yet — drop `<name>.toml` files there to add your own.",
+                "No loadouts directory at {} yet — add your own as `<name>.toml` \
+                 there, or as `<name>/loadout.toml` to keep one under version control.",
                 path.display()
             );
             Vec::new()
@@ -523,19 +572,20 @@ pub fn cmd_loadout_list(args: LoadoutListArgs, global: &GlobalArgs) -> Result<()
     // invisible until the user wondered why their loadout wasn't
     // active.
     let present: std::collections::HashSet<&str> =
-        entries.iter().map(|e| e.file_stem.as_str()).collect();
+        entries.iter().map(|e| e.name.as_str()).collect();
     defaults
         .iter()
         .filter(|missing| !present.contains(missing.as_str()))
         .for_each(|missing| {
             eprintln!(
-                "Warning: `{missing}` listed in default_loadouts but no `{missing}.toml` in {}",
+                "Warning: `{missing}` listed in default_loadouts but no `{missing}.toml` \
+                 or `{missing}/loadout.toml` in {}",
                 dir.display(),
             );
         });
 
     // The built-in `default` loadout is always available, so it gets a
-    // row unless the user has shadowed it with their own `default.toml`.
+    // row unless the user has shadowed it with a `default` of their own.
     let show_builtin = !present.contains(BUILTIN_DEFAULT_NAME);
 
     // Partition discovered entries: parsed loadouts become table rows,
@@ -588,8 +638,10 @@ pub fn cmd_loadout_list(args: LoadoutListArgs, global: &GlobalArgs) -> Result<()
         println!("* default (from `[loadouts].default_loadouts`)");
     }
     if failures > 0 {
+        // "failed to load", not "failed to parse": a conflicting pair
+        // of layouts is counted here too, and it parses fine.
         bail!(
-            "{failures} loadout file{} failed to parse",
+            "{failures} loadout{} failed to load",
             if failures == 1 { "" } else { "s" }
         );
     }
@@ -616,14 +668,14 @@ impl LoadoutRow {
         loadout: &sessions::core::loadout::Loadout,
         defaults: &std::collections::HashSet<String>,
     ) -> Self {
-        let marker = if defaults.contains(&entry.file_stem) {
+        let marker = if defaults.contains(&entry.name) {
             "*"
         } else {
             " "
         };
         Self {
             marker,
-            name: entry.file_stem.clone(),
+            name: entry.name.clone(),
             desc: loadout.description().unwrap_or("").to_string(),
             counts: format!(
                 "{} pkg / {} var / {} patch",
@@ -705,9 +757,9 @@ mod tests {
     }
 
     /// `resolve_active_loadouts` errors when a `--loadout NAME`
-    /// selection names a file that isn't on disk. The concrete
-    /// error goes to stderr via the closure; here we only assert
-    /// the Result is Err.
+    /// selection names a loadout that is on disk in neither layout,
+    /// and the message names both places it looked — a user who
+    /// mistyped needs to know where the file was expected.
     #[test]
     fn resolve_active_loadouts_cli_missing_file_errors() {
         let tmp = tempfile::tempdir().unwrap();
@@ -721,18 +773,30 @@ mod tests {
             no_input: false,
         };
         let selection = LoadoutSelection::Cli(vec!["missing".to_string()]);
-        assert!(resolve_active_loadouts(selection, &cfg, &global).is_err());
+        let err = resolve_active_loadouts(selection, &cfg, &global)
+            .expect_err("a missing --loadout must error");
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("missing.toml"), "got: {rendered}");
+        assert!(rendered.contains("missing/loadout.toml"), "got: {rendered}");
     }
 
-    /// The `--loadout NAME` missing-file error names the underlying OS failure
-    /// exactly once. `LoadError`'s Display already embeds its source, so the
+    /// The `--loadout NAME` error names the underlying failure exactly
+    /// once. `LoadError`'s Display already embeds its source, so the
     /// context chain must not re-render it (see the flatten in
     /// [`resolve_active_loadouts`]).
+    ///
+    /// Exercised through a malformed file rather than a missing one:
+    /// absence is now [`LoadError::NotFound`], which has no source to
+    /// double, so it could not catch a regression here.
+    ///
+    /// [`LoadError::NotFound`]: sessions::client::disk::LoadError::NotFound
     #[test]
-    fn resolve_active_loadouts_cli_missing_file_error_not_doubled() {
+    fn resolve_active_loadouts_cli_error_not_doubled() {
         let tmp = tempfile::tempdir().unwrap();
         let loadouts = tmp.path().join("minimal/loadouts");
         std::fs::create_dir_all(&loadouts).unwrap();
+        let malformed = "= not = toml =";
+        std::fs::write(loadouts.join("broken.toml"), malformed).unwrap();
         let cfg = sessions::client::config::Config::default();
         let global = GlobalArgs {
             repo_dir: None,
@@ -741,20 +805,59 @@ mod tests {
             provider: None,
             no_input: false,
         };
-        let selection = LoadoutSelection::Cli(vec!["missing".to_string()]);
+        let selection = LoadoutSelection::Cli(vec!["broken".to_string()]);
         let err = resolve_active_loadouts(selection, &cfg, &global)
-            .expect_err("a missing --loadout file must error");
+            .expect_err("a malformed --loadout file must error");
         let rendered = format!("{err:#}");
-        // The concrete OS-error text is platform-dependent, so derive it from
-        // the same failing read and assert it appears once, not twice.
-        let needle = std::fs::read_to_string(loadouts.join("missing.toml"))
-            .expect_err("the loadout file must be absent")
+        // The parse-error text belongs to `toml`, so derive it from the
+        // same failing parse and assert it appears once, not twice.
+        let needle = toml::from_str::<sessions::core::loadout::LoadoutFile>(malformed)
+            .expect_err("the fixture must not parse")
             .to_string();
         assert_eq!(
             rendered.matches(&needle).count(),
             1,
-            "OS error should appear once in `{rendered}`",
+            "parse error should appear once in `{rendered}`",
         );
+    }
+
+    /// A `--loadout` value is validated as a name before it is joined
+    /// into a path. Without that, `../../evil` would be interpolated
+    /// straight into a filename and read an arbitrary `.toml` off
+    /// disk — the stem check downstream does not catch it, because
+    /// `file_stem("../../evil.toml")` is just `evil`.
+    #[test]
+    fn resolve_active_loadouts_rejects_a_traversing_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("minimal/loadouts")).unwrap();
+        // Plant the file the traversal would have reached, so the test
+        // fails loudly if the name ever gets through.
+        std::fs::write(
+            tmp.path().join("evil.toml"),
+            "description = \"should never load\"\n",
+        )
+        .unwrap();
+        let cfg = sessions::client::config::Config::default();
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(tmp.path().to_path_buf()),
+            provider: None,
+            no_input: false,
+        };
+        // The dot forms carry no separator, so they need their own
+        // refusal: under the directory layout `..` would resolve
+        // `<loadouts>/../loadout.toml`, one level above the loadouts
+        // directory, and `.` would resolve `<loadouts>/./loadout.toml`
+        // — aliasing the flat loadout named `loadout` under a name
+        // taken from the parent directory.
+        for name in ["../evil", "../../evil", "sub/evil", ".", "..", "  ..  "] {
+            let selection = LoadoutSelection::Cli(vec![name.to_string()]);
+            assert!(
+                resolve_active_loadouts(selection, &cfg, &global).is_err(),
+                "`{name}` must be refused as a loadout name",
+            );
+        }
     }
 
     /// A loadout that declares a session transition script contributes
@@ -989,6 +1092,130 @@ on_activate = { type = "inline", value = "sleep 90", timeout = 90 }
         assert_eq!(loadout_display_list(&out), "default");
     }
 
+    /// A `--loadout NAME` resolves the directory layout,
+    /// `<loadouts>/<name>/loadout.toml`, exactly as it resolves the
+    /// flat file — same name, same contents, and the same
+    /// `loadouts_dir` anchor, which is what makes `$LOADOUT_ROOT` and
+    /// the loadout's hook scripts land in `<loadouts>/<name>/` either
+    /// way.
+    #[test]
+    fn resolve_active_loadouts_reads_the_directory_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loadouts = tmp.path().join("minimal/loadouts");
+        std::fs::create_dir_all(loadouts.join("dev")).unwrap();
+        std::fs::write(
+            loadouts.join("dev").join("loadout.toml"),
+            "description = \"version controlled\"\npackages = [\"helix\"]\n",
+        )
+        .unwrap();
+        let cfg = sessions::client::config::Config::default();
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(tmp.path().to_path_buf()),
+            provider: None,
+            no_input: false,
+        };
+        let out = resolve_active_loadouts(
+            LoadoutSelection::Cli(vec!["dev".to_string()]),
+            &cfg,
+            &global,
+        )
+        .expect("a directory-layout loadout resolves");
+        assert_eq!(out.loadouts.len(), 1);
+        assert_eq!(out.loadouts[0].name().as_ref(), "dev");
+        assert_eq!(out.loadouts[0].description(), Some("version controlled"));
+        assert_eq!(out.loadouts[0].packages(), &["helix"]);
+        // The anchor is the loadouts dir, not the loadout's own
+        // directory — `Source::loadout_dir` appends the name.
+        assert_eq!(out.loadouts_dir.as_str(), loadouts.to_str().unwrap());
+    }
+
+    /// One name in both layouts is refused rather than resolved by
+    /// precedence, and the error names both files.
+    #[test]
+    fn resolve_active_loadouts_refuses_a_name_in_both_layouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loadouts = tmp.path().join("minimal/loadouts");
+        std::fs::create_dir_all(loadouts.join("dev")).unwrap();
+        std::fs::write(loadouts.join("dev.toml"), "description = \"flat\"\n").unwrap();
+        std::fs::write(
+            loadouts.join("dev").join("loadout.toml"),
+            "description = \"dir\"\n",
+        )
+        .unwrap();
+        let cfg = sessions::client::config::Config::default();
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(tmp.path().to_path_buf()),
+            provider: None,
+            no_input: false,
+        };
+        let err = resolve_active_loadouts(
+            LoadoutSelection::Cli(vec!["dev".to_string()]),
+            &cfg,
+            &global,
+        )
+        .expect_err("an ambiguous loadout must error");
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("dev.toml"), "got: {rendered}");
+        assert!(rendered.contains("loadout.toml"), "got: {rendered}");
+    }
+
+    /// A user `default/loadout.toml` shadows the built-in just as
+    /// `default.toml` does — the zero-config probe looks in both
+    /// layouts.
+    #[test]
+    fn resolve_active_loadouts_directory_default_shadows_builtin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loadouts = tmp.path().join("minimal/loadouts");
+        std::fs::create_dir_all(loadouts.join("default")).unwrap();
+        std::fs::write(
+            loadouts.join("default").join("loadout.toml"),
+            "description = \"user override\"\n",
+        )
+        .unwrap();
+        let cfg = sessions::client::config::Config::default();
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(tmp.path().to_path_buf()),
+            provider: None,
+            no_input: false,
+        };
+        let out = resolve_active_loadouts(LoadoutSelection::Defaults, &cfg, &global)
+            .expect("user default resolves");
+        assert_eq!(out.loadouts.len(), 1);
+        assert_eq!(out.loadouts[0].description(), Some("user override"));
+        assert!(!out.builtin_default);
+        assert_eq!(loadout_display_list(&out), "default");
+    }
+
+    /// The zero-config probe reports a `default` that is present but
+    /// unusable, instead of reading the failure as absence and
+    /// silently substituting the built-in — which would leave the user
+    /// wondering why their file had no effect.
+    #[test]
+    fn resolve_active_loadouts_reports_a_broken_user_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loadouts = tmp.path().join("minimal/loadouts");
+        std::fs::create_dir_all(&loadouts).unwrap();
+        std::fs::write(loadouts.join("default.toml"), "= not = toml =").unwrap();
+        let cfg = sessions::client::config::Config::default();
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(tmp.path().to_path_buf()),
+            provider: None,
+            no_input: false,
+        };
+        assert!(
+            resolve_active_loadouts(LoadoutSelection::Defaults, &cfg, &global).is_err(),
+            "a malformed user `default` must be reported, not fall back",
+        );
+    }
+
     /// Every resolution carries the loadouts directory it read from,
     /// and that directory follows `--config-dir` — this is what makes
     /// `$LOADOUT_ROOT` (and a loadout's hook scripts) resolve against
@@ -1092,6 +1319,71 @@ on_activate = { type = "inline", value = "sleep 90", timeout = 90 }
             no_input: false,
         };
         assert!(cmd_loadout_list(args, &global).is_err());
+    }
+
+    /// A name defined in both layouts is a listing failure, exactly as
+    /// a malformed file is: reported on stderr and a non-zero exit,
+    /// with the valid loadouts beside it still listed.
+    #[test]
+    fn cmd_loadout_list_errors_on_a_name_in_both_layouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loadouts = tmp.path().join("loadouts");
+        std::fs::create_dir_all(loadouts.join("dev")).unwrap();
+        std::fs::write(loadouts.join("dev.toml"), "description = \"flat\"\n").unwrap();
+        std::fs::write(
+            loadouts.join("dev").join("loadout.toml"),
+            "description = \"dir\"\n",
+        )
+        .unwrap();
+        std::fs::write(loadouts.join("fine.toml"), "description = \"ok\"\n").unwrap();
+        let args = LoadoutListArgs {
+            dir: Some(loadouts),
+        };
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(tmp.path().to_path_buf()),
+            provider: None,
+            no_input: false,
+        };
+        assert!(cmd_loadout_list(args, &global).is_err());
+    }
+
+    /// The listing shows both layouts, and a `<name>/` directory that
+    /// holds no `loadout.toml` is not one of them — it is the asset
+    /// directory beside a flat `<name>.toml`, and listing it would
+    /// invent a loadout that does not exist.
+    #[test]
+    fn cmd_loadout_list_lists_both_layouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loadouts = tmp.path().join("loadouts");
+        std::fs::create_dir_all(loadouts.join("vc")).unwrap();
+        std::fs::write(loadouts.join("flat.toml"), "description = \"flat\"\n").unwrap();
+        std::fs::write(
+            loadouts.join("vc").join("loadout.toml"),
+            "description = \"dir\"\n",
+        )
+        .unwrap();
+        // Assets beside `flat.toml`: a directory, but not a loadout.
+        std::fs::create_dir_all(loadouts.join("flat")).unwrap();
+        std::fs::write(loadouts.join("flat").join("config.toml"), "x = 1\n").unwrap();
+
+        let entries = sessions::client::disk::list_loadouts(&loadouts).expect("lists");
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["flat", "vc"]);
+        assert!(entries.iter().all(|e| e.loadout.is_ok()));
+
+        let args = LoadoutListArgs {
+            dir: Some(loadouts),
+        };
+        let global = GlobalArgs {
+            repo_dir: None,
+            minimal_dir: None,
+            config_dir: Some(tmp.path().to_path_buf()),
+            provider: None,
+            no_input: false,
+        };
+        assert!(cmd_loadout_list(args, &global).is_ok());
     }
 
     /// A loadout carrying a hook contributes it when hooks are on and

--- a/crates/minimal/tests/bug.rs
+++ b/crates/minimal/tests/bug.rs
@@ -50,11 +50,14 @@ fn find<'a>(files: &'a BTreeMap<String, Vec<u8>>, suffix: &str) -> Option<&'a Ve
         .map(|(_, contents)| contents)
 }
 
-/// A config dir with a loadout holding a canary secret, to prove redaction.
+/// A config dir with loadouts holding a canary secret, to prove
+/// redaction. One of each layout — `dev.toml` and `vc/loadout.toml` —
+/// so a directory-layout loadout is proved to be collected *and*
+/// redacted, not quietly skipped.
 fn fake_config_dir() -> tempfile::TempDir {
     let dir = tempfile::TempDir::new().unwrap();
     let root = dir.path().join("minimal");
-    std::fs::create_dir_all(root.join("loadouts")).unwrap();
+    std::fs::create_dir_all(root.join("loadouts/vc")).unwrap();
     std::fs::write(
         root.join("config.toml"),
         "[loadouts]\ndefault_loadouts = [\"dev\"]\n",
@@ -63,6 +66,11 @@ fn fake_config_dir() -> tempfile::TempDir {
     std::fs::write(
         root.join("loadouts/dev.toml"),
         "packages = [\"ripgrep\"]\n\n[vars]\nGITHUB_TOKEN = \"canary-secret-value\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("loadouts/vc/loadout.toml"),
+        "packages = [\"fd\"]\n\n[vars]\nGITLAB_TOKEN = \"canary-secret-value\"\n",
     )
     .unwrap();
     dir
@@ -347,6 +355,20 @@ async fn planted_secrets_never_reach_the_bundle() {
     std::fs::write(&target, "stolen = \"symlink-target-contents\"\n").unwrap();
     std::os::unix::fs::symlink(&target, config.path().join("minimal/loadouts/evil.toml")).unwrap();
 
+    // The same attack through the directory layout: a symlinked
+    // `<name>/` whose target holds a `loadout.toml`. `O_NOFOLLOW`
+    // cannot stop this one — it guards only the final component — so
+    // the collector must decline to descend into the link at all.
+    let outside_dir = outside.path().join("evildir");
+    std::fs::create_dir_all(&outside_dir).unwrap();
+    std::fs::write(
+        outside_dir.join("loadout.toml"),
+        "stolen = \"symlink-target-contents\"\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&outside_dir, config.path().join("minimal/loadouts/evildir"))
+        .unwrap();
+
     let out_dir = tempfile::TempDir::new().unwrap();
     let out = out_dir.path().join("diag.tar.zst");
     cmd_bug(&args, bug_args(&out)).await.unwrap();
@@ -356,6 +378,8 @@ async fn planted_secrets_never_reach_the_bundle() {
     // The symlink was refused at open, its target never read, and the
     // refusal recorded.
     assert!(find(&files, "evil.toml.redacted").is_none());
+    // The symlinked directory was never descended into.
+    assert!(find(&files, "evildir/loadout.toml.redacted").is_none());
     for contents in files.values() {
         assert!(
             !contents
@@ -374,6 +398,19 @@ async fn planted_secrets_never_reach_the_bundle() {
     assert!(
         loadout.contains("<redacted:len=19>"),
         "masked value records its length: {loadout}"
+    );
+
+    // The directory layout is collected under its own directory, and
+    // redacted by the same path — a loadout kept in git must not be a
+    // hole in the bundle's masking.
+    let vc = find(&files, "loadouts/vc/loadout.toml.redacted")
+        .expect("redacted directory-layout loadout");
+    let vc = String::from_utf8_lossy(vc);
+    assert!(vc.contains("GITLAB_TOKEN"), "keys survive: {vc}");
+    assert!(vc.contains("fd"), "packages survive: {vc}");
+    assert!(
+        vc.contains("<redacted:len=19>"),
+        "masked value records its length: {vc}"
     );
 
     // The canary value never appears anywhere in the archive.

--- a/crates/sessions/src/client/disk.rs
+++ b/crates/sessions/src/client/disk.rs
@@ -1,21 +1,85 @@
 //! On-disk loadout discovery.
 //!
-//! A user's loadouts live at `<config>/minimal/loadouts/<name>.toml`
-//! (where `<config>` is the platform-standard user config dir; the
-//! caller resolves that path and hands it in here). The filename
-//! stem *is* the loadout's identifier — the single place a loadout is
-//! named, so a file and the loadout it defines can never disagree
-//! about which one gets picked up.
+//! A user's loadouts live under `<config>/minimal/loadouts/` (where
+//! `<config>` is the platform-standard user config dir; the caller
+//! resolves that path and hands it in here), in either of two layouts:
+//!
+//! | [`Layout`] | Path | For |
+//! |---|---|---|
+//! | [`Flat`](Layout::Flat) | `<loadouts>/<name>.toml` | a loadout that is just a file |
+//! | [`Directory`](Layout::Directory) | `<loadouts>/<name>/loadout.toml` | a loadout kept under version control |
+//!
+//! The two are equivalent in every way but where the bytes sit. A
+//! loadout's own directory — the anchor for its `$LOADOUT_ROOT` patch
+//! sources and its external hook scripts — is `<loadouts>/<name>/`
+//! under both, because [`Source::loadout_dir`] derives it from the
+//! *name* rather than from the file's path. So `mkdir dev && mv
+//! dev.toml dev/loadout.toml` migrates a loadout with nothing else to
+//! change, and the directory form simply puts the definition inside
+//! the directory its files already lived in.
+//!
+//! Either way the **name comes from the filesystem**, never from
+//! anything written inside the file: the filename stem under
+//! [`Flat`](Layout::Flat), the directory name under
+//! [`Directory`](Layout::Directory). That is the single place a
+//! loadout is named, so a file and the loadout it defines can never
+//! disagree about which one gets picked up.
+//!
+//! Defining one name in both layouts at once is
+//! [`LoadError::ConflictingLayouts`] — an ambiguity worth naming
+//! rather than resolving by a precedence rule nobody would remember.
+//! (`mfile::File::from_dir` refuses the analogous `minimal.toml` /
+//! `.minimal/minimal.toml` pair for the same reason.)
 //!
 //! A file may still carry the vestigial `name` field. It no longer
-//! names anything: [`read_loadout_file`] warns that the field isn't
-//! required and drops it, taking the name from the filename either
-//! way. That is a warning rather than an error so an older loadout
-//! keeps working untouched.
+//! names anything: loading warns that the field isn't required and
+//! drops it, taking the name from the filesystem either way. That is a
+//! warning rather than an error so an older loadout keeps working
+//! untouched.
+//!
+//! [`Source::loadout_dir`]: crate::core::source::Source::loadout_dir
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::core::loadout::{Loadout, LoadoutFile, LoadoutName};
+
+/// The filename a [`Layout::Directory`] loadout is defined in, inside
+/// the directory named after it.
+pub const LOADOUT_FILE_NAME: &str = "loadout.toml";
+
+/// Which on-disk shape a loadout was found in.
+///
+/// Carried on [`LoadoutEntry`] and returned by [`load_loadout`] so a
+/// caller can report where a loadout actually came from. Nothing
+/// downstream branches on it: the two layouts differ only in path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Layout {
+    /// `<loadouts>/<name>.toml` — a loadout that is just a file.
+    Flat,
+    /// `<loadouts>/<name>/loadout.toml` — the definition inside the
+    /// loadout's own directory, so the whole loadout is one
+    /// self-contained tree that can be a git checkout.
+    Directory,
+}
+
+impl Layout {
+    /// The path this layout puts loadout `name` at, under the loadouts
+    /// directory `dir`.
+    ///
+    /// `name` is a [`LoadoutName`], which is validated as a single
+    /// path component that stays put — no separators, no NUL, and
+    /// neither `.` nor `..` — so both joins land directly under `dir`.
+    /// Taking a `LoadoutName` rather than a `&str` is what makes that
+    /// a type-level guarantee instead of a caller's obligation.
+    #[must_use]
+    pub fn path_for(self, dir: &Path, name: &LoadoutName) -> PathBuf {
+        match self {
+            Self::Flat => dir.join(format!("{name}.toml")),
+            Self::Directory => dir.join(name.as_ref()).join(LOADOUT_FILE_NAME),
+        }
+    }
+}
 
 /// Failure loading a single loadout file.
 #[derive(Debug, thiserror::Error)]
@@ -36,7 +100,9 @@ pub enum LoadError {
         #[source]
         source: toml::de::Error,
     },
-    /// The filename stem itself isn't a valid loadout name (e.g.
+    /// The name taken from the filesystem — the filename stem under
+    /// [`Layout::Flat`], the directory name under
+    /// [`Layout::Directory`] — isn't a valid loadout name (e.g.
     /// contains a path separator or NUL). Caught before parsing the
     /// TOML so the operator gets the concrete "your filename is bad"
     /// message instead of a downstream one about the contents.
@@ -46,22 +112,52 @@ pub enum LoadError {
         #[source]
         source: crate::core::loadout::LoadoutNameError,
     },
+    /// One name defined in both layouts at once. Refused rather than
+    /// resolved by precedence: whichever file lost would go on looking
+    /// live while having no effect, which is the failure mode a
+    /// half-finished migration produces and the hardest one to spot.
+    #[error("loadout `{name}` is defined twice:\n  {}\n  {}\nremove one.", flat.display(), directory.display())]
+    ConflictingLayouts {
+        name: String,
+        flat: PathBuf,
+        directory: PathBuf,
+    },
+    /// No loadout by this name in either layout.
+    ///
+    /// Distinct from [`LoadError::Io`] so a caller can treat absence
+    /// as a normal outcome — the zero-config fallback in the `min` CLI
+    /// does exactly that — and so the message can name every path that
+    /// was tried instead of just the last one.
+    #[error("no loadout `{name}` in `{}` (looked for `{name}.toml` and `{name}/{LOADOUT_FILE_NAME}`)", dir.display())]
+    NotFound {
+        name: String,
+        dir: PathBuf,
+        /// The candidate paths stat'd, in probe order. Carried for
+        /// callers that want to list them; the `Display` above
+        /// summarizes them in the shape the user would type.
+        tried: Vec<PathBuf>,
+    },
 }
 
-/// A directory entry produced by [`list_loadouts`]: the filename
-/// stem this entry was found under, and either the parsed
-/// [`Loadout`] or the error that prevented parsing.
+/// An entry produced by [`list_loadouts`]: the name this loadout was
+/// found under, and either the parsed [`Loadout`] or the error that
+/// prevented parsing.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct LoadoutEntry {
-    /// The filename stem (without `.toml`). This is what the user
-    /// interacts with as the loadout identifier, and what
-    /// [`read_loadout_file`] names the parsed loadout after.
-    pub file_stem: String,
-    /// Path to the loadout file. Absolute when `list_loadouts`
-    /// canonicalized the input directory (its normal path); may be
-    /// relative if the caller invoked `read_loadout_file` directly
-    /// with a relative argument.
+    /// The name taken from the filesystem — the filename stem under
+    /// [`Layout::Flat`], the directory name under
+    /// [`Layout::Directory`]. This is what the user interacts with as
+    /// the loadout identifier, and what the parsed loadout is named
+    /// after.
+    pub name: String,
+    /// Which layout this entry was found in.
+    pub layout: Layout,
+    /// Path to the loadout file itself — `<name>.toml` or
+    /// `<name>/loadout.toml`, not the directory. Absolute when
+    /// `list_loadouts` canonicalized the input directory (its normal
+    /// path); may be relative if the caller invoked
+    /// [`read_loadout_file`] directly with a relative argument.
     pub path: PathBuf,
     /// The parsed loadout, or the error explaining why it couldn't
     /// be loaded. Listing surfaces malformed entries so an operator
@@ -91,9 +187,12 @@ pub enum ListError {
     },
 }
 
-/// Parse a single loadout file and name it after its filename stem,
-/// which must be a valid [`LoadoutName`] (rejects path separators,
-/// NUL, empty).
+/// Parse a [`Layout::Flat`] loadout — `<loadouts>/<name>.toml` — and
+/// name it after its filename stem, which must be a valid
+/// [`LoadoutName`] (rejects path separators, NUL, empty).
+///
+/// For the directory layout, see [`read_loadout_dir`]; to resolve a
+/// name across both, [`load_loadout`].
 ///
 /// A `name` field inside the file is vestigial: it is warned about
 /// and discarded, whether or not it agrees with the filename. Loading
@@ -111,12 +210,48 @@ pub fn read_loadout_file(path: &Path) -> Result<Loadout, LoadError> {
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or_default();
-    let file_stem =
-        LoadoutName::try_new(file_stem_str).map_err(|source| LoadError::InvalidStem {
-            path: path.to_path_buf(),
-            source,
-        })?;
+    let name = LoadoutName::try_new(file_stem_str).map_err(|source| LoadError::InvalidStem {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    parse_named(path, &name)
+}
 
+/// Parse a [`Layout::Directory`] loadout — read `dir/loadout.toml` and
+/// name it after `dir` itself, which must be a valid [`LoadoutName`].
+///
+/// The counterpart to [`read_loadout_file`]. They are separate
+/// functions rather than one that sniffs the filename because a flat
+/// loadout may legitimately *be* named `loadout`: sniffing would name
+/// `<loadouts>/loadout.toml` after its parent directory (`loadouts`)
+/// instead of after its stem. Which layout a path is in is knowledge
+/// the caller has and the path alone does not.
+///
+/// # Errors
+///
+/// See [`LoadError`]. A `dir` with no `loadout.toml` in it is
+/// [`LoadError::Io`] with an ENOENT source; [`load_loadout`] probes
+/// for the file before calling here, so it reports absence as
+/// [`LoadError::NotFound`] instead.
+pub fn read_loadout_dir(dir: &Path) -> Result<Loadout, LoadError> {
+    let path = dir.join(LOADOUT_FILE_NAME);
+    // As in `read_loadout_file`: the name is validated before the read
+    // so a bad one is reported as such. The `InvalidStem` path is
+    // named for `dir`, not the file inside it — `dir` is the part the
+    // operator would rename.
+    let dir_name = dir.file_name().and_then(|s| s.to_str()).unwrap_or_default();
+    let name = LoadoutName::try_new(dir_name).map_err(|source| LoadError::InvalidStem {
+        path: dir.to_path_buf(),
+        source,
+    })?;
+    parse_named(&path, &name)
+}
+
+/// Read and parse the loadout file at `path`, naming it `name`.
+///
+/// The shared tail of [`read_loadout_file`] and [`read_loadout_dir`];
+/// they differ only in where the name comes from.
+fn parse_named(path: &Path, name: &LoadoutName) -> Result<Loadout, LoadError> {
     let contents = std::fs::read_to_string(path).map_err(|source| LoadError::Io {
         path: path.to_path_buf(),
         source,
@@ -126,25 +261,66 @@ pub fn read_loadout_file(path: &Path) -> Result<Loadout, LoadError> {
         source,
     })?;
 
-    match DeclaredName::classify(file.declared_name(), &file_stem) {
+    match DeclaredName::classify(file.declared_name(), name) {
         DeclaredName::Absent => {}
         DeclaredName::Redundant => tracing::warn!(
             path = %path.display(),
-            loadout = %file_stem,
-            "loadout `{file_stem}` declares a `name` field; a loadout is now named \
+            loadout = %name,
+            "loadout `{name}` declares a `name` field; a loadout is now named \
              after its file, so the field is no longer required and can be deleted",
         ),
         DeclaredName::Mismatched(declared) => tracing::warn!(
             path = %path.display(),
-            loadout = %file_stem,
+            loadout = %name,
             declared_name = %declared,
-            "loadout `{file_stem}` declares the name `{declared}`, which does not match \
+            "loadout `{name}` declares the name `{declared}`, which does not match \
              its filename; a loadout is now named after its file, so the field is no \
-             longer required — using `{file_stem}` and ignoring the declared name",
+             longer required — using `{name}` and ignoring the declared name",
         ),
     }
 
-    Ok(file.into_loadout(file_stem))
+    Ok(file.into_loadout(name.clone()))
+}
+
+/// Resolve one loadout by name under the loadouts directory `dir`,
+/// across both layouts.
+///
+/// The single name → loadout path in the codebase: callers name a
+/// loadout, this decides which file that is. Probing both layouts here
+/// rather than at each call site is what keeps "which layouts exist"
+/// one fact rather than several.
+///
+/// Both layouts defining `name` is [`LoadError::ConflictingLayouts`],
+/// refused rather than resolved by precedence — see the module docs.
+///
+/// # Errors
+///
+/// [`LoadError::NotFound`] when neither layout has it; otherwise see
+/// [`LoadError`].
+pub fn load_loadout(dir: &Path, name: &LoadoutName) -> Result<(Loadout, Layout), LoadError> {
+    let flat = Layout::Flat.path_for(dir, name);
+    let directory = Layout::Directory.path_for(dir, name);
+
+    // `exists()` follows symlinks, deliberately: a symlinked
+    // `dev.toml` is a loadout the user pointed at something, and the
+    // read below is what would fail if the target is gone. This is
+    // only choosing which path to read.
+    match (flat.exists(), directory.exists()) {
+        (true, true) => Err(LoadError::ConflictingLayouts {
+            name: name.as_ref().to_owned(),
+            flat,
+            directory,
+        }),
+        (true, false) => read_loadout_file(&flat).map(|l| (l, Layout::Flat)),
+        // `read_loadout_dir` takes the loadout's directory, not the
+        // file inside it — that is where it reads the name from.
+        (false, true) => read_loadout_dir(&dir.join(name.as_ref())).map(|l| (l, Layout::Directory)),
+        (false, false) => Err(LoadError::NotFound {
+            name: name.as_ref().to_owned(),
+            dir: dir.to_path_buf(),
+            tried: vec![flat, directory],
+        }),
+    }
 }
 
 /// How a loadout file's declared `name` field stands relative to the
@@ -175,13 +351,22 @@ impl<'a> DeclaredName<'a> {
     }
 }
 
-/// Enumerate every `*.toml` file in `dir` and try to parse each as a
-/// [`Loadout`], named after its file. Returns one [`LoadoutEntry`]
-/// per file, sorted by stem; parse failures are folded into the
-/// entry's `loadout` field so the caller can surface them in the
-/// listing rather than aborting the whole scan.
+/// Enumerate every loadout in `dir`, in both layouts, and try to parse
+/// each. Returns one [`LoadoutEntry`] per loadout **name**, sorted by
+/// name; parse failures are folded into the entry's `loadout` field so
+/// the caller can surface them in the listing rather than aborting the
+/// whole scan.
 ///
-/// Non-`.toml` files and subdirectories are silently ignored.
+/// Picked up: `*.toml` files ([`Layout::Flat`]) and subdirectories
+/// containing a `loadout.toml` ([`Layout::Directory`]). A name found
+/// in both yields a single entry carrying
+/// [`LoadError::ConflictingLayouts`], so a conflict surfaces here the
+/// same way a parse failure does.
+///
+/// Everything else is silently ignored — in particular a subdirectory
+/// with no `loadout.toml`, which is the asset directory a flat
+/// `<name>.toml` anchors its `$LOADOUT_ROOT` patches and hook scripts
+/// at.
 ///
 /// # Errors
 ///
@@ -211,9 +396,14 @@ pub fn list_loadouts(dir: &Path) -> Result<Vec<LoadoutEntry>, ListError> {
         }
     };
 
-    let mut entries: Vec<LoadoutEntry> = read_dir
-        .filter_map(|res| match res {
-            Ok(entry) => Some(entry),
+    // Keyed by name, not by path: the two layouts are two ways of
+    // spelling the same identifier, so a name is one entry however
+    // many files claim it. `BTreeMap` also gives the name ordering the
+    // listing wants for free, across both layouts at once.
+    let mut found: BTreeMap<String, LoadoutEntry> = BTreeMap::new();
+    for entry in read_dir {
+        let entry = match entry {
+            Ok(entry) => entry,
             Err(e) => {
                 // Per-dirent errors are typically transient
                 // (permission-denied on a specific entry, a race
@@ -225,28 +415,85 @@ pub fn list_loadouts(dir: &Path) -> Result<Vec<LoadoutEntry>, ListError> {
                     error = %e,
                     "skipping loadouts directory entry: read failed",
                 );
-                None
+                continue;
             }
-        })
-        .filter_map(|entry| {
-            let path = entry.path();
-            if !path.is_file() {
-                return None;
+        };
+        let path = entry.path();
+        let Some((name, layout, file)) = classify_dirent(&path) else {
+            continue;
+        };
+        match found.entry(name.clone()) {
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                let loadout = match layout {
+                    Layout::Flat => read_loadout_file(&file),
+                    Layout::Directory => read_loadout_dir(&path),
+                };
+                slot.insert(LoadoutEntry {
+                    name,
+                    layout,
+                    path: file,
+                    loadout,
+                });
             }
-            if path.extension().and_then(|e| e.to_str()) != Some("toml") {
-                return None;
+            // Second sighting of a name: the other layout has it too.
+            // Whatever arrived first is replaced by the conflict, so
+            // the listing reports the ambiguity instead of a loadout
+            // that may not be the one in effect.
+            //
+            // The entry is pinned to the flat form rather than to
+            // whichever dirent happened to come second — `read_dir`
+            // order is not defined, and an entry whose `layout` and
+            // `path` flipped run to run would be a listing that
+            // changed without the directory changing. Both paths are
+            // in the error either way, which is where a conflicting
+            // entry's real information lives.
+            std::collections::btree_map::Entry::Occupied(mut slot) => {
+                let existing = slot.get().path.clone();
+                let (flat, directory) = match layout {
+                    Layout::Flat => (file, existing),
+                    Layout::Directory => (existing, file),
+                };
+                let entry = slot.get_mut();
+                entry.layout = Layout::Flat;
+                entry.path.clone_from(&flat);
+                entry.loadout = Err(LoadError::ConflictingLayouts {
+                    name: entry.name.clone(),
+                    flat,
+                    directory,
+                });
             }
-            let file_stem = path.file_stem().and_then(|s| s.to_str())?.to_string();
-            let loadout = read_loadout_file(&path);
-            Some(LoadoutEntry {
-                file_stem,
-                path,
-                loadout,
-            })
-        })
-        .collect();
-    entries.sort_by(|a, b| a.file_stem.cmp(&b.file_stem));
-    Ok(entries)
+        }
+    }
+    Ok(found.into_values().collect())
+}
+
+/// Classify one entry of the loadouts directory into
+/// `(name, layout, loadout file path)`, or `None` for something that
+/// isn't a loadout at all.
+///
+/// The path is taken as given rather than stat'd via the [`DirEntry`]
+/// so `is_file` / `is_dir` follow symlinks — a symlinked `dev.toml`
+/// or a symlinked `dev/` still lists. (Whether a symlinked loadout
+/// *directory* can anchor hook scripts is a separate question, and
+/// `hookscripts::resolve_under_anchor` answers it: it cannot.)
+///
+/// [`DirEntry`]: std::fs::DirEntry
+fn classify_dirent(path: &Path) -> Option<(String, Layout, PathBuf)> {
+    if path.is_dir() {
+        let file = path.join(LOADOUT_FILE_NAME);
+        // A directory without one is not a loadout: it is the asset
+        // directory beside a flat `<name>.toml`.
+        if !file.is_file() {
+            return None;
+        }
+        let name = path.file_name().and_then(|s| s.to_str())?.to_string();
+        return Some((name, Layout::Directory, file));
+    }
+    if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("toml") {
+        return None;
+    }
+    let name = path.file_stem().and_then(|s| s.to_str())?.to_string();
+    Some((name, Layout::Flat, path.to_path_buf()))
 }
 
 #[cfg(test)]
@@ -260,6 +507,29 @@ mod tests {
         let mut f = std::fs::File::create(&path).unwrap();
         f.write_all(contents.as_bytes()).unwrap();
         path
+    }
+
+    /// Lay out a [`Layout::Directory`] loadout: `<dir>/<name>/loadout.toml`.
+    fn write_dir_loadout(dir: &Path, name: &str, contents: &str) -> PathBuf {
+        let root = dir.join(name);
+        std::fs::create_dir_all(&root).unwrap();
+        write_file(&root, LOADOUT_FILE_NAME, contents)
+    }
+
+    fn name(s: &str) -> LoadoutName {
+        LoadoutName::try_new(s).unwrap()
+    }
+
+    /// The tempdir root as [`list_loadouts`] will report it.
+    ///
+    /// That function canonicalizes its input so every reported path is
+    /// absolute, which on macOS rewrites `/var/…` to `/private/var/…`.
+    /// An expectation built from the raw `TempDir` path would compare
+    /// the symlinked form against the resolved one and fail there
+    /// while passing on Linux. Tests of [`load_loadout`] don't need
+    /// this — it takes the directory as given.
+    fn listed_root(dir: &TempDir) -> PathBuf {
+        std::fs::canonicalize(dir.path()).unwrap()
     }
 
     /// A loadout file with no `name` field — the current shape —
@@ -332,15 +602,22 @@ mod tests {
         assert!(matches!(err, LoadError::Parse { .. }));
     }
 
-    /// `list_loadouts` enumerates `.toml` files in stem order,
-    /// ignores non-`.toml` entries and subdirectories, and folds
-    /// per-entry errors into the returned list rather than aborting.
+    /// `list_loadouts` enumerates both layouts in name order, ignores
+    /// non-`.toml` entries and directories that hold no
+    /// `loadout.toml`, and folds per-entry errors into the returned
+    /// list rather than aborting.
     #[test]
     fn list_loadouts_enumerates_and_sorts() {
         let dir = TempDir::new().unwrap();
         write_file(dir.path(), "beta.toml", r#"packages = ["zellij"]"#);
         write_file(dir.path(), "alpha.toml", r#"packages = ["helix"]"#);
         write_file(dir.path(), "readme.txt", "not a loadout");
+        // A directory-layout loadout sorts in among the flat ones by
+        // name, with no marker of which layout it came from beyond
+        // `LoadoutEntry::layout`.
+        write_dir_loadout(dir.path(), "gamma", r#"packages = ["fish"]"#);
+        // A bare subdirectory is not a loadout — it is the asset
+        // directory a flat `<name>.toml` anchors `$LOADOUT_ROOT` at.
         std::fs::create_dir(dir.path().join("nested")).unwrap();
         // Malformed but present — should show up as an entry with
         // a `Parse` error, not skip the file entirely.
@@ -350,14 +627,36 @@ mod tests {
         write_file(dir.path(), "renamed.toml", r#"name = "different""#);
 
         let entries = list_loadouts(dir.path()).expect("should list");
-        let stems: Vec<&str> = entries.iter().map(|e| e.file_stem.as_str()).collect();
-        assert_eq!(stems, vec!["alpha", "beta", "broken", "renamed"]);
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["alpha", "beta", "broken", "gamma", "renamed"],
+            "both layouts list, in one name order; `nested` and `readme.txt` do not",
+        );
 
         assert!(entries[0].loadout.is_ok());
+        assert_eq!(entries[0].layout, Layout::Flat);
         assert!(entries[1].loadout.is_ok());
         assert!(matches!(entries[2].loadout, Err(LoadError::Parse { .. })));
+
+        let gamma = &entries[3];
+        assert_eq!(gamma.layout, Layout::Directory);
         assert_eq!(
-            entries[3]
+            gamma.path,
+            listed_root(&dir).join("gamma").join(LOADOUT_FILE_NAME)
+        );
+        assert_eq!(
+            gamma.loadout.as_ref().expect("gamma").packages(),
+            &["fish"],
+            "a directory loadout is named after its directory",
+        );
+        assert_eq!(
+            gamma.loadout.as_ref().expect("gamma").name().as_ref(),
+            "gamma"
+        );
+
+        assert_eq!(
+            entries[4]
                 .loadout
                 .as_ref()
                 .expect("renamed")
@@ -367,6 +666,38 @@ mod tests {
         );
     }
 
+    /// One name in both layouts lists as a *single* entry carrying the
+    /// conflict, not as two rows or as a silent precedence win. The
+    /// caller (`min loadout list`) already routes an `Err` entry to
+    /// stderr and a non-zero exit, so this is all the reporting the
+    /// ambiguity needs.
+    #[test]
+    fn list_loadouts_reports_a_name_in_both_layouts_once() {
+        let dir = TempDir::new().unwrap();
+        write_file(dir.path(), "dev.toml", r#"packages = ["helix"]"#);
+        write_dir_loadout(dir.path(), "dev", r#"packages = ["zellij"]"#);
+        write_file(dir.path(), "ok.toml", "");
+
+        let entries = list_loadouts(dir.path()).expect("should list");
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["dev", "ok"], "one entry per name");
+
+        let Err(LoadError::ConflictingLayouts {
+            name,
+            flat,
+            directory,
+        }) = &entries[0].loadout
+        else {
+            panic!("expected a conflict, got: {:?}", entries[0].loadout);
+        };
+        let root = listed_root(&dir);
+        assert_eq!(name, "dev");
+        assert_eq!(flat, &root.join("dev.toml"));
+        assert_eq!(directory, &root.join("dev").join(LOADOUT_FILE_NAME));
+        // Unaffected neighbours still load.
+        assert!(entries[1].loadout.is_ok());
+    }
+
     /// A missing directory returns `NotFound`, not a generic I/O error.
     #[test]
     fn list_loadouts_missing_dir_returns_not_found() {
@@ -374,5 +705,125 @@ mod tests {
         let missing = dir.path().join("nope");
         let err = list_loadouts(&missing).expect_err("missing dir should error");
         assert!(matches!(err, ListError::NotFound { .. }));
+    }
+
+    // ---- the directory layout ----
+
+    /// A directory-layout loadout is named after its *directory*, and
+    /// the `loadout.toml` inside it needs no `name` field.
+    #[test]
+    fn read_loadout_dir_names_from_the_directory() {
+        let dir = TempDir::new().unwrap();
+        write_dir_loadout(dir.path(), "dev", r#"packages = ["helix"]"#);
+        let loadout = read_loadout_dir(&dir.path().join("dev")).expect("should load");
+        assert_eq!(loadout.name().as_ref(), "dev");
+        assert_eq!(loadout.packages(), &["helix"]);
+    }
+
+    /// The two layouts describe the same loadout: same name, same
+    /// contents, whichever shape it is filed in.
+    #[test]
+    fn load_loadout_resolves_either_layout() {
+        let dir = TempDir::new().unwrap();
+        write_file(dir.path(), "flat.toml", r#"packages = ["helix"]"#);
+        write_dir_loadout(dir.path(), "vc", r#"packages = ["helix"]"#);
+
+        let (flat, layout) = load_loadout(dir.path(), &name("flat")).expect("flat");
+        assert_eq!(layout, Layout::Flat);
+        assert_eq!(flat.name().as_ref(), "flat");
+
+        let (vc, layout) = load_loadout(dir.path(), &name("vc")).expect("directory");
+        assert_eq!(layout, Layout::Directory);
+        assert_eq!(vc.name().as_ref(), "vc");
+        assert_eq!(vc.packages(), flat.packages());
+    }
+
+    /// Both layouts at once is refused by name, naming both files —
+    /// the ambiguity is reported, never resolved by precedence.
+    #[test]
+    fn load_loadout_refuses_a_name_in_both_layouts() {
+        let dir = TempDir::new().unwrap();
+        write_file(dir.path(), "dev.toml", "");
+        write_dir_loadout(dir.path(), "dev", "");
+
+        let err = load_loadout(dir.path(), &name("dev")).expect_err("ambiguous");
+        assert!(matches!(err, LoadError::ConflictingLayouts { .. }));
+        // The message has to name both files: "remove one" is only
+        // actionable if the user knows which two.
+        let msg = err.to_string();
+        assert!(msg.contains("dev.toml"), "got: {msg}");
+        assert!(msg.contains(LOADOUT_FILE_NAME), "got: {msg}");
+    }
+
+    /// Absence is its own variant, not an I/O error, and names both
+    /// paths that were tried.
+    #[test]
+    fn load_loadout_missing_names_both_candidates() {
+        let dir = TempDir::new().unwrap();
+        let err = load_loadout(dir.path(), &name("nope")).expect_err("missing");
+        let LoadError::NotFound { tried, .. } = &err else {
+            panic!("expected NotFound, got: {err:?}");
+        };
+        assert_eq!(
+            tried,
+            &[
+                dir.path().join("nope.toml"),
+                dir.path().join("nope").join(LOADOUT_FILE_NAME),
+            ]
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("nope.toml"), "got: {msg}");
+        assert!(msg.contains("nope/loadout.toml"), "got: {msg}");
+    }
+
+    /// A bare `<name>/` with no `loadout.toml` is not a loadout: that
+    /// is the asset directory a flat `<name>.toml` anchors its
+    /// `$LOADOUT_ROOT` patches and hook scripts at, and it must keep
+    /// resolving to the flat file beside it.
+    #[test]
+    fn an_asset_directory_beside_a_flat_loadout_is_not_a_conflict() {
+        let dir = TempDir::new().unwrap();
+        write_file(dir.path(), "dev.toml", r#"packages = ["helix"]"#);
+        std::fs::create_dir(dir.path().join("dev")).unwrap();
+        write_file(&dir.path().join("dev"), "config.toml", "theme = 'nord'");
+
+        let (loadout, layout) = load_loadout(dir.path(), &name("dev")).expect("flat still wins");
+        assert_eq!(layout, Layout::Flat);
+        assert_eq!(loadout.packages(), &["helix"]);
+    }
+
+    /// A flat loadout may legitimately be *named* `loadout`, so
+    /// `<loadouts>/loadout.toml` is the loadout `loadout` — not a
+    /// directory-layout file misread as being named after the
+    /// loadouts directory itself. This is why the two layouts have
+    /// separate readers rather than one that sniffs the filename.
+    #[test]
+    fn a_flat_loadout_named_loadout_is_named_after_its_stem() {
+        let dir = TempDir::new().unwrap();
+        write_file(dir.path(), LOADOUT_FILE_NAME, r#"packages = ["helix"]"#);
+
+        let (loadout, layout) = load_loadout(dir.path(), &name("loadout")).expect("should load");
+        assert_eq!(layout, Layout::Flat);
+        assert_eq!(loadout.name().as_ref(), "loadout");
+
+        let entries = list_loadouts(dir.path()).expect("should list");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "loadout");
+        assert_eq!(entries[0].layout, Layout::Flat);
+    }
+
+    /// `Layout::path_for` is the one place a name becomes a path;
+    /// both shapes stay a single component under the loadouts dir.
+    #[test]
+    fn layout_path_for_spells_both_shapes() {
+        let dir = Path::new("/cfg/minimal/loadouts");
+        assert_eq!(
+            Layout::Flat.path_for(dir, &name("dev")),
+            PathBuf::from("/cfg/minimal/loadouts/dev.toml")
+        );
+        assert_eq!(
+            Layout::Directory.path_for(dir, &name("dev")),
+            PathBuf::from("/cfg/minimal/loadouts/dev/loadout.toml")
+        );
     }
 }

--- a/crates/sessions/src/core/lifecyclehook.rs
+++ b/crates/sessions/src/core/lifecyclehook.rs
@@ -528,11 +528,15 @@ pub fn staged_script_path(
 /// Whether `s` is usable as a single path component that stays put:
 /// non-empty, no separators or NUL, and not a relative-directory name.
 ///
-/// [`LoadoutName`](crate::core::loadout::LoadoutName) enforces all of
-/// this except the `.`/`..` cases — a name is a display string first and
-/// a path fragment second, and neither dot form contains a separator.
-/// Both are excluded here because this fragment is joined into a path
-/// the daemon then reads from.
+/// The dot forms are excluded because a fragment reaching here is
+/// joined into a path that is then read from, and neither contains a
+/// separator to be caught by the check above it.
+///
+/// This is also the validation
+/// [`LoadoutName`](crate::core::loadout::LoadoutName) is built on, so a
+/// name constructed on this machine already satisfies it. The function
+/// is still applied at every join, because a name decoded from the wire
+/// has been through no such construction — see [`staged_script_path`].
 #[must_use]
 pub fn safe_path_component(s: &str) -> bool {
     !s.is_empty() && s != "." && s != ".." && !s.contains(['/', '\\', '\0'])

--- a/crates/sessions/src/core/loadout.rs
+++ b/crates/sessions/src/core/loadout.rs
@@ -57,16 +57,23 @@ use nutype::nutype;
 use crate::core::lifecyclehook::LifecycleHook;
 use crate::core::primitives::{LenientVarEntry, Patch, Patches, StrictVarName, VarName, VarValue};
 
-/// A loadout's identifier — trimmed, non-empty, and free of path
-/// separators and NUL bytes.
+/// A loadout's identifier — trimmed, and usable as a single path
+/// component that stays put: non-empty, free of path separators and
+/// NUL bytes, and neither `.` nor `..`.
 ///
 /// Names appear in user-facing contexts (selection menus, error
-/// messages) and are the filename stems the loader reads loadouts
+/// messages) and name the file or directory the loader reads a loadout
 /// from, so they're constrained at construction time rather than at
-/// point of use.
+/// point of use. The rule is [`safe_path_component`] itself, so the
+/// two cannot drift: a name that reaches
+/// [`Layout::path_for`](crate::client::disk::Layout::path_for) is
+/// joined into a path that is then read from, and the `.`/`..` forms
+/// contain no separator yet still move the join somewhere else.
+///
+/// [`safe_path_component`]: crate::core::lifecyclehook::safe_path_component
 #[nutype(
     sanitize(trim),
-    validate(not_empty, predicate = |s: &str| !s.contains(['/', '\\', '\0'])),
+    validate(not_empty, predicate = |s: &str| crate::core::lifecyclehook::safe_path_component(s)),
     derive(
         Clone, Debug, Display, AsRef, PartialEq, Eq, Hash, PartialOrd, Ord,
         Serialize, Deserialize,
@@ -657,6 +664,29 @@ mod tests {
         assert!(LoadoutName::try_new("a\0b").is_err());
         let n = LoadoutName::try_new("  dev  ").unwrap();
         assert_eq!(n.as_ref(), "dev");
+    }
+
+    /// The relative-directory names are refused too. They carry no
+    /// separator, so the check above them does not catch them, yet a
+    /// name is joined into a path that is then read from: `..` would
+    /// send `<loadouts>/<name>/loadout.toml` up out of the loadouts
+    /// directory, and `.` would alias the flat loadout named
+    /// `loadout` while taking its name from the parent directory.
+    ///
+    /// Trimming applies first, so the padded forms are refused as
+    /// well.
+    #[test]
+    fn loadout_name_rejects_relative_directory_names() {
+        for bad in [".", "..", "  .  ", "  ..  "] {
+            assert!(
+                LoadoutName::try_new(bad).is_err(),
+                "`{bad}` must not be a loadout name",
+            );
+        }
+        // Dots are only special as the whole name; they stay legal
+        // inside one.
+        assert_eq!(LoadoutName::try_new("..dev").unwrap().as_ref(), "..dev");
+        assert_eq!(LoadoutName::try_new("dev.v2").unwrap().as_ref(), "dev.v2");
     }
 
     #[test]

--- a/crates/sessions/src/core/source.rs
+++ b/crates/sessions/src/core/source.rs
@@ -33,8 +33,13 @@ pub enum Source {
 }
 
 impl Source {
-    /// The directory a loadout's own files live in: `<loadouts_dir>/<name>/`,
-    /// beside the `<name>.toml` that declared them.
+    /// The directory a loadout's own files live in: `<loadouts_dir>/<name>/`.
+    ///
+    /// Derived from the loadout's *name*, not from the path its
+    /// definition was read from, so it is the same directory under
+    /// either on-disk layout — beside a flat `<name>.toml`, or holding
+    /// the `<name>/loadout.toml` that declared them. See
+    /// [`client::disk`](crate::client::disk).
     ///
     /// One definition of "a loadout's directory", shared by everything
     /// that anchors against it — external hook scripts

--- a/crates/sessions/tests/client_flow1.rs
+++ b/crates/sessions/tests/client_flow1.rs
@@ -606,6 +606,93 @@ source = "${LOADOUT_ROOT}/themes/**/*.toml"
     );
 }
 
+/// The two on-disk layouts are anchor-equivalent: a loadout filed as
+/// `<dir>/vc/loadout.toml` resolves `$LOADOUT_ROOT` to `<dir>/vc/` —
+/// the very directory holding its definition — exactly as the flat
+/// `<dir>/dev.toml` resolves it to the sibling `<dir>/dev/`.
+///
+/// This is the property that makes the directory layout a pure
+/// relocation of the definition file: `Source::loadout_dir` derives
+/// the anchor from the loadout's *name*, so nothing downstream of
+/// discovery has to know which layout was used. A loadout migrates
+/// with `mkdir dev && mv dev.toml dev/loadout.toml` and keeps patching
+/// the same files.
+#[test]
+fn loadout_root_is_the_same_directory_under_both_layouts() {
+    // The same patch declarations, filed both ways below: `dev.toml`
+    // beside a `dev/` of assets, and `vc/loadout.toml` inside its own
+    // `vc/`.
+    const PATCHES: &str = r#"
+[[patches]]
+dest = ".config/helix/config.toml"
+source = "$LOADOUT_ROOT/config.toml"
+
+[[patches]]
+dest = ".config/helix/themes"
+source = "${LOADOUT_ROOT}/themes/**/*.toml"
+"#;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = Utf8Path::from_path(tmp.path()).unwrap();
+    loadouts_dir_fixture(root);
+
+    std::fs::write(root.join("dev.toml").as_std_path(), PATCHES).unwrap();
+    fixture_tree(
+        root,
+        [
+            ("vc/config.toml", "theme = 'nord'\n"),
+            ("vc/themes/nord.toml", "# nord\n"),
+        ],
+    );
+    std::fs::write(root.join("vc/loadout.toml").as_std_path(), PATCHES).unwrap();
+
+    // Resolve each through the shared name→loadout entry point, the
+    // way an activation does, and collect the host paths each ends up
+    // patching from.
+    let sources_for = |name: &str| -> Vec<String> {
+        let loadout_name = sessions::core::loadout::LoadoutName::try_new(name).unwrap();
+        let (loadout, _layout) =
+            sessions::client::disk::load_loadout(root.as_std_path(), &loadout_name)
+                .expect("fixture loadout loads");
+        let mut composer = UserComposer::new()
+            .with_env(pinned_env(&[]))
+            .with_loadouts_dir(paths::HostAbsPath::try_new(root.to_owned()).unwrap());
+        composer.add(loadout).unwrap();
+        let (wire, _) = composer
+            .compose(UserPolicy::empty(), ComposeOptions::default())
+            .unwrap();
+        let mut hosts: Vec<String> = wire
+            .patches
+            .iter()
+            .map(|p| p.patch.host_path.as_str().to_owned())
+            .collect();
+        hosts.sort_unstable();
+        hosts
+    };
+
+    let flat = sources_for("dev");
+    let directory = sources_for("vc");
+
+    assert_eq!(flat.len(), 2, "got: {flat:?}");
+    assert_eq!(directory.len(), 2, "got: {directory:?}");
+    assert_paths_equivalent(&directory[0], root.join("vc/config.toml").as_std_path());
+    assert_paths_equivalent(
+        &directory[1],
+        root.join("vc/themes/nord.toml").as_std_path(),
+    );
+
+    // The same declarations reach the same files under each layout,
+    // differing only in the loadout's own name.
+    let rebased: Vec<String> = directory
+        .iter()
+        .map(|p| p.replace("/vc/", "/dev/"))
+        .collect();
+    assert_eq!(
+        rebased, flat,
+        "the layouts must anchor identically: {directory:?} vs {flat:?}",
+    );
+}
+
 /// The reference is reserved in patch sources: a loadout that also
 /// exports a `LOADOUT_ROOT` variable still patches from its own
 /// directory, and the variable itself reaches the session untouched.

--- a/docs/concepts/loadouts.md
+++ b/docs/concepts/loadouts.md
@@ -43,10 +43,11 @@ packages and environment through the task schema.
 
 ## Where loadouts live
 
-Each loadout is a single TOML file in your user config directory:
+Loadouts live in your user config directory, in either of two layouts:
 
 ```
-~/.config/minimal/loadouts/<name>.toml
+~/.config/minimal/loadouts/<name>.toml          # a loadout that is just a file
+~/.config/minimal/loadouts/<name>/loadout.toml  # a loadout you keep in git
 ```
 
 On Linux this is `$XDG_CONFIG_HOME/minimal/loadouts` (falling back to
@@ -55,10 +56,25 @@ same `~/.config` location for consistency with Minimal's state and cache
 directories. The global `--config-dir` flag overrides the base directory when
 you need a non-default location.
 
-The filename stem is the loadout's identifier. A file named `dev.toml`
-defines the loadout `dev` — nothing inside the file names it, so renaming
-the file renames the loadout. The directory is not created for you: make it
-and drop `<name>.toml` files in to get started.
+The filesystem names the loadout. A file named `dev.toml` and a directory
+named `dev/` holding a `loadout.toml` both define the loadout `dev` —
+nothing inside the file names it, so renaming the file (or the directory)
+renames the loadout. Defining one name both ways at once is an error rather
+than a precedence rule.
+
+The second shape exists so a whole loadout — its definition, the files it
+ships, its hook scripts — is one self-contained directory you can clone:
+
+```console
+$ git clone git@example.com:you/helix-loadout ~/.config/minimal/loadouts/dev
+```
+
+Nothing else changes between the two, because a loadout's own directory is
+`~/.config/minimal/loadouts/<name>/` either way. The
+[reference](../reference/loadouts.md#where-loadouts-live) has the details.
+
+The loadouts directory is not created for you: make it and add loadouts in
+either shape to get started.
 
 ## What a loadout carries
 
@@ -169,7 +185,8 @@ EDITOR = "hx"
 on_activate = { type = "inline", value = "hx --grammar fetch >/dev/null 2>&1 || true" }
 ```
 
-Saved as `~/.config/minimal/loadouts/dev.toml`, it is ready to apply.
+Saved as `~/.config/minimal/loadouts/dev.toml` — or as
+`~/.config/minimal/loadouts/dev/loadout.toml` — it is ready to apply.
 
 ## Applying a loadout
 

--- a/docs/reference/cli-min.md
+++ b/docs/reference/cli-min.md
@@ -93,7 +93,7 @@ the current directory).
 |------|-------|-------------|
 | `--name <NAME>` | `-n` | Optional session name |
 | `--sync <MODE>` | | How to load project files into the session: `tarball` (default: stream a tarball of your project and unpack it) or `none` (do not populate the worktree) |
-| `--loadout <NAME>` | | Apply the named loadout from `<config>/minimal/loadouts/<NAME>.toml`. Repeatable; if given, config-file `default_loadouts` are ignored |
+| `--loadout <NAME>` | | Apply the named loadout from `<config>/minimal/loadouts/<NAME>.toml` or `<config>/minimal/loadouts/<NAME>/loadout.toml`. Repeatable; if given, config-file `default_loadouts` are ignored |
 | `--no-loadouts` | | Apply no loadouts at all (also skips the config's `default_loadouts`). Conflicts with `--loadout` |
 | `--no-hooks` | | Run none of the session's [lifecycle hooks](./loadouts.md#lifecycle_hooks---scripts-at-session-transition-points), from either the loadouts or the project's `minimal.toml`. Recorded on the session, so it applies to the later attach, detach, and destroy transitions too |
 | `--no-prompt` | | Fail instead of prompting when the daemon surfaces items user policy can't auto-decide; implied when stdin/stderr isn't a TTY |
@@ -259,9 +259,15 @@ daemon running).
 min loadout list [--dir <DIR>]
 ```
 
-Lists loadouts from the user's config directory. `--dir` overrides the
+Lists loadouts from the user's config directory, in both layouts —
+`<name>.toml` and `<name>/loadout.toml`. `--dir` overrides the
 loadouts directory (default: `<config>/minimal/loadouts`, e.g.
 `~/.config/minimal/loadouts` on Linux).
+
+A loadout that fails to load is reported on stderr and makes the command exit
+non-zero, leaving the table of valid loadouts intact. That covers a malformed
+file and a name defined in both layouts at once, which is
+[an error rather than a precedence rule](./loadouts.md#where-loadouts-live).
 
 ### `dirs`
 

--- a/docs/reference/loadouts.md
+++ b/docs/reference/loadouts.md
@@ -19,10 +19,11 @@ described in [Tasks](./tasks.md).
 
 ## Where loadouts live
 
-Each loadout is a single TOML file at:
+Loadouts live under `<config>/minimal/loadouts/`, in either of two layouts:
 
 ```
-<config>/minimal/loadouts/<name>.toml
+<config>/minimal/loadouts/<name>.toml          # a loadout that is just a file
+<config>/minimal/loadouts/<name>/loadout.toml  # a loadout you keep in git
 ```
 
 `<config>` is the platform user config directory: `$XDG_CONFIG_HOME` on Linux
@@ -31,19 +32,54 @@ consistency with Minimal's state and cache dirs. The global
 [`--config-dir`](./cli-min.md#global-flags) flag overrides the base, and
 `min dirs` prints the resolved loadouts directory.
 
-The filename stem **is** the loadout's identifier:
+The two layouts are equivalent in every way but where the bytes sit. Pick the
+second when you want the whole loadout — its definition, the files it
+[ships](#loadout_root), its [hook scripts](#lifecycle_hooks) — to be one
+self-contained directory you can put under version control:
 
-- Nothing inside the file names it, so renaming the file renames the
-  loadout.
-- Names are trimmed and must be non-empty, with no `/`, `\`, or NUL
-  characters.
+```console
+$ git clone git@example.com:you/helix-loadout ~/.config/minimal/loadouts/dev
+$ min session activate . --loadout dev
+```
+
+Nothing else changes between them, because a loadout's own directory is
+`<config>/minimal/loadouts/<name>/` under both — see
+[`$LOADOUT_ROOT`](#loadout_root). To migrate an existing loadout, move it
+inside the directory its files already live in:
+
+```console
+$ cd ~/.config/minimal/loadouts && mkdir -p dev && mv dev.toml dev/loadout.toml
+```
+
+The **filesystem** names the loadout — the filename stem for `<name>.toml`, the
+directory name for `<name>/loadout.toml`:
+
+- Nothing inside the file names it, so renaming the file (or the directory)
+  renames the loadout.
+- Names are trimmed and must be usable as a single directory entry: non-empty,
+  neither `.` nor `..`, and with no `/`, `\`, or NUL characters. (A dot is only
+  special as the whole name — `dev.v2` is fine.)
 - A file that still carries the old `name` field loads anyway, with a
   warning that the field is no longer required. If the declared name
   disagrees with the filename, the warning says so and the filename wins;
   the declared name is discarded.
+- Defining one name in **both** layouts at once is an error, not a
+  precedence rule. `min loadout list` names both files and exits non-zero, and
+  so does an activation that selects the name — whichever file lost would
+  otherwise go on looking live while having no effect.
 
-The directory is not created automatically; create it and drop
-`<name>.toml` files there to get started.
+The directory is not created automatically; create it and add loadouts in
+either shape to get started.
+
+Two things to know if you do version-control a loadout:
+
+- A cloned `<name>/` contains a `.git` directory, which a broad
+  `$LOADOUT_ROOT/**/*` patch source would sweep into your session along with
+  everything else. Prefer patterns that name what you actually want.
+- `<name>/` must be a real directory, not a symlink into a dotfiles repo
+  elsewhere: a loadout's [external hook scripts](#lifecycle_hooks) refuse a
+  symlinked anchor, so they would fail to resolve. Clone into
+  `loadouts/<name>/` directly.
 
 ## Example
 
@@ -236,17 +272,22 @@ to the session user, whatever it was owned by on your host.
 
 Not every file a loadout patches in belongs in your dotfiles. For the ones
 that exist only to serve this loadout, keep them beside it and name them
-with `$LOADOUT_ROOT`, which expands to a directory named after the loadout
-next to its `.toml` -- the same directory its
-[external hook scripts](#lifecycle_hooks) resolve against:
+with `$LOADOUT_ROOT`, which expands to a directory named after the loadout --
+the same directory its [external hook scripts](#lifecycle_hooks) resolve
+against.
+
+That directory is `<config>/minimal/loadouts/<name>/` under
+[either layout](#where-loadouts-live). With a flat `dev.toml` it sits beside
+the file; with `dev/loadout.toml` it *is* the directory the definition lives
+in, which is what makes a loadout and its files one version-controllable tree:
 
 ```
-<config>/minimal/loadouts/
-├── dev.toml
-└── dev/
-    ├── config.toml
-    └── themes/
-        └── nord.toml
+<config>/minimal/loadouts/        <config>/minimal/loadouts/
+├── dev.toml                      └── dev/
+└── dev/                              ├── loadout.toml
+    ├── config.toml                   ├── config.toml
+    └── themes/                       └── themes/
+        └── nord.toml                     └── nord.toml
 ```
 
 ```toml
@@ -259,7 +300,8 @@ patches = [
 It resolves against the loadouts directory actually in use, so a
 `--config-dir` or `$XDG_CONFIG_HOME` that moves your config takes the
 loadout's files with it -- which a hard-coded `~/.config/minimal/loadouts/dev/`
-would not.
+would not. It is derived from the loadout's *name*, so it is also the same
+directory whichever layout the loadout is filed in.
 
 Details worth knowing:
 
@@ -321,25 +363,27 @@ resolve against the daemon, not the session. Default to POSIX `sh` where you
 can — it is the one interpreter a session is guaranteed to have.
 
 External script paths must be relative (absolute paths and `..` components
-are rejected at parse time). A loadout's scripts are anchored at a directory
-beside the loadout file, named after the loadout — so `dev.toml`'s scripts
-live in `dev/`:
+are rejected at parse time). A loadout's scripts are anchored at the directory
+named after the loadout — so `dev.toml`'s scripts live in `dev/`, and a
+`dev/loadout.toml`'s live beside it:
 
 ```
-<config>/minimal/loadouts/
-├── dev.toml
-└── dev/
-    ├── activate.sh
-    └── teardown.sh
+<config>/minimal/loadouts/        <config>/minimal/loadouts/
+├── dev.toml                      └── dev/
+└── dev/                              ├── loadout.toml
+    ├── activate.sh                   ├── activate.sh
+    └── teardown.sh                   └── teardown.sh
 ```
 
 This is the same directory [`$LOADOUT_ROOT`](#loadout_root) names, so a
 loadout's scripts and the files it patches in live together.
 
 A script must resolve to a regular file inside that directory. Symlinks are
-rejected rather than followed, at every path component — a symlink is the one
-way a path that passes every other check could still reach outside the
-anchor. All of this is checked on your machine before a session is created,
+rejected rather than followed, at every path component *and at the directory
+itself* — a symlink is the one way a path that passes every other check could
+still reach outside the anchor. (This is why a version-controlled loadout
+directory has to be a real checkout rather than a symlink into a dotfiles
+repo.) All of this is checked on your machine before a session is created,
 so a mistyped path fails immediately and names the file.
 
 Hooks from multiple contributors concatenate in declaration order, and run in

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -917,6 +917,59 @@ LOADOUT
   echo "loadout-declared hooks proof OK (ran, ungated)"
   echo "::endgroup::"
 
+  # -- Directory-layout loadout ----------------------------------------------
+  # The same loadout, filed as `<name>/loadout.toml` instead of `<name>.toml`
+  # so it can be kept under version control. The proof is deliberately an
+  # EXTERNAL hook script plus a patch, because both anchor at
+  # `<loadouts>/<name>/` — which under this layout is the directory holding
+  # `loadout.toml` itself. If discovery and anchoring ever disagreed about
+  # which directory a loadout owns, the script would fail to stage and the
+  # patch would resolve to nothing; neither can pass by accident.
+  echo "::group::loadout layouts: <name>/loadout.toml"
+  mkdir -p "$XDG_CONFIG_HOME/minimal/loadouts/vcdev"
+  cat > "$XDG_CONFIG_HOME/minimal/loadouts/vcdev/loadout.toml" <<'LOADOUT'
+description = "e2e directory-layout loadout"
+
+patches = [
+  { dest = ".config/vcdev.conf", source = "$LOADOUT_ROOT/vcdev.conf" },
+]
+
+[[lifecycle_hooks]]
+on_activate = { type = "external", value = "activate.sh" }
+LOADOUT
+  printf 'VCDEV_PATCH_OK\n' > "$XDG_CONFIG_HOME/minimal/loadouts/vcdev/vcdev.conf"
+  # `/usr/bin/bash` for the same reason the external-hook fixture above uses
+  # it: it is the interpreter the session is known to have.
+  printf '#!/usr/bin/bash\necho HOOK_VCDEV_OK > /home/hook-vcdev\n' \
+    > "$XDG_CONFIG_HOME/minimal/loadouts/vcdev/activate.sh"
+  chmod +x "$XDG_CONFIG_HOME/minimal/loadouts/vcdev/activate.sh"
+  HOOK_SEED_DIR="$(hook_mktemp /tmp/mnlv.XXXXXX)"
+  hook_seed_preamble > "$HOOK_SEED_DIR/minimal.toml"
+  mkdir "$HOOK_SEED_DIR/.git"
+
+  vc_sid="$(cd "$HOOK_SEED_DIR" && mnl session activate . --no-prompt --loadout vcdev 2>"$WORK/loadout-vcdev.err")" || {
+    echo "::error::activation with a directory-layout loadout failed"
+    echo "--- stderr ---"; cat "$WORK/loadout-vcdev.err" 2>/dev/null || true
+    fail
+  }
+  vc_hook="$(mnl session exec "$vc_sid" 'cat /home/hook-vcdev' 2>/dev/null)"
+  if [[ "$vc_hook" != *HOOK_VCDEV_OK* ]]; then
+    echo "::error::directory-layout loadout's external hook did not run (marker: '$vc_hook')"
+    echo "--- activate stderr ---"; cat "$WORK/loadout-vcdev.err" 2>/dev/null || true
+    fail
+  fi
+  vc_patch="$(mnl session exec "$vc_sid" 'cat ~/.config/vcdev.conf' 2>/dev/null)"
+  if [[ "$vc_patch" != *VCDEV_PATCH_OK* ]]; then
+    echo "::error::\$LOADOUT_ROOT patch from a directory-layout loadout did not land (got: '$vc_patch')"
+    echo "--- activate stderr ---"; cat "$WORK/loadout-vcdev.err" 2>/dev/null || true
+    fail
+  fi
+  mnl session destroy --force "$vc_sid" >/dev/null 2>&1 || true
+  rm -rf "$HOOK_SEED_DIR"; HOOK_SEED_DIR=""
+  rm -rf "$XDG_CONFIG_HOME/minimal/loadouts/vcdev"
+  echo "directory-layout loadout proof OK (discovered, \$LOADOUT_ROOT patch + external hook resolved)"
+  echo "::endgroup::"
+
   # -- Patch file modes ------------------------------------------------------
   # A patch's permission bits cross three hops, and each has unit coverage of
   # its own end only: the client stamps the source's mode on the tar header,


### PR DESCRIPTION
  Summary

  Loadouts could only be discovered at <config>/minimal/loadouts/<name>.toml, which left nowhere to put a loadout you want under version control — the definition is a loose file in a directory shared with every other loadout. This adds a second layout, <config>/minimal/loadouts/<name>/loadout.toml, so a whole
  loadout (definition, $LOADOUT_ROOT assets, hook scripts) is one self-contained directory you can git clone into place.

  The change is confined to discovery. A loadout already owned a directory at <loadouts_dir>/<name>/ — the anchor for $LOADOUT_ROOT and external hook scripts — and Source::loadout_dir derives it from the loadout's name, not from its file's path. In the new layout that directory is simply the one holding
  loadout.toml, so expansion, composition, hook staging, the wire types, minimald, and minimal-tui are all untouched. Migration is mkdir dev && mv dev.toml dev/loadout.toml.

  - sessions::client::disk — adds Layout, LOADOUT_FILE_NAME, read_loadout_dir, and load_loadout as the single name→loadout resolver; list_loadouts enumerates both layouts keyed by name. New LoadError::{ConflictingLayouts, NotFound}.
  - Defining one name in both layouts is a hard error, not a precedence rule — mirroring mfile::File::from_dir's ConflictingLayouts for minimal.toml / .minimal/minimal.toml. Whichever file lost would otherwise go on looking live while having no effect.
  - min — activation, the zero-config default probe, min loadout list, and min bug collection all handle both layouts.
  - Also closes a path-traversal wart in the function being replaced: --loadout ../../evil was interpolated into a filename unvalidated and read an arbitrary .toml. The post-read stem check never caught it, since file_stem("../../evil.toml") is evil. Names are now validated before the join.

  Two documented limitations: a cloned <name>/ contains .git, which a broad $LOADOUT_ROOT/**/* would sweep in; and <name>/ must be a real directory, not a symlink into a dotfiles repo, because resolve_under_anchor refuses a symlinked anchor. That security check is deliberately left alone.

  Testing

  cargo fmt --all -- --check and cargo clippy --workspace --all-targets --locked -- -D warnings clean. Full cargo test --workspace --locked green.

  New coverage: 15 tests in disk.rs (both layouts, conflict, not-found naming both candidates, asset-directory-is-not-a-loadout, a flat loadout named loadout), 6 in loadouts.rs, an anchor-equivalence integration test in client_flow1.rs proving both layouts resolve $LOADOUT_ROOT to the same directory, and
  tests/bug.rs extended so a directory-layout loadout is proved collected and redacted.

  Manual, against a scratch --config-dir:

  $ min --config-dir $cfg loadout list        # dev (dir form) + flat, exit 0
  $ min --config-dir $cfg loadout list        # after adding dev.toml:
  loadout `dev` is defined twice:
    /tmp/lo-check/minimal/loadouts/dev.toml
    /tmp/lo-check/minimal/loadouts/dev/loadout.toml
  remove one.
  error: 1 loadout failed to load                                    # exit 1

  $ min ... session activate . --loadout typo
  error: --loadout `typo`: no loadout `typo` in `.../loadouts` (looked for `typo.toml` and `typo/loadout.toml`)

  A real activation with a directory-layout loadout printed Applying loadouts: vcdev and reached FinalizeSession with its $LOADOUT_ROOT patch and external hook script both resolving; it then failed on no such package: base, which is the local environment lacking a package cache.

  Checklist

  - [x] Docs updated if behavior changed — docs/reference/loadouts.md (layouts, conflict rule, both tree diagrams, version-control caveats), docs/concepts/loadouts.md, docs/reference/cli-min.md, README.md
  - [x] BREAKING CHANGE: footer present if this is a breaking change — not breaking; the flat layout is unchanged, and a bare <name>/ asset directory beside a flat <name>.toml still resolves to the flat file (pinned by a test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loadouts now support standalone `<name>.toml` files and `<name>/loadout.toml` directory layouts.
  * Directory-based loadouts can be cloned as self-contained bundles.
  * `$LOADOUT_ROOT` and lifecycle hooks resolve to the loadout’s name-based directory for either layout.
  * Loadout listings include both layouts while retaining valid entries when others fail.

* **Bug Fixes**
  * Invalid names, duplicate definitions, malformed loadouts, and unsafe symlinked directories now produce errors.
  * User-defined default loadouts correctly override the built-in fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->