### PR TITLE
fix: nightly smoke races — detached vcs worktrees, dead-host shutdown gating, e2e teardown

### DIFF
--- a/crates/checkouts/src/lib.rs
+++ b/crates/checkouts/src/lib.rs
@@ -801,6 +801,43 @@ mod tests {
         );
     }
 
+    /// A cache whose bare clone carries only `refs/heads/<branch>` (cloned
+    /// before remote-tracking refs were fetched at clone time, never updated
+    /// since) still serves a branch checkout offline.
+    #[test]
+    fn offline_checkout_of_branch_from_a_legacy_cache_uses_the_local_ref() {
+        use std::process::Command;
+        let (src, hash) = make_local_repo("main");
+        let remote = src.path().to_str().unwrap().to_string();
+        let base = tempfile::tempdir().unwrap();
+
+        // Register the remote online, then strip the remote-tracking refs the
+        // clone-time fetch wrote, leaving the legacy shape.
+        let mut online = Manager::new_in_dir(base.path()).unwrap();
+        online
+            .checkout_of(&remote, GitRef::Commit(hash.clone()))
+            .unwrap();
+        let bare = std::fs::read_dir(base.path().join("git").join("db"))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        let out = Command::new("git")
+            .args(["update-ref", "-d", "refs/remotes/origin/main"])
+            .current_dir(&bare)
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+
+        let mut offline = Manager::new_in_dir_with_offline(base.path(), true).unwrap();
+        let (path, rev) = offline
+            .checkout_of(&remote, GitRef::Branch("main".to_string()))
+            .unwrap();
+        assert_eq!(rev, hash);
+        assert!(path.join("hello.txt").exists());
+    }
+
     /// A refused ref on a remote the manager has never seen leaves no bare
     /// clone behind either: the remote is not recorded, so a leftover
     /// `git/db/<id>` would make the next request clone again under a

--- a/crates/checkouts/src/lib.rs
+++ b/crates/checkouts/src/lib.rs
@@ -400,11 +400,22 @@ impl Manager {
                 };
                 // Make repo
                 let (id, dir) = create_unique_id_and_dir(&self.git_bares_dir(), prefix)?;
-                let mut repo = Repo::new(remote, dir)?;
+                let mut repo = Repo::new(remote, dir.clone())?;
                 // Make checkout
                 let checkout_dir = tempdir_in(self.git_checkouts_dir()).unwrap().keep();
                 let relative_dir = checkout_dir.strip_prefix(self.git_checkouts_dir()).unwrap();
-                let checkout = new_worktree_or_cleanup(&mut repo, &checkout_dir, at.clone())?;
+                // Nothing about this remote is recorded until the checkout
+                // succeeds, so a refused ref must also take the bare clone with
+                // it: left in place, the next request for the same remote would
+                // find the directory taken and clone again under a suffixed id.
+                let checkout = match new_worktree_or_cleanup(&mut repo, &checkout_dir, at.clone()) {
+                    Ok(checkout) => checkout,
+                    Err(err) => {
+                        drop(repo);
+                        let _ = fs::remove_dir_all(&dir);
+                        return Err(err);
+                    }
+                };
                 let git_hash = checkout.rev.clone();
 
                 self.state
@@ -735,6 +746,34 @@ mod tests {
             .unwrap()
             .count();
         assert_eq!(before, after, "the refused add must not leak a directory");
+    }
+
+    /// A refused ref on a remote the manager has never seen leaves no bare
+    /// clone behind either: the remote is not recorded, so a leftover
+    /// `git/db/<id>` would make the next request clone again under a
+    /// suffixed id.
+    #[test]
+    fn checkout_of_unknown_ref_on_new_remote_leaves_no_bare_repo() {
+        let (src, hash) = make_local_repo("main");
+        let remote = src.path().to_str().unwrap().to_string();
+        let base = tempfile::tempdir().unwrap();
+        let mut handle = Manager::new_in_dir(base.path()).unwrap();
+
+        assert!(
+            handle
+                .checkout_of(&remote, GitRef::Tag("no-such-tag".to_string()))
+                .is_err()
+        );
+        let bares = base.path().join("git").join("db");
+        let leftover = std::fs::read_dir(&bares).map(|d| d.count()).unwrap_or(0);
+        assert_eq!(leftover, 0, "the refused add must not leak the bare clone");
+
+        // The remote is still unknown, so a good ref clones once, unsuffixed.
+        let (_, rev) = handle
+            .checkout_of(&remote, GitRef::Commit(hash.clone()))
+            .unwrap();
+        assert_eq!(rev, hash);
+        assert_eq!(std::fs::read_dir(&bares).unwrap().count(), 1);
     }
 
     /// A single unreachable remote must not gate `update_remote` for a

