### PR TITLE
docs(specs): add the GitHub sessions spec for the GitHub auth epic

### DIFF
--- a/.github/workflows/spec-lint.yml
+++ b/.github/workflows/spec-lint.yml
@@ -24,6 +24,12 @@ on:
 
 permissions:
   contents: read
+  # This is the scope that posts and edits the advisory comment. A comment on
+  # a pull request is an issue comment, so the endpoint reads
+  # `issues/<n>/comments` and every review of this file asks for
+  # `issues: write` on the strength of that path. It is not needed: the
+  # number belongs to a pull request, and `pull-requests: write` carries both
+  # the POST and the PATCH. The run record on the installed copies shows it.
   pull-requests: write
 
 concurrency:
@@ -63,7 +69,7 @@ jobs:
       - name: Mint a token for the private linter
         id: app-token
         continue-on-error: true
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.AW_BOT_APP_ID }}
           private-key: ${{ secrets.AW_BOT_PRIVATE_KEY }}
@@ -92,7 +98,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # No `-e`. The selection loop's `[ ] &&` and the `grep -q` below both
+          # return non-zero on ordinary paths, and under `-e` either one ends
+          # the step non-zero — which is the merge gate decision 9 says this
+          # never becomes. Every exit in this script is a deliberate zero.
           set -uo pipefail
+
+          # The checkout step is continue-on-error like every other, so a
+          # failed one arrives here as a missing directory rather than a failed
+          # job. A PR that touches a spec would reach the linter and report no
+          # output; a workflow-only PR would not, because the self-test below
+          # looks for a TEMPLATE.md that is not there, and the log then reads
+          # exactly like a PR that changed no spec. Say the real reason here,
+          # while it is still known.
+          if [ ! -d pr ]; then
+            echo "::warning::the tree under review could not be checked out; no comment this run"
+            echo "state=quiet" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # Changed files come from the API, not from git: a shallow checkout of
           # the head sha has no base to diff against, and deepening it to find
@@ -102,10 +125,24 @@ jobs:
           # predate it, so a PR editing one spec must not be told about findings
           # in eleven it did not write. Renames arrive as added; deletions are
           # dropped, since a file that is gone cannot be linted.
-          mapfile -t changed < <(
-            gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate \
-              --jq '.[] | select(.status != "removed") | .filename' 2>/dev/null || true
-          )
+          #
+          # Read into a variable first, so the exit status survives: a rate
+          # limit or a transient 5xx here returns nothing, and an empty list
+          # reads exactly like a PR that touches no spec. Silence is a real
+          # answer this step gives; it must not double as the failure.
+          if ! changed_out="$(
+                gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate \
+                  --jq '.[] | select(.status != "removed") | .filename' 2>/tmp/files.err
+              )"; then
+            echo "::warning::the changed-file list could not be read from the API; no comment this run"
+            sed -n '1,10p' /tmp/files.err
+            echo "state=quiet" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # `mapfile` on an empty string would yield a one-element array holding
+          # the empty string, which the loop below would then try to match.
+          changed=()
+          [ -n "$changed_out" ] && mapfile -t changed <<< "$changed_out"
 
           # A spec directory holds one spec and any number of supporting
           # documents beside it — `architecture.md` in five of them today.
@@ -186,12 +223,33 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           STATE: ${{ steps.lint.outputs.state }}
         run: |
+          # No `-e`, for the reason the lint step gives: an edit the API
+          # refuses would end this step non-zero, and the job's promise is that
+          # nothing here can fail the check.
           set -uo pipefail
 
           # One comment, edited in place. A PR that pushes six times should
           # carry one current comment, not six historical ones.
+          #
+          # Author and marker, not the marker alone. Anyone can open a comment
+          # that starts with the marker — a quoted reply, a pasted report — and
+          # if theirs sorts first the PATCH below is aimed at a comment
+          # `github.token` may not edit. It fails, this step continues on error,
+          # and the run goes green having said nothing.
+          #
+          # Every match, then `head -1`, because `--paginate` hands `--jq` one
+          # document per page: a filter ending in `.[0]` picks the first match
+          # *of each page*, so a PR past thirty comments puts several ids in a
+          # variable that holds one. `--slurp` would join the pages into one
+          # array, but gh refuses it alongside `--jq` — "the `--slurp` option
+          # is not supported with `--jq` or `--template`", from its own flag
+          # validation — and that error would arrive on the stderr this line
+          # discards, leaving `existing` empty and a fresh comment posted on
+          # every push. Streaming ids in page order and taking the first is the
+          # same answer with no second tool and no flag conflict.
           existing="$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
-            --jq 'map(select(.body | startswith("<!-- spec-lint -->"))) | .[0].id // empty' 2>/dev/null || true)"
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- spec-lint -->"))) | .id' 2>/dev/null \
+            | head -1 || true)"
 
           # A clean run never opens a comment — the absence of one is the
           # result. It does update a comment that already exists, because the

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -25,8 +25,8 @@ inside it as themselves, whether they or an agent typed the command. No token
 is entered, copied, or left on the session. A session spawned by a workflow
 inherits no more access than its parent, and nobody is prompted for it.
 
-This document covers the CLI, the session daemon and the credential path
-inside a session. Signing the developer in, minting and renewing tokens, and
+This document covers the CLI, the session daemon and the host-side credential
+facade that fronts GitHub for every session. Signing the developer in, minting and renewing tokens, and
 enforcing attenuation at issuance are the identity plane's, in
 [the GitHub identity spec](https://github.com/gominimal/gatehouse/blob/main/docs/specs/01-spec-github-identity/01-spec-github-identity.md).
 The browser page that approves a sign-in is in
@@ -34,11 +34,12 @@ The browser page that approves a sign-in is in
 
 **Success:** A developer with no prior Minimal account signs in with GitHub,
 starts a remote session, and a push to their project from inside it lands on
-GitHub attributed to them, with no token typed, copied, or present on the
-session's filesystem or environment.
+GitHub attributed to them, with no credential typed, copied, or present in
+the session or in the guest that hosts it.
 
 **First slice:** The sign-in command, the browser approval, one remote session,
-and a push to the workbench project from inside it with unmodified git.
+and a push to the workbench project from inside it with unmodified git through
+the facade, with no credential in the session.
 
 ## Users and stories
 
@@ -88,12 +89,13 @@ and a push to the workbench project from inside it with unmodified git.
   property: for every declared set D, the set of repositories a git operation may target is exactly the workbench project together with D
   harness:  kani_reach_is_workbench_plus_declared, exhaustive to 8 declared repositories modelled as bounded identifiers (unwind bound 9); the same pure reach decision as GHS-003
 
-- **GHS-005** IF a git operation inside a session targets a repository outside
-  the session's declared set THEN THE SYSTEM SHALL supply no credential for it.
+- **GHS-005** IF a git or GitHub request from a session targets a repository
+  outside the session's declared set THEN THE SYSTEM SHALL refuse it with a
+  403 before the request reaches GitHub.
   tier:     T2
-  verify:   cargo nextest run -p minimal git_op_outside_declared_set_gets_no_credential
-  property: for every declared set and every target repository outside it, the reach decision is a refusal, and no credential is supplied for the operation
-  harness:  kani_outside_reach_is_refused, exhaustive to 8 declared repositories (unwind bound 9); requires the reach decision to be a pure function over owned repository identifiers, consulted by the credential path before any credential is supplied
+  verify:   cargo nextest run -p minimal request_outside_declared_set_is_403_before_github
+  property: for every declared set and every target repository outside it, the reach decision is a refusal, and the refusal reaches the caller as a 403 with nothing forwarded to GitHub
+  harness:  kani_outside_reach_is_refused, exhaustive to 8 declared repositories (unwind bound 9); requires the reach decision to be a pure function over owned repository identifiers, evaluated by the facade before any request is forwarded
 
 - **GHS-006** WHEN a developer runs the sign-in command THE SYSTEM SHALL show
   the address of a browser page and a short code with which the developer
@@ -135,16 +137,17 @@ and a push to the workbench project from inside it with unmodified git.
   tier:     T0
   verify:   cargo nextest run -p minimal session_commits_and_prs_attributed_to_developer
 
-- **GHS-013** THE SYSTEM SHALL write no personal access token and no static
-  private SSH key to a session's filesystem or environment.
+- **GHS-013** THE SYSTEM SHALL keep every GitHub credential, including any
+  personal access token and any static private SSH key, out of a session's
+  filesystem and environment.
   tier:     T0
-  verify:   cargo nextest run -p minimal session_fs_and_env_hold_no_pat_or_static_key
+  verify:   cargo nextest run -p minimal session_fs_and_env_hold_no_github_credential
 
-- **GHS-014** WHEN a git operation inside a session needs a credential THE
-  SYSTEM SHALL obtain one that expires within 8 hours, at the time of the
-  operation.
+- **GHS-014** WHEN a session is created for a signed-in developer THE SYSTEM
+  SHALL hand it addresses for git over HTTPS and the GitHub programming
+  interface that carry no credential.
   tier:     T0
-  verify:   cargo nextest run -p minimal git_credential_is_fetched_per_op_and_expires_within_8h
+  verify:   cargo nextest run -p minimal session_receives_credential_free_github_addresses
 
 - **GHS-015** WHEN a session spawns a child session THE SYSTEM SHALL grant the
   child a GitHub access scope that is a subset of the parent's.
@@ -163,6 +166,33 @@ and a push to the workbench project from inside it with unmodified git.
   tier:     T0
   verify:   cargo nextest run -p minimal parent_end_ends_child_github_access
 
+- **GHS-018** THE SYSTEM SHALL hold a session's GitHub credential on the host,
+  outside the guest virtual machine and outside every session.
+  tier:     T0
+  verify:   cargo nextest run -p minimal facade_holds_credential_outside_guest_and_session
+
+- **GHS-019** WHEN a session ends, by destroy or otherwise, THE SYSTEM SHALL
+  stop answering the session's GitHub addresses and discard every credential
+  held for it.
+  tier:     T0
+  verify:   cargo nextest run -p minimal session_end_stops_addresses_and_discards_credentials
+
+- **GHS-020** WHILE a session is live THE SYSTEM SHALL hold its GitHub
+  credential for at most 8 hours before renewing or discarding it.
+  tier:     T0
+  verify:   cargo nextest run -p minimal facade_credential_held_at_most_8h
+
+- **GHS-021** WHEN a GitHub request from a session is admitted or refused THE
+  SYSTEM SHALL record the decision with the session and the developer
+  identity, and never the credential or the request body.
+  tier:     T0
+  verify:   cargo nextest run -p minimal facade_decisions_are_audited_without_secrets
+
+- **GHS-022** WHERE a session's declared egress excludes github.com THE SYSTEM
+  SHALL complete git and gh operations from it through the facade.
+  tier:     T0
+  verify:   cargo nextest run -p minimal github_work_needs_no_github_egress
+
 ## Non-goals
 
 - Signing the developer in, minting and renewing tokens, and enforcing
@@ -172,19 +202,21 @@ and a push to the workbench project from inside it with unmodified git.
   [the CLI sign-in page spec](https://github.com/gominimal/webapp/blob/main/docs/specs/03-spec-cli-signin-page/03-spec-cli-signin-page.md).
 - Sign-in through any provider other than GitHub.com, including enterprise
   OIDC: Gatehouse §6.1.3 (F2), a later phase of the identity plane.
-- A forced in-session facade for git: retired on 2026-08-20. Standard git and
-  gh are the path (GHS-011).
+- A forced in-session command for git: retired on 2026-08-20. Standard git and
+  gh are the path (GHS-011); the facade is transparent to them.
 - Branch-aware activation, repository pre-priming, and a pull-request prompt
   on session exit: the earlier GitHub-sessions PRD carries them as a
   reference; none is in this epic's criteria.
 - The Actions workflow permission: excluded from the App's permissions
   (GHI-004 in the GitHub identity spec).
-- Ending a session's own GitHub access when the session ends: bounded by token
-  expiry (GHS-014) and by revocation (Gatehouse F13); whether a live grant
-  must end with the session is an open question below. A parent's end ending
-  its children's access is GHS-017.
-- Refusing an out-of-set clone of a public repository: it needs no credential,
-  so nothing but egress enforcement can refuse it; the networking spec.
+- Revoking an already-delivered credential at GitHub: TTL-bounded (Gatehouse
+  §12.9); here a session's end discards what the facade holds (GHS-019).
+- The same facade shape for upstreams other than GitHub, such as the Claude
+  programming interface or model-context servers: a separate credential-broker
+  epic in the inbox proposes it; nothing here binds it.
+- The mechanics that route a session's git remotes and gh requests to the
+  facade: the git rewrite is an implementation choice; gh is an open question
+  below.
 - Sharing a session with another developer or an agent: the session-sharing
   spike in the inbox.
 - A typed control plane for agents over sessions: the sessions MCP proposal in
@@ -220,25 +252,16 @@ workflows sign in before they start.
 workbench project, with the 2026-08-20 ask that workbench-only be an option
 rather than a rule. "Whatever the App installation grants" was set aside
 because it does not meet the per-project bound at all. The bound is enforced
-in two places: the identity plane mints the session's token narrowed to the
-declared set where GitHub can express it (the GitHub identity spec), and the
-credential path inside the session supplies no credential for a repository
-outside the set (GHS-005). The 2026-08-20 record that a user-attributed token
-cannot be narrowed per repository holds for renewal from a refresh token and
-not for minting: GitHub narrows a user access token to named repositories and
-permissions at mint, and the narrowed token stays attributed to the developer.
-The reach decision being pure and separable from the credential path is what
-the T2 harnesses require.
-
-**The epic's 403 is not met literally, and that is recorded rather than
-hidden.** With the token delivered into the session per operation (the custody
-decision below), an out-of-set request that reaches GitHub gets GitHub's own
-answer: a 404 for a private repository the narrowed token cannot see, and
-success for a public repository, which needs no credential at all. Only a
-Minimal-owned point between the session and GitHub could answer a 403, and the
-architecture of record has none. GHS-005 binds what Minimal controls,
-supplying no credential; whether the epic's criterion is amended or a refusal
-point is added to the architecture is an open question below.
+by the facade on every request (GHS-005), which is what makes the epic's 403
+Minimal's own behaviour rather than a status relayed from GitHub, which
+answers 404 for a private repository outside a token's reach and serves a
+public one with no credential at all. The identity plane additionally mints
+the session's token narrowed to the declared set where GitHub can express it
+(the GitHub identity spec); with the facade enforcing the set, that narrowing
+is defence in depth rather than the bound. The 2026-08-20 record that a
+user-attributed token cannot be narrowed per repository holds for renewal from
+a refresh token and not for minting. The reach decision being pure and
+separable from the proxy is what the T2 harnesses require.
 
 **A child session gets a subset of its parent's scope, never more** (GHS-015).
 Whether a child may declare a narrower set, or a running session's set may
@@ -255,27 +278,31 @@ loopback listener has no code to type but needs a browser on the same machine
 as the CLI; GitHub's own device page needs no page of ours but leaves nowhere
 to show what is being approved.
 
-**A credential must never reach the session's filesystem or environment**
-(GHS-013, decided 2026-09-03). The epic says "stored on the box". Reading that
-as anywhere on the host machine would forbid the daemon beside the session
-from holding short-lived material; reading it as the filesystem only would
-allow a token materialised in the environment, which a captured environment
-carries for its lifetime.
-
-**The session's short-lived token is delivered into the session per
-operation, as the architecture of record describes** (decided 2026-09-03,
-with the daemon's placement in front of the decision: on macOS and on Linux
-with hardware virtualisation the session daemon and the broker beside it run
-inside a guest virtual machine, and on native Linux on the host). Three other
-placements were offered and declined: never in the session, with the holder's
-placement left open; never in the guest, held on the host, which is the
-strongest against a sandbox escape or a guest snapshot but commits to a
-component the architecture lacks; and beside the daemon, never in the
-session, which needs no new component but forecloses the host-side design.
-The cost accepted is the one the architecture states itself (Gatehouse §6.4):
-a process in the session holds a bearer credential for up to 8 hours against
-every repository the token reaches, so the bounds are the narrowed mint, the
-8-hour expiry (GHS-014) and the audit of every mint, not custody.
+**No GitHub credential exists in the session or in the guest; a host-side
+facade holds it and attaches it on the way out** (GHS-013, GHS-014, GHS-018,
+decided 2026-09-03, revising a same-day choice). Four placements were on the
+table, with the daemon's placement in front of the decision: on macOS and on
+Linux with hardware virtualisation the session daemon and the broker beside it
+run inside a guest virtual machine, and on native Linux on the host.
+Delivering the token into the session per operation, as the architecture of
+record describes, was chosen first and withdrawn: the architecture itself says
+the token is then a bearer credential any process in the session can reuse for
+its lifetime, which is exactly what a prompt-injected agent would do, and under
+it the epic's 403 cannot be Minimal's own answer. Holding the token beside the
+daemon, never in the session, needs no new component but leaves an 8-hour
+credential inside the guest to a sandbox escape or a guest snapshot. Leaving
+the holder's placement open was declined because the planning step cannot
+decompose the reach requirements without it. The facade on the host is the
+strongest of the four and the only one under which the session never holds a
+credential, the guest never holds one, a request outside the set is refused
+before it leaves, and access ends with the session (GHS-019). It costs a
+component the architecture of record does not have, a path by which the guest
+daemon reaches it for a child's grant, and the in-session routing of gh, which
+has no base-address override for github.com; the first two are the
+architecture question below, the third an open question here. The facade is
+transparent to git and gh: standard commands work (GHS-011), which is what the
+2026-08-20 decision required, and the earlier design of a forced in-session
+command stays retired.
 
 **A session's credential expires within 8 hours**, GitHub's own user-token
 expiry (decided 2026-09-03), rather than an open question or a shorter ceiling
@@ -312,8 +339,8 @@ GHS-015) are at T2: each is a pure decision over bounded repository
 identifiers, and the Kani lane that already proves the path-decision lattice
 runs the harnesses today. What the tier buys is the split each harness line
 names: the decision is a pure function over owned values, separate from the
-credential path that acts on it, and it has to be written that way from the
-start. T0 would leave the decision free to interleave with that path;
+proxy that acts on it, and it has to be written that way from the start. T0
+would leave the decision free to interleave with the proxy;
 T1 would add a property-testing dependency this tree does not carry.
 Everything else stays at T0 because it passes through GitHub, a PTY or a
 socket, and there is no decision to extract. GHS-013 is a universal and stays
@@ -325,39 +352,51 @@ no Lean project to hold a proof.
 
 **Egress is only half covered.** The initiative's constraint that nothing
 enters or leaves a box undeclared is met on the credential side (GHS-013,
-GHS-014). The network side, egress declared before it happens and enforced at
+GHS-018). The network side, egress declared before it happens and enforced at
 the relay, is allow-all in running code today, and the design for enforcing
-it belongs to the networking spec. Whether it is a prerequisite for this work
-is open.
+it belongs to the networking spec. GHS-022 states what the facade makes
+possible: a session with a GitHub grant needs no github.com egress at all, so
+an enforcing policy can deny it. Until egress is enforced the facade removes
+the need for a credential in the session, not the ability of a session to
+reach GitHub with one pasted in. Whether enforcement is a prerequisite for
+this work is open.
 
-**Generality:** GitHub.com is the sole provider by decision (GHS-007), and
-GHS-011, GHS-012 and GHS-014 assume GitHub App token semantics; a second
-provider would enter through the identity plane (Gatehouse F2) and need its
-own reach and attribution requirements. Across hosts the behaviours are
-general as stated, with one dependency named: where the session daemon runs
-decides where the session's token is held between operations, inside a guest
-on macOS and Linux with hardware virtualisation and on the host on native
-Linux; and a local session on a daemon not enrolled with the identity plane
-has no broker to mint from (open question below). A local and a remote
-session otherwise differ only in whether sign-in is required to start
-(GHS-008, GHS-009).
+**Generality:** GitHub.com is the sole provider by decision (GHS-007). The
+facade's shape, a credential-free address per upstream, a credential held
+outside the guest, a per-request reach decision, would fit a second upstream
+such as the Claude programming interface, and a separate epic proposes exactly
+that; every bound stated here, the 403, the permission ceiling, the 8-hour
+lifetime, is GitHub's own model and does not carry. Across hosts the
+behaviours are general: the facade sits on the host on every platform, so
+where the daemon runs, inside a guest on macOS and Linux with hardware
+virtualisation or on the host on native Linux, changes how the daemon reaches
+it and nothing a session observes. A local and a remote session differ only
+in whether sign-in is required to start (GHS-008, GHS-009); a local session on
+a daemon not enrolled with the identity plane depends on the facade acting
+under the developer's own sign-in, an open question below.
 
 ## Security considerations
 
