### PR TITLE
docs(specs): add the shared min client core spec for the remote sessions epic

### DIFF
--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -1,0 +1,959 @@
+---
+id: MCC
+title: "Shared min client core: one Rust core for the CLI, the browser and mobile"
+status: draft
+owner: mitodrummer
+epic: gominimal/inbox#513
+arch: https://github.com/gominimal/arch/blob/main/specs/authn-authz/gatehouse-spec.md
+updated: 2026-09-04
+---
+
+# MCC — Shared min client core: one Rust core for the CLI, the browser and mobile
+
+## Context
+
+A developer reaches a session only from the machine that runs `min`. There is
+no browser client, no credential plane in the CLI (a local socket is the whole
+trust boundary), and no client code a second head could reuse. The "Mobile /
+Web Browser" story below needs a client that lives in a tab, and the owner's
+direction rules out any server in the session path: the tab is itself a mesh
+node and SSH terminates in it.
+
+After this ships one Rust core carries the mesh peer, the attach sequence, the
+RPC driver, the credential flow and host trust for every head: the `min` CLI,
+the browser bundle, and later a mobile app. The direction and its decisions
+are in [the direction plan](../../../plans/browser-min-client-direction.plan.md);
+the identity plane is
+[Gatehouse](https://github.com/gominimal/arch/blob/main/specs/authn-authz/gatehouse-spec.md).
+Neither is restated here.
+
+**Success:** A developer signed in with GitHub attaches from a browser tab to a
+session on a `minimald` they own, over a WireGuard tunnel the tab runs, with
+SSH terminating in the tab, authenticated by a certificate on a key the tab
+cannot export and the host verified against the tenant's Host CA; and the same
+`min` binary attaches to the same session through the same core.
+
+**First slice:** The core promoted from the proof of concept with its native
+tests green, the browser bundle driven headlessly from Node through a full
+attach with certificate authentication and host verification against a
+stand-in daemon, and `min` issuing its non-TTY RPCs through the core.
+
+## Users and stories
+
+**Roles:** developer using long-running agentic workflows; developer running
+sessions both locally and remote; the author of the browser client spec in
+gominimal/webapp (id WMC, gominimal/webapp#763), who consumes the contract
+group below.
+
+- AS A developer using long running agentic workflow, I WANT to monitor and
+  jump into an session via a mobile or desktop web browser, SO THAT I can
+  provide additional input and course correct the agent when I'm not at my
+  workstation.
+  Acceptance criteria:
+  - A user can navigate to a session URL in a desktop or mobile browser, and
+    authenticate via GitHub to access the running workbench stream.
+  - The web interface streams session stdout/stderr in real time and accepts
+    terminal input to course-correct active agent runs.
+  - The web session view renders cleanly on mobile screen width in portrait
+    and landscape without breaking terminal text layouts or input controls.
+  - Closing the browser tab or dropping mobile connection leaves the remote
+    session continuously active in a detached state.
+- AS A developer running sessions both locally and remote, I WANT to enumerate
+  and reconnect with remote sessions just like local sessions, SO THAT I can
+  work with all my sessions the same way. Acceptance criterion: remote boxes
+  are enumerable and attachable through the same CLI surface as local ones.
+- AS A first-time developer (gominimal/inbox#494, G3), I WANT to see my boxes
+  and sessions from both the shell and the browser, SO THAT a session is
+  reachable from wherever I am.
+
+## Requirements
+
+### Core boundary (MCC-001–007)
+
+- **MCC-001** THE SYSTEM SHALL provide the network layer, the attach sequence,
+  the RPC driver, the credential module and host policy from one source tree
+  that builds and passes its tests for `wasm32-unknown-unknown` and the native
+  host targets alike.
+  tier:     T0
+  verify:   just wasm-core-headless one_source_tree_attaches_on_the_wasm_target
+
+- **MCC-002** THE SYSTEM SHALL import into the browser bundle no filesystem,
+  terminal, process-spawning, OS-socket or OS-timer capability; the host
+  supplies the byte stream or datagram pipe, the clock, the timer, the HTTP
+  call and the signer.
+  tier:     T0
+  verify:   just wasm-core-headless bundle_imports_no_host_capability
+
+- **MCC-003** THE SYSTEM SHALL decode a daemon's answer in the core and in the
+  CLI from one definition of the wire types the heads and the daemon share:
+  version, sessions, records, screens, mesh status, rename, stop, destroy,
+  abort and exec.
+  tier:     T0
+  verify:   cargo nextest run -p min-wire core_and_cli_decode_from_one_wire_definition
+
+- **MCC-005** THE SYSTEM SHALL make every time-dependent decision —
+  certificate validity, renewal scheduling, keepalive, dead-peer detection,
+  every timeout below — at the clock the host injects, so a test at a fixed
+  instant decides as the running system would at that instant.
+  tier:     T0
+  verify:   cargo nextest run -p min-core time_dependent_decisions_follow_the_injected_clock
+
+- **MCC-006** WHEN the core connects to a daemon THE SYSTEM SHALL negotiate the
+  protocol version before any session operation, report both versions to the
+  head, and refuse a daemon outside the supported window naming both versions
+  and the remedy, or one that has not answered the version exchange within
+  10 s at the injected clock, naming the timeout.
+  tier:     T0
+  verify:   cargo nextest run -p min-core version_outside_window_fails_closed_naming_both_versions
+
+- **MCC-007** THE SYSTEM SHALL carry no host-only dependency in the wire types
+  the browser uses, so the browser bundle is built from the same definition
+  the CLI decodes (MCC-003).
+  tier:     T0
+  verify:   cargo nextest run -p min-wire wire_types_carry_no_host_only_dependency
+
+### Transport and network layer (MCC-010–017)
+
+- **MCC-010** THE SYSTEM SHALL run the attach sequence and the RPC driver over
+  any byte stream the host supplies — a local socket, a TCP stream inside the
+  tunnel, an in-memory pipe under test — exchanging the same messages with
+  the daemon on each.
+  tier:     T0
+  verify:   cargo nextest run -p min-core same_attach_sequence_over_pipe_socket_and_tunnel
+
+- **MCC-011** WHEN the host supplies a datagram pipe and a peer configuration
+  THE SYSTEM SHALL complete a WireGuard handshake with that peer and open TCP
+  connections inside the tunnel, the host supplying only the two datagram
+  queues and the clock.
+  tier:     T0
+  verify:   cargo nextest run -p min-core ssh_attach_through_the_tunnel
+  - IF no handshake response arrives from the peer within 20 s at the
+    injected clock THEN THE SYSTEM SHALL fail the dial with a `transport:`
+    outcome (MCC-064) naming the endpoint tried.
+    tier:   T0
+    verify: cargo nextest run -p min-core silent_handshake_fails_after_20s_at_the_injected_clock
+
+- **MCC-012** WHERE the datagram pipe is a WebSocket THE SYSTEM SHALL carry
+  exactly one WireGuard datagram per binary frame in each direction.
+  tier:     T0
+  verify:   cargo nextest run -p min-core attach_over_websocket_carried_wireguard
+
+- **MCC-013** WHEN the datagram pipe closes or errors THE SYSTEM SHALL fail
+  every TCP stream inside the tunnel and end every attachment and RPC on it
+  with a `tunnel_lost` outcome (MCC-065); the attachment is then closed, and
+  any re-attach is a new attach call by the head at the head's own cadence
+  (MCC-057 for the CLI; WMC-026 and WMC-028 for the page).
+  tier:     T0
+  verify:   cargo nextest run -p min-core dead_websocket_reaches_the_ssh_layer
+  - IF the pipe stays open but no datagram arrives from the peer for 60 s at
+    the injected clock THEN THE SYSTEM SHALL treat the tunnel as lost.
+    tier:   T0
+    verify: cargo nextest run -p min-core silent_peer_is_lost_after_60s_at_the_injected_clock
+
+- **MCC-014** WHEN a node's reachability options include a direct endpoint THE
+  SYSTEM SHALL dial it first, and SHALL dial the node's relay endpoint with
+  the node's ticket only when the direct dial fails or none is offered.
+  tier:     T0
+  verify:   cargo nextest run -p min-core direct_endpoint_first_relay_as_fallback
+
+- **MCC-015** WHEN a head lists nodes THE SYSTEM SHALL return the peer
+  document's node set with the liveness and `last_seen` the identity plane
+  reports (MCC-070), opening no tunnel.
+  tier:     T0
+  verify:   cargo nextest run -p min-core listing_opens_no_tunnel
+
+- **MCC-016** WHEN the host resumes the core after a suspension, such as a tab
+  returned to the foreground, THE SYSTEM SHALL re-evaluate the tunnel at the
+  injected clock on the first tick and, where it is lost (MCC-013), end the
+  attachment with `tunnel_lost` within 1 s of resume rather than leave it
+  hung; re-attaching is the head's own call (MCC-057, WMC-028).
+  tier:     T0
+  verify:   cargo nextest run -p min-core resume_after_suspension_surfaces_the_lost_tunnel_within_1s
+
+- **MCC-017** WHEN a head selects a node THE SYSTEM SHALL open one tunnel to it
+  and list its sessions through the RPC driver (MCC-072); WMC-013 consumes
+  the listing.
+  tier:     T0
+  verify:   cargo nextest run -p min-core selecting_a_node_opens_one_tunnel_and_lists_its_sessions
+
+### Attach and RPC (MCC-020–024)
+
+- **MCC-020** WHEN a head attaches THE SYSTEM SHALL authenticate, open one
+  session channel, set the session identifier, request a PTY of the given
+  size and a shell, then deliver output and the daemon's error stream in
+  order, forward input and window changes, and deliver the exit status.
+  tier:     T0
+  verify:   cargo nextest run -p min-core attach_write_resize_exit
+  - IF the daemon refuses the shell — no session identifier, no PTY, an
+    unknown session — THEN THE SYSTEM SHALL report which request was refused,
+    an unknown session distinguishably (the `attach:` stage of MCC-064).
+    tier:   T0
+    verify: cargo nextest run -p min-core shell_is_refused_without_a_session_id
+
+- **MCC-021** THE SYSTEM SHALL present as the SSH username the principal the
+  head supplies: `minimal-cli` under local trust, the certificate's box login
+  principal under certificate authentication.
+  tier:     T0
+  verify:   cargo nextest run -p min-core ssh_username_is_the_heads_input
+
+- **MCC-022** WHEN a head closes an attachment THE SYSTEM SHALL close the
+  channel and nothing else, leaving the session running and detached.
+  tier:     T0
+  verify:   cargo nextest run -p minimald core_close_detaches_and_leaves_the_session_running
+
+- **MCC-023** WHEN a head issues a oneshot RPC THE SYSTEM SHALL open a session
+  channel, request the RPC's subsystem, send one request, half-close, and
+  return the answer or the daemon's error text; a refused subsystem is
+  reported naming the RPC, never left hanging.
+  tier:     T0
+  verify:   cargo nextest run -p min-core oneshot_rpc_returns_answer_error_or_refusal
+
+- **MCC-024** WHEN `min` runs a non-PTY command against a session — its exec
+  and task paths — THE SYSTEM SHALL drive the exec channel with the daemon's
+  exec vocabulary and propagate the exit code; the browser never requests it
+  (the daemon refuses exec under `Certified`, MMI-027).
+  tier:     T0
+  verify:   cargo nextest run -p min-core exec_channel_speaks_the_daemon_vocabulary
+
+### Credential, the client half (MCC-030–042)
+
+- **MCC-030** THE SYSTEM SHALL sign every SSH authentication request and every
+  DPoP proof through a signer the head supplies, handing it the exact bytes to
+  sign and taking back a raw signature; the attach and credential paths SHALL
+  reach the key only through that signer, never holding, reading or exporting
+  it (an in-memory signer a head constructs for itself is the head's choice,
+  outside those paths).
+  tier:     T1
+  verify:   cargo nextest run -p min-core signer_output_is_the_buffer_extended_with_the_ssh_encoded_signature
+  property: for every to-sign buffer b and algorithm a ∈ {ssh-ed25519, ecdsa-sha2-nistp256}, with s the signer's raw signature over b, the bytes the core hands the SSH layer are exactly b ‖ string(string(a) ‖ string(blob(a, s))), blob being the identity for Ed25519 and the mpint pair (r, s) for P-256; and every DPoP proof is header.claims.base64url(s) with s the signer's signature over the signing input
+  - IF the signer fails or returns a signature of the wrong length THEN THE
+    SYSTEM SHALL abort with a signing failure and send no authentication
+    request.
+    tier:   T0
+    verify: cargo nextest run -p min-core signer_failure_aborts_before_any_auth_request
+
+- **MCC-031** WHEN a credential is supplied THE SYSTEM SHALL authenticate with
+  the certificate and the signer only.
+  tier:     T0
+  verify:   cargo nextest run -p min-core valid_certificate_attaches_and_the_host_certificate_is_verified
+  - IF the daemon refuses the certificate THEN THE SYSTEM SHALL report an
+    authentication refusal and never retry with `auth_none`.
+    tier:   T0
+    verify: cargo nextest run -p min-core each_refusal_case_is_refused
+
+- **MCC-032** THE SYSTEM SHALL accept a host off a local socket only when it
+  presents a host certificate that verifies under the host policy — the
+  certificate decision of MCC-034 for the host type with an empty revocation
+  set (no host KRL in v1, Design reasoning) and the expected principal named
+  exactly or by the per-node wildcard `*.<node_id>.box.<td>` — refusing
+  anything else before authentication with the failing check named.
+  tier:     T1
+  verify:   cargo nextest run -p min-core host_policy_accepts_iff_every_check_holds
+  property: for every (certificate, anchors, expected, now): accept ⇔ decision(certificate, anchors, host, now, revoked = ∅) = ok (MCC-034) ∧ (expected ∈ principals ∨ ∃ p ∈ principals: p = "*." ‖ suffix ∧ expected ends with "." ‖ suffix); a refusal names the first failing check, the decision's order first and the principal last
+  - IF the host presents a bare key, a certificate from outside the anchors,
+    or one for another principal THEN THE SYSTEM SHALL refuse it.
+    tier:   T0
+    verify: cargo nextest run -p min-core host_policy_refuses_a_wrong_principal_a_rogue_ca_and_a_bare_key
+  - WHERE a principal is the per-node wildcard THE SYSTEM SHALL match every
+    name under the node and no name beside it.
+    tier:   T0
+    verify: cargo nextest run -p min-core per_node_wildcard_principals_match_boxes_under_the_node
+
+- **MCC-033** WHERE the transport is a local UDS or vsock THE SYSTEM SHALL
+  accept the daemon without a host certificate, as today.
+  tier:     T0
+  verify:   cargo nextest run -p min-core local_socket_needs_no_host_certificate
+
+- **MCC-034** THE SYSTEM SHALL provide one certificate decision naming the
+  same codes the daemon's decision names (MMI-022): the seven the
+  architecture's vectors expect — `bad_signature`, `unknown_ca`,
+  `wrong_cert_type`, `cert_not_yet_valid`, `cert_expired`,
+  `unknown_critical_option`, `cert_revoked` — and the core's own
+  `principal_mismatch` for a principal the certificate does not carry.
+  tier:     T1
+  verify:   cargo nextest run -p min-core every_invalid_vector_is_refused_with_its_expected_error
+  property: for every certificate, anchor set, expected type, clock, revocation set and principal, the decision accepts iff every check holds, and a refusal carries the code of the first failing check in the order signature, issuer, type, validity, critical options, revocation, principal
+  - WHEN the architecture's user vector is presented THE SYSTEM SHALL accept
+    it for its principals and refuse every other.
+    tier:   T0
+    verify: cargo nextest run -p min-core valid_user_vector_is_accepted_for_its_principals_only
+
+- **MCC-035** WHEN a head signs in THE SYSTEM SHALL run the public-client
+  flow — a PKCE S256 challenge and the RFC 7638 thumbprint of the signer's
+  key on the authorization request, the verifier and a DPoP proof on the
+  token request, refresh with rotation, the tokens held in the core's
+  memory — differing between heads only in the authorization leg: the
+  browser's HTTPS redirect, the CLI's device flow (GHS-006). Persistence
+  beyond memory is the head's: none in the browser (MCC-076, WMC-004), the
+  CLI's refresh token in its own store (MCC-050).
+  tier:     T0
+  verify:   cargo nextest run -p min-core login_is_pkce_and_dpop_bound_for_every_head
+
+- **MCC-036** THE SYSTEM SHALL attach a fresh DPoP proof, signed through the
+  signer, to every token, certify, mesh-bind, relay-ticket and revoke
+  request it makes.
+  tier:     T0
+  verify:   cargo nextest run -p min-core every_issuer_request_carries_a_fresh_dpop_proof
+
+- **MCC-037** WHEN a head requests a credential while the core holds an access
+  token with `box:ssh` THE SYSTEM SHALL request a certificate for the
+  signer's public key with the profile and TTL the head configures:
+  `interactive` for the CLI, `exchange` with a TTL of at most 900 s for the
+  browser.
+  tier:     T0
+  verify:   cargo nextest run -p min-core certify_carries_the_heads_profile_and_ttl
+
+- **MCC-038** THE SYSTEM SHALL take Host CA anchors only from the CA endpoint
+  of the issuer named in the credential it holds — never from the page
+  origin, the peer, the relay or a peer-document field — and SHALL attempt
+  no attach while it holds none.
+  tier:     T0
+  verify:   cargo nextest run -p min-core anchors_come_only_from_the_credentials_issuer
+  - IF a peer document's issuer field differs from the credential's issuer
+    THEN THE SYSTEM SHALL refuse the document and open no tunnel from it.
+    tier:   T0
+    verify: cargo nextest run -p min-core peer_document_with_a_foreign_issuer_is_refused
+
+- **MCC-039** WHILE an attachment is open under a certificate THE SYSTEM SHALL
+  obtain a fresh certificate 120 s before the current one expires,
+  re-handshake over the same tunnel, re-attach, and continue with the
+  attachment object unchanged (MCC-069) and no action from the user.
+  tier:     T0
+  verify:   cargo nextest run -p min-core renewal_reattaches_before_expiry_at_the_injected_clock
+  - IF the issuer cannot be reached in time THEN THE SYSTEM SHALL let the
+    attachment end at expiry with `credential_expired` (MCC-065), leave the
+    session detached, and retry nothing itself; the re-attach is the head's
+    new attach call at the head's cadence (WMC-007 for the page, MCC-057 for
+    the CLI).
+    tier:   T0
+    verify: cargo nextest run -p min-core issuer_outage_ends_attach_at_expiry_with_credential_expired
+
+- **MCC-040** WHERE the head is a browser THE SYSTEM SHALL renew without user
+  presence only while an attachment is open and less than 8 h have passed
+  since the presence-backed initial certify that began the chain (plan entry
+  8); past either bound, the next attach requires a presence-backed certify.
+  The CLI's rule is MCC-056.
+  tier:     T0
+  verify:   cargo nextest run -p min-core renewal_chain_stops_at_8h_or_without_an_open_attach
+
+- **MCC-041** WHERE the head is a browser THE SYSTEM SHALL generate a fresh
+  WireGuard keypair in memory per page session, request a binding for its
+  public key under the DPoP-bound token, use it for at most 8 h, and discard
+  it when the page session ends. The CLI's node key is MCC-053's.
+  tier:     T0
+  verify:   cargo nextest run -p min-core browser_mesh_key_is_fresh_per_page_session_bound_and_discarded
+
+- **MCC-042** THE SYSTEM SHALL use a head's signing key for DPoP proofs and
+  SSH authentication signatures only, and SHALL derive no SSH-PoP (`sshpop`)
+  assertion from it; a request to an issuer, relay or node is authenticated
+  with DPoP or the SSH certificate, never with an SSH-PoP assertion.
+  tier:     T0
+  verify:   cargo nextest run -p min-core heads_key_signs_only_dpop_and_ssh_userauth
+
+### CLI adoption (MCC-050–058)
+
+- **MCC-050** WHEN a developer runs `min auth login` THE SYSTEM SHALL sign in
+  through the shared credential module by the device flow (MCC-035, GHS-006),
+  obtain the interactive certificate and the Host CA anchors, and keep the
+  key in the CLI's own store (keychain or agent) and the refresh token in the
+  CLI's credential store, neither surviving in the core's memory past the
+  process.
+  tier:     T0
+  verify:   cargo nextest run -p minimal auth_login_installs_certificate_and_anchors
+
+- **MCC-051** WHEN `min` reaches a daemon over any transport other than a
+  local UDS or vsock THE SYSTEM SHALL apply the host policy (MCC-032) and
+  certificate authentication (MCC-031), refusing a daemon that presents a bare
+  key.
+  tier:     T0
+  verify:   cargo nextest run -p minimal remote_daemon_needs_a_host_certificate_and_a_credential
+
+- **MCC-052** WHEN a developer attaches to a session THE SYSTEM SHALL run the
+  attach in-process through the core — raw-mode terminal, resize and signal
+  handling in `min` — with no system `ssh` on the path.
+  tier:     T0
+  verify:   cargo nextest run -p minimal session_attach_runs_in_process_without_ssh
+  - WHILE the system `ssh` remains the TTY attach path THE SYSTEM SHALL
+    generate its `known_hosts` `@cert-authority` fragment from the same
+    anchors and expected principal the host policy uses.
+    tier:   T0
+    verify: cargo nextest run -p minimal known_hosts_fragment_matches_host_policy
+
+- **MCC-053** WHEN a developer runs `min net mesh join <network>` (today `min
+  mesh join`; the architecture's command tree renames it) THE SYSTEM SHALL
+  obtain the binding and the peer document through the credential module and
+  bring the mesh up through the core's network layer over UDP, with no manual
+  key exchange, keeping its mesh node key across invocations for the lifetime
+  of the enrollment (its rotation is an open question).
+  tier:     T0
+  verify:   cargo nextest run -p minimal mesh_join_needs_no_manual_key_exchange
+
+- **MCC-054** WHEN a developer lists sessions THE SYSTEM SHALL include the
+  sessions on every node of the peer document, addressed and attachable with
+  the same grammar as local ones.
+  tier:     T0
+  verify:   cargo nextest run -p minimal list_and_attach_use_one_grammar_for_mesh_nodes
+
+- **MCC-055** WHILE a daemon is reached over a local UDS or vsock THE SYSTEM
+  SHALL keep today's behaviour: `auth_none`, no host certificate, no sign-in.
+  tier:     T0
+  verify:   cargo nextest run -p minimal local_socket_sessions_are_unchanged
+
+- **MCC-056** WHILE `min` holds a refresh token THE SYSTEM SHALL renew the
+  interactive certificate in the background before it expires (Gatehouse
+  §5.7), with no open attachment required and no chain cap beyond the refresh
+  token's own lifetime.
+  tier:     T0
+  verify:   cargo nextest run -p minimal cli_renews_interactive_certificate_in_background
+
+- **MCC-057** WHEN an in-process attachment (MCC-052) ends with `tunnel_lost`
+  or `credential_expired` THE SYSTEM SHALL re-attach by a new attach call,
+  retrying with backoff from 1 s doubling to a 30 s cap until the daemon is
+  reachable and a certificate is held again or the developer detaches,
+  showing a reconnecting state on the terminal and landing on the daemon's
+  repaint (MCC-063).
+  tier:     T0
+  verify:   cargo nextest run -p minimal cli_reattaches_after_loss_with_bounded_backoff
+
+- **MCC-058** WHEN a developer runs `min auth status` THE SYSTEM SHALL report
+  the certificate's principals and expiry and whether a refresh token is held,
+  printing neither.
+  tier:     T0
+  verify:   cargo nextest run -p minimal auth_status_reports_principals_and_expiry
+
+### Browser contract (MCC-060–080)
+
+The browser client spec in gominimal/webapp (WMC) cites these by ID.
+Sub-groups: attach MCC-060–063, errors MCC-064–065, signer and credential
+helpers MCC-066–069, peer document MCC-070, ticket MCC-071, rpc MCC-072,
+bundle integrity MCC-073–075, custody MCC-076–078, size budget MCC-079,
+status MCC-080. Page behaviour is cited to WMC by requirement ID and verified
+there.
+
+- **MCC-060** WHEN the page calls attach with one JSON configuration document,
+  a signer callback, a data callback and a close callback THE SYSTEM SHALL
+  resolve to an attachment offering `write(bytes)`, `resize(cols, rows)` and
+  `close()`, and deliver every byte of session output and of the daemon's
+  error stream, merged in order, to the data callback.
+  tier:     T0
+  verify:   just wasm-core-headless attach_api_shape
+  - IF the attach has not reached the accepted shell within 30 s of the call
+    at the injected clock THEN THE SYSTEM SHALL reject with the prefix of the
+    stage reached (MCC-064).
+    tier:   T0
+    verify: just wasm-core-headless attach_that_never_completes_rejects_within_30s
+
+- **MCC-061** THE SYSTEM SHALL accept as the configuration document the node's
+  peer-document entry (MCC-070) as served, the session identifier, the
+  terminal type and size, and an auth block naming the SSH username and the
+  expected host principal, the certificate and anchors being those the core
+  holds (MCC-067); the document has no scrollback field and the core declares
+  no scrollback request (MMI-052 is a later daemon capability); a missing or
+  malformed field rejects the promise naming the field before any network
+  activity.
+  tier:     T0
+  verify:   just wasm-core-headless config_rejections_name_the_field_before_dialing
+
+- **MCC-062** THE SYSTEM SHALL deliver bytes passed to `write` to the session
+  PTY unmodified and in call order, and apply a `resize` to the session PTY
+  in order with the writes around it.
+  tier:     T0
+  verify:   just wasm-core-headless input_and_resize_are_ordered_and_unmodified
+
+- **MCC-063** WHEN an attachment is established, at first attach and after
+  every transparent renewal, THE SYSTEM SHALL deliver as the first bytes to
+  the data callback the first bytes the daemon writes — its reconstruction of
+  the session's current screen (MMI-051) — adding nothing before them and
+  asking for no scrollback ahead of them; the page's rendering of the repaint
+  is WMC-029.
+  tier:     T0
+  verify:   cargo nextest run -p min-core first_bytes_delivered_are_the_daemons_first_bytes_unprefixed
+
+- **MCC-064** IF the attach fails THEN THE SYSTEM SHALL reject the promise,
+  with no attachment object, carrying a reason whose prefix names the stage:
+  `config:`; `credential:` (the core's own pre-check of its certificate at
+  the injected clock before any dial — expired, not yet valid, host or CA
+  mismatch); `version:`; `transport:` (the relay named when it refused the
+  ticket; a dial or handshake that did not complete in time); `host
+  rejected:` with the failing check's code; `authentication rejected`;
+  `signing:`; `attach:` (the daemon refused the env, pty or shell request,
+  naming which, with `unknown session` distinguishable from every other
+  refusal, or the channel closed before the shell was established).
+  tier:     T0
+  verify:   just wasm-core-headless attach_rejections_name_the_stage
+
+- **MCC-065** WHEN an attachment ends THE SYSTEM SHALL call the close callback
+  exactly once with one cause and an exit status only for `exit`, mapping
+  the daemon's exit signals (MMI-053) and the transport as follows: `exit`
+  for the shell's own exit; `superseded` for `SUPERSEDED@minimal.dev`
+  (another client took the session over); `credential_expired` for
+  `EXPIRED@minimal.dev` (the daemon ended the session at certificate expiry
+  because a renewal did not land in time); `revoked` for
+  `REVOKED@minimal.dev`; `daemon_shutdown` for `SHUTDOWN@minimal.dev`;
+  `tunnel_lost` for a transport loss (MCC-013); `closed` when the head closed
+  it (MCC-022).
+  tier:     T0
+  verify:   just wasm-core-headless close_causes_are_distinct_and_status_only_on_exit
+  - IF `SUPERSEDED@minimal.dev` arrives on a channel the core is itself
+    replacing during a renewal (MCC-069) THEN THE SYSTEM SHALL consume it and
+    surface no close.
+    tier:   T0
+    verify: just wasm-core-headless own_renewal_supersession_is_not_surfaced
+
+- **MCC-066** THE SYSTEM SHALL call the signer callback with the exact bytes to
+  sign and require a raw signature back, 64 bytes for Ed25519, performing
+  every SSH and JWS encoding itself; the page never encodes.
+  tier:     T0
+  verify:   just wasm-core-headless signer_gets_bytes_and_returns_a_raw_signature
+
+- **MCC-067** THE SYSTEM SHALL perform the token exchange, refresh, certify,
+  anchors fetch, mesh-bind, relay-ticket request, renewal and the
+  refresh-token revoke at sign-out itself over an HTTP callback the page
+  supplies, produce the authorization URL the page navigates to, and consume
+  the callback the page hands back, checking its `state` against the request
+  and its `iss` against the deployment issuer set before exchanging; the page
+  composes none of these requests.
+  tier:     T0
+  verify:   just wasm-core-headless credential_helpers_run_in_the_core_over_the_supplied_fetch
+  - IF the callback's `iss` is outside the issuer set or its `state` does not
+    match THEN THE SYSTEM SHALL exchange nothing and report a sign-in failure
+    naming neither the issuer nor the code (WMC-001).
+    tier:   T0
+    verify: just wasm-core-headless foreign_iss_or_bad_state_exchanges_nothing
+
+- **MCC-068** THE SYSTEM SHALL send the certify request and read its response
+  as Gatehouse §6.6 shapes them, and fetch the anchors as §8.2 shapes
+  `GET {iss}/v1/ssh/ca`.
+  tier:     T0
+  verify:   cargo nextest run -p min-core certify_and_anchors_exchanges_match_gatehouse
+
+- **MCC-069** WHILE an attachment is open THE SYSTEM SHALL renew (MCC-039) by
+  opening the new connection and attaching with the fresh certificate first,
+  then closing its old channel itself — with no second attach call, no change
+  to the attachment object and no close callback, the head observing only the
+  repaint (MCC-063), within the chain cap (MCC-040); where the daemon
+  supersedes the old channel before the core closes it (MMI-053), the
+  resulting `SUPERSEDED@minimal.dev` is consumed (MCC-065).
+  tier:     T0
+  verify:   just wasm-core-headless renewal_is_invisible_to_the_page
+
+- **MCC-070** THE SYSTEM SHALL consume from the subject's peer document: per
+  subject and mesh, the tab's tunnel address and prefix length; per node,
+  node identity and friendly name, the node's WireGuard public key, the
+  node's tunnel address, the SSH port, the expected host principal, the
+  issuer field (checked against the credential's, MCC-038), the liveness the
+  identity plane reports with its `last_seen` time, and the reachability
+  options — a direct WebSocket endpoint and/or a relay endpoint with a
+  ticket.
+  tier:     T0
+  verify:   cargo nextest run -p min-core peer_document_maps_onto_the_attach_configuration
+
+- **MCC-071** WHEN dialing through a relay THE SYSTEM SHALL present the node's
+  ticket opaque and unmodified at WebSocket open, use a ticket only for the
+  node it was issued for, and obtain a new one when the relay reports it
+  expired.
+  tier:     T0
+  verify:   cargo nextest run -p min-core relay_ticket_is_opaque_per_node_and_presented_at_open
+
+- **MCC-072** THE SYSTEM SHALL run the browser's v1 command set through the RPC
+  driver (MCC-023) over the selected node's tunnel with the taxonomy of
+  MCC-064: list sessions → each session's name, state and last activity;
+  show → a session's record and current screen; rename → the session renamed
+  or the daemon's refusal; stop → `StopSession` (MMI-028): the session's
+  process ended and the session listed with no running attributes; version →
+  the daemon's version (MCC-006).
+  tier:     T0
+  verify:   just wasm-core-headless v1_rpcs_run_through_the_driver_with_the_attach_taxonomy
+
+- **MCC-073** THE SYSTEM SHALL publish the wasm module and its JS glue as
+  content-addressed assets with one `SHA256SUMS` manifest per CLI release,
+  covering the bundle that release was built with, and `min` SHALL verify a
+  served bundle's hash against the manifest of the release whose core version
+  the bundle reports (MCC-074); checksums are per release, and the auto-cut
+  `release-<sha>` releases make per-commit and per-release the same artefact
+  for a pre-release bundle (what WMC-038 vendors).
+  tier:     T0
+  verify:   cargo nextest run -p minimal served_bundle_hash_verifies_against_the_release_manifest
+
+- **MCC-074** THE SYSTEM SHALL expose, before any network activity, its own
+  version and the daemon protocol window it speaks, so a served bundle
+  reports the core version its checksums were published under (MCC-073); the
+  refusal of a daemon outside the window is MCC-006's, surfaced as
+  `version:` (MCC-064).
+  tier:     T0
+  verify:   just wasm-core-headless version_signal_is_exposed_before_dialing
+
+- **MCC-075** THE SYSTEM SHALL run the browser bundle with `'wasm-unsafe-eval'`
+  as the only script-source allowance beyond `'self'`, needing no
+  `'unsafe-eval'` and no inline script; the page's policy and its loading
+  under integrity are WMC-035 and WMC-036.
+  tier:     T0
+  verify:   just wasm-core-headless bundle_runs_without_unsafe_eval_or_inline_script
+
+- **MCC-076** WHERE the head is a browser THE SYSTEM SHALL hold tokens,
+  certificates, the binding and the mesh key in memory only, the bundle
+  importing no storage capability — web storage, IndexedDB, cookies, the
+  cache — so a reload re-mints through the identity plane's browser session;
+  the page's own storage rule is WMC-004.
+  tier:     T0
+  verify:   just wasm-core-headless bundle_imports_no_storage_capability
+
+- **MCC-077** WHERE the head is a browser THE SYSTEM SHALL take the signing key
+  only as a signer callback: no entry point of the bundle accepts private-key
+  bytes; the key's non-extractability is the page's (WMC-003).
+  tier:     T0
+  verify:   just wasm-core-headless browser_entry_points_accept_no_private_key
+
+- **MCC-078** THE SYSTEM SHALL open network connections only to the
+  credential's issuer, the node endpoints the configuration names, and the
+  relays the configuration names, and to nothing else.
+  tier:     T0
+  verify:   just wasm-core-headless bundle_dials_only_the_issuer_and_configured_endpoints
+
+- **MCC-079** THE SYSTEM SHALL deliver the stripped wasm module at no more than
+  600 KB gzip-compressed (the core ceiling WMC-N02 cites) and its JS glue at
+  no more than 20 KB, measured at each release.
+  tier:     T0
+  verify:   just wasm-core-budget
+
+- **MCC-080** WHEN a head asks for status THE SYSTEM SHALL report the
+  certificate's serial and remaining lifetime at the injected clock, the
+  tunnel path in use (direct or relay) and the age of its last handshake, and
+  the last error code of MCC-064 or MCC-065, from memory and persisting
+  nothing; WMC-031 renders it.
+  tier:     T0
+  verify:   just wasm-core-headless status_reports_certificate_tunnel_and_last_error
+
+## Non-goals
+
+- The daemon's mesh ingress, certificate-auth surface and allowlist, host
+  certificate, rejection delay, terminal state and repaint, supersession, the
+  exit signals, and the relay service:
+  `docs/specs/14-spec-minimald-mesh-ingress/14-spec-minimald-mesh-ingress.md`
+  in this repo, drafted in parallel.
+- The browser page — origin, policy, integrity loading, key generation,
+  storage rule, reconnect cadence, rendering, mobile layout, the terminal
+  emulator, its tests: the browser client spec in gominimal/webapp (WMC).
+- The identity plane's capabilities — the public-client kind, certify for that
+  client, the peer document and node listing, heartbeats, relay tickets, the
+  §5.7 wording for a 15-minute certificate: gominimal/gatehouse, the
+  `01-spec-*` lineage, with the open questions below as the asks.
+- The mobile app and its in-process network stack: plan S13, later, from the
+  same core.
+- Session recording: plan S9 and Gatehouse §14.4(1); daemon-side if ever.
+- Sharing a session and teammate access: plan S8, later.
+- Creating a session, workspace sync, loadouts, file patches, hooks,
+  diagnostics and agent dispatch from the browser: outside the core by
+  construction (no filesystem or TTY in a tab).
+- GitHub sign-in UX and credential-free git from sessions: the GitHub
+  sessions spec (GHS) in this repo; MCC-050 is the credential it rides on.
+- Hosts reached only through providers in the client-managed Box Provider
+  List, un-enrolled with Gatehouse: invisible to the tab in v1 (plan S2),
+  carried with the peer-document open question.
+
+## Non-functional requirements
+
+- **MCC-N01** WHILE attaching over a loopback datagram pipe with certificate
+  authentication and host verification THE SYSTEM SHALL reach the accepted
+  shell request within 200 ms at p95 of the transport opening, measured at
+  the client boundary.
+  tier:   T0
+  verify: just wasm-core-headless attach_latency_p95_under_200ms
+
+- **MCC-N02** WHILE attached over loopback THE SYSTEM SHALL deliver a
+  keystroke's echo to the data callback within 5 ms at p95 of the `write`
+  call.
+  tier:   T0
+  verify: just wasm-core-headless keystroke_round_trip_p95_under_5ms
+
+- **MCC-N03** WHEN the datagram transport closes THE SYSTEM SHALL deliver the
+  close callback within 1 s.
+  tier:   T0
+  verify: just wasm-core-headless tunnel_loss_closes_within_1s
+
+## Design reasoning
+
+**One core, several heads** (decided 2026-09-03, plan §3.1). The alternatives,
+Tailscale's Go browser client and a purpose-built TypeScript thin client,
+both put a second implementation of the mesh peer, the SSH client and host
+trust next to the CLI's, and the first brings a second identity system whose
+SSH skips host-key verification, against Gatehouse §6.2. One Rust core is the
+literal form of "the website is just one more client" (minimal-hosted §1) and
+of the client credential library "also embedded in the `min` client"
+(Gatehouse §4.1); the proof of concept priced it at 91 KB gzip for the network
+layer and a forty-line WireGuard clock patch.
+
+**Crate shape** (plan §4.3; mechanism, so it lives here). `min-core`,
+wasm-clean, holds the network layer, attach, RPC driver, credential module
+and host policy (MCC-001, MCC-002); `min-core-web` is the wasm-bindgen head
+exporting the contract group; `min-wire` carries the wire types carved out of
+`minimald-rpc` and `sessions::wire` with no `common` or `args` dependency,
+which MCC-007 observes. The cryptographic backend is a target-gated,
+non-default feature — `ring` for the browser, the workspace's native backend
+elsewhere — so a native `--workspace` build enables exactly one; MCC-004
+stated that as a requirement and was retired on 2026-09-04 as mechanism, its
+ID not reused. The `min-` prefix is deliberate beside `minimal-*` and
+`minimald-*`: the client core, not the `minimal` crate whose binary is `min`.
+Promotion updates AGENTS.md's crate table and `docs/architecture.md` §3
+(plan S5) and widens the justfile's macOS `scope` to `min-core`, which
+builds there.
+
+**The tab is a mesh node and no server is in the session path** (decided
+2026-09-03, plan entries 12, 18, 23, 24). Servers remain for the page,
+Gatehouse, notifications and a stateless relay forwarding WireGuard
+ciphertext for daemons behind NAT; none holds a box credential or sees SSH
+bytes. A daemon exposes no inbound listener by default and connects outbound
+to its relay; the tab dials direct first (MCC-014) because a reachable daemon
+needs no relay.
+
+**A public client with tokens in memory** (decided 2026-09-03, entries 10,
+15–17). With no backend nothing but the tab can hold tokens, and every token
+is sender-constrained to a non-extractable key (Gatehouse §5.4), which is
+what §6.1.7's rule guarded against. The core holds tokens in memory on every
+head; what outlives the process is the head's — none in the browser (MCC-076,
+WMC-004), the CLI's refresh token in its store (MCC-050). A reload re-mints
+through the SSO session, the client has its own origin, and the bundle is
+content-addressed with one manifest per CLI release (MCC-073); because the
+pipeline auto-cuts a `release-<sha>` per commit on `main`, a pre-release
+bundle's per-commit checksums and its release manifest are one artefact. The
+origin serving the page is trusted for code integrity, never for data, and
+checkably so.
+
+**A 15-minute certificate with transparent renewal, capped** (decided
+2026-09-03, entries 7, 8, 22). The `interactive` 8 h profile would keep §5.7's
+wall warnings at the price of an 8 h window for an XSS that drives the key;
+`exchange` at 15 min keeps the window short and makes reconnect a core duty
+(MCC-039). Unattended renewals stop at the binding's 8 h and without an open
+attach (MCC-040), so the profiles are equivalent in XSS terms and differ in
+revocation latency only. The chain is anchored at the presence-backed initial
+certify (plan entry 8); WMC-009 counts from the sign-in and must align to the
+certify, or the two differ by the length of a login. A Gatehouse outage
+detaches at the next renewal with no grace period. The daemon-side repaint
+makes each forced reconnect land on a full screen, which is why the
+mesh-ingress spec is a v1 prerequisite and MCC-063 states the repaint as
+observed.
+
+**Re-attach ownership** (decided 2026-09-04). A transport-initiated loss
+closes the attachment: the close callback fires once with `tunnel_lost`, and
+any re-attach is a new attach call by the head at its own cadence — MCC-057
+for the CLI; WMC-007, WMC-026 and WMC-028 for the page. The core binds no
+cadence, because when a head wants to be attached is a policy no head can
+express to it. A core-initiated reconnect, the transparent renewal, keeps
+the attachment object, fires no close callback, and shows the head only the
+repaint (MCC-069, MCC-063): the core attaches on the new connection first,
+then closes its old channel itself, and a `SUPERSEDED@minimal.dev` the daemon
+sends on that old channel is consumed, never surfaced as `superseded`
+(MCC-065); MMI-053 carries the mirror statement. One cause per daemon exit
+signal keeps WMC-030's "attached elsewhere" and a revocation distinct.
+
+**Host-certificate revocation** (decided 2026-09-04). v1 does not consult the
+KRL for host certificates: the host policy runs the shared decision with an
+empty revocation set (MCC-032). The exposure is a compromised host key that
+stays acceptable until its certificate's 30-day expiry (Gatehouse §5.7) or a
+Host CA rotation; user-certificate revocation is the daemon's KRL
+(MMI-034–037). Carried as an open question.
+
+**Constants.** The 60 s silent-peer bound (MCC-013) is twice the 25 s
+persistent keepalive the network layer configures; 20 s to the first
+handshake response (MCC-011) is four WireGuard handshake retries at its 5 s
+interval; 10 s for the version exchange (MCC-006) and 30 s for the whole
+attach (MCC-060) are the handshake bound plus SSH key exchange,
+authentication and the attach requests, which take 200 ms at p95 on loopback
+(MCC-N01). Every one is decided at the injected clock (MCC-005).
+
+**Credential helpers run in the core over an injected HTTP call** (decided
+2026-09-04, MCC-067). The proof of concept let the page perform certify and
+mesh-bind. Renewal must run inside the core during an open attach, and one
+request shape across heads is the point of sharing, so the core composes and
+parses every issuer request — the callback's `state` and `iss` checks and the
+revoke at sign-out included — and the host executes it, the same seam as the
+clock; the page only navigates the authorization leg. Anchors are pinned to
+the issuer the credential names (MCC-038): a peer document may repeat that
+issuer, never select it, which is what makes "tenant issuer only" true.
+
+**In-memory mesh key, Ed25519 first** (decided 2026-09-03, entries 3, 11). The
+WireGuard implementation takes the static secret as bytes, so a
+WebCrypto-held X25519 key needs a static-DH hook in the noise core; v1
+accepts an in-memory key rotated per page session and bounded by the 8 h
+binding (MCC-041), the held key being plan S13 hardening. The CLI's node key
+lives as long as the enrollment (MCC-053): a peer that re-keys on every run
+is not the mesh peer plan S6 describes. P-256 is a one-variant fallback for
+the FIPS profile, covered by MCC-030's property.
+
+**Listing is the identity plane's node set plus heartbeats** (decided
+2026-09-03, entry 21). The tab reads nodes, liveness and `last_seen` in one
+call and handshakes only with the node it attaches to (MCC-015, MCC-017); a
+proof-of-concept design that opened a tunnel per node for liveness was
+retired by it.
+
+**CLI adoption order** (decided 2026-09-03, entry 6). The target is the
+in-process attach (MCC-052); the first step shares the non-TTY parts and keeps
+the `ssh` binary for TTY attach with a `known_hosts` fragment from the same
+policy, because that changes a daily-driver path last. The CLI's sign-in leg
+is the device flow the GitHub sessions spec chose (GHS-006 owns its UX),
+DPoP-bound like the browser's auth-code leg (Gatehouse §6.1.2); MCC-035
+shares everything after it. The CLI keeps what the browser must not: a
+refresh token in its store with background renewal (MCC-056), a node key for
+the enrollment's lifetime (MCC-053), and its own reconnect cadence (MCC-057).
+
+**Bundle budget** (decided 2026-09-03, entry 25). 447 KB gzip was accepted for
+v1 and the certificate path measured 501 KB stripped; MCC-079 bounds the
+module at 600 KB, the figure WMC-N02 cites, and the glue separately. The diet
+is later work.
+
+**Working assumptions, not decisions.** Four defaults the owner confirmed on
+2026-09-04 (recorded in WMC) stay written as assumptions so a reversal is one
+visible edit: A1, the v1 browser command set is owner-only list, show,
+attach, rename and stop (MCC-072), with no create, sync, agent dispatch or
+share links; A2, the plan's decisions above stand; A3, the browser client
+lives on its own origin served from the webapp repo (MCC-075, WMC-035); A4,
+the Gatehouse capabilities this spec consumes are dependencies on the identity
+plane, bound by name and carried as HIGH open questions where the architecture
+has not ruled. Overturning one changes the requirements it names, not the
+core's shape.
+
+**Tiers.** Three universals are at T1 — the signer's output shape (MCC-030),
+the host-policy decision (MCC-032) and the certificate decision (MCC-034) —
+because each is a pure function over owned values a property test can drive
+across its input space, and stating the universal forbids interleaving them
+with the transport; the property-testing dependency is confined to
+`min-core`'s development dependencies. T2 was declined because the decisions
+include a signature verification no bounded harness can exhaust. Everything
+else is T0 because it reaches a socket, a daemon or a browser. MCC-001's
+check is the headless attach on the wasm target: the second target compiling
+and running is the observable.
+
+**Verification mechanics.** Native tests run under `cargo nextest` through
+`just test` (`just test-cross` on macOS). `just wasm-core` builds the bundle;
+`just wasm-core-headless` drives the built module from Node against a native
+stand-in through the certificate-authenticated attach and inspects the
+module's import section (MCC-002, MCC-076), the gate before any bundle
+reaches the web side; `just wasm-core-budget` measures MCC-079. MCC-022 uses
+the mesh-ingress spec's daemon harness. Page behaviour is verified in WMC
+under its own runner; this spec names no test of WMC's.
+
+**Generality:** A second head fits by construction: the mobile app is the same
+core behind a UDP datagram pipe and a keystore-backed signer; the CLI is the
+same core behind a local socket and an agent-backed signer. A second daemon
+fits if it terminates SSH inside a WireGuard tunnel and presents a Gatehouse
+host certificate. A second transport is a datagram pipe. A second identity
+plane does not fit: the certify, anchors, peer-document and ticket shapes
+(MCC-068, MCC-070, MCC-071) are Gatehouse's by decision, acceptable because
+Gatehouse is the only identity plane in the system (§6.9).
+
+## Security considerations
+
+- **Invariant:** THE SYSTEM SHALL never hold, read or export a head's signing
+  key in its attach or credential paths; every signature is the head's
+  signer's, over bytes the core supplies.
+  enforced by: the signer seam as the only signing path, and the browser's
+  non-extractable key behind a callback (WMC-003).
+  covered by: MCC-030, MCC-066, MCC-077
+- **Invariant:** THE SYSTEM SHALL attach to no host off a local socket without
+  a host certificate verifying, for the expected principal, against anchors
+  taken from the tenant issuer only.
+  enforced by: the host policy in the server-key check, aborting before
+  authentication (Gatehouse §6.2, no TOFU); the anchors fetch bound to the
+  issuer the credential names, with a peer document naming another issuer
+  refused.
+  covered by: MCC-032, MCC-038, MCC-051
+- **Invariant:** THE SYSTEM SHALL present no bearer credential and derive no
+  SSH-PoP assertion from a head's key; every issuer, relay and node request
+  is DPoP-bound or certificate-authenticated.
+  enforced by: DPoP proofs on every request and PKCE with `dpop_jkt` at
+  sign-in (Gatehouse §6.1.1); the head's key used for DPoP and SSH
+  authentication signatures only.
+  covered by: MCC-035, MCC-036, MCC-042
+- **Invariant:** THE SYSTEM SHALL renew a browser credential unattended for at
+  most 8 h and only while an attachment is open, and hold a browser mesh key
+  for at most 8 h.
+  enforced by: the renewal-chain cap and the binding TTL at the injected
+  clock (Gatehouse §6.9, T22).
+  covered by: MCC-039, MCC-040, MCC-041, MCC-069
+- **Invariant:** THE SYSTEM SHALL persist no token, certificate, key handle or
+  mesh key in a browser, and open no connection from the bundle to an
+  endpoint other than the credential's issuer and the configured endpoints.
+  enforced by: in-memory holders in the core, a bundle importing no storage
+  capability, the page's storage rule (WMC-004), and the core dialing only
+  the issuer and configured endpoints.
+  covered by: MCC-076, MCC-078
+- **Invariant:** THE SYSTEM SHALL run only a bundle whose hash matches the
+  published manifest, and fail closed on a daemon outside the supported
+  protocol window.
+  enforced by: content-addressed assets with one manifest per release, the
+  CLI-verifiable manifest, version negotiation before any session operation,
+  and the page's integrity loading (WMC-036).
+  covered by: MCC-006, MCC-073, MCC-074
+
+## Open questions
+
+- [NEEDS CLARIFICATION (HIGH): A public-client registration kind does not
+  exist in the architecture of record: Gatehouse §6.1.7 says tokens never
+  reach the browser and a SPA holding tokens is out of v1 scope; §14.4(2)
+  leaves the in-browser path open. This spec needs a `public` kind — PKCE
+  with `dpop_jkt`, exact-match HTTPS redirect URIs, DPoP required, no client
+  authentication, tokens held by the client on a non-extractable key, and the
+  statement that the client's key never becomes an SSH-PoP key. MCC-035,
+  MCC-036, MCC-042, MCC-067 and MCC-076 wait on the ruling.]
+- [NEEDS CLARIFICATION (HIGH): Certify for the browser client. §6.1.7 grants
+  web clients no `box:ssh` by default, the website's registration
+  (minimal-hosted §4, §7) omits it, and §6.9 keeps `JoinMesh` deny-by-default.
+  This spec needs both as tenant opt-ins for the public client, a personal
+  tenant's sole admin opting in for themselves, both key thumbprints audited
+  on certify. MCC-037, MCC-041 and MCC-068 depend on it.]
+- [NEEDS CLARIFICATION (HIGH): A 15-minute `exchange` certificate for an
+  interactive browser session. §5.7 gives interactive users 8 h with wall
+  warnings at T-15 and T-1 min. This spec renews at T-2 min with the warnings
+  suppressed for a client that reconnects transparently, caps the unattended
+  chain at 8 h from the initial certify and requires presence there; §5.7
+  must say so. MCC-039, MCC-040 and MCC-069 depend on it.]
+- [NEEDS CLARIFICATION (HIGH): The peer document, node listing and
+  heartbeats. §6.9 issues bindings but no peer configuration; §9 holds nodes
+  with `last_seen` but exposes no per-subject read; §8.2 has no endpoint for
+  either. This spec needs one read returning the fields MCC-070 lists, with
+  liveness and `last_seen` from daemon heartbeats. MCC-014, MCC-015, MCC-017,
+  MCC-053, MCC-054 and MCC-070 depend on it; the un-enrolled provider-list
+  gap rides with it.]
+- [NEEDS CLARIFICATION (HIGH): The relay tier and its tickets. No
+  architecture text describes a stateless ciphertext relay, a Gatehouse-issued
+  per-node ticket bound to the tab's DPoP key, or the daemon's outbound relay
+  connection under `sshpop-host`; box-provider-api §1 and the Cloudflare
+  sketch §1 keep the provider out of the box data path, which a ciphertext
+  relay needs restating. The protocol is the mesh-ingress spec's; the ticket's
+  issuer and shape are Gatehouse's. MCC-014 and MCC-071 depend on it.]
+- [NEEDS CLARIFICATION (MEDIUM): Which principal the host certificate carries
+  for a tunnel-addressed connection. §5.3 lists the names and IPs clients may
+  connect to; the tab dials a tunnel address. Either the address is a
+  principal or the peer document names the node's canonical name and the core
+  resolves it. MCC-032 and MCC-070 allow either; the document must pick one.]
+- [NEEDS CLARIFICATION (MEDIUM): Host-certificate revocation. v1 checks no
+  KRL for host certificates (MCC-032, Design reasoning), leaving a
+  compromised host key acceptable until its 30-day certificate expires
+  (Gatehouse §5.7). Does the identity plane want the client to consult the
+  KRL for host serials, and if so from which feed — the same §8.2 feed the
+  daemon polls (MMI-035) fetched by the core over MCC-067's HTTP callback?]
+- [NEEDS CLARIFICATION (MEDIUM): The CLI's mesh node key lifetime and
+  rotation. MCC-053 keeps it for the enrollment's lifetime; whether it
+  rotates on a schedule, on `min auth login`, or only on re-enrollment, and
+  what the daemon's binding check (MMI-010) needs from a rotation, is
+  unset.]
+- [NEEDS CLARIFICATION (MEDIUM): The SSH username under certificate
+  authentication (plan S4): the box login principal as bound in MCC-021, or
+  the canonical subject with the daemon deriving the sandbox user. The core
+  takes it as input either way; the mesh-ingress spec decides.]
+- [NEEDS CLARIFICATION (MEDIUM): The width of the supported version-skew
+  window (architecture open gap 8). MCC-006 and MCC-074 fail closed outside
+  it; its width is unset.]
+- [NEEDS CLARIFICATION (MEDIUM): The wasm head's packaging for the webapp —
+  npm versioning of `min-core-web`, the wasm-bindgen pin policy, and how the
+  webapp consumes the release manifest of MCC-073.]
+- [NEEDS CLARIFICATION (LOW): Stop is `StopSession` (MMI-028) and bound in
+  MCC-003 and MCC-072; destroy stays Local-only in the daemon (MMI-027). Does
+  the browser ever get destroy of an exited session, which WMC today does not
+  offer?]
+- [NEEDS CLARIFICATION (LOW): Whether `minimald`'s WireGuard pump moves onto
+  the core's network layer or keeps its own driver over the same crate; the
+  mesh-ingress spec's call, invisible to this spec's behaviours.]
+- [NEEDS CLARIFICATION (LOW): Interoperability with WireGuard peers that are
+  not the daemon's implementation; MCC-011 is proven
+  implementation-to-implementation only.]

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -894,33 +894,33 @@ Gatehouse is the only identity plane in the system (§6.9).
   with `dpop_jkt`, exact-match HTTPS redirect URIs, DPoP required, no client
   authentication, tokens held by the client on a non-extractable key, and the
   statement that the client's key never becomes an SSH-PoP key. MCC-035,
-  MCC-036, MCC-042, MCC-067 and MCC-076 wait on the ruling.]
+  MCC-036, MCC-042, MCC-067 and MCC-076 wait on the ruling. Filed: gominimal/arch#16.]
 - [NEEDS CLARIFICATION (HIGH): Certify for the browser client. §6.1.7 grants
   web clients no `box:ssh` by default, the website's registration
   (minimal-hosted §4, §7) omits it, and §6.9 keeps `JoinMesh` deny-by-default.
   This spec needs both as tenant opt-ins for the public client, a personal
   tenant's sole admin opting in for themselves, both key thumbprints audited
-  on certify. MCC-037, MCC-041 and MCC-068 depend on it.]
+  on certify. MCC-037, MCC-041 and MCC-068 depend on it. Filed: gominimal/arch#16.]
 - [NEEDS CLARIFICATION (HIGH): A 15-minute `exchange` certificate for an
   interactive browser session. §5.7 gives interactive users 8 h with wall
   warnings at T-15 and T-1 min. This spec renews at T-2 min with the warnings
   suppressed for a client that reconnects transparently, caps the unattended
   chain at 8 h from the initial certify and requires presence there; §5.7
-  must say so. MCC-039, MCC-040 and MCC-069 depend on it.]
+  must say so. MCC-039, MCC-040 and MCC-069 depend on it. Filed: gominimal/arch#16.]
 - [NEEDS CLARIFICATION (HIGH): The peer document, node listing and
   heartbeats. §6.9 issues bindings but no peer configuration; §9 holds nodes
   with `last_seen` but exposes no per-subject read; §8.2 has no endpoint for
   either. This spec needs one read returning the fields MCC-070 lists, with
   liveness and `last_seen` from daemon heartbeats. MCC-014, MCC-015, MCC-017,
   MCC-053, MCC-054 and MCC-070 depend on it; the un-enrolled provider-list
-  gap rides with it.]
+  gap rides with it. Filed: gominimal/arch#19 and gominimal/arch#17.]
 - [NEEDS CLARIFICATION (HIGH): The relay tier and its tickets. No
   architecture text describes a stateless ciphertext relay, a Gatehouse-issued
   per-node ticket bound to the tab's DPoP key, or the daemon's outbound relay
   connection under `sshpop-host`; box-provider-api §1 and the Cloudflare
   sketch §1 keep the provider out of the box data path, which a ciphertext
   relay needs restating. The protocol is the mesh-ingress spec's; the ticket's
-  issuer and shape are Gatehouse's. MCC-014 and MCC-071 depend on it.]
+  issuer and shape are Gatehouse's. MCC-014 and MCC-071 depend on it. Filed: gominimal/arch#18.]
 - [NEEDS CLARIFICATION (MEDIUM): Which principal the host certificate carries
   for a tunnel-addressed connection. §5.3 lists the names and IPs clients may
   connect to; the tab dials a tunnel address. Either the address is a

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -421,7 +421,7 @@ group below.
   tier:     T0
   verify:   cargo nextest run -p minimal auth_status_reports_principals_and_expiry
 
-### Browser contract (MCC-060–080)
+### Browser contract (MCC-060–081)
 
 The browser client spec in gominimal/webapp (WMC) cites these by ID.
 Sub-groups: attach MCC-060–063, errors MCC-064–065, signer and credential
@@ -473,7 +473,8 @@ there.
   with no attachment object, carrying a reason whose prefix names the stage:
   `config:`; `credential:` (the core's own pre-check of its certificate at
   the injected clock before any dial — expired, not yet valid, host or CA
-  mismatch); `version:`; `transport:` (the relay named when it refused the
+  mismatch — and a credential call that failed, in the shape MCC-081 gives
+  it); `version:`; `transport:` (the relay named when it refused the
   ticket; a dial or handshake that did not complete in time); `host
   rejected:` with the failing check's code; `authentication rejected`;
   `signing:`; `attach:` (the daemon refused the env, pty or shell request,
@@ -623,6 +624,23 @@ there.
   nothing; WMC-031 renders it.
   tier:     T0
   verify:   just wasm-core-headless status_reports_certificate_tunnel_and_last_error
+
+- **MCC-081** IF a credential call of MCC-067 fails THEN THE SYSTEM SHALL
+  report it to the head in one of two shapes and no other: `credential:
+  refused (<code>)` when the issuer answered with an error, carrying the
+  issuer's error code and its human-readable reason verbatim; `credential:
+  unreachable` when no well-formed answer arrived within the call's bound
+  (a connection, TLS, timeout or non-JSON failure), carrying the transport
+  detail; so that a head can show the issuer's reason on a refusal and
+  choose between retrying and signing in again without parsing anything
+  else (WMC-006, WMC-007).
+  tier:     T0
+  verify:   just wasm-core-headless credential_call_failures_are_refused_or_unreachable
+  - IF the call that failed was a renewal during an open attach THEN THE
+    SYSTEM SHALL keep the attachment open and report the failure through the
+    status accessor (MCC-080) until the certificate expires (MCC-039).
+    tier:   T0
+    verify: just wasm-core-headless renewal_failure_is_reported_without_closing_the_attachment
 
 ## Non-goals
 

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -240,9 +240,10 @@ MMI by ID.
     tier:   T0
     verify: cargo nextest run -p min-core each_refusal_case_is_refused
 
-- **MCC-032** THE SYSTEM SHALL accept a host off a local socket only when its
-  host certificate verifies under the host policy — MCC-034's decision for
-  the host type with an empty revocation set — for the expected principal,
+- **MCC-032** THE SYSTEM SHALL accept a host reached over any transport other
+  than a local UDS or vsock (MCC-033) only when its host certificate verifies
+  under the host policy — MCC-034's decision for the host type with an
+  empty revocation set — for the expected principal,
   named exactly or by the per-node wildcard `*.<node_id>.box.<td>`,
   refusing anything else before authentication with the failing check
   named.
@@ -308,7 +309,8 @@ MMI by ID.
 
 - **MCC-038** THE SYSTEM SHALL take Host CA anchors only from
   `{iss}/v1/ssh/ca` of the issuer named in the credential it holds
-  (Gatehouse §8.2), and SHALL attempt no attach while it holds none.
+  (Gatehouse §8.2), and SHALL attempt no certificate-authenticated attach
+  while it holds none; a local UDS or vsock needs none (MCC-033).
   tier:     T1
   verify:   cargo nextest run -p min-core anchors_come_only_from_the_credentials_issuer
   property: for every credential c, every peer document d and every anchor state: the only anchors request the core composes is to `{iss}/v1/ssh/ca` for c's issuer; d is refused and opens no tunnel whenever its `td` differs from c's trust domain; and no attach is composed while no anchors are held
@@ -849,9 +851,10 @@ Gatehouse is the only identity plane in the system.
   enforced by: the signer seam as the only signing path, and the browser's
   non-extractable key behind a callback (WMC-003).
   covered by: MCC-030, MCC-066, MCC-077
-- **Invariant:** THE SYSTEM SHALL attach to no host off a local socket
-  without a host certificate verifying, for the expected principal,
-  against anchors taken from the tenant issuer only.
+- **Invariant:** THE SYSTEM SHALL attach to no host reached over a
+  transport other than a local UDS or vsock without a host certificate
+  verifying, for the expected principal, against anchors taken from the
+  tenant issuer only.
   enforced by: the host policy in the server-key check, aborting before
   authentication (Gatehouse §6.2, no TOFU); the anchors fetch bound to the
   issuer the credential names.

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -130,8 +130,9 @@ MMI by ID.
   connections inside the tunnel.
   tier:     T0
   verify:   cargo nextest run -p min-core ssh_attach_through_the_tunnel
-  - IF no handshake response arrives within 20 s THEN THE SYSTEM SHALL fail
-    the dial with a `transport:` outcome (MCC-064) naming the endpoint.
+  - IF no handshake response arrives within 20 s of the dial request,
+    a pipe that never opens included, THEN THE SYSTEM SHALL cancel the dial
+    and fail it with a `transport:` outcome (MCC-064) naming the endpoint.
     tier:   T0
     verify: cargo nextest run -p min-core silent_handshake_fails_after_20s_at_the_injected_clock
 
@@ -154,9 +155,10 @@ MMI by ID.
 
 - **MCC-014** WHEN a node advertises a direct endpoint THE SYSTEM SHALL dial
   it first, and dial the node's home relay with the node's ticket only when
-  the direct dial fails — a refused connection, or no handshake response
-  within MCC-011's 20 s — or none is advertised (Gatehouse §6.9;
-  architecture D7); the fallback runs inside MCC-060's attach bound.
+  the direct dial fails — a refused connection, or MCC-011's 20 s passing
+  from the dial request with no handshake response, the pipe never opening
+  included — or none is advertised (Gatehouse §6.9; architecture D7); the
+  fallback runs inside MCC-060's attach bound.
   tier:     T0
   verify:   cargo nextest run -p min-core direct_endpoint_first_relay_as_fallback
 
@@ -184,8 +186,8 @@ MMI by ID.
 - **MCC-020** WHEN a head attaches THE SYSTEM SHALL authenticate, open one
   session channel, set the session identifier, request a PTY of the given
   size and a shell, deliver output and the daemon's error stream in the
-  order they arrive on the channel, which is the order the daemon wrote
-  them, forward input and window changes, and deliver the exit status.
+  order they arrive on the channel, forward input and window changes, and
+  deliver the exit status.
   tier:     T0
   verify:   cargo nextest run -p min-core attach_write_resize_exit
   - IF the daemon refuses the shell THEN THE SYSTEM SHALL report which
@@ -252,7 +254,7 @@ MMI by ID.
   named.
   tier:     T1
   verify:   cargo nextest run -p min-core host_policy_accepts_iff_every_check_holds
-  property: for every (certificate, anchors, expected, now): accept ⇔ decision(certificate, anchors, host, now, revoked = ∅) = ok (MCC-034) ∧ (expected ∈ principals ∨ ∃ p ∈ principals: p = "*." ‖ suffix ∧ expected ends with "." ‖ suffix); a refusal names the first failing check, the decision's order first and the principal last
+  property: for every host reached over a transport other than a local UDS or vsock and every (certificate, anchors, expected, now): accept ⇔ decision(certificate, anchors, host, now, revoked = ∅) = ok (MCC-034) ∧ (expected ∈ principals ∨ ∃ p ∈ principals: p = "*." ‖ suffix ∧ expected ends with "." ‖ suffix); a refusal names the first failing check, the decision's order first and the principal last; over a local UDS or vsock the decision is not consulted (MCC-033)
   - IF the host presents a bare key, a certificate from outside the anchors,
     or one for another principal THEN THE SYSTEM SHALL refuse it.
     tier:   T0
@@ -316,7 +318,7 @@ MMI by ID.
   while it holds none; a local UDS or vsock needs none (MCC-033).
   tier:     T1
   verify:   cargo nextest run -p min-core anchors_come_only_from_the_credentials_issuer
-  property: for every credential c, every peer document d and every anchor state: the only anchors request the core composes is to `{iss}/v1/ssh/ca` for c's issuer; d is refused and opens no tunnel whenever its `td` differs from c's trust domain; and no attach is composed while no anchors are held
+  property: for every credential c, every peer document d and every anchor state: the only anchors request the core composes is to `{iss}/v1/ssh/ca` for c's issuer; d is refused and opens no tunnel whenever its `td` differs from c's trust domain; and no certificate-authenticated attach is composed while no anchors are held, an attach over a local UDS or vsock (MCC-033) needing none
   - IF a peer document's `td` differs from the credential's trust domain
     THEN THE SYSTEM SHALL refuse the document and open no tunnel from it.
     tier:   T0

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -153,8 +153,9 @@ MMI by ID.
 
 - **MCC-014** WHEN a node advertises a direct endpoint THE SYSTEM SHALL dial
   it first, and dial the node's home relay with the node's ticket only when
-  the direct dial fails or none is advertised (Gatehouse §6.9; architecture
-  D7).
+  the direct dial fails — a refused connection, or no handshake response
+  within MCC-011's 20 s — or none is advertised (Gatehouse §6.9;
+  architecture D7); the fallback runs inside MCC-060's attach bound.
   tier:     T0
   verify:   cargo nextest run -p min-core direct_endpoint_first_relay_as_fallback
 
@@ -181,8 +182,9 @@ MMI by ID.
 
 - **MCC-020** WHEN a head attaches THE SYSTEM SHALL authenticate, open one
   session channel, set the session identifier, request a PTY of the given
-  size and a shell, deliver output and the daemon's error stream in order,
-  forward input and window changes, and deliver the exit status.
+  size and a shell, deliver output and the daemon's error stream in the
+  order they arrive on the channel, which is the order the daemon wrote
+  them, forward input and window changes, and deliver the exit status.
   tier:     T0
   verify:   cargo nextest run -p min-core attach_write_resize_exit
   - IF the daemon refuses the shell THEN THE SYSTEM SHALL report which
@@ -428,8 +430,8 @@ and verified there.
   document, a signer callback, a data callback and a close callback THE
   SYSTEM SHALL resolve to an attachment offering `write(bytes)`,
   `resize(cols, rows)` and `close()`, and deliver every byte of session
-  output and of the daemon's error stream, merged in order, to the data
-  callback.
+  output and of the daemon's error stream, merged in channel arrival order
+  (MCC-020), to the data callback.
   tier:     T0
   verify:   just wasm-core-headless attach_api_shape
   - IF the attach has not reached the accepted shell within 30 s of the
@@ -492,18 +494,22 @@ and verified there.
     verify: just wasm-core-headless own_renewal_supersession_is_not_surfaced
 
 - **MCC-066** THE SYSTEM SHALL call the signer callback with the exact bytes
-  to sign and require a raw signature back, 64 bytes for Ed25519,
-  performing every SSH and JWS encoding itself.
+  to sign and require a raw signature back — 64 bytes for Ed25519, and
+  64 bytes r ‖ s for P-256 under the FIPS profile, the algorithm being the
+  head key's — performing every SSH and JWS encoding itself (MCC-030).
   tier:     T0
   verify:   just wasm-core-headless signer_gets_bytes_and_returns_a_raw_signature
 
 - **MCC-067** THE SYSTEM SHALL perform the token exchange, refresh, certify,
   anchors fetch, mesh-bind, node listing, peer-document fetch, relay-ticket
   request, renewal and the revoke at sign-out itself over the HTTP call the
-  host supplies, produce the authorization URL the page navigates to, and
+  host supplies, which follows no redirect (a 3xx answer is a refused call,
+  MCC-081), produce the authorization URL the page navigates to, and
   consume the callback the page hands back, checking its `state` against
-  the request and its `iss` against the issuer set (Gatehouse §6.1.6)
-  before exchanging; the page composes none of these requests.
+  the request and its `iss` against the issuer set before exchanging; the
+  check is set membership, not equality with the issuer the request
+  started at, because the front door may land a sign-in on a tenant
+  issuer (Gatehouse §6.1.6); the page composes none of these requests.
   tier:     T0
   verify:   just wasm-core-headless credential_helpers_run_in_the_core_over_the_supplied_fetch
   - IF the callback's `iss` is outside the issuer set or its `state` does
@@ -567,7 +573,9 @@ and verified there.
 - **MCC-073** THE SYSTEM SHALL publish the wasm module and its JS glue as
   content-addressed assets with one manifest per CLI release, and `min`
   SHALL verify a served bundle's hash against the manifest of the release
-  whose core version the bundle reports (MCC-074).
+  whose core version the bundle reports (MCC-074), refusing a bundle whose
+  core release is older than `min`'s own, so that a server cannot roll a
+  client back to an older valid bundle.
   tier:     T0
   verify:   cargo nextest run -p minimal served_bundle_hash_verifies_against_the_release_manifest
 
@@ -619,8 +627,8 @@ and verified there.
   report it to the head in one of two shapes: `credential: refused (<code>)`
   when the issuer answered with an error, carrying its code and reason
   verbatim; `credential: unreachable` when no well-formed answer arrived
-  within the call's bound, carrying the transport detail (WMC-006,
-  WMC-007).
+  within 10 s at the injected clock, the call being cancelled at that
+  bound, carrying the transport detail (WMC-006, WMC-007).
   tier:     T0
   verify:   just wasm-core-headless credential_call_failures_are_refused_or_unreachable
   - IF the call that failed was a renewal during an open attach THEN THE
@@ -746,10 +754,11 @@ rule.
 
 **Constants.** 60 s silent-peer (MCC-013) is twice the 25 s keepalive; 20 s
 to the first handshake response (MCC-011) is four WireGuard retries at 5 s;
-10 s for the version exchange (MCC-006) and 30 s for the whole attach
-(MCC-060) are the handshake bound plus key exchange, authentication and the
-attach requests, which the proof of concept measured at 55 ms median on
-loopback.
+10 s for the version exchange (MCC-006) and for a credential call
+(MCC-081), and 30 s for the whole attach (MCC-060), are the handshake bound
+plus key exchange, authentication and the attach requests, which the proof
+of concept measured at 55 ms median on loopback; a direct dial that fails
+at 20 s leaves 10 s for the relay fallback (MCC-014).
 
 **Credential helpers run in the core over an injected HTTP call** (decided
 2026-09-04, MCC-067). Renewal must run inside the core during an open

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -5,7 +5,7 @@ status: draft
 owner: mitodrummer
 epic: gominimal/inbox#513
 arch: https://github.com/gominimal/arch/blob/main/specs/authn-authz/gatehouse-spec.md
-updated: 2026-09-08
+updated: 2026-09-09
 ---
 
 # MCC — Shared min client core: one Rust core for the CLI, the browser and mobile
@@ -36,7 +36,10 @@ cannot export and the host verified against the tenant's Host CA; and the same
 **First slice:** The core promoted from the proof of concept with its native
 tests green, the browser bundle driven headlessly from Node through a full
 attach with certificate authentication and host verification against a
-stand-in daemon, and `min` issuing its non-TTY RPCs through the core.
+stand-in daemon, and `min` issuing its non-TTY RPCs through the core — so
+that a developer runs `min session list` and sees a mesh node's sessions
+beside the local ones, then watches the headless attach land on one of
+them.
 
 ## Users and stories
 
@@ -62,30 +65,34 @@ group below.
   and reconnect with remote sessions just like local sessions, SO THAT I can
   work with all my sessions the same way. Acceptance criterion: remote boxes
   are enumerable and attachable through the same CLI surface as local ones.
-- AS A first-time developer (gominimal/inbox#494, G3), I WANT to see my boxes
-  and sessions from both the shell and the browser, SO THAT a session is
-  reachable from wherever I am.
+
+The initiative's own words for the browser half of the second story are
+gominimal/inbox#494's sixth done-when step, "See boxes and sessions from
+both the shell and the browser."; it is not a story and is not transcribed
+as one. The epic's "Sync Files Out" story reaches no spec yet (Non-goals).
 
 ## Requirements
 
 ### Core boundary (MCC-001–007)
 
-- **MCC-001** THE SYSTEM SHALL provide the network layer, the attach sequence,
-  the RPC driver, the credential module and host policy from one source tree
-  that builds and passes its tests for `wasm32-unknown-unknown` and the native
-  host targets alike.
+- **MCC-001** THE SYSTEM SHALL build and pass the same tests of the network
+  layer, the attach sequence, the RPC driver, the credential module and host
+  policy for `wasm32-unknown-unknown` and the native host targets alike.
   tier:     T0
   verify:   just wasm-core-headless one_source_tree_attaches_on_the_wasm_target
 
 - **MCC-002** THE SYSTEM SHALL import into the browser bundle no filesystem,
   terminal, process-spawning, OS-socket or OS-timer capability; the host
   supplies the byte stream or datagram pipe, the clock, the timer, the HTTP
-  call and the signer.
+  call and the signer. The host's timer delivers ticks; a suspension is any
+  interval in which the host delivers none (a tab in the background, a
+  sleeping device), and a resume is the first tick delivered after it
+  (MCC-016).
   tier:     T0
   verify:   just wasm-core-headless bundle_imports_no_host_capability
 
-- **MCC-003** THE SYSTEM SHALL decode a daemon's answer in the core and in the
-  CLI from one definition of the wire types the heads and the daemon share:
+- **MCC-003** THE SYSTEM SHALL decode a daemon's answer identically in the
+  core and in the CLI for every wire type the heads and the daemon share:
   version, sessions, records, screens, mesh status, rename, stop, destroy,
   abort and exec.
   tier:     T0
@@ -100,17 +107,14 @@ group below.
 
 - **MCC-006** WHEN the core connects to a daemon THE SYSTEM SHALL negotiate the
   protocol version before any session operation, report both versions to the
-  head, and refuse a daemon outside the supported window naming both versions
-  and the remedy, or one that has not answered the version exchange within
-  10 s at the injected clock, naming the timeout.
-  tier:     T0
+  head, and refuse a daemon outside its protocol window — `protocol_window`,
+  the range of daemon protocol versions the core is built to accept, an
+  interim whose default width is an open question (architecture open gap
+  8) — naming both versions and the remedy, or one that has not answered the
+  version exchange within 10 s at the injected clock, naming the timeout.
+  tier:     T1
   verify:   cargo nextest run -p min-core version_outside_window_fails_closed_naming_both_versions
-
-- **MCC-007** THE SYSTEM SHALL carry no host-only dependency in the wire types
-  the browser uses, so the browser bundle is built from the same definition
-  the CLI decodes (MCC-003).
-  tier:     T0
-  verify:   cargo nextest run -p min-wire wire_types_carry_no_host_only_dependency
+  property: for every window W the core is built with, every daemon version v and every answer time t at the injected clock, a session operation is issued iff v ∈ W and t ≤ 10 s; otherwise nothing but the version exchange is sent, and the refusal names both versions and the remedy, or the timeout
 
 ### Transport and network layer (MCC-010–017)
 
@@ -134,7 +138,9 @@ group below.
     verify: cargo nextest run -p min-core silent_handshake_fails_after_20s_at_the_injected_clock
 
 - **MCC-012** WHERE the datagram pipe is a WebSocket THE SYSTEM SHALL carry
-  exactly one WireGuard datagram per binary frame in each direction.
+  exactly one WireGuard datagram per binary frame in each direction, the
+  framing the daemon's ingress (MMI-001) and the relay (MMI-072) parse
+  (Gatehouse §6.9).
   tier:     T0
   verify:   cargo nextest run -p min-core attach_over_websocket_carried_wireguard
 
@@ -198,7 +204,10 @@ group below.
 
 - **MCC-021** THE SYSTEM SHALL present as the SSH username the principal the
   head supplies: `minimal-cli` under local trust, the certificate's box login
-  principal under certificate authentication.
+  principal under certificate authentication — the box login user of
+  Gatehouse §5.3 (e.g. `dev`), among the certificate's principals and never
+  in canonical-subject form, the value MMI-024 admits; an interim until the
+  mesh-ingress spec's final rule (Open questions).
   tier:     T0
   verify:   cargo nextest run -p min-core ssh_username_is_the_heads_input
 
@@ -283,8 +292,9 @@ group below.
   same codes the daemon's decision names (MMI-022): the seven the
   architecture's vectors expect — `bad_signature`, `unknown_ca`,
   `wrong_cert_type`, `cert_not_yet_valid`, `cert_expired`,
-  `unknown_critical_option`, `cert_revoked` — and the core's own
-  `principal_mismatch` for a principal the certificate does not carry.
+  `unknown_critical_option`, `cert_revoked` — and `principal_mismatch` for a
+  principal the certificate does not carry, which the daemon's decision
+  names too (MMI-022).
   tier:     T1
   verify:   cargo nextest run -p min-core every_invalid_vector_is_refused_with_its_expected_error
   property: for every certificate, anchor set, expected type, clock, revocation set and principal, the decision accepts iff every check holds, and a refusal carries the code of the first failing check in the order signature, issuer, type, validity, critical options, revocation, principal
@@ -308,10 +318,11 @@ group below.
   verify:   cargo nextest run -p min-core login_is_pkce_and_dpop_bound_for_every_head
 
 - **MCC-036** THE SYSTEM SHALL attach a fresh DPoP proof, signed through the
-  signer, to every token, certify, mesh-bind, relay-ticket and revoke
-  request it makes (Gatehouse §6.1.7, §6.9).
-  tier:     T0
+  signer, to every token, certify, mesh-bind, node-listing, peer-document,
+  relay-ticket and revoke request it makes (Gatehouse §6.1.7, §6.9, §8.2).
+  tier:     T1
   verify:   cargo nextest run -p min-core every_issuer_request_carries_a_fresh_dpop_proof
+  property: for every issuer request r the core composes for the host to send, r carries a DPoP proof signed through the signer whose `htm` and `htu` are r's method and URL and whose `jti` differs from every proof composed before it
 
 - **MCC-037** WHEN a head requests a credential while the core holds an access
   token with `box:ssh` THE SYSTEM SHALL request a certificate for the
@@ -329,9 +340,10 @@ group below.
   Gatehouse §6.1.7, §8.2) — never from the page origin, the peer, the relay
   or a peer-document field — and SHALL attempt no attach while it holds
   none.
-  tier:     T0
+  tier:     T1
   verify:   cargo nextest run -p min-core anchors_come_only_from_the_credentials_issuer
-  - IF a peer document's issuer field differs from the credential's issuer
+  property: for every credential c, every peer document d and every anchor state: the only anchors request the core composes is to `{iss}/v1/ssh/ca` for c's issuer; d is refused and opens no tunnel whenever its `td` differs from c's trust domain; and no attach is composed while no anchors are held
+  - IF a peer document's `td` differs from the credential's trust domain
     THEN THE SYSTEM SHALL refuse the document and open no tunnel from it.
     tier:   T0
     verify: cargo nextest run -p min-core peer_document_with_a_foreign_issuer_is_refused
@@ -359,17 +371,20 @@ group below.
   presence step — a user gesture at the head, never a fresh sign-in — which
   starts a new chain; the identity plane's browser session may complete that
   certify silently (WMC-009). The CLI's rule is MCC-056.
-  tier:     T0
+  tier:     T1
   verify:   cargo nextest run -p min-core renewal_chain_stops_at_8h_or_without_an_open_attach
+  property: for every attachment state a ∈ {open, closed}, every chain start c and every instant now at the injected clock, an unattended renewal is composed iff a = open and now − c < 8 h; past either bound the next certify is composed only after a presence step
 
 - **MCC-041** WHERE the head is a browser THE SYSTEM SHALL generate a fresh
-  WireGuard keypair in memory per page session, request a binding for its
-  public key under the DPoP-bound token (`JoinMesh`, a tenant opt-in for a
-  `public` client, Gatehouse §6.9), use it for at most 8 h, and discard it
-  when the page session ends (§6.9, client mesh keys; a WebCrypto-held key
-  is plan S13). The CLI's node key is MCC-053's.
-  tier:     T0
+  WireGuard keypair in memory per page session — the lifetime of one
+  document, ended by a reload or a navigation (MCC-076) — request a binding
+  for its public key under the DPoP-bound token (`JoinMesh`, a tenant opt-in
+  for a `public` client, Gatehouse §6.9), use it for at most 8 h, and
+  discard it when the page session ends (§6.9, client mesh keys; a
+  WebCrypto-held key is plan S13). The CLI's node key is MCC-053's.
+  tier:     T1
   verify:   cargo nextest run -p min-core browser_mesh_key_is_fresh_per_page_session_bound_and_discarded
+  property: for every page session s, the mesh keypair the core holds during s was generated after s began and differs from every earlier session's; no handshake uses it later than 8 h after its binding at the injected clock; and no handle to it survives the end of s
 
 - **MCC-042** THE SYSTEM SHALL use a head's signing key for DPoP proofs and
   SSH authentication signatures only, and SHALL derive no SSH-PoP (`sshpop`)
@@ -377,17 +392,16 @@ group below.
   with DPoP or the SSH certificate, never with an SSH-PoP assertion
   (Gatehouse §6.1.7: the tab's DPoP key is never an SSH-PoP or
   DPoP-for-boxes key).
-  tier:     T0
+  tier:     T1
   verify:   cargo nextest run -p min-core heads_key_signs_only_dpop_and_ssh_userauth
+  property: for every buffer b the core hands the signer, b is a DPoP proof's signing input or an SSH userauth request; no b is the signing input of an SSH-PoP assertion
 
 ### CLI adoption (MCC-050–058)
 
 - **MCC-050** WHEN a developer runs `min auth login` THE SYSTEM SHALL sign in
-  through the shared credential module by the device flow (MCC-035, GHS-006),
-  obtain the interactive certificate and the Host CA anchors, and keep the
-  key in the CLI's own store (keychain or agent) and the refresh token in the
-  CLI's credential store, neither surviving in the core's memory past the
-  process.
+  by the device flow (MCC-035, GHS-006), obtain the interactive certificate
+  and the Host CA anchors, and keep the key and the refresh token in the
+  CLI's own stores, neither surviving in the core's memory past the process.
   tier:     T0
   verify:   cargo nextest run -p minimal auth_login_installs_certificate_and_anchors
 
@@ -398,14 +412,15 @@ group below.
   tier:     T0
   verify:   cargo nextest run -p minimal remote_daemon_needs_a_host_certificate_and_a_credential
 
-- **MCC-052** WHEN a developer attaches to a session THE SYSTEM SHALL run the
-  attach in-process through the core — raw-mode terminal, resize and signal
-  handling in `min` — with no system `ssh` on the path.
+- **MCC-052** WHEN a developer attaches to a session THE SYSTEM SHALL attach
+  with raw-mode terminal, resize and signal handling, on a machine with no
+  `ssh` binary present.
   tier:     T0
   verify:   cargo nextest run -p minimal session_attach_runs_in_process_without_ssh
-  - WHILE the system `ssh` remains the TTY attach path THE SYSTEM SHALL
-    generate its `known_hosts` `@cert-authority` fragment from the same
-    anchors and expected principal the host policy uses.
+  - WHILE the TTY attach still runs through the system `ssh` — the first
+    adoption step (Design reasoning), until the in-process attach ships —
+    THE SYSTEM SHALL generate its `known_hosts` `@cert-authority` fragment
+    from the same anchors and expected principal the host policy uses.
     tier:   T0
     verify: cargo nextest run -p minimal known_hosts_fragment_matches_host_policy
 
@@ -414,17 +429,20 @@ group below.
   request a §6.9 binding and consume the peer document through the
   credential module (the command's shape since Gatehouse v1.14: the manual
   key exchange is retired, the daemon's static peer table being the POC
-  interim, MMI-011) and bring the mesh up through the core's network layer
-  over UDP, keeping its mesh node key across invocations for the lifetime of
-  the enrollment (its rotation is an open question).
+  interim, MMI-011) and bring the mesh up over UDP, keeping its mesh node
+  key across invocations for the lifetime of its enrollment — the mesh
+  membership this command establishes, ending at `min net mesh leave` or a
+  later join — an interim, its rotation being an open question.
   tier:     T0
   verify:   cargo nextest run -p minimal mesh_join_needs_no_manual_key_exchange
 
 - **MCC-054** WHEN a developer lists sessions THE SYSTEM SHALL include the
   sessions on every node the identity plane lists for the developer
   (MCC-015), addressed and attachable with the same grammar as local ones;
-  hosts reached only through a client-managed provider list stay outside
-  that listing by construction (Gatehouse §8.2 scope decision, v1.13).
+  the identity plane's listing excludes hosts reached only through the
+  client-managed provider list (Gatehouse §8.2 scope decision, v1.13), and
+  `min` keeps listing those through that list by today's local path,
+  unchanged here.
   tier:     T0
   verify:   cargo nextest run -p minimal list_and_attach_use_one_grammar_for_mesh_nodes
 
@@ -547,8 +565,10 @@ there.
   itself over an HTTP callback the page
   supplies, produce the authorization URL the page navigates to, and consume
   the callback the page hands back, checking its `state` against the request
-  and its `iss` against the deployment issuer set before exchanging; the page
-  composes none of these requests.
+  and its `iss` against the deployment issuer set — a fixed set the head
+  configures the core with at start, never learned from a callback
+  (Gatehouse §6.1.6) — before exchanging; the page composes none of these
+  requests.
   tier:     T0
   verify:   just wasm-core-headless credential_helpers_run_in_the_core_over_the_supplied_fetch
   - IF the callback's `iss` is outside the issuer set or its `state` does not
@@ -580,12 +600,14 @@ there.
   feed over `GET /v1/mesh/peers?network=<mesh>` with payload `{td, mesh,
   audience sub, seq, issued_at, peers[], revoked_bindings[]}` — taking per
   subject and mesh the tab's tunnel address and prefix length, and per node
-  its identity and friendly name, `wg_pub` (the node's current binding),
-  tunnel address, allowed IPs, the SSH port, the expected host principal
-  (the node's canonical name, §5.3), the issuer field (checked against the
-  credential's, MCC-038), and the reachability options — a direct endpoint
-  and/or the node's home relay, the relay dialed with a ticket; liveness
-  and `last_seen` come from the node listing (MCC-015), not the document.
+  its identity, `wg_pub` (the node's current binding), tunnel address,
+  allowed IPs, the SSH port, the expected host principal (the node's
+  canonical name, §5.3), the document's `td` (checked against the
+  credential's trust domain, MCC-038), and the reachability options — a
+  direct endpoint and/or the node's home relay, the relay dialed with a
+  ticket; liveness, `last_seen` and the node's display name come from the
+  node listing (MCC-015), not the document, a per-node friendly name in the
+  document being a request of the identity plane (Open questions).
   tier:     T0
   verify:   cargo nextest run -p min-core peer_document_maps_onto_the_attach_configuration
   - THE SYSTEM SHALL reject a document whose `seq` regresses below the last
@@ -603,7 +625,9 @@ there.
   DPoP-bound token and issued only where the subject may reach the node
   (`ReadNode`; Gatehouse §6.9, §7.4) — opaque and unmodified at WebSocket
   open, with a DPoP proof over it and the head's own §6.9 mesh binding, from
-  which the relay takes the client's mesh public key (MMI-071); use a ticket
+  which the relay takes the client's mesh public key (MMI-071; the binding
+  beside the ticket is the two specs' shared interim until the architecture
+  says whether the ticket carries `wg_pub`, Open questions); use a ticket
   only for the node it was issued for; and obtain a new one when the relay
   reports it expired. The ticket authorizes routing only: the tunnel's
   security stays the §6.9 binding plus SSH end to end (T29).
@@ -628,15 +652,16 @@ there.
   content-addressed assets with one `SHA256SUMS` manifest per CLI release,
   covering the bundle that release was built with, and `min` SHALL verify a
   served bundle's hash against the manifest of the release whose core version
-  the bundle reports (MCC-074); checksums are per release, and the auto-cut
-  `release-<sha>` releases make per-commit and per-release the same artefact
-  for a pre-release bundle (what WMC-038 vendors).
+  the bundle reports (MCC-074), a pre-release bundle's checksums being those
+  of the release cut for its commit (what WMC-038 vendors; Design
+  reasoning).
   tier:     T0
   verify:   cargo nextest run -p minimal served_bundle_hash_verifies_against_the_release_manifest
 
 - **MCC-074** THE SYSTEM SHALL expose, before any network activity, its own
-  version and the daemon protocol window it speaks, so a served bundle
-  reports the core version its checksums were published under (MCC-073); the
+  version and its protocol window (`protocol_window`, MCC-006), so a served
+  bundle reports the core version its checksums were published under
+  (MCC-073); the
   refusal of a daemon outside the window is MCC-006's, surfaced as
   `version:` (MCC-064).
   tier:     T0
@@ -666,8 +691,9 @@ there.
 - **MCC-078** THE SYSTEM SHALL open network connections only to the
   credential's issuer, the node endpoints the configuration names, and the
   relays the configuration names, and to nothing else.
-  tier:     T0
+  tier:     T1
   verify:   just wasm-core-headless bundle_dials_only_the_issuer_and_configured_endpoints
+  property: for every configuration (issuer, node endpoints, relays) and every dial the core requests of the host through its pipe, the target is that issuer, a named node endpoint or a named relay
 
 - **MCC-079** THE SYSTEM SHALL deliver the stripped wasm module at no more than
   600 KB gzip-compressed (the core ceiling WMC-N02 cites) and its JS glue at
@@ -717,19 +743,24 @@ there.
   session-operation decisions (§7.4, v1.16): recorded in the architecture of
   record on 2026-09-07 (gominimal/arch#16 to #22), implemented in
   gominimal/gatehouse, the `01-spec-*` lineage.
-- The mobile app and its in-process network stack: plan S13, later, from the
-  same core.
+- The mobile app and its in-process network stack: from the same core, on
+  plan S13's intent; nobody owns it yet.
 - Session recording: plan S9 and Gatehouse §14.4(1); daemon-side if ever.
-- Sharing a session and teammate access: plan S8, later.
+- Sharing a session and teammate access: gominimal/inbox#480 (the
+  session-sharing spike) and plan S8; nobody owns it yet.
 - Creating a session, workspace sync, loadouts, file patches, hooks,
-  diagnostics and agent dispatch from the browser: outside the core by
-  construction (no filesystem or TTY in a tab).
+  diagnostics and agent dispatch from the browser: outside the core (no
+  filesystem or TTY in a tab); the browser side is WMC's non-goal, agent
+  dispatch is G4 of gominimal/inbox#494, and a daemon-side checkout (plan
+  S8) has no owner yet.
+- Copying files into or out of a box, the epic's "Sync Files Out" story:
+  CLI-side work no spec binds yet; nobody owns it.
 - GitHub sign-in UX and credential-free git from sessions: the GitHub
   sessions spec (GHS) in this repo; MCC-050 is the credential it rides on.
 - Hosts reached only through providers in the client-managed Box Provider
   List, un-enrolled with Gatehouse: invisible to the tab in v1 (plan S2; the
-  scope decision of Gatehouse §8.2, v1.13, a server-side provider list being
-  the v2 revisit).
+  scope decision of Gatehouse §8.2, v1.13); the server-side provider list it
+  names as the v2 revisit has no owner yet.
 
 ## Non-functional requirements
 
@@ -767,8 +798,10 @@ layer and a forty-line WireGuard clock patch.
 wasm-clean, holds the network layer, attach, RPC driver, credential module
 and host policy (MCC-001, MCC-002); `min-core-web` is the wasm-bindgen head
 exporting the contract group; `min-wire` carries the wire types carved out of
-`minimald-rpc` and `sessions::wire` with no `common` or `args` dependency,
-which MCC-007 observes. The cryptographic backend is a target-gated,
+`minimald-rpc` and `sessions::wire` with no `common` or `args` dependency —
+what MCC-007 stated until it was retired on 2026-09-09 as mechanism, its
+ID not reused, the outcome being MCC-001 and MCC-003. The cryptographic
+backend is a target-gated,
 non-default feature — `ring` for the browser, the workspace's native backend
 elsewhere — so a native `--workspace` build enables exactly one; MCC-004
 stated that as a requirement and was retired on 2026-09-04 as mechanism, its
@@ -852,7 +885,7 @@ KRL for host certificates: the host policy runs the shared decision with an
 empty revocation set (MCC-032). The exposure is a compromised host key that
 stays acceptable until its certificate's 30-day expiry (Gatehouse §5.7) or a
 Host CA rotation; user-certificate revocation is the daemon's KRL
-(MMI-034–037). Carried as an open question.
+(MMI-034, MMI-035, MMI-037). Carried as an open question.
 
 **The expected principal is the node's canonical name** (Gatehouse §5.3,
 v1.15, the arch#21 ruling). A mesh attach dials the daemon's tunnel address
@@ -938,16 +971,31 @@ landed on 2026-09-07 (arch#16 to #22 closed) — no longer an assumption, the
 sections cited where each requirement binds. Overturning one changes the
 requirements it names, not the core's shape.
 
-**Tiers.** Three universals are at T1 — the signer's output shape (MCC-030),
-the host-policy decision (MCC-032) and the certificate decision (MCC-034) —
-because each is a pure function over owned values a property test can drive
-across its input space, and stating the universal forbids interleaving them
-with the transport; the property-testing dependency is confined to
-`min-core`'s development dependencies. T2 was declined because the decisions
-include a signature verification no bounded harness can exhaust. Everything
-else is T0 because it reaches a socket, a daemon or a browser. MCC-001's
-check is the headless attach on the wasm target: the second target compiling
-and running is the observable.
+**Tiers.** Ten universals are at T1 because each is a pure function over
+owned values a property test can drive across its input space, and stating
+the universal forbids interleaving it with the transport: the signer's
+output shape (MCC-030), the host-policy decision (MCC-032) and the
+certificate decision (MCC-034), and — added on 2026-09-09 after review,
+since the injected clock (MCC-005), the signer seam (MCC-030) and the HTTP
+callback (MCC-067) make them decisions over values the core owns — the
+version-window refusal (MCC-006), DPoP on every composed request (MCC-036),
+the anchor source (MCC-038), the renewal-chain cap (MCC-040), the browser
+mesh key's lifetime (MCC-041), the key's permitted signing inputs (MCC-042)
+and the dial set (MCC-078). The property-testing dependency is confined to
+`min-core`'s development dependencies. T2 was declined because the
+decisions include a signature verification no bounded harness can exhaust.
+The invariant-covering requirements that stay at T0 do so for a stated
+reason each: MCC-035 exercises a live issuer, and the universals inside it
+are MCC-036's and MCC-030's; MCC-039 and MCC-069 drive a live tunnel and
+daemon, and the instant at which they act is MCC-040's property; MCC-051
+dispatches to MCC-032's property and adds one refusal run; MCC-066 is
+MCC-030's property seen from the browser head and adds nothing to prove;
+MCC-073's hash comparison is one run per release, the served fetch being
+transport; MCC-074 is an ordering check at the entry point; MCC-076 and
+MCC-077 are exhaustive over the bundle by construction. Everything else is
+T0 because it reaches a socket, a daemon or a browser. MCC-001's check is
+the headless attach on the wasm target: the second target compiling and
+running is the observable.
 
 **Verification mechanics.** Native tests run under `cargo nextest` through
 `just test` (`just test-cross` on macOS). `just wasm-core` builds the bundle;
@@ -1004,12 +1052,13 @@ Gatehouse is the only identity plane in the system (§6.9).
   capability, the page's storage rule (WMC-004), and the core dialing only
   the issuer and configured endpoints.
   covered by: MCC-076, MCC-078
-- **Invariant:** THE SYSTEM SHALL run only a bundle whose hash matches the
-  published manifest, and fail closed on a daemon outside the supported
-  protocol window.
+- **Invariant:** THE SYSTEM SHALL publish every bundle content-addressed
+  under a release manifest `min` verifies a served bundle against, and fail
+  closed on a daemon outside its protocol window; running only a bundle
+  whose hash matches is the page's invariant (WMC-036).
   enforced by: content-addressed assets with one manifest per release, the
-  CLI-verifiable manifest, version negotiation before any session operation,
-  and the page's integrity loading (WMC-036).
+  CLI-verifiable manifest, and version negotiation before any session
+  operation.
   covered by: MCC-006, MCC-073, MCC-074
 
 ## Open questions
@@ -1026,7 +1075,9 @@ Gatehouse is the only identity plane in the system (§6.9).
   key, which the relay needs to address frames (MMI-077). MCC-071 presents
   the head's §6.9 binding beside the ticket and the relay takes the key from
   it (MMI-071); the mesh-ingress spec asks the architecture whether a
-  `wg_pub` claim in the ticket is wanted instead.]
+  `wg_pub` claim in the ticket is wanted instead. Two more fields are
+  requested of the §6.9 peer document for the same reason: a per-node
+  friendly name, which MCC-070 takes from the node listing until then.]
 - [NEEDS CLARIFICATION (MEDIUM): Host-certificate revocation. v1 checks no
   KRL for host certificates (MCC-032, Design reasoning), leaving a
   compromised host key acceptable until its 30-day certificate expires
@@ -1039,12 +1090,13 @@ Gatehouse is the only identity plane in the system (§6.9).
   what the daemon's binding check (MMI-010) needs from a rotation, is
   unset.]
 - [NEEDS CLARIFICATION (MEDIUM): The SSH username under certificate
-  authentication (plan S4): the box login principal as bound in MCC-021, or
-  the canonical subject with the daemon deriving the sandbox user. The core
-  takes it as input either way; the mesh-ingress spec decides.]
-- [NEEDS CLARIFICATION (MEDIUM): The width of the supported version-skew
-  window (architecture open gap 8). MCC-006 and MCC-074 fail closed outside
-  it; its width is unset.]
+  authentication (plan S4): MCC-021 binds the box login principal as the
+  interim MMI-024 admits; whether the canonical subject with the daemon
+  deriving the sandbox user replaces it is the mesh-ingress spec's to
+  decide. The core takes it as input either way.]
+- [NEEDS CLARIFICATION (MEDIUM): The default width of `protocol_window`
+  (architecture open gap 8). MCC-006 and MCC-074 bind to the window; its
+  default is unset.]
 - [NEEDS CLARIFICATION (MEDIUM): The wasm head's packaging for the webapp —
   npm versioning of `min-core-web`, the wasm-bindgen pin policy, and how the
   webapp consumes the release manifest of MCC-073.]

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -19,8 +19,9 @@ that lives in a tab, and the owner's direction rules out any server in the
 session path. After this ships one Rust core carries the mesh peer, the
 attach sequence, the RPC driver, the credential flow and host trust for
 every head: the `min` CLI, the browser bundle, and later a mobile app. The
-direction is [the direction plan](../../../plans/browser-min-client-direction.plan.md)
-and the identity plane is Gatehouse; neither is restated here.
+direction is [the direction plan](https://github.com/gominimal/minimal/blob/feat/min-core-wasm-poc/plans/browser-min-client-direction.plan.md)
+carried on the proof-of-concept branch (#1350), and the identity plane is
+Gatehouse; neither is restated here.
 
 **Success:** A developer signed in with GitHub attaches from a browser tab
 to a session on a daemon they own, SSH terminating in the tab under a

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -5,7 +5,7 @@ status: draft
 owner: mitodrummer
 epic: gominimal/inbox#513
 arch: https://github.com/gominimal/arch/blob/main/specs/authn-authz/gatehouse-spec.md
-updated: 2026-09-04
+updated: 2026-09-08
 ---
 
 # MCC — Shared min client core: one Rust core for the CLI, the browser and mobile
@@ -151,14 +151,20 @@ group below.
     verify: cargo nextest run -p min-core silent_peer_is_lost_after_60s_at_the_injected_clock
 
 - **MCC-014** WHEN a node's reachability options include a direct endpoint THE
-  SYSTEM SHALL dial it first, and SHALL dial the node's relay endpoint with
-  the node's ticket only when the direct dial fails or none is offered.
+  SYSTEM SHALL dial it first, and SHALL dial the node's home relay, as the
+  peer document names it from the node's advertised reachability, with the
+  node's ticket only when the direct dial fails or none is offered
+  (Gatehouse §6.9, architecture D7: direct paths preferred, the relay the
+  fallback and never the route of first resort).
   tier:     T0
   verify:   cargo nextest run -p min-core direct_endpoint_first_relay_as_fallback
 
-- **MCC-015** WHEN a head lists nodes THE SYSTEM SHALL return the peer
-  document's node set with the liveness and `last_seen` the identity plane
-  reports (MCC-070), opening no tunnel.
+- **MCC-015** WHEN a head lists nodes THE SYSTEM SHALL return the identity
+  plane's subject-scoped node listing (`GET /v1/nodes`, Gatehouse §8.2,
+  evaluated as `ReadNode`, §7.4) — each node's name, identity, class,
+  `last_seen`, liveness state (`reachable`, `stale` or `offline`) and
+  advertised reachability — joined to the peer document's entry for the node
+  (MCC-070), opening no tunnel.
   tier:     T0
   verify:   cargo nextest run -p min-core listing_opens_no_tunnel
 
@@ -246,7 +252,12 @@ group below.
   certificate decision of MCC-034 for the host type with an empty revocation
   set (no host KRL in v1, Design reasoning) and the expected principal named
   exactly or by the per-node wildcard `*.<node_id>.box.<td>` — refusing
-  anything else before authentication with the failing check named.
+  anything else before authentication with the failing check named. For a
+  mesh attach the expected principal is the node's canonical
+  `<node_id>.box.<td>` name the peer document carries, never the tunnel
+  address dialed (Gatehouse §5.3 mesh attaches, v1.15): the canonical name
+  must be among the certificate's own principals, since the wildcard covers
+  only the names beneath it.
   tier:     T1
   verify:   cargo nextest run -p min-core host_policy_accepts_iff_every_check_holds
   property: for every (certificate, anchors, expected, now): accept ⇔ decision(certificate, anchors, host, now, revoked = ∅) = ok (MCC-034) ∧ (expected ∈ principals ∨ ∃ p ∈ principals: p = "*." ‖ suffix ∧ expected ends with "." ‖ suffix); a refusal names the first failing check, the decision's order first and the principal last
@@ -258,6 +269,10 @@ group below.
     name under the node and no name beside it.
     tier:   T0
     verify: cargo nextest run -p min-core per_node_wildcard_principals_match_boxes_under_the_node
+  - WHERE the host was dialed at a tunnel address THE SYSTEM SHALL match the
+    canonical node name the peer document names and never the address.
+    tier:   T0
+    verify: cargo nextest run -p min-core tunnel_addressed_host_is_verified_against_its_canonical_name
 
 - **MCC-033** WHERE the transport is a local UDS or vsock THE SYSTEM SHALL
   accept the daemon without a host certificate, as today.
@@ -283,15 +298,18 @@ group below.
   key on the authorization request, the verifier and a DPoP proof on the
   token request, refresh with rotation, the tokens held in the core's
   memory — differing between heads only in the authorization leg: the
-  browser's HTTPS redirect, the CLI's device flow (GHS-006). Persistence
-  beyond memory is the head's: none in the browser (MCC-076, WMC-004), the
-  CLI's refresh token in its own store (MCC-050).
+  browser's HTTPS redirect, the CLI's device flow (GHS-006); in the browser
+  this is the `public` client kind of Gatehouse §6.1.7 (v1.11): exact-match
+  HTTPS redirect URIs on the terminal origin, `dpop_required`,
+  `auth_method = none`. Persistence beyond memory is the head's: none in the
+  browser (MCC-076, WMC-004), the CLI's refresh token in its own store
+  (MCC-050).
   tier:     T0
   verify:   cargo nextest run -p min-core login_is_pkce_and_dpop_bound_for_every_head
 
 - **MCC-036** THE SYSTEM SHALL attach a fresh DPoP proof, signed through the
   signer, to every token, certify, mesh-bind, relay-ticket and revoke
-  request it makes.
+  request it makes (Gatehouse §6.1.7, §6.9).
   tier:     T0
   verify:   cargo nextest run -p min-core every_issuer_request_carries_a_fresh_dpop_proof
 
@@ -299,14 +317,18 @@ group below.
   token with `box:ssh` THE SYSTEM SHALL request a certificate for the
   signer's public key with the profile and TTL the head configures:
   `interactive` for the CLI, `exchange` with a TTL of at most 900 s for the
-  browser.
+  browser (Gatehouse §6.6; the browser min client row of §5.7). The
+  certificate needs `box:ssh` on the token, which for a `public` client is a
+  tenant opt-in (§6.1.7): absent it, the issuer's refusal is reported as
+  MCC-081 shapes it.
   tier:     T0
   verify:   cargo nextest run -p min-core certify_carries_the_heads_profile_and_ttl
 
 - **MCC-038** THE SYSTEM SHALL take Host CA anchors only from the CA endpoint
-  of the issuer named in the credential it holds — never from the page
-  origin, the peer, the relay or a peer-document field — and SHALL attempt
-  no attach while it holds none.
+  of the issuer named in the credential it holds (`{iss}/v1/ssh/ca`,
+  Gatehouse §6.1.7, §8.2) — never from the page origin, the peer, the relay
+  or a peer-document field — and SHALL attempt no attach while it holds
+  none.
   tier:     T0
   verify:   cargo nextest run -p min-core anchors_come_only_from_the_credentials_issuer
   - IF a peer document's issuer field differs from the credential's issuer
@@ -315,9 +337,10 @@ group below.
     verify: cargo nextest run -p min-core peer_document_with_a_foreign_issuer_is_refused
 
 - **MCC-039** WHILE an attachment is open under a certificate THE SYSTEM SHALL
-  obtain a fresh certificate 120 s before the current one expires,
-  re-handshake over the same tunnel, re-attach, and continue with the
-  attachment object unchanged (MCC-069) and no action from the user.
+  obtain a fresh certificate 120 s before the current one expires (the
+  T-2 min renewal of Gatehouse §6.1.7 and §5.7), re-handshake over the same
+  tunnel, re-attach, and continue with the attachment object unchanged
+  (MCC-069) and no action from the user.
   tier:     T0
   verify:   cargo nextest run -p min-core renewal_reattaches_before_expiry_at_the_injected_clock
   - IF the issuer cannot be reached in time THEN THE SYSTEM SHALL let the
@@ -331,22 +354,29 @@ group below.
 - **MCC-040** WHERE the head is a browser THE SYSTEM SHALL renew without user
   presence only while an attachment is open and less than 8 h have passed
   since the presence-backed initial certify that began the chain (plan entry
-  8); past either bound, the next attach requires a presence-backed certify.
-  The CLI's rule is MCC-056.
+  8; Gatehouse §6.1.7's lifecycle rule, the chain cap aligned with the §6.9
+  user-device binding); past either bound, the next certify requires a
+  presence step — a user gesture at the head, never a fresh sign-in — which
+  starts a new chain; the identity plane's browser session may complete that
+  certify silently (WMC-009). The CLI's rule is MCC-056.
   tier:     T0
   verify:   cargo nextest run -p min-core renewal_chain_stops_at_8h_or_without_an_open_attach
 
 - **MCC-041** WHERE the head is a browser THE SYSTEM SHALL generate a fresh
   WireGuard keypair in memory per page session, request a binding for its
-  public key under the DPoP-bound token, use it for at most 8 h, and discard
-  it when the page session ends. The CLI's node key is MCC-053's.
+  public key under the DPoP-bound token (`JoinMesh`, a tenant opt-in for a
+  `public` client, Gatehouse §6.9), use it for at most 8 h, and discard it
+  when the page session ends (§6.9, client mesh keys; a WebCrypto-held key
+  is plan S13). The CLI's node key is MCC-053's.
   tier:     T0
   verify:   cargo nextest run -p min-core browser_mesh_key_is_fresh_per_page_session_bound_and_discarded
 
 - **MCC-042** THE SYSTEM SHALL use a head's signing key for DPoP proofs and
   SSH authentication signatures only, and SHALL derive no SSH-PoP (`sshpop`)
   assertion from it; a request to an issuer, relay or node is authenticated
-  with DPoP or the SSH certificate, never with an SSH-PoP assertion.
+  with DPoP or the SSH certificate, never with an SSH-PoP assertion
+  (Gatehouse §6.1.7: the tab's DPoP key is never an SSH-PoP or
+  DPoP-for-boxes key).
   tier:     T0
   verify:   cargo nextest run -p min-core heads_key_signs_only_dpop_and_ssh_userauth
 
@@ -381,16 +411,20 @@ group below.
 
 - **MCC-053** WHEN a developer runs `min net mesh join <network>` (today `min
   mesh join`; the architecture's command tree renames it) THE SYSTEM SHALL
-  obtain the binding and the peer document through the credential module and
-  bring the mesh up through the core's network layer over UDP, with no manual
-  key exchange, keeping its mesh node key across invocations for the lifetime
-  of the enrollment (its rotation is an open question).
+  request a §6.9 binding and consume the peer document through the
+  credential module (the command's shape since Gatehouse v1.14: the manual
+  key exchange is retired, the daemon's static peer table being the POC
+  interim, MMI-011) and bring the mesh up through the core's network layer
+  over UDP, keeping its mesh node key across invocations for the lifetime of
+  the enrollment (its rotation is an open question).
   tier:     T0
   verify:   cargo nextest run -p minimal mesh_join_needs_no_manual_key_exchange
 
 - **MCC-054** WHEN a developer lists sessions THE SYSTEM SHALL include the
-  sessions on every node of the peer document, addressed and attachable with
-  the same grammar as local ones.
+  sessions on every node the identity plane lists for the developer
+  (MCC-015), addressed and attachable with the same grammar as local ones;
+  hosts reached only through a client-managed provider list stay outside
+  that listing by construction (Gatehouse §8.2 scope decision, v1.13).
   tier:     T0
   verify:   cargo nextest run -p minimal list_and_attach_use_one_grammar_for_mesh_nodes
 
@@ -508,8 +542,9 @@ there.
   verify:   just wasm-core-headless signer_gets_bytes_and_returns_a_raw_signature
 
 - **MCC-067** THE SYSTEM SHALL perform the token exchange, refresh, certify,
-  anchors fetch, mesh-bind, relay-ticket request, renewal and the
-  refresh-token revoke at sign-out itself over an HTTP callback the page
+  anchors fetch, mesh-bind, node listing and peer-document fetch,
+  relay-ticket request, renewal and the refresh-token revoke at sign-out
+  itself over an HTTP callback the page
   supplies, produce the authorization URL the page navigates to, and consume
   the callback the page hands back, checking its `state` against the request
   and its `iss` against the deployment issuer set before exchanging; the page
@@ -523,8 +558,10 @@ there.
     verify: just wasm-core-headless foreign_iss_or_bad_state_exchanges_nothing
 
 - **MCC-068** THE SYSTEM SHALL send the certify request and read its response
-  as Gatehouse §6.6 shapes them, and fetch the anchors as §8.2 shapes
-  `GET {iss}/v1/ssh/ca`.
+  as Gatehouse §6.6 shapes them (dual-CKT audit, `exchange` profile for the
+  `public` client, §6.1.7), fetch the anchors as §8.2 shapes
+  `GET {iss}/v1/ssh/ca`, and read the node listing and the peer document as
+  §8.2 shapes `GET {iss}/v1/nodes` and `GET {iss}/v1/mesh/peers`.
   tier:     T0
   verify:   cargo nextest run -p min-core certify_and_anchors_exchanges_match_gatehouse
 
@@ -532,27 +569,44 @@ there.
   opening the new connection and attaching with the fresh certificate first,
   then closing its old channel itself — with no second attach call, no change
   to the attachment object and no close callback, the head observing only the
-  repaint (MCC-063), within the chain cap (MCC-040); where the daemon
-  supersedes the old channel before the core closes it (MMI-053), the
-  resulting `SUPERSEDED@minimal.dev` is consumed (MCC-065).
+  repaint (MCC-063), within the chain cap (MCC-040; Gatehouse §6.1.7); where
+  the daemon supersedes the old channel before the core closes it (MMI-053),
+  the resulting `SUPERSEDED@minimal.dev` is consumed (MCC-065).
   tier:     T0
   verify:   just wasm-core-headless renewal_is_invisible_to_the_page
 
-- **MCC-070** THE SYSTEM SHALL consume from the subject's peer document: per
-  subject and mesh, the tab's tunnel address and prefix length; per node,
-  node identity and friendly name, the node's WireGuard public key, the
-  node's tunnel address, the SSH port, the expected host principal, the
-  issuer field (checked against the credential's, MCC-038), the liveness the
-  identity plane reports with its `last_seen` time, and the reachability
-  options — a direct WebSocket endpoint and/or a relay endpoint with a
-  ticket.
+- **MCC-070** THE SYSTEM SHALL consume the subject's peer document as
+  Gatehouse §6.9 (v1.14) and §8.2 shape it — a `gatehouse-mesh-peers+jws`
+  feed over `GET /v1/mesh/peers?network=<mesh>` with payload `{td, mesh,
+  audience sub, seq, issued_at, peers[], revoked_bindings[]}` — taking per
+  subject and mesh the tab's tunnel address and prefix length, and per node
+  its identity and friendly name, `wg_pub` (the node's current binding),
+  tunnel address, allowed IPs, the SSH port, the expected host principal
+  (the node's canonical name, §5.3), the issuer field (checked against the
+  credential's, MCC-038), and the reachability options — a direct endpoint
+  and/or the node's home relay, the relay dialed with a ticket; liveness
+  and `last_seen` come from the node listing (MCC-015), not the document.
   tier:     T0
   verify:   cargo nextest run -p min-core peer_document_maps_onto_the_attach_configuration
+  - THE SYSTEM SHALL reject a document whose `seq` regresses below the last
+    one accepted for that (audience, mesh), and SHALL treat a document
+    older than `issued_at` + 5 min at the injected clock as expired: no new
+    tunnel is opened from it, while an established tunnel rides its
+    binding's TTL (§6.9 staleness bound; the revoked-bindings delta rides
+    in-band).
+    tier:   T0
+    verify: cargo nextest run -p min-core stale_or_regressed_peer_document_opens_no_new_tunnel
 
 - **MCC-071** WHEN dialing through a relay THE SYSTEM SHALL present the node's
-  ticket opaque and unmodified at WebSocket open, use a ticket only for the
-  node it was issued for, and obtain a new one when the relay reports it
-  expired.
+  ticket — a `gatehouse-relay-ticket+jws` over `{td, sub, node_id, cnf.jkt,
+  iat, exp, jti}` bound to the head's DPoP key, requested under the
+  DPoP-bound token and issued only where the subject may reach the node
+  (`ReadNode`; Gatehouse §6.9, §7.4) — opaque and unmodified at WebSocket
+  open, with a DPoP proof over it and the head's own §6.9 mesh binding, from
+  which the relay takes the client's mesh public key (MMI-071); use a ticket
+  only for the node it was issued for; and obtain a new one when the relay
+  reports it expired. The ticket authorizes routing only: the tunnel's
+  security stays the §6.9 binding plus SSH end to end (T29).
   tier:     T0
   verify:   cargo nextest run -p min-core relay_ticket_is_opaque_per_node_and_presented_at_open
 
@@ -562,7 +616,11 @@ there.
   show → a session's record and current screen; rename → the session renamed
   or the daemon's refusal; stop → `StopSession` (MMI-028): the session's
   process ended and the session listed with no running attributes; version →
-  the daemon's version (MCC-006).
+  the daemon's version (MCC-006). The daemon evaluates these as Gatehouse
+  §7.4 (v1.16) maps them — sessions are boxes: attach `SshConnect`, show and
+  list rows `BoxRead`, stop `StopBox`, rename `RenameBox`, a node-level
+  listing `ReadNode` — with the owner rule as the ratified interim
+  (MMI-025, MMI-027); the RPC names are the daemon's wire names.
   tier:     T0
   verify:   just wasm-core-headless v1_rpcs_run_through_the_driver_with_the_attach_taxonomy
 
@@ -652,10 +710,13 @@ there.
 - The browser page — origin, policy, integrity loading, key generation,
   storage rule, reconnect cadence, rendering, mobile layout, the terminal
   emulator, its tests: the browser client spec in gominimal/webapp (WMC).
-- The identity plane's capabilities — the public-client kind, certify for that
-  client, the peer document and node listing, heartbeats, relay tickets, the
-  §5.7 wording for a 15-minute certificate: gominimal/gatehouse, the
-  `01-spec-*` lineage, with the open questions below as the asks.
+- The identity plane's capabilities — the `public` client kind and certify
+  for it (Gatehouse §6.1.7, §6.6, §5.7, v1.11), the node listing and
+  heartbeat (§8.2, v1.13), relay tickets (§6.9, v1.12), the peer document
+  (§6.9, v1.14), the mesh-attach host principal (§5.3, v1.15) and the
+  session-operation decisions (§7.4, v1.16): recorded in the architecture of
+  record on 2026-09-07 (gominimal/arch#16 to #22), implemented in
+  gominimal/gatehouse, the `01-spec-*` lineage.
 - The mobile app and its in-process network stack: plan S13, later, from the
   same core.
 - Session recording: plan S9 and Gatehouse §14.4(1); daemon-side if ever.
@@ -666,8 +727,9 @@ there.
 - GitHub sign-in UX and credential-free git from sessions: the GitHub
   sessions spec (GHS) in this repo; MCC-050 is the credential it rides on.
 - Hosts reached only through providers in the client-managed Box Provider
-  List, un-enrolled with Gatehouse: invisible to the tab in v1 (plan S2),
-  carried with the peer-document open question.
+  List, un-enrolled with Gatehouse: invisible to the tab in v1 (plan S2; the
+  scope decision of Gatehouse §8.2, v1.13, a server-side provider list being
+  the v2 revisit).
 
 ## Non-functional requirements
 
@@ -717,17 +779,29 @@ Promotion updates AGENTS.md's crate table and `docs/architecture.md` §3
 builds there.
 
 **The tab is a mesh node and no server is in the session path** (decided
-2026-09-03, plan entries 12, 18, 23, 24). Servers remain for the page,
-Gatehouse, notifications and a stateless relay forwarding WireGuard
-ciphertext for daemons behind NAT; none holds a box credential or sees SSH
-bytes. A daemon exposes no inbound listener by default and connects outbound
-to its relay; the tab dials direct first (MCC-014) because a reachable daemon
-needs no relay.
+2026-09-03, plan entries 12, 18, 23, 24; architecture D7 and Gatehouse §6.9
+since v1.12). Servers remain for the page, Gatehouse, notifications and a
+stateless relay forwarding WireGuard ciphertext for daemons behind NAT; none
+holds a box credential or sees SSH bytes, and a relay compromise reads and
+terminates nothing (T29). A daemon exposes no inbound listener by default
+and connects outbound to its relay, registering with `sshpop-host` against
+a relay URL the issuer advertises in `gatehouse_node_endpoints`; the tab
+dials direct first (MCC-014) because a reachable daemon needs no relay, and
+opens a relay socket with a per-node ticket that authorizes routing only
+(MCC-071).
 
 **A public client with tokens in memory** (decided 2026-09-03, entries 10,
-15–17). With no backend nothing but the tab can hold tokens, and every token
-is sender-constrained to a non-extractable key (Gatehouse §5.4), which is
-what §6.1.7's rule guarded against. The core holds tokens in memory on every
+15–17; Gatehouse §6.1.7 since v1.11, the closure of §14.4(2)). With no
+backend nothing but the tab can hold tokens, and every token is
+sender-constrained to a non-extractable key (Gatehouse §5.4); the
+confidential-client rule that tokens never reach the browser stays for
+every other web client, and the `public` kind — PKCE with `dpop_jkt`,
+`auth_method = none`, tokens and the DPoP key in tab memory, nothing
+persisted, anchors from `{iss}/v1/ssh/ca` — is this one. §6.6 lets the
+certified key equal the DPoP key and the core signs both through one head
+key (MCC-042); §6.1.7's wording, "a fresh in-tab SSH key", is read as
+permitting that and carried as an open question. The core holds tokens in
+memory on every
 head; what outlives the process is the head's — none in the browser (MCC-076,
 WMC-004), the CLI's refresh token in its store (MCC-050). A reload re-mints
 through the SSO session, the client has its own origin, and the bundle is
@@ -738,15 +812,24 @@ origin serving the page is trusted for code integrity, never for data, and
 checkably so.
 
 **A 15-minute certificate with transparent renewal, capped** (decided
-2026-09-03, entries 7, 8, 22). The `interactive` 8 h profile would keep §5.7's
-wall warnings at the price of an 8 h window for an XSS that drives the key;
-`exchange` at 15 min keeps the window short and makes reconnect a core duty
-(MCC-039). Unattended renewals stop at the binding's 8 h and without an open
-attach (MCC-040), so the profiles are equivalent in XSS terms and differ in
-revocation latency only. The chain is anchored at the presence-backed initial
-certify (plan entry 8); WMC-009 counts from the sign-in and must align to the
-certify, or the two differ by the length of a login. A Gatehouse outage
-detaches at the next renewal with no grace period. The daemon-side repaint
+2026-09-03, entries 7, 8, 22; normative since Gatehouse v1.11 as the browser
+min client row of §5.7 and the lifecycle paragraph of §6.1.7). The
+`interactive` 8 h profile would keep §5.7's wall warnings at the price of an
+8 h window for an XSS that drives the key; `exchange` at 15 min keeps the
+window short and makes reconnect a core duty (MCC-039); §5.7 now suppresses
+the warnings for this client (MMI-031 is the daemon rule). Unattended
+renewals stop at the binding's 8 h and without an open attach (MCC-040), so
+the profiles are equivalent in XSS terms and differ in revocation latency
+only: the same 8 h envelope as a CLI cert, delivered as up to 32 short
+certificates. The chain is anchored at the presence-backed initial certify
+(plan entry 8), presence being a user gesture at the tab at the initial
+certify only, never per renewal, and never a fresh sign-in — the SSO
+session may complete the certify silently; WMC-009 counts from that certify.
+`box:ssh` and `JoinMesh` are tenant opt-ins for the `public` client, deny by
+default through the §5.8 issuance intersection, a personal tenant's sole
+admin opting in for themselves; where that opt-in surface lives is WMC's
+question. A Gatehouse outage detaches at the next renewal with no grace
+period. The daemon-side repaint
 makes each forced reconnect land on a full screen, which is why the
 mesh-ingress spec is a v1 prerequisite and MCC-063 states the repaint as
 observed.
@@ -770,6 +853,18 @@ empty revocation set (MCC-032). The exposure is a compromised host key that
 stays acceptable until its certificate's 30-day expiry (Gatehouse §5.7) or a
 Host CA rotation; user-certificate revocation is the daemon's KRL
 (MMI-034–037). Carried as an open question.
+
+**The expected principal is the node's canonical name** (Gatehouse §5.3,
+v1.15, the arch#21 ruling). A mesh attach dials the daemon's tunnel address
+and verifies the host certificate against `<node_id>.box.<td>`, which the
+peer document names in its expected-principal field — the same
+CNAME-onto-canonical move §5.3 makes for friendly names, with the peer
+document standing in for DNS canonicalization. Tunnel addresses are never
+certificate principals and owe no stability guarantee, so mesh renumbering
+forces no out-of-cycle host-cert renewal; the interim that added the
+address as a principal (MCC-032 as first drafted, MMI-029) is superseded.
+The core performs the check natively (MCC-032); the CLI's `known_hosts`
+fragment (MCC-052) is the `HostKeyAlias` form of the same rule.
 
 **Constants.** The 60 s silent-peer bound (MCC-013) is twice the 25 s
 persistent keepalive the network layer configures; 20 s to the first
@@ -799,10 +894,19 @@ is not the mesh peer plan S6 describes. P-256 is a one-variant fallback for
 the FIPS profile, covered by MCC-030's property.
 
 **Listing is the identity plane's node set plus heartbeats** (decided
-2026-09-03, entry 21). The tab reads nodes, liveness and `last_seen` in one
-call and handshakes only with the node it attaches to (MCC-015, MCC-017); a
-proof-of-concept design that opened a tunnel per node for liveness was
-retired by it.
+2026-09-03, entry 21; Gatehouse §8.2 since v1.13). The tab reads nodes,
+liveness and `last_seen` in one call — `GET /v1/nodes`, evaluated as
+`ReadNode` (§7.4), owner-only in v1: the enrolling subject of a
+`local`-class node — and handshakes only with the node it attaches to
+(MCC-015, MCC-017); a proof-of-concept design that opened a tunnel per node
+for liveness was retired by it. Liveness is the identity plane's derivation
+from `POST /v1/nodes/heartbeat` (60 s cadence; `reachable` within 150 s,
+`stale` within 15 min, `offline` beyond — §8.2 working values), and the
+same `ReadNode` decision gates relay-ticket issuance, so what a head can
+list and what it can dial never drift apart. Peer configuration is the
+§6.9 peer document (v1.14): bindings authorize, the document configures,
+with its `seq` and staleness bound enforced in the core (MCC-070); a stale
+document refuses new tunnels and never severs a live one.
 
 **CLI adoption order** (decided 2026-09-03, entry 6). The target is the
 in-process attach (MCC-052); the first step shares the non-TTY parts and keeps
@@ -822,13 +926,17 @@ is later work.
 **Working assumptions, not decisions.** Four defaults the owner confirmed on
 2026-09-04 (recorded in WMC) stay written as assumptions so a reversal is one
 visible edit: A1, the v1 browser command set is owner-only list, show,
-attach, rename and stop (MCC-072), with no create, sync, agent dispatch or
-share links; A2, the plan's decisions above stand; A3, the browser client
-lives on its own origin served from the webapp repo (MCC-075, WMC-035); A4,
-the Gatehouse capabilities this spec consumes are dependencies on the identity
-plane, bound by name and carried as HIGH open questions where the architecture
-has not ruled. Overturning one changes the requirements it names, not the
-core's shape.
+attach, rename and stop (MCC-072; Gatehouse §7.4 since v1.16 maps them onto
+`SshConnect`, `BoxRead`, `StopBox`, `RenameBox` and `ReadNode` — sessions
+are boxes, no parallel action family — and ratifies the daemon's owner rule
+as the interim, destroy staying local-only), with no create, sync, agent
+dispatch or share links; A2, the plan's decisions above stand; A3, the
+browser client lives on its own origin served from the webapp repo (MCC-075,
+WMC-035); A4, the Gatehouse capabilities this spec consumes are dependencies
+on the identity plane, bound by section since the v1.11 to v1.16.1 stack
+landed on 2026-09-07 (arch#16 to #22 closed) — no longer an assumption, the
+sections cited where each requirement binds. Overturning one changes the
+requirements it names, not the core's shape.
 
 **Tiers.** Three universals are at T1 — the signer's output shape (MCC-030),
 the host-policy decision (MCC-032) and the certificate decision (MCC-034) —
@@ -871,7 +979,8 @@ Gatehouse is the only identity plane in the system (§6.9).
   a host certificate verifying, for the expected principal, against anchors
   taken from the tenant issuer only.
   enforced by: the host policy in the server-key check, aborting before
-  authentication (Gatehouse §6.2, no TOFU); the anchors fetch bound to the
+  authentication (Gatehouse §6.2, no TOFU), the expected principal being the
+  node's canonical name (§5.3 mesh attaches); the anchors fetch bound to the
   issuer the credential names, with a peer document naming another issuer
   refused.
   covered by: MCC-032, MCC-038, MCC-051
@@ -905,45 +1014,19 @@ Gatehouse is the only identity plane in the system (§6.9).
 
 ## Open questions
 
-- [NEEDS CLARIFICATION (HIGH): A public-client registration kind does not
-  exist in the architecture of record: Gatehouse §6.1.7 says tokens never
-  reach the browser and a SPA holding tokens is out of v1 scope; §14.4(2)
-  leaves the in-browser path open. This spec needs a `public` kind — PKCE
-  with `dpop_jkt`, exact-match HTTPS redirect URIs, DPoP required, no client
-  authentication, tokens held by the client on a non-extractable key, and the
-  statement that the client's key never becomes an SSH-PoP key. MCC-035,
-  MCC-036, MCC-042, MCC-067 and MCC-076 wait on the ruling. Filed: gominimal/arch#16.]
-- [NEEDS CLARIFICATION (HIGH): Certify for the browser client. §6.1.7 grants
-  web clients no `box:ssh` by default, the website's registration
-  (minimal-hosted §4, §7) omits it, and §6.9 keeps `JoinMesh` deny-by-default.
-  This spec needs both as tenant opt-ins for the public client, a personal
-  tenant's sole admin opting in for themselves, both key thumbprints audited
-  on certify. MCC-037, MCC-041 and MCC-068 depend on it. Filed: gominimal/arch#16.]
-- [NEEDS CLARIFICATION (HIGH): A 15-minute `exchange` certificate for an
-  interactive browser session. §5.7 gives interactive users 8 h with wall
-  warnings at T-15 and T-1 min. This spec renews at T-2 min with the warnings
-  suppressed for a client that reconnects transparently, caps the unattended
-  chain at 8 h from the initial certify and requires presence there; §5.7
-  must say so. MCC-039, MCC-040 and MCC-069 depend on it. Filed: gominimal/arch#16.]
-- [NEEDS CLARIFICATION (HIGH): The peer document, node listing and
-  heartbeats. §6.9 issues bindings but no peer configuration; §9 holds nodes
-  with `last_seen` but exposes no per-subject read; §8.2 has no endpoint for
-  either. This spec needs one read returning the fields MCC-070 lists, with
-  liveness and `last_seen` from daemon heartbeats. MCC-014, MCC-015, MCC-017,
-  MCC-053, MCC-054 and MCC-070 depend on it; the un-enrolled provider-list
-  gap rides with it. Filed: gominimal/arch#19 and gominimal/arch#17.]
-- [NEEDS CLARIFICATION (HIGH): The relay tier and its tickets. No
-  architecture text describes a stateless ciphertext relay, a Gatehouse-issued
-  per-node ticket bound to the tab's DPoP key, or the daemon's outbound relay
-  connection under `sshpop-host`; box-provider-api §1 and the Cloudflare
-  sketch §1 keep the provider out of the box data path, which a ciphertext
-  relay needs restating. The protocol is the mesh-ingress spec's; the ticket's
-  issuer and shape are Gatehouse's. MCC-014 and MCC-071 depend on it. Filed: gominimal/arch#18.]
-- [NEEDS CLARIFICATION (MEDIUM): Which principal the host certificate carries
-  for a tunnel-addressed connection. §5.3 lists the names and IPs clients may
-  connect to; the tab dials a tunnel address. Either the address is a
-  principal or the peer document names the node's canonical name and the core
-  resolves it. MCC-032 and MCC-070 allow either; the document must pick one.]
+- [NEEDS CLARIFICATION (MEDIUM): One key or two. Gatehouse §6.1.7 mints the
+  browser client's certificate "onto a fresh in-tab SSH key" and §6.6 says
+  the certified key "needn't equal the DPoP key"; MCC-042 and WMC-003 sign
+  DPoP proofs and SSH authentication with one head key, as the proof of
+  concept did, so the dual-CKT audit records one thumbprint twice. Confirm
+  that one key is acceptable, or split it: a second signer for SSH costs the
+  head one more key and the core a second signer seam, nothing else.]
+- [NEEDS CLARIFICATION (MEDIUM): The relay ticket's claim set (Gatehouse
+  §6.9: `td, sub, node_id, cnf.jkt, iat, exp, jti`) carries no mesh public
+  key, which the relay needs to address frames (MMI-077). MCC-071 presents
+  the head's §6.9 binding beside the ticket and the relay takes the key from
+  it (MMI-071); the mesh-ingress spec asks the architecture whether a
+  `wg_pub` claim in the ticket is wanted instead.]
 - [NEEDS CLARIFICATION (MEDIUM): Host-certificate revocation. v1 checks no
   KRL for host certificates (MCC-032, Design reasoning), leaving a
   compromised host key acceptable until its 30-day certificate expires
@@ -965,10 +1048,6 @@ Gatehouse is the only identity plane in the system (§6.9).
 - [NEEDS CLARIFICATION (MEDIUM): The wasm head's packaging for the webapp —
   npm versioning of `min-core-web`, the wasm-bindgen pin policy, and how the
   webapp consumes the release manifest of MCC-073.]
-- [NEEDS CLARIFICATION (LOW): Stop is `StopSession` (MMI-028) and bound in
-  MCC-003 and MCC-072; destroy stays Local-only in the daemon (MMI-027). Does
-  the browser ever get destroy of an exited session, which WMC today does not
-  offer?]
 - [NEEDS CLARIFICATION (LOW): Whether `minimald`'s WireGuard pump moves onto
   the core's network layer or keeps its own driver over the same crate; the
   mesh-ingress spec's call, invisible to this spec's behaviours.]

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -755,7 +755,8 @@ no host-cert renewal. The core checks natively (MCC-032); the CLI's
 `known_hosts` fragment (MCC-052) is the `HostKeyAlias` form of the same
 rule.
 
-**Constants.** 60 s silent-peer (MCC-013) is twice the 25 s keepalive; 20 s
+**Constants.** 60 s silent-peer (MCC-013) is two 25 s keepalive intervals
+plus a 10 s margin for a late one; 20 s
 to the first handshake response (MCC-011) is four WireGuard retries at 5 s;
 10 s for the version exchange (MCC-006) and for a credential call
 (MCC-081), and 30 s for the whole attach (MCC-060), are the handshake bound
@@ -812,8 +813,9 @@ decision behind it; MCC-N01 to MCC-N03 were proof-of-concept measurements
 with headroom, not bounds anyone set.
 
 **Working assumptions.** Recorded in WMC and confirmed 2026-09-04: A1, the
-v1 browser command set is owner-only list, show, attach, rename and stop
-(MCC-072; Gatehouse §7.4 since v1.16 maps them, sessions being boxes); A2,
+v1 browser command set is owner-only attach (MCC-020, MCC-060) plus list
+sessions, show, rename, stop and version over the RPC driver (MCC-072;
+Gatehouse §7.4 since v1.16 maps them, sessions being boxes); A2,
 the plan's decisions stand; A3, the browser client lives on its own origin
 (MCC-075). Overturning one changes the requirements it names, not the
 core's shape.

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -1,7 +1,6 @@
 ---
 id: MCC
 title: "Shared min client core: one Rust core for the CLI, the browser and mobile"
-status: draft
 owner: mitodrummer
 epic: gominimal/inbox#513
 arch: https://github.com/gominimal/arch/blob/main/specs/authn-authz/gatehouse-spec.md
@@ -78,11 +77,11 @@ cites them rather than repeating them.
 Siblings: the browser client spec (WMC, webapp#763) consumes the browser
 contract group by ID; the mesh-ingress spec (MMI, #1356) is the daemon
 side, bound by ID here, and may be superseded by the networking spec in
-preparation, whose inputs are the architecture's networking requirements v2
-(arch#46) and its deployment and egress-gateway design — ingress and
-transport bind to that spec by name once it exists; the GitHub sessions
-spec (GHS, #1351) owns the CLI sign-in ceremony; the Box Provider
-abstraction (BPA, arch#45) states what a provider reports about a host.
+preparation, which implements the architecture's networking requirements
+v2 and its [deployment and egress-gateway design](https://github.com/gominimal/arch/blob/main/specs/networking/deployment-and-egress-gateway.md)
+v0.2 (the *networking design*, cited by section); the GitHub sessions spec
+(GHS, #1351) owns the CLI sign-in ceremony; the Box Provider abstraction
+(BPA, arch#45) states what a provider reports about a host.
 
 ### Core boundary
 
@@ -115,9 +114,11 @@ abstraction (BPA, arch#45) states what a provider reports about a host.
 
 ### Transport and network layer
 
-How a daemon is reached — whether the head is a mesh peer or dials a
-gateway — is the networking spec's to decide; until it exists these bind to
-MMI by ID.
+Off the local machine the head is a mesh peer of the node it attaches to.
+On a pinned host the attach path transits the host's Egress Gateway, which
+forwards exactly as a relay does; direct paths are preferred only for
+unpinned nodes (networking design §4.5). The daemon side binds to MMI by
+ID until the networking spec replaces it.
 
 - **MCC-010** THE SYSTEM SHALL run the attach sequence and the RPC driver
   over any byte stream the host supplies, exchanging the same messages with
@@ -157,8 +158,9 @@ MMI by ID.
   it first, and dial the node's home relay with the node's ticket only when
   the direct dial fails — a refused connection, or MCC-011's 20 s passing
   from the dial request with no handshake response, the pipe never opening
-  included — or none is advertised (Gatehouse §6.9; architecture D7); the
-  fallback runs inside MCC-060's attach bound.
+  included — or none is advertised, as for a pinned host, whose home relay
+  is its Egress Gateway (Gatehouse §6.9; architecture D7; networking design
+  §4.5); the fallback runs inside MCC-060's attach bound.
   tier:     T0
   verify:   cargo nextest run -p min-core direct_endpoint_first_relay_as_fallback
 
@@ -543,8 +545,10 @@ and verified there.
   tunnel address and prefix, and per node its identity, `wg_pub`, tunnel
   address, allowed IPs, SSH port, expected host principal, `td` (checked
   against the credential's trust domain, MCC-038) and reachability options
-  — a direct endpoint and/or a home relay dialed with a ticket; liveness,
-  `last_seen` and the display name come from the node listing (MCC-015).
+  — a direct endpoint and/or a home relay dialed with a ticket, which for a
+  pinned host is its Egress Gateway, with no direct endpoint (networking
+  design §4.5); liveness, `last_seen` and the display name come from the
+  node listing (MCC-015).
   tier:     T0
   verify:   cargo nextest run -p min-core peer_document_maps_onto_the_attach_configuration
   - THE SYSTEM SHALL reject a document whose `seq` regresses below the last
@@ -645,7 +649,8 @@ and verified there.
 - The daemon's ingress, certificate-auth surface and allowlist, host
   certificate, terminal state and repaint, exit signals and the relay
   service: the mesh-ingress spec (MMI, #1356), which the networking spec in
-  preparation may supersede.
+  preparation may supersede. The Egress Gateway and its forwarding role:
+  the networking design (§4), implemented by that networking spec.
 - The browser page — origin, policy, integrity loading, key generation,
   storage, reconnect cadence, rendering, mobile layout: the browser client
   spec (WMC, webapp#763).
@@ -699,15 +704,17 @@ the architecture overview (plan S5).
 
 **The tab is a mesh node and no server is in the session path** (decided
 2026-09-03, plan entries 12, 18, 23, 24; Gatehouse §6.9 and architecture
-D7 since v1.12). Servers remain for the page, the identity plane and a
-stateless relay forwarding ciphertext for daemons behind NAT; none holds a
-box credential or sees SSH bytes (T29). The tab dials direct first
-(MCC-014) and opens a relay socket with a per-node ticket that authorizes
-routing only (MCC-071). Whether that shape survives — a tab as a WireGuard
-peer, or a tab dialing a host's gateway ingress — is the networking spec's
-to decide (decided 2026-09-09); this document moves no transport text until
-it exists, and MMI, which this document binds for ingress and the relay,
-may fold into it.
+D7 since v1.12). Servers remain for the page, the identity plane, a
+stateless relay forwarding ciphertext for daemons behind NAT and, for a
+pinned host, its Egress Gateway forwarding the same way; none holds a box
+credential or sees SSH bytes (Gatehouse T29, T30). The tab dials direct
+first (MCC-014) and opens a relay socket with a per-node ticket that
+authorizes routing only (MCC-071). Whether the tab stays a WireGuard peer
+was deferred to the networking spec on 2026-09-09; the networking design
+that spec implements answers it (v0.2, §4.5, §6): the tab stays a peer,
+the gateway admits it by the same ticket, and gateway ingress serves
+public exposure, not attach. MMI, which this document binds for ingress
+and the relay, may fold into that spec.
 
 **A public client with tokens in memory** (decided 2026-09-03, entries 10,
 15 to 17; Gatehouse §6.1.7 since v1.11). With no backend, only the tab can
@@ -750,10 +757,11 @@ Host CA rotates. Carried as an open question.
 **The expected principal is the node's canonical name** (Gatehouse §5.3,
 v1.15). A mesh attach dials a tunnel address and verifies the certificate
 against `<node_id>.box.<td>`, which the peer document names; tunnel
-addresses are never principals and owe no stability, so renumbering forces
-no host-cert renewal. The core checks natively (MCC-032); the CLI's
-`known_hosts` fragment (MCC-052) is the `HostKeyAlias` form of the same
-rule.
+addresses are never principals and owe no stability — since v1.17 they
+come from the tenant's address plan and may renumber freely (§6.9) — so
+renumbering forces no host-cert renewal. The core checks natively
+(MCC-032); the CLI's `known_hosts` fragment (MCC-052) is the
+`HostKeyAlias` form of the same rule.
 
 **Constants.** 60 s silent-peer (MCC-013) is two 25 s keepalive intervals
 plus a 10 s margin for a late one; 20 s
@@ -851,11 +859,11 @@ WMC's.
 **Generality:** A second head fits by construction: the mobile app is the
 same core behind a UDP datagram pipe and a keystore-backed signer; the CLI
 is the same core behind a local socket and an agent-backed signer. A second
-daemon fits if it terminates SSH inside the tunnel the networking spec
-chooses and presents a Gatehouse host certificate. A second identity plane
-does not fit: the certify, anchors, peer-document and ticket shapes
-(MCC-068, MCC-070, MCC-071) are Gatehouse's by decision, acceptable because
-Gatehouse is the only identity plane in the system.
+daemon fits if it terminates SSH inside the mesh tunnel the networking
+design specifies and presents a Gatehouse host certificate. A second
+identity plane does not fit: the certify, anchors, peer-document and
+ticket shapes (MCC-068, MCC-070, MCC-071) are Gatehouse's by decision,
+acceptable because Gatehouse is the only identity plane in the system.
 
 ## Security considerations
 
@@ -880,6 +888,14 @@ Gatehouse is the only identity plane in the system.
   sign-in (Gatehouse §6.1.1); the head's key used for DPoP and SSH
   authentication only.
   covered by: MCC-035, MCC-036, MCC-042
+- **Invariant:** THE SYSTEM SHALL carry nothing through a relay or an
+  Egress Gateway but the WireGuard datagrams of a tunnel to the ticket's
+  node, SSH running end to end inside it, so a forwarder sees ciphertext
+  and metadata only.
+  enforced by: one datagram per frame as the socket's only payload, the
+  ticket used only for its node, and host verification inside the tunnel
+  (Gatehouse T29, T30; networking design §4.5).
+  covered by: MCC-011, MCC-012, MCC-032, MCC-071
 - **Invariant:** THE SYSTEM SHALL renew a browser credential unattended for
   at most 8 h and only while an attachment is open, and hold a browser mesh
   key for at most 8 h.

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -5,7 +5,7 @@ status: draft
 owner: mitodrummer
 epic: gominimal/inbox#513
 arch: https://github.com/gominimal/arch/blob/main/specs/authn-authz/gatehouse-spec.md
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # MCC — Shared min client core: one Rust core for the CLI, the browser and mobile

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -440,8 +440,9 @@ and verified there.
   node's peer-document entry (MCC-070) as served, the session identifier,
   the terminal type and size, and an auth block naming the SSH username and
   the expected host principal, the certificate and anchors being those the
-  core holds (MCC-067); the core declares no scrollback request (MMI-052 is
-  a later daemon capability); a missing or malformed field rejects the
+  core holds (MCC-067); the core declares no scrollback request (the
+  daemon's replay requirement is retired until a head asks); a missing or
+  malformed field rejects the
   promise naming the field before any network activity.
   tier:     T0
   verify:   just wasm-core-headless config_rejections_name_the_field_before_dialing

--- a/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
+++ b/docs/specs/13-spec-min-client-core/13-spec-min-client-core.md
@@ -12,41 +12,32 @@ updated: 2026-09-09
 
 ## Context
 
-A developer reaches a session only from the machine that runs `min`. There is
-no browser client, no credential plane in the CLI (a local socket is the whole
-trust boundary), and no client code a second head could reuse. The "Mobile /
-Web Browser" story below needs a client that lives in a tab, and the owner's
-direction rules out any server in the session path: the tab is itself a mesh
-node and SSH terminates in it.
+A developer reaches a session only from the machine that runs `min`: there
+is no browser client, no credential plane in the CLI, and no client code a
+second head could reuse. The "Mobile / Web Browser" story needs a client
+that lives in a tab, and the owner's direction rules out any server in the
+session path. After this ships one Rust core carries the mesh peer, the
+attach sequence, the RPC driver, the credential flow and host trust for
+every head: the `min` CLI, the browser bundle, and later a mobile app. The
+direction is [the direction plan](../../../plans/browser-min-client-direction.plan.md)
+and the identity plane is Gatehouse; neither is restated here.
 
-After this ships one Rust core carries the mesh peer, the attach sequence, the
-RPC driver, the credential flow and host trust for every head: the `min` CLI,
-the browser bundle, and later a mobile app. The direction and its decisions
-are in [the direction plan](../../../plans/browser-min-client-direction.plan.md);
-the identity plane is
-[Gatehouse](https://github.com/gominimal/arch/blob/main/specs/authn-authz/gatehouse-spec.md).
-Neither is restated here.
+**Success:** A developer signed in with GitHub attaches from a browser tab
+to a session on a daemon they own, SSH terminating in the tab under a
+certificate on a key the tab cannot export and a host verified against the
+tenant's Host CA; and the same `min` binary attaches to the same session
+through the same core.
 
-**Success:** A developer signed in with GitHub attaches from a browser tab to a
-session on a `minimald` they own, over a WireGuard tunnel the tab runs, with
-SSH terminating in the tab, authenticated by a certificate on a key the tab
-cannot export and the host verified against the tenant's Host CA; and the same
-`min` binary attaches to the same session through the same core.
-
-**First slice:** The core promoted from the proof of concept with its native
-tests green, the browser bundle driven headlessly from Node through a full
+**First slice:** The core promoted from the proof of concept with its
+native tests green, the browser bundle driven headlessly through a full
 attach with certificate authentication and host verification against a
-stand-in daemon, and `min` issuing its non-TTY RPCs through the core — so
-that a developer runs `min session list` and sees a mesh node's sessions
-beside the local ones, then watches the headless attach land on one of
-them.
+stand-in daemon, and `min session list` showing a mesh node's sessions
+beside the local ones.
 
 ## Users and stories
 
-**Roles:** developer using long-running agentic workflows; developer running
-sessions both locally and remote; the author of the browser client spec in
-gominimal/webapp (id WMC, gominimal/webapp#763), who consumes the contract
-group below.
+**Roles:** developer using long-running agentic workflows; developer
+running sessions both locally and remote.
 
 - AS A developer using long running agentic workflow, I WANT to monitor and
   jump into an session via a mobile or desktop web browser, SO THAT I can
@@ -66,148 +57,145 @@ group below.
   work with all my sessions the same way. Acceptance criterion: remote boxes
   are enumerable and attachable through the same CLI surface as local ones.
 
-The initiative's own words for the browser half of the second story are
-gominimal/inbox#494's sixth done-when step, "See boxes and sessions from
-both the shell and the browser."; it is not a story and is not transcribed
-as one. The epic's "Sync Files Out" story reaches no spec yet (Non-goals).
+The third acceptance criterion of the first story is the page's (WMC). The
+epic's "Sync Files Out" story reaches no spec yet (Non-goals).
 
 ## Requirements
 
-### Core boundary (MCC-001–007)
+A *head* is a client built on the core: the `min` CLI, the browser bundle,
+later a mobile app. The *host* is the head's runtime; it supplies the core a
+byte stream or datagram pipe, a clock and timer, an HTTP call and a
+*signer*, which signs the bytes the core hands it and returns a raw
+signature. A *suspension* is any interval in which the host delivers no
+timer tick, a *resume* the first tick after it. A *page session* is one
+document's lifetime, ended by a reload or a navigation. The *issuer set* is
+the fixed set of deployment issuers the head configures the core with at
+start. Wire shapes, endpoints and decisions are the architecture of
+record's (Gatehouse, cited by section) and the siblings'; this document
+cites them rather than repeating them.
+
+Siblings: the browser client spec (WMC, webapp#763) consumes the browser
+contract group by ID; the mesh-ingress spec (MMI, #1356) is the daemon
+side, bound by ID here, and may be superseded by the networking spec in
+preparation, whose inputs are the architecture's networking requirements v2
+(arch#46) and its deployment and egress-gateway design — ingress and
+transport bind to that spec by name once it exists; the GitHub sessions
+spec (GHS, #1351) owns the CLI sign-in ceremony; the Box Provider
+abstraction (BPA, arch#45) states what a provider reports about a host.
+
+### Core boundary
 
 - **MCC-001** THE SYSTEM SHALL build and pass the same tests of the network
   layer, the attach sequence, the RPC driver, the credential module and host
-  policy for `wasm32-unknown-unknown` and the native host targets alike.
+  policy on `wasm32-unknown-unknown` and on the native targets.
   tier:     T0
   verify:   just wasm-core-headless one_source_tree_attaches_on_the_wasm_target
 
 - **MCC-002** THE SYSTEM SHALL import into the browser bundle no filesystem,
-  terminal, process-spawning, OS-socket or OS-timer capability; the host
-  supplies the byte stream or datagram pipe, the clock, the timer, the HTTP
-  call and the signer. The host's timer delivers ticks; a suspension is any
-  interval in which the host delivers none (a tab in the background, a
-  sleeping device), and a resume is the first tick delivered after it
-  (MCC-016).
+  terminal, process, OS-socket or OS-timer capability, taking each from the
+  host.
   tier:     T0
   verify:   just wasm-core-headless bundle_imports_no_host_capability
 
-- **MCC-003** THE SYSTEM SHALL decode a daemon's answer identically in the
-  core and in the CLI for every wire type the heads and the daemon share:
-  version, sessions, records, screens, mesh status, rename, stop, destroy,
-  abort and exec.
+- **MCC-003** THE SYSTEM SHALL decode every wire type the heads and the
+  daemon share identically in the core and in the CLI.
   tier:     T0
   verify:   cargo nextest run -p min-wire core_and_cli_decode_from_one_wire_definition
 
-- **MCC-005** THE SYSTEM SHALL make every time-dependent decision —
-  certificate validity, renewal scheduling, keepalive, dead-peer detection,
-  every timeout below — at the clock the host injects, so a test at a fixed
-  instant decides as the running system would at that instant.
-  tier:     T0
-  verify:   cargo nextest run -p min-core time_dependent_decisions_follow_the_injected_clock
-
-- **MCC-006** WHEN the core connects to a daemon THE SYSTEM SHALL negotiate the
-  protocol version before any session operation, report both versions to the
-  head, and refuse a daemon outside its protocol window — `protocol_window`,
-  the range of daemon protocol versions the core is built to accept, an
-  interim whose default width is an open question (architecture open gap
-  8) — naming both versions and the remedy, or one that has not answered the
-  version exchange within 10 s at the injected clock, naming the timeout.
+- **MCC-006** WHEN the core connects to a daemon THE SYSTEM SHALL negotiate
+  the protocol version before any session operation, report both versions
+  to the head, and refuse a daemon outside `protocol_window` — the
+  configured range of daemon versions the core accepts, an interim whose
+  default is an open question — or one that has not answered within 10 s,
+  naming both versions and the remedy, or the timeout.
   tier:     T1
   verify:   cargo nextest run -p min-core version_outside_window_fails_closed_naming_both_versions
   property: for every window W the core is built with, every daemon version v and every answer time t at the injected clock, a session operation is issued iff v ∈ W and t ≤ 10 s; otherwise nothing but the version exchange is sent, and the refusal names both versions and the remedy, or the timeout
 
-### Transport and network layer (MCC-010–017)
+### Transport and network layer
 
-- **MCC-010** THE SYSTEM SHALL run the attach sequence and the RPC driver over
-  any byte stream the host supplies — a local socket, a TCP stream inside the
-  tunnel, an in-memory pipe under test — exchanging the same messages with
+How a daemon is reached — whether the head is a mesh peer or dials a
+gateway — is the networking spec's to decide; until it exists these bind to
+MMI by ID.
+
+- **MCC-010** THE SYSTEM SHALL run the attach sequence and the RPC driver
+  over any byte stream the host supplies, exchanging the same messages with
   the daemon on each.
   tier:     T0
   verify:   cargo nextest run -p min-core same_attach_sequence_over_pipe_socket_and_tunnel
 
 - **MCC-011** WHEN the host supplies a datagram pipe and a peer configuration
-  THE SYSTEM SHALL complete a WireGuard handshake with that peer and open TCP
-  connections inside the tunnel, the host supplying only the two datagram
-  queues and the clock.
+  THE SYSTEM SHALL complete a WireGuard handshake with the peer and open TCP
+  connections inside the tunnel.
   tier:     T0
   verify:   cargo nextest run -p min-core ssh_attach_through_the_tunnel
-  - IF no handshake response arrives from the peer within 20 s at the
-    injected clock THEN THE SYSTEM SHALL fail the dial with a `transport:`
-    outcome (MCC-064) naming the endpoint tried.
+  - IF no handshake response arrives within 20 s THEN THE SYSTEM SHALL fail
+    the dial with a `transport:` outcome (MCC-064) naming the endpoint.
     tier:   T0
     verify: cargo nextest run -p min-core silent_handshake_fails_after_20s_at_the_injected_clock
 
 - **MCC-012** WHERE the datagram pipe is a WebSocket THE SYSTEM SHALL carry
-  exactly one WireGuard datagram per binary frame in each direction, the
-  framing the daemon's ingress (MMI-001) and the relay (MMI-072) parse
-  (Gatehouse §6.9).
+  one WireGuard datagram per binary frame in each direction (Gatehouse
+  §6.9; MMI-001, MMI-072).
   tier:     T0
   verify:   cargo nextest run -p min-core attach_over_websocket_carried_wireguard
 
-- **MCC-013** WHEN the datagram pipe closes or errors THE SYSTEM SHALL fail
-  every TCP stream inside the tunnel and end every attachment and RPC on it
-  with a `tunnel_lost` outcome (MCC-065); the attachment is then closed, and
-  any re-attach is a new attach call by the head at the head's own cadence
-  (MCC-057 for the CLI; WMC-026 and WMC-028 for the page).
+- **MCC-013** WHEN the datagram pipe closes or errors THE SYSTEM SHALL end
+  every attachment and RPC on it with `tunnel_lost` (MCC-065) and retry
+  nothing; a re-attach is the head's new attach call (MCC-057; WMC-026,
+  WMC-028).
   tier:     T0
   verify:   cargo nextest run -p min-core dead_websocket_reaches_the_ssh_layer
-  - IF the pipe stays open but no datagram arrives from the peer for 60 s at
-    the injected clock THEN THE SYSTEM SHALL treat the tunnel as lost.
+  - IF the pipe stays open but no datagram arrives for 60 s THEN THE SYSTEM
+    SHALL treat the tunnel as lost.
     tier:   T0
     verify: cargo nextest run -p min-core silent_peer_is_lost_after_60s_at_the_injected_clock
 
-- **MCC-014** WHEN a node's reachability options include a direct endpoint THE
-  SYSTEM SHALL dial it first, and SHALL dial the node's home relay, as the
-  peer document names it from the node's advertised reachability, with the
-  node's ticket only when the direct dial fails or none is offered
-  (Gatehouse §6.9, architecture D7: direct paths preferred, the relay the
-  fallback and never the route of first resort).
+- **MCC-014** WHEN a node advertises a direct endpoint THE SYSTEM SHALL dial
+  it first, and dial the node's home relay with the node's ticket only when
+  the direct dial fails or none is advertised (Gatehouse §6.9; architecture
+  D7).
   tier:     T0
   verify:   cargo nextest run -p min-core direct_endpoint_first_relay_as_fallback
 
 - **MCC-015** WHEN a head lists nodes THE SYSTEM SHALL return the identity
-  plane's subject-scoped node listing (`GET /v1/nodes`, Gatehouse §8.2,
-  evaluated as `ReadNode`, §7.4) — each node's name, identity, class,
-  `last_seen`, liveness state (`reachable`, `stale` or `offline`) and
-  advertised reachability — joined to the peer document's entry for the node
-  (MCC-070), opening no tunnel.
+  plane's node listing (`GET /v1/nodes`, Gatehouse §8.2) — name, identity,
+  class, `last_seen`, liveness state and advertised reachability — joined to
+  the peer document's entry (MCC-070), opening no tunnel.
   tier:     T0
   verify:   cargo nextest run -p min-core listing_opens_no_tunnel
 
-- **MCC-016** WHEN the host resumes the core after a suspension, such as a tab
-  returned to the foreground, THE SYSTEM SHALL re-evaluate the tunnel at the
-  injected clock on the first tick and, where it is lost (MCC-013), end the
-  attachment with `tunnel_lost` within 1 s of resume rather than leave it
-  hung; re-attaching is the head's own call (MCC-057, WMC-028).
+- **MCC-016** WHEN the host resumes the core after a suspension THE SYSTEM
+  SHALL re-evaluate the tunnel on the first tick and, where it is lost
+  (MCC-013), end the attachment with `tunnel_lost` within 1 s; re-attaching
+  is the head's (MCC-057, WMC-028).
   tier:     T0
   verify:   cargo nextest run -p min-core resume_after_suspension_surfaces_the_lost_tunnel_within_1s
 
-- **MCC-017** WHEN a head selects a node THE SYSTEM SHALL open one tunnel to it
-  and list its sessions through the RPC driver (MCC-072); WMC-013 consumes
-  the listing.
+- **MCC-017** WHEN a head selects a node THE SYSTEM SHALL open one tunnel to
+  it and list its sessions through the RPC driver (MCC-072).
   tier:     T0
   verify:   cargo nextest run -p min-core selecting_a_node_opens_one_tunnel_and_lists_its_sessions
 
-### Attach and RPC (MCC-020–024)
+### Attach and RPC
 
 - **MCC-020** WHEN a head attaches THE SYSTEM SHALL authenticate, open one
   session channel, set the session identifier, request a PTY of the given
-  size and a shell, then deliver output and the daemon's error stream in
-  order, forward input and window changes, and deliver the exit status.
+  size and a shell, deliver output and the daemon's error stream in order,
+  forward input and window changes, and deliver the exit status.
   tier:     T0
   verify:   cargo nextest run -p min-core attach_write_resize_exit
-  - IF the daemon refuses the shell — no session identifier, no PTY, an
-    unknown session — THEN THE SYSTEM SHALL report which request was refused,
-    an unknown session distinguishably (the `attach:` stage of MCC-064).
+  - IF the daemon refuses the shell THEN THE SYSTEM SHALL report which
+    request was refused, an unknown session distinguishably (`attach:`,
+    MCC-064).
     tier:   T0
     verify: cargo nextest run -p min-core shell_is_refused_without_a_session_id
 
 - **MCC-021** THE SYSTEM SHALL present as the SSH username the principal the
-  head supplies: `minimal-cli` under local trust, the certificate's box login
-  principal under certificate authentication — the box login user of
-  Gatehouse §5.3 (e.g. `dev`), among the certificate's principals and never
-  in canonical-subject form, the value MMI-024 admits; an interim until the
-  mesh-ingress spec's final rule (Open questions).
+  head supplies: `minimal-cli` under local trust, the certificate's box
+  login principal (Gatehouse §5.3; the value MMI-024 admits) under
+  certificate authentication — an interim until the daemon side's final
+  rule (Open questions).
   tier:     T0
   verify:   cargo nextest run -p min-core ssh_username_is_the_heads_input
 
@@ -216,28 +204,24 @@ as one. The epic's "Sync Files Out" story reaches no spec yet (Non-goals).
   tier:     T0
   verify:   cargo nextest run -p minimald core_close_detaches_and_leaves_the_session_running
 
-- **MCC-023** WHEN a head issues a oneshot RPC THE SYSTEM SHALL open a session
-  channel, request the RPC's subsystem, send one request, half-close, and
-  return the answer or the daemon's error text; a refused subsystem is
-  reported naming the RPC, never left hanging.
+- **MCC-023** WHEN a head issues a oneshot RPC THE SYSTEM SHALL open a
+  session channel, request the RPC's subsystem, send one request,
+  half-close, and return the answer or the daemon's error; a refused
+  subsystem is reported naming the RPC.
   tier:     T0
   verify:   cargo nextest run -p min-core oneshot_rpc_returns_answer_error_or_refusal
 
-- **MCC-024** WHEN `min` runs a non-PTY command against a session — its exec
-  and task paths — THE SYSTEM SHALL drive the exec channel with the daemon's
-  exec vocabulary and propagate the exit code; the browser never requests it
-  (the daemon refuses exec under `Certified`, MMI-027).
+- **MCC-024** WHEN `min` runs a non-PTY command against a session THE SYSTEM
+  SHALL drive the exec channel with the daemon's exec vocabulary and
+  propagate the exit code; the browser never requests it (MMI-027).
   tier:     T0
   verify:   cargo nextest run -p min-core exec_channel_speaks_the_daemon_vocabulary
 
-### Credential, the client half (MCC-030–042)
+### Credential, the client half
 
-- **MCC-030** THE SYSTEM SHALL sign every SSH authentication request and every
-  DPoP proof through a signer the head supplies, handing it the exact bytes to
-  sign and taking back a raw signature; the attach and credential paths SHALL
-  reach the key only through that signer, never holding, reading or exporting
-  it (an in-memory signer a head constructs for itself is the head's choice,
-  outside those paths).
+- **MCC-030** THE SYSTEM SHALL sign every SSH authentication request and
+  every DPoP proof through the head's signer, handing it the exact bytes and
+  taking back a raw signature, and SHALL reach the key through nothing else.
   tier:     T1
   verify:   cargo nextest run -p min-core signer_output_is_the_buffer_extended_with_the_ssh_encoded_signature
   property: for every to-sign buffer b and algorithm a ∈ {ssh-ed25519, ecdsa-sha2-nistp256}, with s the signer's raw signature over b, the bytes the core hands the SSH layer are exactly b ‖ string(string(a) ‖ string(blob(a, s))), blob being the identity for Ed25519 and the mpint pair (r, s) for P-256; and every DPoP proof is header.claims.base64url(s) with s the signer's signature over the signing input
@@ -247,8 +231,8 @@ as one. The epic's "Sync Files Out" story reaches no spec yet (Non-goals).
     tier:   T0
     verify: cargo nextest run -p min-core signer_failure_aborts_before_any_auth_request
 
-- **MCC-031** WHEN a credential is supplied THE SYSTEM SHALL authenticate with
-  the certificate and the signer only.
+- **MCC-031** WHEN a credential is supplied THE SYSTEM SHALL authenticate
+  with the certificate and the signer only.
   tier:     T0
   verify:   cargo nextest run -p min-core valid_certificate_attaches_and_the_host_certificate_is_verified
   - IF the daemon refuses the certificate THEN THE SYSTEM SHALL report an
@@ -256,17 +240,12 @@ as one. The epic's "Sync Files Out" story reaches no spec yet (Non-goals).
     tier:   T0
     verify: cargo nextest run -p min-core each_refusal_case_is_refused
 
-- **MCC-032** THE SYSTEM SHALL accept a host off a local socket only when it
-  presents a host certificate that verifies under the host policy — the
-  certificate decision of MCC-034 for the host type with an empty revocation
-  set (no host KRL in v1, Design reasoning) and the expected principal named
-  exactly or by the per-node wildcard `*.<node_id>.box.<td>` — refusing
-  anything else before authentication with the failing check named. For a
-  mesh attach the expected principal is the node's canonical
-  `<node_id>.box.<td>` name the peer document carries, never the tunnel
-  address dialed (Gatehouse §5.3 mesh attaches, v1.15): the canonical name
-  must be among the certificate's own principals, since the wildcard covers
-  only the names beneath it.
+- **MCC-032** THE SYSTEM SHALL accept a host off a local socket only when its
+  host certificate verifies under the host policy — MCC-034's decision for
+  the host type with an empty revocation set — for the expected principal,
+  named exactly or by the per-node wildcard `*.<node_id>.box.<td>`,
+  refusing anything else before authentication with the failing check
+  named.
   tier:     T1
   verify:   cargo nextest run -p min-core host_policy_accepts_iff_every_check_holds
   property: for every (certificate, anchors, expected, now): accept ⇔ decision(certificate, anchors, host, now, revoked = ∅) = ok (MCC-034) ∧ (expected ∈ principals ∨ ∃ p ∈ principals: p = "*." ‖ suffix ∧ expected ends with "." ‖ suffix); a refusal names the first failing check, the decision's order first and the principal last
@@ -279,22 +258,20 @@ as one. The epic's "Sync Files Out" story reaches no spec yet (Non-goals).
     tier:   T0
     verify: cargo nextest run -p min-core per_node_wildcard_principals_match_boxes_under_the_node
   - WHERE the host was dialed at a tunnel address THE SYSTEM SHALL match the
-    canonical node name the peer document names and never the address.
+    canonical `<node_id>.box.<td>` name the peer document names and never
+    the address (Gatehouse §5.3, mesh attaches).
     tier:   T0
     verify: cargo nextest run -p min-core tunnel_addressed_host_is_verified_against_its_canonical_name
 
 - **MCC-033** WHERE the transport is a local UDS or vsock THE SYSTEM SHALL
-  accept the daemon without a host certificate, as today.
+  accept the daemon without a host certificate.
   tier:     T0
   verify:   cargo nextest run -p min-core local_socket_needs_no_host_certificate
 
 - **MCC-034** THE SYSTEM SHALL provide one certificate decision naming the
-  same codes the daemon's decision names (MMI-022): the seven the
-  architecture's vectors expect — `bad_signature`, `unknown_ca`,
-  `wrong_cert_type`, `cert_not_yet_valid`, `cert_expired`,
-  `unknown_critical_option`, `cert_revoked` — and `principal_mismatch` for a
-  principal the certificate does not carry, which the daemon's decision
-  names too (MMI-022).
+  seven codes the architecture's vectors expect and `principal_mismatch`
+  for a principal the certificate does not carry, the codes the daemon's
+  decision names too (MMI-022).
   tier:     T1
   verify:   cargo nextest run -p min-core every_invalid_vector_is_refused_with_its_expected_error
   property: for every certificate, anchor set, expected type, clock, revocation set and principal, the decision accepts iff every check holds, and a refusal carries the code of the first failing check in the order signature, issuer, type, validity, critical options, revocation, principal
@@ -304,42 +281,34 @@ as one. The epic's "Sync Files Out" story reaches no spec yet (Non-goals).
     verify: cargo nextest run -p min-core valid_user_vector_is_accepted_for_its_principals_only
 
 - **MCC-035** WHEN a head signs in THE SYSTEM SHALL run the public-client
-  flow — a PKCE S256 challenge and the RFC 7638 thumbprint of the signer's
-  key on the authorization request, the verifier and a DPoP proof on the
-  token request, refresh with rotation, the tokens held in the core's
-  memory — differing between heads only in the authorization leg: the
-  browser's HTTPS redirect, the CLI's device flow (GHS-006); in the browser
-  this is the `public` client kind of Gatehouse §6.1.7 (v1.11): exact-match
-  HTTPS redirect URIs on the terminal origin, `dpop_required`,
-  `auth_method = none`. Persistence beyond memory is the head's: none in the
-  browser (MCC-076, WMC-004), the CLI's refresh token in its own store
-  (MCC-050).
+  flow — PKCE S256 with the signer key's RFC 7638 thumbprint on the
+  authorization request, a DPoP proof on the token request, refresh with
+  rotation, tokens in the core's memory — differing between heads only in
+  the authorization leg: the browser's HTTPS redirect as the `public` client
+  of Gatehouse §6.1.7, the CLI's device flow (GHS-006). Persistence beyond
+  memory is the head's (MCC-050, MCC-076).
   tier:     T0
   verify:   cargo nextest run -p min-core login_is_pkce_and_dpop_bound_for_every_head
 
 - **MCC-036** THE SYSTEM SHALL attach a fresh DPoP proof, signed through the
-  signer, to every token, certify, mesh-bind, node-listing, peer-document,
-  relay-ticket and revoke request it makes (Gatehouse §6.1.7, §6.9, §8.2).
+  signer, to every request it composes for the issuer: token, certify,
+  mesh-bind, node listing, peer document, relay ticket and revoke.
   tier:     T1
   verify:   cargo nextest run -p min-core every_issuer_request_carries_a_fresh_dpop_proof
   property: for every issuer request r the core composes for the host to send, r carries a DPoP proof signed through the signer whose `htm` and `htu` are r's method and URL and whose `jti` differs from every proof composed before it
 
-- **MCC-037** WHEN a head requests a credential while the core holds an access
-  token with `box:ssh` THE SYSTEM SHALL request a certificate for the
-  signer's public key with the profile and TTL the head configures:
-  `interactive` for the CLI, `exchange` with a TTL of at most 900 s for the
-  browser (Gatehouse §6.6; the browser min client row of §5.7). The
-  certificate needs `box:ssh` on the token, which for a `public` client is a
-  tenant opt-in (§6.1.7): absent it, the issuer's refusal is reported as
-  MCC-081 shapes it.
+- **MCC-037** WHEN a head requests a credential while the core holds an
+  access token with `box:ssh` THE SYSTEM SHALL request a certificate for the
+  signer's key with the head's profile and TTL: `interactive` for the CLI,
+  `exchange` at most 900 s for the browser (Gatehouse §6.6, §5.7); an
+  issuer's refusal, a missing tenant opt-in included (§6.1.7), is reported
+  as MCC-081 shapes it.
   tier:     T0
   verify:   cargo nextest run -p min-core certify_carries_the_heads_profile_and_ttl
 
-- **MCC-038** THE SYSTEM SHALL take Host CA anchors only from the CA endpoint
-  of the issuer named in the credential it holds (`{iss}/v1/ssh/ca`,
-  Gatehouse §6.1.7, §8.2) — never from the page origin, the peer, the relay
-  or a peer-document field — and SHALL attempt no attach while it holds
-  none.
+- **MCC-038** THE SYSTEM SHALL take Host CA anchors only from
+  `{iss}/v1/ssh/ca` of the issuer named in the credential it holds
+  (Gatehouse §8.2), and SHALL attempt no attach while it holds none.
   tier:     T1
   verify:   cargo nextest run -p min-core anchors_come_only_from_the_credentials_issuer
   property: for every credential c, every peer document d and every anchor state: the only anchors request the core composes is to `{iss}/v1/ssh/ca` for c's issuer; d is refused and opens no tunnel whenever its `td` differs from c's trust domain; and no attach is composed while no anchors are held
@@ -348,161 +317,132 @@ as one. The epic's "Sync Files Out" story reaches no spec yet (Non-goals).
     tier:   T0
     verify: cargo nextest run -p min-core peer_document_with_a_foreign_issuer_is_refused
 
-- **MCC-039** WHILE an attachment is open under a certificate THE SYSTEM SHALL
-  obtain a fresh certificate 120 s before the current one expires (the
-  T-2 min renewal of Gatehouse §6.1.7 and §5.7), re-handshake over the same
-  tunnel, re-attach, and continue with the attachment object unchanged
-  (MCC-069) and no action from the user.
+- **MCC-039** WHILE an attachment is open under a certificate THE SYSTEM
+  SHALL obtain a fresh certificate 120 s before expiry (Gatehouse §5.7),
+  re-handshake over the same tunnel, re-attach, and continue with the
+  attachment object unchanged (MCC-069).
   tier:     T0
   verify:   cargo nextest run -p min-core renewal_reattaches_before_expiry_at_the_injected_clock
   - IF the issuer cannot be reached in time THEN THE SYSTEM SHALL let the
     attachment end at expiry with `credential_expired` (MCC-065), leave the
-    session detached, and retry nothing itself; the re-attach is the head's
-    new attach call at the head's cadence (WMC-007 for the page, MCC-057 for
-    the CLI).
+    session detached, and retry nothing; the re-attach is the head's new
+    attach call (WMC-007, MCC-057).
     tier:   T0
     verify: cargo nextest run -p min-core issuer_outage_ends_attach_at_expiry_with_credential_expired
 
 - **MCC-040** WHERE the head is a browser THE SYSTEM SHALL renew without user
-  presence only while an attachment is open and less than 8 h have passed
-  since the presence-backed initial certify that began the chain (plan entry
-  8; Gatehouse §6.1.7's lifecycle rule, the chain cap aligned with the §6.9
-  user-device binding); past either bound, the next certify requires a
-  presence step — a user gesture at the head, never a fresh sign-in — which
-  starts a new chain; the identity plane's browser session may complete that
-  certify silently (WMC-009). The CLI's rule is MCC-056.
+  presence only while an attachment is open and less than 8 h after the
+  presence-backed initial certify that began the chain (Gatehouse §6.1.7);
+  past either bound the next certify requires a presence step, a user
+  gesture at the head and never a fresh sign-in (WMC-009). The CLI's rule
+  is MCC-056.
   tier:     T1
   verify:   cargo nextest run -p min-core renewal_chain_stops_at_8h_or_without_an_open_attach
   property: for every attachment state a ∈ {open, closed}, every chain start c and every instant now at the injected clock, an unattended renewal is composed iff a = open and now − c < 8 h; past either bound the next certify is composed only after a presence step
 
 - **MCC-041** WHERE the head is a browser THE SYSTEM SHALL generate a fresh
-  WireGuard keypair in memory per page session — the lifetime of one
-  document, ended by a reload or a navigation (MCC-076) — request a binding
-  for its public key under the DPoP-bound token (`JoinMesh`, a tenant opt-in
-  for a `public` client, Gatehouse §6.9), use it for at most 8 h, and
-  discard it when the page session ends (§6.9, client mesh keys; a
-  WebCrypto-held key is plan S13). The CLI's node key is MCC-053's.
+  WireGuard keypair in memory per page session, request a binding for it
+  under the DPoP-bound token (`JoinMesh`, Gatehouse §6.9), use it for at
+  most 8 h, and discard it when the page session ends. The CLI's node key
+  is MCC-053's.
   tier:     T1
   verify:   cargo nextest run -p min-core browser_mesh_key_is_fresh_per_page_session_bound_and_discarded
   property: for every page session s, the mesh keypair the core holds during s was generated after s began and differs from every earlier session's; no handshake uses it later than 8 h after its binding at the injected clock; and no handle to it survives the end of s
 
 - **MCC-042** THE SYSTEM SHALL use a head's signing key for DPoP proofs and
-  SSH authentication signatures only, and SHALL derive no SSH-PoP (`sshpop`)
-  assertion from it; a request to an issuer, relay or node is authenticated
-  with DPoP or the SSH certificate, never with an SSH-PoP assertion
-  (Gatehouse §6.1.7: the tab's DPoP key is never an SSH-PoP or
-  DPoP-for-boxes key).
+  SSH authentication signatures only, deriving no SSH-PoP assertion from it
+  (Gatehouse §6.1.7).
   tier:     T1
   verify:   cargo nextest run -p min-core heads_key_signs_only_dpop_and_ssh_userauth
   property: for every buffer b the core hands the signer, b is a DPoP proof's signing input or an SSH userauth request; no b is the signing input of an SSH-PoP assertion
 
-### CLI adoption (MCC-050–058)
+### CLI adoption
 
 - **MCC-050** WHEN a developer runs `min auth login` THE SYSTEM SHALL sign in
-  by the device flow (MCC-035, GHS-006), obtain the interactive certificate
-  and the Host CA anchors, and keep the key and the refresh token in the
-  CLI's own stores, neither surviving in the core's memory past the process.
+  by the device flow (MCC-035; its ceremony is GHS-006), obtain the
+  interactive certificate and the Host CA anchors, and keep the key and the
+  refresh token in the CLI's own stores, neither surviving in the core's
+  memory past the process.
   tier:     T0
   verify:   cargo nextest run -p minimal auth_login_installs_certificate_and_anchors
 
 - **MCC-051** WHEN `min` reaches a daemon over any transport other than a
   local UDS or vsock THE SYSTEM SHALL apply the host policy (MCC-032) and
-  certificate authentication (MCC-031), refusing a daemon that presents a bare
-  key.
+  certificate authentication (MCC-031).
   tier:     T0
   verify:   cargo nextest run -p minimal remote_daemon_needs_a_host_certificate_and_a_credential
 
 - **MCC-052** WHEN a developer attaches to a session THE SYSTEM SHALL attach
-  with raw-mode terminal, resize and signal handling, on a machine with no
-  `ssh` binary present.
+  in process, with raw-mode terminal, resize and signal handling, on a
+  machine with no `ssh` binary.
   tier:     T0
   verify:   cargo nextest run -p minimal session_attach_runs_in_process_without_ssh
-  - WHILE the TTY attach still runs through the system `ssh` — the first
-    adoption step (Design reasoning), until the in-process attach ships —
-    THE SYSTEM SHALL generate its `known_hosts` `@cert-authority` fragment
-    from the same anchors and expected principal the host policy uses.
+  - WHILE the TTY attach still runs through the system `ssh`, the first
+    adoption step, THE SYSTEM SHALL generate its `known_hosts`
+    `@cert-authority` fragment from the anchors and expected principal the
+    host policy uses.
     tier:   T0
     verify: cargo nextest run -p minimal known_hosts_fragment_matches_host_policy
 
-- **MCC-053** WHEN a developer runs `min net mesh join <network>` (today `min
-  mesh join`; the architecture's command tree renames it) THE SYSTEM SHALL
-  request a §6.9 binding and consume the peer document through the
-  credential module (the command's shape since Gatehouse v1.14: the manual
-  key exchange is retired, the daemon's static peer table being the POC
-  interim, MMI-011) and bring the mesh up over UDP, keeping its mesh node
-  key across invocations for the lifetime of its enrollment — the mesh
-  membership this command establishes, ending at `min net mesh leave` or a
-  later join — an interim, its rotation being an open question.
+- **MCC-053** WHEN a developer runs `min net mesh join <network>` THE SYSTEM
+  SHALL request a Gatehouse §6.9 binding and consume the peer document
+  through the credential module, with no manual key exchange (the daemon's
+  static peer table is the POC interim, MMI-011), keeping its mesh node key
+  across invocations for the lifetime of the membership the command
+  establishes, until a leave or a later join — an interim, its rotation
+  being an open question.
   tier:     T0
   verify:   cargo nextest run -p minimal mesh_join_needs_no_manual_key_exchange
 
 - **MCC-054** WHEN a developer lists sessions THE SYSTEM SHALL include the
   sessions on every node the identity plane lists for the developer
   (MCC-015), addressed and attachable with the same grammar as local ones;
-  the identity plane's listing excludes hosts reached only through the
-  client-managed provider list (Gatehouse §8.2 scope decision, v1.13), and
-  `min` keeps listing those through that list by today's local path,
-  unchanged here.
+  hosts reached only through the client-managed provider list stay listed
+  by today's path (Gatehouse §8.2 scope decision; BPA-013, BPA-015).
   tier:     T0
   verify:   cargo nextest run -p minimal list_and_attach_use_one_grammar_for_mesh_nodes
 
-- **MCC-055** WHILE a daemon is reached over a local UDS or vsock THE SYSTEM
-  SHALL keep today's behaviour: `auth_none`, no host certificate, no sign-in.
-  tier:     T0
-  verify:   cargo nextest run -p minimal local_socket_sessions_are_unchanged
-
 - **MCC-056** WHILE `min` holds a refresh token THE SYSTEM SHALL renew the
   interactive certificate in the background before it expires (Gatehouse
-  §5.7), with no open attachment required and no chain cap beyond the refresh
-  token's own lifetime.
+  §5.7), with no open attachment required and no chain cap beyond the
+  refresh token's lifetime.
   tier:     T0
   verify:   cargo nextest run -p minimal cli_renews_interactive_certificate_in_background
 
-- **MCC-057** WHEN an in-process attachment (MCC-052) ends with `tunnel_lost`
-  or `credential_expired` THE SYSTEM SHALL re-attach by a new attach call,
-  retrying with backoff from 1 s doubling to a 30 s cap until the daemon is
-  reachable and a certificate is held again or the developer detaches,
-  showing a reconnecting state on the terminal and landing on the daemon's
-  repaint (MCC-063).
+- **MCC-057** WHEN an in-process attachment ends with `tunnel_lost` or
+  `credential_expired` THE SYSTEM SHALL re-attach by a new attach call, with
+  backoff from 1 s doubling to a 30 s cap, until the daemon is reachable and
+  a certificate is held again or the developer detaches, showing a
+  reconnecting state and landing on the daemon's repaint (MCC-063).
   tier:     T0
   verify:   cargo nextest run -p minimal cli_reattaches_after_loss_with_bounded_backoff
 
-- **MCC-058** WHEN a developer runs `min auth status` THE SYSTEM SHALL report
-  the certificate's principals and expiry and whether a refresh token is held,
-  printing neither.
-  tier:     T0
-  verify:   cargo nextest run -p minimal auth_status_reports_principals_and_expiry
+### Browser contract
 
-### Browser contract (MCC-060–081)
+The browser client spec (WMC) cites these by ID; page behaviour is WMC's
+and verified there.
 
-The browser client spec in gominimal/webapp (WMC) cites these by ID.
-Sub-groups: attach MCC-060–063, errors MCC-064–065, signer and credential
-helpers MCC-066–069, peer document MCC-070, ticket MCC-071, rpc MCC-072,
-bundle integrity MCC-073–075, custody MCC-076–078, size budget MCC-079,
-status MCC-080. Page behaviour is cited to WMC by requirement ID and verified
-there.
-
-- **MCC-060** WHEN the page calls attach with one JSON configuration document,
-  a signer callback, a data callback and a close callback THE SYSTEM SHALL
-  resolve to an attachment offering `write(bytes)`, `resize(cols, rows)` and
-  `close()`, and deliver every byte of session output and of the daemon's
-  error stream, merged in order, to the data callback.
+- **MCC-060** WHEN the page calls attach with one JSON configuration
+  document, a signer callback, a data callback and a close callback THE
+  SYSTEM SHALL resolve to an attachment offering `write(bytes)`,
+  `resize(cols, rows)` and `close()`, and deliver every byte of session
+  output and of the daemon's error stream, merged in order, to the data
+  callback.
   tier:     T0
   verify:   just wasm-core-headless attach_api_shape
-  - IF the attach has not reached the accepted shell within 30 s of the call
-    at the injected clock THEN THE SYSTEM SHALL reject with the prefix of the
-    stage reached (MCC-064).
+  - IF the attach has not reached the accepted shell within 30 s of the
+    call THEN THE SYSTEM SHALL reject with the prefix of the stage reached
+    (MCC-064).
     tier:   T0
     verify: just wasm-core-headless attach_that_never_completes_rejects_within_30s
 
-- **MCC-061** THE SYSTEM SHALL accept as the configuration document the node's
-  peer-document entry (MCC-070) as served, the session identifier, the
-  terminal type and size, and an auth block naming the SSH username and the
-  expected host principal, the certificate and anchors being those the core
-  holds (MCC-067); the document has no scrollback field and the core declares
-  no scrollback request (MMI-052 is a later daemon capability); a missing or
-  malformed field rejects the promise naming the field before any network
-  activity.
+- **MCC-061** THE SYSTEM SHALL accept as the configuration document the
+  node's peer-document entry (MCC-070) as served, the session identifier,
+  the terminal type and size, and an auth block naming the SSH username and
+  the expected host principal, the certificate and anchors being those the
+  core holds (MCC-067); the core declares no scrollback request (MMI-052 is
+  a later daemon capability); a missing or malformed field rejects the
+  promise naming the field before any network activity.
   tier:     T0
   verify:   just wasm-core-headless config_rejections_name_the_field_before_dialing
 
@@ -514,551 +454,433 @@ there.
 
 - **MCC-063** WHEN an attachment is established, at first attach and after
   every transparent renewal, THE SYSTEM SHALL deliver as the first bytes to
-  the data callback the first bytes the daemon writes — its reconstruction of
-  the session's current screen (MMI-051) — adding nothing before them and
-  asking for no scrollback ahead of them; the page's rendering of the repaint
-  is WMC-029.
+  the data callback the first bytes the daemon writes — its reconstruction
+  of the session's current screen (MMI-051) — adding nothing before them;
+  the page's rendering is WMC-029.
   tier:     T0
   verify:   cargo nextest run -p min-core first_bytes_delivered_are_the_daemons_first_bytes_unprefixed
 
 - **MCC-064** IF the attach fails THEN THE SYSTEM SHALL reject the promise,
-  with no attachment object, carrying a reason whose prefix names the stage:
-  `config:`; `credential:` (the core's own pre-check of its certificate at
-  the injected clock before any dial — expired, not yet valid, host or CA
-  mismatch — and a credential call that failed, in the shape MCC-081 gives
-  it); `version:`; `transport:` (the relay named when it refused the
-  ticket; a dial or handshake that did not complete in time); `host
-  rejected:` with the failing check's code; `authentication rejected`;
-  `signing:`; `attach:` (the daemon refused the env, pty or shell request,
-  naming which, with `unknown session` distinguishable from every other
-  refusal, or the channel closed before the shell was established).
+  with no attachment object, carrying a reason whose prefix names the
+  stage: `config:`; `credential:` (the core's own pre-check of its
+  certificate before any dial, or a credential call that failed, MCC-081);
+  `version:`; `transport:` (a relay that refused the ticket, or a dial or
+  handshake that did not complete in time); `host rejected:` with the
+  failing check's code; `authentication rejected`; `signing:`; `attach:`
+  (the daemon refused the env, pty or shell request, naming which, with
+  `unknown session` distinguishable, or the channel closed before the
+  shell was established).
   tier:     T0
   verify:   just wasm-core-headless attach_rejections_name_the_stage
 
-- **MCC-065** WHEN an attachment ends THE SYSTEM SHALL call the close callback
-  exactly once with one cause and an exit status only for `exit`, mapping
-  the daemon's exit signals (MMI-053) and the transport as follows: `exit`
-  for the shell's own exit; `superseded` for `SUPERSEDED@minimal.dev`
-  (another client took the session over); `credential_expired` for
-  `EXPIRED@minimal.dev` (the daemon ended the session at certificate expiry
-  because a renewal did not land in time); `revoked` for
-  `REVOKED@minimal.dev`; `daemon_shutdown` for `SHUTDOWN@minimal.dev`;
-  `tunnel_lost` for a transport loss (MCC-013); `closed` when the head closed
-  it (MCC-022).
+- **MCC-065** WHEN an attachment ends THE SYSTEM SHALL call the close
+  callback exactly once with one cause and an exit status only for `exit`:
+  `exit` for the shell's own exit; `superseded` for `SUPERSEDED@minimal.dev`;
+  `credential_expired` for `EXPIRED@minimal.dev`; `revoked` for
+  `REVOKED@minimal.dev`; `daemon_shutdown` for `SHUTDOWN@minimal.dev`
+  (the daemon's exit signals, MMI-053); `tunnel_lost` for a transport loss
+  (MCC-013); `closed` when the head closed it (MCC-022).
   tier:     T0
   verify:   just wasm-core-headless close_causes_are_distinct_and_status_only_on_exit
   - IF `SUPERSEDED@minimal.dev` arrives on a channel the core is itself
-    replacing during a renewal (MCC-069) THEN THE SYSTEM SHALL consume it and
-    surface no close.
+    replacing during a renewal (MCC-069) THEN THE SYSTEM SHALL consume it
+    and surface no close.
     tier:   T0
     verify: just wasm-core-headless own_renewal_supersession_is_not_surfaced
 
-- **MCC-066** THE SYSTEM SHALL call the signer callback with the exact bytes to
-  sign and require a raw signature back, 64 bytes for Ed25519, performing
-  every SSH and JWS encoding itself; the page never encodes.
+- **MCC-066** THE SYSTEM SHALL call the signer callback with the exact bytes
+  to sign and require a raw signature back, 64 bytes for Ed25519,
+  performing every SSH and JWS encoding itself.
   tier:     T0
   verify:   just wasm-core-headless signer_gets_bytes_and_returns_a_raw_signature
 
 - **MCC-067** THE SYSTEM SHALL perform the token exchange, refresh, certify,
-  anchors fetch, mesh-bind, node listing and peer-document fetch,
-  relay-ticket request, renewal and the refresh-token revoke at sign-out
-  itself over an HTTP callback the page
-  supplies, produce the authorization URL the page navigates to, and consume
-  the callback the page hands back, checking its `state` against the request
-  and its `iss` against the deployment issuer set — a fixed set the head
-  configures the core with at start, never learned from a callback
-  (Gatehouse §6.1.6) — before exchanging; the page composes none of these
-  requests.
+  anchors fetch, mesh-bind, node listing, peer-document fetch, relay-ticket
+  request, renewal and the revoke at sign-out itself over the HTTP call the
+  host supplies, produce the authorization URL the page navigates to, and
+  consume the callback the page hands back, checking its `state` against
+  the request and its `iss` against the issuer set (Gatehouse §6.1.6)
+  before exchanging; the page composes none of these requests.
   tier:     T0
   verify:   just wasm-core-headless credential_helpers_run_in_the_core_over_the_supplied_fetch
-  - IF the callback's `iss` is outside the issuer set or its `state` does not
-    match THEN THE SYSTEM SHALL exchange nothing and report a sign-in failure
-    naming neither the issuer nor the code (WMC-001).
+  - IF the callback's `iss` is outside the issuer set or its `state` does
+    not match THEN THE SYSTEM SHALL exchange nothing and report a sign-in
+    failure naming neither the issuer nor the code (WMC-001).
     tier:   T0
     verify: just wasm-core-headless foreign_iss_or_bad_state_exchanges_nothing
 
-- **MCC-068** THE SYSTEM SHALL send the certify request and read its response
-  as Gatehouse §6.6 shapes them (dual-CKT audit, `exchange` profile for the
-  `public` client, §6.1.7), fetch the anchors as §8.2 shapes
+- **MCC-068** THE SYSTEM SHALL send the certify request and read its
+  response as Gatehouse §6.6 shapes them, fetch anchors as §8.2 shapes
   `GET {iss}/v1/ssh/ca`, and read the node listing and the peer document as
   §8.2 shapes `GET {iss}/v1/nodes` and `GET {iss}/v1/mesh/peers`.
   tier:     T0
   verify:   cargo nextest run -p min-core certify_and_anchors_exchanges_match_gatehouse
 
-- **MCC-069** WHILE an attachment is open THE SYSTEM SHALL renew (MCC-039) by
-  opening the new connection and attaching with the fresh certificate first,
-  then closing its old channel itself — with no second attach call, no change
-  to the attachment object and no close callback, the head observing only the
-  repaint (MCC-063), within the chain cap (MCC-040; Gatehouse §6.1.7); where
-  the daemon supersedes the old channel before the core closes it (MMI-053),
-  the resulting `SUPERSEDED@minimal.dev` is consumed (MCC-065).
+- **MCC-069** WHILE an attachment is open THE SYSTEM SHALL renew (MCC-039)
+  by attaching on the new connection with the fresh certificate first, then
+  closing its old channel itself — with no second attach call, no change to
+  the attachment object and no close callback, the head observing only the
+  repaint (MCC-063) — within the chain cap (MCC-040); a
+  `SUPERSEDED@minimal.dev` the daemon sends on the old channel (MMI-053) is
+  consumed (MCC-065).
   tier:     T0
   verify:   just wasm-core-headless renewal_is_invisible_to_the_page
 
 - **MCC-070** THE SYSTEM SHALL consume the subject's peer document as
-  Gatehouse §6.9 (v1.14) and §8.2 shape it — a `gatehouse-mesh-peers+jws`
-  feed over `GET /v1/mesh/peers?network=<mesh>` with payload `{td, mesh,
-  audience sub, seq, issued_at, peers[], revoked_bindings[]}` — taking per
-  subject and mesh the tab's tunnel address and prefix length, and per node
-  its identity, `wg_pub` (the node's current binding), tunnel address,
-  allowed IPs, the SSH port, the expected host principal (the node's
-  canonical name, §5.3), the document's `td` (checked against the
-  credential's trust domain, MCC-038), and the reachability options — a
-  direct endpoint and/or the node's home relay, the relay dialed with a
-  ticket; liveness, `last_seen` and the node's display name come from the
-  node listing (MCC-015), not the document, a per-node friendly name in the
-  document being a request of the identity plane (Open questions).
+  Gatehouse §6.9 and §8.2 shape it, taking per subject and mesh the head's
+  tunnel address and prefix, and per node its identity, `wg_pub`, tunnel
+  address, allowed IPs, SSH port, expected host principal, `td` (checked
+  against the credential's trust domain, MCC-038) and reachability options
+  — a direct endpoint and/or a home relay dialed with a ticket; liveness,
+  `last_seen` and the display name come from the node listing (MCC-015).
   tier:     T0
   verify:   cargo nextest run -p min-core peer_document_maps_onto_the_attach_configuration
   - THE SYSTEM SHALL reject a document whose `seq` regresses below the last
     one accepted for that (audience, mesh), and SHALL treat a document
-    older than `issued_at` + 5 min at the injected clock as expired: no new
-    tunnel is opened from it, while an established tunnel rides its
-    binding's TTL (§6.9 staleness bound; the revoked-bindings delta rides
-    in-band).
+    older than `issued_at` + 5 min as expired: no new tunnel is opened from
+    it, while an established tunnel rides its binding's TTL (§6.9).
     tier:   T0
     verify: cargo nextest run -p min-core stale_or_regressed_peer_document_opens_no_new_tunnel
 
-- **MCC-071** WHEN dialing through a relay THE SYSTEM SHALL present the node's
-  ticket — a `gatehouse-relay-ticket+jws` over `{td, sub, node_id, cnf.jkt,
-  iat, exp, jti}` bound to the head's DPoP key, requested under the
-  DPoP-bound token and issued only where the subject may reach the node
-  (`ReadNode`; Gatehouse §6.9, §7.4) — opaque and unmodified at WebSocket
-  open, with a DPoP proof over it and the head's own §6.9 mesh binding, from
-  which the relay takes the client's mesh public key (MMI-071; the binding
-  beside the ticket is the two specs' shared interim until the architecture
-  says whether the ticket carries `wg_pub`, Open questions); use a ticket
-  only for the node it was issued for; and obtain a new one when the relay
-  reports it expired. The ticket authorizes routing only: the tunnel's
-  security stays the §6.9 binding plus SSH end to end (T29).
+- **MCC-071** WHEN dialing through a relay THE SYSTEM SHALL present the
+  node's ticket (Gatehouse §6.9, issued under `ReadNode`, §7.4) opaque and
+  unmodified at WebSocket open, with a DPoP proof over it and the head's
+  mesh binding, from which the relay takes the client's mesh public key
+  (MMI-071; a shared interim, Open questions); use a ticket only for its
+  node; and obtain a new one when the relay reports it expired.
   tier:     T0
   verify:   cargo nextest run -p min-core relay_ticket_is_opaque_per_node_and_presented_at_open
 
-- **MCC-072** THE SYSTEM SHALL run the browser's v1 command set through the RPC
-  driver (MCC-023) over the selected node's tunnel with the taxonomy of
-  MCC-064: list sessions → each session's name, state and last activity;
-  show → a session's record and current screen; rename → the session renamed
-  or the daemon's refusal; stop → `StopSession` (MMI-028): the session's
-  process ended and the session listed with no running attributes; version →
-  the daemon's version (MCC-006). The daemon evaluates these as Gatehouse
-  §7.4 (v1.16) maps them — sessions are boxes: attach `SshConnect`, show and
-  list rows `BoxRead`, stop `StopBox`, rename `RenameBox`, a node-level
-  listing `ReadNode` — with the owner rule as the ratified interim
-  (MMI-025, MMI-027); the RPC names are the daemon's wire names.
+- **MCC-072** THE SYSTEM SHALL run the browser's v1 command set — list
+  sessions, show, rename, stop and version — through the RPC driver
+  (MCC-023) over the selected node's tunnel with MCC-064's taxonomy; stop
+  is the daemon's `StopSession` (MMI-028), ending the process and keeping
+  the record; the daemon evaluates each as Gatehouse §7.4 maps it, sessions
+  being boxes, with the owner rule as the ratified interim (MMI-025,
+  MMI-027).
   tier:     T0
   verify:   just wasm-core-headless v1_rpcs_run_through_the_driver_with_the_attach_taxonomy
 
 - **MCC-073** THE SYSTEM SHALL publish the wasm module and its JS glue as
-  content-addressed assets with one `SHA256SUMS` manifest per CLI release,
-  covering the bundle that release was built with, and `min` SHALL verify a
-  served bundle's hash against the manifest of the release whose core version
-  the bundle reports (MCC-074), a pre-release bundle's checksums being those
-  of the release cut for its commit (what WMC-038 vendors; Design
-  reasoning).
+  content-addressed assets with one manifest per CLI release, and `min`
+  SHALL verify a served bundle's hash against the manifest of the release
+  whose core version the bundle reports (MCC-074).
   tier:     T0
   verify:   cargo nextest run -p minimal served_bundle_hash_verifies_against_the_release_manifest
 
-- **MCC-074** THE SYSTEM SHALL expose, before any network activity, its own
-  version and its protocol window (`protocol_window`, MCC-006), so a served
-  bundle reports the core version its checksums were published under
-  (MCC-073); the
-  refusal of a daemon outside the window is MCC-006's, surfaced as
-  `version:` (MCC-064).
+- **MCC-074** THE SYSTEM SHALL expose, before any network activity, its
+  version and `protocol_window` (MCC-006); a daemon outside the window is
+  refused per MCC-006 and surfaced as `version:` (MCC-064).
   tier:     T0
   verify:   just wasm-core-headless version_signal_is_exposed_before_dialing
 
-- **MCC-075** THE SYSTEM SHALL run the browser bundle with `'wasm-unsafe-eval'`
-  as the only script-source allowance beyond `'self'`, needing no
-  `'unsafe-eval'` and no inline script; the page's policy and its loading
-  under integrity are WMC-035 and WMC-036.
+- **MCC-075** THE SYSTEM SHALL run the browser bundle with
+  `'wasm-unsafe-eval'` as the only script-source allowance beyond `'self'`,
+  needing no `'unsafe-eval'` and no inline script (WMC-035, WMC-036).
   tier:     T0
   verify:   just wasm-core-headless bundle_runs_without_unsafe_eval_or_inline_script
 
 - **MCC-076** WHERE the head is a browser THE SYSTEM SHALL hold tokens,
   certificates, the binding and the mesh key in memory only, the bundle
-  importing no storage capability — web storage, IndexedDB, cookies, the
-  cache — so a reload re-mints through the identity plane's browser session;
-  the page's own storage rule is WMC-004.
+  importing no storage capability (WMC-004).
   tier:     T0
   verify:   just wasm-core-headless bundle_imports_no_storage_capability
 
-- **MCC-077** WHERE the head is a browser THE SYSTEM SHALL take the signing key
-  only as a signer callback: no entry point of the bundle accepts private-key
-  bytes; the key's non-extractability is the page's (WMC-003).
+- **MCC-077** WHERE the head is a browser THE SYSTEM SHALL take the signing
+  key only as a signer callback; no entry point of the bundle accepts
+  private-key bytes (WMC-003).
   tier:     T0
   verify:   just wasm-core-headless browser_entry_points_accept_no_private_key
 
 - **MCC-078** THE SYSTEM SHALL open network connections only to the
   credential's issuer, the node endpoints the configuration names, and the
-  relays the configuration names, and to nothing else.
+  relays the configuration names.
   tier:     T1
   verify:   just wasm-core-headless bundle_dials_only_the_issuer_and_configured_endpoints
   property: for every configuration (issuer, node endpoints, relays) and every dial the core requests of the host through its pipe, the target is that issuer, a named node endpoint or a named relay
 
-- **MCC-079** THE SYSTEM SHALL deliver the stripped wasm module at no more than
-  600 KB gzip-compressed (the core ceiling WMC-N02 cites) and its JS glue at
-  no more than 20 KB, measured at each release.
+- **MCC-079** THE SYSTEM SHALL deliver the stripped wasm module at no more
+  than 600 KB gzip-compressed and its JS glue at no more than 20 KB,
+  measured at each release (WMC-N02 cites the module ceiling).
   tier:     T0
   verify:   just wasm-core-budget
 
 - **MCC-080** WHEN a head asks for status THE SYSTEM SHALL report the
-  certificate's serial and remaining lifetime at the injected clock, the
-  tunnel path in use (direct or relay) and the age of its last handshake, and
-  the last error code of MCC-064 or MCC-065, from memory and persisting
-  nothing; WMC-031 renders it.
+  certificate's serial and remaining lifetime, the tunnel path in use and
+  the age of its last handshake, and the last error of MCC-064 or MCC-065,
+  from memory, persisting nothing.
   tier:     T0
   verify:   just wasm-core-headless status_reports_certificate_tunnel_and_last_error
 
 - **MCC-081** IF a credential call of MCC-067 fails THEN THE SYSTEM SHALL
-  report it to the head in one of two shapes and no other: `credential:
-  refused (<code>)` when the issuer answered with an error, carrying the
-  issuer's error code and its human-readable reason verbatim; `credential:
-  unreachable` when no well-formed answer arrived within the call's bound
-  (a connection, TLS, timeout or non-JSON failure), carrying the transport
-  detail; so that a head can show the issuer's reason on a refusal and
-  choose between retrying and signing in again without parsing anything
-  else (WMC-006, WMC-007).
+  report it to the head in one of two shapes: `credential: refused (<code>)`
+  when the issuer answered with an error, carrying its code and reason
+  verbatim; `credential: unreachable` when no well-formed answer arrived
+  within the call's bound, carrying the transport detail (WMC-006,
+  WMC-007).
   tier:     T0
   verify:   just wasm-core-headless credential_call_failures_are_refused_or_unreachable
   - IF the call that failed was a renewal during an open attach THEN THE
-    SYSTEM SHALL keep the attachment open and report the failure through the
-    status accessor (MCC-080) until the certificate expires (MCC-039).
+    SYSTEM SHALL keep the attachment open and report the failure through
+    the status accessor (MCC-080) until the certificate expires (MCC-039).
     tier:   T0
     verify: just wasm-core-headless renewal_failure_is_reported_without_closing_the_attachment
 
 ## Non-goals
 
-- The daemon's mesh ingress, certificate-auth surface and allowlist, host
-  certificate, rejection delay, terminal state and repaint, supersession, the
-  exit signals, and the relay service:
-  `docs/specs/14-spec-minimald-mesh-ingress/14-spec-minimald-mesh-ingress.md`
-  in this repo, drafted in parallel.
+- The daemon's ingress, certificate-auth surface and allowlist, host
+  certificate, terminal state and repaint, exit signals and the relay
+  service: the mesh-ingress spec (MMI, #1356), which the networking spec in
+  preparation may supersede.
 - The browser page — origin, policy, integrity loading, key generation,
-  storage rule, reconnect cadence, rendering, mobile layout, the terminal
-  emulator, its tests: the browser client spec in gominimal/webapp (WMC).
-- The identity plane's capabilities — the `public` client kind and certify
-  for it (Gatehouse §6.1.7, §6.6, §5.7, v1.11), the node listing and
-  heartbeat (§8.2, v1.13), relay tickets (§6.9, v1.12), the peer document
-  (§6.9, v1.14), the mesh-attach host principal (§5.3, v1.15) and the
-  session-operation decisions (§7.4, v1.16): recorded in the architecture of
-  record on 2026-09-07 (gominimal/arch#16 to #22), implemented in
-  gominimal/gatehouse, the `01-spec-*` lineage.
-- The mobile app and its in-process network stack: from the same core, on
-  plan S13's intent; nobody owns it yet.
-- Session recording: plan S9 and Gatehouse §14.4(1); daemon-side if ever.
-- Sharing a session and teammate access: gominimal/inbox#480 (the
-  session-sharing spike) and plan S8; nobody owns it yet.
-- Creating a session, workspace sync, loadouts, file patches, hooks,
-  diagnostics and agent dispatch from the browser: outside the core (no
-  filesystem or TTY in a tab); the browser side is WMC's non-goal, agent
-  dispatch is G4 of gominimal/inbox#494, and a daemon-side checkout (plan
-  S8) has no owner yet.
+  storage, reconnect cadence, rendering, mobile layout: the browser client
+  spec (WMC, webapp#763).
+- The identity plane's capabilities this core consumes — the `public`
+  client kind, certify, node listing and heartbeat, relay tickets, the peer
+  document, the mesh-attach host principal, the session-operation decisions:
+  Gatehouse §6.1.7, §6.6, §5.7, §8.2, §6.9, §5.3 and §7.4 (v1.11 to
+  v1.16), implemented by the identity plane's own specs.
+- The mobile app and its in-process network stack: the same core, plan S13;
+  nobody owns it yet.
+- Session recording: plan S9 and Gatehouse §14.4(1); nobody owns it yet.
+- Sharing a session and teammate access: gominimal/inbox#480 and plan S8;
+  nobody owns it yet.
+- Creating a session, workspace sync, loadouts, hooks, diagnostics and agent
+  dispatch from the browser: WMC's non-goal on the page side; agent dispatch
+  is G4 of gominimal/inbox#494; a daemon-side checkout (plan S8) has no
+  owner yet.
 - Copying files into or out of a box, the epic's "Sync Files Out" story:
-  CLI-side work no spec binds yet; nobody owns it.
-- GitHub sign-in UX and credential-free git from sessions: the GitHub
-  sessions spec (GHS) in this repo; MCC-050 is the credential it rides on.
-- Hosts reached only through providers in the client-managed Box Provider
-  List, un-enrolled with Gatehouse: invisible to the tab in v1 (plan S2; the
-  scope decision of Gatehouse §8.2, v1.13); the server-side provider list it
-  names as the v2 revisit has no owner yet.
-
-## Non-functional requirements
-
-- **MCC-N01** WHILE attaching over a loopback datagram pipe with certificate
-  authentication and host verification THE SYSTEM SHALL reach the accepted
-  shell request within 200 ms at p95 of the transport opening, measured at
-  the client boundary.
-  tier:   T0
-  verify: just wasm-core-headless attach_latency_p95_under_200ms
-
-- **MCC-N02** WHILE attached over loopback THE SYSTEM SHALL deliver a
-  keystroke's echo to the data callback within 5 ms at p95 of the `write`
-  call.
-  tier:   T0
-  verify: just wasm-core-headless keystroke_round_trip_p95_under_5ms
-
-- **MCC-N03** WHEN the datagram transport closes THE SYSTEM SHALL deliver the
-  close callback within 1 s.
-  tier:   T0
-  verify: just wasm-core-headless tunnel_loss_closes_within_1s
+  no spec binds it yet; nobody owns it.
+- GitHub sign-in ceremony and credential-free git from sessions: the GitHub
+  sessions spec (GHS, #1351); MCC-050 is the credential it rides on.
+- Hosts reached only through providers in the client-managed provider list,
+  un-enrolled with the identity plane: outside the browser listing in v1
+  (Gatehouse §8.2 scope decision); the provider's own view of a host is BPA
+  (arch#45); a server-side provider list has no owner yet.
+- The CLI's auth status command and any performance bound on the core: the
+  command is the architecture's CLI reference (`min auth`); the proof of
+  concept's loopback measurements are recorded in the direction plan, and
+  no bound is set until an owner sets one.
 
 ## Design reasoning
 
-**One core, several heads** (decided 2026-09-03, plan §3.1). The alternatives,
-Tailscale's Go browser client and a purpose-built TypeScript thin client,
-both put a second implementation of the mesh peer, the SSH client and host
-trust next to the CLI's, and the first brings a second identity system whose
-SSH skips host-key verification, against Gatehouse §6.2. One Rust core is the
-literal form of "the website is just one more client" (minimal-hosted §1) and
-of the client credential library "also embedded in the `min` client"
-(Gatehouse §4.1); the proof of concept priced it at 91 KB gzip for the network
-layer and a forty-line WireGuard clock patch.
+**One core, several heads** (decided 2026-09-03, plan §3.1). Tailscale's Go
+browser client and a purpose-built TypeScript thin client were the
+alternatives; both put a second implementation of the mesh peer, the SSH
+client and host trust beside the CLI's, and the first brings a second
+identity system whose SSH skips host-key verification, against Gatehouse
+§6.2. One Rust core is the literal form of "the website is just one more
+client" (minimal-hosted §1); the proof of concept priced it at 91 KB gzip
+for the network layer.
 
-**Crate shape** (plan §4.3; mechanism, so it lives here). `min-core`,
-wasm-clean, holds the network layer, attach, RPC driver, credential module
-and host policy (MCC-001, MCC-002); `min-core-web` is the wasm-bindgen head
-exporting the contract group; `min-wire` carries the wire types carved out of
-`minimald-rpc` and `sessions::wire` with no `common` or `args` dependency —
-what MCC-007 stated until it was retired on 2026-09-09 as mechanism, its
-ID not reused, the outcome being MCC-001 and MCC-003. The cryptographic
-backend is a target-gated,
-non-default feature — `ring` for the browser, the workspace's native backend
-elsewhere — so a native `--workspace` build enables exactly one; MCC-004
-stated that as a requirement and was retired on 2026-09-04 as mechanism, its
-ID not reused. The `min-` prefix is deliberate beside `minimal-*` and
-`minimald-*`: the client core, not the `minimal` crate whose binary is `min`.
-Promotion updates AGENTS.md's crate table and `docs/architecture.md` §3
-(plan S5) and widens the justfile's macOS `scope` to `min-core`, which
-builds there.
+**Crate shape** (plan §4.3; mechanism, so it lives here and not in the
+requirements). `min-core`, wasm-clean, holds the network layer, attach,
+RPC driver, credential module and host policy; `min-core-web` is the
+wasm-bindgen head; `min-wire` carries the wire types shared with the
+daemon. The cryptographic backend is a target-gated feature, `ring` for the
+browser. The host injects the clock, so every time-dependent decision is
+testable at a fixed instant; the properties above say "at the injected
+clock" for that reason. Promotion updates the crate table in AGENTS.md and
+the architecture overview (plan S5).
 
 **The tab is a mesh node and no server is in the session path** (decided
-2026-09-03, plan entries 12, 18, 23, 24; architecture D7 and Gatehouse §6.9
-since v1.12). Servers remain for the page, Gatehouse, notifications and a
-stateless relay forwarding WireGuard ciphertext for daemons behind NAT; none
-holds a box credential or sees SSH bytes, and a relay compromise reads and
-terminates nothing (T29). A daemon exposes no inbound listener by default
-and connects outbound to its relay, registering with `sshpop-host` against
-a relay URL the issuer advertises in `gatehouse_node_endpoints`; the tab
-dials direct first (MCC-014) because a reachable daemon needs no relay, and
-opens a relay socket with a per-node ticket that authorizes routing only
-(MCC-071).
+2026-09-03, plan entries 12, 18, 23, 24; Gatehouse §6.9 and architecture
+D7 since v1.12). Servers remain for the page, the identity plane and a
+stateless relay forwarding ciphertext for daemons behind NAT; none holds a
+box credential or sees SSH bytes (T29). The tab dials direct first
+(MCC-014) and opens a relay socket with a per-node ticket that authorizes
+routing only (MCC-071). Whether that shape survives — a tab as a WireGuard
+peer, or a tab dialing a host's gateway ingress — is the networking spec's
+to decide (decided 2026-09-09); this document moves no transport text until
+it exists, and MMI, which this document binds for ingress and the relay,
+may fold into it.
 
 **A public client with tokens in memory** (decided 2026-09-03, entries 10,
-15–17; Gatehouse §6.1.7 since v1.11, the closure of §14.4(2)). With no
-backend nothing but the tab can hold tokens, and every token is
-sender-constrained to a non-extractable key (Gatehouse §5.4); the
-confidential-client rule that tokens never reach the browser stays for
-every other web client, and the `public` kind — PKCE with `dpop_jkt`,
-`auth_method = none`, tokens and the DPoP key in tab memory, nothing
-persisted, anchors from `{iss}/v1/ssh/ca` — is this one. §6.6 lets the
-certified key equal the DPoP key and the core signs both through one head
-key (MCC-042); §6.1.7's wording, "a fresh in-tab SSH key", is read as
-permitting that and carried as an open question. The core holds tokens in
-memory on every
-head; what outlives the process is the head's — none in the browser (MCC-076,
-WMC-004), the CLI's refresh token in its store (MCC-050). A reload re-mints
-through the SSO session, the client has its own origin, and the bundle is
-content-addressed with one manifest per CLI release (MCC-073); because the
-pipeline auto-cuts a `release-<sha>` per commit on `main`, a pre-release
-bundle's per-commit checksums and its release manifest are one artefact. The
-origin serving the page is trusted for code integrity, never for data, and
-checkably so.
+15 to 17; Gatehouse §6.1.7 since v1.11). With no backend, only the tab can
+hold tokens, and every token is sender-constrained to a non-extractable key
+(§5.4). §6.6 lets the certified key equal the DPoP key and the core signs
+both through one head key (MCC-042); §6.1.7's "a fresh in-tab SSH key" is
+read as permitting that and carried as an open question. What outlives the
+process is the head's: nothing in the browser (MCC-076), the CLI's refresh
+token in its store (MCC-050). The bundle is content-addressed with one
+manifest per CLI release (MCC-073), the pipeline's per-commit release
+making a pre-release bundle's checksums and its manifest one artefact.
 
 **A 15-minute certificate with transparent renewal, capped** (decided
-2026-09-03, entries 7, 8, 22; normative since Gatehouse v1.11 as the browser
-min client row of §5.7 and the lifecycle paragraph of §6.1.7). The
+2026-09-03, entries 7, 8, 22; Gatehouse §5.7 and §6.1.7 since v1.11). The
 `interactive` 8 h profile would keep §5.7's wall warnings at the price of an
 8 h window for an XSS that drives the key; `exchange` at 15 min keeps the
-window short and makes reconnect a core duty (MCC-039); §5.7 now suppresses
-the warnings for this client (MMI-031 is the daemon rule). Unattended
-renewals stop at the binding's 8 h and without an open attach (MCC-040), so
-the profiles are equivalent in XSS terms and differ in revocation latency
-only: the same 8 h envelope as a CLI cert, delivered as up to 32 short
-certificates. The chain is anchored at the presence-backed initial certify
-(plan entry 8), presence being a user gesture at the tab at the initial
-certify only, never per renewal, and never a fresh sign-in — the SSO
-session may complete the certify silently; WMC-009 counts from that certify.
-`box:ssh` and `JoinMesh` are tenant opt-ins for the `public` client, deny by
-default through the §5.8 issuance intersection, a personal tenant's sole
-admin opting in for themselves; where that opt-in surface lives is WMC's
-question. A Gatehouse outage detaches at the next renewal with no grace
-period. The daemon-side repaint
-makes each forced reconnect land on a full screen, which is why the
-mesh-ingress spec is a v1 prerequisite and MCC-063 states the repaint as
-observed.
+window short and makes reconnect a core duty (MCC-039). Unattended renewals
+stop at 8 h and without an open attach (MCC-040): the same envelope as a
+CLI certificate, delivered as up to 32 short ones. Presence is a user
+gesture at the tab at the initial certify only, never a fresh sign-in; the
+identity plane's browser session may complete the certify silently. Where
+the tenant opt-in for `box:ssh` and `JoinMesh` lives is WMC's question. An
+identity-plane outage detaches at the next renewal with no grace period,
+which is why the daemon's repaint is a v1 prerequisite (MCC-063).
 
 **Re-attach ownership** (decided 2026-09-04). A transport-initiated loss
-closes the attachment: the close callback fires once with `tunnel_lost`, and
-any re-attach is a new attach call by the head at its own cadence — MCC-057
-for the CLI; WMC-007, WMC-026 and WMC-028 for the page. The core binds no
-cadence, because when a head wants to be attached is a policy no head can
-express to it. A core-initiated reconnect, the transparent renewal, keeps
-the attachment object, fires no close callback, and shows the head only the
-repaint (MCC-069, MCC-063): the core attaches on the new connection first,
-then closes its old channel itself, and a `SUPERSEDED@minimal.dev` the daemon
-sends on that old channel is consumed, never surfaced as `superseded`
-(MCC-065); MMI-053 carries the mirror statement. One cause per daemon exit
-signal keeps WMC-030's "attached elsewhere" and a revocation distinct.
+closes the attachment once with `tunnel_lost`, and any re-attach is the
+head's new attach call at its own cadence (MCC-057; WMC-026, WMC-028),
+because when a head wants to be attached is a policy no head can express to
+the core. A core-initiated reconnect, the transparent renewal, keeps the
+attachment object and shows the head only the repaint (MCC-069); the
+daemon's supersession of the old channel is consumed, never surfaced
+(MCC-065), so WMC-030's "attached elsewhere" stays distinct.
 
-**Host-certificate revocation** (decided 2026-09-04). v1 does not consult the
-KRL for host certificates: the host policy runs the shared decision with an
-empty revocation set (MCC-032). The exposure is a compromised host key that
-stays acceptable until its certificate's 30-day expiry (Gatehouse §5.7) or a
-Host CA rotation; user-certificate revocation is the daemon's KRL
-(MMI-034, MMI-035, MMI-037). Carried as an open question.
+**Host-certificate revocation** (decided 2026-09-04). v1 runs the host
+policy with an empty revocation set (MCC-032); a compromised host key stays
+acceptable until its 30-day certificate expires (Gatehouse §5.7) or the
+Host CA rotates. Carried as an open question.
 
 **The expected principal is the node's canonical name** (Gatehouse §5.3,
-v1.15, the arch#21 ruling). A mesh attach dials the daemon's tunnel address
-and verifies the host certificate against `<node_id>.box.<td>`, which the
-peer document names in its expected-principal field — the same
-CNAME-onto-canonical move §5.3 makes for friendly names, with the peer
-document standing in for DNS canonicalization. Tunnel addresses are never
-certificate principals and owe no stability guarantee, so mesh renumbering
-forces no out-of-cycle host-cert renewal; the interim that added the
-address as a principal (MCC-032 as first drafted, MMI-029) is superseded.
-The core performs the check natively (MCC-032); the CLI's `known_hosts`
-fragment (MCC-052) is the `HostKeyAlias` form of the same rule.
+v1.15). A mesh attach dials a tunnel address and verifies the certificate
+against `<node_id>.box.<td>`, which the peer document names; tunnel
+addresses are never principals and owe no stability, so renumbering forces
+no host-cert renewal. The core checks natively (MCC-032); the CLI's
+`known_hosts` fragment (MCC-052) is the `HostKeyAlias` form of the same
+rule.
 
-**Constants.** The 60 s silent-peer bound (MCC-013) is twice the 25 s
-persistent keepalive the network layer configures; 20 s to the first
-handshake response (MCC-011) is four WireGuard handshake retries at its 5 s
-interval; 10 s for the version exchange (MCC-006) and 30 s for the whole
-attach (MCC-060) are the handshake bound plus SSH key exchange,
-authentication and the attach requests, which take 200 ms at p95 on loopback
-(MCC-N01). Every one is decided at the injected clock (MCC-005).
+**Constants.** 60 s silent-peer (MCC-013) is twice the 25 s keepalive; 20 s
+to the first handshake response (MCC-011) is four WireGuard retries at 5 s;
+10 s for the version exchange (MCC-006) and 30 s for the whole attach
+(MCC-060) are the handshake bound plus key exchange, authentication and the
+attach requests, which the proof of concept measured at 55 ms median on
+loopback.
 
 **Credential helpers run in the core over an injected HTTP call** (decided
-2026-09-04, MCC-067). The proof of concept let the page perform certify and
-mesh-bind. Renewal must run inside the core during an open attach, and one
-request shape across heads is the point of sharing, so the core composes and
-parses every issuer request — the callback's `state` and `iss` checks and the
-revoke at sign-out included — and the host executes it, the same seam as the
-clock; the page only navigates the authorization leg. Anchors are pinned to
-the issuer the credential names (MCC-038): a peer document may repeat that
-issuer, never select it, which is what makes "tenant issuer only" true.
+2026-09-04, MCC-067). Renewal must run inside the core during an open
+attach, and one request shape across heads is the point of sharing, so the
+core composes and parses every issuer request and the host executes it; the
+page only navigates the authorization leg. Anchors are pinned to the issuer
+the credential names (MCC-038): a peer document may repeat that issuer,
+never select it.
 
-**In-memory mesh key, Ed25519 first** (decided 2026-09-03, entries 3, 11). The
-WireGuard implementation takes the static secret as bytes, so a
+**In-memory mesh key, Ed25519 first** (decided 2026-09-03, entries 3, 11).
+The WireGuard implementation takes the static secret as bytes, so a
 WebCrypto-held X25519 key needs a static-DH hook in the noise core; v1
 accepts an in-memory key rotated per page session and bounded by the 8 h
-binding (MCC-041), the held key being plan S13 hardening. The CLI's node key
-lives as long as the enrollment (MCC-053): a peer that re-keys on every run
-is not the mesh peer plan S6 describes. P-256 is a one-variant fallback for
-the FIPS profile, covered by MCC-030's property.
+binding (MCC-041), the held key being plan S13. The CLI's node key lives
+as long as the mesh membership (MCC-053). P-256 is a one-variant fallback
+for the FIPS profile, covered by MCC-030's property.
 
 **Listing is the identity plane's node set plus heartbeats** (decided
 2026-09-03, entry 21; Gatehouse §8.2 since v1.13). The tab reads nodes,
-liveness and `last_seen` in one call — `GET /v1/nodes`, evaluated as
-`ReadNode` (§7.4), owner-only in v1: the enrolling subject of a
-`local`-class node — and handshakes only with the node it attaches to
-(MCC-015, MCC-017); a proof-of-concept design that opened a tunnel per node
-for liveness was retired by it. Liveness is the identity plane's derivation
-from `POST /v1/nodes/heartbeat` (60 s cadence; `reachable` within 150 s,
-`stale` within 15 min, `offline` beyond — §8.2 working values), and the
-same `ReadNode` decision gates relay-ticket issuance, so what a head can
-list and what it can dial never drift apart. Peer configuration is the
-§6.9 peer document (v1.14): bindings authorize, the document configures,
-with its `seq` and staleness bound enforced in the core (MCC-070); a stale
-document refuses new tunnels and never severs a live one.
+liveness and `last_seen` in one call, owner-only in v1, and handshakes only
+with the node it attaches to (MCC-015, MCC-017); a proof-of-concept design
+that opened a tunnel per node for liveness was retired by it. The same
+`ReadNode` decision gates relay-ticket issuance, so what a head can list
+and what it can dial never drift apart. Bindings authorize; the peer
+document configures, with its `seq` and staleness bound enforced in the
+core (MCC-070).
 
 **CLI adoption order** (decided 2026-09-03, entry 6). The target is the
-in-process attach (MCC-052); the first step shares the non-TTY parts and keeps
-the `ssh` binary for TTY attach with a `known_hosts` fragment from the same
-policy, because that changes a daily-driver path last. The CLI's sign-in leg
-is the device flow the GitHub sessions spec chose (GHS-006 owns its UX),
-DPoP-bound like the browser's auth-code leg (Gatehouse §6.1.2); MCC-035
-shares everything after it. The CLI keeps what the browser must not: a
-refresh token in its store with background renewal (MCC-056), a node key for
-the enrollment's lifetime (MCC-053), and its own reconnect cadence (MCC-057).
+in-process attach (MCC-052); the first step shares the non-TTY parts and
+keeps the `ssh` binary for TTY attach with a `known_hosts` fragment from
+the same policy, because that changes a daily-driver path last. The CLI
+keeps what the browser must not: a refresh token with background renewal
+(MCC-056), a node key for the membership's lifetime (MCC-053), and its own
+reconnect cadence (MCC-057).
 
-**Bundle budget** (decided 2026-09-03, entry 25). 447 KB gzip was accepted for
-v1 and the certificate path measured 501 KB stripped; MCC-079 bounds the
-module at 600 KB, the figure WMC-N02 cites, and the glue separately. The diet
-is later work.
+**Bundle budget** (decided 2026-09-03, entry 25). 447 KB gzip was accepted
+for v1 and the certificate path measured 501 KB stripped; MCC-079 bounds
+the module at 600 KB and the glue separately. The diet is later work.
 
-**Working assumptions, not decisions.** Four defaults the owner confirmed on
-2026-09-04 (recorded in WMC) stay written as assumptions so a reversal is one
-visible edit: A1, the v1 browser command set is owner-only list, show,
-attach, rename and stop (MCC-072; Gatehouse §7.4 since v1.16 maps them onto
-`SshConnect`, `BoxRead`, `StopBox`, `RenameBox` and `ReadNode` — sessions
-are boxes, no parallel action family — and ratifies the daemon's owner rule
-as the interim, destroy staying local-only), with no create, sync, agent
-dispatch or share links; A2, the plan's decisions above stand; A3, the
-browser client lives on its own origin served from the webapp repo (MCC-075,
-WMC-035); A4, the Gatehouse capabilities this spec consumes are dependencies
-on the identity plane, bound by section since the v1.11 to v1.16.1 stack
-landed on 2026-09-07 (arch#16 to #22 closed) — no longer an assumption, the
-sections cited where each requirement binds. Overturning one changes the
-requirements it names, not the core's shape.
+**Retired identifiers**, never reused. MCC-004 (the crypto backend as a
+feature) and MCC-007 (crate boundaries) were retired on 2026-09-04 and
+2026-09-09 as mechanism, now the Crate shape paragraph. On 2026-09-09,
+under the rule that a requirement traces to an acceptance criterion or a
+recorded decision: MCC-005 (decisions at the injected clock) was mechanism,
+kept as the seam the properties name; MCC-055 duplicated MCC-033 and
+GHS-009; MCC-058 (`min auth status`) had neither a criterion nor a
+decision behind it; MCC-N01 to MCC-N03 were proof-of-concept measurements
+with headroom, not bounds anyone set.
+
+**Working assumptions.** Recorded in WMC and confirmed 2026-09-04: A1, the
+v1 browser command set is owner-only list, show, attach, rename and stop
+(MCC-072; Gatehouse §7.4 since v1.16 maps them, sessions being boxes); A2,
+the plan's decisions stand; A3, the browser client lives on its own origin
+(MCC-075). Overturning one changes the requirements it names, not the
+core's shape.
 
 **Tiers.** Ten universals are at T1 because each is a pure function over
-owned values a property test can drive across its input space, and stating
-the universal forbids interleaving it with the transport: the signer's
-output shape (MCC-030), the host-policy decision (MCC-032) and the
-certificate decision (MCC-034), and — added on 2026-09-09 after review,
-since the injected clock (MCC-005), the signer seam (MCC-030) and the HTTP
-callback (MCC-067) make them decisions over values the core owns — the
+owned values a property test can drive across its input space: the
+signer's output shape (MCC-030), the host-policy and certificate decisions
+(MCC-032, MCC-034), and — since the injected clock, the signer seam and the
+HTTP callback make them decisions over values the core owns — the
 version-window refusal (MCC-006), DPoP on every composed request (MCC-036),
 the anchor source (MCC-038), the renewal-chain cap (MCC-040), the browser
-mesh key's lifetime (MCC-041), the key's permitted signing inputs (MCC-042)
-and the dial set (MCC-078). The property-testing dependency is confined to
-`min-core`'s development dependencies. T2 was declined because the
-decisions include a signature verification no bounded harness can exhaust.
-The invariant-covering requirements that stay at T0 do so for a stated
-reason each: MCC-035 exercises a live issuer, and the universals inside it
-are MCC-036's and MCC-030's; MCC-039 and MCC-069 drive a live tunnel and
-daemon, and the instant at which they act is MCC-040's property; MCC-051
-dispatches to MCC-032's property and adds one refusal run; MCC-066 is
-MCC-030's property seen from the browser head and adds nothing to prove;
-MCC-073's hash comparison is one run per release, the served fetch being
-transport; MCC-074 is an ordering check at the entry point; MCC-076 and
-MCC-077 are exhaustive over the bundle by construction. Everything else is
-T0 because it reaches a socket, a daemon or a browser. MCC-001's check is
-the headless attach on the wasm target: the second target compiling and
-running is the observable.
+mesh key's lifetime (MCC-041), the key's permitted signing inputs
+(MCC-042) and the dial set (MCC-078). The property-testing dependency is
+confined to `min-core`'s development dependencies. T2 was declined because
+the decisions include a signature verification no bounded harness can
+exhaust. The invariant-covering requirements at T0 stay there for a reason
+each: MCC-035 exercises a live issuer and its universals are MCC-030's and
+MCC-036's; MCC-039 and MCC-069 drive a live tunnel and the instant they act
+is MCC-040's property; MCC-051 dispatches to MCC-032's property; MCC-066
+is MCC-030's property seen from the browser head; MCC-073 is one hash
+comparison per release; MCC-074 is an ordering check at the entry point;
+MCC-076 and MCC-077 are exhaustive over the bundle by construction.
+Everything else is T0 because it reaches a socket, a daemon or a browser.
 
 **Verification mechanics.** Native tests run under `cargo nextest` through
-`just test` (`just test-cross` on macOS). `just wasm-core` builds the bundle;
-`just wasm-core-headless` drives the built module from Node against a native
-stand-in through the certificate-authenticated attach and inspects the
-module's import section (MCC-002, MCC-076), the gate before any bundle
-reaches the web side; `just wasm-core-budget` measures MCC-079. MCC-022 uses
-the mesh-ingress spec's daemon harness. Page behaviour is verified in WMC
-under its own runner; this spec names no test of WMC's.
+`just test`; `just wasm-core` builds the bundle; `just wasm-core-headless`
+drives it from Node against a native stand-in through the
+certificate-authenticated attach and inspects the module's import section;
+`just wasm-core-budget` measures MCC-079. MCC-022 uses the daemon side's
+harness. Page behaviour is verified in WMC; this spec names no test of
+WMC's.
 
-**Generality:** A second head fits by construction: the mobile app is the same
-core behind a UDP datagram pipe and a keystore-backed signer; the CLI is the
-same core behind a local socket and an agent-backed signer. A second daemon
-fits if it terminates SSH inside a WireGuard tunnel and presents a Gatehouse
-host certificate. A second transport is a datagram pipe. A second identity
-plane does not fit: the certify, anchors, peer-document and ticket shapes
+**Generality:** A second head fits by construction: the mobile app is the
+same core behind a UDP datagram pipe and a keystore-backed signer; the CLI
+is the same core behind a local socket and an agent-backed signer. A second
+daemon fits if it terminates SSH inside the tunnel the networking spec
+chooses and presents a Gatehouse host certificate. A second identity plane
+does not fit: the certify, anchors, peer-document and ticket shapes
 (MCC-068, MCC-070, MCC-071) are Gatehouse's by decision, acceptable because
-Gatehouse is the only identity plane in the system (§6.9).
+Gatehouse is the only identity plane in the system.
 
 ## Security considerations
 
-- **Invariant:** THE SYSTEM SHALL never hold, read or export a head's signing
-  key in its attach or credential paths; every signature is the head's
-  signer's, over bytes the core supplies.
+- **Invariant:** THE SYSTEM SHALL never hold, read or export a head's
+  signing key in its attach or credential paths; every signature is the
+  head's signer's, over bytes the core supplies.
   enforced by: the signer seam as the only signing path, and the browser's
   non-extractable key behind a callback (WMC-003).
   covered by: MCC-030, MCC-066, MCC-077
-- **Invariant:** THE SYSTEM SHALL attach to no host off a local socket without
-  a host certificate verifying, for the expected principal, against anchors
-  taken from the tenant issuer only.
+- **Invariant:** THE SYSTEM SHALL attach to no host off a local socket
+  without a host certificate verifying, for the expected principal,
+  against anchors taken from the tenant issuer only.
   enforced by: the host policy in the server-key check, aborting before
-  authentication (Gatehouse §6.2, no TOFU), the expected principal being the
-  node's canonical name (§5.3 mesh attaches); the anchors fetch bound to the
-  issuer the credential names, with a peer document naming another issuer
-  refused.
+  authentication (Gatehouse §6.2, no TOFU); the anchors fetch bound to the
+  issuer the credential names.
   covered by: MCC-032, MCC-038, MCC-051
-- **Invariant:** THE SYSTEM SHALL present no bearer credential and derive no
-  SSH-PoP assertion from a head's key; every issuer, relay and node request
-  is DPoP-bound or certificate-authenticated.
+- **Invariant:** THE SYSTEM SHALL present no bearer credential and derive
+  no SSH-PoP assertion from a head's key; every issuer, relay and node
+  request is DPoP-bound or certificate-authenticated.
   enforced by: DPoP proofs on every request and PKCE with `dpop_jkt` at
   sign-in (Gatehouse §6.1.1); the head's key used for DPoP and SSH
-  authentication signatures only.
+  authentication only.
   covered by: MCC-035, MCC-036, MCC-042
-- **Invariant:** THE SYSTEM SHALL renew a browser credential unattended for at
-  most 8 h and only while an attachment is open, and hold a browser mesh key
-  for at most 8 h.
-  enforced by: the renewal-chain cap and the binding TTL at the injected
-  clock (Gatehouse §6.9, T22).
+- **Invariant:** THE SYSTEM SHALL renew a browser credential unattended for
+  at most 8 h and only while an attachment is open, and hold a browser mesh
+  key for at most 8 h.
+  enforced by: the renewal-chain cap and the binding TTL (Gatehouse §6.9,
+  T22).
   covered by: MCC-039, MCC-040, MCC-041, MCC-069
-- **Invariant:** THE SYSTEM SHALL persist no token, certificate, key handle or
-  mesh key in a browser, and open no connection from the bundle to an
-  endpoint other than the credential's issuer and the configured endpoints.
-  enforced by: in-memory holders in the core, a bundle importing no storage
-  capability, the page's storage rule (WMC-004), and the core dialing only
-  the issuer and configured endpoints.
+- **Invariant:** THE SYSTEM SHALL persist no token, certificate, key handle
+  or mesh key in a browser, and open no connection from the bundle to an
+  endpoint other than the credential's issuer and the configured
+  endpoints.
+  enforced by: in-memory holders, a bundle importing no storage capability,
+  and the core dialing only the issuer and configured endpoints.
   covered by: MCC-076, MCC-078
 - **Invariant:** THE SYSTEM SHALL publish every bundle content-addressed
   under a release manifest `min` verifies a served bundle against, and fail
   closed on a daemon outside its protocol window; running only a bundle
   whose hash matches is the page's invariant (WMC-036).
-  enforced by: content-addressed assets with one manifest per release, the
-  CLI-verifiable manifest, and version negotiation before any session
-  operation.
+  enforced by: content-addressed assets with one manifest per release, and
+  version negotiation before any session operation.
   covered by: MCC-006, MCC-073, MCC-074
 
 ## Open questions
@@ -1066,43 +888,42 @@ Gatehouse is the only identity plane in the system (§6.9).
 - [NEEDS CLARIFICATION (MEDIUM): One key or two. Gatehouse §6.1.7 mints the
   browser client's certificate "onto a fresh in-tab SSH key" and §6.6 says
   the certified key "needn't equal the DPoP key"; MCC-042 and WMC-003 sign
-  DPoP proofs and SSH authentication with one head key, as the proof of
-  concept did, so the dual-CKT audit records one thumbprint twice. Confirm
-  that one key is acceptable, or split it: a second signer for SSH costs the
-  head one more key and the core a second signer seam, nothing else.]
+  both with one head key, as the proof of concept did.] Survives because
+  only the identity plane's owner can say which wording rules.
 - [NEEDS CLARIFICATION (MEDIUM): The relay ticket's claim set (Gatehouse
-  §6.9: `td, sub, node_id, cnf.jkt, iat, exp, jti`) carries no mesh public
-  key, which the relay needs to address frames (MMI-077). MCC-071 presents
-  the head's §6.9 binding beside the ticket and the relay takes the key from
-  it (MMI-071); the mesh-ingress spec asks the architecture whether a
-  `wg_pub` claim in the ticket is wanted instead. Two more fields are
-  requested of the §6.9 peer document for the same reason: a per-node
-  friendly name, which MCC-070 takes from the node listing until then.]
+  §6.9) carries no mesh public key, which the relay needs to address frames
+  (MMI-077). MCC-071 presents the head's binding beside the ticket and the
+  relay takes the key from it (MMI-071); the daemon side asks the
+  architecture whether a `wg_pub` claim is wanted instead. A per-node
+  friendly name in the peer document is requested for the same reason;
+  MCC-070 takes it from the node listing until then.] Survives because both
+  are additions to an approved document and belong with its owner.
 - [NEEDS CLARIFICATION (MEDIUM): Host-certificate revocation. v1 checks no
-  KRL for host certificates (MCC-032, Design reasoning), leaving a
-  compromised host key acceptable until its 30-day certificate expires
-  (Gatehouse §5.7). Does the identity plane want the client to consult the
-  KRL for host serials, and if so from which feed — the same §8.2 feed the
-  daemon polls (MMI-035) fetched by the core over MCC-067's HTTP callback?]
+  KRL for host certificates (MCC-032). Does the identity plane want the
+  client to consult the KRL for host serials, and from which feed?]
+  Survives because the identity plane has not said.
 - [NEEDS CLARIFICATION (MEDIUM): The CLI's mesh node key lifetime and
-  rotation. MCC-053 keeps it for the enrollment's lifetime; whether it
-  rotates on a schedule, on `min auth login`, or only on re-enrollment, and
-  what the daemon's binding check (MMI-010) needs from a rotation, is
-  unset.]
+  rotation. MCC-053 keeps it for the membership's lifetime; whether it
+  rotates on a schedule, on `min auth login`, or only on re-join, and what
+  the daemon's binding check (MMI-010) needs from a rotation, is unset.]
+  Survives because it is the networking spec's territory once that exists.
 - [NEEDS CLARIFICATION (MEDIUM): The SSH username under certificate
-  authentication (plan S4): MCC-021 binds the box login principal as the
-  interim MMI-024 admits; whether the canonical subject with the daemon
-  deriving the sandbox user replaces it is the mesh-ingress spec's to
-  decide. The core takes it as input either way.]
+  authentication. MCC-021 binds the box login principal as the interim
+  MMI-024 admits; whether the canonical subject with the daemon deriving
+  the sandbox user replaces it is the daemon side's to decide.] Survives
+  because the daemon side has not decided.
 - [NEEDS CLARIFICATION (MEDIUM): The default width of `protocol_window`
   (architecture open gap 8). MCC-006 and MCC-074 bind to the window; its
-  default is unset.]
+  default is unset.] Survives because the architecture owns the gap.
 - [NEEDS CLARIFICATION (MEDIUM): The wasm head's packaging for the webapp —
   npm versioning of `min-core-web`, the wasm-bindgen pin policy, and how the
-  webapp consumes the release manifest of MCC-073.]
-- [NEEDS CLARIFICATION (LOW): Whether `minimald`'s WireGuard pump moves onto
-  the core's network layer or keeps its own driver over the same crate; the
-  mesh-ingress spec's call, invisible to this spec's behaviours.]
+  webapp consumes the release manifest of MCC-073.] Survives because it
+  needs the page's owner and the release pipeline's together.
+- [NEEDS CLARIFICATION (LOW): Whether the daemon's WireGuard pump moves onto
+  the core's network layer or keeps its own driver over the same crate.]
+  Survives because it is invisible to this spec's behaviours and the
+  daemon side's call.
 - [NEEDS CLARIFICATION (LOW): Interoperability with WireGuard peers that are
   not the daemon's implementation; MCC-011 is proven
-  implementation-to-implementation only.]
+  implementation-to-implementation only.] Survives because no second peer
+  exists to test against.


### PR DESCRIPTION
## Summary

The shared client core for the remote-sessions epic (gominimal/inbox#513): one Rust core carrying the mesh peer, the attach sequence, the RPC driver, the credential flow and host trust for every head — the `min` CLI, the browser bundle, later a mobile app. Fifty-nine requirements under the `MCC` prefix in five groups (core boundary, transport, attach and RPC, credential, CLI adoption, browser contract), ten at T1 with properties over owned values; the rest T0 with the reason stated per invariant-covering requirement.

Trimmed on 2026-09-09 to what the epic's acceptance criteria and the recorded decisions trace to, in the shape of the Box Provider abstraction spec (arch#45): terms defined once, the architecture and the siblings cited rather than restated, one Design reasoning paragraph per decision naming the alternatives, every open question with its reason for surviving. 1108 lines to 929.

## Retirements (IDs never reused)

- MCC-005, decisions at the injected clock: mechanism; the seam stays in Design reasoning and the properties name it.
- MCC-055, local UDS/vsock behaviour unchanged: duplicated MCC-033 and GHS-009.
- MCC-058, `min auth status`: no acceptance criterion or decision behind it; destination the architecture's CLI reference.
- MCC-N01 to MCC-N03, loopback latency and close bounds: proof-of-concept measurements with headroom, not bounds anyone set; the measurements stay in the direction plan.
- Earlier: MCC-004 (2026-09-04) and MCC-007 (2026-09-09), mechanism, now the Crate shape paragraph.

## Siblings

- WMC, the browser client (webapp#763): consumes the browser contract group (MCC-060 to MCC-081) by ID.
- MMI, the daemon's mesh ingress (#1356): bound by ID for ingress, exit signals, repaint, the relay and the owner rule. **MMI may be superseded by the networking spec in preparation**, which implements the architecture's networking requirements v2 and its deployment and egress-gateway design v0.2.
- The networking design (deployment and egress-gateway, v0.2), cited by section: on a pinned host the attach path transits the host's Egress Gateway, which forwards as a relay and admits clients by the same ticket (§4.5); MCC-014 and MCC-070 name it as the home relay, and Security considerations carry the forwarder invariant (T29, T30).
- GHS, GitHub sessions (#1351): the CLI sign-in ceremony MCC-050 rides on.
- BPA, the Box Provider abstraction (arch#45, draft): the provider's view of a host; MCC-054 cites BPA-013 and BPA-015 for provider-list hosts.
- Gatehouse v1.17 (§5.3, §5.7, §6.1.7, §6.6, §6.9, §7.4, §8.2), cited by section.

## Open questions

Nine: one key or two for DPoP and SSH; the relay ticket's missing mesh-key claim and the peer document's missing friendly name; host-certificate revocation; the CLI node key's rotation; the SSH username under certificate auth; the default width of `protocol_window`; the wasm head's packaging; the daemon's WireGuard pump; interoperability with other WireGuard peers. Each states why it survives.

## Verification

`spec-lint` from foundry `main` (84fa718, which drops the `status` field): 58 findings, all P004, one per named test not yet written. The installed plugin (0.3.0) predates that change and adds one F004 for the missing `status:`. Self-scored against the spec-review rubric after the rewrite: no ✕ left on observable, universal, tier, faithful or defined; stories verbatim; every non-goal has a destination; the first slice runs end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SN7GPDMfE3DbTayuqfnQG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive specification for a shared client core supporting CLI, browser, and future mobile clients.
  * Documented transport, attach/RPC, authentication, signing, host trust, renewal, reconnect, status, errors, and bundle verification.
  * Clarified timeout handling, relay fallback, output ordering, local transport exceptions, browser signing options, redirect and issuer validation, and cancellable credential calls.
  * Defined browser security constraints, resource limits, protocol negotiation, verification commands, and security invariants.
  * Specified Egress Gateway routing for pinned hosts, canonical tunnel principals, and ciphertext-only forwarding through relays and gateways.
  * Specified bundle compatibility rules and when host certificate requirements apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