--- a/crates/checkouts/src/lib.rs
+++ b/crates/checkouts/src/lib.rs
@@ -748,6 +748,59 @@ mod tests {
         assert_eq!(before, after, "the refused add must not leak a directory");
     }
 
+    /// A fresh branch checkout lands on the fetched tip, not the bare
+    /// clone's clone-time copy of the branch, and a branch that upstream
+    /// created after the clone resolves at all.
+    #[test]
+    fn checkout_of_branch_lands_on_the_fetched_tip() {
+        use std::process::Command;
+        let (src, first_hash) = make_local_repo("main");
+        let remote = src.path().to_str().unwrap().to_string();
+        let base = tempfile::tempdir().unwrap();
+        let mut handle = Manager::new_in_dir(base.path()).unwrap();
+
+        // Clone the bare repo at the first commit.
+        let (_, rev) = handle
+            .checkout_of(&remote, GitRef::Commit(first_hash.clone()))
+            .unwrap();
+        assert_eq!(rev, first_hash);
+
+        // Move `main` upstream and add a branch that postdates the clone.
+        let git = |args: &[&str]| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(src.path())
+                .output()
+                .unwrap();
+            assert!(out.status.success(), "git {args:?} failed");
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+        std::fs::write(src.path().join("hello.txt"), b"hello again").unwrap();
+        git(&["commit", "-am", "second"]);
+        let second_hash = git(&["rev-parse", "HEAD"]);
+        git(&["branch", "dev"]);
+
+        let (path, rev) = handle
+            .checkout_of(&remote, GitRef::Branch("main".to_string()))
+            .unwrap();
+        assert_eq!(
+            rev, second_hash,
+            "a branch checkout must land on the fetched tip"
+        );
+        assert_eq!(
+            std::fs::read(path.join("hello.txt")).unwrap(),
+            b"hello again"
+        );
+
+        let (_, rev) = handle
+            .checkout_of(&remote, GitRef::Branch("dev".to_string()))
+            .unwrap();
+        assert_eq!(
+            rev, second_hash,
+            "a branch created after the clone must resolve"
+        );
+    }
+
     /// A refused ref on a remote the manager has never seen leaves no bare
     /// clone behind either: the remote is not recorded, so a leftover
     /// `git/db/<id>` would make the next request clone again under a

--- a/crates/checkouts/src/lib.rs
+++ b/crates/checkouts/src/lib.rs
@@ -184,6 +184,15 @@ fn create_unique_id_and_dir(base_dir: &Path, prefix: String) -> std::io::Result<
     ))
 }
 
+/// Runs [`Repo::new_worktree`] into `dir`, removing the directory again when
+/// git refuses: the add is not recorded in the state file, so a leftover would
+/// sit under the checkouts dir unrecorded.
+fn new_worktree_or_cleanup(repo: &mut Repo, dir: &Path, at: GitRef) -> Result<Checkout, Error> {
+    repo.new_worktree(dir.to_path_buf(), at).inspect_err(|_| {
+        let _ = fs::remove_dir_all(dir);
+    })
+}
+
 /// A handle to the manager for source-code checkouts.
 #[derive(Debug, Clone)]
 pub struct ManagerHandle(Arc<Mutex<Manager>>);