-- **Invariant:** THE SYSTEM SHALL keep every long-lived credential, meaning a
-  personal access token, a static private SSH key or a refresh token, off a
-  session's filesystem and environment.
-  enforced by: the credential path obtaining an expiring token at the time of
-  each operation, and the scan of the session filesystem and process
-  environments the architecture requires (Gatehouse INV-1, T3, T15).
-  covered by: GHS-013, GHS-014
-- **Invariant:** THE SYSTEM SHALL supply a session no credential for a
-  repository outside its declared set.
+- **Invariant:** THE SYSTEM SHALL keep every GitHub credential and every
+  private key out of a session's filesystem, environment and memory, and out
+  of the guest virtual machine.
+  enforced by: the facade holding credentials on the host outside the guest
+  and handing sessions only credential-free addresses, and the scan of the
+  session filesystem and process environments the architecture requires
+  (Gatehouse INV-1, T3, T15).
+  covered by: GHS-013, GHS-014, GHS-018
+- **Invariant:** THE SYSTEM SHALL admit through the facade no request for a
+  repository outside the session's declared set.
   enforced by: the reach decision, a pure function over owned repository
-  identifiers checked exhaustively to the stated bound and consulted before
-  any credential is supplied, and the narrowed mint in the identity plane
-  (architecture AT12).
+  identifiers checked exhaustively to the stated bound and evaluated before
+  any request is forwarded, with the narrowed mint in the identity plane as
+  defence in depth (architecture AT12; Gatehouse T4, T9).
   covered by: GHS-003, GHS-004, GHS-005
+- **Invariant:** THE SYSTEM SHALL leave no live GitHub grant for a session
+  that has ended.
+  enforced by: the facade observing session end from the daemon and
+  discarding the session's credentials and addresses (Gatehouse T23).
+  covered by: GHS-017, GHS-019
 - **Invariant:** THE SYSTEM SHALL grant a child session a GitHub access scope
   that is a subset of its parent's.
   enforced by: the child-reach decision here and attenuation at issuance in
@@ -370,29 +409,33 @@ session otherwise differ only in whether sign-in is required to start
 
 ## Open questions
 
+- [NEEDS CLARIFICATION (HIGH): The credential facade is not in the
+  architecture of record, whose §6.4 and §8.3 deliver the token into the box;
+  a proposal for it has been filed against the architecture. Its placement
+  outside the guest, its identity toward the identity plane, and how a child
+  session created inside the guest obtains its grant from it are decided
+  there, and GHS-014, GHS-018 and GHS-019 are not implementable until they
+  are.]
 - [NEEDS CLARIFICATION (HIGH): Is declared-egress enforcement a prerequisite
   for credential-free GitHub access, or its own epic? Egress is allow-all in
   running code, the relay-layer enforcement design was closed without being
   planned, and the initiative's hard constraint says nothing leaves a box
-  undeclared. It is also the only way to refuse an out-of-set clone of a
-  public repository, which needs no credential.]
-- [NEEDS CLARIFICATION (HIGH): The epic's criterion that an out-of-set
-  operation returns a 403 cannot be met with the token delivered into the
-  session: GitHub answers 404 for a private repository outside a narrowed
-  token's reach and serves a public repository with no credential at all.
-  Either the criterion is amended to what GHS-005 binds, or a Minimal-owned
-  refusal point between the session and GitHub is added to the architecture
-  of record, where a host-side credential facade has been proposed.]
+  undeclared. Until it is enforced, the facade removes the need for a
+  credential in a session and not a session's ability to reach GitHub with
+  one pasted in.]
 - [NEEDS CLARIFICATION (HIGH): GHS-012 attributes work from every box a
   developer's workflow spawns to the developer, decided and reconfirmed on
   2026-09-03, while Gatehouse §6.4 defaults every root other than session to
   installation mode. The architecture's per-type default has to move; does
   the agent type give up per-mint narrowing when it does?]
-- [NEEDS CLARIFICATION (HIGH): A session on a daemon not enrolled with the
-  identity plane has no broker and no identity socket, so GHS-010 and GHS-011
-  have no mechanism for a local session until client-mediated local
-  enrollment (Gatehouse F16) exists. Is enrollment a prerequisite for local
-  GitHub access, or does an un-enrolled daemon get a stated weaker path?]
+- [NEEDS CLARIFICATION (HIGH): On a daemon not enrolled with the identity
+  plane, does the facade obtain a session's credential under the developer's
+  own sign-in rather than a box identity, so that local sessions (GHS-009 to
+  GHS-011) work without enrollment? Client-mediated local enrollment
+  (Gatehouse F16) is the alternative.]
+- [NEEDS CLARIFICATION (MEDIUM): gh has no base-address override for
+  github.com. GHS-011 requires it to work through the facade; the in-session
+  configuration that routes its requests there is undecided.]
 - [NEEDS CLARIFICATION (MEDIUM): May a child session declare a repository set
   narrower than its parent's, and may a running session's set change without
   signing in again? Left on 2026-08-20 as something to test against GitHub. A
@@ -403,10 +446,6 @@ session otherwise differ only in whether sign-in is required to start
   second session reuse the existing sign-in or mint a separately scoped token
   by default? Both carried from the earlier PRD; neither is in this epic's
   criteria.]
