### PR TITLE
chore: skip commitlint on Dependabot commits

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,6 +1,9 @@
 // Conventional Commits enforcement. See docs/commit-conventions.md.
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  // Dependabot writes its own bodies (changelog/compare URLs) and always
+  // overruns body-max-line-length; we cannot edit them. Skip its commits.
+  ignores: [(message) => message.includes("Signed-off-by: dependabot[bot]")],
   rules: {
     "type-enum": [
       2,


### PR DESCRIPTION
## Summary

The `commitlint` check fails on every Dependabot PR, and has nothing to do
with the change under review.

Root cause: `commitlint.config.cjs` extends `@commitlint/config-conventional`,
which sets `body-max-line-length: 100`. Dependabot's generated bodies always
overrun it. From PR #1361's commit `9f97538`, this line is 112 characters:

```
Bumps the github-actions group with 1 update: [taiki-e/install-action](https://github.com/taiki-e/install-action).
```

The `- [Commits](...compare/<sha>...)` lines are longer still. We do not
control those messages — Dependabot generates them — so the only lever is on
our side.

This adds an `ignores` predicate that skips commits carrying Dependabot's
own sign-off trailer:

```js
ignores: [(message) => message.includes("Signed-off-by: dependabot[bot]")],
```

The existing `extends` and `type-enum` rules are unchanged; human commits are
linted exactly as before.

Unblocks #1361 and #1362, where `commitlint` is the only red check.

Rejected alternative: disabling `body-max-line-length` repo-wide. That is too
blunt — it drops body wrapping enforcement for every human commit in order to
accommodate one bot. Scoping the exemption to Dependabot's commits keeps the
rule meaningful everywhere it can actually be honored.

`.github/workflows/` is frozen and CODEOWNER-gated, so no workflow was touched;
the fix is entirely in `commitlint.config.cjs`.

## Testing

No local build or test run — this is a commitlint config change with no Rust
impact. The proof is CI itself: `commitlint` must stay green on this PR (which
has a conforming human commit, so the rules still apply), and the check should
go green on #1361 / #1362 once this lands.

## Checklist

- [x] Docs updated if behavior changed — no behavior change to document;
      `docs/commit-conventions.md` describes rules for human commits, which are
      unaffected
- [x] `BREAKING CHANGE:` footer present if this is a breaking change — not breaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)