@@ -363,7 +372,7 @@ impl Manager {
                 if !self.offline {
                     repo.fetch()?;
                 }
-                let checkout = repo.new_worktree(checkout_dir.clone(), at.clone())?;
+                let checkout = new_worktree_or_cleanup(repo, &checkout_dir, at.clone())?;
                 let git_hash = checkout.rev.clone();
 
                 self.state
@@ -395,7 +404,7 @@ impl Manager {
                 // Make checkout
                 let checkout_dir = tempdir_in(self.git_checkouts_dir()).unwrap().keep();
                 let relative_dir = checkout_dir.strip_prefix(self.git_checkouts_dir()).unwrap();
-                let checkout = repo.new_worktree(checkout_dir.clone(), at.clone())?;
+                let checkout = new_worktree_or_cleanup(&mut repo, &checkout_dir, at.clone())?;
                 let git_hash = checkout.rev.clone();
 
                 self.state
@@ -662,6 +671,70 @@ mod tests {
             "commit ref must reuse the branch worktree"
         );
         assert_eq!(commit_rev, hash);
+    }
+
+    /// Two managers over one cache dir, the second holding a registry snapshot
+    /// that predates the first's branch checkout — the shape of two daemon
+    /// contexts scaffolding against the same cache. Each must get a usable
+    /// checkout of `main`: a worktree *on* the branch would make git refuse
+    /// the second one (`cannot force update the branch 'main' used by
+    /// worktree at ...`).
+    #[test]
+    fn checkout_of_branch_from_a_stale_manager_does_not_collide() {
+        let (src, hash) = make_local_repo("main");
+        let remote = src.path().to_str().unwrap().to_string();
+        let base = tempfile::tempdir().unwrap();
+
+        // Register the remote through a commit checkout, so a manager created
+        // now knows the repo but has no checkout of the branch to reuse.
+        let mut first = Manager::new_in_dir(base.path()).unwrap();
+        first
+            .checkout_of(&remote, GitRef::Commit(hash.clone()))
+            .unwrap();
+        let mut stale = Manager::new_in_dir(base.path()).unwrap();
+
+        let (path1, rev1) = first
+            .checkout_of(&remote, GitRef::Branch("main".to_string()))
+            .unwrap();
+        let (path2, rev2) = stale
+            .checkout_of(&remote, GitRef::Branch("main".to_string()))
+            .unwrap();
+
+        assert_eq!(rev1, hash);
+        assert_eq!(rev2, hash);
+        assert_ne!(
+            path1, path2,
+            "the stale manager cannot know the first's checkout"
+        );
+        assert!(path2.join("hello.txt").exists());
+    }
+
+    /// A refused worktree add leaves nothing behind under the checkouts dir.
+    #[test]
+    fn checkout_of_unknown_ref_leaves_no_checkout_dir() {
+        let (src, _) = make_local_repo("main");
+        let remote = src.path().to_str().unwrap().to_string();
+        let base = tempfile::tempdir().unwrap();
+        let mut handle = Manager::new_in_dir(base.path()).unwrap();
+
+        // Registers the remote; the next call takes the known-remote path.
+        handle
+            .checkout_of(&remote, GitRef::Branch("main".to_string()))
+            .unwrap();
+        let before = std::fs::read_dir(base.path().join("git").join("checkouts"))
+            .unwrap()
+            .count();
+
+        assert!(
+            handle
+                .checkout_of(&remote, GitRef::Tag("no-such-tag".to_string()))
+                .is_err()
+        );
+
+        let after = std::fs::read_dir(base.path().join("git").join("checkouts"))
+            .unwrap()
+            .count();
+        assert_eq!(before, after, "the refused add must not leak a directory");
     }
 
     /// A single unreachable remote must not gate `update_remote` for a

--- a/crates/checkouts/src/repo.rs
+++ b/crates/checkouts/src/repo.rs
@@ -123,38 +123,39 @@ impl Repo {
     }
 
     /// Creates a new worktree at the given path, checked-out to the given ref.
+    ///
+    /// Every worktree is a detached checkout, a branch included. Git lets a
+    /// branch be checked out by at most one worktree of a repository, so a
+    /// worktree *on* `main` makes the next `new_worktree` for `main` fail
+    /// (`cannot force update the branch 'main' used by worktree at ...`) —
+    /// and that next request is routine, because every [`crate::Manager`]
+    /// over a shared cache dir carries its own snapshot of the checkout
+    /// registry, and one that predates another's checkout asks for its own.
+    /// Detached, the worktrees are independent; a branch checkout is
+    /// refreshed by [`Self::worktree_checkout`] via `origin/<branch>`
+    /// regardless, which detaches too.
     pub fn new_worktree(&mut self, path: PathBuf, git_ref: GitRef) -> Result<Checkout, Error> {
-        if let GitRef::Branch(b) = &git_ref {
-            self.run_git_bare(
-                GIT_SEC_ARGS
-                    .into_iter()
-                    .chain([
-                        "worktree",
-                        "add",
-                        "-f",
-                        "--track",
-                        "-B",
-                        b.as_str(),
-                        path.to_str().unwrap(),
-                        b.as_str(),
-                    ])
-                    .collect::<Vec<_>>(),
-            )?;
-        } else {
-            self.run_git_bare(
-                GIT_SEC_ARGS
-                    .into_iter()
-                    .chain([
-                        "worktree",
-                        "add",
-                        "-f",
-                        "--checkout",
-                        path.to_str().unwrap(),
-                        git_ref.as_str(),
-                    ])
-                    .collect::<Vec<_>>(),
-            )?;
-        }
+        // Drop registrations whose directories are gone first, so a stale
+        // entry cannot claim the path this add is about to use.
+        self.run_git_bare(
+            GIT_SEC_ARGS
+                .into_iter()
+                .chain(["worktree", "prune"])
+                .collect::<Vec<_>>(),
+        )?;
+        self.run_git_bare(
+            GIT_SEC_ARGS
+                .into_iter()
+                .chain([
+                    "worktree",
+                    "add",
+                    "-f",
+                    "--detach",
+                    path.to_str().unwrap(),
+                    git_ref.as_str(),
+                ])
+                .collect::<Vec<_>>(),
+        )?;
 
         let output = self.run_git_checkout(&path, ["rev-parse", "HEAD"].into())?;
         Ok(Checkout {

--- a/crates/checkouts/src/repo.rs
+++ b/crates/checkouts/src/repo.rs
@@ -160,7 +160,17 @@ impl Repo {
                 .collect::<Vec<_>>(),
         )?;
         let target = match &git_ref {
-            GitRef::Branch(b) => format!("origin/{b}"),
+            // A cache cloned before remote-tracking refs were fetched at clone
+            // time, and never updated since, carries only `refs/heads/<b>`;
+            // offline that is the only copy of the branch there is.
+            GitRef::Branch(b) => {
+                let tracking = format!("refs/remotes/origin/{b}");
+                if self.ref_exists(&tracking) {
+                    tracking
+                } else {
+                    format!("refs/heads/{b}")
+                }
+            }
             GitRef::Commit(s) | GitRef::Tag(s) => s.clone(),
         };
         self.run_git_bare(
@@ -182,6 +192,12 @@ impl Repo {
             version: git_ref,
             rev: String::from_utf8_lossy(&output.stdout).trim().to_string(),
         })
+    }
+
+    /// Whether the bare repository has the given fully-qualified ref.
+    fn ref_exists(&self, full_ref: &str) -> bool {
+        self.run_git_bare(["show-ref", "--verify", "--quiet", full_ref].into())
+            .is_ok()
     }
 
     /// Returns a list of all tags in the repository.

--- a/crates/checkouts/src/repo.rs
+++ b/crates/checkouts/src/repo.rs
@@ -60,7 +60,17 @@ impl Repo {
             });
         }
 
-        Ok(Self { url, bare: base })
+        // A bare clone writes only `refs/heads/*`; every branch lookup in this
+        // crate goes through `refs/remotes/origin/*`, so populate those now
+        // rather than leaving the first branch checkout to fail on a ref the
+        // clone never wrote. A clone that cannot be fetched is not a usable
+        // cache entry: take the directory with the error.
+        let mut repo = Self { url, bare: base };
+        if let Err(err) = repo.fetch() {
+            let _ = std::fs::remove_dir_all(&repo.bare);
+            return Err(err);
+        }
+        Ok(repo)
     }
 
     /// Returns the path to the bare git repository.