-- [NEEDS CLARIFICATION (MEDIUM): Must a session's live GitHub grant end when
-  the session ends, by destroy or otherwise, rather than run out at expiry?
-  The credential-leak motive behind the second story argues for it; the epic
-  does not state it.]
 - [NEEDS CLARIFICATION (LOW): The existing hidden sign-in command mints a
   client certificate for the HTTPS reverse proxy under the name the
   architecture's command tree gives to identity sign-in. What is the

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -85,6 +85,11 @@ the facade, with no credential in the session.
   verify:   cargo nextest run -p minimal request_outside_repository_set_is_403_before_github
   property: for every repository set, the workbench project plus the declared repositories, and every target repository outside it, the reach decision is a refusal, and the refusal reaches the caller as a 403 with nothing forwarded to GitHub
   harness:  kani_outside_reach_is_refused, exhaustive to 8 declared repositories (unwind bound 9); requires the reach decision to be a pure function over owned repository identifiers, evaluated by the facade before any request is forwarded
+  - IF the repository a request targets cannot be resolved to one identifier
+    THEN THE SYSTEM SHALL refuse the request with a 403 before it reaches
+    GitHub.
+    tier:   T0
+    verify: cargo nextest run -p minimal unresolvable_target_is_refused_before_github
 
 - **GHS-006** WHEN a developer runs the sign-in command THE SYSTEM SHALL show
   the address of a browser page and a short code with which the developer
@@ -165,8 +170,12 @@ the facade, with no credential in the session.
   held for it.
   tier:     T0
   verify:   cargo nextest run -p minimal session_end_stops_addresses_and_discards_credentials
+  - IF a session has ended THEN THE SYSTEM SHALL forward no further request on
+    its behalf, admitted before the end or not.
+    tier:   T0
+    verify: cargo nextest run -p minimal session_end_wins_race_with_forwarding
 
-- **GHS-020** WHILE a session is live THE SYSTEM SHALL hold its GitHub
+- **GHS-020** WHILE a session is live THE SYSTEM SHALL hold its GitHub access
   credential for at most 8 hours before renewing or discarding it.
   tier:     T0
   verify:   cargo nextest run -p minimal facade_credential_held_at_most_8h
@@ -181,6 +190,21 @@ the facade, with no credential in the session.
   SHALL complete git and gh operations from it through the facade.
   tier:     T0
   verify:   cargo nextest run -p minimal github_work_needs_no_github_egress
+
+- **GHS-023** WHEN a request arrives at the facade THE SYSTEM SHALL attribute
+  it to exactly one live session and that session's developer before deciding
+  it.
+  tier:     T0
+  verify:   cargo nextest run -p minimal facade_request_bound_to_one_live_session
+  - IF a request cannot be attributed to a live session, or presents another
+    session's address, THEN THE SYSTEM SHALL refuse it with a 403.
+    tier:   T0
+    verify: cargo nextest run -p minimal cross_session_address_reuse_is_refused
+
+- **GHS-024** THE SYSTEM SHALL hold in the facade only a session's access
+  credential, and never the developer's refresh token.
+  tier:     T0
+  verify:   cargo nextest run -p minimal facade_holds_no_refresh_token
 
 ## Non-goals
 
@@ -217,7 +241,7 @@ the facade, with no credential in the session.
 ## Design reasoning
 
 **Three documents.** One spec per surface owner, decided 2026-09-03: this one
-for the CLI, the daemon and the in-session credential path; the identity
+for the CLI, the daemon and the host-side credential facade; the identity
 plane's for sign-in, minting, renewal and attenuation; the website's for the
 approval page. A single document here with the identity behaviours as open
 questions was the cheaper alternative and would have left the identity half
@@ -259,6 +283,21 @@ of its parent's (GHS-015) and its token is minted for that subset. The reach
 decision being pure and separable from the proxy is what the T2 harnesses
 require.
 
+**What a request targets, and who it belongs to.** A request's target is the
+repository GitHub would resolve it to: owner and name compared the way GitHub
+compares them, with or without a trailing `.git`, in any of the address forms
+git and gh emit. A target the facade cannot resolve is refused, not forwarded
+(the failure edge of GHS-005); requests that name no repository at all, such
+as an identity lookup, are an open question below. Every request is attributed
+to exactly one live session before it is decided (GHS-023), so an address
+handed to one session buys nothing in another; the mechanism that binds a
+request to its session, a per-session address, a per-session placeholder the
+facade recognises, or the source the switch attributes, is part of the
+facade's design and belongs with the architecture question below. The point
+of no return at session end is forwarding: a request already sent to GitHub
+completes, and one admitted but not yet forwarded is refused (the failure edge
+of GHS-019).
+
 **A child session gets a subset of its parent's scope, never more** (GHS-015).
 Whether a child may declare a narrower set, or a running session's set may
 change without a fresh sign-in, was left on 2026-08-20 as something to test
@@ -293,9 +332,9 @@ strongest of the four and the only one under which the session never holds a
 credential, the guest never holds one, a request outside the set is refused
 before it leaves, and access ends with the session (GHS-019). It costs a
 component the architecture of record does not have, a path by which the guest
-daemon reaches it for a child's grant, and the in-session routing of gh, which
-has no base-address override for github.com; the first two are the
-architecture question below, the third an open question here. The facade is
+daemon reaches it for a child's grant, and the in-session routing of gh, whose
+only host override treats its target as an enterprise server; the first two
+are the architecture question below, the third an open question here. The facade is
 transparent to git and gh: standard commands work (GHS-011), which is what the
 2026-08-20 decision required, and the earlier design of a forced in-session
 command stays retired.
@@ -303,7 +342,11 @@ command stays retired.
 **A session's credential expires within 8 hours**, GitHub's own user-token
 expiry (decided 2026-09-03), rather than an open question or a shorter ceiling
 set here at the cost of more renewals. It depends on the App's
-token-expiration setting staying on (Gatehouse §6.4.1).
+token-expiration setting staying on (Gatehouse §6.4.1). That bound is the
+access credential's. The developer's refresh token never reaches the facade
+(GHS-024): it stays in the identity plane, which rotates it on every renewal,
+refuses a reused one, and mints each renewed token narrowed to the same
+repository set as the one it replaces (the GitHub identity spec).
 
 **Work is attributed to the developer, from a session and from any box a
 workflow spawns** (GHS-012, decided 2026-09-03). This extends the 2026-08-20
@@ -374,13 +417,18 @@ under the developer's own sign-in, an open question below.
 ## Security considerations
 
 - **Invariant:** THE SYSTEM SHALL keep every GitHub credential and every
-  private key out of a session's filesystem, environment and memory, and out
-  of the guest virtual machine.
+  private key out of a session's filesystem and environment and out of the
+  guest virtual machine, and hand a session nothing that carries one.
   enforced by: the facade holding credentials on the host outside the guest
   and handing sessions only credential-free addresses, and the scan of the
   session filesystem and process environments the architecture requires
   (Gatehouse INV-1, T3, T15).
-  covered by: GHS-013, GHS-014, GHS-018
+  covered by: GHS-013, GHS-014, GHS-018, GHS-024
+- **Invariant:** THE SYSTEM SHALL decide no request at the facade without
+  first attributing it to one live session.
+  enforced by: the facade's per-request session binding, refusing anything it
+  cannot attribute (Gatehouse T15).
+  covered by: GHS-023
 - **Invariant:** THE SYSTEM SHALL admit through the facade no request for a
   repository outside the session's repository set.
   enforced by: the reach decision, a pure function over owned repository
@@ -418,10 +466,10 @@ under the developer's own sign-in, an open question below.
 - [NEEDS CLARIFICATION (HIGH): The credential facade is not in the
   architecture of record, whose §6.4 and §8.3 deliver the token into the box;
   a proposal for it has been filed against the architecture. Its placement
-  outside the guest, its identity toward the identity plane, and how a child
-  session created inside the guest obtains its grant from it are decided
-  there, and GHS-014, GHS-018 and GHS-019 are not implementable until they
-  are.]
+  outside the guest, its identity toward the identity plane, how it binds a
+  request to the session that sent it, and how a child session created inside
+  the guest obtains its grant from it are decided there, and GHS-014, GHS-018,
+  GHS-019 and GHS-023 are not implementable until they are.]
 - [NEEDS CLARIFICATION (HIGH): Is declared-egress enforcement a prerequisite
   for credential-free GitHub access, or its own epic? Egress is allow-all in
   running code, the relay-layer enforcement design was closed without being
@@ -440,8 +488,16 @@ under the developer's own sign-in, an open question below.
   GHS-011) work without enrollment? Client-mediated local enrollment
   (Gatehouse F16) is the alternative.]
 - [NEEDS CLARIFICATION (MEDIUM): gh has no base-address override for
-  github.com. GHS-011 requires it to work through the facade; the in-session
-  configuration that routes its requests there is undecided.]
+  github.com; it does honour a host override that treats any other host as a
+  GitHub Enterprise Server and sends requests to that host's enterprise-shaped
+  paths. Pointing that override at the facade, which serves those paths
+  against github.com, is the candidate mechanism for GHS-011. Which gh
+  behaviours differ under a non-github.com host, and whether any matter for
+  clone, push and pull requests, is undecided.]
+- [NEEDS CLARIFICATION (MEDIUM): Which GitHub requests that name no
+  repository, such as the identity lookup gh makes at start, does the facade
+  admit? GHS-005 bounds repository targets; a request with no repository is
+  neither in nor out of the set.]
 - [NEEDS CLARIFICATION (MEDIUM): May a child session declare a repository set
   narrower than its parent's, and may a running session's set change without
   signing in again? Left on 2026-08-20 as something to test against GitHub. A

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -46,20 +46,8 @@ the facade, with no credential in the session.
 **Roles:** developer who uses the open-source version of Minimal, developer using remote sessions, developer who deploys agentic workflow that spawns new sessions
 
 - AS A developer who uses the open-source version of Minimal, I WANT to sign into Minimal with the `min` CLI and authenticate using my Github.com account in the browser, SO THAT I don't need to manage another credential.
-  <!-- Acceptance criteria, for the EARS step:
-       - Session tokens are automatically refreshed via background refresh token rotation without requiring a secondary browser redirect or terminal prompt. Users do not need to repeatedly authenticate and authorize access.
-       - The minted session token only grants git read/write permission to the project in the workbench. Attempts to clone, push to other repositories inside the workbench, or change repository or organizational settings will return a 403 error.
-       - The only way to log in to Minimal is with a Github.com account.
-  -->
 - AS A developer using remote sessions, I WANT to clone, commit and push changes to my project without being asked to provide login information, SO THAT I don't need to worry about my credentials being leaked.
-  <!-- Acceptance criteria, for the EARS step:
-       - Commits and PRs created from inside a session are attributed to the developer, regardless of if an AI agent was used to create the change.
-       - No personal access tokens or static private SSH keys are stored on the box.
-  -->
 - AS A developer who deploys agentic workflow that spawns new sessions, I WANT the child sessions to complete successfully using access scope that's no wider than its parent, SO THAT my workflow can achieve its objective autonomously.
-  <!-- Acceptance criteria, for the EARS step:
-       - Child sessions inherit access scope strictly equal to or narrower than that of the parent session, without the need to prompt the attached human developer.
-  -->
 
 
 ## Requirements
@@ -90,11 +78,12 @@ the facade, with no credential in the session.
   harness:  kani_reach_is_workbench_plus_declared, exhaustive to 8 declared repositories modelled as bounded identifiers (unwind bound 9); the same pure reach decision as GHS-003
 
 - **GHS-005** IF a git or GitHub request from a session targets a repository
-  outside the session's declared set THEN THE SYSTEM SHALL refuse it with a
-  403 before the request reaches GitHub.
+  outside the session's repository set, meaning the workbench project and the
+  repositories it declared, THEN THE SYSTEM SHALL refuse it with a 403 before
+  the request reaches GitHub.
   tier:     T2
-  verify:   cargo nextest run -p minimal request_outside_declared_set_is_403_before_github
-  property: for every declared set and every target repository outside it, the reach decision is a refusal, and the refusal reaches the caller as a 403 with nothing forwarded to GitHub
+  verify:   cargo nextest run -p minimal request_outside_repository_set_is_403_before_github
+  property: for every repository set, the workbench project plus the declared repositories, and every target repository outside it, the reach decision is a refusal, and the refusal reaches the caller as a 403 with nothing forwarded to GitHub
   harness:  kani_outside_reach_is_refused, exhaustive to 8 declared repositories (unwind bound 9); requires the reach decision to be a pure function over owned repository identifiers, evaluated by the facade before any request is forwarded
 
 - **GHS-006** WHEN a developer runs the sign-in command THE SYSTEM SHALL show
@@ -138,8 +127,8 @@ the facade, with no credential in the session.
   verify:   cargo nextest run -p minimal session_commits_and_prs_attributed_to_developer
 
 - **GHS-013** THE SYSTEM SHALL keep every GitHub credential, including any
-  personal access token and any static private SSH key, out of a session's
-  filesystem and environment.
+  personal access token, any refresh token and any static private SSH key,
+  out of a session's filesystem and environment.
   tier:     T0
   verify:   cargo nextest run -p minimal session_fs_and_env_hold_no_github_credential
 
@@ -150,7 +139,7 @@ the facade, with no credential in the session.
   verify:   cargo nextest run -p minimal session_receives_credential_free_github_addresses
 
 - **GHS-015** WHEN a session spawns a child session THE SYSTEM SHALL grant the
-  child a GitHub access scope that is a subset of the parent's.
+  child a repository set that is a subset of the parent's repository set.
   tier:     T2
   verify:   cargo nextest run -p sessions child_reach_is_subset_of_parent
   property: for every parent reach set P and every child declaration, the child's reach set is a subset of P
@@ -260,8 +249,15 @@ the session's token narrowed to the declared set where GitHub can express it
 (the GitHub identity spec); with the facade enforcing the set, that narrowing
 is defence in depth rather than the bound. The 2026-08-20 record that a
 user-attributed token cannot be narrowed per repository holds for renewal from
-a refresh token and not for minting. The reach decision being pure and
-separable from the proxy is what the T2 harnesses require.
+a refresh token and not for minting. "The session's repository set" means
+the workbench project plus the declared repositories throughout this
+document. Renewal (GHS-001) re-mints against that same set: the set is the
+facade's grant, fixed when the session is created, not a property the token
+has to carry across a refresh. Every session and every box a developer's
+workflow spawns uses a developer-attributed token; a child's set is a subset
+of its parent's (GHS-015) and its token is minted for that subset. The reach
+decision being pure and separable from the proxy is what the T2 harnesses
+require.
 
 **A child session gets a subset of its parent's scope, never more** (GHS-015).
 Whether a child may declare a narrower set, or a running session's set may
@@ -386,7 +382,7 @@ under the developer's own sign-in, an open question below.
   (Gatehouse INV-1, T3, T15).
   covered by: GHS-013, GHS-014, GHS-018
 - **Invariant:** THE SYSTEM SHALL admit through the facade no request for a
-  repository outside the session's declared set.
+  repository outside the session's repository set.
   enforced by: the reach decision, a pure function over owned repository
   identifiers checked exhaustively to the stated bound and evaluated before
   any request is forwarded, with the narrowed mint in the identity plane as
@@ -397,6 +393,16 @@ under the developer's own sign-in, an open question below.
   enforced by: the facade observing session end from the daemon and
   discarding the session's credentials and addresses (Gatehouse T23).
   covered by: GHS-017, GHS-019
+- **Invariant:** THE SYSTEM SHALL hold no session credential longer than 8
+  hours without renewing or discarding it.
+  enforced by: the facade's renewal against the identity plane's 8-hour token
+  lifetime (Gatehouse §5.7, T3).
+  covered by: GHS-020
+- **Invariant:** THE SYSTEM SHALL write no credential and no request body to
+  the audit record.
+  enforced by: the facade recording only the session, the developer identity,
+  the target and the decision (Gatehouse T18, INV-4).
+  covered by: GHS-021
 - **Invariant:** THE SYSTEM SHALL grant a child session a GitHub access scope
   that is a subset of its parent's.
   enforced by: the child-reach decision here and attenuation at issuance in

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -1,0 +1,416 @@
+---
+id: GHS
+title: GitHub sign-in and credential-free repository access from sessions
+status: draft
+owner: norrietaylor
+epic: gominimal/inbox#512
+arch: https://github.com/gominimal/arch/blob/main/specs/authn-authz/gatehouse-spec.md
+updated: 2026-09-03
+---
+
+# GHS — GitHub sign-in and credential-free repository access from sessions
+
+## Context
+
+A developer cannot do real work in a Minimal session today. There is no way to
+authenticate to git from inside one short of pasting a token in, no single
+sign-in path, no per-session credential, and no defined behaviour for what a
+session spawned by another session may inherit. With the open-source launch
+this is the gap between "installed it" and "used it for real work this week",
+and the sign-in itself is the event that proves adoption.
+
+After this ships a developer signs in once with their GitHub.com account in a
+browser, starts a session, and clones, commits and pushes their project from
+inside it as themselves, whether they or an agent typed the command. No token
+is entered, copied, or left on the session. A session spawned by a workflow
+inherits no more access than its parent, and nobody is prompted for it.
+
+This document covers the CLI, the session daemon and the credential path
+inside a session. Signing the developer in, minting and renewing tokens, and
+enforcing attenuation at issuance are the identity plane's, in
+[the GitHub identity spec](https://github.com/gominimal/gatehouse/blob/main/docs/specs/01-spec-github-identity/01-spec-github-identity.md).
+The browser page that approves a sign-in is in
+[the CLI sign-in page spec](https://github.com/gominimal/webapp/blob/main/docs/specs/03-spec-cli-signin-page/03-spec-cli-signin-page.md).
+
+**Success:** A developer with no prior Minimal account signs in with GitHub,
+starts a remote session, and a push to their project from inside it lands on
+GitHub attributed to them, with no token typed, copied, or present on the
+session's filesystem or environment.
+
+**First slice:** The sign-in command, the browser approval, one remote session,
+and a push to the workbench project from inside it with unmodified git.
+
+## Users and stories
+
+**Roles:** developer who uses the open-source version of Minimal, developer using remote sessions, developer who deploys agentic workflow that spawns new sessions
+
+- AS A developer who uses the open-source version of Minimal, I WANT to sign into Minimal with the `min` CLI and authenticate using my Github.com account in the browser, SO THAT I don't need to manage another credential.
+  <!-- Acceptance criteria, for the EARS step:
+       - Session tokens are automatically refreshed via background refresh token rotation without requiring a secondary browser redirect or terminal prompt. Users do not need to repeatedly authenticate and authorize access.
+       - The minted session token only grants git read/write permission to the project in the workbench. Attempts to clone, push to other repositories inside the workbench, or change repository or organizational settings will return a 403 error.
+       - The only way to log in to Minimal is with a Github.com account.
+  -->
+- AS A developer using remote sessions, I WANT to clone, commit and push changes to my project without being asked to provide login information, SO THAT I don't need to worry about my credentials being leaked.
+  <!-- Acceptance criteria, for the EARS step:
+       - Commits and PRs created from inside a session are attributed to the developer, regardless of if an AI agent was used to create the change.
+       - No personal access tokens or static private SSH keys are stored on the box.
+  -->
+- AS A developer who deploys agentic workflow that spawns new sessions, I WANT the child sessions to complete successfully using access scope that's no wider than its parent, SO THAT my workflow can achieve its objective autonomously.
+  <!-- Acceptance criteria, for the EARS step:
+       - Child sessions inherit access scope strictly equal to or narrower than that of the parent session, without the need to prompt the attached human developer.
+  -->
+
+
+## Requirements
+
+- **GHS-001** WHILE a session is running THE SYSTEM SHALL keep GitHub
+  operations inside it working across a token renewal.
+  tier:     T0
+  verify:   cargo nextest run -p minimal git_op_succeeds_across_token_renewal
+
+- **GHS-002** WHILE a session is running THE SYSTEM SHALL renew the token a
+  GitHub operation uses without prompting the developer or the agent.
+  tier:     T0
+  verify:   cargo nextest run -p minimal token_renewal_never_prompts
+
+- **GHS-003** WHERE a session declares no additional repositories THE SYSTEM
+  SHALL bound its GitHub access to the project in its workbench.
+  tier:     T2
+  verify:   cargo nextest run -p sessions reach_default_is_workbench_only
+  property: for every session whose declared set is empty, the set of repositories a git operation may target is exactly the workbench project
+  harness:  kani_reach_is_workbench_plus_declared, exhaustive to 8 declared repositories modelled as bounded identifiers (unwind bound 9); requires the reach decision to be a pure function over owned repository identifiers, separate from the transport that carries the git operation
+
+- **GHS-004** WHERE a session declares additional repositories before it starts
+  THE SYSTEM SHALL bound its GitHub access to the workbench project and the
+  declared repositories, and nothing else.
+  tier:     T2
+  verify:   cargo nextest run -p sessions reach_is_workbench_plus_declared
+  property: for every declared set D, the set of repositories a git operation may target is exactly the workbench project together with D
+  harness:  kani_reach_is_workbench_plus_declared, exhaustive to 8 declared repositories modelled as bounded identifiers (unwind bound 9); the same pure reach decision as GHS-003
+
+- **GHS-005** IF a git operation inside a session targets a repository outside
+  the session's declared set THEN THE SYSTEM SHALL supply no credential for it.
+  tier:     T2
+  verify:   cargo nextest run -p minimal git_op_outside_declared_set_gets_no_credential
+  property: for every declared set and every target repository outside it, the reach decision is a refusal, and no credential is supplied for the operation
+  harness:  kani_outside_reach_is_refused, exhaustive to 8 declared repositories (unwind bound 9); requires the reach decision to be a pure function over owned repository identifiers, consulted by the credential path before any credential is supplied
+
+- **GHS-006** WHEN a developer runs the sign-in command THE SYSTEM SHALL show
+  the address of a browser page and a short code with which the developer
+  authenticates using their GitHub.com account.
+  tier:     T0
+  verify:   cargo nextest run -p minimal signin_shows_page_address_and_code
+
+- **GHS-007** THE SYSTEM SHALL offer no sign-in method other than GitHub.com.
+  tier:     T0
+  verify:   cargo nextest run -p minimal signin_offers_github_only
+
+- **GHS-008** IF a developer starts or attaches to a remote session without a
+  valid sign-in THEN THE SYSTEM SHALL require them to sign in before the
+  session starts or attaches.
+  tier:     T0
+  verify:   cargo nextest run -p minimal remote_session_requires_signin
+
+- **GHS-009** WHEN a developer starts a local session THE SYSTEM SHALL start it
+  without requiring sign-in.
+  tier:     T0
+  verify:   cargo nextest run -p minimal local_session_starts_without_signin
+
+- **GHS-010** IF a process inside a local session attempts a GitHub operation
+  while the developer has no valid sign-in THEN THE SYSTEM SHALL prompt the
+  developer to sign in from inside the session before completing the
+  operation.
+  tier:     T0
+  verify:   cargo nextest run -p minimal local_github_op_prompts_for_signin
+
+- **GHS-011** WHILE a developer is signed in THE SYSTEM SHALL let standard git
+  and gh commands inside a session clone, push and open pull requests without
+  prompting for login information.
+  tier:     T0
+  verify:   cargo nextest run -p minimal raw_git_and_gh_work_without_login_prompt
+
+- **GHS-012** THE SYSTEM SHALL attribute every commit pushed and every pull
+  request opened from inside a session, or from inside any box a developer's
+  workflow spawns, to the developer who signed in.
+  tier:     T0
+  verify:   cargo nextest run -p minimal session_commits_and_prs_attributed_to_developer
+
+- **GHS-013** THE SYSTEM SHALL write no personal access token and no static
+  private SSH key to a session's filesystem or environment.
+  tier:     T0
+  verify:   cargo nextest run -p minimal session_fs_and_env_hold_no_pat_or_static_key
+
+- **GHS-014** WHEN a git operation inside a session needs a credential THE
+  SYSTEM SHALL obtain one that expires within 8 hours, at the time of the
+  operation.
+  tier:     T0
+  verify:   cargo nextest run -p minimal git_credential_is_fetched_per_op_and_expires_within_8h
+
+- **GHS-015** WHEN a session spawns a child session THE SYSTEM SHALL grant the
+  child a GitHub access scope that is a subset of the parent's.
+  tier:     T2
+  verify:   cargo nextest run -p sessions child_reach_is_subset_of_parent
+  property: for every parent reach set P and every child declaration, the child's reach set is a subset of P
+  harness:  kani_child_reach_subset_of_parent, exhaustive to 8 repositories per set (unwind bound 9); requires the child-reach decision to be a pure function over the two owned sets, separate from session creation
+
+- **GHS-016** WHEN a session spawns a child session THE SYSTEM SHALL complete
+  the spawn without prompting the attached developer.
+  tier:     T0
+  verify:   cargo nextest run -p minimal child_session_spawn_needs_no_prompt
+
+- **GHS-017** WHEN a parent session ends THE SYSTEM SHALL end its child
+  sessions' GitHub access.
+  tier:     T0
+  verify:   cargo nextest run -p minimal parent_end_ends_child_github_access
+
+## Non-goals
+
+- Signing the developer in, minting and renewing tokens, and enforcing
+  attenuation at issuance:
+  [the GitHub identity spec](https://github.com/gominimal/gatehouse/blob/main/docs/specs/01-spec-github-identity/01-spec-github-identity.md).
+- The browser page that approves a CLI sign-in:
+  [the CLI sign-in page spec](https://github.com/gominimal/webapp/blob/main/docs/specs/03-spec-cli-signin-page/03-spec-cli-signin-page.md).
+- Sign-in through any provider other than GitHub.com, including enterprise
+  OIDC: Gatehouse §6.1.3 (F2), a later phase of the identity plane.
+- A forced in-session facade for git: retired on 2026-08-20. Standard git and
+  gh are the path (GHS-011).
+- Branch-aware activation, repository pre-priming, and a pull-request prompt
+  on session exit: the earlier GitHub-sessions PRD carries them as a
+  reference; none is in this epic's criteria.
+- The Actions workflow permission: excluded from the App's permissions
+  (GHI-004 in the GitHub identity spec).
+- Ending a session's own GitHub access when the session ends: bounded by token
+  expiry (GHS-014) and by revocation (Gatehouse F13); whether a live grant
+  must end with the session is an open question below. A parent's end ending
+  its children's access is GHS-017.
+- Refusing an out-of-set clone of a public repository: it needs no credential,
+  so nothing but egress enforcement can refuse it; the networking spec.
+- Sharing a session with another developer or an agent: the session-sharing
+  spike in the inbox.
+- A typed control plane for agents over sessions: the sessions MCP proposal in
+  the inbox.
+- Secrets beyond GitHub: out of scope for the initiative this epic belongs to.
+- Counting the sign-in event for adoption telemetry: the telemetry epic under
+  the same initiative.
+
+## Design reasoning
+
+**Three documents.** One spec per surface owner, decided 2026-09-03: this one
+for the CLI, the daemon and the in-session credential path; the identity
+plane's for sign-in, minting, renewal and attenuation; the website's for the
+approval page. A single document here with the identity behaviours as open
+questions was the cheaper alternative and would have left the identity half
+unspecified; two documents without the page would only be right if GitHub's
+own device page were the browser step, which was not chosen.
+
+**Sign-in gates remote sessions and is optional for local ones** (decided
+2026-09-03; mandatory sign-in for remote sessions was reconfirmed on
+2026-08-20). A local session starts with no account, and a GitHub operation
+inside one prompts for sign-in there (GHS-010). The alternatives were sign-in
+for every session including local, which gives one path and counts every
+user but removes the account-free local path today's users have, and remote
+only with local left undecided. The cost accepted is two paths to test and
+document. Prompting inside the session was chosen over refusing with
+instructions because it keeps a developer in flow; the cost is that an agent
+or script inside a local session blocks on a prompt it cannot answer, so such
+workflows sign in before they start.
+
+**Token reach is the workbench by default and wider when declared** (decided
+2026-09-03). This reconciles the epic's criterion, which bounds a token to the
+workbench project, with the 2026-08-20 ask that workbench-only be an option
+rather than a rule. "Whatever the App installation grants" was set aside
+because it does not meet the per-project bound at all. The bound is enforced
+in two places: the identity plane mints the session's token narrowed to the
+declared set where GitHub can express it (the GitHub identity spec), and the
+credential path inside the session supplies no credential for a repository
+outside the set (GHS-005). The 2026-08-20 record that a user-attributed token
+cannot be narrowed per repository holds for renewal from a refresh token and
+not for minting: GitHub narrows a user access token to named repositories and
+permissions at mint, and the narrowed token stays attributed to the developer.
+The reach decision being pure and separable from the credential path is what
+the T2 harnesses require.
+
+**The epic's 403 is not met literally, and that is recorded rather than
+hidden.** With the token delivered into the session per operation (the custody
+decision below), an out-of-set request that reaches GitHub gets GitHub's own
+answer: a 404 for a private repository the narrowed token cannot see, and
+success for a public repository, which needs no credential at all. Only a
+Minimal-owned point between the session and GitHub could answer a 403, and the
+architecture of record has none. GHS-005 binds what Minimal controls,
+supplying no credential; whether the epic's criterion is amended or a refusal
+point is added to the architecture is an open question below.
+
+**A child session gets a subset of its parent's scope, never more** (GHS-015).
+Whether a child may declare a narrower set, or a running session's set may
+change without a fresh sign-in, was left on 2026-08-20 as something to test
+against GitHub and stays open. The alternatives were letting a child declare
+a narrower set, which needs the same non-token enforcement as GHS-004, and
+giving every child exactly its parent's scope, which never exercises the
+"narrower" the criterion allows.
+
+**The browser step is the device flow with a code-entry page on the website**
+(decided 2026-09-03). It works on a headless host and matches the identity
+plane's reference profile (Gatehouse §6.1.2). An auth-code flow with a
+loopback listener has no code to type but needs a browser on the same machine
+as the CLI; GitHub's own device page needs no page of ours but leaves nowhere
+to show what is being approved.
+
+**A credential must never reach the session's filesystem or environment**
+(GHS-013, decided 2026-09-03). The epic says "stored on the box". Reading that
+as anywhere on the host machine would forbid the daemon beside the session
+from holding short-lived material; reading it as the filesystem only would
+allow a token materialised in the environment, which a captured environment
+carries for its lifetime.
+
+**The session's short-lived token is delivered into the session per
+operation, as the architecture of record describes** (decided 2026-09-03,
+with the daemon's placement in front of the decision: on macOS and on Linux
+with hardware virtualisation the session daemon and the broker beside it run
+inside a guest virtual machine, and on native Linux on the host). Three other
+placements were offered and declined: never in the session, with the holder's
+placement left open; never in the guest, held on the host, which is the
+strongest against a sandbox escape or a guest snapshot but commits to a
+component the architecture lacks; and beside the daemon, never in the
+session, which needs no new component but forecloses the host-side design.
+The cost accepted is the one the architecture states itself (Gatehouse §6.4):
+a process in the session holds a bearer credential for up to 8 hours against
+every repository the token reaches, so the bounds are the narrowed mint, the
+8-hour expiry (GHS-014) and the audit of every mint, not custody.
+
+**A session's credential expires within 8 hours**, GitHub's own user-token
+expiry (decided 2026-09-03), rather than an open question or a shorter ceiling
+set here at the cost of more renewals. It depends on the App's
+token-expiration setting staying on (Gatehouse §6.4.1).
+
+**Work is attributed to the developer, from a session and from any box a
+workflow spawns** (GHS-012, decided 2026-09-03). This extends the 2026-08-20
+decision to use GitHub App user access tokens rather than installation
+tokens, taken so that actions are attributed to a real person rather than to
+a bot, with the tradeoff accepted then that user tokens give no per-repository
+narrowing out of the gate (Gatehouse §6.4 states the asymmetry). Covering
+sessions only and leaving agent boxes open, or leaving agent boxes
+bot-attributed, were the alternatives. The consequence is that the
+architecture's per-type default, installation mode for every root other than
+session, has to move; that is an open question below.
+
+**Standard git and gh, no forced interface** (decided 2026-08-20). Once a
+developer is signed in, the token a session uses works with unmodified git and
+gh as the developer (GHS-011). The earlier PRD's design, in which a facade was
+the only route to GitHub, is retired by this.
+
+**Permissions are repository contents, pull requests and issues read and
+write, and metadata read; Actions workflows are excluded** (decided
+2026-09-03). Push and pull requests alone, the criteria read literally, would
+deny an agent the issue triage it does from inside a session; adding workflows
+was excluded by the earlier PRD and by the architecture's manifest ceiling and
+has the widest blast radius for a compromised session. The chosen set widens
+the architecture's v1 manifest, which §6.4.1 treats as a security-review
+event; the GitHub identity spec carries that as an open question.
+
+**Tiers.** The reach and child-subset decisions (GHS-003, GHS-004, GHS-005,
+GHS-015) are at T2: each is a pure decision over bounded repository
+identifiers, and the Kani lane that already proves the path-decision lattice
+runs the harnesses today. What the tier buys is the split each harness line
+names: the decision is a pure function over owned values, separate from the
+credential path that acts on it, and it has to be written that way from the
+start. T0 would leave the decision free to interleave with that path;
+T1 would add a property-testing dependency this tree does not carry.
+Everything else stays at T0 because it passes through GitHub, a PTY or a
+socket, and there is no decision to extract. GHS-013 is a universal and stays
+at T0 on purpose: sessions are not a domain a test can generate, so the
+filesystem-and-environment scan the architecture asks for under INV-1 runs as
+one named test, and the universal is stated in Security considerations. No
+requirement is at T3: every behaviour reaches a socket or GitHub, and there is
+no Lean project to hold a proof.
+
+**Egress is only half covered.** The initiative's constraint that nothing
+enters or leaves a box undeclared is met on the credential side (GHS-013,
+GHS-014). The network side, egress declared before it happens and enforced at
+the relay, is allow-all in running code today, and the design for enforcing
+it belongs to the networking spec. Whether it is a prerequisite for this work
+is open.
+
+**Generality:** GitHub.com is the sole provider by decision (GHS-007), and
+GHS-011, GHS-012 and GHS-014 assume GitHub App token semantics; a second
+provider would enter through the identity plane (Gatehouse F2) and need its
+own reach and attribution requirements. Across hosts the behaviours are
+general as stated, with one dependency named: where the session daemon runs
+decides where the session's token is held between operations, inside a guest
+on macOS and Linux with hardware virtualisation and on the host on native
+Linux; and a local session on a daemon not enrolled with the identity plane
+has no broker to mint from (open question below). A local and a remote
+session otherwise differ only in whether sign-in is required to start
+(GHS-008, GHS-009).
+
+## Security considerations
+
+- **Invariant:** THE SYSTEM SHALL keep every long-lived credential, meaning a
+  personal access token, a static private SSH key or a refresh token, off a
+  session's filesystem and environment.
+  enforced by: the credential path obtaining an expiring token at the time of
+  each operation, and the scan of the session filesystem and process
+  environments the architecture requires (Gatehouse INV-1, T3, T15).
+  covered by: GHS-013, GHS-014
+- **Invariant:** THE SYSTEM SHALL supply a session no credential for a
+  repository outside its declared set.
+  enforced by: the reach decision, a pure function over owned repository
+  identifiers checked exhaustively to the stated bound and consulted before
+  any credential is supplied, and the narrowed mint in the identity plane
+  (architecture AT12).
+  covered by: GHS-003, GHS-004, GHS-005
+- **Invariant:** THE SYSTEM SHALL grant a child session a GitHub access scope
+  that is a subset of its parent's.
+  enforced by: the child-reach decision here and attenuation at issuance in
+  the identity plane (Gatehouse INV-2, §6.5; architecture AT16).
+  covered by: GHS-015
+- **Invariant:** THE SYSTEM SHALL start or attach no remote session for a
+  developer without a valid sign-in.
+  enforced by: the sign-in gate in the CLI before any session request is sent.
+  covered by: GHS-008
+
+## Open questions
+
+- [NEEDS CLARIFICATION (HIGH): Is declared-egress enforcement a prerequisite
+  for credential-free GitHub access, or its own epic? Egress is allow-all in
+  running code, the relay-layer enforcement design was closed without being
+  planned, and the initiative's hard constraint says nothing leaves a box
+  undeclared. It is also the only way to refuse an out-of-set clone of a
+  public repository, which needs no credential.]
+- [NEEDS CLARIFICATION (HIGH): The epic's criterion that an out-of-set
+  operation returns a 403 cannot be met with the token delivered into the
+  session: GitHub answers 404 for a private repository outside a narrowed
+  token's reach and serves a public repository with no credential at all.
+  Either the criterion is amended to what GHS-005 binds, or a Minimal-owned
+  refusal point between the session and GitHub is added to the architecture
+  of record, where a host-side credential facade has been proposed.]
+- [NEEDS CLARIFICATION (HIGH): GHS-012 attributes work from every box a
+  developer's workflow spawns to the developer, decided and reconfirmed on
+  2026-09-03, while Gatehouse §6.4 defaults every root other than session to
+  installation mode. The architecture's per-type default has to move; does
+  the agent type give up per-mint narrowing when it does?]
+- [NEEDS CLARIFICATION (HIGH): A session on a daemon not enrolled with the
+  identity plane has no broker and no identity socket, so GHS-010 and GHS-011
+  have no mechanism for a local session until client-mediated local
+  enrollment (Gatehouse F16) exists. Is enrollment a prerequisite for local
+  GitHub access, or does an un-enrolled daemon get a stated weaker path?]
+- [NEEDS CLARIFICATION (MEDIUM): May a child session declare a repository set
+  narrower than its parent's, and may a running session's set change without
+  signing in again? Left on 2026-08-20 as something to test against GitHub. A
+  narrowed token cannot be narrowed again, so widening means a fresh mint
+  from the refresh token.]
+- [NEEDS CLARIFICATION (MEDIUM): How are the requested repositories and
+  permissions shown to the developer before a session starts, and does a
+  second session reuse the existing sign-in or mint a separately scoped token
+  by default? Both carried from the earlier PRD; neither is in this epic's
+  criteria.]
+- [NEEDS CLARIFICATION (MEDIUM): Must a session's live GitHub grant end when
+  the session ends, by destroy or otherwise, rather than run out at expiry?
+  The credential-leak motive behind the second story argues for it; the epic
+  does not state it.]
+- [NEEDS CLARIFICATION (LOW): The existing hidden sign-in command mints a
+  client certificate for the HTTPS reverse proxy under the name the
+  architecture's command tree gives to identity sign-in. What is the
+  proxy-certificate command renamed to?]
+- [NEEDS CLARIFICATION (LOW): Should tooling that adds a Co-authored-by
+  trailer on an agent's behalf ask first? Recorded as a preference on
+  2026-08-20 with no resolution.]

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -1,7 +1,6 @@
 ---
 id: GHS
 title: GitHub sign-in and credential-free repository access from sessions
-status: draft
 owner: norrietaylor
 epic: gominimal/inbox#512
 arch: https://github.com/gominimal/arch/blob/main/specs/authn-authz/gatehouse-spec.md

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -107,18 +107,18 @@ the sealed-credential path.
 - **GHS-009** WHEN a developer starts a local session whose spec declares no
   GitHub grant THE SYSTEM SHALL start it without requiring sign-in.
   tier:     T0
-  verify:   cargo nextest run -p minimal local_session_without_grant_starts_without_signin
+    verify:   cargo nextest run -p minimal local_session_without_grant_starts_without_signin
+  - IF a process inside a session that declares no GitHub grant attempts a
+    GitHub operation that needs a credential THEN THE SYSTEM SHALL tell it the
+    session declares no GitHub grant, rather than asking for a password.
+    tier:   T0
+    verify: cargo nextest run -p minimal github_op_without_grant_names_the_missing_grant
 
 - **GHS-010** IF a developer starts a local session whose spec declares a
   GitHub grant while they have no valid sign-in THEN THE SYSTEM SHALL require
   them to sign in before the session starts.
   tier:     T0
   verify:   cargo nextest run -p minimal local_session_with_grant_requires_signin
-  - IF a process inside a session that declares no GitHub grant attempts a
-    GitHub operation that needs a credential THEN THE SYSTEM SHALL tell it the
-    session declares no GitHub grant, rather than asking for a password.
-    tier:   T0
-    verify: cargo nextest run -p minimal github_op_without_grant_names_the_missing_grant
 
 - **GHS-011** WHILE a developer is signed in THE SYSTEM SHALL let standard git
   and gh commands inside a session clone, push and open pull requests without
@@ -209,10 +209,11 @@ the sealed-credential path.
   tier:     T0
   verify:   cargo nextest run -p minimal quic_to_credentialed_hosts_is_blocked
 
-- **GHS-030** IF a session's spec sets its network mode to none and declares a
-  runtime GitHub grant THEN THE SYSTEM SHALL refuse the spec as invalid.
+- **GHS-030** IF a session's spec declares a runtime GitHub grant and sets its
+  network mode to none or to the shared host address THEN THE SYSTEM SHALL
+  refuse the spec as invalid.
   tier:     T0
-  verify:   cargo nextest run -p minimal network_none_with_github_grant_is_rejected
+  verify:   cargo nextest run -p minimal github_grant_without_own_address_is_rejected
 
 - **GHS-031** WHERE a session's spec declares a GitHub grant and sets no
   network mode THE SYSTEM SHALL give the session its own network address.
@@ -276,7 +277,7 @@ the session. Sign-in for every session including local was set aside because
 it removes the account-free local path today's users have. The cost accepted
 is that a running local session gains GitHub access only by restarting with
 the grant, and that a GitHub operation in a grant-less session is answered
-with what is missing rather than with a credential (GHS-010's edge).
+with what is missing rather than with a credential (GHS-009's edge).
 
 **A local daemon enrolls itself before its first session with a GitHub grant**
 (GHS-025). A daemon not enrolled with the identity plane has no broker and no
@@ -352,17 +353,19 @@ declared credentialed hosts are steered to the proxy at the node, and QUIC to
 those hosts is blocked so the interceptable path is the only one. On a session
 with its own network address the proxy can attribute a request to the box that
 sent it and a stolen sealed value is dead across boxes; on a shared network
-namespace that attribution is impossible, and the architecture accepts the
-residual, a co-resident thief gets only the session's scoped, audited reach
-until expiry or revocation, as the tier the chooser of that mode accepted. A
-session with a GitHub grant therefore defaults to its own address (GHS-031); a
-spec that sets the shared address explicitly keeps the grant with that
-residual. The architecture's egress gateway design moves egress enforcement
-outside the node and proposes that grants require a node the fabric can pin; a
-laptop cannot be, and this document keeps GitHub grants on local daemons: the
-sealed value is dead off-node, so an escape on a laptop gains only the
-developer's own scoped, audited reach on the developer's own machine, the tier
-the local chooser accepts.
+namespace that attribution is impossible. A session with a GitHub grant
+therefore has its own address: by default when its spec sets no mode
+(GHS-031), and a spec that sets the shared address or no networking with a
+grant is refused (GHS-030). The architecture allows a grant on a shared
+address with a recorded residual; here that combination cannot exist, because
+an egress declaration is valid only on a session with its own address and a
+grant without one is a validation error (GHS-022), so it is refused rather
+than half-supported. The architecture's egress gateway design moves egress
+enforcement outside the node and proposes that grants require a node the
+fabric can pin; a laptop cannot be, and this document keeps GitHub grants on
+local daemons: the sealed value is dead off-node, so an escape on a laptop
+gains only the developer's own scoped, audited reach on the developer's own
+machine, the tier the local chooser accepts.
 
 **Nothing ships between sign-in and the proxy.** The identity plane's own
 build order puts sign-in early and the egress proxy late; this work is
@@ -390,11 +393,11 @@ parent's.
 **Work is attributed to the developer, from a session and from any box a
 workflow spawns** (GHS-012). GHS-012 binds session, agent and task boxes, the
 types a developer's workflow spawns, which default to developer-attributed
-tokens through a type-supplied attribute; service and build boxes default to
-App attribution and are outside the epic's criterion, a service outliving the
-workflow that spawned it; a tenant may forbid developer attribution per type,
-with a defaulted grant downgraded and recorded rather than silently kept
-(GHS-012's edge) and an explicit request refused.
+tokens through a type-supplied attribute; service, build and container-build
+boxes default to App attribution and are outside the epic's criterion, a
+service outliving the workflow that spawned it; a tenant may forbid developer
+attribution per type, with a defaulted grant downgraded and recorded rather
+than silently kept (GHS-012's edge) and an explicit request refused.
 
 **Standard git and gh, no forced interface.** Once a developer is signed in,
 git and gh inside a session work as the developer against the real hostnames
@@ -436,18 +439,18 @@ credential's reach is bounded by the token and the proxy whether or not
 anonymous traffic is filtered.
 
 **Generality:** GitHub.com is the sole provider by decision (GHS-007). The
-sealed-credential path is general by the architecture's design: the same
-proxy takes further upstreams as policy modules, and a separate epic proposes
-the Claude programming interface and model-context servers as the next ones;
-every bound stated here, the 403, the permission ceiling, the 8-hour lifetime,
-is GitHub's own model and does not carry. Across hosts the behaviours are
+sealed-credential path is general by the architecture's design: the same proxy
+takes further upstreams as policy modules, and a separate epic proposes the
+Claude programming interface and model-context servers as the next ones; every
+bound stated here, the 403, the permission ceiling, the 8-hour lifetime, is
+GitHub's own model and does not carry. Across hosts the behaviours are
 general: the session-to-proxy TLS session is the encryption in transit on a
 laptop guest, a cloud instance or a cluster pod alike, with no same-machine
-assumption; a session's network mode changes how strongly a sealed value is
-bound, not whether the path works. A local and a remote session differ only
-in when sign-in is required, always for remote and with a GitHub grant for
-local (GHS-008 to GHS-010), and in the local daemon's self-enrollment
-(GHS-025).
+assumption; a session with a GitHub grant always has its own address, so a
+sealed value is bound to its box everywhere. A local and a remote session
+differ only in when sign-in is required, always for remote and with a GitHub
+grant for local (GHS-008 to GHS-010), and in the local daemon's
+self-enrollment (GHS-025).
 
 ## Security considerations
 
@@ -495,7 +498,6 @@ local (GHS-008 to GHS-010), and in the local daemon's self-enrollment
   covered by: GHS-017, GHS-019
 
 ## Open questions
-
 
 - [NEEDS CLARIFICATION (MEDIUM): May a child session declare a repository set
   narrower than its parent's, and may a running session's set change without

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -80,17 +80,13 @@ the sealed-credential path.
   property: for every declared set D, the set of repositories a git operation may target is exactly the workbench project together with D
   harness:  kani_reach_is_workbench_plus_declared, exhaustive to 8 declared repositories modelled as bounded identifiers (unwind bound 9); the same pure reach decision as GHS-003
 
-- **GHS-005** IF a git or gh request from a session targets a repository
-  outside the session's repository set, meaning the workbench project and the
-  repositories it declared, THEN THE SYSTEM SHALL refuse it with a 403 before
-  the request reaches GitHub.
+- **GHS-005** IF a git or gh request from a session carries the session's
+  sealed GitHub value and targets a repository outside the session's
+  repository set, meaning the workbench project and the repositories it
+  declared, THEN THE SYSTEM SHALL refuse it with a 403 before the request
+  reaches GitHub.
   tier:     T0
   verify:   cargo nextest run -p minimal request_outside_repository_set_is_403_before_github
-  - IF the repository a request targets cannot be resolved to one identifier
-    THEN THE SYSTEM SHALL refuse the request with a 403 before it reaches
-    GitHub.
-    tier:   T0
-    verify: cargo nextest run -p minimal unresolvable_target_is_refused_before_github
 
 - **GHS-006** WHEN a developer runs the sign-in command THE SYSTEM SHALL show
   the address of a browser page and a short code with which the developer
@@ -108,17 +104,21 @@ the sealed-credential path.
   tier:     T0
   verify:   cargo nextest run -p minimal remote_session_requires_signin
 
-- **GHS-009** WHEN a developer starts a local session THE SYSTEM SHALL start it
-  without requiring sign-in.
+- **GHS-009** WHEN a developer starts a local session whose spec declares no
+  GitHub grant THE SYSTEM SHALL start it without requiring sign-in.
   tier:     T0
-  verify:   cargo nextest run -p minimal local_session_starts_without_signin
+  verify:   cargo nextest run -p minimal local_session_without_grant_starts_without_signin
 
-- **GHS-010** IF a process inside a local session attempts a GitHub operation
-  while the developer has no valid sign-in THEN THE SYSTEM SHALL prompt the
-  developer to sign in from inside the session before completing the
-  operation.
+- **GHS-010** IF a developer starts a local session whose spec declares a
+  GitHub grant while they have no valid sign-in THEN THE SYSTEM SHALL require
+  them to sign in before the session starts.
   tier:     T0
-  verify:   cargo nextest run -p minimal local_github_op_prompts_for_signin
+  verify:   cargo nextest run -p minimal local_session_with_grant_requires_signin
+  - IF a process inside a session that declares no GitHub grant attempts a
+    GitHub operation that needs a credential THEN THE SYSTEM SHALL tell it the
+    session declares no GitHub grant, rather than asking for a password.
+    tier:   T0
+    verify: cargo nextest run -p minimal github_op_without_grant_names_the_missing_grant
 
 - **GHS-011** WHILE a developer is signed in THE SYSTEM SHALL let standard git
   and gh commands inside a session clone, push and open pull requests without
@@ -127,10 +127,14 @@ the sealed-credential path.
   verify:   cargo nextest run -p minimal raw_git_and_gh_work_without_login_prompt
 
 - **GHS-012** THE SYSTEM SHALL attribute every commit pushed and every pull
-  request opened from inside a session, or from inside any box a developer's
-  workflow spawns, to the developer who signed in.
+  request opened from inside a session, or from inside any agent or task box
+  a developer's workflow spawns, to the developer who signed in.
   tier:     T0
   verify:   cargo nextest run -p minimal session_commits_and_prs_attributed_to_developer
+  - IF tenant policy forbids developer attribution for the box's type THEN
+    THE SYSTEM SHALL attribute the work to the App and record the downgrade.
+    tier:   T0
+    verify: cargo nextest run -p minimal tenant_policy_downgrade_is_recorded
 
 - **GHS-013** THE SYSTEM SHALL keep every raw GitHub credential, including any
   personal access token, any refresh token and any static private SSH key,
@@ -157,7 +161,7 @@ the sealed-credential path.
 
 - **GHS-019** WHEN a session ends, by destroy or otherwise, THE SYSTEM SHALL
   revoke the session's identity, so that no further sealed value is minted for
-  it and its existing sealed values stop being redeemable.
+  it and its existing sealed values stop being redeemable within 60 seconds.
   tier:     T0
   verify:   cargo nextest run -p minimal session_end_revokes_identity_and_sealed_values
 
@@ -167,17 +171,17 @@ the sealed-credential path.
   verify:   cargo nextest run -p minimal sealed_value_renewed_before_expiry_within_8h
 
 - **GHS-022** IF a session's spec declares a runtime GitHub grant and its
-  declared egress does not admit github.com THEN THE SYSTEM SHALL refuse the
-  spec as invalid.
+  declared egress does not admit every host in the GitHub host set, github.com
+  and api.github.com, THEN THE SYSTEM SHALL refuse the spec as invalid.
   tier:     T0
   verify:   cargo nextest run -p minimal github_grant_without_egress_entry_is_rejected
 
-- **GHS-025** WHEN a signed-in developer first uses GitHub access from a
-  session on a local daemon that is not enrolled with the identity plane THE
-  SYSTEM SHALL enroll that daemon under the developer's sign-in without a
-  further prompt.
+- **GHS-025** WHEN a signed-in developer starts a session that declares a
+  GitHub grant on a local daemon that is not enrolled with the identity plane
+  THE SYSTEM SHALL enroll that daemon under the developer's sign-in before the
+  session is created, without a further prompt.
   tier:     T0
-  verify:   cargo nextest run -p minimal local_daemon_enrolls_on_first_github_use
+  verify:   cargo nextest run -p minimal local_daemon_enrolls_before_first_github_session
 
 - **GHS-026** WHEN a session that declares a GitHub grant is created THE
   SYSTEM SHALL install the tenant's egress-interception certificate authority
@@ -195,7 +199,8 @@ the sealed-credential path.
   verify:   cargo nextest run -p minimal session_receives_sealed_value_only
 
 - **GHS-028** WHILE a session is live THE SYSTEM SHALL steer its connections
-  to its declared credentialed hosts to the egress proxy.
+  to its declared credentialed hosts, for a GitHub grant github.com and
+  api.github.com, to the egress proxy.
   tier:     T0
   verify:   cargo nextest run -p minimal credentialed_host_connections_terminate_at_egress_proxy
 
@@ -208,6 +213,11 @@ the sealed-credential path.
   runtime GitHub grant THEN THE SYSTEM SHALL refuse the spec as invalid.
   tier:     T0
   verify:   cargo nextest run -p minimal network_none_with_github_grant_is_rejected
+
+- **GHS-031** WHERE a session's spec declares a GitHub grant and sets no
+  network mode THE SYSTEM SHALL give the session its own network address.
+  tier:     T0
+  verify:   cargo nextest run -p minimal github_grant_defaults_to_own_address
 
 ## Non-goals
 
@@ -230,8 +240,11 @@ the sealed-credential path.
 - Revoking an already-delivered credential at GitHub: TTL-bounded (Gatehouse
   §12.9); here a session's end revokes its identity (GHS-019), which stops
   redemption of its sealed values.
-- Enforcing the egress list for uncredentialed traffic: the networking spec.
+- Enforcing the egress list for uncredentialed traffic, and whether a node's
+  fabric can pin its egress: the egress gateway design in the architecture.
   This document binds only that credentialed reach rides the egress path.
+- One narrowed token per owner for a repository set that spans owners: later
+  work; such a set is refused at mint (the GitHub identity spec).
 - The same egress-proxy shape for upstreams other than GitHub, such as the
   Claude programming interface or model-context servers: a separate
   credential-broker epic in the inbox; the architecture names the proxy as
@@ -254,27 +267,33 @@ identity plane. A single document here with the identity behaviours as open
 questions was the cheaper alternative and would have left the identity half
 unspecified.
 
-**Sign-in gates remote sessions and is optional for local ones** (decided
-2026-09-03; mandatory sign-in for remote sessions was reconfirmed on
-2026-08-20). A local session starts with no account, and a GitHub operation
-inside one prompts for sign-in there (GHS-010). The alternatives were sign-in
-for every session including local, which gives one path and counts every
-user but removes the account-free local path today's users have, and remote
-only with local left undecided. The cost accepted is two paths to test and
-document. Prompting inside the session was chosen over refusing with
-instructions because it keeps a developer in flow; the cost is that an agent
-or script inside a local session blocks on a prompt it cannot answer, so such
-workflows sign in before they start.
+**Sign-in gates remote sessions, and local ones that declare a GitHub
+grant** (decided 2026-09-03, revised 2026-09-08; mandatory sign-in for
+remote sessions was reconfirmed on 2026-08-20). A local session with no
+GitHub grant starts with no account (GHS-009); one whose spec declares a
+grant asks for sign-in before it starts (GHS-010), and the grant is explicit
+locally, so local stays opt-in. The 2026-09-03 cut prompted for sign-in
+inside a running local session at its first GitHub operation; it was set
+aside because the architecture makes box identity, the interception
+authority and the sealed value creation-time, and a daemon not yet enrolled
+cannot create a session with a grant at all, so the prompt could not be
+honoured without re-creating the session. The alternatives kept from the
+first decision were sign-in for every session including local, which removes
+the account-free local path today's users have, and remote only with local
+undecided. The cost accepted is that a running local session gains GitHub
+access only by restarting with the grant, and that a GitHub operation in a
+grant-less session is answered with what is missing rather than with a
+credential (GHS-010's edge).
 
-**A local daemon enrolls itself on first GitHub use** (GHS-025, decided
-2026-09-08 from the architecture). A daemon not enrolled with the identity
-plane has no broker and no identity socket, so no sealed value can be minted
-for a session on it (Gatehouse §8.3); the architecture's answer is
-client-mediated local enrollment, in which a signed-in developer mints an
-enrollment token for their own laptop daemon (F16). Requiring the developer to
-enroll by hand, and leaving local sessions without GitHub access, were the
-alternatives; the first adds a step the epic's first story is written to
-avoid, the second contradicts the decision above.
+**A local daemon enrolls itself before its first session with a GitHub grant**
+(GHS-025, decided 2026-09-08 from the architecture). A daemon not enrolled
+with the identity plane has no broker and no identity socket, so no sealed
+value can be minted for a session on it (Gatehouse §8.3); the architecture's
+answer is client-mediated local enrollment, in which a signed-in developer
+mints an enrollment token for their own laptop daemon (F16). Requiring the
+developer to enroll by hand, and leaving local sessions without GitHub access,
+were the alternatives; the first adds a step the epic's first story is written
+to avoid, the second contradicts the decision above.
 
 **Token reach is the workbench by default and wider when declared** (decided
 2026-09-03). This reconciles the epic's criterion, which bounds a token to the
@@ -287,7 +306,17 @@ carried digest-bound into the session's creation; two things then bound the
 token to it. The identity plane mints the session's token narrowed to the set
 where GitHub can express it, and its egress proxy refuses, per request and
 before GitHub, anything the sealed value's scope does not cover (GHS-005 is
-the behaviour a session observes; the decision is the identity plane's). The
+the behaviour a session observes; the decision is the identity plane's).
+GHS-005 binds requests that carry the session's sealed value: a request
+without one is anonymous and passes egress-checked, which is what dependency
+fetches from public repositories need and what the epic's criterion, written
+about the minted token, asks; requests that name no repository, GraphQL among
+them, ride the narrowed token's own bound at GitHub; and what a request
+targets is the identity plane's mapping of path and method to a repository,
+defined in the GitHub identity spec and not here (decided 2026-09-08). A set
+spanning more than one owner is refused at mint there, since the un-narrowed
+fallback the architecture allows would carry the developer's whole reach into
+the session; per-owner tokens are later work. The
 2026-08-20 record that a user-attributed token cannot be narrowed per
 repository holds for renewal from a refresh token and not for minting;
 renewal re-mints against the same set. Every session and every box a
@@ -319,25 +348,35 @@ name-constrained interception authority installed in the session's trust
 store (GHS-026), checks node, box, egress declaration and scope, substitutes
 the real credential, and forwards. Sessions talk to the real hostnames, so
 git and gh need no configuration, which is what the 2026-08-20 decision
-required and what dissolves the earlier question about routing gh. The cost
+required and what dissolves the earlier question about routing gh. GitHub is
+two hosts to a session, github.com for git and api.github.com for gh; a
+grant covers both (GHS-022, GHS-028) and the authority's constraint covers
+both. The cost
 is an interception authority inside the session, accepted as the smaller
 change on ephemeral Minimal-built boxes, and a dependency on the identity
 plane's fifth build phase, where the proxy lands.
 
 **What the session side does for that path** (GHS-022, GHS-026, GHS-028,
-GHS-029, GHS-030). The egress list is the single reachability authority: a
-runtime GitHub grant whose upstream is absent from the declared egress is a
-validation error rather than a second path beside it, and a session with no
-networking cannot hold a runtime grant. Connections to declared credentialed
-hosts are steered to the proxy at the node, and QUIC to those hosts is
-blocked so the interceptable path is the only one. On a session with its own
-network address the proxy can attribute a request to the box that sent it and
-a stolen sealed value is dead across boxes; on a shared network namespace that
-attribution is impossible, and the architecture accepts the residual, a
-co-resident thief gets only the session's scoped, audited reach until expiry
-or revocation, as the tier the chooser of that mode accepted. Whether
-sessions with GitHub grants should default to their own address is an open
-question below.
+GHS-029, GHS-030, GHS-031). The egress list is the single reachability
+authority: a runtime GitHub grant whose upstream is absent from the declared
+egress is a validation error rather than a second path beside it, and a
+session with no networking cannot hold a runtime grant. Connections to
+declared credentialed hosts are steered to the proxy at the node, and QUIC to
+those hosts is blocked so the interceptable path is the only one. On a session
+with its own network address the proxy can attribute a request to the box that
+sent it and a stolen sealed value is dead across boxes; on a shared network
+namespace that attribution is impossible, and the architecture accepts the
+residual, a co-resident thief gets only the session's scoped, audited reach
+until expiry or revocation, as the tier the chooser of that mode accepted. A
+session with a GitHub grant therefore defaults to its own address (GHS-031,
+decided 2026-09-08); a spec that sets the shared address explicitly keeps the
+grant with that residual. The architecture's egress gateway design, in its
+issues at the time of writing, moves egress enforcement outside the node and
+proposes that grants require a node the fabric can pin; a laptop cannot be,
+and this document keeps GitHub grants on local daemons (decided 2026-09-08):
+the sealed value is dead off-node, so an escape on a laptop gains only the
+developer's own scoped, audited reach on the developer's own machine, the tier
+the local chooser accepts.
 
 **A session's credential expires within 8 hours**, GitHub's own user-token
 expiry (decided 2026-09-03), rather than an open question or a shorter ceiling
@@ -352,15 +391,18 @@ renewed token narrowed to the same repository set (the GitHub identity spec).
 2026-09-03 and restated 2026-09-08 in the architecture's terms). A session's
 end revokes its identity; the identity plane stops minting for it within a
 minute and its egress proxy consults the revocation feed, so a sealed value
-outlives its session by at most that window. A child's access ends with its
-parent's.
+outlives its session by at most 60 seconds (GHS-019). A child's access ends
+with its parent's.
 
 **Work is attributed to the developer, from a session and from any box a
 workflow spawns** (GHS-012, decided 2026-09-03 and adopted by the architecture
-on 2026-09-05). Session, agent and task boxes default to developer-attributed
-tokens through a type-supplied attribute; service and build boxes default to
-App attribution; a tenant may forbid user mode per type, with a defaulted
-grant downgraded and audited rather than silently kept.
+on 2026-09-05). GHS-012 binds session, agent and task boxes, the types a
+developer's workflow spawns, which default to developer-attributed tokens
+through a type-supplied attribute; service and build boxes default to App
+attribution and are outside the epic's criterion, a service outliving the
+workflow that spawned it; a tenant may forbid developer attribution per type,
+with a defaulted grant downgraded and recorded rather than silently kept
+(GHS-012's edge) and an explicit request refused.
 
 **Standard git and gh, no forced interface** (decided 2026-08-20). Once a
 developer is signed in, git and gh inside a session work as the developer
@@ -390,15 +432,19 @@ filesystem-and-environment scan the architecture asks for under INV-1 runs as
 one named test, and the universal is stated in Security considerations. No
 requirement is at T3: there is no Lean project to hold a proof. Requirements
 GHS-014, GHS-018, GHS-021, GHS-023 and GHS-024 belonged to the superseded
-facade and were withdrawn in this revision; their identifiers are not reused.
+facade and were withdrawn on 2026-09-08; their identifiers are not reused.
+GHS-005's earlier edge for a target that could not be resolved moved to the
+identity spec's rule for requests its module cannot map.
 
-**Egress is half covered.** The initiative's constraint that nothing enters or
+**Egress enforcement is the gateway's, not this epic's prerequisite**
+(decided 2026-09-08). The initiative's constraint that nothing enters or
 leaves a box undeclared is met on the credential side (GHS-013, GHS-027) and,
 for credentialed reach, on the network side too: such reach rides the egress
 path and is re-checked at the proxy (GHS-022, GHS-028). Enforcement of the
-egress list for everything else is allow-all in running code today and
-belongs to the networking spec; whether it is a prerequisite for this work is
-open.
+egress list for everything else is allow-all in running code today and has
+its own design chain in the architecture, the egress gateway; it is not a
+prerequisite here because the credential's reach is bounded by the token and
+the proxy whether or not anonymous traffic is filtered.
 
 **Generality:** GitHub.com is the sole provider by decision (GHS-007). The
 sealed-credential path is general by the architecture's design: the same
@@ -410,20 +456,23 @@ general: the session-to-proxy TLS session is the encryption in transit on a
 laptop guest, a cloud instance or a cluster pod alike, with no same-machine
 assumption; a session's network mode changes how strongly a sealed value is
 bound, not whether the path works. A local and a remote session differ only
-in whether sign-in is required to start (GHS-008, GHS-009) and in the local
-daemon's self-enrollment (GHS-025).
+in when sign-in is required, always for remote and with a GitHub grant for
+local (GHS-008 to GHS-010), and in the local daemon's self-enrollment
+(GHS-025).
 
 ## Security considerations
 
 - **Invariant:** THE SYSTEM SHALL keep every raw GitHub credential and every
   private key out of a session, and hand a session brokered credentials only
   as sealed values it cannot open.
-  enforced by: sealed delivery bound to the session's node and box, and the
-  scan of the session filesystem and process environments the architecture
-  requires (Gatehouse INV-1, §6.10, T3, T28).
+  enforced by: sealed delivery bound to the session's node and box, the
+  proxy's refusal of a value presented off its node, from another box, for
+  another host or outside its scope (GHI-021 to GHI-025 in the GitHub
+  identity spec), and the scan of the session filesystem and process
+  environments the architecture requires (Gatehouse INV-1, §6.10, T3, T28).
   covered by: GHS-013, GHS-027
-- **Invariant:** THE SYSTEM SHALL admit no request from a session for a
-  repository outside the session's repository set.
+- **Invariant:** THE SYSTEM SHALL admit no request carrying a session's
+  sealed value for a repository outside the session's repository set.
   enforced by: the reach set computed here as a pure function over owned
   repository identifiers, checked exhaustively to the stated bound, and the
   identity plane's egress proxy refusing per request before GitHub
@@ -438,18 +487,19 @@ daemon's self-enrollment (GHS-025).
   only along the path its declared egress admits, through the egress proxy.
   enforced by: validation at expansion, steering at the node, the QUIC block,
   and the proxy's own re-check of the declaration (architecture D6).
-  covered by: GHS-022, GHS-028, GHS-029, GHS-030
+  covered by: GHS-022, GHS-028, GHS-029, GHS-030, GHS-031
 - **Invariant:** THE SYSTEM SHALL install an interception authority in no
   session that declares no credentialed upstream.
   enforced by: creation-time injection conditioned on the session's spec
   (Gatehouse T27).
   covered by: GHS-026
-- **Invariant:** THE SYSTEM SHALL start or attach no remote session for a
-  developer without a valid sign-in.
+- **Invariant:** THE SYSTEM SHALL start or attach no remote session, and
+  start no session that declares a GitHub grant, for a developer without a
+  valid sign-in.
   enforced by: the sign-in gate in the CLI before any session request is sent.
-  covered by: GHS-008
+  covered by: GHS-008, GHS-010
 - **Invariant:** THE SYSTEM SHALL leave no redeemable grant for a session that
-  has ended beyond the revocation window.
+  has ended beyond 60 seconds.
   enforced by: revocation of the session's identity at its end, which stops
   minting within a minute and reaches the proxy's revocation feed (Gatehouse
   F13, T23).
@@ -461,16 +511,6 @@ daemon's self-enrollment (GHS-025).
   the identity plane's fifth build phase, and sign-in with its second. What
   ships for sessions in between, and does any interim credential path exist
   before the proxy does?]
-- [NEEDS CLARIFICATION (HIGH): Is enforcement of the egress list for
-  uncredentialed traffic a prerequisite for credential-free GitHub access, or
-  its own epic? Credentialed reach is now re-checked at the proxy, but the
-  list is allow-all in running code for everything else, the relay-layer
-  enforcement design was closed without being planned, and the initiative's
-  hard constraint says nothing leaves a box undeclared.]
-- [NEEDS CLARIFICATION (MEDIUM): Should a session that declares a GitHub grant
-  default to its own network address? Only there can the proxy attribute a
-  request to the box that sent it; on a shared namespace a co-resident
-  process gets the session's scoped, audited reach until expiry.]
 - [NEEDS CLARIFICATION (MEDIUM): May a child session declare a repository set
   narrower than its parent's, and may a running session's set change without
   signing in again? Left on 2026-08-20 as something to test against GitHub. A

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -229,12 +229,10 @@ the sealed-credential path.
   [the website sign-in spec](https://github.com/gominimal/webapp/blob/main/docs/specs/03-spec-website-signin/03-spec-website-signin.md).
 - Sign-in through any provider other than GitHub.com, including enterprise
   OIDC: Gatehouse §6.1.3 (F2), a later phase of the identity plane.
-- A forced in-session command for git: retired on 2026-08-20. Standard git and
-  gh are the path (GHS-011), and since the sealed-credential design they need
-  no configuration at all.
+- A forced in-session command for git: standard git and gh are the path
+  (GHS-011), and with sealed credentials they need no configuration at all.
 - Branch-aware activation, repository pre-priming, and a pull-request prompt
-  on session exit: the earlier GitHub-sessions PRD carries them as a
-  reference; none is in this epic's criteria.
+  on session exit: none is in this epic's criteria.
 - The Actions workflow permission: excluded from the App's permissions
   (GHI-004 in the GitHub identity spec).
 - Revoking an already-delivered credential at GitHub: TTL-bounded (Gatehouse
@@ -259,100 +257,89 @@ the sealed-credential path.
 
 ## Design reasoning
 
-**Three documents.** One spec per surface owner, decided 2026-09-03: this one
-for the CLI, the daemon and the session's side of the credential path; the
-identity plane's for sign-in, its browser pages, minting, sealing, the egress
-proxy and attenuation; the website's for its own sign-in as a client of the
-identity plane. A single document here with the identity behaviours as open
-questions was the cheaper alternative and would have left the identity half
-unspecified.
+**Three documents.** One spec per surface owner: this one for the CLI, the
+daemon and the session's side of the credential path; the identity plane's for
+sign-in, its browser pages, minting, sealing, the egress proxy and
+attenuation; the website's for its own sign-in as a client of the identity
+plane. A single document here with the identity behaviours as open questions
+was the cheaper alternative and would have left the identity half unspecified.
 
-**Sign-in gates remote sessions, and local ones that declare a GitHub
-grant** (decided 2026-09-03, revised 2026-09-08; mandatory sign-in for
-remote sessions was reconfirmed on 2026-08-20). A local session with no
-GitHub grant starts with no account (GHS-009); one whose spec declares a
-grant asks for sign-in before it starts (GHS-010), and the grant is explicit
-locally, so local stays opt-in. The 2026-09-03 cut prompted for sign-in
-inside a running local session at its first GitHub operation; it was set
-aside because the architecture makes box identity, the interception
-authority and the sealed value creation-time, and a daemon not yet enrolled
-cannot create a session with a grant at all, so the prompt could not be
-honoured without re-creating the session. The alternatives kept from the
-first decision were sign-in for every session including local, which removes
-the account-free local path today's users have, and remote only with local
-undecided. The cost accepted is that a running local session gains GitHub
-access only by restarting with the grant, and that a GitHub operation in a
-grant-less session is answered with what is missing rather than with a
-credential (GHS-010's edge).
+**Sign-in gates remote sessions, and local ones that declare a GitHub grant.**
+A local session with no GitHub grant starts with no account (GHS-009); one
+whose spec declares a grant asks for sign-in before it starts (GHS-010), and
+the grant is explicit locally, so local stays opt-in. Prompting for sign-in
+inside a running local session at its first GitHub operation was set aside:
+the architecture makes box identity, the interception authority and the sealed
+value creation-time, and a daemon not yet enrolled cannot create a session
+with a grant at all, so the prompt could not be honoured without re-creating
+the session. Sign-in for every session including local was set aside because
+it removes the account-free local path today's users have. The cost accepted
+is that a running local session gains GitHub access only by restarting with
+the grant, and that a GitHub operation in a grant-less session is answered
+with what is missing rather than with a credential (GHS-010's edge).
 
 **A local daemon enrolls itself before its first session with a GitHub grant**
-(GHS-025, decided 2026-09-08 from the architecture). A daemon not enrolled
-with the identity plane has no broker and no identity socket, so no sealed
-value can be minted for a session on it (Gatehouse §8.3); the architecture's
-answer is client-mediated local enrollment, in which a signed-in developer
-mints an enrollment token for their own laptop daemon (F16). Requiring the
-developer to enroll by hand, and leaving local sessions without GitHub access,
-were the alternatives; the first adds a step the epic's first story is written
-to avoid, the second contradicts the decision above.
+(GHS-025). A daemon not enrolled with the identity plane has no broker and no
+identity socket, so no sealed value can be minted for a session on it
+(Gatehouse §8.3); the architecture's answer is client-mediated local
+enrollment, in which a signed-in developer mints an enrollment token for their
+own laptop daemon (F16). Requiring the developer to enroll by hand, and
+leaving local sessions without GitHub access, were the alternatives; the first
+adds a step the epic's first story is written to avoid, the second contradicts
+the decision above.
 
-**Token reach is the workbench by default and wider when declared** (decided
-2026-09-03). This reconciles the epic's criterion, which bounds a token to the
-workbench project, with the 2026-08-20 ask that workbench-only be an option
-rather than a rule. "Whatever the App installation grants" was set aside
-because it does not meet the per-project bound at all. "The session's
-repository set" means the workbench project plus the declared repositories
-throughout this document. The set is computed here, at spec expansion, and
-carried digest-bound into the session's creation; two things then bound the
-token to it. The identity plane mints the session's token narrowed to the set
-where GitHub can express it, and its egress proxy refuses, per request and
-before GitHub, anything the sealed value's scope does not cover (GHS-005 is
-the behaviour a session observes; the decision is the identity plane's).
-GHS-005 binds requests that carry the session's sealed value: a request
-without one is anonymous and passes egress-checked, which is what dependency
-fetches from public repositories need and what the epic's criterion, written
-about the minted token, asks; requests that name no repository, GraphQL among
-them, ride the narrowed token's own bound at GitHub; and what a request
-targets is the identity plane's mapping of path and method to a repository,
-defined in the GitHub identity spec and not here (decided 2026-09-08). A set
-spanning more than one owner is refused at mint there, since the un-narrowed
-fallback the architecture allows would carry the developer's whole reach into
-the session; per-owner tokens are later work. The
-2026-08-20 record that a user-attributed token cannot be narrowed per
-repository holds for renewal from a refresh token and not for minting;
-renewal re-mints against the same set. Every session and every box a
-developer's workflow spawns uses a developer-attributed token; a child's set
-is a subset of its parent's (GHS-015). The reach decisions computed here
-being pure and separable from expansion is what the T2 harnesses require.
+**Token reach is the workbench by default and wider when declared.** This
+reconciles the epic's criterion, which bounds a token to the workbench
+project, with the ask that workbench-only be an option rather than a rule.
+"Whatever the App installation grants" was set aside because it does not meet
+the per-project bound at all. "The session's repository set" means the
+workbench project plus the declared repositories throughout this document. The
+set is computed here, at spec expansion, and carried digest-bound into the
+session's creation; two things then bound the token to it. The identity plane
+mints the session's token narrowed to the set where GitHub can express it, and
+its egress proxy refuses, per request and before GitHub, anything the sealed
+value's scope does not cover (GHS-005 is the behaviour a session observes; the
+decision is the identity plane's). GHS-005 binds requests that carry the
+session's sealed value: a request without one is anonymous and passes
+egress-checked, which is what dependency fetches from public repositories need
+and what the epic's criterion, written about the minted token, asks; requests
+that name no repository, GraphQL among them, ride the narrowed token's own
+bound at GitHub; and what a request targets is the identity plane's mapping of
+path and method to a repository, defined in the GitHub identity spec and not
+here. A set spanning more than one owner is refused at mint there, since the
+un-narrowed fallback the architecture allows would carry the developer's whole
+reach into the session; per-owner tokens are later work. That a
+user-attributed token cannot be narrowed per repository holds for renewal from
+a refresh token and not for minting; renewal re-mints against the same set.
+Every session and every box a developer's workflow spawns uses a
+developer-attributed token; a child's set is a subset of its parent's
+(GHS-015). The reach decisions computed here being pure and separable from
+expansion is what the T2 harnesses require.
 
 **Custody: the session holds a sealed value, never a raw credential**
-(GHS-013, GHS-027; decided 2026-09-03, revised 2026-09-06 in the architecture
-of record and accepted here 2026-09-08). Four placements were considered on
-2026-09-03. Delivering the raw token into the session per operation, the
-architecture's model at the time, was withdrawn because the architecture
-itself said the token was then a bearer any process in the session could
-reuse for its lifetime, which is what a prompt-injected agent would do.
-Holding it beside the daemon inside the guest left an 8-hour credential
-exposed to a sandbox escape or a guest snapshot. The choice taken that day, a
-host-side facade handing the session credential-free addresses, was itself
-superseded three days later by the architecture's ruling: reachability as
-authorization breaks under a shared network namespace, and a box whose egress
-denied github.com could still reach it through such an address, fragmenting
-the egress model. The shape adopted, and bound here on the session side, is
-the architecture's sealed secret (Gatehouse §6.10): the token is delivered
-exactly where a token was delivered before, the creation-time environment,
-the identity socket and the git credential helper, but encrypted to the
-tenant's egress proxy and bound to this session, its node, the upstream host,
-the minted scope and an expiry. The session presents it as an opaque bearer;
-the egress proxy, which terminates TLS for github.com with a per-tenant,
-name-constrained interception authority installed in the session's trust
-store (GHS-026), checks node, box, egress declaration and scope, substitutes
-the real credential, and forwards. Sessions talk to the real hostnames, so
-git and gh need no configuration, which is what the 2026-08-20 decision
-required and what dissolves the earlier question about routing gh. GitHub is
-two hosts to a session, github.com for git and api.github.com for gh; a
-grant covers both (GHS-022, GHS-028) and the authority's constraint covers
-both. The cost
-is an interception authority inside the session, accepted as the smaller
+(GHS-013, GHS-027). Four placements were weighed. Delivering the raw token
+into the session per operation was set aside because the token is then a
+bearer any process in the session can reuse for its lifetime, which is what a
+prompt-injected agent would do. Holding it beside the daemon inside the guest
+leaves an 8-hour credential exposed to a sandbox escape or a guest snapshot. A
+host-side facade handing the session credential-free addresses was set aside
+because reachability as authorization breaks under a shared network namespace,
+and a box whose egress denied github.com could still reach it through such an
+address, fragmenting the egress model. The shape adopted, and bound here on
+the session side, is the architecture's sealed secret (Gatehouse §6.10): the
+token is delivered exactly where a token was delivered before, the
+creation-time environment, the identity socket and the git credential helper,
+but encrypted to the tenant's egress proxy and bound to this session, its
+node, the upstream host, the minted scope and an expiry. The session presents
+it as an opaque bearer; the egress proxy, which terminates TLS for github.com
+with a per-tenant, name-constrained interception authority installed in the
+session's trust store (GHS-026), checks node, box, egress declaration and
+scope, substitutes the real credential, and forwards. Sessions talk to the
+real hostnames, so git and gh need no configuration, which the standard-tools
+decision below requires and which leaves no question of routing gh. GitHub is
+two hosts to a session, github.com for git and api.github.com for gh; a grant
+covers both (GHS-022, GHS-028) and the authority's constraint covers both. The
+cost is an interception authority inside the session, accepted as the smaller
 change on ephemeral Minimal-built boxes, and a dependency on the identity
 plane's fifth build phase, where the proxy lands.
 
@@ -368,52 +355,47 @@ sent it and a stolen sealed value is dead across boxes; on a shared network
 namespace that attribution is impossible, and the architecture accepts the
 residual, a co-resident thief gets only the session's scoped, audited reach
 until expiry or revocation, as the tier the chooser of that mode accepted. A
-session with a GitHub grant therefore defaults to its own address (GHS-031,
-decided 2026-09-08); a spec that sets the shared address explicitly keeps the
-grant with that residual. The architecture's egress gateway design, in its
-issues at the time of writing, moves egress enforcement outside the node and
-proposes that grants require a node the fabric can pin; a laptop cannot be,
-and this document keeps GitHub grants on local daemons (decided 2026-09-08):
-the sealed value is dead off-node, so an escape on a laptop gains only the
+session with a GitHub grant therefore defaults to its own address (GHS-031); a
+spec that sets the shared address explicitly keeps the grant with that
+residual. The architecture's egress gateway design moves egress enforcement
+outside the node and proposes that grants require a node the fabric can pin; a
+laptop cannot be, and this document keeps GitHub grants on local daemons: the
+sealed value is dead off-node, so an escape on a laptop gains only the
 developer's own scoped, audited reach on the developer's own machine, the tier
 the local chooser accepts.
 
 **A session's credential expires within 8 hours**, GitHub's own user-token
-expiry (decided 2026-09-03), rather than an open question or a shorter ceiling
-set here at the cost of more renewals. It depends on the App's
-token-expiration setting staying on (Gatehouse §6.4.1). That bound is the
-access credential's, and the sealed value carries it as its expiry. The
-developer's refresh token never enters a session: it stays in the identity
-plane, which rotates it on every renewal, refuses a reused one, and mints each
-renewed token narrowed to the same repository set (the GitHub identity spec).
+expiry, rather than an open question or a shorter ceiling set here at the cost
+of more renewals. It depends on the App's token-expiration setting staying on
+(Gatehouse §6.4.1). That bound is the access credential's, and the sealed
+value carries it as its expiry. The developer's refresh token never enters a
+session: it stays in the identity plane, which rotates it on every renewal,
+refuses a reused one, and mints each renewed token narrowed to the same
+repository set (the GitHub identity spec).
 
-**Every end of a session ends its grant** (GHS-017, GHS-019, decided
-2026-09-03 and restated 2026-09-08 in the architecture's terms). A session's
-end revokes its identity; the identity plane stops minting for it within a
-minute and its egress proxy consults the revocation feed, so a sealed value
-outlives its session by at most 60 seconds (GHS-019). A child's access ends
-with its parent's.
+**Every end of a session ends its grant** (GHS-017, GHS-019). A session's end
+revokes its identity; the identity plane stops minting for it within a minute
+and its egress proxy consults the revocation feed, so a sealed value outlives
+its session by at most 60 seconds (GHS-019). A child's access ends with its
+parent's.
 
 **Work is attributed to the developer, from a session and from any box a
-workflow spawns** (GHS-012, decided 2026-09-03 and adopted by the architecture
-on 2026-09-05). GHS-012 binds session, agent and task boxes, the types a
-developer's workflow spawns, which default to developer-attributed tokens
-through a type-supplied attribute; service and build boxes default to App
-attribution and are outside the epic's criterion, a service outliving the
+workflow spawns** (GHS-012). GHS-012 binds session, agent and task boxes, the
+types a developer's workflow spawns, which default to developer-attributed
+tokens through a type-supplied attribute; service and build boxes default to
+App attribution and are outside the epic's criterion, a service outliving the
 workflow that spawned it; a tenant may forbid developer attribution per type,
 with a defaulted grant downgraded and recorded rather than silently kept
 (GHS-012's edge) and an explicit request refused.
 
-**Standard git and gh, no forced interface** (decided 2026-08-20). Once a
-developer is signed in, git and gh inside a session work as the developer
-against the real hostnames (GHS-011). The earlier PRD's forced facade command
-stays retired.
+**Standard git and gh, no forced interface.** Once a developer is signed in,
+git and gh inside a session work as the developer against the real hostnames
+(GHS-011); a forced in-session command in their place is a non-goal above.
 
 **Permissions are repository contents, pull requests and issues read and
-write, and metadata read; Actions workflows are excluded** (decided
-2026-09-03, recorded in the architecture's manifest on 2026-09-05). Push and
-pull requests alone would deny an agent the issue triage it does from inside
-a session; adding workflows has the widest blast radius for a compromised
+write, and metadata read; Actions workflows are excluded.** Push and pull
+requests alone would deny an agent the issue triage it does from inside a
+session; adding workflows has the widest blast radius for a compromised
 session. Each App installation's administrator must approve the widened
 permissions before tokens for that installation carry them.
 
@@ -430,21 +412,20 @@ there is no decision to extract. GHS-013 is a universal and stays at T0 on
 purpose: sessions are not a domain a test can generate, so the
 filesystem-and-environment scan the architecture asks for under INV-1 runs as
 one named test, and the universal is stated in Security considerations. No
-requirement is at T3: there is no Lean project to hold a proof. Requirements
-GHS-014, GHS-018, GHS-021, GHS-023 and GHS-024 belonged to the superseded
-facade and were withdrawn on 2026-09-08; their identifiers are not reused.
-GHS-005's earlier edge for a target that could not be resolved moved to the
-identity spec's rule for requests its module cannot map.
+requirement is at T3: there is no Lean project to hold a proof. The
+identifiers GHS-014, GHS-018, GHS-021, GHS-023 and GHS-024 belonged to the
+set-aside facade and are not reused; the rule for a request the GitHub module
+cannot map to a repository is the identity spec's.
 
-**Egress enforcement is the gateway's, not this epic's prerequisite**
-(decided 2026-09-08). The initiative's constraint that nothing enters or
-leaves a box undeclared is met on the credential side (GHS-013, GHS-027) and,
-for credentialed reach, on the network side too: such reach rides the egress
-path and is re-checked at the proxy (GHS-022, GHS-028). Enforcement of the
-egress list for everything else is allow-all in running code today and has
-its own design chain in the architecture, the egress gateway; it is not a
-prerequisite here because the credential's reach is bounded by the token and
-the proxy whether or not anonymous traffic is filtered.
+**Egress enforcement is the gateway's, not this epic's prerequisite.** The
+initiative's constraint that nothing enters or leaves a box undeclared is met
+on the credential side (GHS-013, GHS-027) and, for credentialed reach, on the
+network side too: such reach rides the egress path and is re-checked at the
+proxy (GHS-022, GHS-028). Enforcement of the egress list for everything else
+is allow-all in running code today and has its own design chain in the
+architecture, the egress gateway; it is not a prerequisite here because the
+credential's reach is bounded by the token and the proxy whether or not
+anonymous traffic is filtered.
 
 **Generality:** GitHub.com is the sole provider by decision (GHS-007). The
 sealed-credential path is general by the architecture's design: the same
@@ -513,18 +494,16 @@ local (GHS-008 to GHS-010), and in the local daemon's self-enrollment
   before the proxy does?]
 - [NEEDS CLARIFICATION (MEDIUM): May a child session declare a repository set
   narrower than its parent's, and may a running session's set change without
-  signing in again? Left on 2026-08-20 as something to test against GitHub. A
-  narrowed token cannot be narrowed again, so widening means a fresh mint
-  from the refresh token.]
+  signing in again? To be tested against GitHub. A narrowed token cannot be
+  narrowed again, so widening means a fresh mint from the refresh token.]
 - [NEEDS CLARIFICATION (MEDIUM): How are the requested repositories and
   permissions shown to the developer before a session starts, and does a
   second session reuse the existing sign-in or mint a separately scoped token
-  by default? Both carried from the earlier PRD; neither is in this epic's
-  criteria.]
+  by default? Neither is in this epic's criteria.]
 - [NEEDS CLARIFICATION (LOW): The existing hidden sign-in command mints a
   client certificate for the HTTPS reverse proxy under the name the
   architecture's command tree gives to identity sign-in. What is the
   proxy-certificate command renamed to?]
 - [NEEDS CLARIFICATION (LOW): Should tooling that adds a Co-authored-by
-  trailer on an agent's behalf ask first? Recorded as a preference on
-  2026-08-20 with no resolution.]
+  trailer on an agent's behalf ask first? A stated preference with no
+  resolution.]

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -340,8 +340,8 @@ decision below requires and which leaves no question of routing gh. GitHub is
 two hosts to a session, github.com for git and api.github.com for gh; a grant
 covers both (GHS-022, GHS-028) and the authority's constraint covers both. The
 cost is an interception authority inside the session, accepted as the smaller
-change on ephemeral Minimal-built boxes, and a dependency on the identity
-plane's fifth build phase, where the proxy lands.
+change on ephemeral Minimal-built boxes, and the proxy itself, which this work
+builds.
 
 **What the session side does for that path** (GHS-022, GHS-026, GHS-028,
 GHS-029, GHS-030, GHS-031). The egress list is the single reachability
@@ -363,6 +363,14 @@ laptop cannot be, and this document keeps GitHub grants on local daemons: the
 sealed value is dead off-node, so an escape on a laptop gains only the
 developer's own scoped, audited reach on the developer's own machine, the tier
 the local chooser accepts.
+
+**Nothing ships between sign-in and the proxy.** The identity plane's own
+build order puts sign-in early and the egress proxy late; this work is
+prioritised above that order, so the proxy and sealed delivery are built with
+it, and a session gets GitHub access only through the sealed path. An interim
+path, a raw or facade-delivered credential until the proxy exists, was set
+aside: it would ship the custody model this document rejects and then retire
+it, and every requirement here would be written twice.
 
 **A session's credential expires within 8 hours**, GitHub's own user-token
 expiry, rather than an open question or a shorter ceiling set here at the cost
@@ -488,10 +496,7 @@ local (GHS-008 to GHS-010), and in the local daemon's self-enrollment
 
 ## Open questions
 
-- [NEEDS CLARIFICATION (HIGH): The egress proxy and sealed delivery land with
-  the identity plane's fifth build phase, and sign-in with its second. What
-  ships for sessions in between, and does any interim credential path exist
-  before the proxy does?]
+
 - [NEEDS CLARIFICATION (MEDIUM): May a child session declare a repository set
   narrower than its parent's, and may a running session's set change without
   signing in again? To be tested against GitHub. A narrowed token cannot be

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -66,18 +66,19 @@ the sealed-credential path.
   verify:   cargo nextest run -p minimal token_renewal_never_prompts
 
 - **GHS-003** WHERE a session declares no additional repositories THE SYSTEM
-  SHALL bound its GitHub access to the project in its workbench.
+  SHALL bound the GitHub access its sealed value grants to the project in its
+  workbench.
   tier:     T2
   verify:   cargo nextest run -p sessions reach_default_is_workbench_only
-  property: for every session whose declared set is empty, the set of repositories a git operation may target is exactly the workbench project
+  property: for every session whose declared set is empty, the set of repositories a git operation carrying the session's sealed value may target is exactly the workbench project
   harness:  kani_reach_is_workbench_plus_declared, exhaustive to 8 declared repositories modelled as bounded identifiers (unwind bound 9); requires the reach decision to be a pure function over owned repository identifiers, separate from spec expansion
 
 - **GHS-004** WHERE a session declares additional repositories before it starts
-  THE SYSTEM SHALL bound its GitHub access to the workbench project and the
-  declared repositories, and nothing else.
+  THE SYSTEM SHALL bound the GitHub access its sealed value grants to the
+  workbench project and the declared repositories, and nothing else.
   tier:     T2
   verify:   cargo nextest run -p sessions reach_is_workbench_plus_declared
-  property: for every declared set D, the set of repositories a git operation may target is exactly the workbench project together with D
+  property: for every declared set D, the set of repositories a git operation carrying the session's sealed value may target is exactly the workbench project together with D
   harness:  kani_reach_is_workbench_plus_declared, exhaustive to 8 declared repositories modelled as bounded identifiers (unwind bound 9); the same pure reach decision as GHS-003
 
 - **GHS-005** IF a git or gh request from a session carries the session's
@@ -231,7 +232,8 @@ the sealed-credential path.
 - Sign-in through any provider other than GitHub.com, including enterprise
   OIDC: Gatehouse §6.1.3 (F2), a later phase of the identity plane.
 - A forced in-session command for git: standard git and gh are the path
-  (GHS-011), and with sealed credentials they need no configuration at all.
+  (GHS-011), and with sealed credentials they need no configuration by the
+  developer; how their connections reach the proxy is GHS-028's.
 - Branch-aware activation, repository pre-priming, and a pull-request prompt
   on session exit: none is in this epic's criteria.
 - The Actions workflow permission: excluded from the App's permissions
@@ -239,9 +241,11 @@ the sealed-credential path.
 - Revoking an already-delivered credential at GitHub: TTL-bounded (Gatehouse
   §12.9); here a session's end revokes its identity (GHS-019), which stops
   redemption of its sealed values.
-- Enforcing the egress list for uncredentialed traffic, and whether a node's
-  fabric can pin its egress: the egress gateway design in the architecture.
-  This document binds only that credentialed reach rides the egress path.
+- Enforcing the egress list for traffic that does not reach the egress proxy,
+  and whether a node's fabric can pin its egress: the egress gateway design
+  in the architecture. Every request that reaches the proxy is egress-checked
+  whether or not it carries a sealed value (the GitHub identity spec); this
+  document binds only that credentialed reach rides that path.
 - One narrowed token per owner for a repository set that spans owners: later
   work; such a set is refused at mint (the GitHub identity spec).
 - The same egress-proxy shape for upstreams other than GitHub, such as the
@@ -350,13 +354,17 @@ authority: a runtime GitHub grant whose upstream is absent from the declared
 egress is a validation error rather than a second path beside it, and a
 session with no networking cannot hold a runtime grant. Connections to
 declared credentialed hosts are steered to the proxy at the node, and QUIC to
-those hosts is blocked so the interceptable path is the only one. On a session
-with its own network address the proxy can attribute a request to the box that
-sent it and a stolen sealed value is dead across boxes; on a shared network
-namespace that attribution is impossible. A session with a GitHub grant
-therefore has its own address: by default when its spec sets no mode
-(GHS-031), and a spec that sets the shared address or no networking with a
-grant is refused (GHS-030). The architecture allows a grant on a shared
+those hosts is blocked so the interceptable path is the only one. GHS-028
+binds the outcome, not the mechanism: the architecture steers at the node, by
+name resolution and routing, so tools need no proxy setting; a proxy variable
+the daemon sets at creation would satisfy it too, at the cost that a tool
+ignoring the variable bypasses the proxy unless egress blocks the direct path.
+On a session with its own network address the proxy can attribute a request to
+the box that sent it and a stolen sealed value is dead across boxes; on a
+shared network namespace that attribution is impossible. A session with a
+GitHub grant therefore has its own address: by default when its spec sets no
+mode (GHS-031), and a spec that sets the shared address or no networking with
+a grant is refused (GHS-030). The architecture allows a grant on a shared
 address with a recorded residual; here that combination cannot exist, because
 an egress declaration is valid only on a session with its own address and a
 grant without one is a validation error (GHS-022), so it is refused rather
@@ -438,7 +446,8 @@ proxy (GHS-022, GHS-028). Enforcement of the egress list for everything else
 is allow-all in running code today and has its own design chain in the
 architecture, the egress gateway; it is not a prerequisite here because the
 credential's reach is bounded by the token and the proxy whether or not
-anonymous traffic is filtered.
+traffic to other hosts is filtered; a request to a credentialed host is
+egress-checked at the proxy with or without a sealed value.
 
 **Generality:** GitHub.com is the sole provider by decision (GHS-007). The
 sealed-credential path is general by the architecture's design: the same proxy

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -107,7 +107,7 @@ the sealed-credential path.
 - **GHS-009** WHEN a developer starts a local session whose spec declares no
   GitHub grant THE SYSTEM SHALL start it without requiring sign-in.
   tier:     T0
-    verify:   cargo nextest run -p minimal local_session_without_grant_starts_without_signin
+  verify:   cargo nextest run -p minimal local_session_without_grant_starts_without_signin
   - IF a process inside a session that declares no GitHub grant attempts a
     GitHub operation that needs a credential THEN THE SYSTEM SHALL tell it the
     session declares no GitHub grant, rather than asking for a password.

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -5,7 +5,7 @@ status: draft
 owner: norrietaylor
 epic: gominimal/inbox#512
 arch: https://github.com/gominimal/arch/blob/main/specs/authn-authz/gatehouse-spec.md
-updated: 2026-09-03
+updated: 2026-09-08
 ---
 
 # GHS — GitHub sign-in and credential-free repository access from sessions
@@ -21,25 +21,29 @@ and the sign-in itself is the event that proves adoption.
 
 After this ships a developer signs in once with their GitHub.com account in a
 browser, starts a session, and clones, commits and pushes their project from
-inside it as themselves, whether they or an agent typed the command. No token
-is entered, copied, or left on the session. A session spawned by a workflow
-inherits no more access than its parent, and nobody is prompted for it.
+inside it as themselves, whether they or an agent typed the command. The
+session never holds a raw credential: what it holds is a sealed value only the
+egress proxy can open, and only for that session, on that node, for GitHub. A
+session spawned by a workflow inherits no more access than its parent, and
+nobody is prompted for it.
 
-This document covers the CLI, the session daemon and the host-side credential
-facade that fronts GitHub for every session. Signing the developer in, minting and renewing tokens, and
-enforcing attenuation at issuance are the identity plane's, in
+This document covers the CLI, the session daemon and the session's side of the
+sealed-credential path: what a session receives, what it can reach, what it
+never holds in the raw, and what its spec must declare. Signing the developer
+in, minting and sealing tokens, the egress proxy that redeems sealed values,
+and the browser pages of the sign-in are the identity plane's, in
 [the GitHub identity spec](https://github.com/gominimal/gatehouse/blob/main/docs/specs/01-spec-github-identity/01-spec-github-identity.md).
-The browser page that approves a sign-in is in
-[the CLI sign-in page spec](https://github.com/gominimal/webapp/blob/main/docs/specs/03-spec-cli-signin-page/03-spec-cli-signin-page.md).
+The website's own sign-in is in
+[the website sign-in spec](https://github.com/gominimal/webapp/blob/main/docs/specs/03-spec-website-signin/03-spec-website-signin.md).
 
 **Success:** A developer with no prior Minimal account signs in with GitHub,
 starts a remote session, and a push to their project from inside it lands on
-GitHub attributed to them, with no credential typed, copied, or present in
-the session or in the guest that hosts it.
+GitHub attributed to them, with no raw credential typed, copied, or present
+anywhere in the session.
 
 **First slice:** The sign-in command, the browser approval, one remote session,
 and a push to the workbench project from inside it with unmodified git through
-the facade, with no credential in the session.
+the sealed-credential path.
 
 ## Users and stories
 
@@ -48,7 +52,6 @@ the facade, with no credential in the session.
 - AS A developer who uses the open-source version of Minimal, I WANT to sign into Minimal with the `min` CLI and authenticate using my Github.com account in the browser, SO THAT I don't need to manage another credential.
 - AS A developer using remote sessions, I WANT to clone, commit and push changes to my project without being asked to provide login information, SO THAT I don't need to worry about my credentials being leaked.
 - AS A developer who deploys agentic workflow that spawns new sessions, I WANT the child sessions to complete successfully using access scope that's no wider than its parent, SO THAT my workflow can achieve its objective autonomously.
-
 
 ## Requirements
 
@@ -67,7 +70,7 @@ the facade, with no credential in the session.
   tier:     T2
   verify:   cargo nextest run -p sessions reach_default_is_workbench_only
   property: for every session whose declared set is empty, the set of repositories a git operation may target is exactly the workbench project
-  harness:  kani_reach_is_workbench_plus_declared, exhaustive to 8 declared repositories modelled as bounded identifiers (unwind bound 9); requires the reach decision to be a pure function over owned repository identifiers, separate from the transport that carries the git operation
+  harness:  kani_reach_is_workbench_plus_declared, exhaustive to 8 declared repositories modelled as bounded identifiers (unwind bound 9); requires the reach decision to be a pure function over owned repository identifiers, separate from spec expansion
 
 - **GHS-004** WHERE a session declares additional repositories before it starts
   THE SYSTEM SHALL bound its GitHub access to the workbench project and the
@@ -77,14 +80,12 @@ the facade, with no credential in the session.
   property: for every declared set D, the set of repositories a git operation may target is exactly the workbench project together with D
   harness:  kani_reach_is_workbench_plus_declared, exhaustive to 8 declared repositories modelled as bounded identifiers (unwind bound 9); the same pure reach decision as GHS-003
 
-- **GHS-005** IF a git or GitHub request from a session targets a repository
+- **GHS-005** IF a git or gh request from a session targets a repository
   outside the session's repository set, meaning the workbench project and the
   repositories it declared, THEN THE SYSTEM SHALL refuse it with a 403 before
   the request reaches GitHub.
-  tier:     T2
+  tier:     T0
   verify:   cargo nextest run -p minimal request_outside_repository_set_is_403_before_github
-  property: for every repository set, the workbench project plus the declared repositories, and every target repository outside it, the reach decision is a refusal, and the refusal reaches the caller as a 403 with nothing forwarded to GitHub
-  harness:  kani_outside_reach_is_refused, exhaustive to 8 declared repositories (unwind bound 9); requires the reach decision to be a pure function over owned repository identifiers, evaluated by the facade before any request is forwarded
   - IF the repository a request targets cannot be resolved to one identifier
     THEN THE SYSTEM SHALL refuse the request with a 403 before it reaches
     GitHub.
@@ -131,17 +132,11 @@ the facade, with no credential in the session.
   tier:     T0
   verify:   cargo nextest run -p minimal session_commits_and_prs_attributed_to_developer
 
-- **GHS-013** THE SYSTEM SHALL keep every GitHub credential, including any
+- **GHS-013** THE SYSTEM SHALL keep every raw GitHub credential, including any
   personal access token, any refresh token and any static private SSH key,
   out of a session's filesystem and environment.
   tier:     T0
-  verify:   cargo nextest run -p minimal session_fs_and_env_hold_no_github_credential
-
-- **GHS-014** WHEN a session is created for a signed-in developer THE SYSTEM
-  SHALL hand it addresses for git over HTTPS and the GitHub programming
-  interface that carry no credential.
-  tier:     T0
-  verify:   cargo nextest run -p minimal session_receives_credential_free_github_addresses
+  verify:   cargo nextest run -p minimal session_fs_and_env_hold_no_raw_github_credential
 
 - **GHS-015** WHEN a session spawns a child session THE SYSTEM SHALL grant the
   child a repository set that is a subset of the parent's repository set.
@@ -160,76 +155,87 @@ the facade, with no credential in the session.
   tier:     T0
   verify:   cargo nextest run -p minimal parent_end_ends_child_github_access
 
-- **GHS-018** THE SYSTEM SHALL hold a session's GitHub credential on the host,
-  outside the guest virtual machine and outside every session.
-  tier:     T0
-  verify:   cargo nextest run -p minimal facade_holds_credential_outside_guest_and_session
-
 - **GHS-019** WHEN a session ends, by destroy or otherwise, THE SYSTEM SHALL
-  stop answering the session's GitHub addresses and discard every credential
-  held for it.
+  revoke the session's identity, so that no further sealed value is minted for
+  it and its existing sealed values stop being redeemable.
   tier:     T0
-  verify:   cargo nextest run -p minimal session_end_stops_addresses_and_discards_credentials
-  - IF a session has ended THEN THE SYSTEM SHALL forward no further request on
-    its behalf, admitted before the end or not.
+  verify:   cargo nextest run -p minimal session_end_revokes_identity_and_sealed_values
+
+- **GHS-020** WHILE a session is live THE SYSTEM SHALL renew its sealed GitHub
+  value before it expires and hold none older than 8 hours.
+  tier:     T0
+  verify:   cargo nextest run -p minimal sealed_value_renewed_before_expiry_within_8h
+
+- **GHS-022** IF a session's spec declares a runtime GitHub grant and its
+  declared egress does not admit github.com THEN THE SYSTEM SHALL refuse the
+  spec as invalid.
+  tier:     T0
+  verify:   cargo nextest run -p minimal github_grant_without_egress_entry_is_rejected
+
+- **GHS-025** WHEN a signed-in developer first uses GitHub access from a
+  session on a local daemon that is not enrolled with the identity plane THE
+  SYSTEM SHALL enroll that daemon under the developer's sign-in without a
+  further prompt.
+  tier:     T0
+  verify:   cargo nextest run -p minimal local_daemon_enrolls_on_first_github_use
+
+- **GHS-026** WHEN a session that declares a GitHub grant is created THE
+  SYSTEM SHALL install the tenant's egress-interception certificate authority
+  in the session's trust store.
+  tier:     T0
+  verify:   cargo nextest run -p minimal github_grant_installs_interception_authority
+  - IF a session declares no credentialed upstream THEN THE SYSTEM SHALL
+    install no interception authority in it.
     tier:   T0
-    verify: cargo nextest run -p minimal session_end_wins_race_with_forwarding
+    verify: cargo nextest run -p minimal no_grant_no_interception_authority
 
-- **GHS-020** WHILE a session is live THE SYSTEM SHALL hold its GitHub access
-  credential for at most 8 hours before renewing or discarding it.
+- **GHS-027** THE SYSTEM SHALL hand a session its brokered GitHub credential
+  only as a sealed value that no process in the session can open.
   tier:     T0
-  verify:   cargo nextest run -p minimal facade_credential_held_at_most_8h
+  verify:   cargo nextest run -p minimal session_receives_sealed_value_only
 
-- **GHS-021** WHEN a GitHub request from a session is admitted or refused THE
-  SYSTEM SHALL record the decision with the session and the developer
-  identity, and never the credential or the request body.
+- **GHS-028** WHILE a session is live THE SYSTEM SHALL steer its connections
+  to its declared credentialed hosts to the egress proxy.
   tier:     T0
-  verify:   cargo nextest run -p minimal facade_decisions_are_audited_without_secrets
+  verify:   cargo nextest run -p minimal credentialed_host_connections_terminate_at_egress_proxy
 
-- **GHS-022** WHERE a session's declared egress excludes github.com THE SYSTEM
-  SHALL complete git and gh operations from it through the facade.
+- **GHS-029** THE SYSTEM SHALL block QUIC from a session to its declared
+  credentialed hosts.
   tier:     T0
-  verify:   cargo nextest run -p minimal github_work_needs_no_github_egress
+  verify:   cargo nextest run -p minimal quic_to_credentialed_hosts_is_blocked
 
-- **GHS-023** WHEN a request arrives at the facade THE SYSTEM SHALL attribute
-  it to exactly one live session and that session's developer before deciding
-  it.
+- **GHS-030** IF a session's spec sets its network mode to none and declares a
+  runtime GitHub grant THEN THE SYSTEM SHALL refuse the spec as invalid.
   tier:     T0
-  verify:   cargo nextest run -p minimal facade_request_bound_to_one_live_session
-  - IF a request cannot be attributed to a live session, or presents another
-    session's address, THEN THE SYSTEM SHALL refuse it with a 403.
-    tier:   T0
-    verify: cargo nextest run -p minimal cross_session_address_reuse_is_refused
-
-- **GHS-024** THE SYSTEM SHALL hold in the facade only a session's access
-  credential, and never the developer's refresh token.
-  tier:     T0
-  verify:   cargo nextest run -p minimal facade_holds_no_refresh_token
+  verify:   cargo nextest run -p minimal network_none_with_github_grant_is_rejected
 
 ## Non-goals
 
-- Signing the developer in, minting and renewing tokens, and enforcing
+- Signing the developer in, the browser pages of the sign-in, minting and
+  sealing tokens, the egress proxy and its GitHub policy module, and
   attenuation at issuance:
   [the GitHub identity spec](https://github.com/gominimal/gatehouse/blob/main/docs/specs/01-spec-github-identity/01-spec-github-identity.md).
-- The browser page that approves a CLI sign-in:
-  [the CLI sign-in page spec](https://github.com/gominimal/webapp/blob/main/docs/specs/03-spec-cli-signin-page/03-spec-cli-signin-page.md).
+- The website's own sign-in and product pages:
+  [the website sign-in spec](https://github.com/gominimal/webapp/blob/main/docs/specs/03-spec-website-signin/03-spec-website-signin.md).
 - Sign-in through any provider other than GitHub.com, including enterprise
   OIDC: Gatehouse §6.1.3 (F2), a later phase of the identity plane.
 - A forced in-session command for git: retired on 2026-08-20. Standard git and
-  gh are the path (GHS-011); the facade is transparent to them.
+  gh are the path (GHS-011), and since the sealed-credential design they need
+  no configuration at all.
 - Branch-aware activation, repository pre-priming, and a pull-request prompt
   on session exit: the earlier GitHub-sessions PRD carries them as a
   reference; none is in this epic's criteria.
 - The Actions workflow permission: excluded from the App's permissions
   (GHI-004 in the GitHub identity spec).
 - Revoking an already-delivered credential at GitHub: TTL-bounded (Gatehouse
-  §12.9); here a session's end discards what the facade holds (GHS-019).
-- The same facade shape for upstreams other than GitHub, such as the Claude
-  programming interface or model-context servers: a separate credential-broker
-  epic in the inbox proposes it; nothing here binds it.
-- The mechanics that route a session's git remotes and gh requests to the
-  facade: the git rewrite is an implementation choice; gh is an open question
-  below.
+  §12.9); here a session's end revokes its identity (GHS-019), which stops
+  redemption of its sealed values.
+- Enforcing the egress list for uncredentialed traffic: the networking spec.
+  This document binds only that credentialed reach rides the egress path.
+- The same egress-proxy shape for upstreams other than GitHub, such as the
+  Claude programming interface or model-context servers: a separate
+  credential-broker epic in the inbox; the architecture names the proxy as
+  their shape too (D6).
 - Sharing a session with another developer or an agent: the session-sharing
   spike in the inbox.
 - A typed control plane for agents over sessions: the sessions MCP proposal in
@@ -241,12 +247,12 @@ the facade, with no credential in the session.
 ## Design reasoning
 
 **Three documents.** One spec per surface owner, decided 2026-09-03: this one
-for the CLI, the daemon and the host-side credential facade; the identity
-plane's for sign-in, minting, renewal and attenuation; the website's for the
-approval page. A single document here with the identity behaviours as open
+for the CLI, the daemon and the session's side of the credential path; the
+identity plane's for sign-in, its browser pages, minting, sealing, the egress
+proxy and attenuation; the website's for its own sign-in as a client of the
+identity plane. A single document here with the identity behaviours as open
 questions was the cheaper alternative and would have left the identity half
-unspecified; two documents without the page would only be right if GitHub's
-own device page were the browser step, which was not chosen.
+unspecified.
 
 **Sign-in gates remote sessions and is optional for local ones** (decided
 2026-09-03; mandatory sign-in for remote sessions was reconfirmed on
@@ -260,244 +266,211 @@ instructions because it keeps a developer in flow; the cost is that an agent
 or script inside a local session blocks on a prompt it cannot answer, so such
 workflows sign in before they start.
 
+**A local daemon enrolls itself on first GitHub use** (GHS-025, decided
+2026-09-08 from the architecture). A daemon not enrolled with the identity
+plane has no broker and no identity socket, so no sealed value can be minted
+for a session on it (Gatehouse §8.3); the architecture's answer is
+client-mediated local enrollment, in which a signed-in developer mints an
+enrollment token for their own laptop daemon (F16). Requiring the developer to
+enroll by hand, and leaving local sessions without GitHub access, were the
+alternatives; the first adds a step the epic's first story is written to
+avoid, the second contradicts the decision above.
+
 **Token reach is the workbench by default and wider when declared** (decided
 2026-09-03). This reconciles the epic's criterion, which bounds a token to the
 workbench project, with the 2026-08-20 ask that workbench-only be an option
 rather than a rule. "Whatever the App installation grants" was set aside
-because it does not meet the per-project bound at all. The bound is enforced
-by the facade on every request (GHS-005), which is what makes the epic's 403
-Minimal's own behaviour rather than a status relayed from GitHub, which
-answers 404 for a private repository outside a token's reach and serves a
-public one with no credential at all. The identity plane additionally mints
-the session's token narrowed to the declared set where GitHub can express it
-(the GitHub identity spec); with the facade enforcing the set, that narrowing
-is defence in depth rather than the bound. The 2026-08-20 record that a
-user-attributed token cannot be narrowed per repository holds for renewal from
-a refresh token and not for minting. "The session's repository set" means
-the workbench project plus the declared repositories throughout this
-document. Renewal (GHS-001) re-mints against that same set: the set is the
-facade's grant, fixed when the session is created, not a property the token
-has to carry across a refresh. Every session and every box a developer's
-workflow spawns uses a developer-attributed token; a child's set is a subset
-of its parent's (GHS-015) and its token is minted for that subset. The reach
-decision being pure and separable from the proxy is what the T2 harnesses
-require.
+because it does not meet the per-project bound at all. "The session's
+repository set" means the workbench project plus the declared repositories
+throughout this document. The set is computed here, at spec expansion, and
+carried digest-bound into the session's creation; two things then bound the
+token to it. The identity plane mints the session's token narrowed to the set
+where GitHub can express it, and its egress proxy refuses, per request and
+before GitHub, anything the sealed value's scope does not cover (GHS-005 is
+the behaviour a session observes; the decision is the identity plane's). The
+2026-08-20 record that a user-attributed token cannot be narrowed per
+repository holds for renewal from a refresh token and not for minting;
+renewal re-mints against the same set. Every session and every box a
+developer's workflow spawns uses a developer-attributed token; a child's set
+is a subset of its parent's (GHS-015). The reach decisions computed here
+being pure and separable from expansion is what the T2 harnesses require.
 
-**What a request targets, and who it belongs to.** A request's target is the
-repository GitHub would resolve it to: owner and name compared the way GitHub
-compares them, with or without a trailing `.git`, in any of the address forms
-git and gh emit. A target the facade cannot resolve is refused, not forwarded
-(the failure edge of GHS-005); requests that name no repository at all, such
-as an identity lookup, are an open question below. Every request is attributed
-to exactly one live session before it is decided (GHS-023), so an address
-handed to one session buys nothing in another; the mechanism that binds a
-request to its session, a per-session address, a per-session placeholder the
-facade recognises, or the source the switch attributes, is part of the
-facade's design and belongs with the architecture question below. The point
-of no return at session end is forwarding: a request already sent to GitHub
-completes, and one admitted but not yet forwarded is refused (the failure edge
-of GHS-019).
+**Custody: the session holds a sealed value, never a raw credential**
+(GHS-013, GHS-027; decided 2026-09-03, revised 2026-09-06 in the architecture
+of record and accepted here 2026-09-08). Four placements were considered on
+2026-09-03. Delivering the raw token into the session per operation, the
+architecture's model at the time, was withdrawn because the architecture
+itself said the token was then a bearer any process in the session could
+reuse for its lifetime, which is what a prompt-injected agent would do.
+Holding it beside the daemon inside the guest left an 8-hour credential
+exposed to a sandbox escape or a guest snapshot. The choice taken that day, a
+host-side facade handing the session credential-free addresses, was itself
+superseded three days later by the architecture's ruling: reachability as
+authorization breaks under a shared network namespace, and a box whose egress
+denied github.com could still reach it through such an address, fragmenting
+the egress model. The shape adopted, and bound here on the session side, is
+the architecture's sealed secret (Gatehouse §6.10): the token is delivered
+exactly where a token was delivered before, the creation-time environment,
+the identity socket and the git credential helper, but encrypted to the
+tenant's egress proxy and bound to this session, its node, the upstream host,
+the minted scope and an expiry. The session presents it as an opaque bearer;
+the egress proxy, which terminates TLS for github.com with a per-tenant,
+name-constrained interception authority installed in the session's trust
+store (GHS-026), checks node, box, egress declaration and scope, substitutes
+the real credential, and forwards. Sessions talk to the real hostnames, so
+git and gh need no configuration, which is what the 2026-08-20 decision
+required and what dissolves the earlier question about routing gh. The cost
+is an interception authority inside the session, accepted as the smaller
+change on ephemeral Minimal-built boxes, and a dependency on the identity
+plane's fifth build phase, where the proxy lands.
 
-**A child session gets a subset of its parent's scope, never more** (GHS-015).
-Whether a child may declare a narrower set, or a running session's set may
-change without a fresh sign-in, was left on 2026-08-20 as something to test
-against GitHub and stays open. The alternatives were letting a child declare
-a narrower set, which needs the same non-token enforcement as GHS-004, and
-giving every child exactly its parent's scope, which never exercises the
-"narrower" the criterion allows.
-
-**The browser step is the device flow with a code-entry page on the website**
-(decided 2026-09-03). It works on a headless host and matches the identity
-plane's reference profile (Gatehouse §6.1.2). An auth-code flow with a
-loopback listener has no code to type but needs a browser on the same machine
-as the CLI; GitHub's own device page needs no page of ours but leaves nowhere
-to show what is being approved.
-
-**No GitHub credential exists in the session or in the guest; a host-side
-facade holds it and attaches it on the way out** (GHS-013, GHS-014, GHS-018,
-decided 2026-09-03, revising a same-day choice). Four placements were on the
-table, with the daemon's placement in front of the decision: on macOS and on
-Linux with hardware virtualisation the session daemon and the broker beside it
-run inside a guest virtual machine, and on native Linux on the host.
-Delivering the token into the session per operation, as the architecture of
-record describes, was chosen first and withdrawn: the architecture itself says
-the token is then a bearer credential any process in the session can reuse for
-its lifetime, which is exactly what a prompt-injected agent would do, and under
-it the epic's 403 cannot be Minimal's own answer. Holding the token beside the
-daemon, never in the session, needs no new component but leaves an 8-hour
-credential inside the guest to a sandbox escape or a guest snapshot. Leaving
-the holder's placement open was declined because the planning step cannot
-decompose the reach requirements without it. The facade on the host is the
-strongest of the four and the only one under which the session never holds a
-credential, the guest never holds one, a request outside the set is refused
-before it leaves, and access ends with the session (GHS-019). It costs a
-component the architecture of record does not have, a path by which the guest
-daemon reaches it for a child's grant, and the in-session routing of gh, whose
-only host override treats its target as an enterprise server; the first two
-are the architecture question below, the third an open question here. The facade is
-transparent to git and gh: standard commands work (GHS-011), which is what the
-2026-08-20 decision required, and the earlier design of a forced in-session
-command stays retired.
+**What the session side does for that path** (GHS-022, GHS-026, GHS-028,
+GHS-029, GHS-030). The egress list is the single reachability authority: a
+runtime GitHub grant whose upstream is absent from the declared egress is a
+validation error rather than a second path beside it, and a session with no
+networking cannot hold a runtime grant. Connections to declared credentialed
+hosts are steered to the proxy at the node, and QUIC to those hosts is
+blocked so the interceptable path is the only one. On a session with its own
+network address the proxy can attribute a request to the box that sent it and
+a stolen sealed value is dead across boxes; on a shared network namespace that
+attribution is impossible, and the architecture accepts the residual, a
+co-resident thief gets only the session's scoped, audited reach until expiry
+or revocation, as the tier the chooser of that mode accepted. Whether
+sessions with GitHub grants should default to their own address is an open
+question below.
 
 **A session's credential expires within 8 hours**, GitHub's own user-token
 expiry (decided 2026-09-03), rather than an open question or a shorter ceiling
 set here at the cost of more renewals. It depends on the App's
 token-expiration setting staying on (Gatehouse §6.4.1). That bound is the
-access credential's. The developer's refresh token never reaches the facade
-(GHS-024): it stays in the identity plane, which rotates it on every renewal,
-refuses a reused one, and mints each renewed token narrowed to the same
-repository set as the one it replaces (the GitHub identity spec).
+access credential's, and the sealed value carries it as its expiry. The
+developer's refresh token never enters a session: it stays in the identity
+plane, which rotates it on every renewal, refuses a reused one, and mints each
+renewed token narrowed to the same repository set (the GitHub identity spec).
+
+**Every end of a session ends its grant** (GHS-017, GHS-019, decided
+2026-09-03 and restated 2026-09-08 in the architecture's terms). A session's
+end revokes its identity; the identity plane stops minting for it within a
+minute and its egress proxy consults the revocation feed, so a sealed value
+outlives its session by at most that window. A child's access ends with its
+parent's.
 
 **Work is attributed to the developer, from a session and from any box a
-workflow spawns** (GHS-012, decided 2026-09-03). This extends the 2026-08-20
-decision to use GitHub App user access tokens rather than installation
-tokens, taken so that actions are attributed to a real person rather than to
-a bot, with the tradeoff accepted then that user tokens give no per-repository
-narrowing out of the gate (Gatehouse §6.4 states the asymmetry). Covering
-sessions only and leaving agent boxes open, or leaving agent boxes
-bot-attributed, were the alternatives. The consequence is that the
-architecture's per-type default, installation mode for every root other than
-session, has to move; that is an open question below.
+workflow spawns** (GHS-012, decided 2026-09-03 and adopted by the architecture
+on 2026-09-05). Session, agent and task boxes default to developer-attributed
+tokens through a type-supplied attribute; service and build boxes default to
+App attribution; a tenant may forbid user mode per type, with a defaulted
+grant downgraded and audited rather than silently kept.
 
 **Standard git and gh, no forced interface** (decided 2026-08-20). Once a
-developer is signed in, the token a session uses works with unmodified git and
-gh as the developer (GHS-011). The earlier PRD's design, in which a facade was
-the only route to GitHub, is retired by this.
+developer is signed in, git and gh inside a session work as the developer
+against the real hostnames (GHS-011). The earlier PRD's forced facade command
+stays retired.
 
 **Permissions are repository contents, pull requests and issues read and
 write, and metadata read; Actions workflows are excluded** (decided
-2026-09-03). Push and pull requests alone, the criteria read literally, would
-deny an agent the issue triage it does from inside a session; adding workflows
-was excluded by the earlier PRD and by the architecture's manifest ceiling and
-has the widest blast radius for a compromised session. The chosen set widens
-the architecture's v1 manifest, which §6.4.1 treats as a security-review
-event; the GitHub identity spec carries that as an open question.
+2026-09-03, recorded in the architecture's manifest on 2026-09-05). Push and
+pull requests alone would deny an agent the issue triage it does from inside
+a session; adding workflows has the widest blast radius for a compromised
+session. Each App installation's administrator must approve the widened
+permissions before tokens for that installation carry them.
 
-**Tiers.** The reach and child-subset decisions (GHS-003, GHS-004, GHS-005,
-GHS-015) are at T2: each is a pure decision over bounded repository
+**Tiers.** The reach and child-subset decisions computed here (GHS-003,
+GHS-004, GHS-015) are at T2: each is a pure decision over bounded repository
 identifiers, and the Kani lane that already proves the path-decision lattice
 runs the harnesses today. What the tier buys is the split each harness line
-names: the decision is a pure function over owned values, separate from the
-proxy that acts on it, and it has to be written that way from the start. T0
-would leave the decision free to interleave with the proxy;
-T1 would add a property-testing dependency this tree does not carry.
-Everything else stays at T0 because it passes through GitHub, a PTY or a
-socket, and there is no decision to extract. GHS-013 is a universal and stays
-at T0 on purpose: sessions are not a domain a test can generate, so the
+names: the decision is a pure function over owned values, separate from spec
+expansion, and it has to be written that way from the start. The refusal a
+session observes (GHS-005) is at T0 here: the decision that produces it lives
+in the identity plane's GitHub policy module and is proved there. Everything
+else stays at T0 because it passes through GitHub, a PTY or the network, and
+there is no decision to extract. GHS-013 is a universal and stays at T0 on
+purpose: sessions are not a domain a test can generate, so the
 filesystem-and-environment scan the architecture asks for under INV-1 runs as
 one named test, and the universal is stated in Security considerations. No
-requirement is at T3: every behaviour reaches a socket or GitHub, and there is
-no Lean project to hold a proof.
+requirement is at T3: there is no Lean project to hold a proof. Requirements
+GHS-014, GHS-018, GHS-021, GHS-023 and GHS-024 belonged to the superseded
+facade and were withdrawn in this revision; their identifiers are not reused.
 
-**Egress is only half covered.** The initiative's constraint that nothing
-enters or leaves a box undeclared is met on the credential side (GHS-013,
-GHS-018). The network side, egress declared before it happens and enforced at
-the relay, is allow-all in running code today, and the design for enforcing
-it belongs to the networking spec. GHS-022 states what the facade makes
-possible: a session with a GitHub grant needs no github.com egress at all, so
-an enforcing policy can deny it. Until egress is enforced the facade removes
-the need for a credential in the session, not the ability of a session to
-reach GitHub with one pasted in. Whether enforcement is a prerequisite for
-this work is open.
+**Egress is half covered.** The initiative's constraint that nothing enters or
+leaves a box undeclared is met on the credential side (GHS-013, GHS-027) and,
+for credentialed reach, on the network side too: such reach rides the egress
+path and is re-checked at the proxy (GHS-022, GHS-028). Enforcement of the
+egress list for everything else is allow-all in running code today and
+belongs to the networking spec; whether it is a prerequisite for this work is
+open.
 
 **Generality:** GitHub.com is the sole provider by decision (GHS-007). The
-facade's shape, a credential-free address per upstream, a credential held
-outside the guest, a per-request reach decision, would fit a second upstream
-such as the Claude programming interface, and a separate epic proposes exactly
-that; every bound stated here, the 403, the permission ceiling, the 8-hour
-lifetime, is GitHub's own model and does not carry. Across hosts the
-behaviours are general: the facade sits on the host on every platform, so
-where the daemon runs, inside a guest on macOS and Linux with hardware
-virtualisation or on the host on native Linux, changes how the daemon reaches
-it and nothing a session observes. A local and a remote session differ only
-in whether sign-in is required to start (GHS-008, GHS-009); a local session on
-a daemon not enrolled with the identity plane depends on the facade acting
-under the developer's own sign-in, an open question below.
+sealed-credential path is general by the architecture's design: the same
+proxy takes further upstreams as policy modules, and a separate epic proposes
+the Claude programming interface and model-context servers as the next ones;
+every bound stated here, the 403, the permission ceiling, the 8-hour lifetime,
+is GitHub's own model and does not carry. Across hosts the behaviours are
+general: the session-to-proxy TLS session is the encryption in transit on a
+laptop guest, a cloud instance or a cluster pod alike, with no same-machine
+assumption; a session's network mode changes how strongly a sealed value is
+bound, not whether the path works. A local and a remote session differ only
+in whether sign-in is required to start (GHS-008, GHS-009) and in the local
+daemon's self-enrollment (GHS-025).
 
 ## Security considerations
 
-- **Invariant:** THE SYSTEM SHALL keep every GitHub credential and every
-  private key out of a session's filesystem and environment and out of the
-  guest virtual machine, and hand a session nothing that carries one.
-  enforced by: the facade holding credentials on the host outside the guest
-  and handing sessions only credential-free addresses, and the scan of the
-  session filesystem and process environments the architecture requires
-  (Gatehouse INV-1, T3, T15).
-  covered by: GHS-013, GHS-014, GHS-018, GHS-024
-- **Invariant:** THE SYSTEM SHALL decide no request at the facade without
-  first attributing it to one live session.
-  enforced by: the facade's per-request session binding, refusing anything it
-  cannot attribute (Gatehouse T15).
-  covered by: GHS-023
-- **Invariant:** THE SYSTEM SHALL admit through the facade no request for a
+- **Invariant:** THE SYSTEM SHALL keep every raw GitHub credential and every
+  private key out of a session, and hand a session brokered credentials only
+  as sealed values it cannot open.
+  enforced by: sealed delivery bound to the session's node and box, and the
+  scan of the session filesystem and process environments the architecture
+  requires (Gatehouse INV-1, §6.10, T3, T28).
+  covered by: GHS-013, GHS-027
+- **Invariant:** THE SYSTEM SHALL admit no request from a session for a
   repository outside the session's repository set.
-  enforced by: the reach decision, a pure function over owned repository
-  identifiers checked exhaustively to the stated bound and evaluated before
-  any request is forwarded, with the narrowed mint in the identity plane as
-  defence in depth (architecture AT12; Gatehouse T4, T9).
+  enforced by: the reach set computed here as a pure function over owned
+  repository identifiers, checked exhaustively to the stated bound, and the
+  identity plane's egress proxy refusing per request before GitHub
+  (architecture AT12; Gatehouse T4, T9).
   covered by: GHS-003, GHS-004, GHS-005
-- **Invariant:** THE SYSTEM SHALL leave no live GitHub grant for a session
-  that has ended.
-  enforced by: the facade observing session end from the daemon and
-  discarding the session's credentials and addresses (Gatehouse T23).
-  covered by: GHS-017, GHS-019
-- **Invariant:** THE SYSTEM SHALL hold no session credential longer than 8
-  hours without renewing or discarding it.
-  enforced by: the facade's renewal against the identity plane's 8-hour token
-  lifetime (Gatehouse §5.7, T3).
-  covered by: GHS-020
-- **Invariant:** THE SYSTEM SHALL write no credential and no request body to
-  the audit record.
-  enforced by: the facade recording only the session, the developer identity,
-  the target and the decision (Gatehouse T18, INV-4).
-  covered by: GHS-021
-- **Invariant:** THE SYSTEM SHALL grant a child session a GitHub access scope
-  that is a subset of its parent's.
+- **Invariant:** THE SYSTEM SHALL grant a child session a repository set that
+  is a subset of its parent's.
   enforced by: the child-reach decision here and attenuation at issuance in
   the identity plane (Gatehouse INV-2, §6.5; architecture AT16).
   covered by: GHS-015
+- **Invariant:** THE SYSTEM SHALL reach a credentialed host from a session
+  only along the path its declared egress admits, through the egress proxy.
+  enforced by: validation at expansion, steering at the node, the QUIC block,
+  and the proxy's own re-check of the declaration (architecture D6).
+  covered by: GHS-022, GHS-028, GHS-029, GHS-030
+- **Invariant:** THE SYSTEM SHALL install an interception authority in no
+  session that declares no credentialed upstream.
+  enforced by: creation-time injection conditioned on the session's spec
+  (Gatehouse T27).
+  covered by: GHS-026
 - **Invariant:** THE SYSTEM SHALL start or attach no remote session for a
   developer without a valid sign-in.
   enforced by: the sign-in gate in the CLI before any session request is sent.
   covered by: GHS-008
+- **Invariant:** THE SYSTEM SHALL leave no redeemable grant for a session that
+  has ended beyond the revocation window.
+  enforced by: revocation of the session's identity at its end, which stops
+  minting within a minute and reaches the proxy's revocation feed (Gatehouse
+  F13, T23).
+  covered by: GHS-017, GHS-019
 
 ## Open questions
 
-- [NEEDS CLARIFICATION (HIGH): The credential facade is not in the
-  architecture of record, whose §6.4 and §8.3 deliver the token into the box;
-  a proposal for it has been filed against the architecture. Its placement
-  outside the guest, its identity toward the identity plane, how it binds a
-  request to the session that sent it, and how a child session created inside
-  the guest obtains its grant from it are decided there, and GHS-014, GHS-018,
-  GHS-019 and GHS-023 are not implementable until they are.]
-- [NEEDS CLARIFICATION (HIGH): Is declared-egress enforcement a prerequisite
-  for credential-free GitHub access, or its own epic? Egress is allow-all in
-  running code, the relay-layer enforcement design was closed without being
-  planned, and the initiative's hard constraint says nothing leaves a box
-  undeclared. Until it is enforced, the facade removes the need for a
-  credential in a session and not a session's ability to reach GitHub with
-  one pasted in.]
-- [NEEDS CLARIFICATION (HIGH): GHS-012 attributes work from every box a
-  developer's workflow spawns to the developer, decided and reconfirmed on
-  2026-09-03, while Gatehouse §6.4 defaults every root other than session to
-  installation mode. The architecture's per-type default has to move; does
-  the agent type give up per-mint narrowing when it does?]
-- [NEEDS CLARIFICATION (HIGH): On a daemon not enrolled with the identity
-  plane, does the facade obtain a session's credential under the developer's
-  own sign-in rather than a box identity, so that local sessions (GHS-009 to
-  GHS-011) work without enrollment? Client-mediated local enrollment
-  (Gatehouse F16) is the alternative.]
-- [NEEDS CLARIFICATION (MEDIUM): gh has no base-address override for
-  github.com; it does honour a host override that treats any other host as a
-  GitHub Enterprise Server and sends requests to that host's enterprise-shaped
-  paths. Pointing that override at the facade, which serves those paths
-  against github.com, is the candidate mechanism for GHS-011. Which gh
-  behaviours differ under a non-github.com host, and whether any matter for
-  clone, push and pull requests, is undecided.]
-- [NEEDS CLARIFICATION (MEDIUM): Which GitHub requests that name no
-  repository, such as the identity lookup gh makes at start, does the facade
-  admit? GHS-005 bounds repository targets; a request with no repository is
-  neither in nor out of the set.]
+- [NEEDS CLARIFICATION (HIGH): The egress proxy and sealed delivery land with
+  the identity plane's fifth build phase, and sign-in with its second. What
+  ships for sessions in between, and does any interim credential path exist
+  before the proxy does?]
+- [NEEDS CLARIFICATION (HIGH): Is enforcement of the egress list for
+  uncredentialed traffic a prerequisite for credential-free GitHub access, or
+  its own epic? Credentialed reach is now re-checked at the proxy, but the
+  list is allow-all in running code for everything else, the relay-layer
+  enforcement design was closed without being planned, and the initiative's
+  hard constraint says nothing leaves a box undeclared.]
+- [NEEDS CLARIFICATION (MEDIUM): Should a session that declares a GitHub grant
+  default to its own network address? Only there can the proxy attribute a
+  request to the box that sent it; on a shared namespace a co-resident
+  process gets the session's scoped, audited reach until expiry.]
 - [NEEDS CLARIFICATION (MEDIUM): May a child session declare a repository set
   narrower than its parent's, and may a running session's set change without
   signing in again? Left on 2026-08-20 as something to test against GitHub. A

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -395,9 +395,11 @@ workflow spawns** (GHS-012). GHS-012 binds session, agent and task boxes, the
 types a developer's workflow spawns, which default to developer-attributed
 tokens through a type-supplied attribute; service, build and container-build
 boxes default to App attribution and are outside the epic's criterion, a
-service outliving the workflow that spawned it; a tenant may forbid developer
-attribution per type, with a defaulted grant downgraded and recorded rather
-than silently kept (GHS-012's edge) and an explicit request refused.
+service outliving the workflow that spawned it, and so is any box in a chain
+rooted in a service rather than a developer, whatever its type; a tenant may
+forbid developer attribution per type, with a defaulted grant downgraded and
+recorded rather than silently kept (GHS-012's edge) and an explicit request
+refused.
 
 **Standard git and gh, no forced interface.** Once a developer is signed in,
 git and gh inside a session work as the developer against the real hostnames
@@ -496,6 +498,12 @@ self-enrollment (GHS-025).
   minting within a minute and reaches the proxy's revocation feed (Gatehouse
   F13, T23).
   covered by: GHS-017, GHS-019
+- **Invariant:** THE SYSTEM SHALL hold in a session no sealed GitHub value
+  older than 8 hours.
+  enforced by: renewal before expiry through the credential helper and the
+  identity socket, and the sealed value carrying the credential's own expiry
+  (Gatehouse §5.7, §6.4.1).
+  covered by: GHS-020
 
 ## Open questions
 

--- a/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
+++ b/docs/specs/12-spec-github-sessions/12-spec-github-sessions.md
@@ -40,9 +40,12 @@ starts a remote session, and a push to their project from inside it lands on
 GitHub attributed to them, with no raw credential typed, copied, or present
 anywhere in the session.
 
-**First slice:** The sign-in command, the browser approval, one remote session,
-and a push to the workbench project from inside it with unmodified git through
-the sealed-credential path.
+**First slice:** The sign-in command, the browser approval, the developer's
+own laptop daemon enrolled with the hosted identity plane under that sign-in
+(GHS-025), one local session that declares a GitHub grant, and a push to the
+workbench project from inside it with unmodified git through the
+sealed-credential path. No remote session: the same path on a remote Box Host
+is the second slice, and lands once a provider lists one.
 
 ## Users and stories
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,112 @@
+# Specs
+
+## What a spec is for
+
+A spec is the durable statement of how something is **supposed to behave** — the
+thing you read when the code tells you what it does but not what it was meant to
+do. It is written before the work, and it stays true after it.
+
+That definition does not hold today. Asked where they last looked to find out how
+Minimal was supposed to behave, three people asked a colleague, two read the code,
+and one inferred it by pointing an agent at the repo. One said the spec. Specs
+earning that lookup is the outcome this format is aimed at.
+
+## When you need one
+
+**Specs are for epics. An epic is defined by its complexity** — if the work is
+big or interlocking enough to be an epic, it is big enough to be worth stating
+before you build it.
+
+**Everything below that takes the fast path: no spec.** Bug fixes, paper cuts,
+iterative UI work, a page here and a design tweak there — open an issue and go.
+Requiring a spec for everything is the fastest way to get the process abandoned,
+and two people named exactly that as their refusal condition.
+
+## The format
+
+One file, [`TEMPLATE.md`](TEMPLATE.md). Copy it, delete the guidance comments,
+fill it in.
+
+Two rules run through it:
+
+- **Be succinct, and work hard not to dictate implementation.** State what must
+  be true, not how to build it. This is the most common complaint on this team
+  about the specs we have already written.
+- **Every requirement must be verifiable.** If a line cannot be checked against a
+  running system, it is background, not a requirement.
+
+Behaviour is written in Given/When/Then, because it reads to non-engineers and
+maps one-to-one onto the test suite. A prose-paragraph requirement was proposed
+and rejected on the second rule: a paragraph is not testable. Each behaviour
+carries a failure line and names the test that proves it. There are no
+requirement IDs — the proof name is the anchor — and there is no line limit.
+
+## Lifecycle
+
+    draft -> PR -> review -> merge
+
+**A merged PR is binding.** There is no separate vote, no change cut-off, and no
+frozen state. If a spec needs to change, open a PR against it.
+
+## Review
+
+**The author presents the spec to the team.** Six of seven respondents wanted a
+presentation in some form, and it is the step that makes "binding" mean
+something. Async review on the PR runs alongside it — read it before the meeting,
+leave comments on the PR, use the meeting for what comments cannot resolve.
+
+For a small spec where everyone agrees the meeting adds nothing, skip it and
+review async. That is the exception, not the default.
+
+## Ownership
+
+**The code owner owns the spec** and keeps it aligned with the code. Ownership
+does not lapse when the feature ships.
+
+In practice the person who keeps it true is **whoever last changed the
+behaviour** — if you change how it works, you update the spec in the same
+breath.
+
+## When the implementation diverges
+
+**Update the spec in the same PR that diverges from it.** Not a follow-up issue,
+not a later cleanup pass — the change and the statement of intent land together.
+
+## Specs for code that already exists
+
+Do not backfill wholesale. Write one **only for an area you are about to
+change**, where the spec is about to do work.
+
+## The lint
+
+`scripts/lint-specs.py` runs on PRs that touch this directory and posts what it
+finds as a comment. **It never blocks a merge and is not a required check.** It
+points at missing sections, behaviours with no failure line or no proof, proofs
+naming a test that does not exist, unmeasured adjectives, unresolved CRITICAL
+open questions, missing ownership, and content that belongs somewhere else.
+
+Run it yourself:
+
+```sh
+python3 scripts/lint-specs.py docs/specs/NN-spec-name/NN-spec-name.md
+```
+
+## What lives elsewhere
+
+| | |
+|---|---|
+| Work decomposition | GitHub issues. |
+| Repository and coding standards | `CONTRIBUTING.md`, `AGENTS.md`. |
+| System architecture | [`gominimal/arch`](https://github.com/gominimal/arch), referenced from the spec. |
+| The proofs themselves | The test suite. The spec names them. |
+
+## Where this came from
+
+The format is the result of a team questionnaire run in August 2026 — seven of
+eight engineers responded — not one person's preference.
+
+The post-launch retro had proposed a vote gate before tasking, a change cut-off
+after which specs freeze, and a CI-enforced document length cap. All three were
+put to the team and rejected: **no respondent wanted the vote gate or the
+cut-off, and six of seven rejected the length cap.** That is why none of them
+appear above.


### PR DESCRIPTION
## Summary

The session-side spec for the GitHub sign-in and credential-free repository access epic, [gominimal/inbox#512](https://github.com/gominimal/inbox/issues/512). One of three siblings, one per surface owner; the identity-plane and website siblings are linked below.

It binds: the sign-in command and the browser step it directs to; sign-in required for remote sessions and for local ones whose spec declares a GitHub grant, with a local daemon enrolling itself before its first such session; standard git and gh working inside a session as the developer against the real hostnames; a repository set of the workbench plus what the session declares, with any request carrying the session's sealed value that targets outside it refused with a 403 before it reaches GitHub; a session holding its GitHub credential only as a sealed value it cannot open, never a raw one; the session's spec declaring egress to github.com and api.github.com to hold a grant, and holding a grant only with its own network address, by default or refused otherwise; the interception authority installed only when a grant is declared; connections to credentialed hosts steered to the egress proxy with QUIC blocked; a session's end revoking its identity within 60 seconds; and a child session's set a subset of its parent's, with no prompt.

## Decisions carried

Recorded in Design reasoning as decision, alternatives and reasons, without dates. Custody moved twice: from the architecture's in-session delivery to a host-side facade on 2026-09-03, then to the architecture's sealed-secret and egress-proxy model, ruled on 2026-09-06 and accepted here on 2026-09-08. The five facade requirements are withdrawn and their identifiers retired. Work from every box a developer's workflow spawns is attributed to the developer, which the architecture adopted on 2026-09-05.

Third review (2026-09-08, after the architecture's egress-gateway issues): the 403 binds credentialed requests, per the epic's token-scoped criterion; local sessions sign in at start when their spec declares a grant, replacing the in-session prompt the creation-time architecture cannot honour; attribution binds session, agent and task boxes; a grant defaults the session to its own address; GitHub grants stay allowed on nodes the fabric cannot pin, which a proposed baseline in [gominimal/arch#40](https://github.com/gominimal/arch/issues/40) would forbid; the GitHub host set and the GraphQL rule are bound ahead of the architecture, asked in [gominimal/arch#44](https://github.com/gominimal/arch/issues/44).

## Siblings

- Identity plane: [gominimal/gatehouse#1](https://github.com/gominimal/gatehouse/pull/1)
- Website: [gominimal/webapp#757](https://github.com/gominimal/webapp/pull/757)

## Open questions

No HIGH: the phase gap closes because this work is prioritised above the identity plane's build order and builds the proxy and sealed delivery with it, with no interim credential path. Two MEDIUM: mid-session widening, and consent display with second-session reuse. Two LOW. Closed in the third review: egress enforcement for uncredentialed traffic, now the architecture's egress-gateway chain rather than this epic's prerequisite, and the own-address default, now a requirement.

## Verification

Advisory spec lint run against this tree: every finding is a named test not yet in the repository. No other finding codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtucHmiu7AmiS7hc7EqoGC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reworked the GitHub Sessions specification around sealed, scope-bound credentials delivered through an egress proxy.
  - Clarified that raw credentials and refresh tokens remain outside sessions.
  - Documented repository reachability, request refusal, egress validation, proxy steering, QUIC blocking, and interception-authority requirements.
  - Added session revocation and child-scope inheritance behavior.
  - Added local-daemon self-enrollment on first GitHub use and expanded security invariants, verification tiers, tests, and open questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
