### PR TITLE
fix(op): make the notices temp filename unique per write

### DIFF
--- a/crates/op/src/notices.rs
+++ b/crates/op/src/notices.rs
@@ -10,6 +10,7 @@
 
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use base64::Engine as _;
 use lcache::{Cache, LocalDir};
@@ -154,8 +155,15 @@ pub fn record(cache: &Cache<LocalDir>, source_sha256: &str, root: &Path) -> io::
         files: scan(root)?,
     };
     let json = serde_json_lenient::to_string_pretty(&notices).map_err(io::Error::other)?;
-    // Write-then-rename so a reader never sees a partial record.
-    let tmp = path.with_extension(format!("json.tmp-{}", std::process::id()));
+    // Write-then-rename so a reader never sees a partial record. The temp name
+    // is unique per write — PID plus a process-local counter — so two
+    // concurrent writers for the same digest never share a temp file, and one
+    // writer's rename can never move another's still-in-flight write. The
+    // rename itself is atomic, so a final record already published by a racing
+    // writer is a fine idempotent outcome (identical archive → identical tree).
+    static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = TMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let tmp = path.with_extension(format!("json.tmp-{}-{seq}", std::process::id()));
     std::fs::write(&tmp, json)?;
     std::fs::rename(&tmp, &path)?;
     Ok(path)


### PR DESCRIPTION
## Summary

`notices::record` publishes `<cache>/notices/<source-sha256>.json` with a
write-then-rename, but the temp filename was derived from the PID alone:

```rust
let tmp = path.with_extension(format!("json.tmp-{}", std::process::id()));
```

Within a single process the PID is a constant, so two concurrent
`SourceLoad::run` calls for the **same** source digest resolve to the same
temp path. The interleaving that bites is:

1. Writer A creates `…json.tmp-<pid>` and starts writing.
2. Writer B truncates and starts writing the same temp path.
3. A finishes and renames the temp file — which is now B's partial write —
   over the final record.
4. B's own rename then fails (`ENOENT`), or, if it lands first, the record
   published is the truncated JSON.

Either outcome is a real failure: a rename error surfacing out of source
extraction, or a malformed attribution record persisted in the cache, where
the write-then-rename existed precisely to guarantee readers never see a
partial record.

The fix makes the temp name unique per write — PID plus a process-local
`AtomicU64` counter — so two concurrent writers for the same digest never
share a temp file, and one writer's rename can never move another's
still-in-flight write. The rename itself stays atomic, so a final record
already published by a racing writer remains a fine idempotent outcome
(identical archive → identical tree), matching `record`'s documented
idempotence.

One file changed, `crates/op/src/notices.rs`: the `AtomicU64`/`Ordering`
import, the counter, and the comment explaining why the name is unique.

### Why this is a separate PR

The finding is CodeRabbit's, on #1345:
https://github.com/gominimal/minimal/pull/1345#discussion_r3933599866

The fix was authored on #1345's branch by mistake — it addresses code
introduced by #1341 (`feat(op): capture upstream NOTICE/COPYRIGHT files at
source extraction`), already merged to `main`, and has nothing to do with
#1345's subject. #1345 is being rebased to drop that commit, so the fix is
extracted here to keep it from being lost. Nothing on #1345 or its branch is
touched by this PR.

Refs: #1341, #1345

## Testing

No local build was run for this change; the PR lanes are the verification.
The edit is confined to `crates/op/src/notices.rs` and is a
behaviour-preserving change to the temp filename plus the `AtomicU64` import
it needs. `git diff --stat origin/main` shows exactly one changed file.

## Checklist

- [x] Docs updated if behavior changed — n/a, no user-visible behavior change
      (the temp filename is an internal implementation detail)
- [x] `BREAKING CHANGE:` footer present if this is a breaking change — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple temporary notice records are written concurrently.
  * Prevented concurrent operations from accidentally sharing temporary file paths during publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->