@@ -134,6 +144,12 @@ impl Repo {
     /// Detached, the worktrees are independent; a branch checkout is
     /// refreshed by [`Self::worktree_checkout`] via `origin/<branch>`
     /// regardless, which detaches too.
+    ///
+    /// A branch is added at `origin/<branch>`, the ref [`Self::fetch`]
+    /// updates, not at the bare name: that resolves to the bare clone's own
+    /// `refs/heads/<branch>`, which nothing refreshes after the clone, so the
+    /// worktree would land on the clone-time tip and a branch created
+    /// upstream since would not resolve at all.
     pub fn new_worktree(&mut self, path: PathBuf, git_ref: GitRef) -> Result<Checkout, Error> {
         // Drop registrations whose directories are gone first, so a stale
         // entry cannot claim the path this add is about to use.
@@ -143,6 +159,10 @@ impl Repo {
                 .chain(["worktree", "prune"])
                 .collect::<Vec<_>>(),
         )?;
+        let target = match &git_ref {
+            GitRef::Branch(b) => format!("origin/{b}"),
+            GitRef::Commit(s) | GitRef::Tag(s) => s.clone(),
+        };
         self.run_git_bare(
             GIT_SEC_ARGS
                 .into_iter()
@@ -152,7 +172,7 @@ impl Repo {
                     "-f",
                     "--detach",
                     path.to_str().unwrap(),
-                    git_ref.as_str(),
+                    target.as_str(),
                 ])
                 .collect::<Vec<_>>(),
         )?;

--- a/crates/minimald/src/rpc.rs
+++ b/crates/minimald/src/rpc.rs
@@ -3164,6 +3164,87 @@ mod tests {
         );
     }
 
+    /// A session whose shell has exited still holds its host (the slot
+    /// outlives the process), but nothing runs there for an unforced shutdown
+    /// to interrupt, so it must not refuse. Driven the way the session e2e
+    /// meets it: exit the shell, keep the session at the exit prompt, then
+    /// stop the daemon.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_without_force_proceeds_once_a_sessions_shell_has_exited() {
+        let server = TestServer::new().await;
+        let mut client = server.connect().await;
+        let session_id = fresh_session(&mut client).await;
+
+        let mut channel = client.open_shell(session_id).await;
+        channel.data_bytes(b"hello\n".to_vec()).await.unwrap();
+        let mut stdout = Vec::new();
+        loop {
+            match channel.wait().await {
+                Some(russh::ChannelMsg::Data { data }) => {
+                    stdout.extend_from_slice(&data);
+                    if String::from_utf8_lossy(&stdout).contains("got:hello") {
+                        break;
+                    }
+                }
+                Some(_) => {}
+                None => panic!("channel closed before the echo arrived"),
+            }
+        }
+
+        // Exit the shell and take the prompt's default (keep): the session
+        // survives, its host gone.
+        channel
+            .data_bytes(format!("{}\n", crate::session_host::MOCK_EXIT_LINE).into_bytes())
+            .await
+            .unwrap();
+        let mut answered = false;
+        let mut prompt_out = Vec::new();
+        while let Ok(msg) =
+            tokio::time::timeout(std::time::Duration::from_secs(10), channel.wait()).await
+        {
+            match msg {
+                Some(russh::ChannelMsg::Data { data }) => {
+                    prompt_out.extend_from_slice(&data);
+                    if !answered
+                        && String::from_utf8_lossy(&prompt_out)
+                            .contains(crate::session_host::SHELL_EXIT_PROMPT)
+                    {
+                        channel.data_bytes(b"\r".to_vec()).await.unwrap();
+                        answered = true;
+                    }
+                }
+                Some(_) => {}
+                None => break,
+            }
+        }
+        assert!(
+            answered,
+            "expected the session-exit prompt to render; got: {:?}",
+            String::from_utf8_lossy(&prompt_out)
+        );
+
+        let mngr = server.state.sessions_manager().await;
+        let session = mngr
+            .get_session(SessionKeyPredicate::Id(session_id))
+            .await
+            .unwrap()
+            .expect("keep leaves the session in place");
+        // The host loop winds down after the channel closes; bounded wait.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        while session.is_busy().await {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "a session whose shell has exited stayed busy",
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        let resp = client
+            .call::<Shutdown>(&ShutdownRequest { force: false })
+            .await;
+        assert_eq!(resp, ShutdownResponse::ShuttingDown);
+    }
+
     #[tokio::test]
     async fn shutdown_with_force_tears_down_live_sessions() {
         let server = TestServer::new().await;

--- a/crates/minimald/src/session.rs
+++ b/crates/minimald/src/session.rs
@@ -1067,7 +1067,14 @@ impl Session {
                 let _ = r.send(match &self.inner {
                     // Awaiting a verdict: a client is mid create flow.
                     SessionInner::Draft { pending } => pending.is_some(),
-                    SessionInner::Active { host, .. } => host.is_some(),
+                    // A *live* host, not merely a held one: the slot outlives
+                    // the process (see `launch_host_for_hooks`), so a session
+                    // whose shell has exited still holds a handle to a host
+                    // that runs nothing — and nothing is what an unforced
+                    // shutdown would interrupt there.
+                    SessionInner::Active { host, .. } => {
+                        host.as_ref().is_some_and(|(h, _)| h.is_alive())
+                    }
                 });
             }
             SessionMessage::Stop(r) => {

--- a/scripts/session-e2e.sh
+++ b/scripts/session-e2e.sh
@@ -1022,6 +1022,15 @@ exit' python3 "$ROOT/scripts/e2e-attach-pty.py" - \
     fail
   fi
   echo "declared shell OK (SHELL=/usr/bin/sh started sh, not bash)"
+  # The driver's "Delete" at the exit prompt is not this proof's teardown: the
+  # daemon hands a shell's exit to the attached binding best-effort (a
+  # non-blocking send it drops when the binding's queue is full — "could not
+  # hand the teardown to the binding; no shell-exit prompt will render"), and
+  # this shell exits within milliseconds of starting. When the hand-off drops,
+  # no prompt renders, the attach still ends cleanly, and the session survives
+  # to block the unforced `min stop` below. Destroy it explicitly; a no-op when
+  # the prompt already did.
+  mnl session destroy --force "$sh_sid" >/dev/null 2>&1 || true
 
   # The fallback: a shell that isn't installed leaves bash running AND tells
   # the user why, on the terminal, before the first prompt.
@@ -1051,6 +1060,8 @@ exit' python3 "$ROOT/scripts/e2e-attach-pty.py" - \
     echo "--- transcript ---"; printf '%s\n' "$miss_out"
     fail
   fi
+  # Same best-effort prompt as above; same explicit teardown.
+  mnl session destroy --force "$miss_sid" >/dev/null 2>&1 || true
   rm -rf "$HOOK_SEED_DIR"; HOOK_SEED_DIR=""
   rm -f "$XDG_CONFIG_HOME/minimal/loadouts/shelldev.toml"
   rm -f "$XDG_CONFIG_HOME/minimal/loadouts/shellmissing.toml"


### PR DESCRIPTION
Two timing-dependent failures in the nightly shipped-binary smoke (`smoke-linux-amd64` on Sep 5/10, `smoke-linux-kvm` on Sep 9; never on the PR lanes for the same shas).

**amd64 — `worktree add -B main` collision.** `checkouts::Repo::new_worktree` checked branches out *on* the branch; git allows one worktree per branch, and every `mctx` context carries its own `state.json` snapshot, so a manager that predates another's `main` checkout asks for a second one and git refuses (`cannot force update the branch 'main' used by worktree at ...`). Worktrees are now detached (`--detach`), `worktree prune` precedes each add, and a refused add cleans up the directory it was handed. Unit test reproduces the nightly error verbatim before the change. Follow-up to #1339 / #1345.

**kvm — `min stop` refused with "daemon has active sessions".** The session-shell proof's `sh` exited before the daemon could hand the teardown to the binding (documented best-effort drop), so no exit prompt rendered and the session survived with a dead host; `IsBusy` counted any held host as live, so the dead one blocked unforced shutdown. Busy now means a *live* host (`is_alive()`), with a test. The e2e also destroys the two session-shell sessions explicitly instead of relying on the prompt's Delete it never asserted.

Verified: `cargo test -p checkouts` (10 passed, both new tests; pre-fix reproduction fails with the nightly error verbatim), minimald shutdown tests + clippy under `cross` (musl; pre-fix reproduction fails), fmt, shellcheck. Not run: full `just test-cross`, `just e2e`.

Follow-up worth filing, not fixed here: per-`Context` `checkouts::Manager` instances write back stale `state.json` snapshots, which is what lets registrations diverge; the detach makes that harmless rather than fixing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD1J7U8uZKsYFhQ4PFtTPB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Failed worktree creation now cleans up incomplete checkouts and newly created repositories.
  - Worktrees use the latest fetched branch revisions, avoid stale branch associations, and support offline legacy repositories.
  - Daemon shutdown no longer remains blocked by sessions whose host process has exited.
  - Session cleanup is more reliable after interactive shell use, including when exit prompts are unavailable.
- **Tests**
  - Added coverage for branch resolution, failed checkout cleanup, offline repositories, daemon shutdown, and shell-session teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->